### PR TITLE
fix: route reranking through gateway fast chain

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Fixed
+- **Rerank gateway routing** — Reranking now routes through the `fastGatewayAgentId` model chain when `modelSource` is `"gateway"`, instead of always using the local LLM. This eliminates the 7–38s local rerank bottleneck when a cloud fast-tier provider is configured.
+
 ## [v9.1.16] — 2026-03-28
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,19 +68,26 @@ After installation, add Engram to your `openclaw.json`:
       "openclaw-engram": {
         "enabled": true,
         "config": {
-          // Use OpenAI for extraction:
+          // Option 1: Use OpenAI for extraction:
           "openaiApiKey": "${OPENAI_API_KEY}"
 
-          // OR use a local LLM (no API key needed):
+          // Option 2: Use a local LLM (no API key needed):
           // "localLlmEnabled": true,
           // "localLlmUrl": "http://localhost:1234/v1",
           // "localLlmModel": "qwen2.5-32b-instruct"
+
+          // Option 3: Use the gateway model chain (multi-provider fallback):
+          // "modelSource": "gateway",
+          // "gatewayAgentId": "engram-llm",
+          // "fastGatewayAgentId": "engram-llm-fast"
         }
       }
     }
   }
 }
 ```
+
+> **Gateway model source:** When `modelSource` is `"gateway"`, Engram routes all LLM calls (extraction, consolidation, reranking) through an OpenClaw agent persona's model chain instead of its own config. Define agent personas in `openclaw.json → agents.list[]` with a `primary` model and `fallbacks[]` array — Engram tries each in order until one succeeds. This lets you build multi-provider fallback chains like Fireworks → local LLM → cloud OpenAI. See the [Gateway Model Source](docs/config-reference.md#gateway-model-source) guide for full setup.
 
 Restart the gateway:
 
@@ -192,9 +199,9 @@ OpenClaw's built-in memory is basic — it works for getting started, but lacks 
 
 Engram uses hybrid search (BM25 + vector + reranking via [QMD](https://github.com/tobilu/qmd)) to find semantically relevant memories. It doesn't just match keywords — it understands what you're working on and surfaces the right context.
 
-### OpenAI or local LLM — your choice
+### Flexible LLM routing — OpenAI, local, or gateway model chain
 
-Use OpenAI for extraction and reranking, or run entirely offline with a local LLM via Ollama, LM Studio, or any OpenAI-compatible endpoint. The `local-llm-heavy` preset is optimized for fully local operation. See the [Local LLM Guide](docs/guides/local-llm.md).
+Use OpenAI for extraction and reranking, run entirely offline with a local LLM (Ollama, LM Studio), or route through the **gateway model chain** to use any provider with automatic fallback. The `local-llm-heavy` preset is optimized for fully local operation. See the [Local LLM Guide](docs/guides/local-llm.md) and the [Gateway Model Source](docs/config-reference.md#gateway-model-source) section for multi-provider setups.
 
 ### Progressive complexity
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -464,6 +464,7 @@ When `modelSource` is `gateway`:
 - `localLlmEnabled` and the direct OpenAI client are bypassed — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
 - The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
+- **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
 
 ### Setup
 

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1525,6 +1525,26 @@ export class Orchestrator {
     return result ? { content: result.content } : null;
   }
 
+  /**
+   * Get a fast-tier LLM client compatible with the rerank interface.
+   * When gateway model source is active, routes through the gateway fast chain.
+   * Otherwise returns the local fast LLM directly.
+   */
+  get fastLlmForRerank(): {
+    chatCompletion: (
+      messages: Array<{ role: string; content: string }>,
+      options?: { maxTokens?: number; temperature?: number; timeoutMs?: number; operation?: string; priority?: "recall-critical" | "background" },
+    ) => Promise<{ content: string } | null>;
+  } {
+    if (this.fastGatewayLlm && this.config.modelSource === "gateway") {
+      return {
+        chatCompletion: (messages, options) =>
+          this.fastChatCompletion(messages, options ?? {}),
+      };
+    }
+    return this.fastLlm;
+  }
+
   async initialize(): Promise<void> {
     await this.storage.ensureDirectories();
     await this.storage.loadAliases();
@@ -6695,7 +6715,7 @@ export class Orchestrator {
               id: r.path,
               snippet: r.snippet || r.path,
             })),
-          local: this.fastLlm,
+          local: this.fastLlmForRerank,
           enabled: true,
           timeoutMs: this.config.rerankTimeoutMs,
           maxCandidates: this.config.rerankMaxCandidates,
@@ -11028,7 +11048,7 @@ export class Orchestrator {
             id: r.path,
             snippet: r.snippet || r.path,
           })),
-        local: this.fastLlm,
+        local: this.fastLlmForRerank,
         enabled: true,
         timeoutMs: this.config.rerankTimeoutMs,
         maxCandidates: this.config.rerankMaxCandidates,


### PR DESCRIPTION
## Summary

- Reranking was still using the local LLM directly (7–38s per call) even when `modelSource` was `"gateway"` — now routes through the `fastGatewayAgentId` model chain
- Added `fastLlmForRerank` getter that returns a gateway-aware wrapper matching the rerank duck-typed interface
- Updated README with gateway model source as a third LLM configuration option
- Updated config-reference to document rerank routing behavior
- CHANGELOG entry for the fix

## Problem

The `rerankLocalOrNoop()` function receives a `local` parameter (duck-typed `chatCompletion` interface). The orchestrator was passing `this.fastLlm` (a `LocalLlmClient`) directly, bypassing the gateway fast chain. This meant rerank calls always hit the local LLM even when `modelSource: "gateway"` with `fastGatewayAgentId` was configured — causing 7–38 second rerank latency.

## Fix

Added a `fastLlmForRerank` getter that:
- When gateway mode is active: returns a wrapper that delegates to `fastChatCompletion()` (which routes through the gateway fast chain)
- Otherwise: returns `this.fastLlm` directly (existing behavior)

Both rerank call sites now use `this.fastLlmForRerank` instead of `this.fastLlm`.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All 37 affected tests pass
- [x] Build succeeds
- [ ] Manual verification: rerank should log gateway fallback chain activity instead of `local LLM queue` messages

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall-time reranking by changing which LLM client is invoked; misrouting or wrapper/interface mismatches could affect rerank latency or fail-open behavior when `modelSource="gateway"` is enabled.
> 
> **Overview**
> Fixes reranking to respect `modelSource: "gateway"` by routing rerank calls through the configured gateway fast chain (`fastGatewayAgentId`) instead of always using the local fast LLM.
> 
> Adds a `fastLlmForRerank` gateway-aware client wrapper in `src/orchestrator.ts` and updates both rerank call sites to use it, and updates `README.md`, `docs/config-reference.md`, and `CHANGELOG.md` to document the gateway rerank behavior and configuration option.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8e5aaf0b4c884028e665f9ae5430a7de54244a8f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->