### PR TITLE
docs: gateway model source setup guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Gateway Model Source** — Route all Engram LLM calls through the OpenClaw gateway's agent model chain instead of Engram's own config. Set `modelSource: "gateway"` and reference agent personas via `gatewayAgentId` and `fastGatewayAgentId`. Enables multi-tier fallback chains (e.g., Fireworks → Z.ai → Anthropic → local LLM) configured once in `openclaw.json`.
+
 ## [v9.1.7] — 2026-03-25
 
 ### Added

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -449,6 +449,79 @@ The original v8 roadmap listed several operator knobs that are now split across 
 | `qmdTierParityHiMemEnabled` | `true` | Keep HiMem episode/note handling parity between hot and cold retrieval paths. |
 | `qmdTierAutoBackfillEnabled` | `false` | Enable automated cold-tier parity backfill jobs. |
 
+## Gateway Model Source
+
+Route all Engram LLM calls through the OpenClaw gateway's agent model chain instead of Engram's own `openaiApiKey`/`localLlm*` configuration. This lets you define a single fallback chain per agent persona in `openclaw.json` and reuse the gateway's provider credentials.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `modelSource` | `plugin` | `plugin` uses Engram's own openai/localLlm config; `gateway` delegates to a gateway agent's model chain |
+| `gatewayAgentId` | `""` | Agent persona ID from `openclaw.json → agents.list[]` for primary LLM calls (extraction, consolidation, summarization). Falls back to `agents.defaults.model` if empty. |
+| `fastGatewayAgentId` | `""` | Agent persona ID for fast-tier ops (rerank, entity summaries, compression guidelines). Uses `gatewayAgentId` chain when empty. |
+
+When `modelSource` is `gateway`:
+
+- `localLlmEnabled` and the direct OpenAI client are bypassed — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
+- The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility
+- `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
+
+### Setup
+
+1. **Define providers** in `agents/main/agent/models.json` with the endpoints and credentials you want Engram to use (e.g., `fireworks`, `zai`, `anthropic`, `lmstudio`).
+
+2. **Create agent personas** in `openclaw.json → agents.list[]`:
+
+```jsonc
+{
+  "id": "engram-llm",
+  "default": false,
+  "name": "Engram LLM Chain",
+  "model": {
+    "primary": "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+    "fallbacks": [
+      "zai/glm-5",
+      "anthropic/claude-sonnet-4-6",
+      "lmstudio/qwen3.5-35b-a3b-mlx-lm"
+    ]
+  }
+},
+{
+  "id": "engram-llm-fast",
+  "default": false,
+  "name": "Engram Fast LLM Chain",
+  "model": {
+    "primary": "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+    "fallbacks": [
+      "zai/glm-5-turbo",
+      "anthropic/claude-sonnet-4-6",
+      "lmstudio/qwen3.5-35b-a3b-mlx-lm"
+    ]
+  }
+}
+```
+
+Model strings use the format `provider/model-id` where `provider` matches a key in the `providers` object of your agent's `models.json`.
+
+3. **Configure Engram** in `openclaw.json → plugins.entries.openclaw-engram.config`:
+
+```jsonc
+{
+  "modelSource": "gateway",
+  "gatewayAgentId": "engram-llm",
+  "fastGatewayAgentId": "engram-llm-fast"
+}
+```
+
+4. **Restart the gateway** for changes to take effect.
+
+### How the fallback chain works
+
+When a primary model call fails (timeout, HTTP error, empty response), `FallbackLlmClient` tries each fallback in order. The chain stops at the first successful response. Both `openai-completions` and `anthropic-messages` API formats are supported — the client auto-detects based on the provider's `api` field.
+
+### Switching back
+
+Set `modelSource` to `plugin` (or remove it) to restore the original behavior where Engram uses its own `localLlm*` and `openaiApiKey` settings.
+
 ## Local LLM / OpenAI-Compatible Endpoint
 
 | Setting | Default | Description |


### PR DESCRIPTION
## Summary

- Adds config reference section for `modelSource`, `gatewayAgentId`, and `fastGatewayAgentId` with full setup walkthrough
- Includes example `openclaw.json` agent persona config and Engram plugin config
- Explains fallback chain behavior and how to switch back to plugin mode
- Updates CHANGELOG with the new feature

Companion to #313 which added the feature implementation.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates describing an already-implemented configuration option and setup flow, with no runtime or schema changes.
> 
> **Overview**
> Documents the new **Gateway Model Source** option for routing Engram LLM calls through the OpenClaw gateway agent model chain via `modelSource`, `gatewayAgentId`, and `fastGatewayAgentId`, including a step-by-step setup and example `openclaw.json` fallback chains.
> 
> Updates `CHANGELOG.md` to announce the feature in *Unreleased* and explains how to switch back to `plugin` mode and how gateway fallback behavior works.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1b261b0787c5e0b9199ef85a2a43096a2b81f578. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->