### PR TITLE
chore(hermes): rebrand Python package to Remnic and prep for PyPI publish

### DIFF
--- a/.github/workflows/hermes-python.yml
+++ b/.github/workflows/hermes-python.yml
@@ -4,10 +4,13 @@ on:
   pull_request:
     paths:
       - "packages/plugin-hermes/**"
+      - ".github/workflows/hermes-python.yml"
   push:
     branches: [main]
     paths:
       - "packages/plugin-hermes/**"
+      - ".github/workflows/hermes-python.yml"
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -28,26 +31,26 @@ jobs:
           python-version: "3.12"
           cache: pip
 
-      - name: Install dependencies
-        run: pip install -e ".[dev]" 2>/dev/null || pip install -e .
+      - name: Install package with dev extras
+        run: pip install -e ".[dev]"
 
       - name: Type check
-        run: pip install mypy && mypy remnic_hermes/ --ignore-missing-imports
+        run: mypy remnic_hermes/ --ignore-missing-imports
 
       - name: Lint
-        run: pip install ruff && ruff check remnic_hermes/
+        run: ruff check remnic_hermes/
 
       - name: Tests
-        run: pip install pytest pytest-asyncio && pytest tests/ -v
+        run: pytest tests/ -v
 
   publish:
     needs: test
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 10
-    defaults:
-      run:
-        working-directory: packages/plugin-hermes
+    environment:
+      name: pypi
+      url: https://pypi.org/p/remnic-hermes
     steps:
       - uses: actions/checkout@v4
 
@@ -60,19 +63,29 @@ jobs:
 
       - name: Check if version already published
         id: check
+        working-directory: packages/plugin-hermes
         run: |
           VERSION="$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"
           ESCAPED="$(echo "$VERSION" | sed 's/\./\\./g')"
           if pip index versions remnic-hermes 2>/dev/null | grep -qE "(^|[ ,])${ESCAPED}([ ,]|$)"; then
             echo "published=true" >> "$GITHUB_OUTPUT"
+            echo "Version $VERSION is already on PyPI — skipping publish."
           else
             echo "published=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Build package
         if: steps.check.outputs.published != 'true'
+        working-directory: packages/plugin-hermes
         run: python -m build
