### PR TITLE
fix: restore protected-main-safe release automation

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -115,22 +115,25 @@ jobs:
           VERSION_OVERRIDE: ${{ inputs.version_override }}
         run: |
           SOURCE_MAIN_SHA=$(git rev-parse HEAD)
-          echo "source_main_sha=${SOURCE_MAIN_SHA}" >> "$GITHUB_OUTPUT"
+          {
+            echo "source_main_sha=${SOURCE_MAIN_SHA}"
+          } >> "$GITHUB_OUTPUT"
 
           # Honor manual version override from workflow_dispatch
           OVERRIDE="${VERSION_OVERRIDE}"
           if [ -n "${OVERRIDE}" ]; then
             # Strip leading 'v' if provided
             OVERRIDE="${OVERRIDE#v}"
-            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-            echo "tag_name=v${OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "new_version=${OVERRIDE}" >> "$GITHUB_OUTPUT"
-            echo "bump_type=override" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag_exists=false"
+              echo "tag_name=v${OVERRIDE}"
+              echo "new_version=${OVERRIDE}"
+              echo "bump_type=override"
+            } >> "$GITHUB_OUTPUT"
             npm version "${OVERRIDE}" --no-git-tag-version --allow-same-version
-            npx tsx scripts/promote-release-changelog.ts "${OVERRIDE}"
-            git add package.json package-lock.json CHANGELOG.md
+            git add package.json package-lock.json
             if git diff --cached --quiet; then
-              echo "::notice title=Release commit skipped::Version already matches v${OVERRIDE}; no release files changed."
+              echo "::notice title=Release commit skipped::Version already matches v${OVERRIDE}; no package files changed."
             else
               git commit -m "chore(release): v${OVERRIDE} [skip ci]"
             fi
@@ -141,16 +144,19 @@ jobs:
           while IFS= read -r tag; do
             [ -z "${tag}" ] && continue
             TAG_TARGET_SHA="$(git rev-parse "refs/tags/${tag}^{}")"
+            TAG_TARGET_PARENT_SHA="$(git rev-parse "${TAG_TARGET_SHA}^" 2>/dev/null || true)"
             if git cat-file -p "refs/tags/${tag}" | grep -Fq "source-main-sha: ${SOURCE_MAIN_SHA}" \
-              && [ "${TAG_TARGET_SHA}" = "${SOURCE_MAIN_SHA}" ]; then
+              && { [ "${TAG_TARGET_SHA}" = "${SOURCE_MAIN_SHA}" ] || [ "${TAG_TARGET_PARENT_SHA}" = "${SOURCE_MAIN_SHA}" ]; }; then
               EXISTING_TAG="${tag}"
               break
             fi
           done < <(git for-each-ref refs/tags --format='%(refname:short)' | grep -E '^v')
           if [ -n "${EXISTING_TAG}" ]; then
-            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
-            echo "tag_name=${EXISTING_TAG}" >> "$GITHUB_OUTPUT"
-            echo "new_version=${EXISTING_TAG#v}" >> "$GITHUB_OUTPUT"
+            {
+              echo "tag_exists=true"
+              echo "tag_name=${EXISTING_TAG}"
+              echo "new_version=${EXISTING_TAG#v}"
+            } >> "$GITHUB_OUTPUT"
             exit 0
           fi
 
@@ -177,23 +183,20 @@ jobs:
               NEXT_VERSION="${MAJOR}.${MINOR}.$((PATCH + 1))"
               ;;
           esac
-          echo "base_tag=${LATEST_TAG}" >> "$GITHUB_OUTPUT"
-          echo "bump_type=${BUMP_TYPE}" >> "$GITHUB_OUTPUT"
-          echo "tag_exists=false" >> "$GITHUB_OUTPUT"
-          echo "tag_name=v${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
-          echo "new_version=${NEXT_VERSION}" >> "$GITHUB_OUTPUT"
+          {
+            echo "base_tag=${LATEST_TAG}"
+            echo "bump_type=${BUMP_TYPE}"
+            echo "tag_exists=false"
+            echo "tag_name=v${NEXT_VERSION}"
+            echo "new_version=${NEXT_VERSION}"
+          } >> "$GITHUB_OUTPUT"
           npm version "${NEXT_VERSION}" --no-git-tag-version --allow-same-version
-          npx tsx scripts/promote-release-changelog.ts "${NEXT_VERSION}"
-          git add package.json package-lock.json CHANGELOG.md
+          git add package.json package-lock.json
           if git diff --cached --quiet; then
