### PR TITLE
feat: ingest corrections/preferences into behavior signal ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,11 @@ All notable changes to this project will be documented in this file.
   - Added behavior-loop auto-tuning config keys with bounded defaults and explicit zero-safe parsing semantics.
   - Added typed behavior-loop policy contracts in `src/types.ts` and corresponding Zod schemas in `src/schemas.ts`.
   - Extended `tests/config-proactive-policy.test.ts` to cover defaults, explicit zero overrides, and numeric clamping for behavior-loop settings.
+- v8.15 behavior-loop Task 2 (signal ingestion pipeline):
+  - Added `src/behavior-signals.ts` for correction/preference signal normalization and deterministic dedupe keys.
+  - Added append-only behavior signal ledger support in storage (`state/behavior-signals.jsonl`) with fail-open reads and persisted dedupe by `memoryId+signalHash`.
+  - Wired extraction persistence to emit namespace-safe correction/preference behavior signals per target storage namespace.
+  - Added `tests/behavior-signals.test.ts` and expanded `tests/storage-policy-state.test.ts` for signal generation, timestamp/namespace safety, and dedupe invariants.
 - v8.8 network sync Task 1 (WebDAV module):
   - Added `src/network/webdav.ts` with opt-in `WebDavServer` startup (`enabled=false` by default).
   - Added strict allowlist path scoping so requests are limited to explicit root aliases and traversal escapes are rejected.

