### PR TITLE
docs(ci): enforce cleaner PR workflow

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,6 +18,8 @@
 - [ ] `bash scripts/check-review-patterns.sh`
 - [ ] Added/updated tests for behavior changes
 - [ ] For retrieval/planner/cache/config changes: ran `docs/ops/pr-review-hardening-playbook.md`
+- [ ] For high-risk memory/retrieval paths: ran `npm run test:entity-hardening`
+- [ ] Ran `npm run review:cursor` locally, or documented why it was unavailable
 
 ## Changelog
 
@@ -49,3 +51,9 @@
 ## Notes for reviewers
 
 <!-- Anything specific you want reviewed closely -->
+
+## PR workflow
+
+- [ ] PR scope is narrow, or the split justification is explained here
+- [ ] Synced with latest `main` before requesting AI review
+- [ ] Batched review fixes by subsystem instead of micro-pushing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,68 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 jobs:
+  detect-risky-paths:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    outputs:
+      entity_hardening: ${{ steps.filter.outputs.entity_hardening }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Detect high-risk review surfaces
+        id: filter
+        uses: dorny/paths-filter@v3
+        with:
+          filters: |
+            entity_hardening:
+              - 'src/orchestrator.ts'
+              - 'src/storage.ts'
+              - 'src/intent.ts'
+              - 'src/memory-cache.ts'
+              - 'src/entity-retrieval.ts'
+              - 'src/config.ts'
+              - 'packages/remnic-core/src/orchestrator.ts'
+              - 'packages/remnic-core/src/storage.ts'
+              - 'packages/remnic-core/src/intent.ts'
+              - 'packages/remnic-core/src/memory-cache.ts'
+              - 'packages/remnic-core/src/entity-retrieval.ts'
+              - 'packages/remnic-core/src/config.ts'
+
+  entity-hardening:
+    needs: detect-risky-paths
+    if: needs.detect-risky-paths.outputs.entity_hardening == 'true' && (github.event_name != 'pull_request' || github.event.pull_request.draft == false)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Rebuild native modules
+        run: pnpm rebuild better-sqlite3
+
+      - name: Entity hardening suite
+        run: pnpm run test:entity-hardening
+
   quality:
+    needs: detect-risky-paths
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,6 @@ jobs:
         run: pnpm run test:entity-hardening
 
   quality:
-    needs: detect-risky-paths
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
     runs-on: ubuntu-latest
     timeout-minutes: 20

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,37 @@ Use these as the canonical starting points for adapter work:
 - Keep standalone and shared-core behavior testable without booting OpenClaw, Hermes, or another host.
 - If a change touches both core semantics and a host adapter, land the core contract first and make the adapter consume it second.
 
+## Cleaner PR Workflow (Mandatory)
+
+These rules are the default workflow for all agents and contributors.
+
+1. Keep PR scope narrow.
+   - One subsystem group per PR whenever possible.
+   - If work spans multiple groups, split it before review. The default split for memory-heavy work is:
+     - schema/surface contract changes
+     - storage/serialization/cache changes
+     - retrieval/planner/freshness behavior changes
+
+2. Sync with `main` before the first serious review cycle.
+   - Rebase or merge `main` before requesting AI review.
+   - Do not let a PR drift for multiple review rounds and then merge `main` halfway through unless forced by a conflict.
+
+3. Batch review fixes by subsystem.
+   - Re-scan unresolved comments, fix the whole subsystem, run verification once, then push once.
+   - Avoid serial micro-pushes that only expose the next adjacent invariant.
+
+4. Run the local hardening gate before claiming review-clean.
+   - Always run `npm run preflight:quick`.
+   - If you touch `src/` or `packages/remnic-core/src/` `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`, `entity-retrieval.ts`, or `config.ts`, also run `npm run test:entity-hardening`.
+   - If Cursor CLI is available, run `npm run review:cursor` before requesting external AI review.
+
+5. Treat external AI review as stale unless it matches the current head.
+   - Do not call a PR clean if the latest positive AI verdict targets an older commit.
+   - A merge-ready PR needs green checks, zero unresolved review threads, and a fresh positive AI verdict on the current head.
+
+Reference workflow:
+`docs/ops/pr-review-hardening-playbook.md`
+
 ## Review Prevention Checklist (All Agents — Read Before Every PR)
 
 These patterns were extracted from 60+ PRs across 2026-04-05 to 2026-04-12

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,3 +144,31 @@ grep "\[engram\]" ~/.openclaw/logs/gateway.log
 53. **Status filters must enumerate ALL non-active states** — filtering only `superseded` and `archived` but not `quarantined`, `rejected`, or `pending_review` causes stale data in user-facing outputs. Define an explicit `ACTIVE_STATUSES` set rather than an ad-hoc exclusion list. When adding a new status, grep ALL filters. PR #396.
 54. **Never delete before write in file replace operations** — `rmSync(target)` then `renameSync(tmp, target)` loses data permanently if rename fails. Write to temp first, then rename atomically. Verify rename success before cleanup. `renameSync` can fail on cross-device moves. PR #394.
 55. **Documented behavior must have a corresponding implementation and test** — if docs say "timeout is applied to all daemon calls", the provider must forward the timeout parameter AND a test must verify it. CI publish workflows must validate `github.ref == 'refs/heads/main'` on the job, not just the trigger. Config properties defined in schema must be wired end-to-end. PR #397, #398.
+
+## Cleaner PR Workflow
+
+Default workflow going forward:
+
+1. Keep each PR narrow.
+   - Prefer one subsystem group per PR.
+   - Split mixed work into separate PRs for schema/surface, storage/cache, and retrieval/planner behavior when possible.
+
+2. Sync `main` before review.
+   - Rebase or merge `main` before the first serious AI review cycle.
+   - Avoid mid-review base refreshes unless a conflict forces it.
+
+3. Batch fixes.
+   - Group unresolved comments by subsystem, fix the full group, verify once, then push once.
+   - Do not use review feedback as a micro-push loop.
+
+4. Run local review gates first.
+   - `npm run preflight:quick`
+   - `npm run test:entity-hardening` when touching `src/` or `packages/remnic-core/src/` `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`, `entity-retrieval.ts`, or `config.ts`
+   - `npm run review:cursor` when the local Cursor CLI is available
+
+5. Treat AI review freshness as a merge criterion.
+   - A stale positive verdict on an older head does not count.
+   - Merge-ready means green checks, zero unresolved review threads, and a fresh positive AI verdict on the current head.
+
+Reference:
+`docs/ops/pr-review-hardening-playbook.md`

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -118,12 +118,16 @@ npx tsx --test tests/specific.test.ts  # one file
 ## Pull Request Process
 
 1. Create a feature branch from `main`
-2. Write documentation first (if adding new features)
-3. Write tests second
-4. Write implementation third
-5. Run `pnpm run build && pnpm test` — everything must pass
-6. Update `CHANGELOG.md` under `[Unreleased]`
-7. Create PR with description following the template
+2. Keep the PR narrow. Split mixed work before review whenever possible.
+3. Sync with latest `main` before requesting AI review.
+4. Write documentation first (if adding new features)
+5. Write tests second
+6. Write implementation third
+7. Run `pnpm run preflight:quick`
+8. If you touched `src/` or `packages/remnic-core/src/` `orchestrator.ts`, `storage.ts`, `intent.ts`, `memory-cache.ts`, `entity-retrieval.ts`, or `config.ts`, run `pnpm run test:entity-hardening`
+9. Run `pnpm run build && pnpm test` — everything must pass
+10. Update `CHANGELOG.md` under `[Unreleased]`
+11. Create PR with description following the template
 
 ### PR Checklist
 
@@ -133,6 +137,7 @@ npx tsx --test tests/specific.test.ts  # one file
 - [ ] Documentation updated (if behavior changed)
 - [ ] No secrets or credentials committed
 - [ ] PR diff <= 400 LOC (or justified)
+- [ ] Review fixes will be batched by subsystem, not pushed as micro-fixes
 
 ## Release Process
 

--- a/docs/ops/pr-review-hardening-playbook.md
+++ b/docs/ops/pr-review-hardening-playbook.md
@@ -81,6 +81,55 @@ Run this before every push:
 4. Self-review staged diff for invariant classes below
 5. Add/adjust tests for each new invariant touched
 
+## PR Scope Discipline
+
+Default rule: one subsystem group per PR.
+
+If a change spans multiple groups, split it before review whenever possible.
+For memory-heavy work, the default split is:
+
+1. schema/surface contract changes
+2. storage/serialization/cache changes
+3. retrieval/planner/freshness behavior changes
+
+Large mixed-surface PRs are where adjacent invariants get rediscovered one review round at a time.
+
+## Review-Cycle Discipline
+
+1. Sync with `main` before requesting the first serious AI review.
+2. Re-scan unresolved comments and group them by subsystem.
+3. Apply one cohesive patch per subsystem group.
+4. Run verification once.
+5. Push once.
+
+Avoid serial micro-pushes that only expose the next nearby invariant.
+
+## High-Risk Path Gate
+
+If you touch any of these files, the hardening suite is mandatory:
+
+- `src/orchestrator.ts`
+- `src/storage.ts`
+- `src/intent.ts`
+- `src/memory-cache.ts`
+- `src/entity-retrieval.ts`
+- `src/config.ts`
+- `packages/remnic-core/src/orchestrator.ts`
+- `packages/remnic-core/src/storage.ts`
+- `packages/remnic-core/src/intent.ts`
+- `packages/remnic-core/src/memory-cache.ts`
+- `packages/remnic-core/src/entity-retrieval.ts`
+- `packages/remnic-core/src/config.ts`
+
+Command:
+
+1. `npm run test:entity-hardening`
+
+Enforcement:
+
+- local preflight runs the suite automatically when those paths are touched
+- CI runs a separate `entity-hardening` job when those paths change
+
 ## Mandatory Pre-Merge Cursor Gate
 
 Before merging any PR that uses Cursor/Bugbot review:
@@ -96,7 +145,17 @@ Repository automation:
 - `npm run hooks:install` configures git hooks that enforce this gate locally.
 - `pre-commit` runs `npm run preflight:quick`
 - `pre-push` runs `npm run preflight`
-- Optional AI pre-push signal: run `npm run review:cursor` manually before pushing.
+- Local AI pre-push signal: run `npm run review:cursor` before requesting external AI review when the CLI is available.
+
+## Stale AI Review Recovery
+
+If `Cursor Bugbot` is still pending after all other checks are green:
+
+1. Verify the current head SHA.
+2. Retrigger once.
+3. Stop pushing while waiting for the fresh verdict unless a real defect is found.
+
+Do not merge based on an older PASS that targeted a previous head.
 
 ## Invariant Classes (must be checked)
 
@@ -203,13 +262,3 @@ If multiple comments touch the same subsystem:
 3. Push once.
 
 Avoid serial micro-fixes unless comments are independent.
-
-## Review Loop Discipline
-
-Before every push in an active review loop:
-
-1. Re-scan all unresolved comments and group by subsystem.
-2. Apply one coherent patch per subsystem group.
-3. Run full verification.
-4. Run one manual “second-order regression” pass over touched paths.
-5. Push once and re-check.

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "check-types": "tsc --noEmit",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
     "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts'",
+    "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts",
     "eval:ci-gate": "tsx scripts/eval-ci-gate.ts",
     "eval:run": "tsx evals/run.ts",
     "eval:download": "bash evals/scripts/download-datasets.sh",

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -10,10 +10,41 @@ run() {
   "$@"
 }
 
+changed_files() {
+  local base_ref="${PREFLIGHT_BASE_REF:-origin/main}"
+
+  if git rev-parse --verify "$base_ref" >/dev/null 2>&1; then
+    git diff --name-only "$(git merge-base HEAD "$base_ref")"...HEAD
+    return
+  fi
+
+  if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+    git diff --name-only HEAD~1...HEAD
+  fi
+}
+
+needs_entity_hardening() {
+  local files
+  files="$(changed_files)"
+  if [[ -z "$files" ]]; then
+    return 1
+  fi
+
+  if printf '%s\n' "$files" | rg -q '^(src|packages/remnic-core/src)/(orchestrator|storage|intent|memory-cache|entity-retrieval|config)\.ts$'; then
+    return 0
+  fi
+
+  return 1
+}
+
 # Core mandatory gate from docs/ops/pr-review-hardening-playbook.md
 run npm run check-types
 run npm run check-config-contract
 run bash scripts/check-review-patterns.sh
+
+if needs_entity_hardening; then
+  run npm run test:entity-hardening
+fi
 
 if [[ "$MODE" == "quick" ]]; then
   # Registration contract tests catch silent lifecycle breakage (issues #282, #285).

--- a/scripts/pr-preflight.sh
+++ b/scripts/pr-preflight.sh
@@ -30,7 +30,7 @@ needs_entity_hardening() {
     return 1
   fi
 
-  if printf '%s\n' "$files" | rg -q '^(src|packages/remnic-core/src)/(orchestrator|storage|intent|memory-cache|entity-retrieval|config)\.ts$'; then
+  if printf '%s\n' "$files" | grep -Eq '^(src|packages/remnic-core/src)/(orchestrator|storage|intent|memory-cache|entity-retrieval|config)\.ts$'; then
     return 0
   fi
 

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -54,6 +54,7 @@ After any change to this directory:
 npm run check-types           # TypeScript strict check
 npm run check-config-contract # Config schema alignment
 npm run preflight:quick       # Fast test gate
+npm run test:entity-hardening # Required for orchestrator/storage/intent/cache/retrieval/config edits
 npm test                      # Full suite
 ```
 


### PR DESCRIPTION
## Summary
- add a mandatory cleaner-PR workflow to the agent and contributor docs
- add `npm run test:entity-hardening` for the high-risk retrieval/planner/cache/config surfaces
- run that hardening suite automatically from local preflight and in a path-scoped CI job
- tighten the PR template around scope, batching, and local AI preflight

## Why
PR #413 took too many review rounds because it mixed multiple high-risk surfaces, relied on micro-pushes, and lacked a single explicit hardening gate for the files that kept regressing.

## Validation
- `npm run test:entity-hardening`
- `bash -n scripts/pr-preflight.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`

## Notes
- `npm run preflight:quick` was started during verification but did not return after the test phase in the current repo state; I am not claiming it passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/workflow automation, scripts, and documentation, with no runtime product logic changes; main risk is CI/preflight flakiness or unexpected extra test time on affected PRs.
> 
> **Overview**
> Enforces a cleaner PR workflow across docs and templates, adding explicit checklist items for narrow scope, syncing with `main`, batching fixes, and running `review:cursor`.
> 
> Introduces a new `test:entity-hardening` script and wires it into gates: `scripts/pr-preflight.sh` now auto-runs it when high-risk files change, and CI adds a path-filtered `entity-hardening` job that runs only when those same core memory/retrieval/config surfaces are modified.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 998e476540bf125b2e65680d1fa3ecec03add75b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->