### PR TITLE
feat: v8.12 task 1 graph expansion scoring controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@ All notable changes to this project will be documented in this file.
   - Added CLI command surface `openclaw engram conversation-index-health` via `runConversationIndexHealthCliCommand`.
   - Added `tests/cli-conversation-index-health.test.ts` coverage for CLI wrapper behavior and backend health/fail-open scenarios.
   - Updated `docs/operations.md` and `docs/setup-config-tuning.md` with conversation-index health command usage.
+- v8.12 graph retrieval phase 2 Task 1 (expansion scoring controls):
+  - Added graph expansion scoring config knobs: `graphExpansionActivationWeight`, `graphExpansionBlendMin`, and `graphExpansionBlendMax` with clamped parse-time handling.
+  - Added bounded blend function for graph-expanded candidate scoring to combine normalized activation with seed QMD signal while enforcing configurable score bounds.
+  - Updated graph expansion path in orchestrator to use blended scoring per namespace seed set.
+  - Added `tests/graph-recall-scoring.test.ts` for monotonic blend behavior and filter-before-cap invariants, plus config clamp/default coverage updates.
+  - Documented new graph scoring controls in `docs/config-reference.md` and `openclaw.plugin.json`.
 - v8.11 compression optimizer Task 5 (runtime integration + guardrails):
   - Added runtime recall integration for active compression guidelines via a guarded section injected only when context-compression actions and guideline learning are both enabled.
   - Added fail-open guideline parsing/extraction helper (`formatCompressionGuidelinesForRecall`) that reads only the suggested-guidelines block for recall usage.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -281,6 +281,9 @@ See [compounding.md](compounding.md).
 | `causalGraphEnabled` | `true` | Enable causal phrase edges |
 | `maxGraphTraversalSteps` | `3` | Max spreading-activation BFS hops |
 | `graphActivationDecay` | `0.7` | Per-hop decay factor |
+| `graphExpansionActivationWeight` | `0.65` | Blend weight for graph activation vs seed QMD score (0-1) |
+| `graphExpansionBlendMin` | `0.05` | Lower clamp bound for blended graph-expanded scores (0-1) |
+| `graphExpansionBlendMax` | `0.95` | Upper clamp bound for blended graph-expanded scores (0-1) |
 
 ## File Hygiene
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -446,6 +446,21 @@
         "default": 0.7,
         "description": "Per-hop activation decay factor (0-1). Default 0.7."
       },
