### PR TITLE
feat(retrieval): apply MMR to final recall selection (#374)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2634,6 +2634,24 @@
         "default": 25000,
         "description": "Default deadline in ms recorded for enrichment recall sections."
       },
+      "recallMmrEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the injected context."
+      },
+      "recallMmrLambda": {
+        "type": "number",
+        "default": 0.7,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
+      },
+      "recallMmrTopN": {
+        "type": "number",
+        "default": 40,
+        "minimum": 0,
+        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
+      },
       "recallPipeline": {
         "type": "array",
         "description": "Ordered recall sections with per-section budgets and feature knobs.",
@@ -3774,6 +3792,23 @@
       "label": "Recall Pipeline",
       "advanced": true,
       "help": "Ordered section configuration for recall assembly and per-section limits"
+    },
+    "recallMmrEnabled": {
+      "label": "Recall MMR (Diversity)",
+      "advanced": true,
+      "help": "Apply Maximal Marginal Relevance per-section so duplicate clusters cannot dominate the recall budget"
+    },
+    "recallMmrLambda": {
+      "label": "MMR Lambda",
+      "advanced": true,
+      "placeholder": "0.7",
+      "help": "1.0 = pure relevance, 0.0 = pure diversity. Default 0.7."
+    },
+    "recallMmrTopN": {
+      "label": "MMR Top-N",
+      "advanced": true,
+      "placeholder": "40",
+      "help": "Number of top candidates per section over which MMR is applied"
     }
   }
 }

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2634,6 +2634,24 @@
         "default": 25000,
         "description": "Default deadline in ms recorded for enrichment recall sections."
       },
