### PR TITLE
feat: add trust zone promotion rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable changes to this project will be documented in this file.
 - Enrich extraction prompt few-shot examples with `entityRef` and entity `facts` fields, using realistic concrete values instead of generic placeholders.
 
 ### Added
+- **Trust-zone promotion path**: added deterministic trust-zone promotion planning, lineage-aware promoted records, guarded `openclaw engram trust-zone-promote`, direct `quarantine -> trusted` denial, and anchored-provenance enforcement for risky `working -> trusted` promotions.
 - **Trust-zone store foundation**: added `trustZonesEnabled`, `quarantinePromotionEnabled`, `trustZoneStoreDir`, a typed trust-zone record store under `state/trust-zones`, and `openclaw engram trust-zone-status` for inspecting quarantine, working, and trusted records before promotion logic lands.
 - **Causal trajectory recall**: added `causalTrajectoryRecallEnabled`, a separate `causal-trajectories` recall-pipeline section, bounded lexical trajectory search, and `## Causal Trajectories` recall injection with lightweight match explainability.
 - **Causal trajectory store foundation**: added `causalTrajectoryMemoryEnabled`, `causalTrajectoryStoreDir`, a typed causal-trajectory record store under `state/causal-trajectories`, and `openclaw engram causal-trajectory-status` for inspecting stored goal-action-observation-outcome chains.

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ AI agents forget everything between conversations. Engram fixes that.
 - **Objective-state recall** — Engram can now store normalized file, process, and tool outcomes and, when `objectiveStateRecallEnabled` is enabled, inject the most relevant objective-state snapshots back into recall context as a separate `Objective State` section.
 - **Causal trajectory graph foundation** — Engram can now persist typed `goal -> action -> observation -> outcome -> follow-up` chains when `causalTrajectoryMemoryEnabled` is enabled and, with `actionGraphRecallEnabled`, emit deterministic action-conditioned edges into the causal graph for later trajectory-aware retrieval.
 - **Causal trajectory recall** — Engram can now, when `causalTrajectoryRecallEnabled` is enabled, inject prompt-relevant causal chains back into recall context as a separate `Causal Trajectories` section with lightweight match explainability.
-- **Trust-zone store foundation** — Engram can now, when `trustZonesEnabled` is enabled, persist typed quarantine, working, and trusted records with provenance metadata into a dedicated trust-zone store for later promotion and defense slices.
+- **Trust-zone promotion path** — Engram can now, when `trustZonesEnabled` and `quarantinePromotionEnabled` are enabled, persist typed quarantine, working, and trusted records, plan explicit promotions, block direct `quarantine -> trusted` jumps, and require anchored provenance before promoting risky working records into `trusted`.
 - **Zero-config start** — Install, add an API key, restart. Engram works out of the box with sensible defaults and progressively unlocks advanced features as you enable them.
 
 ## Quick Start
@@ -160,6 +160,8 @@ openclaw engram benchmark-import <path>      # Import a validated benchmark pack
 openclaw engram benchmark-ci-gate            # Compare base vs candidate eval stores and fail on regressions
 openclaw engram objective-state-status       # Objective-state snapshot counts and latest stored snapshot
 openclaw engram causal-trajectory-status    # Causal-trajectory record counts and latest stored chain
+openclaw engram trust-zone-status           # Trust-zone record counts and latest stored record
+openclaw engram trust-zone-promote          # Dry-run or apply a trust-zone promotion with provenance enforcement
 openclaw engram conversation-index-health    # Conversation index status
 openclaw engram graph-health                 # Entity graph status
 openclaw engram tier-status                  # Hot/cold tier metrics
@@ -190,8 +192,8 @@ Key settings:
 | `causalTrajectoryStoreDir` | `{memoryDir}/state/causal-trajectories` | Root directory for causal-trajectory records |
 | `causalTrajectoryRecallEnabled` | `false` | Inject prompt-relevant causal trajectories into recall context |
 | `actionGraphRecallEnabled` | `false` | Write action-conditioned causal-stage edges from typed trajectory records into the causal graph |
