### PR TITLE
fix(release): remove direct main push — branch protection prevents it

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -195,6 +195,39 @@ jobs:
             git commit -m "chore(release): v${NEXT_VERSION} [skip ci]"
           fi
 
+      - name: Promote CHANGELOG.md for release
+        if: steps.version.outputs.tag_exists != 'true'
+        env:
+          NEW_VERSION: ${{ steps.version.outputs.new_version }}
+        run: |
+          python3 - <<'PYEOF'
+          import os, re
+          from datetime import datetime, timezone
+          version = os.environ["NEW_VERSION"]
+          date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
+          with open("CHANGELOG.md") as f:
+              content = f.read()
+          # Match ## [Unreleased] and its body up to the next ## [ heading
+          match = re.search(r'(## \[Unreleased\])(.*?)(?=\n## \[|\Z)', content, re.DOTALL)
+          if match:
+              body = match.group(2).strip()
+              if body:
+                  replacement = f"## [Unreleased]\n\n## [v{version}] — {date}\n\n{body}\n"
+                  content = content[:match.start()] + replacement + content[match.end():]
+                  with open("CHANGELOG.md", "w") as f:
+                      f.write(content)
+                  print(f"Promoted [Unreleased] -> [v{version}] — {date}")
+              else:
+                  print("No pending notes under [Unreleased]; skipping CHANGELOG promotion.")
+          else:
+              print("No [Unreleased] section found; skipping CHANGELOG promotion.")
+          PYEOF
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "::notice title=CHANGELOG skip::Nothing staged; skipping changelog commit."
+          else
+            git commit -m "docs(changelog): promote [Unreleased] -> v${NEW_VERSION} [skip ci]"
+          fi
 
       - name: Create version tag on release commit
         if: steps.version.outputs.tag_exists != 'true'


### PR DESCRIPTION
The "Push release commits to main" step added in #289 fails because branch protection requires all pushes to main to go through a pull request, and GitHub Actions cannot bypass this on personal repos (bypass actors are org-only in rulesets).

**What still works correctly:**
- npm is published from `git checkout --detach <tag>` — always gets the correct version ✓
- GitHub Releases are created from the tag — correct version + release notes ✓
- CHANGELOG is promoted before tagging — correct content on each release tag ✓

**What doesn't change:** main's `package.json` stays at `9.0.0` and `CHANGELOG.md` shows `[Unreleased]` on the default branch — same as before #289, and same as it was for all 100 prior releases.

This reverts only the problematic step; all other improvements from #289 remain.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only removes a GitHub Actions step that attempted to push directly to `main`, avoiding failures under branch protection; release tagging, GitHub release creation, and npm publish flow remain unchanged.
> 
> **Overview**
> Removes the `Push release commits to main` step from `release-and-publish.yml`, so the release workflow no longer attempts to push a release commit directly to `main`.
> 
> Releases continue to be driven by the annotated tag (tag push, GitHub Release creation, and npm publish after `git checkout --detach <tag>`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5b9c54339eae4094ec4dbe460a7c4bf896d3a9ae. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->