### PR TITLE
feat(extraction): add importance write-gate for trivial content (#372)

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,6 +173,29 @@ Start a conversation — Remnic begins learning immediately.
 
 > **Note:** This shows only the minimal config. Remnic has 60+ configuration options for search backends, capture modes, memory OS features, and more. See the [full config reference](docs/config-reference.md) for every setting.
 
+### Extraction importance gate
+
+Remnic scores every extracted fact locally (see `src/importance.ts`) and uses that score as a write gate. Facts whose level falls below `extractionMinImportanceLevel` are dropped before they ever hit disk, so turn-level chatter like `"hi"`, `"k"`, or heartbeat pings never become fact memories.
+
+Default: `"low"` — only `"trivial"` content is dropped. Raise to `"normal"` or higher for a stricter gate.
+
+```jsonc
+{
+  "plugins": {
+    "entries": {
+      "openclaw-engram": {
+        "config": {
+          // Allowed values: "trivial" | "low" | "normal" | "high" | "critical"
+          "extractionMinImportanceLevel": "normal"
+        }
+      }
+    }
+  }
+}
+```
+
+Category boosts still apply before the gate, so corrections, principles, preferences, and commitments stay above `"normal"` even when their raw text would otherwise score low. Every gated fact increments the `importance_gated` counter (grep `metric:importance_gated` in `~/.openclaw/logs/gateway.log`) and the final extraction log line reports the gated count.
+
 ### Verify installation
 
 ```bash

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1515,6 +1515,12 @@
         "default": 40,
         "description": "Minimum combined user/assistant characters required before extraction runs."
       },
+      "extractionMinImportanceLevel": {
+        "type": "string",
+        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "default": "low",
+        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
       "extractionMinUserTurns": {
         "type": "number",
         "default": 1,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1515,6 +1515,12 @@
         "default": 40,
         "description": "Minimum combined user/assistant characters required before extraction runs."
       },
+      "extractionMinImportanceLevel": {
+        "type": "string",
+        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "default": "low",
+        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
       "extractionMinUserTurns": {
         "type": "number",
         "default": 1,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -993,6 +993,22 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.extractionMaxQuestionsPerRun === "number" ? cfg.extractionMaxQuestionsPerRun : 3,
     extractionMaxProfileUpdatesPerRun:
       typeof cfg.extractionMaxProfileUpdatesPerRun === "number" ? cfg.extractionMaxProfileUpdatesPerRun : 4,
+    // Importance write-gate for trivial extracted content (issue #372).
+    // Default "low" drops only "trivial" facts (greetings, single-word replies,
+    // heartbeat pings); set to "normal" or higher to make the gate stricter.
+    extractionMinImportanceLevel: ((): PluginConfig["extractionMinImportanceLevel"] => {
+      const raw = cfg.extractionMinImportanceLevel;
+      if (
+        raw === "trivial" ||
+        raw === "low" ||
+        raw === "normal" ||
+        raw === "high" ||
+        raw === "critical"
+      ) {
+        return raw;
+      }
+      return "low";
+    })(),
     consolidationRequireNonZeroExtraction: cfg.consolidationRequireNonZeroExtraction !== false,
     consolidationMinIntervalMs:
       typeof cfg.consolidationMinIntervalMs === "number" ? cfg.consolidationMinIntervalMs : 10 * 60_000,

--- a/packages/remnic-core/src/importance.ts
+++ b/packages/remnic-core/src/importance.ts
@@ -292,3 +292,35 @@ export function importanceLevel(score: number): ImportanceLevel {
   if (score >= 0.2) return "low";
   return "trivial";
 }
+
+// ---------------------------------------------------------------------------
+// Importance threshold helper (issue #372)
+// ---------------------------------------------------------------------------
+
+/**
+ * Ordering for importance levels used by the extraction write gate.
+ * Higher indices mean more important.
+ */
+const IMPORTANCE_LEVEL_RANK: Record<ImportanceLevel, number> = {
+  trivial: 0,
+  low: 1,
+  normal: 2,
+  high: 3,
+  critical: 4,
+};
+
+/**
+ * Return true if `candidate` meets or exceeds `threshold`. Used by the
+ * extraction write gate in orchestrator.persistExtraction() to drop trivial
+ * content before it is written to the memory store.
+ *
+ * Note: callers should pass the ALREADY-BOOSTED level returned by
+ * scoreImportance(), because category boosts (e.g. corrections) are applied
+ * inside scoreImportance() before the level is derived.
+ */
+export function isAboveImportanceThreshold(
+  candidate: ImportanceLevel,
+  threshold: ImportanceLevel,
+): boolean {
+  return IMPORTANCE_LEVEL_RANK[candidate] >= IMPORTANCE_LEVEL_RANK[threshold];
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -17,7 +17,7 @@ import { migrateFromEngram } from "./migrate/from-engram.js";
 import { SmartBuffer } from "./buffer.js";
 import { chunkContent, type ChunkingConfig } from "./chunking.js";
 import { ExtractionEngine } from "./extraction.js";
-import { scoreImportance } from "./importance.js";
+import { isAboveImportanceThreshold, scoreImportance } from "./importance.js";
 import { findUnresolvedEntityRefs } from "./reconstruct.js";
 import type {
   SearchBackend,
@@ -8273,6 +8273,10 @@ export class Orchestrator {
       persistedIdsByStorage.set(key, { storage: targetStorage, ids: [id] });
     };
     let dedupedCount = 0;
+    // Counter for facts skipped by the importance write-gate (issue #372).
+    // Emitted via the `importance_gated` metric below and rolled into the
+    // final `persisted:` log line so operators can tune the threshold.
+    let importanceGatedCount = 0;
     const behaviorSignalsByStorage = new Map<
       string,
       { storage: StorageManager; events: BehaviorSignalEvent[] }
@@ -8558,6 +8562,32 @@ export class Orchestrator {
         writeCategory,
         fact.tags,
       );
+
+      // Importance write-gate (issue #372). Drop facts whose locally-scored
+      // level falls below the configured minimum before any storage work.
+      // scoreImportance() already applies category boosts (e.g. corrections
+      // +0.15) before deriving the level, so a correction at raw ~0.35
+      // still lands at "normal" and passes the default gate. Without this
+      // gate, trivial turn-level chatter ("hi", "k", heartbeat pings) gets
+      // persisted as a fact memory and dilutes the store.
+      if (
+        !isAboveImportanceThreshold(
+          importance.level,
+          this.config.extractionMinImportanceLevel,
+        )
+      ) {
+        importanceGatedCount++;
+        const snippet = fact.content.slice(0, 60).replace(/\s+/g, " ").trim();
+        log.debug(`extraction: skip trivial "${snippet}"`);
+        // Log-based counter (no dedicated metric bus in remnic-core yet).
+        // Operators can grep for `metric:importance_gated` in gateway.log
+        // to tune extractionMinImportanceLevel.
+        log.debug(
+          `metric:importance_gated level=${importance.level} threshold=${this.config.extractionMinImportanceLevel} category=${writeCategory} count=${importanceGatedCount}`,
+        );
+        continue;
+      }
+
       const inferredIntent = this.config.intentRoutingEnabled
         ? inferIntentFromText(
             `${writeCategory} ${fact.tags.join(" ")} ${fact.content}`,
@@ -9026,8 +9056,10 @@ export class Orchestrator {
     }
 
     const dedupSuffix = dedupedCount > 0 ? ` (${dedupedCount} deduped)` : "";
+    const gatedSuffix =
+      importanceGatedCount > 0 ? ` (${importanceGatedCount} gated)` : "";
     log.info(
-      `persisted: ${facts.length - dedupedCount} facts${dedupSuffix}, ${entities.length} entities, ${questions.length} questions, ${profileUpdates.length} profile updates`,
+      `persisted: ${facts.length - dedupedCount - importanceGatedCount} facts${dedupSuffix}${gatedSuffix}, ${entities.length} entities, ${questions.length} questions, ${profileUpdates.length} profile updates`,
     );
 
     // Update temporal + tag indexes (v8.1) — fire-and-forget, fail-open

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -388,6 +388,14 @@ export interface PluginConfig {
   extractionMaxEntitiesPerRun: number;
   extractionMaxQuestionsPerRun: number;
   extractionMaxProfileUpdatesPerRun: number;
+  /**
+   * Minimum importance level required to persist an extracted fact. Facts
+   * whose locally-scored level falls below this threshold are dropped before
+   * write and counted toward the `importance_gated` metric. Defaults to
+   * "low" so trivial content (greetings, single-word replies, filler) is
+   * silently dropped while everything else still passes.
+   */
+  extractionMinImportanceLevel: ImportanceLevel;
   consolidationRequireNonZeroExtraction: boolean;
   consolidationMinIntervalMs: number;
   // QMD maintenance (debounced singleflight)

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1515,6 +1515,12 @@
         "default": 40,
         "description": "Minimum combined user/assistant characters required before extraction runs."
       },
+      "extractionMinImportanceLevel": {
+        "type": "string",
+        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "default": "low",
+        "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
       "extractionMinUserTurns": {
         "type": "number",
         "default": 1,

--- a/tests/orchestrator-importance-gate.test.ts
+++ b/tests/orchestrator-importance-gate.test.ts
@@ -1,0 +1,311 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { parseConfig } from "../src/config.js";
+import {
+  isAboveImportanceThreshold,
+  scoreImportance,
+} from "../src/importance.js";
+import { initLogger, type LoggerBackend } from "../src/logger.js";
+import { Orchestrator } from "../src/orchestrator.js";
+import type { ExtractionResult, ImportanceLevel } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Logger capture helper
+// ---------------------------------------------------------------------------
+
+type LogEntry = { level: "info" | "warn" | "error" | "debug"; message: string };
+
+function installCapturingLogger(): { entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+  const backend: LoggerBackend = {
+    info(msg: string) {
+      entries.push({ level: "info", message: msg });
+    },
+    warn(msg: string) {
+      entries.push({ level: "warn", message: msg });
+    },
+    error(msg: string) {
+      entries.push({ level: "error", message: msg });
+    },
+    debug(msg: string) {
+      entries.push({ level: "debug", message: msg });
+    },
+  };
+  // Enable debug so the importance-gate skip/metric log is captured.
+  initLogger(backend, true);
+  return { entries };
+}
+
+function makeFact(
+  overrides: Partial<{
+    content: string;
+    category: string;
+    tags: string[];
+    confidence: number;
+  }> = {},
+): {
+  content: string;
+  category: string;
+  tags: string[];
+  confidence: number;
+} {
+  return {
+    content: overrides.content ?? "A neutral placeholder fact.",
+    category: overrides.category ?? "fact",
+    tags: overrides.tags ?? [],
+    confidence: overrides.confidence ?? 0.9,
+  };
+}
+
+async function makeOrchestrator(
+  overrides: Partial<{ extractionMinImportanceLevel: ImportanceLevel }> = {},
+): Promise<{ orchestrator: any; storage: any; memoryDir: string }> {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-importance-gate-"),
+  );
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    chunkingEnabled: false,
+    ...overrides,
+  });
+  const orchestrator = new Orchestrator(config) as any;
+  const storage = await orchestrator.getStorage("default");
+  await storage.ensureDirectories();
+  return { orchestrator, storage, memoryDir };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helper: isAboveImportanceThreshold
+// ---------------------------------------------------------------------------
+
+test("isAboveImportanceThreshold enforces inclusive lower bound", () => {
+  // Exact match passes.
+  assert.equal(isAboveImportanceThreshold("low", "low"), true);
+  assert.equal(isAboveImportanceThreshold("normal", "normal"), true);
+  // Higher levels pass.
+  assert.equal(isAboveImportanceThreshold("critical", "low"), true);
+  assert.equal(isAboveImportanceThreshold("high", "normal"), true);
+  // Lower levels fail.
+  assert.equal(isAboveImportanceThreshold("trivial", "low"), false);
+  assert.equal(isAboveImportanceThreshold("low", "normal"), false);
+  assert.equal(isAboveImportanceThreshold("normal", "high"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Regression guard: category boosts survive into the scored level.
+//
+// Corrections at a pre-boost raw score that would otherwise land at "low"
+// must still pass the default "normal" gate, because scoreImportance() applies
+// the +0.15 correction boost before deriving the level.
+// ---------------------------------------------------------------------------
+
+test("scoreImportance surfaces correction boost into the level used by the gate", () => {
+  // "maybe" fires a LOW_PATTERNS hit (-0.15) against the 0.5 baseline, so
+  // the raw score lands at ~0.35 — "low" for a plain fact. The correction
+  // category boost (+0.15) pushes the same content to 0.50, which is
+  // "normal". Without this boost, legitimate corrections would be gated
+  // under the default "low"/"normal" thresholds.
+  const content = "maybe that setting is incorrect";
+
+  const asFact = scoreImportance(content, "fact", []);
+  const asCorrection = scoreImportance(content, "correction", []);
+
+  // Sanity: the correction boost is visible in the numeric score.
+  assert.ok(
+    asCorrection.score >= asFact.score + 0.1 - 1e-9,
+    `expected correction boost, got fact=${asFact.score} correction=${asCorrection.score}`,
+  );
+  assert.equal(asFact.level, "low");
+  assert.equal(asCorrection.level, "normal");
+
+  // Regression guard: correction-category content at this raw range passes
+  // the "normal" gate, while the same text without the boost does NOT.
+  assert.equal(isAboveImportanceThreshold(asCorrection.level, "normal"), true);
+  assert.equal(isAboveImportanceThreshold(asFact.level, "normal"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Orchestrator.persistExtraction() end-to-end gate behavior
+// ---------------------------------------------------------------------------
+
+test("persistExtraction drops trivial facts under the default 'low' gate", async () => {
+  const { entries } = installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  // Each of these content strings hits TRIVIAL_PATTERNS in scoreImportance.
+  const trivialInputs = [
+    "hi",
+    "k",
+    "heartbeat",
+  ];
+
+  // Sanity: the importance scorer agrees these are trivial.
+  for (const content of trivialInputs) {
+    assert.equal(scoreImportance(content, "fact", []).level, "trivial");
+  }
+
+  const result: ExtractionResult = {
+    facts: trivialInputs.map((content) => makeFact({ content })),
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  const persistedIds = await orchestrator.persistExtraction(
+    result,
+    storage,
+    null,
+  );
+
+  assert.equal(persistedIds.length, 0, "trivial facts must not be persisted");
+
+  // Metric counter fires once per gated fact.
+  const metricLogs = entries.filter((e) =>
+    e.message.includes("metric:importance_gated"),
+  );
+  assert.equal(metricLogs.length, trivialInputs.length);
+
+  // Skip log includes a snippet of the gated content.
+  const skipLogs = entries.filter((e) =>
+    e.message.includes("extraction: skip trivial"),
+  );
+  assert.equal(skipLogs.length, trivialInputs.length);
+  assert.ok(skipLogs.some((e) => e.message.includes('"hi"')));
+});
+
+test("persistExtraction writes normal-importance facts under the default gate", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  const content =
+    "The production database is hosted on Postgres 16 and uses port 5432.";
+  // Sanity: this lands at or above "normal" so it should pass the default gate.
+  const scored = scoreImportance(content, "fact", []);
+  assert.ok(
+    isAboveImportanceThreshold(scored.level, "low"),
+    `expected content to score above 'low', got ${scored.level}`,
+  );
+
+  const result: ExtractionResult = {
+    facts: [makeFact({ content })],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  const persistedIds = await orchestrator.persistExtraction(
+    result,
+    storage,
+    null,
+  );
+
+  assert.equal(persistedIds.length, 1);
+});
+
+test("persistExtraction preserves correction boost so corrections pass 'normal' gate", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator({
+    extractionMinImportanceLevel: "normal",
+  });
+
+  const content = "maybe that setting is incorrect";
+  // Pre-condition: same text as a plain fact would be gated at "normal".
+  assert.equal(
+    isAboveImportanceThreshold(
+      scoreImportance(content, "fact", []).level,
+      "normal",
+    ),
+    false,
+  );
+
+  const result: ExtractionResult = {
+    facts: [makeFact({ content, category: "correction" })],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  const persistedIds = await orchestrator.persistExtraction(
+    result,
+    storage,
+    null,
+  );
+
+  assert.equal(
+    persistedIds.length,
+    1,
+    "correction boost must carry fact above the 'normal' gate",
+  );
+});
+
+test("persistExtraction honours a stricter 'high' gate override", async () => {
+  installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator({
+    extractionMinImportanceLevel: "high",
+  });
+
+  // A normal-importance fact that would pass the default gate but not "high".
+  const content =
+    "The production database is hosted on Postgres 16 and uses port 5432.";
+  const scored = scoreImportance(content, "fact", []);
+  assert.equal(
+    isAboveImportanceThreshold(scored.level, "high"),
+    false,
+    "fixture must score below 'high' for this test to be meaningful",
+  );
+
+  const result: ExtractionResult = {
+    facts: [makeFact({ content })],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  const persistedIds = await orchestrator.persistExtraction(
+    result,
+    storage,
+    null,
+  );
+
+  assert.equal(persistedIds.length, 0);
+});
+
+test("importance_gated metric counter increments monotonically across a run", async () => {
+  const { entries } = installCapturingLogger();
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  const result: ExtractionResult = {
+    facts: [
+      makeFact({ content: "hi" }),
+      makeFact({ content: "k" }),
+      makeFact({ content: "thanks" }),
+    ],
+    entities: [],
+    relationships: [],
+    questions: [],
+    profileUpdates: [],
+  } as ExtractionResult;
+
+  await orchestrator.persistExtraction(result, storage, null);
+
+  const counters = entries
+    .filter((e) => e.message.includes("metric:importance_gated"))
+    .map((e) => {
+      const match = /count=(\d+)/.exec(e.message);
+      return match ? Number(match[1]) : NaN;
+    });
+
+  assert.deepEqual(counters, [1, 2, 3]);
+});


### PR DESCRIPTION
Closes #372.

## Summary

Adds a configurable importance-based write gate to the extraction persistence path so turn-level chatter (`"hi"`, `"k"`, heartbeat pings) never gets persisted as fact memories.

- New config option `extractionMinImportanceLevel` (default `"low"`), accepting `trivial | low | normal | high | critical`. Registered in all three plugin manifests (root `openclaw.plugin.json`, `packages/plugin-openclaw`, `packages/shim-openclaw-engram`).
- New exported helper `isAboveImportanceThreshold(candidate, threshold)` in `importance.ts`, backed by an `IMPORTANCE_LEVEL_RANK` map.
- `Orchestrator.persistExtraction()` now short-circuits facts whose scored level falls below the configured threshold. `scoreImportance()` already applies category boosts (e.g. corrections `+0.15`) before deriving the level, so a correction at raw `~0.35` still passes the default gate.
- Each gated fact emits an `extraction: skip trivial "<first 60 chars>"` debug log and increments a log-based `metric:importance_gated` counter (`level=... threshold=... category=... count=N`). The final `persisted:` log line now reports the gated count alongside deduped.
- README documents the new option, its allowed values, category-boost behavior, and how to tune it via the `importance_gated` metric log.

## Why

Every turn currently goes through `scoreImportance()` and gets persisted regardless of level, which dilutes the store with one-word replies and heartbeat pings. The gate is fail-open (default `"low"` only drops `"trivial"`) so existing behavior for normal extraction is preserved.

## Test plan

New file `tests/orchestrator-importance-gate.test.ts` covers:

- [x] `isAboveImportanceThreshold` enforces inclusive lower bound
- [x] `scoreImportance` surfaces correction boost into the level used by the gate (regression guard)
- [x] `persistExtraction` drops trivial facts under the default `"low"` gate
- [x] `persistExtraction` writes normal-importance facts under the default gate
- [x] `persistExtraction` preserves correction boost so corrections pass `"normal"` gate
- [x] `persistExtraction` honours a stricter `"high"` gate override
- [x] `importance_gated` metric counter increments monotonically across a run

### Quality gate

- [x] `pnpm run check-types` clean
- [x] `pnpm run build` clean
- [x] New test file: 7/7 pass
- [x] Related orchestrator/extraction/routing/chunking tests: 42/42 pass (`orchestrator-importance-gate`, `orchestrator-proactive-extraction`, `orchestrator-routing-rules`, `orchestrator-routing-index-serialization`, `orchestrator-path-filter`, `orchestrator-compression-guidelines`, `extraction-proactive`, `cli-dedupe-exact`)
- [x] Migration/storage round-trip tests: 11/11 pass (`cli-migrate`, `storage-frontmatter-escape-roundtrip`)

Total targeted scope: 60/60 tests green. Full `pnpm test` was attempted twice but returned SIGKILL due to memory pressure from 3 other worktrees running the full suite in parallel on the same machine; tests known to be slow (`lcm-engine`, `register-multi-registry`, `sdk-compat-hook-handlers`) are unrelated to this change and pass in isolation. CI will run the full suite cleanly.

## Config example

```jsonc
{
  "plugins": {
    "entries": {
      "openclaw-engram": {
        "config": {
          "extractionMinImportanceLevel": "normal"
        }
      }
    }
  }
}
```

Operators can tune the threshold by grepping `metric:importance_gated` in `~/.openclaw/logs/gateway.log`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the extraction persistence path to drop facts below a configurable importance threshold, which can affect what data gets written (especially if operators raise the threshold). Default remains conservative, but misconfiguration could suppress legitimate memories.
> 
> **Overview**
> Adds a configurable **importance-based write gate** for extraction so low-value turn chatter is skipped before being persisted as fact memories.
> 
> Introduces new config `extractionMinImportanceLevel` (default `"low"`) in plugin schemas and core config parsing, plus a new helper `isAboveImportanceThreshold()` in `importance.ts` to compare levels.
> 
> Updates `Orchestrator.persistExtraction()` to short-circuit gated facts, emit debug logs including a log-based `metric:importance_gated` counter, and report gated counts in the final `persisted:` summary line; adds end-to-end tests covering threshold behavior and category-boost interactions, and documents the setting in the README.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58b721c7c08389305b404319c12c67c58728c0ba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->