### PR TITLE
feat: add cue-anchor index foundation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Enrich extraction prompt few-shot examples with `entityRef` and entity `facts` fields, using realistic concrete values instead of generic placeholders.
 
 ### Added
+- **Cue-anchor index foundation**: when `harmonicRetrievalEnabled` and `abstractionAnchorsEnabled` are enabled, Engram can now persist typed cue anchors for entities, files, tools, outcomes, constraints, and dates under `state/abstraction-nodes/anchors`, and inspect them with `openclaw engram cue-anchor-status`.
 - **Abstraction-node foundation**: added `harmonicRetrievalEnabled`, `abstractionAnchorsEnabled`, `abstractionNodeStoreDir`, a typed abstraction-node store under `state/abstraction-nodes`, and `openclaw engram abstraction-node-status` for the first harmonic-retrieval storage slice.
 - **Memory red-team benchmark packs**: added `memoryRedTeamBenchEnabled`, typed `memory-red-team` benchmark manifest support (`benchmarkType`, `attackClass`, `targetSurface`), and benchmark-status accounting for poisoning-defense attack suites.
 - **Risky-promotion corroboration**: when `memoryPoisoningDefenseEnabled` is enabled, risky `working -> trusted` trust-zone promotions now require independent non-`quarantine` corroboration with anchored provenance and overlapping `entityRefs` or `tags`, and successful promotions record corroboration metadata.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ AI agents forget everything between conversations. Engram fixes that.
 - **Trust-zone recall** — Engram can now, when `trustZoneRecallEnabled` is enabled, inject prompt-relevant `working` and `trusted` trust-zone records into recall context as a separate `Trust Zones` section while keeping `quarantine` material out of recall by default.
 - **Poisoning-defense corroboration** — Engram can now, when `memoryPoisoningDefenseEnabled` is enabled, score trust-zone provenance deterministically and require independent non-quarantine corroboration before risky `working -> trusted` promotions succeed.
 - **Red-team benchmark packs** — Engram's eval harness can now validate and count typed `memory-red-team` benchmark packs so poisoning-defense regression suites stay explicit and reviewable instead of hiding inside generic benchmark metadata.
-- **Abstraction-node foundation** — Engram can now, when `harmonicRetrievalEnabled` is enabled, persist typed abstraction nodes for later harmonic retrieval slices, with `abstractionAnchorsEnabled` reserved for the future cue-anchor layer.
+- **Cue-anchor index foundation** — Engram can now, when `harmonicRetrievalEnabled` and `abstractionAnchorsEnabled` are enabled, persist typed cue anchors for entities, files, tools, outcomes, constraints, and dates, inspect them with `openclaw engram cue-anchor-status`, and keep harmonic retrieval grounded in explicit abstraction-to-cue links before blending logic lands.
 - **Zero-config start** — Install, add an API key, restart. Engram works out of the box with sensible defaults and progressively unlocks advanced features as you enable them.
 
 ## Quick Start

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,64 +1,68 @@
-# Theory: Harmonic Retrieval Needs Abstraction Storage Before It Needs Blending
+# Theory: Cue Anchors Need Their Own Index Before Harmonic Blending Lands
 
 ## Problem
 
 Engram now has a measured evaluation harness, objective-state memory, causal
 trajectories, trust zones, provenance scoring, corroboration rules, and typed
-red-team benchmark packs. The next roadmap step is harmonic retrieval, but
-harmonic retrieval cannot be reviewed sanely if abstraction storage and anchor
-logic arrive in the same PR.
+red-team benchmark packs. The next roadmap step is still harmonic retrieval,
+but PR18 should not jump from abstraction nodes straight into blended ranking.
+The missing substrate is a cue-anchor index that makes abstraction nodes
+addressable by concrete cues before any scoring logic is allowed to use them.
 
