### PR TITLE
fix(lcm): handle auto-compaction path missing tokenCount

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@ import { log } from "./logger.js";
 import { Orchestrator, sanitizeSessionKeyForFilename, defaultWorkspaceDir } from "./orchestrator.js";
 import { registerTools } from "./tools.js";
 import { registerLcmTools } from "./lcm/index.js";
+import { estimateTokens as estimateLcmTokens } from "./lcm/archive.js";
 import { registerCli } from "./cli.js";
 import { recordObjectiveStateSnapshotsFromAgentMessages } from "./objective-state-writers.js";
 import { EngramAccessService } from "./access-service.js";
@@ -477,8 +478,23 @@ export default {
           // Token count is stashed here; after_compaction records the final pair.
           if (orchestrator.lcmEngine?.enabled) {
             try {
-              const tokensBefore = typeof event.tokenCount === "number" ? event.tokenCount
-                : (typeof event.tokensBefore === "number" ? event.tokensBefore : 0);
+              let tokensBefore = 0;
+              if (typeof event.tokenCount === "number") {
+                tokensBefore = event.tokenCount;
+              } else if (Array.isArray(event.messages)) {
+                // Auto-compaction path: estimate from messages array
+                for (const msg of event.messages as Array<{ content?: unknown }>) {
+                  if (typeof msg.content === "string") {
+                    tokensBefore += estimateLcmTokens(msg.content);
+                  } else if (Array.isArray(msg.content)) {
+                    for (const block of msg.content) {
+                      if (typeof block === "string") tokensBefore += estimateLcmTokens(block);
+                      else if (block && typeof block === "object" && typeof (block as any).text === "string")
+                        tokensBefore += estimateLcmTokens((block as any).text);
+                    }
+                  }
+                }
+              }
               lcmTokensBefore.set(sessionKey, tokensBefore);
               await orchestrator.lcmEngine.preCompactionFlush(sessionKey);
             } catch (lcmErr) {
@@ -525,8 +541,21 @@ export default {
           // (runs regardless of reset setting — LCM needs compaction metrics)
           if (orchestrator.lcmEngine?.enabled) {
             try {
-              const tokensAfter = typeof event.tokenCount === "number" ? event.tokenCount
-                : (typeof event.tokensAfter === "number" ? event.tokensAfter : 0);
+              let tokensAfter = 0;
+              if (typeof event.tokenCount === "number") {
+                tokensAfter = event.tokenCount;
+              } else {
+                // Auto-compaction path: no token count available.
+                // Estimate from messageCount ratio if we have tokensBefore.
+                const storedBefore = lcmTokensBefore.get(sessionKey) ?? 0;
+                const msgCountAfter = typeof event.messageCount === "number" ? event.messageCount : 0;
+                const compacted = typeof event.compactedCount === "number" ? event.compactedCount : 0;
+                const msgCountBefore = msgCountAfter + compacted;
+                if (storedBefore > 0 && msgCountBefore > 0) {
+                  // Rough estimate: tokens scale proportionally to message count
+                  tokensAfter = Math.round(storedBefore * (msgCountAfter / msgCountBefore));
+                }
+              }
               const tokensBefore = lcmTokensBefore.get(sessionKey) ?? 0;
               lcmTokensBefore.delete(sessionKey);
               await orchestrator.lcmEngine.recordCompaction(sessionKey, tokensBefore, tokensAfter);


### PR DESCRIPTION
## Summary

- The gateway has two compaction paths: standard (passes `tokenCount`) and auto/embedded (passes `messages` array but no `tokenCount`)
- Auto-compaction is used by most cron/agent sessions, causing LCM to always record `tokens 0→0`
- Fix: estimate `tokensBefore` from the messages array when `tokenCount` is absent, estimate `tokensAfter` from message count ratio

## Root Cause

Gateway source analysis revealed:
- **Standard path** (`auth-profiles-DRjqKE3G.js:100226`): `before_compaction` event = `{ messageCount, tokenCount }`
- **Auto path** (`auth-profiles-DRjqKE3G.js:103190`): `before_compaction` event = `{ messageCount, messages, sessionFile }` — no `tokenCount`
- **Auto path** after: `{ messageCount, compactedCount }` — no `tokenCount`

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] Deploy to local gateway, verify compaction events now show real token estimates
- [ ] Confirm via `sqlite3 lcm.sqlite "SELECT * FROM lcm_compaction_events ORDER BY created_at DESC LIMIT 5"`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only affects LCM compaction metrics by adding fallback token estimation when `tokenCount` is missing; no changes to auth, persistence schema, or main compaction/reset control flow.
> 
> **Overview**
> Improves LCM compaction metrics when the gateway emits auto/embedded compaction events without `tokenCount`.
> 
> In `before_compaction`, it now estimates `tokensBefore` by summing `estimateTokens` across `event.messages` (handling both string and block-based content) and stores it per `sessionKey`. In `after_compaction`, when `tokenCount` is absent it estimates `tokensAfter` using the stored `tokensBefore` scaled by the `messageCount`/`compactedCount` ratio, so `recordCompaction()` no longer records `0→0` for auto-compaction paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6ff6247176808019830b39bbd9cdee4714799399. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->