-| `trustZonesEnabled` | `false` | Enable the trust-zone memory foundation for quarantine, working, and trusted records |
-| `quarantinePromotionEnabled` | `false` | Reserve future promotion flows from quarantine into higher-trust zones |
+| `trustZonesEnabled` | `false` | Enable the trust-zone memory foundation and operator-facing promotion path for quarantine, working, and trusted records |
+| `quarantinePromotionEnabled` | `false` | Allow explicit trust-zone promotions such as `quarantine -> working` and guarded `working -> trusted` |
 | `trustZoneStoreDir` | `{memoryDir}/state/trust-zones` | Root directory for trust-zone records |
 
 Full reference: [Config Reference](docs/config-reference.md)

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,73 +1,85 @@
-# Theory: Engram Is Adding Trust Boundaries To The New Memory Surfaces
+# Theory: Trust Zones Need Explicit Promotion Rules Before Retrieval Filtering
 
 ## Problem
 
-Engram now has benchmark storage, objective-state memory, and causal
-trajectories. That progress increases the next risk: those newer memory
-surfaces can accumulate raw tool output, web captures, and subagent traces
-faster than they accumulate trust.
+PR11 created a trust-zone store, but storage alone does not change behavior.
+Without explicit promotion rules, every future writer would still have to invent
+its own ad hoc interpretation of what it means to move something from
+`quarantine` to `working` or from `working` to `trusted`.
 
-The immediate problem is therefore not promotion logic yet. It is establishing
-explicit storage boundaries so later promotion and poisoning-defense work has a
-real substrate. Without separate quarantine, working, and trusted stores,
-future trust logic would still be policy layered over one undifferentiated
-memory mass.
+That would recreate the same ambiguity the store layer was supposed to remove.
+The next step is therefore not retrieval filtering yet. The next step is a
+single promotion contract that defines what is allowed, what is blocked, and
+what provenance is required before higher-trust storage exists.
 
 ## Operating Theory
 
-The roadmap is still working because each new memory surface has arrived in a
-disciplined order:
+The memory-OS roadmap is still working because each new surface is arriving in
+strict order:
 
-1. store the typed source of truth
-2. make the source observable and testable
-3. only then add writers, recall, and ranking behavior
-4. add trust boundaries before aggressive automation
+1. typed store
+2. explicit write/promotion contract
+3. retrieval surface
+4. stronger defenses and automation
 
-That means PR11 should not try to solve promotion or retrieval enforcement in
-one pass. The right first move is a typed trust-zone store:
+For trust zones, that means PR12 should do three things and stop:
 
-- `quarantine` for raw, unpromoted material
-- `working` for operator-useful but not fully trusted state
-- `trusted` for future corroborated/promoted records
+- define promotion eligibility rules
+- enforce minimum provenance for risky promotions
+- write lineage-aware successor records instead of mutating source records
 
-That keeps current behavior stable while making later promotion and retrieval
-enforcement mechanically possible.
+That preserves the value of PR11's storage boundary and creates a stable base
+for PR13 retrieval filters and PR14+ poisoning-defense work.
 
 ## Strategy
 
-The broader thesis remains:
+The product thesis still governs the sequence:
 
 - memory that improves action outcomes
 - memory that survives long horizons and failures
 - memory that can defend itself
 
-For the trust-zone track, the strategy is now:
+For the trust-zone track, that translates to:
 
-1. ship defaults-off storage paths and typed provenance first
-2. keep promotion logic out of this slice
-3. make operator visibility available through status commands
-4. use the stored provenance contract as the base for PR12 and PR13
+1. allow `quarantine -> working`
+2. allow `working -> trusted` only through an explicit guarded path
+3. block `quarantine -> trusted`
+4. require anchored provenance before external/tool-derived material can become
+   `trusted`
+5. keep all of it defaults-off behind the existing flags
 
-This keeps PR11 small and reviewable while preserving the roadmap sequence:
+This keeps the slice small enough for review while making later retrieval and
+defense work less ambiguous.
+
+## Key Discoveries
+
+- Promotion should write a new successor record, not mutate the source. Lineage
+  matters for audits and later poisoning analysis.
+- Direct `quarantine -> trusted` promotion is too permissive for the first
+  trust-aware path. Forcing `working` as an intermediate zone makes later
+  corroboration rules easier to add.
+- Provenance enforcement can start smaller than full corroboration. Requiring
+  anchored provenance (`sourceId` + `evidenceHash`) for risky `working ->
+  trusted` promotions gives the system a real minimum trust floor without
+  front-loading PR15's corroboration logic.
+- A dry-run CLI path is enough operator control for this slice. Automatic
+  promotion can wait until the trust contract has more real-world exposure.
+
+## Next Sequence
+
+The trust-zone roadmap now looks like:
 
 1. PR11: trust-zone schemas and storage
 2. PR12: promotion rules and provenance enforcement
 3. PR13: trust-zone-aware retrieval filters
