### PR TITLE
feat(identity): add continuity incident tools and CLI workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
   - Added regression coverage for raw-prompt preservation in non-cron and cron-policy-disabled paths.
 
 ### Added
+- v8.4 continuity incident workflow slice (PR #39):
+  - Added `continuity_incident_open`, `continuity_incident_close`, and `continuity_incident_list` tools.
+  - Added `openclaw engram continuity incidents`, `openclaw engram continuity incident-open`, and `openclaw engram continuity incident-close` CLI commands.
+  - Added validation for required incident closure fields and state-filtered incident listing behavior.
+  - Added `tests/continuity-incidents.test.ts` coverage for tool gating, open/close flows, and listing behavior.
+  - Documented continuity incident tools and CLI usage in API/operations docs.
 - v8.4 identity anchor tooling slice (PR #38):
   - Added `identity_anchor_get` and `identity_anchor_update` tools behind `identityContinuityEnabled`.
   - Added conservative, section-aware identity-anchor merge behavior to avoid destructive overwrites.

--- a/docs/api.md
+++ b/docs/api.md
@@ -102,6 +102,45 @@ Conservatively merge updates into identity anchor sections (non-destructive by d
 
 ---
 
+### `continuity_incident_open`
+
+Open a continuity incident with symptom and optional context fields.
+
+**Parameters:**
+- `symptom` (string, required)
+- `triggerWindow` (string, optional)
+- `suspectedCause` (string, optional)
+
+**Returns:** Created incident record summary.
+
+---
+
+### `continuity_incident_close`
+
+Close an existing continuity incident with required fix and verification fields.
+
+**Parameters:**
+- `id` (string, required)
+- `fixApplied` (string, required)
+- `verificationResult` (string, required)
+- `preventiveRule` (string, optional)
+
+**Returns:** Closed incident record summary, or not-found message.
+
+---
+
+### `continuity_incident_list`
+
+List continuity incidents with optional state filtering.
+
+**Parameters:**
+- `state` (`open` | `closed` | `all`, optional, default `open`)
+- `limit` (number, optional, default `25`, max `200`)
+
+**Returns:** Formatted incident list.
+
+---
+
 ## CLI Commands
 
 Run via `openclaw engram <command>`:
@@ -114,6 +153,9 @@ Run via `openclaw engram <command>`:
 | `export [--format json\|sqlite\|md]` | Export all memories to a portable file |
 | `import <file>` | Import memories from a portable file |
 | `purge` | Delete all memories (requires confirmation) |
+| `continuity incidents [--state open\|closed\|all] [--limit N]` | List continuity incidents |
+| `continuity incident-open --symptom <text> [--trigger-window <text>] [--suspected-cause <text>]` | Open a continuity incident |
+| `continuity incident-close --id <id> --fix-applied <text> --verification-result <text> [--preventive-rule <text>]` | Close a continuity incident |
 
 ## Plugin Hooks
 

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -176,6 +176,22 @@ Anchor file location:
 <memoryDir>/identity/identity-anchor.md
 ```
 
+## Continuity Incidents
+
+When `identityContinuityEnabled=true` and `continuityIncidentLoggingEnabled=true`, use these CLI commands:
+
+```bash
+openclaw engram continuity incidents --state open --limit 25
+openclaw engram continuity incident-open --symptom "identity anchor missing in recovery response"
+openclaw engram continuity incident-close --id incident-123 --fix-applied "restored merge guard" --verification-result "recovery prompt includes anchor"
+```
+
+Incident artifact location:
+
+```text
+<memoryDir>/identity/incidents/*.md
+```
+
 ## Runbooks
 
 - [PR Review Hardening Playbook](ops/pr-review-hardening-playbook.md)

--- a/docs/plans/2026-02-24-v8.4-agent-identity-continuity.md
+++ b/docs/plans/2026-02-24-v8.4-agent-identity-continuity.md
@@ -15,7 +15,7 @@
 - [x] Task 1 complete (`feat/v8.4-identity-continuity-config-slice` / PR slice A1)
 - [x] Task 2 complete (`feat/v8.4-identity-continuity-storage-slice` / PR slice A2)
 - [x] Task 3 complete (`feat/v8.4-identity-anchor-tools-slice` / PR slice A3)
-- [ ] Task 4 pending
+- [x] Task 4 complete (`feat/v8.4-continuity-incident-workflow-slice` / PR slice A4)
 - [ ] Task 5 pending
 - [ ] Task 6 pending
 - [ ] Task 7 pending

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@ import path from "node:path";
 import { access, readFile, readdir, unlink } from "node:fs/promises";
 import type { Orchestrator } from "./orchestrator.js";
 import { ThreadingManager } from "./threading.js";
-import type { TranscriptEntry } from "./types.js";
+import type { ContinuityIncidentRecord, TranscriptEntry } from "./types.js";
 import { exportJsonBundle } from "./transfer/export-json.js";
 import { exportMarkdownBundle } from "./transfer/export-md.js";
 import { backupMemoryDir } from "./transfer/backup.js";
@@ -207,6 +207,22 @@ async function readAllMemoryFiles(memoryDir: string): Promise<DedupeCandidate[]>
   }
 
   return out;
+}
+
+function formatContinuityIncidentCli(incident: ContinuityIncidentRecord): string {
+  const lines = [
+    `${incident.id} [${incident.state}]`,
+    `  opened: ${incident.openedAt}`,
+  ];
+  if (incident.closedAt) lines.push(`  closed: ${incident.closedAt}`);
+  if (incident.triggerWindow) lines.push(`  window: ${incident.triggerWindow}`);
+  lines.push(`  symptom: ${incident.symptom}`);
+  if (incident.suspectedCause) lines.push(`  suspected-cause: ${incident.suspectedCause}`);
+  if (incident.fixApplied) lines.push(`  fix-applied: ${incident.fixApplied}`);
+  if (incident.verificationResult) lines.push(`  verification: ${incident.verificationResult}`);
+  if (incident.preventiveRule) lines.push(`  preventive-rule: ${incident.preventiveRule}`);
+  if (incident.filePath) lines.push(`  path: ${incident.filePath}`);
+  return lines.join("\n");
 }
 
 export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
@@ -706,6 +722,117 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             return;
           }
           console.log(identity);
+        });
+
+      const continuityCmd = cmd
+        .command("continuity")
+        .description("Identity continuity incident workflow commands");
+
+      continuityCmd
+        .command("incidents")
+        .description("List continuity incidents")
+        .option("--state <state>", "Filter by state: open|closed|all", "open")
+        .option("--limit <number>", "Maximum incidents to list", "25")
+        .action(async (...args: unknown[]) => {
+          if (!orchestrator.config.identityContinuityEnabled) {
+            console.log("Identity continuity is disabled.");
+            return;
+          }
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const stateRaw = String(options.state ?? "open").toLowerCase();
+          const state: "open" | "closed" | "all" =
+            stateRaw === "closed" || stateRaw === "all" ? stateRaw : "open";
+          const limit = Math.max(1, Math.min(200, parseInt(String(options.limit ?? "25"), 10) || 25));
+          const incidents = await orchestrator.storage.readContinuityIncidents(limit);
+          const filtered =
+            state === "all" ? incidents : incidents.filter((incident) => incident.state === state);
+          if (filtered.length === 0) {
+            console.log(`No continuity incidents found for state=${state}.`);
+            return;
+          }
+          console.log(`=== Continuity Incidents (${filtered.length}, state=${state}) ===\n`);
+          for (const incident of filtered) {
+            console.log(formatContinuityIncidentCli(incident));
+            console.log();
+          }
+        });
+
+      continuityCmd
+        .command("incident-open")
+        .description("Open a continuity incident")
+        .option("--symptom <text>", "Required symptom description")
+        .option("--trigger-window <window>", "Optional incident trigger window")
+        .option("--suspected-cause <text>", "Optional suspected cause")
+        .action(async (...args: unknown[]) => {
+          if (!orchestrator.config.identityContinuityEnabled) {
+            console.log("Identity continuity is disabled.");
+            return;
+          }
+          if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+            console.log("Continuity incident logging is disabled.");
+            return;
+          }
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const symptom = String(options.symptom ?? "").trim();
+          if (!symptom) {
+            console.log("Missing required --symptom.");
+            return;
+          }
+          const created = await orchestrator.storage.appendContinuityIncident({
+            symptom,
+            triggerWindow: options.triggerWindow ? String(options.triggerWindow) : undefined,
+            suspectedCause: options.suspectedCause ? String(options.suspectedCause) : undefined,
+          });
+          console.log("Opened continuity incident:\n");
+          console.log(formatContinuityIncidentCli(created));
+        });
+
+      continuityCmd
+        .command("incident-close")
+        .description("Close a continuity incident")
+        .option("--id <id>", "Required incident ID")
+        .option("--fix-applied <text>", "Required fix description")
+        .option("--verification-result <text>", "Required verification result")
+        .option("--preventive-rule <text>", "Optional preventive rule")
+        .action(async (...args: unknown[]) => {
+          if (!orchestrator.config.identityContinuityEnabled) {
+            console.log("Identity continuity is disabled.");
+            return;
+          }
+          if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+            console.log("Continuity incident logging is disabled.");
+            return;
+          }
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const id = String(options.id ?? "").trim();
+          const fixApplied = String(options.fixApplied ?? "").trim();
+          const verificationResult = String(options.verificationResult ?? "").trim();
+          const preventiveRule = options.preventiveRule ? String(options.preventiveRule).trim() : undefined;
+
+          if (!id) {
+            console.log("Missing required --id.");
+            return;
+          }
+          if (!fixApplied) {
+            console.log("Missing required --fix-applied.");
+            return;
+          }
+          if (!verificationResult) {
+            console.log("Missing required --verification-result.");
+            return;
+          }
+
+          const closed = await orchestrator.storage.closeContinuityIncident(id, {
+            fixApplied,
+            verificationResult,
+            preventiveRule,
+          });
+          if (!closed) {
+            console.log(`Incident not found: ${id}`);
+            return;
+          }
+          console.log("Closed continuity incident:\n");
+          console.log(formatContinuityIncidentCli(closed));
         });
 
       cmd

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -131,6 +131,26 @@ function mergeIdentityAnchor(
   return lines.join("\n").replace(/\n{3,}/g, "\n\n").trimEnd() + "\n";
 }
 
+function formatContinuityIncidentSummary(
+  incident: Awaited<ReturnType<Orchestrator["storage"]["appendContinuityIncident"]>>,
+  index?: number,
+): string {
+  const prefix = typeof index === "number" ? `### [${index + 1}] ` : "### ";
+  const lines = [
+    `${prefix}${incident.id} (${incident.state})`,
+    `Opened: ${incident.openedAt}`,
+  ];
+  if (incident.closedAt) lines.push(`Closed: ${incident.closedAt}`);
+  if (incident.triggerWindow) lines.push(`Window: ${incident.triggerWindow}`);
+  lines.push("", `Symptom: ${incident.symptom}`);
+  if (incident.suspectedCause) lines.push(`Suspected Cause: ${incident.suspectedCause}`);
+  if (incident.fixApplied) lines.push(`Fix Applied: ${incident.fixApplied}`);
+  if (incident.verificationResult) lines.push(`Verification: ${incident.verificationResult}`);
+  if (incident.preventiveRule) lines.push(`Preventive Rule: ${incident.preventiveRule}`);
+  if (incident.filePath) lines.push(`Path: ${incident.filePath}`);
+  return lines.join("\n");
+}
+
 export function registerTools(api: ToolApi, orchestrator: Orchestrator): void {
   const actionTypes: MemoryActionType[] = [
     "store_episode",
@@ -227,6 +247,156 @@ Best for:
       },
     },
     { name: "memory_search" },
+  );
+
+  api.registerTool(
+    {
+      name: "continuity_incident_open",
+      label: "Open Continuity Incident",
+      description: "Create a new continuity incident record in append-only storage.",
+      parameters: Type.Object({
+        symptom: Type.String({
+          description: "Observed continuity failure symptom.",
+        }),
+        triggerWindow: Type.Optional(
+          Type.String({
+            description: "Optional time window when incident occurred.",
+          }),
+        ),
+        suspectedCause: Type.Optional(
+          Type.String({
+            description: "Optional suspected root cause.",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.identityContinuityEnabled) {
+          return toolResult(
+            "Identity continuity is disabled. Enable `identityContinuityEnabled: true` to open incidents.",
+          );
+        }
+        if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+          return toolResult(
+            "Continuity incident logging is disabled. Enable `continuityIncidentLoggingEnabled: true` to open incidents.",
+          );
+        }
+        const symptom = typeof params.symptom === "string" ? params.symptom.trim() : "";
+        if (!symptom) {
+          return toolResult("Missing required field: symptom");
+        }
+        const created = await orchestrator.storage.appendContinuityIncident({
+          symptom,
+          triggerWindow: typeof params.triggerWindow === "string" ? params.triggerWindow : undefined,
+          suspectedCause: typeof params.suspectedCause === "string" ? params.suspectedCause : undefined,
+        });
+        log.info(`continuity-incident open id=${created.id}`);
+        return toolResult(`Continuity incident opened.\n\n${formatContinuityIncidentSummary(created)}`);
+      },
+    },
+    { name: "continuity_incident_open" },
+  );
+
+  api.registerTool(
+    {
+      name: "continuity_incident_close",
+      label: "Close Continuity Incident",
+      description: "Close an open continuity incident with required verification details.",
+      parameters: Type.Object({
+        id: Type.String({
+          description: "Incident ID to close.",
+        }),
+        fixApplied: Type.String({
+          description: "What fix was applied.",
+        }),
+        verificationResult: Type.String({
+          description: "How closure was verified.",
+        }),
+        preventiveRule: Type.Optional(
+          Type.String({
+            description: "Optional preventive follow-up rule.",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.identityContinuityEnabled) {
+          return toolResult(
+            "Identity continuity is disabled. Enable `identityContinuityEnabled: true` to close incidents.",
+          );
+        }
+        if (!orchestrator.config.continuityIncidentLoggingEnabled) {
+          return toolResult(
+            "Continuity incident logging is disabled. Enable `continuityIncidentLoggingEnabled: true` to close incidents.",
+          );
+        }
+
+        const id = typeof params.id === "string" ? params.id.trim() : "";
+        const fixApplied = typeof params.fixApplied === "string" ? params.fixApplied.trim() : "";
+        const verificationResult =
+          typeof params.verificationResult === "string" ? params.verificationResult.trim() : "";
+        const preventiveRule =
+          typeof params.preventiveRule === "string" ? params.preventiveRule.trim() : undefined;
+
+        if (!id) return toolResult("Missing required field: id");
+        if (!fixApplied) return toolResult("Missing required field: fixApplied");
+        if (!verificationResult) return toolResult("Missing required field: verificationResult");
+
+        const closed = await orchestrator.storage.closeContinuityIncident(id, {
+          fixApplied,
+          verificationResult,
+          preventiveRule,
+        });
+        if (!closed) return toolResult(`Incident not found: ${id}`);
+        log.info(`continuity-incident close id=${id}`);
+        return toolResult(`Continuity incident closed.\n\n${formatContinuityIncidentSummary(closed)}`);
+      },
+    },
+    { name: "continuity_incident_close" },
+  );
+
+  api.registerTool(
+    {
+      name: "continuity_incident_list",
+      label: "List Continuity Incidents",
+      description: "List continuity incidents and optionally filter by state.",
+      parameters: Type.Object({
+        state: Type.Optional(
+          Type.String({
+            enum: ["open", "closed", "all"],
+            description: "Incident state filter (default: open).",
+          }),
+        ),
+        limit: Type.Optional(
+          Type.Number({
+            description: "Max incidents to return (default: 25, max: 200).",
+            minimum: 1,
+            maximum: 200,
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.identityContinuityEnabled) {
+          return toolResult(
+            "Identity continuity is disabled. Enable `identityContinuityEnabled: true` to list incidents.",
+          );
+        }
+        const state = params.state === "closed" || params.state === "all" ? params.state : "open";
+        const limitRaw = typeof params.limit === "number" ? params.limit : 25;
+        const limit = Math.max(1, Math.min(200, Math.floor(limitRaw)));
+        const incidents = await orchestrator.storage.readContinuityIncidents(limit);
+        const filtered =
+          state === "all" ? incidents : incidents.filter((incident) => incident.state === state);
+
+        if (filtered.length === 0) {
+          return toolResult(`No continuity incidents found for state=${state}.`);
+        }
+
+        const body = filtered
+          .map((incident, index) => formatContinuityIncidentSummary(incident, index))
+          .join("\n\n");
+        return toolResult(`## Continuity Incidents (${filtered.length}, state=${state})\n\n${body}`);
+      },
+    },
+    { name: "continuity_incident_list" },
   );
 
   api.registerTool(

--- a/tests/continuity-incidents.test.ts
+++ b/tests/continuity-incidents.test.ts
@@ -1,0 +1,179 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { registerTools } from "../src/tools.ts";
+import type { ContinuityIncidentRecord } from "../src/types.ts";
+
+type RegisteredTool = {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+  ) => Promise<{ content: Array<{ type: string; text: string }>; details: undefined }>;
+};
+
+function toolText(result: { content: Array<{ type: string; text: string }> }): string {
+  return result.content.map((c) => c.text).join("\n");
+}
+
+function buildHarness(options?: {
+  identityContinuityEnabled?: boolean;
+  continuityIncidentLoggingEnabled?: boolean;
+}) {
+  const tools = new Map<string, RegisteredTool>();
+  const incidents = new Map<string, ContinuityIncidentRecord>();
+  let counter = 0;
+
+  const api = {
+    registerTool(spec: RegisteredTool) {
+      tools.set(spec.name, spec);
+    },
+  };
+
+  const storage = {
+    readIdentity: async () => null,
+    readProfile: async () => null,
+    readAllEntities: async () => [],
+    readIdentityAnchor: async () => null,
+    writeIdentityAnchor: async () => {},
+    appendContinuityIncident: async (input: { symptom: string; triggerWindow?: string; suspectedCause?: string }) => {
+      counter += 1;
+      const id = `incident-${counter}`;
+      const now = new Date(2026, 1, counter).toISOString();
+      const record: ContinuityIncidentRecord = {
+        id,
+        state: "open",
+        openedAt: now,
+        updatedAt: now,
+        triggerWindow: input.triggerWindow,
+        symptom: input.symptom,
+        suspectedCause: input.suspectedCause,
+        filePath: `/tmp/${id}.md`,
+      };
+      incidents.set(id, record);
+      return record;
+    },
+    closeContinuityIncident: async (
+      id: string,
+      closure: { fixApplied: string; verificationResult: string; preventiveRule?: string },
+    ) => {
+      const existing = incidents.get(id);
+      if (!existing) return null;
+      const closed: ContinuityIncidentRecord = {
+        ...existing,
+        state: "closed",
+        updatedAt: new Date(2026, 1, 28).toISOString(),
+        closedAt: new Date(2026, 1, 28).toISOString(),
+        fixApplied: closure.fixApplied,
+        verificationResult: closure.verificationResult,
+        preventiveRule: closure.preventiveRule,
+      };
+      incidents.set(id, closed);
+      return closed;
+    },
+    readContinuityIncidents: async (limit: number) =>
+      [...incidents.values()].slice(0, Math.max(0, Math.floor(limit))),
+  };
+
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      contextCompressionActionsEnabled: false,
+      feedbackEnabled: false,
+      negativeExamplesEnabled: false,
+      conversationIndexEnabled: false,
+      sharedContextEnabled: false,
+      compoundingEnabled: false,
+      identityContinuityEnabled: options?.identityContinuityEnabled === true,
+      continuityIncidentLoggingEnabled: options?.continuityIncidentLoggingEnabled === true,
+    },
+    qmd: {
+      search: async () => [],
+      searchGlobal: async () => [],
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    storage,
+    summarizer: {
+      runHourly: async () => {},
+    },
+    transcript: {
+      listSessionKeys: async () => [],
+    },
+    sharedContext: null,
+    compounding: null,
+    recordMemoryFeedback: async () => {},
+    recordNotUsefulMemories: async () => {},
+    requestQmdMaintenanceForTool: () => {},
+    appendMemoryActionEvent: async () => true,
+  };
+
+  registerTools(api as any, orchestrator as any);
+  return { tools, incidents };
+}
+
+test("continuity incident tools are gated when identity continuity is disabled", async () => {
+  const { tools } = buildHarness({
+    identityContinuityEnabled: false,
+    continuityIncidentLoggingEnabled: true,
+  });
+  const openTool = tools.get("continuity_incident_open");
+  assert.ok(openTool);
+  const result = await openTool.execute("tc1", { symptom: "missing memory" });
+  assert.match(toolText(result), /disabled/i);
+});
+
+test("continuity_incident_open creates incident and continuity_incident_list returns it", async () => {
+  const { tools } = buildHarness({
+    identityContinuityEnabled: true,
+    continuityIncidentLoggingEnabled: true,
+  });
+  const openTool = tools.get("continuity_incident_open");
+  const listTool = tools.get("continuity_incident_list");
+  assert.ok(openTool);
+  assert.ok(listTool);
+
+  const openResult = await openTool.execute("tc2", {
+    symptom: "identity context missing",
+    suspectedCause: "budget truncation",
+  });
+  assert.match(toolText(openResult), /opened/i);
+  assert.match(toolText(openResult), /incident-1/);
+
+  const listResult = await listTool.execute("tc3", { state: "open", limit: 10 });
+  assert.match(toolText(listResult), /Continuity Incidents/);
+  assert.match(toolText(listResult), /incident-1/);
+  assert.match(toolText(listResult), /identity context missing/);
+});
+
+test("continuity_incident_close validates required fields and closes incident", async () => {
+  const { tools } = buildHarness({
+    identityContinuityEnabled: true,
+    continuityIncidentLoggingEnabled: true,
+  });
+  const openTool = tools.get("continuity_incident_open");
+  const closeTool = tools.get("continuity_incident_close");
+  const listTool = tools.get("continuity_incident_list");
+  assert.ok(openTool);
+  assert.ok(closeTool);
+  assert.ok(listTool);
+
+  await openTool.execute("tc4", { symptom: "bad continuity state" });
+
+  const missingFields = await closeTool.execute("tc5", { id: "incident-1", fixApplied: "patched" });
+  assert.match(toolText(missingFields), /verificationResult/);
+
+  const closeResult = await closeTool.execute("tc6", {
+    id: "incident-1",
+    fixApplied: "patched update path",
+    verificationResult: "anchor now injected",
+    preventiveRule: "keep regression tests",
+  });
+  assert.match(toolText(closeResult), /closed/i);
+  assert.match(toolText(closeResult), /anchor now injected/);
+
+  const closedList = await listTool.execute("tc7", { state: "closed", limit: 10 });
+  assert.match(toolText(closedList), /incident-1/);
+  assert.match(toolText(closedList), /closed/);
+});


### PR DESCRIPTION
## Summary
- add continuity incident tools: `continuity_incident_open`, `continuity_incident_close`, `continuity_incident_list`
- add CLI workflow: `openclaw engram continuity incidents`, `incident-open`, and `incident-close`
- enforce required closure fields and state-filtered listing behavior
- add continuity incident tool tests and update v8.4 plan/docs/changelog

## Testing
- npx tsx --test tests/continuity-incidents.test.ts
- npm run check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new tool + CLI surfaces that write/modify incident artifacts on disk; while config-gated, bugs could lead to incorrect incident state or unexpected file writes/reads.
> 
> **Overview**
> Adds an identity continuity *incident workflow* with new tools `continuity_incident_open`, `continuity_incident_close`, and `continuity_incident_list`, including validation for required close fields, state-filtered listing, and formatted summaries.
> 
> Extends the `openclaw engram` CLI with `continuity incidents`, `continuity incident-open`, and `continuity incident-close` commands, gated by `identityContinuityEnabled` (and logging flag for open/close). Updates API/operations docs, the v8.4 plan/changelog, and introduces `tests/continuity-incidents.test.ts` to cover gating, open/close flows, and list behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 75a57426859b27660f75efc6568546855da85563. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->