### PR TITLE
feat(v8.12): add graph assist shadow-eval mode for full recall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,12 @@ All notable changes to this project will be documented in this file.
   - Added CLI command surface `openclaw engram conversation-index-health` via `runConversationIndexHealthCliCommand`.
   - Added `tests/cli-conversation-index-health.test.ts` coverage for CLI wrapper behavior and backend health/fail-open scenarios.
   - Updated `docs/operations.md` and `docs/setup-config-tuning.md` with conversation-index health command usage.
+- v8.12 graph retrieval phase 2 Task 3 (shadow-eval assist mode in full recall):
+  - Added `graphAssistShadowEvalEnabled` config flag (default `false`) to run full-mode graph assist as compare-only shadow evaluation.
+  - Kept full-mode injected recall output baseline-identical when shadow mode is enabled, while still computing graph-expanded candidates.
+  - Added shadow comparison telemetry in recall timings (`graphShadow`) with baseline/graph overlap and average score delta.
+  - Added `tests/graph-shadow-eval.test.ts` for baseline-preservation and telemetry emission coverage.
+  - Updated config + tuning docs (`docs/config-reference.md`, `docs/setup-config-tuning.md`) and plugin schema.
 - v8.12 graph retrieval phase 2 Task 2 (richer graph provenance snapshots):
   - Extended graph spreading-activation outputs to include per-result provenance (`seed`, `hopDepth`, `decayedWeight`, `graphType`).
   - Persisted bounded provenance in `last_graph_recall.json` with capped seed/expanded arrays for high-traffic safety.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -274,6 +274,7 @@ See [compounding.md](compounding.md).
 | `graphRecallEnabled` | `false` | Enable planner `graph_mode` expansion |
 | `graphExpandedIntentEnabled` | `true` | Escalate broader causal/timeline prompts into `graph_mode` |
 | `graphAssistInFullModeEnabled` | `true` | Run bounded graph expansion during `full` recall mode |
+| `graphAssistShadowEvalEnabled` | `false` | In `full` mode, run graph assist as shadow-eval (compute + snapshot + telemetry, no injection change) |
 | `graphAssistMinSeedResults` | `3` | Minimum seed recalls required for full-mode graph assist |
 | `graphWriteSessionAdjacencyEnabled` | `true` | Write fallback time edges between consecutive extracted memories |
 | `entityGraphEnabled` | `true` | Enable entity co-reference edges |

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -349,6 +349,7 @@ Latency:
 Recall quality:
 - Increase `conversationRecallTopK` gradually (3 -> 4 -> 6) and watch prompt bloat.
 - Keep `conversationRecallMaxChars` bounded (1500-3000) to avoid drowning current context.
+- For v8.12 graph assist evaluation in `full` mode, set `graphAssistShadowEvalEnabled: true` first to capture overlap/delta telemetry without changing injected recall output.
 
 Storage growth:
 - Keep `conversationIndexRetentionDays` finite.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -411,6 +411,11 @@
         "default": true,
         "description": "Run bounded graph expansion during full recall mode when seed results exist."
       },
