### PR TITLE
feat: verify promoted semantic rules at recall time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 - Enrich extraction prompt few-shot examples with `entityRef` and entity `facts` fields, using realistic concrete values instead of generic placeholders.
 
 ### Added
+- **Verified rule recall**: when `semanticRuleVerificationEnabled` is enabled, Engram can now re-check promoted semantic rules against their cited source episodes at recall time, downgrade stale provenance before surfacing those rules, inject a dedicated `## Verified Rules` recall section, and preview that surface with `openclaw engram semantic-rule-verify <query>`.
 - **Semantic rule promotion**: when `semanticRulePromotionEnabled` is enabled, Engram can now promote explicit `IF ... THEN ...` rules from verified episodic memories into durable `rule` memories with lineage, source-memory provenance, duplicate suppression, and the operator-facing `openclaw engram semantic-rule-promote --memory-id <id>` CLI.
 - **Verified episodic recall**: added `verifiedRecallEnabled`, `semanticRulePromotionEnabled`, bounded verified-episode search over recent memory boxes, a dedicated `## Verified Episodes` recall section, and `openclaw engram verified-recall-search <query>` for previewing verified episodic matches before semantic-rule promotion lands.
 - **Harmonic retrieval blender**: when `harmonicRetrievalEnabled` is enabled, Engram can now blend abstraction-node evidence and cue-anchor matches into a dedicated `## Harmonic Retrieval` recall section and inspect those blended results with `openclaw engram harmonic-search`.

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ AI agents forget everything between conversations. Engram fixes that.
 - **Harmonic retrieval diagnostics** — Engram can now, when `harmonicRetrievalEnabled` is enabled, blend abstraction-node evidence with cue-anchor matches into a dedicated `Harmonic Retrieval` recall section and inspect those blended results with `openclaw engram harmonic-search`.
 - **Verified episodic recall** — Engram can now, when `verifiedRecallEnabled` is enabled, inject a dedicated `Verified Episodes` recall section that reuses memory boxes but only surfaces boxes whose cited source memories still verify as non-archived episodes.
 - **Semantic rule promotion** — Engram can now, when `semanticRulePromotionEnabled` is enabled, promote explicit `IF ... THEN ...` rules from verified episodic memories into durable `rule` memories with lineage, source-memory provenance, duplicate suppression, and the operator-facing `openclaw engram semantic-rule-promote` CLI.
+- **Verified rule recall** — Engram can now, when `semanticRuleVerificationEnabled` is enabled, inject a dedicated `Verified Rules` recall section that re-checks promoted rule memories against their cited source episodes at recall time and downgrades stale provenance before the rule can surface.
 - **Zero-config start** — Install, add an API key, restart. Engram works out of the box with sensible defaults and progressively unlocks advanced features as you enable them.
 
 ## Quick Start
@@ -211,6 +212,7 @@ Key settings:
 | `abstractionAnchorsEnabled` | `false` | Enable typed cue-anchor indexing for abstraction nodes and expose the anchor store through status tooling |
 | `verifiedRecallEnabled` | `false` | Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes |
 | `semanticRulePromotionEnabled` | `false` | Enable deterministic promotion of explicit `IF ... THEN ...` rules from verified episodic memories via `openclaw engram semantic-rule-promote` |
+| `semanticRuleVerificationEnabled` | `false` | Verify promoted semantic rules against their cited source episodes at recall time and inject a dedicated `Verified Rules` section via `openclaw engram semantic-rule-verify` |
 
 Full reference: [Config Reference](docs/config-reference.md)
 

--- a/THEORY.MD
+++ b/THEORY.MD
@@ -1,80 +1,71 @@
-# Theory: Verified Episodes Should Feed Narrow Semantic Rule Promotion
+# Theory: Promoted Rules Need Recall-Time Verification
 
 ## Problem
 
-PR20 proved that Engram can reuse memory boxes for episodic recall while still
-verifying the cited source memories. The next mistake would be to stop there
-and leave semantic memory disconnected from those verified episodes. The memory
-model from the roadmap is not just "retrieve episodes"; it is "retrieve
-episodes, verify them, and separately extract reusable semantic rules."
+PR21 proved Engram can turn explicit `IF ... THEN ...` clauses from verified
+episodes into durable rule memories. That created a new risk: promoted rules
+can outlive the episode that justified them. If Engram treats those rules as
+durable truth forever, semantic memory becomes easier to poison and harder to
+audit.
 
-That means PR21 needs a promotion path from verified episodic material into
-durable rule memory. The danger is scope creep: a broad "semantic rule" system
-would immediately pull in model inference, ranking, downgrade policy, and
-retrieval blending. This slice needs to stay smaller than that.
+The next step is not broad rule retrieval or invalidation. It is narrower:
+re-check promoted rules against their cited source episode at recall time and
+only surface rules whose provenance still carries enough weight.
 
 ## Operating Theory
 
