### PR TITLE
feat(v8.14): add tier migration/parity config contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,6 +94,10 @@ All notable changes to this project will be documented in this file.
   - Added conservative/balanced/research rollout preset guidance for action-policy and compression-learning settings.
   - Added operator hardening checklist for staged promotion and rollback order.
   - Documented disabled-path compatibility guarantees (`enabled=false` and zero-limit semantics remain hard disables).
+- v8.14 hot/cold parity Task 1 (tier-parity config contract):
+  - Added tier migration/parity config keys and defaults (`qmdTierMigrationEnabled`, demotion/promotion thresholds, parity toggles, auto-backfill flag).
+  - Added parser coverage in `tests/config-cold-qmd.test.ts` for defaults and explicit zero-preservation semantics.
+  - Updated plugin schema/UI surface and config reference documentation for the new tier controls.
 - v8.13 action-policy Task 2 (deterministic evaluator + orchestration traces):
   - Added `src/memory-action-policy.ts` with deterministic `allow|defer|deny` evaluation and explicit rationale precedence.
   - Integrated policy evaluation into orchestrator action-event ingestion so policy decisions run before action telemetry is persisted.

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -167,6 +167,18 @@ Disabled-path compatibility guarantees:
 - `maxCompressionTokensPerHour=0` remains a hard disable (no implicit non-zero coercion).
 - `compressionGuidelineLearningEnabled=false` keeps consolidation behavior baseline-equivalent.
 
+## v8.14 Hot/Cold Tier Parity + Migration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `qmdTierMigrationEnabled` | `false` | Enable value-aware migration between hot and cold QMD tiers. |
+| `qmdTierDemotionMinAgeDays` | `14` | Minimum age (days) before a hot memory can be considered for demotion. |
+| `qmdTierDemotionValueThreshold` | `0.35` | Value threshold at/below which hot memories are eligible for cold demotion. |
+| `qmdTierPromotionValueThreshold` | `0.7` | Value threshold at/above which cold memories are eligible for hot promotion. |
+| `qmdTierParityGraphEnabled` | `true` | Keep graph-assist behavior parity between hot and cold retrieval paths. |
+| `qmdTierParityHiMemEnabled` | `true` | Keep HiMem episode/note handling parity between hot and cold retrieval paths. |
+| `qmdTierAutoBackfillEnabled` | `false` | Enable automated cold-tier parity backfill jobs. |
+
 ## Local LLM / OpenAI-Compatible Endpoint
 
 | Setting | Default | Description |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -85,6 +85,41 @@
         "default": 8,
         "description": "Max cold-tier QMD results considered before final recall cap"
       },
