### PR TITLE
Clarify gateway extraction routing and quiet model logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,12 +71,12 @@ After installation, add Engram to your `openclaw.json`:
           // Option 1: Use OpenAI for extraction:
           "openaiApiKey": "${OPENAI_API_KEY}"
 
-          // Option 2: Use a local LLM (no API key needed):
+          // Option 2: Use Engram's local LLM path (plugin mode only; no API key needed):
           // "localLlmEnabled": true,
           // "localLlmUrl": "http://localhost:1234/v1",
           // "localLlmModel": "qwen2.5-32b-instruct"
 
-          // Option 3: Use the gateway model chain (multi-provider fallback):
+          // Option 3: Use the gateway model chain (primary path in gateway mode):
           // "modelSource": "gateway",
           // "gatewayAgentId": "engram-llm",
           // "fastGatewayAgentId": "engram-llm-fast"
@@ -87,7 +87,7 @@ After installation, add Engram to your `openclaw.json`:
 }
 ```
 
-> **Gateway model source:** When `modelSource` is `"gateway"`, Engram routes all LLM calls (extraction, consolidation, reranking) through an OpenClaw agent persona's model chain instead of its own config. Define agent personas in `openclaw.json → agents.list[]` with a `primary` model and `fallbacks[]` array — Engram tries each in order until one succeeds. This lets you build multi-provider fallback chains like Fireworks → local LLM → cloud OpenAI. See the [Gateway Model Source](docs/config-reference.md#gateway-model-source) guide for full setup.
+> **Gateway model source:** When `modelSource` is `"gateway"`, Engram routes all LLM calls (extraction, consolidation, reranking) through an OpenClaw agent persona's model chain instead of its own config. Extraction starts on the `gatewayAgentId` chain directly in this mode; `localLlm*` settings do not control primary extraction order. Define agent personas in `openclaw.json → agents.list[]` with a `primary` model and `fallbacks[]` array — Engram tries each in order until one succeeds. This lets you build multi-provider fallback chains like Fireworks → local LLM → cloud OpenAI. See the [Gateway Model Source](docs/config-reference.md#gateway-model-source) guide for full setup.
 
 Restart the gateway:
 
@@ -484,10 +484,10 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `openaiApiKey` | `(env)` | OpenAI API key (optional when using a local LLM) |
-| `localLlmEnabled` | `false` | Use a local LLM instead of OpenAI for extraction |
+| `localLlmEnabled` | `false` | Enable Engram's local LLM path when `modelSource` is `plugin` |
 | `localLlmUrl` | unset | Local LLM endpoint (e.g., `http://localhost:1234/v1`) |
 | `localLlmModel` | unset | Local model name (e.g., `qwen2.5-32b-instruct`) |
-| `model` | `gpt-5.2` | OpenAI model for extraction (when not using local LLM) |
+| `model` | `gpt-5.2` | OpenAI model for extraction when `modelSource` is `plugin` and local LLM is disabled |
 | `searchBackend` | `"qmd"` | Search engine: `qmd`, `orama`, `lancedb`, `meilisearch`, `remote`, `noop` |
 | `captureMode` | `implicit` | Memory write policy: `implicit`, `explicit`, `hybrid` |
 | `recallBudgetChars` | `maxMemoryTokens * 4` | Recall budget (default ~8K chars; set 64K+ for large-context models) |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -461,7 +461,8 @@ Route all Engram LLM calls through the OpenClaw gateway's agent model chain inst
 
 When `modelSource` is `gateway`:
 
-- `localLlmEnabled` and the direct OpenAI client are bypassed — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
+- `localLlmEnabled` and the direct OpenAI client are bypassed for primary LLM dispatch — all LLM calls flow through `FallbackLlmClient` with the configured agent chain
+- Extraction and consolidation start on the configured gateway chain directly; the historical "falling back to gateway" wording only applies when Engram is still in `plugin` mode
 - The existing `openaiApiKey`, `model`, and `localLlm*` settings are ignored for LLM dispatch but retained as config for backward compatibility
 - `localLlmFast*` settings are also bypassed when `fastGatewayAgentId` is set
 - **Reranking** uses the `fastGatewayAgentId` chain (or `gatewayAgentId` if fast is unset) instead of the local LLM — this can dramatically reduce rerank latency when the fast chain points at a cloud provider
