### PR TITLE
fix(release): use RELEASE_PAT to push version+changelog commits back to main

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -273,5 +273,10 @@ jobs:
             echo "::notice::Tag ${TAG} not found locally; skipping main push."
             exit 0
           fi
+          git fetch origin main
+          if git merge-base --is-ancestor "${RELEASE_COMMIT}" origin/main; then
+            echo "::notice::Release commit already on main; skipping push."
+            exit 0
+          fi
           git push "https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git" \
             "${RELEASE_COMMIT}:refs/heads/main"


### PR DESCRIPTION
Uses a personal access token (admin-scoped) stored as `RELEASE_PAT` to push release commits directly to main, bypassing the PR requirement in branch protection (`enforce_admins: false` means admins can push directly).

**What this enables:**
- `package.json` on main always reflects the latest released version
- `CHANGELOG.md` on main has versioned sections instead of always showing `[Unreleased]`

**Changes:**
- `actions/checkout` now uses `token: ${{ secrets.RELEASE_PAT }}` so all git operations in the job use the PAT
- Restore "Push release commits to main" step that pushes the tag's commit back to main via the PAT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the GitHub Actions release pipeline to perform a direct authenticated push to `main`, which is security- and branch-protection-sensitive. Misconfiguration or token exposure could allow unintended writes to the default branch.
> 
> **Overview**
> Ensures `main` is fast-forwarded to the exact tagged release commit after a release, so version/changelog release commits don’t remain only on the tag.
> 
> The `release-and-publish` workflow adds a post-publish step that resolves the tag’s commit, checks whether it’s already on `origin/main`, and if not pushes that commit to `main` using `secrets.RELEASE_PAT`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0ebb2389833dc35c035e029f37bb20418e17742. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->