+      "qmdTierMigrationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable value-aware migration between hot and cold QMD tiers"
+      },
+      "qmdTierDemotionMinAgeDays": {
+        "type": "number",
+        "default": 14,
+        "description": "Minimum hot-memory age in days before tier demotion is eligible"
+      },
+      "qmdTierDemotionValueThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "description": "Value-score threshold at or below which hot memories are eligible for cold demotion"
+      },
+      "qmdTierPromotionValueThreshold": {
+        "type": "number",
+        "default": 0.7,
+        "description": "Value-score threshold at or above which cold memories are eligible for hot promotion"
+      },
+      "qmdTierParityGraphEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply graph-assist parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierParityHiMemEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply HiMem episode/note parity checks across hot and cold retrieval tiers"
+      },
+      "qmdTierAutoBackfillEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow automated cold-tier backfill jobs to repair parity gaps"
+      },
       "embeddingFallbackEnabled": {
         "type": "boolean",
         "default": true,
@@ -1388,6 +1423,39 @@
       "label": "Cold QMD Max Results",
       "advanced": true,
       "placeholder": "8"
+    },
+    "qmdTierMigrationEnabled": {
+      "label": "Enable Tier Migration",
+      "advanced": true,
+      "help": "Enable value-aware hot/cold migration controls"
+    },
+    "qmdTierDemotionMinAgeDays": {
+      "label": "Tier Demotion Min Age Days",
+      "advanced": true,
+      "placeholder": "14"
+    },
+    "qmdTierDemotionValueThreshold": {
+      "label": "Tier Demotion Value Threshold",
+      "advanced": true,
+      "placeholder": "0.35"
+    },
+    "qmdTierPromotionValueThreshold": {
+      "label": "Tier Promotion Value Threshold",
+      "advanced": true,
+      "placeholder": "0.7"
+    },
+    "qmdTierParityGraphEnabled": {
+      "label": "Tier Parity Graph Checks",
+      "advanced": true
+    },
+    "qmdTierParityHiMemEnabled": {
+      "label": "Tier Parity HiMem Checks",
+      "advanced": true
+    },
+    "qmdTierAutoBackfillEnabled": {
+      "label": "Tier Auto Backfill",
+      "advanced": true,
+      "help": "Enable automated cold-tier backfill runs for parity repair"
     },
     "embeddingFallbackEnabled": {
       "label": "Embedding Fallback",

--- a/src/config.ts
+++ b/src/config.ts
@@ -230,6 +230,22 @@ export function parseConfig(raw: unknown): PluginConfig {
         : "openclaw-engram-cold",
     qmdColdMaxResults:
       typeof cfg.qmdColdMaxResults === "number" ? cfg.qmdColdMaxResults : 8,
+    qmdTierMigrationEnabled: cfg.qmdTierMigrationEnabled === true,
+    qmdTierDemotionMinAgeDays:
+      typeof cfg.qmdTierDemotionMinAgeDays === "number"
+        ? Math.max(0, Math.floor(cfg.qmdTierDemotionMinAgeDays))
+        : 14,
+    qmdTierDemotionValueThreshold:
+      typeof cfg.qmdTierDemotionValueThreshold === "number"
+        ? Math.max(0, Math.min(1, cfg.qmdTierDemotionValueThreshold))
+        : 0.35,
+    qmdTierPromotionValueThreshold:
+      typeof cfg.qmdTierPromotionValueThreshold === "number"
+        ? Math.max(0, Math.min(1, cfg.qmdTierPromotionValueThreshold))
+        : 0.7,
+    qmdTierParityGraphEnabled: cfg.qmdTierParityGraphEnabled !== false,
+    qmdTierParityHiMemEnabled: cfg.qmdTierParityHiMemEnabled !== false,
+    qmdTierAutoBackfillEnabled: cfg.qmdTierAutoBackfillEnabled === true,
     embeddingFallbackEnabled: cfg.embeddingFallbackEnabled !== false,
     embeddingFallbackProvider:
       cfg.embeddingFallbackProvider === "openai"

--- a/src/types.ts
+++ b/src/types.ts
@@ -66,6 +66,13 @@ export interface PluginConfig {
   qmdColdTierEnabled?: boolean;
   qmdColdCollection?: string;
   qmdColdMaxResults?: number;
+  qmdTierMigrationEnabled: boolean;
+  qmdTierDemotionMinAgeDays: number;
+  qmdTierDemotionValueThreshold: number;
+  qmdTierPromotionValueThreshold: number;
+  qmdTierParityGraphEnabled: boolean;
+  qmdTierParityHiMemEnabled: boolean;
+  qmdTierAutoBackfillEnabled: boolean;
   embeddingFallbackEnabled: boolean;
   embeddingFallbackProvider: "auto" | "openai" | "local";
   /** Optional absolute path to qmd binary. If unset, PATH/fallback discovery is used. */

--- a/tests/config-cold-qmd.test.ts
+++ b/tests/config-cold-qmd.test.ts
@@ -7,6 +7,13 @@ test("parseConfig sets cold QMD tier defaults", () => {
   assert.equal(cfg.qmdColdTierEnabled, false);
   assert.equal(cfg.qmdColdCollection, "openclaw-engram-cold");
   assert.equal(cfg.qmdColdMaxResults, 8);
+  assert.equal(cfg.qmdTierMigrationEnabled, false);
+  assert.equal(cfg.qmdTierDemotionMinAgeDays, 14);
+  assert.equal(cfg.qmdTierDemotionValueThreshold, 0.35);
+  assert.equal(cfg.qmdTierPromotionValueThreshold, 0.7);
+  assert.equal(cfg.qmdTierParityGraphEnabled, true);
+  assert.equal(cfg.qmdTierParityHiMemEnabled, true);
+  assert.equal(cfg.qmdTierAutoBackfillEnabled, false);
   assert.equal(cfg.cronRecallMode, "all");
   assert.deepEqual(cfg.cronRecallAllowlist, []);
   assert.equal(cfg.cronRecallPolicyEnabled, true);
@@ -21,10 +28,24 @@ test("parseConfig preserves explicit cold QMD settings including zero", () => {
     qmdColdTierEnabled: true,
     qmdColdCollection: "engram-cold-custom",
     qmdColdMaxResults: 0,
+    qmdTierMigrationEnabled: true,
+    qmdTierDemotionMinAgeDays: 0,
+    qmdTierDemotionValueThreshold: 0,
+    qmdTierPromotionValueThreshold: 0,
+    qmdTierParityGraphEnabled: false,
+    qmdTierParityHiMemEnabled: false,
+    qmdTierAutoBackfillEnabled: true,
   });
   assert.equal(cfg.qmdColdTierEnabled, true);
   assert.equal(cfg.qmdColdCollection, "engram-cold-custom");
   assert.equal(cfg.qmdColdMaxResults, 0);
+  assert.equal(cfg.qmdTierMigrationEnabled, true);
+  assert.equal(cfg.qmdTierDemotionMinAgeDays, 0);
+  assert.equal(cfg.qmdTierDemotionValueThreshold, 0);
+  assert.equal(cfg.qmdTierPromotionValueThreshold, 0);
+  assert.equal(cfg.qmdTierParityGraphEnabled, false);
+  assert.equal(cfg.qmdTierParityHiMemEnabled, false);
+  assert.equal(cfg.qmdTierAutoBackfillEnabled, true);
 });
 
 test("parseConfig supports cron recall allowlist mode", () => {


### PR DESCRIPTION
## Summary
- add v8.14 tier migration/parity config keys to runtime contract and parser defaults
- preserve explicit zero semantics for applicable tier controls
- extend plugin schema/UI fields and config docs for the new controls

## Tests
- npx tsx --test tests/config-cold-qmd.test.ts
- npm run -s check-types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: additive config/schema/docs updates plus parser defaulting/clamping; main risk is only to callers that construct `PluginConfig` objects manually due to new required fields.
> 
> **Overview**
> Adds the v8.14 hot/cold QMD tier migration + parity configuration surface (migration enable flag, demotion/promotion thresholds, parity toggles, and optional auto-backfill) to the runtime `PluginConfig` contract and `parseConfig` defaults/clamping (including preserving explicit `0` and explicit `false`).
> 
> Updates the plugin manifest UI/schema and `docs/config-reference.md` to document the new settings, and extends `tests/config-cold-qmd.test.ts` to cover defaults and zero-preservation semantics; changelog entry added.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 43b022cc8505e2f0a020f4200685f0ca585e9275. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->