### PR TITLE
v8.3 PR21A: proactive/policy-learning foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 <!-- New items go here before they're released -->
 
 ### Added
+- v8.3 PR 21A (proactive/policy-learning foundation slice):
+  - Added new config surface (default off): `proactiveExtractionEnabled`, `contextCompressionActionsEnabled`, `compressionGuidelineLearningEnabled`.
+  - Added new v8.3 policy limits with zero-safe semantics: `maxProactiveQuestionsPerExtraction` and `maxCompressionTokensPerHour`.
+  - Added typed policy-state storage primitives in `StorageManager` for `state/memory-actions.jsonl` and `state/compression-guidelines.md`.
+  - Added test coverage for proactive/policy config parsing and policy-state storage read/write behavior.
 - v8.3 PR 20D (lifecycle retrieval + docs slice):
   - Added lifecycle-aware retrieval weighting in shared score post-processing with boosts for `active`/`validated` memories and penalties for `candidate`/`stale`/`archived` states.
   - Added stronger retrieval penalty for `verificationState: disputed`.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -97,6 +97,16 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | `lifecycleProtectedCategories` | `["decision","principle","commitment","preference"]` | Categories protected from automatic archive transition. |
 | `lifecycleMetricsEnabled` | `false` (auto-`true` when policy enabled unless explicitly set) | Emit lifecycle metrics snapshot at `state/lifecycle-metrics.json`. |
 
+## v8.3 Proactive + Policy Learning Foundation
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `proactiveExtractionEnabled` | `false` | Enable proactive extraction second-pass paths (feature-gated). |
+| `contextCompressionActionsEnabled` | `false` | Enable context compression action tool paths and action telemetry wiring. |
+| `compressionGuidelineLearningEnabled` | `false` | Enable adaptive compression guideline learning loop. |
+| `maxProactiveQuestionsPerExtraction` | `2` | Hard cap on proactive self-questions per extraction (`0` disables). |
+| `maxCompressionTokensPerHour` | `1500` | Hourly token budget for compression-learning workflows (`0` disables). |
+
 ## Local LLM / OpenAI-Compatible Endpoint
 
 | Setting | Default | Description |

--- a/docs/plans/2026-02-21-engram-memory-os-roadmap.md
+++ b/docs/plans/2026-02-21-engram-memory-os-roadmap.md
@@ -78,6 +78,11 @@ The roadmap implements all requested paper concepts, grouped by the capability t
 - Proactive extraction self-questioning
 - Compression guideline optimizer
 - Memory actions telemetry and policy tuning loop
+- Delivery split (post-PR20 lifecycle completion):
+  - PR 21A: proactive/policy foundation (config + schema + typed state stores)
+  - PR 21B: proactive extraction self-questioning integration (bounded, fail-open)
+  - PR 21C: context compression action tools + memory action telemetry
+  - PR 21D: compression guideline learner + rollout docs + hardening gate
 - Recommended delivery split:
   - PR 20A: lifecycle data model + config
   - PR 20B: lifecycle engine module