-If abstraction nodes and cue anchors land together, every retrieval regression
- becomes ambiguous: did the failure come from bad abstraction schema, bad
- anchor construction, or bad blending logic? The system needs a durable
- abstraction contract before it needs mixed retrieval heuristics.
+If cue-anchor indexing and harmonic blending land together, every retrieval
+regression becomes ambiguous: did the failure come from bad anchor typing, bad
+node linkage, or bad blending weights? The system needs a durable anchor index
+before it needs retrieval heuristics.
 
 ## Operating Theory
 
 The memory-OS rollout keeps working when each retrieval family is decomposed
- into store, writer, retrieval, and policy slices. Harmonic retrieval should
- follow the same pattern:
+into store, writer, retrieval, and policy slices. Harmonic retrieval should
+keep following that pattern:
 
 1. define abstraction-node storage
 2. add cue-anchor indexing
 3. blend abstractions and anchors into retrieval
 4. benchmark whether the blend actually improves recall utility
 
-PR17 is step 1. It should do one thing: make abstraction nodes first-class,
- typed, and inspectable.
+PR18 is step 2. It should do one thing: make cue anchors first-class, typed,
+and inspectable.
 
 That keeps later retrieval work explainable. Reviewers can inspect whether
- abstractions are well-formed before debating how much weight they should have
- against cue anchors or episodic traces.
+anchors are well-formed and linked to the right abstraction nodes before
+debating how much weight they should have against semantic recall or episodic
+traces.
 
 ## Strategy
 
-Keep the abstraction-node contract narrow and deterministic:
+Keep the cue-anchor contract narrow and deterministic:
 
-- add the two roadmap flags now: `harmonicRetrievalEnabled` and `abstractionAnchorsEnabled`
-- add one explicit store directory: `abstractionNodeStoreDir`
-- store typed abstraction nodes by day
-- expose status counts by abstraction kind and level
-- avoid cue-anchor indexing or retrieval blending in this PR
+- reuse the existing roadmap flags: `harmonicRetrievalEnabled` and `abstractionAnchorsEnabled`
+- keep anchor storage under the existing abstraction root instead of adding a second top-level config knob
+- store typed cue anchors by cue type: `entity`, `file`, `tool`, `outcome`, `constraint`, and `date`
+- link each anchor to one or more abstraction-node IDs
+- expose status counts by anchor type plus linked-node totals
+- avoid retrieval blending in this PR
 
-This preserves small-slice discipline. PR17 is not harmonic retrieval. It is
- the smallest bounded storage change that makes harmonic retrieval data visible
- and reviewable before scoring logic appears.
+This preserves small-slice discipline. PR18 is not harmonic retrieval. It is
+the smallest bounded indexing change that makes abstraction cues visible and
+reviewable before scoring logic appears.
 
 ## Key Discoveries
 
-- Harmonic retrieval needs its own storage substrate before it needs ranking.
-- Abstraction nodes should encode compression structure, not every cue. Cue
-  anchors belong in PR18, where they can be reviewed as their own index layer.
+- Harmonic retrieval needs its cue substrate before it needs ranking.
+- Abstraction nodes should encode compression structure, while cue anchors
+  encode retrieval handles. Mixing both into one record would make later
+  diagnostics much harder.
 - Operator-facing status commands keep new stores honest. If a new memory layer
   cannot report valid, invalid, latest, and per-type counts, it is still too
   implicit to tune safely.
 
 ## Open Questions
 
-- Should future abstraction writers produce one node per session episode, per
-  topic cluster, or both?
-- Should later abstraction nodes track confidence or source span coverage, or
-  can `sourceMemoryIds` stay sufficient until recall blending lands?
+- Should future abstraction writers emit anchors directly during node creation,
+  or should a later offline linker derive anchors from existing nodes?
+- Should `file` and `date` anchors normalize to stricter canonical forms before
+  PR19, or is current typed storage sufficient for the first blend?
 - When PR19 arrives, should harmonic blending inject a new dedicated recall
   section first, or blend directly into existing semantic recall ranking?

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -381,7 +381,7 @@ See [advanced-retrieval.md](advanced-retrieval.md) for guidance.
 | `memoryPoisoningDefenseEnabled` | `false` | Enable deterministic provenance trust scoring and corroboration requirements for risky trusted promotions |
 | `memoryRedTeamBenchEnabled` | `false` | Enable typed `memory-red-team` benchmark packs and status accounting for poisoning-defense regression suites |
 | `harmonicRetrievalEnabled` | `false` | Enable the harmonic-retrieval foundation for abstraction-node storage and later abstraction-plus-anchor recall slices |
