### PR TITLE
fix: unblock remnic bootstrap release

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
-# openclaw-engram environment variables
+# Remnic environment variables
 # Copy this file to .env and fill in your values.
 # Never commit the .env file — it is listed in .gitignore.
 
@@ -11,7 +11,7 @@ OPENAI_API_KEY=sk-...
 
 # Optional: Override the extraction model.
 # Defaults to the value in src/model-registry.ts.
-# ENGRAM_EXTRACTION_MODEL=gpt-4o
+# REMNIC_EXTRACTION_MODEL=gpt-4o
 
 # Optional: Enable verbose debug logging.
-# ENGRAM_DEBUG=false
+# REMNIC_DEBUG=false

--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -177,6 +177,43 @@ jobs:
           MINOR="${REST%%.*}"
           PATCH="${REST##*.}"
           BUMP_TYPE="${{ steps.bump.outputs.bump_type }}"
+          PKG_VERSION="$(node -p "require('./package.json').version")"
+          BOOTSTRAP_PACKAGE="@remnic/core"
+          BOOTSTRAP_PUBLISHED="false"
+          if npm view "${BOOTSTRAP_PACKAGE}" version >/dev/null 2>&1; then
+            BOOTSTRAP_PUBLISHED="true"
+          fi
+          if [ "${BOOTSTRAP_PUBLISHED}" != "true" ]; then
+            BOOTSTRAP_TAG="v${PKG_VERSION}"
+            {
+              echo "bootstrap_release=true"
+            } >> "$GITHUB_OUTPUT"
+            if git rev-parse -q --verify "refs/tags/${BOOTSTRAP_TAG}" >/dev/null; then
+              {
+                echo "tag_exists=true"
+                echo "tag_name=${BOOTSTRAP_TAG}"
+                echo "new_version=${PKG_VERSION}"
+                echo "bump_type=bootstrap"
+              } >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            {
+              echo "tag_exists=false"
+              echo "tag_name=${BOOTSTRAP_TAG}"
+              echo "new_version=${PKG_VERSION}"
+              echo "bump_type=bootstrap"
+            } >> "$GITHUB_OUTPUT"
+            echo "::notice title=Bootstrap release::${BOOTSTRAP_PACKAGE} is not published yet; using package.json version ${PKG_VERSION}."
+            pnpm version "${PKG_VERSION}" --no-git-tag-version --allow-same-version
+            git add package.json pnpm-lock.yaml package-lock.json 2>/dev/null || true
+            if git diff --cached --quiet; then
+              echo "::notice title=Release commit skipped::Version already matches v${PKG_VERSION}; no package files changed."
+            else
+              git commit -m "chore(release): v${PKG_VERSION} [skip ci]"
+            fi
+            exit 0
+          fi
+
           case "${BUMP_TYPE}" in
             major)
               AUTO_VERSION="$((MAJOR + 1)).0.0"
@@ -193,7 +230,6 @@ jobs:
           # This lets PRs that intentionally set a version (e.g. 9.1.0) win
           # over the auto-increment (e.g. 9.0.109). PRs that don't touch
           # the version still get auto-incremented as before.
-          PKG_VERSION="$(node -p "require('./package.json').version")"
           # Compare using node for reliable semver comparison
           USE_PKG="$(node -e "
             const [a, b] = ['${PKG_VERSION}', '${AUTO_VERSION}'].map(v => v.split('.').map(Number));

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 # Default target
 help:
-	@echo "openclaw-engram — available make targets:"
+	@echo "remnic — available make targets:"
 	@echo ""
 	@echo "  make build           Compile TypeScript to dist/"
 	@echo "  make test            Run full test suite"

