### PR TITLE
feat(v8.10): task 4 wire FAISS backend into orchestrator flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,10 @@ All notable changes to this project will be documented in this file.
   - Added `scripts/faiss_index.py` JSON-in/JSON-out sidecar commands (`upsert`, `search`, `health`) with fail-open error envelopes and deterministic local `__hash__` embedding mode for smoke validation.
   - Added `scripts/faiss_requirements.txt` and `scripts/faiss/README.md` with dependency and operational contract guidance.
   - Added `tests/conversation-index-faiss-smoke.test.ts` with sidecar contract checks and a dependency-gated FAISS upsert/search smoke path.
+- v8.10 FAISS conversation index Task 4 (orchestrator backend wiring + parity tests):
+  - Wired orchestrator conversation-index flow to select `qmd` or `faiss` backend paths for startup health checks, index updates, and semantic recall queries.
+  - Preserved fail-open recall behavior for FAISS search/upsert failures and kept semantic-recall section formatting backend-agnostic via shared formatter logic.
+  - Added `tests/conversation-index-integration.test.ts` coverage for backend routing (`qmd` vs `faiss`), FAISS fail-open recall, formatting parity, and FAISS update-path routing.
 - v8.7 custom memory routing rules Task 1 (routing engine):
   - Added `src/routing/engine.ts` with deterministic route-rule evaluation, regex/keyword matching, and priority-ordered selection.
   - Added safe route target validation for categories and namespaces (path traversal and separator rejection).

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -50,8 +50,16 @@ import { GraphIndex } from "./graph.js";
 import { normalizeReplaySessionKey, type ReplayTurn } from "./replay/types.js";
 import type { MemorySummary } from "./types.js";
 import { chunkTranscriptEntries } from "./conversation-index/chunker.js";
-import { writeConversationChunks } from "./conversation-index/indexer.js";
+import { upsertConversationChunksFailOpen, writeConversationChunks } from "./conversation-index/indexer.js";
 import { cleanupConversationChunks } from "./conversation-index/cleanup.js";
+import {
+  FaissConversationIndexAdapter,
+  failOpenFaissHealth,
+} from "./conversation-index/faiss-adapter.js";
+import {
+  searchConversationIndex,
+  searchConversationIndexFaissFailOpen,
+} from "./conversation-index/search.js";
 import { NamespaceStorageRouter } from "./namespaces/storage.js";
 import {
   defaultNamespaceForPrincipal,
@@ -503,6 +511,7 @@ export class Orchestrator {
   private readonly storageRouter: NamespaceStorageRouter;
   readonly qmd: QmdClient;
   private readonly conversationQmd?: QmdClient;
+  private readonly conversationFaiss?: FaissConversationIndexAdapter;
   readonly sharedContext?: SharedContextManager;
   readonly compounding?: CompoundingEngine;
   readonly buffer: SmartBuffer;
@@ -597,6 +606,21 @@ export class Orchestrator {
               daemonRecheckIntervalMs: config.qmdDaemonRecheckIntervalMs,
             },
           )
+        : undefined;
+    this.conversationFaiss =
+      config.conversationIndexEnabled && config.conversationIndexBackend === "faiss"
+        ? new FaissConversationIndexAdapter({
+            memoryDir: config.memoryDir,
+            scriptPath: config.conversationIndexFaissScriptPath,
+            pythonBin: config.conversationIndexFaissPythonBin,
+            modelId: config.conversationIndexFaissModelId,
+            indexDir: config.conversationIndexFaissIndexDir,
+            upsertTimeoutMs: config.conversationIndexFaissUpsertTimeoutMs,
+            searchTimeoutMs: config.conversationIndexFaissSearchTimeoutMs,
+            healthTimeoutMs: config.conversationIndexFaissHealthTimeoutMs,
+            maxBatchSize: config.conversationIndexFaissMaxBatchSize,
+            maxSearchK: config.conversationIndexFaissMaxSearchK,
+          })
         : undefined;
     this.sharedContext = config.sharedContextEnabled ? new SharedContextManager(config) : undefined;
     this.compounding = config.compoundingEnabled ? new CompoundingEngine(config) : undefined;
@@ -821,7 +845,11 @@ export class Orchestrator {
       }
     }
 