-| `abstractionAnchorsEnabled` | `false` | Reserve cue-anchor support for later harmonic-retrieval slices while exposing anchor readiness in abstraction-node status output |
+| `abstractionAnchorsEnabled` | `false` | Enable typed cue-anchor indexing for abstraction nodes and expose the anchor store through status tooling |
 | `abstractionNodeStoreDir` | `{memoryDir}/state/abstraction-nodes` | Root directory for abstraction-node artifacts |
 
 Current foundation slice:
@@ -401,7 +401,8 @@ Current foundation slice:
 - With both `memoryPoisoningDefenseEnabled` and `quarantinePromotionEnabled` enabled, risky `working -> trusted` promotions now require at least one independent non-`quarantine` corroborating record with anchored provenance and overlapping `entityRefs` or `tags`.
 - When `memoryRedTeamBenchEnabled` is on, benchmark manifests can also declare `benchmarkType: "memory-red-team"` plus `attackClass` and `targetSurface`, and `openclaw engram benchmark-status` reports red-team pack counts and unique attack metadata.
 - When `harmonicRetrievalEnabled` is on, Engram can persist typed abstraction nodes into a separate abstraction-node store for later harmonic retrieval slices.
-- When `abstractionAnchorsEnabled` is also on, `openclaw engram abstraction-node-status` surfaces whether the abstraction-node store is operating with future cue-anchor support enabled.
+- When `abstractionAnchorsEnabled` is also on, Engram can persist cue-anchor index entries under `{abstractionNodeStoreDir}/anchors` for entities, files, tools, outcomes, constraints, and dates.
+- Use `openclaw engram abstraction-node-status` to inspect node storage and `openclaw engram cue-anchor-status` to inspect anchor counts, latest anchors, and invalid index records.
 - Future slices will add automated benchmark runners on top of this store and gate format.
 
 | `conversationIndexEmbedOnUpdate` | `false` | Run `qmd embed` on each update |

