### PR TITLE
feat(adapters): multi-system identity resolution for Claude Code, Codex, Replit, Hermes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+- **Adapter architecture** for multi-system identity resolution:
+  - `AdapterRegistry` — chainable adapter resolution for incoming requests
+  - `ClaudeCodeAdapter` — resolves Claude Code sessions via MCP client info or `X-Claude-Session-Id` header
+  - `CodexAdapter` — resolves Codex CLI agents via MCP client info or `X-Codex-Agent-Name` header
+  - `ReplitAdapter` — resolves Replit agents via `X-Replit-Project-Id` / `X-Replit-User-Id` headers
+  - `HermesAdapter` — resolves Hermes agents via `X-Hermes-Session-Id` / `X-Hermes-Profile` headers
+  - `GET /engram/v1/adapters` — discovery endpoint showing registered adapters and resolved identity
+- HTTP server now auto-detects connecting system and resolves principal via adapter registry
+
 ## [v9.2.4] — 2026-04-05
 
 ### Added

--- a/src/access-http.ts
+++ b/src/access-http.ts
@@ -11,6 +11,7 @@ import { EngramMcpServer } from "./access-mcp.js";
 import { validateRequest, type SchemaName, type SchemaTypeFor } from "./access-schema.js";
 import type { RecallPlanMode } from "./types.js";
 import { isTrustZoneName, type TrustZoneName, type TrustZoneRecordKind, type TrustZoneSourceClass } from "./trust-zones.js";
+import { AdapterRegistry, type ResolvedIdentity } from "./adapters/index.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -22,6 +23,10 @@ export interface EngramAccessHttpServerOptions {
   adminConsoleEnabled?: boolean;
   adminConsolePublicDir?: string;
   trustPrincipalHeader?: boolean;
+  /** Enable adapter-based identity resolution from request headers */
+  enableAdapters?: boolean;
+  /** Custom adapter registry (defaults to built-in adapters) */
+  adapterRegistry?: AdapterRegistry;
 }
 
 export interface EngramAccessHttpServerStatus {
@@ -98,6 +103,7 @@ export class EngramAccessHttpServer {
   private readonly adminConsoleEnabled: boolean;
   private readonly adminConsolePublicDir: string;
   private readonly trustPrincipalHeader: boolean;
+  private readonly adapterRegistry: AdapterRegistry | null;
   private readonly writeRequestTimestamps: number[] = [];
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
@@ -115,6 +121,9 @@ export class EngramAccessHttpServer {
     this.adminConsoleEnabled = options.adminConsoleEnabled !== false;
     this.adminConsolePublicDir = options.adminConsolePublicDir ?? defaultAdminConsolePublicDir;
     this.trustPrincipalHeader = options.trustPrincipalHeader === true;
+    this.adapterRegistry = options.enableAdapters !== false
+      ? (options.adapterRegistry ?? new AdapterRegistry())
+      : null;
     this.mcpServer = new EngramMcpServer(this.service, { principal: options.principal });
   }
 
@@ -192,7 +201,19 @@ export class EngramAccessHttpServer {
     };
   }
 
+  /**
+   * Resolve the adapter identity for the incoming request.
+   * Returns null if no adapter matches or adapters are disabled.
+   */
+  resolveAdapterIdentity(req: IncomingMessage): ResolvedIdentity | null {
+    if (!this.adapterRegistry) return null;
+    return this.adapterRegistry.resolve({
+      headers: req.headers as Record<string, string | string[] | undefined>,
+    });
+  }
+
   private resolveRequestPrincipal(req: IncomingMessage): string | undefined {
+    // Explicit header override takes priority
     if (this.trustPrincipalHeader) {
       const headerValue = req.headers["x-engram-principal"];
       const raw = Array.isArray(headerValue) ? headerValue[0] : headerValue;
@@ -202,6 +223,11 @@ export class EngramAccessHttpServer {
           return trimmed;
         }
       }
+    }
+    // Try adapter-based identity resolution
+    const adapterIdentity = this.resolveAdapterIdentity(req);
+    if (adapterIdentity) {
+      return adapterIdentity.principal;
     }
     return this.authenticatedPrincipal;
   }
