### PR TITLE
fix: suppress thinking mode on fast-tier local LLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fallback contradiction verification, link suggestion, and memory summarization now normalize gateway/local LLM JSON aliases the same way as the direct OpenAI client, so `winner`, `type`, `summary`, and `entities` responses continue to work without an OpenAI API key.
 - **local-llm**: Read `reasoning_content` when `content` is empty — fixes thinking models (e.g. Qwen 3.5) returning null for entity summaries, consolidation, and question generation.
+- **fast-tier thinking suppression**: fast LLM client now sends `chat_template_kwargs: { enable_thinking: false }` to suppress chain-of-thought on thinking models (e.g. Qwen 3.5 small series). Prevents fast-tier operations from timing out when LM Studio forces thinking mode via chat template.
 - Add explicit `encoding_format: "float"` to local embedding requests for vLLM/LiteLLM compatibility.
 - Enrich extraction prompt few-shot examples with `entityRef` and entity `facts` fields, using realistic concrete values instead of generic placeholders.
 

--- a/src/local-llm.ts
+++ b/src/local-llm.ts
@@ -78,12 +78,22 @@ export class LocalLlmClient {
   private consecutive400s: number = 0;
   private cooldownUntilMs: number = 0;
   private modelRegistry?: ModelRegistry;
+  private _disableThinking: boolean = false;
   private static readonly HEALTH_CHECK_INTERVAL_MS = 60000; // 1 minute
   private static readonly LMS_CACHE_INTERVAL_MS = 30000; // 30 seconds
 
   constructor(config: PluginConfig, modelRegistry?: ModelRegistry) {
     this.config = config;
     this.modelRegistry = modelRegistry;
+  }
+
+  /**
+   * Disable thinking/reasoning mode for models that support it (e.g. Qwen 3.5).
+   * When enabled, adds chat_template_kwargs to suppress chain-of-thought,
+   * reducing latency for fast-tier operations.
+   */
+  set disableThinking(value: boolean) {
+    this._disableThinking = value;
   }
 
   private resolveHomeDir(): string {
@@ -706,6 +716,13 @@ export class LocalLlmClient {
       // Only send if it's json_schema type which some local LLMs support
       if (options.responseFormat?.type === "json_schema") {
         requestBody.response_format = options.responseFormat;
+      }
+
+      // Suppress thinking/reasoning for fast-tier models (e.g. Qwen 3.5 small).
+      // These models default to non-thinking but LM Studio may force thinking via
+      // chat template. Sending this kwarg explicitly disables it.
+      if (this._disableThinking) {
+        requestBody.chat_template_kwargs = { enable_thinking: false };
       }
 
       // Normalize URL (use 127.0.0.1 instead of localhost)

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -717,10 +717,14 @@ export class Orchestrator {
     this.summarizer = new HourlySummarizer(config, config.gatewayConfig, this.modelRegistry, this.transcript);
     this.localLlm = new LocalLlmClient(config, this.modelRegistry);
     this.fastLlm = config.localLlmFastEnabled
-      ? new LocalLlmClient(
-          { ...config, localLlmModel: config.localLlmFastModel || config.localLlmModel, localLlmUrl: config.localLlmFastUrl, localLlmTimeoutMs: config.localLlmFastTimeoutMs },
-          this.modelRegistry,
-        )
+      ? (() => {
+          const client = new LocalLlmClient(
+            { ...config, localLlmModel: config.localLlmFastModel || config.localLlmModel, localLlmUrl: config.localLlmFastUrl, localLlmTimeoutMs: config.localLlmFastTimeoutMs },
+            this.modelRegistry,
+          );
+          client.disableThinking = true;
+          return client;
+        })()
       : this.localLlm;
     this.extraction = new ExtractionEngine(config, this.localLlm, config.gatewayConfig, this.modelRegistry);
     this.threading = new ThreadingManager(


### PR DESCRIPTION
## Summary

- Fast-tier LLM client now sends `chat_template_kwargs: { enable_thinking: false }` to suppress chain-of-thought on thinking models
- Fixes Qwen 3.5 small models timing out in LM Studio due to forced thinking mode (lmstudio-ai/lmstudio-bug-tracker#1559)
- Forward-compatible: will take effect automatically when LM Studio respects this parameter

## Context

Qwen 3.5 small models (0.8B–9B, released March 2026) default to non-thinking per Alibaba's docs, but LM Studio's chat template forces thinking mode. This caused fast-tier operations (rerank, entity_summary, tmt_summary, compression_guideline) to waste their entire time budget on chain-of-thought reasoning, producing no usable output before timeout.

## Changes

- `src/local-llm.ts`: Add `disableThinking` setter; when true, injects `chat_template_kwargs` into request body
- `src/orchestrator.ts`: Fast LLM client automatically sets `disableThinking = true`
- `CHANGELOG.md`: Document the fix

## Test plan

- [x] `npm run build` — no type errors
- [x] `npm test` — 731 tests pass
- [x] Verified `chat_template_kwargs` is sent in request body when `disableThinking` is true
- [x] Gateway confirms `fastLlm=qwen3.5-2b-mlx` after config switch

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low-risk change that only alters the fast-tier local LLM request payload; main risk is compatibility if a local OpenAI-compatible server rejects the new `chat_template_kwargs` field, potentially causing fast-tier calls to fail.
> 
> **Overview**
> Prevents fast-tier local LLM operations from getting stuck in forced chain-of-thought mode by optionally sending `chat_template_kwargs: { enable_thinking: false }` on chat completion requests.
> 
> Adds a `disableThinking` switch to `LocalLlmClient` and enables it automatically when the orchestrator constructs the fast-tier client (`localLlmFastEnabled`). Updates the changelog to document the fix.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8cf9368fcc0b831736e8c5113eb2d72bccf1565d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->