-            echo "::notice title=Release commit skipped::Version already matches v${NEXT_VERSION}; no release files changed."
+            echo "::notice title=Release commit skipped::Version already matches v${NEXT_VERSION}; no package files changed."
           else
             git commit -m "chore(release): v${NEXT_VERSION} [skip ci]"
           fi
-
-      - name: Push release commit to main
-        if: steps.version.outputs.tag_exists != 'true'
-        run: git push origin HEAD:main
 
       - name: Create version tag on release commit
         if: steps.version.outputs.tag_exists != 'true'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,12 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+The notes below describe the current protected-branch-safe release flow on `main`.
+
 ### Added
 - **`traceRecallContent` config option**: When set to `true`, Engram populates `RecallTraceEvent.recalledContent` with the full memory context injected into each agent turn. Allows external trace collectors (Langfuse, LangSmith, etc.) to see exactly which memories were recalled per conversation turn. Disabled by default — opt in only when you want memory content flowing to external systems.
 - Generic memory lifecycle ledger foundation: Engram now records append-only `created`, `updated`, `archived`, and `superseded` events under the local `state/memory-lifecycle-ledger.jsonl`, plus a rebuild utility and CLI for regenerating that ledger from markdown memory state.
 
 ### Changed
-- Release automation now promotes `CHANGELOG.md` from `Unreleased` into a dated versioned section during the auto-release workflow, pushes that release commit back to `main`, and no longer relies on PR authors to keep the changelog release ledger in sync by hand.
+- Release automation now uses a protected-branch-safe flow: it validates the merged `main` commit, creates a local release commit with the package version bump, pushes only the annotated release tag, and publishes from that tagged source instead of trying to push release metadata back to protected `main`.
+- `CHANGELOG.md` on `main` now remains the contributor-facing `Unreleased` ledger, while GitHub Releases provide the published per-version notes for shipped tags.
 - Changelog guard now treats `CHANGELOG.md` as release-workflow owned by default and only validates format when a PR edits the changelog directly.
 - `THEORY.MD` is now ignored and removed from the repo so it does not keep reappearing in commits.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,13 +72,14 @@ For retrieval/planner/cache/config changes, run the mandatory hardening gate:
 
 ## Changelog policy
 
-This repository uses `CHANGELOG.md` as the public source of release notes.
+This repository uses `CHANGELOG.md` on `main` as the contributor-facing ledger for upcoming release notes.
+Published per-version notes ship through GitHub Releases from the tagged release workflow.
 
 - Add a concise entry in `## [Unreleased]` for user-facing changes.
 - Use one of the standard sections when possible: `Added`, `Changed`, `Fixed`, `Security`.
 - Keep entries short and outcome-focused.
 
-A CI check enforces changelog updates when source/config files change.
+A CI check enforces `Unreleased` changelog updates when source/config files change.
 Maintainers can bypass for exceptional cases by applying label `skip-changelog`.
 
 ## AI-assisted contributions


### PR DESCRIPTION
## Summary
- stop the release workflow from pushing synthetic release commits back to protected `main`
- keep rerun detection compatible with annotated tags whose tagged commit is a child of the merged `main` SHA
- align changelog policy docs with the protected-branch-safe release flow

## Root cause
`Release and Publish` was still trying to run `git push origin HEAD:main` after creating a local release commit. `main` now requires pull-request-only updates plus required checks, so every post-merge release run failed with `GH006: Protected branch update failed` before it could create the tag, GitHub release, or npm publish.

## Verification
- `actionlint .github/workflows/release-and-publish.yml`
- `npm run check-types && npm test && npm run build`
- local synthetic-tag rerun simulation proving the workflow now reuses a tag whose tagged commit is a child of the merged `main` commit

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `Release and Publish` GitHub Actions workflow that controls versioning/tagging/publishing; a mistake could block releases or create incorrect tags/versions. No runtime product code is affected.
> 
> **Overview**
> Restores a protected-branch-safe release flow by **stopping the workflow from pushing release commits back to `main`** and instead only creating/pushing an annotated `vX.Y.Z` tag and publishing from that tagged source.
> 
> Improves rerun/idempotency by treating an existing annotated tag as matching when its tagged commit *or its parent* matches the merged `main` SHA, and simplifies the release commit contents to just the npm version bump (no `CHANGELOG.md` promotion).
> 
> Updates `CHANGELOG.md` and `CONTRIBUTING.md` wording to reflect that `main` keeps an `Unreleased` ledger while per-version notes are published via GitHub Releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6509c1c4dcc3726d0d341288371f7ca0312876c2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->