@@ -535,7 +536,7 @@ Set `modelSource` to `plugin` (or remove it) to restore the original behavior wh
 
 | Setting | Default | Description |
 |---------|---------|-------------|
-| `localLlmEnabled` | `false` | Enable local/compatible endpoint |
+| `localLlmEnabled` | `false` | Enable Engram's local/compatible endpoint when `modelSource` remains `plugin` |
 | `localLlmUrl` | `http://localhost:1234/v1` | Base URL for endpoint |
 | `localLlmModel` | `local-model` | Model ID |
 | `localLlmApiKey` | `(unset)` | Optional API key |

--- a/docs/guides/local-llm.md
+++ b/docs/guides/local-llm.md
@@ -2,6 +2,8 @@
 
 Use Engram's local LLM path when you want extraction, reranking, and selected helper flows to stay on an OpenAI-compatible endpoint you control.
 
+This guide applies when `modelSource` is `plugin` (the default). If you switch to `modelSource: "gateway"`, Engram sends extraction/consolidation/rerank calls to the configured gateway agent chain instead, and `localLlm*` settings no longer control the primary extraction path.
+
 ## Fast Start
 
 If you want the preset first:
@@ -38,7 +40,7 @@ Use the fast local tier for short-turn helpers:
 
 | Setting | Why it matters |
 |---------|----------------|
-| `localLlmEnabled` | Master switch for local inference |
+| `localLlmEnabled` | Master switch for Engram's local inference path while `modelSource=plugin` |
 | `localLlmUrl` | Base URL for the OpenAI-compatible endpoint |
 | `localLlmModel` | Main local model ID |
 | `localLlmFastEnabled` | Enables the smaller/faster local tier |

