### PR TITLE
feat(v8.12): add graph health diagnostics command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,11 @@ All notable changes to this project will be documented in this file.
   - Added CLI command surface `openclaw engram conversation-index-health` via `runConversationIndexHealthCliCommand`.
   - Added `tests/cli-conversation-index-health.test.ts` coverage for CLI wrapper behavior and backend health/fail-open scenarios.
   - Updated `docs/operations.md` and `docs/setup-config-tuning.md` with conversation-index health command usage.
+- v8.12 graph retrieval phase 2 Task 4 (graph health diagnostics command):
+  - Added `analyzeGraphHealth(...)` in `src/graph.ts` to report per-edge-file integrity, corruption counts, valid edge totals, and unique node coverage.
+  - Added CLI wrapper/command `openclaw engram graph-health` with optional `--repair-guidance` for non-destructive remediation hints.
+  - Added `tests/cli-graph-health.test.ts` coverage for corruption detection, coverage reporting, and repair-guidance gating.
+  - Updated `docs/operations.md` with graph-health command usage and diagnostics guidance.
 - v8.12 graph retrieval phase 2 Task 3 (shadow-eval assist mode in full recall):
   - Added `graphAssistShadowEvalEnabled` config flag (default `false`) to run full-mode graph assist as compare-only shadow evaluation.
   - Kept full-mode injected recall output baseline-identical when shadow mode is enabled, while still computing graph-expanded candidates.

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -54,12 +54,17 @@ openclaw engram import              # Import memory store
 openclaw engram backup              # Create timestamped backup
 openclaw engram compat              # Run local compatibility diagnostics
 openclaw engram conversation-index-health  # Backend health + index stats
+openclaw engram graph-health        # Graph edge-file integrity + coverage
 ```
 
 Compatibility diagnostics:
 - `openclaw engram compat` reports `ok|warn|error` checks for manifest wiring, startup hooks/service registration, CLI wiring, Node engine floor, and qmd availability.
 - Use `openclaw engram compat --json` for CI/automation consumers.
 - Use `openclaw engram compat --strict` to fail with non-zero exit code on warnings or errors.
+
+Graph diagnostics:
+- `openclaw engram graph-health` reports per-edge-file integrity (`entity/time/causal`), corruption counts, and unique node coverage.
+- Add `--repair-guidance` to include non-destructive remediation suggestions when corruption or empty-graph conditions are detected.
 
 Routing behavior notes:
 - Routing is optional and disabled unless `routingRulesEnabled=true`.
@@ -112,6 +117,9 @@ openclaw engram webdav-stop
 
 # Show conversation-index backend health and basic index stats
 openclaw engram conversation-index-health
+
+# Show graph health with optional repair guidance notes
+openclaw engram graph-health --repair-guidance
 ```
 
 Operational safety notes:

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -33,6 +33,7 @@ import { TailscaleHelper, type TailscaleSyncOptions } from "./network/tailscale.
 import { WebDavServer } from "./network/webdav.js";
 import { runCompatChecks } from "./compat/checks.js";
 import type { CompatReport, CompatRunner } from "./compat/types.js";
+import { analyzeGraphHealth, type GraphHealthReport } from "./graph.js";
 
 interface CliApi {
   registerCli(
@@ -271,6 +272,14 @@ export interface ConversationIndexHealthCliOrchestrator {
   }>;
 }
 
+export interface GraphHealthCliCommandOptions {
+  memoryDir: string;
+  entityGraphEnabled?: boolean;
+  timeGraphEnabled?: boolean;
+  causalGraphEnabled?: boolean;
+  includeRepairGuidance?: boolean;
+}
+
 export interface TailscaleStatusCliCommandOptions {
   helper?: TailscaleHelperLike;
   timeoutMs?: number;
@@ -439,6 +448,17 @@ export async function runConversationIndexHealthCliCommand(
   };
 }> {
   return orchestrator.getConversationIndexHealth();
+}
+
+export async function runGraphHealthCliCommand(
+  options: GraphHealthCliCommandOptions,
+): Promise<GraphHealthReport> {
+  return analyzeGraphHealth(options.memoryDir, {
+    entityGraphEnabled: options.entityGraphEnabled,
+    timeGraphEnabled: options.timeGraphEnabled,
+    causalGraphEnabled: options.causalGraphEnabled,
+    includeRepairGuidance: options.includeRepairGuidance,
+  });
 }
 
 export async function runTailscaleStatusCliCommand(
@@ -1233,6 +1253,23 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         .action(async () => {
           const health = await runConversationIndexHealthCliCommand(orchestrator);
           console.log(JSON.stringify(health, null, 2));
+          console.log("OK");
+        });
+
+      cmd
+        .command("graph-health")
+        .description("Show graph edge-file integrity, node coverage, and corruption counts")
+        .option("--repair-guidance", "Include non-destructive repair guidance")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const report = await runGraphHealthCliCommand({
+            memoryDir: orchestrator.config.memoryDir,
+            entityGraphEnabled: orchestrator.config.entityGraphEnabled,
+            timeGraphEnabled: orchestrator.config.timeGraphEnabled,
+            causalGraphEnabled: orchestrator.config.causalGraphEnabled,
+            includeRepairGuidance: options.repairGuidance === true,
+          });
+          console.log(JSON.stringify(report, null, 2));
           console.log("OK");
         });
 

