### PR TITLE
fix: harden authenticated local LLM probes

### DIFF
--- a/src/local-llm.ts
+++ b/src/local-llm.ts
@@ -245,7 +245,7 @@ export class LocalLlmClient {
     url: string,
     timeoutMs: number = 2000,
     headers?: Record<string, string>,
-  ): Promise<{ ok: boolean; data: unknown }> {
+  ): Promise<{ ok: boolean; data: unknown; status: number | null }> {
     const controller = new AbortController();
     const timeout = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -257,18 +257,18 @@ export class LocalLlmClient {
       clearTimeout(timeout);
 
       if (!response.ok) {
-        return { ok: false, data: null };
+        return { ok: false, data: null, status: response.status };
       }
 
       const contentType = response.headers.get("content-type");
       if (contentType?.includes("application/json")) {
-        return { ok: true, data: await response.json() };
+        return { ok: true, data: await response.json(), status: response.status };
       } else {
-        return { ok: true, data: await response.text() };
+        return { ok: true, data: await response.text(), status: response.status };
       }
     } catch (err) {
       clearTimeout(timeout);
-      return { ok: false, data: null };
+      return { ok: false, data: null, status: null };
     }
   }
 
@@ -296,6 +296,7 @@ export class LocalLlmClient {
     const baseUrl = this.config.localLlmUrl
       .replace("localhost", "127.0.0.1")
       .replace(/\/+$/, "");
+    let sawUnauthorizedProbe = false;
 
     // Try to detect which server type is running
     for (const serverConfig of LOCAL_SERVERS) {
@@ -310,6 +311,9 @@ export class LocalLlmClient {
         log.info(`detected ${serverConfig.type} at ${baseUrl}`);
         return true;
       }
+      if (result.status === 401 || result.status === 403) {
+        sawUnauthorizedProbe = true;
+      }
     }
 
     // Generic check if specific detection failed
@@ -323,6 +327,9 @@ export class LocalLlmClient {
         log.info(`detected generic OpenAI-compatible server at ${baseUrl}`);
         return true;
       }
+      if (result.status === 401 || result.status === 403) {
+        sawUnauthorizedProbe = true;
+      }
     } catch {
       // Fall through to unavailable
     }
@@ -330,6 +337,11 @@ export class LocalLlmClient {
     this.isAvailable = false;
     this.detectedType = null;
     this.lastHealthCheck = now;
+    if (sawUnauthorizedProbe) {
+      log.warn(
+        `local LLM availability probe was unauthorized at ${baseUrl}; verify localLlmApiKey and localLlmAuthHeader settings`,
+      );
+    }
     log.debug("local LLM not available at", baseUrl);
     return false;
   }
@@ -999,6 +1011,11 @@ export class LocalLlmClient {
     try {
       const result = await this.fetchWithTimeout(modelsUrl, 3000);
       if (!result.ok) {
+        if (result.status === 401 || result.status === 403) {
+          log.warn(
+            `Local LLM: unauthorized while fetching models from ${modelsUrl}; verify localLlmApiKey and localLlmAuthHeader settings`,
+          );
+        }
         log.warn(`Local LLM: Failed to fetch models from ${modelsUrl} - server returned error`);
         return null;
       }

--- a/tests/local-llm.test.ts
+++ b/tests/local-llm.test.ts
@@ -113,6 +113,38 @@ test("LocalLlmClient abort exhaustion returns null without marking unavailable",
   }
 });
 
+test("LocalLlmClient checkAvailability sends auth headers to health probes", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmApiKey: "top-secret" }));
+  const originalFetch = globalThis.fetch;
+  const authHeaders: string[] = [];
+  globalThis.fetch = (async (_input, init) => {
+    const headers = new Headers(init?.headers);
+    authHeaders.push(headers.get("authorization") ?? "");
+    return new Response("Ollama", {
+      status: 200,
+      headers: { "content-type": "text/plain" },
+    });
+  }) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, true);
+    assert.deepEqual(authHeaders, ["Bearer top-secret"]);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
 test("LocalLlmClient trips plain-text backend failures using configured cooldown", async () => {
   initLogger(
     {
@@ -146,6 +178,40 @@ test("LocalLlmClient trips plain-text backend failures using configured cooldown
     assert.ok(state.untilMs > Date.now());
   } finally {
     (client as any).getGlobalBackendState().delete((client as any).getBackendKey());
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("LocalLlmClient warns when authenticated availability probes are unauthorized", async () => {
+  const warns: string[] = [];
+  initLogger(
+    {
+      info() {},
+      warn(msg: string) {
+        warns.push(msg);
+      },
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmApiKey: "wrong-key" }));
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async () =>
+    new Response("Unauthorized", {
+      status: 401,
+      headers: { "content-type": "text/plain" },
+    })) as typeof fetch;
+
+  try {
+    const available = await client.checkAvailability();
+    assert.equal(available, false);
+    assert.ok(
+      warns.some((msg) => msg.includes("availability probe was unauthorized")),
+      "expected unauthorized health probe warning",
+    );
+  } finally {
     globalThis.fetch = originalFetch;
   }
 });
@@ -321,5 +387,42 @@ test("LocalLlmClient clears peer health cache while a shared backend circuit is 
     assert.equal((peer as any).lastHealthCheck, 0);
   } finally {
     (primary as any).getGlobalBackendState().delete((primary as any).getBackendKey());
+  }
+});
+
+test("LocalLlmClient getLoadedModelInfo sends auth headers to models probe", async () => {
+  initLogger(
+    {
+      info() {},
+      warn() {},
+      error() {},
+      debug() {},
+    },
+    true,
+  );
+
+  const client = new LocalLlmClient(buildConfig({ localLlmApiKey: "top-secret" }));
+  const originalFetch = globalThis.fetch;
+  let authHeader = "";
+  globalThis.fetch = (async (_input, init) => {
+    authHeader = new Headers(init?.headers).get("authorization") ?? "";
+    return new Response(
+      JSON.stringify({
+        data: [{ id: "local-test-model", max_context_length: 32768 }],
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  }) as typeof fetch;
+
+  try {
+    const modelInfo = await client.getLoadedModelInfo();
+    assert.ok(modelInfo);
+    assert.equal(modelInfo.id, "local-test-model");
+    assert.equal(authHeader, "Bearer top-secret");
+  } finally {
+    globalThis.fetch = originalFetch;
   }
 });


### PR DESCRIPTION
## Summary
- add regression tests proving local LLM availability and model-info probes send auth headers
- surface explicit warnings when authenticated probe requests get 401/403 responses
- keep the issue from regressing even though the header path is already present on current main

## Verification
- npm test -- tests/local-llm.test.ts
- npm run check-types

Fixes #310

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to local LLM health/model probing diagnostics (propagating HTTP status and logging on 401/403) plus new tests, with no impact on core request handling beyond improved observability.
> 
> **Overview**
> Hardens local LLM availability/model probes by having `fetchWithTimeout` return the HTTP `status` and surfacing explicit warnings when authenticated probe requests receive `401/403` (suggesting `localLlmApiKey`/`localLlmAuthHeader` misconfiguration).
> 
> Adds regression tests ensuring auth headers are sent on both availability health checks and `getLoadedModelInfo` model queries, and that unauthorized probe responses produce a warning.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 266c736d3d01872d9dc42dbacadd5721c206a313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->