--- a/docs/plans/2026-02-23-v8.3-pr21-proactive-policy-learning.md
+++ b/docs/plans/2026-02-23-v8.3-pr21-proactive-policy-learning.md
@@ -1,0 +1,92 @@
+# v8.3 PR21: Proactive + Policy Learning Delivery Split
+
+## Objective
+
+Deliver the remaining v8.3 scope after PR20 lifecycle in small, reviewable slices with strict fail-open behavior and budget controls.
+
+## Scope Remaining After PR20
+
+- Proactive extraction self-questioning (ProMem-inspired)
+- Context compression action surface + telemetry (MemAct-inspired)
+- Compression guideline learning loop (ACON-inspired)
+
+## PR Slice Plan
+
+### PR 21A — Foundation: Config + Schema + State Stores
+
+Files:
+- `src/types.ts`
+- `src/config.ts`
+- `openclaw.plugin.json`
+- `src/storage.ts`
+- `tests/config-proactive-policy.test.ts`
+- `tests/storage-policy-state.test.ts`
+
+Tasks:
+1. Add config flags and limits (default-off, bounded):
+   - `proactiveExtractionEnabled` (`false`)
+   - `contextCompressionActionsEnabled` (`false`)
+   - `compressionGuidelineLearningEnabled` (`false`)
+   - `maxProactiveQuestionsPerExtraction` (`2`)
+   - `maxCompressionTokensPerHour` (`1500`)
+2. Add typed storage primitives for:
+   - `state/memory-actions.jsonl`
+   - `state/compression-guidelines.md`
+3. Add tests for config parsing and state read/write behavior.
+4. No orchestration behavior changes in this slice.
+
+### PR 21B — Proactive Extraction Wiring
+
+Files:
+- `src/extraction.ts`
+- `src/orchestrator.ts`
+- tests for extraction/orchestrator proactive path
+
+Tasks:
+1. Add a bounded second-pass self-question generation path behind `proactiveExtractionEnabled`.
+2. Respect `maxProactiveQuestionsPerExtraction` hard cap.
+3. Fail-open: any proactive pass failure falls back to baseline extraction.
+4. Add tests for gating, bounds, and fail-open behavior.
+
+### PR 21C — Compression Action Tools + Telemetry
+
+Files:
+- `src/tools.ts`
+- `src/orchestrator.ts`
+- `src/storage.ts`
+- tests for tool wiring + telemetry output
+
+Tasks:
+1. Add `context_checkpoint` and `memory_action_apply` tool surfaces behind `contextCompressionActionsEnabled`.
+2. Log action telemetry entries to `state/memory-actions.jsonl`.
+3. Ensure action writes are append-only and fail-open.
+4. Add tests for action logging and disabled-mode reachability.
+
+### PR 21D — Guideline Learning Loop + Docs
+
+Files:
+- learner wiring (orchestrator/compounding path)
+- `docs/architecture/memory-lifecycle.md`
+- `docs/config-reference.md`
+- `docs/setup-config-tuning.md`
+
+Tasks:
+1. Add guideline update pass behind `compressionGuidelineLearningEnabled`.
+2. Generate/update `state/compression-guidelines.md` from recent action outcomes.
+3. Add staged rollout guidance and operator tuning playbook.
+4. Run hardening playbook before merge.
+
+## Invariants
+
+1. All new behavior is disabled by default.
+2. `0` numeric limits remain valid and are never coerced upward.
+3. All new writes are fail-open and do not block extraction/recall.
+4. New telemetry/state stores are namespace-safe and backward compatible.
+
+## Verification Gate (Each PR)
+
+1. `npm run check-types`
+2. `npm test`
+3. `npm run build`
+4. `npm run preflight:quick`
+5. PR loop must wait for terminal `Cursor Bugbot` state before claiming clean.

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -152,6 +152,25 @@ Validation checkpoints:
 - Compare stale/disputed recall rates before/after each phase.
 - If relevance drops, keep policy on but disable stale filtering and retune thresholds.
 
