### PR TITLE
feat: v8.11 task 5 runtime compression guideline guardrails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ All notable changes to this project will be documented in this file.
   - Added CLI command surface `openclaw engram conversation-index-health` via `runConversationIndexHealthCliCommand`.
   - Added `tests/cli-conversation-index-health.test.ts` coverage for CLI wrapper behavior and backend health/fail-open scenarios.
   - Updated `docs/operations.md` and `docs/setup-config-tuning.md` with conversation-index health command usage.
+- v8.11 compression optimizer Task 5 (runtime integration + guardrails):
+  - Added runtime recall integration for active compression guidelines via a guarded section injected only when context-compression actions and guideline learning are both enabled.
+  - Added fail-open guideline parsing/extraction helper (`formatCompressionGuidelinesForRecall`) that reads only the suggested-guidelines block for recall usage.
+  - Preserved zero-change path behavior when optimizer learning is disabled by short-circuiting before guideline/state reads.
+  - Added `tests/recall-compression-guideline-application.test.ts` coverage for disabled (byte-equivalent guard), enabled, and malformed guideline/state cases.
 - v8.11 compression optimizer Task 4 (optimizer tool + cron-safe entry point):
   - Added public orchestrator entry point `optimizeCompressionGuidelines(...)` with `dryRun` + `eventLimit` controls and explicit optimization summary fields.
   - Added `compression_guidelines_optimize` tool with dry-run support and summary output including old/new guideline versions and changed-rule count.

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -136,6 +136,21 @@ export function buildCompressionGuidelinesMarkdown(
   return buildCompressionGuidelinesMarkdownV2(events, generatedAtIso);
 }
 
