### PR TITLE
fix: add postinstall to rebuild better-sqlite3 native addon

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
   "files": [
     "dist",
     "bin/engram-access.js",
-    "openclaw.plugin.json"
+    "openclaw.plugin.json",
+    "scripts/rebuild-native.mjs"
   ],
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",

--- a/scripts/rebuild-native.mjs
+++ b/scripts/rebuild-native.mjs
@@ -1,37 +1,24 @@
 #!/usr/bin/env node
 /**
- * postinstall: rebuild better-sqlite3 native addon if the binary is missing.
+ * postinstall: rebuild better-sqlite3 native addon if missing or incompatible.
  *
  * When Engram is installed as an OpenClaw plugin (npm install or gateway
  * plugin copy), the pre-built native binary for better-sqlite3 may not
- * match the target platform or may be absent entirely.  This script
- * detects that and runs `npm rebuild better-sqlite3` to compile it.
+ * match the target platform/Node version or may be absent entirely.
+ * This script detects that and runs `npm rebuild better-sqlite3` to
+ * compile it.
  *
  * Runs silently on success; logs only on rebuild or error.
  */
 
 import { existsSync } from "node:fs";
 import { execSync } from "node:child_process";
+import { createRequire } from "node:module";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const root = join(__dirname, "..");
-
-// The path npm/node-gyp produces after a successful build
-const nativeAddon = join(
-  root,
-  "node_modules",
-  "better-sqlite3",
-  "build",
-  "Release",
-  "better_sqlite3.node",
-);
-
-if (existsSync(nativeAddon)) {
-  // Already compiled — nothing to do.
-  process.exit(0);
-}
 
 // Check if better-sqlite3 is even installed (it may be hoisted or absent
 // in workspace setups).
@@ -42,18 +29,37 @@ if (!existsSync(bsqlDir)) {
   process.exit(0);
 }
 
-console.log("[engram] better-sqlite3 native addon missing — rebuilding...");
+// Try to load the native addon.  This catches both "file missing" and
+// "binary compiled for a different Node ABI version" cases.
+let needsRebuild = false;
+try {
+  const require = createRequire(join(root, "package.json"));
+  require("better-sqlite3");
+} catch {
+  needsRebuild = true;
+}
+
+if (!needsRebuild) {
+  // Addon loads fine — nothing to do.
+  process.exit(0);
+}
+
+console.log("[engram] better-sqlite3 native addon missing or incompatible — rebuilding...");
 try {
   execSync("npm rebuild better-sqlite3", {
     cwd: root,
     stdio: "inherit",
     timeout: 120_000,
   });
-  if (existsSync(nativeAddon)) {
+
+  // Verify the rebuild worked
+  try {
+    const require = createRequire(join(root, "package.json"));
+    require("better-sqlite3");
     console.log("[engram] better-sqlite3 rebuilt successfully.");
-  } else {
+  } catch {
     console.warn(
-      "[engram] WARNING: npm rebuild completed but native addon still missing.",
+      "[engram] WARNING: npm rebuild completed but addon still fails to load.",
     );
     console.warn(
       "[engram] Engram will fall back to non-SQLite storage paths.",


### PR DESCRIPTION
## Summary

When Engram is installed as an OpenClaw gateway plugin (via npm install or gateway plugin copy to extensions/), the `better-sqlite3` native binary may be missing or incompatible with the target platform. This causes runtime errors:

```
Could not locate the bindings file. Tried:
 → .../node_modules/better-sqlite3/build/Release/better_sqlite3.node
```

This breaks `engram.observe`, LCM archive, content-hash dedup, and any other SQLite-dependent feature.

## Fix

Added a `postinstall` script (`scripts/rebuild-native.mjs`) that:
1. Checks if the `better-sqlite3` native addon exists
2. If missing, runs `npm rebuild better-sqlite3` to compile it
3. Degrades gracefully if rebuild fails — Engram continues with non-SQLite paths
4. Runs silently when the addon is already present (no noise on normal installs)

## Test plan

- [x] Build succeeds
- [x] Tests pass
- [x] Script runs cleanly when addon exists (no-op, silent)
- [x] Script rebuilds correctly when addon is missing (tested locally)
- [x] Verified Engram observe/store works after rebuild

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a `postinstall` hook that executes `npm rebuild better-sqlite3`, which can change install-time behavior and fail in some environments (timeouts/toolchains), though it is guarded and non-fatal.
> 
> **Overview**
> Improves plugin install robustness by adding a `postinstall` step that detects a missing/incompatible `better-sqlite3` native addon and attempts an `npm rebuild better-sqlite3` to compile it.
> 
> Packages the new `scripts/rebuild-native.mjs` in published artifacts and keeps installs non-blocking by skipping when `better-sqlite3` isn’t locally present and warning (without failing) if rebuild/verification fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3457e4b75ac1c97739cdb4d1356c80f3acce67df. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->