### PR TITLE
Follow up curated native knowledge sync fixes

### DIFF
--- a/src/native-knowledge.ts
+++ b/src/native-knowledge.ts
@@ -149,7 +149,7 @@ function uniqueSorted(values: string[]): string[] {
   return [...new Set(values.filter((value) => value.trim().length > 0).map((value) => value.trim()))].sort();
 }
 
-function detectSourceKind(filePath: string): NativeKnowledgeChunk["sourceKind"] {
+function detectSourceKind(filePath: string): CuratedIncludeFileState["sourceKind"] {
   const base = path.basename(filePath).toLowerCase();
   if (base.startsWith("identity")) return "identity";
   if (base === "memory.md") return "memory";
@@ -1382,7 +1382,7 @@ export async function syncCuratedIncludeFiles(options: {
       sourcePath,
       parsed,
     });
-    const sourceKind = detectSourceKind(sourcePath) as CuratedIncludeFileState["sourceKind"];
+    const sourceKind = detectSourceKind(sourcePath);
     const sourceHash = createHash("sha256").update(content).digest("hex");
     const title = resolveNoteTitle(sourcePath, parsed);
     const syncConfigHash = createHash("sha256")
@@ -1437,6 +1437,10 @@ export async function syncCuratedIncludeFiles(options: {
 
   for (const [sourcePath, previous] of Object.entries(previousState.files)) {
     if (seen.has(sourcePath) || skipped.has(sourcePath)) continue;
+    if (previous.deleted) {
+      nextFiles[sourcePath] = previous;
+      continue;
+    }
     nextFiles[sourcePath] = {
       ...previous,
       deleted: true,

--- a/tests/native-knowledge.test.ts
+++ b/tests/native-knowledge.test.ts
@@ -288,6 +288,53 @@ test("include-file sync chunkCount reports synced chunks even when recall filter
   assert.equal(result.chunkCount, 1);
 });
 
+test("include-file sync preserves prior tombstones instead of recounting deleted files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "engram-native-knowledge-sync-tombstone-"));
+  const workspaceDir = path.join(root, "workspace");
+  const memoryDir = path.join(root, "memory");
+  await mkdir(workspaceDir, { recursive: true });
+  await mkdir(memoryDir, { recursive: true });
+  const identityPath = path.join(workspaceDir, "IDENTITY.md");
+  await writeFile(identityPath, "# Identity\n\nTemporary note.\n", "utf-8");
+
+  const config = {
+    enabled: true,
+    includeFiles: ["IDENTITY.md"],
+    maxChunkChars: 200,
+    maxResults: 4,
+    maxChars: 2400,
+    stateDir: "state/native-knowledge",
+    obsidianVaults: [],
+  };
+
+  await syncCuratedIncludeFiles({
+    workspaceDir,
+    memoryDir,
+    config,
+    recallNamespaces: ["default"],
+    defaultNamespace: "default",
+  });
+  await unlink(identityPath);
+
+  const firstDeletion = await syncCuratedIncludeFiles({
+    workspaceDir,
+    memoryDir,
+    config,
+    recallNamespaces: ["default"],
+    defaultNamespace: "default",
+  });
+  const secondDeletion = await syncCuratedIncludeFiles({
+    workspaceDir,
+    memoryDir,
+    config,
+    recallNamespaces: ["default"],
+    defaultNamespace: "default",
+  });
+
+  assert.equal(firstDeletion.deletedFiles, 1);
+  assert.equal(secondDeletion.deletedFiles, 0);
+});
+
 test("default private curated chunks remain visible when shared recall also includes default namespace", async () => {
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "engram-native-knowledge-private-default-"));
   await mkdir(workspaceDir, { recursive: true });


### PR DESCRIPTION
## Summary
- narrow curated include source kinds to the values sync state actually supports
- preserve existing include-file tombstones instead of recounting deletions on every sync
- add the regression test that the merged PR missed for repeated deletions

## Testing
- npm run check-types
- npm test -- tests/native-knowledge.test.ts tests/native-knowledge-recall.test.ts
- npm run build

Follow-up for roadmap issue #162 after the merged PR left two local fixes unshipped.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes curated include-file sync state handling by keeping existing tombstones and adjusting `sourceKind` typing; could affect deletion metrics/state transitions but is localized and covered by a new regression test.
> 
> **Overview**
> Fixes curated include-file syncing to use the narrower `sourceKind` set actually supported by `CuratedIncludeFileState`, removing the previous cast and preventing unsupported kinds from entering state.
> 
> Adjusts the deletion pass in `syncCuratedIncludeFiles` to **preserve existing tombstones** (already-`deleted` entries) instead of re-marking them and incrementing `deletedFiles` on every subsequent sync.
> 
> Adds a regression test ensuring repeated syncs after a file is removed only count the deletion once.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ca5d708e74e6e9f0098332642ee276d39d0c1f7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->