-The rollout pattern that has worked across the memory-OS track is still right:
+The rollout that has worked across the memory-OS track still applies here:
 
-1. keep the new capability bounded and inspectable
-2. reuse existing durable substrates when they already encode the right shape
-3. add verification rules before automation rules
-4. benchmark the verified surface before promoting more abstract behavior
+1. store the durable thing first
+2. verify it again when it matters
+3. downgrade confidence before mutating state
+4. keep the new recall surface separate until it is benchmarked
 
-For semantic rule promotion, the highest-leverage first step is not general
-causal inference. It is deterministic promotion of already-explicit rules from
-verified episodic memories:
+For promoted semantic rules, recall-time verification is the smallest honest
+bridge between episodic truth and semantic reuse:
 
-- episodic memories remain the source of truth
-- promoted `rule` memories become the reusable semantic layer
-- lineage and source-memory provenance keep the semantic layer auditable
+- promoted `rule` memories remain durable and inspectable
+- the cited `sourceMemoryId` remains the audit anchor
+- recall re-checks that source before surfacing the rule
+- missing, archived, or non-episodic sources reduce effective confidence
 
-If the source memory is not a live episode, or if it does not contain an
-explicit `IF ... THEN ...` structure, this slice should do nothing.
+That keeps semantic memory useful without pretending provenance never decays.
 
 ## Strategy
 
-Keep PR21 narrow and legible:
+Keep PR22 bounded and feature-flagged:
 
-- keep everything behind `semanticRulePromotionEnabled`
-- add an operator-facing command:
-  - `openclaw engram semantic-rule-promote --memory-id <id> [--dry-run]`
-- accept only non-archived source memories whose `memoryKind` is `episode`
-- normalize only explicit `IF ... THEN ...` rules
-- write promoted rules as normal `rule` memories with:
-  - `memoryKind: note`
-  - `source: semantic-rule-promotion`
-  - `sourceMemoryId`
-  - `lineage`
-  - support link back to the source episode
-- suppress duplicates by canonicalized rule content
+- add `semanticRuleVerificationEnabled`
+- add a dedicated `## Verified Rules` recall section
+- search only `rule` memories written by `semantic-rule-promotion`
+- re-check the cited `sourceMemoryId` at recall time
+- compute an effective confidence:
+  - verified source: keep anchored confidence
+  - missing/archived/non-episode source: downgrade it
+- filter out downgraded rules below a default confidence floor
+- expose the exact surface through:
+  - `openclaw engram semantic-rule-verify <query>`
 
-This keeps the feature aligned with the human-inspired memory direction without
-pretending the full semantic-rule system exists yet. The first question is
-simply: can Engram take an already-explicit rule from a verified episode and
-promote it into durable semantic memory with provenance intact?
+This keeps the verifier inspectable and benchmarkable before any broader
+semantic blending lands.
 
 ## Key Discoveries
 
-- The repo already had a `rule` memory category and causal-rule-aware
-  extraction prompts, but it still lacked an explicit promotion path from
-  episodic evidence into durable rule memory.
-- The cleanest first semantic-rule slice is deterministic rather than model
-  inferred: promote only explicit `IF ... THEN ...` clauses that are already
-  present in verified episodic memories.
-- Canonicalization matters immediately. If punctuation around the condition
-  clause is not normalized, duplicate suppression will drift and rule memories
-  will split on commas rather than meaning.
-- Provenance needs to be written on day one. `sourceMemoryId`, `lineage`, and a
-  support link back to the episode are the minimum structure that makes later
-  downgrade and verifier work possible.
+- PR21 already wrote the critical provenance fields: `sourceMemoryId`,
+  `lineage`, and a `supports` link. That made PR22 possible without changing
+  storage shape.
+- Confidence downgrade is the right first response to provenance decay. It is
+  cheaper and safer than mutating or deleting rule memories during recall.
+- A separate `Verified Rules` section is cleaner than blending promoted rules
+  into generic recall immediately. It makes the new behavior legible and easier
+  to benchmark.
 
 ## Open Questions
 
