### PR TITLE
fix(release): unblock main release workflow parser failure

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -76,9 +76,10 @@ jobs:
             LATEST_TAG="v0.0.0"
           fi
           BASE_VERSION="${LATEST_TAG#v}"
-          IFS=. read -r MAJOR MINOR PATCH <<EOF
-${BASE_VERSION}
-EOF
+          MAJOR="${BASE_VERSION%%.*}"
+          REST="${BASE_VERSION#*.}"
+          MINOR="${REST%%.*}"
+          PATCH="${REST##*.}"
           NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
           echo "base_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
           echo "tag_exists=false" >> "$GITHUB_OUTPUT"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -65,6 +65,7 @@ All notable changes to this project will be documented in this file.
   - Release publish now checks out the tagged source commit before npm publish (and reinstalls dependencies) so reruns publish from the exact tagged versioned source.
   - Next-version tag discovery now ignores non-`vX.Y.Z` tags to avoid malformed version parsing when non-standard tags exist.
   - Rerun tag matching now inspects each annotated tag object (`git cat-file`) instead of line-based parsing, so multiline tag annotations are matched reliably.
+  - Replaced heredoc-based semver split in release workflow with shell parameter expansion to avoid GitHub workflow parser failures on merge-triggered runs.
 - Node version alignment with OpenClaw:
   - `package.json` `engines.node` is now `>=22.12.0` (was `>=20`).
   - CI and release workflows now use Node `22.12.0`.


### PR DESCRIPTION
## Problem
The merged `main` release run failed immediately with:
- `Invalid workflow file: .github/workflows/release-and-publish.yml#L80`
- `YamlSyntaxError: While scanning a simple key, could not find expected ':'`

That produced a 0s failed run with no jobs.

## Fix
- Replaced the heredoc-based semver split in `release-and-publish.yml` with shell parameter expansion (`MAJOR/REST/MINOR/PATCH` extraction).
- Kept existing protected-main-safe, tag-only, idempotent release behavior intact.
- Updated `CHANGELOG.md` under `Unreleased -> Changed` to document this fix.

## Verification
- `npm run check-types`
- `npm test` (33/33)
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to release workflow shell logic; risk is limited to version parsing in the GitHub Actions release job.
> 
> **Overview**
> Fixes `release-and-publish` workflow failures on `main` by replacing the heredoc-based semver split with shell parameter expansion when computing `MAJOR/MINOR/PATCH` from the latest `vX.Y.Z` tag.
> 
> Updates `CHANGELOG.md` to document the workflow parser/compatibility fix; no other release behavior is intended to change.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8792c23a2506f77732b79ac40675757986b0b539. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->