### PR TITLE
feat: add abstraction node foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Enrich extraction prompt few-shot examples with `entityRef` and entity `facts` fields, using realistic concrete values instead of generic placeholders.
 
 ### Added
+- **Abstraction-node foundation**: added `harmonicRetrievalEnabled`, `abstractionAnchorsEnabled`, `abstractionNodeStoreDir`, a typed abstraction-node store under `state/abstraction-nodes`, and `openclaw engram abstraction-node-status` for the first harmonic-retrieval storage slice.
 - **Memory red-team benchmark packs**: added `memoryRedTeamBenchEnabled`, typed `memory-red-team` benchmark manifest support (`benchmarkType`, `attackClass`, `targetSurface`), and benchmark-status accounting for poisoning-defense attack suites.
 - **Risky-promotion corroboration**: when `memoryPoisoningDefenseEnabled` is enabled, risky `working -> trusted` trust-zone promotions now require independent non-`quarantine` corroboration with anchored provenance and overlapping `entityRefs` or `tags`, and successful promotions record corroboration metadata.
 - **Provenance trust scoring**: added `memoryPoisoningDefenseEnabled`, deterministic trust-zone provenance scoring by source class and evidence anchors, and aggregate trust-band reporting in `openclaw engram trust-zone-status` as the first poisoning-defense signal.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ AI agents forget everything between conversations. Engram fixes that.
 - **Trust-zone recall** — Engram can now, when `trustZoneRecallEnabled` is enabled, inject prompt-relevant `working` and `trusted` trust-zone records into recall context as a separate `Trust Zones` section while keeping `quarantine` material out of recall by default.
 - **Poisoning-defense corroboration** — Engram can now, when `memoryPoisoningDefenseEnabled` is enabled, score trust-zone provenance deterministically and require independent non-quarantine corroboration before risky `working -> trusted` promotions succeed.
 - **Red-team benchmark packs** — Engram's eval harness can now validate and count typed `memory-red-team` benchmark packs so poisoning-defense regression suites stay explicit and reviewable instead of hiding inside generic benchmark metadata.
+- **Abstraction-node foundation** — Engram can now, when `harmonicRetrievalEnabled` is enabled, persist typed abstraction nodes for later harmonic retrieval slices, with `abstractionAnchorsEnabled` reserved for the future cue-anchor layer.
 - **Zero-config start** — Install, add an API key, restart. Engram works out of the box with sensible defaults and progressively unlocks advanced features as you enable them.
 
 ## Quick Start

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,70 +1,64 @@
-# Theory: Poisoning Defense Needs Typed Attack Suites, Not Just Policy
+# Theory: Harmonic Retrieval Needs Abstraction Storage Before It Needs Blending
 
 ## Problem
 
-Engram now has real trust tiers, explicit promotion rules, bounded trust-zone
-recall, deterministic provenance trust scoring, and corroboration rules for
-risky promotions. That closes one policy gap, but it still leaves a measurement
-gap: poisoning-defense regressions can still hide inside generic benchmark packs
-with no explicit attack identity.
+Engram now has a measured evaluation harness, objective-state memory, causal
+trajectories, trust zones, provenance scoring, corroboration rules, and typed
+red-team benchmark packs. The next roadmap step is harmonic retrieval, but
+harmonic retrieval cannot be reviewed sanely if abstraction storage and anchor
+logic arrive in the same PR.
 
-If attack suites are not typed, operators and reviewers cannot tell whether the
-eval harness is actually covering provenance spoofing, subagent contamination,
-or trust-zone promotion failures. The defense exists, but the benchmark surface
-stays too implicit to police over time.
+If abstraction nodes and cue anchors land together, every retrieval regression
+ becomes ambiguous: did the failure come from bad abstraction schema, bad
+ anchor construction, or bad blending logic? The system needs a durable
+ abstraction contract before it needs mixed retrieval heuristics.
 
 ## Operating Theory
 
-The trust-zone rollout is working because it has stayed ordered:
+The memory-OS rollout keeps working when each retrieval family is decomposed
+ into store, writer, retrieval, and policy slices. Harmonic retrieval should
+ follow the same pattern:
 