+      "graphAssistShadowEvalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "In full mode, compute graph assist for comparison telemetry and snapshots but keep injected recall output baseline-identical."
+      },
       "graphAssistMinSeedResults": {
         "type": "number",
         "default": 3,

--- a/src/config.ts
+++ b/src/config.ts
@@ -734,6 +734,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     graphRecallEnabled: cfg.graphRecallEnabled === true,
     graphExpandedIntentEnabled: cfg.graphExpandedIntentEnabled !== false,
     graphAssistInFullModeEnabled: cfg.graphAssistInFullModeEnabled !== false,
+    graphAssistShadowEvalEnabled: cfg.graphAssistShadowEvalEnabled === true,
     graphAssistMinSeedResults:
       typeof cfg.graphAssistMinSeedResults === "number"
         ? Math.max(1, Math.floor(cfg.graphAssistMinSeedResults))

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -376,6 +376,42 @@ export function blendGraphExpandedRecallScore(options: {
   return Math.max(minBound, Math.min(maxBound, blended));
 }
 
+export function summarizeGraphShadowComparison(
+  baseline: QmdSearchResult[],
+  merged: QmdSearchResult[],
+  topN: number,
+): {
+  baselineCount: number;
+  graphCount: number;
+  overlapCount: number;
+  overlapRatio: number;
+  averageOverlapDelta: number;
+} {
+  const limit = Math.max(0, Math.floor(topN));
+  const baselineTop = limit > 0 ? baseline.slice(0, limit) : [];
+  const graphTop = limit > 0 ? merged.slice(0, limit) : [];
+  const baselineByPath = new Map(baselineTop.map((item) => [item.path, item.score]));
+  const graphByPath = new Map(graphTop.map((item) => [item.path, item.score]));
+
+  let overlapCount = 0;
+  let overlapDeltaSum = 0;
+  for (const [p, baselineScore] of baselineByPath.entries()) {
+    const graphScore = graphByPath.get(p);
+    if (typeof graphScore !== "number") continue;
+    overlapCount += 1;
+    overlapDeltaSum += graphScore - baselineScore;
+  }
+
+  const baselineCount = baselineTop.length;
+  return {
+    baselineCount,
+    graphCount: graphTop.length,
+    overlapCount,
+    overlapRatio: baselineCount > 0 ? overlapCount / baselineCount : 0,
+    averageOverlapDelta: overlapCount > 0 ? overlapDeltaSum / overlapCount : 0,
+  };
+}
+
 export function mergeArtifactRecallCandidates(
   candidatesByNamespace: MemoryFile[][],
   limit: number,
@@ -1907,13 +1943,19 @@ export class Orchestrator {
       // Artifacts are injected through dedicated verbatim recall flow only.
       memoryResults = memoryResults.filter((r) => !isArtifactMemoryPath(r.path));
 
+      const isFullModeGraphAssist =
+        this.config.multiGraphMemoryEnabled &&
+        this.config.graphAssistInFullModeEnabled !== false &&
+        recallMode === "full" &&
+        memoryResults.length >= Math.max(1, this.config.graphAssistMinSeedResults ?? 3);
       const shouldRunGraphExpansion =
         recallMode === "graph_mode" ||
-        (this.config.multiGraphMemoryEnabled &&
-          this.config.graphAssistInFullModeEnabled !== false &&
-          recallMode === "full" &&
-          memoryResults.length >= Math.max(1, this.config.graphAssistMinSeedResults ?? 3));
+        isFullModeGraphAssist;
+      const graphShadowEvalEnabled =
+        isFullModeGraphAssist &&
+        this.config.graphAssistShadowEvalEnabled === true;
       if (shouldRunGraphExpansion) {
+        const baselineMemoryResults = memoryResults;
         const {
           merged,
           seedPaths,
@@ -1923,7 +1965,20 @@ export class Orchestrator {
           recallNamespaces,
           recallResultLimit,
         });
-        memoryResults = merged;
+        memoryResults = graphShadowEvalEnabled ? baselineMemoryResults : merged;
+
+        if (graphShadowEvalEnabled) {
+          const comparison = summarizeGraphShadowComparison(
+            baselineMemoryResults,
+            merged,
+            recallResultLimit,
+          );
+          timings.graphShadow =
+            `on b=${comparison.baselineCount} g=${comparison.graphCount} ` +
+            `ov=${comparison.overlapCount} (${comparison.overlapRatio.toFixed(2)}) ` +
+            `avgDelta=${comparison.averageOverlapDelta.toFixed(3)}`;
+        }
+
         await this.recordLastGraphRecallSnapshot({
           storage: profileStorage,
           prompt: retrievalQuery,

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,6 +352,8 @@ export interface PluginConfig {
   graphExpandedIntentEnabled?: boolean;
   /** Run bounded graph expansion in full mode when enough recall seeds exist. */
   graphAssistInFullModeEnabled?: boolean;
+  /** In full mode, compute graph assist for telemetry/snapshotting but do not inject merged results. */
+  graphAssistShadowEvalEnabled?: boolean;
   /** Minimum seed results required before full-mode graph assist runs. */
   graphAssistMinSeedResults?: number;
   entityGraphEnabled: boolean;

--- a/tests/config-graph-limits.test.ts
+++ b/tests/config-graph-limits.test.ts
@@ -32,6 +32,14 @@ test("parseConfig keeps graphRecallEnabled opt-in", () => {
   assert.equal(enabled.graphRecallEnabled, true);
 });
 
+test("parseConfig keeps graphAssistShadowEvalEnabled opt-in", () => {
+  const defaults = parseConfig({ openaiApiKey: "sk-test" });
+  const enabled = parseConfig({ openaiApiKey: "sk-test", graphAssistShadowEvalEnabled: true });
+
+  assert.equal(defaults.graphAssistShadowEvalEnabled, false);
+  assert.equal(enabled.graphAssistShadowEvalEnabled, true);
+});
+
 test("parseConfig applies graph expansion scoring defaults and clamps bounds", () => {
   const defaults = parseConfig({ openaiApiKey: "sk-test" });
   assert.equal(defaults.graphExpansionActivationWeight, 0.65);

--- a/tests/graph-shadow-eval.test.ts
+++ b/tests/graph-shadow-eval.test.ts
@@ -1,0 +1,153 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+import type { EngramTraceEvent } from "../src/types.js";
+
+test("full-mode graph shadow eval keeps injected recall baseline-identical", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-shadow-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: true,
+    qmdCollection: "engram-test",
+    qmdMaxResults: 3,
+    recallPlannerEnabled: true,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    graphAssistInFullModeEnabled: true,
+    graphAssistShadowEvalEnabled: true,
+    graphAssistMinSeedResults: 1,
+    verbatimArtifactsEnabled: false,
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  const seedId = await orchestrator.storage.writeMemory("fact", "seed baseline memory");
+  const seedMemory = await orchestrator.storage.getMemoryById(seedId);
+  assert.ok(seedMemory);
+
+  const expandedId = await orchestrator.storage.writeMemory("fact", "shadow-only memory");
+  const expandedMemory = await orchestrator.storage.getMemoryById(expandedId);
+  assert.ok(expandedMemory);
+
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    hybridSearch: async () => [
+      {
+        docid: seedMemory!.frontmatter.id,
+        path: seedMemory!.path,
+        snippet: "seed baseline memory",
+        score: 0.9,
+      },
+    ],
+    search: async () => [],
+  };
+
+  (orchestrator as any).expandResultsViaGraph = async ({ memoryResults }: any) => ({
+    merged: [
+      {
+        docid: expandedMemory!.frontmatter.id,
+        path: expandedMemory!.path,
+        snippet: "shadow-only memory",
+        score: 0.99,
+      },
+      ...memoryResults,
+    ],
+    seedPaths: [seedMemory!.path],
+    expandedPaths: [
+      {
+        path: expandedMemory!.path,
+        score: 0.99,
+        namespace: "default",
+        seed: seedMemory!.path,
+        hopDepth: 1,
+        decayedWeight: 0.7,
+        graphType: "entity",
+      },
+    ],
+  });
+
+  const out = await (orchestrator as any).recallInternal(
+    "Summarize the current project state.",
+    "session-graph-shadow-baseline",
+  );
+
+  assert.match(out, /Relevant Memories/);
+  assert.match(out, /seed baseline memory/);
+  assert.doesNotMatch(out, /shadow-only memory/);
+
+  const raw = await readFile(path.join(memoryDir, "state", "last_graph_recall.json"), "utf-8");
+  const snapshot = JSON.parse(raw) as {
+    mode: string;
+    seedCount: number;
+    expandedCount: number;
+  };
+  assert.equal(snapshot.mode, "full");
+  assert.equal(snapshot.seedCount, 1);
+  assert.equal(snapshot.expandedCount, 1);
+});
+
+test("full-mode graph shadow eval emits overlap telemetry in recall timings", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-graph-shadow-telemetry-"));
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: true,
+    qmdCollection: "engram-test",
+    qmdMaxResults: 3,
+    recallPlannerEnabled: true,
+    graphRecallEnabled: true,
+    multiGraphMemoryEnabled: true,
+    graphAssistInFullModeEnabled: true,
+    graphAssistShadowEvalEnabled: true,
+    graphAssistMinSeedResults: 1,
+    verbatimArtifactsEnabled: false,
+  });
+  const orchestrator = new Orchestrator(cfg);
+
+  const seedId = await orchestrator.storage.writeMemory("fact", "seed baseline memory");
+  const seedMemory = await orchestrator.storage.getMemoryById(seedId);
+  assert.ok(seedMemory);
+
+  (orchestrator as any).qmd = {
+    isAvailable: () => true,
+    hybridSearch: async () => [
+      {
+        docid: seedMemory!.frontmatter.id,
+        path: seedMemory!.path,
+        snippet: "seed baseline memory",
+        score: 0.9,
+      },
+    ],
+    search: async () => [],
+  };
+
+  (orchestrator as any).expandResultsViaGraph = async ({ memoryResults }: any) => ({
+    merged: memoryResults,
+    seedPaths: [seedMemory!.path],
+    expandedPaths: [],
+  });
+
+  const events: EngramTraceEvent[] = [];
+  const previous = (globalThis as any).__openclawEngramTrace;
+  (globalThis as any).__openclawEngramTrace = (event: EngramTraceEvent) => events.push(event);
+  try {
+    const out = await (orchestrator as any).recallInternal(
+      "Summarize the current project state.",
+      "session-graph-shadow-telemetry",
+    );
+    assert.match(out, /Relevant Memories/);
+  } finally {
+    (globalThis as any).__openclawEngramTrace = previous;
+  }
+
+  const recallEvent = events.find((event) => event.kind === "recall_summary");
+  assert.ok(recallEvent && recallEvent.kind === "recall_summary");
+  assert.ok(recallEvent.timings);
+  assert.match(recallEvent.timings!.graphShadow ?? "", /^on b=\d+ g=\d+ ov=\d+ \(\d+\.\d{2}\) avgDelta=-?\d+\.\d{3}$/);
+});


### PR DESCRIPTION
## Summary
- add `graphAssistShadowEvalEnabled` (default off) for full-mode graph assist shadow evaluation
- compute graph-expanded candidates and snapshot/telemetry while keeping injected recall output baseline-identical when shadow mode is on
- add overlap/delta telemetry in recall timing fields (`graphShadow`)
- add tests for baseline-preservation and telemetry output
- document flag in config reference and setup tuning guide

## Validation
- npm run check-types
- npm run check-config-contract
- npm run test -- tests/config-graph-limits.test.ts tests/graph-shadow-eval.test.ts tests/graph-recall-integration.test.ts tests/recall-telemetry.test.ts
- preflight hooks ran full suite + build during commit/push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `recallInternal` retrieval/graph-expansion wiring and adds new timing telemetry; while gated behind a default-off flag, mistakes could still affect recall output ordering or observability fields.
> 
> **Overview**
> Adds an opt-in `graphAssistShadowEvalEnabled` flag to run graph assist during `full` recall as a *compare-only* path: graph expansion and `last_graph_recall.json` snapshotting still run, but injected recall results remain baseline-identical.
> 
> Introduces `summarizeGraphShadowComparison(...)` and emits `timings.graphShadow` overlap/score-delta telemetry for shadow runs, updates plugin schema/docs/config parsing accordingly, and adds tests asserting baseline preservation plus telemetry formatting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 33b691dfcdea0dafe407694e2d3381ae60982c54. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->