--- a/src/behavior-signals.ts
+++ b/src/behavior-signals.ts
@@ -1,0 +1,73 @@
+import { createHash } from "node:crypto";
+import type { BehaviorSignalEvent, MemoryCategory } from "./types.js";
+
+function normalizeSignalText(input: string): string {
+  return input.replace(/\s+/g, " ").trim().toLowerCase();
+}
+
+export function buildBehaviorSignalHash(category: MemoryCategory, content: string): string {
+  const normalized = `${category}:${normalizeSignalText(content)}`;
+  return createHash("sha256").update(normalized).digest("hex").slice(0, 16);
+}
+
+export function buildBehaviorSignalsForMemory(input: {
+  memoryId: string;
+  category: MemoryCategory;
+  content: string;
+  namespace: string;
+  confidence: number;
+  timestamp?: string;
+  source?: "extraction" | "correction";
+}): BehaviorSignalEvent[] {
+  const timestamp = input.timestamp ?? new Date().toISOString();
+  const signalHash = buildBehaviorSignalHash(input.category, input.content);
+  const source = input.source ?? "extraction";
+
+  if (input.category === "correction") {
+    return [
+      {
+        timestamp,
+        namespace: input.namespace,
+        memoryId: input.memoryId,
+        category: "correction",
+        signalType: "correction_override",
+        direction: "negative",
+        confidence: input.confidence,
+        signalHash,
+        source,
+      },
+    ];
+  }
+
+  if (input.category === "preference") {
+    return [
+      {
+        timestamp,
+        namespace: input.namespace,
+        memoryId: input.memoryId,
+        category: "preference",
+        signalType: "preference_affinity",
+        direction: "positive",
+        confidence: input.confidence,
+        signalHash,
+        source,
+      },
+    ];
+  }
+
+  return [];
+}
+
+export function dedupeBehaviorSignalsByMemoryAndHash(
+  signals: BehaviorSignalEvent[],
+): BehaviorSignalEvent[] {
+  const seen = new Set<string>();
+  const out: BehaviorSignalEvent[] = [];
+  for (const signal of signals) {
+    const key = `${signal.memoryId}:${signal.signalHash}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(signal);
+  }
+  return out;
+}

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -91,8 +91,13 @@ import { TierMigrationExecutor } from "./tier-migration.js";
 import { decideTierTransition, type MemoryTier } from "./tier-routing.js";
 import { selectRouteRule, type RouteRule, type RoutingEngineOptions } from "./routing/engine.js";
 import { RoutingRulesStore } from "./routing/store.js";
+import {
+  buildBehaviorSignalsForMemory,
+  dedupeBehaviorSignalsByMemoryAndHash,
+} from "./behavior-signals.js";
 import type {
   AccessTrackingEntry,
+  BehaviorSignalEvent,
   BootstrapOptions,
   BootstrapResult,
   BufferTurn,
@@ -3145,6 +3150,17 @@ export class Orchestrator {
       persistedIdsByStorage.set(key, { storage: targetStorage, ids: [id] });
     };
     let dedupedCount = 0;
+    const behaviorSignalsByStorage = new Map<string, { storage: StorageManager; events: BehaviorSignalEvent[] }>();
+    const trackBehaviorSignals = (targetStorage: StorageManager, events: BehaviorSignalEvent[]): void => {
+      if (events.length === 0) return;
+      const key = targetStorage.dir;
+      const existing = behaviorSignalsByStorage.get(key);
+      if (existing) {
+        existing.events.push(...events);
+        return;
+      }
+      behaviorSignalsByStorage.set(key, { storage: targetStorage, events: [...events] });
+    };
 
     // Defensive: validate result and facts array
     if (!result || !Array.isArray(result.facts)) {
@@ -3390,6 +3406,17 @@ export class Orchestrator {
               graphContext.previousPersistedRelPath = parentRelPath;
             } catch { /* fail-open */ }
           }
+          trackBehaviorSignals(
+            targetStorage,
+            buildBehaviorSignalsForMemory({
+              memoryId: parentId,
+              category: writeCategory,
+              content: fact.content,
+              namespace: this.namespaceFromStorageDir(targetStorage.dir),
+              confidence: fact.confidence,
+              source: "extraction",
+            }),
+          );
           continue; // Skip the normal write below
         }
       }
@@ -3463,6 +3490,17 @@ export class Orchestrator {
           `routing applied for memory ${memoryId}: rule=${routedRuleId} category=${writeCategory} storage=${targetStorage.dir}`,
         );
       }
+      trackBehaviorSignals(
+        targetStorage,
+        buildBehaviorSignalsForMemory({
+          memoryId,
+          category: writeCategory,
+          content: fact.content,
+          namespace: this.namespaceFromStorageDir(targetStorage.dir),
+          confidence: fact.confidence,
+          source: "extraction",
+        }),
+      );
       trackPersistedId(targetStorage, memoryId);
       if (threadEpisodeIdsForGraph && !threadEpisodeIdsForGraph.includes(memoryId)) {
         threadEpisodeIdsForGraph.push(memoryId);
@@ -3600,6 +3638,14 @@ export class Orchestrator {
       await this.contentHashIndex.save().catch((err) =>
         log.warn(`content-hash index save failed: ${err}`),
       );
+    }
+
+    for (const { storage: targetStorage, events } of behaviorSignalsByStorage.values()) {
+      const dedupedSignals = dedupeBehaviorSignalsByMemoryAndHash(events);
+      if (dedupedSignals.length === 0) continue;
+      await targetStorage
+        .appendBehaviorSignals(dedupedSignals)
+        .catch((err) => log.warn(`appendBehaviorSignals failed (non-fatal): ${err}`));
     }
 
     const dedupSuffix = dedupedCount > 0 ? ` (${dedupedCount} deduped)` : "";

--- a/src/storage.ts
+++ b/src/storage.ts
@@ -29,6 +29,7 @@ import type {
   PolicyClass,
   MemoryStatus,
   MemoryActionEvent,
+  BehaviorSignalEvent,
   MemorySummary,
   MetaState,
   CompressionGuidelineOptimizerState,
@@ -728,6 +729,9 @@ export class StorageManager {
   }
   private get compressionGuidelineStatePath(): string {
     return path.join(this.stateDir, "compression-guideline-state.json");
+  }
+  private get behaviorSignalsPath(): string {
+    return path.join(this.stateDir, "behavior-signals.jsonl");
   }
 
   /**
@@ -1568,6 +1572,84 @@ export class StorageManager {
 
     await appendFile(this.memoryActionsPath, payload, "utf-8");
     return events.length;
+  }
+
+  async appendBehaviorSignals(events: BehaviorSignalEvent[]): Promise<number> {
+    if (events.length === 0) return 0;
+    await this.ensureDirectories();
+
+    let existingKeys = new Set<string>();
+    try {
+      const raw = await readFile(this.behaviorSignalsPath, "utf-8");
+      const lines = raw.split("\n");
+      for (const line of lines) {
+        const row = line.trim();
+        if (!row) continue;
+        try {
+          const parsed = JSON.parse(row) as Partial<BehaviorSignalEvent>;
+          if (typeof parsed.memoryId === "string" && typeof parsed.signalHash === "string") {
+            existingKeys.add(`${parsed.memoryId}:${parsed.signalHash}`);
+          }
+        } catch {
+          // Ignore malformed rows (fail-open).
+        }
+      }
+    } catch {
+      existingKeys = new Set<string>();
+    }
+
+    const nowIso = new Date().toISOString();
+    const deduped: BehaviorSignalEvent[] = [];
+    for (const event of events) {
+      const key = `${event.memoryId}:${event.signalHash}`;
+      if (existingKeys.has(key)) continue;
+      existingKeys.add(key);
+      deduped.push({
+        ...event,
+        timestamp: event.timestamp && event.timestamp.length > 0 ? event.timestamp : nowIso,
+      });
+    }
+
+    if (deduped.length === 0) return 0;
+    const payload = deduped.map((event) => `${JSON.stringify(event)}\n`).join("");
+    await appendFile(this.behaviorSignalsPath, payload, "utf-8");
+    return deduped.length;
+  }
+
+  async readBehaviorSignals(limit: number = 200): Promise<BehaviorSignalEvent[]> {
+    const cappedLimit = Math.max(0, Math.floor(limit));
+    if (cappedLimit === 0) return [];
+
+    try {
+      const raw = await readFile(this.behaviorSignalsPath, "utf-8");
+      const out: BehaviorSignalEvent[] = [];
+      const lines = raw.split("\n");
+      for (let i = lines.length - 1; i >= 0 && out.length < cappedLimit; i -= 1) {
+        const row = lines[i]?.trim();
+        if (!row) continue;
+        try {
+          const parsed = JSON.parse(row) as Partial<BehaviorSignalEvent>;
+          if (
+            typeof parsed.timestamp === "string" &&
+            typeof parsed.namespace === "string" &&
+            typeof parsed.memoryId === "string" &&
+            typeof parsed.category === "string" &&
+            typeof parsed.signalType === "string" &&
+            typeof parsed.direction === "string" &&
+            typeof parsed.confidence === "number" &&
+            typeof parsed.signalHash === "string" &&
+            typeof parsed.source === "string"
+          ) {
+            out.push(parsed as BehaviorSignalEvent);
+          }
+        } catch {
+          // Ignore malformed rows (fail-open).
+        }
+      }
+      return out.reverse();
+    } catch {
+      return [];
+    }
   }
 
   async readMemoryActionEvents(limit: number = 200): Promise<MemoryActionEvent[]> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -456,6 +456,21 @@ export interface BehaviorLoopPolicyState {
   updatedAt: string;
 }
 
+export type BehaviorSignalType = "correction_override" | "preference_affinity";
+export type BehaviorSignalDirection = "positive" | "negative";
+
+export interface BehaviorSignalEvent {
+  timestamp: string;
+  namespace: string;
+  memoryId: string;
+  category: Extract<MemoryCategory, "correction" | "preference">;
+  signalType: BehaviorSignalType;
+  direction: BehaviorSignalDirection;
+  confidence: number;
+  signalHash: string;
+  source: "extraction" | "correction";
+}
+
 /** Memory status for lifecycle management */
 export type MemoryStatus = "active" | "superseded" | "archived";
 export type LifecycleState = "candidate" | "validated" | "active" | "stale" | "archived";

--- a/tests/behavior-signals.test.ts
+++ b/tests/behavior-signals.test.ts
@@ -1,0 +1,80 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildBehaviorSignalHash,
+  buildBehaviorSignalsForMemory,
+  dedupeBehaviorSignalsByMemoryAndHash,
+} from "../src/behavior-signals.ts";
+
+test("corrections generate negative override signals", () => {
+  const signals = buildBehaviorSignalsForMemory({
+    memoryId: "correction-1",
+    category: "correction",
+    content: "Actually, use PostgreSQL 15 not 14.",
+    namespace: "default",
+    confidence: 0.98,
+    timestamp: "2026-02-28T00:00:00.000Z",
+  });
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0]?.signalType, "correction_override");
+  assert.equal(signals[0]?.direction, "negative");
+});
+
+test("preferences generate positive affinity signals", () => {
+  const signals = buildBehaviorSignalsForMemory({
+    memoryId: "preference-1",
+    category: "preference",
+    content: "I prefer concise replies.",
+    namespace: "default",
+    confidence: 0.9,
+    timestamp: "2026-02-28T00:00:00.000Z",
+  });
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0]?.signalType, "preference_affinity");
+  assert.equal(signals[0]?.direction, "positive");
+});
+
+test("duplicate correction signals dedupe by memory id + signal hash", () => {
+  const signalHash = buildBehaviorSignalHash("correction", "Same correction content");
+  const deduped = dedupeBehaviorSignalsByMemoryAndHash([
+    {
+      timestamp: "2026-02-28T00:00:00.000Z",
+      namespace: "default",
+      memoryId: "correction-1",
+      category: "correction",
+      signalType: "correction_override",
+      direction: "negative",
+      confidence: 0.8,
+      signalHash,
+      source: "extraction",
+    },
+    {
+      timestamp: "2026-02-28T00:01:00.000Z",
+      namespace: "default",
+      memoryId: "correction-1",
+      category: "correction",
+      signalType: "correction_override",
+      direction: "negative",
+      confidence: 0.8,
+      signalHash,
+      source: "extraction",
+    },
+  ]);
+
+  assert.equal(deduped.length, 1);
+});
+
+test("signals are namespace-safe and timestamped", () => {
+  const signals = buildBehaviorSignalsForMemory({
+    memoryId: "preference-2",
+    category: "preference",
+    content: "Please route this to shared",
+    namespace: "shared",
+    confidence: 0.85,
+    timestamp: "2026-02-28T10:00:00.000Z",
+  });
+
+  assert.equal(signals.length, 1);
+  assert.equal(signals[0]?.namespace, "shared");
+  assert.equal(signals[0]?.timestamp, "2026-02-28T10:00:00.000Z");
+});

--- a/tests/storage-policy-state.test.ts
+++ b/tests/storage-policy-state.test.ts
@@ -151,3 +151,86 @@ test("StorageManager readCompressionGuidelineOptimizerState returns null when st
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("StorageManager appends and reads behavior signals from state store", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-behavior-signals-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const wrote = await storage.appendBehaviorSignals([
+      {
+        timestamp: "2026-02-28T00:00:00.000Z",
+        namespace: "default",
+        memoryId: "correction-1",
+        category: "correction",
+        signalType: "correction_override",
+        direction: "negative",
+        confidence: 0.95,
+        signalHash: "abc123",
+        source: "extraction",
+      },
+      {
+        timestamp: "2026-02-28T00:01:00.000Z",
+        namespace: "default",
+        memoryId: "preference-1",
+        category: "preference",
+        signalType: "preference_affinity",
+        direction: "positive",
+        confidence: 0.88,
+        signalHash: "def456",
+        source: "extraction",
+      },
+    ]);
+
+    assert.equal(wrote, 2);
+    const loaded = await storage.readBehaviorSignals(10);
+    assert.equal(loaded.length, 2);
+    assert.equal(loaded[0]?.memoryId, "correction-1");
+    assert.equal(loaded[1]?.memoryId, "preference-1");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager dedupes behavior signals by memory id + signal hash", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-behavior-dedupe-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const first = await storage.appendBehaviorSignals([
+      {
+        timestamp: "2026-02-28T00:00:00.000Z",
+        namespace: "default",
+        memoryId: "correction-1",
+        category: "correction",
+        signalType: "correction_override",
+        direction: "negative",
+        confidence: 0.95,
+        signalHash: "same",
+        source: "extraction",
+      },
+    ]);
+    const second = await storage.appendBehaviorSignals([
+      {
+        timestamp: "2026-02-28T00:05:00.000Z",
+        namespace: "default",
+        memoryId: "correction-1",
+        category: "correction",
+        signalType: "correction_override",
+        direction: "negative",
+        confidence: 0.95,
+        signalHash: "same",
+        source: "extraction",
+      },
+    ]);
+
+    assert.equal(first, 1);
+    assert.equal(second, 0);
+    const loaded = await storage.readBehaviorSignals(10);
+    assert.equal(loaded.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- add behavior signal normalization helpers for correction and preference memories
- add append-only `state/behavior-signals.jsonl` storage APIs with persisted dedupe by `memoryId+signalHash`
- wire extraction persistence to emit namespace-safe behavior signals per target storage namespace
- add tests for signal generation semantics and storage dedupe/reads

## Tests
- `npx tsx --test tests/behavior-signals.test.ts tests/storage-policy-state.test.ts`
- `npm run check-types`
- preflight hooks (quick/full) during commit and push

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the extraction write path and introduces new persisted JSONL state with read-before-append dedupe, which could impact performance or storage behavior if bugs slip through. Changes are largely additive and fail-open, but affect core persistence flow.
> 
> **Overview**
> Adds a new behavior-signal pipeline that converts `correction` and `preference` memories into normalized `BehaviorSignalEvent`s with deterministic hashes (`src/behavior-signals.ts`).
> 
> Extends persistence to write these events to an append-only ledger at `state/behavior-signals.jsonl`, including in-process and persisted dedupe by `memoryId+signalHash`, and fail-open read/append handling (`StorageManager.appendBehaviorSignals`/`readBehaviorSignals`).
> 
> Wires `persistExtraction(...)` to emit and batch behavior signals per target storage namespace (including routed/chunked writes), and adds tests covering signal semantics, namespace/timestamp safety, and storage dedupe/round-trip.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4829533a1c3bf2cbaad6c88ec26dd8e5cb470c9b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->