### PR TITLE
fix: EmbeddingFallback respects custom openaiBaseUrl

### DIFF
--- a/docs/guides/local-llm.md
+++ b/docs/guides/local-llm.md
@@ -55,6 +55,49 @@ Use the fast local tier for short-turn helpers:
 - If reranking feels slow, lower `rerankTimeoutMs` before changing the main extraction timeout.
 - The local path is fail-open by default. If the endpoint disappears, Engram should degrade rather than block the gateway.
 
+## Custom OpenAI-Compatible Endpoint (Self-Hosted)
+
+If you run a single OpenAI-compatible server (vLLM, Ollama, LM Studio, etc.) that serves both chat completions and embeddings, you can point everything at it with just `openaiBaseUrl`:
+
+```jsonc
+{
+  "openaiBaseUrl": "http://localhost:8005/v1",
+  "openaiApiKey": "dummy",
+  "embeddingFallbackEnabled": true,
+  "embeddingFallbackProvider": "openai"
+}
+```
+
+Engram routes extraction, consolidation, and embedding requests to your endpoint. The embedding path appends `/embeddings` to `openaiBaseUrl` automatically.
+
+### Separate Chat and Embedding Models
+
+If your chat model and embedding model live on different servers, use `openaiBaseUrl` for chat and the `localLlm*` settings for embeddings:
+
+```jsonc
+{
+  "openaiBaseUrl": "http://localhost:8005/v1",
+  "openaiApiKey": "dummy",
+  "localLlmEnabled": true,
+  "localLlmUrl": "http://localhost:8006/v1",
+  "localLlmModel": "bge-m3",
+  "localLlmApiKey": "dummy",
+  "embeddingFallbackEnabled": true,
+  "embeddingFallbackProvider": "local"
+}
+```
+
+### Docker Networking
+
+When running OpenClaw in Docker and the LLM server on the host, use `host.docker.internal` instead of `localhost`:
+
+```jsonc
+{
+  "openaiBaseUrl": "http://host.docker.internal:8005/v1",
+  "openaiApiKey": "dummy"
+}
+```
+
 ## When Not To Use It
 
 - If you do not have a stable local endpoint yet, start with `memoryOsPreset: "balanced"`.

