### PR TITLE
fix: resolve workspace:^ in published packages (#403)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -344,7 +344,10 @@ jobs:
       - name: Publish workspace packages to npm
         run: |
           # Publish in dependency order: core first, then packages that depend on it.
-          # Uses npm (not pnpm) because trusted publishing requires npm's OIDC support.
+          # Uses pnpm (not npm) so that workspace: protocol strings are rewritten to
+          # real version numbers at pack time. npm publish does not perform this
+          # rewriting, which causes "workspace:^" to appear verbatim in the published
+          # package metadata (see issue #403).
           PUBLISH_ORDER=(
             packages/remnic-core
             packages/remnic-server
@@ -371,7 +374,7 @@ jobs:
               continue
             fi
             echo "Publishing ${pkg_name}@${pkg_version} from ${pkg_dir}..."
-            (cd "$pkg_dir" && npm publish --access public --provenance)
+            (cd "$pkg_dir" && pnpm publish --access public --provenance --no-git-checks)
           done
 
       - name: Push release commits to main

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -28,9 +28,7 @@
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {
-    "@remnic/core": "workspace:^"
-  },
+  "dependencies": {},
   "peerDependencies": {
     "openclaw": ">=2026.4.8"
   },

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -38,8 +38,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "^1.0.0",
-    "@remnic/plugin-openclaw": "^1.0.0"
+    "@remnic/core": "workspace:^",
+    "@remnic/plugin-openclaw": "workspace:^"
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.8"

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -38,8 +38,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:^",
-    "@remnic/plugin-openclaw": "workspace:^"
+    "@remnic/core": "^1.0.0",
+    "@remnic/plugin-openclaw": "^1.0.0"
   },
   "peerDependencies": {
     "openclaw": ">=2026.4.8"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,10 +95,6 @@ importers:
         version: link:../remnic-core
 
   packages/plugin-openclaw:
-    dependencies:
-      '@remnic/core':
-        specifier: workspace:^
-        version: link:../remnic-core
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -192,11 +188,11 @@ importers:
   packages/shim-openclaw-engram:
     dependencies:
       '@remnic/core':
-        specifier: workspace:^
-        version: link:../remnic-core
+        specifier: ^1.0.0
+        version: 1.0.2
       '@remnic/plugin-openclaw':
-        specifier: workspace:^
-        version: link:../plugin-openclaw
+        specifier: ^1.0.0
+        version: 1.0.3
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -443,6 +439,14 @@ packages:
 
   '@orama/plugin-data-persistence@3.1.18':
     resolution: {integrity: sha512-pfBbpK96VRW/7IkdMHn2HaW3/+4k2C9Uwyup0IONNuz5bG3L1orCNFZPBmu+zcokOU2YH+IAVuQz6MlvqOe3iw==}
+
+  '@remnic/core@1.0.2':
+    resolution: {integrity: sha512-eBG/JVr5kdsEZLsXbY6ZhyJO9dAQzDTz59YJmhOJ9pHnwlG4U1FK0u04tydIKcxpHLenYJyMrdyf/as2n5o8Fg==}
+
+  '@remnic/plugin-openclaw@1.0.3':
+    resolution: {integrity: sha512-By/L+Mk84t8QDGFJzyRbVimsBvTcQ1bS31jlI70GO8yV4lWF3H9Ji2HENdk/LV3TAAlFNUKiNmd4xDfrEQX55g==}
+    peerDependencies:
+      openclaw: '>=2026.4.8'
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -1206,6 +1210,29 @@ snapshots:
       '@orama/orama': 3.1.18
       dpack: 0.6.22
       seqproto: 0.2.3
+
+  '@remnic/core@1.0.2':
+    dependencies:
+      '@honcho-ai/sdk': 2.1.0
+      '@lancedb/lancedb': 0.26.2(apache-arrow@18.1.0)
+      '@orama/orama': 3.1.18
+      '@orama/plugin-data-persistence': 3.1.18
+      '@sinclair/typebox': 0.34.49
+      apache-arrow: 18.1.0
+      better-sqlite3: 12.8.0
+      meilisearch: 0.46.0
+      openai: 6.33.0(zod@3.25.76)
+      zod: 3.25.76
+    optionalDependencies:
+      '@lancedb/lancedb-darwin-arm64': 0.26.2
+      '@lancedb/lancedb-linux-arm64-gnu': 0.26.2
+      '@lancedb/lancedb-linux-x64-gnu': 0.26.2
+    transitivePeerDependencies:
+      - ws
+
+  '@remnic/plugin-openclaw@1.0.3':
+    dependencies:
+      '@remnic/core': link:packages/remnic-core
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,11 +188,11 @@ importers:
   packages/shim-openclaw-engram:
     dependencies:
       '@remnic/core':
-        specifier: ^1.0.0
-        version: 1.0.2
+        specifier: workspace:^
+        version: link:../remnic-core
       '@remnic/plugin-openclaw':
-        specifier: ^1.0.0
-        version: 1.0.3
+        specifier: workspace:^
+        version: link:../plugin-openclaw
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -439,14 +439,6 @@ packages:
 
   '@orama/plugin-data-persistence@3.1.18':
     resolution: {integrity: sha512-pfBbpK96VRW/7IkdMHn2HaW3/+4k2C9Uwyup0IONNuz5bG3L1orCNFZPBmu+zcokOU2YH+IAVuQz6MlvqOe3iw==}
-
-  '@remnic/core@1.0.2':
-    resolution: {integrity: sha512-eBG/JVr5kdsEZLsXbY6ZhyJO9dAQzDTz59YJmhOJ9pHnwlG4U1FK0u04tydIKcxpHLenYJyMrdyf/as2n5o8Fg==}
-
-  '@remnic/plugin-openclaw@1.0.3':
-    resolution: {integrity: sha512-By/L+Mk84t8QDGFJzyRbVimsBvTcQ1bS31jlI70GO8yV4lWF3H9Ji2HENdk/LV3TAAlFNUKiNmd4xDfrEQX55g==}
-    peerDependencies:
-      openclaw: '>=2026.4.8'
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     resolution: {integrity: sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==}
@@ -1210,29 +1202,6 @@ snapshots:
       '@orama/orama': 3.1.18
       dpack: 0.6.22
       seqproto: 0.2.3
-
-  '@remnic/core@1.0.2':
-    dependencies:
-      '@honcho-ai/sdk': 2.1.0
-      '@lancedb/lancedb': 0.26.2(apache-arrow@18.1.0)
-      '@orama/orama': 3.1.18
-      '@orama/plugin-data-persistence': 3.1.18
-      '@sinclair/typebox': 0.34.49
-      apache-arrow: 18.1.0
-      better-sqlite3: 12.8.0
-      meilisearch: 0.46.0
-      openai: 6.33.0(zod@3.25.76)
-      zod: 3.25.76
-    optionalDependencies:
-      '@lancedb/lancedb-darwin-arm64': 0.26.2
-      '@lancedb/lancedb-linux-arm64-gnu': 0.26.2
-      '@lancedb/lancedb-linux-x64-gnu': 0.26.2
-    transitivePeerDependencies:
-      - ws
-
-  '@remnic/plugin-openclaw@1.0.3':
-    dependencies:
-      '@remnic/core': link:packages/remnic-core
 
   '@rollup/rollup-android-arm-eabi@4.60.1':
     optional: true

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -17,10 +17,11 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");
-  // These must be real semver ranges — NOT workspace: protocol — so that
-  // published packages install correctly without pnpm workspace resolution.
-  assert.equal(dependencies["@remnic/plugin-openclaw"], "^1.0.0");
-  assert.equal(dependencies["@remnic/core"], "^1.0.0");
+  // workspace:^ is intentional for local monorepo linking.
+  // pnpm publish (see release-and-publish.yml) rewrites this to the real
+  // version at pack time, so published packages never contain workspace:^.
+  assert.equal(dependencies["@remnic/plugin-openclaw"], "workspace:^");
+  assert.equal(dependencies["@remnic/core"], "workspace:^");
 });
 
 test("Phase C shim package includes the rename postinstall banner script", async () => {

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -17,8 +17,10 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");
-  assert.equal(dependencies["@remnic/plugin-openclaw"], "workspace:^");
-  assert.equal(dependencies["@remnic/core"], "workspace:^");
+  // These must be real semver ranges — NOT workspace: protocol — so that
+  // published packages install correctly without pnpm workspace resolution.
+  assert.equal(dependencies["@remnic/plugin-openclaw"], "^1.0.0");
+  assert.equal(dependencies["@remnic/core"], "^1.0.0");
 });
 
 test("Phase C shim package includes the rename postinstall banner script", async () => {

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -19,13 +19,10 @@ const packageExpectations = [
       "@remnic/core": "workspace:^",
     },
   },
-  {
-    label: "OpenClaw plugin",
-    path: new URL("../packages/plugin-openclaw/package.json", testDir),
-    deps: {
-      "@remnic/core": "workspace:^",
-    },
-  },
+  // Note: @remnic/plugin-openclaw intentionally has no @remnic/core dependency —
+  // it does not import @remnic/core at runtime. Keeping it would cause the
+  // workspace:^ protocol string to appear verbatim in the published package
+  // metadata when released via npm publish (see issue #403).
 ] as const;
 
 test("runtime workspace packages preserve local linking in source manifests", async () => {


### PR DESCRIPTION
## Summary

Two bugs were introduced by commit `3746d6c` that changed `@remnic/core` from `^1.0.0` to `workspace:^` in workspace package manifests:

**Bug 1 — `@remnic/plugin-openclaw` published with `workspace:^` in its metadata:**
```
npm view @remnic/plugin-openclaw@1.0.3 dependencies
→ { '@remnic/core': 'workspace:^' }
```

**Bug 2 — `@joshuaswarren/openclaw-engram` (shim) published with `workspace:^` in its metadata:**
```
npm view @joshuaswarren/openclaw-engram dependencies
→ { '@remnic/core': 'workspace:^', '@remnic/plugin-openclaw': 'workspace:^' }
```

Both make it impossible to install these packages from npm without hand-patching, because npm/node cannot resolve the `workspace:` protocol.

## Root Cause

The release workflow used `npm publish` for workspace packages. `npm publish` does not rewrite the `workspace:^` protocol — that rewriting is a pnpm-specific feature that only happens when `pnpm publish` is used.

## Fix

1. **Removed the gratuitous `@remnic/core` dependency** from `packages/plugin-openclaw/package.json`. Verified via grep that no file in `packages/plugin-openclaw/src/` actually imports `@remnic/core` — it was only referenced in a code comment. Removing it entirely eliminates the problematic dep for that package.

2. **Replaced `workspace:^` with `^1.0.0`** for both dependencies in `packages/shim-openclaw-engram/package.json`. The shim genuinely imports both `@remnic/plugin-openclaw` (re-exports its entire API) and `@remnic/core` (re-exports `access-cli`), so those deps must remain but must be real semver ranges.

3. **Switched `npm publish` to `pnpm publish --no-git-checks`** in the workspace packages loop of `.github/workflows/release-and-publish.yml`. pnpm rewrites `workspace:^` to the actual resolved version at pack time, providing belt-and-suspenders protection even if a workspace dep is added or missed in future PRs. The root package publish (lines 329-342) is untouched — it exits early anyway since root is private workspace metadata. The `npm view` skip-if-published check is preserved.

4. **Updated two test files** that were asserting the buggy `workspace:^` behavior:
   - `tests/shim-openclaw-engram-package.test.ts`: updated to assert `^1.0.0` for both shim deps
   - `tests/workspace-runtime-deps.test.ts`: removed the entry asserting `@remnic/plugin-openclaw` depends on `workspace:^` for `@remnic/core` (that dep no longer exists)

## Test plan

- [x] `pnpm install` — passes
- [x] `pnpm run check-types` — passes (no TypeScript errors)
- [x] `pnpm run build` — passes (root and all packages build)
- [x] Key tests pass: `monorepo-structure.test.ts`, `shim-openclaw-engram-package.test.ts`, `workspace-runtime-deps.test.ts`

## PR Checklist

* [ ] **All tests pass (`pytest`)** - RUN BEFORE CREATING PR
* [x] All new logic is covered by tests (tests updated to match fixed behavior)
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated (inline comments explain the fix rationale)
* [x] No secrets or creds committed
* [x] PR diff ≤ 400 LOC (small, focused fix)

Closes #403

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release/publish workflow behavior for all workspace packages; a misconfiguration could break publishing even though the change is small and localized.
> 
> **Overview**
> Prevents `workspace:^` dependency ranges from being published to npm by switching the workspace publish loop in `release-and-publish.yml` from `npm publish` to `pnpm publish --no-git-checks`, relying on pnpm’s pack-time rewriting.
> 
> Also drops the unused `@remnic/core` runtime dependency from `@remnic/plugin-openclaw` (and updates `pnpm-lock.yaml`), and adjusts tests (`shim-openclaw-engram-package.test.ts`, `workspace-runtime-deps.test.ts`) to reflect/justify the expected workspace-linking vs published-metadata behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 014ee9553975075804cbcb4d7a3aa260229c254f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->