-
-## Key Discoveries
-
-- The objective-state and causal-trajectory slices already established the
-  right pattern for this work: store contracts first, behavior later.
-- Trust-zone records need provenance fields in the first version; otherwise the
-  later promotion layer would have to backfill missing origin data.
-- A zoned status command is enough operator visibility for this slice. Retrieval
-  behavior can stay untouched until trust-aware filtering exists.
+4. PR14+: trust scoring, corroboration, and poisoning defense
 
 ## Open Questions
 
-- Which stored surfaces should write directly into `working` rather than
-  `quarantine` by default once writers arrive?
-- Should promotion history remain embedded in trust-zone records, or should it
-  become a separate append-only ledger in PR12?
-- Which future retrieval sections should be trust-filtered first: objective
-  state, causal trajectories, or both together?
+- Should future automatic writers target `working` by default for some source
+  classes, or should everything still enter through `quarantine` first?
+- Should promotion reasons remain in record metadata long term, or move into a
+  dedicated append-only promotion ledger in a later slice?
+- When PR13 lands, should trust-zone retrieval filtering apply uniformly across
+  objective-state and causal-trajectory sections, or should the rollout start
+  with one retrieval surface first?

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -374,8 +374,8 @@ See [advanced-retrieval.md](advanced-retrieval.md) for guidance.
 | `causalTrajectoryStoreDir` | `{memoryDir}/state/causal-trajectories` | Root directory for causal-trajectory records |
 | `causalTrajectoryRecallEnabled` | `false` | Inject prompt-relevant causal trajectories into recall context |
 | `actionGraphRecallEnabled` | `false` | Write action-conditioned causal-stage edges from typed trajectory records into the causal graph |
-| `trustZonesEnabled` | `false` | Enable the trust-zone memory foundation for quarantine, working, and trusted records |
-| `quarantinePromotionEnabled` | `false` | Reserve future promotion flows from quarantine into higher-trust zones |
+| `trustZonesEnabled` | `false` | Enable the trust-zone memory foundation and operator-facing promotion path for quarantine, working, and trusted records |
+| `quarantinePromotionEnabled` | `false` | Allow explicit trust-zone promotions such as `quarantine -> working` and guarded `working -> trusted` |
 | `trustZoneStoreDir` | `{memoryDir}/state/trust-zones` | Root directory for trust-zone records |
 
 Current foundation slice:
@@ -388,7 +388,8 @@ Current foundation slice:
 - When `causalTrajectoryMemoryEnabled` is on, Engram can persist typed causal chains into a separate store for later graph/retrieval slices.
 - When `causalTrajectoryRecallEnabled` is on, Engram can inject a separate `## Causal Trajectories` recall section sourced from the causal-trajectory store.
 - When `actionGraphRecallEnabled` is also on, each newly recorded causal trajectory emits deterministic `goal -> action -> observation -> outcome -> follow_up` edges into the causal graph without changing retrieval behavior yet.
-- When `trustZonesEnabled` is on, Engram can persist provenance-bearing records into separate `quarantine`, `working`, and `trusted` storage tiers for later promotion and retrieval slices.
+- When `trustZonesEnabled` is on, Engram can persist provenance-bearing records into separate `quarantine`, `working`, and `trusted` storage tiers.
+- When `quarantinePromotionEnabled` is also on, Engram exposes an explicit promotion path that blocks direct `quarantine -> trusted` jumps and requires anchored provenance before promoting risky working records into `trusted`.
 - Future slices will add automated benchmark runners on top of this store and gate format.
 
 | `conversationIndexEmbedOnUpdate` | `false` | Run `qmd embed` on each update |