--- a/docs/plans/2026-03-07-engram-pr18-cue-anchor-index.md
+++ b/docs/plans/2026-03-07-engram-pr18-cue-anchor-index.md
@@ -1,0 +1,110 @@
+# PR18: Cue-Anchor Index Foundation
+
+## Goal
+
+Add the second harmonic-retrieval substrate slice:
+
+- typed cue-anchor storage for abstraction nodes
+- operator-facing anchor status inspection
+- no retrieval blending yet
+
+## Why This Slice Exists
+
+PR17 made abstraction nodes explicit and inspectable. PR18 makes those nodes
+addressable through concrete cues before any ranking logic tries to blend
+abstractions with semantic recall.
+
+This follows the roadmap sequence in
+`docs/plans/2026-03-06-engram-agentic-memory-roadmap.md`:
+
+1. PR17: abstraction-node schema
+2. PR18: cue-anchor index
+3. PR19: harmonic retrieval blender and diagnostics
+
+## Scope
+
+### Included
+
+- new typed cue-anchor contract
+- cue-anchor storage rooted under `{abstractionNodeStoreDir}/anchors`
+- cue types for:
+  - `entity`
+  - `file`
+  - `tool`
+  - `outcome`
+  - `constraint`
+  - `date`
+- per-anchor linkage to one or more abstraction-node IDs
+- `openclaw engram cue-anchor-status`
+- tests for validation, persistence, status reporting, and CLI wrapper
+- README/config/changelog/theory updates
+
+### Excluded
+
+- no abstraction writer automation yet
+- no retrieval blending yet
+- no scoring/weighting heuristics
+- no new top-level config flags beyond the existing harmonic-retrieval flags
+
+## Contract
+
+Each cue anchor stores:
+
+- `schemaVersion`
+- `anchorId`
+- `anchorType`
+- `anchorValue`
+- `normalizedCue`
+- `recordedAt`
+- `sessionKey`
+- `nodeRefs`
+- optional `tags`
+- optional `metadata`
+
+Persistence layout:
+
+```text
+{memoryDir}/state/abstraction-nodes/anchors/{anchorType}/{anchorId}.json
+```
+
+Status surface reports:
+
+- total / valid / invalid anchors
+- counts by cue type
+- total linked node references
+- latest anchor metadata
+- invalid anchor file list
+
+## Flags
+
+- `harmonicRetrievalEnabled`
+- `abstractionAnchorsEnabled`
+
+Behavior stays fail-open and inert unless operators enable those harmonic
+retrieval flags.
+
+## Test Plan
+
+Focused red-green tests:
+
+- path resolution
+- schema validation
+- typed persistence path
+- unsafe id / empty node-ref rejection
+- valid + invalid status accounting
+- CLI wrapper status output
+
+Verification before PR:
+
+- `npx tsx --test tests/cue-anchors.test.ts tests/abstraction-nodes.test.ts tests/config-eval-harness.test.ts`
+- `npm run check-types`
+- `npm run check-config-contract`
+- `npm test`
+- `npm run build`
+
+## Review Focus
+
+- cue typing and validation should stay deterministic
+- anchor storage should remain separate from retrieval logic
+- CLI/status output should make malformed anchor files obvious
+- no accidental retrieval blending or new ranking behavior should appear in this slice

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1179,7 +1179,7 @@
       "abstractionAnchorsEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Reserve cue-anchor support for later harmonic-retrieval slices while exposing it in abstraction-node status output."
