### PR TITLE
feat: add publicArtifacts support for memory-wiki bridge mode

### DIFF
--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -38,12 +38,77 @@ launchctl kickstart -k gui/501/ai.openclaw.gateway
 This plugin hooks into the OpenClaw gateway lifecycle:
 
 - **`gateway_start`** -- initializes the Remnic memory engine
-- **`before_agent_start`** -- injects relevant memories into the agent's context
+- **`before_agent_start`** / **`before_prompt_build`** -- injects relevant memories into the agent's context
 - **`agent_end`** -- buffers the conversation turn for extraction
+- **`before_compaction`** / **`after_compaction`** -- saves checkpoints and triggers session reset on context compaction
+- **`session_start`** / **`session_end`** -- session lifecycle tracking
+- **`before_tool_call`** / **`after_tool_call`** -- tool usage observation for analytics
+- **`llm_output`** -- LLM token usage tracking
+- **`subagent_spawning`** / **`subagent_ended`** -- subagent lifecycle observation
 - **Tools** -- registers `memory_search`, `memory_stats`, and other agent tools
 - **Commands** -- provides CLI commands for memory management
 
 All memory processing uses [`@remnic/core`](https://www.npmjs.com/package/@remnic/core). Data stays on your local filesystem as plain markdown files.
+
+## Supported OpenClaw Memory Features
+
+Remnic supports the following OpenClaw memory integration points:
+
+### Memory Prompt Injection
+
+| Feature | Status | Since |
+|---------|--------|-------|
+| `before_agent_start` hook (legacy) | Supported | 2025.x |
+| `before_prompt_build` hook (new SDK) | Supported | 2026.3.22 |
+| `registerMemoryPromptSection()` (structured builder) | Supported | 2026.3.22 |
+| `registerMemoryCapability()` (unified capability) | Supported | 2026.4.5 |
+
+### Public Artifacts (memory-wiki bridge)
+
+| Feature | Status | Since |
+|---------|--------|-------|
+| `publicArtifacts.listArtifacts()` | Supported | 2026.4.5 |
+
+When `registerMemoryCapability` is available, Remnic registers a `publicArtifacts` provider that exposes wiki-safe memory files:
+
+- **facts/** -- extracted knowledge (dated subdirectories)
+- **entities/** -- entity knowledge graph
+- **corrections/** -- fact corrections
+- **artifacts/** -- structured artifacts
+- **profile.md** -- agent identity summary
+
+Private runtime state (state/, questions/, transcripts/, archive/, buffers) is never exposed.
+
+With this feature, `openclaw wiki status` reports Remnic artifacts, and `memory-wiki` bridge mode can discover and ingest them.
+
+### Session Lifecycle
+
+| Feature | Status | Since |
+|---------|--------|-------|
+| `session_start` / `session_end` hooks | Supported | 2026.3.22 |
+| `before_compaction` / `after_compaction` hooks | Supported | 2026.3.22 |
+| `api.resetSession()` (compaction reset) | Supported | 2026.3.22 |
+| Checkpoint saves before compaction | Supported | 2026.3.22 |
+
+### Observation Hooks
+
+| Feature | Status | Since |
+|---------|--------|-------|
+| `before_tool_call` / `after_tool_call` | Supported | 2026.3.22 |
+| `llm_output` (token tracking) | Supported | 2026.3.22 |
+| `subagent_spawning` / `subagent_ended` | Supported | 2026.3.22 |
+
+### Dreaming
+
+OpenClaw's dreaming feature (background memory consolidation) is handled by OpenClaw's built-in `memory-core` extension. Remnic implements its own consolidation pipeline (extraction, deduplication, graph maintenance, hourly summaries) that runs independently of OpenClaw's dreaming system. The two systems are complementary -- Remnic's consolidation handles the heavy memory extraction, while OpenClaw's dreaming (if enabled alongside Remnic) can further organize knowledge.
+
+### Bridge Mode
+
+| Feature | Status |
+|---------|--------|
+| Embedded mode (in-process EMO + HTTP :4318) | Supported |
+| Delegate mode (connects to running daemon) | Supported |
+| Auto-detection (daemon running = delegate) | Supported |
 
 ## Standalone usage
 

--- a/packages/plugin-openclaw/src/index.ts
+++ b/packages/plugin-openclaw/src/index.ts
@@ -24,3 +24,10 @@ export {
   type BridgeMode,
   type BridgeConfig,
 } from "./bridge.js";
+
+// Public artifacts for memory-wiki bridge mode
+export {
+  listRemnicPublicArtifacts,
+  type RemnicPublicArtifact,
+  type PublicArtifactContentType,
+} from "./public-artifacts.js";

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -85,18 +85,26 @@ async function isContainedWithin(target: string, boundary: string): Promise<bool
 async function listMarkdownFilesRecursive(
   rootDir: string,
   boundary?: string,
-  visited?: Set<string>,
+  ancestorRealPaths?: ReadonlySet<string>,
 ): Promise<string[]> {
   const boundaryDir = boundary ?? rootDir;
-  // Track visited real paths to detect symlink cycles
-  const visitedPaths = visited ?? new Set<string>();
+  // Cycle detection uses only the current recursion path — the set of real
+  // paths of ancestors we've descended through. This prevents infinite
+  // recursion on symlink cycles while still allowing sibling aliases that
+  // point at the same real directory to each be traversed independently.
+  // Globally tracking visited real paths (as the earlier implementation
+  // did) suppressed all-but-one of the aliases, leaving the surviving one
+  // dependent on readdir() order — a source of unstable relativePath
+  // output across environments/runs.
+  let resolvedRoot: string;
   try {
-    const resolvedRoot = await realpath(rootDir);
-    if (visitedPaths.has(resolvedRoot)) return []; // Cycle detected — stop
-    visitedPaths.add(resolvedRoot);
+    resolvedRoot = await realpath(rootDir);
   } catch {
     return [];
   }
+  if (ancestorRealPaths?.has(resolvedRoot)) return []; // Cycle — stop
+  const nextAncestors = new Set<string>(ancestorRealPaths ?? []);
+  nextAncestors.add(resolvedRoot);
 
   let entries: import("node:fs").Dirent[];
   try {
@@ -104,6 +112,11 @@ async function listMarkdownFilesRecursive(
   } catch {
     return [];
   }
+
+  // Sort entries deterministically before traversal so readdir() order
+  // cannot influence which aliases survive cycle pruning, and so the
+  // overall output order is stable across filesystems.
+  entries.sort((a, b) => String(a.name).localeCompare(String(b.name)));
 
   const files: string[] = [];
   for (const entry of entries) {
@@ -132,7 +145,7 @@ async function listMarkdownFilesRecursive(
     }
 
     if (isDir) {
-      files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir, visitedPaths)));
+      files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir, nextAncestors)));
       continue;
     }
     if (isFile && String(entry.name).endsWith(".md")) {

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -183,8 +183,23 @@ export async function listRemnicPublicArtifacts(params: {
     const dirPath = path.join(memoryDir, spec.dir);
     if (!(await pathExists(dirPath))) continue;
 
-    // Block symlink traversal: verify the directory resolves within memoryDir
+    // Block symlink traversal: verify the directory resolves within memoryDir.
+    // Also reject top-level symlinks that redirect an allowlisted directory
+    // name to a different directory (e.g., facts -> state), which would
+    // expose private files as public artifacts under the wrong kind.
     if (!(await isContainedWithin(dirPath, memoryDir))) continue;
+    try {
+      const resolvedDir = await realpath(dirPath);
+      const expectedParent = await realpath(memoryDir);
+      const resolvedName = path.basename(resolvedDir);
+      // If the resolved directory name doesn't match the expected name,
+      // this is a symlink redirect (e.g., facts -> state). Reject it.
+      if (resolvedName !== spec.dir) continue;
+      // Also verify the resolved dir's parent is memoryDir (not a nested path)
+      if (path.dirname(resolvedDir) !== expectedParent) continue;
+    } catch {
+      continue;
+    }
 
     // Use the specific public directory as the containment boundary (not
     // memoryDir), so symlinks within e.g. facts/ cannot escape into private

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -12,7 +12,7 @@
  * is explicitly excluded.
  */
 
-import { readdir, access, stat } from "node:fs/promises";
+import { readdir, access, stat, lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 
 /**
@@ -37,18 +37,17 @@ export interface RemnicPublicArtifact {
 /**
  * Directories and file patterns that are safe to expose as public artifacts.
  * Each entry maps a directory name (relative to memoryDir) to the artifact
- * kind and content type.
+ * kind and content type. All directories are scanned recursively.
  */
 const PUBLIC_DIRS: ReadonlyArray<{
   dir: string;
   kind: string;
   contentType: PublicArtifactContentType;
-  recursive: boolean;
 }> = [
-  { dir: "facts", kind: "fact", contentType: "markdown", recursive: true },
-  { dir: "entities", kind: "entity", contentType: "markdown", recursive: true },
-  { dir: "corrections", kind: "correction", contentType: "markdown", recursive: true },
-  { dir: "artifacts", kind: "artifact", contentType: "markdown", recursive: true },
+  { dir: "facts", kind: "fact", contentType: "markdown" },
+  { dir: "entities", kind: "entity", contentType: "markdown" },
+  { dir: "corrections", kind: "correction", contentType: "markdown" },
+  { dir: "artifacts", kind: "artifact", contentType: "markdown" },
 ];
 
 /**
@@ -63,24 +62,56 @@ const PUBLIC_FILES: ReadonlyArray<{
 ];
 
 /**
- * Recursively list all markdown files under a directory.
+ * Check whether a path is contained within a boundary directory.
+ * Resolves symlinks via realpath and verifies the resolved path
+ * starts with the boundary prefix, preventing symlink traversal.
  */
-async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
-  let entries: Awaited<ReturnType<typeof readdir>>;
+async function isContainedWithin(target: string, boundary: string): Promise<boolean> {
   try {
-    entries = await readdir(rootDir, { withFileTypes: true });
+    const resolvedTarget = await realpath(target);
+    const resolvedBoundary = await realpath(boundary);
+    // Ensure the resolved path is within the boundary (with trailing sep)
+    return resolvedTarget === resolvedBoundary || resolvedTarget.startsWith(resolvedBoundary + path.sep);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Recursively list all markdown files under a directory.
+ * Skips symlinked directories/files that resolve outside the boundary
+ * to prevent symlink traversal attacks.
+ */
+async function listMarkdownFilesRecursive(rootDir: string, boundary?: string): Promise<string[]> {
+  const boundaryDir = boundary ?? rootDir;
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(rootDir, { withFileTypes: true }) as import("node:fs").Dirent[];
   } catch {
     return [];
   }
 
   const files: string[] = [];
   for (const entry of entries) {
-    const fullPath = path.join(rootDir, entry.name);
+    const fullPath = path.join(rootDir, String(entry.name));
+
+    // Check if entry is a symlink — if so, verify containment
+    try {
+      const linkStat = await lstat(fullPath);
+      if (linkStat.isSymbolicLink()) {
+        if (!(await isContainedWithin(fullPath, boundaryDir))) {
+          continue; // Symlink escapes boundary — skip
+        }
+      }
+    } catch {
+      continue; // Cannot stat — skip
+    }
+
     if (entry.isDirectory()) {
-      files.push(...(await listMarkdownFilesRecursive(fullPath)));
+      files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir)));
       continue;
     }
-    if (entry.isFile() && entry.name.endsWith(".md")) {
+    if (entry.isFile() && String(entry.name).endsWith(".md")) {
       files.push(fullPath);
     }
   }
@@ -128,23 +159,10 @@ export async function listRemnicPublicArtifacts(params: {
     const dirPath = path.join(memoryDir, spec.dir);
     if (!(await pathExists(dirPath))) continue;
 
-    const files = spec.recursive
-      ? await listMarkdownFilesRecursive(dirPath)
-      : [];
+    // Block symlink traversal: verify the directory resolves within memoryDir
+    if (!(await isContainedWithin(dirPath, memoryDir))) continue;
 
-    if (!spec.recursive) {
-      // Non-recursive: only list direct children
-      try {
-        const entries = await readdir(dirPath, { withFileTypes: true });
-        for (const entry of entries) {
-          if (entry.isFile() && entry.name.endsWith(".md")) {
-            files.push(path.join(dirPath, entry.name));
-          }
-        }
-      } catch {
-        // Skip inaccessible directories
-      }
-    }
+    const files = await listMarkdownFilesRecursive(dirPath, memoryDir);
 
     for (const absolutePath of files) {
       const relativePath = path.relative(memoryDir, absolutePath).replace(/\\/g, "/");
@@ -163,6 +181,8 @@ export async function listRemnicPublicArtifacts(params: {
   for (const spec of PUBLIC_FILES) {
     const absolutePath = path.join(memoryDir, spec.relativePath);
     if (!(await pathExists(absolutePath))) continue;
+    // Block symlink traversal for standalone files
+    if (!(await isContainedWithin(absolutePath, memoryDir))) continue;
     // Verify it's a file (not a directory)
     try {
       const fileStat = await stat(absolutePath);

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -95,23 +95,33 @@ async function listMarkdownFilesRecursive(rootDir: string, boundary?: string): P
   for (const entry of entries) {
     const fullPath = path.join(rootDir, String(entry.name));
 
-    // Check if entry is a symlink — if so, verify containment
+    // For symlinks, Dirent.isDirectory()/isFile() return false, so we
+    // must use stat() (which follows symlinks) to determine the target type.
+    // Before following any symlink, verify the resolved path stays within
+    // the boundary to prevent traversal attacks.
+    let isDir = entry.isDirectory();
+    let isFile = entry.isFile();
+
     try {
       const linkStat = await lstat(fullPath);
       if (linkStat.isSymbolicLink()) {
         if (!(await isContainedWithin(fullPath, boundaryDir))) {
           continue; // Symlink escapes boundary — skip
         }
+        // Follow the symlink to determine target type
+        const targetStat = await stat(fullPath);
+        isDir = targetStat.isDirectory();
+        isFile = targetStat.isFile();
       }
     } catch {
       continue; // Cannot stat — skip
     }
 
-    if (entry.isDirectory()) {
+    if (isDir) {
       files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir)));
       continue;
     }
-    if (entry.isFile() && String(entry.name).endsWith(".md")) {
+    if (isFile && String(entry.name).endsWith(".md")) {
       files.push(fullPath);
     }
   }

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -225,6 +225,19 @@ export async function listRemnicPublicArtifacts(params: {
     if (!(await pathExists(absolutePath))) continue;
     // Block symlink traversal for standalone files
     if (!(await isContainedWithin(absolutePath, memoryDir))) continue;
+    // Reject symlinks that redirect to a different file (e.g., profile.md -> state/index.md)
+    try {
+      const linkStat = await lstat(absolutePath);
+      if (linkStat.isSymbolicLink()) {
+        const resolvedPath = await realpath(absolutePath);
+        const expectedParent = await realpath(memoryDir);
+        // Resolved path must be directly in memoryDir with the expected basename
+        if (path.dirname(resolvedPath) !== expectedParent) continue;
+        if (path.basename(resolvedPath) !== path.basename(spec.relativePath)) continue;
+      }
+    } catch {
+      continue;
+    }
     // Verify it's a file (not a directory)
     try {
       const fileStat = await stat(absolutePath);

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -82,8 +82,22 @@ async function isContainedWithin(target: string, boundary: string): Promise<bool
  * Skips symlinked directories/files that resolve outside the boundary
  * to prevent symlink traversal attacks.
  */
-async function listMarkdownFilesRecursive(rootDir: string, boundary?: string): Promise<string[]> {
+async function listMarkdownFilesRecursive(
+  rootDir: string,
+  boundary?: string,
+  visited?: Set<string>,
+): Promise<string[]> {
   const boundaryDir = boundary ?? rootDir;
+  // Track visited real paths to detect symlink cycles
+  const visitedPaths = visited ?? new Set<string>();
+  try {
+    const resolvedRoot = await realpath(rootDir);
+    if (visitedPaths.has(resolvedRoot)) return []; // Cycle detected — stop
+    visitedPaths.add(resolvedRoot);
+  } catch {
+    return [];
+  }
+
   let entries: import("node:fs").Dirent[];
   try {
     entries = await readdir(rootDir, { withFileTypes: true }) as import("node:fs").Dirent[];
@@ -118,7 +132,7 @@ async function listMarkdownFilesRecursive(rootDir: string, boundary?: string): P
     }
 
     if (isDir) {
-      files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir)));
+      files.push(...(await listMarkdownFilesRecursive(fullPath, boundaryDir, visitedPaths)));
       continue;
     }
     if (isFile && String(entry.name).endsWith(".md")) {

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -1,0 +1,192 @@
+/**
+ * Public artifacts provider for memory-wiki bridge mode.
+ *
+ * Enumerates Remnic artifacts that are safe for wiki ingestion:
+ *   - facts/   (extracted knowledge)
+ *   - entities/ (entity knowledge graph)
+ *   - corrections/ (fact corrections)
+ *   - artifacts/ (structured artifacts)
+ *   - profile.md (agent personality/identity — public summary only)
+ *
+ * Private/runtime state (state/, questions/, transcripts, buffers, etc.)
+ * is explicitly excluded.
+ */
+
+import { readdir, access, stat } from "node:fs/promises";
+import path from "node:path";
+
+/**
+ * Content type for a public artifact.
+ * Mirrors MemoryPluginPublicArtifactContentType from OpenClaw SDK.
+ */
+export type PublicArtifactContentType = "markdown" | "json" | "text";
+
+/**
+ * A single public artifact entry.
+ * Mirrors MemoryPluginPublicArtifact from OpenClaw SDK.
+ */
+export interface RemnicPublicArtifact {
+  kind: string;
+  workspaceDir: string;
+  relativePath: string;
+  absolutePath: string;
+  agentIds: string[];
+  contentType: PublicArtifactContentType;
+}
+
+/**
+ * Directories and file patterns that are safe to expose as public artifacts.
+ * Each entry maps a directory name (relative to memoryDir) to the artifact
+ * kind and content type.
+ */
+const PUBLIC_DIRS: ReadonlyArray<{
+  dir: string;
+  kind: string;
+  contentType: PublicArtifactContentType;
+  recursive: boolean;
+}> = [
+  { dir: "facts", kind: "fact", contentType: "markdown", recursive: true },
+  { dir: "entities", kind: "entity", contentType: "markdown", recursive: true },
+  { dir: "corrections", kind: "correction", contentType: "markdown", recursive: true },
+  { dir: "artifacts", kind: "artifact", contentType: "markdown", recursive: true },
+];
+
+/**
+ * Standalone files (relative to memoryDir) that are safe to expose.
+ */
+const PUBLIC_FILES: ReadonlyArray<{
+  relativePath: string;
+  kind: string;
+  contentType: PublicArtifactContentType;
+}> = [
+  { relativePath: "profile.md", kind: "memory-root", contentType: "markdown" },
+];
+
+/**
+ * Recursively list all markdown files under a directory.
+ */
+async function listMarkdownFilesRecursive(rootDir: string): Promise<string[]> {
+  let entries: Awaited<ReturnType<typeof readdir>>;
+  try {
+    entries = await readdir(rootDir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+
+  const files: string[] = [];
+  for (const entry of entries) {
+    const fullPath = path.join(rootDir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...(await listMarkdownFilesRecursive(fullPath)));
+      continue;
+    }
+    if (entry.isFile() && entry.name.endsWith(".md")) {
+      files.push(fullPath);
+    }
+  }
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Check if a file or directory exists.
+ */
+async function pathExists(inputPath: string): Promise<boolean> {
+  try {
+    await access(inputPath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * List all public artifacts from a Remnic memory directory.
+ *
+ * This is the core implementation that enumerates safe/public memory files
+ * for wiki ingestion. It intentionally excludes:
+ *   - state/        (runtime indexes, caches, internal state)
+ *   - questions/    (pending review queue — private)
+ *   - transcripts/  (raw conversation logs — private)
+ *   - archive/      (archived/demoted memories — stale)
+ *   - buffers       (in-flight extraction state)
+ *   - tokens/       (auth credentials)
+ *
+ * @param memoryDir - Absolute path to the Remnic memory directory
+ * @param workspaceDir - The workspace directory for this agent
+ * @param agentIds - Agent IDs that own this memory
+ */
+export async function listRemnicPublicArtifacts(params: {
+  memoryDir: string;
+  workspaceDir: string;
+  agentIds: string[];
+}): Promise<RemnicPublicArtifact[]> {
+  const { memoryDir, workspaceDir, agentIds } = params;
+  const artifacts: RemnicPublicArtifact[] = [];
+
+  // Scan public directories
+  for (const spec of PUBLIC_DIRS) {
+    const dirPath = path.join(memoryDir, spec.dir);
+    if (!(await pathExists(dirPath))) continue;
+
+    const files = spec.recursive
+      ? await listMarkdownFilesRecursive(dirPath)
+      : [];
+
+    if (!spec.recursive) {
+      // Non-recursive: only list direct children
+      try {
+        const entries = await readdir(dirPath, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isFile() && entry.name.endsWith(".md")) {
+            files.push(path.join(dirPath, entry.name));
+          }
+        }
+      } catch {
+        // Skip inaccessible directories
+      }
+    }
+
+    for (const absolutePath of files) {
+      const relativePath = path.relative(memoryDir, absolutePath).replace(/\\/g, "/");
+      artifacts.push({
+        kind: spec.kind,
+        workspaceDir,
+        relativePath,
+        absolutePath,
+        agentIds: [...agentIds],
+        contentType: spec.contentType,
+      });
+    }
+  }
+
+  // Scan standalone public files
+  for (const spec of PUBLIC_FILES) {
+    const absolutePath = path.join(memoryDir, spec.relativePath);
+    if (!(await pathExists(absolutePath))) continue;
+    // Verify it's a file (not a directory)
+    try {
+      const fileStat = await stat(absolutePath);
+      if (!fileStat.isFile()) continue;
+    } catch {
+      continue;
+    }
+    artifacts.push({
+      kind: spec.kind,
+      workspaceDir,
+      relativePath: spec.relativePath,
+      absolutePath,
+      agentIds: [...agentIds],
+      contentType: spec.contentType,
+    });
+  }
+
+  // Deduplicate by (workspaceDir, relativePath, kind) — defensive against
+  // overlapping scans or symlinks.
+  const deduped = new Map<string, RemnicPublicArtifact>();
+  for (const artifact of artifacts) {
+    const key = `${artifact.workspaceDir}\0${artifact.relativePath}\0${artifact.kind}`;
+    deduped.set(key, artifact);
+  }
+
+  return [...deduped.values()];
+}

--- a/packages/plugin-openclaw/src/public-artifacts.ts
+++ b/packages/plugin-openclaw/src/public-artifacts.ts
@@ -186,7 +186,10 @@ export async function listRemnicPublicArtifacts(params: {
     // Block symlink traversal: verify the directory resolves within memoryDir
     if (!(await isContainedWithin(dirPath, memoryDir))) continue;
 
-    const files = await listMarkdownFilesRecursive(dirPath, memoryDir);
+    // Use the specific public directory as the containment boundary (not
+    // memoryDir), so symlinks within e.g. facts/ cannot escape into private
+    // directories like state/ or questions/ that live under memoryDir.
+    const files = await listMarkdownFilesRecursive(dirPath, dirPath);
 
     for (const absolutePath of files) {
       const relativePath = path.relative(memoryDir, absolutePath).replace(/\\/g, "/");

--- a/packages/remnic-core/src/sdk-compat.ts
+++ b/packages/remnic-core/src/sdk-compat.ts
@@ -49,9 +49,17 @@ export function detectSdkCapabilities(api: Record<string, unknown>): SdkCapabili
   const isNewSdk =
     hasRegisterMemoryPromptSection || hasRegisterMemoryCapability || hasRuntimeNamespace || hasRegistrationMode;
 
-  // New hook system requires registerMemoryPromptSection or registrationMode.
-  // Just having runtime.version is NOT sufficient — some legacy builds expose it.
-  const hasNewHookSystem = hasRegisterMemoryPromptSection || hasRegistrationMode;
+  // New hook system requires one of the authoritative new-SDK signals:
+  //   - registerMemoryPromptSection (pre-capability new SDKs, ≥2026.3.22)
+  //   - registerMemoryCapability   (capability-based SDKs, ≥2026.4.5; the
+  //     deprecated registerMemoryPromptSection may be absent)
+  //   - registrationMode           (explicit registration lifecycle signal)
+  // Just having runtime.version is NOT sufficient — some legacy builds
+  // expose it. Omitting registerMemoryCapability here would cause the
+  // legacy before_agent_start hook to be registered on new SDKs that only
+  // expose registerMemoryCapability, silently breaking memory injection.
+  const hasNewHookSystem =
+    hasRegisterMemoryPromptSection || hasRegisterMemoryCapability || hasRegistrationMode;
 
   return {
     hasBeforePromptBuild: hasNewHookSystem,

--- a/packages/remnic-core/src/sdk-compat.ts
+++ b/packages/remnic-core/src/sdk-compat.ts
@@ -13,6 +13,8 @@ export interface SdkCapabilities {
   hasBeforePromptBuild: boolean;
   /** api.registerMemoryPromptSection() exists */
   hasRegisterMemoryPromptSection: boolean;
+  /** api.registerMemoryCapability() exists (new SDK >=2026.4.5) */
+  hasRegisterMemoryCapability: boolean;
   /** definePluginEntry from openclaw/plugin-sdk/plugin-entry is importable */
   hasDefinePluginEntry: boolean;
   /** api.runtime.* namespace exists */
@@ -30,6 +32,8 @@ export interface SdkCapabilities {
 export function detectSdkCapabilities(api: Record<string, unknown>): SdkCapabilities {
   const hasRegisterMemoryPromptSection =
     typeof (api as any).registerMemoryPromptSection === "function";
+  const hasRegisterMemoryCapability =
+    typeof (api as any).registerMemoryCapability === "function";
   const hasRuntimeNamespace =
     typeof (api as any).runtime === "object" && (api as any).runtime !== null;
   const hasRegistrationMode = typeof (api as any).registrationMode === "string";
@@ -43,7 +47,7 @@ export function detectSdkCapabilities(api: Record<string, unknown>): SdkCapabili
 
   // New SDK is indicated by any of the new API surfaces being present.
   const isNewSdk =
-    hasRegisterMemoryPromptSection || hasRuntimeNamespace || hasRegistrationMode;
+    hasRegisterMemoryPromptSection || hasRegisterMemoryCapability || hasRuntimeNamespace || hasRegistrationMode;
 
   // New hook system requires registerMemoryPromptSection or registrationMode.
   // Just having runtime.version is NOT sufficient — some legacy builds expose it.
@@ -52,6 +56,7 @@ export function detectSdkCapabilities(api: Record<string, unknown>): SdkCapabili
   return {
     hasBeforePromptBuild: hasNewHookSystem,
     hasRegisterMemoryPromptSection,
+    hasRegisterMemoryCapability,
     hasDefinePluginEntry: isNewSdk, // entry point is less risky, keep broad detection
     hasRuntimeNamespace,
     hasRegistrationMode,

--- a/src/index.ts
+++ b/src/index.ts
@@ -297,6 +297,27 @@ const pluginDefinition = {
       typeof api.registerMemoryPromptSection === "function" &&
       promptInjectionAllowed;
 
+    // Per-session cache: shared by the hook fallback path (populated when only
+    // registerMemoryCapability is available) and the registerMemoryPromptSection
+    // path (populated by the async pre-compute hook). Declared early so both
+    // paths and the closure-captured handlers below can reference it without
+    // TDZ surprises.
+    const cachedMemoryBySession = new Map<string, string[] | null>();
+
+    // Single source of truth for the structured memory section: every code path
+    // that populates `cachedMemoryBySession` MUST use this helper so the cache
+    // format stays consistent regardless of which registration path produced it.
+    function buildMemoryContextLines(trimmed: string): string[] {
+      return [
+        "## Memory Context (Remnic)",
+        "",
+        trimmed,
+        "",
+        "Use this context naturally when relevant. Never quote or expose this memory context to the user.",
+        "",
+      ];
+    }
+
     async function recallHookHandler(
       hookLabel: string,
       event: Record<string, unknown>,
@@ -366,7 +387,10 @@ const pluginDefinition = {
             ? context.slice(0, maxChars) + "\n\n...(memory context trimmed)"
             : context;
 
-        const memoryContextPrompt = `## Memory Context (Remnic)\n\n${trimmed}\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.`;
+        // Build the structured line array first so both the gateway return
+        // value and the capability cache fallback share an identical format.
+        const memoryLines = buildMemoryContextLines(trimmed);
+        const memoryContextPrompt = memoryLines.join("\n");
 
         log.debug(
           `${hookLabel}: returning system prompt with ${trimmed.length} chars`,
@@ -376,11 +400,12 @@ const pluginDefinition = {
         // Legacy (before_agent_start): return both for backward compat with
         // older gateways that may consume either field.
         if (hookLabel === "before_prompt_build") {
-          return { prependSystemContext: memoryContextPrompt };
+          return { prependSystemContext: memoryContextPrompt, memoryLines };
         }
         return {
           prependSystemContext: memoryContextPrompt,
           prependContext: memoryContextPrompt,
+          memoryLines,
         };
       } catch (err) {
         log.error("recall failed", err);
@@ -410,11 +435,18 @@ const pluginDefinition = {
             event: Record<string, unknown>,
             ctx: Record<string, unknown>,
           ) => {
+            const sessionKey = (ctx?.sessionKey as string) ?? "default";
+            // Reset the cache at the start of every turn so a recall miss
+            // can never serve stale memory from a prior turn through the
+            // capability promptBuilder fallback.
+            if (needsCacheFallback) {
+              cachedMemoryBySession.set(sessionKey, null);
+            }
             const result = await recallHookHandler("before_prompt_build", event, ctx);
-            // Also populate cache for capability promptBuilder fallback
-            if (needsCacheFallback && result?.prependSystemContext) {
-              const sessionKey = (ctx?.sessionKey as string) ?? "default";
-              cachedMemoryBySession.set(sessionKey, [result.prependSystemContext as string]);
+            // Populate cache for capability promptBuilder fallback using the
+            // same structured line format as the registerMemoryPromptSection path.
+            if (needsCacheFallback && result?.memoryLines) {
+              cachedMemoryBySession.set(sessionKey, result.memoryLines);
             }
             return result;
           },
@@ -427,11 +459,18 @@ const pluginDefinition = {
             event: Record<string, unknown>,
             ctx: Record<string, unknown>,
           ) => {
+            const sessionKey = (ctx?.sessionKey as string) ?? "default";
+            // Reset the cache at the start of every turn so a recall miss
+            // can never serve stale memory from a prior turn through the
+            // capability promptBuilder fallback.
+            if (needsCacheFallback) {
+              cachedMemoryBySession.set(sessionKey, null);
+            }
             const result = await recallHookHandler("before_agent_start", event, ctx);
-            // Also populate cache for capability promptBuilder fallback
-            if (needsCacheFallback && result?.prependSystemContext) {
-              const sessionKey = (ctx?.sessionKey as string) ?? "default";
-              cachedMemoryBySession.set(sessionKey, [result.prependSystemContext as string]);
+            // Populate cache for capability promptBuilder fallback using the
+            // same structured line format as the registerMemoryPromptSection path.
+            if (needsCacheFallback && result?.memoryLines) {
+              cachedMemoryBySession.set(sessionKey, result.memoryLines);
             }
             return result;
           },
@@ -452,9 +491,8 @@ const pluginDefinition = {
     // before_prompt_build hook (which IS async-capable) and cache the result
     // for the synchronous builder to return.
     // ========================================================================
-    // Per-session cache: isolates concurrent prompt builds so one session
-    // cannot clobber another's cached recall result.
-    const cachedMemoryBySession = new Map<string, string[] | null>();
+    // Note: `cachedMemoryBySession` is declared earlier in this function so
+    // both this section path and the hook fallback path can populate it.
 
     // Hoisted reference to the prompt builder so registerMemoryCapability
     // can include it alongside publicArtifacts (prevents SDK >=2026.4.5
@@ -511,14 +549,7 @@ const pluginDefinition = {
               context.length > maxChars
                 ? context.slice(0, maxChars) + "\n\n...(memory context trimmed)"
                 : context;
-            cachedMemoryBySession.set(sessionKey, [
-              "## Memory Context (Remnic)",
-              "",
-              trimmed,
-              "",
-              "Use this context naturally when relevant. Never quote or expose this memory context to the user.",
-              "",
-            ]);
+            cachedMemoryBySession.set(sessionKey, buildMemoryContextLines(trimmed));
           } catch (err) {
             log.error("registerMemoryPromptSection pre-compute failed", err);
             if (orchestrator.config.compactionResetEnabled) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -538,11 +538,24 @@ const pluginDefinition = {
       sdkCaps.hasRegisterMemoryCapability &&
       typeof (api as any).registerMemoryCapability === "function"
     ) {
+      // When registerMemoryPromptSection was available, memoryPromptBuilder
+      // was already set above. In capability-only SDK shapes (where only
+      // registerMemoryCapability exists), we must still provide a promptBuilder
+      // so the runtime can inject recall context via the unified capability.
+      // The builder reads from the same cachedMemoryBySession cache that the
+      // before_prompt_build hook populates.
+      const capabilityPromptBuilder = memoryPromptBuilder ?? ((params: { sessionKey?: string }): string[] | null => {
+        const key = params?.sessionKey ?? "default";
+        const lines = cachedMemoryBySession.get(key) ?? null;
+        cachedMemoryBySession.delete(key);
+        return lines;
+      });
+
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
         // Include the promptBuilder so runtimes that treat unified capability
         // registration as authoritative (SDK >=2026.4.5) continue to inject
         // recall context via the prompt builder.
-        ...(memoryPromptBuilder ? { promptBuilder: memoryPromptBuilder } : {}),
+        promptBuilder: capabilityPromptBuilder,
         publicArtifacts: {
           listArtifacts: async (_params: { cfg: unknown }) => {
             try {
@@ -560,8 +573,8 @@ const pluginDefinition = {
       };
       (api as any).registerMemoryCapability(memoryCapability);
       log.info(
-        `registered memory capability with publicArtifacts provider` +
-        (memoryPromptBuilder ? " and promptBuilder" : " (promptBuilder unavailable — legacy hook path)"),
+        `registered memory capability with publicArtifacts provider and promptBuilder` +
+        (memoryPromptBuilder ? " (from registerMemoryPromptSection)" : " (capability-only fallback)"),
       );
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,7 +430,14 @@ const pluginDefinition = {
       }
     }
 
-    if (!useMemoryPromptSection) {
+    // Memory recall injection through hook handlers is only legal when the
+    // operator policy allows prompt injection. When
+    // `hooks.allowPromptInjection=false`, the capability registration below
+    // already omits `promptBuilder`, so we also MUST NOT register the recall
+    // hook here: otherwise `recallHookHandler` would still return
+    // `prependSystemContext`, silently bypassing the policy on capability-only
+    // SDKs (and on legacy SDKs too).
+    if (!useMemoryPromptSection && promptInjectionAllowed) {
       // When registerMemoryCapability is available but registerMemoryPromptSection
       // is not (capability-only SDK), we need a hybrid approach: continue using
       // the hook for backward compat, but also populate cachedMemoryBySession so
@@ -443,7 +450,6 @@ const pluginDefinition = {
       // branch can never observe a capability-enabled runtime and therefore
       // does not populate the cache.
       const needsCacheFallback =
-        promptInjectionAllowed &&
         sdkCaps.hasRegisterMemoryCapability &&
         typeof (api as any).registerMemoryCapability === "function";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import { createOpikExporter } from "./opik-exporter.js";
 import { readEnvVar, resolveHomeDir } from "./runtime/env.js";
 import { migrateFromEngram } from "./migrate/from-engram.js";
 import { cleanUserMessage } from "./user-message-cleaning.js";
+import { listRemnicPublicArtifacts } from "../packages/plugin-openclaw/src/public-artifacts.js";
 
 const ENGRAM_REGISTERED_GUARD = "__openclawEngramRegistered";
 /** Tracks which api objects have already had hooks bound to prevent duplicate handlers. */
@@ -512,6 +513,41 @@ const pluginDefinition = {
       (memoryBuildFn as any).id = "engram-memory";
       (memoryBuildFn as any).label = "Engram Memory Context";
       api.registerMemoryPromptSection(memoryBuildFn as any);
+    }
+
+    // ========================================================================
+    // registerMemoryCapability — unified memory plugin registration (new SDK)
+    // ========================================================================
+    // When registerMemoryCapability is available (>=2026.4.5), register the
+    // full capability object including publicArtifacts so memory-wiki bridge
+    // mode can discover and ingest Remnic artifacts.
+    //
+    // This does NOT replace the existing registerMemoryPromptSection / hook
+    // paths above — those handle recall injection. registerMemoryCapability
+    // adds the publicArtifacts provider and establishes Remnic as the active
+    // memory plugin for the gateway.
+    if (
+      sdkCaps.hasRegisterMemoryCapability &&
+      typeof (api as any).registerMemoryCapability === "function"
+    ) {
+      const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
+        publicArtifacts: {
+          listArtifacts: async (_params: { cfg: unknown }) => {
+            try {
+              return await listRemnicPublicArtifacts({
+                memoryDir: orchestrator.config.memoryDir,
+                workspaceDir: orchestrator.config.workspaceDir || defaultWorkspaceDir(),
+                agentIds: ["generalist"],
+              });
+            } catch (err) {
+              log.error("publicArtifacts.listArtifacts failed", err);
+              return [];
+            }
+          },
+        },
+      };
+      (api as any).registerMemoryCapability(memoryCapability);
+      log.info("registered memory capability with publicArtifacts provider");
     }
 
     // ========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -318,6 +318,16 @@ const pluginDefinition = {
       ];
     }
 
+    // Flat-string rendering for the gateway `prependSystemContext` slot.
+    // Derives from `buildMemoryContextLines` so the wording stays in lock-step
+    // with the capability/section builder cache. The trailing empty element
+    // produced by `buildMemoryContextLines` would become a trailing newline
+    // after joining — strip it to preserve the exact format the gateway
+    // expects for `prependSystemContext`.
+    function renderMemoryContextPrompt(trimmed: string): string {
+      return buildMemoryContextLines(trimmed).join("\n").replace(/\n$/, "");
+    }
+
     async function recallHookHandler(
       hookLabel: string,
       event: Record<string, unknown>,
@@ -387,14 +397,14 @@ const pluginDefinition = {
             ? context.slice(0, maxChars) + "\n\n...(memory context trimmed)"
             : context;
 
-        // Build the structured line array for the capability cache fallback.
-        // The flat `prependSystemContext` string uses the original template
-        // literal form (no trailing newline) to preserve the exact prompt
-        // format expected by the gateway. `memoryLines` is an internal return
-        // field consumed by the wrapping closure and MUST be stripped before
-        // the hook result is passed back to the gateway.
+        // Build the structured line array for the capability cache fallback,
+        // then derive the flat `prependSystemContext` string from the same
+        // source so the hook-based and capability-based memory-injection
+        // paths can never drift. `memoryLines` is an internal return field
+        // consumed by the wrapping closure and MUST be stripped before the
+        // hook result is passed back to the gateway.
         const memoryLines = buildMemoryContextLines(trimmed);
-        const memoryContextPrompt = `## Memory Context (Remnic)\n\n${trimmed}\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.`;
+        const memoryContextPrompt = renderMemoryContextPrompt(trimmed);
 
         log.debug(
           `${hookLabel}: returning system prompt with ${trimmed.length} chars`,

--- a/src/index.ts
+++ b/src/index.ts
@@ -430,6 +430,11 @@ const pluginDefinition = {
     // cannot clobber another's cached recall result.
     const cachedMemoryBySession = new Map<string, string[] | null>();
 
+    // Hoisted reference to the prompt builder so registerMemoryCapability
+    // can include it alongside publicArtifacts (prevents SDK >=2026.4.5
+    // from treating the capability as authoritative without a promptBuilder).
+    let memoryPromptBuilder: ((params: { sessionKey?: string }) => string[] | null) | undefined;
+
     if (useMemoryPromptSection && api.registerMemoryPromptSection) {
       // Async pre-compute: run recall in before_prompt_build and cache result.
       // The hook receives both event and ctx — session identity is in ctx.
@@ -513,6 +518,9 @@ const pluginDefinition = {
       (memoryBuildFn as any).id = "engram-memory";
       (memoryBuildFn as any).label = "Engram Memory Context";
       api.registerMemoryPromptSection(memoryBuildFn as any);
+
+      // Hoist for registerMemoryCapability below
+      memoryPromptBuilder = memoryBuildFn;
     }
 
     // ========================================================================
@@ -531,6 +539,10 @@ const pluginDefinition = {
       typeof (api as any).registerMemoryCapability === "function"
     ) {
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
+        // Include the promptBuilder so runtimes that treat unified capability
+        // registration as authoritative (SDK >=2026.4.5) continue to inject
+        // recall context via the prompt builder.
+        ...(memoryPromptBuilder ? { promptBuilder: memoryPromptBuilder } : {}),
         publicArtifacts: {
           listArtifacts: async (_params: { cfg: unknown }) => {
             try {
@@ -547,7 +559,10 @@ const pluginDefinition = {
         },
       };
       (api as any).registerMemoryCapability(memoryCapability);
-      log.info("registered memory capability with publicArtifacts provider");
+      log.info(
+        `registered memory capability with publicArtifacts provider` +
+        (memoryPromptBuilder ? " and promptBuilder" : " (promptBuilder unavailable — legacy hook path)"),
+      );
     }
 
     // ========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -555,18 +555,25 @@ const pluginDefinition = {
       sdkCaps.hasRegisterMemoryCapability &&
       typeof (api as any).registerMemoryCapability === "function"
     ) {
-      // When registerMemoryPromptSection was available, memoryPromptBuilder
-      // was already set above. In capability-only SDK shapes (where only
-      // registerMemoryCapability exists), we must still provide a promptBuilder
-      // so the runtime can inject recall context via the unified capability.
-      // The builder reads from the same cachedMemoryBySession cache that the
-      // before_prompt_build hook populates.
-      const capabilityPromptBuilder = memoryPromptBuilder ?? ((params: { sessionKey?: string }): string[] | null => {
-        const key = params?.sessionKey ?? "default";
-        const lines = cachedMemoryBySession.get(key) ?? null;
-        cachedMemoryBySession.delete(key);
-        return lines;
-      });
+      // Build a promptBuilder for the capability. When registerMemoryPromptSection
+      // was also registered, the section builder already does a destructive read
+      // (get + delete). To avoid double-consumption if the runtime calls both,
+      // the capability builder uses a non-destructive peek (get without delete).
+      // In capability-only SDK shapes, the capability builder IS the sole
+      // consumer so it performs the destructive read.
+      const capabilityPromptBuilder = memoryPromptBuilder
+        ? (params: { sessionKey?: string }): string[] | null => {
+            // Non-destructive peek — the section builder will handle cleanup
+            const key = params?.sessionKey ?? "default";
+            return cachedMemoryBySession.get(key) ?? null;
+          }
+        : (params: { sessionKey?: string }): string[] | null => {
+            // Capability-only: destructive read since we are the sole consumer
+            const key = params?.sessionKey ?? "default";
+            const lines = cachedMemoryBySession.get(key) ?? null;
+            cachedMemoryBySession.delete(key);
+            return lines;
+          };
 
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
         // Include the promptBuilder so runtimes that treat unified capability

--- a/src/index.ts
+++ b/src/index.ts
@@ -587,7 +587,9 @@ const pluginDefinition = {
         // Include the promptBuilder so runtimes that treat unified capability
         // registration as authoritative (SDK >=2026.4.5) continue to inject
         // recall context via the prompt builder.
-        promptBuilder: capabilityPromptBuilder,
+        // Respect promptInjectionAllowed policy — omit promptBuilder if injection
+        // is disabled, so the capability only provides publicArtifacts.
+        ...(promptInjectionAllowed ? { promptBuilder: capabilityPromptBuilder } : {}),
         publicArtifacts: {
           listArtifacts: async (_params: { cfg: unknown }) => {
             try {

--- a/src/index.ts
+++ b/src/index.ts
@@ -392,6 +392,15 @@ const pluginDefinition = {
     }
 
     if (!useMemoryPromptSection) {
+      // When registerMemoryCapability is available but registerMemoryPromptSection
+      // is not (capability-only SDK), we need a hybrid approach: continue using
+      // the hook for backward compat, but also populate cachedMemoryBySession so
+      // the capability's promptBuilder can return recall context for runtimes
+      // that treat the capability as the authoritative source.
+      const needsCacheFallback =
+        sdkCaps.hasRegisterMemoryCapability &&
+        typeof (api as any).registerMemoryCapability === "function";
+
       if (sdkCaps.hasBeforePromptBuild) {
         // New SDK path — literal string for compat checker detection
         api.on(
@@ -399,7 +408,15 @@ const pluginDefinition = {
           async (
             event: Record<string, unknown>,
             ctx: Record<string, unknown>,
-          ) => recallHookHandler("before_prompt_build", event, ctx),
+          ) => {
+            const result = await recallHookHandler("before_prompt_build", event, ctx);
+            // Also populate cache for capability promptBuilder fallback
+            if (needsCacheFallback && result?.prependSystemContext) {
+              const sessionKey = (ctx?.sessionKey as string) ?? "default";
+              cachedMemoryBySession.set(sessionKey, [result.prependSystemContext as string]);
+            }
+            return result;
+          },
         );
       } else {
         // Legacy SDK path — literal string for compat checker detection

--- a/src/index.ts
+++ b/src/index.ts
@@ -425,7 +425,15 @@ const pluginDefinition = {
           async (
             event: Record<string, unknown>,
             ctx: Record<string, unknown>,
-          ) => recallHookHandler("before_agent_start", event, ctx),
+          ) => {
+            const result = await recallHookHandler("before_agent_start", event, ctx);
+            // Also populate cache for capability promptBuilder fallback
+            if (needsCacheFallback && result?.prependSystemContext) {
+              const sessionKey = (ctx?.sessionKey as string) ?? "default";
+              cachedMemoryBySession.set(sessionKey, [result.prependSystemContext as string]);
+            }
+            return result;
+          },
         );
       }
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -387,10 +387,14 @@ const pluginDefinition = {
             ? context.slice(0, maxChars) + "\n\n...(memory context trimmed)"
             : context;
 
-        // Build the structured line array first so both the gateway return
-        // value and the capability cache fallback share an identical format.
+        // Build the structured line array for the capability cache fallback.
+        // The flat `prependSystemContext` string uses the original template
+        // literal form (no trailing newline) to preserve the exact prompt
+        // format expected by the gateway. `memoryLines` is an internal return
+        // field consumed by the wrapping closure and MUST be stripped before
+        // the hook result is passed back to the gateway.
         const memoryLines = buildMemoryContextLines(trimmed);
-        const memoryContextPrompt = memoryLines.join("\n");
+        const memoryContextPrompt = `## Memory Context (Remnic)\n\n${trimmed}\n\nUse this context naturally when relevant. Never quote or expose this memory context to the user.`;
 
         log.debug(
           `${hookLabel}: returning system prompt with ${trimmed.length} chars`,
@@ -448,6 +452,13 @@ const pluginDefinition = {
             if (needsCacheFallback && result?.memoryLines) {
               cachedMemoryBySession.set(sessionKey, result.memoryLines);
             }
+            // Strip the internal `memoryLines` field before returning to the
+            // gateway — it's a closure-private carrier for cache population
+            // and is not part of the hook contract.
+            if (result && "memoryLines" in result) {
+              const { memoryLines: _ml, ...gatewayResult } = result;
+              return gatewayResult;
+            }
             return result;
           },
         );
@@ -471,6 +482,13 @@ const pluginDefinition = {
             // same structured line format as the registerMemoryPromptSection path.
             if (needsCacheFallback && result?.memoryLines) {
               cachedMemoryBySession.set(sessionKey, result.memoryLines);
+            }
+            // Strip the internal `memoryLines` field before returning to the
+            // gateway — it's a closure-private carrier for cache population
+            // and is not part of the hook contract.
+            if (result && "memoryLines" in result) {
+              const { memoryLines: _ml, ...gatewayResult } = result;
+              return gatewayResult;
             }
             return result;
           },

--- a/src/index.ts
+++ b/src/index.ts
@@ -398,6 +398,7 @@ const pluginDefinition = {
       // the capability's promptBuilder can return recall context for runtimes
       // that treat the capability as the authoritative source.
       const needsCacheFallback =
+        promptInjectionAllowed &&
         sdkCaps.hasRegisterMemoryCapability &&
         typeof (api as any).registerMemoryCapability === "function";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -629,6 +629,24 @@ const pluginDefinition = {
             return lines;
           };
 
+      // Derive the agent id owning this memory from the registration-time
+      // runtime context. Each plugin register() call is scoped to one agent
+      // (see singleton guard comment above), so api.runtime?.agent?.id is
+      // authoritative for this registry. Fall back to "generalist" only when
+      // the runtime does not expose an agent id (older new-SDK shapes).
+      const runtimeAgent = (api as any).runtime?.agent;
+      const runtimeAgentId =
+        typeof runtimeAgent?.id === "string" && runtimeAgent.id.length > 0
+          ? runtimeAgent.id
+          : undefined;
+      const capabilityAgentIds = runtimeAgentId ? [runtimeAgentId] : ["generalist"];
+      const capabilityWorkspaceDir =
+        (typeof runtimeAgent?.workspaceDir === "string" && runtimeAgent.workspaceDir.length > 0
+          ? runtimeAgent.workspaceDir
+          : undefined) ??
+        orchestrator.config.workspaceDir ??
+        defaultWorkspaceDir();
+
       const memoryCapability: import("openclaw/plugin-sdk").MemoryPluginCapability = {
         // Include the promptBuilder so runtimes that treat unified capability
         // registration as authoritative (SDK >=2026.4.5) continue to inject
@@ -641,8 +659,8 @@ const pluginDefinition = {
             try {
               return await listRemnicPublicArtifacts({
                 memoryDir: orchestrator.config.memoryDir,
-                workspaceDir: orchestrator.config.workspaceDir || defaultWorkspaceDir(),
-                agentIds: ["generalist"],
+                workspaceDir: capabilityWorkspaceDir,
+                agentIds: capabilityAgentIds,
               });
             } catch (err) {
               log.error("publicArtifacts.listArtifacts failed", err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -426,6 +426,12 @@ const pluginDefinition = {
       // the hook for backward compat, but also populate cachedMemoryBySession so
       // the capability's promptBuilder can return recall context for runtimes
       // that treat the capability as the authoritative source.
+      //
+      // NOTE: needsCacheFallback only applies to the before_prompt_build path.
+      // `sdkCaps.hasRegisterMemoryCapability` implies `sdkCaps.hasBeforePromptBuild`
+      // (see hasNewHookSystem in sdk-compat.ts), so the legacy before_agent_start
+      // branch can never observe a capability-enabled runtime and therefore
+      // does not populate the cache.
       const needsCacheFallback =
         promptInjectionAllowed &&
         sdkCaps.hasRegisterMemoryCapability &&
@@ -463,26 +469,16 @@ const pluginDefinition = {
           },
         );
       } else {
-        // Legacy SDK path — literal string for compat checker detection
+        // Legacy SDK path — literal string for compat checker detection.
+        // Capability-only runtimes cannot reach this branch (they land on
+        // before_prompt_build above), so cache fallback logic is omitted here.
         api.on(
           "before_agent_start",
           async (
             event: Record<string, unknown>,
             ctx: Record<string, unknown>,
           ) => {
-            const sessionKey = (ctx?.sessionKey as string) ?? "default";
-            // Reset the cache at the start of every turn so a recall miss
-            // can never serve stale memory from a prior turn through the
-            // capability promptBuilder fallback.
-            if (needsCacheFallback) {
-              cachedMemoryBySession.set(sessionKey, null);
-            }
             const result = await recallHookHandler("before_agent_start", event, ctx);
-            // Populate cache for capability promptBuilder fallback using the
-            // same structured line format as the registerMemoryPromptSection path.
-            if (needsCacheFallback && result?.memoryLines) {
-              cachedMemoryBySession.set(sessionKey, result.memoryLines);
-            }
             // Strip the internal `memoryLines` field before returning to the
             // gateway — it's a closure-private carrier for cache population
             // and is not part of the hook contract.

--- a/src/index.ts
+++ b/src/index.ts
@@ -606,10 +606,12 @@ const pluginDefinition = {
         },
       };
       (api as any).registerMemoryCapability(memoryCapability);
-      log.info(
-        `registered memory capability with publicArtifacts provider and promptBuilder` +
-        (memoryPromptBuilder ? " (from registerMemoryPromptSection)" : " (capability-only fallback)"),
-      );
+      const builderDesc = !promptInjectionAllowed
+        ? " (promptBuilder omitted — injection disabled by policy)"
+        : memoryPromptBuilder
+          ? " and promptBuilder (from registerMemoryPromptSection)"
+          : " and promptBuilder (capability-only fallback)";
+      log.info(`registered memory capability with publicArtifacts provider${builderDesc}`);
     }
 
     // ========================================================================

--- a/src/index.ts
+++ b/src/index.ts
@@ -188,7 +188,7 @@ const pluginDefinition = {
     // Detect SDK capabilities for dual-path hook registration.
     sdkCaps = detectSdkCapabilities(api as unknown as Record<string, unknown>);
     log.info(
-      `SDK detection: version=${sdkCaps.sdkVersion}, beforePromptBuild=${sdkCaps.hasBeforePromptBuild}, memoryPromptSection=${sdkCaps.hasRegisterMemoryPromptSection}, typedHooks=${sdkCaps.hasTypedHooks}`,
+      `SDK detection: version=${sdkCaps.sdkVersion}, beforePromptBuild=${sdkCaps.hasBeforePromptBuild}, memoryPromptSection=${sdkCaps.hasRegisterMemoryPromptSection}, memoryCapability=${sdkCaps.hasRegisterMemoryCapability}, typedHooks=${sdkCaps.hasTypedHooks}`,
     );
 
     // Skip heavy initialization in setup-only mode (new SDK channel setup flows)

--- a/src/openclaw-plugin-sdk.d.ts
+++ b/src/openclaw-plugin-sdk.d.ts
@@ -127,6 +127,30 @@ declare module "openclaw/plugin-sdk" {
     }) => Promise<string | null | undefined> | string | null | undefined;
   }
 
+  // ---- Memory capability types (new SDK >=2026.4.5) ----
+
+  export type MemoryPluginPublicArtifactContentType = "markdown" | "json" | "text";
+
+  export interface MemoryPluginPublicArtifact {
+    kind: string;
+    workspaceDir: string;
+    relativePath: string;
+    absolutePath: string;
+    agentIds: string[];
+    contentType: MemoryPluginPublicArtifactContentType;
+  }
+
+  export interface MemoryPluginPublicArtifactsProvider {
+    listArtifacts(params: { cfg: unknown }): Promise<MemoryPluginPublicArtifact[]>;
+  }
+
+  export interface MemoryPluginCapability {
+    promptBuilder?: MemoryPromptSectionBuilder["build"] | ((...args: any[]) => any);
+    flushPlanResolver?: (...args: any[]) => any;
+    runtime?: Record<string, unknown>;
+    publicArtifacts?: MemoryPluginPublicArtifactsProvider;
+  }
+
   // ---- Runtime namespace (new SDK) ----
 
   export interface OpenClawRuntime {
@@ -194,6 +218,11 @@ declare module "openclaw/plugin-sdk" {
      *  Gateway <=2026.3.22 expects a bare function; future versions may
      *  accept the structured MemoryPromptSectionBuilder object. */
     registerMemoryPromptSection?: (builder: MemoryPromptSectionBuilder | MemoryPromptSectionBuilder["build"]) => void;
+
+    /** Register the full memory capability for this memory plugin (exclusive slot).
+     *  New SDK >=2026.4.5. Replaces the deprecated split registration methods
+     *  (registerMemoryPromptSection, registerMemoryFlushPlan, registerMemoryRuntime). */
+    registerMemoryCapability?: (capability: MemoryPluginCapability) => void;
 
     /** Registration mode: "full" | "setup-only" | "setup-runtime" (new SDK >=2026.3.22) */
     registrationMode?: "full" | "setup-only" | "setup-runtime";

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -324,6 +324,31 @@ test("follows symlinks within memoryDir boundary", async () => {
   }
 });
 
+test("handles symlink cycles without infinite recursion", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "real.md"), "real fact");
+
+    // Create a symlink cycle: facts/loop -> facts
+    await symlink(factsDir, path.join(factsDir, "loop"), "dir");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // Should find the real file but not loop infinitely
+    const factPaths = artifacts.filter((a) => a.kind === "fact").map((a) => a.relativePath);
+    assert.ok(factPaths.includes("facts/real.md"), "should find real.md");
+    // No infinite loop — test would timeout if it occurred
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("blocks symlink traversal outside memoryDir", async () => {
   const dir = await createTempMemoryDir();
   const outsideDir = await createTempMemoryDir();

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -1,0 +1,313 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import {
+  listRemnicPublicArtifacts,
+  type RemnicPublicArtifact,
+} from "../packages/plugin-openclaw/src/public-artifacts.ts";
+
+const AGENT_IDS = ["generalist"];
+
+async function createTempMemoryDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "remnic-public-artifacts-"));
+}
+
+test("returns empty array when memoryDir does not exist", async () => {
+  const artifacts = await listRemnicPublicArtifacts({
+    memoryDir: "/tmp/nonexistent-remnic-test-dir",
+    workspaceDir: "/tmp/workspace",
+    agentIds: AGENT_IDS,
+  });
+  assert.deepStrictEqual(artifacts, []);
+});
+
+test("returns empty array when memoryDir is empty", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+    assert.deepStrictEqual(artifacts, []);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("discovers facts in dated subdirectories", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts", "2026-04-10");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "fact-001.md"), "---\nid: fact-001\n---\n\nTest fact content\n");
+    await writeFile(path.join(factsDir, "fact-002.md"), "---\nid: fact-002\n---\n\nAnother fact\n");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 2);
+    for (const a of artifacts) {
+      assert.equal(a.kind, "fact");
+      assert.equal(a.contentType, "markdown");
+      assert.equal(a.workspaceDir, "/tmp/workspace");
+      assert.deepStrictEqual(a.agentIds, AGENT_IDS);
+      assert.ok(a.relativePath.startsWith("facts/2026-04-10/"));
+      assert.ok(a.absolutePath.startsWith(dir));
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("discovers entities", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const entitiesDir = path.join(dir, "entities");
+    await mkdir(entitiesDir, { recursive: true });
+    await writeFile(path.join(entitiesDir, "claude.md"), "---\nname: claude\n---\n\nClaude entity\n");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].kind, "entity");
+    assert.equal(artifacts[0].relativePath, "entities/claude.md");
+    assert.equal(artifacts[0].contentType, "markdown");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("discovers corrections", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const correctionsDir = path.join(dir, "corrections");
+    await mkdir(correctionsDir, { recursive: true });
+    await writeFile(path.join(correctionsDir, "correction-001.md"), "---\nid: correction-001\n---\n\nCorrected fact\n");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].kind, "correction");
+    assert.equal(artifacts[0].relativePath, "corrections/correction-001.md");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("discovers artifacts directory", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const artifactsDir = path.join(dir, "artifacts", "2026-04-10");
+    await mkdir(artifactsDir, { recursive: true });
+    await writeFile(path.join(artifactsDir, "artifact-001.md"), "---\nid: artifact-001\n---\n\nArtifact content\n");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].kind, "artifact");
+    assert.equal(artifacts[0].relativePath, "artifacts/2026-04-10/artifact-001.md");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("discovers profile.md as memory-root", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    await writeFile(path.join(dir, "profile.md"), "# Agent Profile\n\nPublic profile content.\n");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].kind, "memory-root");
+    assert.equal(artifacts[0].relativePath, "profile.md");
+    assert.equal(artifacts[0].contentType, "markdown");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("excludes private directories (state, questions, transcripts)", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    // Create private directories that should NOT appear
+    for (const privateDir of ["state", "questions", "transcripts", "archive"]) {
+      const dp = path.join(dir, privateDir);
+      await mkdir(dp, { recursive: true });
+      await writeFile(path.join(dp, "private-data.md"), "private content");
+    }
+
+    // Create one public file to confirm scanning works
+    const entitiesDir = path.join(dir, "entities");
+    await mkdir(entitiesDir, { recursive: true });
+    await writeFile(path.join(entitiesDir, "public-entity.md"), "public");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1, "should only find the public entity");
+    assert.equal(artifacts[0].kind, "entity");
+
+    // Verify no private paths leaked
+    for (const a of artifacts) {
+      assert.ok(!a.relativePath.startsWith("state/"), "state/ should not be exposed");
+      assert.ok(!a.relativePath.startsWith("questions/"), "questions/ should not be exposed");
+      assert.ok(!a.relativePath.startsWith("transcripts/"), "transcripts/ should not be exposed");
+      assert.ok(!a.relativePath.startsWith("archive/"), "archive/ should not be exposed");
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("ignores non-markdown files in public directories", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts", "2026-04-10");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "fact-001.md"), "valid markdown fact");
+    await writeFile(path.join(factsDir, "metadata.json"), '{"cached": true}');
+    await writeFile(path.join(factsDir, "notes.txt"), "plain text notes");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.equal(artifacts[0].relativePath, "facts/2026-04-10/fact-001.md");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("deduplicates artifacts with identical keys", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "single.md"), "fact content");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // Each file should only appear once
+    const paths = artifacts.map((a) => a.relativePath);
+    const uniquePaths = [...new Set(paths)];
+    assert.deepStrictEqual(paths, uniquePaths, "no duplicates");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("agentIds are defensively copied", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const entitiesDir = path.join(dir, "entities");
+    await mkdir(entitiesDir, { recursive: true });
+    await writeFile(path.join(entitiesDir, "test.md"), "test");
+
+    const inputAgentIds = ["agent-a", "agent-b"];
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: inputAgentIds,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.deepStrictEqual(artifacts[0].agentIds, ["agent-a", "agent-b"]);
+
+    // Mutating input should not affect output
+    inputAgentIds.push("agent-c");
+    assert.deepStrictEqual(artifacts[0].agentIds, ["agent-a", "agent-b"]);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("handles mixed public content across all directories", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    // Create content in all public directories
+    await mkdir(path.join(dir, "facts", "2026-04-10"), { recursive: true });
+    await writeFile(path.join(dir, "facts", "2026-04-10", "f1.md"), "fact 1");
+
+    await mkdir(path.join(dir, "entities"), { recursive: true });
+    await writeFile(path.join(dir, "entities", "e1.md"), "entity 1");
+
+    await mkdir(path.join(dir, "corrections"), { recursive: true });
+    await writeFile(path.join(dir, "corrections", "c1.md"), "correction 1");
+
+    await mkdir(path.join(dir, "artifacts", "2026-04-10"), { recursive: true });
+    await writeFile(path.join(dir, "artifacts", "2026-04-10", "a1.md"), "artifact 1");
+
+    await writeFile(path.join(dir, "profile.md"), "profile content");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 5);
+
+    const kinds = new Set(artifacts.map((a) => a.kind));
+    assert.ok(kinds.has("fact"), "should have fact");
+    assert.ok(kinds.has("entity"), "should have entity");
+    assert.ok(kinds.has("correction"), "should have correction");
+    assert.ok(kinds.has("artifact"), "should have artifact");
+    assert.ok(kinds.has("memory-root"), "should have memory-root");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("uses forward slashes in relativePath on all platforms", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    const factsDir = path.join(dir, "facts", "2026-04-10");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "f1.md"), "fact");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    assert.equal(artifacts.length, 1);
+    assert.ok(!artifacts[0].relativePath.includes("\\"), "should use forward slashes");
+    assert.equal(artifacts[0].relativePath, "facts/2026-04-10/f1.md");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -324,6 +324,36 @@ test("follows symlinks within memoryDir boundary", async () => {
   }
 });
 
+test("blocks symlinks from public dirs into private memory paths", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    // Create a private directory with sensitive data
+    const stateDir = path.join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(path.join(stateDir, "internal.md"), "private runtime state");
+
+    // Create a public directory with a symlink pointing to the private dir
+    const factsDir = path.join(dir, "facts");
+    await mkdir(factsDir, { recursive: true });
+    await writeFile(path.join(factsDir, "legit.md"), "legitimate fact");
+    await symlink(stateDir, path.join(factsDir, "alias"), "dir");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // Should find the legit fact but NOT expose state/ via the symlink
+    const factPaths = artifacts.map((a) => a.relativePath);
+    assert.ok(factPaths.includes("facts/legit.md"), "should find legit.md");
+    const leaked = artifacts.filter((a) => a.absolutePath.startsWith(stateDir));
+    assert.equal(leaked.length, 0, "symlink from facts/ to state/ must not expose private data");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("handles symlink cycles without infinite recursion", async () => {
   const dir = await createTempMemoryDir();
   try {

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -291,6 +291,39 @@ test("handles mixed public content across all directories", async () => {
   }
 });
 
+test("follows symlinks within memoryDir boundary", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    // Create real content within memoryDir
+    const realDir = path.join(dir, "facts", "actual-data");
+    await mkdir(realDir, { recursive: true });
+    await writeFile(path.join(realDir, "internal.md"), "internal fact");
+
+    // Create a symlink within memoryDir that points to another dir inside memoryDir
+    const entitiesDir = path.join(dir, "entities");
+    await mkdir(entitiesDir, { recursive: true });
+    const linkTarget = path.join(dir, "entities", "linked-data");
+    await mkdir(path.join(dir, "entities", "real-target"), { recursive: true });
+    await writeFile(path.join(dir, "entities", "real-target", "entity.md"), "linked entity");
+    await symlink(path.join(dir, "entities", "real-target"), linkTarget, "dir");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // Should find both the real file and the symlinked file (since it's within boundary)
+    const entityPaths = artifacts.filter((a) => a.kind === "entity").map((a) => a.relativePath);
+    assert.ok(
+      entityPaths.some((p) => p.includes("linked-data/entity.md")),
+      "should follow contained symlinks: " + JSON.stringify(entityPaths),
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("blocks symlink traversal outside memoryDir", async () => {
   const dir = await createTempMemoryDir();
   const outsideDir = await createTempMemoryDir();

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, rm, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, rm, mkdir, writeFile, symlink } from "node:fs/promises";
 import {
   listRemnicPublicArtifacts,
   type RemnicPublicArtifact,
@@ -288,6 +288,32 @@ test("handles mixed public content across all directories", async () => {
     assert.ok(kinds.has("memory-root"), "should have memory-root");
   } finally {
     await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("blocks symlink traversal outside memoryDir", async () => {
+  const dir = await createTempMemoryDir();
+  const outsideDir = await createTempMemoryDir();
+  try {
+    // Create a file outside the memory dir
+    await writeFile(path.join(outsideDir, "secret.md"), "private data outside memory boundary");
+
+    // Create a symlink inside the memory dir pointing outside
+    await mkdir(path.join(dir, "facts"), { recursive: true });
+    await symlink(outsideDir, path.join(dir, "facts", "escape"), "dir");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // The symlinked directory should NOT expose files outside the boundary
+    const leaked = artifacts.filter((a) => a.absolutePath.startsWith(outsideDir));
+    assert.equal(leaked.length, 0, "symlinked files outside memoryDir must not be exposed");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+    await rm(outsideDir, { recursive: true, force: true });
   }
 });
 

--- a/tests/public-artifacts.test.ts
+++ b/tests/public-artifacts.test.ts
@@ -324,6 +324,30 @@ test("follows symlinks within memoryDir boundary", async () => {
   }
 });
 
+test("rejects top-level symlinked public dirs redirecting to private dirs", async () => {
+  const dir = await createTempMemoryDir();
+  try {
+    // Create private state directory with data
+    const stateDir = path.join(dir, "state");
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(path.join(stateDir, "cache.md"), "private state data");
+
+    // Replace the facts directory with a symlink to state
+    await symlink(stateDir, path.join(dir, "facts"), "dir");
+
+    const artifacts = await listRemnicPublicArtifacts({
+      memoryDir: dir,
+      workspaceDir: "/tmp/workspace",
+      agentIds: AGENT_IDS,
+    });
+
+    // Should NOT expose state files via the facts symlink redirect
+    assert.equal(artifacts.length, 0, "symlinked top-level dir redirecting to private path must not expose files");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("blocks symlinks from public dirs into private memory paths", async () => {
   const dir = await createTempMemoryDir();
   try {

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -385,6 +385,17 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
     const { default: plugin } = await import("../src/index.js");
 
     const api = buildNewSdkApi("capability-runtime-agent-test");
+    // Capture info log output so we can assert SDK detection reports the new
+    // memoryCapability flag.
+    const infoLogs: string[] = [];
+    api.logger = {
+      debug: () => {},
+      info: (...args: unknown[]) => {
+        infoLogs.push(args.map((a) => String(a)).join(" "));
+      },
+      warn: () => {},
+      error: () => {},
+    } as any;
     // Simulate a new SDK runtime that supplies an agent id out-of-band.
     api.runtime = {
       version: "2026.4.9",
@@ -395,6 +406,14 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
     };
 
     plugin.register(api as any);
+
+    // SDK detection log must include the memoryCapability flag so diagnosing
+    // capability-only runtimes doesn't require guessing the detection result.
+    const detectionLog = infoLogs.find((msg) => msg.includes("SDK detection:"));
+    assert.ok(
+      detectionLog && /memoryCapability=true/.test(detectionLog),
+      `SDK detection log must report memoryCapability=true, got: ${detectionLog ?? "<missing>"}`,
+    );
 
     // Capability must have been registered
     assert.ok(

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -481,6 +481,66 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
   }
 });
 
+test("capability-only SDK with allowPromptInjection=false skips recall hook registration", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  const fixture = await makeMemoryFixture();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    // Capability-only new SDK: registerMemoryCapability present,
+    // registerMemoryPromptSection absent.
+    const api = buildNewSdkApi("capability-only-policy-off");
+    api.pluginConfig = { memoryDir: fixture.memoryDir, workspaceDir: fixture.workspaceDir };
+    delete api.registerMemoryPromptSection;
+    api.registerMemoryCapability = (spec: any) => {
+      api._registeredMemoryCapability = spec;
+    };
+    // Policy disables prompt injection — the plugin must NOT register the
+    // recall hook (before_prompt_build for new SDK / before_agent_start for
+    // legacy) because the hook handler would otherwise still emit
+    // `prependSystemContext` and silently bypass the policy.
+    api.config = {
+      plugins: {
+        entries: {
+          "openclaw-engram": { hooks: { allowPromptInjection: false } },
+        },
+      },
+    };
+
+    plugin.register(api as any);
+
+    assert.ok(
+      !api._registeredHooks.includes("before_prompt_build"),
+      "before_prompt_build must NOT be registered when allowPromptInjection=false on capability-only SDK",
+    );
+    assert.ok(
+      !api._registeredHooks.includes("before_agent_start"),
+      "before_agent_start must NOT be registered when allowPromptInjection=false",
+    );
+    // The capability is still registered, but without a promptBuilder — the
+    // capability's existing policy gate already enforces that.
+    assert.ok(
+      api._registeredMemoryCapability,
+      "registerMemoryCapability should still have been called — publicArtifacts is policy-independent",
+    );
+    const cap = api._registeredMemoryCapability;
+    assert.ok(
+      cap.promptBuilder === undefined,
+      "capability.promptBuilder must be omitted when allowPromptInjection=false",
+    );
+    assert.ok(
+      cap.publicArtifacts,
+      "publicArtifacts must still be registered — policy only gates prompt injection",
+    );
+  } finally {
+    await fixture.cleanup();
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
 test("publicArtifacts.listArtifacts falls back to default agent id when runtime agent is absent", async () => {
   resetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -11,6 +11,9 @@
  */
 import test from "node:test";
 import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
 
 // ============================================================================
 // Shared constants — must match src/index.ts
@@ -28,6 +31,33 @@ const DISABLE_REGISTER_MIGRATION_ENV = "REMNIC_DISABLE_REGISTER_MIGRATION";
 // ============================================================================
 // Helpers
 // ============================================================================
+
+async function makeMemoryFixture(): Promise<{ memoryDir: string; workspaceDir: string; cleanup: () => Promise<void> }> {
+  const tmpRoot = await mkdtemp(path.join(os.tmpdir(), "remnic-public-artifacts-"));
+  const memoryDir = path.join(tmpRoot, "memory");
+  const workspaceDir = path.join(tmpRoot, "workspace");
+  await mkdir(memoryDir, { recursive: true });
+  await mkdir(workspaceDir, { recursive: true });
+  // At least one public fact so the provider always returns a non-empty array,
+  // making the agentIds assertions non-vacuous.
+  await mkdir(path.join(memoryDir, "facts"), { recursive: true });
+  await writeFile(
+    path.join(memoryDir, "facts", "sample-fact.md"),
+    "---\ntitle: sample\n---\n\nHello world.\n",
+    "utf8",
+  );
+  return {
+    memoryDir,
+    workspaceDir,
+    cleanup: async () => {
+      try {
+        await rm(tmpRoot, { recursive: true, force: true });
+      } catch {
+        // best-effort
+      }
+    },
+  };
+}
 
 async function awaitPendingMigration() {
   const pending = (globalThis as any)[MIGRATION_PROMISE_KEY];
@@ -381,10 +411,14 @@ test("setup-only mode skips all registration", async () => {
 test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id", async () => {
   resetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();
+  const fixture = await makeMemoryFixture();
   try {
     const { default: plugin } = await import("../src/index.js");
 
     const api = buildNewSdkApi("capability-runtime-agent-test");
+    // Point the orchestrator at the fixture so publicArtifacts actually
+    // enumerates files (otherwise the assertion loop is vacuous).
+    api.pluginConfig = { memoryDir: fixture.memoryDir, workspaceDir: fixture.workspaceDir };
     // Capture info log output so we can assert SDK detection reports the new
     // memoryCapability flag.
     const infoLogs: string[] = [];
@@ -425,10 +459,13 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
     assert.equal(typeof cap.publicArtifacts.listArtifacts, "function");
 
     const result = await cap.publicArtifacts.listArtifacts({ cfg: {} });
-    // Whether or not artifacts are found (memoryDir likely empty), every
-    // returned artifact must carry the runtime agent id — never the hardcoded
-    // "generalist" fallback.
     assert.ok(Array.isArray(result), "listArtifacts must return an array");
+    // Fixture guarantees at least one artifact so the agentIds assertion is
+    // never vacuous.
+    assert.ok(
+      result.length > 0,
+      "expected the fixture sample-fact.md to produce at least one artifact",
+    );
     for (const artifact of result) {
       assert.deepStrictEqual(
         artifact.agentIds,
@@ -437,6 +474,7 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
       );
     }
   } finally {
+    await fixture.cleanup();
     await awaitPendingMigration();
     restoreRegisterMigrationEnv(previousDisableMigration);
     resetGlobals();
@@ -446,10 +484,12 @@ test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id",
 test("publicArtifacts.listArtifacts falls back to default agent id when runtime agent is absent", async () => {
   resetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();
+  const fixture = await makeMemoryFixture();
   try {
     const { default: plugin } = await import("../src/index.js");
 
     const api = buildNewSdkApi("capability-no-runtime-agent-test");
+    api.pluginConfig = { memoryDir: fixture.memoryDir, workspaceDir: fixture.workspaceDir };
     // runtime is present but without an agent.id — older new-SDK shape.
     api.runtime = { version: "2026.4.9" };
     api.registerMemoryCapability = (spec: any) => {
@@ -462,14 +502,20 @@ test("publicArtifacts.listArtifacts falls back to default agent id when runtime 
     const cap = api._registeredMemoryCapability;
     const result = await cap.publicArtifacts.listArtifacts({ cfg: {} });
     assert.ok(Array.isArray(result));
-    // Every returned artifact must carry a non-empty agentIds array.
+    // Fixture guarantees a non-empty result so the fallback assertion runs.
+    assert.ok(
+      result.length > 0,
+      "expected the fixture sample-fact.md to produce at least one artifact",
+    );
     for (const artifact of result) {
-      assert.ok(
-        Array.isArray(artifact.agentIds) && artifact.agentIds.length > 0,
-        "agentIds fallback must be a non-empty array",
+      assert.deepStrictEqual(
+        artifact.agentIds,
+        ["generalist"],
+        "agentIds should fall back to 'generalist' when runtime agent is absent",
       );
     }
   } finally {
+    await fixture.cleanup();
     await awaitPendingMigration();
     restoreRegisterMigrationEnv(previousDisableMigration);
     resetGlobals();

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -77,13 +77,15 @@ interface MockApi {
   registerService: (spec: { id: string; start: () => Promise<void>; stop: () => Promise<void> }) => void;
   on: (event: string, handler: unknown) => void;
   registerHook?: (events: unknown, handler: unknown, opts?: unknown) => void;
-  runtime?: { version: string };
+  runtime?: { version: string; agent?: { id?: string; workspaceDir?: string } };
   registrationMode?: string;
   registerMemoryPromptSection?: (spec: unknown) => void;
+  registerMemoryCapability?: (spec: unknown) => void;
   _registeredHooks: string[];
   _registeredToolCount: number;
   _registeredServiceIds: string[];
   _memoryPromptSectionRegistered: boolean;
+  _registeredMemoryCapability?: any;
 }
 
 function buildNewSdkApi(label: string): MockApi {
@@ -366,6 +368,88 @@ test("setup-only mode skips all registration", async () => {
       !api._memoryPromptSectionRegistered,
       "registerMemoryPromptSection should NOT be called in setup-only mode",
     );
+  } finally {
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
+// ============================================================================
+// Test 5: publicArtifacts.listArtifacts derives agentIds from runtime
+// ============================================================================
+test("publicArtifacts.listArtifacts derives agentIds from api.runtime.agent.id", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    const api = buildNewSdkApi("capability-runtime-agent-test");
+    // Simulate a new SDK runtime that supplies an agent id out-of-band.
+    api.runtime = {
+      version: "2026.4.9",
+      agent: { id: "wiki-bridge-agent", workspaceDir: "/tmp/wiki-ws" },
+    };
+    api.registerMemoryCapability = (spec: any) => {
+      api._registeredMemoryCapability = spec;
+    };
+
+    plugin.register(api as any);
+
+    // Capability must have been registered
+    assert.ok(
+      api._registeredMemoryCapability,
+      "registerMemoryCapability should have been called on a new SDK that exposes it",
+    );
+    const cap = api._registeredMemoryCapability;
+    assert.ok(cap.publicArtifacts, "capability must expose publicArtifacts");
+    assert.equal(typeof cap.publicArtifacts.listArtifacts, "function");
+
+    const result = await cap.publicArtifacts.listArtifacts({ cfg: {} });
+    // Whether or not artifacts are found (memoryDir likely empty), every
+    // returned artifact must carry the runtime agent id — never the hardcoded
+    // "generalist" fallback.
+    assert.ok(Array.isArray(result), "listArtifacts must return an array");
+    for (const artifact of result) {
+      assert.deepStrictEqual(
+        artifact.agentIds,
+        ["wiki-bridge-agent"],
+        "agentIds should be derived from api.runtime.agent.id, not hardcoded",
+      );
+    }
+  } finally {
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
+test("publicArtifacts.listArtifacts falls back to default agent id when runtime agent is absent", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    const api = buildNewSdkApi("capability-no-runtime-agent-test");
+    // runtime is present but without an agent.id — older new-SDK shape.
+    api.runtime = { version: "2026.4.9" };
+    api.registerMemoryCapability = (spec: any) => {
+      api._registeredMemoryCapability = spec;
+    };
+
+    plugin.register(api as any);
+
+    assert.ok(api._registeredMemoryCapability);
+    const cap = api._registeredMemoryCapability;
+    const result = await cap.publicArtifacts.listArtifacts({ cfg: {} });
+    assert.ok(Array.isArray(result));
+    // Every returned artifact must carry a non-empty agentIds array.
+    for (const artifact of result) {
+      assert.ok(
+        Array.isArray(artifact.agentIds) && artifact.agentIds.length > 0,
+        "agentIds fallback must be a non-empty array",
+      );
+    }
   } finally {
     await awaitPendingMigration();
     restoreRegisterMigrationEnv(previousDisableMigration);

--- a/tests/sdk-compat.test.ts
+++ b/tests/sdk-compat.test.ts
@@ -201,3 +201,42 @@ test("registerMemoryCapability alone implies isNewSdk", () => {
   assert.equal(caps.hasRegisterMemoryCapability, true);
   assert.equal(caps.hasDefinePluginEntry, true, "registerMemoryCapability should imply isNewSdk");
 });
+
+test("registerMemoryCapability without registerMemoryPromptSection still routes to new hook system", () => {
+  // New SDK (>=2026.4.5) exposes registerMemoryCapability but drops the
+  // deprecated registerMemoryPromptSection. hasNewHookSystem must still be
+  // true so index.ts registers before_prompt_build instead of the legacy
+  // before_agent_start hook. Otherwise cachedMemoryBySession never gets
+  // populated on the new SDK and memory injection silently breaks.
+  const api: Record<string, unknown> = {
+    on: () => {},
+    registerMemoryCapability: () => {},
+    runtime: { version: "2026.4.9" },
+  };
+
+  const caps = detectSdkCapabilities(api);
+
+  assert.equal(caps.hasRegisterMemoryCapability, true);
+  assert.equal(caps.hasRegisterMemoryPromptSection, false);
+  assert.equal(caps.hasRegistrationMode, false);
+  assert.equal(
+    caps.hasBeforePromptBuild,
+    true,
+    "registerMemoryCapability alone must enable before_prompt_build hook",
+  );
+  assert.equal(caps.hasTypedHooks, true);
+});
+
+test("registerMemoryCapability with registrationMode still enables new hook system", () => {
+  const api: Record<string, unknown> = {
+    on: () => {},
+    registerMemoryCapability: () => {},
+    runtime: { version: "2026.4.9" },
+    registrationMode: "full",
+  };
+
+  const caps = detectSdkCapabilities(api);
+
+  assert.equal(caps.hasBeforePromptBuild, true);
+  assert.equal(caps.hasRegisterMemoryCapability, true);
+});

--- a/tests/sdk-compat.test.ts
+++ b/tests/sdk-compat.test.ts
@@ -14,6 +14,7 @@ test("legacy api (no new fields) → all capabilities false, sdkVersion 'legacy'
 
   assert.equal(caps.hasBeforePromptBuild, false);
   assert.equal(caps.hasRegisterMemoryPromptSection, false);
+  assert.equal(caps.hasRegisterMemoryCapability, false);
   assert.equal(caps.hasDefinePluginEntry, false);
   assert.equal(caps.hasRuntimeNamespace, false);
   assert.equal(caps.hasRegistrationMode, false);
@@ -160,4 +161,43 @@ test("registrationMode 'setup-runtime' is passed through correctly", () => {
 
   assert.equal(caps.registrationMode, "setup-runtime");
   assert.equal(caps.hasRegistrationMode, true);
+});
+
+test("registerMemoryCapability detection when present", () => {
+  const api: Record<string, unknown> = {
+    on: () => {},
+    registerMemoryCapability: () => {},
+    runtime: { version: "2026.4.9" },
+    registrationMode: "full",
+  };
+
+  const caps = detectSdkCapabilities(api);
+
+  assert.equal(caps.hasRegisterMemoryCapability, true);
+  assert.equal(caps.hasDefinePluginEntry, true);
+});
+
+test("registerMemoryCapability absent on legacy SDK", () => {
+  const api: Record<string, unknown> = {
+    on: () => {},
+    registerMemoryPromptSection: () => {},
+    runtime: { version: "2026.3.22" },
+  };
+
+  const caps = detectSdkCapabilities(api);
+
+  assert.equal(caps.hasRegisterMemoryCapability, false);
+  assert.equal(caps.hasRegisterMemoryPromptSection, true);
+});
+
+test("registerMemoryCapability alone implies isNewSdk", () => {
+  const api: Record<string, unknown> = {
+    on: () => {},
+    registerMemoryCapability: () => {},
+  };
+
+  const caps = detectSdkCapabilities(api);
+
+  assert.equal(caps.hasRegisterMemoryCapability, true);
+  assert.equal(caps.hasDefinePluginEntry, true, "registerMemoryCapability should imply isNewSdk");
 });


### PR DESCRIPTION
## Summary

- Implements GitHub issue #353: add `publicArtifacts` support so `memory-wiki` bridge mode can discover and ingest Remnic artifacts
- Registers full memory capability via `api.registerMemoryCapability()` when available (OpenClaw SDK >=2026.4.5)
- Adds a `publicArtifacts.listArtifacts()` provider that enumerates safe/public Remnic artifacts (facts, entities, corrections, artifacts, profile.md)
- Explicitly excludes private runtime state (state/, questions/, transcripts/, archive/, buffers, tokens)
- Documents all supported OpenClaw memory features in the plugin-openclaw README including hooks, prompt injection paths, public artifacts, session lifecycle, observation hooks, dreaming compatibility, and bridge modes

## Changes

| File | What |
|------|------|
| `packages/plugin-openclaw/src/public-artifacts.ts` | New: enumerates public Remnic artifacts for wiki ingestion |
| `packages/plugin-openclaw/src/index.ts` | Re-exports public artifacts types and functions |
| `packages/remnic-core/src/sdk-compat.ts` | Detects `registerMemoryCapability` on the API object |
| `src/index.ts` | Wires `registerMemoryCapability()` call with publicArtifacts provider |
| `src/openclaw-plugin-sdk.d.ts` | Adds `MemoryPluginCapability`, `MemoryPluginPublicArtifact`, and related types |
| `packages/plugin-openclaw/README.md` | Documents all supported OpenClaw memory features |
| `tests/public-artifacts.test.ts` | 13 tests for artifact discovery, privacy, dedup |
| `tests/sdk-compat.test.ts` | 3 new tests for `registerMemoryCapability` detection |

## Test plan

- [x] All 13 public-artifacts tests pass (empty dirs, facts, entities, corrections, artifacts, profile.md, private exclusion, non-md filtering, dedup, defensive copy, mixed content, forward slashes)
- [x] All 3 new sdk-compat tests pass (capability present, absent on legacy, implies isNewSdk)
- [x] Pre-existing tests continue to pass (compat-checks, monorepo-structure)
- [ ] Manual: install on OpenClaw >=2026.4.5, verify `openclaw wiki status` reports Remnic artifacts
- [ ] Manual: verify `memory-wiki` bridge import discovers Remnic-provided artifacts

Closes #353

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new OpenClaw SDK (>=2026.4.5) integration path and changes memory-injection registration behavior, so mis-detection or policy gating bugs could affect prompt construction or leak artifacts if the filesystem boundary logic is wrong.
> 
> **Overview**
> Adds **memory-wiki bridge support** by registering `api.registerMemoryCapability()` (when available) with a `publicArtifacts.listArtifacts()` provider so OpenClaw can discover Remnic’s wiki-safe files (`facts/`, `entities/`, `corrections/`, `artifacts/`, `profile.md`). The new artifact enumerator is defensive: recursive markdown scanning is deterministic and blocks symlink traversal/redirects to avoid exposing private runtime state.
> 
> Updates SDK compatibility detection to treat `registerMemoryCapability` as a first-class new-SDK signal, wires capability-based prompt injection to share the same cached memory-section output (and respects `allowPromptInjection=false` by skipping recall hook registration), and expands types/docs/tests to cover the new capability + public artifacts behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8442f052310b961a67ab8acb2011e71516cd148. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->