### PR TITLE
fix: configurable extraction output tokens + recall span observability

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2069,6 +2069,11 @@
         "default": 900,
         "description": "Token budget for each proactive extraction sub-call (0 disables the proactive second pass)."
       },
+      "extractionMaxOutputTokens": {
+        "type": "number",
+        "default": 16384,
+        "description": "Maximum output tokens (max_completion_tokens) for the direct-client extraction call."
+      },
       "proactiveExtractionCategoryAllowlist": {
         "type": "array",
         "items": { "type": "string" },
@@ -3044,6 +3049,11 @@
       "label": "Proactive Extraction Max Tokens",
       "advanced": true,
       "placeholder": "900"
+    },
+    "extractionMaxOutputTokens": {
+      "label": "Extraction Max Output Tokens",
+      "advanced": true,
+      "placeholder": "16384"
     },
     "proactiveExtractionCategoryAllowlist": {
       "label": "Proactive Category Allowlist",

--- a/src/config.ts
+++ b/src/config.ts
@@ -1201,6 +1201,10 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.proactiveExtractionMaxTokens === "number"
         ? Math.max(0, Math.floor(cfg.proactiveExtractionMaxTokens))
         : 900,
+    extractionMaxOutputTokens:
+      typeof cfg.extractionMaxOutputTokens === "number"
+        ? Math.max(1, Math.floor(cfg.extractionMaxOutputTokens))
+        : 16384,
     proactiveExtractionCategoryAllowlist: Array.isArray(cfg.proactiveExtractionCategoryAllowlist)
       ? (cfg.proactiveExtractionCategoryAllowlist as unknown[]).filter(
           (category): category is PluginConfig["lifecycleProtectedCategories"][number] =>

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -982,7 +982,10 @@ ${truncatedConversation}`;
   ): Promise<ExtractionResult | null> {
     if (!this.client) return null;
 
-    log.debug(`extractWithDirectClient: calling ${this.config.model}...`);
+    const tokenParams = buildChatCompletionTokenLimit(this.config.model, this.config.extractionMaxOutputTokens, {
+      assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
+    });
+    log.info(`extractWithDirectClient: calling model=${this.config.model} tokenParams=${JSON.stringify(tokenParams)}`);
 
     const response = await this.client.chat.completions.create({
       model: this.config.model,
@@ -1002,18 +1005,16 @@ ${truncatedConversation}`;
         },
         { role: "user", content: conversation },
       ],
-      ...buildChatCompletionTokenLimit(this.config.model, 4096, {
-        assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
-      }),
+      ...tokenParams,
     });
 
     const content = response.choices?.[0]?.message?.content?.trim();
     if (!content) {
-      log.debug("extractWithDirectClient: empty response");
+      log.info(`extractWithDirectClient: empty response — choices=${JSON.stringify(response.choices?.length ?? 0)} finishReason=${response.choices?.[0]?.finish_reason ?? "n/a"}`);
       return null;
     }
 
-    log.debug(
+    log.info(
       `extractWithDirectClient: got response, length=${content.length}`,
     );
 
@@ -1027,7 +1028,7 @@ ${truncatedConversation}`;
       }
     }
 
-    log.debug("extractWithDirectClient: failed to parse JSON from response");
+    log.info(`extractWithDirectClient: failed to parse JSON from response (first 200 chars: ${content.slice(0, 200)})`);
     return null;
   }
 

--- a/src/opik-exporter.ts
+++ b/src/opik-exporter.ts
@@ -351,6 +351,16 @@ export class OpikExporter {
     // Ensure parent trace exists so the span is not orphaned in Opik.
     await this.ensureTrace(traceId, evt.sessionKey ?? "engram:recall", startTime, endTime);
 
+    const output: Record<string, unknown> = {
+      injected: evt.injected,
+      recalledMemoryCount: evt.recalledMemoryCount,
+      contextChars: evt.contextChars,
+      durationMs: evt.durationMs,
+    };
+    if (this.cfg.traceRecallContent && evt.recalledContent) {
+      output.recalledContent = evt.recalledContent;
+    }
+
     const span = {
       id: uuidV7(),
       trace_id: traceId,
@@ -360,6 +370,7 @@ export class OpikExporter {
       start_time: startTime,
       end_time: endTime,
       input,
+      output,
       metadata,
       tags: ["engram", "recall"],
     };

--- a/src/types.ts
+++ b/src/types.ts
@@ -509,6 +509,7 @@ export interface PluginConfig {
   maxProactiveQuestionsPerExtraction: number;
   proactiveExtractionTimeoutMs: number;
   proactiveExtractionMaxTokens: number;
+  extractionMaxOutputTokens: number;
   proactiveExtractionCategoryAllowlist?: MemoryCategory[];
   maxCompressionTokensPerHour: number;
   behaviorLoopAutoTuneEnabled: boolean;


### PR DESCRIPTION
## Summary
- **Configurable extraction token limit**: Add `extractionMaxOutputTokens` config option (default 16384) to replace the hardcoded 4096 value that caused `finishReason=length` truncation failures on gpt-5-mini
- **Opik recall span output**: Add `output` field to recall spans with `injected`, `recalledMemoryCount`, `contextChars`, `durationMs`, and optionally `recalledContent`
- **Better extraction diagnostics**: Upgrade `extractWithDirectClient` logging from `debug` to `info` with token params, finish reason, and response preview on parse failure

## Files changed
- `src/types.ts` — add `extractionMaxOutputTokens` to `PluginConfig`
- `src/config.ts` — parse with default 16384, minimum 1
- `src/extraction.ts` — use config value instead of hardcoded 4096; improve log messages
- `src/opik-exporter.ts` — add `output` field to recall spans
- `openclaw.plugin.json` — schema property + UI hint

## Test plan
- [x] All 1333 tests pass (0 failures)
- [ ] Verify extraction succeeds with `extractionMaxOutputTokens: 16384` in live config
- [ ] Verify Opik recall spans include output field
- [ ] Verify tuning the value in openclaw.json takes effect without code changes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes LLM extraction call parameters (token budgets/costs) and increases `info`-level observability, including optional response/recalled-content snippets that could surface sensitive data if enabled.
> 
> **Overview**
> **Makes direct-client extraction output size configurable** by introducing `extractionMaxOutputTokens` (default `16384`, min `1`) in config/types and wiring it into `extractWithDirectClient` instead of a hardcoded `4096` limit.
> 
> **Improves observability**: extraction now logs `info`-level token-limit params, finish reason/choice counts on empty responses, and a short response preview on JSON parse failures; Opik `engram:recall` spans now include an `output` payload (and optionally `recalledContent` when `traceRecallContent` is enabled).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cfd9d67e5610ff8f0fb5b4e2f8cc889281061be0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->