-1. store trust tiers
-2. define promotion boundaries
-3. expose bounded recall
-4. surface deterministic trust signals
-5. require independent corroboration for risky promotions
-6. make attack suites first-class benchmark assets
-7. only then benchmark attacks at scale and tune policy
+1. define abstraction-node storage
+2. add cue-anchor indexing
+3. blend abstractions and anchors into retrieval
+4. benchmark whether the blend actually improves recall utility
 
-PR14 completed step 4. PR15 completed step 5. PR16 is step 6: teach the eval
-harness to recognize poisoning-defense suites explicitly through typed
-`memory-red-team` benchmark manifests.
+PR17 is step 1. It should do one thing: make abstraction nodes first-class,
+ typed, and inspectable.
 
-That keeps the benchmark layer explainable. A defense suite is no longer just a
-tagged benchmark pack. It becomes an explicit attack surface with a known class
-and target.
+That keeps later retrieval work explainable. Reviewers can inspect whether
+ abstractions are well-formed before debating how much weight they should have
+ against cue anchors or episodic traces.
 
 ## Strategy
 
-Keep the attack-pack contract narrow and deterministic:
+Keep the abstraction-node contract narrow and deterministic:
 
-- preserve backward compatibility for existing standard benchmark packs
-- add one explicit new benchmark type: `memory-red-team`
-- require `attackClass` and `targetSurface`
-- surface those fields in validation, import, and status output
-- avoid adding runner orchestration or replay logic yet
+- add the two roadmap flags now: `harmonicRetrievalEnabled` and `abstractionAnchorsEnabled`
+- add one explicit store directory: `abstractionNodeStoreDir`
+- store typed abstraction nodes by day
+- expose status counts by abstraction kind and level
+- avoid cue-anchor indexing or retrieval blending in this PR
 
-This preserves small-slice discipline. PR16 is not a full red-team runner. It
-is the smallest bounded benchmark-surface change that makes poisoning-defense
-coverage visible and enforceable in review.
+This preserves small-slice discipline. PR17 is not harmonic retrieval. It is
+ the smallest bounded storage change that makes harmonic retrieval data visible
+ and reviewable before scoring logic appears.
 
 ## Key Discoveries
 
-- Poisoning-defense benchmarks need explicit attack identity, not just tags.
-  Tags are useful filters, but they are too weak to serve as the contract for
-  a regression suite the team wants to protect in CI and review.
-- Benchmark typing should stay smaller than runner typing. The harness can
-  become attack-aware before it becomes attack-executing.
-- The first typed attack metadata should live at the manifest level. That is
-  enough to classify and count suites before deciding whether case-level attack
-  annotations are worth the complexity.
-- Benchmark visibility belongs before attack automation. The system should first
-  know what attack coverage exists before it tries to scale execution.
+- Harmonic retrieval needs its own storage substrate before it needs ranking.
+- Abstraction nodes should encode compression structure, not every cue. Cue
+  anchors belong in PR18, where they can be reviewed as their own index layer.
+- Operator-facing status commands keep new stores honest. If a new memory layer
+  cannot report valid, invalid, latest, and per-type counts, it is still too
+  implicit to tune safely.
 
 ## Open Questions
 
-- Should later red-team slices attach attack metadata per case as well as per
-  manifest, or is pack-level classification enough for the first generation?
-- Should future CI gates require minimum red-team coverage by `attackClass` and
-  `targetSurface`, or stay at pass/fail deltas only?
-- When replay execution lands, should `memory-red-team` packs run through the
-  same runner contracts as standard packs or a distinct adversarial path?
+- Should future abstraction writers produce one node per session episode, per
+  topic cluster, or both?
+- Should later abstraction nodes track confidence or source span coverage, or
+  can `sourceMemoryIds` stay sufficient until recall blending lands?
+- When PR19 arrives, should harmonic blending inject a new dedicated recall
+  section first, or blend directly into existing semantic recall ranking?

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -380,6 +380,9 @@ See [advanced-retrieval.md](advanced-retrieval.md) for guidance.
 | `trustZoneRecallEnabled` | `false` | Inject prompt-relevant working and trusted trust-zone records into recall context |
 | `memoryPoisoningDefenseEnabled` | `false` | Enable deterministic provenance trust scoring and corroboration requirements for risky trusted promotions |
 | `memoryRedTeamBenchEnabled` | `false` | Enable typed `memory-red-team` benchmark packs and status accounting for poisoning-defense regression suites |