--- a/src/embedding-fallback.ts
+++ b/src/embedding-fallback.ts
@@ -101,10 +101,11 @@ export class EmbeddingFallback {
 
     for (const p of providers) {
       if (p === "openai" && this.config.openaiApiKey) {
+        const baseUrl = this.config.openaiBaseUrl ?? "https://api.openai.com/v1";
         return {
           type: "openai",
           model: DEFAULT_OPENAI_MODEL,
-          endpoint: "https://api.openai.com/v1/embeddings",
+          endpoint: `${baseUrl.replace(/\/$/, "")}/embeddings`,
           headers: {
             "Content-Type": "application/json",
             Authorization: `Bearer ${this.config.openaiApiKey}`,

--- a/tests/embedding-fallback.test.ts
+++ b/tests/embedding-fallback.test.ts
@@ -1,0 +1,72 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EmbeddingFallback } from "../src/embedding-fallback.js";
+import type { PluginConfig } from "../src/types.js";
+
+function stubConfig(overrides: Partial<PluginConfig> = {}): PluginConfig {
+  return {
+    openaiApiKey: "test-key",
+    openaiBaseUrl: undefined,
+    memoryDir: "/tmp/engram-embedding-test",
+    embeddingFallbackEnabled: true,
+    embeddingFallbackProvider: "openai",
+    localLlmEnabled: false,
+    localLlmUrl: undefined,
+    localLlmModel: undefined,
+    localLlmApiKey: undefined,
+    localLlmHeaders: undefined,
+    localLlmAuthHeader: true,
+    ...overrides,
+  } as PluginConfig;
+}
+
+test("EmbeddingFallback uses default OpenAI endpoint when openaiBaseUrl is unset", async () => {
+  const fallback = new EmbeddingFallback(stubConfig());
+  // Access the private resolveProvider via prototype to inspect the endpoint
+  const provider = await (fallback as any).resolveProvider();
+  assert.ok(provider);
+  assert.equal(provider.endpoint, "https://api.openai.com/v1/embeddings");
+  assert.equal(provider.type, "openai");
+});
+
+test("EmbeddingFallback respects custom openaiBaseUrl", async () => {
+  const fallback = new EmbeddingFallback(stubConfig({
+    openaiBaseUrl: "http://localhost:8005/v1",
+  }));
+  const provider = await (fallback as any).resolveProvider();
+  assert.ok(provider);
+  assert.equal(provider.endpoint, "http://localhost:8005/v1/embeddings");
+  assert.equal(provider.type, "openai");
+});
+
+test("EmbeddingFallback strips trailing slash from custom openaiBaseUrl", async () => {
+  const fallback = new EmbeddingFallback(stubConfig({
+    openaiBaseUrl: "http://localhost:8005/v1/",
+  }));
+  const provider = await (fallback as any).resolveProvider();
+  assert.ok(provider);
+  assert.equal(provider.endpoint, "http://localhost:8005/v1/embeddings");
+});
+
+test("EmbeddingFallback uses local provider when embeddingFallbackProvider is local", async () => {
+  const fallback = new EmbeddingFallback(stubConfig({
+    embeddingFallbackProvider: "local",
+    localLlmEnabled: true,
+    localLlmUrl: "http://host.docker.internal:8006/v1",
+    localLlmModel: "bge-m3",
+    localLlmApiKey: "dummy",
+  }));
+  const provider = await (fallback as any).resolveProvider();
+  assert.ok(provider);
+  assert.equal(provider.type, "local");
+  assert.equal(provider.model, "bge-m3");
+  assert.equal(provider.endpoint, "http://host.docker.internal:8006/v1/embeddings");
+});
+
+test("EmbeddingFallback returns null when disabled", async () => {
+  const fallback = new EmbeddingFallback(stubConfig({
+    embeddingFallbackEnabled: false,
+  }));
+  const provider = await (fallback as any).resolveProvider();
+  assert.equal(provider, null);
+});


### PR DESCRIPTION
## Summary

- EmbeddingFallback hardcoded `https://api.openai.com/v1/embeddings` as the OpenAI embedding endpoint, ignoring the user's `openaiBaseUrl` config. Users with self-hosted OpenAI-compatible servers (vLLM, Ollama, LM Studio, etc.) had embeddings routed to the real OpenAI API instead of their local endpoint.
- Now derives the embedding endpoint from `openaiBaseUrl` when set, matching the pattern already used by `EmbedHelper`.
- Added documentation for self-hosted setups (single server, split chat/embedding, Docker networking) to `docs/guides/local-llm.md`.
- Added 5 new tests for EmbeddingFallback provider resolution.

Closes #265

## Test plan

- [x] All 1334 tests pass (0 failures)
- [x] New `tests/embedding-fallback.test.ts` covers: default endpoint, custom base URL, trailing slash stripping, local provider, disabled state
- [x] Pre-commit hooks pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, localized change to how the embedding fallback builds its OpenAI endpoint, plus additive tests/docs. Main risk is misrouting embeddings if a custom `openaiBaseUrl` is malformed or non-`/v1` compatible.
> 
> **Overview**
> Fixes `EmbeddingFallback` to build the OpenAI embeddings URL from `openaiBaseUrl` (with trailing-slash stripping) instead of hardcoding `https://api.openai.com/v1/embeddings`, enabling self-hosted OpenAI-compatible endpoints to receive embedding traffic.
> 
> Adds a focused test suite for provider resolution (default vs custom base URL, trailing slash handling, local provider selection, and disabled behavior) and expands the local LLM guide with configuration examples for self-hosted endpoints (single server, split chat/embeddings, and Docker host networking).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 16cdd673fbc6f2372bc6b2e7f9d7f851215c936d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->