### PR TITLE
docs: harden behavior-loop rollout and review checklist (v8.15 task 6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,10 @@ All notable changes to this project will be documented in this file.
   - Added runtime policy snapshot/diff helpers with evidence counts and top contributing behavior-signal summaries.
   - Added per-turn recall telemetry policy version tagging in recall summary events and last-recall impressions.
   - Added `tests/cli-policy-tuning.test.ts` and expanded `tests/recall-telemetry.test.ts` for policy-version and CLI report coverage.
+- v8.15 behavior-loop Task 6 (guardrails + rollout hardening docs):
+  - Added explicit behavior-loop hardening checklist to `docs/ops/pr-review-hardening-playbook.md` (artifact isolation, cap-after-filter ordering, config contract, planner mode reachability, and policy-version parity).
+  - Added v8.15 auto-tuning rollout guidance and operator command runbook to `docs/setup-config-tuning.md`.
+  - Documented rollback-first operator guidance for regression handling during behavior-loop rollout.
 - v8.8 network sync Task 1 (WebDAV module):
   - Added `src/network/webdav.ts` with opt-in `WebDavServer` startup (`enabled=false` by default).
   - Added strict allowlist path scoping so requests are limited to explicit root aliases and traversal escapes are rejected.

--- a/docs/ops/pr-review-hardening-playbook.md
+++ b/docs/ops/pr-review-hardening-playbook.md
@@ -134,6 +134,30 @@ Regex/heuristic classifiers must support common language variants and avoid malf
 10. TTL correctness:
 Cache `loadedAt` timestamps must represent completion time of cache rebuild, not start time.
 
+## v8.15 Behavior-Loop Hardening Checklist
+
+Use this checklist for PRs that touch behavior-loop auto-tuning, runtime policy application, or policy observability paths.
+
+1. Artifact isolation preserved:
+- Generic QMD/embedding recall paths must continue excluding `artifacts/`.
+- Artifact recall must stay isolated to dedicated verbatim artifact paths.
+
+2. Cap-after-filter preserved:
+- Retrieval order must remain `headroom -> filter -> rerank/boost -> cap -> format`.
+- Any top-K limits exposed to users must be applied after policy/path/status filtering.
+
+3. Config contract preserved (`enabled=false` and `0` limits):
+- `behaviorLoopAutoTuneEnabled=false` remains a hard disable (no learner apply side effects).
+- Numeric `0` values remain explicit hard caps/disables and are never coerced to non-zero defaults.
+
+4. Planner mode semantics unchanged:
+- `no_recall`, `minimal`, `full`, and `graph_mode` must remain reachable.
+- `no_recall` must still gate all recall fallbacks.
+- `minimal` mode recall budgets must remain bounded.
+
+5. Policy version parity:
+- Policy version shown by CLI (`policy-status` / `policy-diff`) must match policy version emitted in recall telemetry for the same effective runtime policy values.
+
 ## Required Tests for These Changes
 
 When relevant, add tests for:

--- a/docs/setup-config-tuning.md
+++ b/docs/setup-config-tuning.md
@@ -191,6 +191,44 @@ Operator hardening checklist before promotion:
 - If regressions appear, first disable `compressionGuidelineSemanticRefinementEnabled`, then disable `compressionGuidelineLearningEnabled`.
 - Confirm disabled-path behavior by toggling all action-policy features off and verifying recall outputs remain baseline-equivalent.
 
+## 2e) v8.15 Behavior-Loop Auto-Tuning Rollout
+
+Keep behavior-loop learning disabled by default, then enable in stages:
+
+```jsonc
+{
+  "behaviorLoopAutoTuneEnabled": false,
+  "behaviorLoopLearningWindowDays": 14,
+  "behaviorLoopMinSignalCount": 10,
+  "behaviorLoopMaxDeltaPerCycle": 0.1,
+  "behaviorLoopProtectedParams": [
+    "qmdMaxResults",
+    "maxMemoryTokens",
+    "verbatimArtifactsMaxRecall",
+    "cronRecallInstructionHeavyTokenCap"
+  ]
+}
+```
+
+Recommended rollout:
+- Stage 1 (observe only): keep `behaviorLoopAutoTuneEnabled=false` and monitor `policy-status`/`policy-diff` outputs.
+- Stage 2 (canary namespace): enable auto-tune for a low-risk namespace and monitor policy stability for at least one full cycle.
+- Stage 3 (broader rollout): expand only after policy changes are bounded, stable, and rollback rate stays low.
+
+Operational guardrails:
+- Treat `behaviorLoopAutoTuneEnabled=false` as a hard disable.
+- Treat numeric `0` limits as intentional hard caps/disables; do not rely on implicit coercion.
+- Preserve planner mode behavior (`no_recall`, `minimal`, `full`, `graph_mode`) during rollout verification.
+- If recall quality regresses, run `openclaw engram policy-rollback` and disable auto-tune before further changes.
+
+Policy observability commands:
+
+```bash
+openclaw engram policy-status
+openclaw engram policy-diff --since 7d
+openclaw engram policy-rollback
+```
+
 Conversation index health check command:
 
 ```bash


### PR DESCRIPTION
## Summary
- add explicit v8.15 behavior-loop hardening checklist to the PR review playbook
- add v8.15 auto-tuning rollout guidance and operator commands to setup/tuning docs
- add changelog entry for v8.15 task 6 docs hardening slice

## Verification
- npm run check-types
- npm test
- npm run build
- npm run preflight:quick

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates (no runtime logic changes), mainly affecting reviewer/operator guidance.
> 
> **Overview**
> Adds a **v8.15 behavior-loop hardening checklist** to the PR review playbook, codifying invariants like artifact isolation, cap-after-filter ordering, zero/disabled config semantics, planner-mode reachability, and CLI/telemetry policy-version parity.
> 
> Extends the setup/tuning runbook with **staged rollout guidance** for behavior-loop auto-tuning, including recommended config defaults, operator guardrails, and rollback-first usage of `openclaw engram policy-status`, `policy-diff`, and `policy-rollback`. Updates `CHANGELOG.md` to note the v8.15 Task 6 docs slice.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 595a2061fe9d7d9c8435048a06ea8f531176d58f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->