### PR TITLE
fix: harden OpenClaw memory-slot selection

### DIFF
--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -124,6 +124,35 @@ test("slot validator points canonical slot users at the legacy plugin id when va
   );
 });
 
+test("slot validator does not recommend the nearest alternate Remnic id as the active fix target", () => {
+  const { logger } = buildLogger();
+
+  assert.throws(
+    () =>
+      validateSlotSelection({
+        pluginId: CANONICAL_PLUGIN_ID,
+        runtimeConfig: {
+          plugins: {
+            slots: {
+              memory: "openclaw-engra",
+            },
+          },
+        },
+        requireExclusive: true,
+        onMismatch: "error",
+        logger,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, /openclaw-engra/);
+      assert.match(error.message, new RegExp(LEGACY_PLUGIN_ID));
+      assert.match(error.message, new RegExp(CANONICAL_PLUGIN_ID));
+      assert.match(error.message, /only activates when plugins\.slots\.memory is "openclaw-remnic"/);
+      return true;
+    },
+  );
+});
+
 test("slot validator returns passive and warns on mismatch when configured to warn", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -1,8 +1,10 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
 import { validateSlotSelection } from "./slot-validator.js";
 import type { SlotMismatchMode } from "./slot-validator.js";
+
+const CANONICAL_PLUGIN_ID = "openclaw-remnic";
+const LEGACY_PLUGIN_ID = "openclaw-engram";
 
 function buildLogger() {
   const warnings: string[] = [];
@@ -22,11 +24,11 @@ function buildLogger() {
 test("slot validator returns ok when memory slot matches this plugin", () => {
   const { logger } = buildLogger();
   const result = validateSlotSelection({
-    pluginId: PLUGIN_ID,
+    pluginId: CANONICAL_PLUGIN_ID,
     runtimeConfig: {
       plugins: {
         slots: {
-          memory: PLUGIN_ID,
+          memory: CANONICAL_PLUGIN_ID,
         },
       },
     },
@@ -44,7 +46,7 @@ test("slot validator throws actionable error on mismatch when configured to erro
   assert.throws(
     () =>
       validateSlotSelection({
-        pluginId: PLUGIN_ID,
+        pluginId: CANONICAL_PLUGIN_ID,
         runtimeConfig: {
           plugins: {
             slots: {
@@ -59,7 +61,7 @@ test("slot validator throws actionable error on mismatch when configured to erro
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, /other-memory-plugin/);
-      assert.match(error.message, new RegExp(PLUGIN_ID));
+      assert.match(error.message, new RegExp(CANONICAL_PLUGIN_ID));
       assert.match(error.message, /closest known memory-slot plugin id/i);
       assert.match(error.message, /slotBehavior\.onSlotMismatch/);
       assert.match(error.message, /docs\/plugins\/openclaw\.md#slot-selection/);
@@ -74,7 +76,7 @@ test("slot validator points legacy slot users at the canonical plugin id", () =>
   assert.throws(
     () =>
       validateSlotSelection({
-        pluginId: PLUGIN_ID,
+        pluginId: CANONICAL_PLUGIN_ID,
         runtimeConfig: {
           plugins: {
             slots: {
@@ -89,7 +91,7 @@ test("slot validator points legacy slot users at the canonical plugin id", () =>
     (error: unknown) => {
       assert.ok(error instanceof Error);
       assert.match(error.message, new RegExp(LEGACY_PLUGIN_ID));
-      assert.match(error.message, new RegExp(PLUGIN_ID));
+      assert.match(error.message, new RegExp(CANONICAL_PLUGIN_ID));
       return true;
     },
   );
@@ -98,7 +100,7 @@ test("slot validator points legacy slot users at the canonical plugin id", () =>
 test("slot validator returns passive and warns on mismatch when configured to warn", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({
-    pluginId: PLUGIN_ID,
+    pluginId: CANONICAL_PLUGIN_ID,
     runtimeConfig: {
       plugins: {
         slots: {
@@ -119,7 +121,7 @@ test("slot validator returns passive and warns on mismatch when configured to wa
 test("slot validator returns passive silently on mismatch when configured silent", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({
-    pluginId: PLUGIN_ID,
+    pluginId: CANONICAL_PLUGIN_ID,
     runtimeConfig: {
       plugins: {
         slots: {
@@ -139,11 +141,11 @@ test("slot validator returns passive silently on mismatch when configured silent
 test("slot validator recommends explicit slot selection when unset and exclusive", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({
-    pluginId: PLUGIN_ID,
+    pluginId: CANONICAL_PLUGIN_ID,
     runtimeConfig: {
       plugins: {
         entries: {
-          [PLUGIN_ID]: {},
+          [CANONICAL_PLUGIN_ID]: {},
         },
       },
     },
@@ -160,7 +162,7 @@ test("slot validator recommends explicit slot selection when unset and exclusive
 test("slot validator tolerates malformed runtime config", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({
-    pluginId: PLUGIN_ID,
+    pluginId: CANONICAL_PLUGIN_ID,
     runtimeConfig: undefined,
     requireExclusive: true,
     onMismatch: "error",
@@ -184,14 +186,14 @@ for (const requireExclusive of [true, false]) {
             ? {
                 plugins: {
                   entries: {
-                    [PLUGIN_ID]: {},
+                    [CANONICAL_PLUGIN_ID]: {},
                   },
                 },
               }
             : {
                 plugins: {
                   slots: {
-                    memory: slotState === "self" ? PLUGIN_ID : "other-memory-plugin",
+                    memory: slotState === "self" ? CANONICAL_PLUGIN_ID : "other-memory-plugin",
                   },
                 },
               };
@@ -199,7 +201,7 @@ for (const requireExclusive of [true, false]) {
         if (slotState === "other" && onMismatch === "error") {
           assert.throws(() =>
             validateSlotSelection({
-              pluginId: PLUGIN_ID,
+              pluginId: CANONICAL_PLUGIN_ID,
               runtimeConfig,
               requireExclusive,
               onMismatch,
@@ -211,7 +213,7 @@ for (const requireExclusive of [true, false]) {
         }
 
         const result = validateSlotSelection({
-          pluginId: PLUGIN_ID,
+          pluginId: CANONICAL_PLUGIN_ID,
           runtimeConfig,
           requireExclusive,
           onMismatch,

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -97,6 +97,33 @@ test("slot validator points legacy slot users at the canonical plugin id", () =>
   );
 });
 
+test("slot validator points canonical slot users at the legacy plugin id when validating legacy mode", () => {
+  const { logger } = buildLogger();
+
+  assert.throws(
+    () =>
+      validateSlotSelection({
+        pluginId: LEGACY_PLUGIN_ID,
+        runtimeConfig: {
+          plugins: {
+            slots: {
+              memory: CANONICAL_PLUGIN_ID,
+            },
+          },
+        },
+        requireExclusive: true,
+        onMismatch: "error",
+        logger,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, new RegExp(CANONICAL_PLUGIN_ID));
+      assert.match(error.message, new RegExp(LEGACY_PLUGIN_ID));
+      return true;
+    },
+  );
+});
+
 test("slot validator returns passive and warns on mismatch when configured to warn", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
-import { validateSlotSelection } from "./slot-validator.js";
+import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
+import { SlotMismatchMode, validateSlotSelection } from "./slot-validator.js";
 
 function buildLogger() {
   const warnings: string[] = [];
@@ -59,8 +59,36 @@ test("slot validator throws actionable error on mismatch when configured to erro
       assert.ok(error instanceof Error);
       assert.match(error.message, /other-memory-plugin/);
       assert.match(error.message, new RegExp(PLUGIN_ID));
+      assert.match(error.message, /closest known memory-slot plugin id/i);
       assert.match(error.message, /slotBehavior\.onSlotMismatch/);
       assert.match(error.message, /docs\/plugins\/openclaw\.md#slot-selection/);
+      return true;
+    },
+  );
+});
+
+test("slot validator points legacy slot users at the canonical plugin id", () => {
+  const { logger } = buildLogger();
+
+  assert.throws(
+    () =>
+      validateSlotSelection({
+        pluginId: PLUGIN_ID,
+        runtimeConfig: {
+          plugins: {
+            slots: {
+              memory: LEGACY_PLUGIN_ID,
+            },
+          },
+        },
+        requireExclusive: true,
+        onMismatch: "error",
+        logger,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, new RegExp(LEGACY_PLUGIN_ID));
+      assert.match(error.message, new RegExp(PLUGIN_ID));
       return true;
     },
   );
@@ -141,3 +169,68 @@ test("slot validator tolerates malformed runtime config", () => {
   assert.equal(result, "ok");
   assert.deepEqual(warnings, []);
 });
+
+const mismatchModes: SlotMismatchMode[] = ["error", "warn", "silent"];
+const slotStates = ["unset", "self", "other"] as const;
+
+for (const requireExclusive of [true, false]) {
+  for (const onMismatch of mismatchModes) {
+    for (const slotState of slotStates) {
+      test(`slot validator matrix covers slot=${slotState}, mode=${onMismatch}, requireExclusive=${requireExclusive}`, () => {
+        const { logger, warnings } = buildLogger();
+        const runtimeConfig =
+          slotState === "unset"
+            ? {
+                plugins: {
+                  entries: {
+                    [PLUGIN_ID]: {},
+                  },
+                },
+              }
+            : {
+                plugins: {
+                  slots: {
+                    memory: slotState === "self" ? PLUGIN_ID : "other-memory-plugin",
+                  },
+                },
+              };
+
+        if (slotState === "other" && onMismatch === "error") {
+          assert.throws(() =>
+            validateSlotSelection({
+              pluginId: PLUGIN_ID,
+              runtimeConfig,
+              requireExclusive,
+              onMismatch,
+              logger,
+            }),
+          );
+          assert.equal(warnings.length, 0);
+          return;
+        }
+
+        const result = validateSlotSelection({
+          pluginId: PLUGIN_ID,
+          runtimeConfig,
+          requireExclusive,
+          onMismatch,
+          logger,
+        });
+
+        if (slotState === "unset" || slotState === "self") {
+          assert.equal(result, "ok");
+        } else {
+          assert.equal(result, "passive");
+        }
+
+        const expectedWarnings =
+          slotState === "unset"
+            ? (requireExclusive ? 1 : 0)
+            : slotState === "other" && onMismatch === "warn"
+              ? 1
+              : 0;
+        assert.equal(warnings.length, expectedWarnings);
+      });
+    }
+  }
+}

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -1,7 +1,8 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
-import { SlotMismatchMode, validateSlotSelection } from "./slot-validator.js";
+import { validateSlotSelection } from "./slot-validator.js";
+import type { SlotMismatchMode } from "./slot-validator.js";
 
 function buildLogger() {
   const warnings: string[] = [];

--- a/packages/plugin-openclaw/src/slot-validator.test.ts
+++ b/packages/plugin-openclaw/src/slot-validator.test.ts
@@ -153,6 +153,34 @@ test("slot validator does not recommend the nearest alternate Remnic id as the a
   );
 });
 
+test("slot validator skips distance scoring for oversized slot values", () => {
+  const { logger } = buildLogger();
+  const oversizedSlot = "x".repeat(2048);
+
+  assert.throws(
+    () =>
+      validateSlotSelection({
+        pluginId: CANONICAL_PLUGIN_ID,
+        runtimeConfig: {
+          plugins: {
+            slots: {
+              memory: oversizedSlot,
+            },
+          },
+        },
+        requireExclusive: true,
+        onMismatch: "error",
+        logger,
+      }),
+    (error: unknown) => {
+      assert.ok(error instanceof Error);
+      assert.match(error.message, new RegExp(CANONICAL_PLUGIN_ID));
+      assert.doesNotMatch(error.message, new RegExp(LEGACY_PLUGIN_ID));
+      return true;
+    },
+  );
+});
+
 test("slot validator returns passive and warns on mismatch when configured to warn", () => {
   const { logger, warnings } = buildLogger();
   const result = validateSlotSelection({

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -57,8 +57,9 @@ function levenshteinDistance(a: string, b: string): number {
 
 function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
   if (
-    pluginId === CANONICAL_REMNIC_MEMORY_SLOT_ID &&
-    actualSlot === LEGACY_REMNIC_MEMORY_SLOT_ID
+    actualSlot !== pluginId &&
+    (actualSlot === CANONICAL_REMNIC_MEMORY_SLOT_ID ||
+      actualSlot === LEGACY_REMNIC_MEMORY_SLOT_ID)
   ) {
     return pluginId;
   }

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -55,6 +55,10 @@ function levenshteinDistance(a: string, b: string): number {
 }
 
 function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
+  if (actualSlot !== pluginId && (actualSlot === PLUGIN_ID || actualSlot === LEGACY_PLUGIN_ID)) {
+    return pluginId;
+  }
+
   const candidates = Array.from(new Set([pluginId, PLUGIN_ID, LEGACY_PLUGIN_ID]));
   let best = candidates[0] ?? pluginId;
   let bestDistance = Number.POSITIVE_INFINITY;

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -87,9 +87,14 @@ function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
 
 function mismatchMessage(pluginId: string, actualSlot: string): string {
   const suggestedSlot = suggestLikelyRemnicSlot(pluginId, actualSlot);
+  const suggestionLine =
+    suggestedSlot === pluginId
+      ? `The closest known memory-slot plugin id is "${pluginId}".`
+      : `The closest known Remnic memory-slot plugin id to that value is "${suggestedSlot}", but this loaded plugin only activates when plugins.slots.memory is "${pluginId}".`;
+
   return [
     `[remnic] plugins.slots.memory is set to "${actualSlot}", so ${pluginId} will not attach active memory hooks.`,
-    `If you meant Remnic here, the closest known memory-slot plugin id is "${suggestedSlot}".`,
+    suggestionLine,
     `Set plugins.slots.memory to "${pluginId}" to make Remnic the active memory plugin,`,
     `or set slotBehavior.onSlotMismatch = "silent" to load passively on purpose.`,
     "See docs/plugins/openclaw.md#slot-selection for the full contract.",

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -1,7 +1,8 @@
-import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
-
 export type SlotMismatchMode = "error" | "warn" | "silent";
 export type SlotValidationResult = "ok" | "passive";
+
+const CANONICAL_REMNIC_MEMORY_SLOT_ID = "openclaw-remnic";
+const LEGACY_REMNIC_MEMORY_SLOT_ID = "openclaw-engram";
 
 export interface SlotValidationContext {
   pluginId: string;
@@ -55,11 +56,20 @@ function levenshteinDistance(a: string, b: string): number {
 }
 
 function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
-  if (actualSlot !== pluginId && (actualSlot === PLUGIN_ID || actualSlot === LEGACY_PLUGIN_ID)) {
+  if (
+    pluginId === CANONICAL_REMNIC_MEMORY_SLOT_ID &&
+    actualSlot === LEGACY_REMNIC_MEMORY_SLOT_ID
+  ) {
     return pluginId;
   }
 
-  const candidates = Array.from(new Set([pluginId, PLUGIN_ID, LEGACY_PLUGIN_ID]));
+  const candidates = Array.from(
+    new Set([
+      pluginId,
+      CANONICAL_REMNIC_MEMORY_SLOT_ID,
+      LEGACY_REMNIC_MEMORY_SLOT_ID,
+    ]),
+  );
   let best = candidates[0] ?? pluginId;
   let bestDistance = Number.POSITIVE_INFINITY;
 

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -3,6 +3,7 @@ export type SlotValidationResult = "ok" | "passive";
 
 const CANONICAL_REMNIC_MEMORY_SLOT_ID = "openclaw-remnic";
 const LEGACY_REMNIC_MEMORY_SLOT_ID = "openclaw-engram";
+const MAX_SLOT_DISTANCE_INPUT_LENGTH = 256;
 
 export interface SlotValidationContext {
   pluginId: string;
@@ -56,6 +57,10 @@ function levenshteinDistance(a: string, b: string): number {
 }
 
 function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
+  if (actualSlot.length > MAX_SLOT_DISTANCE_INPUT_LENGTH) {
+    return pluginId;
+  }
+
   if (
     actualSlot !== pluginId &&
     (actualSlot === CANONICAL_REMNIC_MEMORY_SLOT_ID ||

--- a/packages/plugin-openclaw/src/slot-validator.ts
+++ b/packages/plugin-openclaw/src/slot-validator.ts
@@ -1,3 +1,5 @@
+import { LEGACY_PLUGIN_ID, PLUGIN_ID } from "../../remnic-core/src/plugin-id.js";
+
 export type SlotMismatchMode = "error" | "warn" | "silent";
 export type SlotValidationResult = "ok" | "passive";
 
@@ -26,9 +28,53 @@ function resolveMemorySlot(runtimeConfig: unknown): string | undefined {
     : undefined;
 }
 
+function levenshteinDistance(a: string, b: string): number {
+  const rows = a.length + 1;
+  const cols = b.length + 1;
+  const matrix = Array.from({ length: rows }, () => Array<number>(cols).fill(0));
+
+  for (let i = 0; i < rows; i += 1) {
+    matrix[i]![0] = i;
+  }
+  for (let j = 0; j < cols; j += 1) {
+    matrix[0]![j] = j;
+  }
+
+  for (let i = 1; i < rows; i += 1) {
+    for (let j = 1; j < cols; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      matrix[i]![j] = Math.min(
+        matrix[i - 1]![j]! + 1,
+        matrix[i]![j - 1]! + 1,
+        matrix[i - 1]![j - 1]! + substitutionCost,
+      );
+    }
+  }
+
+  return matrix[rows - 1]![cols - 1]!;
+}
+
+function suggestLikelyRemnicSlot(pluginId: string, actualSlot: string): string {
+  const candidates = Array.from(new Set([pluginId, PLUGIN_ID, LEGACY_PLUGIN_ID]));
+  let best = candidates[0] ?? pluginId;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const candidate of candidates) {
+    const distance = levenshteinDistance(actualSlot, candidate);
+    if (distance < bestDistance) {
+      best = candidate;
+      bestDistance = distance;
+    }
+  }
+
+  return best;
+}
+
 function mismatchMessage(pluginId: string, actualSlot: string): string {
+  const suggestedSlot = suggestLikelyRemnicSlot(pluginId, actualSlot);
   return [
     `[remnic] plugins.slots.memory is set to "${actualSlot}", so ${pluginId} will not attach active memory hooks.`,
+    `If you meant Remnic here, the closest known memory-slot plugin id is "${suggestedSlot}".`,
     `Set plugins.slots.memory to "${pluginId}" to make Remnic the active memory plugin,`,
     `or set slotBehavior.onSlotMismatch = "silent" to load passively on purpose.`,
     "See docs/plugins/openclaw.md#slot-selection for the full contract.",


### PR DESCRIPTION
## Summary
- harden slot mismatch guidance so canonical and legacy Remnic ids suggest the right active memory slot
- remove the cross-package source import from the slot validator and keep the slot contract local to the plugin package
- extend slot validator coverage with the full slot/mode/exclusive matrix and legacy-slot guidance assertions

## Validation
- npx tsx --test packages/plugin-openclaw/src/slot-validator.test.ts tests/sdk-compat-integration.test.ts tests/config-openclaw-runtime-surfaces.test.ts tests/openclaw-plugin-runtime-surfaces.test.ts
- npm run check-types
- npm run build
- npm run review:cursor

Closes #386

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to slot-selection validation messaging and test coverage, with no changes to core runtime behavior beyond clearer mismatch suggestions.
> 
> **Overview**
> Improves OpenClaw/Remnic memory-slot mismatch diagnostics by keeping canonical/legacy plugin ids local, adding Levenshtein-based suggestion of the closest known slot id, and guarding distance scoring for oversized slot values.
> 
> Expands `slot-validator` tests to cover canonical vs legacy id guidance and a full `slot`/`onMismatch`/`requireExclusive` matrix, ensuring consistent `ok`/`passive` behavior and warning/throw expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3327e3a2705c74ed77ff6432d6aa560f301594d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->