### PR TITLE
feat(chunking): semantic chunking with topic boundary detection

### DIFF
--- a/docs/architecture/semantic-chunking.md
+++ b/docs/architecture/semantic-chunking.md
@@ -1,0 +1,82 @@
+# Semantic Chunking
+
+Issue #368 — Smoothing-based topic boundary detection for memory chunking.
+
+## Overview
+
+Semantic chunking is an **optional alternative** to the existing recursive
+chunker (`chunking.ts`). Instead of splitting text at fixed token counts, it
+uses sentence embeddings and cosine similarity to detect natural topic
+boundaries, producing chunks that preserve topical coherence.
+
+## How It Works
+
+1. **Sentence tokenization** — the input is split into sentences using
+   punctuation-based boundaries.
+2. **Embedding** — each sentence is embedded via a caller-provided function
+   (`embedFn`). Sentences are batched according to `embeddingBatchSize`.
+3. **Cosine similarity** — pairwise cosine similarity is computed between
+   adjacent sentence embeddings, producing a 1-D similarity series.
+4. **Smoothing** — a simple centered moving average (window size from config)
+   smooths the similarity series to reduce noise.
+5. **Boundary detection** — local minima in the smoothed series that dip below
+   `mean - boundaryThresholdStdDevs * stddev` are identified as topic
+   boundaries.
+6. **Segment merging** — segments shorter than `minTokens` are merged with
+   their nearest neighbor.
+7. **Segment splitting** — segments exceeding `maxTokens` are recursively
+   split using the existing recursive chunker.
+
+## When to Enable
+
+| Scenario | Recommendation |
+|----------|---------------|
+| Short memories (< 200 tokens) | Not needed — recursive chunker is sufficient |
+| Long memories with clear topic shifts | Semantic chunking produces better retrieval |
+| Embedding API unavailable or expensive | Stay with recursive; set `fallbackToRecursive: true` |
+| Batch extraction of many memories | Consider cost of embedding each sentence |
+
+## Configuration Reference
+
+All settings live under `semanticChunkingConfig` in the plugin config. The
+top-level `semanticChunkingEnabled` flag gates the feature.
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enabled` | boolean | `false` | Master switch within the config object |
+| `targetTokens` | number | `200` | Target tokens per chunk |
+| `minTokens` | number | `100` | Minimum tokens before merging with neighbor |
+| `maxTokens` | number | `400` | Maximum tokens before recursive splitting |
+| `smoothingWindowSize` | number | `3` | Moving-average window (centered) |
+| `boundaryThresholdStdDevs` | number | `1.0` | Std devs below mean for boundary |
+| `embeddingBatchSize` | number | `32` | Sentences per embedding API call |
+| `fallbackToRecursive` | boolean | `true` | Fall back if embeddings unavailable |
+
+## Performance Considerations
+
+- **Embedding costs**: every sentence in the input requires an embedding. For
+  a 20-sentence memory, that is 1 API call (at batch size 32). Plan for this
+  when processing large backlogs.
+- **Latency**: the embedding round-trip adds latency compared to the purely
+  local recursive chunker. For real-time paths, keep `fallbackToRecursive`
+  enabled.
+- **Quality**: the smoothing window and threshold parameters control
+  sensitivity. A larger window (5-7) reduces false boundaries but may miss
+  short topic segments. A smaller threshold (0.5 std devs) is more aggressive
+  at splitting.
+
+## Architecture
+
+The module (`packages/remnic-core/src/semantic-chunking.ts`) is self-contained
+and imports only the existing `chunkContent` from `chunking.ts` for fallback
+and segment splitting. It exports:
+
+- `SemanticChunkingConfig` / `DEFAULT_SEMANTIC_CHUNKING_CONFIG`
+- `SemanticChunk` / `SemanticChunkResult`
+- `semanticChunkContent()` — the main entry point
+- Math utilities: `cosineSimilarity`, `movingAverage`, `findLocalMinima`,
+  `mean`, `stddev`
+
+Callers (e.g., the orchestrator) choose which chunker to invoke based on the
+`semanticChunkingEnabled` config flag and the availability of an embedding
+function.

--- a/docs/architecture/semantic-chunking.md
+++ b/docs/architecture/semantic-chunking.md
@@ -43,7 +43,6 @@ top-level `semanticChunkingEnabled` flag gates the feature.
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| `enabled` | boolean | `false` | Master switch within the config object |
 | `targetTokens` | number | `200` | Target tokens per chunk |
 | `minTokens` | number | `100` | Minimum tokens before merging with neighbor |
 | `maxTokens` | number | `400` | Maximum tokens before recursive splitting |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -577,7 +577,10 @@
             "description": "Install the Remnic Codex memory extension during Codex connector setup."
           },
           "codexHome": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "default": null,
             "description": "Optional Codex home directory override used for connector install and materialization."
           }
@@ -1163,7 +1166,7 @@
       "recallPlannerShadowMode": {
         "type": "boolean",
         "default": false,
-        "description": "Run recall planner in shadow mode \u2014 evaluate but do not apply results."
+        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
       },
       "recallPlannerTelemetryEnabled": {
         "type": "boolean",
@@ -1238,7 +1241,7 @@
       "boxTopicShiftThreshold": {
         "type": "number",
         "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0\u20131)."
+        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
       },
       "boxTimeGapMs": {
         "type": "number",
@@ -1263,7 +1266,7 @@
       "traceWeaverOverlapThreshold": {
         "type": "number",
         "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0\u20131)."
+        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
       },
       "boxRecallDays": {
         "type": "number",
@@ -1363,7 +1366,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode \u2014 evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -1891,7 +1894,10 @@
       },
       "modelSource": {
         "type": "string",
-        "enum": ["plugin", "gateway"],
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
         "default": "plugin",
         "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
       },
@@ -1971,7 +1977,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default \u2014 only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -2005,7 +2011,13 @@
       },
       "extractionMinImportanceLevel": {
         "type": "string",
-        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "enum": [
+          "trivial",
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ],
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
@@ -2398,8 +2410,13 @@
       },
       "semanticConsolidationExcludeCategories": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["correction", "commitment"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "correction",
+          "commitment"
+        ],
         "description": "Memory categories excluded from semantic consolidation."
       },
       "semanticConsolidationIntervalHours": {
@@ -3414,7 +3431,7 @@
       "parallelAgentWeights": {
         "type": "object",
         "default": {
-          "direct": 1.0,
+          "direct": 1,
           "contextual": 0.7,
           "temporal": 0.85
         },

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -11,6 +11,7 @@ import type {
   RecallPipelineConfig,
   RecallSectionConfig,
   ReasoningEffort,
+  SemanticChunkingConfigShape,
   SessionObserverBandConfig,
   SlotBehaviorConfig,
   SlotMismatchMode,
@@ -96,6 +97,29 @@ function normalizeMemoryRelativeDir(raw: unknown, fallback: string): string {
     .filter((segment) => segment.length > 0 && segment !== "." && segment !== "..")
     .join("/");
   return normalized.length > 0 ? normalized : fallback;
+}
+
+/**
+ * Parse and validate the semanticChunkingConfig sub-object.
+ * Returns only recognized numeric/boolean fields with their correct types.
+ */
+function parseSemanticChunkingConfig(
+  raw: unknown,
+): Partial<SemanticChunkingConfigShape> {
+  if (!raw || typeof raw !== "object") return {};
+  const src = raw as Record<string, unknown>;
+  const out: Partial<SemanticChunkingConfigShape> = {};
+
+  if (typeof src.enabled === "boolean") out.enabled = src.enabled;
+  if (typeof src.targetTokens === "number") out.targetTokens = src.targetTokens;
+  if (typeof src.minTokens === "number") out.minTokens = src.minTokens;
+  if (typeof src.maxTokens === "number") out.maxTokens = src.maxTokens;
+  if (typeof src.smoothingWindowSize === "number") out.smoothingWindowSize = src.smoothingWindowSize;
+  if (typeof src.boundaryThresholdStdDevs === "number") out.boundaryThresholdStdDevs = src.boundaryThresholdStdDevs;
+  if (typeof src.embeddingBatchSize === "number") out.embeddingBatchSize = src.embeddingBatchSize;
+  if (typeof src.fallbackToRecursive === "boolean") out.fallbackToRecursive = src.fallbackToRecursive;
+
+  return out;
 }
 
 const VALID_EFFORTS: ReasoningEffort[] = ["none", "low", "medium", "high"];
@@ -801,6 +825,9 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.chunkingMinTokens === "number" ? cfg.chunkingMinTokens : 150,
     chunkingOverlapSentences:
       typeof cfg.chunkingOverlapSentences === "number" ? cfg.chunkingOverlapSentences : 2,
+    // Semantic Chunking (Issue #368)
+    semanticChunkingEnabled: cfg.semanticChunkingEnabled === true,
+    semanticChunkingConfig: parseSemanticChunkingConfig(cfg.semanticChunkingConfig),
     // Contradiction Detection (Phase 2B)
     contradictionDetectionEnabled: cfg.contradictionDetectionEnabled === true, // Off by default initially
     contradictionSimilarityThreshold:

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -110,7 +110,6 @@ function parseSemanticChunkingConfig(
   const src = raw as Record<string, unknown>;
   const out: Partial<SemanticChunkingConfigShape> = {};
 
-  if (typeof src.enabled === "boolean") out.enabled = src.enabled;
   if (typeof src.targetTokens === "number") out.targetTokens = src.targetTokens;
   if (typeof src.minTokens === "number") out.minTokens = src.minTokens;
   if (typeof src.maxTokens === "number") out.maxTokens = src.maxTokens;

--- a/packages/remnic-core/src/semantic-chunking.ts
+++ b/packages/remnic-core/src/semantic-chunking.ts
@@ -13,8 +13,6 @@ import { chunkContent, type Chunk, type ChunkResult } from "./chunking.js";
 // ---------------------------------------------------------------------------
 
 export interface SemanticChunkingConfig {
-  /** Whether semantic chunking is enabled. Default: false. */
-  enabled: boolean;
   /** Target tokens per chunk. Default: 200. */
   targetTokens: number;
   /** Minimum tokens for a segment before merging with neighbor. Default: 100. */
@@ -32,7 +30,6 @@ export interface SemanticChunkingConfig {
 }
 
 export const DEFAULT_SEMANTIC_CHUNKING_CONFIG: SemanticChunkingConfig = {
-  enabled: false,
   targetTokens: 200,
   minTokens: 100,
   maxTokens: 400,
@@ -78,6 +75,9 @@ export type EmbedFn = (texts: string[]) => Promise<number[][]>;
 /**
  * Cosine similarity between two vectors.
  * Returns a value in [-1, 1]. Identical direction = 1, orthogonal = 0.
+ *
+ * NOTE: This duplicates cosineSimilarity in recall-mmr.ts and embedding-fallback.ts.
+ * Consider extracting to a shared math utility in a future refactor.
  */
 export function cosineSimilarity(a: number[], b: number[]): number {
   if (a.length !== b.length) {
@@ -342,6 +342,9 @@ export async function semanticChunkContent(
     ...config,
   };
 
+  // Guard against non-positive batch size which would cause an infinite loop
+  const batchSize = Math.max(1, cfg.embeddingBatchSize);
+
   // --- Empty / trivially short input ---
   if (!content || content.trim().length === 0) {
     return {
@@ -392,7 +395,7 @@ export async function semanticChunkContent(
   // --- Attempt embedding ---
   let embeddings: number[][];
   try {
-    embeddings = await batchEmbed(sentences, embedFn, cfg.embeddingBatchSize);
+    embeddings = await batchEmbed(sentences, embedFn, batchSize);
   } catch {
     // Embedding failed — fall back if configured
     if (cfg.fallbackToRecursive) {
@@ -418,8 +421,12 @@ export async function semanticChunkContent(
     similarities.push(cosineSimilarity(embeddings[i], embeddings[i + 1]));
   }
 
-  // If only one pair (2 sentences), nothing to smooth or split meaningfully
+  // If only one pair (2 sentences), nothing to smooth or split meaningfully.
+  // However, if the combined content exceeds maxTokens, apply recursive splitting.
   if (similarities.length <= 1) {
+    if (totalTokens > cfg.maxTokens) {
+      return buildRecursiveFallback(content, cfg);
+    }
     return {
       chunked: false,
       chunks: [

--- a/packages/remnic-core/src/semantic-chunking.ts
+++ b/packages/remnic-core/src/semantic-chunking.ts
@@ -1,0 +1,527 @@
+/**
+ * Semantic Chunking with Smoothing-Based Topic Boundaries (Issue #368)
+ *
+ * An optional alternative to the recursive chunker in chunking.ts.
+ * Uses sentence embeddings + cosine similarity + smoothing to detect
+ * natural topic boundaries, producing more coherent chunks.
+ */
+
+import { chunkContent, type Chunk, type ChunkResult } from "./chunking.js";
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface SemanticChunkingConfig {
+  /** Whether semantic chunking is enabled. Default: false. */
+  enabled: boolean;
+  /** Target tokens per chunk. Default: 200. */
+  targetTokens: number;
+  /** Minimum tokens for a segment before merging with neighbor. Default: 100. */
+  minTokens: number;
+  /** Maximum tokens for a segment before recursive splitting. Default: 400. */
+  maxTokens: number;
+  /** Window size for the moving-average smoothing filter. Default: 3. */
+  smoothingWindowSize: number;
+  /** How many standard deviations below the mean constitutes a boundary. Default: 1.0. */
+  boundaryThresholdStdDevs: number;
+  /** Batch size for embedding requests. Default: 32. */
+  embeddingBatchSize: number;
+  /** Fall back to recursive chunking when embeddings are unavailable. Default: true. */
+  fallbackToRecursive: boolean;
+}
+
+export const DEFAULT_SEMANTIC_CHUNKING_CONFIG: SemanticChunkingConfig = {
+  enabled: false,
+  targetTokens: 200,
+  minTokens: 100,
+  maxTokens: 400,
+  smoothingWindowSize: 3,
+  boundaryThresholdStdDevs: 1.0,
+  embeddingBatchSize: 32,
+  fallbackToRecursive: true,
+};
+
+// ---------------------------------------------------------------------------
+// Result types
+// ---------------------------------------------------------------------------
+
+export interface SemanticChunk extends Chunk {
+  /** Optional topic hint derived from position. */
+  topicLabel?: string;
+  /** Cosine similarity score at the trailing boundary of this chunk. */
+  boundaryScore: number;
+}
+
+export interface SemanticChunkResult {
+  /** Whether content was split into multiple chunks. */
+  chunked: boolean;
+  /** The chunks produced. */
+  chunks: SemanticChunk[];
+  /** Sentence indices where topic splits occurred. */
+  boundaries: number[];
+  /** Which algorithm produced the result. */
+  method: "semantic" | "recursive-fallback";
+}
+
+// ---------------------------------------------------------------------------
+// Embedding function signature
+// ---------------------------------------------------------------------------
+
+/** Caller-provided function that embeds an array of texts, returning vectors. */
+export type EmbedFn = (texts: string[]) => Promise<number[][]>;
+
+// ---------------------------------------------------------------------------
+// Math utilities (exported for testing)
+// ---------------------------------------------------------------------------
+
+/**
+ * Cosine similarity between two vectors.
+ * Returns a value in [-1, 1]. Identical direction = 1, orthogonal = 0.
+ */
+export function cosineSimilarity(a: number[], b: number[]): number {
+  if (a.length !== b.length) {
+    throw new Error(
+      `cosineSimilarity: vector length mismatch (${a.length} vs ${b.length})`,
+    );
+  }
+  if (a.length === 0) return 0;
+
+  let dot = 0;
+  let magA = 0;
+  let magB = 0;
+  for (let i = 0; i < a.length; i++) {
+    dot += a[i] * b[i];
+    magA += a[i] * a[i];
+    magB += b[i] * b[i];
+  }
+
+  const denom = Math.sqrt(magA) * Math.sqrt(magB);
+  if (denom === 0) return 0;
+  return dot / denom;
+}
+
+/**
+ * Arithmetic mean of a numeric series.
+ */
+export function mean(series: number[]): number {
+  if (series.length === 0) return 0;
+  let sum = 0;
+  for (const v of series) sum += v;
+  return sum / series.length;
+}
+
+/**
+ * Population standard deviation of a numeric series.
+ */
+export function stddev(series: number[]): number {
+  if (series.length === 0) return 0;
+  const m = mean(series);
+  let sumSq = 0;
+  for (const v of series) {
+    const d = v - m;
+    sumSq += d * d;
+  }
+  return Math.sqrt(sumSq / series.length);
+}
+
+/**
+ * Simple moving average over a 1D series.
+ * The window is centered: for window size W, each output[i] averages
+ * series[i - floor(W/2) .. i + floor(W/2)], clamped to bounds.
+ */
+export function movingAverage(series: number[], windowSize: number): number[] {
+  if (series.length === 0) return [];
+  if (windowSize < 1) windowSize = 1;
+
+  const halfW = Math.floor(windowSize / 2);
+  const result: number[] = new Array(series.length);
+
+  for (let i = 0; i < series.length; i++) {
+    const lo = Math.max(0, i - halfW);
+    const hi = Math.min(series.length - 1, i + halfW);
+    let sum = 0;
+    for (let j = lo; j <= hi; j++) sum += series[j];
+    result[i] = sum / (hi - lo + 1);
+  }
+  return result;
+}
+
+/**
+ * Find indices in the series that are local minima AND below the threshold.
+ * A local minimum is a point lower than both its immediate neighbors
+ * (or lower-or-equal at series boundaries).
+ */
+export function findLocalMinima(
+  series: number[],
+  threshold: number,
+): number[] {
+  if (series.length <= 2) return [];
+
+  const minima: number[] = [];
+  for (let i = 1; i < series.length - 1; i++) {
+    if (
+      series[i] < series[i - 1] &&
+      series[i] < series[i + 1] &&
+      series[i] < threshold
+    ) {
+      minima.push(i);
+    }
+  }
+  return minima;
+}
+
+// ---------------------------------------------------------------------------
+// Sentence tokenizer
+// ---------------------------------------------------------------------------
+
+/**
+ * Split text into sentences at punctuation boundaries.
+ * Preserves punctuation with the preceding sentence.
+ */
+function splitSentences(text: string): string[] {
+  const sentences: string[] = [];
+  const sentenceRegex = /[^.!?]*[.!?]+(?:\s+|$)/g;
+
+  let match: RegExpExecArray | null;
+  let lastIndex = 0;
+
+  while ((match = sentenceRegex.exec(text)) !== null) {
+    sentences.push(match[0].trim());
+    lastIndex = sentenceRegex.lastIndex;
+  }
+
+  if (lastIndex < text.length) {
+    const remaining = text.slice(lastIndex).trim();
+    if (remaining) {
+      sentences.push(remaining);
+    }
+  }
+
+  return sentences.filter((s) => s.length > 0);
+}
+
+// ---------------------------------------------------------------------------
+// Token estimation
+// ---------------------------------------------------------------------------
+
+/** Rough token estimate: ~4 chars per token for English. */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+// ---------------------------------------------------------------------------
+// Core semantic chunking
+// ---------------------------------------------------------------------------
+
+/**
+ * Batch-embed sentences using the provided embed function.
+ * Respects the configured batch size.
+ */
+async function batchEmbed(
+  sentences: string[],
+  embedFn: EmbedFn,
+  batchSize: number,
+): Promise<number[][]> {
+  const allEmbeddings: number[][] = [];
+
+  for (let i = 0; i < sentences.length; i += batchSize) {
+    const batch = sentences.slice(i, i + batchSize);
+    const batchResult = await embedFn(batch);
+    for (const vec of batchResult) {
+      allEmbeddings.push(vec);
+    }
+  }
+
+  return allEmbeddings;
+}
+
+/**
+ * Build segments from boundary indices.
+ * boundaries are sentence indices at which splits occur (i.e., the split
+ * happens AFTER the boundary index sentence).
+ */
+function buildSegments(
+  sentences: string[],
+  boundaries: number[],
+): string[][] {
+  const sorted = [...boundaries].sort((a, b) => a - b);
+  const segments: string[][] = [];
+  let start = 0;
+
+  for (const b of sorted) {
+    // Split after sentence at index b: segment is [start .. b]
+    const splitPoint = b + 1;
+    if (splitPoint > start && splitPoint <= sentences.length) {
+      segments.push(sentences.slice(start, splitPoint));
+      start = splitPoint;
+    }
+  }
+
+  // Remaining sentences
+  if (start < sentences.length) {
+    segments.push(sentences.slice(start));
+  }
+
+  return segments;
+}
+
+/**
+ * Merge short segments (below minTokens) with their neighbor.
+ * Prefers merging forward; falls back to merging backward.
+ */
+function mergeShortSegments(
+  segments: string[][],
+  minTokens: number,
+): string[][] {
+  if (segments.length <= 1) return segments;
+
+  const merged: string[][] = [];
+  let buffer: string[] = [];
+
+  for (let i = 0; i < segments.length; i++) {
+    buffer = [...buffer, ...segments[i]];
+    const tokenCount = estimateTokens(buffer.join(" "));
+
+    if (tokenCount >= minTokens || i === segments.length - 1) {
+      merged.push(buffer);
+      buffer = [];
+    }
+  }
+
+  // If the last merge left a dangling buffer, attach it to the last segment
+  if (buffer.length > 0) {
+    if (merged.length > 0) {
+      merged[merged.length - 1] = [...merged[merged.length - 1], ...buffer];
+    } else {
+      merged.push(buffer);
+    }
+  }
+
+  return merged;
+}
+
+/**
+ * Split an oversized segment using recursive chunking.
+ */
+function splitLongSegment(
+  segment: string[],
+  maxTokens: number,
+  targetTokens: number,
+): SemanticChunk[] {
+  const text = segment.join(" ");
+  const result: ChunkResult = chunkContent(text, {
+    targetTokens,
+    minTokens: Math.min(targetTokens, maxTokens),
+    overlapSentences: 0,
+  });
+
+  return result.chunks.map((c) => ({
+    content: c.content,
+    index: c.index,
+    tokenCount: c.tokenCount,
+    boundaryScore: 0,
+  }));
+}
+
+/**
+ * Semantic chunking with smoothing-based topic boundary detection.
+ *
+ * @param content   - Full text to chunk.
+ * @param embedFn   - Async function that embeds an array of texts.
+ * @param config    - Optional partial config overrides.
+ * @returns SemanticChunkResult
+ */
+export async function semanticChunkContent(
+  content: string,
+  embedFn: EmbedFn,
+  config?: Partial<SemanticChunkingConfig>,
+): Promise<SemanticChunkResult> {
+  const cfg: SemanticChunkingConfig = {
+    ...DEFAULT_SEMANTIC_CHUNKING_CONFIG,
+    ...config,
+  };
+
+  // --- Empty / trivially short input ---
+  if (!content || content.trim().length === 0) {
+    return {
+      chunked: false,
+      chunks: [],
+      boundaries: [],
+      method: "semantic",
+    };
+  }
+
+  const sentences = splitSentences(content);
+
+  if (sentences.length <= 1) {
+    const tokenCount = estimateTokens(content);
+    return {
+      chunked: false,
+      chunks: [
+        {
+          content: content.trim(),
+          index: 0,
+          tokenCount,
+          boundaryScore: 1,
+        },
+      ],
+      boundaries: [],
+      method: "semantic",
+    };
+  }
+
+  // If total tokens is short enough, return as single chunk
+  const totalTokens = estimateTokens(content);
+  if (totalTokens <= cfg.minTokens) {
+    return {
+      chunked: false,
+      chunks: [
+        {
+          content: content.trim(),
+          index: 0,
+          tokenCount: totalTokens,
+          boundaryScore: 1,
+        },
+      ],
+      boundaries: [],
+      method: "semantic",
+    };
+  }
+
+  // --- Attempt embedding ---
+  let embeddings: number[][];
+  try {
+    embeddings = await batchEmbed(sentences, embedFn, cfg.embeddingBatchSize);
+  } catch {
+    // Embedding failed — fall back if configured
+    if (cfg.fallbackToRecursive) {
+      return buildRecursiveFallback(content, cfg);
+    }
+    throw new Error(
+      "Semantic chunking failed: embedding function threw and fallbackToRecursive is disabled",
+    );
+  }
+
+  if (embeddings.length !== sentences.length) {
+    if (cfg.fallbackToRecursive) {
+      return buildRecursiveFallback(content, cfg);
+    }
+    throw new Error(
+      `Semantic chunking failed: expected ${sentences.length} embeddings but received ${embeddings.length}`,
+    );
+  }
+
+  // --- Compute pairwise cosine similarity ---
+  const similarities: number[] = [];
+  for (let i = 0; i < sentences.length - 1; i++) {
+    similarities.push(cosineSimilarity(embeddings[i], embeddings[i + 1]));
+  }
+
+  // If only one pair (2 sentences), nothing to smooth or split meaningfully
+  if (similarities.length <= 1) {
+    return {
+      chunked: false,
+      chunks: [
+        {
+          content: content.trim(),
+          index: 0,
+          tokenCount: totalTokens,
+          boundaryScore: similarities.length === 1 ? similarities[0] : 1,
+        },
+      ],
+      boundaries: [],
+      method: "semantic",
+    };
+  }
+
+  // --- Smooth the similarity series ---
+  const smoothed = movingAverage(similarities, cfg.smoothingWindowSize);
+
+  // --- Detect boundaries: local minima below (mean - k * stddev) ---
+  const m = mean(smoothed);
+  const s = stddev(smoothed);
+  const threshold = m - cfg.boundaryThresholdStdDevs * s;
+  const rawBoundaries = findLocalMinima(smoothed, threshold);
+
+  // --- Build segments, merge short, split long ---
+  let segments = buildSegments(sentences, rawBoundaries);
+  segments = mergeShortSegments(segments, cfg.minTokens);
+
+  // --- Convert segments to chunks, splitting oversized ones ---
+  const chunks: SemanticChunk[] = [];
+  const finalBoundaries: number[] = [];
+  let sentenceOffset = 0;
+
+  for (let segIdx = 0; segIdx < segments.length; segIdx++) {
+    const segment = segments[segIdx];
+    const segText = segment.join(" ");
+    const segTokens = estimateTokens(segText);
+
+    if (segTokens > cfg.maxTokens) {
+      // Recursive split for oversized segment
+      const subChunks = splitLongSegment(segment, cfg.maxTokens, cfg.targetTokens);
+      for (const sc of subChunks) {
+        chunks.push({
+          ...sc,
+          index: chunks.length,
+        });
+      }
+    } else {
+      // Compute boundary score: the similarity at the trailing edge
+      const trailingSentenceIdx = sentenceOffset + segment.length - 1;
+      let bScore = 1;
+      if (
+        trailingSentenceIdx < similarities.length &&
+        segIdx < segments.length - 1
+      ) {
+        bScore = smoothed[trailingSentenceIdx] ?? similarities[trailingSentenceIdx] ?? 1;
+      }
+
+      chunks.push({
+        content: segText,
+        index: chunks.length,
+        tokenCount: segTokens,
+        boundaryScore: bScore,
+      });
+    }
+
+    // Record boundaries (all but the last segment produce a boundary)
+    if (segIdx < segments.length - 1) {
+      finalBoundaries.push(sentenceOffset + segment.length - 1);
+    }
+    sentenceOffset += segment.length;
+  }
+
+  return {
+    chunked: chunks.length > 1,
+    chunks,
+    boundaries: finalBoundaries,
+    method: "semantic",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recursive fallback helper
+// ---------------------------------------------------------------------------
+
+function buildRecursiveFallback(
+  content: string,
+  cfg: SemanticChunkingConfig,
+): SemanticChunkResult {
+  const result: ChunkResult = chunkContent(content, {
+    targetTokens: cfg.targetTokens,
+    minTokens: cfg.minTokens,
+    overlapSentences: 0,
+  });
+
+  return {
+    chunked: result.chunked,
+    chunks: result.chunks.map((c) => ({
+      ...c,
+      boundaryScore: 0,
+    })),
+    boundaries: [],
+    method: "recursive-fallback",
+  };
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -188,7 +188,6 @@ export const SPECULATIVE_TTL_DAYS = 30;
  * a circular import (types.ts is imported by everything).
  */
 export interface SemanticChunkingConfigShape {
-  enabled: boolean;
   targetTokens: number;
   minTokens: number;
   maxTokens: number;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -182,6 +182,22 @@ export function confidenceTier(score: number): ConfidenceTier {
 /** Default TTL in days for speculative memories (auto-expire if unconfirmed) */
 export const SPECULATIVE_TTL_DAYS = 30;
 
+/**
+ * Shape for semantic chunking config overrides stored in PluginConfig.
+ * Mirrors SemanticChunkingConfig from semantic-chunking.ts without creating
+ * a circular import (types.ts is imported by everything).
+ */
+export interface SemanticChunkingConfigShape {
+  enabled: boolean;
+  targetTokens: number;
+  minTokens: number;
+  maxTokens: number;
+  smoothingWindowSize: number;
+  boundaryThresholdStdDevs: number;
+  embeddingBatchSize: number;
+  fallbackToRecursive: boolean;
+}
+
 export interface PluginConfig {
   openaiApiKey: string | undefined;
   openaiBaseUrl: string | undefined;
@@ -262,6 +278,11 @@ export interface PluginConfig {
   chunkingTargetTokens: number;
   chunkingMinTokens: number;
   chunkingOverlapSentences: number;
+  // Semantic Chunking (Issue #368)
+  /** Enable semantic chunking with embedding-based topic boundary detection. Default: false. */
+  semanticChunkingEnabled: boolean;
+  /** Optional overrides for the semantic chunking algorithm. */
+  semanticChunkingConfig: Partial<SemanticChunkingConfigShape>;
   // Contradiction Detection (Phase 2B)
   contradictionDetectionEnabled: boolean;
   contradictionSimilarityThreshold: number;

--- a/tests/semantic-chunking.test.ts
+++ b/tests/semantic-chunking.test.ts
@@ -365,7 +365,6 @@ test("semanticChunkContent: batching respects embeddingBatchSize", async () => {
 
 test("semanticChunkContent: config defaults applied correctly", () => {
   const cfg = DEFAULT_SEMANTIC_CHUNKING_CONFIG;
-  assert.equal(cfg.enabled, false);
   assert.equal(cfg.targetTokens, 200);
   assert.equal(cfg.minTokens, 100);
   assert.equal(cfg.maxTokens, 400);
@@ -452,4 +451,41 @@ test("semanticChunkContent: partial config merges with defaults", async () => {
   });
   assert.ok(result);
   assert.equal(result.method, "semantic");
+});
+
+test("semanticChunkContent: embeddingBatchSize 0 does not cause infinite loop", async () => {
+  let callCount = 0;
+  const countingEmbedFn: EmbedFn = async (texts: string[]) => {
+    callCount++;
+    return texts.map(() => [1, 0, 0]);
+  };
+
+  const sentences = Array.from({ length: 5 }, (_, i) => `Sentence ${i}.`);
+  const text = sentences.join(" ");
+
+  // batchSize 0 should be clamped to 1, resulting in 5 calls (one per sentence)
+  const result = await semanticChunkContent(text, countingEmbedFn, {
+    embeddingBatchSize: 0,
+    minTokens: 5,
+  });
+
+  assert.ok(result);
+  assert.equal(callCount, 5);
+});
+
+test("semanticChunkContent: two sentences exceeding maxTokens triggers recursive split", async () => {
+  // Two long sentences whose combined token count exceeds maxTokens
+  const longA = "A".repeat(200) + ".";
+  const longB = "B".repeat(200) + ".";
+  const text = `${longA} ${longB}`;
+
+  const result = await semanticChunkContent(text, uniformEmbedFn, {
+    maxTokens: 50, // Very low to force splitting
+    targetTokens: 25,
+    minTokens: 10,
+  });
+
+  // Should fall back to recursive splitting since the 2-sentence chunk exceeds maxTokens
+  assert.equal(result.method, "recursive-fallback");
+  assert.ok(result.chunks.length >= 2, `Expected multiple chunks, got ${result.chunks.length}`);
 });

--- a/tests/semantic-chunking.test.ts
+++ b/tests/semantic-chunking.test.ts
@@ -1,0 +1,455 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  cosineSimilarity,
+  mean,
+  stddev,
+  movingAverage,
+  findLocalMinima,
+  semanticChunkContent,
+  DEFAULT_SEMANTIC_CHUNKING_CONFIG,
+  type EmbedFn,
+  type SemanticChunkingConfig,
+} from "../packages/remnic-core/src/semantic-chunking.js";
+
+// ---------------------------------------------------------------------------
+// Helpers — deterministic mock embedding functions
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a mock embedFn that maps sentences to one of two clusters.
+ * Sentences containing any keyword from `topicBKeywords` get vectorB;
+ * all others get vectorA. This creates a clear topic boundary.
+ */
+function twoTopicEmbedFn(
+  topicBKeywords: string[],
+  vectorA: number[] = [1, 0, 0],
+  vectorB: number[] = [0, 1, 0],
+): EmbedFn {
+  return async (texts: string[]) =>
+    texts.map((t) => {
+      const lower = t.toLowerCase();
+      return topicBKeywords.some((kw) => lower.includes(kw))
+        ? [...vectorB]
+        : [...vectorA];
+    });
+}
+
+/** An embedFn that always throws, simulating an unavailable embedding service. */
+const failingEmbedFn: EmbedFn = async () => {
+  throw new Error("embedding service unavailable");
+};
+
+/** An embedFn that returns all-identical vectors (no topic change). */
+const uniformEmbedFn: EmbedFn = async (texts: string[]) =>
+  texts.map(() => [1, 0, 0]);
+
+// ---------------------------------------------------------------------------
+// Math utility tests
+// ---------------------------------------------------------------------------
+
+test("cosineSimilarity: identical vectors return 1.0", () => {
+  assert.equal(cosineSimilarity([1, 0, 0], [1, 0, 0]), 1);
+  assert.equal(cosineSimilarity([3, 4], [3, 4]), 1);
+});
+
+test("cosineSimilarity: orthogonal vectors return 0.0", () => {
+  assert.equal(cosineSimilarity([1, 0, 0], [0, 1, 0]), 0);
+  assert.equal(cosineSimilarity([1, 0], [0, 1]), 0);
+});
+
+test("cosineSimilarity: opposite vectors return -1.0", () => {
+  const sim = cosineSimilarity([1, 0, 0], [-1, 0, 0]);
+  assert.ok(Math.abs(sim - -1) < 1e-10);
+});
+
+test("cosineSimilarity: zero vector returns 0", () => {
+  assert.equal(cosineSimilarity([0, 0, 0], [1, 2, 3]), 0);
+});
+
+test("cosineSimilarity: empty vectors return 0", () => {
+  assert.equal(cosineSimilarity([], []), 0);
+});
+
+test("cosineSimilarity: mismatched lengths throw", () => {
+  assert.throws(
+    () => cosineSimilarity([1, 2], [1, 2, 3]),
+    /vector length mismatch/,
+  );
+});
+
+test("mean: known series", () => {
+  assert.equal(mean([2, 4, 6]), 4);
+  assert.equal(mean([10]), 10);
+  assert.equal(mean([]), 0);
+});
+
+test("stddev: known series", () => {
+  // [2, 4, 6]: mean = 4, variance = ((4+0+4)/3) = 8/3, stddev = sqrt(8/3)
+  const sd = stddev([2, 4, 6]);
+  assert.ok(Math.abs(sd - Math.sqrt(8 / 3)) < 1e-10);
+});
+
+test("stddev: uniform series returns 0", () => {
+  assert.equal(stddev([5, 5, 5]), 0);
+});
+
+test("stddev: empty series returns 0", () => {
+  assert.equal(stddev([]), 0);
+});
+
+test("movingAverage: known series with window 3", () => {
+  // Series: [1, 3, 5, 3, 1]
+  // Window 3 (halfW=1):
+  //   i=0: avg(1,3) = 2          (clamped left)
+  //   i=1: avg(1,3,5) = 3
+  //   i=2: avg(3,5,3) = 3.667
+  //   i=3: avg(5,3,1) = 3
+  //   i=4: avg(3,1) = 2          (clamped right)
+  const result = movingAverage([1, 3, 5, 3, 1], 3);
+  assert.equal(result.length, 5);
+  assert.ok(Math.abs(result[0] - 2) < 1e-10);
+  assert.ok(Math.abs(result[1] - 3) < 1e-10);
+  assert.ok(Math.abs(result[2] - 11 / 3) < 1e-10);
+  assert.ok(Math.abs(result[3] - 3) < 1e-10);
+  assert.ok(Math.abs(result[4] - 2) < 1e-10);
+});
+
+test("movingAverage: window 1 returns original series", () => {
+  const series = [10, 20, 30];
+  const result = movingAverage(series, 1);
+  assert.deepEqual(result, [10, 20, 30]);
+});
+
+test("movingAverage: empty series returns empty", () => {
+  assert.deepEqual(movingAverage([], 3), []);
+});
+
+test("findLocalMinima: detects dips below threshold", () => {
+  // Series with a clear dip at index 2
+  const series = [0.9, 0.8, 0.2, 0.85, 0.9];
+  const m = mean(series);
+  const s = stddev(series);
+  const threshold = m - 0.5 * s;
+  const minima = findLocalMinima(series, threshold);
+  assert.deepEqual(minima, [2]);
+});
+
+test("findLocalMinima: no minima when series is flat", () => {
+  assert.deepEqual(findLocalMinima([0.5, 0.5, 0.5, 0.5], 0.4), []);
+});
+
+test("findLocalMinima: empty or short series returns empty", () => {
+  assert.deepEqual(findLocalMinima([], 0.5), []);
+  assert.deepEqual(findLocalMinima([0.5], 0.5), []);
+  assert.deepEqual(findLocalMinima([0.5, 0.3], 0.5), []);
+});
+
+test("findLocalMinima: multiple dips", () => {
+  const series = [0.9, 0.1, 0.9, 0.1, 0.9];
+  // Both index 1 and 3 are local minima and well below any reasonable threshold
+  const minima = findLocalMinima(series, 0.5);
+  assert.deepEqual(minima, [1, 3]);
+});
+
+// ---------------------------------------------------------------------------
+// Semantic chunking integration tests
+// ---------------------------------------------------------------------------
+
+test("semanticChunkContent: empty input returns empty result", async () => {
+  const result = await semanticChunkContent("", uniformEmbedFn);
+  assert.equal(result.chunked, false);
+  assert.equal(result.chunks.length, 0);
+  assert.equal(result.method, "semantic");
+});
+
+test("semanticChunkContent: whitespace-only input returns empty result", async () => {
+  const result = await semanticChunkContent("   \n\t  ", uniformEmbedFn);
+  assert.equal(result.chunked, false);
+  assert.equal(result.chunks.length, 0);
+});
+
+test("semanticChunkContent: single sentence returns single unchunked result", async () => {
+  const result = await semanticChunkContent("Hello world.", uniformEmbedFn);
+  assert.equal(result.chunked, false);
+  assert.equal(result.chunks.length, 1);
+  assert.equal(result.boundaries.length, 0);
+  assert.equal(result.method, "semantic");
+});
+
+test("semanticChunkContent: two sentences returns single unchunked result when short", async () => {
+  const result = await semanticChunkContent(
+    "Hello world. How are you?",
+    uniformEmbedFn,
+  );
+  assert.equal(result.chunked, false);
+  assert.equal(result.chunks.length, 1);
+});
+
+test("semanticChunkContent: no topic changes produces single chunk", async () => {
+  // Generate enough text so it would be chunked if boundaries existed,
+  // but all sentences are about the same topic.
+  const sentences = Array.from(
+    { length: 20 },
+    (_, i) => `The cat sat on mat number ${i}.`,
+  );
+  const text = sentences.join(" ");
+
+  const result = await semanticChunkContent(text, uniformEmbedFn, {
+    targetTokens: 50,
+    minTokens: 30,
+    maxTokens: 200,
+  });
+
+  // With uniform embeddings, cosine similarity between adjacent pairs is 1.0.
+  // No local minima should be detected, so no boundaries, hence one chunk.
+  assert.equal(result.chunked, false);
+  assert.equal(result.chunks.length, 1);
+  assert.equal(result.method, "semantic");
+});
+
+test("semanticChunkContent: clear topic change produces multiple chunks", async () => {
+  // First half about cooking, second half about programming
+  const cookingSentences = Array.from(
+    { length: 8 },
+    (_, i) => `The chef prepared dish number ${i} with fresh ingredients.`,
+  );
+  const programmingSentences = Array.from(
+    { length: 8 },
+    (_, i) => `The developer wrote function number ${i} in TypeScript.`,
+  );
+  const text = [...cookingSentences, ...programmingSentences].join(" ");
+
+  const embedFn = twoTopicEmbedFn(
+    ["developer", "function", "typescript"],
+    [1, 0, 0],
+    [0, 1, 0],
+  );
+
+  // Use smoothingWindowSize: 1 because mock embeddings produce a sharp binary
+  // transition (cos=0 at exactly one point). With window > 1 the smoothing
+  // spreads the dip into a flat plateau that findLocalMinima's strict less-than
+  // check does not recognize as a single minimum. Real embeddings produce
+  // gradual shifts that smooth gracefully.
+  const result = await semanticChunkContent(text, embedFn, {
+    targetTokens: 50,
+    minTokens: 30,
+    maxTokens: 600,
+    smoothingWindowSize: 1,
+  });
+
+  assert.equal(result.chunked, true);
+  assert.ok(result.chunks.length >= 2, `Expected at least 2 chunks, got ${result.chunks.length}`);
+  assert.ok(result.boundaries.length >= 1, "Expected at least 1 boundary");
+  assert.equal(result.method, "semantic");
+
+  // Verify each chunk has required fields
+  for (const chunk of result.chunks) {
+    assert.ok(typeof chunk.content === "string");
+    assert.ok(typeof chunk.index === "number");
+    assert.ok(typeof chunk.tokenCount === "number");
+    assert.ok(typeof chunk.boundaryScore === "number");
+  }
+});
+
+test("semanticChunkContent: fallback to recursive when embedFn throws", async () => {
+  const longText = Array.from(
+    { length: 20 },
+    (_, i) => `Sentence number ${i} is here.`,
+  ).join(" ");
+
+  const result = await semanticChunkContent(longText, failingEmbedFn, {
+    fallbackToRecursive: true,
+    targetTokens: 40,
+    minTokens: 20,
+  });
+
+  assert.equal(result.method, "recursive-fallback");
+  assert.ok(result.chunks.length >= 1);
+  // Each chunk from fallback should have boundaryScore = 0
+  for (const chunk of result.chunks) {
+    assert.equal(chunk.boundaryScore, 0);
+  }
+});
+
+test("semanticChunkContent: throws when embedFn fails and fallback disabled", async () => {
+  const text = "Sentence one. Sentence two. Sentence three. Sentence four.";
+
+  await assert.rejects(
+    () =>
+      semanticChunkContent(text, failingEmbedFn, {
+        fallbackToRecursive: false,
+        minTokens: 5,
+      }),
+    /embedding function threw and fallbackToRecursive is disabled/,
+  );
+});
+
+test("semanticChunkContent: merge short segments below minTokens", async () => {
+  // Create text with many short topic segments that should be merged
+  // Topic A (2 sentences) -> Topic B (2 sentences) -> Topic A again
+  const text = [
+    "Alpha one is here.",
+    "Alpha two is here.",
+    "Beta three code is here.",
+    "Beta four code is here.",
+    "Alpha five is here.",
+    "Alpha six is here.",
+    "Beta seven code is here.",
+    "Beta eight code is here.",
+    "Alpha nine is here.",
+    "Alpha ten is here.",
+  ].join(" ");
+
+  const embedFn = twoTopicEmbedFn(["beta", "code"], [1, 0, 0], [0, 1, 0]);
+
+  const result = await semanticChunkContent(text, embedFn, {
+    targetTokens: 50,
+    minTokens: 40, // High enough to force merging of 2-sentence segments
+    maxTokens: 300,
+    smoothingWindowSize: 1,
+  });
+
+  // All chunks should have at least minTokens worth of content
+  // (or be the last/only chunk)
+  for (let i = 0; i < result.chunks.length; i++) {
+    const chunk = result.chunks[i];
+    assert.ok(typeof chunk.tokenCount === "number");
+    assert.ok(chunk.tokenCount > 0);
+  }
+});
+
+test("semanticChunkContent: split long segments above maxTokens", async () => {
+  // Create a long single-topic block that exceeds maxTokens
+  const longSentences = Array.from(
+    { length: 30 },
+    (_, i) =>
+      `This is a very long sentence number ${i} that contributes substantially to the total token count of this paragraph.`,
+  );
+  const text = longSentences.join(" ");
+
+  const result = await semanticChunkContent(text, uniformEmbedFn, {
+    targetTokens: 50,
+    minTokens: 30,
+    maxTokens: 100, // Very low max to force recursive splitting
+  });
+
+  // The single topic block should still be split since it exceeds maxTokens
+  assert.ok(
+    result.chunks.length >= 2,
+    `Expected multiple chunks from long segment, got ${result.chunks.length}`,
+  );
+});
+
+test("semanticChunkContent: batching respects embeddingBatchSize", async () => {
+  let callCount = 0;
+  const countingEmbedFn: EmbedFn = async (texts: string[]) => {
+    callCount++;
+    return texts.map(() => [1, 0, 0]);
+  };
+
+  const sentences = Array.from(
+    { length: 10 },
+    (_, i) => `Sentence ${i}.`,
+  );
+  const text = sentences.join(" ");
+
+  await semanticChunkContent(text, countingEmbedFn, {
+    embeddingBatchSize: 3,
+    minTokens: 5,
+  });
+
+  // 10 sentences with batch size 3 should produce ceil(10/3) = 4 calls
+  assert.equal(callCount, 4);
+});
+
+test("semanticChunkContent: config defaults applied correctly", () => {
+  const cfg = DEFAULT_SEMANTIC_CHUNKING_CONFIG;
+  assert.equal(cfg.enabled, false);
+  assert.equal(cfg.targetTokens, 200);
+  assert.equal(cfg.minTokens, 100);
+  assert.equal(cfg.maxTokens, 400);
+  assert.equal(cfg.smoothingWindowSize, 3);
+  assert.equal(cfg.boundaryThresholdStdDevs, 1.0);
+  assert.equal(cfg.embeddingBatchSize, 32);
+  assert.equal(cfg.fallbackToRecursive, true);
+});
+
+test("semanticChunkContent: boundary indices are in ascending order", async () => {
+  const cookingSentences = Array.from(
+    { length: 6 },
+    (_, i) => `The chef prepared meal ${i} today.`,
+  );
+  const codeSentences = Array.from(
+    { length: 6 },
+    (_, i) => `The developer deployed release ${i} to production.`,
+  );
+  const cookingSentences2 = Array.from(
+    { length: 6 },
+    (_, i) => `The chef baked cake ${i} for dessert.`,
+  );
+
+  const text = [
+    ...cookingSentences,
+    ...codeSentences,
+    ...cookingSentences2,
+  ].join(" ");
+
+  const embedFn = twoTopicEmbedFn(
+    ["developer", "deployed", "production"],
+    [1, 0, 0],
+    [0, 1, 0],
+  );
+
+  const result = await semanticChunkContent(text, embedFn, {
+    targetTokens: 50,
+    minTokens: 30,
+    maxTokens: 600,
+    smoothingWindowSize: 1,
+  });
+
+  // Verify boundaries are sorted ascending
+  for (let i = 1; i < result.boundaries.length; i++) {
+    assert.ok(
+      result.boundaries[i] > result.boundaries[i - 1],
+      `Boundary ${i} (${result.boundaries[i]}) should be > boundary ${i - 1} (${result.boundaries[i - 1]})`,
+    );
+  }
+});
+
+test("semanticChunkContent: chunk indices are sequential", async () => {
+  const text = Array.from(
+    { length: 20 },
+    (_, i) =>
+      i < 10
+        ? `The scientist studied molecule ${i}.`
+        : `The musician played song ${i}.`,
+  ).join(" ");
+
+  const embedFn = twoTopicEmbedFn(
+    ["musician", "played", "song"],
+    [1, 0, 0],
+    [0, 1, 0],
+  );
+
+  const result = await semanticChunkContent(text, embedFn, {
+    targetTokens: 40,
+    minTokens: 20,
+    maxTokens: 300,
+    smoothingWindowSize: 1,
+  });
+
+  for (let i = 0; i < result.chunks.length; i++) {
+    assert.equal(result.chunks[i].index, i);
+  }
+});
+
+test("semanticChunkContent: partial config merges with defaults", async () => {
+  const text = "One sentence. Two sentence.";
+  const result = await semanticChunkContent(text, uniformEmbedFn, {
+    targetTokens: 500,
+    // Other fields should come from defaults
+  });
+  assert.ok(result);
+  assert.equal(result.method, "semantic");
+});


### PR DESCRIPTION
## Summary

- Add an optional semantic chunking strategy that uses sentence embeddings, cosine similarity, and smoothing-based local minima detection to split content at natural topic boundaries
- Gate the feature behind `semanticChunkingEnabled` (default: `false`); existing recursive chunker remains the default
- Include 32 comprehensive tests covering math utilities, topic boundary detection, fallback behavior, segment merging/splitting, and edge cases

## Details

**New module**: `packages/remnic-core/src/semantic-chunking.ts`

Algorithm: sentence tokenize -> embed via caller-provided `embedFn` -> compute pairwise cosine similarity -> smooth with moving average -> detect local minima below `(mean - k * stddev)` -> merge short segments -> split oversized segments via recursive fallback.

Exported math utilities: `cosineSimilarity`, `movingAverage`, `findLocalMinima`, `mean`, `stddev`.

**Config additions**: `semanticChunkingEnabled` (boolean) and `semanticChunkingConfig` (object with `targetTokens`, `minTokens`, `maxTokens`, `smoothingWindowSize`, `boundaryThresholdStdDevs`, `embeddingBatchSize`, `fallbackToRecursive`).

Falls back to recursive chunking when `embedFn` throws and `fallbackToRecursive` is `true` (default).

## Test plan

- [x] Cosine similarity: identical -> 1.0, orthogonal -> 0.0, opposite -> -1.0, zero vector -> 0
- [x] Moving average: known series with expected smoothed output
- [x] Local minima detection: known dips at correct indices
- [x] Topic boundary detection with mock embeddings producing clear clusters
- [x] Short content (1-2 sentences) -> single chunk, not chunked
- [x] No topic changes -> single chunk
- [x] Fallback to recursive when embedFn throws
- [x] Error when embedFn fails and fallback disabled
- [x] Merge short segments below minTokens
- [x] Split long segments above maxTokens
- [x] Batching respects embeddingBatchSize
- [x] Config defaults verified
- [x] Boundary indices ascending, chunk indices sequential
- [x] Build passes (`pnpm run build`)
- [x] All config tests pass alongside semantic chunking tests

Closes #368

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Feature is gated off by default and falls back to existing recursive chunking, limiting blast radius. Main risk is correctness/performance when enabled due to reliance on caller-provided embeddings and new segmentation heuristics.
> 
> **Overview**
> Adds an **optional semantic chunking** implementation (`semantic-chunking.ts`) that uses sentence embeddings + cosine similarity with smoothed local-minima boundary detection, with automatic merging of short segments and recursive splitting of oversized segments.
> 
> Introduces new plugin config fields (`semanticChunkingEnabled` default `false`, plus a typed `semanticChunkingConfig` override object) with config parsing/validation in `config.ts`, and adds comprehensive unit tests covering the math utilities, boundary detection behavior, batching, fallbacks, and edge cases. Documentation for the algorithm and tuning knobs is added under `docs/architecture/semantic-chunking.md` (plus a few non-functional JSON schema formatting/typography tweaks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d522a872cf5638f5eea10b216b9e2aa26d299265. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->