+| `harmonicRetrievalEnabled` | `false` | Enable the harmonic-retrieval foundation for abstraction-node storage and later abstraction-plus-anchor recall slices |
+| `abstractionAnchorsEnabled` | `false` | Reserve cue-anchor support for later harmonic-retrieval slices while exposing anchor readiness in abstraction-node status output |
+| `abstractionNodeStoreDir` | `{memoryDir}/state/abstraction-nodes` | Root directory for abstraction-node artifacts |
 
 Current foundation slice:
 - `openclaw engram benchmark-status` scans `benchmarks/**.json` and `runs/**.json`, validates manifests/run summaries, and reports the latest completed run.
@@ -397,6 +400,8 @@ Current foundation slice:
 - When `memoryPoisoningDefenseEnabled` is also on, `openclaw engram trust-zone-status` reports deterministic provenance trust scores derived from source class plus `sourceId` / `evidenceHash` / `sessionKey` anchors so later poisoning defenses can build on explicit signals instead of hidden heuristics.
 - With both `memoryPoisoningDefenseEnabled` and `quarantinePromotionEnabled` enabled, risky `working -> trusted` promotions now require at least one independent non-`quarantine` corroborating record with anchored provenance and overlapping `entityRefs` or `tags`.
 - When `memoryRedTeamBenchEnabled` is on, benchmark manifests can also declare `benchmarkType: "memory-red-team"` plus `attackClass` and `targetSurface`, and `openclaw engram benchmark-status` reports red-team pack counts and unique attack metadata.
+- When `harmonicRetrievalEnabled` is on, Engram can persist typed abstraction nodes into a separate abstraction-node store for later harmonic retrieval slices.
+- When `abstractionAnchorsEnabled` is also on, `openclaw engram abstraction-node-status` surfaces whether the abstraction-node store is operating with future cue-anchor support enabled.
 - Future slices will add automated benchmark runners on top of this store and gate format.
 
 | `conversationIndexEmbedOnUpdate` | `false` | Run `qmd embed` on each update |

--- a/docs/plans/2026-03-07-engram-pr17-abstraction-node-schema.md
+++ b/docs/plans/2026-03-07-engram-pr17-abstraction-node-schema.md
@@ -1,0 +1,68 @@
+# PR17: Abstraction-Node Schema
+
+## Goal
+
+Ship the first harmonic-retrieval foundation slice without blending anything
+ into live recall yet.
+
+This PR introduces a typed abstraction-node store so later slices can attach
+ cue anchors and retrieval blending to a stable persistence contract instead of
+ inventing schema and heuristics at the same time.
+
+## Scope
+
+- add `harmonicRetrievalEnabled`
+- add `abstractionAnchorsEnabled`
+- add `abstractionNodeStoreDir`
+- add a typed abstraction-node contract and dated store layout
+- add `openclaw engram abstraction-node-status`
+- document the new foundation surface
+
+## Non-Goals
+
+- no cue-anchor index yet
+- no harmonic retrieval ranking/blending yet
+- no new recall-pipeline injection yet
+- no model-generated abstraction writer yet
+
+## Contract
+
+Abstraction nodes are typed summaries that compress durable memory structure
+ without trying to store every retrieval cue in this slice.
+
+Schema:
+
+- `nodeId`
+- `recordedAt`
+- `sessionKey`
+- `kind`: `episode | topic | project | workflow | constraint`
+- `abstractionLevel`: `micro | meso | macro`
+- `title`
+- `summary`
+- optional `sourceMemoryIds`
+- optional `entityRefs`
+- optional `tags`
+- optional `metadata`
+
+Storage layout:
+
+- `{memoryDir}/state/abstraction-nodes/nodes/YYYY-MM-DD/<nodeId>.json`
+
+## Why This Slice First
+
+The harmonic retrieval roadmap depends on an explicit abstraction layer:
+
+1. PR17 defines abstraction-node storage.
+2. PR18 adds cue-anchor indexing for entities/files/tools/outcomes/constraints/dates.
+3. PR19 blends abstractions and anchors into retrieval diagnostics.
+
+Keeping PR17 storage-only preserves small-slice discipline and makes later
+ review easier because any retrieval regression will happen after the data
+ contract is already stable.
+
+## Verification
+
+- config parsing defaults/custom overrides
+- abstraction-node validation and persistence
+- abstraction-node store status with invalid artifact reporting
+- CLI status wrapper for operator inspection

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1171,6 +1171,20 @@
         "default": false,
         "description": "Enable operator-facing memory red-team benchmark packs and status accounting for poisoning-defense regression suites."
       },
