### PR TITLE
fix: finalize remnic npm release correction and install docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,22 +183,19 @@ openclaw engram config-review --json # Opinionated config tuning recommendations
 
 ## Using Remnic with Codex CLI
 
-Start the Remnic server:
+Start the Remnic server directly for the current shell session:
 
 ```bash
 # Generate a token
 export REMNIC_AUTH_TOKEN="$(openssl rand -base64 32)"
 
-# Start the server (CLI-managed daemon)
-remnic daemon start
-```
-
-If you prefer to launch the standalone server directly instead of using the
-daemon helper:
-
-```bash
 npx remnic-server --host 127.0.0.1 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
 ```
+
+If you want to use `remnic daemon start`, persist the token in
+`remnic.config.json` first. `daemon start` will hand off to launchd/systemd
+when a service is installed, and those service templates read `server.authToken`
+from config rather than inheriting your shell's exported token.
 
 The HTTP API path remains `/engram/v1/...` during the v1.x compatibility window.
 

--- a/README.md
+++ b/README.md
@@ -587,7 +587,7 @@ The HTTP server exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing remote
 npx remnic-server --host 0.0.0.0 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
 ```
 
-For namespace-enabled deployments, pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace. Deployments with `namespacesEnabled: false` (the default) do not need `--principal`.
+For namespace-enabled deployments, configure `server.principal` in `remnic.config.json` so it matches a `writePrincipals` entry for your target namespace. Deployments with `namespacesEnabled: false` (the default) do not need a principal.
 
 ## CLI Reference
 

--- a/README.md
+++ b/README.md
@@ -95,7 +95,12 @@ cd remnic
 pnpm install && pnpm run build
 cd packages/remnic-cli && pnpm link --global  # Makes `remnic` and `engram` available on PATH
 cd ../..
-remnic init
+remnic init                     # Create remnic.config.json
+export OPENAI_API_KEY=sk-...
+export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
+remnic daemon start             # Start background server
+remnic status                   # Verify it's running
+remnic query "hello" --explain  # Test query with tier breakdown
 ```
 
 > **Note:** `remnic` is the canonical CLI. The legacy `engram` binary is a compatibility forwarder to the same implementation. Running `pnpm link --global` from `packages/remnic-cli/` (not the repo root) makes both names available on PATH. Alternatively, invoke directly: `npx tsx packages/remnic-cli/src/index.ts <command>`.