-- Should later slices broaden promotion beyond explicit `IF ... THEN ...`
-  phrasing into causal paraphrases like "X failed because Y"?
-- Should semantic-rule recall stay separate from principle/rule recall until
-  downgrade paths exist, or is provenance alone enough for early blending?
-- When PR22 adds verifier and confidence downgrade behavior, should duplicate
-  rule detection also compare lineage sets, or is normalized content enough?
+- Should a future slice record verifier outcomes back onto the rule memory, or
+  should recall stay purely read-only?
+- When broader semantic-rule retrieval arrives, should verified rules blend
+  with principles, or stay in a distinct section until benchmark results prove
+  parity?
+- Do later slices need learned downgrade weights, or is deterministic
+  provenance scoring enough for the semantic-rule track?

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -385,6 +385,7 @@ See [advanced-retrieval.md](advanced-retrieval.md) for guidance.
 | `abstractionNodeStoreDir` | `{memoryDir}/state/abstraction-nodes` | Root directory for abstraction-node artifacts |
 | `verifiedRecallEnabled` | `false` | Inject prompt-relevant memory boxes only when their cited source memories verify as non-archived episodes |
 | `semanticRulePromotionEnabled` | `false` | Enable deterministic promotion of explicit `IF ... THEN ...` rules from verified episodic memories via `openclaw engram semantic-rule-promote` |
+| `semanticRuleVerificationEnabled` | `false` | Verify promoted semantic rules against their cited source episodes at recall time and inject a dedicated `Verified Rules` section via `openclaw engram semantic-rule-verify` |
 
 Current foundation slice:
 - `openclaw engram benchmark-status` scans `benchmarks/**.json` and `runs/**.json`, validates manifests/run summaries, and reports the latest completed run.
@@ -409,6 +410,8 @@ Current foundation slice:
 - When `verifiedRecallEnabled` is on, Engram can inject a separate `## Verified Episodes` recall section sourced from recent memory boxes, but only when each surfaced box still cites at least one non-archived source memory whose `memoryKind` remains `episode`.
 - Use `openclaw engram verified-recall-search <query>` to preview verified episodic recall matches, including verified memory counts, matched fields, and cited episodic memory IDs.
 - When `semanticRulePromotionEnabled` is on, `openclaw engram semantic-rule-promote --memory-id <id>` can promote an explicit `IF ... THEN ...` rule from a non-archived episodic memory into a durable `rule` memory with lineage, `sourceMemoryId`, and duplicate suppression.
+- When `semanticRuleVerificationEnabled` is on, Engram can inject a separate `## Verified Rules` recall section sourced from promoted `rule` memories, but only when each surfaced rule still clears a provenance-aware effective-confidence threshold after re-checking its `sourceMemoryId`.
+- Use `openclaw engram semantic-rule-verify <query>` to preview verified semantic-rule matches, including verification status, effective confidence, and the cited source memory id.
 - Future slices will add automated benchmark runners on top of this store and gate format.
 
 | `conversationIndexEmbedOnUpdate` | `false` | Run `qmd embed` on each update |

--- a/docs/plans/2026-03-07-engram-pr22-semantic-rule-verifier.md
+++ b/docs/plans/2026-03-07-engram-pr22-semantic-rule-verifier.md
@@ -1,0 +1,68 @@
+# PR22: Semantic Rule Verifier and Confidence Downgrade
+
+## Goal
+
+Re-check promoted semantic rules against their cited episodic source memories at recall time so Engram can trust verified rules more than stale or orphaned ones.
+
+## Scope
+
+- Keep the slice behind a new explicit flag: `semanticRuleVerificationEnabled`
+- Add a dedicated recall section:
+  - `## Verified Rules`
+- Verify only `rule` memories written by `semantic-rule-promotion`
+- Re-check each promoted rule against `sourceMemoryId` at recall time
+- Downgrade effective confidence when the source memory:
+  - is missing
+  - is archived
+  - is no longer an `episode`
+- Filter out downgraded rules below the default effective-confidence floor
+- Add an operator-facing CLI preview:
+  - `openclaw engram semantic-rule-verify <query>`
+
+## Non-Goals
+
+- No broad semantic-rule mining from free-form prose
+- No automatic rule invalidation or mutation of stored rule memories yet
+- No blending into generic `memories` recall
+- No learned downgrade weights yet
+
+## Why This Slice
+
+PR21 proved that Engram can promote explicit `IF ... THEN ...` rules from verified episodes into durable rule memories. The immediate risk after promotion is overtrust: a promoted rule can outlive, drift away from, or lose the source episode that justified it.
+
+This slice keeps the next step bounded:
+
+- verify rule provenance at recall time
+- surface only bounded verified-rule recall
+- downgrade confidence rather than mutating memory
+
+That matches the roadmap’s PR22 target without pulling in the larger invalidation and learning systems too early.
+
+## Test Plan
+
+1. Red:
+   - verified semantic-rule search returns promoted rules whose source episode still verifies
+   - archived or invalid source memories downgrade effective confidence below the default recall floor
+   - CLI honors `semanticRuleVerificationEnabled`
+   - recall injects `## Verified Rules` only when the flag and recall section are enabled
+2. Green:
+   - add `src/semantic-rule-verifier.ts`
+   - wire `runSemanticRuleVerifyCliCommand(...)`
+   - add `verified-rules` recall section in the orchestrator
+   - add `semanticRuleVerificationEnabled` config wiring and recall-pipeline default
+3. Verify:
+   - targeted PR22 tests
+   - config contract tests
+   - `npm run check-types`
+   - `npm test`
+   - `npm run build`
+
+## Expected Review Risks
+
+- Treating promoted rules as verified without source-memory rechecks
+- Letting downgraded rules still leak into recall through overly generous thresholds
+- Missing or stale config/docs surface for the new flag and recall section
+
+## Follow-On Slice
+
+PR23 moves into creation-memory with a work-product ledger. Semantic-rule invalidation, learned downgrade weights, and broader rule retrieval can wait until the recoverability track is in place.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1195,6 +1195,11 @@
         "default": false,
         "description": "Enable deterministic promotion of explicit IF/THEN rules from verified episodic memories."
       },
