### PR TITLE
docs: document MCP-over-HTTP endpoint and --principal flag

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -79,7 +79,7 @@ The HTTP server also exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing r
 openclaw engram access http-serve --host 0.0.0.0 --port 4318 --token "$TOKEN"
 ```
 
-Clients send standard MCP JSON-RPC requests to `http://<host>:4318/mcp` with an `Authorization: Bearer <token>` header. All 8 MCP tools are available. Write operations (`engram.memory_store`, `engram.suggestion_submit`) are subject to the same rate limits as the REST write endpoints.
+Clients send standard MCP JSON-RPC requests to `http://<host>:4318/mcp` with an `Authorization: Bearer <token>` header. All 8 MCP tools are available. Write operations (`engram.memory_store`, `engram.suggestion_submit`) are rate-limited consistently with the REST write endpoints — dry runs and idempotency replays do not count toward the limit.
 
 **Namespace-enabled deployments:** If you have `namespacesEnabled: true`, pass `--principal <name>` to set the authenticated principal for all MCP connections. The principal must appear in `writePrincipals` for the target namespace. Without `--principal`, the principal resolves to `"default"`, which may not have write access:
 

--- a/src/access-http.ts
+++ b/src/access-http.ts
@@ -384,15 +384,25 @@ export class EngramAccessHttpServer {
 
     // Enforce write rate limiting for MCP tool calls that mutate state,
     // matching the same protection applied to the REST write endpoints.
-    if (request.method === "tools/call") {
-      const toolName = typeof request.params?.name === "string" ? request.params.name : "";
-      if (toolName === "engram.memory_store" || toolName === "engram.suggestion_submit") {
-        this.ensureWriteRateLimitAvailable();
-        this.recordWriteRateLimitHit();
-      }
+    // Pre-check ensures capacity; post-check skips counting dry runs and
+    // idempotency replays, consistent with the REST handlers.
+    const isMcpWrite =
+      request.method === "tools/call" &&
+      typeof request.params?.name === "string" &&
+      (request.params.name === "engram.memory_store" || request.params.name === "engram.suggestion_submit");
+    if (isMcpWrite) {
+      this.ensureWriteRateLimitAvailable();
     }
 
     const response = await this.mcpServer.handleRequest(request);
+
+    if (isMcpWrite && response !== null) {
+      const result = (response as Record<string, unknown>).result as Record<string, unknown> | undefined;
+      const structured = result?.structuredContent as { dryRun?: boolean; idempotencyReplay?: boolean } | undefined;
+      if (!structured || this.shouldCountWriteRateLimit(structured)) {
+        this.recordWriteRateLimitHit();
+      }
+    }
     if (response === null) {
       res.statusCode = 202;
       res.end();

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, rm } from "node:fs/promises";
 import { EngramAccessHttpServer } from "../src/access-http.js";
-import { EngramAccessInputError, EngramAccessService, type EngramAccessService } from "../src/access-service.js";
+import { EngramAccessInputError, EngramAccessService } from "../src/access-service.js";
 import { StorageManager } from "../src/storage.js";
 
 function createFakeService(): EngramAccessService {


### PR DESCRIPTION
## Summary

- Documents the `/mcp` JSON-RPC endpoint added in PR #251
- Explains `--principal` requirement for namespace-enabled deployments
- Covers auth, rate limiting, and example usage for remote MCP clients (Codex CLI, Claude Code)

## Context

The `/mcp` endpoint was added but not documented. Users with `namespacesEnabled: true` hit "namespace is not writable" errors because the MCP principal defaults to `"default"` which isn't in any `writePrincipals` list. The `--principal` flag resolves this. Deployments with `namespacesEnabled: false` (default) are unaffected.

## Test plan

- [x] Verified MCP writes work with `--principal generalist` on namespace-enabled deployment
- [x] Confirmed default deployments (`namespacesEnabled: false`) don't need `--principal`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts write rate-limiting behavior for MCP tool calls, which could impact throttling/abuse protection if the response parsing or counting logic is wrong. Documentation updates are low risk.
> 
> **Overview**
> Documents the MCP JSON-RPC endpoint exposed by the HTTP server at `POST /mcp`, including bearer auth usage, rate-limiting expectations, and how `--principal` affects writes in namespace-enabled deployments.
> 
> Updates `EngramAccessHttpServer` MCP handling so write tool calls (`engram.memory_store`, `engram.suggestion_submit`) *pre-check* capacity but only *consume* the write-rate-limit budget when the call is not a dry run and not an idempotency replay (matching REST write endpoints). Also removes an unused type import in `access-http` tests.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3612e56ddfdb9dd3d2498401908be3acbb92574e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->