+
+      - name: Verify package metadata
+        if: steps.check.outputs.published != 'true'
+        working-directory: packages/plugin-hermes
+        run: |
+          pip install twine
+          twine check dist/*
 
       - name: Publish to PyPI
         if: steps.check.outputs.published != 'true'

--- a/.github/workflows/hermes-python.yml
+++ b/.github/workflows/hermes-python.yml
@@ -45,7 +45,7 @@ jobs:
 
   publish:
     needs: test
-    if: (github.event_name == 'push' && github.ref == 'refs/heads/main') || github.event_name == 'workflow_dispatch'
+    if: github.ref == 'refs/heads/main' && (github.event_name == 'push' || github.event_name == 'workflow_dispatch')
     runs-on: ubuntu-latest
     timeout-minutes: 10
     environment:

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -48,13 +48,14 @@ The plugin also registers tools the agent can call directly:
 
 | Tool | Description |
 |------|-------------|
-| `engram_recall` | Search memories with a query |
-| `engram_store` | Store a memory explicitly |
-| `engram_search` | Semantic search across all memories |
+| `remnic_recall` | Search memories with a query |
+| `remnic_store` | Store a memory explicitly |
+| `remnic_search` | Semantic search across all memories |
 
-Hermes still exposes the legacy `engram_*` tool names today. The product and
-connector are Remnic; the tool names stay legacy until the Hermes-side
-compatibility window closes.
+Legacy aliases `engram_recall`, `engram_store`, and `engram_search` are also
+registered during the Engram → Remnic compat window so existing Hermes configs
+that reference the older names keep working. New integrations should use the
+`remnic_*` names.
 
 ## Why MemoryProvider > MCP
 
@@ -62,8 +63,8 @@ MCP gives Hermes tools to call, but the agent must choose to call them. The Memo
 
 | Aspect | MCP Only | MemoryProvider |
 |--------|----------|---------------|
-| Recall | Agent must call `engram.recall` | Automatic on every turn |
-| Observe | Agent must call `engram.observe` | Automatic after every response |
+| Recall | Agent must call `remnic_recall` | Automatic on every turn |
+| Observe | Agent must call `remnic_store` | Automatic after every response |
 | Latency | Tool call overhead | Pre-fetched, non-blocking |
 | Reliability | Agent may forget to call | Structural — cannot be skipped |
 

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -24,19 +24,31 @@ Add to your Hermes `config.yaml`:
 plugins:
   - remnic_hermes
 
-engram:
+remnic:
   host: "127.0.0.1"
   port: 4318
-  token: ""  # auto-loaded from ~/.engram/tokens.json
+  token: ""  # auto-loaded from ~/.remnic/tokens.json
 ```
 
-The Hermes-side config block is still named `engram:` today for compatibility.
-Install and connector management are Remnic-branded; the plugin config surface
-will stay legacy until the Hermes compatibility window closes.
+A legacy `engram:` block is still accepted during the Engram → Remnic compat
+window. The plugin reads `remnic:` first and falls back to `engram:` if the
+new key is absent, so existing configs keep working without edits.
 
 ## How It Works
 
-- **`pre_llm_call`** — Recalls relevant memories before each LLM call and injects them into the system prompt
+- **`pre_llm_call`** — Recalls relevant memories before each LLM call and injects them into the system prompt as a `<remnic-memory>` block
 - **`sync_turn`** — Observes each conversation turn for future recall
 - **`extract_memories`** — Performs deep extraction at session end
-- **Explicit tools** — `engram_recall`, `engram_store`, `engram_search` registered as Hermes tools
+- **Explicit tools** — `remnic_recall`, `remnic_store`, `remnic_search` registered as Hermes tools (legacy `engram_*` aliases remain available during the compat window)
+
+## Python API
+
+```python
+from remnic_hermes import RemnicMemoryProvider, RemnicClient, RemnicHermesConfig
+```
+
+The legacy names `EngramMemoryProvider`, `EngramClient`, and `EngramHermesConfig` are kept as aliases for backward compatibility and will be removed in a future major release.
+
+## License
+
+MIT

--- a/packages/plugin-hermes/plugin.yaml
+++ b/packages/plugin-hermes/plugin.yaml
@@ -1,6 +1,6 @@
 name: remnic
-version: 0.1.0
-description: Universal memory for AI agents — MemoryProvider integration for Hermes
+version: 1.0.0
+description: Universal memory for AI agents — Remnic MemoryProvider integration for Hermes
 author: Joshua Warren
 homepage: https://github.com/joshuaswarren/remnic
 entry: remnic_hermes

--- a/packages/plugin-hermes/pyproject.toml
+++ b/packages/plugin-hermes/pyproject.toml
@@ -16,6 +16,10 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3 :: Only",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
 ]
 dependencies = [
@@ -23,6 +27,12 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+dev = [
+    "pytest>=7.0",
+    "pytest-asyncio>=0.21.0",
+    "mypy>=1.0",
+    "ruff>=0.1",
+]
 test = [
     "pytest>=7.0",
     "pytest-asyncio>=0.21.0",
@@ -35,6 +45,14 @@ Issues = "https://github.com/joshuaswarren/remnic/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["remnic_hermes"]
+
+[tool.hatch.build.targets.sdist]
+include = [
+    "remnic_hermes/",
+    "README.md",
+    "pyproject.toml",
+    "plugin.yaml",
+]
 
 [tool.mypy]
 strict = true

--- a/packages/plugin-hermes/remnic_hermes/__init__.py
+++ b/packages/plugin-hermes/remnic_hermes/__init__.py
@@ -1,8 +1,24 @@
-"""Engram MemoryProvider plugin for Hermes Agent."""
+"""Remnic MemoryProvider plugin for Hermes Agent."""
 
-from remnic_hermes.provider import EngramMemoryProvider
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.config import RemnicHermesConfig
+from remnic_hermes.provider import RemnicMemoryProvider
 
-__all__ = ["EngramMemoryProvider", "register"]
+# Legacy aliases — preserved for the Engram → Remnic compat window.
+# These will be removed in a future major release.
+EngramMemoryProvider = RemnicMemoryProvider
+EngramClient = RemnicClient
+EngramHermesConfig = RemnicHermesConfig
+
+__all__ = [
+    "RemnicMemoryProvider",
+    "RemnicClient",
+    "RemnicHermesConfig",
+    "EngramMemoryProvider",
+    "EngramClient",
+    "EngramHermesConfig",
+    "register",
+]
 
 
 def register(ctx):  # type: ignore[no-untyped-def]
@@ -10,8 +26,16 @@ def register(ctx):  # type: ignore[no-untyped-def]
     config = ctx.config.get("remnic")
     if not isinstance(config, dict):
         config = ctx.config.get("engram", {})
-    provider = EngramMemoryProvider(config)
+    provider = RemnicMemoryProvider(config)
     ctx.register_memory_provider(provider)
-    ctx.register_tool("engram_recall", provider.recall_schema, provider.recall)
-    ctx.register_tool("engram_store", provider.store_schema, provider.store)
-    ctx.register_tool("engram_search", provider.search_schema, provider.search)
+
+    # Primary tool names (Remnic-branded).
+    ctx.register_tool("remnic_recall", provider.recall_schema, provider.recall)
+    ctx.register_tool("remnic_store", provider.store_schema, provider.store)
+    ctx.register_tool("remnic_search", provider.search_schema, provider.search)
+
+    # Legacy tool aliases — existing Hermes configs may reference the engram_*
+    # names. Keep them wired until the compat window closes.
+    ctx.register_tool("engram_recall", provider.legacy_recall_schema, provider.recall)
+    ctx.register_tool("engram_store", provider.legacy_store_schema, provider.store)
+    ctx.register_tool("engram_search", provider.legacy_search_schema, provider.search)

--- a/packages/plugin-hermes/remnic_hermes/client.py
+++ b/packages/plugin-hermes/remnic_hermes/client.py
@@ -7,8 +7,14 @@ from typing import Any
 import httpx
 
 
-class EngramClient:
-    """Typed async HTTP client for the EMO daemon."""
+class RemnicClient:
+    """Typed async HTTP client for the Remnic daemon.
+
+    NOTE: HTTP paths and the client-id header still use the legacy ``engram``
+    prefix because the server exposes the legacy surface for the v1.x compat
+    window. These will switch to a ``/remnic/v1`` surface once the daemon ships
+    the dual-path rollout.
+    """
 
     def __init__(
         self,
@@ -81,3 +87,7 @@ class EngramClient:
 
     async def close(self) -> None:
         await self._http.aclose()
+
+
+# Legacy class alias — import path compat for pre-rename consumers.
+EngramClient = RemnicClient

--- a/packages/plugin-hermes/remnic_hermes/config.py
+++ b/packages/plugin-hermes/remnic_hermes/config.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 
 
 @dataclass
-class EngramHermesConfig:
+class RemnicHermesConfig:
     """Configuration for the Remnic Hermes MemoryProvider."""
 
     host: str = "127.0.0.1"
@@ -18,7 +18,7 @@ class EngramHermesConfig:
     timeout: float = 30.0
 
     @classmethod
-    def from_hermes_config(cls, config: dict[str, object]) -> EngramHermesConfig:
+    def from_hermes_config(cls, config: dict[str, object]) -> RemnicHermesConfig:
         """Load from the Remnic config section (already extracted by the register() caller).
 
         Accepts either the top-level Hermes config (with 'remnic' or legacy
@@ -28,23 +28,27 @@ class EngramHermesConfig:
         remnic_candidate = config.get("remnic")
         engram_candidate = config.get("engram")
         if isinstance(remnic_candidate, dict):
-            engram = remnic_candidate
+            section = remnic_candidate
         elif isinstance(engram_candidate, dict):
-            engram = engram_candidate
+            section = engram_candidate
         else:
-            engram = config
+            section = config
 
-        token = str(engram.get("token", ""))
+        token = str(section.get("token", ""))
         if not token:
             token = _load_token_from_file()
 
         return cls(
-            host=str(engram.get("host", _read_compat_env("REMNIC_HOST", "ENGRAM_HOST", "127.0.0.1"))),
-            port=int(engram.get("port", _read_compat_env("REMNIC_PORT", "ENGRAM_PORT", "4318"))),
+            host=str(section.get("host", _read_compat_env("REMNIC_HOST", "ENGRAM_HOST", "127.0.0.1"))),
+            port=int(section.get("port", _read_compat_env("REMNIC_PORT", "ENGRAM_PORT", "4318"))),
             token=token,
-            session_key=str(engram.get("session_key", "")),
-            timeout=float(engram.get("timeout", 30.0)),
+            session_key=str(section.get("session_key", "")),
+            timeout=float(section.get("timeout", 30.0)),
         )
+
+
+# Legacy class alias — import path compat for pre-rename consumers.
+EngramHermesConfig = RemnicHermesConfig
 
 
 def _read_compat_env(primary: str, legacy: str, default: str) -> str:

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -1,19 +1,19 @@
-"""Engram MemoryProvider protocol implementation for Hermes Agent."""
+"""Remnic MemoryProvider protocol implementation for Hermes Agent."""
 
 from __future__ import annotations
 
 import uuid
 from typing import Any
 
-from remnic_hermes.client import EngramClient
-from remnic_hermes.config import EngramHermesConfig
+from remnic_hermes.client import RemnicClient
+from remnic_hermes.config import RemnicHermesConfig
 
 
-class EngramMemoryProvider:
-    """MemoryProvider that delegates to the EMO daemon via HTTP.
+class RemnicMemoryProvider:
+    """MemoryProvider that delegates to the Remnic daemon via HTTP.
 
     Lifecycle:
-      - initialize()        → connect to EMO, verify health
+      - initialize()        → connect to Remnic, verify health
       - pre_llm_call()      → recall relevant memories, inject into system prompt
       - sync_turn()         → observe the latest conversation turn
       - extract_memories()  → structured extraction at session end
@@ -21,16 +21,16 @@ class EngramMemoryProvider:
     """
 
     def __init__(self, config: dict[str, Any] | None = None) -> None:
-        cfg = EngramHermesConfig.from_hermes_config(config or {})
+        cfg = RemnicHermesConfig.from_hermes_config(config or {})
         self._host = cfg.host
         self._port = cfg.port
         self._token = cfg.token
         self._session_key = cfg.session_key or f"hermes-{uuid.uuid4().hex[:12]}"
-        self._client: EngramClient | None = None
+        self._client: RemnicClient | None = None
 
     async def initialize(self, config: dict[str, Any] | None = None) -> None:
-        """Connect to EMO daemon and verify health."""
-        self._client = EngramClient(
+        """Connect to Remnic daemon and verify health."""
+        self._client = RemnicClient(
             host=self._host,
             port=self._port,
             token=self._token,
@@ -66,7 +66,7 @@ class EngramMemoryProvider:
             context = result.get("context", "")
             count = result.get("count", 0)
             if context and count > 0:
-                return f"<engram-memory count=\"{count}\">\n{context}\n</engram-memory>"
+                return f"<remnic-memory count=\"{count}\">\n{context}\n</remnic-memory>"
         except Exception:
             pass
 
@@ -113,8 +113,8 @@ class EngramMemoryProvider:
     # -- Explicit tool schemas for Hermes tool registration --
 
     recall_schema = {
-        "name": "engram_recall",
-        "description": "Recall memories from Engram matching a natural language query",
+        "name": "remnic_recall",
+        "description": "Recall memories from Remnic matching a natural language query",
         "parameters": {
             "type": "object",
             "properties": {
@@ -125,8 +125,8 @@ class EngramMemoryProvider:
     }
 
     store_schema = {
-        "name": "engram_store",
-        "description": "Store a memory in Engram for future recall",
+        "name": "remnic_store",
+        "description": "Store a memory in Remnic for future recall",
         "parameters": {
             "type": "object",
             "properties": {
@@ -137,8 +137,8 @@ class EngramMemoryProvider:
     }
 
     search_schema = {
-        "name": "engram_search",
-        "description": "Full-text search across all Engram memories",
+        "name": "remnic_search",
+        "description": "Full-text search across all Remnic memories",
         "parameters": {
             "type": "object",
             "properties": {
@@ -148,20 +148,31 @@ class EngramMemoryProvider:
         },
     }
 
+    # Legacy schemas — same handlers, engram_* tool names. Kept so existing
+    # Hermes configs that reference engram_recall / engram_store / engram_search
+    # continue to resolve. Remove once the compat window closes.
+    legacy_recall_schema = {**recall_schema, "name": "engram_recall"}
+    legacy_store_schema = {**store_schema, "name": "engram_store"}
+    legacy_search_schema = {**search_schema, "name": "engram_search"}
+
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
-        """Tool handler for engram_recall."""
+        """Tool handler for remnic_recall / engram_recall."""
         if not self._client:
-            return {"error": "Not connected to Engram"}
+            return {"error": "Not connected to Remnic"}
         return await self._client.recall(query=query, session_key=self._session_key)
 
     async def store(self, content: str, **kwargs: Any) -> dict[str, Any]:
-        """Tool handler for engram_store."""
+        """Tool handler for remnic_store / engram_store."""
         if not self._client:
-            return {"error": "Not connected to Engram"}
+            return {"error": "Not connected to Remnic"}
         return await self._client.store(content=content)
 
     async def search(self, query: str, **kwargs: Any) -> dict[str, Any]:
-        """Tool handler for engram_search."""
+        """Tool handler for remnic_search / engram_search."""
         if not self._client:
-            return {"error": "Not connected to Engram"}
+            return {"error": "Not connected to Remnic"}
         return await self._client.search(query=query)
+
+
+# Legacy class alias — import path compat for pre-rename consumers.
+EngramMemoryProvider = RemnicMemoryProvider

--- a/packages/plugin-hermes/remnic_hermes/provider.py
+++ b/packages/plugin-hermes/remnic_hermes/provider.py
@@ -150,10 +150,24 @@ class RemnicMemoryProvider:
 
     # Legacy schemas — same handlers, engram_* tool names. Kept so existing
     # Hermes configs that reference engram_recall / engram_store / engram_search
-    # continue to resolve. Remove once the compat window closes.
-    legacy_recall_schema = {**recall_schema, "name": "engram_recall"}
-    legacy_store_schema = {**store_schema, "name": "engram_store"}
-    legacy_search_schema = {**search_schema, "name": "engram_search"}
+    # continue to resolve. Descriptions keep the Engram brand so the tool name
+    # and description agree when LLMs surface the legacy names. Remove once
+    # the compat window closes.
+    legacy_recall_schema = {
+        **recall_schema,
+        "name": "engram_recall",
+        "description": "Recall memories from Engram matching a natural language query",
+    }
+    legacy_store_schema = {
+        **store_schema,
+        "name": "engram_store",
+        "description": "Store a memory in Engram for future recall",
+    }
+    legacy_search_schema = {
+        **search_schema,
+        "name": "engram_search",
+        "description": "Full-text search across all Engram memories",
+    }
 
     async def recall(self, query: str, **kwargs: Any) -> dict[str, Any]:
         """Tool handler for remnic_recall / engram_recall."""

--- a/packages/plugin-hermes/tests/test_client.py
+++ b/packages/plugin-hermes/tests/test_client.py
@@ -1,19 +1,21 @@
-"""Tests for the EngramClient HTTP methods."""
+"""Tests for the RemnicClient HTTP methods."""
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, MagicMock
 
-from remnic_hermes.client import EngramClient
+from remnic_hermes import EngramClient
+from remnic_hermes.client import RemnicClient
 
 
 @pytest.fixture
 def client():
     """Create a client with test config."""
-    return EngramClient(host="127.0.0.1", port=4318, token="test-token", client_id="hermes")
+    return RemnicClient(host="127.0.0.1", port=4318, token="test-token", client_id="hermes")
 
 
 class TestClientInit:
     def test_base_url(self, client):
+        # HTTP path still uses the legacy /engram/v1 prefix during the compat window.
         assert client.base_url == "http://127.0.0.1:4318/engram/v1"
 
     def test_token_set(self, client):
@@ -30,3 +32,9 @@ class TestClientClose:
         client._http.aclose = AsyncMock()
         await client.close()
         client._http.aclose.assert_awaited_once()
+
+
+class TestLegacyAlias:
+    def test_engram_client_is_alias(self):
+        """The legacy EngramClient name resolves to RemnicClient."""
+        assert EngramClient is RemnicClient

--- a/packages/plugin-hermes/tests/test_config.py
+++ b/packages/plugin-hermes/tests/test_config.py
@@ -1,13 +1,14 @@
-"""Basic tests for remnic_hermes config module."""
+"""Tests for remnic_hermes config module."""
 
 import json
 
-from remnic_hermes.config import EngramHermesConfig, _load_token_from_file
+from remnic_hermes import EngramHermesConfig
+from remnic_hermes.config import RemnicHermesConfig, _load_token_from_file
 
 
 def test_default_config():
-    """EngramHermesConfig has sensible defaults."""
-    config = EngramHermesConfig()
+    """RemnicHermesConfig has sensible defaults."""
+    config = RemnicHermesConfig()
     assert config.host == "127.0.0.1"
     assert config.port == 4318
     assert config.token == ""
@@ -15,22 +16,22 @@ def test_default_config():
 
 
 def test_custom_config():
-    """EngramHermesConfig accepts custom host/port."""
-    config = EngramHermesConfig(host="192.168.1.1", port=9999)
+    """RemnicHermesConfig accepts custom host/port."""
+    config = RemnicHermesConfig(host="192.168.1.1", port=9999)
     assert config.host == "192.168.1.1"
     assert config.port == 9999
 
 
 def test_from_hermes_config_empty():
     """from_hermes_config handles empty config dict."""
-    config = EngramHermesConfig.from_hermes_config({})
+    config = RemnicHermesConfig.from_hermes_config({})
     assert config.host == "127.0.0.1"
     assert config.port == 4318
 
 
 def test_from_hermes_config_prefers_remnic_section():
     """Remnic-keyed Hermes config blocks are unwrapped before legacy fallbacks."""
-    config = EngramHermesConfig.from_hermes_config(
+    config = RemnicHermesConfig.from_hermes_config(
         {
             "remnic": {
                 "host": "10.0.0.5",
@@ -46,6 +47,22 @@ def test_from_hermes_config_prefers_remnic_section():
     assert config.token == "remnic-token"
     assert config.session_key == "sess-123"
     assert config.timeout == 12.5
+
+
+def test_from_hermes_config_falls_back_to_engram_section():
+    """Legacy engram-keyed Hermes config blocks still unwrap when remnic key is absent."""
+    config = RemnicHermesConfig.from_hermes_config(
+        {
+            "engram": {
+                "host": "10.0.0.9",
+                "port": 9002,
+                "token": "engram-token",
+            }
+        }
+    )
+    assert config.host == "10.0.0.9"
+    assert config.port == 9002
+    assert config.token == "engram-token"
 
 
 def test_load_token_prefers_remnic_store(monkeypatch, tmp_path):
@@ -79,3 +96,8 @@ def test_load_token_falls_back_to_legacy_store(monkeypatch, tmp_path):
     )
 
     assert _load_token_from_file() == "engram-token"
+
+
+def test_engram_hermes_config_is_alias():
+    """The legacy EngramHermesConfig name resolves to RemnicHermesConfig."""
+    assert EngramHermesConfig is RemnicHermesConfig

--- a/packages/plugin-hermes/tests/test_provider.py
+++ b/packages/plugin-hermes/tests/test_provider.py
@@ -1,22 +1,23 @@
-"""Tests for the EngramMemoryProvider lifecycle and methods."""
+"""Tests for the RemnicMemoryProvider lifecycle and methods."""
 
 import pytest
-from unittest.mock import AsyncMock, patch, MagicMock
+from unittest.mock import AsyncMock, patch
 
-from remnic_hermes.provider import EngramMemoryProvider
+from remnic_hermes import EngramMemoryProvider
+from remnic_hermes.provider import RemnicMemoryProvider
 
 
 @pytest.fixture
 def provider():
     """Create a provider with test config."""
-    return EngramMemoryProvider({"host": "127.0.0.1", "port": 4318, "token": "test-token"})
+    return RemnicMemoryProvider({"host": "127.0.0.1", "port": 4318, "token": "test-token"})
 
 
 class TestProviderLifecycle:
     @pytest.mark.asyncio
     async def test_initialize_creates_client(self, provider):
-        """initialize() should create an EngramClient."""
-        with patch("remnic_hermes.provider.EngramClient") as MockClient:
+        """initialize() should create a RemnicClient."""
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             await provider.initialize()
@@ -26,7 +27,7 @@ class TestProviderLifecycle:
     @pytest.mark.asyncio
     async def test_shutdown_closes_client(self, provider):
         """shutdown() should close the HTTP client."""
-        with patch("remnic_hermes.provider.EngramClient") as MockClient:
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.close = AsyncMock()
@@ -45,7 +46,7 @@ class TestPreLlmCall:
     @pytest.mark.asyncio
     async def test_skips_short_queries(self, provider):
         """pre_llm_call skips queries shorter than 3 words."""
-        with patch("remnic_hermes.provider.EngramClient") as MockClient:
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.recall = AsyncMock()
@@ -53,6 +54,21 @@ class TestPreLlmCall:
             result = await provider.pre_llm_call([{"role": "user", "content": "hi"}])
             assert result == ""
             instance.recall.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_injects_remnic_memory_block(self, provider):
+        """pre_llm_call wraps recalled context in a <remnic-memory> block."""
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
+            instance = MockClient.return_value
+            instance.health = AsyncMock()
+            instance.recall = AsyncMock(return_value={"context": "prior memories", "count": 3})
+            await provider.initialize()
+            result = await provider.pre_llm_call(
+                [{"role": "user", "content": "what did we decide last week"}]
+            )
+            assert result.startswith('<remnic-memory count="3">')
+            assert "prior memories" in result
+            assert result.endswith("</remnic-memory>")
 
 
 class TestSyncTurn:
@@ -64,7 +80,7 @@ class TestSyncTurn:
     @pytest.mark.asyncio
     async def test_sends_recent_messages(self, provider):
         """sync_turn sends last 2 messages to observe endpoint."""
-        with patch("remnic_hermes.provider.EngramClient") as MockClient:
+        with patch("remnic_hermes.provider.RemnicClient") as MockClient:
             instance = MockClient.return_value
             instance.health = AsyncMock()
             instance.observe = AsyncMock(return_value={})
@@ -79,3 +95,9 @@ class TestSyncTurn:
             instance.observe.assert_awaited_once()
             call_args = instance.observe.call_args
             assert len(call_args.kwargs["messages"]) == 2
+
+
+class TestLegacyAlias:
+    def test_engram_memory_provider_is_alias(self):
+        """The legacy EngramMemoryProvider name resolves to RemnicMemoryProvider."""
+        assert EngramMemoryProvider is RemnicMemoryProvider

--- a/packages/plugin-hermes/tests/test_register.py
+++ b/packages/plugin-hermes/tests/test_register.py
@@ -6,26 +6,64 @@ from remnic_hermes import register
 
 def test_register_prefers_remnic_config_key():
     """Hermes registration should pass remnic-keyed config to the provider."""
+    registered_tools: list[str] = []
     ctx = SimpleNamespace(
         config={
             "remnic": {"token": "remnic-token", "host": "10.0.0.5"},
             "engram": {"token": "legacy-token", "host": "127.0.0.1"},
         },
         register_memory_provider=lambda provider: None,
-        register_tool=lambda name, schema, handler: None,
+        register_tool=lambda name, schema, handler: registered_tools.append(name),
     )
 
-    with patch("remnic_hermes.EngramMemoryProvider") as mock_provider:
+    with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
         provider = mock_provider.return_value
-        provider.recall_schema = {}
+        provider.recall_schema = {"name": "remnic_recall"}
+        provider.legacy_recall_schema = {"name": "engram_recall"}
         provider.recall = object()
-        provider.store_schema = {}
+        provider.store_schema = {"name": "remnic_store"}
+        provider.legacy_store_schema = {"name": "engram_store"}
         provider.store = object()
-        provider.search_schema = {}
+        provider.search_schema = {"name": "remnic_search"}
+        provider.legacy_search_schema = {"name": "engram_search"}
         provider.search = object()
 
         register(ctx)
 
     mock_provider.assert_called_once_with(
         {"token": "remnic-token", "host": "10.0.0.5"},
+    )
+    # Both primary and legacy tool names must be registered during the compat window.
+    assert "remnic_recall" in registered_tools
+    assert "remnic_store" in registered_tools
+    assert "remnic_search" in registered_tools
+    assert "engram_recall" in registered_tools
+    assert "engram_store" in registered_tools
+    assert "engram_search" in registered_tools
+
+
+def test_register_falls_back_to_engram_config_key():
+    """Legacy engram-keyed configs still reach the provider."""
+    ctx = SimpleNamespace(
+        config={"engram": {"token": "legacy-token", "host": "127.0.0.1"}},
+        register_memory_provider=lambda provider: None,
+        register_tool=lambda name, schema, handler: None,
+    )
+
+    with patch("remnic_hermes.RemnicMemoryProvider") as mock_provider:
+        provider = mock_provider.return_value
+        provider.recall_schema = {}
+        provider.legacy_recall_schema = {}
+        provider.recall = object()
+        provider.store_schema = {}
+        provider.legacy_store_schema = {}
+        provider.store = object()
+        provider.search_schema = {}
+        provider.legacy_search_schema = {}
+        provider.search = object()
+
+        register(ctx)
+
+    mock_provider.assert_called_once_with(
+        {"token": "legacy-token", "host": "127.0.0.1"},
     )

--- a/tests/integration/plugin-structure.test.ts
+++ b/tests/integration/plugin-structure.test.ts
@@ -101,7 +101,11 @@ test("plugin-hermes has MemoryProvider module", () => {
   const initPy = path.join(PACKAGES, "plugin-hermes", "remnic_hermes", "__init__.py");
   assert.ok(fs.existsSync(initPy));
   const content = fs.readFileSync(initPy, "utf-8");
-  assert.ok(content.includes("EngramMemoryProvider"), "Must export EngramMemoryProvider");
+  assert.ok(content.includes("RemnicMemoryProvider"), "Must export RemnicMemoryProvider");
+  assert.ok(
+    content.includes("EngramMemoryProvider"),
+    "Must keep the EngramMemoryProvider alias during the compat window",
+  );
   assert.ok(content.includes("def register"), "Must have register() entry point");
 });
 


### PR DESCRIPTION
## Summary

Rebrands the Hermes MemoryProvider plugin to Remnic-first identifiers so we can claim the `remnic-hermes` name on PyPI via the pending trusted publisher, and fixes the publish workflow so the first push to `main` after merge actually reaches PyPI.

Every Engram-era name is preserved as an alias for the v1.x compat window — existing Hermes configs (with `engram_recall` tool calls, `engram:` config blocks, or imports of `EngramMemoryProvider`) keep working.

## What changed

**Identifier renames (with aliases preserved):**

| Old (alias) | New (primary) |
|---|---|
| `EngramMemoryProvider` | `RemnicMemoryProvider` |
| `EngramClient` | `RemnicClient` |
| `EngramHermesConfig` | `RemnicHermesConfig` |
| `engram_recall` / `engram_store` / `engram_search` tools | `remnic_recall` / `remnic_store` / `remnic_search` (both registered) |
| `<engram-memory>` injected block | `<remnic-memory>` |
| `engram:` config section | `remnic:` (falls back to `engram:`) |
| `~/.engram/tokens.json` | `~/.remnic/tokens.json` (falls back to legacy path) |

**Intentionally unchanged:** the HTTP surface still uses `/engram/v1` and `X-Engram-Client-Id`, so the plugin keeps talking to today's daemon. That's documented inline in `client.py`.

**Publish workflow fixes (`.github/workflows/hermes-python.yml`):**
- Install with `pip install -e \".[dev]\"` without a silent fallback so broken extras surface loudly (the old fallback quietly installed without test deps).
- Add `environment: { name: pypi, url: https://pypi.org/p/remnic-hermes }` so GitHub's OIDC token matches the trusted publisher config you registered on PyPI.
- Add `workflow_dispatch` trigger for manual re-runs.
- Add `twine check dist/*` before publish.
- Bump `plugin.yaml` version `0.1.0` → `1.0.0` to match `pyproject.toml`.

**`pyproject.toml`:**
- Rename extras `[test]` → `[dev]` (adds `mypy` + `ruff`), keep `[test]` as a smaller alias for callers that still use it.
- Add Python 3.10/3.11/3.12 classifiers.
- Add explicit sdist include list.

## Verification

Ran locally against a fresh venv before pushing:

- \`pytest tests/ -v\` → **23 passed**
- \`mypy remnic_hermes/ --ignore-missing-imports\` → \"Success: no issues found in 4 source files\"
- \`ruff check remnic_hermes/\` → \"All checks passed!\"
- \`python -m build\` → builds both \`remnic_hermes-1.0.0.tar.gz\` and \`remnic_hermes-1.0.0-py3-none-any.whl\`
- \`twine check dist/*\` → PASSED on both artifacts
- Inspected sdist/wheel contents: no test files, no \`__pycache__\`, no editable artifacts
- Smoke test in a separate fresh venv: installed from the built wheel, imported \`RemnicMemoryProvider\` + all Engram aliases, instantiated \`RemnicHermesConfig.from_hermes_config({'remnic': {'host': '10.0.0.1', 'port': 1234}})\` and verified host/port — prints \`OK: remnic_hermes 1.0.0 imports cleanly from wheel\`

## After merge

The \`publish\` job in \`hermes-python.yml\` triggers on push to \`main\`, builds the package, runs \`twine check\`, and publishes to PyPI via the trusted publisher that's already pending on your side. First successful publish claims the \`remnic-hermes\` name.

## Test plan

- [x] \`pytest tests/ -v\` passes in \`packages/plugin-hermes\`
- [x] \`mypy\` and \`ruff\` clean
- [x] \`python -m build\` produces valid sdist + wheel
- [x] \`twine check\` passes
- [x] Smoke install from wheel imports primary + alias classes
- [ ] CI \`test\` job passes on this PR
- [ ] After merge: \`publish\` job succeeds and \`remnic-hermes 1.0.0\` appears on PyPI

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the Hermes plugin’s public identifiers/tool names and CI publishing flow; backwards-compatible aliases reduce runtime breakage, but release automation and packaging metadata changes could impact distribution if misconfigured.
> 
> **Overview**
> Rebrands the Hermes Python MemoryProvider plugin to be **Remnic-first**: primary exports are now `RemnicMemoryProvider`/`RemnicClient`/`RemnicHermesConfig`, the injected context block becomes `<remnic-memory>`, and the primary explicit tools become `remnic_recall`/`remnic_store`/`remnic_search`.
> 
> Preserves **Engram compatibility** by accepting `engram:` config as a fallback, loading tokens from `~/.remnic/tokens.json` with `~/.engram` fallback, and keeping `Engram*` class aliases plus registering `engram_*` tool aliases with legacy schemas.
> 
> Preps packaging/release: bumps plugin version to `1.0.0`, adds `dev` extras and sdist include list in `pyproject.toml`, updates docs/README, and updates the GitHub Actions workflow to support manual runs, install dev extras for lint/typecheck/tests, run `twine check`, and publish to PyPI using a configured `pypi` environment.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a882c5fd07bf33f440ce7ec2775c42939952c93a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->