### PR TITLE
feat(identity): add continuity audit generation and compounding linkage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ All notable changes to this project will be documented in this file.
   - Added regression coverage for raw-prompt preservation in non-cron and cron-policy-disabled paths.
 
 ### Added
+- v8.4 continuity audit generator slice (PR #40):
+  - Added `continuity_audit_generate` tool for deterministic weekly/monthly continuity audit artifacts.
+  - Extended `CompoundingEngine` with continuity audit synthesis and signal checks (anchor presence, incident counts, improvement-loop presence, compounding pattern count).
+  - Added weekly compounding report linking for available continuity audits when `continuityAuditEnabled=true`.
+  - Added `tests/continuity-audit.test.ts` coverage for audit generation, compounding linkage, and tool behavior.
+  - Updated `docs/compounding.md` with continuity audit workflow and output locations.
 - v8.4 continuity incident workflow slice (PR #39):
   - Added `continuity_incident_open`, `continuity_incident_close`, and `continuity_incident_list` tools.
   - Added `openclaw engram continuity incidents`, `openclaw engram continuity incident-open`, and `openclaw engram continuity incident-close` CLI commands.

--- a/docs/compounding.md
+++ b/docs/compounding.md
@@ -36,3 +36,14 @@ compounding_weekly_synthesize
 Recommended scheduling:
 - Use OpenClaw cron with an isolated agent turn that calls `compounding_weekly_synthesize`.
 
+## Continuity Audit Generation
+
+When `identityContinuityEnabled=true`, `continuityAuditEnabled=true`, and `compoundingEnabled=true`, use:
+
+- `continuity_audit_generate` with `period=weekly|monthly` and optional `key`.
+
+Outputs:
+- `memoryDir/identity/audits/weekly/<YYYY-Www>.md`
+- `memoryDir/identity/audits/monthly/<YYYY-MM>.md`
+
+When continuity audits are enabled, weekly compounding reports include a `Continuity Audits` section linking available weekly/monthly audit artifacts.

--- a/docs/plans/2026-02-24-v8.4-agent-identity-continuity.md
+++ b/docs/plans/2026-02-24-v8.4-agent-identity-continuity.md
@@ -16,7 +16,7 @@
 - [x] Task 2 complete (`feat/v8.4-identity-continuity-storage-slice` / PR slice A2)
 - [x] Task 3 complete (`feat/v8.4-identity-anchor-tools-slice` / PR slice A3)
 - [x] Task 4 complete (`feat/v8.4-continuity-incident-workflow-slice` / PR slice A4)
-- [ ] Task 5 pending
+- [x] Task 5 complete (`feat/v8.4-continuity-audit-slice` / PR slice A5)
 - [ ] Task 6 pending
 - [ ] Task 7 pending
 - [ ] Task 8 pending

--- a/src/compounding/engine.ts
+++ b/src/compounding/engine.ts
@@ -1,9 +1,10 @@
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
 import path from "node:path";
 import os from "node:os";
 import { log } from "../logger.js";
-import type { PluginConfig } from "../types.js";
+import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
 import { SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
+import { parseContinuityIncident } from "../identity-continuity.js";
 
 type MistakesFile = {
   updatedAt: string;
@@ -21,6 +22,24 @@ function isoWeekId(d: Date): string {
   return `${yyyy}-W${String(week).padStart(2, "0")}`;
 }
 
+function isoMonthId(d: Date): string {
+  return `${d.getUTCFullYear()}-${String(d.getUTCMonth() + 1).padStart(2, "0")}`;
+}
+
+function monthIdFromIsoWeek(weekId: string): string {
+  const match = weekId.match(/^(\d{4})-W(\d{2})$/);
+  if (!match) return isoMonthId(new Date());
+  const year = Number(match[1]);
+  const week = Number(match[2]);
+  const jan4 = new Date(Date.UTC(year, 0, 4));
+  const jan4Day = jan4.getUTCDay() || 7;
+  const isoWeekOneMonday = new Date(jan4);
+  isoWeekOneMonday.setUTCDate(jan4.getUTCDate() - (jan4Day - 1));
+  const monday = new Date(isoWeekOneMonday);
+  monday.setUTCDate(isoWeekOneMonday.getUTCDate() + (week - 1) * 7);
+  return isoMonthId(monday);
+}
+
 function sharedContextDir(config: PluginConfig): string {
   if (typeof config.sharedContextDir === "string" && config.sharedContextDir.length > 0) {
     return config.sharedContextDir;
@@ -32,11 +51,21 @@ export class CompoundingEngine {
   private readonly weeklyDir: string;
   private readonly mistakesPath: string;
   private readonly feedbackInboxPath: string;
+  private readonly identityAnchorPath: string;
+  private readonly identityIncidentsDir: string;
+  private readonly identityAuditWeeklyDir: string;
+  private readonly identityAuditMonthlyDir: string;
+  private readonly identityImprovementLoopsPath: string;
 
   constructor(private readonly config: PluginConfig) {
     this.weeklyDir = path.join(config.memoryDir, "compounding", "weekly");
     this.mistakesPath = path.join(config.memoryDir, "compounding", "mistakes.json");
     this.feedbackInboxPath = path.join(sharedContextDir(config), "feedback", "inbox.jsonl");
+    this.identityAnchorPath = path.join(config.memoryDir, "identity", "identity-anchor.md");
+    this.identityIncidentsDir = path.join(config.memoryDir, "identity", "incidents");
+    this.identityAuditWeeklyDir = path.join(config.memoryDir, "identity", "audits", "weekly");
+    this.identityAuditMonthlyDir = path.join(config.memoryDir, "identity", "audits", "monthly");
+    this.identityImprovementLoopsPath = path.join(config.memoryDir, "identity", "improvement-loops.md");
   }
 
   async ensureDirs(): Promise<void> {
@@ -50,10 +79,11 @@ export class CompoundingEngine {
 
     const entries = await this.readFeedbackEntriesForWeek(weekId);
     const mistakes = this.buildMistakes(entries);
+    const continuity = await this.readContinuityAuditReferences(weekId);
 
     // Write weekly report (always, even if empty: "day-one outcomes").
     const reportPath = path.join(this.weeklyDir, `${weekId}.md`);
-    const md = this.formatWeeklyReport(weekId, entries, mistakes.patterns);
+    const md = this.formatWeeklyReport(weekId, entries, mistakes.patterns, continuity);
     await writeFile(reportPath, md, "utf-8");
 
     // Update mistakes.json (always).
@@ -61,6 +91,78 @@ export class CompoundingEngine {
 
     log.info(`compounding: wrote weekly=${reportPath} mistakes=${this.mistakesPath}`);
     return { weekId, reportPath, mistakesCount: mistakes.patterns.length };
+  }
+
+  async synthesizeContinuityAudit(opts?: {
+    period?: "weekly" | "monthly";
+    key?: string;
+  }): Promise<{ period: "weekly" | "monthly"; key: string; reportPath: string }> {
+    const period = opts?.period === "monthly" ? "monthly" : "weekly";
+    const key = opts?.key?.trim() || (period === "weekly" ? isoWeekId(new Date()) : isoMonthId(new Date()));
+    const nowIso = new Date().toISOString();
+    const [anchorPresent, improvementLoopPresent, incidents, mistakes] = await Promise.all([
+      this.readNonEmptyFile(this.identityAnchorPath),
+      this.readNonEmptyFile(this.identityImprovementLoopsPath),
+      this.readContinuityIncidents(),
+      this.readMistakes(),
+    ]);
+
+    const openIncidents = incidents.filter((i) => i.state === "open");
+    const closedIncidents = incidents.filter((i) => i.state === "closed");
+    const hardeningCandidates: string[] = [];
+    if (!anchorPresent) {
+      hardeningCandidates.push("Create/update identity anchor baseline and verify recovery injection path.");
+    }
+    if (openIncidents.length > 0) {
+      hardeningCandidates.push(
+        `Close or downgrade ${openIncidents.length} open continuity incident${openIncidents.length === 1 ? "" : "s"}.`,
+      );
+    }
+    if (!improvementLoopPresent) {
+      hardeningCandidates.push("Initialize continuity improvement-loops register with cadence and kill conditions.");
+    }
+    if ((mistakes?.patterns.length ?? 0) > 0) {
+      hardeningCandidates.push("Review latest compounding mistakes and convert one pattern into preventive continuity rule.");
+    }
+    const nextAction = hardeningCandidates[0] ?? "No critical drift detected; keep weekly/monthly continuity audit cadence.";
+
+    const lines: string[] = [
+      `# Continuity Audit — ${period} ${key}`,
+      "",
+      `Generated: ${nowIso}`,
+      `Scope: ${period}`,
+      "",
+      "## Signal Summary",
+      `- Identity anchor present: ${anchorPresent ? "yes" : "no"}`,
+      `- Improvement-loop register present: ${improvementLoopPresent ? "yes" : "no"}`,
+      `- Open incidents: ${openIncidents.length}`,
+      `- Closed incidents: ${closedIncidents.length}`,
+      `- Compounding mistake patterns: ${mistakes?.patterns.length ?? 0}`,
+      "",
+      "## Drift Checks",
+      `- Identity anchor drift: ${anchorPresent ? "pass" : "needs attention"}`,
+      `- Incident backlog: ${openIncidents.length === 0 ? "pass" : "needs attention"}`,
+      `- Improvement-loop coverage: ${improvementLoopPresent ? "pass" : "needs attention"}`,
+      "",
+      "## Stale Rule Detection",
+      `- Open incidents older than closure window: ${openIncidents.length > 0 ? "possible" : "none detected"}`,
+      `- Preventive rule coverage on closed incidents: ${
+        closedIncidents.some((i) => (i.preventiveRule ?? "").trim().length > 0) ? "present" : "not detected"
+      }`,
+      "",
+      "## Next Hardening Action",
+      `- ${nextAction}`,
+      "",
+      "## Open Incident IDs",
+      ...(openIncidents.length > 0 ? openIncidents.slice(0, 20).map((i) => `- ${i.id}`) : ["- (none)"]),
+      "",
+    ];
+
+    const dir = period === "weekly" ? this.identityAuditWeeklyDir : this.identityAuditMonthlyDir;
+    await mkdir(dir, { recursive: true });
+    const reportPath = path.join(dir, `${key}.md`);
+    await writeFile(reportPath, lines.join("\n"), "utf-8");
+    return { period, key, reportPath };
   }
 
   async readMistakes(): Promise<MistakesFile | null> {
@@ -115,7 +217,12 @@ export class CompoundingEngine {
     return { updatedAt: new Date().toISOString(), patterns: uniq };
   }
 
-  private formatWeeklyReport(weekId: string, entries: SharedFeedbackEntry[], patterns: string[]): string {
+  private formatWeeklyReport(
+    weekId: string,
+    entries: SharedFeedbackEntry[],
+    patterns: string[],
+    continuity: { monthId: string; weeklyPath: string | null; monthlyPath: string | null },
+  ): string {
     const byAgent = new Map<string, SharedFeedbackEntry[]>();
     for (const e of entries) {
       const list = byAgent.get(e.agent) ?? [];
@@ -157,8 +264,70 @@ export class CompoundingEngine {
       for (const p of patterns.slice(0, 100)) lines.push(`- ${p}`);
     }
     lines.push("");
+    if (this.config.continuityAuditEnabled) {
+      lines.push("## Continuity Audits");
+      if (continuity.weeklyPath) {
+        lines.push(`- weekly: ${continuity.weeklyPath}`);
+      } else {
+        lines.push(`- weekly: (missing for ${weekId})`);
+      }
+      if (continuity.monthlyPath) {
+        lines.push(`- monthly: ${continuity.monthlyPath}`);
+      } else {
+        lines.push(`- monthly: (missing for ${continuity.monthId})`);
+      }
+      lines.push("");
+    }
 
     return lines.join("\n");
   }
-}
 
+  private async readNonEmptyFile(filePath: string): Promise<boolean> {
+    try {
+      const raw = await readFile(filePath, "utf-8");
+      return raw.trim().length > 0;
+    } catch {
+      return false;
+    }
+  }
+
+  private async readContinuityIncidents(): Promise<ContinuityIncidentRecord[]> {
+    const incidents: ContinuityIncidentRecord[] = [];
+    try {
+      const names = await readdir(this.identityIncidentsDir);
+      const files = names.filter((n) => n.endsWith(".md")).sort().reverse();
+      for (const file of files) {
+        const filePath = path.join(this.identityIncidentsDir, file);
+        try {
+          const raw = await readFile(filePath, "utf-8");
+          const parsed = parseContinuityIncident(raw);
+          if (parsed) incidents.push(parsed);
+        } catch {
+          // fail-open
+        }
+      }
+    } catch {
+      // fail-open
+    }
+    return incidents;
+  }
+
+  private async readContinuityAuditReferences(weekId: string): Promise<{
+    weekId: string;
+    monthId: string;
+    weeklyPath: string | null;
+    monthlyPath: string | null;
+  }> {
+    const monthId = monthIdFromIsoWeek(weekId);
+    const weeklyPath = path.join(this.identityAuditWeeklyDir, `${weekId}.md`);
+    const monthlyPath = path.join(this.identityAuditMonthlyDir, `${monthId}.md`);
+    const weeklyExists = await this.readNonEmptyFile(weeklyPath);
+    const monthlyExists = await this.readNonEmptyFile(monthlyPath);
+    return {
+      weekId,
+      monthId,
+      weeklyPath: weeklyExists ? weeklyPath : null,
+      monthlyPath: monthlyExists ? monthlyPath : null,
+    };
+  }
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -251,6 +251,56 @@ Best for:
 
   api.registerTool(
     {
+      name: "continuity_audit_generate",
+      label: "Generate Continuity Audit",
+      description:
+        "Generate a deterministic identity continuity audit report (weekly/monthly) and persist it under identity/audits.",
+      parameters: Type.Object({
+        period: Type.Optional(
+          Type.String({
+            enum: ["weekly", "monthly"],
+            description: "Audit period. Defaults to weekly.",
+          }),
+        ),
+        key: Type.Optional(
+          Type.String({
+            description:
+              "Optional period key (weekly: YYYY-Www, monthly: YYYY-MM). Defaults to current period.",
+          }),
+        ),
+      }),
+      async execute(_toolCallId, params) {
+        if (!orchestrator.config.identityContinuityEnabled) {
+          return toolResult(
+            "Identity continuity is disabled. Enable `identityContinuityEnabled: true` to generate continuity audits.",
+          );
+        }
+        if (!orchestrator.config.continuityAuditEnabled) {
+          return toolResult(
+            "Continuity audits are disabled. Enable `continuityAuditEnabled: true` to generate continuity audits.",
+          );
+        }
+        if (!orchestrator.compounding) {
+          return toolResult(
+            "Compounding engine is disabled. Enable `compoundingEnabled: true` to generate continuity audits.",
+          );
+        }
+        const period = params.period === "monthly" ? "monthly" : "weekly";
+        const key = typeof params.key === "string" ? params.key : undefined;
+        const audit = await orchestrator.compounding.synthesizeContinuityAudit({
+          period,
+          key,
+        });
+        return toolResult(
+          `OK\n\nperiod: ${audit.period}\nkey: ${audit.key}\nreport: ${audit.reportPath}`,
+        );
+      },
+    },
+    { name: "continuity_audit_generate" },
+  );
+
+  api.registerTool(
+    {
       name: "continuity_incident_open",
       label: "Open Continuity Incident",
       description: "Create a new continuity incident record in append-only storage.",

--- a/tests/continuity-audit.test.ts
+++ b/tests/continuity-audit.test.ts
@@ -1,0 +1,270 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import type { PluginConfig } from "../src/types.js";
+import { CompoundingEngine } from "../src/compounding/engine.js";
+import { registerTools } from "../src/tools.ts";
+
+function tmpDir(prefix: string): string {
+  return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+}
+
+function minimalConfig(memoryDir: string, sharedContextDir: string): PluginConfig {
+  return {
+    openaiApiKey: undefined,
+    model: "gpt-5.2",
+    reasoningEffort: "low",
+    triggerMode: "smart",
+    bufferMaxTurns: 5,
+    bufferMaxMinutes: 15,
+    consolidateEveryN: 3,
+    highSignalPatterns: [],
+    maxMemoryTokens: 2000,
+    qmdEnabled: false,
+    qmdCollection: "openclaw-engram",
+    qmdMaxResults: 8,
+    memoryDir,
+    debug: false,
+    identityEnabled: false,
+    identityContinuityEnabled: true,
+    identityInjectionMode: "recovery_only",
+    identityMaxInjectChars: 1200,
+    continuityIncidentLoggingEnabled: true,
+    continuityAuditEnabled: true,
+    injectQuestions: false,
+    commitmentDecayDays: 90,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    accessTrackingEnabled: false,
+    accessTrackingBufferMaxSize: 100,
+    recencyWeight: 0.2,
+    boostAccessCount: true,
+    queryExpansionEnabled: false,
+    queryExpansionMaxQueries: 4,
+    queryExpansionMinTokenLen: 3,
+    rerankEnabled: false,
+    rerankProvider: "local",
+    rerankMaxCandidates: 10,
+    rerankTimeoutMs: 1000,
+    rerankCacheEnabled: true,
+    rerankCacheTtlMs: 1000,
+    feedbackEnabled: false,
+    negativeExamplesEnabled: false,
+    negativeExamplesPenaltyPerHit: 0.05,
+    negativeExamplesPenaltyCap: 0.25,
+    chunkingEnabled: false,
+    chunkingTargetTokens: 200,
+    chunkingMinTokens: 150,
+    chunkingOverlapSentences: 2,
+    contradictionDetectionEnabled: false,
+    contradictionSimilarityThreshold: 0.7,
+    contradictionMinConfidence: 0.9,
+    contradictionAutoResolve: true,
+    memoryLinkingEnabled: false,
+    threadingEnabled: false,
+    threadingGapMinutes: 30,
+    summarizationEnabled: false,
+    summarizationTriggerCount: 1000,
+    summarizationRecentToKeep: 300,
+    summarizationImportanceThreshold: 0.3,
+    summarizationProtectedTags: [],
+    topicExtractionEnabled: false,
+    topicExtractionTopN: 50,
+    transcriptEnabled: false,
+    transcriptRetentionDays: 7,
+    transcriptSkipChannelTypes: ["cron"],
+    transcriptRecallHours: 12,
+    maxTranscriptTurns: 50,
+    maxTranscriptTokens: 1000,
+    checkpointEnabled: false,
+    checkpointTurns: 15,
+    hourlySummariesEnabled: false,
+    hourlySummaryCronAutoRegister: false,
+    summaryRecallHours: 24,
+    maxSummaryCount: 6,
+    summaryModel: "gpt-5.2",
+    hourlySummariesExtendedEnabled: false,
+    hourlySummariesIncludeToolStats: false,
+    hourlySummariesIncludeSystemMessages: false,
+    hourlySummariesMaxTurnsPerRun: 60,
+    conversationIndexEnabled: false,
+    conversationIndexBackend: "qmd",
+    conversationIndexQmdCollection: "openclaw-engram-convo",
+    conversationIndexRetentionDays: 14,
+    conversationRecallTopK: 3,
+    conversationRecallMaxChars: 2000,
+    conversationRecallTimeoutMs: 500,
+    localLlmEnabled: false,
+    localLlmUrl: "http://localhost:1234/v1",
+    localLlmModel: "local-model",
+    localLlmFallback: true,
+    localLlmTimeoutMs: 1000,
+    slowLogEnabled: false,
+    slowLogThresholdMs: 30_000,
+    extractionDedupeEnabled: true,
+    extractionDedupeWindowMs: 60_000,
+    extractionMinChars: 20,
+    extractionMinUserTurns: 1,
+    extractionMaxTurnChars: 4000,
+    extractionMaxFactsPerRun: 12,
+    extractionMaxEntitiesPerRun: 6,
+    extractionMaxQuestionsPerRun: 3,
+    extractionMaxProfileUpdatesPerRun: 4,
+    consolidationRequireNonZeroExtraction: true,
+    consolidationMinIntervalMs: 60_000,
+    qmdMaintenanceEnabled: true,
+    qmdMaintenanceDebounceMs: 500,
+    qmdAutoEmbedEnabled: false,
+    qmdEmbedMinIntervalMs: 60_000,
+    localLlmRetry5xxCount: 1,
+    localLlmRetryBackoffMs: 50,
+    localLlm400TripThreshold: 3,
+    localLlm400CooldownMs: 10_000,
+    namespacesEnabled: false,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    namespacePolicies: [],
+    defaultRecallNamespaces: ["self"],
+    cronRecallMode: "all",
+    cronRecallAllowlist: [],
+    autoPromoteToSharedEnabled: false,
+    autoPromoteToSharedCategories: ["correction"],
+    autoPromoteMinConfidenceTier: "explicit",
+    sharedContextEnabled: false,
+    sharedContextDir,
+    sharedContextMaxInjectChars: 4000,
+    crossSignalsSemanticEnabled: false,
+    crossSignalsSemanticTimeoutMs: 1000,
+    compoundingEnabled: true,
+    compoundingWeeklyCronEnabled: false,
+    compoundingSemanticEnabled: false,
+    compoundingSynthesisTimeoutMs: 1000,
+    compoundingInjectEnabled: true,
+  };
+}
+
+test("continuity audit generator writes deterministic weekly audit", async () => {
+  const memoryDir = tmpDir("engram-continuity-audit");
+  const sharedDir = tmpDir("engram-continuity-audit-shared");
+  await mkdir(path.join(memoryDir, "identity", "incidents"), { recursive: true });
+  await mkdir(sharedDir, { recursive: true });
+
+  await writeFile(
+    path.join(memoryDir, "identity", "identity-anchor.md"),
+    "# Identity Continuity Anchor\n",
+    "utf-8",
+  );
+  await writeFile(
+    path.join(memoryDir, "identity", "incidents", "2026-02-24-incident-1.md"),
+    [
+      "---",
+      "id: \"incident-1\"",
+      "state: \"open\"",
+      "openedAt: \"2026-02-24T00:00:00.000Z\"",
+      "updatedAt: \"2026-02-24T00:00:00.000Z\"",
+      "---",
+      "",
+      "## Symptom",
+      "",
+      "anchor missing",
+      "",
+    ].join("\n"),
+    "utf-8",
+  );
+
+  const eng = new CompoundingEngine(minimalConfig(memoryDir, sharedDir));
+  const res = await eng.synthesizeContinuityAudit({ period: "weekly", key: "2026-W09" });
+  const md = await readFile(res.reportPath, "utf-8");
+
+  assert.match(md, /Continuity Audit — weekly 2026-W09/);
+  assert.match(md, /Identity anchor present: yes/);
+  assert.match(md, /Open incidents: 1/);
+  assert.match(md, /Next Hardening Action/);
+});
+
+test("weekly compounding report links continuity audit outputs when enabled", async () => {
+  const memoryDir = tmpDir("engram-compound-audit-link");
+  const sharedDir = tmpDir("engram-compound-audit-link-shared");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(sharedDir, { recursive: true });
+
+  const eng = new CompoundingEngine(minimalConfig(memoryDir, sharedDir));
+  const weekly = await eng.synthesizeWeekly();
+  await eng.synthesizeContinuityAudit({ period: "weekly", key: weekly.weekId });
+
+  const rerun = await eng.synthesizeWeekly({ weekId: weekly.weekId });
+  const report = await readFile(rerun.reportPath, "utf-8");
+  assert.match(report, /## Continuity Audits/);
+  assert.match(report, new RegExp(`weekly: .*${weekly.weekId}\\.md`));
+});
+
+test("continuity_audit_generate tool is config-gated and returns report path", async () => {
+  type RegisteredTool = {
+    name: string;
+    execute: (
+      toolCallId: string,
+      params: Record<string, unknown>,
+    ) => Promise<{ content: Array<{ type: string; text: string }>; details: undefined }>;
+  };
+
+  const tools = new Map<string, RegisteredTool>();
+  const api = {
+    registerTool(spec: RegisteredTool) {
+      tools.set(spec.name, spec);
+    },
+  };
+
+  const orchestrator = {
+    config: {
+      defaultNamespace: "default",
+      contextCompressionActionsEnabled: false,
+      feedbackEnabled: false,
+      negativeExamplesEnabled: false,
+      conversationIndexEnabled: false,
+      sharedContextEnabled: false,
+      compoundingEnabled: true,
+      identityContinuityEnabled: true,
+      continuityAuditEnabled: true,
+      continuityIncidentLoggingEnabled: true,
+    },
+    compounding: {
+      synthesizeContinuityAudit: async ({ period, key }: { period: "weekly" | "monthly"; key?: string }) => ({
+        period,
+        key: key ?? "2026-W09",
+        reportPath: "/tmp/identity/audits/weekly/2026-W09.md",
+      }),
+      synthesizeWeekly: async () => ({ weekId: "2026-W09", reportPath: "/tmp/r.md", mistakesCount: 0 }),
+    },
+    qmd: { search: async () => [], searchGlobal: async () => [] },
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    storage: {
+      readIdentity: async () => null,
+      readProfile: async () => null,
+      readAllEntities: async () => [],
+      readIdentityAnchor: async () => null,
+      writeIdentityAnchor: async () => {},
+      appendContinuityIncident: async () => null,
+      closeContinuityIncident: async () => null,
+      readContinuityIncidents: async () => [],
+    },
+    summarizer: { runHourly: async () => {} },
+    transcript: { listSessionKeys: async () => [] },
+    sharedContext: null,
+    recordMemoryFeedback: async () => {},
+    recordNotUsefulMemories: async () => {},
+    requestQmdMaintenanceForTool: () => {},
+    appendMemoryActionEvent: async () => true,
+  };
+
+  registerTools(api as any, orchestrator as any);
+  const tool = tools.get("continuity_audit_generate");
+  assert.ok(tool);
+
+  const result = await tool.execute("tc-audit", { period: "weekly", key: "2026-W09" });
+  const text = result.content.map((c) => c.text).join("\n");
+  assert.match(text, /period: weekly/);
+  assert.match(text, /report: \/tmp\/identity\/audits\/weekly\/2026-W09\.md/);
+});


### PR DESCRIPTION
## Summary
- add `continuity_audit_generate` tool (weekly/monthly deterministic continuity audits)
- extend `CompoundingEngine` with continuity audit synthesis and signal checks
- link continuity audit artifacts into weekly compounding report when enabled
- add continuity-audit test coverage and update compounding docs/changelog/plan status

## Testing
- npx tsx --test tests/continuity-audit.test.ts tests/compounding.test.ts
- npm run check-types
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new file-writing/report-generation paths and expands compounding report output, which could affect operators’ workflows and storage layout, but is config-gated and fail-open.
> 
> **Overview**
> Adds a new config-gated `continuity_audit_generate` tool that writes deterministic weekly/monthly identity continuity audit markdown artifacts under `memoryDir/identity/audits/`.
> 
> Extends `CompoundingEngine` to synthesize audits by checking for anchor/improvement-loop presence, summarizing incident counts and mistake-pattern counts, and emitting a single “next hardening action”; weekly compounding reports now optionally link the relevant weekly/monthly audit files when `continuityAuditEnabled` is on.
> 
> Includes new `tests/continuity-audit.test.ts` coverage plus documentation/changelog/plan updates describing the workflow and artifact locations.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fe174cc0ebb839285ccda2e863ebf6b6b5356cc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->