+export function formatCompressionGuidelinesForRecall(raw: string, maxLines: number = 5): string | null {
+  if (typeof raw !== "string" || raw.trim().length === 0) return null;
+  const sectionMatch = raw.match(/## Suggested Guidelines\s*\n([\s\S]*?)(?:\n##\s+|\s*$)/i);
+  if (!sectionMatch) return null;
+
+  const lines = sectionMatch[1]
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.startsWith("- "))
+    .slice(0, Math.max(1, Math.floor(maxLines)));
+  if (lines.length === 0) return null;
+
+  return lines.join("\n");
+}
+
 export function filterRecallCandidates(
   candidates: QmdSearchResult[],
   options: {
@@ -2171,6 +2186,12 @@ export class Orchestrator {
       }
     }
 
+    // 2.5. Compression guideline recall section (v8.11 Task 5)
+    const compressionGuidelineSection = await this.buildCompressionGuidelineRecallSection();
+    if (compressionGuidelineSection) {
+      sections.push(compressionGuidelineSection);
+    }
+
     // 3. TRANSCRIPT INJECTION (NEW)
     const transcriptT0 = Date.now();
     log.debug(`recall: transcriptEnabled=${this.config.transcriptEnabled}, sessionKey=${sessionKey}`);
@@ -3807,6 +3828,27 @@ export class Orchestrator {
     } catch (err) {
       log.warn(`compression guideline learning failed (ignored): ${err}`);
     }
+  }
+
+  private async buildCompressionGuidelineRecallSection(): Promise<string | null> {
+    if (!this.config.contextCompressionActionsEnabled) return null;
+    if (!this.config.compressionGuidelineLearningEnabled) return null;
+
+    const state = await this.storage.readCompressionGuidelineOptimizerState().catch(() => null);
+    if (!state || state.guidelineVersion <= 0) return null;
+
+    const raw = await this.storage.readCompressionGuidelines().catch(() => null);
+    const summary = raw ? formatCompressionGuidelinesForRecall(raw, 5) : null;
+    if (!summary) return null;
+
+    return [
+      "## Active Compression Guidelines",
+      "",
+      `Guideline version: ${state.guidelineVersion}`,
+      `Updated: ${state.updatedAt}`,
+      "",
+      summary,
+    ].join("\n");
   }
 
   private parseCompressionSemanticRefinement(

--- a/tests/recall-compression-guideline-application.test.ts
+++ b/tests/recall-compression-guideline-application.test.ts
@@ -1,0 +1,106 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { formatCompressionGuidelinesForRecall, Orchestrator } from "../src/orchestrator.ts";
+
+test("formatCompressionGuidelinesForRecall extracts suggested guideline bullets", () => {
+  const raw = [
+    "# Compression Guidelines",
+    "",
+    "Generated: 2026-02-27T20:00:00.000Z",
+    "## Suggested Guidelines",
+    "- summarize_node: increase (+0.020, confidence=medium) — prefer concise summarization when recall quality remains stable.",
+    "- store_note: hold (0.000, confidence=low) — sparse signal; keep baseline.",
+    "",
+    "## Action Distribution",
+    "- summarize_node: 4",
+  ].join("\n");
+
+  const result = formatCompressionGuidelinesForRecall(raw, 3);
+  assert.ok(result);
+  assert.match(result ?? "", /summarize_node: increase/);
+  assert.match(result ?? "", /store_note: hold/);
+});
+
+test("formatCompressionGuidelinesForRecall returns null for malformed guideline content", () => {
+  const raw = "# Compression Guidelines\n\nGenerated: 2026-02-27T20:00:00.000Z\n";
+  assert.equal(formatCompressionGuidelinesForRecall(raw), null);
+});
+
+test("buildCompressionGuidelineRecallSection keeps zero-change path when optimizer is disabled", async () => {
+  let stateReads = 0;
+  let guidelineReads = 0;
+
+  const ctx: any = {
+    config: {
+      contextCompressionActionsEnabled: true,
+      compressionGuidelineLearningEnabled: false,
+    },
+    storage: {
+      readCompressionGuidelineOptimizerState: async () => {
+        stateReads += 1;
+        return null;
+      },
+      readCompressionGuidelines: async () => {
+        guidelineReads += 1;
+        return null;
+      },
+    },
+  };
+
+  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  assert.equal(section, null);
+  assert.equal(stateReads, 0);
+  assert.equal(guidelineReads, 0);
+});
+
+test("buildCompressionGuidelineRecallSection emits active guideline section when enabled", async () => {
+  const ctx: any = {
+    config: {
+      contextCompressionActionsEnabled: true,
+      compressionGuidelineLearningEnabled: true,
+    },
+    storage: {
+      readCompressionGuidelineOptimizerState: async () => ({
+        version: 2,
+        updatedAt: "2026-02-27T20:10:00.000Z",
+        sourceWindow: {
+          from: "2026-02-27T19:00:00.000Z",
+          to: "2026-02-27T20:00:00.000Z",
+        },
+        eventCounts: { total: 2, applied: 2, skipped: 0, failed: 0 },
+        guidelineVersion: 3,
+      }),
+      readCompressionGuidelines: async () =>
+        [
+          "# Compression Guidelines",
+          "",
+          "Generated: 2026-02-27T20:10:00.000Z",
+          "## Suggested Guidelines",
+          "- summarize_node: increase (+0.020, confidence=medium) — keep recaps concise.",
+          "",
+        ].join("\n"),
+    },
+  };
+
+  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  assert.ok(section);
+  assert.match(section ?? "", /## Active Compression Guidelines/);
+  assert.match(section ?? "", /Guideline version: 3/);
+  assert.match(section ?? "", /summarize_node: increase/);
+});
+
+test("buildCompressionGuidelineRecallSection fail-opens on malformed guideline state/guidelines", async () => {
+  const ctx: any = {
+    config: {
+      contextCompressionActionsEnabled: true,
+      compressionGuidelineLearningEnabled: true,
+    },
+    storage: {
+      readCompressionGuidelineOptimizerState: async () => null,
+      readCompressionGuidelines: async () => "# Compression Guidelines\n\nGenerated: now",
+    },
+  };
+
+  const section = await (Orchestrator.prototype as any).buildCompressionGuidelineRecallSection.call(ctx);
+  assert.equal(section, null);
+});


### PR DESCRIPTION
## Summary
- apply active compression guidelines in recall assembly only for compression-action contexts
- fail-open on missing/malformed guideline state or guideline markdown
- preserve zero-change behavior when guideline learning is disabled by short-circuiting reads
- add runtime guardrail tests for disabled/enabled/malformed paths

## Validation
- npm run -s check-types
- npm run -s check-config-contract
- npm run -s test -- tests/recall-compression-guideline-application.test.ts tests/orchestrator-compression-guidelines.test.ts tests/tools-compression-optimize.test.ts tests/compression-optimizer.test.ts tests/compression-optimizer-semantic.test.ts tests/tools-compression-actions.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are gated behind `contextCompressionActionsEnabled` + `compressionGuidelineLearningEnabled` and are fail-open on missing/malformed state, so default recall behavior should remain unchanged.
> 
> **Overview**
> Adds an *optional* recall-assembly section, `## Active Compression Guidelines`, which injects the current learned compression guideline bullets (plus version/updated metadata) into runtime context when both compression actions and guideline learning are enabled.
> 
> Introduces `formatCompressionGuidelinesForRecall` to extract only the `## Suggested Guidelines` bullet list from stored guideline markdown with defensive parsing, and adds tests covering disabled short-circuiting, enabled output, and malformed/state-missing fail-open behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d77a8172fb88b78ba773a2624d7aef25b1403b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->