--- a/src/extraction.ts
+++ b/src/extraction.ts
@@ -94,8 +94,8 @@ export class ExtractionEngine {
     this.fallbackLlm = new FallbackLlmClient(gatewayConfig);
     this.modelRegistry = modelRegistry ?? new ModelRegistry(config.memoryDir);
     if (config.modelSource === "gateway") {
-      log.info(
-        `extraction engine: using gateway model source` +
+      log.debug(
+        `extraction engine: gateway model source active; extraction uses the gateway chain as its primary path` +
           (config.gatewayAgentId ? ` (agent: ${config.gatewayAgentId})` : " (defaults)"),
       );
     }
@@ -838,11 +838,20 @@ export class ExtractionEngine {
       } catch { /* trace emit must not block fallback */ }
     }
 
-    // Fall back to gateway's default AI — emit a fresh llm_start so the fallback
-    // gets its own trace rather than being orphaned under the direct-client traceId.
+    // In gateway mode this is the primary extraction path. In plugin mode it is the
+    // final fallback after local/direct attempts fail. Emit a fresh llm_start so the
+    // gateway-backed call gets its own trace rather than being orphaned under the
+    // direct-client traceId.
     const fallbackTraceId = crypto.randomUUID();
     const fallbackStartTime = Date.now();
-    log.info("extraction: falling back to gateway default AI");
+    if (this.useGatewayModelSource) {
+      log.debug(
+        `extraction: using gateway model chain as primary path` +
+          (this.config.gatewayAgentId ? ` (agent: ${this.config.gatewayAgentId})` : " (defaults)"),
+      );
+    } else {
+      log.info("extraction: falling back to gateway default AI");
+    }
 
     try {
       const messages = [
@@ -1070,7 +1079,7 @@ ${truncatedConversation}`;
     const tokenParams = buildChatCompletionTokenLimit(this.config.model, this.config.extractionMaxOutputTokens, {
       assumeOpenAI: this.directClientUsesOpenAiTokenSemantics(),
     });
-    log.info(`extractWithDirectClient: calling model=${this.config.model} tokenParams=${JSON.stringify(tokenParams)}`);
+    log.debug(`extractWithDirectClient: calling model=${this.config.model} tokenParams=${JSON.stringify(tokenParams)}`);
 
     const response = await this.client.chat.completions.create({
       model: this.config.model,

--- a/src/fallback-llm.ts
+++ b/src/fallback-llm.ts
@@ -77,7 +77,7 @@ export class FallbackLlmClient {
           const result = await this.tryModel(model, messages, options);
           if (result) {
             if (isFallback) {
-              log.info(`fallback LLM: succeeded using ${model.modelString} (fallback ${i})`);
+              log.debug(`fallback LLM: succeeded using ${model.modelString} (fallback ${i})`);
             }
             return {
               content: result.content,

--- a/src/index.ts
+++ b/src/index.ts
@@ -221,7 +221,10 @@ const pluginDefinition = {
     // Re-initialize with correct debug setting
     initLogger(api.logger, cfg.debug);
     log.info(
-      `initialized (debug=${cfg.debug}, qmdEnabled=${cfg.qmdEnabled}, transcriptEnabled=${cfg.transcriptEnabled}, hourlySummariesEnabled=${cfg.hourlySummariesEnabled}, localLlmEnabled=${cfg.localLlmEnabled}${cfg.localLlmFastEnabled ? `, fastLlm=${cfg.localLlmFastModel || "(primary)"}` : ""})`,
+      `initialized (debug=${cfg.debug}, qmdEnabled=${cfg.qmdEnabled}, transcriptEnabled=${cfg.transcriptEnabled}, hourlySummariesEnabled=${cfg.hourlySummariesEnabled})`,
+    );
+    log.debug(
+      `init llm routing (modelSource=${cfg.modelSource}, localLlmEnabled=${cfg.localLlmEnabled}${cfg.localLlmFastEnabled ? `, fastLlm=${cfg.localLlmFastModel || "(primary)"}` : ""})`,
     );
 
     // Singleton guard: the gateway calls register() once per agent (each with a

--- a/src/local-llm.ts
+++ b/src/local-llm.ts
@@ -730,9 +730,9 @@ export class LocalLlmClient {
     const operation = options.operation ?? "unspecified";
     const startedAtMs = Date.now();
     if (queueMeta) {
-      log.info(
-        `local LLM queue start: priority=${queueMeta.priority} waitMs=${startedAtMs - queueMeta.enqueuedAtMs} op=${operation}`,
-      );
+        log.debug(
+          `local LLM queue start: priority=${queueMeta.priority} waitMs=${startedAtMs - queueMeta.enqueuedAtMs} op=${operation}`,
+        );
     }
 
     try {
@@ -986,7 +986,7 @@ export class LocalLlmClient {
       if (queueMeta) {
         const finishedAtMs = Date.now();
         const waitMs = startedAtMs - queueMeta.enqueuedAtMs;
-        log.info(
+        log.debug(
           `local LLM queue finish: priority=${queueMeta.priority} waitMs=${waitMs} runMs=${finishedAtMs - startedAtMs} totalMs=${finishedAtMs - queueMeta.enqueuedAtMs} op=${operation}`,
         );
       }
@@ -1006,7 +1006,7 @@ export class LocalLlmClient {
     const modelsUrl = baseUrl.endsWith("/v1")
       ? `${baseUrl}/models`
       : `${baseUrl}/v1/models`;
-    log.info(`Fetching model info from ${modelsUrl}`);
+    log.debug(`Fetching model info from ${modelsUrl}`);
 
     try {
       const result = await this.fetchWithTimeout(modelsUrl, 3000);

--- a/src/orchestrator.ts
+++ b/src/orchestrator.ts
@@ -1238,7 +1238,7 @@ export class Orchestrator {
       ? new FallbackLlmClient(config.gatewayConfig)
       : null;
     if (config.modelSource === "gateway") {
-      log.info(
+      log.debug(
         `orchestrator: gateway model source active` +
           (config.gatewayAgentId ? ` (primary: ${config.gatewayAgentId})` : "") +
           (config.fastGatewayAgentId ? ` (fast: ${config.fastGatewayAgentId})` : ""),
@@ -3086,7 +3086,7 @@ export class Orchestrator {
    * Warns the user if there's a mismatch.
    */
   private async validateLocalLlmModel(): Promise<void> {
-    log.info("Local LLM: Validating model configuration...");
+    log.debug("Local LLM: validating model configuration");
     try {
       const modelInfo = await this.localLlm.getLoadedModelInfo();
       if (!modelInfo) {
@@ -3104,7 +3104,7 @@ export class Orchestrator {
       const configuredMaxContext = this.config.localLlmMaxContext;
 
       if (modelInfo.contextWindow) {
-        log.info(
+        log.debug(
           `Local LLM: ${modelInfo.id} loaded with ${modelInfo.contextWindow.toLocaleString()} token context window`,
         );
 
@@ -3123,7 +3123,7 @@ export class Orchestrator {
             modelInfo.contextWindow;
         }
       } else {
-        log.info(
+        log.debug(
           `Local LLM: ${modelInfo.id} loaded (context window not reported by server)`,
         );
 

--- a/tests/no-openai-fallback.test.ts
+++ b/tests/no-openai-fallback.test.ts
@@ -28,6 +28,19 @@ function buildLocalOnlyEngine() {
   return new ExtractionEngine(config);
 }
 
+function buildGatewayModeEngine() {
+  const config = parseConfig({
+    memoryDir: ".tmp/memory",
+    workspaceDir: ".tmp/workspace",
+    openaiApiKey: "test-key",
+    modelSource: "gateway",
+    gatewayAgentId: "engram-llm",
+    localLlmEnabled: true,
+    localLlmFallback: true,
+  });
+  return new ExtractionEngine(config);
+}
+
 test("verifyContradiction falls back to gateway AI when no OpenAI key is configured", async () => {
   const engine = buildEngine();
   let fallbackCalled = false;
@@ -334,4 +347,56 @@ test("summarizeMemories honors localLlmEnabled before cloud routing", async () =
     keyFacts: ["Carrier outage delayed shipments", "Customers were notified about delays"],
     keyEntities: ["carrier", "customers"],
   });
+});
+
+test("extract routes directly to the gateway chain when modelSource is gateway", async () => {
+  const engine = buildGatewayModeEngine();
+  let localCalled = false;
+  let fallbackCalled = false;
+  let fallbackOptions: Record<string, unknown> | undefined;
+
+  (engine as any).localLlm = {
+    chatCompletion: async () => {
+      localCalled = true;
+      return {
+        content: "{\"facts\":[],\"profileUpdates\":[],\"entities\":[],\"questions\":[]}",
+      };
+    },
+  };
+  (engine as any).fallbackLlm = {
+    parseWithSchemaDetailed: async (_messages: unknown, _schema: unknown, options: Record<string, unknown>) => {
+      fallbackCalled = true;
+      fallbackOptions = options;
+      return {
+        result: {
+          facts: [
+            {
+              category: "fact",
+              content: "Fireworks Kimi is the primary extraction path in gateway mode.",
+              confidence: 0.95,
+              tags: ["gateway"],
+            },
+          ],
+          profileUpdates: [],
+          entities: [],
+          questions: [],
+        },
+        modelUsed: "fireworks/accounts/fireworks/routers/kimi-k2p5-turbo",
+      };
+    },
+  };
+
+  const result = await engine.extract([
+    {
+      role: "user",
+      content: "Remember that gateway mode should start on the configured chain.",
+      timestamp: new Date().toISOString(),
+    },
+  ]);
+
+  assert.equal(localCalled, false);
+  assert.equal(fallbackCalled, true);
+  assert.equal(fallbackOptions?.agentId, "engram-llm");
+  assert.equal(result.facts.length, 1);
+  assert.equal(result.facts[0]?.content, "Fireworks Kimi is the primary extraction path in gateway mode.");
 });


### PR DESCRIPTION
## Summary
- clarify that gateway mode uses the gateway chain as the primary extraction path instead of logging it as a fallback
- move model-routing and model-selection chatter from normal info logs to debug-level logging
- update README and config docs to explain that `localLlm*` does not control primary extraction order in gateway mode
- add a regression test proving extraction bypasses the local path and forwards `gatewayAgentId` when `modelSource` is `gateway`

## Verification
- `npm test -- tests/no-openai-fallback.test.ts`
- `npm run check-types`
- `npm run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Behavior is mostly unchanged (routing already existed) and changes are largely logging/docs, with a small risk of reduced operational visibility due to quieter `info` logs.
> 
> **Overview**
> Clarifies and enforces that when `modelSource` is `gateway`, extraction starts on the configured `gatewayAgentId` chain (i.e., the gateway chain is the *primary* path), and updates tracing/log messages to reflect this instead of describing it as a fallback.
> 
> Reduces log noise by moving several model-routing/model-selection messages from `info` to `debug` across extraction, local LLM, fallback LLM, and orchestrator initialization. Documentation is updated (README + config/local-LLM guides) to explicitly state that `localLlm*` only controls the local path in `modelSource=plugin` and does not influence primary extraction order in gateway mode, and a new test asserts extraction bypasses the local path and forwards `agentId` when in gateway mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb8d324500ab179f7c5f172c2eedf1247604cb5d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->