### PR TITLE
docs: fix Hermes documentation inaccuracies

### DIFF
--- a/docs/integration/connector-setup.md
+++ b/docs/integration/connector-setup.md
@@ -261,9 +261,9 @@ mcp_servers:
 
 ### Option B: MemoryProvider Plugin (recommended for production)
 
-Hermes v0.7.0+ has a Python `MemoryProvider` protocol (`initialize`, `enrich_turn`, `sync_turn`, `shutdown`) that provides tighter integration than MCP alone — including automatic turn-level memory sync and context enrichment.
+Hermes v0.7.0+ has a Python `MemoryProvider` protocol (`initialize`, `pre_llm_call`, `sync_turn`, `extract_memories`, `shutdown`) that provides tighter integration than MCP alone — including automatic turn-level memory sync and context enrichment.
 
-See the [Hermes MemoryProvider guide](../guides/hermes-setup.md) for the `@remnic/hermes-provider` plugin setup.
+See the [Hermes plugin reference](../plugins/hermes.md) for the `remnic-hermes` plugin setup.
 
 **Capabilities:** observe, recall, store, search, entity sync, turn-level memory
 
@@ -330,20 +330,20 @@ Any tool that supports the [Model Context Protocol](https://modelcontextprotocol
 
 ## Managing Connectors
 
-Use the `engram connectors` CLI to manage connector installations:
+Use the `remnic connectors` CLI to manage connector installations:
 
 ```bash
 # List all available connectors
-engram connectors list
+remnic connectors list
 
 # Install a connector (creates config file)
-engram connectors install claude-code
+remnic connectors install claude-code
 
 # Check connector health
-engram connectors doctor claude-code
+remnic connectors doctor claude-code
 
 # Remove a connector
-engram connectors remove claude-code
+remnic connectors remove claude-code
 ```
 
 ---
@@ -355,7 +355,7 @@ engram connectors remove claude-code
 The Remnic server isn't running. Start it:
 
 ```bash
-engram daemon start    # standalone
+remnic daemon start    # standalone
 # or
 openclaw engram access http-serve --port 4318 --token "$REMNIC_AUTH_TOKEN"  # OpenClaw
 ```

--- a/docs/integration/hermes-setup.md
+++ b/docs/integration/hermes-setup.md
@@ -1,107 +1,18 @@
 # Hermes Integration Guide
 
-Connect an LLM agent to Remnic via HTTP.
+> **This guide has moved.** The Hermes MemoryProvider plugin documentation now lives in the main plugin reference.
 
- Hermes is a lightweight HTTP client for connecting LLM agents to Remnic's memory system without requiring a full Remnic installation.
+See:
 
-## Why Hermes?
+- **[Hermes plugin reference](../plugins/hermes.md)** — full setup, configuration, and troubleshooting
+- **[remnic-hermes README](https://github.com/joshuaswarren/remnic/blob/main/packages/plugin-hermes/README.md)** — quick-start on GitHub
+- **[remnic-hermes on PyPI](https://pypi.org/project/remnic-hermes/)** — package install
 
-Hermes is designed for external tool integration. It It works alongside existing OpenClaw plugins, via HTTP calls, — no filesystem access, daemon, or native library dependency.
-
-## Installation
-
-### As a standalone npm package (v9.1.36+)
-
-Hermes is available as `@remnic/hermes-provider` for use in any Node.js project:
+## Quick install
 
 ```bash
-npm install @remnic/hermes-provider
+pip install remnic-hermes
+remnic connectors install hermes
 ```
 
-### Alternative: via the Remnic CLI
-
-If you have the `remnic` CLI installed, you can use `remnic daemon start` to launch the server that Hermes connects to, rather than running `openclaw engram access http-serve` manually.
-
-## Quick Start
-
-1. Install the package:
-```bash
-npm install @remnic/hermes-provider
-# or
-bun
-# or
-```
-
-2. Configure the client:
-```typescript
-import { HermesClient } from "@remnic/hermes-provider";
-
-const client = new HermesClient({
-  baseUrl: "http://127.0.0.1:4318",
-  authToken: "your-secret-token-here",
-});
-```
-
-3. Start using:
-```typescript
-// Check health
-const health = await client.health();
-console.log(health);
-// { ok: true, memoryDir: "...", ... }
-
-// Recall memories
-const recallResult = await client.recall("What did the Python last week?");
-console.log(recallResult.context);
-
-console.log(`${recallResult.count} memories recalled`);
-```
-
-### Example: Observe (feed conversation)
-```typescript
-const messages = [
-  { role: "user", content: "Remember that I prefer dark mode" },
-  { role: "assistant", content: "Noted. Use dark mode." },
-];
-
-const observeResult = await client.observe({
-  sessionKey: "my-session-2024-04-03",
-  messages,
-});
-console.log(observeResult);
-// { accepted: 2, sessionKey: "my-session-2024-04-03", ... }
-```
-
-### API Methods
-| Method | Description | Returns |
-|--------|-------------|---------|
-| `health()` | Check server health | `EngramAccessHealthResponse` |
-| `recall(query, options?)` | Recall memories | `EngramAccessRecallResponse` |
-| `observe(sessionKey, messages, options?)` | Feed conversation | `EngramAccessObserveResponse` |
-| `store(request)` | Store a memory | `EngramAccessWriteResponse` |
-| `getEntities(options?)` | List entities | `EngramAccessEntityListResponse` |
-
-## Standalone Usage
-
-The `@remnic/hermes-provider` package can be used without any Remnic installation. Point it at any running Remnic HTTP server:
-
-```typescript
-import { HermesClient } from "@remnic/hermes-provider";
-
-const client = new HermesClient({
-  baseUrl: "https://remnic.example.com",  // remote Remnic instance
-  authToken: process.env.REMNIC_TOKEN,
-});
-
-const results = await client.recall("project decisions");
-```
-
-This is useful for:
-- Connecting scripts and automation to a shared Remnic instance
-- Building custom agent integrations without the full Remnic engine
-- Connecting to a remote Remnic server managed by another team
-
-## Error Handling
-Hermes retries failed requests with exponential backoff (default: 3 retries, 100ms delay). 429/529/1s timeout). 500 errors throw after 10 retries. Connection errors are logged. Graceful degradation -- returns empty results or null for the unknown errors.
-
-## TypeScript Support
-Works with any TypeScript project. Types are inferred from the response schemas.
+Then restart Hermes to pick up the new plugin.

--- a/docs/integration/sample-hermes-config.json
+++ b/docs/integration/sample-hermes-config.json
@@ -1,15 +1,9 @@
 {
-  "engram": {
-    "baseUrl": "http://127.0.0.1:4318",
-    "authToken": "your-secret-token-here",
-    "namespace": "default",
-    "sessionKey": "hermes-session",
-    "recallOptions": {
-      "topK": 5,
-      "mode": "auto"
-    },
-    "observeOptions": {
-      "skipExtraction": false
-    }
+  "remnic": {
+    "host": "127.0.0.1",
+    "port": 4318,
+    "token": "",
+    "session_key": "",
+    "timeout": 30.0
   }
 }

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -127,11 +127,16 @@ The auth token is **not** read from an environment variable. It comes from the i
 
 `remnic connectors install hermes` handles the full flow:
 
-1. Starts the Remnic daemon if it is not running.
+1. Validates the Hermes profile and config directory.
 2. Generates a per-connector auth token scoped to Hermes.
-3. Writes the token to `~/.remnic/tokens.json`.
-4. Adds the `remnic:` block to Hermes `config.yaml`.
-5. Runs a daemon health check.
+3. Adds the `remnic:` block to Hermes `config.yaml` (with rollback on failure).
+4. Commits the token to `~/.remnic/tokens.json`.
+5. Writes the connector config to `~/.config/engram/.engram-connectors/connectors/hermes.json`.
+6. Runs a daemon health check — reports whether the daemon is reachable but does **not** start it. If unreachable, install still succeeds and prints `remnic daemon start` as the next step.
+
+To install into a non-default Hermes profile:
+
+    remnic connectors install hermes --config profile=Research
 
 ### Manual
 

--- a/docs/plugins/hermes.md
+++ b/docs/plugins/hermes.md
@@ -53,7 +53,7 @@ pip install remnic-hermes
 remnic connectors install hermes
 ```
 
-`remnic connectors install hermes` starts the daemon if needed, generates an auth token, writes `~/.remnic/tokens.json`, and adds the `remnic:` block to your Hermes `config.yaml`. Restart Hermes after running it.
+`remnic connectors install hermes` generates an auth token, writes `~/.remnic/tokens.json`, adds the `remnic:` block to your Hermes `config.yaml`, and runs a daemon health check. It does **not** start the daemon — if unreachable, it prints `remnic daemon start` as the next step. Restart Hermes after running it.
 
 ### Option B: pip only (manual config)
 

--- a/packages/plugin-hermes/README.md
+++ b/packages/plugin-hermes/README.md
@@ -26,7 +26,7 @@ MCP tools give an agent the ability to call memory functions, but only when the 
    pip install remnic-hermes
    ```
 
-2. Wire Hermes to Remnic (starts the daemon if needed, generates an auth token, and writes the Hermes config entry):
+2. Wire Hermes to Remnic (generates an auth token, writes the Hermes config entry, and checks daemon health):
    ```bash
    remnic connectors install hermes
    ```
@@ -74,11 +74,12 @@ The auth token is not read from an environment variable. It is either set inline
 
 `remnic connectors install hermes` is the recommended way to get a token into place. It:
 
-1. Starts the Remnic daemon if it is not already running.
+1. Validates the Hermes profile directory and config structure.
 2. Generates a dedicated per-connector auth token scoped to Hermes.
-3. Writes the token to `~/.remnic/tokens.json`.
-4. Adds the `remnic:` block to your Hermes `config.yaml`.
-5. Runs a health check against the daemon.
+3. Adds the `remnic:` block to your Hermes `config.yaml` (with rollback on failure).
+4. Commits the token to `~/.remnic/tokens.json`.
+5. Writes the connector config file.
+6. Runs a health check against the daemon (does not start it — prints `remnic daemon start` if unreachable).
 
 If you provision tokens manually, write a JSON file at `~/.remnic/tokens.json` in the format:
 


### PR DESCRIPTION
## Summary
- Remove false "starts the daemon" claim from `docs/plugins/hermes.md` and `packages/plugin-hermes/README.md`
- Document the 6-phase atomic install flow and `--config profile=` option
- Replace `docs/integration/hermes-setup.md` with redirect to correct plugin reference (was describing nonexistent npm package)
- Rewrite `docs/integration/sample-hermes-config.json` with correct config fields
- Fix stale `engram` CLI references in `docs/integration/connector-setup.md`
- Fix MemoryProvider protocol method names in connector-setup.md

## Test plan
- [ ] Verify all internal doc links resolve
- [ ] Confirm config field names match `packages/plugin-hermes/remnic_hermes/config.py`
- [ ] Confirm CLI commands match `packages/remnic-cli/src/index.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates that change setup instructions and config examples; the main risk is user confusion if any links/commands/field names are still inaccurate.
> 
> **Overview**
> Updates Hermes integration docs to match the current `remnic-hermes` plugin and CLI behavior: fixes the documented MemoryProvider hook method names, replaces stale `engram` CLI commands with `remnic`, and points Hermes setup guidance to the central `docs/plugins/hermes.md` reference.
> 
> Replaces the Hermes sample config with the correct `remnic` block schema (`host`, `port`, `token`, `session_key`, `timeout`) and clarifies that `remnic connectors install hermes` performs an *atomic* multi-step install with validation/rollback and a daemon health check, but **does not** start the daemon; also documents the `--config profile=...` install option.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9eff4bb5c40306cf336c81cbedba0eaba91178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->