+## 2d) v8.3 Proactive + Policy Learning Foundation
+
+Start with all new policy-learning behavior disabled, then enable incrementally:
+
+```jsonc
+{
+  "proactiveExtractionEnabled": false,
+  "contextCompressionActionsEnabled": false,
+  "compressionGuidelineLearningEnabled": false,
+  "maxProactiveQuestionsPerExtraction": 2,
+  "maxCompressionTokensPerHour": 1500
+}
+```
+
+Rollout suggestion:
+- Enable `proactiveExtractionEnabled` first and validate extraction quality/latency.
+- Enable `contextCompressionActionsEnabled` after tool-level validation.
+- Enable `compressionGuidelineLearningEnabled` last, once memory-action telemetry is stable.
+
 QMD collection (`~/.config/qmd/index.yml`):
 
 ```yaml

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1015,6 +1015,31 @@
         "default": true,
         "description": "Emit lifecycle metrics snapshots to state/lifecycle-metrics.json when policy is enabled."
       },
+      "proactiveExtractionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable proactive self-questioning extraction second-pass (v8.3, default off)."
+      },
+      "contextCompressionActionsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable context compression action tooling and telemetry paths (v8.3, default off)."
+      },
+      "compressionGuidelineLearningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable adaptive compression guideline learning from memory-action outcomes (v8.3, default off)."
+      },
+      "maxProactiveQuestionsPerExtraction": {
+        "type": "number",
+        "default": 2,
+        "description": "Maximum proactive self-questions generated per extraction pass (0 disables question generation)."
+      },
+      "maxCompressionTokensPerHour": {
+        "type": "number",
+        "default": 1500,
+        "description": "Hourly token budget for compression actions/guideline generation (0 disables budgeted compression work)."
+      },
       "qmdDaemonEnabled": {
         "type": "boolean",
         "default": true,
@@ -1465,6 +1490,28 @@
       "label": "Lifecycle Metrics",
       "advanced": true,
       "help": "Write lifecycle metrics snapshots to state/lifecycle-metrics.json"
+    },
+    "proactiveExtractionEnabled": {
+      "label": "Proactive Extraction",
+      "help": "Enable proactive self-questioning extraction second-pass (v8.3, default off)"
+    },
+    "contextCompressionActionsEnabled": {
+      "label": "Context Compression Actions",
+      "help": "Enable context compression action tools and action telemetry (v8.3, default off)"
+    },
+    "compressionGuidelineLearningEnabled": {
+      "label": "Compression Guideline Learning",
+      "help": "Enable adaptive compression guideline learning from action outcomes (v8.3, default off)"
+    },
+    "maxProactiveQuestionsPerExtraction": {
+      "label": "Max Proactive Questions / Extraction",
+      "advanced": true,
+      "placeholder": "2"
+    },
+    "maxCompressionTokensPerHour": {
+      "label": "Max Compression Tokens / Hour",
+      "advanced": true,
+      "placeholder": "1500"
     },
     "knowledgeIndexEnabled": {
       "label": "Knowledge Index",

--- a/src/config.ts
+++ b/src/config.ts
@@ -542,6 +542,18 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.lifecycleMetricsEnabled === "boolean"
         ? cfg.lifecycleMetricsEnabled
         : cfg.lifecyclePolicyEnabled === true,
+    // v8.3 proactive + policy learning (default off)
+    proactiveExtractionEnabled: cfg.proactiveExtractionEnabled === true,
+    contextCompressionActionsEnabled: cfg.contextCompressionActionsEnabled === true,
+    compressionGuidelineLearningEnabled: cfg.compressionGuidelineLearningEnabled === true,
+    maxProactiveQuestionsPerExtraction:
+      typeof cfg.maxProactiveQuestionsPerExtraction === "number"
+        ? Math.max(0, Math.floor(cfg.maxProactiveQuestionsPerExtraction))
+        : 2,
+    maxCompressionTokensPerHour:
+      typeof cfg.maxCompressionTokensPerHour === "number"
+        ? Math.max(0, Math.floor(cfg.maxCompressionTokensPerHour))
+        : 1500,
     // v8.0 phase 1
     recallPlannerEnabled: cfg.recallPlannerEnabled !== false,
     recallPlannerMaxQmdResultsMinimal:

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile, mkdir, unlink, rename } from "node:fs/promises";
+import { readdir, readFile, writeFile, mkdir, unlink, rename, appendFile } from "node:fs/promises";
 import { appendFileSync, mkdirSync, statSync } from "node:fs";
 import { createHash } from "node:crypto";
 import path from "node:path";
@@ -22,6 +22,7 @@ import type {
   VerificationState,
   PolicyClass,
   MemoryStatus,
+  MemoryActionEvent,
   MemorySummary,
   MetaState,
   PluginConfig,
@@ -684,6 +685,12 @@ export class StorageManager {
   }
   private get profilePath(): string {
     return path.join(this.baseDir, "profile.md");
+  }
+  private get memoryActionsPath(): string {
+    return path.join(this.stateDir, "memory-actions.jsonl");
+  }
+  private get compressionGuidelinesPath(): string {
+    return path.join(this.stateDir, "compression-guidelines.md");
   }
 
   /**
@@ -1371,6 +1378,66 @@ export class StorageManager {
     await this.ensureDirectories();
     const metaPath = path.join(this.stateDir, "meta.json");
     await writeFile(metaPath, JSON.stringify(state, null, 2), "utf-8");
+  }
+
+  async appendMemoryActionEvents(events: MemoryActionEvent[]): Promise<number> {
+    if (events.length === 0) return 0;
+    await this.ensureDirectories();
+
+    const nowIso = new Date().toISOString();
+    const payload = events.map((event) => {
+      const normalized: MemoryActionEvent = {
+        ...event,
+        timestamp: event.timestamp && event.timestamp.length > 0 ? event.timestamp : nowIso,
+      };
+      return `${JSON.stringify(normalized)}\n`;
+    }).join("");
+
+    await appendFile(this.memoryActionsPath, payload, "utf-8");
+    return events.length;
+  }
+
+  async readMemoryActionEvents(limit: number = 200): Promise<MemoryActionEvent[]> {
+    const cappedLimit = Math.max(0, Math.floor(limit));
+    if (cappedLimit === 0) return [];
+
+    try {
+      const raw = await readFile(this.memoryActionsPath, "utf-8");
+      const out: MemoryActionEvent[] = [];
+      const lines = raw.split("\n");
+      for (let i = lines.length - 1; i >= 0 && out.length < cappedLimit; i -= 1) {
+        const line = lines[i]?.trim();
+        if (!line) continue;
+        try {
+          const parsed = JSON.parse(line) as Partial<MemoryActionEvent>;
+          if (
+            typeof parsed.timestamp === "string" &&
+            typeof parsed.action === "string" &&
+            typeof parsed.outcome === "string"
+          ) {
+            out.push(parsed as MemoryActionEvent);
+          }
+        } catch {
+          // Ignore malformed rows (fail-open).
+        }
+      }
+      return out.reverse();
+    } catch {
+      return [];
+    }
+  }
+
+  async writeCompressionGuidelines(content: string): Promise<void> {
+    await this.ensureDirectories();
+    await writeFile(this.compressionGuidelinesPath, content, "utf-8");
+  }
+
+  async readCompressionGuidelines(): Promise<string | null> {
+    try {
+      return await readFile(this.compressionGuidelinesPath, "utf-8");
+    } catch {
+      return null;
+    }
   }
 
   // ---------------------------------------------------------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -264,6 +264,12 @@ export interface PluginConfig {
   lifecycleArchiveDecayThreshold: number;
   lifecycleProtectedCategories: MemoryCategory[];
   lifecycleMetricsEnabled: boolean;
+  // v8.3 proactive + policy learning
+  proactiveExtractionEnabled: boolean;
+  contextCompressionActionsEnabled: boolean;
+  compressionGuidelineLearningEnabled: boolean;
+  maxProactiveQuestionsPerExtraction: number;
+  maxCompressionTokensPerHour: number;
   // v8.0 Phase 1: recall planner + intent routing + verbatim artifacts
   recallPlannerEnabled: boolean;
   recallPlannerMaxQmdResultsMinimal: number;
@@ -605,6 +611,27 @@ export interface MetaState {
   lastConsolidationAt: string | null;
   totalMemories: number;
   totalEntities: number;
+}
+
+export type MemoryActionType =
+  | "store_episode"
+  | "store_note"
+  | "update_note"
+  | "create_artifact"
+  | "summarize_node"
+  | "discard"
+  | "link_graph";
+
+export type MemoryActionOutcome = "applied" | "skipped" | "failed";
+
+export interface MemoryActionEvent {
+  timestamp: string;
+  action: MemoryActionType;
+  outcome: MemoryActionOutcome;
+  reason?: string;
+  memoryId?: string;
+  namespace?: string;
+  promptHash?: string;
 }
 
 /** Entry in the access tracking buffer (batched updates) */

--- a/tests/config-proactive-policy.test.ts
+++ b/tests/config-proactive-policy.test.ts
@@ -1,0 +1,40 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseConfig } from "../src/config.js";
+
+test("parseConfig sets proactive/policy-learning defaults", () => {
+  const cfg = parseConfig({ openaiApiKey: "sk-test" });
+  assert.equal(cfg.proactiveExtractionEnabled, false);
+  assert.equal(cfg.contextCompressionActionsEnabled, false);
+  assert.equal(cfg.compressionGuidelineLearningEnabled, false);
+  assert.equal(cfg.maxProactiveQuestionsPerExtraction, 2);
+  assert.equal(cfg.maxCompressionTokensPerHour, 1500);
+});
+
+test("parseConfig supports explicit proactive/policy-learning settings and preserves zero limits", () => {
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    proactiveExtractionEnabled: true,
+    contextCompressionActionsEnabled: true,
+    compressionGuidelineLearningEnabled: true,
+    maxProactiveQuestionsPerExtraction: 0,
+    maxCompressionTokensPerHour: 0,
+  });
+
+  assert.equal(cfg.proactiveExtractionEnabled, true);
+  assert.equal(cfg.contextCompressionActionsEnabled, true);
+  assert.equal(cfg.compressionGuidelineLearningEnabled, true);
+  assert.equal(cfg.maxProactiveQuestionsPerExtraction, 0);
+  assert.equal(cfg.maxCompressionTokensPerHour, 0);
+});
+
+test("parseConfig clamps proactive/policy-learning numeric limits to non-negative integers", () => {
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    maxProactiveQuestionsPerExtraction: -1.7,
+    maxCompressionTokensPerHour: -500.9,
+  });
+
+  assert.equal(cfg.maxProactiveQuestionsPerExtraction, 0);
+  assert.equal(cfg.maxCompressionTokensPerHour, 0);
+});

--- a/tests/storage-policy-state.test.ts
+++ b/tests/storage-policy-state.test.ts
@@ -1,0 +1,85 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { appendFile, mkdtemp, rm } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+
+test("StorageManager appends and reads memory action events from state store", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-policy-actions-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const wrote = await storage.appendMemoryActionEvents([
+      {
+        timestamp: "2026-02-23T00:00:00.000Z",
+        action: "store_note",
+        outcome: "applied",
+        reason: "seed",
+      },
+      {
+        timestamp: "2026-02-23T00:00:01.000Z",
+        action: "summarize_node",
+        outcome: "skipped",
+      },
+      {
+        timestamp: "2026-02-23T00:00:02.000Z",
+        action: "discard",
+        outcome: "failed",
+      },
+    ]);
+
+    assert.equal(wrote, 3);
+
+    const events = await storage.readMemoryActionEvents(2);
+    assert.equal(events.length, 2);
+    assert.equal(events[0]?.action, "summarize_node");
+    assert.equal(events[1]?.action, "discard");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager readMemoryActionEvents ignores malformed rows (fail-open)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-policy-malformed-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    await storage.appendMemoryActionEvents([
+      {
+        timestamp: "2026-02-23T00:00:00.000Z",
+        action: "store_episode",
+        outcome: "applied",
+      },
+    ]);
+
+    const malformedPath = path.join(dir, "state", "memory-actions.jsonl");
+    await appendFile(malformedPath, "{not-json}\n", "utf-8");
+
+    const events = await storage.readMemoryActionEvents(10);
+    assert.equal(events.length, 1);
+    assert.equal(events.every((e) => typeof e.timestamp === "string" && e.timestamp.length > 0), true);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager writes and reads compression guidelines", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-policy-guidelines-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    assert.equal(await storage.readCompressionGuidelines(), null);
+
+    const content = "# Compression Guidelines\n\n- Prefer concise summary bullets.\n";
+    await storage.writeCompressionGuidelines(content);
+
+    const loaded = await storage.readCompressionGuidelines();
+    assert.equal(loaded, content);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- split remaining v8.3 work into PR21A-PR21D in plan docs
- add v8.3 proactive/policy config flags and zero-safe numeric limits
- add typed storage state helpers for memory-action telemetry and compression guidelines
- add config and storage tests for new foundation behavior
- keep all new behavior default-off (no orchestrator behavior change in this slice)

## Validation
- npm run check-types
- npx tsx --test tests/config-proactive-policy.test.ts tests/storage-policy-state.test.ts
- npm test
- npm run build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are additive and gated by default-off flags, mainly extending config parsing/schema and adding new state read/write helpers with tests.
> 
> **Overview**
> Introduces the v8.3 proactive/policy-learning **foundation layer** by adding new default-off config flags plus zero-safe numeric limits (`maxProactiveQuestionsPerExtraction`, `maxCompressionTokensPerHour`) across `PluginConfig`, `parseConfig`, and `openclaw.plugin.json` UI/schema.
> 
> Adds typed policy state storage primitives in `StorageManager` for append-only `state/memory-actions.jsonl` (with fail-open reads that skip malformed rows) and `state/compression-guidelines.md`, with accompanying tests.
> 
> Updates docs and plans (`config-reference`, `setup-config-tuning`, roadmap) to document the new settings and PR21 delivery split; no orchestration/runtime behavior is enabled by default in this slice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c5b07ca8851aa4c4247368b2acea4b1745bc75cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->