### PR TITLE
fix(remnic): rebuild better-sqlite3 on postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
     "review:patterns": "bash scripts/check-review-patterns.sh",
     "hooks:install": "bash scripts/install-git-hooks.sh",
     "migrate": "tsx scripts/migrate.ts",
+    "postinstall": "pnpm rebuild better-sqlite3",
     "prepack": "npm run build"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- Adds `postinstall` script to run `pnpm rebuild better-sqlite3` after every `pnpm install`
- Prevents LCM initialization failures when Node.js is upgraded and the native bindings become stale
- Complements the existing `pnpm.onlyBuiltDependencies` entry which only covers initial builds, not Node.js version changes

## Context
After upgrading to Node.js v25.9.0, the existing better-sqlite3 native bindings were compiled for the previous version. LCM failed with `Could not locate the bindings file`, causing Discord bot errors (`Cannot read properties of undefined (reading 'properties')`).

## Test plan
- [ ] Run `pnpm install` on a fresh clone — verify better-sqlite3 rebuilds automatically
- [ ] Upgrade Node.js version — run `pnpm install` — verify LCM initializes without binding errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds an install-time script to rebuild a native dependency; main risk is longer installs or unexpected rebuild failures on some environments.
> 
> **Overview**
> Ensures `better-sqlite3` native bindings are rebuilt automatically after `pnpm install` by adding a root `postinstall` script (`pnpm rebuild better-sqlite3`).
> 
> This reduces failures when the Node.js version changes and previously-built `better-sqlite3` bindings become incompatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8bfe8106b52a85cecd63b5bf7530208188b5e82d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->