-    if (this.config.conversationIndexEnabled && this.conversationQmd) {
+    if (
+      this.config.conversationIndexEnabled &&
+      this.config.conversationIndexBackend === "qmd" &&
+      this.conversationQmd
+    ) {
       const available = await this.conversationQmd.probe();
       if (available) {
         log.info(`Conversation index QMD: available ${this.conversationQmd.debugStatus()}`);
@@ -842,6 +870,19 @@ export class Orchestrator {
         }
       } else {
         log.warn(`Conversation index QMD: not available ${this.conversationQmd.debugStatus()}`);
+      }
+    }
+
+    if (
+      this.config.conversationIndexEnabled &&
+      this.config.conversationIndexBackend === "faiss" &&
+      this.conversationFaiss
+    ) {
+      const health = await failOpenFaissHealth(this.conversationFaiss);
+      if (health.ok) {
+        log.info(`Conversation index FAISS: available (status=${health.status})`);
+      } else {
+        log.warn(`Conversation index FAISS: degraded (${health.message ?? health.status})`);
       }
     }
 
@@ -1046,6 +1087,39 @@ export class Orchestrator {
     ].join("\n");
   }
 
+  private async searchConversationRecallResults(
+    retrievalQuery: string,
+    topK: number,
+  ): Promise<Array<{ path: string; snippet: string; score: number }>> {
+    if (this.config.conversationIndexBackend === "faiss") {
+      return searchConversationIndexFaissFailOpen(this.conversationFaiss, retrievalQuery, topK);
+    }
+    if (this.conversationQmd && this.conversationQmd.isAvailable()) {
+      return searchConversationIndex(this.conversationQmd, retrievalQuery, topK);
+    }
+    return [];
+  }
+
+  private formatConversationRecallSection(
+    results: Array<{ path: string; snippet: string; score: number }>,
+    maxChars: number,
+  ): string | null {
+    if (!Array.isArray(results) || results.length === 0) return null;
+    const lines: string[] = ["## Semantic Recall (Past Conversations)", ""];
+    let used = 0;
+    for (const r of results) {
+      if (!r?.snippet) continue;
+      const chunk =
+        `### ${r.path}\n` +
+        `Score: ${r.score.toFixed(3)}\n\n` +
+        `${r.snippet.trim()}\n`;
+      if (used + chunk.length > maxChars) break;
+      lines.push(chunk);
+      used += chunk.length;
+    }
+    return used > 0 ? lines.join("\n") : null;
+  }
+
   async updateConversationIndex(
     sessionKey: string,
     hours: number = 24,
@@ -1081,18 +1155,24 @@ export class Orchestrator {
       this.conversationIndexDir,
       this.config.conversationIndexRetentionDays,
     );
-    // Best-effort: ask qmd to update indexes (will no-op if qmd missing).
-    const q = this.conversationQmd ?? this.qmd;
-    const usingPrimaryQmdClient = q === this.qmd;
     const shouldEmbed = opts?.embed ?? this.config.conversationIndexEmbedOnUpdate;
     let embedded = false;
-    if ((!usingPrimaryQmdClient || this.config.qmdEnabled) && q.isAvailable()) {
-      await q.update();
-      if (shouldEmbed) {
-        await q.embed();
-        embedded = true;
+
+    if (this.config.conversationIndexBackend === "faiss") {
+      await upsertConversationChunksFailOpen(this.conversationFaiss, chunks);
+    } else {
+      // Best-effort: ask qmd to update indexes (will no-op if qmd missing).
+      const q = this.conversationQmd ?? this.qmd;
+      const usingPrimaryQmdClient = q === this.qmd;
+      if ((!usingPrimaryQmdClient || this.config.qmdEnabled) && q.isAvailable()) {
+        await q.update();
+        if (shouldEmbed) {
+          await q.embed();
+          embedded = true;
+        }
       }
     }
+
     this.conversationIndexLastUpdateAtMs.set(sessionKey, Date.now());
     return { chunks: chunks.length, skipped: false, embedded };
   }
@@ -2151,19 +2231,14 @@ export class Orchestrator {
     // 4.5. Conversation semantic recall hook (optional, default off).
     // This searches over transcript chunk docs (ideally a separate QMD collection).
     const convT0 = Date.now();
-    if (
-      this.config.conversationIndexEnabled &&
-      !queryPolicy.skipConversationRecall &&
-      this.conversationQmd &&
-      this.conversationQmd.isAvailable()
-    ) {
+    if (this.config.conversationIndexEnabled && !queryPolicy.skipConversationRecall) {
       const startedAtMs = Date.now();
       const timeoutMs = Math.max(200, this.config.conversationRecallTimeoutMs);
       const topK = Math.max(1, this.config.conversationRecallTopK);
       const maxChars = Math.max(400, this.config.conversationRecallMaxChars);
 
       const results = (await Promise.race([
-        this.conversationQmd.search(retrievalQuery, undefined, topK),
+        this.searchConversationRecallResults(retrievalQuery, topK),
         new Promise<[]>(resolve => setTimeout(() => resolve([]), timeoutMs)),
       ]).catch(() => [])) as Array<{ path: string; snippet: string; score: number }>;
 
@@ -2172,22 +2247,9 @@ export class Orchestrator {
         log.debug(`conversation recall: timed out after ${timeoutMs}ms`);
       }
 
-      if (Array.isArray(results) && results.length > 0) {
-        const lines: string[] = ["## Semantic Recall (Past Conversations)", ""];
-        let used = 0;
-        for (const r of results) {
-          if (!r?.snippet) continue;
-          const chunk =
-            `### ${r.path}\n` +
-            `Score: ${r.score.toFixed(3)}\n\n` +
-            `${r.snippet.trim()}\n`;
-          if (used + chunk.length > maxChars) break;
-          lines.push(chunk);
-          used += chunk.length;
-        }
-        if (used > 0) {
-          sections.push(lines.join("\n"));
-        }
+      const formattedConversationRecall = this.formatConversationRecallSection(results, maxChars);
+      if (formattedConversationRecall) {
+        sections.push(formattedConversationRecall);
       }
     }
 

--- a/tests/conversation-index-integration.test.ts
+++ b/tests/conversation-index-integration.test.ts
@@ -1,0 +1,142 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir } from "node:fs/promises";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+
+function tmpDir(prefix: string): string {
+  return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+}
+
+async function makeOrchestrator(overrides: Record<string, unknown>): Promise<Orchestrator> {
+  const memoryDir = tmpDir("engram-conv-index-int");
+  const workspaceDir = path.join(memoryDir, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    identityEnabled: false,
+    identityContinuityEnabled: false,
+    sharedContextEnabled: false,
+    ...overrides,
+  });
+  return new Orchestrator(config);
+}
+
+test("conversation recall search uses qmd backend when configured", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: true,
+    conversationIndexBackend: "qmd",
+  });
+
+  let qmdCalls = 0;
+  let faissCalls = 0;
+
+  (orchestrator as any).conversationQmd = {
+    isAvailable: () => true,
+    search: async () => {
+      qmdCalls += 1;
+      return [{ path: "qmd/chunk-1", snippet: "QMD hit", score: 0.7 }];
+    },
+  };
+  (orchestrator as any).conversationFaiss = {
+    searchChunks: async () => {
+      faissCalls += 1;
+      return [{ path: "faiss/chunk-1", snippet: "FAISS hit", score: 0.9 }];
+    },
+  };
+
+  const results = await (orchestrator as any).searchConversationRecallResults("query", 3);
+  assert.equal(qmdCalls, 1);
+  assert.equal(faissCalls, 0);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].path, "qmd/chunk-1");
+});
+
+test("conversation recall search fail-opens for faiss backend errors", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: true,
+    conversationIndexBackend: "faiss",
+  });
+
+  (orchestrator as any).conversationFaiss = {
+    searchChunks: async () => {
+      throw new Error("boom");
+    },
+  };
+
+  const results = await (orchestrator as any).searchConversationRecallResults("query", 3);
+  assert.deepEqual(results, []);
+});
+
+test("conversation recall section formatting stays backend-agnostic", async () => {
+  const orchestrator = await makeOrchestrator({ conversationIndexEnabled: true });
+
+  const rows = [
+    { path: "chunk/one.md", snippet: "  first snippet  ", score: 0.81234 },
+    { path: "chunk/two.md", snippet: "second snippet", score: 0.5 },
+  ];
+
+  const formatted = (orchestrator as any).formatConversationRecallSection(rows, 10_000);
+  assert.ok(formatted);
+  assert.match(formatted, /## Semantic Recall \(Past Conversations\)/);
+  assert.match(formatted, /### chunk\/one\.md/);
+  assert.match(formatted, /Score: 0\.812/);
+  assert.match(formatted, /first snippet/);
+  assert.match(formatted, /### chunk\/two\.md/);
+  assert.match(formatted, /Score: 0\.500/);
+});
+
+test("updateConversationIndex routes writes through FAISS backend when selected", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: true,
+    conversationIndexBackend: "faiss",
+    conversationIndexEmbedOnUpdate: true,
+  });
+
+  let upsertCalls = 0;
+  let qmdCalls = 0;
+
+  (orchestrator as any).transcript = {
+    readRecent: async () => [
+      {
+        timestamp: "2026-02-27T00:00:00.000Z",
+        role: "user",
+        content: "hello from transcript",
+      },
+    ],
+  };
+
+  (orchestrator as any).conversationFaiss = {
+    upsertChunks: async (chunks: unknown[]) => {
+      upsertCalls += 1;
+      return chunks.length;
+    },
+  };
+
+  (orchestrator as any).conversationQmd = {
+    isAvailable: () => true,
+    update: async () => {
+      qmdCalls += 1;
+    },
+    embed: async () => {
+      qmdCalls += 1;
+    },
+  };
+
+  const result = await orchestrator.updateConversationIndex("session-a", 24, {
+    enforceMinInterval: false,
+  });
+
+  assert.equal(upsertCalls, 1);
+  assert.equal(qmdCalls, 0);
+  assert.equal(result.skipped, false);
+  assert.equal(result.embedded, false);
+  assert.equal(result.chunks > 0, true);
+});


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [ ] `npm run check-types`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Not needed (explain why)

## Risk assessment

- [ ] No secrets/tokens added
- [ ] Backwards compatibility considered
- [ ] Migration/config impact documented (if applicable)
- [ ] Zero-value semantics validated (`0` limits stay disabled, never coerced)
- [ ] Flag symmetry validated (`enabled=false` disables both write and read-path effects)
- [ ] Cache invalidation/coherency reviewed (cross-instance + concurrent updates)

## Notes for reviewers

<!-- Anything specific you want reviewed closely -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies orchestrator startup/recall/update logic to route conversation indexing and semantic recall through either QMD or a new FAISS sidecar, which can affect retrieval behavior and runtime stability despite fail-open guards.
> 
> **Overview**
> Adds orchestrator-level backend routing for the conversation index so `conversationIndexBackend` selects *QMD* vs *FAISS* for startup health checks, index update/upsert, and semantic-recall search.
> 
> Refactors conversation recall to use shared helpers for backend selection and section formatting, preserving existing fail-open behavior (FAISS errors degrade to empty/no-op). Adds an integration test suite covering backend routing, FAISS fail-open behavior, formatting parity, and update-path routing, and updates `CHANGELOG.md` to document Task 4.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47e4a69d5b58330fd934112c7fdf2abbdd591e51. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->