### PR TITLE
feat: complete lifecycle projection integrity tooling

### DIFF
--- a/docs/operations.md
+++ b/docs/operations.md
@@ -371,6 +371,16 @@ Engram can also rebuild a derived SQLite projection for current-state inspection
 # Rebuild the derived projection from markdown memory files plus lifecycle events
 openclaw engram rebuild-memory-projection
 
+# Scope the rebuild to one namespace root and one updated-at window
+openclaw engram rebuild-memory-projection --namespace shared --updated-after 2026-03-01T00:00:00Z --write
+
+# Verify projection drift against authoritative markdown + lifecycle data
+openclaw engram verify-memory-projection
+
+# Preview a projection repair, then apply it
+openclaw engram repair-memory-projection
+openclaw engram repair-memory-projection --write
+
 # Inspect one memory timeline from the derived projection (or fail-open fallback path)
 openclaw engram memory-timeline fact-123
 ```
@@ -384,6 +394,8 @@ openclaw engram rebuild-memory-projection --write
 Operational guarantees:
 - markdown memories remain authoritative
 - projection rebuilds are backup-first and safe to discard/regenerate
+- projection verify/repair can target a namespace root plus optional updated-at window
+- scoped projection rebuilds only replace rows inside the selected window; out-of-scope rows stay untouched
 - timeline reads fail open to the lifecycle ledger when projection data is unavailable
 - projection writes use a separate derived SQLite store under `state/memory-projection.sqlite`
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -34,7 +34,11 @@ import {
   restoreMemoryGovernanceRun,
   runMemoryGovernance,
 } from "./maintenance/memory-governance.js";
-import { rebuildMemoryProjection } from "./maintenance/rebuild-memory-projection.js";
+import {
+  rebuildMemoryProjection,
+  repairMemoryProjection,
+  verifyMemoryProjection,
+} from "./maintenance/rebuild-memory-projection.js";
 import { rebuildObservations } from "./maintenance/rebuild-observations.js";
 import { migrateObservations } from "./maintenance/migrate-observations.js";
 import {
@@ -328,6 +332,22 @@ export interface RebuildMemoryProjectionCliCommandOptions {
   memoryDir: string;
   write?: boolean;
   now?: Date;
+  updatedAfter?: string;
+  updatedBefore?: string;
+}
+
+export interface VerifyMemoryProjectionCliCommandOptions {
+  memoryDir: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+}
+
+export interface RepairMemoryProjectionCliCommandOptions {
+  memoryDir: string;
+  write?: boolean;
+  now?: Date;
+  updatedAfter?: string;
+  updatedBefore?: string;
 }
 
 export interface MemoryTimelineCliCommandOptions {
@@ -787,6 +807,30 @@ export async function runRebuildMemoryProjectionCliCommand(
     memoryDir: options.memoryDir,
     dryRun: options.write !== true,
     now: options.now,
+    updatedAfter: options.updatedAfter,
+    updatedBefore: options.updatedBefore,
+  });
+}
+
+export async function runVerifyMemoryProjectionCliCommand(
+  options: VerifyMemoryProjectionCliCommandOptions,
+) {
+  return verifyMemoryProjection({
+    memoryDir: options.memoryDir,
+    updatedAfter: options.updatedAfter,
+    updatedBefore: options.updatedBefore,
+  });
+}
+
+export async function runRepairMemoryProjectionCliCommand(
+  options: RepairMemoryProjectionCliCommandOptions,
+) {
+  return repairMemoryProjection({
+    memoryDir: options.memoryDir,
+    dryRun: options.write !== true,
+    now: options.now,
+    updatedAfter: options.updatedAfter,
+    updatedBefore: options.updatedBefore,
   });
 }
 
@@ -4650,11 +4694,24 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         .command("rebuild-memory-projection")
         .description("Rebuild the derived memory projection store from markdown memories and lifecycle events (dry-run by default)")
         .option("--write", "Write rebuilt projection (default: dry-run)")
+        .option("--namespace <ns>", "Namespace to rebuild (default: config defaultNamespace)", "")
+        .option("--updated-after <iso>", "Only report/rebuild memories updated on or after this ISO timestamp", "")
+        .option("--updated-before <iso>", "Only report/rebuild memories updated on or before this ISO timestamp", "")
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
+          const namespace = typeof options.namespace === "string" && options.namespace.trim().length > 0
+            ? options.namespace.trim()
+            : undefined;
+          const memoryDir = await resolveMemoryDirForNamespace(orchestrator, namespace);
           const result = await runRebuildMemoryProjectionCliCommand({
-            memoryDir: orchestrator.config.memoryDir,
+            memoryDir,
             write: options.write === true,
+            updatedAfter: typeof options.updatedAfter === "string" && options.updatedAfter.trim().length > 0
+              ? options.updatedAfter.trim()
+              : undefined,
+            updatedBefore: typeof options.updatedBefore === "string" && options.updatedBefore.trim().length > 0
+              ? options.updatedBefore.trim()
+              : undefined,
           });
 
           console.log(`Dry run: ${result.dryRun ? "yes" : "no"}`);
@@ -4662,8 +4719,80 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(`Current-state rows: ${result.currentRows}`);
           console.log(`Timeline rows: ${result.timelineRows}`);
           console.log(`Used lifecycle ledger: ${result.usedLifecycleLedger ? "yes" : "no"}`);
+          console.log(`Updated-after scope: ${result.scope.updatedAfter ?? "none"}`);
+          console.log(`Updated-before scope: ${result.scope.updatedBefore ?? "none"}`);
           console.log(`Output path: ${result.outputPath}`);
           if (result.backupPath) console.log(`Backup path: ${result.backupPath}`);
+          console.log("OK");
+        });
+
+      cmd
+        .command("verify-memory-projection")
+        .description("Verify the derived memory projection against markdown memories and lifecycle events")
+        .option("--namespace <ns>", "Namespace to verify (default: config defaultNamespace)", "")
+        .option("--updated-after <iso>", "Only verify memories updated on or after this ISO timestamp", "")
+        .option("--updated-before <iso>", "Only verify memories updated on or before this ISO timestamp", "")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const namespace = typeof options.namespace === "string" && options.namespace.trim().length > 0
+            ? options.namespace.trim()
+            : undefined;
+          const memoryDir = await resolveMemoryDirForNamespace(orchestrator, namespace);
+          const result = await runVerifyMemoryProjectionCliCommand({
+            memoryDir,
+            updatedAfter: typeof options.updatedAfter === "string" && options.updatedAfter.trim().length > 0
+              ? options.updatedAfter.trim()
+              : undefined,
+            updatedBefore: typeof options.updatedBefore === "string" && options.updatedBefore.trim().length > 0
+              ? options.updatedBefore.trim()
+              : undefined,
+          });
+
+          console.log(`Projection exists: ${result.projectionExists ? "yes" : "no"}`);
+          console.log(`OK: ${result.ok ? "yes" : "no"}`);
+          console.log(`Expected current rows: ${result.expectedCurrentRows}`);
+          console.log(`Actual current rows: ${result.actualCurrentRows}`);
+          console.log(`Expected timeline rows: ${result.expectedTimelineRows}`);
+          console.log(`Actual timeline rows: ${result.actualTimelineRows}`);
+          console.log(`Missing current memories: ${result.missingCurrentMemoryIds.join(", ") || "none"}`);
+          console.log(`Extra current memories: ${result.extraCurrentMemoryIds.join(", ") || "none"}`);
+          console.log(`Mismatched current memories: ${result.mismatchedCurrentMemoryIds.join(", ") || "none"}`);
+          console.log(`Missing timeline events: ${result.missingTimelineEventIds.join(", ") || "none"}`);
+          console.log(`Extra timeline events: ${result.extraTimelineEventIds.join(", ") || "none"}`);
+          console.log("OK");
+        });
+
+      cmd
+        .command("repair-memory-projection")
+        .description("Repair projection drift by rebuilding the derived projection (dry-run by default)")
+        .option("--write", "Write repaired projection (default: dry-run)")
+        .option("--namespace <ns>", "Namespace to repair (default: config defaultNamespace)", "")
+        .option("--updated-after <iso>", "Only repair memories updated on or after this ISO timestamp", "")
+        .option("--updated-before <iso>", "Only repair memories updated on or before this ISO timestamp", "")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const namespace = typeof options.namespace === "string" && options.namespace.trim().length > 0
+            ? options.namespace.trim()
+            : undefined;
+          const memoryDir = await resolveMemoryDirForNamespace(orchestrator, namespace);
+          const result = await runRepairMemoryProjectionCliCommand({
+            memoryDir,
+            write: options.write === true,
+            updatedAfter: typeof options.updatedAfter === "string" && options.updatedAfter.trim().length > 0
+              ? options.updatedAfter.trim()
+              : undefined,
+            updatedBefore: typeof options.updatedBefore === "string" && options.updatedBefore.trim().length > 0
+              ? options.updatedBefore.trim()
+              : undefined,
+          });
+
+          console.log(`Dry run: ${result.dryRun ? "yes" : "no"}`);
+          console.log(`Repaired: ${result.repaired ? "yes" : "no"}`);
+          console.log(`Verification OK: ${result.verify.ok ? "yes" : "no"}`);
+          if (result.rebuild) {
+            console.log(`Output path: ${result.rebuild.outputPath}`);
+            if (result.rebuild.backupPath) console.log(`Backup path: ${result.rebuild.backupPath}`);
+          }
           console.log("OK");
         });
 

--- a/src/maintenance/rebuild-memory-projection.ts
+++ b/src/maintenance/rebuild-memory-projection.ts
@@ -20,12 +20,16 @@ import {
   getMemoryProjectionPath,
   initializeMemoryProjectionDb,
   MEMORY_PROJECTION_SCHEMA_VERSION,
+  parseCurrentRow,
+  parseTimelineRows,
 } from "../memory-projection-store.js";
 
 export interface RebuildMemoryProjectionOptions {
   memoryDir: string;
   dryRun?: boolean;
   now?: Date;
+  updatedAfter?: string;
+  updatedBefore?: string;
 }
 
 export interface RebuildMemoryProjectionResult {
@@ -36,6 +40,45 @@ export interface RebuildMemoryProjectionResult {
   outputPath: string;
   backupPath?: string;
   usedLifecycleLedger: boolean;
+  scope: {
+    updatedAfter: string | null;
+    updatedBefore: string | null;
+  };
+}
+
+export interface VerifyMemoryProjectionOptions {
+  memoryDir: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+}
+
+export interface VerifyMemoryProjectionResult {
+  outputPath: string;
+  projectionExists: boolean;
+  ok: boolean;
+  expectedCurrentRows: number;
+  actualCurrentRows: number;
+  expectedTimelineRows: number;
+  actualTimelineRows: number;
+  missingCurrentMemoryIds: string[];
+  extraCurrentMemoryIds: string[];
+  mismatchedCurrentMemoryIds: string[];
+  missingTimelineEventIds: string[];
+  extraTimelineEventIds: string[];
+  usedLifecycleLedger: boolean;
+  scope: {
+    updatedAfter: string | null;
+    updatedBefore: string | null;
+  };
+}
+
+export interface RepairMemoryProjectionOptions extends RebuildMemoryProjectionOptions {}
+
+export interface RepairMemoryProjectionResult {
+  dryRun: boolean;
+  repaired: boolean;
+  verify: VerifyMemoryProjectionResult;
+  rebuild?: RebuildMemoryProjectionResult;
 }
 
 async function backupExistingProjection(
@@ -104,6 +147,230 @@ function loadTimelineEvents(
     events: sortMemoryLifecycleEvents(memories.flatMap((memory) => buildLifecycleEventsForMemory(memory))),
     usedLifecycleLedger: false,
   };
+}
+
+function normalizeScopedIso(value: string | undefined): string | null {
+  if (!value) return null;
+  const trimmed = value.trim();
+  if (!trimmed) return null;
+  const parsed = new Date(trimmed);
+  if (Number.isNaN(parsed.getTime())) {
+    throw new Error(`invalid projection scope timestamp: ${value}`);
+  }
+  return parsed.toISOString();
+}
+
+function normalizeProjectionScope(options: {
+  updatedAfter?: string;
+  updatedBefore?: string;
+}): {
+  updatedAfter: string | null;
+  updatedBefore: string | null;
+} {
+  const updatedAfter = normalizeScopedIso(options.updatedAfter);
+  const updatedBefore = normalizeScopedIso(options.updatedBefore);
+  if (
+    updatedAfter &&
+    updatedBefore &&
+    new Date(updatedAfter).getTime() > new Date(updatedBefore).getTime()
+  ) {
+    throw new Error("updatedAfter must be less than or equal to updatedBefore");
+  }
+  return {
+    updatedAfter,
+    updatedBefore,
+  };
+}
+
+function hasScopedProjectionFilter(scope: {
+  updatedAfter: string | null;
+  updatedBefore: string | null;
+}): boolean {
+  return scope.updatedAfter !== null || scope.updatedBefore !== null;
+}
+
+function memoryScopeTimestamp(memory: MemoryFile): string {
+  const candidate = memory.frontmatter.updated || memory.frontmatter.created;
+  return candidate;
+}
+
+function isTimestampInProjectionScope(
+  timestamp: string,
+  scope: { updatedAfter: string | null; updatedBefore: string | null },
+): boolean {
+  if (!scope.updatedAfter && !scope.updatedBefore) return true;
+  const parsed = new Date(timestamp);
+  if (Number.isNaN(parsed.getTime())) return false;
+  if (scope.updatedAfter && parsed.getTime() < new Date(scope.updatedAfter).getTime()) return false;
+  if (scope.updatedBefore && parsed.getTime() > new Date(scope.updatedBefore).getTime()) return false;
+  return true;
+}
+
+function filterMemoriesForProjectionScope(
+  memories: MemoryFile[],
+  scope: { updatedAfter: string | null; updatedBefore: string | null },
+): MemoryFile[] {
+  if (!scope.updatedAfter && !scope.updatedBefore) return memories;
+  return memories.filter((memory) => isTimestampInProjectionScope(memoryScopeTimestamp(memory), scope));
+}
+
+function filterCurrentStateRowsForProjectionScope(
+  rows: MemoryProjectionCurrentState[],
+  scope: { updatedAfter: string | null; updatedBefore: string | null },
+): MemoryProjectionCurrentState[] {
+  if (!scope.updatedAfter && !scope.updatedBefore) return rows;
+  return rows.filter((row) => isTimestampInProjectionScope(row.updated || row.created, scope));
+}
+
+function serializeCurrentStateRow(row: MemoryProjectionCurrentState): string {
+  return JSON.stringify({
+    memoryId: row.memoryId,
+    category: row.category,
+    status: row.status,
+    lifecycleState: row.lifecycleState ?? null,
+    pathRel: row.pathRel,
+    created: row.created,
+    updated: row.updated,
+    archivedAt: row.archivedAt ?? null,
+    supersededAt: row.supersededAt ?? null,
+    entityRef: row.entityRef ?? null,
+    source: row.source,
+    confidence: row.confidence,
+    confidenceTier: row.confidenceTier,
+    memoryKind: row.memoryKind ?? null,
+    accessCount: row.accessCount ?? null,
+    lastAccessed: row.lastAccessed ?? null,
+  });
+}
+
+function serializeTimelineEvent(event: MemoryLifecycleEvent): string {
+  return JSON.stringify({
+    eventId: event.eventId,
+    memoryId: event.memoryId,
+    eventType: event.eventType,
+    timestamp: event.timestamp,
+    actor: event.actor,
+    reasonCode: event.reasonCode ?? null,
+    ruleVersion: event.ruleVersion,
+    relatedMemoryIds: event.relatedMemoryIds ?? [],
+    before: event.before ?? null,
+    after: event.after ?? null,
+    correlationId: event.correlationId ?? null,
+  });
+}
+
+async function loadAuthoritativeProjectionSnapshot(options: {
+  memoryDir: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+}): Promise<{
+  allMemories: MemoryFile[];
+  currentRows: MemoryProjectionCurrentState[];
+  timelineRows: MemoryLifecycleEvent[];
+  scopedCurrentRows: MemoryProjectionCurrentState[];
+  scopedTimelineRows: MemoryLifecycleEvent[];
+  usedLifecycleLedger: boolean;
+  scope: {
+    updatedAfter: string | null;
+    updatedBefore: string | null;
+  };
+}> {
+  const storage = new StorageManager(options.memoryDir);
+  const allMemories = [...await storage.readAllMemories(), ...await storage.readArchivedMemories()]
+    .sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id));
+  const lifecycleEvents = await storage.readAllMemoryLifecycleEvents();
+  const { events, usedLifecycleLedger } = loadTimelineEvents(allMemories, lifecycleEvents);
+  const currentRows = allMemories.map((memory) => toCurrentStateRow(options.memoryDir, memory));
+  const scope = normalizeProjectionScope(options);
+  const scopedMemories = filterMemoriesForProjectionScope(allMemories, scope);
+  const scopedMemoryIds = new Set(scopedMemories.map((memory) => memory.frontmatter.id));
+
+  return {
+    allMemories,
+    currentRows,
+    timelineRows: events,
+    scopedCurrentRows: currentRows.filter((row) => scopedMemoryIds.has(row.memoryId)),
+    scopedTimelineRows: events.filter((event) => scopedMemoryIds.has(event.memoryId)),
+    usedLifecycleLedger,
+    scope,
+  };
+}
+
+function readProjectedCurrentRows(
+  memoryDir: string,
+): { projectionExists: boolean; rows: MemoryProjectionCurrentState[] } {
+  const dbPath = getMemoryProjectionPath(memoryDir);
+  try {
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    try {
+      const rows = db.prepare(`
+        SELECT
+          memory_id,
+          category,
+          status,
+          lifecycle_state,
+          path_rel,
+          created_at,
+          updated_at,
+          archived_at,
+          superseded_at,
+          entity_ref,
+          source,
+          confidence,
+          confidence_tier,
+          memory_kind,
+          access_count,
+          last_accessed
+        FROM memory_current
+      `).all() as Array<Record<string, unknown>>;
+
+      return {
+        projectionExists: true,
+        rows: rows
+          .map((row) => parseCurrentRow(memoryDir, row))
+          .filter((row): row is MemoryProjectionCurrentState => row !== null),
+      };
+    } finally {
+      db.close();
+    }
+  } catch {
+    return { projectionExists: false, rows: [] };
+  }
+}
+
+function readProjectedTimelineRows(
+  memoryDir: string,
+): { projectionExists: boolean; rows: MemoryLifecycleEvent[] } {
+  const dbPath = getMemoryProjectionPath(memoryDir);
+  try {
+    const db = new Database(dbPath, { readonly: true, fileMustExist: true });
+    try {
+      const rows = db.prepare(`
+        SELECT
+          event_id,
+          memory_id,
+          event_type,
+          timestamp,
+          actor,
+          reason_code,
+          rule_version,
+          related_memory_ids_json,
+          before_json,
+          after_json,
+          correlation_id
+        FROM memory_timeline
+      `).all() as Array<Record<string, unknown>>;
+
+      return {
+        projectionExists: true,
+        rows: parseTimelineRows(rows),
+      };
+    } finally {
+      db.close();
+    }
+  } catch {
+    return { projectionExists: false, rows: [] };
+  }
 }
 
 function writeProjectionDb(
@@ -206,30 +473,73 @@ function writeProjectionDb(
   }
 }
 
+function mergeScopedCurrentRows(
+  existingRows: MemoryProjectionCurrentState[],
+  replacementRows: MemoryProjectionCurrentState[],
+  scopedMemoryIds: Set<string>,
+): MemoryProjectionCurrentState[] {
+  return [...existingRows.filter((row) => !scopedMemoryIds.has(row.memoryId)), ...replacementRows]
+    .sort((a, b) => a.memoryId.localeCompare(b.memoryId));
+}
+
+function mergeScopedTimelineRows(
+  existingRows: MemoryLifecycleEvent[],
+  replacementRows: MemoryLifecycleEvent[],
+  scopedMemoryIds: Set<string>,
+): MemoryLifecycleEvent[] {
+  return sortMemoryLifecycleEvents([
+    ...existingRows.filter((event) => !scopedMemoryIds.has(event.memoryId)),
+    ...replacementRows,
+  ]);
+}
+
 export async function rebuildMemoryProjection(
   options: RebuildMemoryProjectionOptions,
 ): Promise<RebuildMemoryProjectionResult> {
   const dryRun = options.dryRun !== false;
   const now = options.now ?? new Date();
-  const storage = new StorageManager(options.memoryDir);
   const outputPath = getMemoryProjectionPath(options.memoryDir);
-  const allMemories = [...await storage.readAllMemories(), ...await storage.readArchivedMemories()]
-    .sort((a, b) => a.frontmatter.id.localeCompare(b.frontmatter.id));
-  const lifecycleEvents = await storage.readAllMemoryLifecycleEvents();
-  const { events, usedLifecycleLedger } = loadTimelineEvents(allMemories, lifecycleEvents);
-  const currentRows = allMemories.map((memory) => toCurrentStateRow(options.memoryDir, memory));
+  const snapshot = await loadAuthoritativeProjectionSnapshot(options);
 
   let backupPath: string | undefined;
   if (!dryRun) {
+    let nextCurrentRows = snapshot.currentRows;
+    let nextTimelineRows = snapshot.timelineRows;
+    if (hasScopedProjectionFilter(snapshot.scope)) {
+      const projectedCurrent = readProjectedCurrentRows(options.memoryDir);
+      const projectedTimeline = readProjectedTimelineRows(options.memoryDir);
+      if (projectedCurrent.projectionExists && projectedTimeline.projectionExists) {
+        const actualScopedCurrentRows = filterCurrentStateRowsForProjectionScope(
+          projectedCurrent.rows,
+          snapshot.scope,
+        );
+        const scopedMemoryIds = new Set([
+          ...snapshot.scopedCurrentRows.map((row) => row.memoryId),
+          ...snapshot.scopedTimelineRows.map((event) => event.memoryId),
+          ...actualScopedCurrentRows.map((row) => row.memoryId),
+        ]);
+        nextCurrentRows = mergeScopedCurrentRows(
+          projectedCurrent.rows,
+          snapshot.scopedCurrentRows,
+          scopedMemoryIds,
+        );
+        nextTimelineRows = mergeScopedTimelineRows(
+          projectedTimeline.rows,
+          snapshot.scopedTimelineRows,
+          scopedMemoryIds,
+        );
+      }
+    }
+
     const tempPath = `${outputPath}.tmp`;
     await mkdir(path.dirname(outputPath), { recursive: true });
     await rm(tempPath, { force: true });
     writeProjectionDb(
       tempPath,
       now.toISOString(),
-      currentRows,
-      events,
-      usedLifecycleLedger,
+      nextCurrentRows,
+      nextTimelineRows,
+      snapshot.usedLifecycleLedger,
     );
     backupPath = await backupExistingProjection(options.memoryDir, outputPath, now);
     await rename(tempPath, outputPath);
@@ -237,11 +547,116 @@ export async function rebuildMemoryProjection(
 
   return {
     dryRun,
-    scannedMemories: allMemories.length,
-    currentRows: currentRows.length,
-    timelineRows: events.length,
+    scannedMemories: snapshot.allMemories.length,
+    currentRows: snapshot.scopedCurrentRows.length,
+    timelineRows: snapshot.scopedTimelineRows.length,
     outputPath,
     backupPath,
-    usedLifecycleLedger,
+    usedLifecycleLedger: snapshot.usedLifecycleLedger,
+    scope: snapshot.scope,
+  };
+}
+
+export async function verifyMemoryProjection(
+  options: VerifyMemoryProjectionOptions,
+): Promise<VerifyMemoryProjectionResult> {
+  const outputPath = getMemoryProjectionPath(options.memoryDir);
+  const snapshot = await loadAuthoritativeProjectionSnapshot(options);
+  const projectedCurrent = readProjectedCurrentRows(options.memoryDir);
+  const projectedTimeline = readProjectedTimelineRows(options.memoryDir);
+  const projectionExists = projectedCurrent.projectionExists || projectedTimeline.projectionExists;
+
+  const actualScopedCurrentRows = filterCurrentStateRowsForProjectionScope(projectedCurrent.rows, snapshot.scope);
+  const expectedCurrentById = new Map(
+    snapshot.scopedCurrentRows.map((row) => [row.memoryId, serializeCurrentStateRow(row)]),
+  );
+  const actualCurrentById = new Map(
+    actualScopedCurrentRows.map((row) => [row.memoryId, serializeCurrentStateRow(row)]),
+  );
+
+  const missingCurrentMemoryIds = [...expectedCurrentById.keys()]
+    .filter((memoryId) => !actualCurrentById.has(memoryId))
+    .sort();
+  const extraCurrentMemoryIds = [...actualCurrentById.keys()]
+    .filter((memoryId) => !expectedCurrentById.has(memoryId))
+    .sort();
+  const mismatchedCurrentMemoryIds = [...expectedCurrentById.keys()]
+    .filter((memoryId) =>
+      actualCurrentById.has(memoryId) && actualCurrentById.get(memoryId) !== expectedCurrentById.get(memoryId)
+    )
+    .sort();
+
+  const selectedMemoryIds = new Set([
+    ...snapshot.scopedCurrentRows.map((row) => row.memoryId),
+    ...actualScopedCurrentRows.map((row) => row.memoryId),
+  ]);
+  const expectedTimelineById = new Map(
+    snapshot.scopedTimelineRows.map((event) => [event.eventId, serializeTimelineEvent(event)]),
+  );
+  const actualTimelineRows = projectedTimeline.rows.filter((event) => selectedMemoryIds.has(event.memoryId));
+  const actualTimelineById = new Map(
+    actualTimelineRows.map((event) => [event.eventId, serializeTimelineEvent(event)]),
+  );
+  const missingTimelineEventIds = [...expectedTimelineById.keys()]
+    .filter((eventId) => !actualTimelineById.has(eventId))
+    .sort();
+  const extraTimelineEventIds = [...actualTimelineById.keys()]
+    .filter((eventId) => !expectedTimelineById.has(eventId))
+    .sort();
+
+  return {
+    outputPath,
+    projectionExists,
+    ok:
+      projectionExists &&
+      missingCurrentMemoryIds.length === 0 &&
+      extraCurrentMemoryIds.length === 0 &&
+      mismatchedCurrentMemoryIds.length === 0 &&
+      missingTimelineEventIds.length === 0 &&
+      extraTimelineEventIds.length === 0,
+    expectedCurrentRows: snapshot.scopedCurrentRows.length,
+    actualCurrentRows: actualScopedCurrentRows.length,
+    expectedTimelineRows: snapshot.scopedTimelineRows.length,
+    actualTimelineRows: actualTimelineRows.length,
+    missingCurrentMemoryIds,
+    extraCurrentMemoryIds,
+    mismatchedCurrentMemoryIds,
+    missingTimelineEventIds,
+    extraTimelineEventIds,
+    usedLifecycleLedger: snapshot.usedLifecycleLedger,
+    scope: snapshot.scope,
+  };
+}
+
+export async function repairMemoryProjection(
+  options: RepairMemoryProjectionOptions,
+): Promise<RepairMemoryProjectionResult> {
+  const dryRun = options.dryRun !== false;
+  const verify = await verifyMemoryProjection(options);
+  if (verify.ok) {
+    return {
+      dryRun,
+      repaired: false,
+      verify,
+    };
+  }
+  if (dryRun) {
+    return {
+      dryRun: true,
+      repaired: false,
+      verify,
+    };
+  }
+
+  const rebuild = await rebuildMemoryProjection({
+    ...options,
+    dryRun: false,
+  });
+  const verified = await verifyMemoryProjection(options);
+  return {
+    dryRun: false,
+    repaired: verified.ok,
+    verify: verified,
+    rebuild,
   };
 }

--- a/src/memory-projection-store.ts
+++ b/src/memory-projection-store.ts
@@ -70,7 +70,7 @@ function openProjectionReadonly(memoryDir: string): Database.Database | null {
   }
 }
 
-function parseCurrentRow(
+export function parseCurrentRow(
   memoryDir: string,
   row: Record<string, unknown> | undefined,
 ): MemoryProjectionCurrentState | null {
@@ -116,7 +116,7 @@ function parseCurrentRow(
   };
 }
 
-function parseTimelineRows(rows: Array<Record<string, unknown>>): MemoryLifecycleEvent[] {
+export function parseTimelineRows(rows: Array<Record<string, unknown>>): MemoryLifecycleEvent[] {
   const out: MemoryLifecycleEvent[] = [];
   for (const row of rows) {
     if (

--- a/tests/cli-maintenance-suite.test.ts
+++ b/tests/cli-maintenance-suite.test.ts
@@ -8,8 +8,10 @@ import {
   runMemoryTimelineCliCommand,
   runRebuildMemoryLifecycleLedgerCliCommand,
   runRebuildMemoryProjectionCliCommand,
+  runRepairMemoryProjectionCliCommand,
   runMigrateObservationsCliCommand,
   runRebuildObservationsCliCommand,
+  runVerifyMemoryProjectionCliCommand,
 } from "../src/cli.js";
 
 async function writeText(baseDir: string, relPath: string, content: string): Promise<void> {
@@ -157,6 +159,69 @@ alpha
     memoryId: "fact-1",
   });
   assert.deepEqual(rows.map((row) => row.eventType), ["created", "updated"]);
+});
+
+test("verify-memory-projection and repair-memory-projection CLI wrappers detect and repair drift", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-cli-verify-memory-projection-"));
+  await writeText(
+    memoryDir,
+    "facts/2026-03-08/fact-1.md",
+    `---
+id: fact-1
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T01:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["alpha"]
+---
+
+alpha
+`,
+  );
+  await runRebuildMemoryProjectionCliCommand({
+    memoryDir,
+    write: true,
+    now: new Date("2026-03-08T02:00:00.000Z"),
+  });
+
+  await writeText(
+    memoryDir,
+    "facts/2026-03-08/fact-2.md",
+    `---
+id: fact-2
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T03:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["beta"]
+---
+
+beta
+`,
+  );
+
+  const verify = await runVerifyMemoryProjectionCliCommand({ memoryDir });
+  assert.equal(verify.ok, false);
+  assert.deepEqual(verify.missingCurrentMemoryIds, ["fact-2"]);
+
+  const dryRunRepair = await runRepairMemoryProjectionCliCommand({ memoryDir });
+  assert.equal(dryRunRepair.dryRun, true);
+  assert.equal(dryRunRepair.repaired, false);
+
+  const writeRepair = await runRepairMemoryProjectionCliCommand({
+    memoryDir,
+    write: true,
+    now: new Date("2026-03-08T04:00:00.000Z"),
+  });
+  assert.equal(writeRepair.dryRun, false);
+  assert.equal(writeRepair.repaired, true);
+
+  const verifiedAfter = await runVerifyMemoryProjectionCliCommand({ memoryDir });
+  assert.equal(verifiedAfter.ok, true);
 });
 
 test("migrate-observations CLI wrapper respects dry-run default and write mode", async () => {

--- a/tests/memory-projection.test.ts
+++ b/tests/memory-projection.test.ts
@@ -5,7 +5,11 @@ import path from "node:path";
 import Database from "better-sqlite3";
 import { mkdtemp, mkdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { StorageManager } from "../src/storage.ts";
-import { rebuildMemoryProjection } from "../src/maintenance/rebuild-memory-projection.ts";
+import {
+  rebuildMemoryProjection,
+  repairMemoryProjection,
+  verifyMemoryProjection,
+} from "../src/maintenance/rebuild-memory-projection.ts";
 import {
   getMemoryProjectionPath,
   initializeMemoryProjectionDb,
@@ -212,6 +216,269 @@ archivedAt should override active
     const current = readProjectedMemoryState(memoryDir, "fact-archived-override");
     assert.ok(current);
     assert.equal(current?.status, "archived");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("rebuildMemoryProjection can refresh only memories inside an updated-at window", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-window-"));
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-older.md",
+      `---
+id: fact-older
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T01:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+entityRef: project-older
+tags: ["older"]
+---
+
+older
+`,
+    );
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-recent.md",
+      `---
+id: fact-recent
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T03:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+entityRef: project-before
+tags: ["recent"]
+---
+
+recent
+`,
+    );
+
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T04:00:00.000Z"),
+    });
+    {
+      const db = new Database(getMemoryProjectionPath(memoryDir));
+      try {
+        db.prepare("UPDATE memory_current SET entity_ref = ? WHERE memory_id = ?")
+          .run("project-corrupt", "fact-older");
+      } finally {
+        db.close();
+      }
+    }
+
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-recent.md",
+      `---
+id: fact-recent
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T05:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+entityRef: project-after
+tags: ["recent"]
+---
+
+recent updated
+`,
+    );
+
+    const scoped = await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      updatedAfter: "2026-03-08T02:00:00.000Z",
+      now: new Date("2026-03-08T06:00:00.000Z"),
+    });
+
+    assert.equal(scoped.currentRows, 1);
+    const scopedVerify = await verifyMemoryProjection({
+      memoryDir,
+      updatedAfter: "2026-03-08T02:00:00.000Z",
+    });
+    assert.equal(scopedVerify.ok, true);
+    const older = readProjectedMemoryState(memoryDir, "fact-older");
+    const recent = readProjectedMemoryState(memoryDir, "fact-recent");
+    assert.equal(older?.entityRef, "project-corrupt");
+    assert.equal(recent?.entityRef, "project-after");
+
+    const fullVerify = await verifyMemoryProjection({ memoryDir });
+    assert.equal(fullVerify.ok, false);
+    assert.deepEqual(fullVerify.mismatchedCurrentMemoryIds, ["fact-older"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("scoped rebuild removes deleted memories that still exist in the projection", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-delete-window-"));
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-recent.md",
+      `---
+id: fact-recent
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T05:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["recent"]
+---
+
+recent
+`,
+    );
+
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T06:00:00.000Z"),
+    });
+
+    await rm(path.join(memoryDir, "facts/2026-03-08/fact-recent.md"));
+
+    const scoped = await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      updatedAfter: "2026-03-08T02:00:00.000Z",
+      now: new Date("2026-03-08T07:00:00.000Z"),
+    });
+
+    assert.equal(scoped.currentRows, 0);
+    assert.equal(readProjectedMemoryState(memoryDir, "fact-recent"), null);
+    assert.equal(readProjectedMemoryTimeline(memoryDir, "fact-recent", 20), null);
+
+    const verify = await verifyMemoryProjection({ memoryDir });
+    assert.equal(verify.ok, true);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("verifyMemoryProjection reports drift when projection is missing current rows", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-verify-"));
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-1.md",
+      `---
+id: fact-1
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T01:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["alpha"]
+---
+
+alpha
+`,
+    );
+
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T02:00:00.000Z"),
+    });
+
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-2.md",
+      `---
+id: fact-2
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T03:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["beta"]
+---
+
+beta
+`,
+    );
+
+    const verify = await verifyMemoryProjection({ memoryDir });
+    assert.equal(verify.ok, false);
+    assert.deepEqual(verify.missingCurrentMemoryIds, ["fact-2"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("repairMemoryProjection dry-run reports drift and write mode repairs it", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-memory-projection-repair-"));
+  try {
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-1.md",
+      `---
+id: fact-1
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T01:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["alpha"]
+---
+
+alpha
+`,
+    );
+
+    await rebuildMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T02:00:00.000Z"),
+    });
+
+    await writeText(
+      memoryDir,
+      "facts/2026-03-08/fact-2.md",
+      `---
+id: fact-2
+category: fact
+created: 2026-03-08T00:00:00.000Z
+updated: 2026-03-08T03:00:00.000Z
+source: test
+confidence: 0.8
+confidenceTier: implied
+tags: ["beta"]
+---
+
+beta
+`,
+    );
+
+    const dryRun = await repairMemoryProjection({ memoryDir });
+    assert.equal(dryRun.dryRun, true);
+    assert.equal(dryRun.repaired, false);
+    assert.equal(dryRun.verify.ok, false);
+
+    const writeResult = await repairMemoryProjection({
+      memoryDir,
+      dryRun: false,
+      now: new Date("2026-03-08T04:00:00.000Z"),
+    });
+    assert.equal(writeResult.dryRun, false);
+    assert.equal(writeResult.repaired, true);
+    assert.equal(writeResult.verify.ok, true);
   } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }


### PR DESCRIPTION
## Summary
- add projection verify and repair commands plus scoped updated-at CLI options
- make scoped projection rebuilds update only the selected memory window instead of rewriting out-of-scope rows
- cover scoped rebuild/verify behavior with regression tests and document the maintenance workflow

Closes #159.

## Verification
- npm test -- tests/memory-projection.test.ts tests/cli-maintenance-suite.test.ts
- npm run check-types
- npm run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Modifies projection rebuild/write behavior and introduces merge logic against existing SQLite state, which could affect data correctness if scoping or row parsing is wrong. Changes are mitigated by new verification/repair flows and regression tests.
> 
> **Overview**
> Adds projection integrity tooling by introducing `verify-memory-projection` and `repair-memory-projection` commands, plus `--namespace` and `--updated-after/--updated-before` scoping across projection maintenance.
> 
> Updates `rebuildMemoryProjection` to support *windowed* rebuilds that merge scoped rows into the existing SQLite projection (leaving out-of-scope rows untouched) and implements drift detection/repair logic (`verifyMemoryProjection`, `repairMemoryProjection`). Tests and ops docs are expanded to cover drift scenarios, scoped rebuild semantics (including deletions), and the new maintenance workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 58ca92ebd64c83200783c8f8831e9e02403a9936. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->