### PR TITLE
feat: add MCP JSON-RPC endpoint to HTTP access server

### DIFF
--- a/src/access-http.ts
+++ b/src/access-http.ts
@@ -375,12 +375,24 @@ export class EngramAccessHttpServer {
 
   private async handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
     const body = await this.readJsonBody(req);
-    const response = await this.mcpServer.handleRequest(body as {
+    const request = body as {
       jsonrpc?: string;
       id?: string | number | null;
       method?: string;
       params?: Record<string, unknown>;
-    });
+    };
+
+    // Enforce write rate limiting for MCP tool calls that mutate state,
+    // matching the same protection applied to the REST write endpoints.
+    if (request.method === "tools/call") {
+      const toolName = typeof request.params?.name === "string" ? request.params.name : "";
+      if (toolName === "engram.memory_store" || toolName === "engram.suggestion_submit") {
+        this.ensureWriteRateLimitAvailable();
+        this.recordWriteRateLimitHit();
+      }
+    }
+
+    const response = await this.mcpServer.handleRequest(request);
     if (response === null) {
       res.statusCode = 202;
       res.end();

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -1169,6 +1169,77 @@ test("access HTTP server exposes MCP JSON-RPC endpoint at /mcp", async () => {
   }
 });
 
+test("access HTTP server rate-limits MCP write tool calls", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 4096,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const headers = {
+      Authorization: "Bearer secret-token",
+      "Content-Type": "application/json",
+    };
+
+    // Exhaust the write rate limit via MCP memory_store calls
+    for (let i = 0; i < 30; i++) {
+      const res = await fetch(`${base}/mcp`, {
+        method: "POST",
+        headers,
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          id: i + 10,
+          method: "tools/call",
+          params: {
+            name: "engram.memory_store",
+            arguments: { content: `memory ${i}` },
+          },
+        }),
+      });
+      assert.equal(res.status, 200);
+    }
+
+    // 31st write should be rate-limited
+    const limited = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 999,
+        method: "tools/call",
+        params: {
+          name: "engram.memory_store",
+          arguments: { content: "overflow" },
+        },
+      }),
+    });
+    assert.equal(limited.status, 429);
+
+    // Read-only MCP calls should still work
+    const recallRes = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1000,
+        method: "tools/call",
+        params: {
+          name: "engram.recall",
+          arguments: { query: "test" },
+        },
+      }),
+    });
+    assert.equal(recallRes.status, 200);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("access HTTP server returns 400 for explicit-capture validation errors", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-http-validation-"));
   const storage = new StorageManager(memoryDir);


### PR DESCRIPTION
## Summary

- Adds a `POST /mcp` endpoint to the existing HTTP access server that accepts MCP JSON-RPC requests and returns JSON-RPC responses
- Enables MCP clients like Codex CLI and Claude Code to connect to Engram over HTTP instead of requiring a local STDIO process
- Reuses the existing `EngramMcpServer.handleRequest()` method — all 8 MCP tools work identically over both transports
- Notifications return 202 (no body); all other requests return 200 with JSON-RPC response
- Bearer token auth enforced on the `/mcp` endpoint (same as REST endpoints)

## Motivation

Codex CLI supports HTTP MCP servers via `url` in config.toml. This change allows Engram running on one machine (e.g., MacStudio) to serve memory to Codex running on another machine (e.g., laptop) over the network — no local OpenClaw installation required on the client side.

## Test plan

- [x] All 17 HTTP access tests pass (including new MCP endpoint test)
- [x] All 5 MCP STDIO tests still pass (no regressions)
- [x] New test covers: initialize handshake, tools/list, tools/call (engram.recall), notifications (202), and auth enforcement

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated HTTP endpoint that proxies MCP JSON-RPC requests into server-side tool execution, expanding the network-facing surface area. Also introduces new rate-limiting behavior for MCP write tool calls, which could affect clients if misclassified or tuned incorrectly.
> 
> **Overview**
> Adds a new authenticated `POST /mcp` endpoint to `EngramAccessHttpServer` that accepts MCP JSON-RPC requests and forwards them to `EngramMcpServer.handleRequest()`.
> 
> MCP notifications return `202` with no body, while normal JSON-RPC requests return `200` with the JSON-RPC response; write-like tool calls (`engram.memory_store`, `engram.suggestion_submit`) now consume/enforce the existing write rate limit similarly to REST write endpoints.
> 
> Extends `access-http` tests to cover MCP initialize/tools/list/tools/call flows, auth enforcement, and MCP-specific write rate limiting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ae66d1ba39da3e454079192e9db07462f4843cff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->