--- a/dashboard/public/index.html
+++ b/dashboard/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Engram Graph Dashboard</title>
+    <title>Remnic Graph Dashboard</title>
     <style>
       :root {
         color-scheme: light;
@@ -68,7 +68,7 @@
   </head>
   <body>
     <div class="wrap">
-      <h1>Engram Graph Dashboard</h1>
+      <h1>Remnic Graph Dashboard</h1>
       <div class="card">
         <div class="row">
           <span class="pill">status: <strong id="status">loading</strong></span>
@@ -92,4 +92,3 @@
     <script src="/app.js"></script>
   </body>
   </html>
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# Engram Docs
+# Remnic Docs
 
 ## Getting Started
 
@@ -40,6 +40,6 @@
 
 ## Plans / Roadmaps
 
-- [Engram Feature Roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1) — Current priority order, blockers, and next work
+- [Remnic Feature Roadmap (GitHub Project)](https://github.com/users/joshuaswarren/projects/1) — Current priority order, blockers, and next work
 - [Plans Index](plans/README.md) — Historical design plans and archive layout
 - [Research Paper Mapping](research/paper-mapping.md) — How live features map to the papers and concepts that inspired them

--- a/docs/RENAME.md
+++ b/docs/RENAME.md
@@ -1,6 +1,6 @@
 # Engram → Remnic Rename Plan
 
-**Status:** Proposed
+**Status:** In Progress
 **Owner:** @joshuaswarren
 **Target:** Execute before first 1.0.0 publish
 
@@ -484,7 +484,7 @@ conditions are evidence-based, not calendar-based.
 
 ## Decisions Open
 
-_None — plan is fully locked. Ready to merge and execute Phase A + B._
+_None — plan is fully locked. Execution is underway; publish and brand rollout remain._
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,27 +6,27 @@ The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder
 
 | Command | Description |
 |---------|-------------|
-| `engram init` | Create `engram.config.json` in the current directory |
-| `engram status [--json]` | Show server/daemon status and health |
-| `engram query <text> [--json] [--explain]` | Query memories; `--explain` shows per-tier latency breakdown |
-| `engram doctor` | Run diagnostics (Node version, config, API key, memory dir, daemon status) |
-| `engram config` | Show current resolved configuration |
-| `engram daemon <start\|stop\|restart>` | Manage the background HTTP server |
-| `engram tree <generate\|watch\|validate>` | Workspace context tree operations |
-| `engram onboard [dir] [--json]` | Analyze a project directory (language detection, doc discovery, ingestion plan) |
-| `engram curate <path> [--json]` | Curate files into memory with duplicate/contradiction detection |
-| `engram review <list\|approve\|dismiss\|flag> [id]` | Review inbox management |
-| `engram sync <run\|watch> [--source <dir>]` | Diff-aware filesystem sync |
-| `engram dedup [--json]` | Find duplicate memories |
-| `engram connectors <list\|install\|remove\|doctor> [id]` | Manage host adapter connectors |
-| `engram space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
-| `engram benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
+| `remnic init` | Create `remnic.config.json` in the current directory |
+| `remnic status [--json]` | Show server/daemon status and health |
+| `remnic query <text> [--json] [--explain]` | Query memories; `--explain` shows per-tier latency breakdown |
+| `remnic doctor` | Run diagnostics (Node version, config, API key, memory dir, daemon status) |
+| `remnic config` | Show current resolved configuration |
+| `remnic daemon <start\|stop\|restart>` | Manage the background HTTP server |
+| `remnic tree <generate\|watch\|validate>` | Workspace context tree operations |
+| `remnic onboard [dir] [--json]` | Analyze a project directory (language detection, doc discovery, ingestion plan) |
+| `remnic curate <path> [--json]` | Curate files into memory with duplicate/contradiction detection |
+| `remnic review <list\|approve\|dismiss\|flag> [id]` | Review inbox management |
+| `remnic sync <run\|watch> [--source <dir>]` | Diff-aware filesystem sync |
+| `remnic dedup [--json]` | Find duplicate memories |
+| `remnic connectors <list\|install\|remove\|doctor> [id]` | Manage host adapter connectors |
+| `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
+| `remnic benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
 
 All commands accept `--json` for machine-readable output. The CLI resolves configuration from:
 
-1. `ENGRAM_CONFIG_PATH` environment variable
-2. `./engram.config.json` in the current directory
-4. `~/.config/engram/config.json` (default)
+1. `REMNIC_CONFIG_PATH` environment variable (`ENGRAM_CONFIG_PATH` is still accepted in v1.x)
+2. `./remnic.config.json` in the current directory
+3. `~/.config/remnic/config.json` (default)
 
 See the [Platform Migration Guide](guides/platform-migration.md) for detailed setup and usage instructions.
 
@@ -203,22 +203,24 @@ openclaw engram access mcp-serve
 
 Available MCP tools:
 
-- `engram.recall`
-- `engram.recall_explain`
-- `engram.memory_get`
-- `engram.memory_timeline`
-- `engram.memory_store`
-- `engram.suggestion_submit`
-- `engram.entity_get`
-- `engram.review_queue_list`
-- `engram.observe`
-- `engram.lcm_search`
+- `remnic.recall`
+- `remnic.recall_explain`
+- `remnic.memory_get`
+- `remnic.memory_timeline`
+- `remnic.memory_store`
+- `remnic.suggestion_submit`
+- `remnic.entity_get`
+- `remnic.review_queue_list`
+- `remnic.observe`
+- `remnic.lcm_search`
+
+The legacy `engram.*` aliases remain available through the v1.x compatibility window.
 
 The MCP adapter calls the same `EngramAccessService` methods used by HTTP, so equivalent request classes return the same structured payloads.
 
-#### `engram.observe`
+#### `remnic.observe`
 
-Feed conversation messages into Engram's memory pipeline (LCM archive + extraction).
+Feed conversation messages into Remnic's memory pipeline (LCM archive + extraction).
 
 **Parameters:**
 - `sessionKey` (string, required) — conversation session identifier
@@ -228,7 +230,7 @@ Feed conversation messages into Engram's memory pipeline (LCM archive + extracti
 
 **Returns:** `{ accepted, sessionKey, namespace, lcmArchived, extractionQueued }`
 
-#### `engram.lcm_search`
+#### `remnic.lcm_search`
 
 Search the LCM conversation archive for matching content using full-text search.
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -34,7 +34,7 @@ Published automatically by `.github/workflows/release-and-publish.yml`:
 |---------|----------|----------|
 | `packages/remnic-core` | `@remnic/core` | npm |
 | `packages/remnic-server` | `@remnic/server` | npm |
-| `packages/remnic-cli` | `engram` | npm |
+| `packages/remnic-cli` | `@remnic/cli` | npm |
 | `packages/plugin-openclaw` | `@remnic/plugin-openclaw` | npm |
 | `packages/shim-openclaw-engram` | `@joshuaswarren/openclaw-engram` | npm |
 | `packages/plugin-claude-code` | `@remnic/plugin-claude-code` | npm |
@@ -44,6 +44,12 @@ Published automatically by `.github/workflows/release-and-publish.yml`:
 | `packages/hermes-provider` | `@remnic/hermes-provider` | npm |
 
 All npm publishes include provenance attestations.
+
+For the first public Remnic publish, the workflow treats the workspace root
+`package.json` version as authoritative while `@remnic/core` is still absent
+from npm. That bootstrap rule prevents the release job from inheriting the old
+Engram `v9.x` tag line before the `1.0.0` Remnic packages exist on the
+registry.
 
 ### PyPI Package
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -72,7 +72,7 @@ Verify startup:
 
 ```bash
 grep '\[engram\]' ~/.openclaw/logs/gateway.log | tail -5
-# Should see: [engram] started
+# Should see the memory service start line (the log prefix remains [engram] during v1.x)
 ```
 
 ## Set Up QMD (Recommended)
@@ -145,7 +145,7 @@ qmd status           # should show existing collections
 # 4. Restart the gateway
 launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
 
-# 5. Verify Engram picked up QMD 2.0
+# 5. Verify Remnic picked up QMD 2.0
 grep "cliVersion" ~/.openclaw/logs/gateway.log | tail -1
 # Should show: cliVersion=qmd 2.0.x
 ```

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -1,33 +1,33 @@
-# Using Engram with Codex CLI
+# Using Remnic with Codex CLI
 
-[Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-based coding agent. It reads, writes, and executes code locally while keeping your source on your machine. This guide shows how to give Codex persistent, cross-session memory through Engram — so it remembers your projects, preferences, and past decisions every time you start a session.
+[Codex CLI](https://github.com/openai/codex) is OpenAI's terminal-based coding agent. It reads, writes, and executes code locally while keeping your source on your machine. This guide shows how to give Codex persistent, cross-session memory through Remnic — so it remembers your projects, preferences, and past decisions every time you start a session.
 
 ## Why give Codex memory?
 
-Codex is stateless by default. Every session starts from zero — it doesn't know your project conventions, past debugging sessions, or architecture decisions unless you re-explain them. Engram fixes this.
+Codex is stateless by default. Every session starts from zero — it doesn't know your project conventions, past debugging sessions, or architecture decisions unless you re-explain them. Remnic fixes this.
 
-### What changes with Engram
+### What changes with Remnic
 
-| Without Engram | With Engram |
+| Without Remnic | With Remnic |
 |---|---|
 | Re-explain project conventions every session | Codex recalls coding standards, naming patterns, and folder structure automatically |
 | Repeat architecture context for every task | Entity knowledge surfaces DB schemas, API contracts, and module boundaries on demand |
 | Lose debugging context between sessions | Past root-cause analyses and dead-end paths are recalled, avoiding repeated work |
 | Manually state preferences (test runner, linter, git workflow) | Preferences persist across sessions and projects |
-| Third-party integration details forgotten | Engram entities store API details, service endpoints, and integration patterns |
+| Third-party integration details forgotten | Remnic entities store API details, service endpoints, and integration patterns |
 | Context-switching tax when resuming work | Session-start recall brings you back to speed instantly |
 
 ### Concrete examples
 
-- **"Use snake_case for database columns"** — Engram recalls this convention before Codex generates a migration.
-- **"The payments module talks to Stripe via `PaymentGateway` service"** — Engram surfaces this when Codex works on checkout code.
-- **"Last time we debugged the N+1 query, the fix was eager-loading `user.orders`"** — Engram prevents re-investigating the same issue.
-- **"Joshua prefers pytest with strict typing and async-first design"** — Engram adapts Codex's suggestions to your style.
+- **"Use snake_case for database columns"** — Remnic recalls this convention before Codex generates a migration.
+- **"The payments module talks to Stripe via `PaymentGateway` service"** — Remnic surfaces this when Codex works on checkout code.
+- **"Last time we debugged the N+1 query, the fix was eager-loading `user.orders`"** — Remnic prevents re-investigating the same issue.
+- **"Joshua prefers pytest with strict typing and async-first design"** — Remnic adapts Codex's suggestions to your style.
 
 ## Prerequisites
 
 - Codex CLI v0.114.0+ (`codex --version`)
-- Engram HTTP server running and reachable (see [API docs](../api.md#mcp-over-http))
+- Remnic HTTP server running and reachable (see [API docs](../api.md#mcp-over-http))
 - A bearer token for authentication
 - `python3` and `curl` available in your PATH
 
@@ -35,53 +35,53 @@ Codex is stateless by default. Every session starts from zero — it doesn't kno
 
 ### 1. Generate and set the token
 
-Generate a secure token and add it to your shell profile (`~/.zshenv`, `~/.bashrc`, etc.) on every machine where Codex or Engram runs:
+Generate a secure token and add it to your shell profile (`~/.zshenv`, `~/.bashrc`, etc.) on every machine where Codex or Remnic runs:
 
 ```bash
 # Generate a token (or use any secure random string)
 openssl rand -base64 32
 
 # Add to your shell profile
-export OPENCLAW_ENGRAM_ACCESS_TOKEN="<paste-generated-token-here>"
+export OPENCLAW_REMNIC_ACCESS_TOKEN="<paste-generated-token-here>"
 ```
 
 Source the profile or open a new terminal so the variable is available.
 
-### 2. Start the Engram HTTP server
+### 2. Start the Remnic HTTP server
 
-On the machine where Engram runs:
+On the machine where Remnic runs:
 
 ```bash
 openclaw engram access http-serve \
   --host 0.0.0.0 \
   --port 4318 \
-  --token "$OPENCLAW_ENGRAM_ACCESS_TOKEN"
+  --token "$OPENCLAW_REMNIC_ACCESS_TOKEN"
 ```
 
-If you have `namespacesEnabled: true` in your Engram config, also pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace:
+If you have `namespacesEnabled: true` in your Remnic config, also pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace:
 
 ```bash
 openclaw engram access http-serve \
   --host 0.0.0.0 \
   --port 4318 \
   --principal generalist \
-  --token "$OPENCLAW_ENGRAM_ACCESS_TOKEN"
+  --token "$OPENCLAW_REMNIC_ACCESS_TOKEN"
 ```
 
 For persistent operation, set up a launchd plist (macOS), systemd unit (Linux), or similar service manager so the server survives reboots.
 
-### 3. Add Engram as an MCP server
+### 3. Add Remnic as an MCP server
 
 Edit `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.engram]
-url = "http://<engram-host>:4318/mcp"
-bearer_token_env_var = "OPENCLAW_ENGRAM_ACCESS_TOKEN"
+[mcp_servers.remnic]
+url = "http://<remnic-host>:4318/mcp"
+bearer_token_env_var = "OPENCLAW_REMNIC_ACCESS_TOKEN"
 ```
 
-Replace `<engram-host>` with:
-- `127.0.0.1` if Codex and Engram run on the same machine
+Replace `<remnic-host>` with:
+- `127.0.0.1` if Codex and Remnic run on the same machine
 - The machine's LAN IP or Tailscale IP for cross-machine access
 
 Verify with:
@@ -90,17 +90,17 @@ Verify with:
 codex mcp list
 ```
 
-You should see `engram` in the URL-based servers section with `Bearer token` auth.
+You should see `remnic` in the URL-based servers section with `Bearer token` auth.
 
 ### 4. Set up the SessionStart hook (recommended)
 
-The hook automatically recalls relevant Engram memories at the start of every Codex session, injecting them as context before your first message.
+The hook automatically recalls relevant Remnic memories at the start of every Codex session, injecting them as context before your first message.
 
-Create the hook script at `~/.codex/scripts/engram-session-recall.sh`:
+Create the hook script at `~/.codex/scripts/remnic-session-recall.sh`:
 
 ```bash
 #!/usr/bin/env bash
-# Codex SessionStart hook: recall Engram context at session start.
+# Codex SessionStart hook: recall Remnic context at session start.
 set -euo pipefail
 
 REMNIC_HOST="${REMNIC_HOST:-127.0.0.1}"
@@ -119,11 +119,11 @@ QUERY="Starting a new coding session in project: ${PROJECT_NAME}. Recall relevan
 
 # If no token, skip gracefully
 if [ -z "$REMNIC_TOKEN" ]; then
-  echo '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"[Engram: no token set — skipping memory recall]"}}'
+  echo '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"[Remnic: no token set — skipping memory recall]"}}'
   exit 0
 fi
 
-# Call Engram recall API
+# Call Remnic recall API
 RESPONSE="$(curl -s --max-time 8 \
   -X POST "$REMNIC_URL" \
   -H "Authorization: Bearer ${REMNIC_TOKEN}" \
@@ -140,14 +140,14 @@ try:
     ctx = d.get('context', '')
     count = d.get('count', 0)
     if ctx:
-        print(f'[Engram Memory Recall — {count} memories]\n\n{ctx}')
+        print(f'[Remnic Memory Recall — {count} memories]\n\n{ctx}')
     else:
-        print('[Engram: no relevant memories found for this session]')
+        print('[Remnic: no relevant memories found for this session]')
 except Exception:
-    print('[Engram: recall response parse error]')
-" 2>/dev/null || echo "[Engram: recall failed]")"
+    print('[Remnic: recall response parse error]')
+" 2>/dev/null || echo "[Remnic: recall failed]")"
 else
-  CONTEXT="[Engram: server unreachable — continuing without memory recall]"
+  CONTEXT="[Remnic: server unreachable — continuing without memory recall]"
 fi
 
 # Return hook output with additionalContext
@@ -168,7 +168,7 @@ print(json.dumps(output))
 Make it executable:
 
 ```bash
-chmod +x ~/.codex/scripts/engram-session-recall.sh
+chmod +x ~/.codex/scripts/remnic-session-recall.sh
 ```
 
 Configure the hook in `~/.codex/hooks.json`:
@@ -181,7 +181,7 @@ Configure the hook in `~/.codex/hooks.json`:
         "hooks": [
           {
             "type": "command",
-            "command": "<full-path-to>/engram-session-recall.sh",
+            "command": "<full-path-to>/remnic-session-recall.sh",
             "timeout": 15
           }
         ]
@@ -191,44 +191,44 @@ Configure the hook in `~/.codex/hooks.json`:
 }
 ```
 
-Replace `<full-path-to>` with the absolute path (e.g., `/Users/you/.codex/scripts/engram-session-recall.sh`).
+Replace `<full-path-to>` with the absolute path (e.g., `/Users/you/.codex/scripts/remnic-session-recall.sh`).
 
-### 5. Tell Codex how to use Engram (optional)
+### 5. Tell Codex how to use Remnic (optional)
 
-You can add instructions to your `AGENTS.md` (global or project-level) to guide Codex on when to use Engram tools:
+You can add instructions to your `AGENTS.md` (global or project-level) to guide Codex on when to use Remnic tools:
 
 ```markdown
 ## Memory
 
 Remnic is available as an MCP server for long-term memory.
 
-- Use `engram.recall` for targeted lookups on specific topics.
-- Use `engram.memory_store` to persist durable facts, preferences, decisions, and corrections.
-- Use `engram.entity_get` to look up known entities (people, projects, tools, companies).
-- If the Engram MCP server is unavailable, proceed without memory.
+- Use `remnic.recall` for targeted lookups on specific topics.
+- Use `remnic.memory_store` to persist durable facts, preferences, decisions, and corrections.
+- Use `remnic.entity_get` to look up known entities (people, projects, tools, companies).
+- If the Remnic MCP server is unavailable, proceed without memory.
 ```
 
 ## Available tools
 
-Once connected, Codex has access to these Engram MCP tools:
+Once connected, Codex has access to these Remnic MCP tools:
 
 | Tool | Purpose |
 |------|---------|
-| `engram.recall` | Retrieve relevant memories for a query |
-| `engram.recall_explain` | Debug the last recall (what was retrieved and why) |
-| `engram.memory_get` | Fetch a specific memory by ID |
-| `engram.memory_timeline` | View a memory's lifecycle history |
-| `engram.memory_store` | Store a new explicit memory |
-| `engram.suggestion_submit` | Queue a memory suggestion for review |
-| `engram.entity_get` | Look up a known entity by name |
-| `engram.review_queue_list` | View the governance review queue |
+| `remnic.recall` | Retrieve relevant memories for a query |
+| `remnic.recall_explain` | Debug the last recall (what was retrieved and why) |
+| `remnic.memory_get` | Fetch a specific memory by ID |
+| `remnic.memory_timeline` | View a memory's lifecycle history |
+| `remnic.memory_store` | Store a new explicit memory |
+| `remnic.suggestion_submit` | Queue a memory suggestion for review |
+| `remnic.entity_get` | Look up a known entity by name |
+| `remnic.review_queue_list` | View the governance review queue |
 
 ## Cross-machine setup
 
-If Engram runs on a different machine than Codex (e.g., a home server), use a VPN or overlay network like [Tailscale](https://tailscale.com) to make the HTTP server reachable:
+If Remnic runs on a different machine than Codex (e.g., a home server), use a VPN or overlay network like [Tailscale](https://tailscale.com) to make the HTTP server reachable:
 
 1. Install Tailscale on both machines
-2. Use the Engram host's Tailscale IP in `config.toml` and the hook script
+2. Use the Remnic host's Tailscale IP in `config.toml` and the hook script
 3. Set `REMNIC_HOST` in the hook script to the Tailscale IP
 
 The hook script gracefully degrades — if the Remnic server is unreachable or the token is missing, it skips recall and lets the session proceed normally.
@@ -237,24 +237,24 @@ The hook script gracefully degrades — if the Remnic server is unreachable or t
 
 After setup, start a new Codex session and check:
 
-1. **MCP tools available:** Ask Codex to list its available tools — you should see `engram.*` tools.
-2. **Recall working:** The session should start with `[Engram Memory Recall — N memories]` context if the hook is configured.
-3. **Writes working:** Ask Codex to store a test memory: `Use engram.memory_store to save "test memory from Codex" with category "fact" and dryRun true`. It should return `"status": "validated"`.
+1. **MCP tools available:** Ask Codex to list its available tools — you should see `remnic.*` tools.
+2. **Recall working:** The session should start with `[Remnic Memory Recall — N memories]` context if the hook is configured.
+3. **Writes working:** Ask Codex to store a test memory: `Use remnic.memory_store to save "test memory from Codex" with category "fact" and dryRun true`. It should return `"status": "validated"`.
 
 ## Troubleshooting
 
-**Engram tools not showing up in Codex:**
+**Remnic tools not showing up in Codex:**
 - Codex loads MCP servers at session start. If the server was down when the session started, restart Codex.
-- Verify with `codex mcp list` — engram should show `enabled` with `Bearer token` auth.
-- Check the server is reachable: `curl -s http://<host>:4318/mcp -X POST -H "Authorization: Bearer $OPENCLAW_ENGRAM_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
+- Verify with `codex mcp list` — remnic should show `enabled` with `Bearer token` auth.
+- Check the server is reachable: `curl -s http://<host>:4318/mcp -X POST -H "Authorization: Bearer $OPENCLAW_REMNIC_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
 
 **"namespace is not writable" error:**
-- You have `namespacesEnabled: true` in your Engram config. Pass `--principal <name>` when starting the HTTP server, where `<name>` is in the `writePrincipals` list for your target namespace.
+- You have `namespacesEnabled: true` in your Remnic config. Pass `--principal <name>` when starting the HTTP server, where `<name>` is in the `writePrincipals` list for your target namespace.
 
 **Hook not firing:**
 - Verify `~/.codex/hooks.json` exists and uses the correct absolute path.
 - Ensure the script is executable (`chmod +x`).
-- Check that `OPENCLAW_ENGRAM_ACCESS_TOKEN` is set in your shell environment.
+- Check that `OPENCLAW_REMNIC_ACCESS_TOKEN` is set in your shell environment.
 
 **Slow session start:**
 - The hook has a 15-second timeout. If the Remnic server is slow to respond, increase the `timeout` value in `hooks.json` or reduce `topK` in the recall query.

--- a/docs/guides/daemon-management.md
+++ b/docs/guides/daemon-management.md
@@ -1,11 +1,11 @@
 # Daemon Management
 
-EMO (Engram Memory Orchestrator) runs as a background daemon that starts automatically on boot.
+The Remnic daemon runs as a background service that starts automatically on boot. Older docs and compatibility surfaces may still refer to it as EMO (Engram Memory Orchestrator).
 
 ## Installation
 
 ```bash
-engram daemon install
+remnic daemon install
 ```
 
 This:
@@ -16,41 +16,41 @@ This:
 
 ### macOS (launchd)
 
-Service file: `~/Library/LaunchAgents/ai.engram.daemon.plist`
+Service file: `~/Library/LaunchAgents/ai.remnic.daemon.plist`
 
 ```bash
 # Manual control
-launchctl kickstart -k gui/$(id -u)/ai.engram.daemon    # restart
-launchctl kill SIGTERM gui/$(id -u)/ai.engram.daemon     # stop
+launchctl kickstart -k gui/$(id -u)/ai.remnic.daemon    # restart
+launchctl kill SIGTERM gui/$(id -u)/ai.remnic.daemon    # stop
 ```
 
 ### Linux (systemd)
 
-Service file: `~/.config/systemd/user/engram.service`
+Service file: `~/.config/systemd/user/remnic.service`
 
 ```bash
 # Manual control
-systemctl --user restart engram
-systemctl --user stop engram
-systemctl --user status engram
+systemctl --user restart remnic
+systemctl --user stop remnic
+systemctl --user status remnic
 ```
 
 ## CLI Commands
 
 ```bash
-engram daemon install     # write service file + enable + start
-engram daemon uninstall   # disable + remove service file
-engram daemon start       # start now (without installing service)
-engram daemon stop        # stop now
-engram daemon restart     # restart
-engram daemon status      # show running state, port, memory path
+remnic daemon install     # write service file + enable + start
+remnic daemon uninstall   # disable + remove service file
+remnic daemon start       # start now (without installing service)
+remnic daemon stop        # stop now
+remnic daemon restart     # restart
+remnic daemon status      # show running state, port, memory path
 ```
 
 ## Configuration
 
 ### Config File
 
-`~/.config/engram/config.json` (or `ENGRAM_CONFIG_PATH` env var):
+`~/.config/remnic/config.json` (or `REMNIC_CONFIG_PATH`; `ENGRAM_CONFIG_PATH` still works during v1.x):
 
 ```json
 {
@@ -59,8 +59,8 @@ engram daemon status      # show running state, port, memory path
     "port": 4318,
     "maxBodyBytes": 10485760
   },
-  "engram": {
-    "memoryDir": "~/.engram/memory/",
+  "remnic": {
+    "memoryDir": "~/.remnic/memory/",
     "openaiApiKey": "${OPENAI_API_KEY}",
     "searchBackend": "qmd",
     "recallBudgetChars": 64000
@@ -72,8 +72,8 @@ engram daemon status      # show running state, port, memory path
 
 | Variable | Default | Description |
 |----------|---------|-------------|
-| `ENGRAM_CONFIG_PATH` | `~/.config/engram/config.json` | Config file path |
-| `ENGRAM_MEMORY_DIR` | `~/.engram/memory/` | Memory store directory |
+| `REMNIC_CONFIG_PATH` | `~/.config/remnic/config.json` | Config file path (`ENGRAM_CONFIG_PATH` also supported in v1.x) |
+| `REMNIC_MEMORY_DIR` | `~/.remnic/memory/` | Memory store directory (`ENGRAM_MEMORY_DIR` also supported in v1.x) |
 | `REMNIC_HOST` | `127.0.0.1` | Bind address (`ENGRAM_HOST` also supported) |
 | `REMNIC_PORT` | `4318` | Bind port (`ENGRAM_PORT` also supported) |
 | `OPENAI_API_KEY` | — | Required for LLM extraction |
@@ -82,24 +82,24 @@ engram daemon status      # show running state, port, memory path
 
 ```bash
 # View daemon logs
-tail -f ~/.engram/logs/daemon.log
+tail -f ~/.remnic/logs/daemon.log
 
 # View hook-specific logs
-tail -f ~/.engram/logs/engram-session-recall.log
-tail -f ~/.engram/logs/engram-post-tool-observe.log
+tail -f ~/.remnic/logs/engram-session-recall.log
+tail -f ~/.remnic/logs/engram-post-tool-observe.log
 ```
 
 ## Health Check
 
 ```bash
 # CLI check
-engram daemon status
+remnic daemon status
 
 # HTTP check
 curl http://localhost:4318/engram/v1/health
 
 # Full diagnostics
-engram doctor
+remnic doctor
 ```
 
 ## Port Conflicts
@@ -111,24 +111,24 @@ If another process is using `:4318`:
 lsof -i :4318
 
 # Use a different port
-engram daemon stop
-# Edit ~/.config/engram/config.json → "port": 4320
-engram daemon start
+remnic daemon stop
+# Edit ~/.config/remnic/config.json → "port": 4320
+remnic daemon start
 ```
 
 Then update your plugin configs to use the new port.
 
 ## Security
 
-- EMO binds to `127.0.0.1` by default (localhost only)
-- To expose EMO on the network, set `"host": "0.0.0.0"` — but ensure token auth is configured
-- Tokens stored in `~/.engram/tokens.json` with `0600` permissions
+- Remnic binds to `127.0.0.1` by default (localhost only)
+- To expose it on the network, set `"host": "0.0.0.0"` — but ensure token auth is configured
+- Tokens are stored in `~/.remnic/tokens.json`; `~/.engram/tokens.json` is still read as a migration fallback during v1.x
 - See [auth-model.md](../architecture/auth-model.md) for token management
 
 ## Uninstall
 
 ```bash
-engram daemon uninstall
+remnic daemon uninstall
 ```
 
-This stops the daemon and removes the service file. Memory files at `~/.engram/memory/` are preserved.
+This stops the daemon and removes the service file. Memory files at `~/.remnic/memory/` are preserved.

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -1,27 +1,27 @@
-# Quickstart: Install Engram in 5 Minutes
+# Quickstart: Install Remnic in 5 Minutes
 
 Remnic is a universal memory system for AI agents. Install it once, connect your tools, and all your agents share the same memory.
 
-## Step 1: Install Engram
+## Step 1: Install Remnic
 
 ```bash
-npm install -g engram
+npm install -g @remnic/cli
 ```
 
 ## Step 2: Start the Daemon
 
 ```bash
-engram daemon install
+remnic daemon install
 ```
 
-This starts EMO (Engram Memory Orchestrator) and configures it to auto-start on boot.
+This starts the Remnic daemon (historically called EMO) and configures it to auto-start on boot.
 
 Verify:
 
 ```bash
-engram daemon status
-# ✓ EMO running on :4318
-# ✓ Memory store: ~/.engram/memory/
+remnic daemon status
+# ✓ Remnic server running on :4318
+# ✓ Memory store: ~/.remnic/memory/
 # ✓ Auto-start: enabled
 ```
 
@@ -31,16 +31,16 @@ Install plugins for the AI tools you use:
 
 ```bash
 # Connect Claude Code (hooks + MCP + skills)
-engram connectors install claude-code
+remnic connectors install claude-code
 
 # Connect Codex CLI (hooks + MCP + skills)
-engram connectors install codex
+remnic connectors install codex
 
 # Connect Hermes Agent (MemoryProvider + tools)
-engram connectors install hermes
+remnic connectors install hermes
 
 # Connect Replit Agent (MCP only)
-engram connectors install replit
+remnic connectors install replit
 ```
 
 Each command generates a dedicated auth token and installs the native plugin for that platform.
@@ -48,7 +48,7 @@ Each command generates a dedicated auth token and installs the native plugin for
 ## Step 4: Verify
 
 ```bash
-engram connectors doctor
+remnic connectors doctor
 # ✓ claude-code: connected, 44 tools available
 # ✓ codex: connected, 44 tools available
 # ✓ hermes: connected, MemoryProvider active
@@ -57,11 +57,11 @@ engram connectors doctor
 
 ## Step 5: Use It
 
-Just use your AI tools normally. Engram works automatically:
+Just use your AI tools normally. Remnic works automatically:
 
-- **Start a session** → Engram recalls your preferences and project context
-- **Type a prompt** → Engram injects relevant memories
-- **Edit files** → Engram observes and learns patterns
+- **Start a session** → Remnic recalls your preferences and project context
+- **Type a prompt** → Remnic injects relevant memories
+- **Edit files** → Remnic observes and learns patterns
 - **Switch tools** → memories carry over instantly
 
 ### Try it
@@ -72,6 +72,8 @@ In Claude Code:
 > /engram:recall programming preferences
 ```
 
+The slash commands still use the legacy `/engram:*` names during the v1.x compatibility window. The product and CLI are now `remnic`.
+
 Then open Codex CLI and start a new session — it already knows your preference.
 
 ## Already Using OpenClaw?
@@ -79,7 +81,7 @@ Then open Codex CLI and start a new session — it already knows your preference
 If you're an existing OpenClaw user:
 
 ```bash
-engram connectors install openclaw
+remnic connectors install openclaw
 ```
 
 This upgrades OEO to expose `:4318` so other agents can share the same memory store OpenClaw uses. Your existing memories are untouched.

--- a/docs/plugins/claude-code.md
+++ b/docs/plugins/claude-code.md
@@ -1,15 +1,15 @@
 # Claude Code Plugin
 
-Native Engram plugin for Claude Code. Provides automatic memory recall on every prompt, observation of file changes, and explicit memory skills.
+Native Remnic plugin for Claude Code. Provides automatic memory recall on every prompt, observation of file changes, and explicit memory skills.
 
 ## Installation
 
 ```bash
-engram connectors install claude-code
+remnic connectors install claude-code
 ```
 
 This:
-1. Starts the EMO daemon if not running (with auto-start on boot)
+1. Starts the Remnic daemon if not running (with auto-start on boot)
 2. Generates a dedicated auth token
 3. Installs the plugin to Claude Code's plugin directory
 4. Configures MCP server pointing to `http://localhost:4318/mcp`
@@ -37,11 +37,11 @@ Memory is **mandatory** — the plugin enforces it via lifecycle hooks. You don'
 | `/engram:recall <query>` | Search memories ("what do I know about auth?") |
 | `/engram:search <query>` | Semantic search across all memories |
 | `/engram:entities` | List all tracked entities (people, projects, tools) |
-| `/engram:status` | Show Engram connection status and memory stats |
+| `/engram:status` | Show Remnic connection status and memory stats |
 
 ### MCP Tools
 
-All 44 Engram MCP tools are available for advanced operations: governance, work tracking, shared context, identity continuity, etc.
+All 44 Remnic MCP tools are available for advanced operations: governance, work tracking, shared context, identity continuity, etc. The slash commands still use the legacy `/engram:*` names during the v1.x compatibility window.
 
 ## How Memory Injection Works
 
@@ -76,7 +76,7 @@ When Claude Code writes or edits a file, the hook:
 
 ## Configuration
 
-The plugin reads its token from `~/.engram/tokens.json` and connects to EMO at `127.0.0.1:4318`.
+The plugin reads its token from `~/.remnic/tokens.json`, with `~/.engram/tokens.json` still accepted as a migration fallback, and connects to the Remnic daemon at `127.0.0.1:4318`.
 
 Override the server address:
 
@@ -87,13 +87,13 @@ export REMNIC_PORT=4318
 
 ## Troubleshooting
 
-### "Engram: server unreachable"
+### "Remnic: server unreachable"
 
-EMO daemon isn't running. Fix:
+The Remnic daemon isn't running. Fix:
 
 ```bash
-engram daemon status     # check
-engram daemon install    # install + start
+remnic daemon status     # check
+remnic daemon install    # install + start
 ```
 
 ### Slow recall on prompts
@@ -101,7 +101,7 @@ engram daemon install    # install + start
 The `UserPromptSubmit` hook has a 20s timeout. If recall is consistently slow:
 
 ```bash
-engram doctor            # check search backend health
+remnic doctor            # check search backend health
 ```
 
 ### No memories being stored
@@ -109,17 +109,17 @@ engram doctor            # check search backend health
 Check that the `PostToolUse` hook is firing:
 
 ```bash
-tail -f ~/.engram/logs/engram-post-tool-observe.log
+tail -f ~/.remnic/logs/engram-post-tool-observe.log
 ```
 
 ### Plugin not loading
 
 ```bash
-engram connectors doctor claude-code
+remnic connectors doctor claude-code
 ```
 
 ## Uninstall
 
 ```bash
-engram connectors remove claude-code
+remnic connectors remove claude-code
 ```

--- a/docs/plugins/codex.md
+++ b/docs/plugins/codex.md
@@ -1,19 +1,19 @@
 # Codex CLI Plugin
 
-Native Engram plugin for OpenAI Codex CLI. Provides automatic memory recall, observation, and session-end learning capture.
+Native Remnic plugin for OpenAI Codex CLI. Provides automatic memory recall, observation, and session-end learning capture.
 
 ## Installation
 
 ```bash
-engram connectors install codex
+remnic connectors install codex
 ```
 
 This:
-1. Starts the EMO daemon if not running
+1. Starts the Remnic daemon if not running
 2. Generates a dedicated auth token
 3. Installs the plugin to `~/.codex/plugins/`
 4. Enables hooks (`[features] codex_hooks = true` in `~/.codex/config.toml`)
-5. Configures MCP server pointing to EMO
+5. Configures MCP server pointing to Remnic
 6. Runs a health check
 
 ## What It Does
@@ -35,7 +35,7 @@ This:
 
 ### MCP Tools
 
-All 44 Engram MCP tools available via the `.mcp.json` configuration.
+All 44 Remnic MCP tools are available via the `.mcp.json` configuration. The legacy `engram.*` aliases remain available during v1.x.
 
 ## How It Differs from Claude Code Plugin
 
@@ -46,7 +46,7 @@ All 44 Engram MCP tools available via the `.mcp.json` configuration.
 
 ## Configuration
 
-Token read from `~/.engram/tokens.json`. Server defaults to `127.0.0.1:4318`.
+Token is read from `~/.remnic/tokens.json`, with `~/.engram/tokens.json` still accepted as a migration fallback. Server defaults to `127.0.0.1:4318`.
 
 ## Troubleshooting
 
@@ -66,5 +66,5 @@ grep codex_hooks ~/.codex/config.toml
 ## Uninstall
 
 ```bash
-engram connectors remove codex
+remnic connectors remove codex
 ```

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -15,7 +15,7 @@ remnic connectors install hermes
 
 ```bash
 # Copy to Hermes plugins directory
-cp -r packages/plugin-hermes/remnic_hermes ~/.hermes/plugins/engram/
+cp -r packages/plugin-hermes/remnic_hermes ~/.hermes/plugins/remnic/
 
 # Or install as development plugin
 cd packages/plugin-hermes
@@ -23,7 +23,7 @@ pip install -e .
 ```
 
 The `remnic connectors install hermes` command:
-1. Starts the EMO daemon if not running
+1. Starts the Remnic daemon if not running
 2. Generates a dedicated auth token
 3. Writes Hermes `config.yaml` entry
 4. Runs a health check
@@ -36,9 +36,9 @@ The plugin implements Hermes v0.7.0+ MemoryProvider protocol:
 
 | Method | When | What Happens |
 |--------|------|-------------|
-| `initialize(config)` | Plugin loads | Connects to EMO, validates token |
+| `initialize(config)` | Plugin loads | Connects to Remnic, validates token |
 | `pre_llm_call(messages)` | Before every LLM call | Recalls relevant memories, injects into system prompt |
-| `sync_turn(transcript)` | After every response | Observes conversation turn, sends to EMO for extraction |
+| `sync_turn(transcript)` | After every response | Observes conversation turn, sends to Remnic for extraction |
 | `extract_memories(session)` | Session ends | Triggers structured extraction of session learnings |
 | `shutdown()` | Plugin unloads | Cleanup, flush pending observations |
 
@@ -51,6 +51,10 @@ The plugin also registers tools the agent can call directly:
 | `engram_recall` | Search memories with a query |
 | `engram_store` | Store a memory explicitly |
 | `engram_search` | Semantic search across all memories |
+
+Hermes still exposes the legacy `engram_*` tool names today. The product and
+connector are Remnic; the tool names stay legacy until the Hermes-side
+compatibility window closes.
 
 ## Why MemoryProvider > MCP
 
@@ -97,13 +101,13 @@ Hermes profiles isolate agent state under `~/.hermes/profiles/<name>/`. Each pro
 ```yaml
 # Profile: research
 memory_providers:
-  - name: engram
+  - name: remnic
     config:
       namespace: "research"
 
 # Profile: coding
 memory_providers:
-  - name: engram
+  - name: remnic
     config:
       namespace: "coding"
 ```
@@ -114,7 +118,7 @@ Or use the default namespace to share memories across profiles.
 
 ### "MemoryProvider remnic failed to initialize"
 
-EMO daemon isn't running:
+Remnic daemon isn't running:
 
 ```bash
 remnic daemon status
@@ -123,10 +127,11 @@ remnic daemon install
 
 ### Memories not appearing in context
 
-Check that `pre_llm_call` is being called:
+Check both sides of the integration:
 
 ```bash
-tail -f ~/.engram/logs/hermes-provider.log
+remnic daemon status
+hermes --version
 ```
 
 ### Import errors
@@ -142,5 +147,5 @@ pip show remnic-hermes
 
 ```bash
 pip uninstall remnic-hermes
-engram connectors remove hermes
+remnic connectors remove hermes
 ```

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -1,6 +1,6 @@
 # remnic-hermes
 
-Engram MemoryProvider plugin for [Hermes Agent](https://github.com/hermes-agent/hermes).
+Remnic MemoryProvider plugin for [Hermes Agent](https://github.com/hermes-agent/hermes).
 
 Provides automatic memory recall on every LLM turn and observation of every response via the Hermes MemoryProvider protocol.
 
@@ -10,10 +10,10 @@ Provides automatic memory recall on every LLM turn and observation of every resp
 pip install remnic-hermes
 ```
 
-Or via the Engram CLI:
+Or via the Remnic CLI:
 
 ```bash
-engram connectors install hermes
+remnic connectors install hermes
 ```
 
 ## Configuration
@@ -29,6 +29,10 @@ engram:
   port: 4318
   token: ""  # auto-loaded from ~/.engram/tokens.json
 ```
+
+The Hermes-side config block is still named `engram:` today for compatibility.
+Install and connector management are Remnic-branded; the plugin config surface
+will stay legacy until the Hermes compatibility window closes.
 
 ## How It Works
 

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -24,7 +24,7 @@
     "provenance": true
   },
   "scripts": {
-    "build": "tsup src/index.ts --format esm --target es2022 --platform node --outDir dist --no-external @remnic/bench",
+    "build": "tsup --config tsup.config.ts",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "es2022",
+  platform: "node",
+  outDir: "dist",
+  clean: true,
+  noExternal: ["@remnic/bench"],
+});

--- a/tests/dashboard-server.test.ts
+++ b/tests/dashboard-server.test.ts
@@ -55,45 +55,47 @@ test("dashboard server serves health, graph, static assets, and websocket upgrad
     publicDir: path.join(process.cwd(), "dashboard", "public"),
   });
   const started = await server.start();
-  assert.equal(started.running, true);
-  assert.equal(started.port > 0, true);
+  try {
+    assert.equal(started.running, true);
+    assert.equal(started.port > 0, true);
 
-  const base = `http://${started.host}:${started.port}`;
-  const healthRes = await fetch(`${base}/api/health`);
-  assert.equal(healthRes.status, 200);
-  const health = await healthRes.json() as { ok: boolean };
-  assert.equal(health.ok, true);
+    const base = `http://${started.host}:${started.port}`;
+    const healthRes = await fetch(`${base}/api/health`);
+    assert.equal(healthRes.status, 200);
+    const health = await healthRes.json() as { ok: boolean };
+    assert.equal(health.ok, true);
 
-  const graphRes = await fetch(`${base}/api/graph`);
-  assert.equal(graphRes.status, 200);
-  const graph = await graphRes.json() as { stats: { edges: number; nodes: number } };
-  assert.equal(graph.stats.edges, 1);
-  assert.equal(graph.stats.nodes, 2);
+    const graphRes = await fetch(`${base}/api/graph`);
+    assert.equal(graphRes.status, 200);
+    const graph = await graphRes.json() as { stats: { edges: number; nodes: number } };
+    assert.equal(graph.stats.edges, 1);
+    assert.equal(graph.stats.nodes, 2);
 
-  const htmlRes = await fetch(`${base}/`);
-  assert.equal(htmlRes.status, 200);
-  const html = await htmlRes.text();
-  assert.match(html, /Engram Graph Dashboard/);
+    const htmlRes = await fetch(`${base}/`);
+    assert.equal(htmlRes.status, 200);
+    const html = await htmlRes.text();
+    assert.match(html, /Remnic Graph Dashboard/);
 
-  const socket = net.createConnection({ host: started.host, port: started.port });
-  socket.write(
-    [
-      "GET / HTTP/1.1",
-      `Host: ${started.host}:${started.port}`,
-      "Upgrade: WebSocket",
-      "Connection: Upgrade",
-      `Origin: http://${started.host}:${started.port}`,
-      "Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==",
-      "Sec-WebSocket-Version: 13",
-      "",
-      "",
-    ].join("\r\n"),
-  );
-  const upgradeResponse = await waitForSocketChunk(socket);
-  assert.match(upgradeResponse, /101 Switching Protocols/);
-  socket.destroy();
-
-  await server.stop();
+    const socket = net.createConnection({ host: started.host, port: started.port });
+    socket.write(
+      [
+        "GET / HTTP/1.1",
+        `Host: ${started.host}:${started.port}`,
+        "Upgrade: WebSocket",
+        "Connection: Upgrade",
+        `Origin: http://${started.host}:${started.port}`,
+        "Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==",
+        "Sec-WebSocket-Version: 13",
+        "",
+        "",
+      ].join("\r\n"),
+    );
+    const upgradeResponse = await waitForSocketChunk(socket);
+    assert.match(upgradeResponse, /101 Switching Protocols/);
+    socket.destroy();
+  } finally {
+    await server.stop();
+  }
 });
 
 test("dashboard origin check allows explicit and default http port 80", () => {
@@ -136,26 +138,27 @@ test("dashboard websocket upgrade rejects non-loopback origin", async () => {
     publicDir: path.join(process.cwd(), "dashboard", "public"),
   });
   const started = await server.start();
-
-  const socket = net.createConnection({ host: started.host, port: started.port });
-  socket.write(
-    [
-      "GET / HTTP/1.1",
-      `Host: ${started.host}:${started.port}`,
-      "Upgrade: WebSocket",
-      "Connection: Upgrade",
-      "Origin: http://evil.example",
-      "Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==",
-      "Sec-WebSocket-Version: 13",
-      "",
-      "",
-    ].join("\r\n"),
-  );
-  const upgradeResponse = await waitForSocketChunk(socket);
-  assert.match(upgradeResponse, /403 Forbidden/);
-  socket.destroy();
-
-  await server.stop();
+  try {
+    const socket = net.createConnection({ host: started.host, port: started.port });
+    socket.write(
+      [
+        "GET / HTTP/1.1",
+        `Host: ${started.host}:${started.port}`,
+        "Upgrade: WebSocket",
+        "Connection: Upgrade",
+        "Origin: http://evil.example",
+        "Sec-WebSocket-Key: AAAAAAAAAAAAAAAAAAAAAA==",
+        "Sec-WebSocket-Version: 13",
+        "",
+        "",
+      ].join("\r\n"),
+    );
+    const upgradeResponse = await waitForSocketChunk(socket);
+    assert.match(upgradeResponse, /403 Forbidden/);
+    socket.destroy();
+  } finally {
+    await server.stop();
+  }
 });
 
 test("dashboard server start recovers after listen failure", async () => {

--- a/tests/remnic-cli-package.test.ts
+++ b/tests/remnic-cli-package.test.ts
@@ -3,14 +3,18 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
 test("remnic CLI bundles the private bench package instead of publishing it as a runtime dependency", async () => {
-  const raw = await readFile("packages/remnic-cli/package.json", "utf8");
-  const pkg = JSON.parse(raw) as {
+  const [pkgRaw, tsupRaw] = await Promise.all([
+    readFile("packages/remnic-cli/package.json", "utf8"),
+    readFile("packages/remnic-cli/tsup.config.ts", "utf8"),
+  ]);
+  const pkg = JSON.parse(pkgRaw) as {
     scripts?: { build?: string };
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
   };
 
-  assert.match(pkg.scripts?.build ?? "", /--no-external @remnic\/bench/);
+  assert.equal(pkg.scripts?.build, "tsup --config tsup.config.ts");
+  assert.match(tsupRaw, /noExternal:\s*\["@remnic\/bench"\]/);
   assert.equal(pkg.dependencies?.["@remnic/bench"], undefined);
   assert.equal(pkg.devDependencies?.["@remnic/bench"], "workspace:*");
 });


### PR DESCRIPTION
## Summary
- fix the `@remnic/cli` release build by moving `@remnic/bench` bundling into `packages/remnic-cli/tsup.config.ts`
- bootstrap the first Remnic release from `package.json` `1.0.0` while `@remnic/core` is still unpublished, instead of inheriting the old `v9.x` tag line
- sweep the main user-facing docs so Remnic is canonical and Engram is explicitly documented as compatibility-only where it still exists

## Verification
- `pnpm --dir packages/remnic-cli run build`
- `pnpm run build`
- `pnpm run check-types`
- `pnpm test` did not complete locally after several minutes and remained idle/inconclusive; I did not mark that as passing

## Notes
- local workflow bootstrap check now resolves to `v1.0.0` because `npm view @remnic/core` still returns unpublished
- `docs/RENAME.md` status is updated to `In Progress` to match the current repo state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release workflow’s version/tag computation and introduces a bootstrap path that can affect what gets tagged/published on main; mistakes could publish the wrong version. Other changes are primarily documentation/branding and small test/build adjustments.
> 
> **Overview**
> **Unblocks first Remnic release** by updating `release-and-publish.yml` to treat the workspace root `package.json` version as authoritative *until* `@remnic/core` exists on npm, avoiding inheriting legacy `v9.x` tags.
> 
> **Fixes `@remnic/cli` build/publish behavior** by moving `@remnic/bench` bundling into a new `tsup.config.ts` (and updating tests accordingly) so the private bench package is bundled rather than shipped as a runtime dependency.
> 
> **Renames/sweeps user-facing surfaces** (docs, `.env.example`, Makefile banner, dashboard title, and tests) to use Remnic as the canonical name and clarify where `engram` remains as a compatibility alias during v1.x.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 51e7b8c76bb457841bd93a9225dc3942fd64dd3d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->