+      "harmonicRetrievalEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the harmonic-retrieval foundation for abstraction-node storage and later abstraction-plus-anchor recall slices."
+      },
+      "abstractionAnchorsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Reserve cue-anchor support for later harmonic-retrieval slices while exposing it in abstraction-node status output."
+      },
+      "abstractionNodeStoreDir": {
+        "type": "string",
+        "description": "Override the abstraction-node store directory (defaults to {memoryDir}/state/abstraction-nodes)."
+      },
       "actionGraphRecallEnabled": {
         "type": "boolean",
         "default": false,
@@ -2154,6 +2168,21 @@
       "label": "Memory Red-Team Benchmarks",
       "advanced": true,
       "help": "Enable operator-facing red-team benchmark pack support and status accounting for poisoning-defense suites."
+    },
+    "harmonicRetrievalEnabled": {
+      "label": "Harmonic Retrieval",
+      "help": "Enable the harmonic-retrieval foundation for abstraction-node storage and later abstraction-plus-anchor recall slices."
+    },
+    "abstractionAnchorsEnabled": {
+      "label": "Abstraction Anchors",
+      "advanced": true,
+      "help": "Reserve cue-anchor support for later harmonic-retrieval slices while exposing anchor readiness in abstraction-node status output."
+    },
+    "abstractionNodeStoreDir": {
+      "label": "Abstraction-Node Store Directory",
+      "advanced": true,
+      "placeholder": "{memoryDir}/state/abstraction-nodes",
+      "help": "Override where abstraction nodes are stored."
     },
     "actionGraphRecallEnabled": {
       "label": "Action Graph Recall",

--- a/src/abstraction-nodes.ts
+++ b/src/abstraction-nodes.ts
@@ -1,0 +1,162 @@
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { listJsonFiles, readJsonFile } from "./json-store.js";
+import {
+  assertIsoRecordedAt,
+  assertSafePathSegment,
+  assertString,
+  isRecord,
+  optionalStringArray,
+  recordStoreDay,
+  validateStringRecord,
+} from "./store-contract.js";
+
+export type AbstractionNodeKind = "episode" | "topic" | "project" | "workflow" | "constraint";
+export type AbstractionLevel = "micro" | "meso" | "macro";
+
+export interface AbstractionNode {
+  schemaVersion: 1;
+  nodeId: string;
+  recordedAt: string;
+  sessionKey: string;
+  kind: AbstractionNodeKind;
+  abstractionLevel: AbstractionLevel;
+  title: string;
+  summary: string;
+  sourceMemoryIds?: string[];
+  entityRefs?: string[];
+  tags?: string[];
+  metadata?: Record<string, string>;
+}
+
+export interface AbstractionNodeStoreStatus {
+  enabled: boolean;
+  anchorsEnabled: boolean;
+  rootDir: string;
+  nodesDir: string;
+  nodes: {
+    total: number;
+    valid: number;
+    invalid: number;
+    byKind: Partial<Record<AbstractionNodeKind, number>>;
+    byLevel: Partial<Record<AbstractionLevel, number>>;
+    latestNodeId?: string;
+    latestRecordedAt?: string;
+    latestSessionKey?: string;
+  };
+  latestNode?: AbstractionNode;
+  invalidNodes: Array<{
+    path: string;
+    error: string;
+  }>;
+}
+
+function validateKind(raw: unknown): AbstractionNodeKind {
+  const value = assertString(raw, "kind");
+  if (!["episode", "topic", "project", "workflow", "constraint"].includes(value)) {
+    throw new Error("kind must be one of episode|topic|project|workflow|constraint");
+  }
+  return value as AbstractionNodeKind;
+}
+
+function validateLevel(raw: unknown): AbstractionLevel {
+  const value = assertString(raw, "abstractionLevel");
+  if (!["micro", "meso", "macro"].includes(value)) {
+    throw new Error("abstractionLevel must be one of micro|meso|macro");
+  }
+  return value as AbstractionLevel;
+}
+
+export function resolveAbstractionNodeStoreDir(memoryDir: string, overrideDir?: string): string {
+  if (typeof overrideDir === "string" && overrideDir.trim().length > 0) {
+    return overrideDir.trim();
+  }
+  return path.join(memoryDir, "state", "abstraction-nodes");
+}
+
+export function validateAbstractionNode(raw: unknown): AbstractionNode {
+  if (!isRecord(raw)) throw new Error("abstraction node must be an object");
+  if (raw.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
+
+  return {
+    schemaVersion: 1,
+    nodeId: assertSafePathSegment(assertString(raw.nodeId, "nodeId"), "nodeId"),
+    recordedAt: assertIsoRecordedAt(assertString(raw.recordedAt, "recordedAt")),
+    sessionKey: assertString(raw.sessionKey, "sessionKey"),
+    kind: validateKind(raw.kind),
+    abstractionLevel: validateLevel(raw.abstractionLevel),
+    title: assertString(raw.title, "title"),
+    summary: assertString(raw.summary, "summary"),
+    sourceMemoryIds: optionalStringArray(raw.sourceMemoryIds, "sourceMemoryIds"),
+    entityRefs: optionalStringArray(raw.entityRefs, "entityRefs"),
+    tags: optionalStringArray(raw.tags, "tags"),
+    metadata: validateStringRecord(raw.metadata, "metadata"),
+  };
+}
+
+export async function recordAbstractionNode(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  node: AbstractionNode;
+}): Promise<string> {
+  const rootDir = resolveAbstractionNodeStoreDir(options.memoryDir, options.abstractionNodeStoreDir);
+  const validated = validateAbstractionNode(options.node);
+  const day = recordStoreDay(validated.recordedAt);
+  const nodesDir = path.join(rootDir, "nodes", day);
+  const filePath = path.join(nodesDir, `${validated.nodeId}.json`);
+  await mkdir(nodesDir, { recursive: true });
+  await writeFile(filePath, JSON.stringify(validated, null, 2), "utf8");
+  return filePath;
+}
+
+export async function getAbstractionNodeStoreStatus(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  enabled: boolean;
+  anchorsEnabled: boolean;
+}): Promise<AbstractionNodeStoreStatus> {
+  const rootDir = resolveAbstractionNodeStoreDir(options.memoryDir, options.abstractionNodeStoreDir);
+  const nodesDir = path.join(rootDir, "nodes");
+  const files = await listJsonFiles(nodesDir);
+  const nodes: AbstractionNode[] = [];
+  const invalidNodes: Array<{ path: string; error: string }> = [];
+
+  for (const filePath of files) {
+    try {
+      nodes.push(validateAbstractionNode(await readJsonFile(filePath)));
+    } catch (error) {
+      invalidNodes.push({
+        path: filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  nodes.sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
+
+  const byKind: Partial<Record<AbstractionNodeKind, number>> = {};
+  const byLevel: Partial<Record<AbstractionLevel, number>> = {};
+  for (const node of nodes) {
+    byKind[node.kind] = (byKind[node.kind] ?? 0) + 1;
+    byLevel[node.abstractionLevel] = (byLevel[node.abstractionLevel] ?? 0) + 1;
+  }
+
+  return {
+    enabled: options.enabled,
+    anchorsEnabled: options.anchorsEnabled,
+    rootDir,
+    nodesDir,
+    nodes: {
+      total: files.length,
+      valid: nodes.length,
+      invalid: invalidNodes.length,
+      byKind,
+      byLevel,
+      latestNodeId: nodes[0]?.nodeId,
+      latestRecordedAt: nodes[0]?.recordedAt,
+      latestSessionKey: nodes[0]?.sessionKey,
+    },
+    latestNode: nodes[0],
+    invalidNodes,
+  };
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -57,6 +57,10 @@ import {
   getCausalTrajectoryStoreStatus,
   type CausalTrajectoryStoreStatus,
 } from "./causal-trajectory.js";
+import {
+  getAbstractionNodeStoreStatus,
+  type AbstractionNodeStoreStatus,
+} from "./abstraction-nodes.js";
 import { getObjectiveStateStoreStatus, type ObjectiveStateStoreStatus } from "./objective-state.js";
 import {
   getTrustZoneStoreStatus,
@@ -681,6 +685,20 @@ export async function runTrustZoneStatusCliCommand(options: {
     enabled: options.trustZonesEnabled,
     promotionEnabled: options.quarantinePromotionEnabled,
     poisoningDefenseEnabled: options.memoryPoisoningDefenseEnabled,
+  });
+}
+
+export async function runAbstractionNodeStatusCliCommand(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  harmonicRetrievalEnabled: boolean;
+  abstractionAnchorsEnabled: boolean;
+}): Promise<AbstractionNodeStoreStatus> {
+  return getAbstractionNodeStoreStatus({
+    memoryDir: options.memoryDir,
+    abstractionNodeStoreDir: options.abstractionNodeStoreDir,
+    enabled: options.harmonicRetrievalEnabled,
+    anchorsEnabled: options.abstractionAnchorsEnabled,
   });
 }
 
@@ -2320,6 +2338,20 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             trustZonesEnabled: orchestrator.config.trustZonesEnabled,
             quarantinePromotionEnabled: orchestrator.config.quarantinePromotionEnabled,
             memoryPoisoningDefenseEnabled: orchestrator.config.memoryPoisoningDefenseEnabled,
+          });
+          console.log(JSON.stringify(status, null, 2));
+          console.log("OK");
+        });
+
+      cmd
+        .command("abstraction-node-status")
+        .description("Show abstraction-node store status, abstraction counts, and latest stored node")
+        .action(async () => {
+          const status = await runAbstractionNodeStatusCliCommand({
+            memoryDir: orchestrator.config.memoryDir,
+            abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
+            harmonicRetrievalEnabled: orchestrator.config.harmonicRetrievalEnabled,
+            abstractionAnchorsEnabled: orchestrator.config.abstractionAnchorsEnabled,
           });
           console.log(JSON.stringify(status, null, 2));
           console.log("OK");

--- a/src/config.ts
+++ b/src/config.ts
@@ -507,6 +507,12 @@ export function parseConfig(raw: unknown): PluginConfig {
     trustZoneRecallEnabled: cfg.trustZoneRecallEnabled === true,
     memoryPoisoningDefenseEnabled: cfg.memoryPoisoningDefenseEnabled === true,
     memoryRedTeamBenchEnabled: cfg.memoryRedTeamBenchEnabled === true,
+    harmonicRetrievalEnabled: cfg.harmonicRetrievalEnabled === true,
+    abstractionAnchorsEnabled: cfg.abstractionAnchorsEnabled === true,
+    abstractionNodeStoreDir:
+      typeof cfg.abstractionNodeStoreDir === "string" && cfg.abstractionNodeStoreDir.trim().length > 0
+        ? cfg.abstractionNodeStoreDir.trim()
+        : path.join(memoryDir, "state", "abstraction-nodes"),
     // Local LLM Provider (v2.1)
     localLlmEnabled: cfg.localLlmEnabled === true || cfg.localLlmEnabled === "true", // default: false
     localLlmUrl:

--- a/src/types.ts
+++ b/src/types.ts
@@ -234,6 +234,10 @@ export interface PluginConfig {
   trustZoneRecallEnabled: boolean;
   memoryPoisoningDefenseEnabled: boolean;
   memoryRedTeamBenchEnabled: boolean;
+  // Harmonic retrieval foundation
+  harmonicRetrievalEnabled: boolean;
+  abstractionAnchorsEnabled: boolean;
+  abstractionNodeStoreDir: string;
   // Local LLM Provider (v2.1)
   localLlmEnabled: boolean;
   localLlmUrl: string;

--- a/tests/abstraction-nodes.test.ts
+++ b/tests/abstraction-nodes.test.ts
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import {
+  getAbstractionNodeStoreStatus,
+  recordAbstractionNode,
+  resolveAbstractionNodeStoreDir,
+  validateAbstractionNode,
+} from "../src/abstraction-nodes.js";
+import { runAbstractionNodeStatusCliCommand } from "../src/cli.js";
+
+test("abstraction-node config path resolves under memoryDir by default", () => {
+  assert.equal(
+    resolveAbstractionNodeStoreDir("/tmp/engram-memory"),
+    path.join("/tmp/engram-memory", "state", "abstraction-nodes"),
+  );
+  assert.equal(
+    resolveAbstractionNodeStoreDir("/tmp/engram-memory", "  /tmp/custom-abstraction-nodes  "),
+    "/tmp/custom-abstraction-nodes",
+  );
+});
+
+test("validateAbstractionNode accepts the normalized abstraction-node contract", () => {
+  const node = validateAbstractionNode({
+    schemaVersion: 1,
+    nodeId: "abstraction-1",
+    recordedAt: "2026-03-07T21:00:00.000Z",
+    sessionKey: "agent:main",
+    kind: "workflow",
+    abstractionLevel: "meso",
+    title: "PR loop recovery pattern",
+    summary: "Summarizes the stable PR-loop recovery workflow for review-driven Engram slices.",
+    sourceMemoryIds: ["mem-1", "mem-2"],
+    entityRefs: ["project:openclaw-engram"],
+    tags: ["harmonic-retrieval", "workflow"],
+    metadata: {
+      source: "roadmap",
+    },
+  });
+
+  assert.equal(node.kind, "workflow");
+  assert.equal(node.abstractionLevel, "meso");
+  assert.deepEqual(node.sourceMemoryIds, ["mem-1", "mem-2"]);
+});
+
+test("recordAbstractionNode persists nodes into dated abstraction-node storage", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-abstraction-node-record-"));
+  const filePath = await recordAbstractionNode({
+    memoryDir,
+    node: {
+      schemaVersion: 1,
+      nodeId: "abstraction-2",
+      recordedAt: "2026-03-07T21:01:00.000Z",
+      sessionKey: "agent:main",
+      kind: "topic",
+      abstractionLevel: "macro",
+      title: "Agentic memory benchmark strategy",
+      summary: "Captures the benchmark-first memory operating system direction.",
+      tags: ["roadmap"],
+    },
+  });
+
+  assert.equal(
+    filePath,
+    path.join(memoryDir, "state", "abstraction-nodes", "nodes", "2026-03-07", "abstraction-2.json"),
+  );
+});
+
+test("recordAbstractionNode rejects unsafe ids and malformed timestamps", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-abstraction-node-reject-"));
+
+  await assert.rejects(
+    () =>
+      recordAbstractionNode({
+        memoryDir,
+        node: {
+          schemaVersion: 1,
+          nodeId: "../escape",
+          recordedAt: "2026-03-07T21:01:00.000Z",
+          sessionKey: "agent:main",
+          kind: "topic",
+          abstractionLevel: "macro",
+          title: "invalid id",
+          summary: "invalid id",
+        },
+      }),
+    /nodeId must be a safe path segment/i,
+  );
+
+  await assert.rejects(
+    () =>
+      recordAbstractionNode({
+        memoryDir,
+        node: {
+          schemaVersion: 1,
+          nodeId: "abstraction-bad-date",
+          recordedAt: "not-a-date",
+          sessionKey: "agent:main",
+          kind: "topic",
+          abstractionLevel: "macro",
+          title: "invalid recordedAt",
+          summary: "invalid date",
+        },
+      }),
+    /recordedAt must be an ISO timestamp/i,
+  );
+});
+
+test("abstraction-node status reports valid and invalid nodes", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-abstraction-node-status-"));
+  await recordAbstractionNode({
+    memoryDir,
+    node: {
+      schemaVersion: 1,
+      nodeId: "abstraction-3",
+      recordedAt: "2026-03-07T21:02:00.000Z",
+      sessionKey: "agent:main",
+      kind: "constraint",
+      abstractionLevel: "micro",
+      title: "Wait for Cursor terminal state",
+      summary: "Captures the repo rule that open PRs stay live until Cursor is terminal.",
+      tags: ["pr-loop"],
+    },
+  });
+
+  const invalidDir = path.join(memoryDir, "state", "abstraction-nodes", "nodes", "2026-03-07");
+  await mkdir(invalidDir, { recursive: true });
+  await writeFile(path.join(invalidDir, "invalid.json"), "{\"schemaVersion\":2}", "utf8");
+
+  const status = await getAbstractionNodeStoreStatus({
+    memoryDir,
+    enabled: true,
+    anchorsEnabled: false,
+  });
+
+  assert.equal(status.enabled, true);
+  assert.equal(status.anchorsEnabled, false);
+  assert.equal(status.nodes.total, 2);
+  assert.equal(status.nodes.valid, 1);
+  assert.equal(status.nodes.invalid, 1);
+  assert.equal(status.nodes.byKind.constraint, 1);
+  assert.equal(status.nodes.byLevel.micro, 1);
+  assert.equal(status.latestNode?.nodeId, "abstraction-3");
+  assert.match(status.invalidNodes[0]?.path ?? "", /invalid\.json$/);
+});
+
+test("abstraction-node-status CLI command returns the store summary", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-abstraction-node-cli-"));
+  await recordAbstractionNode({
+    memoryDir,
+    node: {
+      schemaVersion: 1,
+      nodeId: "abstraction-cli-1",
+      recordedAt: "2026-03-07T21:03:00.000Z",
+      sessionKey: "agent:main",
+      kind: "project",
+      abstractionLevel: "macro",
+      title: "Engram memory OS",
+      summary: "Project-level abstraction for the memory operating system roadmap.",
+      entityRefs: ["project:openclaw-engram"],
+    },
+  });
+
+  const status = await runAbstractionNodeStatusCliCommand({
+    memoryDir,
+    harmonicRetrievalEnabled: true,
+    abstractionAnchorsEnabled: false,
+    abstractionNodeStoreDir: undefined,
+  });
+
+  assert.equal(status.nodes.total, 1);
+  assert.equal(status.latestNode?.nodeId, "abstraction-cli-1");
+  assert.equal(status.nodes.byKind.project, 1);
+});

