### PR TITLE
docs(v8.8): add network security and operations guidance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,9 @@ All notable changes to this project will be documented in this file.
   - Added network CLI wrappers in `src/cli.ts`: `runTailscaleStatusCliCommand`, `runTailscaleSyncCliCommand`, `runWebDavServeCliCommand`, and `runWebDavStopCliCommand`.
   - Added command surfaces: `openclaw engram tailscale-status`, `openclaw engram tailscale-sync`, `openclaw engram webdav-serve`, and `openclaw engram webdav-stop`.
   - Added `tests/cli-network-commands.test.ts` coverage for helper passthrough, WebDAV serve/stop lifecycle, and auth argument validation.
+- v8.8 network sync Task 4 (security + docs):
+  - Updated `docs/operations.md` with network sync/WebDAV command runbook and operational safety notes.
+  - Updated `SECURITY.md` with explicit v8.8 network-surface guardrails (opt-in defaults, allowlist-only exposure, loopback bind posture, and auth requirements).
 - v8.7 custom memory routing rules Task 1 (routing engine):
   - Added `src/routing/engine.ts` with deterministic route-rule evaluation, regex/keyword matching, and priority-ordered selection.
   - Added safe route target validation for categories and namespaces (path traversal and separator rejection).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -30,3 +30,17 @@ Security-sensitive areas include:
 - Never commit secrets/tokens.
 - Never include personal/private memory data in fixtures, tests, or docs.
 - Redact logs before sharing.
+
+## Network feature safety (v8.8)
+
+Network sync and WebDAV surfaces are security-sensitive and must remain strict opt-in.
+
+- Default posture: disabled/not running unless explicitly invoked.
+- WebDAV exposure must be constrained to explicit allowlist roots only.
+- WebDAV should remain loopback-bound (`127.0.0.1`) by default.
+- If auth is used, require non-empty username + password together.
+- Reject traversal and symlink escape attempts outside allowlisted roots.
+- Do not add automatic public exposure behavior (for example, funnel/public listeners) as default behavior.
+
+Operational recommendation:
+- Prefer private-network transport (for example, Tailscale) when syncing memory across hosts.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -59,6 +59,38 @@ Routing behavior notes:
 - Rules are applied at write-time for extracted facts before persistence.
 - Rule targets may override `category`, `namespace`, or both; invalid targets fail-open to default writes.
 
+## Network Sync and WebDAV (v8.8)
+
+Network features are opt-in and not started by default.
+
+```bash
+# Check Tailscale availability + daemon state
+openclaw engram tailscale-status
+
+# Sync memory directory to a private Tailscale peer over rsync
+openclaw engram tailscale-sync \
+  --source-dir ~/.openclaw/workspace/memory/local \
+  --destination engram-peer:/srv/engram-memory \
+  --dry-run
+
+# Start local WebDAV service for explicit allowlisted directories
+openclaw engram webdav-serve \
+  --allowlist ~/.openclaw/workspace/memory/local \
+  --host 127.0.0.1 \
+  --port 8080 \
+  --username engram \
+  --password '<strong-password>'
+
+# Stop WebDAV service in the running gateway process
+openclaw engram webdav-stop
+```
+
+Operational safety notes:
+- Keep WebDAV bound to `127.0.0.1` unless you have a private-network control plane in front of it.
+- Use non-empty username/password together; partial or blank auth fields are rejected.
+- WebDAV exposure is limited to the exact allowlist roots you pass via `--allowlist`.
+- `tailscale-sync` requires both `tailscale` and `rsync` availability plus a running Tailscale daemon.
+
 ## Hourly Summaries (Cron)
 
 Engram can generate hourly summaries of conversation activity.


### PR DESCRIPTION
## Summary
- add v8.8 network sync/WebDAV runbook commands and safety notes to operations docs
- add explicit v8.8 network-surface security guardrails in SECURITY.md
- record v8.8 Task 4 docs/security completion in changelog

## Testing
- preflight ran during commit/push (check-types, targeted tests, full test suite, build)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes, but they cover security-sensitive network surfaces; the main risk is operators misconfiguring exposure if guidance is misunderstood.
> 
> **Overview**
> Adds v8.8 documentation for the new network sync/WebDAV surfaces: a runbook with example `openclaw engram tailscale-status|tailscale-sync|webdav-serve|webdav-stop` commands plus operational safety notes (loopback binding, allowlist-only roots, and non-empty basic-auth requirements).
> 
> Updates `SECURITY.md` with explicit v8.8 network feature guardrails (strict opt-in, traversal/symlink escape rejection, no default public exposure) and records Task 4 completion in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3cad8293b226eb0da1a72225f0b199c72084a63b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->