--- a/src/graph.ts
+++ b/src/graph.ts
@@ -101,6 +101,140 @@ export async function readAllEdges(
   return parts.flat();
 }
 
+export interface GraphHealthFileStats {
+  type: GraphType;
+  filePath: string;
+  exists: boolean;
+  totalLines: number;
+  validEdges: number;
+  corruptLines: number;
+  uniqueNodes: number;
+}
+
+export interface GraphHealthReport {
+  generatedAt: string;
+  enabledTypes: GraphType[];
+  totals: {
+    totalLines: number;
+    validEdges: number;
+    corruptLines: number;
+    uniqueNodes: number;
+  };
+  files: GraphHealthFileStats[];
+  repairGuidance?: string[];
+}
+
+function isValidGraphEdge(raw: unknown, expectedType: GraphType): raw is GraphEdge {
+  if (!raw || typeof raw !== "object") return false;
+  const edge = raw as Record<string, unknown>;
+  return (
+    edge.type === expectedType &&
+    typeof edge.from === "string" && edge.from.length > 0 &&
+    typeof edge.to === "string" && edge.to.length > 0 &&
+    typeof edge.weight === "number" && Number.isFinite(edge.weight) &&
+    typeof edge.label === "string" &&
+    typeof edge.ts === "string"
+  );
+}
+
+export async function analyzeGraphHealth(
+  memoryDir: string,
+  options?: {
+    entityGraphEnabled?: boolean;
+    timeGraphEnabled?: boolean;
+    causalGraphEnabled?: boolean;
+    includeRepairGuidance?: boolean;
+  },
+): Promise<GraphHealthReport> {
+  const enabledTypes: GraphType[] = [];
+  if (options?.entityGraphEnabled !== false) enabledTypes.push("entity");
+  if (options?.timeGraphEnabled !== false) enabledTypes.push("time");
+  if (options?.causalGraphEnabled !== false) enabledTypes.push("causal");
+
+  const files: GraphHealthFileStats[] = [];
+  const globalNodes = new Set<string>();
+
+  for (const type of enabledTypes) {
+    const filePath = graphFilePath(memoryDir, type);
+    let exists = true;
+    let totalLines = 0;
+    let validEdges = 0;
+    let corruptLines = 0;
+    const nodes = new Set<string>();
+
+    try {
+      const raw = await readFile(filePath, "utf8");
+      for (const line of raw.split("\n")) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        totalLines += 1;
+        try {
+          const parsed = JSON.parse(trimmed) as unknown;
+          if (!isValidGraphEdge(parsed, type)) {
+            corruptLines += 1;
+            continue;
+          }
+          validEdges += 1;
+          nodes.add(parsed.from);
+          nodes.add(parsed.to);
+          globalNodes.add(parsed.from);
+          globalNodes.add(parsed.to);
+        } catch {
+          corruptLines += 1;
+        }
+      }
+    } catch {
+      exists = false;
+    }
+
+    files.push({
+      type,
+      filePath,
+      exists,
+      totalLines,
+      validEdges,
+      corruptLines,
+      uniqueNodes: nodes.size,
+    });
+  }
+
+  const totals = files.reduce(
+    (acc, item) => {
+      acc.totalLines += item.totalLines;
+      acc.validEdges += item.validEdges;
+      acc.corruptLines += item.corruptLines;
+      return acc;
+    },
+    {
+      totalLines: 0,
+      validEdges: 0,
+      corruptLines: 0,
+      uniqueNodes: globalNodes.size,
+    },
+  );
+  totals.uniqueNodes = globalNodes.size;
+
+  const report: GraphHealthReport = {
+    generatedAt: new Date().toISOString(),
+    enabledTypes,
+    totals,
+    files,
+  };
+
+  if (options?.includeRepairGuidance === true) {
+    const guidance: string[] = [];
+    if (totals.corruptLines > 0) {
+      guidance.push("Corrupt graph lines detected: back up memory/state/graphs, then rebuild graphs from clean memory replay/extraction runs.");
+    }
+    if (totals.validEdges === 0) {
+      guidance.push("No valid edges detected yet: run normal extraction traffic (or replay ingestion) to seed graph files.");
+    }
+    if (guidance.length > 0) report.repairGuidance = guidance;
+  }
+
+  return report;
+}
+
 /**
  * Detect causal signal phrases in text. Returns the first matched phrase, or null.
  */