+      "semanticRuleVerificationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
+      },
       "actionGraphRecallEnabled": {
         "type": "boolean",
         "default": false,
@@ -2202,6 +2207,11 @@
       "label": "Semantic Rule Promotion",
       "advanced": true,
       "help": "Promote explicit IF/THEN rules from verified episodic memories into durable rule memories."
+    },
+    "semanticRuleVerificationEnabled": {
+      "label": "Semantic Rule Verification",
+      "advanced": true,
+      "help": "Verify promoted semantic rules against their cited source episodes at recall time before surfacing them in recall."
     },
     "actionGraphRecallEnabled": {
       "label": "Action Graph Recall",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -74,6 +74,10 @@ import {
   type VerifiedEpisodeResult,
 } from "./verified-recall.js";
 import {
+  searchVerifiedSemanticRules,
+  type VerifiedSemanticRuleResult,
+} from "./semantic-rule-verifier.js";
+import {
   promoteSemanticRuleFromMemory,
   type SemanticRulePromotionReport,
 } from "./semantic-rule-promotion.js";
@@ -779,6 +783,20 @@ export async function runSemanticRulePromoteCliCommand(options: {
     enabled: options.semanticRulePromotionEnabled,
     sourceMemoryId: options.sourceMemoryId,
     dryRun: options.dryRun,
+  });
+}
+
+export async function runSemanticRuleVerifyCliCommand(options: {
+  memoryDir: string;
+  semanticRuleVerificationEnabled: boolean;
+  query: string;
+  maxResults?: number;
+}): Promise<VerifiedSemanticRuleResult[]> {
+  if (!options.semanticRuleVerificationEnabled) return [];
+  return searchVerifiedSemanticRules({
+    memoryDir: options.memoryDir,
+    query: options.query,
+    maxResults: Math.max(1, Math.floor(options.maxResults ?? 3)),
   });
 }
 
@@ -2540,6 +2558,27 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             dryRun: options.dryRun === true,
           });
           console.log(JSON.stringify(result, null, 2));
+          console.log("OK");
+        });
+
+      cmd
+        .command("semantic-rule-verify")
+        .description("Preview verified semantic-rule recall with provenance-aware confidence downgrades")
+        .argument("<query>", "Prompt-like query to evaluate against verified semantic-rule recall")
+        .option("--max-results <count>", "Maximum number of verified semantic rules to return", "3")
+        .action(async (...args: unknown[]) => {
+          const query = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          const maxResults = typeof options.maxResults === "string"
+            ? Number.parseInt(options.maxResults, 10)
+            : 3;
+          const results = await runSemanticRuleVerifyCliCommand({
+            memoryDir: orchestrator.config.memoryDir,
+            semanticRuleVerificationEnabled: orchestrator.config.semanticRuleVerificationEnabled,
+            query,
+            maxResults: Number.isFinite(maxResults) ? maxResults : 3,
+          });
+          console.log(JSON.stringify(results, null, 2));
           console.log("OK");
         });
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -511,6 +511,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     abstractionAnchorsEnabled: cfg.abstractionAnchorsEnabled === true,
     verifiedRecallEnabled: cfg.verifiedRecallEnabled === true,
     semanticRulePromotionEnabled: cfg.semanticRulePromotionEnabled === true,
+    semanticRuleVerificationEnabled: cfg.semanticRuleVerificationEnabled === true,
     abstractionNodeStoreDir:
       typeof cfg.abstractionNodeStoreDir === "string" && cfg.abstractionNodeStoreDir.trim().length > 0
         ? cfg.abstractionNodeStoreDir.trim()
@@ -1023,6 +1024,12 @@ function buildDefaultRecallPipeline(cfg: Record<string, unknown>): RecallSection
     {
       id: "verified-episodes",
       enabled: cfg.verifiedRecallEnabled === true,
+      maxResults: 3,
+      maxChars: 1800,
+    },
+    {
+      id: "verified-rules",
+      enabled: cfg.semanticRuleVerificationEnabled === true,
       maxResults: 3,
       maxChars: 1800,
     },

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -73,6 +73,7 @@ import { searchObjectiveStateSnapshots, type ObjectiveStateSearchResult } from "
 import { searchTrustZoneRecords, type TrustZoneSearchResult } from "./trust-zones.js";
 import { searchHarmonicRetrieval, type HarmonicRetrievalResult } from "./harmonic-retrieval.js";
 import { searchVerifiedEpisodes, type VerifiedEpisodeResult } from "./verified-recall.js";
