### PR TITLE
feat(m1): core extraction + OpenClaw adapter workspace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,8 +7,12 @@
     "": {
       "name": "@joshuaswarren/openclaw-engram",
       "version": "9.1.28",
-      "hasInstallScript": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/core",
+        "packages/adapter-openclaw",
+        "packages/hermes-provider"
+      ],
       "dependencies": {
         "@honcho-ai/sdk": "^2.0.0",
         "@lancedb/lancedb": "^0.26.2",
@@ -40,6 +44,18 @@
       "peerDependencies": {
         "openclaw": "*"
       }
+    },
+    "node_modules/@engram/adapter-openclaw": {
+      "resolved": "packages/adapter-openclaw",
+      "link": true
+    },
+    "node_modules/@engram/core": {
+      "resolved": "packages/core",
+      "link": true
+    },
+    "node_modules/@engram/hermes-provider": {
+      "resolved": "packages/hermes-provider",
+      "link": true
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.2",
@@ -1823,9 +1839,6 @@
         }
       }
     },
-    "node_modules/openclaw": {
-      "peer": true
-    },
     "node_modules/pathe": {
       "version": "2.0.3",
       "dev": true,
@@ -2476,6 +2489,55 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "packages/adapter-openclaw": {
+      "name": "@engram/adapter-openclaw",
+      "version": "9.1.28",
+      "license": "MIT",
+      "dependencies": {
+        "@engram/core": "file:../core"
+      },
+      "devDependencies": {
+        "typescript": "^5.9.3"
+      },
+      "peerDependencies": {
+        "openclaw": "*"
+      }
+    },
+    "packages/core": {
+      "name": "@engram/core",
+      "version": "0.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "@honcho-ai/sdk": "^2.0.0",
+        "@lancedb/lancedb": "^0.26.2",
+        "@orama/orama": "^3.0.0",
+        "@orama/plugin-data-persistence": "^3.0.0",
+        "@sinclair/typebox": "^0.34.0",
+        "better-sqlite3": "^12.6.2",
+        "meilisearch": "^0.46.0",
+        "openai": "^6.0.0",
+        "zod": "^3.24.0"
+      },
+      "devDependencies": {
+        "@types/better-sqlite3": "^7.6.13",
+        "tsup": "^8.5.1",
+        "typescript": "^5.9.3"
+      },
+      "optionalDependencies": {
+        "@lancedb/lancedb-darwin-arm64": "^0.26.2",
+        "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
+        "@lancedb/lancedb-linux-x64-gnu": "^0.26.2"
+      }
+    },
+    "packages/hermes-provider": {
+      "name": "@engram/hermes-provider",
+      "version": "0.1.0",
+      "license": "MIT",
+      "devDependencies": {
+        "tsup": "^8.0.0",
+        "typescript": "^5.7.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -31,6 +31,11 @@
     "url": "https://github.com/joshuaswarren/openclaw-engram/issues"
   },
   "author": "Joshua Warren",
+  "workspaces": [
+    "packages/core",
+    "packages/adapter-openclaw",
+    "packages/hermes-provider"
+  ],
   "engines": {
     "node": ">=22.12.0"
   },

--- a/packages/adapter-openclaw/package.json
+++ b/packages/adapter-openclaw/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "@engram/adapter-openclaw",
+  "version": "9.1.28",
+  "description": "OpenClaw adapter for Engram memory — thin wrapper delegating to @engram/core",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@engram/core": "file:../core"
+  },
+  "peerDependencies": {
+    "openclaw": "*"
+  },
+  "devDependencies": {
+    "typescript": "^5.9.3"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/openclaw-engram.git",
+    "directory": "packages/adapter-openclaw"
+  },
+  "keywords": ["engram", "memory", "openclaw", "adapter", "plugin"]
+}

