### PR TITLE
fix: remove hardcoded temperature from direct client extraction

### DIFF
--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -1272,7 +1272,6 @@ Respond with valid JSON only, matching this schema:
           { role: "user", content: "Consolidate the new memories against existing ones." },
         ],
         ...(this.config.reasoningEffort !== "none" ? { reasoning_effort: this.config.reasoningEffort } : {}),
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 4096, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),
@@ -1546,7 +1545,6 @@ Respond with valid JSON matching this schema:
           { role: "user", content: fullProfileContent },
         ],
         ...(this.config.reasoningEffort !== "none" ? { reasoning_effort: this.config.reasoningEffort } : {}),
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 4096, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),
@@ -1761,7 +1759,6 @@ Respond with valid JSON matching this schema:
           { role: "user", content: fullIdentityContent },
         ],
         ...(this.config.reasoningEffort !== "none" ? { reasoning_effort: this.config.reasoningEffort } : {}),
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 4096, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),
@@ -1979,7 +1976,6 @@ Respond with valid JSON matching this schema:
           { role: "system", content: systemPrompt },
           { role: "user", content: input },
         ],
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 2048, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),
@@ -2095,7 +2091,6 @@ Respond with valid JSON matching this schema:
           { role: "system", content: systemPrompt },
           { role: "user", content: input },
         ],
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 2048, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),
@@ -2200,7 +2195,6 @@ Respond with valid JSON matching this schema:
           { role: "system", content: systemPrompt },
           { role: "user", content: `Summarize these ${memories.length} memories:\n\n${memoryList}` },
         ],
-        temperature: 0.3,
         ...buildChatCompletionTokenLimit(this.config.model, 4096, {
           assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
         }),


### PR DESCRIPTION
## Summary

- Remove hardcoded `temperature: 0.3` from `extractWithDirectClient()` in `extraction.ts`
- gpt-5.2 rejects non-default temperature values with `400 Unsupported value: 'temperature' does not support 0.3 with this model`
- The extraction prompt is structured JSON output — model defaults work well here
- Removes the parameter entirely rather than special-casing per model family

## Context

Every extraction attempt via the direct OpenAI client has been failing with a 400 error since the gpt-5.2 model was configured. The fallback path hits a local LLM (qwen3-next-80b) which produces unparseable output, resulting in zero facts extracted today.

## Test plan

- [x] All 1332 tests pass (1 pre-existing failure in operator-toolkit unrelated to this change)
- [ ] After deploy, verify extraction succeeds via `grep "used direct client" ~/.openclaw/logs/gateway.log`
- [ ] Verify facts appear in `~/.openclaw/workspace/memory/local/facts/`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Removes an explicit `temperature` setting from multiple OpenAI Chat Completions requests, which can change output determinism/parseability even while fixing model compatibility errors.
> 
> **Overview**
> Fixes direct OpenAI-compatible extraction/consolidation flows by **removing the hardcoded `temperature: 0.3`** from Chat Completions requests (including `extractWithDirectClient` and other direct-client LLM operations).
> 
> This avoids 400 errors on models that reject non-default temperature values and lets those calls rely on model defaults instead of per-call temperature overrides.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9dfce14ddec2892e5a09a9930a52709bd337ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->