### PR TITLE
fix(release): use deploy key SSH push to bypass ruleset

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -285,10 +285,11 @@ jobs:
             exit 0
           fi
           # Configure deploy key for SSH push. Ruleset DeployKey bypass allows this.
+          # Use a trap to ensure the key file is removed even if the push fails.
           mkdir -p ~/.ssh
           echo "${RELEASE_DEPLOY_KEY}" > ~/.ssh/release_deploy_key
           chmod 600 ~/.ssh/release_deploy_key
+          trap 'rm -f ~/.ssh/release_deploy_key' EXIT
           export GIT_SSH_COMMAND="ssh -i ~/.ssh/release_deploy_key -o StrictHostKeyChecking=no"
           git push "git@github.com:${{ github.repository }}.git" "${RELEASE_COMMIT}:refs/heads/main"
-          rm -f ~/.ssh/release_deploy_key
 


### PR DESCRIPTION
## Summary
- Switches the push-to-main step from HTTPS PAT to SSH deploy key
- PAT-based pushes (both fine-grained and classic) do not satisfy the `RepositoryRole` bypass actor on personal-repo rulesets — GitHub does not propagate admin role to PAT credentials for ruleset bypass on user-owned repos
- A `DeployKey` bypass actor is reliable and works on personal repos

## Setup already done
- Deploy key "Release Push Key" (ID 146300175) added to repo with write access
- `RELEASE_DEPLOY_KEY` secret added to Actions with the private key
- Ruleset 14191574 updated to include `DeployKey` bypass actor

## Test plan
- [ ] Merge this PR — triggers a release run
- [ ] Confirm "Push release commits to main" step succeeds
- [ ] Confirm `package.json` version on main matches npm published version

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the release workflow’s credentials and transport for pushing to `main`, which can break automated releases if the deploy key/ruleset bypass is misconfigured. Limited scope to CI infrastructure; no runtime code changes.
> 
> **Overview**
> Updates the `release-and-publish` workflow to push the release commit back to `main` using an SSH deploy key (`RELEASE_DEPLOY_KEY`) instead of an HTTPS PAT.
> 
> The push step now writes the key to a temp file, sets `GIT_SSH_COMMAND`, and cleans up via `trap`, to reliably bypass branch ruleset restrictions for automated releases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21a4c4c6b32f94364baade4b7596de26d41c3de5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->