### PR TITLE
Guard unbound OpenClaw register calls

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -367,8 +367,18 @@ const pluginDefinition = {
     // Capture the id from the definition object so shim re-exports with
     // overridden ids (e.g. "openclaw-engram" in the backward-compat shim)
     // still register the service under the correct id (#403).
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const serviceId: string = (this as any).id ?? PLUGIN_ID;
+    // OpenClaw's cli-metadata loader currently invokes register(api) as an
+    // unbound function, so `this` can legitimately be undefined there.
+    // Guard that path and fall back to the canonical id when no bound entry
+    // object is available.
+    const registerThis =
+      typeof this === "object" && this !== null
+        ? (this as { id?: unknown })
+        : undefined;
+    const serviceId: string =
+      typeof registerThis?.id === "string" && registerThis.id.trim().length > 0
+        ? registerThis.id
+        : PLUGIN_ID;
     // Scope all per-plugin runtime singletons (orchestrator, start guards,
     // access service, HTTP server, etc.) by serviceId so a migration install
     // can host both `openclaw-remnic` and `openclaw-engram` without the second

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -344,6 +344,34 @@ test("slot mismatch warn mode suppresses hook registration but still registers t
   }
 });
 
+test("new SDK tolerates unbound register(api) calls from cli metadata loaders", async () => {
+  resetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    const api = buildNewSdkApi("unbound-register");
+    const unboundRegister = plugin.register;
+
+    assert.doesNotThrow(
+      () => unboundRegister(api as any),
+      "register(api) should tolerate an unbound call and fall back to PLUGIN_ID",
+    );
+    assert.ok(
+      api._memoryPromptSectionRegistered,
+      "registerMemoryPromptSection should still be called for new SDK",
+    );
+    assert.ok(
+      api._registeredServiceIds.includes("openclaw-remnic"),
+      "service should still register under the canonical plugin id",
+    );
+  } finally {
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    resetGlobals();
+  }
+});
+
 test("new SDK registers active-memory tool names and slash commands", async () => {
   resetGlobals();
   const previousDisableMigration = disableRegisterMigrationForTest();


### PR DESCRIPTION
## Summary
- guard `register(api)` against unbound calls where `this` is undefined
- fall back to the canonical `PLUGIN_ID` when no bound plugin definition object is present
- add a regression test for the OpenClaw CLI metadata loader path

## Verification
- `pnpm exec tsx --test tests/sdk-compat-integration.test.ts`
- `pnpm --filter @remnic/plugin-openclaw build`

## Context
OpenClaw's CLI metadata loader invokes `register(api)` as an unbound function. Remnic previously assumed `this.id` always existed, which caused plugin registration to throw during `openclaw plugins list` and similar metadata flows.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a defensive change to `register(api)` context handling plus a regression test; behavior should only differ in the previously-crashing unbound invocation path.
> 
> **Overview**
> Prevents `register(api)` from throwing when invoked unbound (e.g., by OpenClaw CLI metadata loaders) by safely deriving `serviceId` from `this.id` only when `this` is a valid object, otherwise falling back to `PLUGIN_ID`.
> 
> Adds an integration regression test that calls `plugin.register` as an unbound function and asserts registration still succeeds and the service registers under the canonical id.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e254094a4e776c1447e453fd77b7d7ccacf61b1e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->