--- a/tests/config-eval-harness.test.ts
+++ b/tests/config-eval-harness.test.ts
@@ -27,6 +27,9 @@ test("evaluation harness config defaults off and derives store dir from memoryDi
   assert.equal(cfg.trustZoneRecallEnabled, false);
   assert.equal(cfg.memoryPoisoningDefenseEnabled, false);
   assert.equal(cfg.memoryRedTeamBenchEnabled, false);
+  assert.equal(cfg.harmonicRetrievalEnabled, false);
+  assert.equal(cfg.abstractionAnchorsEnabled, false);
+  assert.equal(cfg.abstractionNodeStoreDir, path.join(memoryDir, "state", "abstraction-nodes"));
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "objective-state" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "causal-trajectories" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "trust-zones" && entry.enabled === false), true);
@@ -53,6 +56,9 @@ test("evaluation harness config respects explicit flags and custom store dir", (
     trustZoneRecallEnabled: true,
     memoryPoisoningDefenseEnabled: true,
     memoryRedTeamBenchEnabled: true,
+    harmonicRetrievalEnabled: true,
+    abstractionAnchorsEnabled: true,
+    abstractionNodeStoreDir: "/tmp/abstraction-node-store",
   });
 
   assert.equal(cfg.evalHarnessEnabled, true);