--- a/tests/cli-graph-health.test.ts
+++ b/tests/cli-graph-health.test.ts
@@ -1,0 +1,90 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdir, writeFile } from "node:fs/promises";
+import { runGraphHealthCliCommand } from "../src/cli.js";
+import { analyzeGraphHealth } from "../src/graph.js";
+
+function tmpDir(prefix: string): string {
+  return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
+}
+
+test("graph-health CLI wrapper reports integrity, coverage, and corruption counts", async () => {
+  const memoryDir = tmpDir("engram-graph-health");
+  const graphsDir = path.join(memoryDir, "state", "graphs");
+  await mkdir(graphsDir, { recursive: true });
+
+  const entityPath = path.join(graphsDir, "entity.jsonl");
+  await writeFile(
+    entityPath,
+    [
+      JSON.stringify({
+        from: "facts/2026-02-27/a.md",
+        to: "facts/2026-02-27/b.md",
+        type: "entity",
+        weight: 1,
+        label: "project",
+        ts: "2026-02-27T00:00:00.000Z",
+      }),
+      "not-json",
+      JSON.stringify({
+        from: "facts/2026-02-27/c.md",
+        to: "facts/2026-02-27/d.md",
+        type: "time",
+        weight: 1,
+        label: "thread",
+        ts: "2026-02-27T00:00:00.000Z",
+      }),
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+
+  const report = await runGraphHealthCliCommand({
+    memoryDir,
+    entityGraphEnabled: true,
+    timeGraphEnabled: false,
+    causalGraphEnabled: true,
+    includeRepairGuidance: true,
+  });
+
+  assert.deepEqual(report.enabledTypes, ["entity", "causal"]);
+  assert.equal(report.totals.totalLines, 3);
+  assert.equal(report.totals.validEdges, 1);
+  assert.equal(report.totals.corruptLines, 2);
+  assert.equal(report.totals.uniqueNodes, 2);
+
+  const entity = report.files.find((item) => item.type === "entity");
+  assert.ok(entity);
+  assert.equal(entity.exists, true);
+  assert.equal(entity.totalLines, 3);
+  assert.equal(entity.validEdges, 1);
+  assert.equal(entity.corruptLines, 2);
+  assert.equal(entity.uniqueNodes, 2);
+
+  const causal = report.files.find((item) => item.type === "causal");
+  assert.ok(causal);
+  assert.equal(causal.exists, false);
+
+  assert.ok(report.repairGuidance && report.repairGuidance.length > 0);
+  assert.match(report.repairGuidance![0], /Corrupt graph lines detected/i);
+});
+
+test("analyzeGraphHealth omits repair guidance unless requested", async () => {
+  const memoryDir = tmpDir("engram-graph-health-no-guidance");
+  const graphsDir = path.join(memoryDir, "state", "graphs");
+  await mkdir(graphsDir, { recursive: true });
+  await writeFile(path.join(graphsDir, "entity.jsonl"), "", "utf8");
+
+  const report = await analyzeGraphHealth(memoryDir, {
+    entityGraphEnabled: true,
+    timeGraphEnabled: false,
+    causalGraphEnabled: false,
+    includeRepairGuidance: false,
+  });
+
+  assert.deepEqual(report.enabledTypes, ["entity"]);
+  assert.equal(report.totals.validEdges, 0);
+  assert.equal(report.repairGuidance, undefined);
+});


### PR DESCRIPTION
## Summary
- add graph diagnostics analyzer in `src/graph.ts` for per-file integrity, corruption counts, and node coverage
- add CLI wrapper + command `openclaw engram graph-health` with optional `--repair-guidance`
- include non-destructive repair guidance messaging only when requested
- add `tests/cli-graph-health.test.ts`
- document command usage in operations docs

## Validation
- npm run check-types
- npm run check-config-contract
- npm run test -- tests/cli-graph-health.test.ts tests/graph.test.ts tests/cli-conversation-index-health.test.ts
- preflight hooks ran full suite + build during commit/push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, operator-only CLI diagnostics that reads existing graph JSONL files and reports stats; no write paths or security-sensitive logic changed.
> 
> **Overview**
> Adds a new graph diagnostics surface: `analyzeGraphHealth(...)` inspects enabled graph JSONL edge files and reports per-file existence, valid vs corrupt line counts, and unique-node coverage totals.
> 
> Exposes this via `openclaw engram graph-health` (optional `--repair-guidance`), with accompanying CLI wrapper, tests for corruption/guidance behavior, and updated ops docs + changelog entry.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8f707192c4c3fe961d44206b4af43ac31ab8ffc5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->