### PR TITLE
fix: QMD v2 daemon API compatibility

### DIFF
--- a/src/qmd.ts
+++ b/src/qmd.ts
@@ -1159,6 +1159,9 @@ export class QmdClient implements SearchBackend {
         if (options?.intent) {
           args.intent = options.intent;
         }
+        if (options?.explain === true) {
+          args.explain = true;
+        }
       } else {
         // QMD v1: query tool accepts { query, collection?, limit }
         args = { query, limit: maxResults };

--- a/tests/operator-toolkit.test.ts
+++ b/tests/operator-toolkit.test.ts
@@ -169,55 +169,57 @@ test("operator doctor surfaces auth and qmd problems", async () => {
   // Clear env var so authToken falls back to undefined (test expects "error" status)
   const savedToken = process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
   delete process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
-  const fixture = await makeFixture({
-    qmdEnabled: true,
-    agentAccessHttp: { enabled: true, port: 8765 },
-    fileHygiene: {
+  try {
+    const fixture = await makeFixture({
+      qmdEnabled: true,
+      agentAccessHttp: { enabled: true, port: 8765 },
+      fileHygiene: {
+        enabled: true,
+        lintEnabled: true,
+        lintPaths: ["MEMORY.md"],
+        lintBudgetBytes: 100,
+        lintWarnRatio: 0.5,
+      },
+    });
+    await writeFile(path.join(fixture.workspaceDir, "MEMORY.md"), "x".repeat(80), "utf-8");
+    fixture.orchestrator.qmd = {
+      async probe() {
+        return false;
+      },
+      isAvailable() {
+        return false;
+      },
+      async ensureCollection() {
+        return "missing";
+      },
+      debugStatus() {
+        return "cli=false";
+      },
+    };
+    fixture.orchestrator.getConversationIndexHealth = async () => ({
       enabled: true,
-      lintEnabled: true,
-      lintPaths: ["MEMORY.md"],
-      lintBudgetBytes: 100,
-      lintWarnRatio: 0.5,
-    },
-  });
-  await writeFile(path.join(fixture.workspaceDir, "MEMORY.md"), "x".repeat(80), "utf-8");
-  fixture.orchestrator.qmd = {
-    async probe() {
-      return false;
-    },
-    isAvailable() {
-      return false;
-    },
-    async ensureCollection() {
-      return "missing";
-    },
-    debugStatus() {
-      return "cli=false";
-    },
-  };
-  fixture.orchestrator.getConversationIndexHealth = async () => ({
-    enabled: true,
-    backend: "qmd",
-    status: "degraded",
-    chunkDocCount: 0,
-    lastUpdateAt: null,
-    qmdAvailable: false,
-  });
+      backend: "qmd",
+      status: "degraded",
+      chunkDocCount: 0,
+      lastUpdateAt: null,
+      qmdAvailable: false,
+    });
 
-  const report = await runOperatorDoctor({
-    orchestrator: fixture.orchestrator,
-    configPath: fixture.configPath,
-  });
+    const report = await runOperatorDoctor({
+      orchestrator: fixture.orchestrator,
+      configPath: fixture.configPath,
+    });
 
-  assert.equal(report.ok, false);
-  assert.ok(report.summary.error >= 1);
-  assert.equal(report.checks.some((check) => check.key === "access_http_auth" && check.status === "error"), true);
-  assert.equal(report.checks.some((check) => check.key === "qmd" && check.status === "error"), true);
-  assert.equal(report.checks.some((check) => check.key === "conversation_index" && check.status === "error"), true);
-  assert.equal(report.checks.some((check) => check.key === "file_hygiene" && check.status === "warn"), true);
-
-  // Restore env var
-  if (savedToken !== undefined) process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = savedToken;
+    assert.equal(report.ok, false);
+    assert.ok(report.summary.error >= 1);
+    assert.equal(report.checks.some((check) => check.key === "access_http_auth" && check.status === "error"), true);
+    assert.equal(report.checks.some((check) => check.key === "qmd" && check.status === "error"), true);
+    assert.equal(report.checks.some((check) => check.key === "conversation_index" && check.status === "error"), true);
+    assert.equal(report.checks.some((check) => check.key === "file_hygiene" && check.status === "warn"), true);
+  } finally {
+    if (savedToken !== undefined) process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = savedToken;
+    else delete process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+  }
 });
 
 test("operator doctor treats unreachable qmd as an error even when collection state is unknown", async () => {


### PR DESCRIPTION
## Summary

- **Root cause**: QMD 2.0 removed the `search` and `vsearch` MCP tools, replacing them with a unified `query` tool that accepts typed sub-queries (`searches: [{ type, query }]`) and `collections` (plural array) instead of `collection` (singular string). This broke all daemon-path searches after the upgrade from QMD 1.1.5 → 2.0.1, causing **every agent to get 0 recalled memories**.
- Adds `isQmdV2()` version gate (>= 2.0.0) that switches daemon calls to the v2 API format
- `searchViaDaemon`: builds `{ searches: [lex+vec], collections: [...] }` for v2
- `bm25SearchViaDaemon`: routes through `query` tool with lex sub-query instead of the removed `search` tool
- `vsearchViaDaemon`: routes through `query` tool with vec sub-query instead of the removed `vsearch` tool  
- Subprocess CLI commands unchanged (qmd search/query/vsearch still work in v2 CLI)
- Fixes pre-existing env-dependent test failure in operator-toolkit

## Test plan

- [x] Build passes (`npm run build`)
- [x] All 1333 tests pass, 0 failures (`npm test`)
- [x] Pre-existing operator-toolkit test failure fixed (env var leak)
- [ ] Deploy to gateway and verify agents start getting recall results again
- [ ] Confirm v1 backward compatibility (if downgrading QMD)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the QMD daemon search call shape and tool selection based on detected CLI version; mistakes here could break memory recall for daemon mode across v1/v2 installations. Scope is limited and version-gated, with subprocess fallback preserved.
> 
> **Overview**
> Restores QMD daemon-mode recall compatibility with **QMD v2 (>=2.0.0)** by version-gating MCP tool calls.
> 
> Daemon search paths now route through the unified `query` tool for v2 (using typed `searches` and `collections`), while retaining the v1 `query`/`search`/`vsearch` behavior; logs were updated to include the v2 flag for easier debugging.
> 
> Also fixes an env-dependent `operator doctor` test by clearing/restoring `OPENCLAW_ENGRAM_ACCESS_TOKEN` to avoid leaking auth state between environments.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1fd4343d0595320107b72e90892d91720b56c630. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->