### PR TITLE
fix: apply consistent /v1 prefix handling to chat completions URL

### DIFF
--- a/src/fallback-llm.ts
+++ b/src/fallback-llm.ts
@@ -254,7 +254,10 @@ export class FallbackLlmClient {
     options: FallbackLlmOptions,
     assumeOpenAI: boolean,
   ): Promise<{ content: string; usage?: FallbackLlmResponse["usage"] } | null> {
-    const url = `${config.baseUrl.replace(/\/$/, "")}/chat/completions`;
+    const base = config.baseUrl.replace(/\/$/, "");
+    const url = base.endsWith("/v1")
+      ? `${base}/chat/completions`
+      : `${base}/v1/chat/completions`;
 
     const headers: Record<string, string> = {
       "Content-Type": "application/json",

--- a/src/local-llm.ts
+++ b/src/local-llm.ts
@@ -729,7 +729,9 @@ export class LocalLlmClient {
       const baseUrl = this.config.localLlmUrl
         .replace("localhost", "127.0.0.1")
         .replace(/\/+$/, "");
-      const chatUrl = `${baseUrl}/chat/completions`;
+      const chatUrl = baseUrl.endsWith("/v1")
+        ? `${baseUrl}/chat/completions`
+        : `${baseUrl}/v1/chat/completions`;
 
       const requestBodyJson = JSON.stringify(requestBody);
       log.debug(


### PR DESCRIPTION
When `localLlmUrl` includes `/v1` (e.g. `http://127.0.0.1:11434/v1`), chat completions were incorrectly constructed as `.../v1/chat/completions` (double `/v1` prefix) because the URL construction did not account for `localLlmUrl` already containing `/v1`.

This applies the same conditional pattern already used for `embeddings` and `models` endpoints:
- If `localLlmUrl` ends with `/v1`, use the URL as-is
- Otherwise, append `/v1` prefix

**Before:**
```js
const chatUrl = `${baseUrl}/chat/completions`;  // always missing /v1
```

**After:**
```js
const chatUrl = baseUrl.endsWith("/v1")
  ? `${baseUrl}/chat/completions`
  : `${baseUrl}/v1/chat/completions`;
```

Fixes 404 errors on chat completions calls when `localLlmUrl` does not include `/v1` suffix. This makes `localLlmUrl` configuration consistent across all three Ollama endpoints (models, embeddings, chat).