--- a/docs/plans/2026-03-07-engram-pr12-trust-zone-promotion.md
+++ b/docs/plans/2026-03-07-engram-pr12-trust-zone-promotion.md
@@ -1,0 +1,41 @@
+# PR12: Trust-Zone Promotion Rules And Provenance Enforcement
+
+## Goal
+
+Add the first explicit promotion path on top of the trust-zone store introduced
+in PR11 without changing retrieval behavior yet.
+
+## Scope
+
+- Add deterministic promotion planning for `quarantine -> working` and
+  `working -> trusted`.
+- Block direct `quarantine -> trusted` promotion.
+- Require anchored provenance (`sourceId` + `evidenceHash`) before promoting
+  tool/web/subagent-derived working records into `trusted`.
+- Add a dry-run/apply CLI wrapper for promotions.
+- Preserve defaults-off behavior via existing trust-zone flags.
+
+## Non-Goals
+
+- No automatic promotion from hooks or background jobs.
+- No corroboration engine yet.
+- No trust-zone-aware retrieval filtering yet.
+- No poisoning benchmark packs yet.
+
+## Contract
+
+- `trustZonesEnabled` must be `true`.
+- `quarantinePromotionEnabled` must be `true`.
+- Promotion writes a new trust-zone record rather than mutating the source.
+- Promoted records carry:
+  - `promotedFromZone`
+  - lineage metadata with `sourceRecordId`
+  - `promotionReason`
+
+## Tests
+
+- Direct `quarantine -> trusted` promotion is denied.
+- `working -> trusted` promotion is denied when risky provenance lacks anchors.
+- `working -> trusted` promotion is allowed when provenance is anchored.
+- Promotion writes a lineage-aware successor record.
+- CLI dry-run returns the plan without writing.

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -58,7 +58,13 @@ import {
   type CausalTrajectoryStoreStatus,
 } from "./causal-trajectory.js";
 import { getObjectiveStateStoreStatus, type ObjectiveStateStoreStatus } from "./objective-state.js";
-import { getTrustZoneStoreStatus, type TrustZoneStoreStatus } from "./trust-zones.js";
+import {
+  getTrustZoneStoreStatus,
+  promoteTrustZoneRecord,
+  type TrustZoneName,
+  type TrustZonePromotionResult,
+  type TrustZoneStoreStatus,
+} from "./trust-zones.js";
 import {
   analyzeSessionIntegrity,
   applySessionRepair,
@@ -667,6 +673,37 @@ export async function runTrustZoneStatusCliCommand(options: {
     enabled: options.trustZonesEnabled,
     promotionEnabled: options.quarantinePromotionEnabled,
   });
+}
+
+export async function runTrustZonePromoteCliCommand(options: {
+  memoryDir: string;
+  trustZoneStoreDir?: string;
+  trustZonesEnabled: boolean;
+  quarantinePromotionEnabled: boolean;
+  sourceRecordId: string;
+  targetZone: TrustZoneName;
+  promotionReason: string;
+  recordedAt?: string;
+  summary?: string;
+  dryRun?: boolean;
+}): Promise<TrustZonePromotionResult & { dryRun: boolean }> {
+  const result = await promoteTrustZoneRecord({
+    memoryDir: options.memoryDir,
+    trustZoneStoreDir: options.trustZoneStoreDir,
+    enabled: options.trustZonesEnabled,
+    promotionEnabled: options.quarantinePromotionEnabled,
+    sourceRecordId: options.sourceRecordId,
+    targetZone: options.targetZone,
+    recordedAt: options.recordedAt ?? new Date().toISOString(),
+    promotionReason: options.promotionReason,
+    summary: options.summary,
+    dryRun: options.dryRun === true,
+  });
+
+  return {
+    ...result,
+    dryRun: options.dryRun === true,
+  };
 }
 
 export async function runSessionCheckCliCommand(
@@ -2270,6 +2307,33 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             quarantinePromotionEnabled: orchestrator.config.quarantinePromotionEnabled,
           });
           console.log(JSON.stringify(status, null, 2));