+      "graphExpansionActivationWeight": {
+        "type": "number",
+        "default": 0.65,
+        "description": "Blend weight for graph activation when scoring expanded results (0-1). Higher values favor graph activation over seed QMD score."
+      },
+      "graphExpansionBlendMin": {
+        "type": "number",
+        "default": 0.05,
+        "description": "Lower clamp bound for blended graph-expanded recall scores (0-1)."
+      },
+      "graphExpansionBlendMax": {
+        "type": "number",
+        "default": 0.95,
+        "description": "Upper clamp bound for blended graph-expanded recall scores (0-1)."
+      },
       "maxEntityGraphEdgesPerMemory": {
         "type": "number",
         "default": 10,

--- a/src/config.ts
+++ b/src/config.ts
@@ -748,6 +748,18 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.graphActivationDecay === "number"
         ? Math.min(1, Math.max(0, cfg.graphActivationDecay))
         : 0.7,
+    graphExpansionActivationWeight:
+      typeof cfg.graphExpansionActivationWeight === "number"
+        ? Math.min(1, Math.max(0, cfg.graphExpansionActivationWeight))
+        : 0.65,
+    graphExpansionBlendMin:
+      typeof cfg.graphExpansionBlendMin === "number"
+        ? Math.min(1, Math.max(0, cfg.graphExpansionBlendMin))
+        : 0.05,
+    graphExpansionBlendMax:
+      typeof cfg.graphExpansionBlendMax === "number"
+        ? Math.min(1, Math.max(0, cfg.graphExpansionBlendMax))
+        : 0.95,
     maxEntityGraphEdgesPerMemory:
       typeof cfg.maxEntityGraphEdgesPerMemory === "number"
         ? Math.max(0, cfg.maxEntityGraphEdgesPerMemory)

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -346,12 +346,29 @@ export function graphPathRelativeToStorage(storageDir: string, candidatePath: st
   return rel.split(path.sep).join("/");
 }
 
-function graphActivationScoreToRecallScore(score: number): number {
+function normalizeGraphActivationScore(score: number): number {
   const bounded = Number.isFinite(score) && score > 0 ? score : 0;
-  // Keep graph-expanded candidates in the same rough score range as QMD
-  // without overpowering direct retrieval hits.
-  const normalized = bounded / (1 + bounded);
-  return Math.max(0.05, Math.min(0.95, normalized));
+  return bounded / (1 + bounded);
+}
+
+export function blendGraphExpandedRecallScore(options: {
+  graphActivationScore: number;
+  seedRecallScore: number;
+  activationWeight: number;
+  blendMin: number;
+  blendMax: number;
+}): number {
+  const graphNorm = normalizeGraphActivationScore(options.graphActivationScore);
+  const seedScore = Number.isFinite(options.seedRecallScore)
+    ? Math.min(1, Math.max(0, options.seedRecallScore))
+    : 0;
+  const weight = Math.min(1, Math.max(0, options.activationWeight));
+  const rawMin = Math.min(1, Math.max(0, options.blendMin));
+  const rawMax = Math.min(1, Math.max(0, options.blendMax));
+  const minBound = Math.min(rawMin, rawMax);
+  const maxBound = Math.max(rawMin, rawMax);
+  const blended = (graphNorm * weight) + (seedScore * (1 - weight));
+  return Math.max(minBound, Math.min(maxBound, blended));
 }
 
 export function mergeArtifactRecallCandidates(
@@ -1504,12 +1521,13 @@ export class Orchestrator {
 
     for (const [namespace, nsResults] of byNamespace.entries()) {
       const storage = await this.storageRouter.storageFor(namespace);
-      const seedRelativePaths = nsResults
-        .slice(0, perNamespaceSeedCap)
+      const seedCandidates = nsResults.slice(0, perNamespaceSeedCap);
+      const seedRelativePaths = seedCandidates
         .map((result) => graphPathRelativeToStorage(storage.dir, result.path))
         .filter((value): value is string => typeof value === "string" && value.length > 0);
       if (seedRelativePaths.length === 0) continue;
 
+      const seedRecallScore = seedCandidates.reduce((max, item) => Math.max(max, item.score), 0);
       seedPaths.push(...seedRelativePaths.map((rel) => path.join(storage.dir, rel)));
       const seedSet = new Set(seedRelativePaths);
       const expanded = await this.graphIndexFor(storage).spreadingActivation(
@@ -1527,7 +1545,13 @@ export class Orchestrator {
         if (memory.frontmatter.status && memory.frontmatter.status !== "active") continue;
 
         const snippet = memory.content.slice(0, 400);
-        const score = graphActivationScoreToRecallScore(candidate.score);
+        const score = blendGraphExpandedRecallScore({
+          graphActivationScore: candidate.score,
+          seedRecallScore,
+          activationWeight: this.config.graphExpansionActivationWeight,
+          blendMin: this.config.graphExpansionBlendMin,
+          blendMax: this.config.graphExpansionBlendMax,
+        });
         expandedResults.push({
           docid: memory.frontmatter.id,
           path: memory.path,

--- a/src/types.ts
+++ b/src/types.ts
@@ -361,6 +361,12 @@ export interface PluginConfig {
   causalGraphEnabled: boolean;
   maxGraphTraversalSteps: number;
   graphActivationDecay: number;
+  /** Weight of graph activation score when blending with seed QMD score (0-1). */
+  graphExpansionActivationWeight: number;
+  /** Lower bound for blended graph-expanded recall scores (0-1). */
+  graphExpansionBlendMin: number;
+  /** Upper bound for blended graph-expanded recall scores (0-1). */
+  graphExpansionBlendMax: number;
   maxEntityGraphEdgesPerMemory: number;
   // v8.2: Temporal Memory Tree
   temporalMemoryTreeEnabled: boolean;

--- a/tests/config-graph-limits.test.ts
+++ b/tests/config-graph-limits.test.ts
@@ -31,3 +31,20 @@ test("parseConfig keeps graphRecallEnabled opt-in", () => {
   assert.equal(defaults.graphRecallEnabled, false);
   assert.equal(enabled.graphRecallEnabled, true);
 });
+
+test("parseConfig applies graph expansion scoring defaults and clamps bounds", () => {
+  const defaults = parseConfig({ openaiApiKey: "sk-test" });
+  assert.equal(defaults.graphExpansionActivationWeight, 0.65);
+  assert.equal(defaults.graphExpansionBlendMin, 0.05);
+  assert.equal(defaults.graphExpansionBlendMax, 0.95);
+
+  const clamped = parseConfig({
+    openaiApiKey: "sk-test",
+    graphExpansionActivationWeight: 2,
+    graphExpansionBlendMin: -1,
+    graphExpansionBlendMax: 9,
+  });
+  assert.equal(clamped.graphExpansionActivationWeight, 1);
+  assert.equal(clamped.graphExpansionBlendMin, 0);
+  assert.equal(clamped.graphExpansionBlendMax, 1);
+});

--- a/tests/graph-recall-scoring.test.ts
+++ b/tests/graph-recall-scoring.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { blendGraphExpandedRecallScore, filterRecallCandidates } from "../src/orchestrator.ts";
+
+test("blendGraphExpandedRecallScore is monotonic for higher graph activation scores", () => {
+  const low = blendGraphExpandedRecallScore({
+    graphActivationScore: 0.1,
+    seedRecallScore: 0.6,
+    activationWeight: 0.7,
+    blendMin: 0.05,
+    blendMax: 0.95,
+  });
+  const mid = blendGraphExpandedRecallScore({
+    graphActivationScore: 0.8,
+    seedRecallScore: 0.6,
+    activationWeight: 0.7,
+    blendMin: 0.05,
+    blendMax: 0.95,
+  });
+  const high = blendGraphExpandedRecallScore({
+    graphActivationScore: 5,
+    seedRecallScore: 0.6,
+    activationWeight: 0.7,
+    blendMin: 0.05,
+    blendMax: 0.95,
+  });
+
+  assert.equal(low < mid, true);
+  assert.equal(mid < high, true);
+});
+
+test("blendGraphExpandedRecallScore clamps to configured bounds", () => {
+  const clamped = blendGraphExpandedRecallScore({
+    graphActivationScore: 10,
+    seedRecallScore: 1,
+    activationWeight: 1,
+    blendMin: 0.2,
+    blendMax: 0.4,
+  });
+  assert.equal(clamped, 0.4);
+
+  const swappedBounds = blendGraphExpandedRecallScore({
+    graphActivationScore: 0,
+    seedRecallScore: 0,
+    activationWeight: 1,
+    blendMin: 0.9,
+    blendMax: 0.2,
+  });
+  assert.equal(swappedBounds, 0.2);
+});
+
+test("filterRecallCandidates applies artifact/path filtering before cap", () => {
+  const candidates = [
+    { docid: "1", path: "/mem/artifacts/a.md", snippet: "a", score: 0.99 },
+    { docid: "2", path: "/mem/facts/a.md", snippet: "b", score: 0.90 },
+    { docid: "3", path: "/mem/facts/b.md", snippet: "c", score: 0.80 },
+    { docid: "4", path: "/mem/facts/c.md", snippet: "d", score: 0.70 },
+  ];
+
+  const filtered = filterRecallCandidates(candidates as any, {
+    namespacesEnabled: true,
+    recallNamespaces: ["default"],
+    resolveNamespace: () => "default",
+    limit: 2,
+  });
+
+  assert.equal(filtered.length, 2);
+  assert.deepEqual(
+    filtered.map((item) => item.path),
+    ["/mem/facts/a.md", "/mem/facts/b.md"],
+  );
+});


### PR DESCRIPTION
## Summary
- add graph expansion scoring knobs for activation weighting and blend bounds
- apply bounded graph-vs-seed blend scoring for expanded candidates
- add monotonic/clamp scoring tests and cap-after-filter invariant coverage
- update config docs/changelog for v8.12 task 1

## Validation
- npm run -s check-types
- npm run -s check-config-contract
- npm run -s test -- tests/config-graph-limits.test.ts tests/graph-recall-scoring.test.ts tests/graph-recall-integration.test.ts tests/recall-no-recall-short-circuit.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retrieval ranking for graph-expanded candidates by introducing a new blended scoring function and config-driven bounds, which could shift recall ordering/quality. Risk is mitigated by clamped config parsing and added unit tests for monotonicity and bound handling.
> 
> **Overview**
> Adds new graph expansion scoring controls (`graphExpansionActivationWeight`, `graphExpansionBlendMin`, `graphExpansionBlendMax`) with parse-time clamping, and documents them in `docs/config-reference.md` and `openclaw.plugin.json`.
> 
> Updates graph expansion recall scoring to blend normalized spreading-activation scores with the best seed QMD score per namespace (bounded by the new min/max clamps) via a new exported `blendGraphExpandedRecallScore` helper.
> 
> Extends tests to cover config defaults/clamping and scoring invariants (monotonicity, bound swapping, and filter-before-cap behavior), and records the change in `CHANGELOG.md`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b9aa4a1b1a2e728e107efae4809f78333c6b8dd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->