### PR TITLE
feat(connectors): materialize Codex-native memory artifacts from Remnic (#378)

### DIFF
--- a/docs/guides/codex-cli.md
+++ b/docs/guides/codex-cli.md
@@ -274,3 +274,25 @@ After setup, start a new Codex session and check:
 
 **Slow session start:**
 - The hook has a 15-second timeout. If the Remnic server is slow to respond, increase the `timeout` value in `hooks.json` or reduce `topK` in the recall query.
+
+## Native memory materialization
+
+Codex's phase-2 consolidation reads canonical files under `<codex_home>/memories/`
+(`memory_summary.md`, `MEMORY.md`, `raw_memories.md`, `rollout_summaries/*.md`).
+Remnic can mirror hot memories into this exact layout so the always-loaded
+`memory_summary.md` is populated with Remnic content — giving Codex a quick
+cross-session pass without any MCP roundtrips.
+
+Materialization is **opt-in via a sentinel file** (`<codex_home>/memories/.remnic-managed`):
+if the sentinel is missing, Remnic will skip the directory and log a warning,
+so hand-edited layouts are never clobbered. Writes are atomic (temp dir +
+rename), and idempotent no-ops happen whenever the content hash is unchanged.
+
+Triggers (all configurable):
+
+- After semantic or causal consolidation completes (`codexMaterializeOnConsolidation`)
+- At Codex session end via the `session-end.sh` hook (`codexMaterializeOnSessionEnd`)
+- Manually: `tsx scripts/codex-materialize.ts --reason manual`
+
+See [plugins/codex.md — Native memory materialization](../plugins/codex.md#native-memory-materialization)
+for the full list of config knobs and the opt-out procedure.

--- a/docs/plugins/codex.md
+++ b/docs/plugins/codex.md
@@ -63,6 +63,64 @@ grep codex_hooks ~/.codex/config.toml
 # Should show: codex_hooks = true
 ```
 
+## Native memory materialization
+
+Codex CLI's phase-2 consolidation reads memories directly from files under
+`<codex_home>/memories/` — `memory_summary.md` (always-loaded),
+`MEMORY.md` (searchable handbook, task-group schema), `raw_memories.md`, and
+per-session `rollout_summaries/*.md`. Remnic can mirror its hot memories into
+this exact layout so Codex's native read path picks up Remnic content with
+zero MCP calls.
+
+### How it works
+
+1. **Opt-in sentinel.** Remnic will only write into a memories directory that
+   already contains a `.remnic-managed` sentinel file. If the sentinel is
+   missing, the materializer **skips with a warning and never touches the
+   directory** — this preserves any hand-edits the user has made. Use
+   `remnic connectors install codex-cli` (or drop a `.remnic-managed` file
+   yourself) to opt in.
+2. **Atomic writes.** Every file is rendered under `<codex_home>/memories/.remnic-tmp/`
+   first and then `rename()`-ed into place, so Codex never observes a
+   half-written file.
+3. **Schema validation.** `MEMORY.md` is validated against Codex's task-group
+   schema before it is written. Invalid output throws — the materializer
+   refuses to leave garbage on disk.
+4. **Idempotent no-ops.** The sentinel stores a content hash of the last
+   render. If the next run produces identical content, the materializer
+   short-circuits with zero writes.
+5. **Token budget.** `memory_summary.md` is capped at
+   `codexMaterializeMaxSummaryTokens` whitespace tokens (default `4500`),
+   leaving headroom under Codex's 5000-token summary limit.
+
+### Triggers
+
+| Trigger | Config flag | Notes |
+|---|---|---|
+| Semantic / causal consolidation complete | `codexMaterializeOnConsolidation` (default `true`) | Runs immediately after a consolidation pass finishes. |
+| Codex `Stop` / session-end hook | `codexMaterializeOnSessionEnd` (default `true`) | `session-end.sh` shells out to `scripts/codex-materialize.ts`. |
+| Manual | — | `tsx scripts/codex-materialize.ts --reason manual` |
+
+### Configuration
+
+Every knob is exposed via plugin config so users have maximum control:
+
+| Key | Default | Description |
+|---|---|---|
+| `codexMaterializeMemories` | `true` | Master switch — set `false` to disable all materialization. |
+| `codexMaterializeNamespace` | `"auto"` | Namespace to materialize. `"auto"` derives it from the connector context. |
+| `codexMaterializeMaxSummaryTokens` | `4500` | Whitespace-tokenized cap for `memory_summary.md`. |
+| `codexMaterializeRolloutRetentionDays` | `30` | Prune rollout summaries older than this window. |
+| `codexMaterializeOnConsolidation` | `true` | Run after semantic/causal consolidation completes. |
+| `codexMaterializeOnSessionEnd` | `true` | Run from the plugin-codex session-end hook. |
+
+### Opting out
+
+Set `codexMaterializeMemories = false` in your Remnic plugin config. The
+materializer becomes a no-op immediately. Alternatively, delete the
+`.remnic-managed` sentinel — Remnic will start warning and will not touch the
+directory again until the sentinel is restored.
+
 ## Uninstall
 
 ```bash

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2870,6 +2870,36 @@
         "type": "number",
         "default": 20,
         "description": "Maximum results fetched per agent before merge."
+      },
+      "codexMaterializeMemories": {
+        "type": "boolean",
+        "default": true,
+        "description": "Materialize Remnic memories into Codex's native ~/.codex/memories/ layout so Codex's phase-2 read path picks up Remnic content without MCP roundtrips. Respects a .remnic-managed sentinel to honor user hand-edits."
+      },
+      "codexMaterializeNamespace": {
+        "type": "string",
+        "default": "auto",
+        "description": "Namespace to materialize into the Codex memories layout. 'auto' derives the namespace from the connector context."
+      },
+      "codexMaterializeMaxSummaryTokens": {
+        "type": "number",
+        "default": 4500,
+        "description": "Maximum whitespace-tokenized size of the materialized memory_summary.md. Default 4500 leaves headroom under Codex's 5000-token summary budget."
+      },
+      "codexMaterializeRolloutRetentionDays": {
+        "type": "number",
+        "default": 30,
+        "description": "Number of days to retain files under rollout_summaries/ before pruning during materialization."
+      },
+      "codexMaterializeOnConsolidation": {
+        "type": "boolean",
+        "default": true,
+        "description": "Trigger Codex materialization after semantic or causal consolidation completes for a namespace."
+      },
+      "codexMaterializeOnSessionEnd": {
+        "type": "boolean",
+        "default": true,
+        "description": "Trigger Codex materialization from the plugin-codex session-end hook."
       }
     }
   },

--- a/packages/plugin-codex/bin/materialize.cjs
+++ b/packages/plugin-codex/bin/materialize.cjs
@@ -1,0 +1,201 @@
+#!/usr/bin/env node
+/**
+ * @remnic/plugin-codex materialize binary.
+ *
+ * This is the packaged runtime entrypoint the session-end hook calls when a
+ * user runs Remnic inside a published install. The hook used to shell out
+ * to `scripts/codex-materialize.ts` via tsx, but that file is NOT shipped in
+ * any published package payload — only developer source checkouts have it.
+ * See PR #392 review thread PRRT_kwDORJXyws56TOVo.
+ *
+ * This wrapper:
+ *  1. Loads the published `@remnic/core` ESM bundle via dynamic import.
+ *  2. Re-parses argv in the same shape `scripts/codex-materialize.ts` uses
+ *     (`--namespace`, `--codex-home`, `--memory-dir`, `--reason`, `--json`).
+ *  3. Resolves the user's OpenClaw/Remnic config from the same search paths
+ *     the dev script uses, so behavior is identical between dev and
+ *     distributed installs.
+ *  4. Delegates to `runCodexMaterialize` and surfaces the result.
+ *
+ * Exits 0 on success (including intentional skips), non-zero only on hard
+ * failures callers actually need to notice.
+ */
+
+/* eslint-disable no-console */
+
+"use strict";
+
+const path = require("node:path");
+const fs = require("node:fs");
+
+function parseArgs(argv) {
+  const args = {
+    namespace: undefined,
+    codexHome: undefined,
+    memoryDir: undefined,
+    reason: "cli",
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--namespace":
+      case "-n":
+        args.namespace = argv[++i];
+        break;
+      case "--codex-home":
+        args.codexHome = argv[++i];
+        break;
+      case "--memory-dir":
+        args.memoryDir = argv[++i];
+        break;
+      case "--reason":
+        args.reason = argv[++i] || "cli";
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "-h":
+      case "--help":
+        args.help = true;
+        break;
+      default:
+        // ignore unknown tokens — keeps the hook loosely coupled
+        break;
+    }
+  }
+  return args;
+}
+
+/**
+ * Pull out the Remnic plugin config block from an OpenClaw-shaped or
+ * legacy-Remnic-shaped raw config object.
+ *
+ * OpenClaw stores Remnic settings under
+ * `plugins.entries["openclaw-engram"].config`; the legacy Remnic/Engram
+ * layouts kept them at the top level.
+ */
+function unwrapOpenClawEntry(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const entry =
+    raw.plugins && typeof raw.plugins === "object"
+      ? raw.plugins.entries
+      : undefined;
+  const pluginConfig =
+    entry && typeof entry === "object" && entry["openclaw-engram"]
+      ? entry["openclaw-engram"].config
+      : undefined;
+  if (pluginConfig && typeof pluginConfig === "object") {
+    return pluginConfig;
+  }
+  // Legacy / developer config layout — the top-level object IS the config.
+  return raw;
+}
+
+function loadRawConfig() {
+  const home = process.env.HOME || "";
+  const openclawConfigPath =
+    process.env.OPENCLAW_ENGRAM_CONFIG_PATH ||
+    process.env.OPENCLAW_CONFIG_PATH ||
+    path.join(home, ".openclaw", "openclaw.json");
+  const candidates = [
+    process.env.REMNIC_CONFIG,
+    openclawConfigPath,
+    path.join(home, ".config", "remnic", "config.json"),
+    path.join(home, ".config", "engram", "config.json"),
+    path.join(home, ".remnic", "config.json"),
+  ].filter((p) => typeof p === "string" && p.length > 0);
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    try {
+      const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+      const unwrapped = unwrapOpenClawEntry(raw);
+      if (unwrapped) return unwrapped;
+    } catch (_err) {
+      // fall through to next candidate
+    }
+  }
+  return {};
+}
+
+function printHelp() {
+  console.log(
+    [
+      "codex-materialize — render Remnic memories into ~/.codex/memories/",
+      "",
+      "Usage: node bin/materialize.cjs [options]",
+      "",
+      "Options:",
+      "  --namespace <name>    Namespace to materialize (default: config / 'default')",
+      "  --memory-dir <path>   Override memory directory",
+      "  --codex-home <path>   Override <codex_home>",
+      "  --reason <string>     Logged reason tag (cli | session_end | consolidation | manual)",
+      "  --json                Emit the result as JSON",
+      "  -h, --help            Show this help",
+    ].join("\n"),
+  );
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printHelp();
+    return 0;
+  }
+
+  // Dynamic import because @remnic/core is ESM-only.
+  const core = await import("@remnic/core");
+  const { parseConfig, runCodexMaterialize } = core;
+  if (typeof parseConfig !== "function" || typeof runCodexMaterialize !== "function") {
+    throw new Error(
+      "codex-materialize: @remnic/core is missing expected exports (parseConfig, runCodexMaterialize)",
+    );
+  }
+
+  const rawConfig = loadRawConfig();
+  const config = parseConfig(rawConfig);
+  if (args.memoryDir) {
+    // parseConfig already locked in a memoryDir, but the CLI override wins.
+    config.memoryDir = args.memoryDir;
+  }
+
+  const result = await runCodexMaterialize({
+    config,
+    namespace: args.namespace,
+    memoryDir: args.memoryDir,
+    codexHome: args.codexHome,
+    reason: args.reason,
+  });
+
+  if (args.json) {
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result === null) {
+    console.log("codex-materialize: skipped (disabled or guarded)");
+  } else if (result.skippedNoSentinel) {
+    console.log(
+      `codex-materialize: sentinel missing in ${result.memoriesDir}; skipped to honor hand-edits`,
+    );
+  } else if (result.skippedIdempotent) {
+    console.log(
+      `codex-materialize: no changes for namespace=${result.namespace} (hash unchanged)`,
+    );
+  } else {
+    console.log(
+      `codex-materialize: wrote ${result.filesWritten.length} file(s) for namespace=${result.namespace}`,
+    );
+  }
+
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (error) => {
+    console.error(
+      `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  },
+);

--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -102,4 +102,21 @@ rmdir "/tmp/remnic-lock-${SESSION_ID}.d" 2>/dev/null
 rm -f "/tmp/engram-cursor-${SESSION_ID}" 2>/dev/null
 rmdir "/tmp/engram-lock-${SESSION_ID}.d" 2>/dev/null
 
+# Codex-native memory materialization (#378). The script honors the
+# `codexMaterializeMemories` config flag and the `.remnic-managed` sentinel,
+# so it's safe to run unconditionally here.
+if [ "${REMNIC_CODEX_MATERIALIZE:-1}" != "0" ]; then
+  REMNIC_REPO_ROOT="${REMNIC_REPO_ROOT:-}"
+  if [ -z "$REMNIC_REPO_ROOT" ] && command -v remnic >/dev/null 2>&1; then
+    REMNIC_REPO_ROOT="$(remnic --print-root 2>/dev/null || true)"
+  fi
+  if [ -n "$REMNIC_REPO_ROOT" ] && [ -f "${REMNIC_REPO_ROOT}/scripts/codex-materialize.ts" ]; then
+    (
+      cd "$REMNIC_REPO_ROOT"
+      npx --yes tsx scripts/codex-materialize.ts --reason session_end >> "$LOG" 2>&1 || \
+        log "codex-materialize session_end failed"
+    )
+  fi
+fi
+
 exit 0

--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -105,10 +105,32 @@ rmdir "/tmp/engram-lock-${SESSION_ID}.d" 2>/dev/null
 # Codex-native memory materialization (#378). The script honors the
 # `codexMaterializeMemories` config flag and the `.remnic-managed` sentinel,
 # so it's safe to run unconditionally here.
+#
+# Root-resolution order (first hit wins):
+#   1. $REMNIC_REPO_ROOT — explicit override from the environment.
+#   2. Hook's own filesystem location. This script ships inside the repo at
+#      `packages/plugin-codex/hooks/bin/session-end.sh`, so `<this script>/../../../..`
+#      is the repo root. We resolve through `cd -P` so symlinked checkouts
+#      (pnpm hoisted installs, worktree copies) still land at the real path.
+#      This is the reliable source the P1 review asked for — it does not
+#      depend on any optional CLI sub-command that may not exist.
+#   3. If neither of the above yielded a usable path, we log the miss and
+#      exit the block without running the materializer, rather than silently
+#      skipping. A verbose log line is strictly better than a mysterious
+#      no-op when `codexMaterializeMemories=true`.
 if [ "${REMNIC_CODEX_MATERIALIZE:-1}" != "0" ]; then
   REMNIC_REPO_ROOT="${REMNIC_REPO_ROOT:-}"
-  if [ -z "$REMNIC_REPO_ROOT" ] && command -v remnic >/dev/null 2>&1; then
-    REMNIC_REPO_ROOT="$(remnic --print-root 2>/dev/null || true)"
+  if [ -z "$REMNIC_REPO_ROOT" ]; then
+    # Resolve relative to this script. BASH_SOURCE[0] is robust against
+    # symlinks / sourced execution; we chase the dirname with `cd -P` so the
+    # final path is fully physical (no symlink components).
+    HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || HOOK_DIR=""
+    if [ -n "$HOOK_DIR" ]; then
+      CANDIDATE_ROOT="$(cd -P "${HOOK_DIR}/../../../.." 2>/dev/null && pwd)" || CANDIDATE_ROOT=""
+      if [ -n "$CANDIDATE_ROOT" ] && [ -f "${CANDIDATE_ROOT}/scripts/codex-materialize.ts" ]; then
+        REMNIC_REPO_ROOT="$CANDIDATE_ROOT"
+      fi
+    fi
   fi
   if [ -n "$REMNIC_REPO_ROOT" ] && [ -f "${REMNIC_REPO_ROOT}/scripts/codex-materialize.ts" ]; then
     (
@@ -116,6 +138,8 @@ if [ "${REMNIC_CODEX_MATERIALIZE:-1}" != "0" ]; then
       npx --yes tsx scripts/codex-materialize.ts --reason session_end >> "$LOG" 2>&1 || \
         log "codex-materialize session_end failed"
     )
+  else
+    log "codex-materialize skipped — could not resolve REMNIC_REPO_ROOT (hook_dir=${HOOK_DIR:-unset})"
   fi
 fi
 

--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -106,40 +106,57 @@ rmdir "/tmp/engram-lock-${SESSION_ID}.d" 2>/dev/null
 # `codexMaterializeMemories` config flag and the `.remnic-managed` sentinel,
 # so it's safe to run unconditionally here.
 #
-# Root-resolution order (first hit wins):
-#   1. $REMNIC_REPO_ROOT — explicit override from the environment.
-#   2. Hook's own filesystem location. This script ships inside the repo at
-#      `packages/plugin-codex/hooks/bin/session-end.sh`, so `<this script>/../../../..`
-#      is the repo root. We resolve through `cd -P` so symlinked checkouts
-#      (pnpm hoisted installs, worktree copies) still land at the real path.
-#      This is the reliable source the P1 review asked for — it does not
-#      depend on any optional CLI sub-command that may not exist.
-#   3. If neither of the above yielded a usable path, we log the miss and
-#      exit the block without running the materializer, rather than silently
-#      skipping. A verbose log line is strictly better than a mysterious
-#      no-op when `codexMaterializeMemories=true`.
+# Entrypoint-resolution order (first hit wins):
+#   1. $REMNIC_CODEX_MATERIALIZE_BIN — explicit override from the environment.
+#      Set this to point at a custom Node wrapper if you need to short-circuit
+#      the search order.
+#   2. The packaged CJS wrapper shipped with @remnic/plugin-codex at
+#      `packages/plugin-codex/bin/materialize.cjs`, resolved relative to this
+#      hook's own filesystem location. This is the preferred path for
+#      published installs — the wrapper imports `@remnic/core` directly and
+#      has zero dependency on the source tree. We resolve the path via
+#      `BASH_SOURCE[0]` + `cd -P` so symlinked checkouts (pnpm hoisted
+#      installs, worktree copies) land on the real file.
+#   3. Dev fallback: `scripts/codex-materialize.ts` at the repo root. Only
+#      present in source checkouts — we use it when the packaged bin isn't
+#      available, so local developers keep working without having to run a
+#      build first. See PR #392 review thread PRRT_kwDORJXyws56TOVo for why
+#      we can't rely on this in distributed installs.
+#   4. If neither yielded a usable path, we log the miss and exit the block
+#      without running the materializer. A verbose log line is strictly
+#      better than a mysterious no-op when `codexMaterializeMemories=true`.
 if [ "${REMNIC_CODEX_MATERIALIZE:-1}" != "0" ]; then
-  REMNIC_REPO_ROOT="${REMNIC_REPO_ROOT:-}"
-  if [ -z "$REMNIC_REPO_ROOT" ]; then
-    # Resolve relative to this script. BASH_SOURCE[0] is robust against
-    # symlinks / sourced execution; we chase the dirname with `cd -P` so the
-    # final path is fully physical (no symlink components).
-    HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || HOOK_DIR=""
-    if [ -n "$HOOK_DIR" ]; then
-      CANDIDATE_ROOT="$(cd -P "${HOOK_DIR}/../../../.." 2>/dev/null && pwd)" || CANDIDATE_ROOT=""
-      if [ -n "$CANDIDATE_ROOT" ] && [ -f "${CANDIDATE_ROOT}/scripts/codex-materialize.ts" ]; then
-        REMNIC_REPO_ROOT="$CANDIDATE_ROOT"
-      fi
+  HOOK_DIR="$(cd -P "$(dirname "${BASH_SOURCE[0]}")" 2>/dev/null && pwd)" || HOOK_DIR=""
+
+  MATERIALIZE_BIN="${REMNIC_CODEX_MATERIALIZE_BIN:-}"
+  if [ -z "$MATERIALIZE_BIN" ] && [ -n "$HOOK_DIR" ]; then
+    # hooks/bin/session-end.sh → ../../bin/materialize.cjs lands at
+    # packages/plugin-codex/bin/materialize.cjs.
+    CANDIDATE_BIN="${HOOK_DIR}/../../bin/materialize.cjs"
+    if [ -f "$CANDIDATE_BIN" ]; then
+      MATERIALIZE_BIN="$(cd -P "$(dirname "$CANDIDATE_BIN")" 2>/dev/null && pwd)/$(basename "$CANDIDATE_BIN")" || MATERIALIZE_BIN=""
     fi
   fi
-  if [ -n "$REMNIC_REPO_ROOT" ] && [ -f "${REMNIC_REPO_ROOT}/scripts/codex-materialize.ts" ]; then
+
+  REMNIC_REPO_ROOT="${REMNIC_REPO_ROOT:-}"
+  if [ -z "$REMNIC_REPO_ROOT" ] && [ -n "$HOOK_DIR" ]; then
+    CANDIDATE_ROOT="$(cd -P "${HOOK_DIR}/../../../.." 2>/dev/null && pwd)" || CANDIDATE_ROOT=""
+    if [ -n "$CANDIDATE_ROOT" ] && [ -f "${CANDIDATE_ROOT}/scripts/codex-materialize.ts" ]; then
+      REMNIC_REPO_ROOT="$CANDIDATE_ROOT"
+    fi
+  fi
+
+  if [ -n "$MATERIALIZE_BIN" ] && [ -f "$MATERIALIZE_BIN" ]; then
+    node "$MATERIALIZE_BIN" --reason session_end >> "$LOG" 2>&1 || \
+      log "codex-materialize session_end failed (packaged bin=${MATERIALIZE_BIN})"
+  elif [ -n "$REMNIC_REPO_ROOT" ] && [ -f "${REMNIC_REPO_ROOT}/scripts/codex-materialize.ts" ]; then
     (
       cd "$REMNIC_REPO_ROOT"
       npx --yes tsx scripts/codex-materialize.ts --reason session_end >> "$LOG" 2>&1 || \
-        log "codex-materialize session_end failed"
+        log "codex-materialize session_end failed (dev script)"
     )
   else
-    log "codex-materialize skipped — could not resolve REMNIC_REPO_ROOT (hook_dir=${HOOK_DIR:-unset})"
+    log "codex-materialize skipped — could not resolve packaged bin or REMNIC_REPO_ROOT (hook_dir=${HOOK_DIR:-unset})"
   fi
 fi
 

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -20,8 +20,12 @@
   "private": true,
   "files": [
     ".codex-plugin",
+    "bin",
     "hooks",
     "skills",
     ".mcp.json"
-  ]
+  ],
+  "dependencies": {
+    "@remnic/core": "workspace:*"
+  }
 }

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -21,7 +21,7 @@ import { FallbackLlmClient } from "./fallback-llm.js";
 import type { GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
 import path from "node:path";
 import { log } from "./logger.js";
-import { runCodexMaterialize } from "./connectors/codex-materialize-runner.js";
+import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
 import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -350,25 +350,7 @@ export async function materializeAfterCausalConsolidation(options: {
   rolloutSummaries?: RolloutSummaryInput[];
   now?: Date;
 }): Promise<MaterializeResult | null> {
-  if (!options.config.codexMaterializeMemories) return null;
-  if (!options.config.codexMaterializeOnConsolidation) return null;
-  try {
-    return await runCodexMaterialize({
-      config: options.config,
-      namespace: options.namespace,
-      memories: options.memories,
-      memoryDir: options.memoryDir,
-      codexHome: options.codexHome,
-      rolloutSummaries: options.rolloutSummaries,
-      now: options.now,
-      reason: "consolidation",
-    });
-  } catch (error) {
-    log.warn(
-      `[cmc] Codex materialize post-hook failed (non-fatal): ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return null;
-  }
+  // Delegates to the shared post-consolidation helper — see
+  // runPostConsolidationMaterialize in codex-materialize-runner.ts.
+  return runPostConsolidationMaterialize("[cmc]", options);
 }

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -18,9 +18,11 @@ import { readChainIndex, resolveChainsDir, type CausalChainIndex, type CausalEdg
 import { listJsonFiles, readJsonFile } from "./json-store.js";
 import { isRecord } from "./store-contract.js";
 import { FallbackLlmClient } from "./fallback-llm.js";
-import type { GatewayConfig } from "./types.js";
+import type { GatewayConfig, MemoryFile, PluginConfig } from "./types.js";
 import path from "node:path";
 import { log } from "./logger.js";
+import { runCodexMaterialize } from "./connectors/codex-materialize-runner.js";
+import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -326,6 +328,47 @@ export async function synthesizeCausalPreferencesViaLlm(options: {
     return lines.join("\n");
   } catch (error) {
     log.warn(`[cmc] preference synthesis failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`);
+    return null;
+  }
+}
+
+/**
+ * Optional post-consolidation hook — materializes Codex-native memory artifacts
+ * after a causal consolidation run. Guarded by `codexMaterializeMemories` and
+ * `codexMaterializeOnConsolidation`. Returns `null` when disabled or when the
+ * sentinel is missing (honors user hand-edits).
+ *
+ * Split from the orchestrator-owned flow so #378 avoids touching
+ * orchestrator.ts while Wave 1 edits are in flight.
+ */
+export async function materializeAfterCausalConsolidation(options: {
+  config: PluginConfig;
+  namespace?: string;
+  memories?: MemoryFile[];
+  memoryDir?: string;
+  codexHome?: string;
+  rolloutSummaries?: RolloutSummaryInput[];
+  now?: Date;
+}): Promise<MaterializeResult | null> {
+  if (!options.config.codexMaterializeMemories) return null;
+  if (!options.config.codexMaterializeOnConsolidation) return null;
+  try {
+    return await runCodexMaterialize({
+      config: options.config,
+      namespace: options.namespace,
+      memories: options.memories,
+      memoryDir: options.memoryDir,
+      codexHome: options.codexHome,
+      rolloutSummaries: options.rolloutSummaries,
+      now: options.now,
+      reason: "consolidation",
+    });
+  } catch (error) {
+    log.warn(
+      `[cmc] Codex materialize post-hook failed (non-fatal): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
     return null;
   }
 }

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -498,7 +498,7 @@ export class CompoundingEngine {
       : [];
     if (this.config.cmcConsolidationEnabled) {
       try {
-        const { deriveCausalPromotionCandidates } = await import("../causal-consolidation.js");
+        const { deriveCausalPromotionCandidates, materializeAfterCausalConsolidation } = await import("../causal-consolidation.js");
         const causalCandidates = await deriveCausalPromotionCandidates({
           memoryDir: this.config.memoryDir,
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
@@ -512,6 +512,25 @@ export class CompoundingEngine {
         });
         if (causalCandidates.length > 0) {
           promotionCandidates = [...promotionCandidates, ...causalCandidates];
+        }
+        // #378: fire the Codex materialize post-hook so
+        // `codexMaterializeOnConsolidation` actually has a runtime effect
+        // when the causal consolidation path runs. The helper silently no-ops
+        // when the feature flag or the per-trigger toggle is off, when the
+        // sentinel is missing, or when nothing has changed since the previous
+        // run. Wrapped in its own try/catch so a failed materialize never
+        // aborts weekly synthesis.
+        try {
+          await materializeAfterCausalConsolidation({
+            config: this.config,
+            memoryDir: this.config.memoryDir,
+          });
+        } catch (materializeError) {
+          log.warn(
+            `[cmc] Codex materialize post-hook failed (non-fatal): ${
+              materializeError instanceof Error ? materializeError.message : String(materializeError)
+            }`,
+          );
         }
       } catch (error) {
         log.warn(`[cmc] causal consolidation in synthesizeWeekly failed (non-fatal): ${error instanceof Error ? error.message : String(error)}`);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1561,6 +1561,23 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.parallelMaxResultsPerAgent === "number"
         ? Math.max(0, Math.floor(cfg.parallelMaxResultsPerAgent))
         : 20,
+
+    // Codex CLI — native memory materialization (#378)
+    codexMaterializeMemories: cfg.codexMaterializeMemories !== false,
+    codexMaterializeNamespace:
+      typeof cfg.codexMaterializeNamespace === "string" && cfg.codexMaterializeNamespace.trim().length > 0
+        ? cfg.codexMaterializeNamespace.trim()
+        : "auto",
+    codexMaterializeMaxSummaryTokens:
+      typeof cfg.codexMaterializeMaxSummaryTokens === "number"
+        ? Math.max(0, Math.floor(cfg.codexMaterializeMaxSummaryTokens))
+        : 4500,
+    codexMaterializeRolloutRetentionDays:
+      typeof cfg.codexMaterializeRolloutRetentionDays === "number"
+        ? Math.max(0, Math.floor(cfg.codexMaterializeRolloutRetentionDays))
+        : 30,
+    codexMaterializeOnConsolidation: cfg.codexMaterializeOnConsolidation !== false,
+    codexMaterializeOnSessionEnd: cfg.codexMaterializeOnSessionEnd !== false,
   };
 }
 

--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -10,6 +10,7 @@
  */
 
 import path from "node:path";
+import { existsSync } from "node:fs";
 
 import { log } from "../logger.js";
 import { StorageManager } from "../storage.js";
@@ -55,6 +56,16 @@ export async function runCodexMaterialize(
     return null;
   }
 
+  // Per-trigger gate: session-end runs must honor codexMaterializeOnSessionEnd.
+  // session-end.sh passes reason="session_end"; when the user has turned off the
+  // session-end trigger we short-circuit here without touching disk.
+  if (options.reason === "session_end" && cfg.codexMaterializeOnSessionEnd === false) {
+    log.debug(
+      `[codex-materialize] skipped — session-end disabled via codexMaterializeOnSessionEnd=false`,
+    );
+    return null;
+  }
+
   const namespace = resolveNamespace(options.namespace, cfg);
   const memoryDir = options.memoryDir ?? cfg.memoryDir;
   if (!memoryDir) {
@@ -66,7 +77,7 @@ export async function runCodexMaterialize(
   if (options.memories) {
     memories = options.memories;
   } else {
-    const nsDir = resolveNamespaceDir(memoryDir, namespace);
+    const nsDir = resolveNamespaceDir(memoryDir, namespace, cfg);
     const storage = new StorageManager(nsDir);
     try {
       memories = await storage.readAllMemories();
@@ -108,15 +119,41 @@ export async function runCodexMaterialize(
 function resolveNamespace(override: string | undefined, cfg: PluginConfig): string {
   const requested = (override ?? cfg.codexMaterializeNamespace ?? "auto").trim();
   if (requested.length === 0 || requested === "auto") {
-    return "default";
+    // When the caller asks for "auto", fall back to the configured default
+    // namespace (if any) so storage-root resolution lines up with what
+    // NamespaceStorageRouter would do for the same install.
+    return cfg.defaultNamespace && cfg.defaultNamespace.length > 0
+      ? cfg.defaultNamespace
+      : "default";
   }
   return requested;
 }
 
-function resolveNamespaceDir(memoryDir: string, namespace: string): string {
-  if (!namespace || namespace === "default") return memoryDir;
-  // Remnic stores namespaces under `memoryDir/<namespace>/` per the repo's
-  // existing convention; fall back to `memoryDir` itself if we cannot locate
-  // a dedicated subdir.
-  return path.join(memoryDir, namespace);
+/**
+ * Resolve the on-disk storage root for a namespace, matching
+ * `NamespaceStorageRouter` in `packages/remnic-core/src/namespaces/storage.ts`.
+ *
+ * Contract:
+ *  - When namespaces are disabled, every namespace maps to `memoryDir` itself.
+ *  - When namespaces are enabled, non-default namespaces always live under
+ *    `memoryDir/namespaces/<namespace>`.
+ *  - The default namespace prefers `memoryDir/namespaces/<defaultNamespace>`
+ *    when that directory already exists (migrated install); otherwise it
+ *    falls back to the legacy `memoryDir` root so materialization does not
+ *    silently switch directories out from under an existing install.
+ */
+function resolveNamespaceDir(
+  memoryDir: string,
+  namespace: string,
+  cfg: PluginConfig,
+): string {
+  if (!cfg.namespacesEnabled) return memoryDir;
+
+  const ns = namespace || cfg.defaultNamespace || "default";
+  const namespacedRoot = path.join(memoryDir, "namespaces", ns);
+
+  if (ns === cfg.defaultNamespace) {
+    return existsSync(namespacedRoot) ? namespacedRoot : memoryDir;
+  }
+  return namespacedRoot;
 }

--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -21,6 +21,17 @@ import {
   type RolloutSummaryInput,
 } from "./codex-materialize.js";
 
+/** Options accepted by the shared post-consolidation materialize helper. */
+export interface PostConsolidationMaterializeOptions {
+  config: PluginConfig;
+  namespace?: string;
+  memories?: MemoryFile[];
+  memoryDir?: string;
+  codexHome?: string;
+  rolloutSummaries?: RolloutSummaryInput[];
+  now?: Date;
+}
+
 /** Options accepted by the runner. */
 export interface RunMaterializeOptions {
   /** Remnic config — we only read the `codexMaterialize*` fields. */
@@ -109,6 +120,43 @@ export async function runCodexMaterialize(
   } catch (error) {
     log.warn(
       `[codex-materialize] run failed (non-fatal): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+/**
+ * Shared helper for post-consolidation materialize hooks.
+ *
+ * `materializeAfterSemanticConsolidation` and `materializeAfterCausalConsolidation`
+ * used to be two nearly-identical copies of this logic; keeping the actual
+ * body here means any future guard/logging change happens in one place.
+ *
+ * The only per-caller knob is `logPrefix`, which is used to tag the
+ * non-fatal warning emitted when the materializer throws.
+ */
+export async function runPostConsolidationMaterialize(
+  logPrefix: string,
+  options: PostConsolidationMaterializeOptions,
+): Promise<MaterializeResult | null> {
+  if (!options.config.codexMaterializeMemories) return null;
+  if (!options.config.codexMaterializeOnConsolidation) return null;
+  try {
+    return await runCodexMaterialize({
+      config: options.config,
+      namespace: options.namespace,
+      memories: options.memories,
+      memoryDir: options.memoryDir,
+      codexHome: options.codexHome,
+      rolloutSummaries: options.rolloutSummaries,
+      now: options.now,
+      reason: "consolidation",
+    });
+  } catch (error) {
+    log.warn(
+      `${logPrefix} Codex materialize post-hook failed (non-fatal): ${
         error instanceof Error ? error.message : String(error)
       }`,
     );

--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -102,29 +102,27 @@ export async function runCodexMaterialize(
     }
   }
 
-  try {
-    const result = materializeForNamespace(namespace, {
-      memories,
-      codexHome: options.codexHome,
-      maxSummaryTokens: cfg.codexMaterializeMaxSummaryTokens,
-      rolloutRetentionDays: cfg.codexMaterializeRolloutRetentionDays,
-      rolloutSummaries: options.rolloutSummaries,
-      now: options.now,
-    });
-    if (options.reason) {
-      log.debug(
-        `[codex-materialize] ran reason=${options.reason} wrote=${result.wrote} files=${result.filesWritten.length}`,
-      );
-    }
-    return result;
-  } catch (error) {
-    log.warn(
-      `[codex-materialize] run failed (non-fatal): ${
-        error instanceof Error ? error.message : String(error)
-      }`,
+  // Intentionally NOT catching here: per the JSDoc contract above,
+  // schema-validation and I/O errors from `materializeForNamespace` must
+  // surface to callers so they can exit non-zero (CLI) or log + recover
+  // (consolidation post-hook, which has its own narrower try/catch).
+  // Catching everything would make a broken MEMORY.md render look like a
+  // successful skip, and invisible failures are strictly worse than loud
+  // ones for a feature that writes to `~/.codex/memories`.
+  const result = materializeForNamespace(namespace, {
+    memories,
+    codexHome: options.codexHome,
+    maxSummaryTokens: cfg.codexMaterializeMaxSummaryTokens,
+    rolloutRetentionDays: cfg.codexMaterializeRolloutRetentionDays,
+    rolloutSummaries: options.rolloutSummaries,
+    now: options.now,
+  });
+  if (options.reason) {
+    log.debug(
+      `[codex-materialize] ran reason=${options.reason} wrote=${result.wrote} files=${result.filesWritten.length}`,
     );
-    return null;
   }
+  return result;
 }
 
 /**

--- a/packages/remnic-core/src/connectors/codex-materialize-runner.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize-runner.ts
@@ -1,0 +1,122 @@
+/**
+ * codex-materialize-runner.ts — Thin I/O bridge for the Codex materializer.
+ *
+ * The pure rendering logic lives in {@link ./codex-materialize.js}. This file
+ * is the place callers (consolidation hooks, CLI, session-end hook) go when
+ * they want the whole "load memories from storage → render → write" flow.
+ *
+ * Kept deliberately small so #378 never has to reach into orchestrator.ts /
+ * importance.ts — the two files Wave 1 agents are editing concurrently.
+ */
+
+import path from "node:path";
+
+import { log } from "../logger.js";
+import { StorageManager } from "../storage.js";
+import type { PluginConfig, MemoryFile } from "../types.js";
+import {
+  materializeForNamespace,
+  type MaterializeResult,
+  type RolloutSummaryInput,
+} from "./codex-materialize.js";
+
+/** Options accepted by the runner. */
+export interface RunMaterializeOptions {
+  /** Remnic config — we only read the `codexMaterialize*` fields. */
+  config: PluginConfig;
+  /** Namespace to materialize. Overrides the config's `codexMaterializeNamespace`. */
+  namespace?: string;
+  /** Override the memory directory (defaults to `config.memoryDir`). */
+  memoryDir?: string;
+  /** Override `<codex_home>` (useful for tests). */
+  codexHome?: string;
+  /** Optional pre-loaded memories (bypasses disk read — used in tests). */
+  memories?: MemoryFile[];
+  /** Optional rollout summaries supplied by the caller. */
+  rolloutSummaries?: RolloutSummaryInput[];
+  /** Current time injection for deterministic runs. */
+  now?: Date;
+  /** Reason string — logged for observability. */
+  reason?: "consolidation" | "session_end" | "manual" | "cli";
+}
+
+/**
+ * Run the Codex materialization end-to-end. Returns `null` when the feature
+ * is disabled in config or when the user hasn't opted in via the sentinel.
+ * Never throws for "expected" skips; only throws on schema validation or I/O
+ * errors that callers actually need to surface.
+ */
+export async function runCodexMaterialize(
+  options: RunMaterializeOptions,
+): Promise<MaterializeResult | null> {
+  const cfg = options.config;
+  if (!cfg.codexMaterializeMemories) {
+    log.debug(`[codex-materialize] skipped — codexMaterializeMemories=false`);
+    return null;
+  }
+
+  const namespace = resolveNamespace(options.namespace, cfg);
+  const memoryDir = options.memoryDir ?? cfg.memoryDir;
+  if (!memoryDir) {
+    log.warn(`[codex-materialize] skipped — no memoryDir available`);
+    return null;
+  }
+
+  let memories: MemoryFile[];
+  if (options.memories) {
+    memories = options.memories;
+  } else {
+    const nsDir = resolveNamespaceDir(memoryDir, namespace);
+    const storage = new StorageManager(nsDir);
+    try {
+      memories = await storage.readAllMemories();
+    } catch (error) {
+      log.warn(
+        `[codex-materialize] skipped — failed to read memories from ${nsDir}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+      return null;
+    }
+  }
+
+  try {
+    const result = materializeForNamespace(namespace, {
+      memories,
+      codexHome: options.codexHome,
+      maxSummaryTokens: cfg.codexMaterializeMaxSummaryTokens,
+      rolloutRetentionDays: cfg.codexMaterializeRolloutRetentionDays,
+      rolloutSummaries: options.rolloutSummaries,
+      now: options.now,
+    });
+    if (options.reason) {
+      log.debug(
+        `[codex-materialize] ran reason=${options.reason} wrote=${result.wrote} files=${result.filesWritten.length}`,
+      );
+    }
+    return result;
+  } catch (error) {
+    log.warn(
+      `[codex-materialize] run failed (non-fatal): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
+}
+
+function resolveNamespace(override: string | undefined, cfg: PluginConfig): string {
+  const requested = (override ?? cfg.codexMaterializeNamespace ?? "auto").trim();
+  if (requested.length === 0 || requested === "auto") {
+    return "default";
+  }
+  return requested;
+}
+
+function resolveNamespaceDir(memoryDir: string, namespace: string): string {
+  if (!namespace || namespace === "default") return memoryDir;
+  // Remnic stores namespaces under `memoryDir/<namespace>/` per the repo's
+  // existing convention; fall back to `memoryDir` itself if we cannot locate
+  // a dedicated subdir.
+  return path.join(memoryDir, namespace);
+}

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -48,7 +48,6 @@ import {
   readFileSync,
   renameSync,
   rmSync,
-  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -227,10 +226,17 @@ export function materializeForNamespace(
   const rawMemories = renderRawMemories({ memories });
 
   const retainedRollouts = pruneRollouts(rolloutSummaries, rolloutRetentionDays, now);
-  const rolloutFiles = retainedRollouts.map((r) => ({
-    name: `${sanitizeSlug(r.slug)}.md`,
-    body: renderRolloutSummary(r),
-  }));
+  // Deduplicate on sanitized filename. Two different slugs ("Session 1" and
+  // "session_1") can sanitize to the same output ("session-1"), which would
+  // otherwise make the first entry's tmp file get overwritten and cause the
+  // later rename step to crash with ENOENT. We keep the *last* entry with a
+  // given sanitized name so the most-recent rollout for that slot wins.
+  const rolloutFileMap = new Map<string, { name: string; body: string }>();
+  for (const r of retainedRollouts) {
+    const name = `${sanitizeSlug(r.slug)}.md`;
+    rolloutFileMap.set(name, { name, body: renderRolloutSummary(r) });
+  }
+  const rolloutFiles = [...rolloutFileMap.values()];
 
   // ── Idempotence check ──────────────────────────────────────────────────
   const hash = computeContentHash({
@@ -819,15 +825,6 @@ export function describeMemoriesDir(memoriesDir: string): {
           files.push(path.join(ROLLOUT_SUBDIR, entry.name));
         }
       }
-    } catch {
-      // ignore
-    }
-  }
-  // Touch statSync so the compiler doesn't drop the import if unused in
-  // future edits — and it's genuinely useful when callers want mtimes.
-  if (files.length > 0) {
-    try {
-      statSync(path.join(memoriesDir, files[0]));
     } catch {
       // ignore
     }

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -752,7 +752,13 @@ function pruneRollouts(
   retentionDays: number,
   now: Date,
 ): RolloutSummaryInput[] {
-  if (retentionDays <= 0) return rollouts;
+  // Negative retention → "infinite retention" escape hatch. `parseConfig`
+  // clamps the knob to >= 0, so in practice only callers passing a negative
+  // value intentionally get the all-pass behavior.
+  if (retentionDays < 0) return rollouts;
+  // retentionDays === 0 → cutoff is exactly `now`, which prunes every
+  // rollout whose `updatedAt` is in the past (i.e. all of them in practice).
+  // This matches the documented semantics of "retain for 0 days".
   const cutoffMs = now.getTime() - retentionDays * 24 * 60 * 60 * 1000;
   return rollouts.filter((r) => {
     if (!r.updatedAt) return true;

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -48,6 +48,7 @@ import {
   readFileSync,
   renameSync,
   rmSync,
+  statSync,
   unlinkSync,
   writeFileSync,
 } from "node:fs";
@@ -207,10 +208,42 @@ export function materializeForNamespace(
   const rolloutsSupplied = options.rolloutSummaries !== undefined;
   const rolloutSummaries = options.rolloutSummaries ?? [];
 
+  // Prune-before-render: MEMORY.md and memory_summary.md both embed rollout
+  // filenames in their body, so they must only ever see the *retained* set.
+  // Running pruneRollouts after the renderers (as an earlier revision did)
+  // caused MEMORY.md to list `rollout_summaries/<slug>.md` paths for rollouts
+  // that were then pruned and never written — a broken link pointing at a
+  // ghost file. See review feedback on PR #392.
+  const retainedRollouts = pruneRollouts(rolloutSummaries, rolloutRetentionDays, now);
+
+  // Deduplicate on sanitized filename. Two different slugs ("Session 1" and
+  // "session!!!1") can sanitize to the same output ("session-1"), which would
+  // otherwise make the first entry's tmp file get overwritten and cause the
+  // later rename step to crash with ENOENT. We keep the *last* entry with a
+  // given sanitized name so the most-recent rollout for that slot wins.
+  // We do this at the retained-input level (not just at the written-file
+  // level) so MEMORY.md's "rollout_summary_files" section lists each slot
+  // exactly once and matches what actually gets written to disk.
+  const dedupedRollouts: RolloutSummaryInput[] = [];
+  const seenNames = new Map<string, number>();
+  for (const r of retainedRollouts) {
+    const name = `${sanitizeSlug(r.slug)}.md`;
+    const existingIdx = seenNames.get(name);
+    if (existingIdx === undefined) {
+      seenNames.set(name, dedupedRollouts.length);
+      dedupedRollouts.push(r);
+    } else {
+      // Last-wins: replace the previous entry with this one so the newest
+      // rollout for that filename slot is what MEMORY.md and the rendered
+      // file both reflect.
+      dedupedRollouts[existingIdx] = r;
+    }
+  }
+
   const memorySummary = renderMemorySummary({
     namespace,
     memories,
-    rolloutSummaries,
+    rolloutSummaries: dedupedRollouts,
     maxTokens: maxSummaryTokens,
     now,
   });
@@ -218,7 +251,7 @@ export function materializeForNamespace(
   const memoryMd = renderMemoryMd({
     namespace,
     memories,
-    rolloutSummaries,
+    rolloutSummaries: dedupedRollouts,
     now,
   });
 
@@ -232,18 +265,10 @@ export function materializeForNamespace(
 
   const rawMemories = renderRawMemories({ memories });
 
-  const retainedRollouts = pruneRollouts(rolloutSummaries, rolloutRetentionDays, now);
-  // Deduplicate on sanitized filename. Two different slugs ("Session 1" and
-  // "session_1") can sanitize to the same output ("session-1"), which would
-  // otherwise make the first entry's tmp file get overwritten and cause the
-  // later rename step to crash with ENOENT. We keep the *last* entry with a
-  // given sanitized name so the most-recent rollout for that slot wins.
-  const rolloutFileMap = new Map<string, { name: string; body: string }>();
-  for (const r of retainedRollouts) {
-    const name = `${sanitizeSlug(r.slug)}.md`;
-    rolloutFileMap.set(name, { name, body: renderRolloutSummary(r) });
-  }
-  const rolloutFiles = [...rolloutFileMap.values()];
+  const rolloutFiles = dedupedRollouts.map((r) => ({
+    name: `${sanitizeSlug(r.slug)}.md`,
+    body: renderRolloutSummary(r),
+  }));
 
   // ── Idempotence check ──────────────────────────────────────────────────
   const hash = computeContentHash({
@@ -286,11 +311,45 @@ export function materializeForNamespace(
   }
 
   // ── Atomic writes ──────────────────────────────────────────────────────
-  const tmpDir = path.join(memoriesDir, TMP_DIR);
+  // Use a unique, per-run staging sub-directory so two overlapping runs
+  // (e.g. a session-end trigger overlapping with a consolidation post-hook)
+  // can't stomp each other's tmp files mid-rename. The old "fixed TMP_DIR,
+  // wipe-on-entry" layout meant run B would delete run A's staging area out
+  // from under it, causing ENOENT on A's rename loop. Per-run uniqueness
+  // turns the shared dir into an insulated workspace. See review feedback on
+  // PR #392.
+  const runTag = `${process.pid}-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+  const tmpDir = path.join(memoriesDir, `${TMP_DIR}-${runTag}`);
+  // Opportunistic GC for stale scratch dirs left behind by a previous
+  // crashed run. We only remove entries whose mtime is older than the
+  // stale-threshold below — that way we never delete another in-flight
+  // run's staging area out from under it. The threshold is deliberately
+  // generous (1h) because a healthy materialize completes in milliseconds
+  // and there's no legitimate reason for a live staging dir to be older.
+  //
+  // NB: we compare against `Date.now()` (wall-clock), not against the
+  // injected `options.now`. Tests and deterministic replays commonly
+  // inject a non-current timestamp, but file mtimes on disk are always
+  // wall-clock, so mixing the two would either false-positive delete
+  // fresh dirs (test-time in the past) or false-negative skip stale ones
+  // (test-time in the future).
+  const TMP_STALE_MS = 60 * 60 * 1000;
+  const wallClockMs = Date.now();
   try {
-    rmSync(tmpDir, { recursive: true, force: true });
+    for (const entry of readdirSync(memoriesDir, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      if (!entry.name.startsWith(TMP_DIR)) continue;
+      const stalePath = path.join(memoriesDir, entry.name);
+      try {
+        const stat = statSync(stalePath);
+        if (wallClockMs - stat.mtimeMs < TMP_STALE_MS) continue;
+        rmSync(stalePath, { recursive: true, force: true });
+      } catch {
+        // ignore — another concurrent run may own it, or we lack perms
+      }
+    }
   } catch {
-    // ignore
+    // ignore — dir may not exist yet
   }
   mkdirSync(tmpDir, { recursive: true });
   mkdirSync(path.join(tmpDir, ROLLOUT_SUBDIR), { recursive: true });

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -180,15 +180,32 @@ export function materializeForNamespace(
       ? options.rolloutRetentionDays
       : 30;
 
-  mkdirSync(memoriesDir, { recursive: true });
-
   // ── Sentinel check ─────────────────────────────────────────────────────
+  // We deliberately do NOT `mkdirSync(memoriesDir)` before reading the
+  // sentinel: creating `~/.codex/memories/` for every user (including ones
+  // who never use Codex) would make Remnic's post-consolidation hook leave
+  // empty opt-in directories behind on disk. Instead we only check whether
+  // the sentinel already exists — if the parent dir doesn't exist, the
+  // sentinel can't exist either and we fall straight through to the skip
+  // path without touching the filesystem. The `mkdirSync` for `memoriesDir`
+  // happens later, only once we know we're actually going to write.
   const sentinelPath = path.join(memoriesDir, SENTINEL_FILE);
   const existingSentinel = readSentinel(sentinelPath);
   if (!existingSentinel) {
-    logger.warn(
-      `sentinel ${SENTINEL_FILE} missing in ${memoriesDir}; skipping materialization to preserve hand-edits`,
-    );
+    // Log at `debug` when the entire memories dir doesn't exist — that's
+    // the common "user never opted in" case and should not be noisy.
+    // Keep the `warn` level only when the dir exists but lacks a sentinel,
+    // which is the "user hand-curated layout, don't overwrite" case that
+    // genuinely warrants attention.
+    if (existsSync(memoriesDir)) {
+      logger.warn(
+        `sentinel ${SENTINEL_FILE} missing in ${memoriesDir}; skipping materialization to preserve hand-edits`,
+      );
+    } else {
+      logger.debug?.(
+        `skipping materialization — ${memoriesDir} does not exist (user not opted in)`,
+      );
+    }
     return {
       namespace,
       memoriesDir,
@@ -199,6 +216,13 @@ export function materializeForNamespace(
       contentHash: "",
     };
   }
+
+  // Now that we know the user has opted in (sentinel exists), it's safe to
+  // ensure the memories dir is present. In practice this is almost always a
+  // no-op because the sentinel read above already succeeded, but a defensive
+  // mkdirSync protects against a race where the dir was removed between the
+  // sentinel read and the first write.
+  mkdirSync(memoriesDir, { recursive: true });
 
   // ── Render ─────────────────────────────────────────────────────────────
   const memories = [...options.memories];
@@ -219,23 +243,34 @@ export function materializeForNamespace(
   // Deduplicate on sanitized filename. Two different slugs ("Session 1" and
   // "session!!!1") can sanitize to the same output ("session-1"), which would
   // otherwise make the first entry's tmp file get overwritten and cause the
-  // later rename step to crash with ENOENT. We keep the *last* entry with a
-  // given sanitized name so the most-recent rollout for that slot wins.
+  // later rename step to crash with ENOENT. For each collision slot we keep
+  // the entry with the newest `updatedAt` so an unsorted input (or a caller
+  // that accidentally appends older recaps after newer ones) can't have an
+  // older recap clobber a newer one.
   // We do this at the retained-input level (not just at the written-file
   // level) so MEMORY.md's "rollout_summary_files" section lists each slot
   // exactly once and matches what actually gets written to disk.
   const dedupedRollouts: RolloutSummaryInput[] = [];
   const seenNames = new Map<string, number>();
+  const parseTs = (value: string | undefined): number => {
+    if (!value) return Number.NEGATIVE_INFINITY;
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : Number.NEGATIVE_INFINITY;
+  };
   for (const r of retainedRollouts) {
     const name = `${sanitizeSlug(r.slug)}.md`;
     const existingIdx = seenNames.get(name);
     if (existingIdx === undefined) {
       seenNames.set(name, dedupedRollouts.length);
       dedupedRollouts.push(r);
-    } else {
-      // Last-wins: replace the previous entry with this one so the newest
-      // rollout for that filename slot is what MEMORY.md and the rendered
-      // file both reflect.
+      continue;
+    }
+    // Newest-wins: only replace the existing entry if the incoming one has a
+    // strictly newer timestamp. Ties keep the earlier entry (stable for
+    // unsorted inputs) because overwriting on ties would flip rendering output
+    // for benign call-order changes.
+    const existing = dedupedRollouts[existingIdx];
+    if (parseTs(r.updatedAt) > parseTs(existing.updatedAt)) {
       dedupedRollouts[existingIdx] = r;
     }
   }
@@ -245,14 +280,12 @@ export function materializeForNamespace(
     memories,
     rolloutSummaries: dedupedRollouts,
     maxTokens: maxSummaryTokens,
-    now,
   });
 
   const memoryMd = renderMemoryMd({
     namespace,
     memories,
     rolloutSummaries: dedupedRollouts,
-    now,
   });
 
   // Fail fast on schema issues — do not write garbage.
@@ -465,7 +498,12 @@ interface RenderContext {
   namespace: string;
   memories: MemoryFile[];
   rolloutSummaries: RolloutSummaryInput[];
-  now: Date;
+  // Historically this interface exposed a `now: Date` field, but neither
+  // `renderMemoryMd` nor `renderMemorySummary` ever read it (rendered output
+  // is purely a function of `namespace`, `memories`, and `rolloutSummaries`).
+  // The field was flagged as dead weight in PR #392 review and removed.
+  // If a future renderer needs a timestamp, re-add it here and update both
+  // call sites and the schema test.
 }
 
 interface SummaryRenderContext extends RenderContext {

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -1,0 +1,841 @@
+/**
+ * codex-materialize.ts — Codex CLI native memory artifact materialization (#378)
+ *
+ * Periodically writes Remnic memories into the file layout that Codex CLI's
+ * phase-2 consolidation reads directly under `<codex_home>/memories/`:
+ *
+ *   memory_summary.md                — always-loaded at session start (tight budget)
+ *   MEMORY.md                        — searchable handbook (task-group schema)
+ *   raw_memories.md                  — mechanical merge of raw memories, latest first
+ *   rollout_summaries/<slug>.md      — per-session recaps
+ *
+ * Codex's own read path is agnostic to which producer wrote these files — it
+ * tags reads by `memory_md` / `memory_summary` / `raw_memories` /
+ * `rollout_summaries` / `skills`. By materializing Remnic content into this
+ * exact layout we let Codex pick up Remnic memories without a single MCP call.
+ *
+ * Safety invariants
+ * ─────────────────
+ *  - **Atomic writes.** Every file is rendered under `.remnic-tmp/` and then
+ *    `rename()`d into place so Codex never observes a half-written file.
+ *  - **Sentinel-based opt-in.** If `<codex_home>/memories/.remnic-managed` is
+ *    missing, we SKIP materialization entirely and log a warning. This honors
+ *    user hand-edits to the directory — a user who manually curated their
+ *    Codex memory layout will never have those edits overwritten.
+ *  - **Schema validation.** `MEMORY.md` content is validated against the
+ *    task-group schema before write. Invalid content throws and nothing is
+ *    written.
+ *  - **Idempotent no-ops.** A content hash is written into the sentinel. If
+ *    the re-rendered hash matches the previous run, we skip writes entirely.
+ *  - **Token budget.** `memory_summary.md` is truncated to fit under the
+ *    configured token budget (whitespace-tokenized approximation), leaving
+ *    headroom under Codex's 5000-token summary cap.
+ *
+ * Privacy
+ * ───────
+ * This module does not persist any user content outside `<codex_home>/memories`
+ * — it only mirrors the memories that Remnic already wrote. It does not log
+ * memory content to stdout; it logs file names, counts, and hashes.
+ */
+
+import {
+  createHash,
+} from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  renameSync,
+  rmSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+import { log } from "../logger.js";
+import type { MemoryFile } from "../types.js";
+
+// ─── Types ─────────────────────────────────────────────────────────────────
+
+/**
+ * Input for {@link materializeForNamespace}. Prefer passing pre-loaded
+ * `memories` so this module stays I/O-agnostic and trivially testable.
+ */
+export interface MaterializeOptions {
+  /** Pre-loaded Remnic memories for this namespace (required). */
+  memories: MemoryFile[];
+  /** Override `<codex_home>`. Defaults to `$CODEX_HOME` or `~/.codex`. */
+  codexHome?: string;
+  /** Maximum whitespace-tokenized size of memory_summary.md. Default 4500. */
+  maxSummaryTokens?: number;
+  /** Maximum age of rollout_summaries/*.md in days. Default 30. */
+  rolloutRetentionDays?: number;
+  /** Per-session rollout summaries to render. */
+  rolloutSummaries?: RolloutSummaryInput[];
+  /** Current time, injected for deterministic tests. */
+  now?: Date;
+  /** Optional logger override for tests. */
+  logger?: { info: (msg: string) => void; warn: (msg: string) => void; debug?: (msg: string) => void };
+}
+
+/** Input describing one Codex rollout summary file. */
+export interface RolloutSummaryInput {
+  /** Stable slug for the file (becomes `<slug>.md`). */
+  slug: string;
+  /** Working directory used during the rollout. */
+  cwd?: string;
+  /** Path to the raw Codex rollout log, if known. */
+  rolloutPath?: string;
+  /** ISO-8601 timestamp of the last update. */
+  updatedAt?: string;
+  /** Opaque thread / session id. */
+  threadId?: string;
+  /** Markdown body for the recap. */
+  body: string;
+  /** Freeform keywords / search hints. */
+  keywords?: string[];
+}
+
+/** Result of a materialization run. */
+export interface MaterializeResult {
+  /** Namespace that was materialized. */
+  namespace: string;
+  /** `<codex_home>/memories` path this run targeted. */
+  memoriesDir: string;
+  /** Was anything actually written (vs. skipped / idempotent no-op)? */
+  wrote: boolean;
+  /** True if the sentinel was missing and we skipped with a warning. */
+  skippedNoSentinel: boolean;
+  /** True if the hash matched the previous run and we short-circuited. */
+  skippedIdempotent: boolean;
+  /** Files that were written this run (relative to `memoriesDir`). */
+  filesWritten: string[];
+  /** Content hash computed for this run. */
+  contentHash: string;
+}
+
+/** On-disk shape of the `.remnic-managed` sentinel. */
+interface SentinelFile {
+  version: number;
+  namespace: string;
+  updated_at: string;
+  content_hash: string;
+}
+
+// ─── Constants ─────────────────────────────────────────────────────────────
+
+/** Bump when the on-disk layout or semantics change. */
+export const MATERIALIZE_VERSION = 1;
+
+/** Sentinel file name at the root of the materialized memories dir. */
+export const SENTINEL_FILE = ".remnic-managed";
+
+/** Scratch directory used for atomic renames. */
+export const TMP_DIR = ".remnic-tmp";
+
+/** File names we own. Anything else in the directory is considered user-managed. */
+const OWNED_FILES = new Set<string>([
+  "memory_summary.md",
+  "MEMORY.md",
+  "raw_memories.md",
+]);
+
+/** Sub-directory for per-session rollout recaps. */
+const ROLLOUT_SUBDIR = "rollout_summaries";
+
+// ─── Public entry points ───────────────────────────────────────────────────
+
+/**
+ * Materialize a Remnic namespace into Codex's native memory layout.
+ *
+ * Returns a {@link MaterializeResult} describing what happened. Callers
+ * should treat "skipped" as success — the sentinel / idempotent cases are
+ * expected and intentional.
+ *
+ * @throws if `MEMORY.md` fails schema validation (we do not write garbage).
+ */
+export function materializeForNamespace(
+  namespace: string,
+  options: MaterializeOptions,
+): MaterializeResult {
+  const logger = options.logger ?? {
+    info: (msg) => log.info(`[codex-materialize] ${msg}`),
+    warn: (msg) => log.warn(`[codex-materialize] ${msg}`),
+    debug: (msg) => log.debug(`[codex-materialize] ${msg}`),
+  };
+  const codexHome = resolveCodexHome(options.codexHome);
+  const memoriesDir = path.join(codexHome, "memories");
+  const now = options.now ?? new Date();
+  const maxSummaryTokens =
+    typeof options.maxSummaryTokens === "number" && options.maxSummaryTokens > 0
+      ? options.maxSummaryTokens
+      : 4500;
+  const rolloutRetentionDays =
+    typeof options.rolloutRetentionDays === "number" && options.rolloutRetentionDays >= 0
+      ? options.rolloutRetentionDays
+      : 30;
+
+  mkdirSync(memoriesDir, { recursive: true });
+
+  // ── Sentinel check ─────────────────────────────────────────────────────
+  const sentinelPath = path.join(memoriesDir, SENTINEL_FILE);
+  const existingSentinel = readSentinel(sentinelPath);
+  if (!existingSentinel) {
+    logger.warn(
+      `sentinel ${SENTINEL_FILE} missing in ${memoriesDir}; skipping materialization to preserve hand-edits`,
+    );
+    return {
+      namespace,
+      memoriesDir,
+      wrote: false,
+      skippedNoSentinel: true,
+      skippedIdempotent: false,
+      filesWritten: [],
+      contentHash: "",
+    };
+  }
+
+  // ── Render ─────────────────────────────────────────────────────────────
+  const memories = [...options.memories];
+  const rolloutSummaries = options.rolloutSummaries ?? [];
+
+  const memorySummary = renderMemorySummary({
+    namespace,
+    memories,
+    rolloutSummaries,
+    maxTokens: maxSummaryTokens,
+    now,
+  });
+
+  const memoryMd = renderMemoryMd({
+    namespace,
+    memories,
+    rolloutSummaries,
+    now,
+  });
+
+  // Fail fast on schema issues — do not write garbage.
+  const validation = validateMemoryMd(memoryMd);
+  if (!validation.valid) {
+    const reason = validation.errors.join("; ");
+    logger.warn(`MEMORY.md failed schema validation: ${reason}`);
+    throw new Error(`codex-materialize: MEMORY.md schema validation failed: ${reason}`);
+  }
+
+  const rawMemories = renderRawMemories({ memories });
+
+  const retainedRollouts = pruneRollouts(rolloutSummaries, rolloutRetentionDays, now);
+  const rolloutFiles = retainedRollouts.map((r) => ({
+    name: `${sanitizeSlug(r.slug)}.md`,
+    body: renderRolloutSummary(r),
+  }));
+
+  // ── Idempotence check ──────────────────────────────────────────────────
+  const hash = computeContentHash({
+    namespace,
+    memorySummary,
+    memoryMd,
+    rawMemories,
+    rolloutFiles,
+  });
+
+  if (existingSentinel.content_hash === hash) {
+    logger.debug?.(`no-op materialization for namespace=${namespace} (hash unchanged)`);
+    return {
+      namespace,
+      memoriesDir,
+      wrote: false,
+      skippedNoSentinel: false,
+      skippedIdempotent: true,
+      filesWritten: [],
+      contentHash: hash,
+    };
+  }
+
+  // ── Atomic writes ──────────────────────────────────────────────────────
+  const tmpDir = path.join(memoriesDir, TMP_DIR);
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+  mkdirSync(tmpDir, { recursive: true });
+  mkdirSync(path.join(tmpDir, ROLLOUT_SUBDIR), { recursive: true });
+
+  const filesWritten: string[] = [];
+
+  writeFileSync(path.join(tmpDir, "memory_summary.md"), memorySummary);
+  filesWritten.push("memory_summary.md");
+
+  writeFileSync(path.join(tmpDir, "MEMORY.md"), memoryMd);
+  filesWritten.push("MEMORY.md");
+
+  writeFileSync(path.join(tmpDir, "raw_memories.md"), rawMemories);
+  filesWritten.push("raw_memories.md");
+
+  for (const rollout of rolloutFiles) {
+    writeFileSync(path.join(tmpDir, ROLLOUT_SUBDIR, rollout.name), rollout.body);
+    filesWritten.push(path.join(ROLLOUT_SUBDIR, rollout.name));
+  }
+
+  // Rename into place. Atomic per-file is sufficient — Codex reads each file
+  // independently and tolerates an inconsistent in-between snapshot across
+  // files for the duration of the rename loop (milliseconds).
+  for (const rel of ["memory_summary.md", "MEMORY.md", "raw_memories.md"]) {
+    const src = path.join(tmpDir, rel);
+    const dest = path.join(memoriesDir, rel);
+    renameSync(src, dest);
+  }
+
+  const destRolloutsDir = path.join(memoriesDir, ROLLOUT_SUBDIR);
+  mkdirSync(destRolloutsDir, { recursive: true });
+  // Clear any rollout files we previously owned but that are no longer in the set.
+  const retainedRolloutNames = new Set(rolloutFiles.map((r) => r.name));
+  try {
+    for (const entry of readdirSync(destRolloutsDir, { withFileTypes: true })) {
+      if (!entry.isFile()) continue;
+      if (!entry.name.endsWith(".md")) continue;
+      if (retainedRolloutNames.has(entry.name)) continue;
+      try {
+        unlinkSync(path.join(destRolloutsDir, entry.name));
+      } catch {
+        // ignore
+      }
+    }
+  } catch {
+    // ignore — directory may not exist yet
+  }
+
+  for (const rollout of rolloutFiles) {
+    const src = path.join(tmpDir, ROLLOUT_SUBDIR, rollout.name);
+    const dest = path.join(destRolloutsDir, rollout.name);
+    renameSync(src, dest);
+  }
+
+  // Update sentinel last so a crash leaves hash mismatched → next run rewrites.
+  const sentinel: SentinelFile = {
+    version: MATERIALIZE_VERSION,
+    namespace,
+    updated_at: now.toISOString(),
+    content_hash: hash,
+  };
+  writeFileSync(sentinelPath, `${JSON.stringify(sentinel, null, 2)}\n`);
+
+  try {
+    rmSync(tmpDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+
+  logger.info(
+    `materialized namespace=${namespace} files=${filesWritten.length} hash=${hash.slice(0, 12)}`,
+  );
+
+  return {
+    namespace,
+    memoriesDir,
+    wrote: true,
+    skippedNoSentinel: false,
+    skippedIdempotent: false,
+    filesWritten,
+    contentHash: hash,
+  };
+}
+
+/**
+ * Create (or refresh) the `.remnic-managed` sentinel. Callers must do this
+ * explicitly the first time they want Remnic to start managing a directory —
+ * we never write it implicitly, because its presence is the user's opt-in.
+ */
+export function ensureSentinel(memoriesDir: string, namespace: string, now: Date = new Date()): void {
+  mkdirSync(memoriesDir, { recursive: true });
+  const sentinelPath = path.join(memoriesDir, SENTINEL_FILE);
+  if (existsSync(sentinelPath)) return;
+  const sentinel: SentinelFile = {
+    version: MATERIALIZE_VERSION,
+    namespace,
+    updated_at: now.toISOString(),
+    content_hash: "",
+  };
+  writeFileSync(sentinelPath, `${JSON.stringify(sentinel, null, 2)}\n`);
+}
+
+// ─── Rendering ─────────────────────────────────────────────────────────────
+
+interface RenderContext {
+  namespace: string;
+  memories: MemoryFile[];
+  rolloutSummaries: RolloutSummaryInput[];
+  now: Date;
+}
+
+interface SummaryRenderContext extends RenderContext {
+  maxTokens: number;
+}
+
+/**
+ * Render `memory_summary.md` — the always-loaded file.
+ * Budget-capped at `maxTokens` whitespace tokens.
+ */
+export function renderMemorySummary(ctx: SummaryRenderContext): string {
+  const lines: string[] = [];
+  lines.push("# Memory Summary");
+  lines.push("");
+  lines.push(`_namespace: ${ctx.namespace}_`);
+  lines.push(`_source: remnic_`);
+  lines.push("");
+
+  const highValue = selectSummaryMemories(ctx.memories, 12);
+  if (highValue.length > 0) {
+    lines.push("## Top memories");
+    lines.push("");
+    for (const mem of highValue) {
+      lines.push(`- ${oneLineSummary(mem)}`);
+    }
+    lines.push("");
+  }
+
+  if (ctx.rolloutSummaries.length > 0) {
+    lines.push("## Recent rollouts");
+    lines.push("");
+    const sorted = [...ctx.rolloutSummaries]
+      .sort((a, b) => (b.updatedAt ?? "").localeCompare(a.updatedAt ?? ""))
+      .slice(0, 5);
+    for (const r of sorted) {
+      const when = r.updatedAt ? ` (${r.updatedAt})` : "";
+      lines.push(`- ${r.slug}${when}`);
+    }
+    lines.push("");
+  }
+
+  const full = lines.join("\n").replace(/\n+$/u, "\n");
+  return truncateToTokenBudget(full, ctx.maxTokens);
+}
+
+/**
+ * Render `MEMORY.md` — the searchable handbook in Codex's task-group schema.
+ */
+export function renderMemoryMd(ctx: RenderContext): string {
+  const lines: string[] = [];
+  lines.push(`# Task Group: ${ctx.namespace}`);
+  lines.push(`scope: ${ctx.namespace}`);
+  lines.push(`applies_to: cwd=*; reuse_rule=namespace-match`);
+  lines.push("");
+
+  // One "task" per top-level topic cluster. For the first cut we group by
+  // memory category so the schema validator always sees at least one task.
+  const byCategory = groupMemoriesByCategory(ctx.memories);
+  let taskIndex = 1;
+  if (byCategory.size === 0) {
+    lines.push(`## Task ${taskIndex}: baseline — no memories yet`);
+    lines.push("");
+    lines.push("### rollout_summary_files");
+    for (const r of ctx.rolloutSummaries) {
+      lines.push(
+        `- rollout_summaries/${sanitizeSlug(r.slug)}.md (cwd=${r.cwd ?? "*"}, rollout_path=${r.rolloutPath ?? ""}, updated_at=${r.updatedAt ?? ""}, thread_id=${r.threadId ?? ""})`,
+      );
+    }
+    if (ctx.rolloutSummaries.length === 0) {
+      lines.push("- (none)");
+    }
+    lines.push("");
+    lines.push("### keywords");
+    lines.push(`- ${ctx.namespace}`);
+    lines.push("");
+    taskIndex += 1;
+  } else {
+    for (const [category, mems] of byCategory) {
+      lines.push(`## Task ${taskIndex}: ${category} memories, outcome=surface-to-codex`);
+      lines.push("");
+      lines.push("### rollout_summary_files");
+      const relevantRollouts = ctx.rolloutSummaries.slice(0, 5);
+      if (relevantRollouts.length === 0) {
+        lines.push("- (none)");
+      } else {
+        for (const r of relevantRollouts) {
+          lines.push(
+            `- rollout_summaries/${sanitizeSlug(r.slug)}.md (cwd=${r.cwd ?? "*"}, rollout_path=${r.rolloutPath ?? ""}, updated_at=${r.updatedAt ?? ""}, thread_id=${r.threadId ?? ""})`,
+          );
+        }
+      }
+      lines.push("");
+      lines.push("### keywords");
+      const keywords = collectKeywords(mems, category, ctx.namespace);
+      lines.push(`- ${keywords.join(", ")}`);
+      lines.push("");
+      taskIndex += 1;
+    }
+  }
+
+  lines.push("## User preferences");
+  const prefs = pickCategory(ctx.memories, ["preference"]);
+  if (prefs.length === 0) {
+    lines.push("- (none recorded)");
+  } else {
+    for (const pref of prefs.slice(0, 20)) {
+      lines.push(`- ${oneLineSummary(pref)}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Reusable knowledge");
+  const knowledge = pickCategory(ctx.memories, ["fact", "decision", "principle", "rule", "skill"]);
+  if (knowledge.length === 0) {
+    lines.push("- (none recorded)");
+  } else {
+    for (const mem of knowledge.slice(0, 30)) {
+      lines.push(`- ${oneLineSummary(mem)}`);
+    }
+  }
+  lines.push("");
+
+  lines.push("## Failures and how to do differently");
+  const corrections = pickCategory(ctx.memories, ["correction"]);
+  if (corrections.length === 0) {
+    lines.push("- (none recorded)");
+  } else {
+    for (const mem of corrections.slice(0, 20)) {
+      lines.push(`- ${oneLineSummary(mem)}`);
+    }
+  }
+  lines.push("");
+
+  return lines.join("\n");
+}
+
+/** Render `raw_memories.md` — mechanical dump, latest first. */
+export function renderRawMemories(ctx: { memories: MemoryFile[] }): string {
+  const sorted = [...ctx.memories].sort((a, b) => {
+    const aUpdated = a.frontmatter.updated ?? a.frontmatter.created ?? "";
+    const bUpdated = b.frontmatter.updated ?? b.frontmatter.created ?? "";
+    return bUpdated.localeCompare(aUpdated);
+  });
+
+  const lines: string[] = ["# Raw Memories", "", "_source: remnic — latest first_", ""];
+  for (const mem of sorted) {
+    const fm = mem.frontmatter;
+    const id = fm.id ?? "unknown";
+    const category = fm.category ?? "unknown";
+    const updated = fm.updated ?? fm.created ?? "";
+    lines.push(`## ${id} (${category}, updated=${updated})`);
+    lines.push("");
+    lines.push(mem.content.trim());
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** Render a single rollout summary file. */
+export function renderRolloutSummary(input: RolloutSummaryInput): string {
+  const lines: string[] = [];
+  lines.push(`# Rollout Summary: ${input.slug}`);
+  lines.push("");
+  const meta: string[] = [];
+  if (input.cwd) meta.push(`cwd=${input.cwd}`);
+  if (input.rolloutPath) meta.push(`rollout_path=${input.rolloutPath}`);
+  if (input.updatedAt) meta.push(`updated_at=${input.updatedAt}`);
+  if (input.threadId) meta.push(`thread_id=${input.threadId}`);
+  if (meta.length > 0) {
+    lines.push(`_${meta.join("; ")}_`);
+    lines.push("");
+  }
+  if (input.keywords && input.keywords.length > 0) {
+    lines.push(`**keywords:** ${input.keywords.join(", ")}`);
+    lines.push("");
+  }
+  lines.push(input.body.trim());
+  lines.push("");
+  return lines.join("\n");
+}
+
+// ─── Schema validation ─────────────────────────────────────────────────────
+
+export interface MemoryMdValidation {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate that a rendered `MEMORY.md` matches Codex's task-group schema.
+ * We enforce the minimum set of structural requirements called out in #378:
+ *
+ *  - one `# Task Group:` header
+ *  - `scope:` and `applies_to:` lines directly beneath it
+ *  - at least one `## Task N:` section
+ *  - each task section has `### rollout_summary_files` and `### keywords`
+ *  - `## User preferences`, `## Reusable knowledge`,
+ *    `## Failures and how to do differently` sections all present
+ */
+export function validateMemoryMd(content: string): MemoryMdValidation {
+  const errors: string[] = [];
+  const lines = content.split(/\r?\n/u);
+
+  const taskGroupIndex = lines.findIndex((l) => /^#\s+Task Group:\s+\S+/u.test(l));
+  if (taskGroupIndex === -1) {
+    errors.push("missing `# Task Group:` header");
+  } else {
+    const tail = lines.slice(taskGroupIndex + 1, taskGroupIndex + 5);
+    if (!tail.some((l) => /^scope:\s*\S+/u.test(l))) {
+      errors.push("missing `scope:` line under Task Group header");
+    }
+    if (!tail.some((l) => /^applies_to:\s*\S+/u.test(l))) {
+      errors.push("missing `applies_to:` line under Task Group header");
+    }
+  }
+
+  const taskHeaders = lines.filter((l) => /^##\s+Task\s+\d+:/u.test(l));
+  if (taskHeaders.length === 0) {
+    errors.push("at least one `## Task N:` section is required");
+  }
+
+  // For every task section, make sure we have rollout_summary_files + keywords
+  // before the next `##` header at the same level.
+  const sectionRegex = /^##\s+/u;
+  for (let i = 0; i < lines.length; i++) {
+    if (!/^##\s+Task\s+\d+:/u.test(lines[i])) continue;
+    let hasRollout = false;
+    let hasKeywords = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      if (sectionRegex.test(lines[j])) break;
+      if (/^###\s+rollout_summary_files\s*$/u.test(lines[j])) hasRollout = true;
+      if (/^###\s+keywords\s*$/u.test(lines[j])) hasKeywords = true;
+    }
+    if (!hasRollout) errors.push(`task block at line ${i + 1} missing \`### rollout_summary_files\``);
+    if (!hasKeywords) errors.push(`task block at line ${i + 1} missing \`### keywords\``);
+  }
+
+  const requiredSections = [
+    /^##\s+User preferences\s*$/u,
+    /^##\s+Reusable knowledge\s*$/u,
+    /^##\s+Failures and how to do differently\s*$/u,
+  ];
+  for (const re of requiredSections) {
+    if (!lines.some((l) => re.test(l))) {
+      errors.push(`missing required section: ${re.source}`);
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ─── Helpers ───────────────────────────────────────────────────────────────
+
+function resolveCodexHome(override?: string): string {
+  if (override && override.trim().length > 0) return override;
+  const fromEnv = process.env.CODEX_HOME;
+  if (fromEnv && fromEnv.trim().length > 0) return fromEnv;
+  const home = process.env.HOME ?? process.env.USERPROFILE ?? "";
+  return path.join(home, ".codex");
+}
+
+function readSentinel(sentinelPath: string): SentinelFile | null {
+  if (!existsSync(sentinelPath)) return null;
+  try {
+    const raw = readFileSync(sentinelPath, "utf-8");
+    const parsed = JSON.parse(raw) as Partial<SentinelFile>;
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return {
+      version: typeof parsed.version === "number" ? parsed.version : MATERIALIZE_VERSION,
+      namespace: typeof parsed.namespace === "string" ? parsed.namespace : "",
+      updated_at: typeof parsed.updated_at === "string" ? parsed.updated_at : "",
+      content_hash: typeof parsed.content_hash === "string" ? parsed.content_hash : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+function selectSummaryMemories(memories: MemoryFile[], limit: number): MemoryFile[] {
+  const scored = memories
+    .filter((m) => !m.frontmatter.status || m.frontmatter.status === "active")
+    .map((m) => {
+      const confidence = typeof m.frontmatter.confidence === "number" ? m.frontmatter.confidence : 0;
+      const importance =
+        typeof m.frontmatter.importance === "object" &&
+        m.frontmatter.importance !== null &&
+        typeof (m.frontmatter.importance as { score?: number }).score === "number"
+          ? ((m.frontmatter.importance as { score: number }).score ?? 0)
+          : 0;
+      const updated = m.frontmatter.updated ?? m.frontmatter.created ?? "";
+      return { memory: m, score: importance * 2 + confidence, updated };
+    });
+
+  scored.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    return b.updated.localeCompare(a.updated);
+  });
+
+  return scored.slice(0, limit).map((s) => s.memory);
+}
+
+function oneLineSummary(memory: MemoryFile): string {
+  const raw = memory.content.replace(/\s+/gu, " ").trim();
+  if (raw.length <= 160) return raw;
+  return `${raw.slice(0, 157)}...`;
+}
+
+function groupMemoriesByCategory(memories: MemoryFile[]): Map<string, MemoryFile[]> {
+  const map = new Map<string, MemoryFile[]>();
+  for (const memory of memories) {
+    if (memory.frontmatter.status && memory.frontmatter.status !== "active") continue;
+    const category = memory.frontmatter.category ?? "unknown";
+    const list = map.get(category) ?? [];
+    list.push(memory);
+    map.set(category, list);
+  }
+  return map;
+}
+
+function pickCategory(memories: MemoryFile[], categories: string[]): MemoryFile[] {
+  const allowed = new Set(categories);
+  return memories.filter(
+    (m) =>
+      (!m.frontmatter.status || m.frontmatter.status === "active") &&
+      allowed.has(m.frontmatter.category ?? ""),
+  );
+}
+
+function collectKeywords(memories: MemoryFile[], category: string, namespace: string): string[] {
+  const keywords = new Set<string>();
+  keywords.add(category);
+  keywords.add(namespace);
+  for (const mem of memories.slice(0, 10)) {
+    for (const tag of mem.frontmatter.tags ?? []) {
+      if (typeof tag === "string" && tag.trim().length > 0) keywords.add(tag.trim());
+    }
+  }
+  return [...keywords].slice(0, 16);
+}
+
+function pruneRollouts(
+  rollouts: RolloutSummaryInput[],
+  retentionDays: number,
+  now: Date,
+): RolloutSummaryInput[] {
+  if (retentionDays <= 0) return rollouts;
+  const cutoffMs = now.getTime() - retentionDays * 24 * 60 * 60 * 1000;
+  return rollouts.filter((r) => {
+    if (!r.updatedAt) return true;
+    const t = Date.parse(r.updatedAt);
+    if (!Number.isFinite(t)) return true;
+    return t >= cutoffMs;
+  });
+}
+
+function sanitizeSlug(slug: string): string {
+  return slug
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/gu, "-")
+    .replace(/^-+|-+$/gu, "")
+    .slice(0, 96)
+    || "rollout";
+}
+
+/**
+ * Whitespace-tokenized approximation used by the budget check. Matches the
+ * simple heuristic Codex's usage.rs reporting uses for the "5000 token"
+ * memory_summary cap.
+ */
+export function approximateTokenCount(text: string): number {
+  const trimmed = text.trim();
+  if (trimmed.length === 0) return 0;
+  return trimmed.split(/\s+/u).length;
+}
+
+/**
+ * Truncate `text` so it fits under `maxTokens` whitespace tokens. We drop
+ * trailing lines until we're under the budget and then append an ellipsis
+ * marker so downstream readers can see that truncation happened.
+ */
+export function truncateToTokenBudget(text: string, maxTokens: number): string {
+  if (maxTokens <= 0) return "";
+  if (approximateTokenCount(text) <= maxTokens) return text;
+
+  const lines = text.split(/\r?\n/u);
+  while (lines.length > 0 && approximateTokenCount(lines.join("\n")) > maxTokens - 1) {
+    lines.pop();
+  }
+  lines.push("_[truncated for summary budget]_");
+  let result = lines.join("\n");
+
+  // If a single huge line still blows the budget, hard-cut tokens.
+  if (approximateTokenCount(result) > maxTokens) {
+    const tokens = result.split(/\s+/u);
+    result = `${tokens.slice(0, Math.max(0, maxTokens - 1)).join(" ")} [truncated]`;
+  }
+  return result;
+}
+
+function computeContentHash(input: {
+  namespace: string;
+  memorySummary: string;
+  memoryMd: string;
+  rawMemories: string;
+  rolloutFiles: Array<{ name: string; body: string }>;
+}): string {
+  const hash = createHash("sha256");
+  hash.update(`v${MATERIALIZE_VERSION}\n`);
+  hash.update(`namespace=${input.namespace}\n`);
+  hash.update("---memory_summary---\n");
+  hash.update(input.memorySummary);
+  hash.update("\n---memory_md---\n");
+  hash.update(input.memoryMd);
+  hash.update("\n---raw_memories---\n");
+  hash.update(input.rawMemories);
+  const sortedRollouts = [...input.rolloutFiles].sort((a, b) => a.name.localeCompare(b.name));
+  for (const r of sortedRollouts) {
+    hash.update(`\n---rollout:${r.name}---\n`);
+    hash.update(r.body);
+  }
+  return hash.digest("hex");
+}
+
+// ─── Stat helper for tests / debugging ─────────────────────────────────────
+
+/**
+ * Return basic stats about a materialized memories dir. Useful for tests and
+ * debug CLI output. Returns `null` if the dir does not exist.
+ */
+export function describeMemoriesDir(memoriesDir: string): {
+  exists: boolean;
+  hasSentinel: boolean;
+  files: string[];
+  sentinel: SentinelFile | null;
+} | null {
+  if (!existsSync(memoriesDir)) return null;
+  const sentinelPath = path.join(memoriesDir, SENTINEL_FILE);
+  const sentinel = readSentinel(sentinelPath);
+  const files: string[] = [];
+  for (const entry of readdirSync(memoriesDir, { withFileTypes: true })) {
+    if (entry.isFile() && OWNED_FILES.has(entry.name)) files.push(entry.name);
+  }
+  const rolloutsDir = path.join(memoriesDir, ROLLOUT_SUBDIR);
+  if (existsSync(rolloutsDir)) {
+    try {
+      for (const entry of readdirSync(rolloutsDir, { withFileTypes: true })) {
+        if (entry.isFile() && entry.name.endsWith(".md")) {
+          files.push(path.join(ROLLOUT_SUBDIR, entry.name));
+        }
+      }
+    } catch {
+      // ignore
+    }
+  }
+  // Touch statSync so the compiler doesn't drop the import if unused in
+  // future edits — and it's genuinely useful when callers want mtimes.
+  if (files.length > 0) {
+    try {
+      statSync(path.join(memoriesDir, files[0]));
+    } catch {
+      // ignore
+    }
+  }
+  return {
+    exists: true,
+    hasSentinel: sentinel !== null,
+    files: files.sort(),
+    sentinel,
+  };
+}

--- a/packages/remnic-core/src/connectors/codex-materialize.ts
+++ b/packages/remnic-core/src/connectors/codex-materialize.ts
@@ -167,8 +167,11 @@ export function materializeForNamespace(
   const codexHome = resolveCodexHome(options.codexHome);
   const memoriesDir = path.join(codexHome, "memories");
   const now = options.now ?? new Date();
+  // Honor `0` as "no summary budget" — parseConfig already clamps to non-
+  // negative integers, so any provided number is meaningful. Only fall back
+  // to the default when the caller did not provide the option at all.
   const maxSummaryTokens =
-    typeof options.maxSummaryTokens === "number" && options.maxSummaryTokens > 0
+    typeof options.maxSummaryTokens === "number" && options.maxSummaryTokens >= 0
       ? options.maxSummaryTokens
       : 4500;
   const rolloutRetentionDays =
@@ -198,6 +201,10 @@ export function materializeForNamespace(
 
   // ── Render ─────────────────────────────────────────────────────────────
   const memories = [...options.memories];
+  // Track whether the caller actually supplied a rollout set. `undefined`
+  // means "don't touch rollout_summaries/"; an empty array is still
+  // authoritative and means "we own this dir and it should be empty".
+  const rolloutsSupplied = options.rolloutSummaries !== undefined;
   const rolloutSummaries = options.rolloutSummaries ?? [];
 
   const memorySummary = renderMemorySummary({
@@ -248,16 +255,34 @@ export function materializeForNamespace(
   });
 
   if (existingSentinel.content_hash === hash) {
-    logger.debug?.(`no-op materialization for namespace=${namespace} (hash unchanged)`);
-    return {
-      namespace,
-      memoriesDir,
-      wrote: false,
-      skippedNoSentinel: false,
-      skippedIdempotent: true,
-      filesWritten: [],
-      contentHash: hash,
-    };
+    // Idempotence early-return is only safe when the managed files we would
+    // have written are still on disk. If a user or external process deleted
+    // `MEMORY.md` / `memory_summary.md` / `raw_memories.md` (or any retained
+    // rollout file) while the sentinel's hash stayed the same, we must fall
+    // through and rewrite — otherwise Codex would be stuck with missing
+    // artifacts until a memory-content change happens to flip the hash.
+    const requiredFiles = [
+      path.join(memoriesDir, "memory_summary.md"),
+      path.join(memoriesDir, "MEMORY.md"),
+      path.join(memoriesDir, "raw_memories.md"),
+      ...rolloutFiles.map((r) => path.join(memoriesDir, ROLLOUT_SUBDIR, r.name)),
+    ];
+    const allPresent = requiredFiles.every((f) => existsSync(f));
+    if (allPresent) {
+      logger.debug?.(`no-op materialization for namespace=${namespace} (hash unchanged)`);
+      return {
+        namespace,
+        memoriesDir,
+        wrote: false,
+        skippedNoSentinel: false,
+        skippedIdempotent: true,
+        filesWritten: [],
+        contentHash: hash,
+      };
+    }
+    logger.debug?.(
+      `hash unchanged for namespace=${namespace} but managed file missing — forcing rewrite`,
+    );
   }
 
   // ── Atomic writes ──────────────────────────────────────────────────────
@@ -297,21 +322,28 @@ export function materializeForNamespace(
 
   const destRolloutsDir = path.join(memoriesDir, ROLLOUT_SUBDIR);
   mkdirSync(destRolloutsDir, { recursive: true });
-  // Clear any rollout files we previously owned but that are no longer in the set.
-  const retainedRolloutNames = new Set(rolloutFiles.map((r) => r.name));
-  try {
-    for (const entry of readdirSync(destRolloutsDir, { withFileTypes: true })) {
-      if (!entry.isFile()) continue;
-      if (!entry.name.endsWith(".md")) continue;
-      if (retainedRolloutNames.has(entry.name)) continue;
-      try {
-        unlinkSync(path.join(destRolloutsDir, entry.name));
-      } catch {
-        // ignore
+  // Only garbage-collect rollout files when the caller actually supplied a
+  // `rolloutSummaries` array — otherwise we'd wipe legitimately
+  // user/Codex-created recap files on every session-end run, since those
+  // calls typically omit the rollout set entirely. When rollouts were
+  // supplied (even as an empty array — meaning "we own this dir and it
+  // should be empty"), we clear the stale files we previously owned.
+  if (rolloutsSupplied) {
+    const retainedRolloutNames = new Set(rolloutFiles.map((r) => r.name));
+    try {
+      for (const entry of readdirSync(destRolloutsDir, { withFileTypes: true })) {
+        if (!entry.isFile()) continue;
+        if (!entry.name.endsWith(".md")) continue;
+        if (retainedRolloutNames.has(entry.name)) continue;
+        try {
+          unlinkSync(path.join(destRolloutsDir, entry.name));
+        } catch {
+          // ignore
+        }
       }
+    } catch {
+      // ignore — directory may not exist yet
     }
-  } catch {
-    // ignore — directory may not exist yet
   }
 
   for (const rollout of rolloutFiles) {
@@ -759,17 +791,30 @@ export function truncateToTokenBudget(text: string, maxTokens: number): string {
   if (maxTokens <= 0) return "";
   if (approximateTokenCount(text) <= maxTokens) return text;
 
+  // Reserve headroom for the truncation marker so the line-preserving path
+  // can actually fit the marker without flipping to the hard-cut fallback.
+  // Both markers are counted with the same whitespace heuristic the budget
+  // check uses, so the arithmetic stays consistent.
+  const lineMarker = "_[truncated for summary budget]_";
+  const tailMarker = "[truncated]";
+  const lineMarkerTokens = approximateTokenCount(lineMarker);
+  const tailMarkerTokens = approximateTokenCount(tailMarker);
+
   const lines = text.split(/\r?\n/u);
-  while (lines.length > 0 && approximateTokenCount(lines.join("\n")) > maxTokens - 1) {
+  const lineBudget = Math.max(0, maxTokens - lineMarkerTokens);
+  while (lines.length > 0 && approximateTokenCount(lines.join("\n")) > lineBudget) {
     lines.pop();
   }
-  lines.push("_[truncated for summary budget]_");
+  lines.push(lineMarker);
   let result = lines.join("\n");
 
-  // If a single huge line still blows the budget, hard-cut tokens.
+  // If a single huge line still blows the budget, hard-cut tokens. Reserve
+  // space for the tail marker's own token count so the final string stays
+  // within maxTokens rather than sneaking over by a few tokens.
   if (approximateTokenCount(result) > maxTokens) {
     const tokens = result.split(/\s+/u);
-    result = `${tokens.slice(0, Math.max(0, maxTokens - 1)).join(" ")} [truncated]`;
+    const keep = Math.max(0, maxTokens - tailMarkerTokens);
+    result = keep > 0 ? `${tokens.slice(0, keep).join(" ")} ${tailMarker}` : tailMarker;
   }
   return result;
 }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -8,6 +8,32 @@
 import fs from "node:fs";
 import path from "node:path";
 
+// Native memory artifact materialization for Codex CLI (#378). Surfaced here
+// so downstream callers can `import { materializeForNamespace } from "@remnic/core/connectors"`.
+export {
+  materializeForNamespace,
+  ensureSentinel,
+  describeMemoriesDir,
+  renderMemorySummary,
+  renderMemoryMd,
+  renderRawMemories,
+  renderRolloutSummary,
+  validateMemoryMd,
+  approximateTokenCount,
+  truncateToTokenBudget,
+  MATERIALIZE_VERSION,
+  SENTINEL_FILE,
+  TMP_DIR,
+  type MaterializeOptions,
+  type MaterializeResult,
+  type RolloutSummaryInput,
+  type MemoryMdValidation,
+} from "./codex-materialize.js";
+export {
+  runCodexMaterialize,
+  type RunMaterializeOptions,
+} from "./codex-materialize-runner.js";
+
 // ── Types ────────────────────────────────────────────────────────────────────
 
 export interface ConnectorManifest {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -274,6 +274,27 @@ export {
 } from "./tokens.js";
 
 // ---------------------------------------------------------------------------
+// Codex materializer (#378)
+// ---------------------------------------------------------------------------
+
+export {
+  runCodexMaterialize,
+  runPostConsolidationMaterialize,
+  type RunMaterializeOptions,
+  type PostConsolidationMaterializeOptions,
+} from "./connectors/codex-materialize-runner.js";
+export {
+  materializeForNamespace,
+  ensureSentinel,
+  describeMemoriesDir,
+  SENTINEL_FILE,
+  MATERIALIZE_VERSION,
+  type MaterializeOptions,
+  type MaterializeResult,
+  type RolloutSummaryInput,
+} from "./connectors/codex-materialize.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -166,6 +166,7 @@ import {
   findSimilarClusters,
   buildConsolidationPrompt,
   parseConsolidationResponse,
+  materializeAfterSemanticConsolidation,
   type SemanticConsolidationResult,
 } from "./semantic-consolidation.js";
 import { chunkTranscriptEntries } from "./conversation-index/chunker.js";
@@ -2154,6 +2155,27 @@ export class Orchestrator {
     log.info(
       `[semantic-consolidation] complete: clusters=${result.clustersFound}, consolidated=${result.memoriesConsolidated}, archived=${result.memoriesArchived}, errors=${result.errors}`,
     );
+
+    // #378: fire the Codex materialize post-hook so `codexMaterializeOnConsolidation`
+    // actually has a runtime effect. The helper silently no-ops when the
+    // feature flag or the per-trigger toggle is off, when the sentinel is
+    // missing, or when nothing has changed since the previous run, so it's
+    // safe to always call here. Wrapped in a try/catch because a failed
+    // materialize must never abort the consolidation result — consolidation
+    // is the load-bearing operation; materialization is an optional mirror.
+    try {
+      await materializeAfterSemanticConsolidation({
+        config: this.config,
+        memoryDir: this.config.memoryDir,
+      });
+    } catch (err) {
+      log.warn(
+        `[semantic-consolidation] Codex materialize post-hook failed (non-fatal): ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+
     return result;
   }
 

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -6,10 +6,9 @@
  * Reduces memory store bloat while preserving all unique information.
  */
 
-import { log } from "./logger.js";
 import type { MemoryFile, PluginConfig } from "./types.js";
 import { normalizeRecallTokens, countRecallTokenOverlap } from "./recall-tokenization.js";
-import { runCodexMaterialize } from "./connectors/codex-materialize-runner.js";
+import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
 import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
 
 export interface ConsolidationCluster {
@@ -160,25 +159,7 @@ export async function materializeAfterSemanticConsolidation(options: {
   rolloutSummaries?: RolloutSummaryInput[];
   now?: Date;
 }): Promise<MaterializeResult | null> {
-  if (!options.config.codexMaterializeMemories) return null;
-  if (!options.config.codexMaterializeOnConsolidation) return null;
-  try {
-    return await runCodexMaterialize({
-      config: options.config,
-      namespace: options.namespace,
-      memories: options.memories,
-      memoryDir: options.memoryDir,
-      codexHome: options.codexHome,
-      rolloutSummaries: options.rolloutSummaries,
-      now: options.now,
-      reason: "consolidation",
-    });
-  } catch (error) {
-    log.warn(
-      `[semantic-consolidation] Codex materialize post-hook failed (non-fatal): ${
-        error instanceof Error ? error.message : String(error)
-      }`,
-    );
-    return null;
-  }
+  // Delegates to the shared post-consolidation helper so semantic and causal
+  // flows stay in lock-step — any guard/logging change happens in one place.
+  return runPostConsolidationMaterialize("[semantic-consolidation]", options);
 }

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -7,8 +7,10 @@
  */
 
 import { log } from "./logger.js";
-import type { MemoryFile } from "./types.js";
+import type { MemoryFile, PluginConfig } from "./types.js";
 import { normalizeRecallTokens, countRecallTokenOverlap } from "./recall-tokenization.js";
+import { runCodexMaterialize } from "./connectors/codex-materialize-runner.js";
+import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
 
 export interface ConsolidationCluster {
   category: string;
@@ -138,4 +140,45 @@ Write ONLY the consolidated memory content (no metadata, no explanation, no prea
  */
 export function parseConsolidationResponse(response: string): string {
   return response.trim();
+}
+
+/**
+ * Optional post-consolidation hook — materializes the namespace into Codex's
+ * native memory layout when the consolidation run finishes. Kept here (rather
+ * than in orchestrator.ts) so #378 doesn't conflict with Wave 1 edits.
+ *
+ * Safe to call regardless of config state: honors `codexMaterializeMemories`
+ * and `codexMaterializeOnConsolidation` and silently becomes a no-op when
+ * either is disabled.
+ */
+export async function materializeAfterSemanticConsolidation(options: {
+  config: PluginConfig;
+  namespace?: string;
+  memories?: MemoryFile[];
+  memoryDir?: string;
+  codexHome?: string;
+  rolloutSummaries?: RolloutSummaryInput[];
+  now?: Date;
+}): Promise<MaterializeResult | null> {
+  if (!options.config.codexMaterializeMemories) return null;
+  if (!options.config.codexMaterializeOnConsolidation) return null;
+  try {
+    return await runCodexMaterialize({
+      config: options.config,
+      namespace: options.namespace,
+      memories: options.memories,
+      memoryDir: options.memoryDir,
+      codexHome: options.codexHome,
+      rolloutSummaries: options.rolloutSummaries,
+      now: options.now,
+      reason: "consolidation",
+    });
+  } catch (error) {
+    log.warn(
+      `[semantic-consolidation] Codex materialize post-hook failed (non-fatal): ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+    return null;
+  }
 }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -719,6 +719,20 @@ export interface PluginConfig {
   parallelAgentWeights: { direct: number; contextual: number; temporal: number };
   /** Max results fetched per agent before merge. */
   parallelMaxResultsPerAgent: number;
+
+  // Codex CLI — native memory materialization (#378)
+  /** Materialize Remnic memories into Codex's expected ~/.codex/memories/ layout. Default true. */
+  codexMaterializeMemories: boolean;
+  /** Namespace to materialize; "auto" derives from the connector context. Default "auto". */
+  codexMaterializeNamespace: string;
+  /** Max whitespace-tokenized size of memory_summary.md. Default 4500. */
+  codexMaterializeMaxSummaryTokens: number;
+  /** Max age in days for rollout_summaries/*.md before pruning. Default 30. */
+  codexMaterializeRolloutRetentionDays: number;
+  /** Run materialization after semantic/causal consolidation completes. Default true. */
+  codexMaterializeOnConsolidation: boolean;
+  /** Run materialization at Codex session-end hook. Default true. */
+  codexMaterializeOnSessionEnd: boolean;
 }
 
 export interface BootstrapOptions {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,7 +88,11 @@ importers:
 
   packages/plugin-claude-code: {}
 
-  packages/plugin-codex: {}
+  packages/plugin-codex:
+    dependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
 
   packages/plugin-openclaw:
     dependencies:

--- a/scripts/codex-materialize.ts
+++ b/scripts/codex-materialize.ts
@@ -66,13 +66,51 @@ function parseArgs(argv: string[]): Args {
   return args;
 }
 
+/**
+ * Resolve a plugin config block from an OpenClaw-shaped config file.
+ *
+ * OpenClaw stores Remnic settings under
+ * `plugins.entries["openclaw-engram"].config`; the legacy Remnic/Engram layouts
+ * kept them at the top level. We accept both so we can run uniformly in
+ * standard OpenClaw installs AND in developer sandboxes.
+ */
+function unwrapOpenClawEntry(raw: unknown): Record<string, unknown> | null {
+  if (!raw || typeof raw !== "object") return null;
+  const obj = raw as Record<string, unknown>;
+  const entry = (obj.plugins as Record<string, unknown> | undefined)?.entries as
+    | Record<string, unknown>
+    | undefined;
+  const pluginConfig = (entry?.["openclaw-engram"] as Record<string, unknown> | undefined)
+    ?.config;
+  if (pluginConfig && typeof pluginConfig === "object") {
+    return pluginConfig as Record<string, unknown>;
+  }
+  // Legacy / developer config layout — the top-level object IS the plugin config.
+  return obj;
+}
+
 function loadRawConfig(): Record<string, unknown> {
   // Try the common config locations without importing bootstrap.ts (which
   // pulls in the full orchestrator). A missing config is fine — parseConfig
   // produces sane defaults.
+  //
+  // Order of precedence:
+  //   1. `REMNIC_CONFIG` env var (developer escape hatch)
+  //   2. `OPENCLAW_ENGRAM_CONFIG_PATH` / `OPENCLAW_CONFIG_PATH` — the same
+  //      env vars the Remnic plugin reads at runtime
+  //   3. `~/.openclaw/openclaw.json` — standard OpenClaw install location
+  //   4. Legacy `~/.config/remnic/config.json`, `~/.config/engram/config.json`,
+  //      `~/.remnic/config.json`
+  //
+  // For (3) and (2) we unwrap `plugins.entries["openclaw-engram"].config`.
   const home = process.env.HOME ?? "";
+  const openclawConfigPath =
+    process.env.OPENCLAW_ENGRAM_CONFIG_PATH ??
+    process.env.OPENCLAW_CONFIG_PATH ??
+    path.join(home, ".openclaw", "openclaw.json");
   const candidates = [
     process.env.REMNIC_CONFIG,
+    openclawConfigPath,
     path.join(home, ".config", "remnic", "config.json"),
     path.join(home, ".config", "engram", "config.json"),
     path.join(home, ".remnic", "config.json"),
@@ -82,7 +120,8 @@ function loadRawConfig(): Record<string, unknown> {
     if (!fs.existsSync(candidate)) continue;
     try {
       const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
-      if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+      const unwrapped = unwrapOpenClawEntry(raw);
+      if (unwrapped) return unwrapped;
     } catch {
       // fall through to next candidate
     }

--- a/scripts/codex-materialize.ts
+++ b/scripts/codex-materialize.ts
@@ -1,0 +1,165 @@
+#!/usr/bin/env tsx
+/**
+ * codex-materialize.ts — thin CLI entrypoint for Codex memory materialization.
+ *
+ * Intended caller: `packages/plugin-codex/hooks/bin/session-end.sh` (via tsx)
+ * and operators debugging materialization. Keeps the hook edit minimal — the
+ * shell hook just shells out to this script with a namespace.
+ *
+ * Usage:
+ *   tsx scripts/codex-materialize.ts [--namespace <name>] [--codex-home <path>] \
+ *     [--memory-dir <path>] [--reason <string>] [--json]
+ *
+ * Exits 0 on success (including intentional no-op skips), non-zero only on
+ * hard failures the caller needs to notice.
+ */
+
+import path from "node:path";
+import fs from "node:fs";
+
+import { parseConfig } from "../packages/remnic-core/src/config.js";
+import { runCodexMaterialize } from "../packages/remnic-core/src/connectors/codex-materialize-runner.js";
+
+interface Args {
+  namespace?: string;
+  codexHome?: string;
+  memoryDir?: string;
+  reason: "session_end" | "manual" | "cli" | "consolidation";
+  json: boolean;
+  help: boolean;
+}
+
+function parseArgs(argv: string[]): Args {
+  const args: Args = {
+    reason: "cli",
+    json: false,
+    help: false,
+  };
+  for (let i = 0; i < argv.length; i++) {
+    const a = argv[i];
+    switch (a) {
+      case "--namespace":
+      case "-n":
+        args.namespace = argv[++i];
+        break;
+      case "--codex-home":
+        args.codexHome = argv[++i];
+        break;
+      case "--memory-dir":
+        args.memoryDir = argv[++i];
+        break;
+      case "--reason":
+        args.reason = (argv[++i] as Args["reason"]) ?? "cli";
+        break;
+      case "--json":
+        args.json = true;
+        break;
+      case "-h":
+      case "--help":
+        args.help = true;
+        break;
+      default:
+        // ignore unknown tokens — keeps the hook loosely coupled
+        break;
+    }
+  }
+  return args;
+}
+
+function loadRawConfig(): Record<string, unknown> {
+  // Try the common config locations without importing bootstrap.ts (which
+  // pulls in the full orchestrator). A missing config is fine — parseConfig
+  // produces sane defaults.
+  const home = process.env.HOME ?? "";
+  const candidates = [
+    process.env.REMNIC_CONFIG,
+    path.join(home, ".config", "remnic", "config.json"),
+    path.join(home, ".config", "engram", "config.json"),
+    path.join(home, ".remnic", "config.json"),
+  ].filter((p): p is string => typeof p === "string" && p.length > 0);
+
+  for (const candidate of candidates) {
+    if (!fs.existsSync(candidate)) continue;
+    try {
+      const raw = JSON.parse(fs.readFileSync(candidate, "utf-8"));
+      if (raw && typeof raw === "object") return raw as Record<string, unknown>;
+    } catch {
+      // fall through to next candidate
+    }
+  }
+  return {};
+}
+
+async function main(): Promise<number> {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    // eslint-disable-next-line no-console
+    console.log(
+      [
+        "codex-materialize — render Remnic memories into ~/.codex/memories/",
+        "",
+        "Usage: tsx scripts/codex-materialize.ts [options]",
+        "",
+        "Options:",
+        "  --namespace <name>    Namespace to materialize (default: config / 'default')",
+        "  --memory-dir <path>   Override memory directory",
+        "  --codex-home <path>   Override <codex_home>",
+        "  --reason <string>     Logged reason tag (cli | session_end | consolidation | manual)",
+        "  --json                Emit the result as JSON",
+        "  -h, --help            Show this help",
+      ].join("\n"),
+    );
+    return 0;
+  }
+
+  const rawConfig = loadRawConfig();
+  const config = parseConfig(rawConfig);
+  if (args.memoryDir) {
+    // parseConfig already locked in a memoryDir, but the CLI override wins.
+    (config as unknown as Record<string, unknown>).memoryDir = args.memoryDir;
+  }
+
+  const result = await runCodexMaterialize({
+    config,
+    namespace: args.namespace,
+    memoryDir: args.memoryDir,
+    codexHome: args.codexHome,
+    reason: args.reason,
+  });
+
+  if (args.json) {
+    // eslint-disable-next-line no-console
+    console.log(JSON.stringify(result, null, 2));
+  } else if (result === null) {
+    // eslint-disable-next-line no-console
+    console.log("codex-materialize: skipped (disabled or guarded)");
+  } else if (result.skippedNoSentinel) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `codex-materialize: sentinel missing in ${result.memoriesDir}; skipped to honor hand-edits`,
+    );
+  } else if (result.skippedIdempotent) {
+    // eslint-disable-next-line no-console
+    console.log(
+      `codex-materialize: no changes for namespace=${result.namespace} (hash unchanged)`,
+    );
+  } else {
+    // eslint-disable-next-line no-console
+    console.log(
+      `codex-materialize: wrote ${result.filesWritten.length} file(s) for namespace=${result.namespace}`,
+    );
+  }
+
+  return 0;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (error) => {
+    // eslint-disable-next-line no-console
+    console.error(
+      `codex-materialize failed: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    process.exit(1);
+  },
+);

--- a/src/connectors/codex-materialize-runner.ts
+++ b/src/connectors/codex-materialize-runner.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/remnic-core/src/connectors/codex-materialize-runner.js";

--- a/src/connectors/codex-materialize.ts
+++ b/src/connectors/codex-materialize.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/remnic-core/src/connectors/codex-materialize.js";

--- a/tests/codex-materialize-consolidation-wiring.test.ts
+++ b/tests/codex-materialize-consolidation-wiring.test.ts
@@ -1,0 +1,109 @@
+/**
+ * codex-materialize-consolidation-wiring.test.ts — regression guard for
+ * PR #392 review feedback (thread PRRT_kwDORJXyws56TH1B): the
+ * `materializeAfterSemanticConsolidation` and `materializeAfterCausalConsolidation`
+ * helpers were defined but never called from the active consolidation code
+ * paths, so `codexMaterializeOnConsolidation=true` was effectively inert.
+ *
+ * The full orchestrator integration path is too heavy to spin up in a unit
+ * test, so we check the call sites structurally by reading the relevant
+ * source files. If someone refactors the consolidation runtime and forgets
+ * to re-wire the hook, these tests fail loudly at build time.
+ *
+ * This file uses synthetic read-only file inspection — no network, no real
+ * user data.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+test("orchestrator.runSemanticConsolidation invokes materializeAfterSemanticConsolidation", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/orchestrator.ts"),
+    "utf-8",
+  );
+  // The import line must exist…
+  assert.match(
+    src,
+    /materializeAfterSemanticConsolidation/u,
+    "orchestrator.ts must import materializeAfterSemanticConsolidation",
+  );
+  // …and there must be at least one call site after the semantic-consolidation
+  // completion log line. We check by locating the log and asserting a call
+  // follows it in the same function body. The helper is awaited so the
+  // substring `await materializeAfterSemanticConsolidation` is distinctive.
+  const awaitIdx = src.indexOf("await materializeAfterSemanticConsolidation");
+  assert.ok(
+    awaitIdx >= 0,
+    "orchestrator.ts must await materializeAfterSemanticConsolidation at runtime",
+  );
+
+  // Sanity: the call is inside a try/catch so a materialize failure never
+  // aborts the consolidation result. We check for the presence of a catch
+  // block following the call within a small window.
+  const window = src.slice(awaitIdx, awaitIdx + 1000);
+  assert.match(
+    window,
+    /catch \(err\)/u,
+    "materialize call must be wrapped in try/catch so failures stay non-fatal",
+  );
+});
+
+test("compounding engine.synthesizeWeekly invokes materializeAfterCausalConsolidation", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/compounding/engine.ts"),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /materializeAfterCausalConsolidation/u,
+    "compounding/engine.ts must import materializeAfterCausalConsolidation",
+  );
+  const awaitIdx = src.indexOf("await materializeAfterCausalConsolidation");
+  assert.ok(
+    awaitIdx >= 0,
+    "compounding/engine.ts must await materializeAfterCausalConsolidation at runtime",
+  );
+  const window = src.slice(awaitIdx, awaitIdx + 1000);
+  assert.match(
+    window,
+    /catch \(materializeError\)/u,
+    "causal materialize call must be wrapped in try/catch so failures stay non-fatal",
+  );
+});
+
+test("session-end.sh resolves REMNIC_REPO_ROOT from its own filesystem location", () => {
+  // Regression (PR #392 review): the old hook only ran the materializer
+  // when either $REMNIC_REPO_ROOT was set OR `remnic --print-root` returned
+  // a path. Neither condition holds in most installs, so the materializer
+  // silently never ran. The fix resolves relative to `$BASH_SOURCE`.
+  const src = readFileSync(
+    path.join(repoRoot, "packages/plugin-codex/hooks/bin/session-end.sh"),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /BASH_SOURCE\[0\]/u,
+    "session-end.sh must resolve root from its own filesystem location",
+  );
+  // The old reliance on `remnic --print-root` must be gone.
+  assert.doesNotMatch(
+    src,
+    /remnic --print-root/u,
+    "session-end.sh must not depend on the non-existent `remnic --print-root` flag",
+  );
+  // And the resolution must verify the candidate root by checking for
+  // the sentinel script before running it.
+  assert.match(
+    src,
+    /scripts\/codex-materialize\.ts/u,
+    "session-end.sh must verify the candidate root contains scripts/codex-materialize.ts",
+  );
+});

--- a/tests/codex-materialize-consolidation-wiring.test.ts
+++ b/tests/codex-materialize-consolidation-wiring.test.ts
@@ -99,11 +99,99 @@ test("session-end.sh resolves REMNIC_REPO_ROOT from its own filesystem location"
     /remnic --print-root/u,
     "session-end.sh must not depend on the non-existent `remnic --print-root` flag",
   );
-  // And the resolution must verify the candidate root by checking for
-  // the sentinel script before running it.
+  // Dev fallback path must still verify the candidate root by checking
+  // for the dev script before running it.
   assert.match(
     src,
     /scripts\/codex-materialize\.ts/u,
     "session-end.sh must verify the candidate root contains scripts/codex-materialize.ts",
+  );
+});
+
+test("session-end.sh prefers the packaged materialize.cjs binary for distributed installs", () => {
+  // Regression (PR #392 review thread PRRT_kwDORJXyws56TOVo): the old hook
+  // only knew how to run `scripts/codex-materialize.ts` via tsx, which is
+  // never shipped inside any published package payload. The fix ships a
+  // packaged CJS wrapper at `packages/plugin-codex/bin/materialize.cjs` and
+  // has the hook prefer it before falling back to the dev script.
+  const src = readFileSync(
+    path.join(repoRoot, "packages/plugin-codex/hooks/bin/session-end.sh"),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /materialize\.cjs/u,
+    "session-end.sh must reference the packaged materialize.cjs binary",
+  );
+  assert.match(
+    src,
+    /REMNIC_CODEX_MATERIALIZE_BIN/u,
+    "session-end.sh must honor a REMNIC_CODEX_MATERIALIZE_BIN env override",
+  );
+  // The packaged bin is preferred: its resolution block must appear before
+  // the dev-script fallback in the file so distributed installs never hit
+  // the tsx shim.
+  const binIdx = src.indexOf("materialize.cjs");
+  const scriptIdx = src.indexOf("scripts/codex-materialize.ts");
+  assert.ok(binIdx >= 0 && scriptIdx >= 0, "both paths must exist");
+  assert.ok(
+    binIdx < scriptIdx,
+    "packaged bin resolution must appear before the dev-script fallback",
+  );
+});
+
+test("packaged materialize.cjs exists and delegates to @remnic/core", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/plugin-codex/bin/materialize.cjs"),
+    "utf-8",
+  );
+  // Must dynamically import @remnic/core (ESM-only).
+  assert.match(
+    src,
+    /import\(["']@remnic\/core["']\)/u,
+    "materialize.cjs must dynamically import @remnic/core",
+  );
+  // Must call runCodexMaterialize and parseConfig (the public contract the
+  // hook depends on).
+  assert.match(
+    src,
+    /runCodexMaterialize/u,
+    "materialize.cjs must invoke runCodexMaterialize",
+  );
+  assert.match(
+    src,
+    /parseConfig/u,
+    "materialize.cjs must invoke parseConfig to build a PluginConfig",
+  );
+});
+
+test("plugin-codex package ships bin/ and depends on @remnic/core", () => {
+  const pkg = JSON.parse(
+    readFileSync(path.join(repoRoot, "packages/plugin-codex/package.json"), "utf-8"),
+  );
+  assert.ok(
+    Array.isArray(pkg.files) && pkg.files.includes("bin"),
+    "plugin-codex package.json must ship the bin/ directory",
+  );
+  assert.ok(
+    pkg.dependencies && pkg.dependencies["@remnic/core"],
+    "plugin-codex package.json must declare a @remnic/core runtime dependency",
+  );
+});
+
+test("@remnic/core re-exports runCodexMaterialize for external consumers", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/index.ts"),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /runCodexMaterialize/u,
+    "@remnic/core index.ts must export runCodexMaterialize so the packaged bin can import it",
+  );
+  assert.match(
+    src,
+    /materializeForNamespace/u,
+    "@remnic/core index.ts must export materializeForNamespace",
   );
 });

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -158,22 +158,19 @@ test("runner skips when reason=session_end and codexMaterializeOnSessionEnd=fals
 test("runner propagates schema errors instead of silently returning null", async () => {
   // Regression (Cursor Bugbot on #392): the old catch-all turned schema
   // validation throws from materializeForNamespace into silent `null`
-  // returns, breaking the JSDoc contract. Verify a rendered MEMORY.md that
-  // fails validation bubbles up to the caller.
+  // returns, breaking the JSDoc contract. Verify a hard I/O error bubbles
+  // up to the caller instead of being swallowed.
   //
-  // We trigger a schema failure by stubbing renderMemoryMd via a namespace
-  // with an obviously-bogus structure: easiest path is to hand runCodexMaterialize
-  // a memories list that causes rendered content to miss required sections.
+  // To hit an actual write-path failure we need:
+  //   - `codexHome/memories/` exists as a real directory (opt-in branch)
+  //   - a valid sentinel is present (idempotent guard doesn't short-circuit)
+  //   - writing to `memoriesDir` fails at rename time
   //
-  // The straightforward failure path is: pass a non-existent codexHome
-  // where we can't create the sentinel → a sentinel-missing path returns
-  // normally. To actually hit a schema throw we pre-populate a sentinel
-  // then supply memories whose rendered MEMORY.md we can break. Since the
-  // renderer is deterministic, the cleanest approach is to drive a known
-  // validator failure by stubbing via monkey-patching — but the simpler
-  // and realistic check is to verify that IF the materializer throws, the
-  // runner throws too (not returns null). We do this by passing a memoryDir
-  // that points to an unwritable path so the writer throws EACCES/ENOENT.
+  // We accomplish the write failure by placing a pre-existing *directory*
+  // at the destination path `memoriesDir/memory_summary.md`. renameSync
+  // cannot replace a directory with a file, so we get EISDIR which the
+  // runner must propagate rather than silently swallow.
+  const fsMod = await import("node:fs");
   const memoryDir = makeTempDir("codex-materialize-runner-throw-memdir-");
   const workspaceDir = makeTempDir("codex-materialize-runner-throw-workspace-");
   const { root: codexHome, memoriesDir } = makeCodexHome();
@@ -191,23 +188,24 @@ test("runner propagates schema errors instead of silently returning null", async
       codexMaterializeMemories: true,
     });
 
-    // Delete the codex memories dir mid-flight via a sentinel path that
-    // does not exist as a directory, so writeFileSync throws. We point
-    // codexHome at a regular file so `path.join(codexHome, "memories")`
-    // becomes an invalid path.
-    const badFilePath = path.join(os.tmpdir(), `codex-materialize-runner-badfile-${Date.now()}`);
-    (await import("node:fs")).writeFileSync(badFilePath, "not a directory");
+    // Block the rename by planting a directory where the renamer wants to
+    // put a file. On POSIX this surfaces as EISDIR; on Windows it shows up
+    // as EPERM/EACCES/EEXIST. Match any of those.
+    fsMod.mkdirSync(path.join(memoriesDir, "memory_summary.md"), { recursive: true });
+    fsMod.writeFileSync(
+      path.join(memoriesDir, "memory_summary.md", "blocker.txt"),
+      "synthetic blocker — forces rename to fail",
+    );
 
     await assert.rejects(
       runCodexMaterialize({
         config,
-        codexHome: badFilePath,
+        codexHome,
         reason: "manual",
         now: new Date("2026-04-02T00:00:00Z"),
       }),
-      /ENOTDIR|EEXIST|not a directory|EACCES|file already exists/iu,
+      /EISDIR|ENOTEMPTY|EEXIST|EPERM|EACCES|is a directory|directory not empty|file already exists/iu,
     );
-    (await import("node:fs")).rmSync(badFilePath, { force: true });
   } finally {
     rmSync(memoryDir, { recursive: true, force: true });
     rmSync(workspaceDir, { recursive: true, force: true });

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -1,0 +1,198 @@
+/**
+ * codex-materialize-runner.test.ts — runner-level behavior for #378.
+ *
+ * These tests exercise the I/O bridge in
+ * `packages/remnic-core/src/connectors/codex-materialize-runner.ts`:
+ *
+ *  1. Namespaced memories are read from the same storage root that
+ *     `NamespaceStorageRouter` writes to (`memoryDir/namespaces/<ns>`),
+ *     not from the legacy `memoryDir/<ns>` layout. The default namespace
+ *     still maps to `memoryDir` itself unless a namespaced root exists.
+ *  2. `reason="session_end"` short-circuits when
+ *     `codexMaterializeOnSessionEnd=false`, honoring the per-trigger toggle
+ *     that users control via config.
+ *
+ * All memory data is synthetic — no real user content per repo privacy
+ * policy (see CLAUDE.md).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, existsSync, readdirSync, rmSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import { runCodexMaterialize } from "../src/connectors/codex-materialize-runner.js";
+import { ensureSentinel, SENTINEL_FILE } from "../src/connectors/codex-materialize.js";
+import { parseConfig } from "../src/config.js";
+import { StorageManager } from "../src/storage.js";
+
+function makeTempDir(prefix: string): string {
+  return mkdtempSync(path.join(os.tmpdir(), prefix));
+}
+
+function makeCodexHome(): { root: string; memoriesDir: string } {
+  const root = makeTempDir("codex-materialize-runner-home-");
+  const memoriesDir = path.join(root, "memories");
+  mkdirSync(memoriesDir, { recursive: true });
+  return { root, memoriesDir };
+}
+
+test("runner reads namespaced memories from memoryDir/namespaces/<ns> (P1 fix)", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    // Seed a synthetic memory into the *namespaced* storage root that
+    // NamespaceStorageRouter would use for non-default namespaces.
+    const nsName = "synth-ns";
+    const nsRoot = path.join(memoryDir, "namespaces", nsName);
+    mkdirSync(nsRoot, { recursive: true });
+    const nsStorage = new StorageManager(nsRoot);
+    await nsStorage.writeMemory(
+      "fact",
+      "synthetic namespaced memory used to verify runner path resolution.",
+      { source: "runner-test" },
+    );
+
+    // Intentionally also write a memory to the WRONG legacy path
+    // (memoryDir/<ns>) so we can assert the runner is *not* reading it.
+    const legacyPath = path.join(memoryDir, nsName);
+    mkdirSync(legacyPath, { recursive: true });
+    const legacyStorage = new StorageManager(legacyPath);
+    await legacyStorage.writeMemory(
+      "fact",
+      "LEGACY decoy memory that the runner must NOT pick up.",
+      { source: "runner-test-decoy" },
+    );
+
+    // Opt-in sentinel so the materializer actually writes.
+    ensureSentinel(memoriesDir, nsName, new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      codexMaterializeMemories: true,
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      namespace: nsName,
+      codexHome,
+      reason: "manual",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "runner should have materialized instead of skipping");
+    assert.equal(result!.wrote, true);
+    assert.equal(result!.skippedNoSentinel, false);
+
+    // MEMORY.md should include the synthetic namespaced memory, and must
+    // not include the decoy. We sniff the raw_memories.md contents for
+    // concreteness.
+    const raw = readdirSync(memoriesDir);
+    assert.ok(raw.includes("raw_memories.md"));
+    const rawContents = (await import("node:fs")).readFileSync(
+      path.join(memoriesDir, "raw_memories.md"),
+      "utf-8",
+    );
+    assert.match(rawContents, /synthetic namespaced memory/);
+    assert.doesNotMatch(rawContents, /LEGACY decoy/);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner skips when reason=session_end and codexMaterializeOnSessionEnd=false (P2 fix)", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-sessend-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-sessend-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory(
+      "fact",
+      "synthetic session-end gating memory.",
+      { source: "runner-test" },
+    );
+
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      codexMaterializeMemories: true,
+      codexMaterializeOnSessionEnd: false,
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "session_end",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.equal(result, null, "runner should short-circuit for disabled session_end");
+
+    // No Codex artifacts beyond the sentinel should have been created.
+    const filesAfter = readdirSync(memoriesDir).sort();
+    assert.deepEqual(filesAfter, [SENTINEL_FILE]);
+    assert.equal(existsSync(path.join(memoriesDir, "MEMORY.md")), false);
+    assert.equal(existsSync(path.join(memoriesDir, "memory_summary.md")), false);
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
+test("runner still runs on session_end when codexMaterializeOnSessionEnd=true (default)", async () => {
+  const memoryDir = makeTempDir("codex-materialize-runner-sessend-on-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-sessend-on-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory(
+      "fact",
+      "synthetic session-end enabled memory.",
+      { source: "runner-test" },
+    );
+
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      codexMaterializeMemories: true,
+      // codexMaterializeOnSessionEnd defaults to true.
+    });
+
+    const result = await runCodexMaterialize({
+      config,
+      codexHome,
+      reason: "session_end",
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.ok(result, "runner should have materialized on session_end when toggle is on");
+    assert.equal(result!.wrote, true);
+    assert.ok(existsSync(path.join(memoriesDir, "MEMORY.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "memory_summary.md")));
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});

--- a/tests/codex-materialize-runner.test.ts
+++ b/tests/codex-materialize-runner.test.ts
@@ -155,6 +155,66 @@ test("runner skips when reason=session_end and codexMaterializeOnSessionEnd=fals
   }
 });
 
+test("runner propagates schema errors instead of silently returning null", async () => {
+  // Regression (Cursor Bugbot on #392): the old catch-all turned schema
+  // validation throws from materializeForNamespace into silent `null`
+  // returns, breaking the JSDoc contract. Verify a rendered MEMORY.md that
+  // fails validation bubbles up to the caller.
+  //
+  // We trigger a schema failure by stubbing renderMemoryMd via a namespace
+  // with an obviously-bogus structure: easiest path is to hand runCodexMaterialize
+  // a memories list that causes rendered content to miss required sections.
+  //
+  // The straightforward failure path is: pass a non-existent codexHome
+  // where we can't create the sentinel → a sentinel-missing path returns
+  // normally. To actually hit a schema throw we pre-populate a sentinel
+  // then supply memories whose rendered MEMORY.md we can break. Since the
+  // renderer is deterministic, the cleanest approach is to drive a known
+  // validator failure by stubbing via monkey-patching — but the simpler
+  // and realistic check is to verify that IF the materializer throws, the
+  // runner throws too (not returns null). We do this by passing a memoryDir
+  // that points to an unwritable path so the writer throws EACCES/ENOENT.
+  const memoryDir = makeTempDir("codex-materialize-runner-throw-memdir-");
+  const workspaceDir = makeTempDir("codex-materialize-runner-throw-workspace-");
+  const { root: codexHome, memoriesDir } = makeCodexHome();
+
+  try {
+    const storage = new StorageManager(memoryDir);
+    await storage.writeMemory("fact", "synthetic throw propagation memory.", { source: "runner-test" });
+    ensureSentinel(memoriesDir, "default", new Date("2026-04-02T00:00:00Z"));
+
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      codexMaterializeMemories: true,
+    });
+
+    // Delete the codex memories dir mid-flight via a sentinel path that
+    // does not exist as a directory, so writeFileSync throws. We point
+    // codexHome at a regular file so `path.join(codexHome, "memories")`
+    // becomes an invalid path.
+    const badFilePath = path.join(os.tmpdir(), `codex-materialize-runner-badfile-${Date.now()}`);
+    (await import("node:fs")).writeFileSync(badFilePath, "not a directory");
+
+    await assert.rejects(
+      runCodexMaterialize({
+        config,
+        codexHome: badFilePath,
+        reason: "manual",
+        now: new Date("2026-04-02T00:00:00Z"),
+      }),
+      /ENOTDIR|EEXIST|not a directory|EACCES|file already exists/iu,
+    );
+    (await import("node:fs")).rmSync(badFilePath, { force: true });
+  } finally {
+    rmSync(memoryDir, { recursive: true, force: true });
+    rmSync(workspaceDir, { recursive: true, force: true });
+    rmSync(codexHome, { recursive: true, force: true });
+  }
+});
+
 test("runner still runs on session_end when codexMaterializeOnSessionEnd=true (default)", async () => {
   const memoryDir = makeTempDir("codex-materialize-runner-sessend-on-memdir-");
   const workspaceDir = makeTempDir("codex-materialize-runner-sessend-on-workspace-");

--- a/tests/codex-materialize-schema.test.ts
+++ b/tests/codex-materialize-schema.test.ts
@@ -1,0 +1,161 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  renderMemoryMd,
+  validateMemoryMd,
+} from "../src/connectors/codex-materialize.js";
+import type { MemoryFile } from "../src/types.js";
+
+function makeMemory(overrides: {
+  id?: string;
+  category?: string;
+  content?: string;
+  tags?: string[];
+}): MemoryFile {
+  const id = overrides.id ?? `syn-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    path: `/tmp/remnic-test/facts/${id}.md`,
+    frontmatter: {
+      id,
+      category: (overrides.category ?? "fact") as any,
+      created: "2026-04-01T00:00:00Z",
+      updated: "2026-04-01T00:00:00Z",
+      source: "synthetic-test",
+      confidence: 0.8,
+      confidenceTier: "implied",
+      tags: overrides.tags ?? [],
+    } as any,
+    content: overrides.content ?? "synthetic content",
+  };
+}
+
+test("validateMemoryMd accepts rendered output with multiple categories", () => {
+  const memories = [
+    makeMemory({ id: "f-1", category: "fact", content: "Synthetic fact A.", tags: ["alpha"] }),
+    makeMemory({ id: "p-1", category: "preference", content: "Synthetic preference A.", tags: ["beta"] }),
+    makeMemory({ id: "c-1", category: "correction", content: "Synthetic correction A." }),
+    makeMemory({ id: "d-1", category: "decision", content: "Synthetic decision A." }),
+  ];
+
+  const rendered = renderMemoryMd({
+    namespace: "schema-ns",
+    memories,
+    rolloutSummaries: [
+      {
+        slug: "session-1",
+        cwd: "/fake",
+        rolloutPath: "/fake/rollout.jsonl",
+        updatedAt: "2026-04-01T00:00:00Z",
+        threadId: "synthetic-thread",
+        body: "Synthetic recap.",
+      },
+    ],
+    now: new Date("2026-04-02T00:00:00Z"),
+  });
+
+  const validation = validateMemoryMd(rendered);
+  if (!validation.valid) {
+    // Surface errors clearly on failure.
+    assert.fail(`schema validation failed: ${validation.errors.join("; ")}`);
+  }
+
+  assert.match(rendered, /^# Task Group: schema-ns/u);
+  assert.match(rendered, /^scope:\s+/mu);
+  assert.match(rendered, /^applies_to:\s+/mu);
+  assert.match(rendered, /^## Task 1:/mu);
+  assert.match(rendered, /^### rollout_summary_files$/mu);
+  assert.match(rendered, /^### keywords$/mu);
+  assert.match(rendered, /^## User preferences$/mu);
+  assert.match(rendered, /^## Reusable knowledge$/mu);
+  assert.match(rendered, /^## Failures and how to do differently$/mu);
+});
+
+test("validateMemoryMd accepts the empty-namespace baseline rendering", () => {
+  const rendered = renderMemoryMd({
+    namespace: "empty-ns",
+    memories: [],
+    rolloutSummaries: [],
+    now: new Date("2026-04-02T00:00:00Z"),
+  });
+  const validation = validateMemoryMd(rendered);
+  assert.equal(validation.valid, true, validation.errors.join("; "));
+  // Baseline task block must still be present so Codex's reader has
+  // something to anchor on.
+  assert.match(rendered, /^## Task 1:/mu);
+});
+
+test("validateMemoryMd rejects content missing the Task Group header", () => {
+  const broken = [
+    "scope: x",
+    "applies_to: y",
+    "",
+    "## Task 1: x",
+    "",
+    "### rollout_summary_files",
+    "- (none)",
+    "",
+    "### keywords",
+    "- x",
+    "",
+    "## User preferences",
+    "- x",
+    "",
+    "## Reusable knowledge",
+    "- x",
+    "",
+    "## Failures and how to do differently",
+    "- x",
+    "",
+  ].join("\n");
+  const validation = validateMemoryMd(broken);
+  assert.equal(validation.valid, false);
+  assert.ok(validation.errors.some((e) => e.includes("Task Group")));
+});
+
+test("validateMemoryMd rejects content missing required bottom sections", () => {
+  const broken = [
+    "# Task Group: x",
+    "scope: x",
+    "applies_to: y",
+    "",
+    "## Task 1: x",
+    "",
+    "### rollout_summary_files",
+    "- (none)",
+    "",
+    "### keywords",
+    "- x",
+    "",
+  ].join("\n");
+  const validation = validateMemoryMd(broken);
+  assert.equal(validation.valid, false);
+  assert.ok(validation.errors.some((e) => e.includes("User preferences")));
+  assert.ok(validation.errors.some((e) => e.includes("Reusable knowledge")));
+  assert.ok(validation.errors.some((e) => e.includes("Failures and how to do differently")));
+});
+
+test("validateMemoryMd rejects a task block missing required sub-headers", () => {
+  const broken = [
+    "# Task Group: x",
+    "scope: x",
+    "applies_to: y",
+    "",
+    "## Task 1: missing subheaders",
+    "some body",
+    "",
+    "## User preferences",
+    "- x",
+    "",
+    "## Reusable knowledge",
+    "- x",
+    "",
+    "## Failures and how to do differently",
+    "- x",
+    "",
+  ].join("\n");
+  const validation = validateMemoryMd(broken);
+  assert.equal(validation.valid, false);
+  assert.ok(validation.errors.some((e) => e.includes("rollout_summary_files")));
+  assert.ok(validation.errors.some((e) => e.includes("keywords")));
+});

--- a/tests/codex-materialize-schema.test.ts
+++ b/tests/codex-materialize-schema.test.ts
@@ -51,7 +51,6 @@ test("validateMemoryMd accepts rendered output with multiple categories", () => 
         body: "Synthetic recap.",
       },
     ],
-    now: new Date("2026-04-02T00:00:00Z"),
   });
 
   const validation = validateMemoryMd(rendered);
@@ -76,7 +75,6 @@ test("validateMemoryMd accepts the empty-namespace baseline rendering", () => {
     namespace: "empty-ns",
     memories: [],
     rolloutSummaries: [],
-    now: new Date("2026-04-02T00:00:00Z"),
   });
   const validation = validateMemoryMd(rendered);
   assert.equal(validation.valid, true, validation.errors.join("; "));

--- a/tests/codex-materialize-sentinel.test.ts
+++ b/tests/codex-materialize-sentinel.test.ts
@@ -1,0 +1,109 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, existsSync, writeFileSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ensureSentinel,
+  materializeForNamespace,
+  SENTINEL_FILE,
+  MATERIALIZE_VERSION,
+} from "../src/connectors/codex-materialize.js";
+import type { MemoryFile } from "../src/types.js";
+
+function makeMemory(): MemoryFile {
+  return {
+    path: "/tmp/remnic-test/facts/sentinel.md",
+    frontmatter: {
+      id: "sentinel-synthetic",
+      category: "fact" as any,
+      created: "2026-04-01T00:00:00Z",
+      updated: "2026-04-01T00:00:00Z",
+      source: "synthetic-test",
+      confidence: 0.9,
+      confidenceTier: "implied",
+      tags: [],
+    } as any,
+    content: "synthetic sentinel content",
+  };
+}
+
+function makeTempCodexHome(): { root: string; memoriesDir: string } {
+  const root = mkdtempSync(path.join(os.tmpdir(), "codex-materialize-sentinel-test-"));
+  const memoriesDir = path.join(root, "memories");
+  mkdirSync(memoriesDir, { recursive: true });
+  return { root, memoriesDir };
+}
+
+test("sentinel missing → warns and skips, leaves directory untouched", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  let warnings = 0;
+  try {
+    const result = materializeForNamespace("synthetic-ns", {
+      memories: [makeMemory()],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+      logger: {
+        info: () => {},
+        warn: () => {
+          warnings++;
+        },
+      },
+    });
+    assert.equal(result.skippedNoSentinel, true);
+    assert.equal(result.wrote, false);
+    assert.ok(warnings >= 1, "materializer should emit at least one warning");
+    assert.equal(existsSync(path.join(memoriesDir, "MEMORY.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("ensureSentinel is idempotent and does not overwrite an existing hash", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    // First create the sentinel, then run a real materialization to populate hash.
+    ensureSentinel(memoriesDir, "idem-ns");
+    const result = materializeForNamespace("idem-ns", {
+      memories: [makeMemory()],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+      logger: { info: () => {}, warn: () => {} },
+    });
+    assert.equal(result.wrote, true);
+    const before = JSON.parse(readFileSync(path.join(memoriesDir, SENTINEL_FILE), "utf-8"));
+    assert.equal(before.version, MATERIALIZE_VERSION);
+    assert.ok(before.content_hash.length > 0);
+
+    // Second ensureSentinel() must NOT clobber the hash — the real hash
+    // should survive so the next run's idempotent check still works.
+    ensureSentinel(memoriesDir, "idem-ns");
+    const after = JSON.parse(readFileSync(path.join(memoriesDir, SENTINEL_FILE), "utf-8"));
+    assert.equal(after.content_hash, before.content_hash);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("missing sentinel + hand-edited user files must never be overwritten", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    // Pretend the user already created their own MEMORY.md by hand.
+    const userContent = "# Hand-edited by user, do not touch\n";
+    writeFileSync(path.join(memoriesDir, "MEMORY.md"), userContent);
+
+    const result = materializeForNamespace("synthetic-ns", {
+      memories: [makeMemory()],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+      logger: { info: () => {}, warn: () => {} },
+    });
+    assert.equal(result.skippedNoSentinel, true);
+    assert.equal(result.wrote, false);
+    const after = readFileSync(path.join(memoriesDir, "MEMORY.md"), "utf-8");
+    assert.equal(after, userContent);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/codex-materialize-token-limit.test.ts
+++ b/tests/codex-materialize-token-limit.test.ts
@@ -63,7 +63,6 @@ test("renderMemorySummary stays under the configured token budget", () => {
     memories,
     rolloutSummaries: [],
     maxTokens: budget,
-    now: new Date("2026-04-02T00:00:00Z"),
   });
 
   assert.ok(
@@ -106,7 +105,6 @@ test("renderMemorySummary honors maxTokens=0 by emitting no summary body", () =>
     memories: [makeMemory("synthetic long enough memory body text", "zero-1")],
     rolloutSummaries: [],
     maxTokens: 0,
-    now: new Date("2026-04-02T00:00:00Z"),
   });
   assert.equal(rendered, "");
 });
@@ -122,7 +120,6 @@ test("renderMemorySummary with default budget stays under Codex's 5000-token cap
     memories,
     rolloutSummaries: [],
     maxTokens: 4500, // matches the config default
-    now: new Date("2026-04-02T00:00:00Z"),
   });
   assert.ok(approximateTokenCount(rendered) < 5000);
 });

--- a/tests/codex-materialize-token-limit.test.ts
+++ b/tests/codex-materialize-token-limit.test.ts
@@ -1,0 +1,89 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  renderMemorySummary,
+  approximateTokenCount,
+  truncateToTokenBudget,
+} from "../src/connectors/codex-materialize.js";
+import type { MemoryFile } from "../src/types.js";
+
+function makeMemory(content: string, id: string): MemoryFile {
+  return {
+    path: `/tmp/remnic-test/facts/${id}.md`,
+    frontmatter: {
+      id,
+      category: "fact" as any,
+      created: "2026-04-01T00:00:00Z",
+      updated: "2026-04-01T00:00:00Z",
+      source: "synthetic-test",
+      confidence: 0.9,
+      confidenceTier: "implied",
+      tags: [],
+    } as any,
+    content,
+  };
+}
+
+test("approximateTokenCount counts whitespace-separated tokens", () => {
+  assert.equal(approximateTokenCount(""), 0);
+  assert.equal(approximateTokenCount("one"), 1);
+  assert.equal(approximateTokenCount("one two three"), 3);
+  assert.equal(approximateTokenCount("  leading  and  trailing  "), 3);
+});
+
+test("truncateToTokenBudget leaves small content alone", () => {
+  const text = "one two three four";
+  assert.equal(truncateToTokenBudget(text, 100), text);
+});
+
+test("truncateToTokenBudget drops trailing content over budget", () => {
+  const text = "one two three four five six seven eight nine ten eleven twelve";
+  const result = truncateToTokenBudget(text, 5);
+  assert.ok(approximateTokenCount(result) <= 5 + 1);
+  assert.match(result, /truncated/u);
+});
+
+test("renderMemorySummary stays under the configured token budget", () => {
+  // Create a lot of long synthetic memories so the base rendering blows the
+  // budget without truncation.
+  const memories: MemoryFile[] = [];
+  for (let i = 0; i < 200; i++) {
+    memories.push(
+      makeMemory(
+        `synthetic memory payload item number ${i} with filler words intended to inflate the whitespace token count beyond the summary budget used by codex cli`,
+        `syn-${i}`,
+      ),
+    );
+  }
+
+  const budget = 120;
+  const rendered = renderMemorySummary({
+    namespace: "token-ns",
+    memories,
+    rolloutSummaries: [],
+    maxTokens: budget,
+    now: new Date("2026-04-02T00:00:00Z"),
+  });
+
+  assert.ok(
+    approximateTokenCount(rendered) <= budget,
+    `rendered token count ${approximateTokenCount(rendered)} exceeds budget ${budget}`,
+  );
+});
+
+test("renderMemorySummary with default budget stays under Codex's 5000-token cap", () => {
+  const memories: MemoryFile[] = [];
+  for (let i = 0; i < 50; i++) {
+    memories.push(makeMemory(`synthetic memory line ${i} with a few filler tokens`, `syn-${i}`));
+  }
+
+  const rendered = renderMemorySummary({
+    namespace: "default-budget-ns",
+    memories,
+    rolloutSummaries: [],
+    maxTokens: 4500, // matches the config default
+    now: new Date("2026-04-02T00:00:00Z"),
+  });
+  assert.ok(approximateTokenCount(rendered) < 5000);
+});

--- a/tests/codex-materialize-token-limit.test.ts
+++ b/tests/codex-materialize-token-limit.test.ts
@@ -72,6 +72,45 @@ test("renderMemorySummary stays under the configured token budget", () => {
   );
 });
 
+test("truncateToTokenBudget reserves enough headroom for the truncation marker", () => {
+  // Regression (Cursor Bugbot on #392): the line-preserving path used to
+  // reserve only 1 token for a ~4-token marker, forcing the hard-cut
+  // fallback that flattens the entire output. Verify the line-preserving
+  // path actually preserves line structure when the budget is tight but
+  // comfortable.
+  const text = [
+    "# header",
+    "line one with filler",
+    "line two with filler",
+    "line three with filler",
+    "line four with filler",
+    "line five with filler",
+  ].join("\n");
+  const result = truncateToTokenBudget(text, 10);
+  // Stays under budget — the marker's token cost is accounted for.
+  assert.ok(
+    approximateTokenCount(result) <= 10,
+    `token count ${approximateTokenCount(result)} exceeds budget 10`,
+  );
+  // Line structure preserved (the result still contains a newline) — if
+  // the old hard-cut fallback ran we'd see no newlines at all.
+  assert.match(result, /\n/u);
+});
+
+test("renderMemorySummary honors maxTokens=0 by emitting no summary body", () => {
+  // Regression (Codex on #392): maxTokens=0 used to be silently reset to the
+  // 4500-token default. A zero-token budget must actually produce an empty
+  // body.
+  const rendered = renderMemorySummary({
+    namespace: "zero-budget-ns",
+    memories: [makeMemory("synthetic long enough memory body text", "zero-1")],
+    rolloutSummaries: [],
+    maxTokens: 0,
+    now: new Date("2026-04-02T00:00:00Z"),
+  });
+  assert.equal(rendered, "");
+});
+
 test("renderMemorySummary with default budget stays under Codex's 5000-token cap", () => {
   const memories: MemoryFile[] = [];
   for (let i = 0; i < 50; i++) {

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -110,6 +110,95 @@ test("skips materialization when sentinel file is missing", () => {
   }
 });
 
+test("idempotent guard forces rewrite when a managed file is missing", () => {
+  // Regression (Codex on #392): the sentinel hash check used to skip even
+  // when MEMORY.md / memory_summary.md / raw_memories.md had been deleted.
+  // Verify a missing file flips the short-circuit back to a rewrite.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "idem-missing-ns");
+    const memories = [makeMemory({ id: "idem-missing-1", content: "synthetic idempotence payload" })];
+
+    const first = materializeForNamespace("idem-missing-ns", {
+      memories,
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(first.wrote, true);
+
+    // Simulate external deletion of a managed file.
+    rmSync(path.join(memoriesDir, "MEMORY.md"));
+    assert.equal(existsSync(path.join(memoriesDir, "MEMORY.md")), false);
+
+    const second = materializeForNamespace("idem-missing-ns", {
+      memories,
+      codexHome: root,
+      now: new Date("2026-04-03T00:00:00Z"),
+    });
+    assert.equal(second.wrote, true);
+    assert.equal(second.skippedIdempotent, false);
+    assert.ok(existsSync(path.join(memoriesDir, "MEMORY.md")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rollout_summaries/ is untouched when caller omits rolloutSummaries", () => {
+  // Regression (Codex on #392): passing no rolloutSummaries used to wipe
+  // every .md in rollout_summaries/ on the next run. Seed a user-created
+  // recap file, materialize without rollouts, and assert the file survives.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "rollout-preserve-ns");
+    mkdirSync(path.join(memoriesDir, "rollout_summaries"), { recursive: true });
+    const userRecapPath = path.join(memoriesDir, "rollout_summaries", "user-notes.md");
+    writeFileSync(userRecapPath, "# synthetic user notes — must not be wiped\n");
+
+    materializeForNamespace("rollout-preserve-ns", {
+      memories: [makeMemory({ content: "synthetic preserve payload" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+      // NOTE: rolloutSummaries intentionally omitted.
+    });
+
+    assert.ok(existsSync(userRecapPath), "user-authored rollout file must survive");
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("rollout_summaries/ GC still runs when caller supplies an empty rolloutSummaries", () => {
+  // Symmetry: passing an explicit empty array IS authoritative — it means
+  // "we own this dir and it should be empty". Stale owned files should
+  // disappear on the next run.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "rollout-gc-ns");
+    // First run with a rollout that will later become stale.
+    materializeForNamespace("rollout-gc-ns", {
+      memories: [makeMemory({ content: "synthetic gc payload round 1" })],
+      codexHome: root,
+      rolloutSummaries: [
+        { slug: "stale-session", updatedAt: "2026-04-01T00:00:00Z", body: "stale synthetic recap." },
+      ],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    const stalePath = path.join(memoriesDir, "rollout_summaries", "stale-session.md");
+    assert.ok(existsSync(stalePath));
+
+    // Second run: empty authoritative set → stale file must be removed.
+    materializeForNamespace("rollout-gc-ns", {
+      memories: [makeMemory({ content: "synthetic gc payload round 2 (different content)" })],
+      codexHome: root,
+      rolloutSummaries: [],
+      now: new Date("2026-04-03T00:00:00Z"),
+    });
+    assert.equal(existsSync(stalePath), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("idempotent no-op when nothing changed since last run", () => {
   const { root, memoriesDir } = makeTempCodexHome();
   try {

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -1,0 +1,239 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  materializeForNamespace,
+  ensureSentinel,
+  describeMemoriesDir,
+  SENTINEL_FILE,
+  TMP_DIR,
+  MATERIALIZE_VERSION,
+} from "../src/connectors/codex-materialize.js";
+import type { MemoryFile } from "../src/types.js";
+
+// Synthetic memory factory — NEVER use real user data in tests.
+function makeMemory(overrides: {
+  id?: string;
+  category?: string;
+  content?: string;
+  created?: string;
+  updated?: string;
+  tags?: string[];
+  status?: string;
+  confidence?: number;
+}): MemoryFile {
+  const id = overrides.id ?? `fact-${Math.random().toString(36).slice(2, 8)}`;
+  return {
+    path: `/tmp/remnic-test/facts/${id}.md`,
+    frontmatter: {
+      id,
+      category: (overrides.category ?? "fact") as any,
+      created: overrides.created ?? "2026-04-01T00:00:00Z",
+      updated: overrides.updated ?? "2026-04-01T00:00:00Z",
+      source: "synthetic-test",
+      confidence: overrides.confidence ?? 0.8,
+      confidenceTier: "implied",
+      tags: overrides.tags ?? [],
+      ...(overrides.status ? { status: overrides.status as any } : {}),
+    } as any,
+    content: overrides.content ?? "synthetic test memory content",
+  };
+}
+
+function makeTempCodexHome(): { root: string; memoriesDir: string } {
+  const root = mkdtempSync(path.join(os.tmpdir(), "codex-materialize-test-"));
+  const memoriesDir = path.join(root, "memories");
+  mkdirSync(memoriesDir, { recursive: true });
+  return { root, memoriesDir };
+}
+
+test("writes memory_summary.md, MEMORY.md, raw_memories.md when sentinel present", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "synthetic-ns", new Date("2026-04-01T00:00:00Z"));
+
+    const memories = [
+      makeMemory({ id: "syn-1", category: "fact", content: "The synthetic fixture uses placeholder data only." }),
+      makeMemory({ id: "syn-2", category: "preference", content: "Prefer structured synthetic fixtures over real data." }),
+      makeMemory({ id: "syn-3", category: "correction", content: "Avoid coupling tests to real user history." }),
+    ];
+
+    const result = materializeForNamespace("synthetic-ns", {
+      memories,
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.equal(result.skippedNoSentinel, false);
+    assert.equal(result.skippedIdempotent, false);
+    assert.equal(result.wrote, true);
+    assert.ok(result.filesWritten.includes("memory_summary.md"));
+    assert.ok(result.filesWritten.includes("MEMORY.md"));
+    assert.ok(result.filesWritten.includes("raw_memories.md"));
+
+    assert.ok(existsSync(path.join(memoriesDir, "memory_summary.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "MEMORY.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "raw_memories.md")));
+    assert.ok(existsSync(path.join(memoriesDir, SENTINEL_FILE)));
+
+    const sentinelRaw = readFileSync(path.join(memoriesDir, SENTINEL_FILE), "utf-8");
+    const sentinel = JSON.parse(sentinelRaw);
+    assert.equal(sentinel.version, MATERIALIZE_VERSION);
+    assert.equal(sentinel.namespace, "synthetic-ns");
+    assert.equal(typeof sentinel.content_hash, "string");
+    assert.ok(sentinel.content_hash.length > 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("skips materialization when sentinel file is missing", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    // No sentinel written → materializer should skip.
+    const result = materializeForNamespace("synthetic-ns", {
+      memories: [makeMemory({ content: "synthetic fallback" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.equal(result.skippedNoSentinel, true);
+    assert.equal(result.wrote, false);
+    assert.equal(result.filesWritten.length, 0);
+    assert.equal(existsSync(path.join(memoriesDir, "MEMORY.md")), false);
+    assert.equal(existsSync(path.join(memoriesDir, "memory_summary.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("idempotent no-op when nothing changed since last run", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "idem-ns");
+    const memories = [
+      makeMemory({ id: "idem-1", content: "synthetic content A" }),
+      makeMemory({ id: "idem-2", content: "synthetic content B" }),
+    ];
+
+    const first = materializeForNamespace("idem-ns", {
+      memories,
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(first.wrote, true);
+
+    const second = materializeForNamespace("idem-ns", {
+      memories,
+      codexHome: root,
+      now: new Date("2026-04-03T00:00:00Z"),
+    });
+    assert.equal(second.skippedIdempotent, true);
+    assert.equal(second.wrote, false);
+    assert.equal(second.filesWritten.length, 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("renders rollout_summaries/*.md and respects retention days", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "rollout-ns");
+    const now = new Date("2026-04-02T00:00:00Z");
+
+    const result = materializeForNamespace("rollout-ns", {
+      memories: [makeMemory({ content: "anchor" })],
+      codexHome: root,
+      rolloutRetentionDays: 30,
+      rolloutSummaries: [
+        {
+          slug: "recent-session",
+          cwd: "/fake/project",
+          updatedAt: "2026-04-01T00:00:00Z",
+          threadId: "synthetic-thread",
+          body: "Synthetic recap of a recent session.",
+          keywords: ["synthetic"],
+        },
+        {
+          // Older than retention window — should be pruned.
+          slug: "old-session",
+          updatedAt: "2025-01-01T00:00:00Z",
+          body: "Synthetic old recap.",
+        },
+      ],
+      now,
+    });
+
+    assert.equal(result.wrote, true);
+    assert.ok(result.filesWritten.some((f) => f.endsWith("recent-session.md")));
+    assert.ok(!result.filesWritten.some((f) => f.endsWith("old-session.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "rollout_summaries", "recent-session.md")));
+    assert.equal(existsSync(path.join(memoriesDir, "rollout_summaries", "old-session.md")), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("leaves no .remnic-tmp/ scratch directory after a successful run", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "cleanup-ns");
+    materializeForNamespace("cleanup-ns", {
+      memories: [makeMemory({ content: "synthetic cleanup" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(existsSync(path.join(memoriesDir, TMP_DIR)), false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("describeMemoriesDir reports owned files and sentinel state", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    // Before sentinel → describe returns dir but no sentinel.
+    let info = describeMemoriesDir(memoriesDir);
+    assert.ok(info);
+    assert.equal(info?.hasSentinel, false);
+
+    ensureSentinel(memoriesDir, "describe-ns");
+    info = describeMemoriesDir(memoriesDir);
+    assert.ok(info);
+    assert.equal(info?.hasSentinel, true);
+    assert.equal(info?.sentinel?.namespace, "describe-ns");
+
+    materializeForNamespace("describe-ns", {
+      memories: [makeMemory({ content: "synthetic describe" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    info = describeMemoriesDir(memoriesDir);
+    assert.ok(info?.files.includes("memory_summary.md"));
+    assert.ok(info?.files.includes("MEMORY.md"));
+    assert.ok(info?.files.includes("raw_memories.md"));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("does not overwrite a corrupted sentinel silently (treats as missing)", () => {
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    // Write a junk sentinel → readSentinel() returns null → skip with warning.
+    writeFileSync(path.join(memoriesDir, SENTINEL_FILE), "not-json");
+    const result = materializeForNamespace("corrupt-ns", {
+      memories: [makeMemory({ content: "synthetic corrupt" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(result.skippedNoSentinel, true);
+    assert.equal(result.wrote, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -228,6 +228,39 @@ test("idempotent no-op when nothing changed since last run", () => {
   }
 });
 
+test("rolloutRetentionDays=0 prunes every rollout with a past updatedAt", () => {
+  // Regression (Cursor Bugbot on #392): retentionDays=0 used to short-
+  // circuit to "return all" instead of "retain for 0 days". The only
+  // all-pass escape hatch is a negative value.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "retention-ns");
+    const result = materializeForNamespace("retention-ns", {
+      memories: [makeMemory({ content: "synthetic retention payload" })],
+      codexHome: root,
+      rolloutRetentionDays: 0,
+      rolloutSummaries: [
+        {
+          slug: "past-session",
+          updatedAt: "2026-04-01T00:00:00Z",
+          body: "past synthetic recap.",
+        },
+      ],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(result.wrote, true);
+    // No rollout files should have been written — retention=0 prunes it.
+    const rolloutWritten = result.filesWritten.filter((f) => f.includes("rollout_summaries"));
+    assert.equal(rolloutWritten.length, 0);
+    assert.equal(
+      existsSync(path.join(memoriesDir, "rollout_summaries", "past-session.md")),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("renders rollout_summaries/*.md and respects retention days", () => {
   const { root, memoriesDir } = makeTempCodexHome();
   try {

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync, utimesSync } from "node:fs";
 import os from "node:os";
 import path from "node:path";
 
@@ -392,6 +392,152 @@ test("does not overwrite a corrupted sentinel silently (treats as missing)", () 
     });
     assert.equal(result.skippedNoSentinel, true);
     assert.equal(result.wrote, false);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("MEMORY.md does not reference rollouts pruned by retention", () => {
+  // Regression (PR #392 review): renderMemoryMd/renderMemorySummary used to
+  // receive the raw rolloutSummaries array before pruneRollouts ran, so
+  // MEMORY.md listed `rollout_summaries/<slug>.md` paths for files that
+  // were never written. Verify the retained set flows all the way through.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "prune-render-ns");
+    materializeForNamespace("prune-render-ns", {
+      memories: [makeMemory({ content: "synthetic prune-render anchor" })],
+      codexHome: root,
+      rolloutRetentionDays: 30,
+      rolloutSummaries: [
+        {
+          slug: "fresh-session",
+          updatedAt: "2026-04-01T00:00:00Z",
+          body: "fresh synthetic recap.",
+        },
+        {
+          // Older than retention — must not appear anywhere in rendered output.
+          slug: "ancient-ghost-session",
+          updatedAt: "2025-01-01T00:00:00Z",
+          body: "ancient synthetic recap.",
+        },
+      ],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    const memoryMd = readFileSync(path.join(memoriesDir, "MEMORY.md"), "utf-8");
+    const memorySummary = readFileSync(
+      path.join(memoriesDir, "memory_summary.md"),
+      "utf-8",
+    );
+
+    // The retained rollout is listed.
+    assert.match(memoryMd, /rollout_summaries\/fresh-session\.md/u);
+    // The pruned rollout is NOT listed (would be a broken link).
+    assert.doesNotMatch(memoryMd, /ancient-ghost-session/u);
+    assert.doesNotMatch(memorySummary, /ancient-ghost-session/u);
+    // And it's also not on disk.
+    assert.equal(
+      existsSync(path.join(memoriesDir, "rollout_summaries", "ancient-ghost-session.md")),
+      false,
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("MEMORY.md does not list colliding-slug duplicates", () => {
+  // Regression (PR #392 review): dedupe used to happen only on the final
+  // `rolloutFiles` list, not on the input that was passed to renderMemoryMd.
+  // That meant MEMORY.md could list the same `rollout_summaries/session-1.md`
+  // entry twice while only one file was written. Verify the rendered list
+  // has exactly one entry for a collided slug.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "dedupe-render-ns");
+    materializeForNamespace("dedupe-render-ns", {
+      memories: [makeMemory({ content: "synthetic dedupe-render anchor" })],
+      codexHome: root,
+      rolloutSummaries: [
+        {
+          slug: "Session 1",
+          updatedAt: "2026-04-01T00:00:00Z",
+          body: "first synthetic recap.",
+        },
+        {
+          slug: "session!!!1",
+          updatedAt: "2026-04-01T12:00:00Z",
+          body: "second synthetic recap.",
+        },
+      ],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    const memoryMd = readFileSync(path.join(memoriesDir, "MEMORY.md"), "utf-8");
+    const matches = memoryMd.match(/rollout_summaries\/session-1\.md/gu) ?? [];
+    // Exactly one listing — not two. (The `else` branch of renderMemoryMd
+    // emits one per task block; with a single fact-category task this is
+    // exactly one entry.)
+    assert.equal(matches.length, 1);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("concurrent materialize runs use isolated staging dirs", () => {
+  // Regression (PR #392 review): the shared `.remnic-tmp/` staging dir was
+  // deleted at the start of every run, so two overlapping runs could delete
+  // each other's tmp files mid-rename and crash with ENOENT. Per-run tmp dirs
+  // avoid that — simulate overlap by kicking two runs from inside the same
+  // process and asserting both succeed.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "concurrent-ns");
+    // First run stages and completes.
+    const r1 = materializeForNamespace("concurrent-ns", {
+      memories: [makeMemory({ id: "r1", content: "synthetic concurrent payload A" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+    assert.equal(r1.wrote, true);
+
+    // Seed a stale tmp dir that a previous crashed run would have left
+    // behind. Set its mtime to 2 hours ago so the GC sweeps it.
+    const staleDir = path.join(memoriesDir, ".remnic-tmp-crashed-run");
+    mkdirSync(staleDir, { recursive: true });
+    writeFileSync(path.join(staleDir, "leftover.txt"), "crash residue");
+    const twoHoursAgo = Date.now() / 1000 - 2 * 60 * 60;
+    utimesSync(staleDir, twoHoursAgo, twoHoursAgo);
+
+    // Seed a FRESH tmp dir that represents an in-flight concurrent run.
+    // Its mtime is "now" so the GC must NOT delete it.
+    const freshDir = path.join(memoriesDir, ".remnic-tmp-inflight-run");
+    mkdirSync(freshDir, { recursive: true });
+    writeFileSync(path.join(freshDir, "inflight.txt"), "in-flight payload");
+
+    // Second run should:
+    //   - succeed
+    //   - remove the stale dir (mtime > 1h)
+    //   - leave the fresh dir alone (mtime ≈ now)
+    const r2 = materializeForNamespace("concurrent-ns", {
+      memories: [makeMemory({ id: "r2", content: "synthetic concurrent payload B — distinct" })],
+      codexHome: root,
+      now: new Date("2026-04-02T01:00:00Z"),
+    });
+    assert.equal(r2.wrote, true);
+    assert.equal(existsSync(staleDir), false, "stale tmp dir must be GC'd");
+    assert.equal(existsSync(freshDir), true, "fresh tmp dir must survive");
+    assert.equal(existsSync(path.join(freshDir, "inflight.txt")), true);
+
+    // And the final artifacts are still intact after the second run.
+    assert.ok(existsSync(path.join(memoriesDir, "MEMORY.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "memory_summary.md")));
+    assert.ok(existsSync(path.join(memoriesDir, "raw_memories.md")));
+
+    // Clean up the simulated in-flight dir ourselves so the assert in the
+    // "leaves no .remnic-tmp/ scratch directory" test doesn't false-negative
+    // if the test ordering changes. (We own this dir — it's synthetic.)
+    rmSync(freshDir, { recursive: true, force: true });
   } finally {
     rmSync(root, { recursive: true, force: true });
   }

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -542,3 +542,73 @@ test("concurrent materialize runs use isolated staging dirs", () => {
     rmSync(root, { recursive: true, force: true });
   }
 });
+
+test("dedupe keeps the newest rollout for a collision slot regardless of input order", () => {
+  // Regression (PR #392 review thread PRRT_kwDORJXyws56TOVr): the old last-wins
+  // dedupe allowed an unsorted caller to have an older recap overwrite a newer
+  // one when two slugs sanitized to the same filename. Verify newest-by-
+  // `updatedAt` survives no matter which order they arrive in.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "dedupe-newest-ns");
+    // Newer entry appears FIRST in the array. Last-wins would have clobbered
+    // it with the older entry; newest-wins must keep it.
+    const result = materializeForNamespace("dedupe-newest-ns", {
+      memories: [makeMemory({ content: "synthetic dedupe anchor" })],
+      codexHome: root,
+      rolloutSummaries: [
+        {
+          slug: "Session 1",
+          updatedAt: "2026-04-05T12:00:00Z",
+          body: "NEWER synthetic recap — must survive dedupe.",
+        },
+        {
+          slug: "session!!!1",
+          updatedAt: "2026-04-01T00:00:00Z",
+          body: "older synthetic recap — must be dropped.",
+        },
+      ],
+      now: new Date("2026-04-06T00:00:00Z"),
+    });
+
+    assert.equal(result.wrote, true);
+    const rolloutPath = path.join(memoriesDir, "rollout_summaries", "session-1.md");
+    assert.ok(existsSync(rolloutPath), "collided rollout file must exist");
+    const body = readFileSync(rolloutPath, "utf-8");
+    assert.match(body, /NEWER synthetic recap/u, "newest updatedAt must win the slot");
+    assert.doesNotMatch(body, /older synthetic recap/u);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test("does not create <codex_home>/memories/ when the user has not opted in", () => {
+  // Regression (PR #392 review thread PRRT_kwDORJXyws56TOHE): the old
+  // implementation called `mkdirSync(memoriesDir, { recursive: true })` before
+  // the sentinel check, so every Remnic user — including those who never
+  // touch Codex — ended up with an empty `~/.codex/memories/` dir after the
+  // first post-consolidation hook. The fix defers the mkdirSync until after
+  // we've confirmed the sentinel exists.
+  const root = mkdtempSync(path.join(os.tmpdir(), "codex-materialize-optout-"));
+  try {
+    const memoriesDir = path.join(root, "memories");
+    // Intentionally do NOT create `memoriesDir` and do NOT ensureSentinel.
+    assert.equal(existsSync(memoriesDir), false);
+
+    const result = materializeForNamespace("optout-ns", {
+      memories: [makeMemory({ content: "synthetic opt-out payload" })],
+      codexHome: root,
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.equal(result.skippedNoSentinel, true);
+    assert.equal(result.wrote, false);
+    assert.equal(
+      existsSync(memoriesDir),
+      false,
+      "memories/ must not be created for users without a sentinel",
+    );
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});

--- a/tests/codex-materialize.test.ts
+++ b/tests/codex-materialize.test.ts
@@ -221,6 +221,43 @@ test("describeMemoriesDir reports owned files and sentinel state", () => {
   }
 });
 
+test("deduplicates rollouts whose slugs sanitize to the same filename", () => {
+  // Regression: two different input slugs can sanitize to the same .md name
+  // (e.g. "Session 1" and "session!!!1" both → "session-1.md"). The old
+  // code would write the same tmp file twice and then crash with ENOENT
+  // during rename. See Cursor Bugbot report on PR #392.
+  const { root, memoriesDir } = makeTempCodexHome();
+  try {
+    ensureSentinel(memoriesDir, "dedupe-ns");
+    const result = materializeForNamespace("dedupe-ns", {
+      memories: [makeMemory({ content: "synthetic dedupe anchor" })],
+      codexHome: root,
+      rolloutSummaries: [
+        {
+          slug: "Session 1",
+          updatedAt: "2026-04-01T00:00:00Z",
+          body: "first synthetic recap.",
+        },
+        {
+          slug: "session!!!1",
+          updatedAt: "2026-04-01T12:00:00Z",
+          body: "second synthetic recap (collides on sanitized slug).",
+        },
+      ],
+      now: new Date("2026-04-02T00:00:00Z"),
+    });
+
+    assert.equal(result.wrote, true);
+    // Exactly one rollout file should be written for the collided name.
+    const rolloutFiles = result.filesWritten.filter((f) => f.includes("rollout_summaries"));
+    assert.equal(rolloutFiles.length, 1);
+    assert.ok(rolloutFiles[0].endsWith("session-1.md"));
+    assert.ok(existsSync(path.join(memoriesDir, "rollout_summaries", "session-1.md")));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
 test("does not overwrite a corrupted sentinel silently (treats as missing)", () => {
   const { root, memoriesDir } = makeTempCodexHome();
   try {


### PR DESCRIPTION
## Summary

Mirrors Remnic's hot memories into Codex CLI's native `<codex_home>/memories/` layout so Codex's phase-2 read path (`memory_summary.md` always-loaded, `MEMORY.md` task-group handbook, `raw_memories.md`, `rollout_summaries/*.md`) picks up Remnic content with zero MCP roundtrips. Closes #378.

- **Opt-in via `.remnic-managed` sentinel** — missing sentinel = skip + warn, so hand-edited layouts are never clobbered
- **Atomic writes** via `.remnic-tmp/` scratch dir + `rename()` — Codex never observes a half-written file
- **Schema validation** on `MEMORY.md` (task-group header, `applies_to`, `## Task N:` blocks with `### rollout_summary_files` / `### keywords`, required bottom sections)
- **Idempotent no-ops** — sentinel stores a sha256 content hash; unchanged render = zero writes
- **Token budget** — `memory_summary.md` capped at `codexMaterializeMaxSummaryTokens` (default `4500`, headroom under Codex's 5000 limit)
- **6 new config knobs** surfaced in `openclaw.plugin.json` configSchema
- **Triggers** — `materializeAfter{Semantic,Causal}Consolidation()` helpers + `plugin-codex` `session-end.sh` hook + manual `tsx scripts/codex-materialize.ts --reason manual`
- **Docs** — `docs/plugins/codex.md` and `docs/guides/codex-cli.md` updated

## Scope notes

Per the Wave 1 PR coordination, this PR deliberately does NOT modify `importance.ts`, `orchestrator.ts`, or `config.ts` outside adding the new config fields. The consolidation hooks are exported helper functions (`materializeAfterSemanticConsolidation`, `materializeAfterCausalConsolidation`) ready for orchestrator wiring in a follow-up once Wave 1 lands.

## Files changed

- `packages/remnic-core/src/connectors/codex-materialize.ts` (new, ~600 LOC) — pure renderer/validator/writer
- `packages/remnic-core/src/connectors/codex-materialize-runner.ts` (new) — I/O bridge that reads memories via `StorageManager` and calls the materializer
- `packages/remnic-core/src/connectors/index.ts` — re-exports
- `packages/remnic-core/src/{semantic,causal}-consolidation.ts` — post-consolidation helper functions
- `packages/remnic-core/src/{types,config}.ts` — 6 new `PluginConfig` fields + defaults
- `packages/plugin-codex/hooks/bin/session-end.sh` — fires the runner via `tsx scripts/codex-materialize.ts --reason session_end`
- `scripts/codex-materialize.ts` (new) — tsx-runnable CLI (`--namespace`, `--codex-home`, `--memory-dir`, `--reason`, `--json`)
- `openclaw.plugin.json` — configSchema entries for all 6 knobs
- `docs/plugins/codex.md`, `docs/guides/codex-cli.md` — user docs
- `tests/codex-materialize{,-schema,-token-limit,-sentinel}.test.ts` (new) — 20 tests across 4 files

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `pnpm run build` — clean
- [x] 20 new tests pass in isolation (`tests/codex-materialize*.test.ts`)
- [x] Affected-area tests pass (`tests/semantic-consolidation.test.ts`, `tests/config-{routing-rules,lifecycle-policy}.test.ts`)
- [ ] CI full `pnpm test` (verifying on PR — local `pnpm test` has a pre-existing hang on `register-multi-registry.test.ts` / `sdk-compat-hook-handlers.test.ts` affecting all parallel worktrees equally, unrelated to this change)

### Key test cases

- **`codex-materialize.test.ts`** (7): writes all 4 file types with sentinel, skips when sentinel missing, idempotent no-op, rollout retention pruning, no `.remnic-tmp/` leaks, `describeMemoriesDir`, corrupted sentinel treated as missing
- **`codex-materialize-schema.test.ts`** (5): validates rendered `MEMORY.md`, accepts empty-namespace baseline, rejects missing Task Group header / bottom sections / subheaders
- **`codex-materialize-token-limit.test.ts`** (5): `approximateTokenCount`, `truncateToTokenBudget`, `renderMemorySummary` respects small + default (4500) budgets
- **`codex-materialize-sentinel.test.ts`** (3): missing sentinel → warn+skip, `ensureSentinel` idempotent, hand-edited `MEMORY.md` never touched

## Privacy

No personal data, secrets, or real memory content. All test data is synthetic (`syn-${i}` IDs, placeholder content). Verified before commit.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new on-disk writer that mirrors memory content into Codex’s `~/.codex/memories` layout and wires it into consolidation/session-end flows; although guarded by a sentinel and atomic writes, it still touches user files and hook execution paths.
> 
> **Overview**
> Adds **Codex-native memory materialization** that mirrors Remnic memories into `<codex_home>/memories/` (`memory_summary.md`, `MEMORY.md`, `raw_memories.md`, `rollout_summaries/*.md`) with **sentinel opt-in** (`.remnic-managed`), **atomic temp-dir renames**, **schema validation** for `MEMORY.md`, and **hash-based idempotence**.
> 
> Wires the materializer into runtime triggers: post semantic consolidation in `orchestrator.ts`, post causal consolidation via the compounding engine, and the Codex `session-end.sh` hook (now preferring a packaged `bin/materialize.cjs` wrapper for published installs, with a dev `scripts/codex-materialize.ts` fallback). Exposes new `codexMaterialize*` config knobs in `openclaw.plugin.json`/config parsing and adds comprehensive unit/regression tests plus updated docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49571b9981e815271a866c762f078fd31cfb3172. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->