### PR TITLE
v8.3 PR21C: compression action tools + telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ All notable changes to this project will be documented in this file.
 <!-- New items go here before they're released -->
 
 ### Added
+- v8.3 PR 21C (compression action tools + telemetry slice):
+  - Added `context_checkpoint` and `memory_action_apply` tools behind `contextCompressionActionsEnabled`.
+  - Added append-only telemetry wiring through `Orchestrator.appendMemoryActionEvent(...)` to persist policy-learning events into namespace-scoped `state/memory-actions.jsonl`.
+  - Added fail-open behavior for tool telemetry writes so action paths do not block runtime flow on storage errors.
+  - Added tool-focused coverage in `tests/tools-compression-actions.test.ts` for disabled-mode gating, telemetry writes, namespace handling, and fail-open behavior.
 - v8.3 PR 21B (proactive extraction slice):
   - Added a proactive second-pass extraction path in `ExtractionEngine` behind `proactiveExtractionEnabled`.
   - Added strict cap enforcement for proactive follow-up questions via `maxProactiveQuestionsPerExtraction` with zero-safe semantics.

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -59,6 +59,7 @@ import type {
   BufferTurn,
   ExtractionResult,
   LifecycleState,
+  MemoryActionEvent,
   MemoryLink,
   MemoryFile,
   MemoryFrontmatter,
@@ -780,6 +781,31 @@ export class Orchestrator {
   async getStorage(namespace?: string): Promise<StorageManager> {
     const ns = namespace && namespace.length > 0 ? namespace : this.config.defaultNamespace;
     return this.storageRouter.storageFor(ns);
+  }
+
+  async appendMemoryActionEvent(
+    event: Omit<MemoryActionEvent, "timestamp"> & { timestamp?: string },
+  ): Promise<boolean> {
+    const namespace =
+      typeof event.namespace === "string" && event.namespace.length > 0
+        ? event.namespace
+        : this.config.defaultNamespace;
+    try {
+      const storage = await this.getStorage(namespace);
+      const toWrite: MemoryActionEvent = {
+        ...event,
+        namespace,
+        timestamp:
+          typeof event.timestamp === "string" && event.timestamp.length > 0
+            ? event.timestamp
+            : new Date().toISOString(),
+      };
+      await storage.appendMemoryActionEvents([toWrite]);
+      return true;
+    } catch (err) {
+      log.warn(`appendMemoryActionEvent failed (non-fatal): ${err}`);
+      return false;
+    }
   }
 
   async getLastGraphRecallSnapshot(namespace?: string): Promise<GraphRecallSnapshot | null> {

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1,7 +1,8 @@
 import path from "node:path";
+import { createHash } from "node:crypto";
 import { Type } from "@sinclair/typebox";
 import type { Orchestrator } from "./orchestrator.js";
-import type { MemoryCategory } from "./types.js";
+import type { MemoryActionType, MemoryCategory } from "./types.js";
 import { indexMemory, indexesExist } from "./temporal-index.js";
 
 interface ToolApi {
@@ -29,6 +30,21 @@ function toolResult(text: string) {
 }
 
 export function registerTools(api: ToolApi, orchestrator: Orchestrator): void {
+  const actionTypes: MemoryActionType[] = [
+    "store_episode",
+    "store_note",
+    "update_note",
+    "create_artifact",
+    "summarize_node",
+    "discard",
+    "link_graph",
+  ];
+
+  function promptHashForTelemetry(input?: string): string | undefined {
+    if (typeof input !== "string" || input.trim().length === 0) return undefined;
+    return createHash("sha256").update(input).digest("hex").slice(0, 16);
+  }
+
   function namespaceFromPath(p: string): string {
     const m = p.match(/[\\/]+namespaces[\\/]+([^\\/]+)[\\/]+/);
     return m && m[1] ? m[1] : orchestrator.config.defaultNamespace;
@@ -332,6 +348,133 @@ Best for:
       },
     },
     { name: "memory_feedback_last_recall" },
+  );
+
+  api.registerTool(
+    {
+      name: "context_checkpoint",
+      label: "Context Checkpoint",
+      description:
+        "Record a context-compression checkpoint event for policy-learning telemetry (v8.3).",
+      parameters: Type.Object({
+        summary: Type.String({
+          description: "Short summary of what was checkpointed.",
+        }),
+        sourcePrompt: Type.Optional(
+          Type.String({
+            description: "Optional source prompt text used for hashing in telemetry.",
+          }),
+        ),
+        namespace: Type.Optional(
+          Type.String({
+            description: "Optional namespace. Defaults to defaultNamespace.",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.contextCompressionActionsEnabled) {
+          return toolResult(
+            "Context compression actions are disabled. Enable `contextCompressionActionsEnabled: true` to use this tool.",
+          );
+        }
+        const { summary, sourcePrompt, namespace } = params as {
+          summary: string;
+          sourcePrompt?: string;
+          namespace?: string;
+        };
+        const ns =
+          typeof namespace === "string" && namespace.length > 0
+            ? namespace
+            : orchestrator.config.defaultNamespace;
+        const wrote = await orchestrator.appendMemoryActionEvent({
+          action: "summarize_node",
+          outcome: "applied",
+          namespace: ns,
+          reason: `context_checkpoint:${summary.slice(0, 200)}`,
+          promptHash: promptHashForTelemetry(sourcePrompt),
+        });
+        if (!wrote) {
+          return toolResult("Checkpoint recorded best-effort failed (fail-open).");
+        }
+        return toolResult(`Recorded context checkpoint telemetry in namespace=${ns}.`);
+      },
+    },
+    { name: "context_checkpoint" },
+  );
+
+  api.registerTool(
+    {
+      name: "memory_action_apply",
+      label: "Apply Memory Action",
+      description:
+        "Record a memory-action application event for policy-learning telemetry (v8.3).",
+      parameters: Type.Object({
+        action: Type.String({
+          enum: actionTypes,
+          description: "Memory action type.",
+        }),
+        outcome: Type.Optional(
+          Type.String({
+            enum: ["applied", "skipped", "failed"],
+            description: "Outcome status (default: applied).",
+          }),
+        ),
+        reason: Type.Optional(
+          Type.String({
+            description: "Optional reason/notes for this action outcome.",
+          }),
+        ),
+        memoryId: Type.Optional(
+          Type.String({
+            description: "Optional memory ID targeted by this action.",
+          }),
+        ),
+        sourcePrompt: Type.Optional(
+          Type.String({
+            description: "Optional source prompt text used for hashing in telemetry.",
+          }),
+        ),
+        namespace: Type.Optional(
+          Type.String({
+            description: "Optional namespace. Defaults to defaultNamespace.",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.contextCompressionActionsEnabled) {
+          return toolResult(
+            "Context compression actions are disabled. Enable `contextCompressionActionsEnabled: true` to use this tool.",
+          );
+        }
+        const { action, outcome, reason, memoryId, sourcePrompt, namespace } = params as {
+          action: MemoryActionType;
+          outcome?: "applied" | "skipped" | "failed";
+          reason?: string;
+          memoryId?: string;
+          sourcePrompt?: string;
+          namespace?: string;
+        };
+        const ns =
+          typeof namespace === "string" && namespace.length > 0
+            ? namespace
+            : orchestrator.config.defaultNamespace;
+        const wrote = await orchestrator.appendMemoryActionEvent({
+          action,
+          outcome: outcome ?? "applied",
+          namespace: ns,
+          reason,
+          memoryId,
+          promptHash: promptHashForTelemetry(sourcePrompt),
+        });
+        if (!wrote) {
+          return toolResult("Memory action telemetry write failed (fail-open).");
+        }
+        return toolResult(
+          `Recorded memory action telemetry: action=${action}, outcome=${outcome ?? "applied"}, namespace=${ns}.`,
+        );
+      },
+    },
+    { name: "memory_action_apply" },
   );
 
   api.registerTool(

--- a/tests/tools-compression-actions.test.ts
+++ b/tests/tools-compression-actions.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerTools } from "../src/tools.ts";
+
+type RegisteredTool = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; details: undefined }>;
+};
+
+function buildHarness(options?: {
+  contextCompressionActionsEnabled?: boolean;
+  appendMemoryActionEventResult?: boolean;
+}) {
+  const tools = new Map<string, RegisteredTool>();
+  const capturedEvents: any[] = [];
+  const api = {
+    registerTool(spec: RegisteredTool) {
+      tools.set(spec.name, spec);
+    },
+  };
+
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      contextCompressionActionsEnabled: options?.contextCompressionActionsEnabled === true,
+      feedbackEnabled: false,
+      negativeExamplesEnabled: false,
+      conversationIndexEnabled: false,
+      sharedContextEnabled: false,
+      compoundingEnabled: false,
+    },
+    appendMemoryActionEvent: async (event: unknown) => {
+      capturedEvents.push(event);
+      return options?.appendMemoryActionEventResult ?? true;
+    },
+    qmd: {
+      search: async () => [],
+      searchGlobal: async () => [],
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    storage: {
+      readIdentity: async () => null,
+      readProfile: async () => null,
+      readAllEntities: async () => [],
+    },
+    summarizer: {
+      runHourly: async () => {},
+    },
+    transcript: {
+      listSessionKeys: async () => [],
+    },
+    sharedContext: null,
+    compounding: null,
+    recordMemoryFeedback: async () => {},
+    recordNotUsefulMemories: async () => {},
+    requestQmdMaintenanceForTool: () => {},
+  };
+
+  registerTools(api as any, orchestrator as any);
+  return { tools, capturedEvents };
+}
+
+function toolText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content.map((c) => c.text).join("\n");
+}
+
+test("context_checkpoint is gated off when context compression actions are disabled", async () => {
+  const { tools, capturedEvents } = buildHarness({
+    contextCompressionActionsEnabled: false,
+  });
+  const tool = tools.get("context_checkpoint");
+  assert.ok(tool);
+
+  const result = await tool.execute("tc1", { summary: "checkpoint summary" });
+  assert.match(toolText(result), /disabled/i);
+  assert.equal(capturedEvents.length, 0);
+});
+
+test("memory_action_apply records telemetry event when enabled", async () => {
+  const { tools, capturedEvents } = buildHarness({
+    contextCompressionActionsEnabled: true,
+  });
+  const tool = tools.get("memory_action_apply");
+  assert.ok(tool);
+
+  const result = await tool.execute("tc2", {
+    action: "store_note",
+    sourcePrompt: "trim this context",
+  });
+
+  assert.match(toolText(result), /Recorded memory action telemetry/i);
+  assert.equal(capturedEvents.length, 1);
+  assert.equal(capturedEvents[0].action, "store_note");
+  assert.equal(capturedEvents[0].outcome, "applied");
+  assert.equal(capturedEvents[0].namespace, "default");
+  assert.equal(typeof capturedEvents[0].promptHash, "string");
+  assert.equal(capturedEvents[0].promptHash.length, 16);
+});
+
+test("context_checkpoint logs summarize_node telemetry in requested namespace", async () => {
+  const { tools, capturedEvents } = buildHarness({
+    contextCompressionActionsEnabled: true,
+  });
+  const tool = tools.get("context_checkpoint");
+  assert.ok(tool);
+
+  const result = await tool.execute("tc3", {
+    summary: "trimmed low-signal context",
+    namespace: "team-alpha",
+  });
+
+  assert.match(toolText(result), /Recorded context checkpoint telemetry/i);
+  assert.equal(capturedEvents.length, 1);
+  assert.equal(capturedEvents[0].action, "summarize_node");
+  assert.equal(capturedEvents[0].namespace, "team-alpha");
+  assert.match(capturedEvents[0].reason, /^context_checkpoint:/);
+});
+
+test("memory_action_apply fails open when telemetry write fails", async () => {
+  const { tools } = buildHarness({
+    contextCompressionActionsEnabled: true,
+    appendMemoryActionEventResult: false,
+  });
+  const tool = tools.get("memory_action_apply");
+  assert.ok(tool);
+
+  const result = await tool.execute("tc4", {
+    action: "discard",
+    outcome: "failed",
+  });
+
+  assert.match(toolText(result), /fail-open/i);
+});


### PR DESCRIPTION
## Summary
- add `context_checkpoint` and `memory_action_apply` tools behind `contextCompressionActionsEnabled`
- add namespace-safe, fail-open telemetry append path via `Orchestrator.appendMemoryActionEvent`
- add tool tests for disabled-mode gating, telemetry writes, namespace routing, and fail-open behavior

## Validation
- npm run check-types
- npx tsx --test tests/tools-compression-actions.test.ts
- npm test
- npm run build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tool surfaces and telemetry writes to disk (namespace-scoped) which could impact runtime behavior if misrouted or noisy, though errors are explicitly fail-open and isolated to a new append path.
> 
> **Overview**
> Adds two new tool entrypoints, `context_checkpoint` and `memory_action_apply`, gated behind `contextCompressionActionsEnabled`, to emit policy-learning telemetry for context-compression/memory actions.
> 
> Introduces `Orchestrator.appendMemoryActionEvent(...)` to append namespace-scoped `MemoryActionEvent` rows to `state/memory-actions.jsonl` with prompt hashing and *fail-open* behavior so storage/IO failures don’t block tool execution, plus new tests covering gating, namespace routing, telemetry payload basics, and fail-open writes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 222c4ca274cdfbd1e008699352969eaee619e799. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->