### PR TITLE
feat(v8.10): task 5 add conversation-index-health command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,11 @@ All notable changes to this project will be documented in this file.
   - Wired orchestrator conversation-index flow to select `qmd` or `faiss` backend paths for startup health checks, index updates, and semantic recall queries.
   - Preserved fail-open recall behavior for FAISS search/upsert failures and kept semantic-recall section formatting backend-agnostic via shared formatter logic.
   - Added `tests/conversation-index-integration.test.ts` coverage for backend routing (`qmd` vs `faiss`), FAISS fail-open recall, formatting parity, and FAISS update-path routing.
+- v8.10 FAISS conversation index Task 5 (ops health command + docs):
+  - Added orchestrator `getConversationIndexHealth()` with backend-aware status (`qmd`/`faiss`), chunk-doc counts, and last-update metadata.
+  - Added CLI command surface `openclaw engram conversation-index-health` via `runConversationIndexHealthCliCommand`.
+  - Added `tests/cli-conversation-index-health.test.ts` coverage for CLI wrapper behavior and backend health/fail-open scenarios.
+  - Updated `docs/operations.md` and `docs/setup-config-tuning.md` with conversation-index health command usage.
 - v8.7 custom memory routing rules Task 1 (routing engine):
   - Added `src/routing/engine.ts` with deterministic route-rule evaluation, regex/keyword matching, and priority-ordered selection.
   - Added safe route target validation for categories and namespaces (path traversal and separator rejection).

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -53,6 +53,7 @@ openclaw engram export              # Export memory store
 openclaw engram import              # Import memory store
 openclaw engram backup              # Create timestamped backup
 openclaw engram compat              # Run local compatibility diagnostics
+openclaw engram conversation-index-health  # Backend health + index stats
 ```
 
 Compatibility diagnostics:
@@ -89,6 +90,9 @@ openclaw engram webdav-serve \
 
 # Stop WebDAV service in the running gateway process
 openclaw engram webdav-stop
+
+# Show conversation-index backend health and basic index stats
+openclaw engram conversation-index-health
 ```
 
 Operational safety notes:

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -177,6 +177,12 @@ Operational checks after enabling guideline learning:
 - Verify fail-open behavior by temporarily making state unwritable and confirming consolidation still completes.
 - If guidance quality regresses, keep telemetry enabled and disable only `compressionGuidelineLearningEnabled`.
 
