### PR TITLE
fix: limit gateway resolver discovery retries

### DIFF
--- a/src/resolve-provider-secret.ts
+++ b/src/resolve-provider-secret.ts
@@ -24,8 +24,8 @@ type ResolveApiKeyFn = (params: {
 
 let _resolveApiKeyForProvider: ResolveApiKeyFn | null = null;
 let _resolverLoaded = false;
-let _resolverAttempts = 0;
-const MAX_RESOLVER_ATTEMPTS = 3;
+let _resolverNextRetryAt = 0;
+const RESOLVER_RETRY_BACKOFF_MS = 60_000; // 1 minute between retries after first failure
 const resolvedCache = new Map<string, string | undefined>();
 
 /**
@@ -35,6 +35,11 @@ const resolvedCache = new Map<string, string | undefined>();
 async function getGatewayResolver(): Promise<ResolveApiKeyFn | null> {
   if (_resolverLoaded) {
     return _resolveApiKeyForProvider;
+  }
+  // Backoff: don't re-scan filesystem on every call when module wasn't found.
+  // After a failure, wait RESOLVER_RETRY_BACKOFF_MS before trying again.
+  if (_resolverNextRetryAt > 0 && Date.now() < _resolverNextRetryAt) {
+    return null;
   }
 
   try {
@@ -65,17 +70,11 @@ async function getGatewayResolver(): Promise<ResolveApiKeyFn | null> {
     // Silent
   }
 
-  // Allow a limited number of retries in case the gateway module
-  // becomes available after plugin init (e.g., lazy loading).
-  // After MAX_RESOLVER_ATTEMPTS, stop scanning to avoid repeated
-  // filesystem operations in standalone/testing environments.
-  _resolverAttempts++;
-  if (_resolverAttempts >= MAX_RESOLVER_ATTEMPTS) {
-    _resolverLoaded = true;
-    log.debug("gateway resolveApiKeyForProvider not available after multiple attempts — giving up");
-  } else {
-    log.debug(`gateway resolveApiKeyForProvider not available — will retry (attempt ${_resolverAttempts}/${MAX_RESOLVER_ATTEMPTS})`);
-  }
+  // Backoff before retrying — avoid repeated fs scanning.
+  // Retries after RESOLVER_RETRY_BACKOFF_MS so the resolver can
+  // recover if the gateway restarts or the module becomes available.
+  _resolverNextRetryAt = Date.now() + RESOLVER_RETRY_BACKOFF_MS;
+  log.debug(`gateway resolveApiKeyForProvider not available — will retry after ${RESOLVER_RETRY_BACKOFF_MS / 1000}s`);
   return null;
 }
 
@@ -237,5 +236,5 @@ export function clearSecretCache(): void {
   resolvedCache.clear();
   _resolveApiKeyForProvider = null;
   _resolverLoaded = false;
-  _resolverAttempts = 0;
+  _resolverNextRetryAt = 0;
 }


### PR DESCRIPTION
## Summary

Addresses Cursor Bugbot feedback from #318 about repeated filesystem scanning when the gateway module isn't available.

When `resolveApiKeyForProvider` can't find the gateway's `runtime-model-auth` module, it now retries up to 3 times before marking the resolver as permanently unavailable. Previously it retried on every call, causing `readdirSync` + `realpathSync` + `require.resolve` on each invocation — problematic in standalone/testing environments where the gateway module will never be available.

`clearSecretCache()` resets the attempt counter for key rotation or testing scenarios.

## Test plan

- [x] TypeScript compiles cleanly
- [x] All tests pass
- [x] Build succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is limited to retry/backoff behavior when the gateway resolver module can’t be discovered, with no changes to successful secret resolution paths.
> 
> **Overview**
> Adds a time-based backoff to gateway `resolveApiKeyForProvider` discovery so repeated calls don’t continuously rescan the filesystem when the runtime module isn’t present.
> 
> Introduces `_resolverNextRetryAt` with a 60s retry delay and resets this backoff state in `clearSecretCache()` so tests/key-rotation flows can force rediscovery.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit aa243c5e08158db486badad1b7d6542c90f95a65. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->