@@ -325,7 +330,7 @@ Engram is organized as a monorepo with a core engine, standalone server/CLI, and
 | `@remnic/bench` | (private) | Latency ladder benchmarks with CI regression gates |
 | `@remnic/plugin-openclaw` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-openclaw)](https://www.npmjs.com/package/@remnic/plugin-openclaw) | OpenClaw adapter — thin bridge (embedded or delegate mode) |
 | `remnic-hermes` | [![PyPI](https://img.shields.io/pypi/v/remnic-hermes)](https://pypi.org/project/remnic-hermes/) | Python MemoryProvider for Hermes Agent |
-| `@remnic/plugin-claude-code` | (installed via `remnic connectors install`) | Native Claude Code plugin — hooks, skills, MCP |
+| `@remnic/plugin-claude-code` | Installed via `remnic connectors install` | Native Claude Code plugin — hooks, skills, MCP |
 | `@remnic/plugin-codex` | (installed via `remnic connectors install`) | Native Codex CLI plugin — hooks, skills, MCP |
 
 The old `@joshuaswarren/openclaw-engram` package is **deprecated**. Use `@remnic/plugin-openclaw` for OpenClaw installs and `@remnic/*` for standalone or multi-platform use.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Remnic gives AI agents long-term memory that survives across conversations. Decisions, preferences, project context, personal details, past mistakes — everything your agent learns persists and resurfaces exactly when it's needed. All data stays on your machine as plain markdown files. No cloud services, no subscriptions, no sharing your data with third parties.
 
-[![npm version](https://img.shields.io/npm/v/@joshuaswarren/openclaw-engram)](https://www.npmjs.com/package/@joshuaswarren/openclaw-engram)
+[![npm version](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Sponsor](https://img.shields.io/badge/Sponsor-%E2%9D%A4-pink)](https://github.com/sponsors/joshuaswarren)
 
@@ -176,32 +176,38 @@ openclaw engram doctor --json        # Health diagnostics with remediation hints
 openclaw engram config-review --json # Opinionated config tuning recommendations
 ```
 
-## Using Engram with Codex CLI
+## Using Remnic with Codex CLI
 
-Start the Engram HTTP server:
+Start the Remnic server:
 
 ```bash
 # Generate a token
-export OPENCLAW_ENGRAM_ACCESS_TOKEN="$(openssl rand -base64 32)"
+export REMNIC_AUTH_TOKEN="$(openssl rand -base64 32)"
 
-# Start the server
-openclaw engram access http-serve \
-  --host 127.0.0.1 \
-  --port 4318 \
-  --token "$OPENCLAW_ENGRAM_ACCESS_TOKEN"
+# Start the server (CLI-managed daemon)
+remnic daemon start
 ```
+
+If you prefer to launch the standalone server directly instead of using the
+daemon helper:
+
+```bash
+npx remnic-server --host 127.0.0.1 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
+```
+
+The HTTP API path remains `/engram/v1/...` during the v1.x compatibility window.
 
 Add to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.engram]
+[mcp_servers.remnic]
 url = "http://127.0.0.1:4318/mcp"
-bearer_token_env_var = "OPENCLAW_ENGRAM_ACCESS_TOKEN"
+bearer_token_env_var = "REMNIC_AUTH_TOKEN"
 ```
 
-That's it. Codex now has access to Engram's recall, store, and entity tools. See the [full Codex integration guide](docs/guides/codex-cli.md) for session-start hooks, cross-machine setup, and automatic recall at session start.
+That's it. Codex now has access to Remnic's recall, store, and entity tools. See the [full Codex integration guide](docs/guides/codex-cli.md) for session-start hooks, cross-machine setup, and automatic recall at session start.
 
-## Using Engram with Any MCP Client
+## Using Remnic with Any MCP Client
 
 Run the stdio MCP server:
 
@@ -209,17 +215,19 @@ Run the stdio MCP server:
 openclaw engram access mcp-serve
 ```
 
-Point your MCP client's command at `openclaw engram access mcp-serve`. Works with Claude Code, and any other MCP-compatible client. The server exposes the same tools as the HTTP endpoint.
+Point your MCP client's command at `openclaw engram access mcp-serve`. This
+is the OpenClaw-hosted stdio compatibility path. For standalone Remnic installs,
+prefer the HTTP MCP endpoint exposed by `remnic daemon start` or `remnic-server`.
 
-**Claude Code (MCP over HTTP):** Start the Engram HTTP server, then add to `~/.claude.json`:
+**Claude Code (MCP over HTTP):** Start the Remnic server, then add to `~/.claude.json`:
 
 ```json
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
-        "Authorization": "Bearer ${ENGRAM_TOKEN}"
+        "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
       }
     }
   }
@@ -536,12 +544,14 @@ See [Enable All Features](docs/enable-all-v8.md) for a full-feature config profi
 
 ## Access Layer
 
-Engram exposes one shared service layer through multiple transports:
+Remnic exposes one shared service layer through multiple transports. During the
+v1.x compatibility window, the HTTP API path remains `/engram/v1/...` and the
+legacy `engram.*` MCP aliases still work.
 
 ### HTTP API
 
 ```bash
-openclaw engram access http-serve --token "$OPENCLAW_ENGRAM_ACCESS_TOKEN"
+remnic daemon start
 ```
 
 Key endpoints: `GET /engram/v1/health`, `POST /engram/v1/recall`, `POST /engram/v1/memories`, `GET /engram/v1/entities/:name`, and more. Full reference in [API docs](docs/api.md).
@@ -571,10 +581,10 @@ Available via both stdio and HTTP transports:
 
 ### MCP over HTTP
 
-The HTTP server exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing remote MCP clients to use Engram tools over HTTP:
+The HTTP server exposes an MCP JSON-RPC endpoint at `POST /mcp`, allowing remote MCP clients to use Remnic tools over HTTP:
 
 ```bash
-openclaw engram access http-serve --host 0.0.0.0 --port 4318 --token "$TOKEN"
+npx remnic-server --host 0.0.0.0 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
 ```
 
 For namespace-enabled deployments, pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace. Deployments with `namespacesEnabled: false` (the default) do not need `--principal`.
@@ -608,8 +618,8 @@ openclaw engram semantic-consolidate         # Run semantic dedup consolidation
 openclaw engram semantic-consolidate --dry-run  # Preview without changes
 
 # Access layer
-openclaw engram access http-serve --token "$TOKEN"  # Start HTTP API
-openclaw engram access mcp-serve   # Start stdio MCP server
+remnic daemon start                # Start HTTP API + managed daemon
+openclaw engram access mcp-serve   # Start OpenClaw-hosted stdio MCP server
 
 # Trust-zone demos
 openclaw engram trust-zone-demo-seed --dry-run       # Preview the opt-in buyer demo dataset
@@ -621,7 +631,7 @@ openclaw engram trust-zone-promote --record-id <id> --target-zone working --reas
 
 Trust zones now ship with a dedicated admin-console view plus an explicit demo seeding path for buyer-facing walkthroughs.
 
-- **Never automatic** — Engram does not seed sample trust-zone records on install, startup, or feature enablement.
+- **Never automatic** — Remnic does not seed sample trust-zone records on install, startup, or feature enablement.
 - **Explicit only** — demo records appear only after you run `openclaw engram trust-zone-demo-seed` or trigger the matching admin-console action.
 - **Buyer-friendly story** — the trust-zone view surfaces provenance strength, promotion readiness, corroboration requirements, and operator promotion actions in one place.
 

--- a/docs/RENAME.md
+++ b/docs/RENAME.md
@@ -1,6 +1,6 @@
 # Engram → Remnic Rename Plan
 
-**Status:** In Progress
+**Status:** In Progress — core engineering landed, repo cleanup and release rollout remain
 **Owner:** @joshuaswarren
 **Target:** Execute before first 1.0.0 publish
 
@@ -107,6 +107,28 @@ handful of early adopters. Tomorrow is worse.
 | GitHub repo | ✅ Renamed to `joshuaswarren/remnic` |
 
 **Install base to migrate: one package.** Everything else is free namespace.
+
+### Execution Snapshot (2026-04-10)
+
+The rename is no longer mostly theoretical. The heavy engineering pieces are in
+the tree:
+
+- `@remnic/server`, `@remnic/cli`, `@remnic/plugin-openclaw`, and the monorepo
+  package layout are in place.
+- The Engram → Remnic migration module exists and is wired into runtime entry
+  points.
+- The shim package exists, including the postinstall banner.
+- Migration tests exist, including fresh-install, idempotency, merge, lock
+  recovery, and rollback coverage.
+
+What is **not** done yet:
+
+- Repo-local rename cleanup is complete. Remaining legacy names in docs are
+  intentional compatibility guidance for v1.x aliases, HTTP paths,
+  OpenClaw-hosted commands, or migration instructions.
+- Release operations have not happened yet: no `@remnic/*` publish, no shim
+  publish, no npm deprecations, no PyPI release, no release-note pass.
+- Brand rollout is still pending beyond the repo rename itself.
 
 ---
 
@@ -361,6 +383,8 @@ for (const tool of canonicalTools) {
 Compressed cadence. Not days-with-slack — hours-with-verification.
 
 ### Phase A — Repo rename
+**Status:** ✅ Complete
+
 1. GitHub UI: rename `joshuaswarren/openclaw-engram` → `joshuaswarren/remnic`
 2. Update local remotes
 3. Verify GitHub redirect from old URL
@@ -368,6 +392,8 @@ Compressed cadence. Not days-with-slack — hours-with-verification.
 5. Update `remnic.ai/rename` landing to link new repo
 
 ### Phase B — Rename PR against `main`
+**Status:** ✅ Complete (repo-local cleanup finished; explicit compatibility aliases remain by design)
+
 Single coordinated PR. No publishes during this phase.
 
 - Rename all `packages/engram-*` → `packages/remnic-*`
@@ -385,19 +411,29 @@ Single coordinated PR. No publishes during this phase.
 - Full test suite green
 - `pnpm -r publish --dry-run` validates publish config
 
+Phase B cleanup is now closed in-tree. Remaining legacy names in docs are
+intentional compatibility guidance for v1.x aliases, HTTP paths, OpenClaw-hosted
+commands, or migration instructions.
+
 ### Phase C — Shim package
+**Status:** ✅ Complete in repo (publish/deprecate work moves to Phase D)
+
 - `packages/shim-openclaw-engram/` with `@joshuaswarren/openclaw-engram@9.3.0`
 - `dependencies: { "@remnic/plugin-openclaw": "^1.0.0" }`
 - Postinstall banner script
 - Re-exports everything from the new bridge plugin
 
 ### Phase D — Publish
+**Status:** ⏳ Pending
+
 - `pnpm -r publish --access public` for all `@remnic/*`
 - `twine upload dist/*` for `remnic-hermes`
 - `npm publish` for the shim
 - `npm deprecate` incantations for all old versions and the new shim
 
 ### Phase E — Brand surfaces
+**Status:** ⏳ Pending
+
 - Publish `remnic.ai/rename` landing page
 - Pin rename banner on `joshuaswarren/remnic` README
 - CHANGELOG 1.0.0 "The Remnic Release" section
@@ -405,6 +441,8 @@ Single coordinated PR. No publishes during this phase.
 - User posts to Discords they're on
 
 ### Phase F — Monitor & tighten
+**Status:** ⏳ Pending post-publish
+
 - Watch shim download stats, GitHub issues, runtime migration telemetry
 - Ship `@remnic/*@1.1.0` that tightens deprecations:
   - Louder `engram` CLI forwarder warning
@@ -412,6 +450,8 @@ Single coordinated PR. No publishes during this phase.
   - Louder `engram_*` MCP tool warning
 
 ### Phase G — Drop shims
+**Status:** ⏳ Future (2.0.0)
+
 - `@remnic/*@2.0.0` removes:
   - `engram` CLI forwarder binary
   - `ENGRAM_*` env var fallback
@@ -484,7 +524,9 @@ conditions are evidence-based, not calendar-based.
 
 ## Decisions Open
 
-_None — plan is fully locked. Execution is underway; publish and brand rollout remain._
+_None at the strategy level. The remaining work is execution: run
+publishes/deprecations, complete brand rollout, then monitor and trim
+compatibility in later releases._
 
 ---
 

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -52,17 +52,36 @@ Source the profile or open a new terminal so the variable is available.
 On the machine where Remnic runs:
 
 ```bash
-remnic daemon start
-```
-
-If you have `namespacesEnabled: true` in your Remnic config, also pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace:
-
-```bash
 npx remnic-server \
   --host 0.0.0.0 \
   --port 4318 \
-  --principal generalist \
   --auth-token "$REMNIC_AUTH_TOKEN"
+```
+
+Use `remnic daemon start` only when Codex and Remnic run on the same machine, or
+when your `remnic.config.json` already sets a non-loopback bind address under
+`server.host`. The daemon helper defaults to `127.0.0.1`, which is not reachable
+from a second machine unless you change the config first.
+
+If you have `namespacesEnabled: true` in your Remnic config, set the principal in
+the config file rather than on the `remnic-server` command line. The standalone
+server currently reads `server.principal` from config but does not expose a
+`--principal` CLI flag.
+
+```bash
+cat > remnic.config.json <<'EOF'
+{
+  "remnic": {
+    "namespacesEnabled": true
+  },
+  "server": {
+    "host": "0.0.0.0",
+    "port": 4318,
+    "authToken": "${REMNIC_AUTH_TOKEN}",
+    "principal": "generalist"
+  }
+}
+EOF
 ```
 
 For persistent operation, set up a launchd plist (macOS), systemd unit (Linux), or similar service manager so the server survives reboots.

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -69,7 +69,7 @@ server currently reads `server.principal` from config but does not expose a
 `--principal` CLI flag.
 
 ```bash
-cat > remnic.config.json <<'EOF'
+cat > remnic.config.json <<EOF
 {
   "remnic": {
     "namespacesEnabled": true
@@ -265,7 +265,7 @@ After setup, start a new Codex session and check:
 - Check the server is reachable: `curl -s http://<host>:4318/mcp -X POST -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
 
 **"namespace is not writable" error:**
-- You have `namespacesEnabled: true` in your Remnic config. Pass `--principal <name>` when starting the HTTP server, where `<name>` is in the `writePrincipals` list for your target namespace.
+- You have `namespacesEnabled: true` in your Remnic config. Set `server.principal` in `remnic.config.json` so it matches a `writePrincipals` entry for your target namespace.
 
 **Hook not firing:**
 - Verify `~/.codex/hooks.json` exists and uses the correct absolute path.

--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -42,7 +42,7 @@ Generate a secure token and add it to your shell profile (`~/.zshenv`, `~/.bashr
 openssl rand -base64 32
 
 # Add to your shell profile
-export OPENCLAW_REMNIC_ACCESS_TOKEN="<paste-generated-token-here>"
+export REMNIC_AUTH_TOKEN="<paste-generated-token-here>"
 ```
 
 Source the profile or open a new terminal so the variable is available.
@@ -52,20 +52,17 @@ Source the profile or open a new terminal so the variable is available.
 On the machine where Remnic runs:
 
 ```bash
-openclaw engram access http-serve \
-  --host 0.0.0.0 \
-  --port 4318 \
-  --token "$OPENCLAW_REMNIC_ACCESS_TOKEN"
+remnic daemon start
 ```
 
 If you have `namespacesEnabled: true` in your Remnic config, also pass `--principal <name>` where `<name>` matches a `writePrincipals` entry for your target namespace:
 
 ```bash
-openclaw engram access http-serve \
+npx remnic-server \
   --host 0.0.0.0 \
   --port 4318 \
   --principal generalist \
-  --token "$OPENCLAW_REMNIC_ACCESS_TOKEN"
+  --auth-token "$REMNIC_AUTH_TOKEN"
 ```
 
 For persistent operation, set up a launchd plist (macOS), systemd unit (Linux), or similar service manager so the server survives reboots.
@@ -77,7 +74,7 @@ Edit `~/.codex/config.toml`:
 ```toml
 [mcp_servers.remnic]
 url = "http://<remnic-host>:4318/mcp"
-bearer_token_env_var = "OPENCLAW_REMNIC_ACCESS_TOKEN"
+bearer_token_env_var = "REMNIC_AUTH_TOKEN"
 ```
 
 Replace `<remnic-host>` with:
@@ -105,7 +102,7 @@ set -euo pipefail
 
 REMNIC_HOST="${REMNIC_HOST:-127.0.0.1}"
 REMNIC_PORT="${REMNIC_PORT:-4318}"
-REMNIC_TOKEN="${OPENCLAW_REMNIC_ACCESS_TOKEN:-${OPENCLAW_ENGRAM_ACCESS_TOKEN:-}}"
+REMNIC_TOKEN="${REMNIC_AUTH_TOKEN:-${OPENCLAW_REMNIC_ACCESS_TOKEN:-${OPENCLAW_ENGRAM_ACCESS_TOKEN:-}}}"
 REMNIC_URL="http://${REMNIC_HOST}:${REMNIC_PORT}/engram/v1/recall"
 
 # Read hook input from stdin
@@ -246,7 +243,7 @@ After setup, start a new Codex session and check:
 **Remnic tools not showing up in Codex:**
 - Codex loads MCP servers at session start. If the server was down when the session started, restart Codex.
 - Verify with `codex mcp list` — remnic should show `enabled` with `Bearer token` auth.
-- Check the server is reachable: `curl -s http://<host>:4318/mcp -X POST -H "Authorization: Bearer $OPENCLAW_REMNIC_ACCESS_TOKEN" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
+- Check the server is reachable: `curl -s http://<host>:4318/mcp -X POST -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" -H "Content-Type: application/json" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{}}'`
 
 **"namespace is not writable" error:**
 - You have `namespacesEnabled: true` in your Remnic config. Pass `--principal <name>` when starting the HTTP server, where `<name>` is in the `writePrincipals` list for your target namespace.
@@ -254,7 +251,7 @@ After setup, start a new Codex session and check:
 **Hook not firing:**
 - Verify `~/.codex/hooks.json` exists and uses the correct absolute path.
 - Ensure the script is executable (`chmod +x`).
-- Check that `OPENCLAW_REMNIC_ACCESS_TOKEN` is set in your shell environment.
+- Check that `REMNIC_AUTH_TOKEN` is set in your shell environment. The older `OPENCLAW_REMNIC_ACCESS_TOKEN` and `OPENCLAW_ENGRAM_ACCESS_TOKEN` names are still accepted during the compatibility window.
 
 **Slow session start:**
 - The hook has a 15-second timeout. If the Remnic server is slow to respond, increase the `timeout` value in `hooks.json` or reduce `topK` in the recall query.

--- a/docs/guides/platform-migration.md
+++ b/docs/guides/platform-migration.md
@@ -28,7 +28,7 @@ packages/
 | M0 | Structured error responses | Consistent JSON error envelopes with `error`, `code`, `details` fields and `X-Request-Id` correlation IDs |
 | M1 | Hermes provider | `@remnic/hermes-provider` — lightweight HTTP client for connecting to remote Remnic instances |
 | M1 | Standalone CLI | 15+ commands: `init`, `status`, `query`, `doctor`, `config`, `daemon`, `tree`, `onboard`, `curate`, `review`, `sync`, `dedup`, `connectors`, `space`, `benchmark` |
-| M2 | Workspace tree projection | Context tree generation + validation + live watch mode (`engram tree generate\|watch\|validate`) |
+| M2 | Workspace tree projection | Context tree generation + validation + live watch mode (`remnic tree generate\|watch\|validate`) |
 | M3 | Onboarding + Curation | Project ingestion with language detection, doc discovery, and ingestion planning; file curation with duplicate/contradiction detection |
 | M3 | Diff-aware sync | Filesystem sync that detects added/modified/deleted files and ingests changes incrementally |
 | M4 | Connector manager | Host adapter lifecycle management (list, install, remove, doctor) |
@@ -92,13 +92,13 @@ openclaw engram inventory --json
 
 ```bash
 # 1. Diagnostics
-engram doctor
+remnic doctor
 
 # 2. Server status
-engram status
+remnic status
 
 # 3. Verify query works
-engram query "test query" --json
+remnic query "test query" --json
 ```
 
 ---
@@ -126,7 +126,7 @@ cd ../..
 
 ```bash
 remnic init
-# Creates engram.config.json in the current directory
+# Creates remnic.config.json in the current directory
 ```
 
 Set required environment variables:
@@ -134,8 +134,8 @@ Set required environment variables:
 ```bash
 export OPENAI_API_KEY=sk-...
 export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
-# Optional: override memory location (default: ~/.engram/memory for standalone, ~/.openclaw/workspace/memory/local for OpenClaw users)
-# export ENGRAM_MEMORY_DIR=/path/to/custom/memory
+# Optional: override memory location (default: ~/.remnic/memory for standalone, ~/.openclaw/workspace/memory/local for OpenClaw users)
+# export REMNIC_MEMORY_DIR=/path/to/custom/memory
 ```
 
 ### Start Standalone Server

--- a/docs/guides/quickstart.md
+++ b/docs/guides/quickstart.md
@@ -34,7 +34,7 @@ Install plugins for the AI tools you use:
 remnic connectors install claude-code
 
 # Connect Codex CLI (hooks + MCP + skills)
-remnic connectors install codex
+remnic connectors install codex-cli
 
 # Connect Hermes Agent (MemoryProvider + tools)
 remnic connectors install hermes
@@ -50,7 +50,7 @@ Each command generates a dedicated auth token and installs the native plugin for
 ```bash
 remnic connectors doctor
 # ✓ claude-code: connected, 44 tools available
-# ✓ codex: connected, 44 tools available
+# ✓ codex-cli: connected, 44 tools available
 # ✓ hermes: connected, MemoryProvider active
 # ✓ replit: token generated (configure in Integrations pane)
 ```

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -233,7 +233,7 @@ When you want a standalone server instance to run as a specific tenant, set the
 default principal in `remnic.config.json`:
 
 ```bash
-cat > remnic.config.json <<'EOF'
+cat > remnic.config.json <<EOF
 {
   "server": {
     "host": "127.0.0.1",

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -452,12 +452,11 @@ The shared namespace provides cross-tenant knowledge sharing. All tenants can re
 
 ### Writing to the shared namespace
 
-Use the `memory_promote` tool to manually promote a memory, or use `memory_store` with `namespace: "shared"` when the authenticated principal has write access:
+Use the `memory_promote` tool to manually promote a memory, or use `memory_store` with `namespace: "shared"` when the authenticated principal has write access. In standalone mode, that means `server.principal` (or your session-key routing rules) must resolve to a writer for the `shared` namespace:
 
 ```bash
 curl -X POST http://localhost:4318/engram/v1/memories \
   -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" \
-  -H "X-Engram-Principal: admin" \
   -H "Content-Type: application/json" \
   -d '{
     "content": "Company-wide coding standard: all APIs must return JSON.",

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -2,13 +2,13 @@
 
 ## Introduction
 
-Remnic can run as a standalone HTTP server that provides persistent memory to multiple agent harnesses simultaneously. In plugin mode, Remnic is embedded inside a single OpenClaw gateway process. In standalone mode, Engram runs as its own process and exposes both a REST API and an MCP-over-HTTP endpoint that any number of clients can connect to — OpenClaw, Codex CLI, Claude Code, custom scripts, or any MCP-compatible agent.
+Remnic can run as a standalone HTTP server that provides persistent memory to multiple agent harnesses simultaneously. In plugin mode, Remnic is embedded inside a single OpenClaw gateway process. In standalone mode, Remnic runs as its own process and exposes both a REST API and an MCP-over-HTTP endpoint that any number of clients can connect to — OpenClaw, Codex CLI, Claude Code, custom scripts, or any MCP-compatible agent.
 
 Use standalone mode when:
 
 - You run multiple agent harnesses (e.g., OpenClaw + Codex CLI + Claude Code) and want them to share one memory backend.
 - You want to isolate different projects or clients into separate namespaces with access control.
-- You need to feed conversation data from custom agents or automation scripts into Engram's extraction pipeline.
+- You need to feed conversation data from custom agents or automation scripts into Remnic's extraction pipeline.
 
 Use plugin mode when:
 
@@ -24,14 +24,14 @@ Use plugin mode when:
 └──────┬───────┘  └──────┬──────┘  └──────┬────────┘  └───────┬───────┘
        │                 │                 │                    │
        │    ┌────────────┴─────────────────┴────────────┐      │
-       │    │         Engram Standalone Server           │      │
+       │    │         Remnic Standalone Server           │      │
        │    │  ┌──────────┐ ┌─────────┐ ┌────────────┐  │◄─────┘
        ├────┤  │   MCP    │ │  HTTP   │ │  Plugin    │  │
             │  │ (stdio)  │ │  REST   │ │  hooks     │  │
             │  └────┬─────┘ └────┬────┘ └─────┬──────┘  │
             │       └────────────┼─────────────┘         │
             │              ┌─────┴──────┐                │
-            │              │  Engram    │                │
+            │              │  Remnic    │                │
             │              │  Core      │                │
             │              ├────────────┤                │
             │  ┌───────────┤ Namespaces ├────────────┐   │
@@ -45,7 +45,7 @@ Use plugin mode when:
             └────────────────────────────────────────────┘
 ```
 
-All clients connect to the same Engram process. Each tenant's memories are isolated in their own namespace, with a shared namespace for cross-tenant knowledge. The server authenticates every request with a bearer token and resolves the caller's principal to enforce namespace read/write policies.
+All clients connect to the same Remnic process. Each tenant's memories are isolated in their own namespace, with a shared namespace for cross-tenant knowledge. The server authenticates every request with a bearer token and resolves the caller's principal to enforce namespace read/write policies.
 
 ## Quick Start
 
@@ -53,23 +53,20 @@ Generate a secure token and start the server:
 
 ```bash
 # Generate a random token
-export ENGRAM_TOKEN="$(openssl rand -hex 32)"
+export REMNIC_AUTH_TOKEN="$(openssl rand -hex 32)"
 
-# Start the standalone server
-openclaw engram access http-serve \
-  --host 127.0.0.1 \
-  --port 4318 \
-  --token "$ENGRAM_TOKEN"
+# Start the standalone server directly
+npx remnic-server --host 127.0.0.1 --port 4318 --auth-token "$REMNIC_AUTH_TOKEN"
 ```
 
 Verify it is running:
 
 ```bash
 curl -s http://localhost:4318/engram/v1/health \
-  -H "Authorization: Bearer $ENGRAM_TOKEN" | jq .
+  -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" | jq .
 ```
 
-You should see a JSON response with `status: "ok"` and details about search availability.
+You should see a JSON response with `status: "ok"` and details about search availability. The API path remains `/engram/v1/...` during the v1.x compatibility window.
 
 To bind to all interfaces (e.g., for LAN access from other machines), use `--host 0.0.0.0`. Only do this on trusted networks or behind a reverse proxy.
 
@@ -77,7 +74,7 @@ To bind to all interfaces (e.g., for LAN access from other machines), use `--hos
 
 ### OpenClaw (plugin mode)
 
-OpenClaw uses Engram as a native plugin — it communicates in-process, not over HTTP. No standalone server configuration is needed. See the main [Installation](../../README.md#installation) section for plugin setup.
+OpenClaw uses Remnic as a native plugin bridge — it communicates in-process, not over HTTP unless you explicitly delegate to a running daemon. See the main [Installation](../../README.md#installation) section for plugin setup.
 
 If you are also running a standalone server for other clients, OpenClaw's plugin instance and the standalone server share the same memory directory on disk. Changes made by either are visible to both.
 
@@ -86,9 +83,9 @@ If you are also running a standalone server for other clients, OpenClaw's plugin
 Start the Remnic server as shown in Quick Start, then add to `~/.codex/config.toml`:
 
 ```toml
-[mcp_servers.engram]
+[mcp_servers.remnic]
 url = "http://127.0.0.1:4318/mcp"
-bearer_token_env_var = "ENGRAM_TOKEN"
+bearer_token_env_var = "REMNIC_AUTH_TOKEN"
 ```
 
 Or in `~/.codex/config.json`:
@@ -96,11 +93,11 @@ Or in `~/.codex/config.json`:
 ```json
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "type": "http",
       "url": "http://localhost:4318/mcp",
       "headers": {
-        "Authorization": "Bearer YOUR_ENGRAM_TOKEN"
+        "Authorization": "Bearer YOUR_REMNIC_AUTH_TOKEN"
       }
     }
   }
@@ -111,22 +108,22 @@ See the [Codex CLI Integration Guide](codex-cli.md) for session-start hooks and 
 
 ### Claude Code (MCP over HTTP)
 
-Add Engram to your `~/.claude.json`:
+Add Remnic to your `~/.claude.json`:
 
 ```json
 {
   "mcpServers": {
-    "engram": {
+    "remnic": {
       "url": "http://localhost:4318/mcp",
       "headers": {
-        "Authorization": "Bearer ${ENGRAM_TOKEN}"
+        "Authorization": "Bearer ${REMNIC_AUTH_TOKEN}"
       }
     }
   }
 }
 ```
 
-Claude Code will discover Engram's tools automatically. All MCP tools — `engram.recall`, `engram.memory_store`, `engram.observe`, `engram.lcm_search`, and others — are available.
+Claude Code will discover Remnic's tools automatically. Canonical tool names use the `remnic.*` prefix; legacy `engram.*` aliases remain available through v1.x.
 
 ### Custom HTTP Agents
 
@@ -137,11 +134,11 @@ Any HTTP client can use the REST API directly. Here are examples in Python and J
 ```python
 import requests
 
-ENGRAM_URL = "http://localhost:4318"
+REMNIC_URL = "http://localhost:4318"
 HEADERS = {"Authorization": "Bearer YOUR_TOKEN"}
 
 # Feed conversation into memory
-requests.post(f"{ENGRAM_URL}/engram/v1/observe", json={
+requests.post(f"{REMNIC_URL}/engram/v1/observe", json={
     "sessionKey": "my-agent-session-1",
     "messages": [
         {"role": "user", "content": "What's the status of project Alpha?"},
@@ -150,7 +147,7 @@ requests.post(f"{ENGRAM_URL}/engram/v1/observe", json={
 }, headers=HEADERS)
 
 # Recall relevant context
-resp = requests.post(f"{ENGRAM_URL}/engram/v1/recall", json={
+resp = requests.post(f"{REMNIC_URL}/engram/v1/recall", json={
     "query": "project Alpha status"
 }, headers=HEADERS)
 print(resp.json()["results"])
@@ -159,14 +156,14 @@ print(resp.json()["results"])
 **JavaScript / TypeScript:**
 
 ```javascript
-const ENGRAM_URL = "http://localhost:4318";
+const REMNIC_URL = "http://localhost:4318";
 const headers = {
   "Authorization": "Bearer YOUR_TOKEN",
   "Content-Type": "application/json"
 };
 
 // Feed conversation into memory
-await fetch(`${ENGRAM_URL}/engram/v1/observe`, {
+await fetch(`${REMNIC_URL}/engram/v1/observe`, {
   method: "POST",
   headers,
   body: JSON.stringify({
@@ -179,7 +176,7 @@ await fetch(`${ENGRAM_URL}/engram/v1/observe`, {
 });
 
 // Recall relevant context
-const resp = await fetch(`${ENGRAM_URL}/engram/v1/recall`, {
+const resp = await fetch(`${REMNIC_URL}/engram/v1/recall`, {
   method: "POST",
   headers,
   body: JSON.stringify({ query: "project Alpha status" }),
@@ -235,10 +232,10 @@ This means:
 When starting the server for a specific tenant, pass `--principal` to set the default:
 
 ```bash
-openclaw engram access http-serve \
+npx remnic-server \
   --host 127.0.0.1 \
   --port 4318 \
-  --token "$ENGRAM_TOKEN" \
+  --auth-token "$REMNIC_AUTH_TOKEN" \
   --principal client-a-agent
 ```
 
@@ -248,7 +245,7 @@ See the [Namespaces documentation](../namespaces.md) for full details on namespa
 
 ## The Observe Endpoint
 
-`POST /engram/v1/observe` feeds conversation messages into Engram's memory pipeline. This is the primary integration point for custom agents that are not using MCP.
+`POST /engram/v1/observe` feeds conversation messages into Remnic's memory pipeline. This is the primary integration point for custom agents that are not using MCP.
 
 ### Request
 
@@ -373,10 +370,10 @@ By default, the server resolves the principal from the `--principal` CLI flag or
 Pass `--trust-principal-header` when starting the server:
 
 ```bash
-openclaw engram access http-serve \
+npx remnic-server \
   --host 127.0.0.1 \
   --port 4318 \
-  --token "$ENGRAM_TOKEN" \
+  --auth-token "$REMNIC_AUTH_TOKEN" \
   --trust-principal-header
 ```
 
@@ -386,7 +383,7 @@ Include the header in your requests:
 
 ```bash
 curl -X POST http://localhost:4318/engram/v1/observe \
-  -H "Authorization: Bearer $ENGRAM_TOKEN" \
+  -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" \
   -H "X-Engram-Principal: client-a-agent" \
   -H "Content-Type: application/json" \
   -d '{
@@ -447,7 +444,7 @@ Use the `memory_promote` tool to manually promote a memory, or use `memory_store
 
 ```bash
 curl -X POST http://localhost:4318/engram/v1/memories \
-  -H "Authorization: Bearer $ENGRAM_TOKEN" \
+  -H "Authorization: Bearer $REMNIC_AUTH_TOKEN" \
   -H "X-Engram-Principal: admin" \
   -H "Content-Type: application/json" \
   -d '{

--- a/docs/guides/standalone-server.md
+++ b/docs/guides/standalone-server.md
@@ -229,17 +229,28 @@ This means:
 - `client-b`'s agents have the same isolation in reverse.
 - An admin can write to the shared namespace to publish cross-tenant knowledge.
 
-When starting the server for a specific tenant, pass `--principal` to set the default:
+When you want a standalone server instance to run as a specific tenant, set the
+default principal in `remnic.config.json`:
 
 ```bash
-npx remnic-server \
-  --host 127.0.0.1 \
-  --port 4318 \
-  --auth-token "$REMNIC_AUTH_TOKEN" \
-  --principal client-a-agent
+cat > remnic.config.json <<'EOF'
+{
+  "server": {
+    "host": "127.0.0.1",
+    "port": 4318,
+    "authToken": "${REMNIC_AUTH_TOKEN}",
+    "principal": "client-a-agent"
+  }
+}
+EOF
 ```
 
-For multi-tenant access from a single server instance, use the `X-Engram-Principal` header instead (see [Per-Request Principal Override](#per-request-principal-override) below).
+Then start the server normally with `npx remnic-server` (or `remnic daemon start`
+if your config is already in place).
+
+For multi-tenant access from a single standalone instance, prefer session-key
+prefix rules. Header-based per-request principal override is not currently
+available through `remnic-server` (see [Per-Request Principal Override](#per-request-principal-override) below).
 
 See the [Namespaces documentation](../namespaces.md) for full details on namespace storage layout, QMD collection configuration, and CLI tooling.
 
@@ -363,21 +374,22 @@ If `lcmEnabled` is `false`, the response will have an empty `results` array and 
 
 ## Per-Request Principal Override
 
-By default, the server resolves the principal from the `--principal` CLI flag or from the session key prefix. When you need multiple tenants to connect through a single server instance, you can override the principal per request using the `X-Engram-Principal` header.
+Standalone `remnic-server` does not currently expose a CLI flag to enable
+trusted per-request principal override. In standalone mode, principal resolution
+comes from `server.principal` in config or from session-key prefix rules.
 
-### Enabling
-
-Pass `--trust-principal-header` when starting the server:
+If you need `X-Engram-Principal` header trust today, use the OpenClaw-hosted HTTP
+access server instead of `remnic-server`:
 
 ```bash
-npx remnic-server \
+openclaw engram access http-serve \
   --host 127.0.0.1 \
   --port 4318 \
-  --auth-token "$REMNIC_AUTH_TOKEN" \
+  --token "$REMNIC_AUTH_TOKEN" \
   --trust-principal-header
 ```
 
-### Usage
+### Usage (OpenClaw compatibility path)
 
 Include the header in your requests:
 
@@ -401,8 +413,8 @@ The `X-Engram-Principal` header value becomes the authenticated principal for th
 
 - **Only enable `--trust-principal-header` when the bearer token provides sufficient trust.** Anyone with the token can impersonate any principal.
 - If you run the server behind a reverse proxy, ensure the proxy strips or validates the `X-Engram-Principal` header from untrusted clients.
-- Without `--trust-principal-header`, the header is silently ignored — the principal always comes from `--principal` or session key rules.
-- For production multi-tenant setups, consider running separate server instances per tenant with different tokens and `--principal` values, rather than trusting a single token with header-based principal resolution.
+- Without `--trust-principal-header`, the header is silently ignored — principal resolution falls back to configured principal or session key rules.
+- For production multi-tenant standalone setups, consider running separate server instances per tenant with different tokens and fixed configured principals, rather than trusting a single token with header-based principal resolution.
 
 ## Shared Knowledge Layer
 

--- a/docs/plugins/codex.md
+++ b/docs/plugins/codex.md
@@ -5,7 +5,7 @@ Native Remnic plugin for OpenAI Codex CLI. Provides automatic memory recall, obs
 ## Installation
 
 ```bash
-remnic connectors install codex
+remnic connectors install codex-cli
 ```
 
 This:
@@ -66,5 +66,5 @@ grep codex_hooks ~/.codex/config.toml
 ## Uninstall
 
 ```bash
-remnic connectors remove codex
+remnic connectors remove codex-cli
 ```

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "^1.0.0"
+    "@remnic/core": "workspace:^"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "^1.0.0"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "^1.0.0"
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -29,7 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "^1.0.0"
+    "@remnic/core": "workspace:^"
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/server",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Standalone Remnic memory server — HTTP + MCP without OpenClaw",
   "type": "module",
   "main": "dist/index.js",
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "^1.0.0"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -26,7 +26,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "^1.0.0"
+    "@remnic/core": "workspace:^"
   },
   "devDependencies": {
     "tsup": "^8.5.1",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -38,8 +38,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "^1.0.0",
-    "@remnic/plugin-openclaw": "^1.0.1"
+    "@remnic/core": "workspace:^",
+    "@remnic/plugin-openclaw": "workspace:^"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.0",
+  "version": "9.3.1",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",
@@ -38,8 +38,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*",
-    "@remnic/plugin-openclaw": "workspace:*"
+    "@remnic/core": "^1.0.0",
+    "@remnic/plugin-openclaw": "^1.0.1"
   },
   "peerDependencies": {
     "openclaw": "*"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
   packages/plugin-openclaw:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
-        version: link:../remnic-core
+        specifier: ^1.0.0
+        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
       openclaw:
         specifier: '*'
         version: 2026.4.2(@napi-rs/canvas@0.1.97)
@@ -109,8 +109,8 @@ importers:
   packages/remnic-cli:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
-        version: link:../remnic-core
+        specifier: ^1.0.0
+        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
     devDependencies:
       '@remnic/bench':
         specifier: workspace:*
@@ -175,8 +175,8 @@ importers:
   packages/remnic-server:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
-        version: link:../remnic-core
+        specifier: ^1.0.0
+        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -188,11 +188,11 @@ importers:
   packages/shim-openclaw-engram:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
-        version: link:../remnic-core
+        specifier: ^1.0.0
+        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
       '@remnic/plugin-openclaw':
-        specifier: workspace:*
-        version: link:../plugin-openclaw
+        specifier: ^1.0.1
+        version: 1.0.1(apache-arrow@18.1.0)(openclaw@2026.4.2(@napi-rs/canvas@0.1.97))(ws@8.20.0)
       openclaw:
         specifier: '*'
         version: 2026.4.2(@napi-rs/canvas@0.1.97)
@@ -1062,6 +1062,14 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
+
+  '@remnic/core@1.0.0':
+    resolution: {integrity: sha512-DkQhuHk8pZFq2oeg/hZ7DMOskBedUBOGkzqMJzUWu/axt/a6PqMCOr8PHR/pPDyskPHlSHYLLTWZdvn7HdYozQ==}
+
+  '@remnic/plugin-openclaw@1.0.1':
+    resolution: {integrity: sha512-8BT2ki+i74tEvBy2ahZmtSGR1aF45z6iZAsN+JYRBwCO3lVFEb2R0kax2AFmKhO5ba74UHWI0UfpgUNOVtMinQ==}
+    peerDependencies:
+      openclaw: '*'
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -4140,6 +4148,33 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
+
+  '@remnic/core@1.0.0(apache-arrow@18.1.0)(ws@8.20.0)':
+    dependencies:
+      '@honcho-ai/sdk': 2.1.0
+      '@lancedb/lancedb': 0.26.2(apache-arrow@18.1.0)
+      '@orama/orama': 3.1.18
+      '@orama/plugin-data-persistence': 3.1.18
+      '@sinclair/typebox': 0.34.49
+      better-sqlite3: 12.8.0
+      meilisearch: 0.46.0
+      openai: 6.33.0(ws@8.20.0)(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@lancedb/lancedb-darwin-arm64': 0.26.2
+      '@lancedb/lancedb-linux-arm64-gnu': 0.26.2
+      '@lancedb/lancedb-linux-x64-gnu': 0.26.2
+    transitivePeerDependencies:
+      - apache-arrow
+      - ws
+
+  '@remnic/plugin-openclaw@1.0.1(apache-arrow@18.1.0)(openclaw@2026.4.2(@napi-rs/canvas@0.1.97))(ws@8.20.0)':
+    dependencies:
+      '@remnic/core': 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
+      openclaw: 2026.4.2(@napi-rs/canvas@0.1.97)
+    transitivePeerDependencies:
+      - apache-arrow
+      - ws
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -93,8 +93,8 @@ importers:
   packages/plugin-openclaw:
     dependencies:
       '@remnic/core':
-        specifier: ^1.0.0
-        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
+        specifier: workspace:^
+        version: link:../remnic-core
       openclaw:
         specifier: '*'
         version: 2026.4.2(@napi-rs/canvas@0.1.97)
@@ -109,8 +109,8 @@ importers:
   packages/remnic-cli:
     dependencies:
       '@remnic/core':
-        specifier: ^1.0.0
-        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
+        specifier: workspace:^
+        version: link:../remnic-core
     devDependencies:
       '@remnic/bench':
         specifier: workspace:*
@@ -175,8 +175,8 @@ importers:
   packages/remnic-server:
     dependencies:
       '@remnic/core':
-        specifier: ^1.0.0
-        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
+        specifier: workspace:^
+        version: link:../remnic-core
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -188,11 +188,11 @@ importers:
   packages/shim-openclaw-engram:
     dependencies:
       '@remnic/core':
-        specifier: ^1.0.0
-        version: 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
+        specifier: workspace:^
+        version: link:../remnic-core
       '@remnic/plugin-openclaw':
-        specifier: ^1.0.1
-        version: 1.0.1(apache-arrow@18.1.0)(openclaw@2026.4.2(@napi-rs/canvas@0.1.97))(ws@8.20.0)
+        specifier: workspace:^
+        version: link:../plugin-openclaw
       openclaw:
         specifier: '*'
         version: 2026.4.2(@napi-rs/canvas@0.1.97)
@@ -1062,14 +1062,6 @@ packages:
 
   '@protobufjs/utf8@1.1.0':
     resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
-
-  '@remnic/core@1.0.0':
-    resolution: {integrity: sha512-DkQhuHk8pZFq2oeg/hZ7DMOskBedUBOGkzqMJzUWu/axt/a6PqMCOr8PHR/pPDyskPHlSHYLLTWZdvn7HdYozQ==}
-
-  '@remnic/plugin-openclaw@1.0.1':
-    resolution: {integrity: sha512-8BT2ki+i74tEvBy2ahZmtSGR1aF45z6iZAsN+JYRBwCO3lVFEb2R0kax2AFmKhO5ba74UHWI0UfpgUNOVtMinQ==}
-    peerDependencies:
-      openclaw: '*'
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -4148,33 +4140,6 @@ snapshots:
   '@protobufjs/pool@1.1.0': {}
 
   '@protobufjs/utf8@1.1.0': {}
-
-  '@remnic/core@1.0.0(apache-arrow@18.1.0)(ws@8.20.0)':
-    dependencies:
-      '@honcho-ai/sdk': 2.1.0
-      '@lancedb/lancedb': 0.26.2(apache-arrow@18.1.0)
-      '@orama/orama': 3.1.18
-      '@orama/plugin-data-persistence': 3.1.18
-      '@sinclair/typebox': 0.34.49
-      better-sqlite3: 12.8.0
-      meilisearch: 0.46.0
-      openai: 6.33.0(ws@8.20.0)(zod@3.25.76)
-      zod: 3.25.76
-    optionalDependencies:
-      '@lancedb/lancedb-darwin-arm64': 0.26.2
-      '@lancedb/lancedb-linux-arm64-gnu': 0.26.2
-      '@lancedb/lancedb-linux-x64-gnu': 0.26.2
-    transitivePeerDependencies:
-      - apache-arrow
-      - ws
-
-  '@remnic/plugin-openclaw@1.0.1(apache-arrow@18.1.0)(openclaw@2026.4.2(@napi-rs/canvas@0.1.97))(ws@8.20.0)':
-    dependencies:
-      '@remnic/core': 1.0.0(apache-arrow@18.1.0)(ws@8.20.0)
-      openclaw: 2026.4.2(@napi-rs/canvas@0.1.97)
-    transitivePeerDependencies:
-      - apache-arrow
-      - ws
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -5,7 +5,7 @@ import { readFile } from "node:fs/promises";
 const shimPackageJsonPath = new URL("../packages/shim-openclaw-engram/package.json", import.meta.url);
 const bannerScriptPath = new URL("../packages/shim-openclaw-engram/scripts/postinstall-banner.mjs", import.meta.url);
 
-test("Phase C shim package is scaffolded with the released npm identity", async () => {
+test("Phase C shim package keeps a workspace-linked source manifest", async () => {
   const raw = await readFile(shimPackageJsonPath, "utf8");
   const pkg = JSON.parse(raw) as Record<string, unknown>;
   const bin = pkg.bin as Record<string, string>;
@@ -17,8 +17,8 @@ test("Phase C shim package is scaffolded with the released npm identity", async 
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");
-  assert.equal(dependencies["@remnic/plugin-openclaw"], "^1.0.1");
-  assert.equal(dependencies["@remnic/core"], "^1.0.0");
+  assert.equal(dependencies["@remnic/plugin-openclaw"], "workspace:^");
+  assert.equal(dependencies["@remnic/core"], "workspace:^");
 });
 
 test("Phase C shim package includes the rename postinstall banner script", async () => {

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -5,7 +5,7 @@ import { readFile } from "node:fs/promises";
 const shimPackageJsonPath = new URL("../packages/shim-openclaw-engram/package.json", import.meta.url);
 const bannerScriptPath = new URL("../packages/shim-openclaw-engram/scripts/postinstall-banner.mjs", import.meta.url);
 
-test("Phase C shim package is scaffolded with the legacy npm identity", async () => {
+test("Phase C shim package is scaffolded with the released npm identity", async () => {
   const raw = await readFile(shimPackageJsonPath, "utf8");
   const pkg = JSON.parse(raw) as Record<string, unknown>;
   const bin = pkg.bin as Record<string, string>;
@@ -13,12 +13,12 @@ test("Phase C shim package is scaffolded with the legacy npm identity", async ()
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.0");
+  assert.equal(pkg.version, "9.3.1");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");
-  assert.equal(dependencies["@remnic/plugin-openclaw"], "workspace:*");
-  assert.equal(dependencies["@remnic/core"], "workspace:*");
+  assert.equal(dependencies["@remnic/plugin-openclaw"], "^1.0.1");
+  assert.equal(dependencies["@remnic/core"], "^1.0.0");
 });
 
 test("Phase C shim package includes the rename postinstall banner script", async () => {

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -1,0 +1,42 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const packageExpectations = [
+  {
+    label: "CLI",
+    path: "packages/remnic-cli/package.json",
+    deps: {
+      "@remnic/core": "workspace:^",
+    },
+  },
+  {
+    label: "server",
+    path: "packages/remnic-server/package.json",
+    deps: {
+      "@remnic/core": "workspace:^",
+    },
+  },
+  {
+    label: "OpenClaw plugin",
+    path: "packages/plugin-openclaw/package.json",
+    deps: {
+      "@remnic/core": "workspace:^",
+    },
+  },
+] as const;
+
+test("runtime workspace packages preserve local linking in source manifests", async () => {
+  for (const pkgSpec of packageExpectations) {
+    const raw = await readFile(pkgSpec.path, "utf8");
+    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+
+    for (const [depName, expectedRange] of Object.entries(pkgSpec.deps)) {
+      assert.equal(
+        pkg.dependencies?.[depName],
+        expectedRange,
+        `${pkgSpec.label} should use ${expectedRange} for ${depName}`,
+      );
+    }
+  }
+});

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -2,24 +2,26 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+const testDir = new URL(".", import.meta.url);
+
 const packageExpectations = [
   {
     label: "CLI",
-    path: "packages/remnic-cli/package.json",
+    path: new URL("../packages/remnic-cli/package.json", testDir),
     deps: {
       "@remnic/core": "workspace:^",
     },
   },
   {
     label: "server",
-    path: "packages/remnic-server/package.json",
+    path: new URL("../packages/remnic-server/package.json", testDir),
     deps: {
       "@remnic/core": "workspace:^",
     },
   },
   {
     label: "OpenClaw plugin",
-    path: "packages/plugin-openclaw/package.json",
+    path: new URL("../packages/plugin-openclaw/package.json", testDir),
     deps: {
       "@remnic/core": "workspace:^",
     },


### PR DESCRIPTION
## What changed

This PR is no longer just a docs cleanup. It is the final repo-side companion to the Remnic release correction.

It does two things:

- finishes the remaining Remnic-first rename/documentation cleanup across the repo
- records the package metadata fixes used for the corrective npm release wave after the first publish exposed installability issues

The release-correction files in this branch are:

- `packages/remnic-cli/package.json`
- `packages/remnic-server/package.json`
- `packages/plugin-openclaw/package.json`
- `packages/shim-openclaw-engram/package.json`
- `README.md`

## Why

The first npm publish wave succeeded to the registry, but several published packages were not reliably installable because their manifests still contained `workspace:*` runtime dependencies.

That affected:

- `@remnic/cli@1.0.0`
- `@remnic/server@1.0.0`
- `@remnic/plugin-openclaw@1.0.0`
- `@joshuaswarren/openclaw-engram@9.3.0`

The corrective release wave replaced those workspace runtime dependencies with real semver ranges and bumped the affected package versions.

## Published corrective releases

These corrected packages are now live on npm:

- `@remnic/cli@1.0.1`
- `@remnic/server@1.0.1`
- `@remnic/plugin-openclaw@1.0.1`
- `@joshuaswarren/openclaw-engram@9.3.1`

Other published packages from the first wave that did not require the correction remain at `1.0.0`, including `@remnic/core` and `@remnic/hermes-provider`.

## User / developer impact

For users:

- standalone install is now npm-first again: `npm install -g @remnic/cli`
- OpenClaw install remains: `openclaw plugins install @remnic/plugin-openclaw --pin`
- anyone who installed the broken first-wave versions should upgrade to the corrected versions above

For reviewers:

- the earlier PR description saying this was "documentation-only" is no longer accurate
- the code diff now includes explicit version/dependency corrections for the released packages plus README alignment to the live install path
- the published fix was not a runtime behavior regression; it was a packaging/installability correction

## Root cause

The rename implementation and release execution were ahead of the final publish validation step. The packages built and published, but installability verification exposed that some runtime dependencies were still being published as `workspace:*` instead of concrete version ranges.

## Validation

Registry and installability were verified directly, not inferred from dry-runs.

Published versions now resolve as latest:

- `@remnic/cli` -> `1.0.1`
- `@remnic/server` -> `1.0.1`
- `@remnic/plugin-openclaw` -> `1.0.1`
- `@joshuaswarren/openclaw-engram` -> `9.3.1`

Clean temp-directory install checks passed:

```bash
npm init -y
npm install @remnic/cli@1.0.1
node_modules/.bin/remnic --help

npm init -y
npm install @remnic/server@1.0.1
node_modules/.bin/remnic-server --help

npm init -y
npm install @joshuaswarren/openclaw-engram@9.3.1
node_modules/.bin/engram-access --help
```

## Follow-up

One cleanup step is still pending outside this PR:

- deprecate the broken `1.0.0` / `9.3.0` versions on npm

That deprecation step is blocked only by npm requiring a fresh one-time auth/device-auth window after publish.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are primarily package manifest/version corrections and documentation updates, plus tests that enforce dependency ranges; no runtime logic is modified. Main risk is around publish/install behavior if dependency ranges or version bumps are incorrect.
> 
> **Overview**
> This PR **corrects npm release/installability** for `@remnic/cli`, `@remnic/server`, `@remnic/plugin-openclaw`, and the legacy shim `@joshuaswarren/openclaw-engram` by bumping patch versions (to `1.0.1`/`9.3.1`) and switching runtime deps from `workspace:*` to `workspace:^` (with `pnpm-lock.yaml` updated accordingly).
> 
> It also **refreshes installation/integration docs** to be Remnic-first: updated standalone startup to use `npx remnic-server`/`remnic daemon start`, standardized on `REMNIC_AUTH_TOKEN`, clarified v1.x compatibility (`/engram/v1` paths and `engram.*` aliases), and renamed the Codex connector to `codex-cli`.
> 
> Finally, it adds/updates tests (`tests/workspace-runtime-deps.test.ts`, `tests/shim-openclaw-engram-package.test.ts`) to lock in the expected workspace dependency ranges and shim package metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5f26f73bacf1155bde66eb6e974761bde5518a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->