+Conversation index health check command:
+
+```bash
+openclaw engram conversation-index-health
+```
+
 QMD collection (`~/.config/qmd/index.yml`):
 
 ```yaml

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -254,6 +254,23 @@ interface TailscaleHelperLike {
   syncDirectory(options: TailscaleSyncOptions): Promise<void>;
 }
 
+export interface ConversationIndexHealthCliOrchestrator {
+  getConversationIndexHealth(): Promise<{
+    enabled: boolean;
+    backend: "qmd" | "faiss";
+    status: "ok" | "degraded" | "disabled";
+    chunkDocCount: number;
+    lastUpdateAt: string | null;
+    qmdAvailable?: boolean;
+    faiss?: {
+      ok: boolean;
+      status: "ok" | "degraded" | "error";
+      indexPath: string;
+      message?: string;
+    };
+  }>;
+}
+
 export interface TailscaleStatusCliCommandOptions {
   helper?: TailscaleHelperLike;
   timeoutMs?: number;
@@ -403,6 +420,25 @@ export async function runMigrateObservationsCliCommand(
     dryRun: options.write !== true,
     now: options.now,
   });
+}
+
+export async function runConversationIndexHealthCliCommand(
+  orchestrator: ConversationIndexHealthCliOrchestrator,
+): Promise<{
+  enabled: boolean;
+  backend: "qmd" | "faiss";
+  status: "ok" | "degraded" | "disabled";
+  chunkDocCount: number;
+  lastUpdateAt: string | null;
+  qmdAvailable?: boolean;
+  faiss?: {
+    ok: boolean;
+    status: "ok" | "degraded" | "error";
+    indexPath: string;
+    message?: string;
+  };
+}> {
+  return orchestrator.getConversationIndexHealth();
 }
 
 export async function runTailscaleStatusCliCommand(
@@ -1188,6 +1224,15 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
               console.log(`  ... and ${summary.warnings.length - 20} more`);
             }
           }
+          console.log("OK");
+        });
+
+      cmd
+        .command("conversation-index-health")
+        .description("Show conversation index backend health and index stats")
+        .action(async () => {
+          const health = await runConversationIndexHealthCliCommand(orchestrator);
+          console.log(JSON.stringify(health, null, 2));
           console.log("OK");
         });
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1,7 +1,7 @@
 import { log } from "./logger.js";
 import path from "node:path";
 import { createHash } from "node:crypto";
-import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import { SmartBuffer } from "./buffer.js";
 import { chunkContent, type ChunkingConfig } from "./chunking.js";
 import { ExtractionEngine } from "./extraction.js";
@@ -1118,6 +1118,77 @@ export class Orchestrator {
       used += chunk.length;
     }
     return used > 0 ? lines.join("\n") : null;
+  }
+
+  private async countConversationChunkDocs(dir: string): Promise<number> {
+    try {
+      const entries = await readdir(dir, { withFileTypes: true });
+      let total = 0;
+      for (const entry of entries) {
+        const fullPath = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          total += await this.countConversationChunkDocs(fullPath);
+          continue;
+        }
+        if (entry.isFile() && entry.name.endsWith(".md")) {
+          total += 1;
+        }
+      }
+      return total;
+    } catch {
+      return 0;
+    }
+  }
+
+  async getConversationIndexHealth(): Promise<{
+    enabled: boolean;
+    backend: "qmd" | "faiss";
+    status: "ok" | "degraded" | "disabled";
+    chunkDocCount: number;
+    lastUpdateAt: string | null;
+    qmdAvailable?: boolean;
+    faiss?: {
+      ok: boolean;
+      status: "ok" | "degraded" | "error";
+      indexPath: string;
+      message?: string;
+    };
+  }> {
+    const chunkDocCount = await this.countConversationChunkDocs(this.conversationIndexDir);
+    const lastUpdateAtMs = Math.max(0, ...this.conversationIndexLastUpdateAtMs.values());
+    const lastUpdateAt = lastUpdateAtMs > 0 ? new Date(lastUpdateAtMs).toISOString() : null;
+
+    if (!this.config.conversationIndexEnabled) {
+      return {
+        enabled: false,
+        backend: this.config.conversationIndexBackend,
+        status: "disabled",
+        chunkDocCount,
+        lastUpdateAt,
+      };
+    }
+
+    if (this.config.conversationIndexBackend === "faiss") {
+      const faiss = await failOpenFaissHealth(this.conversationFaiss);
+      return {
+        enabled: true,
+        backend: "faiss",
+        status: faiss.ok ? "ok" : "degraded",
+        chunkDocCount,
+        lastUpdateAt,
+        faiss,
+      };
+    }
+
+    const qmdAvailable = !!this.conversationQmd?.isAvailable();
+    return {
+      enabled: true,
+      backend: "qmd",
+      status: qmdAvailable ? "ok" : "degraded",
+      chunkDocCount,
+      lastUpdateAt,
+      qmdAvailable,
+    };
   }
 
   async updateConversationIndex(

--- a/tests/cli-conversation-index-health.test.ts
+++ b/tests/cli-conversation-index-health.test.ts
@@ -1,0 +1,102 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdir } from "node:fs/promises";
+import { runConversationIndexHealthCliCommand } from "../src/cli.js";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+
+function tmpDir(prefix: string): string {
+  return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+}
+
+test("conversation-index-health CLI wrapper returns orchestrator health payload", async () => {
+  const expected = {
+    enabled: true,
+    backend: "qmd" as const,
+    status: "ok" as const,
+    chunkDocCount: 12,
+    lastUpdateAt: "2026-02-27T18:00:00.000Z",
+    qmdAvailable: true,
+  };
+
+  const result = await runConversationIndexHealthCliCommand({
+    async getConversationIndexHealth() {
+      return expected;
+    },
+  });
+
+  assert.deepEqual(result, expected);
+});
+
+async function makeOrchestrator(overrides: Record<string, unknown>): Promise<Orchestrator> {
+  const memoryDir = tmpDir("engram-conv-health");
+  const workspaceDir = path.join(memoryDir, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    identityEnabled: false,
+    identityContinuityEnabled: false,
+    sharedContextEnabled: false,
+    ...overrides,
+  });
+  return new Orchestrator(config);
+}
+
+test("orchestrator conversation index health reports qmd backend availability", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: true,
+    conversationIndexBackend: "qmd",
+  });
+
+  (orchestrator as any).conversationQmd = {
+    isAvailable: () => true,
+  };
+
+  const health = await orchestrator.getConversationIndexHealth();
+
+  assert.equal(health.enabled, true);
+  assert.equal(health.backend, "qmd");
+  assert.equal(health.status, "ok");
+  assert.equal(health.qmdAvailable, true);
+  assert.equal(typeof health.chunkDocCount, "number");
+});
+
+test("orchestrator conversation index health reports faiss degradation fail-open", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: true,
+    conversationIndexBackend: "faiss",
+  });
+
+  (orchestrator as any).conversationFaiss = {
+    async health() {
+      throw new Error("sidecar unavailable");
+    },
+  };
+
+  const health = await orchestrator.getConversationIndexHealth();
+
+  assert.equal(health.enabled, true);
+  assert.equal(health.backend, "faiss");
+  assert.equal(health.status, "degraded");
+  assert.equal(health.faiss?.ok, false);
+});
+
+test("orchestrator conversation index health reports disabled state", async () => {
+  const orchestrator = await makeOrchestrator({
+    conversationIndexEnabled: false,
+    conversationIndexBackend: "qmd",
+  });
+
+  const health = await orchestrator.getConversationIndexHealth();
+
+  assert.equal(health.enabled, false);
+  assert.equal(health.status, "disabled");
+  assert.equal(health.backend, "qmd");
+});


### PR DESCRIPTION
## Summary

<!-- What changed and why? -->

## Type of change

- [ ] Bug fix
- [ ] Feature
- [ ] Docs
- [ ] Refactor
- [ ] Security / hardening

## Validation

- [ ] `npm run check-types`
- [ ] `npm test`
- [ ] `npm run build`
- [ ] Added/updated tests for behavior changes
- [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`