@@ -232,6 +258,16 @@ export class EngramAccessHttpServer {
 
     if (req.method === "GET" && pathname === "/engram/v1/health") {
       this.respondJson(res, 200, await this.service.health());
+      return;
+    }
+
+    if (req.method === "GET" && pathname === "/engram/v1/adapters") {
+      const identity = this.resolveAdapterIdentity(req);
+      this.respondJson(res, 200, {
+        adaptersEnabled: this.adapterRegistry !== null,
+        registered: this.adapterRegistry?.list() ?? [],
+        resolved: identity,
+      });
       return;
     }
 

--- a/src/adapters/claude-code.ts
+++ b/src/adapters/claude-code.ts
@@ -1,0 +1,60 @@
+import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+
+/**
+ * Claude Code adapter.
+ *
+ * Detects Claude Code connections via MCP client info (name contains
+ * "claude") or the X-Claude-Session-Id header. Maps the project path
+ * or session ID to an Engram namespace.
+ */
+export class ClaudeCodeAdapter implements EngramAdapter {
+  readonly id = "claude-code";
+
+  matches(context: AdapterContext): boolean {
+    const clientName = context.clientInfo?.name?.toLowerCase() ?? "";
+    if (clientName.includes("claude")) return true;
+
+    const sessionHeader = headerValue(context.headers, "x-claude-session-id");
+    if (sessionHeader) return true;
+
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    const sessionId = headerValue(context.headers, "x-claude-session-id");
+    const projectPath = headerValue(context.headers, "x-claude-project-path");
+
+    const namespace = projectPath
+      ? slugify(projectPath)
+      : "claude-code";
+
+    const principal = headerValue(context.headers, "x-engram-principal")
+      || context.clientInfo?.name
+      || "claude-code";
+
+    return {
+      namespace,
+      principal,
+      sessionKey: sessionId ?? context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const raw = headers[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function slugify(s: string): string {
+  let slug = s.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  while (start < slug.length && slug[start] === "-") start++;
+  let end = slug.length;
+  while (end > start && slug[end - 1] === "-") end--;
+  return slug.slice(start, end).slice(0, 80) || "claude-code";
+}

--- a/src/adapters/codex.ts
+++ b/src/adapters/codex.ts
@@ -1,0 +1,61 @@
+import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+
+/**
+ * Codex CLI adapter.
+ *
+ * Detects Codex connections via MCP client info (name contains "codex")
+ * or the X-Codex-Agent-Name header. Maps the agent name and project
+ * directory to Engram namespace.
+ */
+export class CodexAdapter implements EngramAdapter {
+  readonly id = "codex";
+
+  matches(context: AdapterContext): boolean {
+    const clientName = context.clientInfo?.name?.toLowerCase() ?? "";
+    if (clientName.includes("codex")) return true;
+
+    const agentHeader = headerValue(context.headers, "x-codex-agent-name");
+    if (agentHeader) return true;
+
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    const agentName = headerValue(context.headers, "x-codex-agent-name");
+    const projectDir = headerValue(context.headers, "x-codex-project-dir");
+
+    const namespace = projectDir
+      ? slugify(projectDir)
+      : "codex";
+
+    const principal = headerValue(context.headers, "x-engram-principal")
+      || agentName
+      || context.clientInfo?.name
+      || "codex";
+
+    return {
+      namespace,
+      principal,
+      sessionKey: context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const raw = headers[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function slugify(s: string): string {
+  let slug = s.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  while (start < slug.length && slug[start] === "-") start++;
+  let end = slug.length;
+  while (end > start && slug[end - 1] === "-") end--;
+  return slug.slice(start, end).slice(0, 80) || "codex";
+}

--- a/src/adapters/hermes.ts
+++ b/src/adapters/hermes.ts
@@ -1,0 +1,56 @@
+import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+
+/**
+ * Hermes Agent adapter.
+ *
+ * Detects Hermes connections via the X-Hermes-Session-Id header or
+ * X-Hermes-Profile header. Hermes profiles isolate agents, so the
+ * profile name maps to the Engram namespace.
+ */
+export class HermesAdapter implements EngramAdapter {
+  readonly id = "hermes";
+
+  matches(context: AdapterContext): boolean {
+    if (headerValue(context.headers, "x-hermes-session-id")) return true;
+    if (headerValue(context.headers, "x-hermes-profile")) return true;
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    const sessionId = headerValue(context.headers, "x-hermes-session-id");
+    const profile = headerValue(context.headers, "x-hermes-profile");
+
+    const namespace = profile
+      ? slugify(profile)
+      : "hermes";
+
+    const principal = headerValue(context.headers, "x-engram-principal")
+      || profile
+      || "hermes-agent";
+
+    return {
+      namespace,
+      principal,
+      sessionKey: sessionId ?? context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const raw = headers[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function slugify(s: string): string {
+  let slug = s.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  let start = 0;
+  while (start < slug.length && slug[start] === "-") start++;
+  let end = slug.length;
+  while (end > start && slug[end - 1] === "-") end--;
+  return slug.slice(start, end).slice(0, 80) || "hermes";
+}

--- a/src/adapters/index.ts
+++ b/src/adapters/index.ts
@@ -1,0 +1,6 @@
+export type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+export { ClaudeCodeAdapter } from "./claude-code.js";
+export { CodexAdapter } from "./codex.js";
+export { ReplitAdapter } from "./replit.js";
+export { HermesAdapter } from "./hermes.js";
+export { AdapterRegistry } from "./registry.js";

--- a/src/adapters/registry.ts
+++ b/src/adapters/registry.ts
@@ -1,0 +1,41 @@
+import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+import { ClaudeCodeAdapter } from "./claude-code.js";
+import { CodexAdapter } from "./codex.js";
+import { ReplitAdapter } from "./replit.js";
+import { HermesAdapter } from "./hermes.js";
+
+/**
+ * Adapter registry. Attempts to identify which external system is
+ * connecting by checking each registered adapter in order. Falls back
+ * to explicit namespace/principal from the request args.
+ */
+export class AdapterRegistry {
+  private readonly adapters: EngramAdapter[];
+
+  constructor(adapters?: EngramAdapter[]) {
+    this.adapters = adapters ?? [
+      new HermesAdapter(),
+      new ReplitAdapter(),
+      new CodexAdapter(),
+      new ClaudeCodeAdapter(),
+    ];
+  }
+
+  /**
+   * Try each adapter in order. Return the first match, or null if
+   * no adapter recognizes the request context.
+   */
+  resolve(context: AdapterContext): ResolvedIdentity | null {
+    for (const adapter of this.adapters) {
+      if (adapter.matches(context)) {
+        return adapter.resolveIdentity(context);
+      }
+    }
+    return null;
+  }
+
+  /** List registered adapter IDs */
+  list(): string[] {
+    return this.adapters.map((a) => a.id);
+  }
+}

--- a/src/adapters/replit.ts
+++ b/src/adapters/replit.ts
@@ -1,0 +1,50 @@
+import type { AdapterContext, EngramAdapter, ResolvedIdentity } from "./types.js";
+
+/**
+ * Replit Agent adapter.
+ *
+ * Detects Replit connections via the X-Replit-Project-Id header or
+ * X-Replit-User-Id header. Replit uses HTTP REST, not MCP stdio,
+ * so detection relies entirely on headers.
+ */
+export class ReplitAdapter implements EngramAdapter {
+  readonly id = "replit";
+
+  matches(context: AdapterContext): boolean {
+    if (headerValue(context.headers, "x-replit-project-id")) return true;
+    if (headerValue(context.headers, "x-replit-user-id")) return true;
+    return false;
+  }
+
+  resolveIdentity(context: AdapterContext): ResolvedIdentity {
+    const projectId = headerValue(context.headers, "x-replit-project-id");
+    const userId = headerValue(context.headers, "x-replit-user-id");
+
+    const namespace = projectId
+      ? `replit-${sanitizeId(projectId)}`
+      : "replit";
+
+    const principal = headerValue(context.headers, "x-engram-principal")
+      || (userId ? `replit-user-${sanitizeId(userId)}` : "replit-agent");
+
+    return {
+      namespace,
+      principal,
+      sessionKey: context.sessionKey,
+      adapterId: this.id,
+    };
+  }
+}
+
+function headerValue(
+  headers: Record<string, string | string[] | undefined>,
+  key: string,
+): string | undefined {
+  const raw = headers[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function sanitizeId(s: string): string {
+  return s.replace(/[^a-zA-Z0-9_-]/g, "").slice(0, 64);
+}

--- a/src/adapters/types.ts
+++ b/src/adapters/types.ts
@@ -1,0 +1,38 @@
+/**
+ * Adapter interface for external system identity resolution.
+ *
+ * Each adapter maps an external system's session/identity conventions
+ * to Engram's namespace + principal model. Adapters are stateless and
+ * lightweight — they don't manage lifecycles or load plugins.
+ */
+
+export interface AdapterContext {
+  /** Raw HTTP headers from the incoming request */
+  headers: Record<string, string | string[] | undefined>;
+  /** MCP client info (from initialize handshake, if available) */
+  clientInfo?: { name: string; version?: string };
+  /** Explicit session key from request args */
+  sessionKey?: string;
+}
+
+export interface ResolvedIdentity {
+  /** Engram namespace (scopes memory access) */
+  namespace: string;
+  /** Engram principal (authorization subject) */
+  principal: string;
+  /** Session key for continuity tracking */
+  sessionKey?: string;
+  /** Which adapter resolved this identity */
+  adapterId: string;
+}
+
+export interface EngramAdapter {
+  /** Adapter identifier (e.g., "claude-code", "codex", "hermes", "replit") */
+  readonly id: string;
+
+  /** Whether this adapter recognizes the given request context */
+  matches(context: AdapterContext): boolean;
+
+  /** Map external session/identity to Engram namespace + principal */
+  resolveIdentity(context: AdapterContext): ResolvedIdentity;
+}

--- a/tests/adapters.test.ts
+++ b/tests/adapters.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { AdapterRegistry } from "../src/adapters/registry.js";
+import { ClaudeCodeAdapter } from "../src/adapters/claude-code.js";
+import { CodexAdapter } from "../src/adapters/codex.js";
+import { ReplitAdapter } from "../src/adapters/replit.js";
+import { HermesAdapter } from "../src/adapters/hermes.js";
+
+test("AdapterRegistry returns null when no adapter matches", () => {
+  const registry = new AdapterRegistry();
+  const result = registry.resolve({ headers: {} });
+  assert.equal(result, null);
+});
+
+test("ClaudeCodeAdapter matches on client info containing 'claude'", () => {
+  const adapter = new ClaudeCodeAdapter();
+  assert.equal(adapter.matches({ headers: {}, clientInfo: { name: "claude-code", version: "1.0" } }), true);
+  assert.equal(adapter.matches({ headers: {} }), false);
+});
+
+test("ClaudeCodeAdapter matches on X-Claude-Session-Id header", () => {
+  const adapter = new ClaudeCodeAdapter();
+  assert.equal(adapter.matches({ headers: { "x-claude-session-id": "sess-abc" } }), true);
+});
+
+test("ClaudeCodeAdapter resolves project path to namespace", () => {
+  const adapter = new ClaudeCodeAdapter();
+  const identity = adapter.resolveIdentity({
+    headers: {
+      "x-claude-session-id": "sess-abc",
+      "x-claude-project-path": "/Users/dev/my-project",
+    },
+    clientInfo: { name: "claude-code" },
+  });
+  assert.equal(identity.adapterId, "claude-code");
+  assert.equal(identity.namespace, "users-dev-my-project");
+  assert.equal(identity.principal, "claude-code");
+  assert.equal(identity.sessionKey, "sess-abc");
+});
+
+test("CodexAdapter matches on client info containing 'codex'", () => {
+  const adapter = new CodexAdapter();
+  assert.equal(adapter.matches({ headers: {}, clientInfo: { name: "codex-cli" } }), true);
+  assert.equal(adapter.matches({ headers: {} }), false);
+});
+
+test("CodexAdapter matches on X-Codex-Agent-Name header", () => {
+  const adapter = new CodexAdapter();
+  assert.equal(adapter.matches({ headers: { "x-codex-agent-name": "project-manager" } }), true);
+});
+
+test("CodexAdapter resolves agent name to principal", () => {
+  const adapter = new CodexAdapter();
+  const identity = adapter.resolveIdentity({
+    headers: { "x-codex-agent-name": "project-manager", "x-codex-project-dir": "/src/my-app" },
+  });
+  assert.equal(identity.adapterId, "codex");
+  assert.equal(identity.namespace, "src-my-app");
+  assert.equal(identity.principal, "project-manager");
+});
+
+test("ReplitAdapter matches on X-Replit-Project-Id header", () => {
+  const adapter = new ReplitAdapter();
+  assert.equal(adapter.matches({ headers: { "x-replit-project-id": "proj-123" } }), true);
+  assert.equal(adapter.matches({ headers: {} }), false);
+});
+
+test("ReplitAdapter resolves project ID to namespace", () => {
+  const adapter = new ReplitAdapter();
+  const identity = adapter.resolveIdentity({
+    headers: { "x-replit-project-id": "proj-123", "x-replit-user-id": "user-456" },
+  });
+  assert.equal(identity.adapterId, "replit");
+  assert.equal(identity.namespace, "replit-proj-123");
+  assert.equal(identity.principal, "replit-user-user-456");
+});
+
+test("HermesAdapter matches on X-Hermes-Session-Id header", () => {
+  const adapter = new HermesAdapter();
+  assert.equal(adapter.matches({ headers: { "x-hermes-session-id": "herm-abc" } }), true);
+  assert.equal(adapter.matches({ headers: {} }), false);
+});
+
+test("HermesAdapter matches on X-Hermes-Profile header", () => {
+  const adapter = new HermesAdapter();
+  assert.equal(adapter.matches({ headers: { "x-hermes-profile": "research-agent" } }), true);
+});
+
+test("HermesAdapter resolves profile to namespace", () => {
+  const adapter = new HermesAdapter();
+  const identity = adapter.resolveIdentity({
+    headers: { "x-hermes-session-id": "herm-abc", "x-hermes-profile": "Research Agent" },
+  });
+  assert.equal(identity.adapterId, "hermes");
+  assert.equal(identity.namespace, "research-agent");
+  assert.equal(identity.principal, "Research Agent");
+  assert.equal(identity.sessionKey, "herm-abc");
+});
+
+test("AdapterRegistry resolves first matching adapter (Hermes before Claude Code)", () => {
+  const registry = new AdapterRegistry();
+  const result = registry.resolve({
+    headers: { "x-hermes-session-id": "herm-abc" },
+    clientInfo: { name: "claude-code" },
+  });
+  assert.equal(result?.adapterId, "hermes");
+});
+
+test("AdapterRegistry lists registered adapter IDs", () => {
+  const registry = new AdapterRegistry();
+  const ids = registry.list();
+  assert.deepEqual(ids, ["hermes", "replit", "codex", "claude-code"]);
+});
+
+test("X-Engram-Principal header overrides adapter-resolved principal", () => {
+  const adapter = new ClaudeCodeAdapter();
+  const identity = adapter.resolveIdentity({
+    headers: {
+      "x-claude-session-id": "sess-abc",
+      "x-engram-principal": "custom-principal",
+    },
+    clientInfo: { name: "claude-code" },
+  });
+  assert.equal(identity.principal, "custom-principal");
+});


### PR DESCRIPTION
## Summary

- Adds adapter architecture for auto-detecting which external system is connecting to Engram
- 4 system adapters: Claude Code, Codex CLI, Replit Agent, Hermes Agent
- Each adapter detects connections via MCP client info or system-specific HTTP headers
- Resolves namespace + principal automatically from request context
- Integrated into HTTP server (enabled by default, opt-out via `enableAdapters: false`)
- Discovery endpoint: `GET /engram/v1/adapters` shows registered adapters and resolved identity
- 15 unit tests covering all adapters and registry behavior

### Detection headers per system

| System | Detection | Namespace source | Principal source |
|--------|-----------|-----------------|-----------------|
| Claude Code | `clientInfo.name` contains "claude" or `X-Claude-Session-Id` | `X-Claude-Project-Path` | `X-Engram-Principal` or clientInfo name |
| Codex CLI | `clientInfo.name` contains "codex" or `X-Codex-Agent-Name` | `X-Codex-Project-Dir` | `X-Codex-Agent-Name` or clientInfo name |
| Replit | `X-Replit-Project-Id` or `X-Replit-User-Id` | project ID | user ID |
| Hermes | `X-Hermes-Session-Id` or `X-Hermes-Profile` | profile name | profile name |

Part B of the full feature parity plan. Independent of PR #345 (Part A: 21 new tools).

## Test plan

- [x] `npm run build` — TypeScript compiles clean
- [x] `npx tsx --test tests/adapters.test.ts` — 15 adapter tests pass
- [x] `npx tsx --test tests/access-mcp.test.ts` — existing MCP tests pass
- [ ] CI quality gate passes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `authenticatedPrincipal` is derived for HTTP/MCP requests by introducing header/client-info based resolution, which can affect authorization behavior if headers are mis-set. Surface area is limited and covered by focused unit tests, but it touches request handling on core endpoints.
> 
> **Overview**
> Introduces a new **adapter architecture** (`src/adapters/*`) that can detect the calling system (Claude Code, Codex, Replit, Hermes) from headers and/or MCP `clientInfo`, and resolve a consistent `{namespace, principal, sessionKey}` identity via an ordered `AdapterRegistry`.
> 
> Wires this into the HTTP server so `resolveRequestPrincipal()` can fall back to adapter-resolved principals (configurable via `enableAdapters` / `adapterRegistry`), and adds `GET /engram/v1/adapters` to report whether adapters are enabled, which adapters are registered, and what identity would resolve for the current request. Adds unit tests validating adapter matching, precedence, and override behavior, and documents the feature in `CHANGELOG.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8c99816db5513d1fdf1f9012dc5e77c182ff4da1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->