### PR TITLE
fix: resolve built-in OpenClaw providers in gateway fallback LLM

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -502,7 +502,7 @@ When `modelSource` is `gateway`:
 }
 ```
 
-Model strings use the format `provider/model-id` where `provider` matches a key in the `providers` object of your agent's `models.json`.
+Model strings use the format `provider/model-id` where `provider` matches a key in the `providers` object of your agent's `models.json`. Built-in OpenClaw providers (e.g., `openai-codex`, `google-vertex`, `github-copilot`) work automatically — they don't need explicit entries in `models.json` since the gateway materializes them from its plugin catalogs.
 
 3. **Configure Engram** in `openclaw.json → plugins.entries.openclaw-engram.config`:
 
@@ -518,15 +518,17 @@ Model strings use the format `provider/model-id` where `provider` matches a key 
 
 ### How the fallback chain works
 
-When a primary model call fails (timeout, HTTP error, empty response), `FallbackLlmClient` tries each fallback in order. The chain stops at the first successful response. Both `openai-completions` and `anthropic-messages` API formats are supported — the client auto-detects based on the provider's `api` field.
+When a primary model call fails (timeout, HTTP error, empty response), `FallbackLlmClient` tries each fallback in order. The chain stops at the first successful response.
+
+Provider lookup checks the explicit `models.providers` config first, then falls back to the gateway's materialized `models.json` (`~/.openclaw/agents/main/agent/models.json`), which contains all providers including built-in ones registered by gateway plugins (e.g., `openai-codex` with OAuth, `google-vertex`, `github-copilot`). This means any provider the gateway knows about — including OAuth-based providers — can be used in Engram's model chain without additional configuration.
 
 ### API key resolution
 
-Provider API keys in `models.json` are resolved using OpenClaw's own auth system. Engram delegates to the gateway's `resolveApiKeyForProvider()` function, which handles all secret reference formats (SecretRef objects, `"secretref-managed"`, auth profiles, 1Password, Vault, env vars, etc.) using the same codepath the gateway uses for its own agent sessions.
+Provider auth is resolved using OpenClaw's native runtime. Engram first tries the gateway's `getRuntimeAuthForModel()` function, which handles all provider-specific transforms — OAuth token exchange (for `openai-codex`, `github-copilot`, etc.), base URL overrides, profile-based credentials, and secret reference formats — using the same codepath the gateway uses for its own agent sessions.
 
-This means your existing secret management setup works automatically — no special configuration needed for Engram. Plain-text API keys also work as-is.
+If the gateway runtime isn't available (e.g., running outside the gateway process), Engram falls back to `resolveProviderApiKey()` for secret ref resolution, then checks the `PROVIDER_NAME_API_KEY` environment variable before skipping the provider.
 
-If a provider's API key can't be resolved (e.g., the gateway auth module isn't available), Engram checks the `PROVIDER_NAME_API_KEY` environment variable as a fallback before skipping the provider.
+This means your existing auth setup works automatically — OAuth providers, API keys, 1Password, Vault, env vars, and plain-text keys all work without special Engram configuration.
 
 ### Switching back
 

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,49 +1,58 @@
 import { log } from "./logger.js";
-import type { GatewayConfig, ModelProviderConfig, ModelApi, AgentPersona } from "./types.js";
+import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
   buildChatCompletionTokenLimit,
   shouldAssumeOpenAiChatCompletions,
 } from "./openai-chat-compat.js";
 import { resolveProviderApiKey } from "./resolve-provider-secret.js";
+import { loadModelsJsonProviders } from "./models-json.js";
 
 /**
- * Map of well-known provider ID prefixes to their API format and base URL.
- * Used to synthesize a ModelProviderConfig when the provider isn't declared
- * in the user's models.providers config (e.g., OAuth-based providers like
- * openai-codex or anthropic-enterprise).
+ * Supported API formats that FallbackLlmClient can drive directly.
  */
-const KNOWN_PROVIDER_DEFAULTS: Record<
-  string,
-  { format: ModelApi; baseUrl: string }
-> = {
-  openai: { format: "openai-completions", baseUrl: "https://api.openai.com/v1" },
-  anthropic: { format: "anthropic-messages", baseUrl: "https://api.anthropic.com" },
-  google: { format: "google-generative", baseUrl: "https://generativelanguage.googleapis.com" },
-};
+type SupportedApi = "openai-completions" | "anthropic-messages";
 
 /**
- * Infer the API format and base URL for a provider ID that isn't in the
- * explicit providers map. Matches exact entries first, then tries prefixes
- * (e.g., "openai-codex" matches the "openai" prefix). For completely
- * unknown providers, falls back to OpenAI-compatible format since that's
- * the most common API shape for third-party providers.
+ * Normalize a provider's API format to one this client can drive.
+ *
+ * The gateway supports many transport formats (openai-codex-responses, ollama,
+ * github-copilot, etc.) via its plugin system. This client only speaks
+ * openai-completions and anthropic-messages. For providers using unsupported
+ * formats, we map to a compatible format when the provider's auth token is
+ * valid at a standard endpoint (e.g., openai-codex OAuth tokens work at
+ * api.openai.com).
  */
-function inferApiFormat(
+function normalizeApiTransport(
+  api: string | undefined,
   providerId: string,
-): { format: ModelApi; baseUrl: string } {
-  if (KNOWN_PROVIDER_DEFAULTS[providerId]) {
-    return KNOWN_PROVIDER_DEFAULTS[providerId];
+): { api: SupportedApi; baseUrl?: string } {
+  switch (api) {
+    case "openai-completions":
+    case "openai-responses":
+    case undefined:
+      return { api: "openai-completions" };
+
+    case "anthropic-messages":
+      return { api: "anthropic-messages" };
+
+    // OpenAI-family transports: codex-responses uses ChatGPT backend-api but
+    // the OAuth token is also valid at the standard OpenAI API endpoint.
+    case "openai-codex-responses":
+    case "azure-openai-responses":
+      return { api: "openai-completions", baseUrl: "https://api.openai.com/v1" };
+
+    // Google Generative AI: uses a different protocol but shares API keys
+    // with the OpenAI-compatible endpoint that Google also serves.
+    case "google-generative-ai":
+      return { api: "openai-completions", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai" };
+
+    default:
+      log.debug(`fallback LLM: unsupported API format "${api}" for provider "${providerId}"`);
+      // Return openai-completions as a best-effort — tryModel() will catch
+      // HTTP errors and the chain will continue to the next fallback.
+      return { api: "openai-completions" };
   }
-  for (const [prefix, defaults] of Object.entries(KNOWN_PROVIDER_DEFAULTS)) {
-    if (providerId.startsWith(`${prefix}-`)) {
-      return defaults;
-    }
-  }
-  // Unknown provider — assume OpenAI-compatible. The gateway resolver will
-  // handle auth; if it can't resolve a key, tryModel() will skip this
-  // provider and the chain continues to the next fallback.
-  return { format: "openai-completions", baseUrl: "https://api.openai.com/v1" };
 }
 
 export interface FallbackLlmOptions {
@@ -279,32 +288,31 @@ export class FallbackLlmClient {
     const providerId = parts[0];
     const modelId = parts.slice(1).join("/"); // Handle cases like "openai/gpt-5.2-turbo"
 
-    // Look up explicit config first; fall back to synthesizing a config
-    // for built-in providers (e.g., OAuth-based providers like openai-codex)
-    const providerConfig = providers[providerId] ?? this.synthesizeBuiltinProvider(providerId);
+    // Look up explicit config first; fall back to the gateway's materialized
+    // models.json which contains built-in providers (openai-codex, etc.)
+    const providerConfig = providers[providerId] ?? this.resolveFromModelsJson(providerId);
+    if (!providerConfig) {
+      log.warn(`fallback LLM: provider not found: ${providerId}`);
+      return null;
+    }
 
     return { providerId, modelId, providerConfig, modelString };
   }
 
   /**
-   * Synthesize a ModelProviderConfig for a provider that isn't declared in
-   * models.providers (e.g., "openai-codex" using OAuth, or any built-in
-   * OpenClaw provider).
-   *
-   * The gateway's resolveApiKeyForProvider() knows how to resolve auth for
-   * these providers, so we only need to supply enough config for the HTTP
-   * call. The API format and base URL are inferred from the provider ID.
+   * Look up a provider from the gateway's materialized models.json, which
+   * contains all providers including built-in ones (openai-codex, google-vertex,
+   * etc.) that aren't in the user's openclaw.json but are registered by
+   * gateway plugins. Returns null if the provider isn't found there either.
    */
-  private synthesizeBuiltinProvider(providerId: string): ModelProviderConfig {
-    const api = inferApiFormat(providerId);
-
-    log.debug(`fallback LLM: synthesizing config for built-in provider "${providerId}" (api: ${api.format})`);
-    return {
-      baseUrl: api.baseUrl,
-      apiKey: "secretref-managed",
-      api: api.format,
-      models: [],
-    };
+  private resolveFromModelsJson(providerId: string): ModelProviderConfig | null {
+    const allProviders = loadModelsJsonProviders();
+    const config = allProviders[providerId];
+    if (config) {
+      log.debug(`fallback LLM: resolved provider "${providerId}" from models.json (api: ${config.api ?? "default"})`);
+      return config;
+    }
+    return null;
   }
 
   /**
@@ -342,17 +350,33 @@ export class FallbackLlmClient {
       ? { ...model.providerConfig, apiKey: resolvedApiKey }
       : model.providerConfig;
 
-    switch (model.providerConfig.api) {
+    // Resolve API format to a transport this client supports.
+    // Some providers use specialized formats (openai-codex-responses, ollama,
+    // github-copilot) that we can't drive directly — normalizeApiTransport()
+    // maps them to a compatible format when possible.
+    const transport = normalizeApiTransport(model.providerConfig.api, model.providerId);
+
+    switch (transport.api) {
       case "anthropic-messages":
-        return await this.callAnthropic(configWithResolvedKey, model.modelId, messages, options);
-      case "openai-completions":
-      default:
+        return await this.callAnthropic(
+          transport.baseUrl ? { ...configWithResolvedKey, baseUrl: transport.baseUrl } : configWithResolvedKey,
+          model.modelId, messages, options,
+        );
+      case "openai-completions": {
+        const effectiveConfig = transport.baseUrl
+          ? { ...configWithResolvedKey, baseUrl: transport.baseUrl }
+          : configWithResolvedKey;
         return await this.callOpenAI(
-          configWithResolvedKey,
+          effectiveConfig,
           model.modelId,
           messages,
           options,
-          shouldAssumeOpenAiChatCompletions(model.providerConfig.baseUrl),
+          shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
+        );
+      }
+      default:
+        throw new Error(
+          `unsupported API format "${model.providerConfig.api}" for provider "${model.providerId}"`,
         );
     }
   }

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -5,55 +5,8 @@ import {
   buildChatCompletionTokenLimit,
   shouldAssumeOpenAiChatCompletions,
 } from "./openai-chat-compat.js";
-import { resolveProviderApiKey } from "./resolve-provider-secret.js";
+import { resolveProviderApiKey, getGatewayRuntimeAuthForModel } from "./resolve-provider-secret.js";
 import { loadModelsJsonProviders } from "./models-json.js";
-
-/**
- * Supported API formats that FallbackLlmClient can drive directly.
- */
-type SupportedApi = "openai-completions" | "anthropic-messages";
-
-/**
- * Normalize a provider's API format to one this client can drive.
- *
- * The gateway supports many transport formats (openai-codex-responses, ollama,
- * github-copilot, etc.) via its plugin system. This client only speaks
- * openai-completions and anthropic-messages. For providers using unsupported
- * formats, we map to a compatible format when the provider's auth token is
- * valid at a standard endpoint (e.g., openai-codex OAuth tokens work at
- * api.openai.com).
- */
-function normalizeApiTransport(
-  api: string | undefined,
-  providerId: string,
-): { api: SupportedApi; baseUrl?: string } {
-  switch (api) {
-    case "openai-completions":
-    case "openai-responses":
-    case undefined:
-      return { api: "openai-completions" };
-
-    case "anthropic-messages":
-      return { api: "anthropic-messages" };
-
-    // OpenAI-family transports: codex-responses uses ChatGPT backend-api but
-    // the OAuth token is also valid at the standard OpenAI API endpoint.
-    case "openai-codex-responses":
-    case "azure-openai-responses":
-      return { api: "openai-completions", baseUrl: "https://api.openai.com/v1" };
-
-    // Google Generative AI: uses a different protocol but shares API keys
-    // with the OpenAI-compatible endpoint that Google also serves.
-    case "google-generative-ai":
-      return { api: "openai-completions", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai" };
-
-    default:
-      log.debug(`fallback LLM: unsupported API format "${api}" for provider "${providerId}"`);
-      // Return openai-completions as a best-effort — tryModel() will catch
-      // HTTP errors and the chain will continue to the next fallback.
-      return { api: "openai-completions" };
-  }
-}
 
 export interface FallbackLlmOptions {
   temperature?: number;
@@ -316,56 +269,46 @@ export class FallbackLlmClient {
   }
 
   /**
-   * Resolve the API key for a provider, handling OpenClaw secret ref formats.
-   * Results are cached per provider so exec calls only happen once.
-   */
-  private async resolveApiKey(
-    providerId: string,
-    providerConfig: ModelProviderConfig,
-  ): Promise<string | undefined> {
-    return resolveProviderApiKey(providerId, providerConfig.apiKey, this.gatewayConfig);
-  }
-
-  /**
    * Try to call a single model.
+   *
+   * Uses the gateway's native getRuntimeAuthForModel when available — this
+   * handles all provider-specific auth transforms (OAuth token exchange,
+   * base URL overrides for codex/copilot/etc.) through the same codepath
+   * the gateway itself uses. Falls back to resolveProviderApiKey for
+   * simpler providers or when the runtime module isn't loaded.
    */
   private async tryModel(
     model: ModelRef,
     messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
     options: FallbackLlmOptions,
   ): Promise<{ content: string; usage?: FallbackLlmResponse["usage"] } | null> {
-    // Resolve the API key from secret refs before making the call.
+    // Try the gateway's native runtime auth first — it handles all provider-
+    // specific transforms (OAuth exchange, base URL rewrite, etc.)
+    const runtimeAuth = await this.resolveRuntimeAuth(model);
+    const effectiveBaseUrl = runtimeAuth?.baseUrl ?? model.providerConfig.baseUrl;
+    const resolvedApiKey = runtimeAuth?.apiKey ?? await this.resolveFallbackApiKey(model);
+
     // If the raw key looks like an unresolved secret ref and resolution fails,
     // skip this provider entirely so the chain falls through to the next.
     const rawKey = model.providerConfig.apiKey;
     const needsResolution = rawKey === "secretref-managed"
       || (typeof rawKey === "object" && rawKey !== null);
-    const resolvedApiKey = await this.resolveApiKey(model.providerId, model.providerConfig);
-
     if (needsResolution && !resolvedApiKey) {
       throw new Error(`API key for provider "${model.providerId}" could not be resolved from secret ref`);
     }
 
-    const configWithResolvedKey = resolvedApiKey
-      ? { ...model.providerConfig, apiKey: resolvedApiKey }
-      : model.providerConfig;
+    const effectiveConfig: ModelProviderConfig = {
+      ...model.providerConfig,
+      baseUrl: effectiveBaseUrl,
+      ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
+    };
 
-    // Resolve API format to a transport this client supports.
-    // Some providers use specialized formats (openai-codex-responses, ollama,
-    // github-copilot) that we can't drive directly — normalizeApiTransport()
-    // maps them to a compatible format when possible.
-    const transport = normalizeApiTransport(model.providerConfig.api, model.providerId);
-
-    switch (transport.api) {
+    switch (model.providerConfig.api) {
       case "anthropic-messages":
-        return await this.callAnthropic(
-          transport.baseUrl ? { ...configWithResolvedKey, baseUrl: transport.baseUrl } : configWithResolvedKey,
-          model.modelId, messages, options,
-        );
-      case "openai-completions": {
-        const effectiveConfig = transport.baseUrl
-          ? { ...configWithResolvedKey, baseUrl: transport.baseUrl }
-          : configWithResolvedKey;
+        return await this.callAnthropic(effectiveConfig, model.modelId, messages, options);
+      case "openai-completions":
+      case "openai-responses":
+      case undefined:
         return await this.callOpenAI(
           effectiveConfig,
           model.modelId,
@@ -373,12 +316,63 @@ export class FallbackLlmClient {
           options,
           shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
         );
-      }
       default:
-        throw new Error(
-          `unsupported API format "${model.providerConfig.api}" for provider "${model.providerId}"`,
+        // For other API formats (openai-codex-responses, ollama, etc.),
+        // try OpenAI chat completions — the gateway's runtime auth resolver
+        // returns the request-ready base URL and credentials that work with
+        // the standard chat completions endpoint for many providers.
+        return await this.callOpenAI(
+          effectiveConfig,
+          model.modelId,
+          messages,
+          options,
+          shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
         );
     }
+  }
+
+  /**
+   * Resolve request-ready auth through the gateway's native runtime, which
+   * handles provider-specific transforms (OAuth token exchange for codex/copilot,
+   * base URL rewrite, etc.). Returns null if the runtime isn't available.
+   */
+  private async resolveRuntimeAuth(
+    model: ModelRef,
+  ): Promise<{ apiKey?: string; baseUrl?: string } | null> {
+    try {
+      const getRuntimeAuth = await getGatewayRuntimeAuthForModel();
+      if (!getRuntimeAuth) return null;
+
+      const result = await getRuntimeAuth({
+        model: {
+          provider: model.providerId,
+          id: model.modelId,
+          api: model.providerConfig.api,
+          baseUrl: model.providerConfig.baseUrl,
+        },
+        cfg: this.gatewayConfig,
+      });
+
+      if (result?.apiKey) {
+        log.debug(
+          `fallback LLM: resolved runtime auth for "${model.modelString}" (source: ${result.source ?? "unknown"}, mode: ${result.mode ?? "unknown"})`,
+        );
+        return { apiKey: result.apiKey, baseUrl: result.baseUrl };
+      }
+    } catch (err) {
+      log.debug(
+        `fallback LLM: gateway runtime auth failed for "${model.modelString}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    return null;
+  }
+
+  /**
+   * Resolve API key through the existing provider-level resolution (env vars,
+   * secret refs, etc.). Used as fallback when gateway runtime auth isn't available.
+   */
+  private async resolveFallbackApiKey(model: ModelRef): Promise<string | undefined> {
+    return resolveProviderApiKey(model.providerId, model.providerConfig.apiKey, this.gatewayConfig);
   }
 
   /**

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -173,9 +173,7 @@ export class FallbackLlmClient {
    */
   private getModelChain(agentId?: string): ModelRef[] {
     const chain: ModelRef[] = [];
-    const providers = this.gatewayConfig?.models?.providers;
-
-    if (!providers) return chain;
+    const providers = this.gatewayConfig?.models?.providers ?? {};
 
     // Resolve the model config: agent persona chain or global defaults
     let modelConfig: { primary?: string; fallbacks?: string[] } | undefined;
@@ -303,32 +301,21 @@ export class FallbackLlmClient {
       ...(resolvedApiKey ? { apiKey: resolvedApiKey } : {}),
     };
 
-    switch (model.providerConfig.api) {
-      case "anthropic-messages":
-        return await this.callAnthropic(effectiveConfig, model.modelId, messages, options);
-      case "openai-completions":
-      case "openai-responses":
-      case undefined:
-        return await this.callOpenAI(
-          effectiveConfig,
-          model.modelId,
-          messages,
-          options,
-          shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
-        );
-      default:
-        // For other API formats (openai-codex-responses, ollama, etc.),
-        // try OpenAI chat completions — the gateway's runtime auth resolver
-        // returns the request-ready base URL and credentials that work with
-        // the standard chat completions endpoint for many providers.
-        return await this.callOpenAI(
-          effectiveConfig,
-          model.modelId,
-          messages,
-          options,
-          shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
-        );
+    if (model.providerConfig.api === "anthropic-messages") {
+      return await this.callAnthropic(effectiveConfig, model.modelId, messages, options);
     }
+
+    // For OpenAI-compatible APIs (openai-completions, openai-responses,
+    // openai-codex-responses, ollama, etc.) and unknown formats, use
+    // OpenAI chat completions — the gateway's runtime auth resolver returns
+    // request-ready base URL and credentials for most providers.
+    return await this.callOpenAI(
+      effectiveConfig,
+      model.modelId,
+      messages,
+      options,
+      shouldAssumeOpenAiChatCompletions(effectiveConfig.baseUrl),
+    );
   }
 
   /**
@@ -353,7 +340,7 @@ export class FallbackLlmClient {
         cfg: this.gatewayConfig,
       });
 
-      if (result?.apiKey) {
+      if (result?.apiKey || result?.baseUrl) {
         log.debug(
           `fallback LLM: resolved runtime auth for "${model.modelString}" (source: ${result.source ?? "unknown"}, mode: ${result.mode ?? "unknown"})`,
         );

--- a/packages/remnic-core/src/fallback-llm.ts
+++ b/packages/remnic-core/src/fallback-llm.ts
@@ -1,11 +1,50 @@
 import { log } from "./logger.js";
-import type { GatewayConfig, ModelProviderConfig, AgentPersona } from "./types.js";
+import type { GatewayConfig, ModelProviderConfig, ModelApi, AgentPersona } from "./types.js";
 import { extractJsonCandidates } from "./json-extract.js";
 import {
   buildChatCompletionTokenLimit,
   shouldAssumeOpenAiChatCompletions,
 } from "./openai-chat-compat.js";
 import { resolveProviderApiKey } from "./resolve-provider-secret.js";
+
+/**
+ * Map of well-known provider ID prefixes to their API format and base URL.
+ * Used to synthesize a ModelProviderConfig when the provider isn't declared
+ * in the user's models.providers config (e.g., OAuth-based providers like
+ * openai-codex or anthropic-enterprise).
+ */
+const KNOWN_PROVIDER_DEFAULTS: Record<
+  string,
+  { format: ModelApi; baseUrl: string }
+> = {
+  openai: { format: "openai-completions", baseUrl: "https://api.openai.com/v1" },
+  anthropic: { format: "anthropic-messages", baseUrl: "https://api.anthropic.com" },
+  google: { format: "google-generative", baseUrl: "https://generativelanguage.googleapis.com" },
+};
+
+/**
+ * Infer the API format and base URL for a provider ID that isn't in the
+ * explicit providers map. Matches exact entries first, then tries prefixes
+ * (e.g., "openai-codex" matches the "openai" prefix). For completely
+ * unknown providers, falls back to OpenAI-compatible format since that's
+ * the most common API shape for third-party providers.
+ */
+function inferApiFormat(
+  providerId: string,
+): { format: ModelApi; baseUrl: string } {
+  if (KNOWN_PROVIDER_DEFAULTS[providerId]) {
+    return KNOWN_PROVIDER_DEFAULTS[providerId];
+  }
+  for (const [prefix, defaults] of Object.entries(KNOWN_PROVIDER_DEFAULTS)) {
+    if (providerId.startsWith(`${prefix}-`)) {
+      return defaults;
+    }
+  }
+  // Unknown provider — assume OpenAI-compatible. The gateway resolver will
+  // handle auth; if it can't resolve a key, tryModel() will skip this
+  // provider and the chain continues to the next fallback.
+  return { format: "openai-completions", baseUrl: "https://api.openai.com/v1" };
+}
 
 export interface FallbackLlmOptions {
   temperature?: number;
@@ -240,13 +279,32 @@ export class FallbackLlmClient {
     const providerId = parts[0];
     const modelId = parts.slice(1).join("/"); // Handle cases like "openai/gpt-5.2-turbo"
 
-    const providerConfig = providers[providerId];
-    if (!providerConfig) {
-      log.warn(`fallback LLM: provider not found: ${providerId}`);
-      return null;
-    }
+    // Look up explicit config first; fall back to synthesizing a config
+    // for built-in providers (e.g., OAuth-based providers like openai-codex)
+    const providerConfig = providers[providerId] ?? this.synthesizeBuiltinProvider(providerId);
 
     return { providerId, modelId, providerConfig, modelString };
+  }
+
+  /**
+   * Synthesize a ModelProviderConfig for a provider that isn't declared in
+   * models.providers (e.g., "openai-codex" using OAuth, or any built-in
+   * OpenClaw provider).
+   *
+   * The gateway's resolveApiKeyForProvider() knows how to resolve auth for
+   * these providers, so we only need to supply enough config for the HTTP
+   * call. The API format and base URL are inferred from the provider ID.
+   */
+  private synthesizeBuiltinProvider(providerId: string): ModelProviderConfig {
+    const api = inferApiFormat(providerId);
+
+    log.debug(`fallback LLM: synthesizing config for built-in provider "${providerId}" (api: ${api.format})`);
+    return {
+      baseUrl: api.baseUrl,
+      apiKey: "secretref-managed",
+      api: api.format,
+      models: [],
+    };
   }
 
   /**

--- a/packages/remnic-core/src/models-json.ts
+++ b/packages/remnic-core/src/models-json.ts
@@ -1,0 +1,69 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { log } from "./logger.js";
+import type { ModelProviderConfig } from "./types.js";
+
+/**
+ * Read the gateway's materialized models.json to get the full provider map,
+ * including built-in providers (openai-codex, google-vertex, etc.) that are
+ * not declared in the user's openclaw.json but are registered by gateway
+ * plugins at runtime.
+ *
+ * The gateway writes models.json to ~/.openclaw/agents/main/agent/models.json
+ * with all providers merged: user-defined (from openclaw.json) + built-in
+ * (from plugin catalogs). Each entry has the correct baseUrl, api format,
+ * and auth mode for that provider.
+ *
+ * Results are cached for the process lifetime since models.json only changes
+ * when the gateway restarts or `openclaw models` commands run.
+ */
+
+let _cachedProviders: Record<string, ModelProviderConfig> | null = null;
+let _loadAttempted = false;
+
+/**
+ * Load the full providers map from the gateway's models.json.
+ * Returns an empty object if the file doesn't exist or can't be parsed.
+ */
+export function loadModelsJsonProviders(): Record<string, ModelProviderConfig> {
+  if (_loadAttempted) {
+    return _cachedProviders ?? {};
+  }
+  _loadAttempted = true;
+
+  try {
+    const modelsPath = join(homedir(), ".openclaw", "agents", "main", "agent", "models.json");
+    const raw = readFileSync(modelsPath, "utf-8");
+    const parsed = JSON.parse(raw);
+    const providers = parsed?.providers;
+
+    if (providers && typeof providers === "object" && !Array.isArray(providers)) {
+      _cachedProviders = providers as Record<string, ModelProviderConfig>;
+      log.debug(`loaded ${Object.keys(_cachedProviders).length} providers from models.json`);
+      return _cachedProviders;
+    }
+  } catch (err) {
+    log.debug(
+      `could not load models.json: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  return {};
+}
+
+/**
+ * Clear the cached providers (useful for testing).
+ */
+export function clearModelsJsonCache(): void {
+  _cachedProviders = null;
+  _loadAttempted = false;
+}
+
+/**
+ * Inject a providers map for testing, bypassing file I/O.
+ */
+export function __setModelsJsonForTest(providers: Record<string, ModelProviderConfig>): void {
+  _cachedProviders = providers;
+  _loadAttempted = true;
+}

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -23,7 +23,24 @@ type ResolveApiKeyFn = (params: {
   agentDir?: string;
 }) => Promise<{ apiKey?: string; source?: string; mode?: string } | null>;
 
+/**
+ * Resolve request-ready auth for a model, including provider-owned transforms
+ * (e.g., OAuth token exchange, base URL override for openai-codex).
+ */
+export type GetRuntimeAuthForModelFn = (params: {
+  model: { provider: string; id: string; api?: string; baseUrl?: string };
+  cfg?: unknown;
+  workspaceDir?: string;
+}) => Promise<{
+  apiKey?: string;
+  baseUrl?: string;
+  source?: string;
+  mode?: string;
+  profileId?: string;
+} | null>;
+
 let _resolveApiKeyForProvider: ResolveApiKeyFn | null = null;
+let _getRuntimeAuthForModel: GetRuntimeAuthForModelFn | null = null;
 let _resolverLoaded = false;
 let _resolverNextRetryAt = 0;
 const RESOLVER_RETRY_BACKOFF_MS = 60_000; // 1 minute between retries after first failure
@@ -59,6 +76,10 @@ async function getGatewayResolver(): Promise<ResolveApiKeyFn | null> {
         const mod = await import(importUrl);
         if (typeof mod.resolveApiKeyForProvider === "function") {
           _resolveApiKeyForProvider = mod.resolveApiKeyForProvider;
+          if (typeof mod.getRuntimeAuthForModel === "function") {
+            _getRuntimeAuthForModel = mod.getRuntimeAuthForModel;
+            log.debug("loaded gateway getRuntimeAuthForModel from runtime module");
+          }
           _resolverLoaded = true;
           log.debug("loaded gateway resolveApiKeyForProvider from runtime module");
           return _resolveApiKeyForProvider;
@@ -231,11 +252,25 @@ function resolveFromEnv(providerId: string): string | undefined {
 }
 
 /**
+ * Get the gateway's getRuntimeAuthForModel function, if available.
+ * This resolves request-ready auth including provider-owned transforms
+ * (OAuth token exchange, base URL override for codex/copilot/etc.).
+ * Must be called after at least one resolveProviderApiKey() call to
+ * trigger the lazy module load.
+ */
+export async function getGatewayRuntimeAuthForModel(): Promise<GetRuntimeAuthForModelFn | null> {
+  // Ensure the runtime module has been loaded
+  await getGatewayResolver();
+  return _getRuntimeAuthForModel;
+}
+
+/**
  * Clear the resolution cache (useful for testing or key rotation).
  */
 export function clearSecretCache(): void {
   resolvedCache.clear();
   _resolveApiKeyForProvider = null;
+  _getRuntimeAuthForModel = null;
   _resolverLoaded = false;
   _resolverNextRetryAt = 0;
 }

--- a/src/models-json.ts
+++ b/src/models-json.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/models-json.js";

--- a/tests/fallback-llm-builtin-provider.test.ts
+++ b/tests/fallback-llm-builtin-provider.test.ts
@@ -175,6 +175,31 @@ test("FallbackLlmClient resolves google provider from models.json", () => {
   assert.equal(chain[0].providerConfig.api, "google-generative-ai");
 });
 
+test("FallbackLlmClient resolves models.json provider when config has no providers key", () => {
+  setModelsJson({
+    "openai-codex": {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      auth: "oauth",
+      models: [],
+    },
+  });
+
+  // Config with no providers property at all (models key is missing)
+  const config: GatewayConfig = {
+    agents: {
+      defaults: {
+        model: { primary: "openai-codex/gpt-5.4" },
+      },
+    },
+  };
+  const client = new FallbackLlmClient(config);
+  assert.ok(client.isAvailable(), "client should be available via models.json even without explicit providers");
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.api, "openai-codex-responses");
+});
+
 test("FallbackLlmClient chatCompletion attempts built-in provider and invokes tryModel", async () => {
   setModelsJson({
     "openai-codex": {

--- a/tests/fallback-llm-builtin-provider.test.ts
+++ b/tests/fallback-llm-builtin-provider.test.ts
@@ -1,0 +1,138 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { FallbackLlmClient } from "../src/fallback-llm.ts";
+import type { GatewayConfig } from "../src/types.ts";
+
+/**
+ * Helper: create a gateway config with explicit providers and a model chain.
+ */
+function makeConfig(
+  providers: GatewayConfig["models"],
+  primary: string,
+  fallbacks: string[] = [],
+): GatewayConfig {
+  return {
+    models: providers,
+    agents: {
+      defaults: {
+        model: { primary, fallbacks },
+      },
+    },
+  };
+}
+
+test("FallbackLlmClient resolves built-in openai-codex provider not in explicit providers", () => {
+  // Config has no "openai-codex" in providers, but the model chain references it
+  const config = makeConfig(
+    { providers: {} },
+    "openai-codex/gpt-5.4",
+  );
+
+  const client = new FallbackLlmClient(config);
+  assert.ok(client.isAvailable(), "client should report available for built-in provider");
+});
+
+test("FallbackLlmClient resolves built-in anthropic-prefixed provider", () => {
+  const config = makeConfig(
+    { providers: {} },
+    "anthropic-enterprise/claude-opus-4-6",
+  );
+
+  const client = new FallbackLlmClient(config);
+  assert.ok(client.isAvailable(), "client should report available for anthropic-prefixed provider");
+});
+
+test("FallbackLlmClient resolves unknown provider via fallback synthesis", () => {
+  const config = makeConfig(
+    { providers: {} },
+    "custom-provider/some-model",
+  );
+
+  const client = new FallbackLlmClient(config);
+  assert.ok(client.isAvailable(), "client should report available for unknown provider (gateway resolver handles auth)");
+});
+
+test("FallbackLlmClient prefers explicit provider config over synthesized", () => {
+  const config = makeConfig(
+    {
+      providers: {
+        "openai-codex": {
+          baseUrl: "https://custom.endpoint.example.com/v1",
+          apiKey: "sk-test-key",
+          api: "openai-completions",
+          models: [],
+        },
+      },
+    },
+    "openai-codex/gpt-5.4",
+  );
+
+  const client = new FallbackLlmClient(config);
+  assert.ok(client.isAvailable());
+
+  // Access the internal model chain to verify the explicit config is used
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.baseUrl, "https://custom.endpoint.example.com/v1");
+  assert.equal(chain[0].providerConfig.apiKey, "sk-test-key");
+});
+
+test("FallbackLlmClient synthesizes correct API format for anthropic prefix", () => {
+  const config = makeConfig(
+    { providers: {} },
+    "anthropic-oauth/claude-opus-4-6",
+  );
+
+  const client = new FallbackLlmClient(config);
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.api, "anthropic-messages");
+  assert.equal(chain[0].providerConfig.apiKey, "secretref-managed");
+});
+
+test("FallbackLlmClient synthesizes correct API format for google prefix", () => {
+  const config = makeConfig(
+    { providers: {} },
+    "google-vertex/gemini-pro",
+  );
+
+  const client = new FallbackLlmClient(config);
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.api, "google-generative");
+});
+
+test("FallbackLlmClient builds mixed chain with explicit and synthesized providers", () => {
+  const config = makeConfig(
+    {
+      providers: {
+        openai: {
+          baseUrl: "https://api.openai.com/v1",
+          apiKey: "sk-real",
+          api: "openai-completions",
+          models: [],
+        },
+      },
+    },
+    "openai/gpt-5.2",
+    ["openai-codex/gpt-5.4", "anthropic-oauth/claude-opus-4-6"],
+  );
+
+  const client = new FallbackLlmClient(config);
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 3);
+
+  // First: explicit provider
+  assert.equal(chain[0].providerId, "openai");
+  assert.equal(chain[0].providerConfig.apiKey, "sk-real");
+
+  // Second: synthesized openai-codex
+  assert.equal(chain[1].providerId, "openai-codex");
+  assert.equal(chain[1].providerConfig.apiKey, "secretref-managed");
+  assert.equal(chain[1].providerConfig.api, "openai-completions");
+
+  // Third: synthesized anthropic-oauth
+  assert.equal(chain[2].providerId, "anthropic-oauth");
+  assert.equal(chain[2].providerConfig.apiKey, "secretref-managed");
+  assert.equal(chain[2].providerConfig.api, "anthropic-messages");
+});

--- a/tests/fallback-llm-builtin-provider.test.ts
+++ b/tests/fallback-llm-builtin-provider.test.ts
@@ -1,7 +1,8 @@
-import test from "node:test";
+import test, { beforeEach } from "node:test";
 import assert from "node:assert/strict";
 import { FallbackLlmClient } from "../src/fallback-llm.ts";
-import type { GatewayConfig } from "../src/types.ts";
+import { clearModelsJsonCache, __setModelsJsonForTest } from "../src/models-json.ts";
+import type { GatewayConfig, ModelProviderConfig } from "../src/types.ts";
 
 /**
  * Helper: create a gateway config with explicit providers and a model chain.
@@ -21,38 +22,71 @@ function makeConfig(
   };
 }
 
-test("FallbackLlmClient resolves built-in openai-codex provider not in explicit providers", () => {
-  // Config has no "openai-codex" in providers, but the model chain references it
-  const config = makeConfig(
-    { providers: {} },
-    "openai-codex/gpt-5.4",
-  );
+/**
+ * Helper: inject test providers into the models.json cache.
+ */
+function setModelsJson(providers: Record<string, ModelProviderConfig>): void {
+  clearModelsJsonCache();
+  __setModelsJsonForTest(providers);
+}
 
+// Reset the models.json cache before each test.
+beforeEach(() => {
+  clearModelsJsonCache();
+});
+
+test("FallbackLlmClient resolves built-in openai-codex provider from models.json", () => {
+  setModelsJson({
+    "openai-codex": {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      auth: "oauth",
+      models: [],
+    },
+  });
+
+  const config = makeConfig({ providers: {} }, "openai-codex/gpt-5.4");
   const client = new FallbackLlmClient(config);
   assert.ok(client.isAvailable(), "client should report available for built-in provider");
 });
 
-test("FallbackLlmClient resolves built-in anthropic-prefixed provider", () => {
-  const config = makeConfig(
-    { providers: {} },
-    "anthropic-enterprise/claude-opus-4-6",
-  );
+test("FallbackLlmClient resolves anthropic provider from models.json with correct API format", () => {
+  setModelsJson({
+    anthropic: {
+      baseUrl: "https://api.anthropic.com",
+      api: "anthropic-messages",
+      auth: "token",
+      apiKey: "secretref-managed",
+      models: [],
+    },
+  });
 
+  const config = makeConfig({ providers: {} }, "anthropic/claude-opus-4-6");
   const client = new FallbackLlmClient(config);
-  assert.ok(client.isAvailable(), "client should report available for anthropic-prefixed provider");
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.api, "anthropic-messages");
+  assert.equal(chain[0].providerConfig.baseUrl, "https://api.anthropic.com");
 });
 
-test("FallbackLlmClient resolves unknown provider via fallback synthesis", () => {
-  const config = makeConfig(
-    { providers: {} },
-    "custom-provider/some-model",
-  );
+test("FallbackLlmClient returns unavailable when provider not in config or models.json", () => {
+  setModelsJson({});
 
+  const config = makeConfig({ providers: {} }, "nonexistent-provider/some-model");
   const client = new FallbackLlmClient(config);
-  assert.ok(client.isAvailable(), "client should report available for unknown provider (gateway resolver handles auth)");
+  assert.equal(client.isAvailable(), false);
 });
 
-test("FallbackLlmClient prefers explicit provider config over synthesized", () => {
+test("FallbackLlmClient prefers explicit provider config over models.json", () => {
+  setModelsJson({
+    "openai-codex": {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      auth: "oauth",
+      models: [],
+    },
+  });
+
   const config = makeConfig(
     {
       providers: {
@@ -68,41 +102,29 @@ test("FallbackLlmClient prefers explicit provider config over synthesized", () =
   );
 
   const client = new FallbackLlmClient(config);
-  assert.ok(client.isAvailable());
-
-  // Access the internal model chain to verify the explicit config is used
   const chain = (client as any).getModelChain();
   assert.equal(chain.length, 1);
   assert.equal(chain[0].providerConfig.baseUrl, "https://custom.endpoint.example.com/v1");
   assert.equal(chain[0].providerConfig.apiKey, "sk-test-key");
 });
 
-test("FallbackLlmClient synthesizes correct API format for anthropic prefix", () => {
-  const config = makeConfig(
-    { providers: {} },
-    "anthropic-oauth/claude-opus-4-6",
-  );
+test("FallbackLlmClient builds mixed chain with explicit and models.json providers", () => {
+  setModelsJson({
+    "openai-codex": {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      auth: "oauth",
+      models: [],
+    },
+    anthropic: {
+      baseUrl: "https://api.anthropic.com",
+      api: "anthropic-messages",
+      auth: "token",
+      apiKey: "secretref-managed",
+      models: [],
+    },
+  });
 
-  const client = new FallbackLlmClient(config);
-  const chain = (client as any).getModelChain();
-  assert.equal(chain.length, 1);
-  assert.equal(chain[0].providerConfig.api, "anthropic-messages");
-  assert.equal(chain[0].providerConfig.apiKey, "secretref-managed");
-});
-
-test("FallbackLlmClient synthesizes correct API format for google prefix", () => {
-  const config = makeConfig(
-    { providers: {} },
-    "google-vertex/gemini-pro",
-  );
-
-  const client = new FallbackLlmClient(config);
-  const chain = (client as any).getModelChain();
-  assert.equal(chain.length, 1);
-  assert.equal(chain[0].providerConfig.api, "google-generative");
-});
-
-test("FallbackLlmClient builds mixed chain with explicit and synthesized providers", () => {
   const config = makeConfig(
     {
       providers: {
@@ -115,7 +137,7 @@ test("FallbackLlmClient builds mixed chain with explicit and synthesized provide
       },
     },
     "openai/gpt-5.2",
-    ["openai-codex/gpt-5.4", "anthropic-oauth/claude-opus-4-6"],
+    ["openai-codex/gpt-5.4", "anthropic/claude-opus-4-6"],
   );
 
   const client = new FallbackLlmClient(config);
@@ -126,13 +148,29 @@ test("FallbackLlmClient builds mixed chain with explicit and synthesized provide
   assert.equal(chain[0].providerId, "openai");
   assert.equal(chain[0].providerConfig.apiKey, "sk-real");
 
-  // Second: synthesized openai-codex
+  // Second: from models.json (openai-codex)
   assert.equal(chain[1].providerId, "openai-codex");
-  assert.equal(chain[1].providerConfig.apiKey, "secretref-managed");
-  assert.equal(chain[1].providerConfig.api, "openai-completions");
+  assert.equal(chain[1].providerConfig.api, "openai-codex-responses");
+  assert.equal(chain[1].providerConfig.baseUrl, "https://chatgpt.com/backend-api");
 
-  // Third: synthesized anthropic-oauth
-  assert.equal(chain[2].providerId, "anthropic-oauth");
-  assert.equal(chain[2].providerConfig.apiKey, "secretref-managed");
+  // Third: from models.json (anthropic)
+  assert.equal(chain[2].providerId, "anthropic");
   assert.equal(chain[2].providerConfig.api, "anthropic-messages");
+});
+
+test("FallbackLlmClient resolves google provider from models.json", () => {
+  setModelsJson({
+    google: {
+      baseUrl: "https://generativelanguage.googleapis.com/v1beta",
+      api: "google-generative-ai",
+      apiKey: "secretref-managed",
+      models: [],
+    },
+  });
+
+  const config = makeConfig({ providers: {} }, "google/gemini-pro");
+  const client = new FallbackLlmClient(config);
+  const chain = (client as any).getModelChain();
+  assert.equal(chain.length, 1);
+  assert.equal(chain[0].providerConfig.api, "google-generative-ai");
 });

--- a/tests/fallback-llm-builtin-provider.test.ts
+++ b/tests/fallback-llm-builtin-provider.test.ts
@@ -174,3 +174,40 @@ test("FallbackLlmClient resolves google provider from models.json", () => {
   assert.equal(chain.length, 1);
   assert.equal(chain[0].providerConfig.api, "google-generative-ai");
 });
+
+test("FallbackLlmClient chatCompletion attempts built-in provider and invokes tryModel", async () => {
+  setModelsJson({
+    "openai-codex": {
+      baseUrl: "https://chatgpt.com/backend-api",
+      api: "openai-codex-responses",
+      auth: "oauth",
+      models: [],
+    },
+  });
+
+  const config = makeConfig({ providers: {} }, "openai-codex/gpt-5.4");
+  const client = new FallbackLlmClient(config);
+
+  // Stub tryModel to verify it's called with the correct model ref
+  // (without actually making HTTP calls)
+  let triedModel: { providerId: string; modelId: string; api?: string } | null = null;
+  (client as any).tryModel = async (model: any) => {
+    triedModel = {
+      providerId: model.providerId,
+      modelId: model.modelId,
+      api: model.providerConfig.api,
+    };
+    return { content: '{"test": true}', usage: { inputTokens: 10, outputTokens: 5, totalTokens: 15 } };
+  };
+
+  const result = await client.chatCompletion([
+    { role: "user", content: "test" },
+  ]);
+
+  assert.ok(result, "chatCompletion should return a result");
+  assert.equal(result.modelUsed, "openai-codex/gpt-5.4");
+  assert.ok(triedModel, "tryModel should have been called");
+  assert.equal(triedModel!.providerId, "openai-codex");
+  assert.equal(triedModel!.modelId, "gpt-5.4");
+  assert.equal(triedModel!.api, "openai-codex-responses");
+});


### PR DESCRIPTION
## Summary

When `FallbackLlmClient` encounters a model route like `openai-codex/gpt-5.4` that isn't declared in `models.providers`, it now resolves the provider config from the gateway's materialized `models.json` (`~/.openclaw/agents/main/agent/models.json`), which contains **all** providers including built-in ones with their correct `baseUrl`, `api` format, and auth mode.

For auth resolution, the client now uses the gateway's native `getRuntimeAuthForModel()` function (from the same runtime module that provides `resolveApiKeyForProvider()`), which handles all provider-specific transforms: OAuth token exchange for codex/copilot, base URL overrides, profile-based credentials, etc. — the same codepath the gateway uses for its own agent sessions.

### Changes

- **`models-json.ts`** (new): Reads and caches the gateway's materialized `models.json` to get the full provider map including built-in providers
- **`fallback-llm.ts`**: Provider lookup now falls back to `models.json` when not found in explicit config; auth resolution uses native `getRuntimeAuthForModel()` before falling back to `resolveProviderApiKey()`
- **`resolve-provider-secret.ts`**: Exports `getGatewayRuntimeAuthForModel()` — captures the gateway's `getRuntimeAuthForModel` function from the same runtime module already loaded for `resolveApiKeyForProvider`

### Resolution order

1. Explicit `models.providers` config (user-defined) — highest priority
2. Gateway's `models.json` (built-in providers from plugin catalogs)
3. Auth via `getRuntimeAuthForModel()` (native gateway runtime)
4. Auth via `resolveProviderApiKey()` (secret refs, env vars)

Fixes #358

## Test plan

- [x] New test: built-in `openai-codex` provider resolves from models.json
- [x] New test: anthropic provider resolves from models.json with correct API format
- [x] New test: unknown provider (not in config or models.json) reports unavailable
- [x] New test: explicit provider config takes precedence over models.json
- [x] New test: mixed chains with explicit and models.json providers
- [x] New test: google provider resolves from models.json
- [x] Existing `fallback-llm-parse` test still passes
- [x] Monorepo structure tests pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes model/provider resolution and credential handling for gateway-routed LLM calls, which could affect which endpoints/auth modes are used at runtime (especially OAuth-based providers). Scope is contained to `FallbackLlmClient` with added tests and documented behavior.
> 
> **Overview**
> **Gateway fallback LLM can now use built-in OpenClaw providers without explicit config.** `FallbackLlmClient` provider lookup now prefers `openclaw.json` `models.providers` but falls back to the gateway’s materialized `~/.openclaw/agents/main/agent/models.json`, enabling routes like `openai-codex/...`, `google-vertex/...`, and `github-copilot/...` to work automatically.
> 
> **Auth resolution is upgraded to gateway runtime semantics.** Requests now try `getRuntimeAuthForModel()` first (to apply provider-specific transforms like OAuth token exchange and base URL overrides), then fall back to existing `resolveProviderApiKey()` behavior.
> 
> Adds `models-json` loader/caching utilities (with test injection), updates docs to describe the new lookup/auth order, and introduces a focused test suite covering explicit-vs-built-in precedence and mixed chains.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebd7ad09b5d121fc4b67df619780efc32a91ab00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->