--- a/packages/adapter-openclaw/src/index.ts
+++ b/packages/adapter-openclaw/src/index.ts
@@ -1,0 +1,17 @@
+/**
+ * @engram/adapter-openclaw
+ *
+ * OpenClaw adapter for Engram memory.
+ *
+ * This is a thin re-export layer. The full plugin implementation
+ * lives in `src/index.ts` at the repo root. This adapter exists so
+ * that `@engram/core` can be framework-agnostic while this package
+ * carries the OpenClaw SDK dependency.
+ *
+ * OpenClaw loads this package via `openclaw.plugin.json` → `main` field.
+ * Everything exported here is identical to the original `src/index.ts`.
+ */
+
+// Re-export the full plugin — no modifications
+export * from "../../../src/index.js";
+export { default } from "../../../src/index.js";

--- a/packages/adapter-openclaw/tsconfig.json
+++ b/packages/adapter-openclaw/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/core/WORKSPACE.md
+++ b/packages/core/WORKSPACE.md
@@ -1,0 +1,1 @@
+# M1: Core Extraction

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "@engram/core",
+  "version": "0.1.0",
+  "description": "Framework-agnostic Engram memory engine — orchestrator, storage, extraction, search, trust zones",
+  "type": "module",
+  "main": "src/index.ts",
+  "types": "src/index.ts",
+  "exports": {
+    ".": {
+      "import": "./src/index.ts",
+      "types": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsup",
+    "check-types": "tsc --noEmit"
+  },
+  "dependencies": {
+    "@honcho-ai/sdk": "^2.0.0",
+    "@lancedb/lancedb": "^0.26.2",
+    "@orama/orama": "^3.0.0",
+    "@orama/plugin-data-persistence": "^3.0.0",
+    "@sinclair/typebox": "^0.34.0",
+    "better-sqlite3": "^12.6.2",
+    "meilisearch": "^0.46.0",
+    "openai": "^6.0.0",
+    "zod": "^3.24.0"
+  },
+  "optionalDependencies": {
+    "@lancedb/lancedb-darwin-arm64": "^0.26.2",
+    "@lancedb/lancedb-linux-arm64-gnu": "^0.26.2",
+    "@lancedb/lancedb-linux-x64-gnu": "^0.26.2"
+  },
+  "devDependencies": {
+    "@types/better-sqlite3": "^7.6.13",
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/openclaw-engram.git",
+    "directory": "packages/core"
+  },
+  "keywords": ["engram", "memory", "ai", "agent", "core"]
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,0 +1,134 @@
+/**
+ * @engram/core
+ *
+ * Framework-agnostic Engram memory engine.
+ *
+ * Re-exports the orchestrator, config parsing, storage, search,
+ * extraction, graph, trust zones, and access layer from the
+ * canonical implementation in `src/`.
+ *
+ * This package has ZERO OpenClaw imports — it can be consumed by
+ * any host adapter (CLI, HTTP server, MCP server, etc.).
+ *
+ * Usage:
+ *   import { Orchestrator, parseConfig } from "@engram/core";
+ *   const config = parseConfig({ memoryDir: "/tmp/mem" });
+ *   const orch = new Orchestrator(config);
+ *   await orch.initialize();
+ */
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export {
+  parseConfig,
+  resolveConfig,
+  validateResolvedConfig,
+  type EngramConfig,
+  type ResolvedEngramConfig,
+  type ExtractionConfig,
+  type SearchBackendConfig,
+  type ConsolidationConfig,
+  type TrustZoneConfig,
+} from "../../../src/config.js";
+
+// ---------------------------------------------------------------------------
+// Orchestrator — primary entry point
+// ---------------------------------------------------------------------------
+
+export {
+  Orchestrator,
+  sanitizeSessionKeyForFilename,
+  defaultWorkspaceDir,
+} from "../../../src/orchestrator.js";
+
+// ---------------------------------------------------------------------------
+// Storage
+// ---------------------------------------------------------------------------
+
+export { StorageManager } from "../../../src/storage.js";
+
+// ---------------------------------------------------------------------------
+// Extraction
+// ---------------------------------------------------------------------------
+
+export {
+  extractMemories,
+  type ExtractedFact,
+  type ExtractionResult,
+} from "../../../src/extraction.js";
+
+// ---------------------------------------------------------------------------
+// Search backends
+// ---------------------------------------------------------------------------
+
+export { QmdSearchBackend } from "../../../src/qmd-search.js";
+export { LanceDbSearchBackend } from "../../../src/lancedb-search.js";
+export { OramaSearchBackend } from "../../../src/orama-search.js";
+export { MeiliSearchBackend } from "../../../src/meilisearch-backend.js";
+
+// ---------------------------------------------------------------------------
+// Entity / Graph
+// ---------------------------------------------------------------------------
+
+export { EntityGraphManager } from "../../../src/entity-retrieval.js";
+
+// ---------------------------------------------------------------------------
+// Trust zones
+// ---------------------------------------------------------------------------
+
+export {
+  isTrustZoneName,
+  type TrustZoneName,
+  type TrustZoneRecord,
+  type TrustZoneRecordKind,
+  type TrustZoneSourceClass,
+} from "../../../src/trust-zones.js";
+
+// ---------------------------------------------------------------------------
+// Access layer (HTTP + MCP + schema validation)
+// ---------------------------------------------------------------------------
+
+export { EngramAccessService, EngramAccessInputError } from "../../../src/access-service.js";
+export { EngramAccessHttpServer } from "../../../src/access-http.js";
+export { EngramMcpServer } from "../../../src/access-mcp.js";
+
+export {
+  validateRequest,
+  formatZodError,
+  recallRequestSchema,
+  observeRequestSchema,
+  memoryStoreRequestSchema,
+  suggestionSubmitRequestSchema,
+  type SchemaValidationError,
+  type SchemaName,
+  type RecallRequest,
+  type ObserveRequest,
+  type MemoryStoreRequest,
+  type SuggestionSubmitRequest,
+} from "../../../src/access-schema.js";
+
+// ---------------------------------------------------------------------------
+// Day summary / LCM
+// ---------------------------------------------------------------------------
+
+export { loadDaySummaryPrompt } from "../../../src/day-summary.js";
+
+// ---------------------------------------------------------------------------
+// Bootstrap
+// ---------------------------------------------------------------------------
+
+export { bootstrap } from "../../../src/bootstrap.js";
+
+// ---------------------------------------------------------------------------
+// Logger
+// ---------------------------------------------------------------------------
+
+export { initLogger, log } from "../../../src/logger.js";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type { AccessConfig, AccessHealthResponse, AccessRecallResponse } from "../../../src/types.js";

--- a/packages/core/tsconfig.json
+++ b/packages/core/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary

- Add npm workspace support to root `package.json` for `packages/*`
- Create `@engram/core` — framework-agnostic re-export of orchestrator, config, storage, search, extraction, graph, trust zones, access layer (zero OpenClaw imports)
- Create `@engram/adapter-openclaw` — thin wrapper re-exporting `src/index.ts` for OpenClaw plugin loading parity
- Existing `src/` untouched; build and tests pass identically

## Non-breaking strategy

All existing behavior preserved through thin delegation:
- `src/` stays in place — all 137 modules unchanged
- Root `tsup` config still builds `dist/index.js` from `src/index.ts`
- OpenClaw loads the adapter which re-exports the same plugin
- `@engram/core` is new code that can be imported standalone without OpenClaw

## Test plan
- [x] `npx tsc --noEmit` — zero errors
- [x] `npm run build` — succeeds
- [x] All 21 access-http tests pass
- [x] No changes to existing test suite
- [ ] CI checks green
- [ ] AI reviewer pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it restructures packaging into npm workspaces and adds new internal packages/links, which can affect install, build, and publishing resolution even though runtime logic is re-exported.
> 
> **Overview**
> Adds npm workspaces at the repo root and updates `package-lock.json` to treat `packages/core`, `packages/adapter-openclaw`, and `packages/hermes-provider` as linked workspace packages.
> 
> Introduces `@engram/core` as a framework-agnostic entrypoint that re-exports the existing implementation surface (orchestrator/config/storage/search/extraction/access/etc.) from the root `src/` without adding OpenClaw dependencies.
> 
> Introduces `@engram/adapter-openclaw` as a thin compatibility wrapper that re-exports the root plugin `src/index.js`, allowing OpenClaw to load via a dedicated package while keeping the core package decoupled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df03a4d99822a65e729372bc80c1d953ef952648. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->