+import { searchVerifiedSemanticRules, type VerifiedSemanticRuleResult } from "./semantic-rule-verifier.js";
 import { normalizeReplaySessionKey, type ReplayTurn } from "./replay/types.js";
 import type { MemorySummary } from "./types.js";
 import { chunkTranscriptEntries } from "./conversation-index/chunker.js";
@@ -2298,6 +2299,31 @@ export class Orchestrator {
       return results.length > 0 ? this.formatVerifiedEpisodeResults(results) : null;
     })();
 
+    const verifiedRulesPromise = (async (): Promise<string | null> => {
+      const t0 = Date.now();
+      if (
+        !this.config.semanticRuleVerificationEnabled ||
+        !this.isRecallSectionEnabled("verified-rules", this.config.semanticRuleVerificationEnabled === true)
+      ) {
+        timings.verifiedRules = "skip";
+        return null;
+      }
+      const maxResults = this.getRecallSectionNumber("verified-rules", "maxResults") ?? 3;
+      if (maxResults <= 0) {
+        timings.verifiedRules = "skip(limit=0)";
+        return null;
+      }
+
+      const results = await searchVerifiedSemanticRules({
+        memoryDir: this.config.memoryDir,
+        query: retrievalQuery,
+        maxResults,
+      });
+
+      timings.verifiedRules = `${Date.now() - t0}ms`;
+      return results.length > 0 ? this.formatVerifiedSemanticRuleResults(results) : null;
+    })();
+
     // 2. QMD search (the slow part — runs in parallel with preamble)
     type QmdPhaseResult = {
       memoryResultsLists: QmdSearchResult[][];
@@ -2566,6 +2592,7 @@ export class Orchestrator {
       trustZoneSection,
       harmonicRetrievalSection,
       verifiedRecallSection,
+      verifiedRulesSection,
       qmdResult,
       transcriptSection,
       compactionSection,
@@ -2583,6 +2610,7 @@ export class Orchestrator {
       trustZonePromise,
       harmonicRetrievalPromise,
       verifiedRecallPromise,
+      verifiedRulesPromise,
       qmdPromise,
       transcriptPromise,
       compactionPromise,
@@ -2675,6 +2703,10 @@ export class Orchestrator {
 
     if (verifiedRecallSection) {
       this.appendRecallSection(sectionBuckets, "verified-episodes", verifiedRecallSection);
+    }
+
+    if (verifiedRulesSection) {
+      this.appendRecallSection(sectionBuckets, "verified-rules", verifiedRulesSection);
     }
 
     // 2. QMD results — post-process and format
@@ -5476,6 +5508,26 @@ export class Orchestrator {
     });
 
     return `## Verified Episodes\n\n${lines.join("\n\n")}`;
+  }
+
+  private formatVerifiedSemanticRuleResults(results: VerifiedSemanticRuleResult[]): string {
+    const lines = results.map(({ rule, sourceMemoryId, verificationStatus, effectiveConfidence, matchedFields }, index) => {
+      const header = [
+        `[${index + 1}] ${rule.frontmatter.updated.replace("T", " ").slice(0, 16)}`,
+        verificationStatus,
+        `confidence:${effectiveConfidence.toFixed(2)}`,
+      ].join(" | ");
+      const details = [
+        rule.content,
+        `source memory: ${sourceMemoryId}`,
+      ];
+      if (matchedFields.length > 0) {
+        details.push(`matched: ${matchedFields.join(", ")}`);
+      }
+      return `${header}\n${details.join("\n")}`;
+    });
+
+    return `## Verified Rules\n\n${lines.join("\n\n")}`;
   }
 
   private summarizeIdentityText(raw: string, maxLines: number, maxChars: number): string {

--- a/src/semantic-rule-verifier.ts
+++ b/src/semantic-rule-verifier.ts
@@ -1,0 +1,147 @@
+import { StorageManager } from "./storage.js";
+import type { MemoryFile } from "./types.js";
+import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
+
+export type SemanticRuleVerificationStatus =
+  | "verified"
+  | "source-memory-missing"
+  | "source-memory-archived"
+  | "source-memory-not-episode";
+
+export interface VerifiedSemanticRuleResult {
+  rule: MemoryFile;
+  score: number;
+  sourceMemoryId: string;
+  verificationStatus: SemanticRuleVerificationStatus;
+  effectiveConfidence: number;
+  matchedFields: string[];
+}
+
+const DEFAULT_MIN_EFFECTIVE_CONFIDENCE = 0.45;
+
+function verificationConfidenceMultiplier(status: SemanticRuleVerificationStatus): number {
+  switch (status) {
+    case "verified":
+      return 1;
+    case "source-memory-not-episode":
+      return 0.45;
+    case "source-memory-archived":
+      return 0.4;
+    case "source-memory-missing":
+      return 0.35;
+    default:
+      return 0.35;
+  }
+}
+
+function resolveVerificationStatus(sourceMemory: MemoryFile | undefined): SemanticRuleVerificationStatus {
+  if (!sourceMemory) return "source-memory-missing";
+  if (sourceMemory.frontmatter.status === "archived") return "source-memory-archived";
+  if (sourceMemory.frontmatter.memoryKind !== "episode") return "source-memory-not-episode";
+  return "verified";
+}
+
+function resolveEffectiveConfidence(rule: MemoryFile, sourceMemory: MemoryFile | undefined): {
+  status: SemanticRuleVerificationStatus;
+  effectiveConfidence: number;
+} {
+  const status = resolveVerificationStatus(sourceMemory);
+  const ruleConfidence = Number.isFinite(rule.frontmatter.confidence) ? rule.frontmatter.confidence : 0.8;
+  const sourceConfidence = Number.isFinite(sourceMemory?.frontmatter.confidence)
+    ? sourceMemory!.frontmatter.confidence
+    : ruleConfidence;
+  const anchoredConfidence = Math.min(ruleConfidence, sourceConfidence);
+  const effectiveConfidence = Math.max(
+    0,
+    Math.min(1, anchoredConfidence * verificationConfidenceMultiplier(status)),
+  );
+  return { status, effectiveConfidence };
+}
+
+function scoreVerifiedSemanticRuleCandidate(
+  rule: MemoryFile,
+  sourceMemory: MemoryFile | undefined,
+  queryTokens: Set<string>,
+  effectiveConfidence: number,
+): { score: number; matchedFields: Set<string> } {
+  const matchedFields = new Set<string>();
+  let score = 0;
+
+  const ruleContentMatches = countRecallTokenOverlap(queryTokens, rule.content);
+  if (ruleContentMatches > 0) {
+    score += ruleContentMatches * 5;
+    matchedFields.add("ruleContent");
+  }
+
+  const tagMatches = countRecallTokenOverlap(queryTokens, rule.frontmatter.tags?.join(" "));
+  if (tagMatches > 0) {
+    score += tagMatches * 2;
+    matchedFields.add("tags");
+  }
+
+  const sourceContentMatches = countRecallTokenOverlap(queryTokens, sourceMemory?.content);
+  if (sourceContentMatches > 0) {
+    score += sourceContentMatches * 2;
+    matchedFields.add("sourceContent");
+  }
+
+  if (score > 0) {
+    score += effectiveConfidence;
+  }
+
+  return { score, matchedFields };
+}
+
+export async function searchVerifiedSemanticRules(options: {
+  memoryDir: string;
+  query: string;
+  maxResults: number;
+  minEffectiveConfidence?: number;
+}): Promise<VerifiedSemanticRuleResult[]> {
+  const queryTokens = new Set(normalizeRecallTokens(options.query, ["what", "which"]));
+  if (queryTokens.size === 0 || options.maxResults <= 0) return [];
+
+  const storage = new StorageManager(options.memoryDir);
+  const allMemories = await storage.readAllMemories();
+  const memoryById = new Map(allMemories.map((memory) => [memory.frontmatter.id, memory] as const));
+  const minEffectiveConfidence = options.minEffectiveConfidence ?? DEFAULT_MIN_EFFECTIVE_CONFIDENCE;
+
+  const candidates: VerifiedSemanticRuleResult[] = [];
+  for (const memory of allMemories) {
+    if (memory.frontmatter.category !== "rule") continue;
+    if (memory.frontmatter.status === "archived") continue;
+    if (memory.frontmatter.source !== "semantic-rule-promotion") continue;
+    const sourceMemoryId = memory.frontmatter.sourceMemoryId;
+    if (!sourceMemoryId) continue;
+
+    const sourceMemory = memoryById.get(sourceMemoryId);
+    const { status, effectiveConfidence } = resolveEffectiveConfidence(memory, sourceMemory);
+    if (effectiveConfidence < minEffectiveConfidence) continue;
+
+    const { score, matchedFields } = scoreVerifiedSemanticRuleCandidate(
+      memory,
+      sourceMemory,
+      queryTokens,
+      effectiveConfidence,
+    );
+    if (score <= 0) continue;
+
+    candidates.push({
+      rule: memory,
+      score,
+      sourceMemoryId,
+      verificationStatus: status,
+      effectiveConfidence,
+      matchedFields: [...matchedFields].sort(),
+    });
+  }
+
+  return candidates
+    .sort(
+      (left, right) =>
+        right.score - left.score
+        || right.effectiveConfidence - left.effectiveConfidence
+        || right.rule.frontmatter.updated.localeCompare(left.rule.frontmatter.updated),
+    )
+    .slice(0, options.maxResults);
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -241,6 +241,7 @@ export interface PluginConfig {
   // Episodic/semantic split foundation
   verifiedRecallEnabled: boolean;
   semanticRulePromotionEnabled: boolean;
+  semanticRuleVerificationEnabled: boolean;
   // Local LLM Provider (v2.1)
   localLlmEnabled: boolean;
   localLlmUrl: string;

--- a/tests/config-eval-harness.test.ts
+++ b/tests/config-eval-harness.test.ts
@@ -31,12 +31,14 @@ test("evaluation harness config defaults off and derives store dir from memoryDi
   assert.equal(cfg.abstractionAnchorsEnabled, false);
   assert.equal(cfg.verifiedRecallEnabled, false);
   assert.equal(cfg.semanticRulePromotionEnabled, false);
+  assert.equal(cfg.semanticRuleVerificationEnabled, false);
   assert.equal(cfg.abstractionNodeStoreDir, path.join(memoryDir, "state", "abstraction-nodes"));
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "objective-state" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "causal-trajectories" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "trust-zones" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "harmonic-retrieval" && entry.enabled === false), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "verified-episodes" && entry.enabled === false), true);
+  assert.equal(cfg.recallPipeline.some((entry) => entry.id === "verified-rules" && entry.enabled === false), true);
 });
 
 test("evaluation harness config respects explicit flags and custom store dir", () => {
@@ -64,6 +66,7 @@ test("evaluation harness config respects explicit flags and custom store dir", (
     abstractionAnchorsEnabled: true,
     verifiedRecallEnabled: true,
     semanticRulePromotionEnabled: true,
+    semanticRuleVerificationEnabled: true,
     abstractionNodeStoreDir: "/tmp/abstraction-node-store",
   });
 
@@ -88,7 +91,9 @@ test("evaluation harness config respects explicit flags and custom store dir", (
   assert.equal(cfg.abstractionAnchorsEnabled, true);
   assert.equal(cfg.verifiedRecallEnabled, true);
   assert.equal(cfg.semanticRulePromotionEnabled, true);
+  assert.equal(cfg.semanticRuleVerificationEnabled, true);
   assert.equal(cfg.abstractionNodeStoreDir, "/tmp/abstraction-node-store");
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "harmonic-retrieval" && entry.enabled === true), true);
   assert.equal(cfg.recallPipeline.some((entry) => entry.id === "verified-episodes" && entry.enabled === true), true);
+  assert.equal(cfg.recallPipeline.some((entry) => entry.id === "verified-rules" && entry.enabled === true), true);
 });

--- a/tests/semantic-rule-verifier.test.ts
+++ b/tests/semantic-rule-verifier.test.ts
@@ -1,0 +1,163 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+import { StorageManager } from "../src/storage.js";
+import { promoteSemanticRuleFromMemory } from "../src/semantic-rule-promotion.js";
+import {
+  runSemanticRuleVerifyCliCommand,
+} from "../src/cli.js";
+import {
+  searchVerifiedSemanticRules,
+} from "../src/semantic-rule-verifier.js";
+
+async function createSemanticRuleHarness() {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-semantic-rule-verify-"));
+  const storage = new StorageManager(memoryDir);
+  return { memoryDir, storage };
+}
+
+async function seedPromotedRule(memoryDir: string, storage: StorageManager) {
+  const sourceMemoryId = await storage.writeMemory(
+    "fact",
+    "IF Cursor Bugbot is still pending THEN wait for the terminal result before merging.",
+    {
+      source: "test",
+      tags: ["pr-loop", "cursor"],
+      confidence: 0.92,
+      memoryKind: "episode",
+    },
+  );
+
+  const promotion = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId,
+  });
+
+  assert.equal(promotion.promoted.length, 1);
+  return {
+    sourceMemoryId,
+    ruleMemoryId: promotion.promoted[0]!.id,
+  };
+}
+
+test("searchVerifiedSemanticRules returns promoted rules whose source episode still verifies", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const { ruleMemoryId, sourceMemoryId } = await seedPromotedRule(memoryDir, storage);
+
+  const results = await searchVerifiedSemanticRules({
+    memoryDir,
+    query: "What rule says to wait for Cursor before merging?",
+    maxResults: 3,
+  });
+
+  assert.equal(results.length, 1);
+  assert.equal(results[0]?.rule.frontmatter.id, ruleMemoryId);
+  assert.equal(results[0]?.sourceMemoryId, sourceMemoryId);
+  assert.equal(results[0]?.verificationStatus, "verified");
+  assert.equal((results[0]?.effectiveConfidence ?? 0) > 0.8, true);
+});
+
+test("searchVerifiedSemanticRules downgrades archived-source rules below the default recall threshold", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const { sourceMemoryId } = await seedPromotedRule(memoryDir, storage);
+  const sourceMemory = await storage.getMemoryById(sourceMemoryId);
+  assert.ok(sourceMemory);
+  await storage.writeMemoryFrontmatter(sourceMemory, {
+    status: "archived",
+    archivedAt: "2026-03-08T00:00:00.000Z",
+  });
+
+  const results = await searchVerifiedSemanticRules({
+    memoryDir,
+    query: "What rule says to wait for Cursor before merging?",
+    maxResults: 3,
+  });
+
+  assert.deepEqual(results, []);
+});
+
+test("semantic-rule-verify CLI command honors the verification feature flag", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const { ruleMemoryId } = await seedPromotedRule(memoryDir, storage);
+
+  const disabled = await runSemanticRuleVerifyCliCommand({
+    memoryDir,
+    semanticRuleVerificationEnabled: false,
+    query: "wait for Cursor before merging",
+    maxResults: 3,
+  });
+  assert.deepEqual(disabled, []);
+
+  const enabled = await runSemanticRuleVerifyCliCommand({
+    memoryDir,
+    semanticRuleVerificationEnabled: true,
+    query: "wait for Cursor before merging",
+    maxResults: 3,
+  });
+  assert.equal(enabled[0]?.rule.frontmatter.id, ruleMemoryId);
+});
+
+test("recall injects verified semantic rules only when the verifier flag and recall section are enabled", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  await seedPromotedRule(memoryDir, storage);
+
+  const enabled = new Orchestrator(parseConfig({
+    openaiApiKey: "test-openai-key",
+    memoryDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    sharedContextEnabled: false,
+    conversationIndexEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    semanticRulePromotionEnabled: true,
+    semanticRuleVerificationEnabled: true,
+    recallPipeline: [
+      {
+        id: "verified-rules",
+        enabled: true,
+        maxResults: 3,
+        maxChars: 1800,
+      },
+    ],
+  }));
+
+  const enabledContext = await (enabled as any).recallInternal(
+    "What rule says to wait for Cursor before merging?",
+    "agent:main",
+  );
+  assert.match(enabledContext, /## Verified Rules/);
+  assert.match(enabledContext, /wait for the terminal result before merging/i);
+
+  const disabled = new Orchestrator(parseConfig({
+    openaiApiKey: "test-openai-key",
+    memoryDir,
+    qmdEnabled: false,
+    transcriptEnabled: false,
+    sharedContextEnabled: false,
+    conversationIndexEnabled: false,
+    hourlySummariesEnabled: false,
+    injectQuestions: false,
+    semanticRulePromotionEnabled: true,
+    semanticRuleVerificationEnabled: false,
+    recallPipeline: [
+      {
+        id: "verified-rules",
+        enabled: true,
+        maxResults: 3,
+        maxChars: 1800,
+      },
+    ],
+  }));
+
+  const disabledContext = await (disabled as any).recallInternal(
+    "What rule says to wait for Cursor before merging?",
+    "agent:main",
+  );
+  assert.equal(disabledContext.includes("## Verified Rules"), false);
+});