+        "description": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
       },
       "abstractionNodeStoreDir": {
         "type": "string",
@@ -2176,7 +2176,7 @@
     "abstractionAnchorsEnabled": {
       "label": "Abstraction Anchors",
       "advanced": true,
-      "help": "Reserve cue-anchor support for later harmonic-retrieval slices while exposing anchor readiness in abstraction-node status output."
+      "help": "Enable typed cue-anchor indexing for abstraction nodes and expose it through cue-anchor status tooling."
     },
     "abstractionNodeStoreDir": {
       "label": "Abstraction-Node Store Directory",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -61,6 +61,10 @@ import {
   getAbstractionNodeStoreStatus,
   type AbstractionNodeStoreStatus,
 } from "./abstraction-nodes.js";
+import {
+  getCueAnchorStoreStatus,
+  type CueAnchorStoreStatus,
+} from "./cue-anchors.js";
 import { getObjectiveStateStoreStatus, type ObjectiveStateStoreStatus } from "./objective-state.js";
 import {
   getTrustZoneStoreStatus,
@@ -695,6 +699,20 @@ export async function runAbstractionNodeStatusCliCommand(options: {
   abstractionAnchorsEnabled: boolean;
 }): Promise<AbstractionNodeStoreStatus> {
   return getAbstractionNodeStoreStatus({
+    memoryDir: options.memoryDir,
+    abstractionNodeStoreDir: options.abstractionNodeStoreDir,
+    enabled: options.harmonicRetrievalEnabled,
+    anchorsEnabled: options.abstractionAnchorsEnabled,
+  });
+}
+
+export async function runCueAnchorStatusCliCommand(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  harmonicRetrievalEnabled: boolean;
+  abstractionAnchorsEnabled: boolean;
+}): Promise<CueAnchorStoreStatus> {
+  return getCueAnchorStoreStatus({
     memoryDir: options.memoryDir,
     abstractionNodeStoreDir: options.abstractionNodeStoreDir,
     enabled: options.harmonicRetrievalEnabled,
@@ -2348,6 +2366,20 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         .description("Show abstraction-node store status, abstraction counts, and latest stored node")
         .action(async () => {
           const status = await runAbstractionNodeStatusCliCommand({
+            memoryDir: orchestrator.config.memoryDir,
+            abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
+            harmonicRetrievalEnabled: orchestrator.config.harmonicRetrievalEnabled,
+            abstractionAnchorsEnabled: orchestrator.config.abstractionAnchorsEnabled,
+          });
+          console.log(JSON.stringify(status, null, 2));
+          console.log("OK");
+        });
+
+      cmd
+        .command("cue-anchor-status")
+        .description("Show cue-anchor index status, anchor counts, and the latest stored cue anchor")
+        .action(async () => {
+          const status = await runCueAnchorStatusCliCommand({
             memoryDir: orchestrator.config.memoryDir,
             abstractionNodeStoreDir: orchestrator.config.abstractionNodeStoreDir,
             harmonicRetrievalEnabled: orchestrator.config.harmonicRetrievalEnabled,

--- a/src/cue-anchors.ts
+++ b/src/cue-anchors.ts
@@ -1,0 +1,163 @@
+import path from "node:path";
+import { mkdir, writeFile } from "node:fs/promises";
+import { listJsonFiles, readJsonFile } from "./json-store.js";
+import {
+  assertIsoRecordedAt,
+  assertSafePathSegment,
+  assertString,
+  isRecord,
+  optionalStringArray,
+  validateStringRecord,
+} from "./store-contract.js";
+
+export type CueAnchorType = "entity" | "file" | "tool" | "outcome" | "constraint" | "date";
+
+export interface CueAnchor {
+  schemaVersion: 1;
+  anchorId: string;
+  anchorType: CueAnchorType;
+  anchorValue: string;
+  normalizedCue: string;
+  recordedAt: string;
+  sessionKey: string;
+  nodeRefs: string[];
+  tags?: string[];
+  metadata?: Record<string, string>;
+}
+
+export interface CueAnchorStoreStatus {
+  enabled: boolean;
+  anchorsEnabled: boolean;
+  rootDir: string;
+  anchors: {
+    total: number;
+    valid: number;
+    invalid: number;
+    byType: Partial<Record<CueAnchorType, number>>;
+    totalNodeRefs: number;
+    latestAnchorId?: string;
+    latestRecordedAt?: string;
+    latestSessionKey?: string;
+  };
+  latestAnchor?: CueAnchor;
+  invalidAnchors: Array<{
+    path: string;
+    error: string;
+  }>;
+}
+
+function validateAnchorType(raw: unknown): CueAnchorType {
+  const value = assertString(raw, "anchorType");
+  if (!["entity", "file", "tool", "outcome", "constraint", "date"].includes(value)) {
+    throw new Error("anchorType must be one of entity|file|tool|outcome|constraint|date");
+  }
+  return value as CueAnchorType;
+}
+
+function validateNodeRefs(raw: unknown): string[] {
+  const nodeRefs = optionalStringArray(raw, "nodeRefs");
+  if (!nodeRefs || nodeRefs.length === 0) {
+    throw new Error("nodeRefs must contain at least one node reference");
+  }
+  return nodeRefs.map((nodeRef, index) => assertSafePathSegment(nodeRef, `nodeRefs[${index}]`));
+}
+
+export function resolveCueAnchorStoreDir(
+  abstractionNodeStoreDir: string,
+  overrideDir?: string,
+): string {
+  if (typeof overrideDir === "string" && overrideDir.trim().length > 0) {
+    return overrideDir.trim();
+  }
+  return path.join(abstractionNodeStoreDir, "anchors");
+}
+
+export function validateCueAnchor(raw: unknown): CueAnchor {
+  if (!isRecord(raw)) throw new Error("cue anchor must be an object");
+  if (raw.schemaVersion !== 1) throw new Error("schemaVersion must be 1");
+
+  return {
+    schemaVersion: 1,
+    anchorId: assertSafePathSegment(assertString(raw.anchorId, "anchorId"), "anchorId"),
+    anchorType: validateAnchorType(raw.anchorType),
+    anchorValue: assertString(raw.anchorValue, "anchorValue"),
+    normalizedCue: assertString(raw.normalizedCue, "normalizedCue"),
+    recordedAt: assertIsoRecordedAt(assertString(raw.recordedAt, "recordedAt")),
+    sessionKey: assertString(raw.sessionKey, "sessionKey"),
+    nodeRefs: validateNodeRefs(raw.nodeRefs),
+    tags: optionalStringArray(raw.tags, "tags"),
+    metadata: validateStringRecord(raw.metadata, "metadata"),
+  };
+}
+
+export async function recordCueAnchor(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  cueAnchorStoreDir?: string;
+  anchor: CueAnchor;
+}): Promise<string> {
+  const abstractionNodeStoreDir = options.abstractionNodeStoreDir?.trim().length
+    ? options.abstractionNodeStoreDir.trim()
+    : path.join(options.memoryDir, "state", "abstraction-nodes");
+  const rootDir = resolveCueAnchorStoreDir(abstractionNodeStoreDir, options.cueAnchorStoreDir);
+  const validated = validateCueAnchor(options.anchor);
+  const anchorDir = path.join(rootDir, validated.anchorType);
+  const filePath = path.join(anchorDir, `${validated.anchorId}.json`);
+  await mkdir(anchorDir, { recursive: true });
+  await writeFile(filePath, JSON.stringify(validated, null, 2), "utf8");
+  return filePath;
+}
+
+export async function getCueAnchorStoreStatus(options: {
+  memoryDir: string;
+  abstractionNodeStoreDir?: string;
+  cueAnchorStoreDir?: string;
+  enabled: boolean;
+  anchorsEnabled: boolean;
+}): Promise<CueAnchorStoreStatus> {
+  const abstractionNodeStoreDir = options.abstractionNodeStoreDir?.trim().length
+    ? options.abstractionNodeStoreDir.trim()
+    : path.join(options.memoryDir, "state", "abstraction-nodes");
+  const rootDir = resolveCueAnchorStoreDir(abstractionNodeStoreDir, options.cueAnchorStoreDir);
+  const files = await listJsonFiles(rootDir);
+  const anchors: CueAnchor[] = [];
+  const invalidAnchors: Array<{ path: string; error: string }> = [];
+
+  for (const filePath of files) {
+    try {
+      anchors.push(validateCueAnchor(await readJsonFile(filePath)));
+    } catch (error) {
+      invalidAnchors.push({
+        path: filePath,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  anchors.sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
+
+  const byType: Partial<Record<CueAnchorType, number>> = {};
+  let totalNodeRefs = 0;
+  for (const anchor of anchors) {
+    byType[anchor.anchorType] = (byType[anchor.anchorType] ?? 0) + 1;
+    totalNodeRefs += anchor.nodeRefs.length;
+  }
+
+  return {
+    enabled: options.enabled,
+    anchorsEnabled: options.anchorsEnabled,
+    rootDir,
+    anchors: {
+      total: files.length,
+      valid: anchors.length,
+      invalid: invalidAnchors.length,
+      byType,
+      totalNodeRefs,
+      latestAnchorId: anchors[0]?.anchorId,
+      latestRecordedAt: anchors[0]?.recordedAt,
+      latestSessionKey: anchors[0]?.sessionKey,
+    },
+    latestAnchor: anchors[0],
+    invalidAnchors,
+  };
+}

--- a/tests/cue-anchors.test.ts
+++ b/tests/cue-anchors.test.ts
@@ -1,0 +1,186 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import {
+  getCueAnchorStoreStatus,
+  recordCueAnchor,
+  resolveCueAnchorStoreDir,
+  validateCueAnchor,
+} from "../src/cue-anchors.js";
+import { runCueAnchorStatusCliCommand } from "../src/cli.js";
+
+test("cue-anchor config path resolves under abstraction-node storage by default", () => {
+  assert.equal(
+    resolveCueAnchorStoreDir("/tmp/engram-memory/state/abstraction-nodes"),
+    path.join("/tmp/engram-memory/state/abstraction-nodes", "anchors"),
+  );
+  assert.equal(
+    resolveCueAnchorStoreDir("/tmp/engram-memory/state/abstraction-nodes", "  /tmp/custom-cue-anchors  "),
+    "/tmp/custom-cue-anchors",
+  );
+});
+
+test("validateCueAnchor accepts the normalized cue-anchor contract", () => {
+  const anchor = validateCueAnchor({
+    schemaVersion: 1,
+    anchorId: "project-openclaw-engram",
+    anchorType: "entity",
+    anchorValue: "project:openclaw-engram",
+    normalizedCue: "project openclaw engram",
+    recordedAt: "2026-03-07T23:10:00.000Z",
+    sessionKey: "agent:main",
+    nodeRefs: ["abstraction-1", "abstraction-2"],
+    tags: ["harmonic-retrieval", "project"],
+    metadata: {
+      source: "roadmap",
+    },
+  });
+
+  assert.equal(anchor.anchorType, "entity");
+  assert.equal(anchor.anchorValue, "project:openclaw-engram");
+  assert.deepEqual(anchor.nodeRefs, ["abstraction-1", "abstraction-2"]);
+});
+
+test("recordCueAnchor persists anchors into type-partitioned cue-anchor storage", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cue-anchor-record-"));
+  const filePath = await recordCueAnchor({
+    memoryDir,
+    anchor: {
+      schemaVersion: 1,
+      anchorId: "tool-benchmark-status",
+      anchorType: "tool",
+      anchorValue: "benchmark-status",
+      normalizedCue: "benchmark status",
+      recordedAt: "2026-03-07T23:11:00.000Z",
+      sessionKey: "agent:main",
+      nodeRefs: ["abstraction-2"],
+    },
+  });
+
+  assert.equal(
+    filePath,
+    path.join(
+      memoryDir,
+      "state",
+      "abstraction-nodes",
+      "anchors",
+      "tool",
+      "tool-benchmark-status.json",
+    ),
+  );
+});
+
+test("recordCueAnchor rejects unsafe ids and empty node refs", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cue-anchor-reject-"));
+
+  await assert.rejects(
+    () =>
+      recordCueAnchor({
+        memoryDir,
+        anchor: {
+          schemaVersion: 1,
+          anchorId: "../escape",
+          anchorType: "entity",
+          anchorValue: "project:openclaw-engram",
+          normalizedCue: "project openclaw engram",
+          recordedAt: "2026-03-07T23:12:00.000Z",
+          sessionKey: "agent:main",
+          nodeRefs: ["abstraction-1"],
+        },
+      }),
+    /anchorId must be a safe path segment/i,
+  );
+
+  await assert.rejects(
+    () =>
+      recordCueAnchor({
+        memoryDir,
+        anchor: {
+          schemaVersion: 1,
+          anchorId: "empty-node-refs",
+          anchorType: "constraint",
+          anchorValue: "wait for cursor terminal state",
+          normalizedCue: "wait for cursor terminal state",
+          recordedAt: "2026-03-07T23:12:00.000Z",
+          sessionKey: "agent:main",
+          nodeRefs: [],
+        },
+      }),
+    /nodeRefs must contain at least one node reference/i,
+  );
+});
+
+test("cue-anchor status reports valid and invalid anchors", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cue-anchor-status-"));
+  await recordCueAnchor({
+    memoryDir,
+    anchor: {
+      schemaVersion: 1,
+      anchorId: "date-2026-03-07",
+      anchorType: "date",
+      anchorValue: "2026-03-07",
+      normalizedCue: "2026 03 07",
+      recordedAt: "2026-03-07T23:13:00.000Z",
+      sessionKey: "agent:main",
+      nodeRefs: ["abstraction-3", "abstraction-4"],
+      tags: ["timeline"],
+    },
+  });
+
+  const invalidDir = path.join(
+    memoryDir,
+    "state",
+    "abstraction-nodes",
+    "anchors",
+    "entity",
+  );
+  await mkdir(invalidDir, { recursive: true });
+  await writeFile(path.join(invalidDir, "invalid.json"), "{\"schemaVersion\":2}", "utf8");
+
+  const status = await getCueAnchorStoreStatus({
+    memoryDir,
+    abstractionNodeStoreDir: undefined,
+    enabled: true,
+    anchorsEnabled: true,
+  });
+
+  assert.equal(status.enabled, true);
+  assert.equal(status.anchorsEnabled, true);
+  assert.equal(status.anchors.total, 2);
+  assert.equal(status.anchors.valid, 1);
+  assert.equal(status.anchors.invalid, 1);
+  assert.equal(status.anchors.byType.date, 1);
+  assert.equal(status.anchors.totalNodeRefs, 2);
+  assert.equal(status.latestAnchor?.anchorId, "date-2026-03-07");
+  assert.match(status.invalidAnchors[0]?.path ?? "", /invalid\.json$/);
+});
+
+test("cue-anchor-status CLI command returns the cue-anchor summary", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cue-anchor-cli-"));
+  await recordCueAnchor({
+    memoryDir,
+    anchor: {
+      schemaVersion: 1,
+      anchorId: "constraint-terminal-cursor",
+      anchorType: "constraint",
+      anchorValue: "wait for cursor terminal state",
+      normalizedCue: "wait for cursor terminal state",
+      recordedAt: "2026-03-07T23:14:00.000Z",
+      sessionKey: "agent:main",
+      nodeRefs: ["abstraction-cli-1"],
+    },
+  });
+
+  const status = await runCueAnchorStatusCliCommand({
+    memoryDir,
+    harmonicRetrievalEnabled: true,
+    abstractionAnchorsEnabled: true,
+    abstractionNodeStoreDir: undefined,
+  });
+
+  assert.equal(status.anchors.total, 1);
+  assert.equal(status.latestAnchor?.anchorId, "constraint-terminal-cursor");
+  assert.equal(status.anchors.byType.constraint, 1);
+});


### PR DESCRIPTION
## Summary
- add typed cue-anchor storage for harmonic retrieval anchors under the abstraction-node store
- add cue-anchor status tooling and CLI coverage
- update roadmap/docs/changelog for the PR18 slice

## Verification
- npx tsx --test tests/cue-anchors.test.ts tests/abstraction-nodes.test.ts tests/config-eval-harness.test.ts
- npm run check-types
- npm run check-config-contract
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive, opt-in storage + CLI/status tooling for a new harmonic-retrieval cue-anchor index; minimal impact on existing runtime paths beyond registering a new command and config text updates.
> 
> **Overview**
> Adds a **typed cue-anchor index** for harmonic retrieval: cue anchors (entity/file/tool/outcome/constraint/date) can be validated and persisted under `state/abstraction-nodes/anchors/<type>/<id>.json`, with status reporting that counts valid/invalid anchors, per-type totals, linked node-ref totals, and the latest anchor.
> 
> Exposes a new operator command `openclaw engram cue-anchor-status` (plus CLI wrapper) and adds test coverage for validation, persistence paths, invalid-file accounting, and the CLI surface. Documentation/config text is updated to reflect `abstractionAnchorsEnabled` now enabling cue-anchor indexing (and adds the PR18 plan + theory updates).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7008d9e54ee5cbc045ea3ec6a3bf46eda3e9316e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->