### PR TITLE
fix: block cross-site dashboard websocket upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ All notable changes to this project will be documented in this file.
 <!-- New items go here before they're released -->
 
 ### Fixed
+- Dashboard websocket origin validation now treats omitted default HTTP port as port 80, so same-origin upgrades on `http://127.0.0.1` and `http://127.0.0.1:80` both pass when the dashboard is bound to port 80; also removed an unreachable bracketed IPv6 loopback host entry.
 - Fallback contradiction verification, link suggestion, and memory summarization now normalize gateway/local LLM JSON aliases the same way as the direct OpenAI client, so `winner`, `type`, `summary`, and `entities` responses continue to work without an OpenAI API key.
 - **local-llm**: Read `reasoning_content` when `content` is empty — fixes thinking models (e.g. Qwen 3.5) returning null for entity summaries, consolidation, and question generation.
 - **fast-tier thinking suppression**: fast LLM client now sends `chat_template_kwargs: { enable_thinking: false }` to suppress chain-of-thought on thinking models (e.g. Qwen 3.5 small series). Prevents fast-tier operations from timing out when LM Studio forces thinking mode via chat template.

--- a/docs/graph-dashboard.md
+++ b/docs/graph-dashboard.md
@@ -23,6 +23,7 @@ Default behavior:
 ## Safety Notes
 
 - Keep loopback bind unless you explicitly need remote access.
+- WebSocket upgrades require an explicit `Origin` header that is loopback (`127.0.0.1`, `localhost`, or `::1`) and uses the dashboard's bound HTTP port (`http:` only).
 - If you expose non-loopback binds, place the service behind network controls.
 - Dashboard is read-only and does not mutate memory artifacts.
 

--- a/src/dashboard-runtime.ts
+++ b/src/dashboard-runtime.ts
@@ -30,7 +30,14 @@ type WsClient = {
   socket: Duplex;
 };
 
-const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1"]);
+
+function normalizeOriginHostname(hostname: string): string {
+  if (hostname.startsWith("[") && hostname.endsWith("]")) {
+    return hostname.slice(1, -1);
+  }
+  return hostname;
+}
 
 function websocketAcceptKey(clientKey: string): string {
   return createHash("sha1")
@@ -260,9 +267,11 @@ export class GraphDashboardServer {
     if (!origin) return false;
     try {
       const parsed = new URL(origin);
-      if (!LOOPBACK_HOSTS.has(parsed.hostname)) return false;
+      const hostname = normalizeOriginHostname(parsed.hostname);
+      if (!LOOPBACK_HOSTS.has(hostname)) return false;
       if (parsed.protocol !== "http:") return false;
-      return parsed.port === String(this.boundPort);
+      const originPort = parsed.port ? Number(parsed.port) : 80;
+      return Number.isFinite(originPort) && originPort === this.boundPort;
     } catch {
       return false;
     }

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -96,6 +96,35 @@ test("dashboard server serves health, graph, static assets, and websocket upgrad
   await server.stop();
 });
 
+test("dashboard origin check allows explicit and default http port 80", () => {
+  const server = new GraphDashboardServer({
+    memoryDir: "/tmp",
+    host: "127.0.0.1",
+    port: 80,
+    publicDir: path.join(process.cwd(), "dashboard", "public"),
+  });
+  (server as unknown as { boundPort: number }).boundPort = 80;
+
+  const isAllowedOrigin = (server as unknown as { isAllowedOrigin: (origin: string) => boolean }).isAllowedOrigin.bind(server);
+
+  assert.equal(isAllowedOrigin("http://127.0.0.1:80"), true);
+  assert.equal(isAllowedOrigin("http://127.0.0.1"), true);
+  assert.equal(isAllowedOrigin("http://localhost"), true);
+});
+
+test("dashboard origin check allows IPv6 loopback without brackets in hostname parsing", () => {
+  const server = new GraphDashboardServer({
+    memoryDir: "/tmp",
+    host: "127.0.0.1",
+    port: 8080,
+    publicDir: path.join(process.cwd(), "dashboard", "public"),
+  });
+  (server as unknown as { boundPort: number }).boundPort = 8080;
+
+  const isAllowedOrigin = (server as unknown as { isAllowedOrigin: (origin: string) => boolean }).isAllowedOrigin.bind(server);
+
+  assert.equal(isAllowedOrigin("http://[::1]:8080"), true);
+});
 test("dashboard websocket upgrade rejects non-loopback origin", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-dashboard-server-ws-origin-"));
   await mkdir(path.join(memoryDir, "state", "graphs"), { recursive: true });


### PR DESCRIPTION
### Motivation
- The dashboard WebSocket upgrade handler previously accepted any upgrade with a valid `Sec-WebSocket-Key` and immediately sent the full graph snapshot, allowing cross-site WebSocket hijacking and data exfiltration. 
- The change prevents arbitrary web pages from connecting to the local dashboard endpoint and reading sensitive graph data without validation.

### Description
- Added strict origin validation to the WebSocket upgrade handler in `src/dashboard-runtime.ts`, rejecting upgrades with missing or non-loopback `Origin` values. 
- Implemented `isAllowedOrigin()` which ensures the `Origin` parses to an `http:` loopback hostname and that the origin port matches the server's bound port. 
- Updated tests in `tests/dashboard-server.test.ts` to send a same-origin `Origin` for the successful upgrade case and added a regression test that asserts a `403 Forbidden` response for a non-loopback origin (`http://evil.example`).

### Testing
- Ran the dashboard server tests with `npm test -- tests/dashboard-server.test.ts` and both the existing and new websocket-origin tests passed. 
- Executed `npm run check-types` and `npm run check-config-contract` which succeeded with no type or config contract errors. 
- Ran the quick preflight `npm run preflight:quick` and the project's test suites used by the preflight completed successfully with all checks passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aba28c4c88832e82828532a80691cd)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the dashboard’s WebSocket upgrade path (a security-sensitive surface) and may block previously-working clients if they omit/modify the `Origin` header or use non-`http:` origins/ports.
> 
> **Overview**
> Prevents cross-site connections to the graph dashboard WebSocket by **requiring a valid loopback `Origin`** during upgrade and returning `403` when it’s missing or non-loopback.
> 
> Origin parsing is hardened to treat an omitted port as `80` (so `http://127.0.0.1` matches a server bound to port 80) and to normalize bracketed IPv6 hostnames; docs, changelog, and tests are updated to cover same-origin upgrades and rejection of non-loopback origins.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8d632ece18aeb73e4391155eb732348ff08b5fee. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->