### PR TITLE
fix: use 1Password service account for secret resolution

### DIFF
--- a/src/resolve-provider-secret.ts
+++ b/src/resolve-provider-secret.ts
@@ -225,12 +225,17 @@ function resolveFileSecret(ref: SecretRef): string | undefined {
         if (result) {
           try {
             const parsed = JSON.parse(result);
-            const value = parsed?.value ?? parsed;
+            // op returns various shapes:
+            // - Single field object: {"value": "sk-...", ...}
+            // - Array of field objects: [{"value": "sk-...", ...}]
+            // - Plain string (older op versions)
+            const field = Array.isArray(parsed) ? parsed[0] : parsed;
+            const value = field?.value ?? field;
             if (typeof value === "string" && value.length > 0) {
               return value;
             }
           } catch {
-            if (result.length > 0 && !result.startsWith("{")) {
+            if (result.length > 0 && !result.startsWith("{") && !result.startsWith("[")) {
               return result;
             }
           }


### PR DESCRIPTION
## Summary

- Read `OP_SERVICE_ACCOUNT_TOKEN` from `~/.openclaw/secrets/op-service-account-token`
- Pass `--vault OpenClaw` to `op item get` calls
- Set the service account token in the exec environment for all op CLI calls

## Problem

The secret resolver was calling `op` without the service account token and without specifying a vault. Service accounts require `--vault` and `OP_SERVICE_ACCOUNT_TOKEN` to be set. Without these, every 1Password resolution failed, causing the gateway model chain to fall through to the local LLM for every call.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All tests pass
- [x] `op item get agent-models-fireworks-apiKey --vault OpenClaw --fields credential` resolves correctly with service account token

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes secret resolution behavior for the `op` provider by injecting service-account credentials and switching to `op item get` with vault selection, which could impact all provider auth at runtime if misconfigured or if the op CLI output format differs.
> 
> **Overview**
> Fixes 1Password (`op`) secret resolution by ensuring all `op` CLI calls run with an `OP_SERVICE_ACCOUNT_TOKEN` (read from `~/.openclaw/secrets/op-service-account-token` when not already in the environment).
> 
> Updates file-based `op` secret handling to support both `op://...` URIs (via `op read`) and item-title lookups (via `op item get --vault <name> --fields credential --format json`), with vault chosen from `~/.openclaw/secrets/op-vault-name`, `OP_VAULT`, or defaulting to `OpenClaw`, and increases `op` command timeouts to 15s.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ee422c9eed0c690b7d7cef2f6dbd4c102ca52c97. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->