### PR TITLE
fix: remove broken push-to-main step

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -286,6 +286,6 @@ jobs:
           fi
           # Plain fast-forward push. Fails safely on non-fast-forward (concurrent commits).
           # Ruleset admin bypass allows this; GITHUB_TOKEN cannot bypass the ruleset.
-          git push "https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git" \
-            "${RELEASE_COMMIT}:refs/heads/main"
+          PUSH_URL="https://x-access-token:${RELEASE_PAT}@github.com/${{ github.repository }}.git"
+          git push "${PUSH_URL}" "${RELEASE_COMMIT}:refs/heads/main"
 


### PR DESCRIPTION
## Problem

Two issues left over from #291:

1. **Workflow fails every release** — classic branch protection rejected direct pushes even from admin PATs with \`GH006\`. Push-to-main always failed.
2. **\`[Unreleased]\` state on main** — \`package.json\` and \`CHANGELOG.md\` on main never matched what was published to npm.

## Solution

Migrate from classic branch protection to a **repository ruleset** with a **Repository Admin bypass actor**. The \`RELEASE_PAT\` (owned by the repo admin) satisfies the bypass and can push directly. The ruleset enforces the same protections as before (PR required, required status checks, thread resolution).

## Changes

- **Restore** \`Push release commits to main\` step — now works via ruleset bypass with \`RELEASE_PAT\`
- **Restore \`[skip ci]\`** on all release commit messages — required to prevent an infinite release loop: when \`RELEASE_PAT\` pushes to main, \`github.actor\` is the PAT owner (not \`github-actions[bot]\`), so the job-level guard doesn't fire; without \`[skip ci]\`, the push would re-trigger the release workflow and create a new version on every release commit

## Effect

After merge, \`package.json\` and \`CHANGELOG.md\` on \`main\` will always match what is published to npm. The push is idempotent — if the release commit is already on main (e.g. on rerun), it skips safely.

## Ruleset

Already configured via API: same required status checks as before + Repository Admin as explicit bypass actor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release automation’s `main` update mechanism and relies on a privileged `RELEASE_PAT`, so misconfiguration could block releases or push unintended commits.
> 
> **Overview**
> Ensures the `Release and Publish` workflow can fast-forward `main` to the tagged release commit by pushing via an admin-scoped `RELEASE_PAT` (explicitly documenting the required ruleset bypass). 
> 
> Refactors the push command to use a `PUSH_URL` and adds guardrails/comments around idempotency and the need for `[skip ci]` on release commits to prevent the push from re-triggering the release workflow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e0b5b296c9bc41385a5f813bd0d56cdbc3e8f08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->