@@ -72,4 +78,7 @@ test("evaluation harness config respects explicit flags and custom store dir", (
   assert.equal(cfg.trustZoneRecallEnabled, true);
   assert.equal(cfg.memoryPoisoningDefenseEnabled, true);
   assert.equal(cfg.memoryRedTeamBenchEnabled, true);
+  assert.equal(cfg.harmonicRetrievalEnabled, true);
+  assert.equal(cfg.abstractionAnchorsEnabled, true);
+  assert.equal(cfg.abstractionNodeStoreDir, "/tmp/abstraction-node-store");
 });


### PR DESCRIPTION
## Summary
- add the first harmonic-retrieval storage contract via typed abstraction nodes
- expose harmonic retrieval flags and abstraction-node store config through the plugin surface
- add abstraction-node status CLI/docs/tests without introducing retrieval blending yet

## Verification
- npx tsx --test tests/abstraction-nodes.test.ts tests/config-eval-harness.test.ts
- npm run check-types
- npm run check-config-contract
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive, behind new config flags, and limited to a new store contract plus a status CLI command; no retrieval/blending logic changes. Main risk is minor config/schema wiring regressions (new fields and default paths) affecting plugin consumers.
> 
> **Overview**
> Introduces the first harmonic-retrieval *storage-only* slice by adding a typed `AbstractionNode` contract, persistence to `{memoryDir}/state/abstraction-nodes/nodes/YYYY-MM-DD/<nodeId>.json`, and a store status scanner that reports valid/invalid artifacts plus counts by kind/level.
> 
> Wires the foundation into the plugin surface via new config flags (`harmonicRetrievalEnabled`, `abstractionAnchorsEnabled`) and `abstractionNodeStoreDir`, adds `openclaw engram abstraction-node-status`, and updates docs/README/changelog plus new tests covering validation, persistence, status reporting, and config defaults/overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b71f50f1d3d703ddd76d1f17ac54229efa461469. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->