### PR TITLE
fix: use UUID v7 for Opik span/trace IDs

### DIFF
--- a/src/opik-exporter.ts
+++ b/src/opik-exporter.ts
@@ -409,21 +409,15 @@ export class OpikExporter {
   // -------------------------------------------------------------------------
 
   /**
-   * Convert a sessionKey to a stable UUID v7-shaped deterministic ID so that
+   * Convert a sessionKey to a stable, deterministic UUID v7-shaped ID so that
    * spans for the same session share a trace_id and are threaded in Opik.
-   * Uses SHA-256 for collision resistance, stamps UUID v7 version/variant bits.
+   * Uses SHA-256 for collision resistance. The timestamp bytes (0-5) come from
+   * the hash itself — they don't reflect real time, but Opik only validates
+   * the version/variant bits, not timestamp ordering.
    */
   private sessionToTraceId(sessionKey: string): string {
     const digest = createHash("sha256").update(sessionKey).digest();
-    // Inject current timestamp into bytes 0-5 for UUID v7 time component
-    const now = Date.now();
-    digest[0] = (now / 2 ** 40) & 0xff;
-    digest[1] = (now / 2 ** 32) & 0xff;
-    digest[2] = (now / 2 ** 24) & 0xff;
-    digest[3] = (now / 2 ** 16) & 0xff;
-    digest[4] = (now / 2 ** 8) & 0xff;
-    digest[5] = now & 0xff;
-    // Version 7
+    // Version 7 (bytes 0-5 are hash-derived, not real timestamps)
     digest[6] = (digest[6] & 0x0f) | 0x70;
     // Variant 10xx
     digest[8] = (digest[8] & 0x3f) | 0x80;


### PR DESCRIPTION
## Summary
- Opik API requires UUID v7 (time-ordered) for span and trace IDs, but the exporter was generating v4 UUIDs via `randomUUID()`, causing **all span batch POSTs to silently fail** with HTTP 400: `"Span id must be a version 7 UUID"`
- Added a `uuidV7()` generator using timestamp + `randomBytes` and updated `sessionToTraceId()` to stamp v7 version bits
- This was the root cause of zero engram spans appearing in Opik despite the exporter being subscribed and receiving events

## Test plan
- [x] Verified: span batch POST returns 204 (was 400)
- [x] Verified: `engram:extraction` spans now appear in Opik search results
- [ ] Monitor for `engram:recall` spans appearing on next agent session start

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span/trace ID generation to a custom UUIDv7 implementation; if the format is off, Opik ingestion could still fail or trace grouping could change.
> 
> **Overview**
> Fixes Opik span ingestion by switching the exporter from `randomUUID()` (v4) IDs to UUID v7 IDs.
> 
> Adds a `uuidV7()` generator using timestamp + `randomBytes`, updates recall/LLM span creation to use v7 IDs, and adjusts `sessionToTraceId()` to stamp deterministic hash-based IDs with v7 version/variant bits so trace threading remains stable.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 92ad7795fe72e737e48ec73d85b1968e14474355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->