### PR TITLE
docs: add Codex CLI integration guide

### DIFF
--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -33,15 +33,25 @@ Codex is stateless by default. Every session starts from zero — it doesn't kno
 
 ## Setup
 
-### 1. Start the Engram HTTP server
+### 1. Generate and set the token
 
-On the machine where Engram runs:
+Generate a secure token and add it to your shell profile (`~/.zshenv`, `~/.bashrc`, etc.) on every machine where Codex or Engram runs:
 
 ```bash
 # Generate a token (or use any secure random string)
 openssl rand -base64 32
 
-# Start the server
+# Add to your shell profile
+export OPENCLAW_ENGRAM_ACCESS_TOKEN="<paste-generated-token-here>"
+```
+
+Source the profile or open a new terminal so the variable is available.
+
+### 2. Start the Engram HTTP server
+
+On the machine where Engram runs:
+
+```bash
 openclaw engram access http-serve \
   --host 0.0.0.0 \
   --port 4318 \
@@ -59,16 +69,6 @@ openclaw engram access http-serve \
 ```
 
 For persistent operation, set up a launchd plist (macOS), systemd unit (Linux), or similar service manager so the server survives reboots.
-
-### 2. Set the token environment variable
-
-Add to your shell profile (`~/.zshenv`, `~/.bashrc`, etc.):
-
-```bash
-export OPENCLAW_ENGRAM_ACCESS_TOKEN="<your-token-here>"
-```
-
-This must be set on every machine where Codex runs.
 
 ### 3. Add Engram as an MCP server
 


### PR DESCRIPTION
## Summary

- New guide at `docs/guides/codex-cli.md` covering how to use Engram with OpenAI's Codex CLI
- Explains why persistent memory improves Codex (with concrete before/after examples)
- Step-by-step setup: HTTP server, MCP config, SessionStart hook, AGENTS.md instructions
- Covers cross-machine networking (Tailscale), namespace-enabled deployments, and troubleshooting
- Includes the full hook script inline so users can copy-paste

## Context

Engram's MCP-over-HTTP endpoint (PR #251, #254) enables Codex to use Engram as a persistent memory backend. This guide documents the complete integration for new users.

## Test plan

- [x] All setup steps verified on a working Codex + Engram deployment
- [x] Hook script tested end-to-end (recall, graceful degradation, token missing)
- [x] MCP tools verified accessible from Codex session
- [x] Namespace write permissions verified with `--principal` flag

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only change with no runtime or API modifications. The only caution is that the guide includes copy-pastable shell/hook commands that users may run manually.
> 
> **Overview**
> Adds a new guide, `docs/guides/codex-cli.md`, explaining how to connect Codex CLI to Engram over MCP to provide persistent cross-session memory.
> 
> Documents end-to-end setup (token, `openclaw engram access http-serve`, Codex `config.toml` MCP config), an optional SessionStart hook script that calls `POST /engram/v1/recall`, plus cross-machine/Tailscale notes, namespace `--principal` guidance, verification steps, and troubleshooting.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dca028689c55d7620485658cbcac76c461613e9a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->