### PR TITLE
docs(v8.9): add compatibility diagnostics rollout docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,9 @@ All notable changes to this project will be documented in this file.
   - Added fixture catalog under `tests/compat-fixtures/` for healthy, missing-manifest, and empty-package repository states.
   - Added `tests/compat-fixtures.test.ts` to validate deterministic check outcomes across fixture scenarios.
   - Added fixture usage notes in `tests/compat-fixtures/README.md`.
+- v8.9 compatibility diagnostics Task 4 (docs + rollout guidance):
+  - Updated `docs/operations.md` CLI runbook with `openclaw engram compat` usage and strict/json mode guidance.
+  - Updated `README.md` with compatibility diagnostics quickstart commands for operator rollout checks.
 - v8.7 custom memory routing rules Task 1 (routing engine):
   - Added `src/routing/engine.ts` with deterministic route-rule evaluation, regex/keyword matching, and priority-ordered selection.
   - Added safe route target validation for categories and namespaces (path traversal and separator rejection).

--- a/README.md
+++ b/README.md
@@ -59,6 +59,18 @@ kill -USR1 $(pgrep openclaw-gateway)
 - **Verbatim Artifacts** (`verbatimArtifactsEnabled`) — High-confidence decisions/constraints stored as trusted retrieval anchors.
 - **Recall Planner** (`recallPlannerEnabled`, default `true`) — Lightweight retrieve-vs-think gating.
 
+## Compatibility Diagnostics
+
+Use the built-in compatibility check before rollouts or after plugin wiring changes:
+
+```bash
+openclaw engram compat
+openclaw engram compat --json
+openclaw engram compat --strict
+```
+
+`--strict` exits non-zero when any warning/error is present.
+
 ## Agent Tools
 
 | Tool | Description |

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -52,7 +52,13 @@ openclaw engram route test ...      # Test routing rule match
 openclaw engram export              # Export memory store
 openclaw engram import              # Import memory store
 openclaw engram backup              # Create timestamped backup
+openclaw engram compat              # Run local compatibility diagnostics
 ```
+
+Compatibility diagnostics:
+- `openclaw engram compat` reports `ok|warn|error` checks for manifest wiring, startup hooks/service registration, CLI wiring, Node engine floor, and qmd availability.
+- Use `openclaw engram compat --json` for CI/automation consumers.
+- Use `openclaw engram compat --strict` to fail with non-zero exit code on warnings or errors.
 
 Routing behavior notes:
 - Routing is optional and disabled unless `routingRulesEnabled=true`.


### PR DESCRIPTION
## Summary
- document `openclaw engram compat` in operations CLI runbook
- add strict/json mode rollout notes for operators and CI
- add README compatibility diagnostics quickstart section
- update changelog with v8.9 task 4 docs rollout entry

## Testing
- preflight checks run on push (typecheck + tests + build)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that describe existing `openclaw engram compat` behavior; no runtime code paths are modified.
> 
> **Overview**
> Documents the new `openclaw engram compat` compatibility diagnostics command in the operator runbook and adds quickstart usage in `README.md`, including guidance for `--json` automation output and `--strict` non-zero exit behavior.
> 
> Updates `CHANGELOG.md` to record the v8.9 Task 4 docs/rollout guidance entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37b962e01c57c7f33872db2fa446b74bb9ce9107. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->