+          console.log("OK");
+        });
+
+      cmd
+        .command("trust-zone-promote")
+        .description("Dry-run or apply a trust-zone promotion with provenance enforcement")
+        .requiredOption("--record-id <recordId>", "Source trust-zone record id")
+        .requiredOption("--target-zone <targetZone>", "Promotion target zone (working|trusted)")
+        .requiredOption("--reason <reason>", "Human-readable promotion reason")
+        .option("--recorded-at <isoTimestamp>", "Promotion timestamp (defaults to now)")
+        .option("--summary <summary>", "Optional replacement summary for the promoted record")
+        .option("--dry-run", "Show the promotion plan without writing the promoted record")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const result = await runTrustZonePromoteCliCommand({
+            memoryDir: orchestrator.config.memoryDir,
+            trustZoneStoreDir: orchestrator.config.trustZoneStoreDir,
+            trustZonesEnabled: orchestrator.config.trustZonesEnabled,
+            quarantinePromotionEnabled: orchestrator.config.quarantinePromotionEnabled,
+            sourceRecordId: String(options.recordId ?? ""),
+            targetZone: String(options.targetZone ?? "") as TrustZoneName,
+            promotionReason: String(options.reason ?? ""),
+            recordedAt: typeof options.recordedAt === "string" ? options.recordedAt : undefined,
+            summary: typeof options.summary === "string" ? options.summary : undefined,
+            dryRun: options.dryRun === true,
+          });
+          console.log(JSON.stringify(result, null, 2));
           console.log("OK");
         });
 

--- a/src/trust-zones.ts
+++ b/src/trust-zones.ts
@@ -66,6 +66,23 @@ export interface TrustZoneStoreStatus {
   }>;
 }
 
+export interface TrustZonePromotionPlan {
+  allowed: boolean;
+  reasons: string[];
+  sourceRecordId: string;
+  sourceZone: TrustZoneName;
+  targetZone: TrustZoneName;
+  provenanceAnchored: boolean;
+}
+
+export interface TrustZonePromotionResult {
+  plan: TrustZonePromotionPlan;
+  wroteRecord: boolean;
+  record: TrustZoneRecord;
+  filePath?: string;
+  sourceRecord: TrustZoneRecord;
+}
+
 function validateMetadata(raw: unknown): Record<string, string> | undefined {
   return validateStringRecord(raw, "metadata");
 }