+      "recallMmrEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Apply Maximal Marginal Relevance to the final recall selection per-section so one redundant cluster cannot dominate the injected context."
+      },
+      "recallMmrLambda": {
+        "type": "number",
+        "default": 0.7,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "MMR lambda parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7 tilts toward relevance with meaningful diversity."
+      },
+      "recallMmrTopN": {
+        "type": "number",
+        "default": 40,
+        "minimum": 0,
+        "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
+      },
       "recallPipeline": {
         "type": "array",
         "description": "Ordered recall sections with per-section budgets and feature knobs.",
@@ -3774,6 +3792,23 @@
       "label": "Recall Pipeline",
       "advanced": true,
       "help": "Ordered section configuration for recall assembly and per-section limits"
+    },
+    "recallMmrEnabled": {
+      "label": "Recall MMR (Diversity)",
+      "advanced": true,
+      "help": "Apply Maximal Marginal Relevance per-section so duplicate clusters cannot dominate the recall budget"
+    },
+    "recallMmrLambda": {
+      "label": "MMR Lambda",
+      "advanced": true,
+      "placeholder": "0.7",
+      "help": "1.0 = pure relevance, 0.0 = pure diversity. Default 0.7."
+    },
+    "recallMmrTopN": {
+      "label": "MMR Top-N",
+      "advanced": true,
+      "placeholder": "40",
+      "help": "Number of top candidates per section over which MMR is applied"
     }
   }
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1187,6 +1187,15 @@ export function parseConfig(raw: unknown): PluginConfig {
         ? Math.max(0, Math.floor(cfg.recallEnrichmentDeadlineMs))
         : 25_000,
     recallPipeline: recallPipelineConfig.pipeline,
+    recallMmrEnabled: cfg.recallMmrEnabled !== false,
+    recallMmrLambda:
+      typeof cfg.recallMmrLambda === "number" && Number.isFinite(cfg.recallMmrLambda)
+        ? Math.min(1, Math.max(0, cfg.recallMmrLambda))
+        : 0.7,
+    recallMmrTopN:
+      typeof cfg.recallMmrTopN === "number" && Number.isFinite(cfg.recallMmrTopN)
+        ? Math.max(0, Math.floor(cfg.recallMmrTopN))
+        : 40,
     qmdRecallCacheTtlMs:
       typeof cfg.qmdRecallCacheTtlMs === "number" ? Math.max(0, Math.floor(cfg.qmdRecallCacheTtlMs)) : 60_000,
     qmdRecallCacheStaleTtlMs:

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -51,6 +51,11 @@ import {
   type ParallelSearchResult,
 } from "./retrieval-agents.js";
 import { RerankCache, rerankLocalOrNoop } from "./rerank.js";
+import {
+  applyMmrToCandidates,
+  summarizeMmrDiversity,
+  type MmrCandidate,
+} from "./recall-mmr.js";
 import { RelevanceStore } from "./relevance.js";
 import { NegativeExampleStore } from "./negative.js";
 import {
@@ -10805,14 +10810,105 @@ export class Orchestrator {
       truncated: boolean;
     };
   }): void {
-    const memoryIds = this.extractMemoryIdsFromResults(options.results);
+    const sectionId = "memories";
+    const diversified = this.applyMmrToQmdResults(
+      sectionId,
+      options.results,
+    );
+    const memoryIds = this.extractMemoryIdsFromResults(diversified);
     this.trackMemoryAccess(memoryIds);
 
     this.appendRecallSection(
       options.sectionBuckets,
-      "memories",
-      this.formatQmdResults(options.title, options.results),
+      sectionId,
+      this.formatQmdResults(options.title, diversified),
     );
+  }
+
+  /**
+   * Apply Maximal Marginal Relevance to a section's ordered candidate list.
+   *
+   * Operates per-section so one redundant cluster cannot dominate a section,
+   * and so one section's MMR pass cannot starve other sections. Returns the
+   * input unchanged when disabled, when there are fewer than 2 candidates, or
+   * when no budget information is available.
+   */
+  private applyMmrToQmdResults(
+    sectionId: string,
+    results: QmdSearchResult[],
+  ): QmdSearchResult[] {
+    if (this.config.recallMmrEnabled === false) return results;
+    if (!Array.isArray(results) || results.length < 2) return results;
+
+    const topN = Math.max(1, Math.floor(this.config.recallMmrTopN ?? 40));
+    const lambda = this.config.recallMmrLambda ?? 0.7;
+
+    const candidates: MmrCandidate[] = results.map((r, index) => ({
+      id: r.docid || r.path || `idx-${index}`,
+      content: r.snippet ?? "",
+      score: typeof r.score === "number" ? r.score : 0,
+      // Upstream QmdSearchResult does not currently carry an embedding; MMR
+      // will transparently fall back to Jaccard over normalized tokens.
+      embedding: null,
+    }));
+
+    const selectedMmr = applyMmrToCandidates({
+      candidates,
+      lambda,
+      topN,
+      budget: results.length,
+    });
+
+    // Map selected MMR candidates back to the original QmdSearchResult order.
+    const byId = new Map<string, QmdSearchResult>();
+    for (let i = 0; i < results.length; i += 1) {
+      const key = candidates[i]!.id;
+      if (!byId.has(key)) byId.set(key, results[i]!);
+    }
+
+    const reordered: QmdSearchResult[] = [];
+    const seen = new Set<string>();
+    for (const c of selectedMmr) {
+      const original = byId.get(c.id);
+      if (!original) continue;
+      if (seen.has(c.id)) continue;
+      seen.add(c.id);
+      reordered.push(original);
+    }
+    // Safety: append any candidates MMR did not select so nothing is dropped.
+    if (reordered.length < results.length) {
+      for (let i = 0; i < results.length; i += 1) {
+        const key = candidates[i]!.id;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        reordered.push(results[i]!);
+      }
+    }
+
+    // Emit a concise diversity metric for the top-N slice only (before vs
+    // after). This mirrors how other recall stages log single-line summaries.
+    try {
+      const report = summarizeMmrDiversity(
+        candidates,
+        reordered.slice(0, topN).map((r, index) => ({
+          id: r.docid || r.path || `idx-${index}`,
+          content: r.snippet ?? "",
+          score: typeof r.score === "number" ? r.score : 0,
+          embedding: null,
+        })),
+        topN,
+      );
+      log.info(
+        `recall_mmr: section=${sectionId} kept=${report.kept}/${report.considered} ` +
+          `avgSimBefore=${report.avgPairwiseSimBefore.toFixed(3)} ` +
+          `avgSimAfter=${report.avgPairwiseSimAfter.toFixed(3)} ` +
+          `lambda=${lambda.toFixed(2)}`,
+      );
+    } catch {
+      // Metrics must never break recall.
+    }
+
+    return reordered;
   }
 
   private buildLastRecallBudgetSummary(options: {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -11201,7 +11201,15 @@ export class Orchestrator {
       );
     }
 
-    return results.slice(0, options.recallResultLimit);
+    // Apply MMR before final truncation so the cold fallback path mirrors
+    // the diversification policy applied in the hot QMD/embedding/recent
+    // paths. Running MMR post-slice would be unable to promote diverse
+    // candidates sitting just below the cutoff.
+    return this.diversifyAndLimitRecallResults(
+      "memories",
+      results,
+      options.recallResultLimit,
+    );
   }
 
   // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10854,15 +10854,17 @@ export class Orchestrator {
     results: QmdSearchResult[],
     limit: number,
   ): QmdSearchResult[] {
-    const safeLimit = Math.max(
-      0,
+    const safeLimit =
       typeof limit === "number" && Number.isFinite(limit)
-        ? Math.floor(limit)
-        : 0,
-    );
+        ? Math.max(0, Math.floor(limit))
+        : 0;
     if (!Array.isArray(results) || results.length === 0) return [];
+    // `recallResultLimit === 0` is a true zero limit (e.g. when
+    // `memoriesSectionEnabled` is false) and must return an empty array so
+    // the memories section is genuinely skipped. This mirrors the
+    // `slice(0, 0)` semantics of every call site this helper replaced.
+    if (safeLimit === 0) return [];
     const diversified = this.applyMmrToQmdResults(sectionId, results);
-    if (safeLimit === 0) return diversified;
     return diversified.slice(0, safeLimit);
   }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10836,7 +10836,17 @@ export class Orchestrator {
     if (this.config.recallMmrEnabled === false) return results;
     if (!Array.isArray(results) || results.length < 2) return results;
 
-    const topN = Math.max(1, Math.floor(this.config.recallMmrTopN ?? 40));
+    // Config is runtime API (see AGENTS.md §4): preserve `0` as a true zero
+    // limit rather than coercing it to a non-zero value. A configured topN of
+    // 0 means "apply MMR over an empty window" — i.e. skip the reorder and
+    // return the upstream candidates unchanged. This keeps read-time
+    // behavior symmetric with the write-time semantics parseConfig exposes.
+    const configuredTopN = this.config.recallMmrTopN;
+    const topN =
+      typeof configuredTopN === "number" && Number.isFinite(configuredTopN)
+        ? Math.max(0, Math.floor(configuredTopN))
+        : 40;
+    if (topN === 0) return results;
     const lambda = this.config.recallMmrLambda ?? 0.7;
 
     // Delegate to the pure helper so candidate keying (path-first, index

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -51,11 +51,7 @@ import {
   type ParallelSearchResult,
 } from "./retrieval-agents.js";
 import { RerankCache, rerankLocalOrNoop } from "./rerank.js";
-import {
-  applyMmrToCandidates,
-  summarizeMmrDiversity,
-  type MmrCandidate,
-} from "./recall-mmr.js";
+import { reorderRecallResultsWithMmr } from "./recall-mmr.js";
 import { RelevanceStore } from "./relevance.js";
 import { NegativeExampleStore } from "./negative.js";
 import {
@@ -10843,65 +10839,19 @@ export class Orchestrator {
     const topN = Math.max(1, Math.floor(this.config.recallMmrTopN ?? 40));
     const lambda = this.config.recallMmrLambda ?? 0.7;
 
-    const candidates: MmrCandidate[] = results.map((r, index) => ({
-      id: r.docid || r.path || `idx-${index}`,
-      content: r.snippet ?? "",
-      score: typeof r.score === "number" ? r.score : 0,
-      // Upstream QmdSearchResult does not currently carry an embedding; MMR
-      // will transparently fall back to Jaccard over normalized tokens.
-      embedding: null,
-    }));
-
-    const selectedMmr = applyMmrToCandidates({
-      candidates,
+    // Delegate to the pure helper so candidate keying (path-first, index
+    // suffixed for uniqueness) and the head-of-list diversity metric are
+    // exercised by the same code path that the unit tests cover.
+    const { reordered, diversity } = reorderRecallResultsWithMmr(results, {
       lambda,
       topN,
-      budget: results.length,
     });
 
-    // Map selected MMR candidates back to the original QmdSearchResult order.
-    const byId = new Map<string, QmdSearchResult>();
-    for (let i = 0; i < results.length; i += 1) {
-      const key = candidates[i]!.id;
-      if (!byId.has(key)) byId.set(key, results[i]!);
-    }
-
-    const reordered: QmdSearchResult[] = [];
-    const seen = new Set<string>();
-    for (const c of selectedMmr) {
-      const original = byId.get(c.id);
-      if (!original) continue;
-      if (seen.has(c.id)) continue;
-      seen.add(c.id);
-      reordered.push(original);
-    }
-    // Safety: append any candidates MMR did not select so nothing is dropped.
-    if (reordered.length < results.length) {
-      for (let i = 0; i < results.length; i += 1) {
-        const key = candidates[i]!.id;
-        if (seen.has(key)) continue;
-        seen.add(key);
-        reordered.push(results[i]!);
-      }
-    }
-
-    // Emit a concise diversity metric for the top-N slice only (before vs
-    // after). This mirrors how other recall stages log single-line summaries.
     try {
-      const report = summarizeMmrDiversity(
-        candidates,
-        reordered.slice(0, topN).map((r, index) => ({
-          id: r.docid || r.path || `idx-${index}`,
-          content: r.snippet ?? "",
-          score: typeof r.score === "number" ? r.score : 0,
-          embedding: null,
-        })),
-        topN,
-      );
       log.info(
-        `recall_mmr: section=${sectionId} kept=${report.kept}/${report.considered} ` +
-          `avgSimBefore=${report.avgPairwiseSimBefore.toFixed(3)} ` +
-          `avgSimAfter=${report.avgPairwiseSimAfter.toFixed(3)} ` +
+        `recall_mmr: section=${sectionId} kept=${diversity.kept}/${diversity.considered} ` +
+          `avgSimBefore=${diversity.avgPairwiseSimBefore.toFixed(3)} ` +
+          `avgSimAfter=${diversity.avgPairwiseSimAfter.toFixed(3)} ` +
           `lambda=${lambda.toFixed(2)}`,
       );
     } catch {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -10907,6 +10907,7 @@ export class Orchestrator {
     try {
       log.info(
         `recall_mmr: section=${sectionId} kept=${diversity.kept}/${diversity.considered} ` +
+          `headReorderCount=${diversity.headReorderCount} ` +
           `avgSimBefore=${diversity.avgPairwiseSimBefore.toFixed(3)} ` +
           `avgSimAfter=${diversity.avgPairwiseSimAfter.toFixed(3)} ` +
           `lambda=${lambda.toFixed(2)}`,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6796,7 +6796,14 @@ export class Orchestrator {
         }
       }
 
-      memoryResults = memoryResults.slice(0, recallResultLimit);
+      // Diversify via MMR over the full candidate pool *before* truncating to
+      // the final recall limit. Running MMR after the slice would be unable
+      // to promote diverse candidates sitting just below the cutoff.
+      memoryResults = this.diversifyAndLimitRecallResults(
+        "memories",
+        memoryResults,
+        recallResultLimit,
+      );
 
       // E-Mem-inspired memory reconstruction: fill gaps for referenced entities
       if (this.config.memoryReconstructionEnabled && memoryResults.length > 0) {
@@ -6889,13 +6896,18 @@ export class Orchestrator {
             limit: embeddingFetchLimit,
           },
         );
-        const scoped = (
-          await this.boostSearchResults(
-            scopedCandidates,
-            recallNamespaces,
-            retrievalQuery,
-          )
-        ).slice(0, recallResultLimit);
+        const boostedScoped = await this.boostSearchResults(
+          scopedCandidates,
+          recallNamespaces,
+          retrievalQuery,
+        );
+        // MMR runs on the pre-truncation pool so diverse candidates just
+        // below the cutoff can be promoted into the injected set.
+        const scoped = this.diversifyAndLimitRecallResults(
+          "memories",
+          boostedScoped,
+          recallResultLimit,
+        );
         if (scoped.length > 0) {
           if (shouldPersistGraphSnapshot) {
             graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -7017,13 +7029,18 @@ export class Orchestrator {
           limit: embeddingFetchLimit,
         },
       );
-      const scoped = (
-        await this.boostSearchResults(
-          scopedCandidates,
-          recallNamespaces,
-          retrievalQuery,
-        )
-      ).slice(0, recallResultLimit);
+      const boostedScoped = await this.boostSearchResults(
+        scopedCandidates,
+        recallNamespaces,
+        retrievalQuery,
+      );
+      // MMR runs on the pre-truncation pool so diverse candidates just
+      // below the cutoff can be promoted into the injected set.
+      const scoped = this.diversifyAndLimitRecallResults(
+        "memories",
+        boostedScoped,
+        recallResultLimit,
+      );
       if (scoped.length > 0) {
         if (shouldPersistGraphSnapshot) {
           graphSnapshotFinalResults = this.buildGraphRecallRankedResults(
@@ -7123,16 +7140,21 @@ export class Orchestrator {
                 score: 1.0 - i / Math.max(recentSorted.length, 1),
               }),
             );
-            const recent = (
+            const boostedRecent = (
               await this.boostSearchResults(
                 recentAsResults,
                 recallNamespaces,
                 retrievalQuery,
                 preloadedMap,
               )
-            )
-              .sort((a, b) => b.score - a.score)
-              .slice(0, recallResultLimit);
+            ).sort((a, b) => b.score - a.score);
+            // MMR runs on the pre-truncation pool so diverse candidates just
+            // below the cutoff can be promoted into the injected set.
+            const recent = this.diversifyAndLimitRecallResults(
+              "memories",
+              boostedRecent,
+              recallResultLimit,
+            );
 
             if (recent.length > 0) {
               if (shouldPersistGraphSnapshot) {
@@ -10807,18 +10829,41 @@ export class Orchestrator {
     };
   }): void {
     const sectionId = "memories";
-    const diversified = this.applyMmrToQmdResults(
-      sectionId,
-      options.results,
-    );
-    const memoryIds = this.extractMemoryIdsFromResults(diversified);
+    const memoryIds = this.extractMemoryIdsFromResults(options.results);
     this.trackMemoryAccess(memoryIds);
 
     this.appendRecallSection(
       options.sectionBuckets,
       sectionId,
-      this.formatQmdResults(options.title, diversified),
+      this.formatQmdResults(options.title, options.results),
     );
+  }
+
+  /**
+   * Apply MMR over the pre-truncation recall candidate pool and then slice
+   * the result to `limit`. This is the single place in the pipeline where
+   * MMR runs, and it must be called *before* callers throw away candidates
+   * that would otherwise sit below the final cutoff. Running MMR post-slice
+   * is a no-op in the cases we care about — diverse candidates just below
+   * the cutoff are already gone and can never be promoted.
+   *
+   * Callers must pass the full candidate pool (post-rerank, pre-slice).
+   */
+  private diversifyAndLimitRecallResults(
+    sectionId: string,
+    results: QmdSearchResult[],
+    limit: number,
+  ): QmdSearchResult[] {
+    const safeLimit = Math.max(
+      0,
+      typeof limit === "number" && Number.isFinite(limit)
+        ? Math.floor(limit)
+        : 0,
+    );
+    if (!Array.isArray(results) || results.length === 0) return [];
+    const diversified = this.applyMmrToQmdResults(sectionId, results);
+    if (safeLimit === 0) return diversified;
+    return diversified.slice(0, safeLimit);
   }
 
   /**

--- a/packages/remnic-core/src/recall-budget-config.test.ts
+++ b/packages/remnic-core/src/recall-budget-config.test.ts
@@ -51,3 +51,28 @@ test("parseConfig preserves zero recall timeout settings to disable those limits
   assert.equal(config.recallCoreDeadlineMs, 0);
   assert.equal(config.recallEnrichmentDeadlineMs, 0);
 });
+
+test("parseConfig applies MMR defaults (enabled, lambda=0.7, topN=40)", () => {
+  const config = parseConfig({});
+  assert.equal(config.recallMmrEnabled, true);
+  assert.equal(config.recallMmrLambda, 0.7);
+  assert.equal(config.recallMmrTopN, 40);
+});
+
+test("parseConfig honors explicit MMR overrides", () => {
+  const config = parseConfig({
+    recallMmrEnabled: false,
+    recallMmrLambda: 0.3,
+    recallMmrTopN: 25,
+  });
+  assert.equal(config.recallMmrEnabled, false);
+  assert.equal(config.recallMmrLambda, 0.3);
+  assert.equal(config.recallMmrTopN, 25);
+});
+
+test("parseConfig clamps MMR lambda into [0, 1]", () => {
+  const tooLow = parseConfig({ recallMmrLambda: -0.5 });
+  assert.equal(tooLow.recallMmrLambda, 0);
+  const tooHigh = parseConfig({ recallMmrLambda: 1.7 });
+  assert.equal(tooHigh.recallMmrLambda, 1);
+});

--- a/packages/remnic-core/src/recall-budget-config.test.ts
+++ b/packages/remnic-core/src/recall-budget-config.test.ts
@@ -76,3 +76,12 @@ test("parseConfig clamps MMR lambda into [0, 1]", () => {
   const tooHigh = parseConfig({ recallMmrLambda: 1.7 });
   assert.equal(tooHigh.recallMmrLambda, 1);
 });
+
+test("parseConfig preserves recallMmrTopN=0 as a true zero limit", () => {
+  // AGENTS.md §4 ("Config is runtime API"): `0` limits are compatibility
+  // guarantees. The write-time representation of `recallMmrTopN=0` must be
+  // preserved, and the read-time behavior in applyMmrToQmdResults must
+  // honor the zero limit by skipping MMR entirely (see orchestrator.ts).
+  const config = parseConfig({ recallMmrTopN: 0 });
+  assert.equal(config.recallMmrTopN, 0);
+});

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -420,6 +420,27 @@ test(
 );
 
 test(
+  "reorderRecallResultsWithMmr with topN=0 is a full no-op preserving input order",
+  () => {
+    // AGENTS.md §4: never coerce zero limits to non-zero. A topN of 0 means
+    // "apply MMR over an empty window" — no candidate gets dropped and the
+    // original order is preserved.
+    const results: MmrRecallResult[] = [
+      { docid: "a", path: "p/a", snippet: "one", score: 0.9 },
+      { docid: "b", path: "p/b", snippet: "two", score: 0.8 },
+      { docid: "c", path: "p/c", snippet: "three", score: 0.7 },
+    ];
+    const { reordered } = reorderRecallResultsWithMmr(results, { topN: 0 });
+    assert.equal(reordered.length, results.length);
+    assert.deepEqual(
+      reordered.map((r) => r.docid),
+      ["a", "b", "c"],
+      "topN=0 should be a no-op and preserve input order",
+    );
+  },
+);
+
+test(
   "reorderRecallResultsWithMmr diversity report defaults to head-of-list sample",
   () => {
     // Integration check for the orchestration helper: even with

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -690,6 +690,68 @@ test(
   },
 );
 
+// ---------------------------------------------------------------------------
+// Regression: diversity metric must detect head swaps even when two results
+// share the same base key (path or docid). Previously the reordered-side
+// candidate ids were rebuilt with the *post-MMR* position index, so the
+// position suffix cancelled out and two same-path results swapping into the
+// same head position looked like a no-op.
+// (Cursor Bugbot Low-severity review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "reorderRecallResultsWithMmr detects head swaps for results sharing a base key",
+  () => {
+    // Both results share the same `path` and empty `docid`, so the base
+    // portion of makeRecallKey is identical. Only the input-index suffix
+    // distinguishes them. If the diversity report rebuilt the reordered
+    // candidate ids with the post-MMR position index, a swap at position 0
+    // would be invisible because both reorderings produce the same
+    // `"shared-path::0"` id. After the fix the original-index-suffixed ids
+    // are preserved, so the head swap is counted.
+    const results: MmrRecallResult[] = [
+      {
+        docid: "",
+        path: "shared/path.md",
+        // Strongly duplicate-cluster-forming snippet at top.
+        snippet: "dup alpha content alpha",
+        score: 0.99,
+      },
+      {
+        docid: "",
+        path: "shared/path.md",
+        snippet: "dup alpha content alpha near",
+        score: 0.98,
+      },
+      {
+        docid: "",
+        path: "shared/path.md",
+        // Orthogonal diverse candidate.
+        snippet: "rocket propellant chemistry",
+        score: 0.97,
+      },
+    ];
+    const { reordered, diversity } = reorderRecallResultsWithMmr(results, {
+      lambda: 0.3,
+      diversitySampleSize: 2,
+    });
+    // MMR should have surfaced the diverse "rocket" candidate into the head
+    // two — verify by checking the first two snippets include the diverse
+    // one (order of the cluster pair is implementation-dependent).
+    const headSnippets = reordered.slice(0, 2).map((r) => r.snippet);
+    assert.ok(
+      headSnippets.some((s) => s && s.includes("rocket")),
+      `diverse candidate should be in head-of-list: ${headSnippets.join(" | ")}`,
+    );
+    // The real regression: headReorderCount must be > 0 even though all
+    // three inputs share the same base key.
+    assert.ok(
+      diversity.headReorderCount > 0,
+      `headReorderCount must detect same-base-key head swaps, got ${diversity.headReorderCount}`,
+    );
+  },
+);
+
 test(
   "reorderRecallResultsWithMmr diversity report defaults to head-of-list sample",
   () => {

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -691,6 +691,26 @@ test(
 );
 
 // ---------------------------------------------------------------------------
+// Regression: single-element input must report considered=1 kept=1, not the
+// 0/0 sentinel meant for the empty case.
+// (Cursor Bugbot Low-severity review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "reorderRecallResultsWithMmr reports considered=1 kept=1 for single-element input",
+  () => {
+    const results: MmrRecallResult[] = [
+      { docid: "only", path: "p/only", snippet: "sole result", score: 0.9 },
+    ];
+    const { reordered, diversity } = reorderRecallResultsWithMmr(results);
+    assert.equal(reordered.length, 1);
+    assert.equal(diversity.considered, 1);
+    assert.equal(diversity.kept, 1);
+    assert.equal(diversity.headReorderCount, 0);
+  },
+);
+
+// ---------------------------------------------------------------------------
 // Regression: diversity metric must detect head swaps even when two results
 // share the same base key (path or docid). Previously the reordered-side
 // candidate ids were rebuilt with the *post-MMR* position index, so the

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -518,6 +518,178 @@ test(
   },
 );
 
+// ---------------------------------------------------------------------------
+// Regression: Unicode-aware Jaccard tokenization for multilingual snippets
+// (ChatGPT Codex P2 review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "normalizeTokens preserves non-ASCII scripts for multilingual Jaccard",
+  () => {
+    // Cyrillic: two near-identical snippets must share tokens, not collapse
+    // to an empty set like the old [^a-z0-9]+ tokenizer did.
+    const ruA = normalizeTokens("Привет, мир! Это тест.");
+    const ruB = normalizeTokens("Привет мир это тест");
+    assert.ok(ruA.size > 0, "Cyrillic snippet should produce non-empty tokens");
+    let ruOverlap = 0;
+    for (const t of ruA) if (ruB.has(t)) ruOverlap += 1;
+    assert.ok(
+      ruOverlap >= 3,
+      `Cyrillic near-duplicates should share most tokens, overlap=${ruOverlap}`,
+    );
+
+    // Greek: same near-duplicate invariant.
+    const grA = normalizeTokens("Καλημέρα κόσμε");
+    const grB = normalizeTokens("καλημέρα κόσμε!");
+    assert.ok(grA.size > 0);
+    let grOverlap = 0;
+    for (const t of grA) if (grB.has(t)) grOverlap += 1;
+    assert.ok(
+      grOverlap >= 2,
+      `Greek near-duplicates should share tokens, overlap=${grOverlap}`,
+    );
+
+    // CJK (Chinese): no whitespace word breaks, so tokens are per-character.
+    // Two snippets that share most characters must produce overlapping token
+    // sets, not the empty set the old tokenizer returned.
+    const zhA = normalizeTokens("用户喜欢深色模式");
+    const zhB = normalizeTokens("用户偏好深色模式");
+    assert.ok(zhA.size > 0, "CJK snippet should produce non-empty tokens");
+    let zhOverlap = 0;
+    for (const t of zhA) if (zhB.has(t)) zhOverlap += 1;
+    assert.ok(
+      zhOverlap >= 5,
+      `Chinese near-duplicates should share most chars, overlap=${zhOverlap}`,
+    );
+  },
+);
+
+test(
+  "reorderRecallResultsWithMmr detects non-ASCII near-duplicates and diversifies",
+  () => {
+    // Without Unicode-aware tokenization, the Jaccard fallback returned 0 for
+    // all non-Latin snippets and MMR degenerated to plain relevance ordering.
+    // After the fix the duplicate Cyrillic cluster must give up at least one
+    // head-of-list slot to the diverse candidate.
+    const results: MmrRecallResult[] = [
+      { docid: "ru1", path: "p/ru1", snippet: "Пользователь предпочитает тёмный режим в терминале", score: 0.99 },
+      { docid: "ru2", path: "p/ru2", snippet: "Пользователь предпочитает тёмный режим в терминалах", score: 0.98 },
+      { docid: "ru3", path: "p/ru3", snippet: "Пользователь любит тёмный режим в терминале", score: 0.97 },
+      { docid: "ru4", path: "p/ru4", snippet: "Пользователь предпочитает тёмную тему в терминале", score: 0.96 },
+      { docid: "dv1", path: "p/dv1", snippet: "Ракетное топливо на основе жидкого кислорода", score: 0.9 },
+    ];
+    const { reordered, diversity } = reorderRecallResultsWithMmr(results, {
+      lambda: 0.3,
+      diversitySampleSize: 4,
+    });
+    const headIds = reordered.slice(0, 4).map((r) => r.docid);
+    assert.ok(
+      headIds.includes("dv1"),
+      `diverse Cyrillic candidate should be promoted into head: ${headIds.join(",")}`,
+    );
+    assert.ok(
+      diversity.headReorderCount > 0,
+      `headReorderCount should be > 0 after MMR promoted a diverse candidate, got ${diversity.headReorderCount}`,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Regression: min-max normalization used to defeat MMR for tight score
+// clusters. After the fix, scores that already live in [0, 1] pass through
+// untouched so the (1 - lambda) * maxSim penalty can actually outweigh a
+// 0.01 relevance gap.
+// (Cursor Bugbot Medium review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "applyMmrToCandidates diversifies tight reranker score clusters",
+  () => {
+    // Three near-duplicates tightly clustered in [0.93, 0.95], plus one
+    // genuinely diverse candidate slightly below at 0.92. The old min-max
+    // normalization would scale the diverse candidate's relevance to 0.0 and
+    // it could never beat any duplicate; after the fix it must be promoted.
+    const candidates: MmrCandidate[] = [
+      { id: "dup1", content: "alpha content", score: 0.95, embedding: [1, 0.001, 0] },
+      { id: "dup2", content: "alpha content near", score: 0.94, embedding: [1, 0.002, 0] },
+      { id: "dup3", content: "alpha content close", score: 0.93, embedding: [1, 0.003, 0] },
+      { id: "div", content: "completely orthogonal", score: 0.92, embedding: [0, 1, 0] },
+    ];
+    const reordered = applyMmrToCandidates({
+      candidates,
+      lambda: 0.7,
+      budget: 2,
+    });
+    const ids = reordered.map((c) => c.id);
+    assert.equal(reordered.length, 2);
+    assert.ok(
+      ids.includes("div"),
+      `tight-cluster MMR should promote diverse candidate into top-2: ${ids.join(",")}`,
+    );
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Regression: diversity metric must emit an actionable signal even in
+// reorder-only mode. `kept/considered` alone is unactionable when MMR never
+// drops candidates; the new `headReorderCount` field makes the metric useful.
+// (Cursor Bugbot Low-severity review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "summarizeMmrDiversity emits headReorderCount > 0 when MMR reorders the head",
+  () => {
+    // Near-dup cluster up front plus diverse candidates behind — MMR with
+    // low lambda must swap at least one head-of-list slot, producing a
+    // positive headReorderCount signal.
+    const candidates: MmrCandidate[] = [
+      { id: "a1", content: "dup alpha one", score: 0.99, embedding: [1, 0, 0] },
+      { id: "a2", content: "dup alpha two", score: 0.98, embedding: [1, 0.001, 0] },
+      { id: "a3", content: "dup alpha three", score: 0.97, embedding: [1, 0.002, 0] },
+      { id: "b1", content: "diverse beta", score: 0.8, embedding: [0, 1, 0] },
+      { id: "b2", content: "diverse gamma", score: 0.75, embedding: [0, 0, 1] },
+    ];
+    const reordered = applyMmrToCandidates({
+      candidates,
+      lambda: 0.3,
+      budget: candidates.length,
+    });
+    const report = summarizeMmrDiversity(candidates, reordered, 3);
+    assert.equal(report.considered, candidates.length);
+    assert.equal(report.kept, reordered.length);
+    assert.ok(
+      report.headReorderCount > 0,
+      `headReorderCount should be > 0 after MMR swapped head slots, got ${report.headReorderCount}`,
+    );
+  },
+);
+
+test(
+  "summarizeMmrDiversity headReorderCount is 0 for an identity reorder",
+  () => {
+    // If MMR leaves the head untouched (e.g. all candidates are already
+    // maximally diverse), headReorderCount should be exactly 0 so callers
+    // can distinguish "no head change" from "head was reshuffled".
+    const candidates: MmrCandidate[] = [
+      { id: "x", content: "one", score: 0.9, embedding: [1, 0, 0] },
+      { id: "y", content: "two", score: 0.8, embedding: [0, 1, 0] },
+      { id: "z", content: "three", score: 0.7, embedding: [0, 0, 1] },
+    ];
+    const reordered = applyMmrToCandidates({
+      candidates,
+      lambda: 0.7,
+      budget: candidates.length,
+    });
+    // Sanity: MMR should not reshuffle a perfectly diverse pool.
+    assert.deepEqual(
+      reordered.map((c) => c.id),
+      ["x", "y", "z"],
+    );
+    const report = summarizeMmrDiversity(candidates, reordered);
+    assert.equal(report.headReorderCount, 0);
+  },
+);
+
 test(
   "reorderRecallResultsWithMmr diversity report defaults to head-of-list sample",
   () => {

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -472,6 +472,31 @@ test(
   },
 );
 
+// NOTE: the orchestrator's `diversifyAndLimitRecallResults` helper is a
+// private method, but its zero-limit behavior is covered by the pure
+// equivalent below: when the caller wants zero results, MMR plus a slice of
+// zero should yield an empty array. This mirrors the legacy
+// `.slice(0, recallResultLimit)` semantics when `recallResultLimit === 0`
+// (which happens when `memoriesSectionEnabled` is false). Cursor Bugbot flagged
+// this regression on PR #391.
+
+test(
+  "MMR + slice(0) idiom yields empty array when limit is zero",
+  () => {
+    const results: MmrRecallResult[] = [
+      { docid: "a", path: "p/a", snippet: "one", score: 0.9 },
+      { docid: "b", path: "p/b", snippet: "two", score: 0.8 },
+    ];
+    const { reordered } = reorderRecallResultsWithMmr(results);
+    const limited = reordered.slice(0, 0);
+    assert.equal(
+      limited.length,
+      0,
+      "slice(0, 0) must still yield an empty array after MMR",
+    );
+  },
+);
+
 test(
   "reorderRecallResultsWithMmr with topN=0 is a full no-op preserving input order",
   () => {

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -3,9 +3,11 @@ import test from "node:test";
 
 import {
   applyMmrToCandidates,
+  reorderRecallResultsWithMmr,
   summarizeMmrDiversity,
   normalizeTokens,
   type MmrCandidate,
+  type MmrRecallResult,
 } from "./recall-mmr.js";
 
 function makeCandidate(
@@ -293,3 +295,161 @@ test("applyMmrToCandidates end-to-end: duplicate sentences reduced vs disabled",
     `MMR should surface at least one diverse candidate: ${mmrIds}`,
   );
 });
+
+// ---------------------------------------------------------------------------
+// Regression: path-first keying for reorderRecallResultsWithMmr
+// (ChatGPT Codex P2 review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "reorderRecallResultsWithMmr preserves distinct results that share a docid",
+  () => {
+    // Two results with IDENTICAL docids but DIFFERENT paths. A docid-keyed
+    // implementation would collapse these into one and silently drop a valid
+    // recall candidate.
+    const results: MmrRecallResult[] = [
+      {
+        docid: "fact-007",
+        path: "memories/facts/source-a/fact-007.md",
+        snippet: "Some fact from source A",
+        score: 0.95,
+      },
+      {
+        docid: "fact-007",
+        path: "memories/facts/source-b/fact-007.md",
+        snippet: "A very different fact from source B",
+        score: 0.92,
+      },
+      {
+        docid: "fact-008",
+        path: "memories/facts/source-a/fact-008.md",
+        snippet: "Yet another unrelated fact",
+        score: 0.9,
+      },
+    ];
+
+    const { reordered } = reorderRecallResultsWithMmr(results);
+
+    assert.equal(
+      reordered.length,
+      results.length,
+      "no candidate should be dropped when docids collide across paths",
+    );
+    const paths = reordered.map((r) => r.path).sort();
+    assert.deepEqual(paths, [
+      "memories/facts/source-a/fact-007.md",
+      "memories/facts/source-a/fact-008.md",
+      "memories/facts/source-b/fact-007.md",
+    ]);
+  },
+);
+
+test(
+  "reorderRecallResultsWithMmr keeps results with empty path AND empty docid distinct",
+  () => {
+    // Pathological input: every result has empty path and empty docid. The
+    // stable index-suffix fallback must still give each candidate its own
+    // key so none of them collapse.
+    const results: MmrRecallResult[] = [
+      { docid: "", path: "", snippet: "alpha content", score: 0.9 },
+      { docid: "", path: "", snippet: "beta content", score: 0.8 },
+      { docid: "", path: "", snippet: "gamma content", score: 0.7 },
+    ];
+
+    const { reordered } = reorderRecallResultsWithMmr(results);
+    assert.equal(reordered.length, 3);
+    const snippets = reordered.map((r) => r.snippet).sort();
+    assert.deepEqual(snippets, ["alpha content", "beta content", "gamma content"]);
+  },
+);
+
+// ---------------------------------------------------------------------------
+// Regression: head-of-list diversity metric actually reflects reordering
+// (Cursor Bugbot Medium review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "summarizeMmrDiversity with small sample size reflects head-of-list reordering",
+  () => {
+    // Input: 5 near-duplicate high-score "a*" candidates up front, then 3
+    // diverse candidates. With `budget = candidates.length`, MMR reorders but
+    // drops nothing — the two slices pre- and post-MMR contain the same
+    // SET. If the diversity metric used a large sample size it would report
+    // identical before/after averages. With a small head-of-list sample size
+    // the head *does* differ, so avgPairwiseSimAfter < avgPairwiseSimBefore.
+    const candidates: MmrCandidate[] = [
+      { id: "a1", content: "alpha", score: 0.99, embedding: [1, 0.001, 0] },
+      { id: "a2", content: "alpha", score: 0.98, embedding: [1, 0.002, 0] },
+      { id: "a3", content: "alpha", score: 0.97, embedding: [1, 0.003, 0] },
+      { id: "a4", content: "alpha", score: 0.96, embedding: [1, 0.004, 0] },
+      { id: "a5", content: "alpha", score: 0.95, embedding: [1, 0.005, 0] },
+      { id: "b1", content: "beta", score: 0.9, embedding: [0, 1, 0] },
+      { id: "b2", content: "gamma", score: 0.85, embedding: [0, 0, 1] },
+      { id: "b3", content: "delta", score: 0.8, embedding: [1, 1, 0] },
+    ];
+
+    const reordered = applyMmrToCandidates({
+      candidates,
+      lambda: 0.3, // push hard toward diversity
+      budget: candidates.length, // same set, just reordered — same bug regime
+    });
+    assert.equal(reordered.length, candidates.length);
+
+    // Default small sample size (10 is larger than our 8-element pool, so
+    // everything is compared — this recreates the bug the comment flagged).
+    const trivialReport = summarizeMmrDiversity(
+      candidates,
+      reordered,
+      candidates.length,
+    );
+    // With full-pool sampling the before/after average pairwise similarity
+    // is order-independent — the bug condition.
+    assert.ok(
+      Math.abs(trivialReport.avgPairwiseSimBefore - trivialReport.avgPairwiseSimAfter) < 1e-9,
+      "sanity: full-pool sampling is order-independent and hides diversity gains",
+    );
+
+    // With a small head-of-list sample size (4), MMR's reordering *must*
+    // show up as a strictly lower average pairwise similarity.
+    const headReport = summarizeMmrDiversity(candidates, reordered, 4);
+    assert.ok(
+      headReport.avgPairwiseSimAfter + 1e-9 < headReport.avgPairwiseSimBefore,
+      `head-of-list sample should show MMR diversity gain: before=${headReport.avgPairwiseSimBefore} after=${headReport.avgPairwiseSimAfter}`,
+    );
+  },
+);
+
+test(
+  "reorderRecallResultsWithMmr diversity report defaults to head-of-list sample",
+  () => {
+    // Integration check for the orchestration helper: even with
+    // `budget = results.length`, the default diversity report should surface
+    // the fact that MMR promoted diverse candidates to the head.
+    const results: MmrRecallResult[] = [
+      { docid: "a1", path: "p/a1", snippet: "the quick brown fox jumps over the lazy dog", score: 0.99 },
+      { docid: "a2", path: "p/a2", snippet: "the quick brown fox jumps over a lazy dog", score: 0.98 },
+      { docid: "a3", path: "p/a3", snippet: "a quick brown fox jumps over the lazy dog", score: 0.97 },
+      { docid: "a4", path: "p/a4", snippet: "quick brown fox jumping over lazy dogs", score: 0.96 },
+      { docid: "a5", path: "p/a5", snippet: "brown foxes jumping over lazy dogs", score: 0.95 },
+      { docid: "d1", path: "p/d1", snippet: "rocket thrust vectoring", score: 0.6 },
+      { docid: "d2", path: "p/d2", snippet: "violin bow rosin reservoir", score: 0.5 },
+      { docid: "d3", path: "p/d3", snippet: "coffee brewing at high altitude", score: 0.4 },
+    ];
+
+    const { reordered, diversity } = reorderRecallResultsWithMmr(results, {
+      lambda: 0.3,
+      diversitySampleSize: 4,
+    });
+    assert.equal(reordered.length, results.length);
+    assert.ok(
+      diversity.avgPairwiseSimAfter + 1e-9 < diversity.avgPairwiseSimBefore,
+      `head-of-list MMR should lower avg pairwise similarity: before=${diversity.avgPairwiseSimBefore} after=${diversity.avgPairwiseSimAfter}`,
+    );
+    // Sanity: MMR should have pulled at least one diverse candidate into the head.
+    const headDocids = reordered.slice(0, 4).map((r) => r.docid);
+    assert.ok(
+      headDocids.some((d) => d && d.startsWith("d")),
+      `expected a diverse candidate in the head after MMR: ${headDocids.join(",")}`,
+    );
+  },
+);

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  applyMmrToCandidates,
+  summarizeMmrDiversity,
+  normalizeTokens,
+  type MmrCandidate,
+} from "./recall-mmr.js";
+
+function makeCandidate(
+  id: string,
+  content: string,
+  score: number,
+  embedding?: number[],
+): MmrCandidate {
+  return { id, content, score, embedding: embedding ?? null };
+}
+
+test("applyMmrToCandidates returns [] for empty input", () => {
+  const out = applyMmrToCandidates({ candidates: [] });
+  assert.deepEqual(out, []);
+});
+
+test("applyMmrToCandidates is a no-op for a single candidate", () => {
+  const input = [makeCandidate("a", "hello", 1)];
+  const out = applyMmrToCandidates({ candidates: input });
+  assert.equal(out.length, 1);
+  assert.equal(out[0]?.id, "a");
+});
+
+test("applyMmrToCandidates does not mutate input", () => {
+  const input: MmrCandidate[] = [
+    makeCandidate("a", "one", 0.9, [1, 0, 0, 0]),
+    makeCandidate("b", "two", 0.8, [0, 1, 0, 0]),
+  ];
+  const before = input.map((c) => c.id).join(",");
+  applyMmrToCandidates({ candidates: input, budget: 1 });
+  assert.equal(
+    input.map((c) => c.id).join(","),
+    before,
+    "input order should be unchanged",
+  );
+});
+
+test("applyMmrToCandidates collapses near-duplicate clusters (cosine)", () => {
+  // Five near-duplicate candidates all pointing toward [1,0,0,0] with tiny
+  // perturbations, plus four diverse candidates along orthogonal axes.
+  const epsilon = 0.001;
+  const nearDupe = (idx: number): number[] => [1, epsilon * idx, 0, 0];
+  const candidates: MmrCandidate[] = [
+    makeCandidate("dupe-1", "alpha one", 0.99, nearDupe(1)),
+    makeCandidate("dupe-2", "alpha two", 0.98, nearDupe(2)),
+    makeCandidate("dupe-3", "alpha three", 0.97, nearDupe(3)),
+    makeCandidate("dupe-4", "alpha four", 0.96, nearDupe(4)),
+    makeCandidate("dupe-5", "alpha five", 0.95, nearDupe(5)),
+    makeCandidate("div-y", "beta", 0.9, [0, 1, 0, 0]),
+    makeCandidate("div-z", "gamma", 0.85, [0, 0, 1, 0]),
+    makeCandidate("div-w", "delta", 0.8, [0, 0, 0, 1]),
+    makeCandidate("div-a", "epsilon", 0.75, [1, 1, 0, 0]),
+  ];
+
+  // Budget = 4 — with 4 distinct axes available (plus a 5th dupe cluster),
+  // MMR should pick 1 dupe + 3 diverse before ever revisiting the cluster.
+  const selected = applyMmrToCandidates({
+    candidates,
+    lambda: 0.5, // balance relevance + diversity
+    topN: 40,
+    budget: 4,
+  });
+
+  assert.equal(selected.length, 4);
+
+  const dupeCount = selected.filter((c) => c.id.startsWith("dupe-")).length;
+  assert.ok(
+    dupeCount <= 1,
+    `expected at most 1 representative from the duplicate cluster, got ${dupeCount}: ${selected
+      .map((c) => c.id)
+      .join(",")}`,
+  );
+
+  // The highest-relevance duplicate should still be included.
+  const ids = selected.map((c) => c.id);
+  assert.ok(ids.includes("dupe-1"), `expected dupe-1 in selection: ${ids}`);
+  // All three fully diverse axes should also surface.
+  assert.ok(ids.includes("div-y"));
+  assert.ok(ids.includes("div-z"));
+  assert.ok(ids.includes("div-w"));
+});
+
+test("applyMmrToCandidates falls back to Jaccard when embeddings are missing", () => {
+  // Three candidates with heavy lexical overlap + two diverse ones.
+  const candidates: MmrCandidate[] = [
+    makeCandidate(
+      "s1",
+      "The cat sat on the red mat in the sunny kitchen",
+      0.95,
+    ),
+    makeCandidate(
+      "s2",
+      "The cat sat on the red mat in the sunny kitchen today",
+      0.94,
+    ),
+    makeCandidate(
+      "s3",
+      "A cat is sitting on the red mat in the kitchen",
+      0.93,
+    ),
+    makeCandidate(
+      "d1",
+      "Quantum tunneling explains alpha decay in heavy nuclei",
+      0.5,
+    ),
+    makeCandidate(
+      "d2",
+      "Bicycle gears shift when pedaling uphill on pavement",
+      0.4,
+    ),
+  ];
+
+  const selected = applyMmrToCandidates({
+    candidates,
+    lambda: 0.4, // push harder toward diversity so clustering shows up
+    topN: 40,
+    budget: 3,
+  });
+
+  assert.equal(selected.length, 3);
+  const ids = selected.map((c) => c.id);
+  // The top-scored lexical duplicate should be included...
+  assert.ok(ids.includes("s1"));
+  // ...but MMR should prefer the diverse candidates over the other near-dupes.
+  const sxCount = ids.filter((id) => id.startsWith("s")).length;
+  assert.ok(
+    sxCount < 3,
+    `MMR should not fill the slate with lexical duplicates: ${ids.join(",")}`,
+  );
+  assert.ok(
+    ids.includes("d1") || ids.includes("d2"),
+    `at least one diverse candidate should appear: ${ids.join(",")}`,
+  );
+});
+
+test("applyMmrToCandidates is sensitive to lambda", () => {
+  const candidates: MmrCandidate[] = [
+    makeCandidate("a", "alpha one", 1.0, [1, 0.001, 0, 0]),
+    makeCandidate("b", "alpha two", 0.99, [1, 0.002, 0, 0]),
+    makeCandidate("c", "beta", 0.5, [0, 1, 0, 0]),
+    makeCandidate("d", "gamma", 0.4, [0, 0, 1, 0]),
+  ];
+
+  // Lambda = 1.0 → pure relevance, no diversity adjustment.
+  const pureRelevance = applyMmrToCandidates({
+    candidates,
+    lambda: 1.0,
+    budget: 2,
+  });
+  assert.deepEqual(pureRelevance.map((c) => c.id), ["a", "b"]);
+
+  // Lambda = 0.2 → diversity dominates, the second pick should avoid the
+  // near-duplicate of `a`.
+  const diverse = applyMmrToCandidates({
+    candidates,
+    lambda: 0.2,
+    budget: 2,
+  });
+  assert.equal(diverse[0]?.id, "a", "highest-relevance should still lead");
+  assert.notEqual(
+    diverse[1]?.id,
+    "b",
+    "diversity-heavy MMR should avoid the near-duplicate",
+  );
+});
+
+test("applyMmrToCandidates preserves all candidates when budget >= length", () => {
+  const candidates: MmrCandidate[] = [
+    makeCandidate("a", "one", 1, [1, 0, 0]),
+    makeCandidate("b", "two", 0.9, [0, 1, 0]),
+    makeCandidate("c", "three", 0.8, [0, 0, 1]),
+  ];
+  const out = applyMmrToCandidates({
+    candidates,
+    budget: 10,
+  });
+  assert.equal(out.length, 3);
+  const ids = out.map((c) => c.id).sort();
+  assert.deepEqual(ids, ["a", "b", "c"]);
+});
+
+test("applyMmrToCandidates respects topN clamping", () => {
+  const candidates: MmrCandidate[] = Array.from({ length: 50 }, (_, i) =>
+    makeCandidate(`c-${i}`, `content ${i}`, 1 - i * 0.01, [1, i * 0.001, 0]),
+  );
+  const out = applyMmrToCandidates({
+    candidates,
+    topN: 10,
+    budget: 5,
+  });
+  assert.equal(out.length, 5);
+  // All selected should come from the top 10 (indices 0-9).
+  for (const c of out) {
+    const idx = Number.parseInt(c.id.split("-")[1]!, 10);
+    assert.ok(idx < 10, `selected candidate ${c.id} outside topN window`);
+  }
+});
+
+test("applyMmrToCandidates handles budget=0 as empty selection", () => {
+  const candidates = [makeCandidate("a", "one", 1), makeCandidate("b", "two", 0.5)];
+  const out = applyMmrToCandidates({ candidates, budget: 0 });
+  // budget=0 is clamped to 0, nothing selected
+  assert.equal(out.length, 0);
+});
+
+test("summarizeMmrDiversity reports higher before-sim for dup-heavy input", () => {
+  const dupHeavy: MmrCandidate[] = [
+    makeCandidate("a", "the cat sat on the mat", 1, [1, 0.001, 0]),
+    makeCandidate("b", "a cat sat on the mat", 0.99, [1, 0.002, 0]),
+    makeCandidate("c", "cats sit on mats", 0.98, [1, 0.003, 0]),
+  ];
+  const diversified = applyMmrToCandidates({
+    candidates: dupHeavy.concat([
+      makeCandidate("d", "rocket thrust vectoring", 0.5, [0, 1, 0]),
+      makeCandidate("e", "violin bow rosin", 0.4, [0, 0, 1]),
+    ]),
+    lambda: 0.4,
+    budget: 3,
+  });
+
+  const report = summarizeMmrDiversity(dupHeavy, diversified, 40);
+  assert.ok(
+    report.avgPairwiseSimAfter <= report.avgPairwiseSimBefore + 1e-9,
+    `avg pairwise similarity should not increase after MMR: before=${report.avgPairwiseSimBefore} after=${report.avgPairwiseSimAfter}`,
+  );
+});
+
+test("normalizeTokens lowercases and strips punctuation", () => {
+  assert.deepEqual(
+    [...normalizeTokens("Hello, World! 42 TIMES.")],
+    ["hello", "world", "42", "times"],
+  );
+  assert.deepEqual([...normalizeTokens("")], []);
+  assert.deepEqual([...normalizeTokens("   ")], []);
+});
+
+test("applyMmrToCandidates end-to-end: duplicate sentences reduced vs disabled", () => {
+  // Small seeded fixture: 4 near-duplicate "fact" sentences + 3 diverse.
+  const fixture: MmrCandidate[] = [
+    makeCandidate(
+      "f1",
+      "The user prefers dark mode for their terminal",
+      0.95,
+    ),
+    makeCandidate(
+      "f2",
+      "User likes dark mode in the terminal interface",
+      0.94,
+    ),
+    makeCandidate(
+      "f3",
+      "Prefers dark mode setting for terminal usage",
+      0.93,
+    ),
+    makeCandidate(
+      "f4",
+      "The terminal should use dark mode",
+      0.92,
+    ),
+    makeCandidate("d1", "Coffee is brewed at 195 degrees fahrenheit", 0.8),
+    makeCandidate("d2", "The sunset reflected orange on the ocean waves", 0.75),
+    makeCandidate("d3", "Linear algebra underpins modern machine learning", 0.7),
+  ];
+
+  // Without MMR: top-4 would be f1..f4, all near-duplicates.
+  const noMmrTop4 = fixture.slice(0, 4);
+  const mmrTop4 = applyMmrToCandidates({
+    candidates: fixture,
+    lambda: 0.4,
+    budget: 4,
+  });
+
+  const noMmrIds = noMmrTop4.map((c) => c.id);
+  const mmrIds = mmrTop4.map((c) => c.id);
+
+  const countDupes = (ids: string[]) =>
+    ids.filter((id) => id.startsWith("f")).length;
+
+  assert.ok(
+    countDupes(mmrIds) < countDupes(noMmrIds),
+    `MMR should strictly reduce duplicate cluster count: noMmr=${noMmrIds} mmr=${mmrIds}`,
+  );
+  assert.ok(
+    mmrIds.some((id) => id.startsWith("d")),
+    `MMR should surface at least one diverse candidate: ${mmrIds}`,
+  );
+});

--- a/packages/remnic-core/src/recall-mmr.test.ts
+++ b/packages/remnic-core/src/recall-mmr.test.ts
@@ -419,6 +419,59 @@ test(
   },
 );
 
+// ---------------------------------------------------------------------------
+// Regression: MMR must run before truncation so diverse candidates just below
+// the cutoff can be promoted into the final injected set.
+// (ChatGPT Codex P2 review comment on PR #391)
+// ---------------------------------------------------------------------------
+
+test(
+  "reorderRecallResultsWithMmr promotes sub-cutoff diverse candidates when run pre-slice",
+  () => {
+    // Simulate a near-duplicate cluster of 5 high-score candidates followed
+    // by a truly diverse candidate at position 5 (just below a final limit
+    // of 5). If MMR ran only on the already-truncated top-5, the diverse
+    // candidate would never make it into the injected set. Running MMR on
+    // the full 6-candidate pool and then slicing to 5 must pull the diverse
+    // candidate into the final slice.
+    const results: MmrRecallResult[] = [
+      { docid: "a1", path: "p/a1", snippet: "alpha fact one", score: 0.99 },
+      { docid: "a2", path: "p/a2", snippet: "alpha fact two", score: 0.98 },
+      { docid: "a3", path: "p/a3", snippet: "alpha fact three", score: 0.97 },
+      { docid: "a4", path: "p/a4", snippet: "alpha fact four", score: 0.96 },
+      { docid: "a5", path: "p/a5", snippet: "alpha fact five", score: 0.95 },
+      {
+        docid: "d1",
+        path: "p/d1",
+        snippet: "orthogonal concept rocket fuel chemistry",
+        score: 0.94,
+      },
+    ];
+
+    // Simulate the buggy "slice then MMR" behavior.
+    const sliceFirst = results.slice(0, 5);
+    const sliceFirstMmr = reorderRecallResultsWithMmr(sliceFirst, {
+      lambda: 0.3,
+    }).reordered;
+    const sliceFirstIds = sliceFirstMmr.map((r) => r.docid);
+    assert.ok(
+      !sliceFirstIds.includes("d1"),
+      "sanity: slicing before MMR cannot recover the sub-cutoff diverse candidate",
+    );
+
+    // Now the correct "MMR then slice" behavior.
+    const mmrFirst = reorderRecallResultsWithMmr(results, {
+      lambda: 0.3,
+    }).reordered.slice(0, 5);
+    const mmrFirstIds = mmrFirst.map((r) => r.docid);
+    assert.equal(mmrFirst.length, 5);
+    assert.ok(
+      mmrFirstIds.includes("d1"),
+      `MMR-then-slice should promote the diverse candidate into the top-5: ${mmrFirstIds.join(",")}`,
+    );
+  },
+);
+
 test(
   "reorderRecallResultsWithMmr with topN=0 is a full no-op preserving input order",
   () => {

--- a/packages/remnic-core/src/recall-mmr.ts
+++ b/packages/remnic-core/src/recall-mmr.ts
@@ -1,0 +1,320 @@
+/**
+ * Maximal Marginal Relevance (MMR) re-selection for recall candidates.
+ *
+ * After the reranker produces its ordered candidate list, we run an MMR pass
+ * over the top N candidates (per-section) so that a cluster of near-duplicate
+ * high-scoring facts cannot dominate the injected context.
+ *
+ *     MMR(d) = λ * sim(d, query) − (1 − λ) * max_{d' ∈ selected} sim(d, d')
+ *
+ * - λ defaults to 0.7 (tilted toward relevance, with meaningful diversity).
+ * - Similarity uses cosine over pre-computed embeddings when available, and
+ *   falls back to Jaccard over normalized tokens (lowercased alphanumerics)
+ *   when embeddings are missing.
+ * - Per-section application is the caller's responsibility: pass each
+ *   section's ordered candidate slice independently so one cluster in one
+ *   section cannot starve another section.
+ *
+ * Pure, deterministic, no IO. Input arrays are never mutated.
+ */
+
+/** Minimal candidate shape used by MMR. Callers may wrap their own records. */
+export interface MmrCandidate {
+  /** Stable identifier for the candidate. Only used for tie-breaking. */
+  id: string;
+  /** Text content used for the Jaccard similarity fallback. */
+  content: string;
+  /**
+   * Relevance score from the upstream ranker (e.g. rerank score or RRF).
+   * Used as the `sim(d, query)` term when no query embedding is available.
+   */
+  score: number;
+  /** Optional pre-computed embedding vector for cosine similarity. */
+  embedding?: readonly number[] | null;
+}
+
+export interface ApplyMmrOptions<C extends MmrCandidate> {
+  /** Ordered candidate list (most relevant first). */
+  candidates: readonly C[];
+  /** Optional query embedding. If provided and candidates carry embeddings,
+   *  relevance is measured by cosine similarity to the query. Otherwise
+   *  candidate `score` is normalized and used. */
+  queryEmbedding?: readonly number[] | null;
+  /** λ ∈ [0, 1]. 1 = pure relevance, 0 = pure diversity. Default 0.7. */
+  lambda?: number;
+  /** Apply MMR only over the top N candidates. Default 40. */
+  topN?: number;
+  /** Maximum number of candidates to select. Default = candidates length. */
+  budget?: number;
+}
+
+export interface MmrDiversityReport {
+  /** Number of candidates considered after topN clamping. */
+  considered: number;
+  /** Number of candidates kept after MMR. */
+  kept: number;
+  /** Average pairwise similarity of the top-K input slice (pre-MMR). */
+  avgPairwiseSimBefore: number;
+  /** Average pairwise similarity of the selected set (post-MMR). */
+  avgPairwiseSimAfter: number;
+}
+
+const DEFAULT_LAMBDA = 0.7;
+const DEFAULT_TOP_N = 40;
+
+/**
+ * Pure MMR re-selection over an ordered candidate list.
+ *
+ * Returns a new array — the input is never mutated. When `candidates.length`
+ * is `<= 1` or `budget <= 0`, a defensive copy is returned as a no-op.
+ */
+export function applyMmrToCandidates<C extends MmrCandidate>(
+  opts: ApplyMmrOptions<C>,
+): C[] {
+  const candidates = Array.isArray(opts.candidates) ? opts.candidates : [];
+  if (candidates.length === 0) return [];
+
+  const lambda = clampLambda(opts.lambda);
+  const topN = clampPositiveInt(opts.topN, DEFAULT_TOP_N);
+  const budget = clampPositiveInt(opts.budget, candidates.length);
+
+  if (budget <= 0) return [];
+  if (candidates.length === 1) return [candidates[0]!];
+
+  // Only reorder the top-N slice; anything past it keeps its original position
+  // appended at the end (but will not be selected unless budget > topN).
+  const pool = candidates.slice(0, topN);
+  const tail = candidates.slice(topN);
+
+  // Relevance scores as `sim(d, query)`. Prefer cosine to the query embedding
+  // when we can compute it; otherwise fall back to the candidate's own score
+  // normalized into [0, 1] across the pool.
+  const relevance = computeRelevanceScores(pool, opts.queryEmbedding);
+
+  // Pre-compute pairwise candidate-candidate similarity lazily as needed.
+  const pairSim = new Map<string, number>();
+  const pairKey = (i: number, j: number): string =>
+    i < j ? `${i}:${j}` : `${j}:${i}`;
+  const sim = (i: number, j: number): number => {
+    if (i === j) return 1;
+    const key = pairKey(i, j);
+    const cached = pairSim.get(key);
+    if (cached !== undefined) return cached;
+    const a = pool[i]!;
+    const b = pool[j]!;
+    const s = similarity(a, b);
+    pairSim.set(key, s);
+    return s;
+  };
+
+  const selectedIdx: number[] = [];
+  const remaining = new Set<number>();
+  for (let i = 0; i < pool.length; i += 1) remaining.add(i);
+
+  while (selectedIdx.length < budget && remaining.size > 0) {
+    let bestIdx = -1;
+    let bestMmr = Number.NEGATIVE_INFINITY;
+    for (const idx of remaining) {
+      const rel = relevance[idx] ?? 0;
+      let maxSimToSelected = 0;
+      if (selectedIdx.length > 0) {
+        for (const s of selectedIdx) {
+          const pairwise = sim(idx, s);
+          if (pairwise > maxSimToSelected) maxSimToSelected = pairwise;
+        }
+      }
+      const mmr = lambda * rel - (1 - lambda) * maxSimToSelected;
+      if (
+        mmr > bestMmr ||
+        // Stable tie-breaker: prefer the earlier original position.
+        (mmr === bestMmr && (bestIdx < 0 || idx < bestIdx))
+      ) {
+        bestMmr = mmr;
+        bestIdx = idx;
+      }
+    }
+    if (bestIdx < 0) break;
+    selectedIdx.push(bestIdx);
+    remaining.delete(bestIdx);
+  }
+
+  const selected: C[] = selectedIdx.map((i) => pool[i]!);
+
+  // If the caller set a budget larger than topN, append tail candidates in
+  // their original order until budget is filled. This keeps MMR scoped to the
+  // top-N slice while still respecting the caller's requested size.
+  if (selected.length < budget && tail.length > 0) {
+    for (const c of tail) {
+      if (selected.length >= budget) break;
+      selected.push(c);
+    }
+  }
+
+  return selected;
+}
+
+/**
+ * Summarize how much MMR collapsed duplicate clusters, for logging. Optional —
+ * callers can skip this if they don't care about metrics.
+ */
+export function summarizeMmrDiversity<C extends MmrCandidate>(
+  before: readonly C[],
+  after: readonly C[],
+  topN: number = DEFAULT_TOP_N,
+): MmrDiversityReport {
+  const beforeSlice = before.slice(0, topN);
+  return {
+    considered: beforeSlice.length,
+    kept: after.length,
+    avgPairwiseSimBefore: averagePairwiseSimilarity(beforeSlice),
+    avgPairwiseSimAfter: averagePairwiseSimilarity(after),
+  };
+}
+
+// -----------------------------------------------------------------------------
+// Internals
+// -----------------------------------------------------------------------------
+
+function clampLambda(value: number | undefined): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return DEFAULT_LAMBDA;
+  if (value < 0) return 0;
+  if (value > 1) return 1;
+  return value;
+}
+
+function clampPositiveInt(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  if (value <= 0) return 0;
+  return Math.floor(value);
+}
+
+function computeRelevanceScores<C extends MmrCandidate>(
+  pool: readonly C[],
+  queryEmbedding: readonly number[] | null | undefined,
+): number[] {
+  // If we have a query embedding, use cosine against each candidate embedding
+  // where possible. Candidates without embeddings fall back to normalized score.
+  const canUseQueryEmbedding =
+    Array.isArray(queryEmbedding) && queryEmbedding.length > 0;
+
+  if (canUseQueryEmbedding) {
+    const scores: number[] = [];
+    for (const c of pool) {
+      if (Array.isArray(c.embedding) && c.embedding.length > 0) {
+        scores.push(cosineSimilarity(queryEmbedding!, c.embedding));
+      } else {
+        // Fall back to the upstream relevance score for this one candidate.
+        scores.push(normalizeFinite(c.score));
+      }
+    }
+    return normalizeVector(scores);
+  }
+
+  // No query embedding — use normalized candidate scores.
+  const raw = pool.map((c) => normalizeFinite(c.score));
+  return normalizeVector(raw);
+}
+
+function similarity<C extends MmrCandidate>(a: C, b: C): number {
+  if (
+    Array.isArray(a.embedding) &&
+    a.embedding.length > 0 &&
+    Array.isArray(b.embedding) &&
+    b.embedding.length > 0 &&
+    a.embedding.length === b.embedding.length
+  ) {
+    return cosineSimilarity(a.embedding, b.embedding);
+  }
+  return jaccardSimilarity(a.content ?? "", b.content ?? "");
+}
+
+function cosineSimilarity(
+  a: readonly number[],
+  b: readonly number[],
+): number {
+  if (a.length === 0 || b.length === 0) return 0;
+  const len = Math.min(a.length, b.length);
+  let dot = 0;
+  let na = 0;
+  let nb = 0;
+  for (let i = 0; i < len; i += 1) {
+    const av = a[i] ?? 0;
+    const bv = b[i] ?? 0;
+    dot += av * bv;
+    na += av * av;
+    nb += bv * bv;
+  }
+  if (na === 0 || nb === 0) return 0;
+  const cos = dot / (Math.sqrt(na) * Math.sqrt(nb));
+  // Clamp to [0, 1]. Negative cosines (opposite directions) are treated as 0
+  // for MMR purposes — two embeddings pointing opposite ways should be
+  // "maximally diverse", not discouraged further.
+  if (cos < 0) return 0;
+  if (cos > 1) return 1;
+  return cos;
+}
+
+export function normalizeTokens(text: string): Set<string> {
+  if (!text) return new Set();
+  // Lowercase, strip punctuation to spaces, collapse runs, split.
+  const cleaned = text
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, " ")
+    .trim();
+  if (cleaned.length === 0) return new Set();
+  return new Set(cleaned.split(/\s+/));
+}
+
+function jaccardSimilarity(a: string, b: string): number {
+  const ta = normalizeTokens(a);
+  const tb = normalizeTokens(b);
+  if (ta.size === 0 && tb.size === 0) return 0;
+  let intersection = 0;
+  for (const t of ta) if (tb.has(t)) intersection += 1;
+  const union = ta.size + tb.size - intersection;
+  if (union === 0) return 0;
+  return intersection / union;
+}
+
+function normalizeFinite(value: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  return value;
+}
+
+function normalizeVector(values: number[]): number[] {
+  if (values.length === 0) return values;
+  let min = Number.POSITIVE_INFINITY;
+  let max = Number.NEGATIVE_INFINITY;
+  for (const v of values) {
+    if (v < min) min = v;
+    if (v > max) max = v;
+  }
+  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+    return values.map(() => 0);
+  }
+  if (max === min) {
+    // All scores equal — give everyone 1 so diversity fully drives selection.
+    return values.map(() => 1);
+  }
+  const span = max - min;
+  return values.map((v) => (v - min) / span);
+}
+
+function averagePairwiseSimilarity<C extends MmrCandidate>(
+  candidates: readonly C[],
+): number {
+  if (candidates.length < 2) return 0;
+  let sum = 0;
+  let count = 0;
+  for (let i = 0; i < candidates.length; i += 1) {
+    for (let j = i + 1; j < candidates.length; j += 1) {
+      sum += similarity(candidates[i]!, candidates[j]!);
+      count += 1;
+    }
+  }
+  if (count === 0) return 0;
+  return sum / count;
+}

--- a/packages/remnic-core/src/recall-mmr.ts
+++ b/packages/remnic-core/src/recall-mmr.ts
@@ -49,18 +49,27 @@ export interface ApplyMmrOptions<C extends MmrCandidate> {
 }
 
 export interface MmrDiversityReport {
-  /** Number of candidates considered after topN clamping. */
+  /** Number of candidates considered after sample-size clamping. */
   considered: number;
   /** Number of candidates kept after MMR. */
   kept: number;
-  /** Average pairwise similarity of the top-K input slice (pre-MMR). */
+  /** Average pairwise similarity of the head-of-list input slice (pre-MMR). */
   avgPairwiseSimBefore: number;
-  /** Average pairwise similarity of the selected set (post-MMR). */
+  /** Average pairwise similarity of the head-of-list MMR output slice. */
   avgPairwiseSimAfter: number;
 }
 
-const DEFAULT_LAMBDA = 0.7;
-const DEFAULT_TOP_N = 40;
+export const DEFAULT_LAMBDA = 0.7;
+export const DEFAULT_TOP_N = 40;
+/**
+ * Default number of head-of-list candidates compared by
+ * {@link summarizeMmrDiversity}. Small on purpose: we want to measure whether
+ * MMR actually *changed* the head of the list. Comparing the full top-N slice
+ * is meaningless when `budget >= candidates.length` because both slices
+ * contain the same set (just reordered), making pairwise-similarity
+ * order-independent and identical before vs after.
+ */
+const DEFAULT_DIVERSITY_SAMPLE_SIZE = 10;
 
 /**
  * Pure MMR re-selection over an ordered candidate list.
@@ -154,20 +163,35 @@ export function applyMmrToCandidates<C extends MmrCandidate>(
 }
 
 /**
- * Summarize how much MMR collapsed duplicate clusters, for logging. Optional —
- * callers can skip this if they don't care about metrics.
+ * Summarize how much MMR reshuffled the head of the candidate list, for
+ * logging. Optional — callers can skip this if they don't care about metrics.
+ *
+ * IMPORTANT: `before` should be the score-ordered input (the same ordering the
+ * upstream reranker emitted, *not* the MMR output), and `after` should be the
+ * MMR-reordered list. Both are truncated to `sampleSize` before their pairwise
+ * similarity is averaged.
+ *
+ * The sample size intentionally defaults to a small number
+ * ({@link DEFAULT_DIVERSITY_SAMPLE_SIZE}) so that when the caller uses
+ * `budget >= candidates.length` (i.e. MMR only reorders without dropping), the
+ * head-of-list comparison still reflects whether MMR promoted diverse
+ * candidates. Passing a sample size `>= candidates.length` in that situation
+ * makes `avgPairwiseSimBefore` and `avgPairwiseSimAfter` trivially equal
+ * because pairwise similarity is order-independent.
  */
 export function summarizeMmrDiversity<C extends MmrCandidate>(
   before: readonly C[],
   after: readonly C[],
-  topN: number = DEFAULT_TOP_N,
+  sampleSize: number = DEFAULT_DIVERSITY_SAMPLE_SIZE,
 ): MmrDiversityReport {
-  const beforeSlice = before.slice(0, topN);
+  const n = clampPositiveInt(sampleSize, DEFAULT_DIVERSITY_SAMPLE_SIZE);
+  const beforeSlice = before.slice(0, n);
+  const afterSlice = after.slice(0, n);
   return {
     considered: beforeSlice.length,
-    kept: after.length,
+    kept: afterSlice.length,
     avgPairwiseSimBefore: averagePairwiseSimilarity(beforeSlice),
-    avgPairwiseSimAfter: averagePairwiseSimilarity(after),
+    avgPairwiseSimAfter: averagePairwiseSimilarity(afterSlice),
   };
 }
 
@@ -317,4 +341,144 @@ function averagePairwiseSimilarity<C extends MmrCandidate>(
   }
   if (count === 0) return 0;
   return sum / count;
+}
+
+// -----------------------------------------------------------------------------
+// Orchestration helper: MMR for recall results keyed by path-first
+// -----------------------------------------------------------------------------
+
+/**
+ * Minimum shape the recall-MMR orchestration helper expects from a result.
+ * Any richer result type (e.g. {@link QmdSearchResult}) satisfies this.
+ */
+export interface MmrRecallResult {
+  readonly docid?: string;
+  readonly path?: string;
+  readonly snippet?: string;
+  readonly score?: number;
+}
+
+export interface ReorderRecallResultsOptions {
+  readonly lambda?: number;
+  readonly topN?: number;
+  /**
+   * Head-of-list sample size used by the diversity metric. Defaults to
+   * {@link DEFAULT_DIVERSITY_SAMPLE_SIZE}. Intentionally small so the metric
+   * reflects head-of-list changes even when `budget >= results.length`.
+   */
+  readonly diversitySampleSize?: number;
+}
+
+export interface ReorderRecallResultsOutcome<R extends MmrRecallResult> {
+  readonly reordered: R[];
+  readonly diversity: MmrDiversityReport;
+  readonly lambda: number;
+}
+
+/**
+ * Apply MMR to an ordered list of recall results and return the reordered
+ * list plus a head-of-list diversity report.
+ *
+ * This helper is the single source of truth for the orchestrator's
+ * per-section MMR pass. It is pure and deterministic so it can be unit
+ * tested without constructing an Orchestrator.
+ *
+ * Key invariants:
+ * 1. **No silent drops.** Candidates are keyed by a stable unique key derived
+ *    from `path` first, falling back to `docid`, and always suffixed with the
+ *    candidate's original index. Two results that share a basename-style
+ *    docid but differ in path are treated as distinct candidates and both
+ *    survive the reorder.
+ * 2. **No mutation.** The input array is never mutated; a new array is
+ *    returned.
+ * 3. **Diversity metric is meaningful.** The report compares the *head of
+ *    list* before and after MMR using a small sample size, so it reflects
+ *    whether MMR promoted diverse candidates even when
+ *    `budget >= results.length`.
+ */
+export function reorderRecallResultsWithMmr<R extends MmrRecallResult>(
+  results: readonly R[],
+  options: ReorderRecallResultsOptions = {},
+): ReorderRecallResultsOutcome<R> {
+  const emptyReport: MmrDiversityReport = {
+    considered: 0,
+    kept: 0,
+    avgPairwiseSimBefore: 0,
+    avgPairwiseSimAfter: 0,
+  };
+  const lambda = clampLambda(options.lambda);
+
+  if (!Array.isArray(results) || results.length === 0) {
+    return { reordered: [], diversity: emptyReport, lambda };
+  }
+  if (results.length < 2) {
+    return {
+      reordered: [results[0]!],
+      diversity: emptyReport,
+      lambda,
+    };
+  }
+
+  const topN = clampPositiveInt(options.topN, DEFAULT_TOP_N);
+
+  // Build a per-result *unique* key so distinct results with colliding
+  // docids or paths are never silently collapsed by id-based lookups.
+  const candidateKeys: string[] = new Array(results.length);
+  const byKey = new Map<string, R>();
+  const candidates: MmrCandidate[] = results.map((r, index) => {
+    const key = makeRecallKey(r, index);
+    candidateKeys[index] = key;
+    byKey.set(key, r);
+    return {
+      id: key,
+      content: r.snippet ?? "",
+      score: typeof r.score === "number" ? r.score : 0,
+      embedding: null,
+    };
+  });
+
+  const selectedMmr = applyMmrToCandidates({
+    candidates,
+    lambda,
+    topN,
+    budget: results.length,
+  });
+
+  const reordered: R[] = [];
+  const seen = new Set<string>();
+  for (const c of selectedMmr) {
+    if (seen.has(c.id)) continue;
+    const original = byKey.get(c.id);
+    if (!original) continue;
+    seen.add(c.id);
+    reordered.push(original);
+  }
+  // Safety: append any candidates MMR did not select so nothing is dropped.
+  if (reordered.length < results.length) {
+    for (let i = 0; i < results.length; i += 1) {
+      const key = candidateKeys[i]!;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      reordered.push(results[i]!);
+    }
+  }
+
+  const reorderedCandidates: MmrCandidate[] = reordered.map((r, index) => ({
+    id: makeRecallKey(r, index),
+    content: r.snippet ?? "",
+    score: typeof r.score === "number" ? r.score : 0,
+    embedding: null,
+  }));
+  const diversity = summarizeMmrDiversity(
+    candidates,
+    reorderedCandidates,
+    options.diversitySampleSize,
+  );
+
+  return { reordered, diversity, lambda };
+}
+
+function makeRecallKey(r: MmrRecallResult, index: number): string {
+  const baseKey = r.path || r.docid || "";
+  return `${baseKey}::${index}`;
 }

--- a/packages/remnic-core/src/recall-mmr.ts
+++ b/packages/remnic-core/src/recall-mmr.ts
@@ -49,10 +49,28 @@ export interface ApplyMmrOptions<C extends MmrCandidate> {
 }
 
 export interface MmrDiversityReport {
-  /** Number of candidates considered after sample-size clamping. */
+  /**
+   * Total number of candidates MMR considered (the full input pool, pre-MMR).
+   * Previously this mirrored `kept` and was therefore uninformative; it now
+   * reflects the true pool size so `kept/considered` logs carry signal even
+   * though MMR is reorder-only.
+   */
   considered: number;
-  /** Number of candidates kept after MMR. */
+  /**
+   * Number of candidates present in the MMR output. With the current
+   * orchestrator pipeline MMR is reorder-only (no drops), so this is the
+   * same as `considered`. It's still reported separately so a future
+   * drop-mode MMR can distinguish them without another schema change.
+   */
   kept: number;
+  /**
+   * Head-of-list positions whose candidate identity changed between the
+   * pre-MMR and post-MMR slices. This is the *actionable* diversity signal:
+   * it tells the caller how many of the top `sampleSize` results MMR
+   * promoted or demoted. Zero means MMR had no head-of-list effect; a value
+   * greater than zero means at least one diverse candidate was swapped in.
+   */
+  headReorderCount: number;
   /** Average pairwise similarity of the head-of-list input slice (pre-MMR). */
   avgPairwiseSimBefore: number;
   /** Average pairwise similarity of the head-of-list MMR output slice. */
@@ -187,9 +205,18 @@ export function summarizeMmrDiversity<C extends MmrCandidate>(
   const n = clampPositiveInt(sampleSize, DEFAULT_DIVERSITY_SAMPLE_SIZE);
   const beforeSlice = before.slice(0, n);
   const afterSlice = after.slice(0, n);
+  // Count how many head-of-list positions MMR actually changed. A zero value
+  // means MMR left the head untouched; a positive value is the actionable
+  // "MMR promoted N diverse candidates" signal the previous metric lacked.
+  let headReorderCount = 0;
+  const compareLength = Math.min(beforeSlice.length, afterSlice.length);
+  for (let i = 0; i < compareLength; i += 1) {
+    if (beforeSlice[i]!.id !== afterSlice[i]!.id) headReorderCount += 1;
+  }
   return {
-    considered: beforeSlice.length,
-    kept: afterSlice.length,
+    considered: before.length,
+    kept: after.length,
+    headReorderCount,
     avgPairwiseSimBefore: averagePairwiseSimilarity(beforeSlice),
     avgPairwiseSimAfter: averagePairwiseSimilarity(afterSlice),
   };
@@ -283,13 +310,55 @@ function cosineSimilarity(
 
 export function normalizeTokens(text: string): Set<string> {
   if (!text) return new Set();
-  // Lowercase, strip punctuation to spaces, collapse runs, split.
+  // Unicode-aware normalization. We lowercase and replace any character that
+  // is NOT a Unicode letter or number with a space, then split on whitespace.
+  // This preserves non-Latin scripts (Cyrillic, Greek, Hebrew, Arabic, etc.)
+  // so the Jaccard fallback still detects near-duplicates in multilingual
+  // snippets. Without this fix, `[^a-z0-9]+` strips all non-ASCII and two
+  // identical Chinese/Japanese/Cyrillic snippets both collapse to the empty
+  // set, returning similarity 0 and letting duplicates dominate recall.
   const cleaned = text
     .toLowerCase()
-    .replace(/[^a-z0-9]+/g, " ")
+    .replace(/[^\p{L}\p{N}]+/gu, " ")
     .trim();
-  if (cleaned.length === 0) return new Set();
-  return new Set(cleaned.split(/\s+/));
+  if (cleaned.length === 0) {
+    // CJK fallback: scripts like Chinese/Japanese/Korean do not use word
+    // breaks, so after the Unicode strip the above split-on-whitespace yields
+    // one big token. The Latin-style split is a bad match for these scripts;
+    // use per-codepoint character tokens instead, which approximates a
+    // unigram shingle and is accurate enough for near-duplicate detection.
+    const chars = new Set<string>();
+    for (const ch of text.toLowerCase()) {
+      if (/\s/.test(ch)) continue;
+      chars.add(ch);
+    }
+    return chars;
+  }
+  const tokens = new Set<string>();
+  for (const token of cleaned.split(/\s+/)) {
+    if (!token) continue;
+    // A single "token" that is actually a run of CJK codepoints (no spaces in
+    // the source) should still be split into per-character tokens so the
+    // Jaccard overlap works. Latin/Cyrillic/etc. keep their word-level tokens.
+    if (token.length >= 2 && hasUnsegmentableScript(token)) {
+      for (const ch of token) tokens.add(ch);
+    } else {
+      tokens.add(token);
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Returns true when `token` contains at least one codepoint in a script that
+ * does not use whitespace for word segmentation (CJK Unified Ideographs,
+ * Hiragana, Katakana, Hangul). These are tokenized per-character so Jaccard
+ * similarity can still detect near-duplicate snippets.
+ */
+function hasUnsegmentableScript(token: string): boolean {
+  return /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u.test(
+    token,
+  );
 }
 
 function jaccardSimilarity(a: string, b: string): number {
@@ -310,21 +379,55 @@ function normalizeFinite(value: number): number {
 
 function normalizeVector(values: number[]): number[] {
   if (values.length === 0) return values;
+  // Intentionally *not* min-max normalized. Min-max maps the lowest score to
+  // 0 and the highest to 1, which amplifies tiny relevance gaps (e.g. a tight
+  // reranker cluster like [0.93, 0.94, 0.95]) into the full [0, 1] range.
+  // That lets a near-duplicate at the top permanently beat a diverse
+  // candidate at the bottom because `lambda * 0 - (1 - lambda) * 0 = 0` is
+  // always worse than `lambda * 1 - (1 - lambda) * maxSim` for any
+  // maxSim < lambda / (1 - lambda). MMR is supposed to escape exactly that
+  // scenario; min-max defeats it.
+  //
+  // Instead we preserve the relative score gaps by scaling only if the
+  // scores leave the MMR-friendly `[0, 1]` range. Negative or out-of-range
+  // scores are clamped to `[0, 1]` by dividing by the max absolute value; if
+  // everything is already inside `[0, 1]`, we pass through untouched so
+  // tight clusters stay tight and MMR can promote a diverse candidate from
+  // the bottom of the cluster.
+  let max = 0;
   let min = Number.POSITIVE_INFINITY;
-  let max = Number.NEGATIVE_INFINITY;
   for (const v of values) {
+    if (!Number.isFinite(v)) continue;
+    const a = Math.abs(v);
+    if (a > max) max = a;
     if (v < min) min = v;
-    if (v > max) max = v;
   }
-  if (!Number.isFinite(min) || !Number.isFinite(max)) {
+  if (!Number.isFinite(min)) {
     return values.map(() => 0);
   }
-  if (max === min) {
-    // All scores equal — give everyone 1 so diversity fully drives selection.
+  if (max === 0) {
+    // All scores are zero — give everyone 1 so diversity fully drives
+    // selection (otherwise every candidate has `lambda * 0 = 0` and the
+    // first-found wins trivially, hiding any diversity benefit).
     return values.map(() => 1);
   }
-  const span = max - min;
-  return values.map((v) => (v - min) / span);
+  // If scores already live in [0, 1], pass them through so tight clusters
+  // (e.g. [0.93, 0.94, 0.95]) stay tight and the (1 - lambda) * maxSim term
+  // can actually outweigh a 0.01 relevance gap, which is the whole point of
+  // MMR. Otherwise divide by `max` to bring the top score to 1 while
+  // preserving *relative* gaps (e.g. [100, 200, 300] -> [0.33, 0.67, 1.0]).
+  if (min >= 0 && max <= 1) {
+    return values.map((v) =>
+      Number.isFinite(v) ? (v < 0 ? 0 : v > 1 ? 1 : v) : 0,
+    );
+  }
+  return values.map((v) => {
+    if (!Number.isFinite(v)) return 0;
+    const scaled = v / max;
+    if (scaled < 0) return 0;
+    if (scaled > 1) return 1;
+    return scaled;
+  });
 }
 
 function averagePairwiseSimilarity<C extends MmrCandidate>(
@@ -403,6 +506,7 @@ export function reorderRecallResultsWithMmr<R extends MmrRecallResult>(
   const emptyReport: MmrDiversityReport = {
     considered: 0,
     kept: 0,
+    headReorderCount: 0,
     avgPairwiseSimBefore: 0,
     avgPairwiseSimAfter: 0,
   };

--- a/packages/remnic-core/src/recall-mmr.ts
+++ b/packages/remnic-core/src/recall-mmr.ts
@@ -527,19 +527,26 @@ export function reorderRecallResultsWithMmr<R extends MmrRecallResult>(
 
   // Build a per-result *unique* key so distinct results with colliding
   // docids or paths are never silently collapsed by id-based lookups.
-  const candidateKeys: string[] = new Array(results.length);
-  const byKey = new Map<string, R>();
-  const candidates: MmrCandidate[] = results.map((r, index) => {
-    const key = makeRecallKey(r, index);
-    candidateKeys[index] = key;
-    byKey.set(key, r);
-    return {
-      id: key,
-      content: r.snippet ?? "",
-      score: typeof r.score === "number" ? r.score : 0,
-      embedding: null,
-    };
-  });
+  // Keys are always suffixed with the original input index so two results
+  // that share the same `path` (or share the same `docid` when `path` is
+  // empty) still get distinct identities.
+  const candidates: MmrCandidate[] = results.map((r, index) => ({
+    id: makeRecallKey(r, index),
+    content: r.snippet ?? "",
+    score: typeof r.score === "number" ? r.score : 0,
+    embedding: null,
+  }));
+  // Index lookup by id so we can map MMR-selected candidates back to their
+  // *original* position (and therefore their original `candidates[i]` object,
+  // which preserves its `id` across the reorder). Reusing those original
+  // candidate objects in the diversity comparison means
+  // `headReorderCount` works correctly even when two results in the input
+  // share the same base key: a swap at the same head position shows up
+  // because their original-index-suffixed ids still differ.
+  const indexById = new Map<string, number>();
+  for (let i = 0; i < candidates.length; i += 1) {
+    indexById.set(candidates[i]!.id, i);
+  }
 
   const selectedMmr = applyMmrToCandidates({
     candidates,
@@ -549,30 +556,30 @@ export function reorderRecallResultsWithMmr<R extends MmrRecallResult>(
   });
 
   const reordered: R[] = [];
+  // Parallel array of the *original* candidate objects in the new (post-MMR)
+  // order. Used for a faithful diversity comparison that preserves each
+  // candidate's original identity.
+  const reorderedCandidates: MmrCandidate[] = [];
   const seen = new Set<string>();
   for (const c of selectedMmr) {
     if (seen.has(c.id)) continue;
-    const original = byKey.get(c.id);
-    if (!original) continue;
+    const origIndex = indexById.get(c.id);
+    if (origIndex === undefined) continue;
     seen.add(c.id);
-    reordered.push(original);
+    reordered.push(results[origIndex]!);
+    reorderedCandidates.push(candidates[origIndex]!);
   }
   // Safety: append any candidates MMR did not select so nothing is dropped.
   if (reordered.length < results.length) {
     for (let i = 0; i < results.length; i += 1) {
-      const key = candidateKeys[i]!;
-      if (seen.has(key)) continue;
-      seen.add(key);
+      const origCandidate = candidates[i]!;
+      if (seen.has(origCandidate.id)) continue;
+      seen.add(origCandidate.id);
       reordered.push(results[i]!);
+      reorderedCandidates.push(origCandidate);
     }
   }
 
-  const reorderedCandidates: MmrCandidate[] = reordered.map((r, index) => ({
-    id: makeRecallKey(r, index),
-    content: r.snippet ?? "",
-    score: typeof r.score === "number" ? r.score : 0,
-    embedding: null,
-  }));
   const diversity = summarizeMmrDiversity(
     candidates,
     reorderedCandidates,

--- a/packages/remnic-core/src/recall-mmr.ts
+++ b/packages/remnic-core/src/recall-mmr.ts
@@ -516,9 +516,21 @@ export function reorderRecallResultsWithMmr<R extends MmrRecallResult>(
     return { reordered: [], diversity: emptyReport, lambda };
   }
   if (results.length < 2) {
+    // Single-element input: MMR is a trivial no-op but the diversity report
+    // must still reflect the real pool size so external callers see
+    // `considered=1 kept=1` rather than the `0/0` sentinel used for the
+    // empty case. This is also the exact path the orchestrator short-circuits
+    // past, but the helper is a public export and external callers cannot
+    // rely on that invariant.
     return {
       reordered: [results[0]!],
-      diversity: emptyReport,
+      diversity: {
+        considered: 1,
+        kept: 1,
+        headReorderCount: 0,
+        avgPairwiseSimBefore: 0,
+        avgPairwiseSimAfter: 0,
+      },
       lambda,
     };
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -527,6 +527,12 @@ export interface PluginConfig {
   recallCoreDeadlineMs: number;
   recallEnrichmentDeadlineMs: number;
   recallPipeline: RecallSectionConfig[];
+  /** Apply Maximal Marginal Relevance to the final recall selection per-section. */
+  recallMmrEnabled: boolean;
+  /** MMR λ parameter. 1.0 = pure relevance, 0.0 = pure diversity. Default 0.7. */
+  recallMmrLambda: number;
+  /** MMR is applied over the top N candidates per section. Default 40. */
+  recallMmrTopN: number;
   qmdRecallCacheTtlMs: number;
   qmdRecallCacheStaleTtlMs: number;
   qmdRecallCacheMaxEntries: number;

--- a/tests/recall-mmr-orchestrator.test.ts
+++ b/tests/recall-mmr-orchestrator.test.ts
@@ -1,0 +1,125 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { Orchestrator } from "../src/orchestrator.js";
+import { parseConfig } from "../src/config.js";
+import type { QmdSearchResult } from "../src/types.js";
+
+async function makeOrchestrator(
+  prefix: string,
+  overrides: Record<string, unknown> = {},
+): Promise<Orchestrator> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    knowledgeIndexEnabled: false,
+    compoundingInjectEnabled: false,
+    memoryBoxesEnabled: false,
+    temporalMemoryTreeEnabled: false,
+    injectQuestions: false,
+    ...overrides,
+  });
+  return new Orchestrator(config);
+}
+
+function fakeResult(
+  docid: string,
+  pathValue: string,
+  snippet: string,
+  score: number,
+): QmdSearchResult {
+  return { docid, path: pathValue, snippet, score };
+}
+
+test(
+  "diversifyAndLimitRecallResults returns [] when limit is zero",
+  async () => {
+    // Regression for Cursor Bugbot Medium comment on PR #391: when
+    // `recallResultLimit === 0` (e.g. `memoriesSectionEnabled === false`),
+    // the helper must return an empty array instead of the full
+    // diversified list. Otherwise a disabled memories section would still
+    // get injected.
+    const orch = await makeOrchestrator("remnic-mmr-zero-");
+    const results: QmdSearchResult[] = [
+      fakeResult("a", "p/a", "one", 0.9),
+      fakeResult("b", "p/b", "two", 0.8),
+      fakeResult("c", "p/c", "three", 0.7),
+    ];
+    const out = (orch as unknown as {
+      diversifyAndLimitRecallResults(
+        sectionId: string,
+        r: QmdSearchResult[],
+        limit: number,
+      ): QmdSearchResult[];
+    }).diversifyAndLimitRecallResults("memories", results, 0);
+    assert.equal(
+      out.length,
+      0,
+      "limit=0 must return an empty array (legacy slice(0, 0) semantics)",
+    );
+  },
+);
+
+test(
+  "diversifyAndLimitRecallResults runs MMR on full pool before slicing to limit",
+  async () => {
+    // Regression for ChatGPT Codex P2 comment on PR #391: MMR must run on
+    // the pre-truncation pool so diverse candidates sitting just below the
+    // final recall limit can still be promoted into the injected set.
+    const orch = await makeOrchestrator("remnic-mmr-preslice-");
+    const results: QmdSearchResult[] = [
+      fakeResult("a1", "p/a1", "alpha fact one", 0.99),
+      fakeResult("a2", "p/a2", "alpha fact two", 0.98),
+      fakeResult("a3", "p/a3", "alpha fact three", 0.97),
+      fakeResult("a4", "p/a4", "alpha fact four", 0.96),
+      fakeResult("a5", "p/a5", "alpha fact five", 0.95),
+      fakeResult("d1", "p/d1", "orthogonal rocket fuel chemistry concept", 0.94),
+    ];
+    const out = (orch as unknown as {
+      diversifyAndLimitRecallResults(
+        sectionId: string,
+        r: QmdSearchResult[],
+        limit: number,
+      ): QmdSearchResult[];
+    }).diversifyAndLimitRecallResults("memories", results, 5);
+    assert.equal(out.length, 5, "limit=5 must truncate to 5");
+    const ids = out.map((r) => r.docid);
+    assert.ok(
+      ids.includes("d1"),
+      `MMR-then-slice should pull the sub-cutoff diverse candidate into the head: ${ids.join(",")}`,
+    );
+  },
+);
+
+test(
+  "diversifyAndLimitRecallResults honors recallMmrEnabled=false",
+  async () => {
+    // When MMR is disabled, the helper should fall back to a plain
+    // score-ordered slice to the requested limit.
+    const orch = await makeOrchestrator("remnic-mmr-off-", {
+      recallMmrEnabled: false,
+    });
+    const results: QmdSearchResult[] = [
+      fakeResult("a", "p/a", "one", 0.9),
+      fakeResult("b", "p/b", "two", 0.8),
+      fakeResult("c", "p/c", "three", 0.7),
+    ];
+    const out = (orch as unknown as {
+      diversifyAndLimitRecallResults(
+        sectionId: string,
+        r: QmdSearchResult[],
+        limit: number,
+      ): QmdSearchResult[];
+    }).diversifyAndLimitRecallResults("memories", results, 2);
+    assert.equal(out.length, 2);
+    assert.deepEqual(out.map((r) => r.docid), ["a", "b"]);
+  },
+);


### PR DESCRIPTION
## Summary

Closes #374.

Apply Maximal Marginal Relevance (MMR) to the final recall selection so one redundant cluster of near-duplicate high-scoring facts cannot dominate the injected recall context. MMR runs **per-section** before the final truncate so one cluster cannot starve other sections.

- New pure module `packages/remnic-core/src/recall-mmr.ts`:
  - `applyMmrToCandidates({ candidates, lambda, topN, budget })` — uses cosine similarity when embeddings are present and falls back transparently to Jaccard over normalized tokens when they are not.
  - `summarizeMmrDiversity` returns before/after average pairwise similarity for concise metric logging.
  - Defensive: never mutates input, returns `[]` on empty, is a no-op on singletons, clamps budget/topN, preserves stable tie-breakers.

- Orchestrator integration: `publishRecallResults` now runs MMR on each section's ordered QMD candidate list before `formatQmdResults` / `appendRecallSection`. Any candidates MMR does not pick are safely appended after the selected ones so nothing is silently dropped. A single-line `recall_mmr` metric is emitted (before/after average pairwise similarity, kept/considered, lambda). The metric is wrapped in try/catch so it can never break recall.

- Config (wired through `types.ts`, `config.ts`, root `openclaw.plugin.json`, and `packages/plugin-openclaw/openclaw.plugin.json`):
  - `recallMmrEnabled` — default `true`
  - `recallMmrLambda` — default `0.7` (tilted toward relevance), clamped to `[0, 1]`
  - `recallMmrTopN` — default `40`

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `pnpm run build` — clean (tsup built `remnic-core` dist)
- [x] Targeted unit tests pass (`node --test recall-mmr.test.ts recall-budget-config.test.ts qmd-recall-cache.test.ts recall-qos.test.ts` → 26/26 pass, 340 ms)
- [x] `recall-mmr.test.ts` — 12 new unit tests:
  - empty input returns `[]`
  - single-candidate is a no-op
  - input array is not mutated
  - 4 near-duplicate cosine cluster collapse to 1 representative with 4-slot budget
  - Jaccard fallback correctly down-ranks lexically similar sentences when embeddings are missing
  - lambda sensitivity (λ=1.0 picks top-relevance pair, λ=0.2 avoids near-duplicate in position 2)
  - `budget >= length` preserves all candidates
  - `topN` clamping keeps selection inside the top-N window
  - `budget=0` yields empty selection
  - `summarizeMmrDiversity` reports non-increasing avg similarity after MMR
  - `normalizeTokens` lowercases and strips punctuation
  - end-to-end: 4 dupe "dark mode" sentences + 3 diverse → MMR strictly reduces dupe count and surfaces at least one diverse candidate
- [x] `recall-budget-config.test.ts` — 3 new tests cover MMR config defaults, explicit overrides, and λ clamping to `[0, 1]`.

## Notes

- Every other active worktree branch (`issue-370`, `issue-372`, `issue-377`, `issue-378`, `issue-380`) is currently stuck on the same trio of tests (`lcm-engine.test.ts`, `register-multi-registry.test.ts`, `sdk-compat-hook-handlers.test.ts`) due to parallel `pnpm test` contention (system load ~11). Those tests do not exercise the recall path and are pre-existing flake unrelated to this PR. Targeted recall-suite run is green (26/26).
- Upstream `QmdSearchResult` does not currently carry embeddings, so today MMR uses the Jaccard fallback in production. The module is ready to use cosine the moment embeddings flow through — no additional changes required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the core recall selection ordering across multiple retrieval paths by applying MMR before truncation, which can materially alter injected context and relevance behavior. Configurable knobs and extensive unit tests reduce implementation risk but rollout may affect answer quality/performance.
> 
> **Overview**
> Adds **per-section Maximal Marginal Relevance (MMR)** to diversify the final recalled memory set so near-duplicate clusters don’t dominate injected context.
> 
> Introduces a new pure `recall-mmr.ts` module (cosine similarity when embeddings exist, Jaccard token fallback otherwise) plus diversity logging/metrics, and wires it into the orchestrator so MMR runs on the **full pre-truncation candidate pool** before applying `recallResultLimit` (including hot QMD, embedding fallback, recent scan, and cold fallback paths).
> 
> Exposes new config/UI settings `recallMmrEnabled` (default on), `recallMmrLambda` (clamped 0–1, default 0.7), and `recallMmrTopN` (default 40, preserves `0` as a true no-op), updates types/config parsing, and adds targeted unit/integration tests covering defaults, clamping, zero-limit semantics, and key MMR behaviors (no drops, stable keying, multilingual tokenization, head-of-list diversity signals).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c58860bf48cc5d6c8c46dbf6786227243219b89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->