### PR DESCRIPTION
## Summary
- add verified semantic rule recall that re-checks promoted rules against live episodic source memory
- surface verified-rule recall through the orchestrator, CLI, config, and plugin manifest behind a feature flag
- document the slice and cover downgrade/filter behavior with targeted tests

## Testing
- npx tsx --test tests/semantic-rule-verifier.test.ts tests/config-eval-harness.test.ts
- npm run check-types
- npm run check-config-contract
- npm test
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recall-time retrieval path (and CLI) that scans stored `rule` memories and re-reads cited source episodes to downgrade/filter results; while gated by `semanticRuleVerificationEnabled`, it touches orchestrator recall assembly and could impact recall output/performance when enabled.
> 
> **Overview**
> Adds **verified semantic-rule recall** behind `semanticRuleVerificationEnabled`: promoted `rule` memories (`source: semantic-rule-promotion`) are re-checked against their `sourceMemoryId` at recall time, assigned an effective confidence (downgraded when the source is missing/archived/not an `episode`), filtered below a default floor, and injected as a new `## Verified Rules` section.
> 
> Introduces `openclaw engram semantic-rule-verify <query>` to preview this surface, wires the new flag/section into config parsing, plugin schema/UI, types, and the default `recallPipeline`, and adds targeted tests covering downgrade behavior, CLI gating, and orchestrator injection.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8c4a3a76af6d9695ea41a02731d65c01052071b9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->