@@ -140,6 +157,155 @@ export async function recordTrustZoneRecord(options: {
   await mkdir(zoneDir, { recursive: true });
   await writeFile(filePath, JSON.stringify(validated, null, 2), "utf8");
   return filePath;
+}
+
+function hasAnchoredProvenance(record: TrustZoneRecord): boolean {
+  return Boolean(record.provenance.sourceId && record.provenance.evidenceHash);
+}
+
+function buildPromotionRecordId(sourceRecordId: string, targetZone: TrustZoneName, recordedAt: string): string {
+  const suffix = recordedAt.replace(/[^0-9]/g, "").slice(0, 14);
+  return `${sourceRecordId}-${targetZone}-${suffix}`;
+}
+
+function dedupeStrings(values: Array<string | undefined>): string[] | undefined {
+  const out = values.filter((value): value is string => typeof value === "string" && value.length > 0);
+  if (out.length === 0) return undefined;
+  return [...new Set(out)];
+}
+
+export function planTrustZonePromotion(options: {
+  record: TrustZoneRecord;
+  targetZone: TrustZoneName;
+}): TrustZonePromotionPlan {
+  const { record, targetZone } = options;
+  const reasons: string[] = [];
+  const provenanceAnchored = hasAnchoredProvenance(record);
+
+  if (record.zone === targetZone) {
+    reasons.push(`record is already in the ${targetZone} zone`);
+  }
+  if (record.zone === "trusted") {
+    reasons.push("trusted records are terminal and cannot be promoted again");
+  }
+  if (record.zone === "quarantine" && targetZone === "trusted") {
+    reasons.push("quarantine records must pass through working before trusted promotion");
+  }
+  if (record.zone === "working" && targetZone === "quarantine") {
+    reasons.push("working records cannot be demoted back into quarantine in this promotion path");
+  }
+  if (record.zone === "quarantine" && targetZone !== "working") {
+    reasons.push("quarantine promotions only support the working zone");
+  }
+  if (record.zone === "working" && targetZone !== "trusted") {
+    reasons.push("working promotions only support the trusted zone");
+  }
+  if (
+    targetZone === "trusted" &&
+    ["tool_output", "web_content", "subagent_trace"].includes(record.provenance.sourceClass) &&
+    provenanceAnchored !== true
+  ) {
+    reasons.push("trusted promotion for external/tool-derived provenance requires both provenance.sourceId and provenance.evidenceHash");
+  }
+
+  return {
+    allowed: reasons.length === 0,
+    reasons,
+    sourceRecordId: record.recordId,
+    sourceZone: record.zone,
+    targetZone,
+    provenanceAnchored,
+  };
+}
+
+async function findTrustZoneRecordById(options: {
+  memoryDir: string;
+  trustZoneStoreDir?: string;
+  recordId: string;
+}): Promise<TrustZoneRecord | null> {
+  const { records } = await readTrustZoneRecords(options);
+  records.sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
+  return records.find((record) => record.recordId === options.recordId) ?? null;
+}
+
+export async function promoteTrustZoneRecord(options: {
+  memoryDir: string;
+  trustZoneStoreDir?: string;
+  enabled: boolean;
+  promotionEnabled: boolean;
+  sourceRecordId: string;
+  targetZone: TrustZoneName;
+  recordedAt: string;
+  promotionReason: string;
+  summary?: string;
+  dryRun?: boolean;
+}): Promise<TrustZonePromotionResult> {
+  if (options.enabled !== true) {
+    throw new Error("trust zone promotion requires trustZonesEnabled=true");
+  }
+  if (options.promotionEnabled !== true) {
+    throw new Error("trust zone promotion requires quarantinePromotionEnabled=true");
+  }
+
+  const sourceRecord = await findTrustZoneRecordById({
+    memoryDir: options.memoryDir,
+    trustZoneStoreDir: options.trustZoneStoreDir,
+    recordId: assertSafePathSegment(assertString(options.sourceRecordId, "sourceRecordId"), "sourceRecordId"),
+  });
+  if (!sourceRecord) {
+    throw new Error(`source trust-zone record not found: ${options.sourceRecordId}`);
+  }
+
+  const plan = planTrustZonePromotion({
+    record: sourceRecord,
+    targetZone: options.targetZone,
+  });
+  if (!plan.allowed) {
+    throw new Error(`trust-zone promotion denied: ${plan.reasons.join("; ")}`);
+  }
+
+  const recordedAt = assertIsoRecordedAt(assertString(options.recordedAt, "recordedAt"));
+  const promotionReason = assertString(options.promotionReason, "promotionReason");
+  const nextRecord: TrustZoneRecord = {
+    schemaVersion: 1,
+    recordId: buildPromotionRecordId(sourceRecord.recordId, options.targetZone, recordedAt),
+    zone: options.targetZone,
+    recordedAt,
+    kind: sourceRecord.kind,
+    summary: optionalString(options.summary) ?? sourceRecord.summary,
+    provenance: sourceRecord.provenance,
+    promotedFromZone: sourceRecord.zone,
+    entityRefs: sourceRecord.entityRefs,
+    tags: dedupeStrings([...(sourceRecord.tags ?? []), "promotion"]),
+    metadata: {
+      ...(sourceRecord.metadata ?? {}),
+      sourceRecordId: sourceRecord.recordId,
+      promotionReason,
+    },
+  };
+
+  if (options.dryRun === true) {
+    return {
+      plan,
+      wroteRecord: false,
+      record: nextRecord,
+      sourceRecord,
+    };
+  }
+
+  const filePath = await recordTrustZoneRecord({
+    memoryDir: options.memoryDir,
+    trustZoneStoreDir: options.trustZoneStoreDir,
+    record: nextRecord,
+  });
+
+  return {
+    plan,
+    wroteRecord: true,
+    record: nextRecord,
+    filePath,
+    sourceRecord,
+  };
 }
 
 async function readTrustZoneRecords(options: {

--- a/tests/trust-zones.test.ts
+++ b/tests/trust-zones.test.ts
@@ -5,11 +5,13 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import test from "node:test";
 import {
   getTrustZoneStoreStatus,
+  planTrustZonePromotion,
+  promoteTrustZoneRecord,
   recordTrustZoneRecord,
   resolveTrustZoneStoreDir,
   validateTrustZoneRecord,
 } from "../src/trust-zones.js";
-import { runTrustZoneStatusCliCommand } from "../src/cli.js";
+import { runTrustZonePromoteCliCommand, runTrustZoneStatusCliCommand } from "../src/cli.js";
 
 test("trust-zones config path resolves under memoryDir by default", () => {
   assert.equal(
@@ -219,4 +221,158 @@ test("trust-zone-status CLI command returns the store summary", async () => {
   });
   assert.equal(summary.records.valid, 1);
   assert.equal(summary.latestRecord.recordId, "tz-cli-1");
+});
+
+test("planTrustZonePromotion blocks direct quarantine to trusted promotion", () => {
+  const plan = planTrustZonePromotion({
+    record: validateTrustZoneRecord({
+      schemaVersion: 1,
+      recordId: "tz-plan-1",
+      zone: "quarantine",
+      recordedAt: "2026-03-07T18:06:00.000Z",
+      kind: "external",
+      summary: "Raw web result awaiting corroboration.",
+      provenance: {
+        sourceClass: "web_content",
+        observedAt: "2026-03-07T18:05:00.000Z",
+      },
+    }),
+    targetZone: "trusted",
+  });
+
+  assert.equal(plan.allowed, false);
+  assert.match(plan.reasons.join(" "), /quarantine/i);
+  assert.match(plan.reasons.join(" "), /trusted/i);
+});
+
+test("planTrustZonePromotion requires provenance anchors before promoting working records to trusted", () => {
+  const denied = planTrustZonePromotion({
+    record: validateTrustZoneRecord({
+      schemaVersion: 1,
+      recordId: "tz-plan-2",
+      zone: "working",
+      recordedAt: "2026-03-07T18:07:00.000Z",
+      kind: "state",
+      summary: "Intermediate state derived from tool output.",
+      provenance: {
+        sourceClass: "tool_output",
+        observedAt: "2026-03-07T18:06:30.000Z",
+      },
+    }),
+    targetZone: "trusted",
+  });
+  assert.equal(denied.allowed, false);
+  assert.match(denied.reasons.join(" "), /sourceId/i);
+  assert.match(denied.reasons.join(" "), /evidenceHash/i);
+
+  const allowed = planTrustZonePromotion({
+    record: validateTrustZoneRecord({
+      schemaVersion: 1,
+      recordId: "tz-plan-3",
+      zone: "working",
+      recordedAt: "2026-03-07T18:08:00.000Z",
+      kind: "state",
+      summary: "Intermediate state with anchored provenance.",
+      provenance: {
+        sourceClass: "tool_output",
+        observedAt: "2026-03-07T18:07:30.000Z",
+        sourceId: "tool:build",
+        evidenceHash: "sha256:trust-anchor",
+      },
+    }),
+    targetZone: "trusted",
+  });
+  assert.equal(allowed.allowed, true);
+  assert.equal(allowed.reasons.length, 0);
+});
+
+test("promoteTrustZoneRecord writes a lineage-aware promoted record", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-trust-zone-promote-"));
+  await recordTrustZoneRecord({
+    memoryDir,
+    record: {
+      schemaVersion: 1,
+      recordId: "tz-promote-source",
+      zone: "working",
+      recordedAt: "2026-03-07T18:09:00.000Z",
+      kind: "artifact",
+      summary: "Candidate artifact promoted after manual review.",
+      provenance: {
+        sourceClass: "manual",
+        observedAt: "2026-03-07T18:08:30.000Z",
+        sourceId: "review:ops",
+        evidenceHash: "sha256:manual-review",
+      },
+      tags: ["reviewed"],
+    },
+  });
+
+  const result = await promoteTrustZoneRecord({
+    memoryDir,
+    enabled: true,
+    promotionEnabled: true,
+    sourceRecordId: "tz-promote-source",
+    targetZone: "trusted",
+    recordedAt: "2026-03-07T18:10:00.000Z",
+    promotionReason: "Manual review approved the artifact for trusted recall.",
+  });
+
+  assert.equal(result.record.zone, "trusted");
+  assert.equal(result.record.promotedFromZone, "working");
+  assert.equal(result.record.metadata?.sourceRecordId, "tz-promote-source");
+  assert.equal(result.record.metadata?.promotionReason?.includes("Manual review approved"), true);
+  assert.equal(result.filePath.endsWith(".json"), true);
+
+  const status = await getTrustZoneStoreStatus({
+    memoryDir,
+    enabled: true,
+    promotionEnabled: true,
+  });
+  assert.equal(status.records.valid, 2);
+  assert.equal(status.records.byZone.working, 1);
+  assert.equal(status.records.byZone.trusted, 1);
+  assert.equal(status.latestRecord?.recordId, result.record.recordId);
+});
+
+test("trust-zone-promote CLI dry-run returns the promotion plan without writing", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-trust-zone-cli-promote-"));
+  await recordTrustZoneRecord({
+    memoryDir,
+    record: {
+      schemaVersion: 1,
+      recordId: "tz-cli-promote-source",
+      zone: "quarantine",
+      recordedAt: "2026-03-07T18:11:00.000Z",
+      kind: "external",
+      summary: "Raw fetch result with anchored provenance.",
+      provenance: {
+        sourceClass: "web_content",
+        observedAt: "2026-03-07T18:10:30.000Z",
+        sourceId: "https://example.com/source",
+        evidenceHash: "sha256:web-proof",
+      },
+    },
+  });
+
+  const plan = await runTrustZonePromoteCliCommand({
+    memoryDir,
+    trustZonesEnabled: true,
+    quarantinePromotionEnabled: true,
+    sourceRecordId: "tz-cli-promote-source",
+    targetZone: "working",
+    promotionReason: "Promote into working memory for corroboration.",
+    dryRun: true,
+  });
+
+  assert.equal(plan.dryRun, true);
+  assert.equal(plan.plan.allowed, true);
+  assert.equal(plan.wroteRecord, false);
+
+  const status = await getTrustZoneStoreStatus({
+    memoryDir,
+    enabled: true,
+    promotionEnabled: true,
+  });
+  assert.equal(status.records.valid, 1);
+  assert.equal(status.records.byZone.quarantine, 1);
 });


### PR DESCRIPTION
# PR12: Trust-Zone Promotion Rules And Provenance Enforcement

## Goal

Add the first explicit promotion path on top of the trust-zone store introduced
in PR11 without changing retrieval behavior yet.

## Scope

- Add deterministic promotion planning for `quarantine -> working` and
  `working -> trusted`.
- Block direct `quarantine -> trusted` promotion.
- Require anchored provenance (`sourceId` + `evidenceHash`) before promoting
  tool/web/subagent-derived working records into `trusted`.
- Add a dry-run/apply CLI wrapper for promotions.
- Preserve defaults-off behavior via existing trust-zone flags.

## Non-Goals

- No automatic promotion from hooks or background jobs.
- No corroboration engine yet.
- No trust-zone-aware retrieval filtering yet.
- No poisoning benchmark packs yet.

## Contract

- `trustZonesEnabled` must be `true`.
- `quarantinePromotionEnabled` must be `true`.
- Promotion writes a new trust-zone record rather than mutating the source.
- Promoted records carry:
  - `promotedFromZone`
  - lineage metadata with `sourceRecordId`
  - `promotionReason`

## Tests

- Direct `quarantine -> trusted` promotion is denied.
- `working -> trusted` promotion is denied when risky provenance lacks anchors.
- `working -> trusted` promotion is allowed when provenance is anchored.
- Promotion writes a lineage-aware successor record.
- CLI dry-run returns the plan without writing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new operator-driven state mutation for trust-zone records (including provenance-based gating) and a new CLI command; behavior is defaults-off but mistakes could incorrectly promote unanchored records or break promotion workflows.
> 
> **Overview**
> Adds a **guarded trust-zone promotion path** on top of the existing trust-zone store: deterministic `planTrustZonePromotion(...)` rules, a `promoteTrustZoneRecord(...)` writer that creates **lineage-aware successor records** (no mutation), blocks `quarantine -> trusted`, and requires anchored provenance (`sourceId` + `evidenceHash`) for risky `working -> trusted` promotions.
> 
> Exposes this via a new `openclaw engram trust-zone-promote` CLI command (supports `--dry-run`), adds focused tests for denial/allow cases and record writing, and updates docs/README/config reference/changelog to describe the new promotion contract and flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7de31d27f4fa63d00e112884fef6b5a18ff97e3f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->