### PR TITLE
chore(release): scope package to @joshuaswarren and use npm trusted publishing

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -26,7 +26,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: '22.12.0'
+          node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
           cache: npm
 
       - name: Sync with latest main before validation
@@ -117,17 +118,12 @@ jobs:
       - name: Install dependencies for tagged source
         run: npm ci
 
-      - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Publish to npm (trusted publishing)
         run: |
           VERSION="${{ steps.version.outputs.new_version }}"
-          if npm view "openclaw-engram@${VERSION}" version >/dev/null 2>&1; then
-            echo "::notice title=NPM publish skipped::openclaw-engram@${VERSION} is already published."
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          if npm view "${PACKAGE_NAME}@${VERSION}" version >/dev/null 2>&1; then
+            echo "::notice title=NPM publish skipped::${PACKAGE_NAME}@${VERSION} is already published."
             exit 0
           fi
-          if [ -z "${NODE_AUTH_TOKEN:-}" ]; then
-            echo "::warning title=NPM publish skipped::Set repository secret NPM_TOKEN to publish openclaw-engram to npm."
-            exit 0
-          fi
-          npm publish --provenance --access public
+          npm publish --access public

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - npm-first distribution + release automation:
-  - New `Release and Publish` workflow (`.github/workflows/release-and-publish.yml`) that runs on `main` merges, verifies quality gates, bumps patch version, tags, creates GitHub release, and publishes to npm (when `NPM_TOKEN` is configured).
+  - New `Release and Publish` workflow (`.github/workflows/release-and-publish.yml`) that runs on `main` merges, verifies quality gates, bumps patch version, tags, creates GitHub release, and publishes to npm.
   - Package publish metadata in `package.json`: `engines.node`, `prepack`, and `publishConfig` (`access: public`, `provenance: true`).
 - Contributor onboarding and contribution governance docs:
   - New `CONTRIBUTING.md` with standards for issues/PRs, testing, changelog policy, and AI-assisted contributions.
@@ -59,9 +59,9 @@ All notable changes to this project will be documented in this file.
   - `release-and-publish` now uses a protected-branch-safe flow: sync + validate latest `origin/main`, compute next patch version from tags, create a local release commit with version bump (not pushed to `main`), tag that commit, push only the release tag, then create GitHub release and publish to npm.
   - Release tags are now created as annotated tags to ensure `git push --follow-tags` reliably publishes them.
   - Release workflow concurrency no longer cancels in-progress runs, avoiding partial side effects (tag/commit pushed) from interrupted releases.
-  - npm publish now gates on token presence within shell logic, warning and skipping publish when `NPM_TOKEN` is unset, while scoping `NODE_AUTH_TOKEN` only to the publish step.
+  - npm publish now uses npm trusted publishing (OIDC via GitHub Actions) instead of `NPM_TOKEN` secrets.
   - Added rerun-stable idempotency: tags now include `source-main-sha` metadata and reruns reuse the same tag/version for the same source commit instead of incrementing patch again.
-  - npm publish now also skips when the computed `openclaw-engram@version` already exists on npm.
+  - npm publish now also skips when the computed package name + version (read from `package.json`) already exists on npm.
   - Release publish now checks out the tagged source commit before npm publish (and reinstalls dependencies) so reruns publish from the exact tagged versioned source.
   - Next-version tag discovery now ignores non-`vX.Y.Z` tags to avoid malformed version parsing when non-standard tags exist.
   - Rerun tag matching now inspects each annotated tag object (`git cat-file`) instead of line-based parsing, so multiline tag annotations are matched reliably.
@@ -70,7 +70,8 @@ All notable changes to this project will be documented in this file.
   - `package.json` `engines.node` is now `>=22.12.0` (was `>=20`).
   - CI and release workflows now use Node `22.12.0`.
   - Contributing guide now documents Node `>=22.12.0` for local development.
-- Installation docs now lead with `openclaw plugins install openclaw-engram --pin` and move git clone/build to a developer-only path.
+- Installation docs now lead with `openclaw plugins install @joshuaswarren/openclaw-engram --pin` and move git clone/build to a developer-only path.
+- npm package name is now scoped to `@joshuaswarren/openclaw-engram` for user-scoped publishing.
 - `agent_end` ingestion now ignores non-`user`/`assistant` message roles for extraction to avoid tool-output memory churn.
 - Extractions with no durable outputs skip persistence/log churn paths.
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ QMD supports hybrid search combining BM25 and vector embeddings with reranking.
 
 ```bash
 # Install from npm (records install provenance in openclaw.json.plugins.installs)
-openclaw plugins install openclaw-engram --pin
+openclaw plugins install @joshuaswarren/openclaw-engram --pin
 ```
 
 Then enable and configure in `openclaw.json`:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,13 @@
 {
-  "name": "openclaw-engram",
+  "name": "@joshuaswarren/openclaw-engram",
   "version": "7.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "openclaw-engram",
+      "name": "@joshuaswarren/openclaw-engram",
       "version": "7.2.1",
+      "license": "MIT",
       "dependencies": {
         "@honcho-ai/sdk": "^2.0.0",
         "@sinclair/typebox": "^0.34.0",
@@ -19,6 +20,9 @@
         "tsup": "^8.5.1",
         "tsx": "^4.0.0",
         "typescript": "^5.9.3"
+      },
+      "engines": {
+        "node": ">=22.12.0"
       },
       "peerDependencies": {
         "openclaw": "*"

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "openclaw-engram",
+  "name": "@joshuaswarren/openclaw-engram",
   "version": "7.2.1",
   "type": "module",
   "description": "Local-first memory plugin for OpenClaw. LLM-powered extraction, markdown storage, hybrid search via QMD.",


### PR DESCRIPTION
## Summary
- Switch package name to `@joshuaswarren/openclaw-engram`.
- Move release publish step to npm trusted publishing (OIDC) instead of `NPM_TOKEN`.
- Update install docs to use the new scoped package name.
- Keep version-exists guard but read package name dynamically from `package.json`.

## Why
npm does not provide a separate package-creation UI for public packages. The package is created at first successful publish. This PR aligns the repo with that flow and trusted publishing.

## Validation
- `npm run check-types`
- `npm test` (33/33 pass)
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release/publishing automation and package identity; misconfiguration could break releases or publish under the wrong name, but runtime plugin logic is unchanged.
> 
> **Overview**
> This PR renames the npm package to the scoped `@joshuaswarren/openclaw-engram` (updating `package.json`/`package-lock.json`) and updates install docs to use the new name.
> 
> The `release-and-publish` GitHub Action is adjusted to publish via npm *trusted publishing* (OIDC) rather than `NPM_TOKEN`, and the “already published” guard now reads the package name from `package.json` before checking `npm view`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 29c9be2806d6c5bbadfd8a18b9f07aa8b30db196. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->