## Changelog

- [ ] Added/updated `CHANGELOG.md` under `## [Unreleased]`
- [ ] Not needed (explain why)

## Risk assessment

- [ ] No secrets/tokens added
- [ ] Backwards compatibility considered
- [ ] Migration/config impact documented (if applicable)
- [ ] Zero-value semantics validated (`0` limits stay disabled, never coerced)
- [ ] Flag symmetry validated (`enabled=false` disables both write and read-path effects)
- [ ] Cache invalidation/coherency reviewed (cross-instance + concurrent updates)

## Notes for reviewers

<!-- Anything specific you want reviewed closely -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new read-only CLI/Orchestrator health/status query for the conversation index; main risk is minor performance/behavior quirks from recursive chunk file counting and backend availability probing.
> 
> **Overview**
> Adds an ops-facing `openclaw engram conversation-index-health` CLI command that returns a JSON health payload from the orchestrator.
> 
> The orchestrator now exposes `getConversationIndexHealth()` to report **enabled/disabled**, selected backend (`qmd` vs `faiss`), an `ok|degraded` status (including FAISS *fail-open* health), `chunkDocCount`, and `lastUpdateAt` metadata.
> 
> Updates docs (`operations.md`, `setup-config-tuning.md`), `CHANGELOG.md`, and adds tests covering the CLI wrapper plus `qmd`/`faiss`/disabled health scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 420c9ce81259210824e788e85a9b871f2cdcc723. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->