### PR TITLE
feat(storage): add page-level versioning with history and revert

### DIFF
--- a/docs/architecture/page-versioning.md
+++ b/docs/architecture/page-versioning.md
@@ -1,0 +1,102 @@
+# Page-Level Versioning
+
+Issue: #371
+
+## Overview
+
+Page-level versioning provides snapshot-based history for memory files.
+Every time a memory page (fact, entity, profile) is overwritten, the
+previous content is saved as a numbered snapshot in a sidecar directory.
+Users can list, inspect, diff, and revert to any prior version.
+
+## How it differs from file rotation
+
+| Aspect | File rotation (hygiene.ts) | Page versioning |
+|--------|---------------------------|-----------------|
+| Trigger | File exceeds size threshold | Every write |
+| Granularity | Tail-of-file kept, rest archived | Full-page snapshot |
+| Purpose | Prevent unbounded growth | Track change history |
+| Revert | Manual copy from archive | `remnic versions revert` |
+
+Both features coexist. Rotation handles growth; versioning handles history.
+
+## Sidecar directory layout
+
+```
+~/.remnic/
+  facts/
+    preferences.md              <- current file
+  entities/
+    alice.md                    <- current entity page
+  .versions/
+    facts__preferences/
+      manifest.json             <- version history metadata
+      1.md                      <- snapshot 1
+      2.md                      <- snapshot 2
+    entities__alice/
+      manifest.json
+      1.md
+      2.md
+```
+
+The sidecar key is derived from the relative path within memoryDir,
+with path separators replaced by `__` and the `.md` extension stripped.
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `versioningEnabled` | boolean | `false` | Enable page versioning |
+| `versioningMaxPerPage` | integer | `50` | Max snapshots per page (0 = unlimited) |
+| `versioningSidecarDir` | string | `".versions"` | Sidecar directory name |
+
+Example `remnic.config.json`:
+
+```json
+{
+  "remnic": {
+    "versioningEnabled": true,
+    "versioningMaxPerPage": 100,
+    "versioningSidecarDir": ".versions"
+  }
+}
+```
+
+## CLI commands
+
+```bash
+# List all versions of a page
+remnic versions list ~/.remnic/facts/preferences.md
+
+# Show content of a specific version
+remnic versions show ~/.remnic/facts/preferences.md 3
+
+# Diff two versions
+remnic versions diff ~/.remnic/facts/preferences.md 1 5
+
+# Revert to a previous version
+remnic versions revert ~/.remnic/facts/preferences.md 3
+```
+
+All commands accept `--json` for machine-readable output.
+
+## Storage overhead
+
+Each version snapshot is a full copy of the page at that point in time.
+For a typical memory page of 2-5 KB, 50 versions adds roughly 100-250 KB
+of overhead per page. The `maxVersionsPerPage` setting automatically prunes
+the oldest snapshots when the limit is exceeded.
+
+The `.versions` directory can be excluded from search indexing (QMD, etc.)
+since it contains historical data only accessed through the versioning API.
+
+## Write triggers
+
+Versioning hooks into these storage write paths:
+
+- `writeMemory` / `appendToMemoryFile` -- facts and corrections
+- Entity page writes (`writeEntity`)
+- Profile consolidation (`writeProfile`)
+
+Each hook snapshots the **previous** content before the overwrite occurs,
+ensuring no data is lost even if the write fails.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -577,7 +577,10 @@
             "description": "Install the Remnic Codex memory extension during Codex connector setup."
           },
           "codexHome": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "default": null,
             "description": "Optional Codex home directory override used for connector install and materialization."
           }
@@ -614,6 +617,22 @@
         "type": "boolean",
         "default": true,
         "description": "Run Codex memory materialization from the Codex session-end hook."
+      },
+      "versioningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable page-level versioning with sidecar snapshots."
+      },
+      "versioningMaxPerPage": {
+        "type": "integer",
+        "default": 50,
+        "minimum": 0,
+        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
+      },
+      "versioningSidecarDir": {
+        "type": "string",
+        "default": ".versions",
+        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
       },
       "codexCompat": {
         "type": "object",
@@ -1163,7 +1182,7 @@
       "recallPlannerShadowMode": {
         "type": "boolean",
         "default": false,
-        "description": "Run recall planner in shadow mode \u2014 evaluate but do not apply results."
+        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
       },
       "recallPlannerTelemetryEnabled": {
         "type": "boolean",
@@ -1238,7 +1257,7 @@
       "boxTopicShiftThreshold": {
         "type": "number",
         "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0\u20131)."
+        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
       },
       "boxTimeGapMs": {
         "type": "number",
@@ -1263,7 +1282,7 @@
       "traceWeaverOverlapThreshold": {
         "type": "number",
         "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0\u20131)."
+        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
       },
       "boxRecallDays": {
         "type": "number",
@@ -1363,7 +1382,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode \u2014 evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -1891,7 +1910,10 @@
       },
       "modelSource": {
         "type": "string",
-        "enum": ["plugin", "gateway"],
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
         "default": "plugin",
         "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
       },
@@ -1971,7 +1993,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default \u2014 only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -2005,7 +2027,13 @@
       },
       "extractionMinImportanceLevel": {
         "type": "string",
-        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "enum": [
+          "trivial",
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ],
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
@@ -2398,8 +2426,13 @@
       },
       "semanticConsolidationExcludeCategories": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["correction", "commitment"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "correction",
+          "commitment"
+        ],
         "description": "Memory categories excluded from semantic consolidation."
       },
       "semanticConsolidationIntervalHours": {
@@ -3414,7 +3447,7 @@
       "parallelAgentWeights": {
         "type": "object",
         "default": {
-          "direct": 1.0,
+          "direct": 1,
           "contextual": 0.7,
           "temporal": 0.85
         },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -615,6 +615,22 @@
         "default": true,
         "description": "Run Codex memory materialization from the Codex session-end hook."
       },
+      "versioningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable page-level versioning with sidecar snapshots."
+      },
+      "versioningMaxPerPage": {
+        "type": "integer",
+        "default": 50,
+        "minimum": 0,
+        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
+      },
+      "versioningSidecarDir": {
+        "type": "string",
+        "default": ".versions",
+        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -425,6 +425,8 @@ async function cmdVersions(rest: string[]): Promise<void> {
     sidecarDir: config.versioningSidecarDir,
   };
 
+  const memDir = resolveMemoryDir();
+
   const action = rest[0] ?? "help";
   const json = rest.includes("--json");
 
@@ -436,7 +438,7 @@ async function cmdVersions(rest: string[]): Promise<void> {
         process.exit(1);
       }
       const absPath = path.resolve(pagePath);
-      const history = await listVersions(absPath, versioningConfig);
+      const history = await listVersions(absPath, versioningConfig, memDir);
       if (json) {
         console.log(JSON.stringify(history, null, 2));
       } else {
@@ -462,7 +464,7 @@ async function cmdVersions(rest: string[]): Promise<void> {
       }
       const absPath = path.resolve(pagePath);
       try {
-        const content = await getVersion(absPath, versionId, versioningConfig);
+        const content = await getVersion(absPath, versionId, versioningConfig, memDir);
         console.log(content);
       } catch (err) {
         console.error(err instanceof Error ? err.message : String(err));
@@ -481,7 +483,7 @@ async function cmdVersions(rest: string[]): Promise<void> {
       }
       const absPath = path.resolve(pagePath);
       try {
-        const diffOutput = await diffVersions(absPath, v1, v2, versioningConfig);
+        const diffOutput = await diffVersions(absPath, v1, v2, versioningConfig, memDir);
         console.log(diffOutput);
       } catch (err) {
         console.error(err instanceof Error ? err.message : String(err));
@@ -499,7 +501,7 @@ async function cmdVersions(rest: string[]): Promise<void> {
       }
       const absPath = path.resolve(pagePath);
       try {
-        const version = await revertToVersion(absPath, versionId, versioningConfig);
+        const version = await revertToVersion(absPath, versionId, versioningConfig, undefined, memDir);
         if (json) {
           console.log(JSON.stringify(version, null, 2));
         } else {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -70,6 +70,10 @@ import {
   resolveBriefingSaveDir,
   briefingFilename,
   FileCalendarSource,
+  listVersions,
+  getVersion,
+  revertToVersion,
+  diffVersions,
 } from "@remnic/core";
 import {
   runBenchSuite,
@@ -396,6 +400,133 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     for (const m of memories) {
       console.log(`- ${m.content}`);
     }
+  }
+}
+
+// ── Page-level versioning (issue #371) ─────────────────────────────────────
+
+async function cmdVersions(rest: string[]): Promise<void> {
+  initLogger();
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const config = parseConfig(remnicCfg);
+
+  if (!config.versioningEnabled) {
+    console.error("Page versioning is disabled (versioningEnabled = false).");
+    process.exit(1);
+  }
+
+  const versioningConfig = {
+    enabled: config.versioningEnabled,
+    maxVersionsPerPage: config.versioningMaxPerPage,
+    sidecarDir: config.versioningSidecarDir,
+  };
+
+  const action = rest[0] ?? "help";
+  const json = rest.includes("--json");
+
+  switch (action) {
+    case "list": {
+      const pagePath = rest[1];
+      if (!pagePath) {
+        console.error("Usage: remnic versions list <page-path>");
+        process.exit(1);
+      }
+      const absPath = path.resolve(pagePath);
+      const history = await listVersions(absPath, versioningConfig);
+      if (json) {
+        console.log(JSON.stringify(history, null, 2));
+      } else {
+        if (history.versions.length === 0) {
+          console.log(`No versions found for ${pagePath}`);
+        } else {
+          console.log(`Versions for ${pagePath} (current: v${history.currentVersion}):\n`);
+          for (const v of history.versions) {
+            const note = v.note ? ` — ${v.note}` : "";
+            console.log(`  v${v.versionId}  ${v.timestamp}  ${v.trigger}  ${v.sizeBytes} bytes${note}`);
+          }
+        }
+      }
+      break;
+    }
+
+    case "show": {
+      const pagePath = rest[1];
+      const versionId = rest[2];
+      if (!pagePath || !versionId) {
+        console.error("Usage: remnic versions show <page-path> <version-id>");
+        process.exit(1);
+      }
+      const absPath = path.resolve(pagePath);
+      try {
+        const content = await getVersion(absPath, versionId, versioningConfig);
+        console.log(content);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      break;
+    }
+
+    case "diff": {
+      const pagePath = rest[1];
+      const v1 = rest[2];
+      const v2 = rest[3];
+      if (!pagePath || !v1 || !v2) {
+        console.error("Usage: remnic versions diff <page-path> <v1> <v2>");
+        process.exit(1);
+      }
+      const absPath = path.resolve(pagePath);
+      try {
+        const diffOutput = await diffVersions(absPath, v1, v2, versioningConfig);
+        console.log(diffOutput);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      break;
+    }
+
+    case "revert": {
+      const pagePath = rest[1];
+      const versionId = rest[2];
+      if (!pagePath || !versionId) {
+        console.error("Usage: remnic versions revert <page-path> <version-id>");
+        process.exit(1);
+      }
+      const absPath = path.resolve(pagePath);
+      try {
+        const version = await revertToVersion(absPath, versionId, versioningConfig);
+        if (json) {
+          console.log(JSON.stringify(version, null, 2));
+        } else {
+          console.log(`Reverted ${pagePath} to version ${versionId}.`);
+          console.log(`Created snapshot v${version.versionId} of previous content.`);
+        }
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      break;
+    }
+
+    default:
+      console.log(`
+remnic versions — Page-level versioning
+
+Usage:
+  remnic versions list <page-path>              List all versions of a page
+  remnic versions show <page-path> <id>         Print content of a specific version
+  remnic versions diff <page-path> <v1> <v2>    Show diff between two versions
+  remnic versions revert <page-path> <id>       Revert page to a specific version
+
+Options:
+  --json    Output in JSON format
+`);
+      break;
   }
 }
 
@@ -2182,6 +2313,11 @@ Options:
       break;
     }
 
+    case "versions": {
+      await cmdVersions(rest);
+      break;
+    }
+
     case "openclaw": {
       const subAction = rest[0] ?? "help";
       if (subAction === "install") {
@@ -2239,6 +2375,8 @@ Usage:
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.
+  remnic versions <list|show|diff|revert> <page-path> [id] [--json]
+    Page-level versioning: list, show, diff, or revert page snapshots.
 
 Options:
   --json    Output in JSON format

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1909,6 +1909,17 @@ export function parseConfig(raw: unknown): PluginConfig {
         : 30,
     codexMaterializeOnConsolidation: cfg.codexMaterializeOnConsolidation !== false,
     codexMaterializeOnSessionEnd: cfg.codexMaterializeOnSessionEnd !== false,
+
+    // Page-level versioning (issue #371)
+    versioningEnabled: cfg.versioningEnabled === true,
+    versioningMaxPerPage:
+      typeof cfg.versioningMaxPerPage === "number"
+        ? Math.max(0, Math.floor(cfg.versioningMaxPerPage))
+        : 50,
+    versioningSidecarDir:
+      typeof cfg.versioningSidecarDir === "string" && cfg.versioningSidecarDir.trim().length > 0
+        ? cfg.versioningSidecarDir.trim()
+        : ".versions",
   };
 }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -182,6 +182,23 @@ export { CODEX_THREAD_KEY_PREFIX } from "./codex-thread-key.js";
 export type { CodexCompatConfig } from "./types.js";
 
 // ---------------------------------------------------------------------------
+// Page-level versioning (issue #371)
+// ---------------------------------------------------------------------------
+
+export {
+  createVersion,
+  listVersions,
+  getVersion,
+  revertToVersion,
+  diffVersions,
+  type PageVersion,
+  type VersionTrigger,
+  type VersionHistory,
+  type VersioningConfig,
+  type VersioningLogger,
+} from "./page-versioning.js";
+
+// ---------------------------------------------------------------------------
 // Logger
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1308,6 +1308,12 @@ export class Orchestrator {
     // Propagate the inline-attribution template so the storage layer can strip
     // citations from legacy facts during the hash-index rebuild path.
     this.storage.citationTemplate = config.inlineSourceAttributionFormat;
+    // Wire page-level versioning (issue #371)
+    this.storage.setVersioningConfig({
+      enabled: config.versioningEnabled,
+      maxVersionsPerPage: config.versioningMaxPerPage,
+      sidecarDir: config.versioningSidecarDir,
+    });
     this.qmd = createSearchBackend(config);
     const conversationIndexRuntime = createConversationIndexRuntime(config, {
       getQmd: () => this.conversationQmd,

--- a/packages/remnic-core/src/page-versioning.ts
+++ b/packages/remnic-core/src/page-versioning.ts
@@ -1,0 +1,427 @@
+/**
+ * Page-level versioning with history and revert (issue #371).
+ *
+ * Provides snapshot-based versioning for memory files using a sidecar
+ * directory layout.  Each memory page gets a `.versions/<pageName>/`
+ * subdirectory containing numbered snapshots and a `manifest.json` that
+ * records the version history.
+ *
+ * Storage layout:
+ *   memoryDir/
+ *     facts/preferences.md              <- current file
+ *     .versions/
+ *       facts__preferences/
+ *         manifest.json                  <- VersionHistory
+ *         1.md                           <- version 1 snapshot
+ *         2.md                           <- version 2 snapshot
+ */
+
+import { createHash } from "node:crypto";
+import path from "node:path";
+import {
+  access,
+  mkdir,
+  readdir,
+  readFile,
+  writeFile,
+  unlink,
+} from "node:fs/promises";
+
+// ---------------------------------------------------------------------------
+// Public interfaces
+// ---------------------------------------------------------------------------
+
+export interface PageVersion {
+  versionId: string;
+  timestamp: string;
+  contentHash: string;
+  sizeBytes: number;
+  trigger: VersionTrigger;
+  note?: string;
+}
+
+export type VersionTrigger = "write" | "consolidation" | "revert" | "manual";
+
+export interface VersionHistory {
+  pagePath: string;
+  versions: PageVersion[];
+  currentVersion: string;
+}
+
+export interface VersioningConfig {
+  enabled: boolean;
+  maxVersionsPerPage: number;
+  sidecarDir: string;
+}
+
+// ---------------------------------------------------------------------------
+// Logger interface (minimal, avoids coupling to the host logger)
+// ---------------------------------------------------------------------------
+
+export interface VersioningLogger {
+  debug(msg: string): void;
+  warn(msg: string): void;
+}
+
+const NOOP_LOGGER: VersioningLogger = {
+  debug: () => {},
+  warn: () => {},
+};
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function contentHash(content: string): string {
+  return createHash("sha256").update(content, "utf-8").digest("hex");
+}
+
+/**
+ * Derive a filesystem-safe sidecar key from a page path relative to memoryDir.
+ *
+ * `facts/2026-01-15/pref-001.md` -> `facts__2026-01-15__pref-001`
+ */
+function sidecarKey(pagePath: string): string {
+  const withoutExt = pagePath.replace(/\.md$/i, "");
+  return withoutExt.replace(/[\\/]/g, "__");
+}
+
+function sidecarDir(memoryDir: string, sidecar: string, pagePath: string): string {
+  return path.join(memoryDir, sidecar, sidecarKey(pagePath));
+}
+
+function manifestPath(memoryDir: string, sidecar: string, pagePath: string): string {
+  return path.join(sidecarDir(memoryDir, sidecar, pagePath), "manifest.json");
+}
+
+async function fileExists(p: string): Promise<boolean> {
+  try {
+    await access(p);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function readManifest(
+  memoryDir: string,
+  sidecar: string,
+  pagePath: string,
+): Promise<VersionHistory> {
+  const mp = manifestPath(memoryDir, sidecar, pagePath);
+  try {
+    const raw = await readFile(mp, "utf-8");
+    const parsed: unknown = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) {
+      return { pagePath, versions: [], currentVersion: "0" };
+    }
+    const obj = parsed as Record<string, unknown>;
+    const versions = Array.isArray(obj.versions) ? (obj.versions as PageVersion[]) : [];
+    const currentVersion = typeof obj.currentVersion === "string" ? obj.currentVersion : "0";
+    return { pagePath: typeof obj.pagePath === "string" ? obj.pagePath : pagePath, versions, currentVersion };
+  } catch {
+    return { pagePath, versions: [], currentVersion: "0" };
+  }
+}
+
+async function writeManifest(
+  memoryDir: string,
+  sidecar: string,
+  pagePath: string,
+  history: VersionHistory,
+): Promise<void> {
+  const dir = sidecarDir(memoryDir, sidecar, pagePath);
+  await mkdir(dir, { recursive: true });
+  const mp = manifestPath(memoryDir, sidecar, pagePath);
+  await writeFile(mp, JSON.stringify(history, null, 2) + "\n", "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a new version snapshot for a page.
+ *
+ * Call this BEFORE overwriting the current file so the previous content is
+ * preserved. If the file does not exist yet (first write), the provided
+ * `content` is snapshotted as version 1.
+ *
+ * Pruning: when the number of versions exceeds `config.maxVersionsPerPage`,
+ * the oldest snapshots (and their files) are removed.
+ */
+export async function createVersion(
+  pagePath: string,
+  content: string,
+  trigger: VersionTrigger,
+  config: VersioningConfig,
+  log: VersioningLogger = NOOP_LOGGER,
+  note?: string,
+): Promise<PageVersion> {
+  const { sidecarDir: sidecar, maxVersionsPerPage } = config;
+  const memoryDir = resolveMemoryDir(pagePath, config);
+
+  const history = await readManifest(memoryDir, sidecar, relPath(pagePath, memoryDir));
+  const nextId = String(history.versions.length > 0
+    ? Math.max(...history.versions.map((v) => Number(v.versionId))) + 1
+    : 1);
+
+  const hash = contentHash(content);
+  const version: PageVersion = {
+    versionId: nextId,
+    timestamp: new Date().toISOString(),
+    contentHash: hash,
+    sizeBytes: Buffer.byteLength(content, "utf-8"),
+    trigger,
+    ...(note !== undefined ? { note } : {}),
+  };
+
+  // Write snapshot file
+  const dir = sidecarDir(memoryDir, sidecar, relPath(pagePath, memoryDir));
+  await mkdir(dir, { recursive: true });
+  const ext = path.extname(pagePath) || ".md";
+  const snapshotPath = path.join(dir, `${nextId}${ext}`);
+  await writeFile(snapshotPath, content, "utf-8");
+
+  history.versions.push(version);
+  history.currentVersion = nextId;
+
+  // Prune old versions if exceeding max
+  if (maxVersionsPerPage > 0 && history.versions.length > maxVersionsPerPage) {
+    const toRemove = history.versions.splice(0, history.versions.length - maxVersionsPerPage);
+    for (const old of toRemove) {
+      const oldPath = path.join(dir, `${old.versionId}${ext}`);
+      try {
+        await unlink(oldPath);
+      } catch {
+        log.debug(`page-versioning: could not remove old snapshot ${oldPath}`);
+      }
+    }
+  }
+
+  await writeManifest(memoryDir, sidecar, relPath(pagePath, memoryDir), history);
+  log.debug(`page-versioning: created version ${nextId} for ${pagePath} (trigger=${trigger})`);
+
+  return version;
+}
+
+/**
+ * List all versions for a page.
+ */
+export async function listVersions(
+  pagePath: string,
+  config: VersioningConfig,
+): Promise<VersionHistory> {
+  const memoryDir = resolveMemoryDir(pagePath, config);
+  const rel = relPath(pagePath, memoryDir);
+  const history = await readManifest(memoryDir, config.sidecarDir, rel);
+  // Sort ascending by versionId (numeric)
+  history.versions.sort((a, b) => Number(a.versionId) - Number(b.versionId));
+  return history;
+}
+
+/**
+ * Read the content of a specific version.
+ */
+export async function getVersion(
+  pagePath: string,
+  versionId: string,
+  config: VersioningConfig,
+): Promise<string> {
+  const memoryDir = resolveMemoryDir(pagePath, config);
+  const rel = relPath(pagePath, memoryDir);
+  const ext = path.extname(pagePath) || ".md";
+  const dir = sidecarDir(memoryDir, config.sidecarDir, rel);
+  const snapshotPath = path.join(dir, `${versionId}${ext}`);
+
+  if (!(await fileExists(snapshotPath))) {
+    throw new Error(`Version ${versionId} not found for ${pagePath}`);
+  }
+
+  return readFile(snapshotPath, "utf-8");
+}
+
+/**
+ * Revert a page to a previous version.
+ *
+ * 1. Reads the target version's content.
+ * 2. Snapshots the CURRENT content as a new version (trigger: "revert").
+ * 3. Writes the reverted content to the page file.
+ *
+ * Returns the newly created version entry for the revert snapshot.
+ */
+export async function revertToVersion(
+  pagePath: string,
+  versionId: string,
+  config: VersioningConfig,
+  log: VersioningLogger = NOOP_LOGGER,
+): Promise<PageVersion> {
+  // Read target version content
+  const targetContent = await getVersion(pagePath, versionId, config);
+
+  // Snapshot current content before overwriting
+  let currentContent = "";
+  try {
+    currentContent = await readFile(pagePath, "utf-8");
+  } catch {
+    // File may not exist; that's okay
+  }
+
+  const version = await createVersion(
+    pagePath,
+    currentContent,
+    "revert",
+    config,
+    log,
+    `reverted to version ${versionId}`,
+  );
+
+  // Write the reverted content to the actual page
+  await writeFile(pagePath, targetContent, "utf-8");
+  log.debug(`page-versioning: reverted ${pagePath} to version ${versionId}`);
+
+  return version;
+}
+
+/**
+ * Simple line-based diff between two versions.
+ *
+ * Returns a unified-style diff string showing added (+) and removed (-) lines.
+ */
+export async function diffVersions(
+  pagePath: string,
+  v1: string,
+  v2: string,
+  config: VersioningConfig,
+): Promise<string> {
+  const content1 = await getVersion(pagePath, v1, config);
+  const content2 = await getVersion(pagePath, v2, config);
+
+  const lines1 = content1.split("\n");
+  const lines2 = content2.split("\n");
+
+  const result: string[] = [];
+  result.push(`--- version ${v1}`);
+  result.push(`+++ version ${v2}`);
+
+  // Simple LCS-based diff
+  const lcs = computeLCS(lines1, lines2);
+  let i = 0;
+  let j = 0;
+  let k = 0;
+
+  while (k < lcs.length) {
+    // Emit removed lines before the next common line
+    while (i < lines1.length && lines1[i] !== lcs[k]) {
+      result.push(`-${lines1[i]}`);
+      i++;
+    }
+    // Emit added lines before the next common line
+    while (j < lines2.length && lines2[j] !== lcs[k]) {
+      result.push(`+${lines2[j]}`);
+      j++;
+    }
+    // Common line
+    result.push(` ${lcs[k]}`);
+    i++;
+    j++;
+    k++;
+  }
+  // Remaining removed lines
+  while (i < lines1.length) {
+    result.push(`-${lines1[i]}`);
+    i++;
+  }
+  // Remaining added lines
+  while (j < lines2.length) {
+    result.push(`+${lines2[j]}`);
+    j++;
+  }
+
+  return result.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// LCS helper for diffVersions
+// ---------------------------------------------------------------------------
+
+function computeLCS(a: string[], b: string[]): string[] {
+  const m = a.length;
+  const n = b.length;
+  // Build DP table
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array<number>(n + 1).fill(0));
+  for (let i = 1; i <= m; i++) {
+    for (let j = 1; j <= n; j++) {
+      if (a[i - 1] === b[j - 1]) {
+        dp[i][j] = dp[i - 1][j - 1] + 1;
+      } else {
+        dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+      }
+    }
+  }
+  // Backtrack to build LCS
+  const result: string[] = [];
+  let i = m;
+  let j = n;
+  while (i > 0 && j > 0) {
+    if (a[i - 1] === b[j - 1]) {
+      result.unshift(a[i - 1]);
+      i--;
+      j--;
+    } else if (dp[i - 1][j] > dp[i][j - 1]) {
+      i--;
+    } else {
+      j--;
+    }
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Given an absolute page path, resolve the memory directory.
+ *
+ * If `pagePath` is absolute, the memory directory is derived by stripping
+ * the relative portion.  The config's sidecarDir is always resolved relative
+ * to the memory directory.
+ */
+function resolveMemoryDir(pagePath: string, _config: VersioningConfig): string {
+  // The pagePath is always absolute.  The "memoryDir" is the root that
+  // contains the page.  We resolve it by checking common subdirectories.
+  // In practice, the caller's memoryDir is known from context, but here
+  // we infer it from the absolute path by looking for known subdirs.
+  //
+  // For simplicity, we walk up from the pagePath until we find a directory
+  // that does NOT match known subdirectory names.
+  const knownSubdirs = new Set([
+    "facts",
+    "corrections",
+    "entities",
+    "state",
+    "artifacts",
+    "questions",
+    "profiles",
+  ]);
+
+  let dir = path.dirname(pagePath);
+  // Walk up past date directories (YYYY-MM-DD) and known subdirs
+  for (let depth = 0; depth < 5; depth++) {
+    const base = path.basename(dir);
+    if (knownSubdirs.has(base) || /^\d{4}-\d{2}-\d{2}$/.test(base)) {
+      dir = path.dirname(dir);
+    } else {
+      break;
+    }
+  }
+  return dir;
+}
+
+/**
+ * Compute relative path of a page within its memory directory.
+ */
+function relPath(pagePath: string, memoryDir: string): string {
+  return path.relative(memoryDir, pagePath);
+}

--- a/packages/remnic-core/src/page-versioning.ts
+++ b/packages/remnic-core/src/page-versioning.ts
@@ -21,7 +21,6 @@ import path from "node:path";
 import {
   access,
   mkdir,
-  readdir,
   readFile,
   writeFile,
   unlink,
@@ -67,6 +66,19 @@ const NOOP_LOGGER: VersioningLogger = {
   debug: () => {},
   warn: () => {},
 };
+
+// ---------------------------------------------------------------------------
+// Per-page write lock (promise-chain pattern, see gotcha #40)
+// ---------------------------------------------------------------------------
+
+const writeLocks = new Map<string, Promise<void>>();
+
+function withPageLock<T>(pageKey: string, fn: () => Promise<T>): Promise<T> {
+  const prev = writeLocks.get(pageKey) ?? Promise.resolve();
+  const next = prev.then(fn, fn); // run fn after previous completes, even if previous failed
+  writeLocks.set(pageKey, next.then(() => {}, () => {})); // recover chain per gotcha #40
+  return next;
+}
 
 // ---------------------------------------------------------------------------
 // Internal helpers
@@ -157,52 +169,56 @@ export async function createVersion(
   config: VersioningConfig,
   log: VersioningLogger = NOOP_LOGGER,
   note?: string,
+  memoryDir?: string,
 ): Promise<PageVersion> {
   const { sidecarDir: sidecar, maxVersionsPerPage } = config;
-  const memoryDir = resolveMemoryDir(pagePath, config);
+  const resolvedMemoryDir = memoryDir ?? resolveMemoryDir(pagePath);
+  const mPath = manifestPath(resolvedMemoryDir, sidecar, relPath(pagePath, resolvedMemoryDir));
 
-  const history = await readManifest(memoryDir, sidecar, relPath(pagePath, memoryDir));
-  const nextId = String(history.versions.length > 0
-    ? Math.max(...history.versions.map((v) => Number(v.versionId))) + 1
-    : 1);
+  return withPageLock(mPath, async () => {
+    const history = await readManifest(resolvedMemoryDir, sidecar, relPath(pagePath, resolvedMemoryDir));
+    const nextId = String(history.versions.length > 0
+      ? Math.max(...history.versions.map((v) => Number(v.versionId))) + 1
+      : 1);
 
-  const hash = contentHash(content);
-  const version: PageVersion = {
-    versionId: nextId,
-    timestamp: new Date().toISOString(),
-    contentHash: hash,
-    sizeBytes: Buffer.byteLength(content, "utf-8"),
-    trigger,
-    ...(note !== undefined ? { note } : {}),
-  };
+    const hash = contentHash(content);
+    const version: PageVersion = {
+      versionId: nextId,
+      timestamp: new Date().toISOString(),
+      contentHash: hash,
+      sizeBytes: Buffer.byteLength(content, "utf-8"),
+      trigger,
+      ...(note !== undefined ? { note } : {}),
+    };
 
-  // Write snapshot file
-  const dir = sidecarDir(memoryDir, sidecar, relPath(pagePath, memoryDir));
-  await mkdir(dir, { recursive: true });
-  const ext = path.extname(pagePath) || ".md";
-  const snapshotPath = path.join(dir, `${nextId}${ext}`);
-  await writeFile(snapshotPath, content, "utf-8");
+    // Write snapshot file
+    const dir = sidecarDir(resolvedMemoryDir, sidecar, relPath(pagePath, resolvedMemoryDir));
+    await mkdir(dir, { recursive: true });
+    const ext = path.extname(pagePath) || ".md";
+    const snapshotPath = path.join(dir, `${nextId}${ext}`);
+    await writeFile(snapshotPath, content, "utf-8");
 
-  history.versions.push(version);
-  history.currentVersion = nextId;
+    history.versions.push(version);
+    history.currentVersion = nextId;
 
-  // Prune old versions if exceeding max
-  if (maxVersionsPerPage > 0 && history.versions.length > maxVersionsPerPage) {
-    const toRemove = history.versions.splice(0, history.versions.length - maxVersionsPerPage);
-    for (const old of toRemove) {
-      const oldPath = path.join(dir, `${old.versionId}${ext}`);
-      try {
-        await unlink(oldPath);
-      } catch {
-        log.debug(`page-versioning: could not remove old snapshot ${oldPath}`);
+    // Prune old versions if exceeding max
+    if (maxVersionsPerPage > 0 && history.versions.length > maxVersionsPerPage) {
+      const toRemove = history.versions.splice(0, history.versions.length - maxVersionsPerPage);
+      for (const old of toRemove) {
+        const oldPath = path.join(dir, `${old.versionId}${ext}`);
+        try {
+          await unlink(oldPath);
+        } catch {
+          log.debug(`page-versioning: could not remove old snapshot ${oldPath}`);
+        }
       }
     }
-  }
 
-  await writeManifest(memoryDir, sidecar, relPath(pagePath, memoryDir), history);
-  log.debug(`page-versioning: created version ${nextId} for ${pagePath} (trigger=${trigger})`);
+    await writeManifest(resolvedMemoryDir, sidecar, relPath(pagePath, resolvedMemoryDir), history);
+    log.debug(`page-versioning: created version ${nextId} for ${pagePath} (trigger=${trigger})`);
 
-  return version;
+    return version;
+  });
 }
 
 /**
@@ -211,10 +227,11 @@ export async function createVersion(
 export async function listVersions(
   pagePath: string,
   config: VersioningConfig,
+  memoryDir?: string,
 ): Promise<VersionHistory> {
-  const memoryDir = resolveMemoryDir(pagePath, config);
-  const rel = relPath(pagePath, memoryDir);
-  const history = await readManifest(memoryDir, config.sidecarDir, rel);
+  const resolvedMemoryDir = memoryDir ?? resolveMemoryDir(pagePath);
+  const rel = relPath(pagePath, resolvedMemoryDir);
+  const history = await readManifest(resolvedMemoryDir, config.sidecarDir, rel);
   // Sort ascending by versionId (numeric)
   history.versions.sort((a, b) => Number(a.versionId) - Number(b.versionId));
   return history;
@@ -227,11 +244,12 @@ export async function getVersion(
   pagePath: string,
   versionId: string,
   config: VersioningConfig,
+  memoryDir?: string,
 ): Promise<string> {
-  const memoryDir = resolveMemoryDir(pagePath, config);
-  const rel = relPath(pagePath, memoryDir);
+  const resolvedMemoryDir = memoryDir ?? resolveMemoryDir(pagePath);
+  const rel = relPath(pagePath, resolvedMemoryDir);
   const ext = path.extname(pagePath) || ".md";
-  const dir = sidecarDir(memoryDir, config.sidecarDir, rel);
+  const dir = sidecarDir(resolvedMemoryDir, config.sidecarDir, rel);
   const snapshotPath = path.join(dir, `${versionId}${ext}`);
 
   if (!(await fileExists(snapshotPath))) {
@@ -255,9 +273,12 @@ export async function revertToVersion(
   versionId: string,
   config: VersioningConfig,
   log: VersioningLogger = NOOP_LOGGER,
+  memoryDir?: string,
 ): Promise<PageVersion> {
+  const resolvedMemoryDir = memoryDir ?? resolveMemoryDir(pagePath);
+
   // Read target version content
-  const targetContent = await getVersion(pagePath, versionId, config);
+  const targetContent = await getVersion(pagePath, versionId, config, resolvedMemoryDir);
 
   // Snapshot current content before overwriting
   let currentContent = "";
@@ -274,6 +295,7 @@ export async function revertToVersion(
     config,
     log,
     `reverted to version ${versionId}`,
+    resolvedMemoryDir,
   );
 
   // Write the reverted content to the actual page
@@ -293,9 +315,11 @@ export async function diffVersions(
   v1: string,
   v2: string,
   config: VersioningConfig,
+  memoryDir?: string,
 ): Promise<string> {
-  const content1 = await getVersion(pagePath, v1, config);
-  const content2 = await getVersion(pagePath, v2, config);
+  const resolvedMemoryDir = memoryDir ?? resolveMemoryDir(pagePath);
+  const content1 = await getVersion(pagePath, v1, config, resolvedMemoryDir);
+  const content2 = await getVersion(pagePath, v2, config, resolvedMemoryDir);
 
   const lines1 = content1.split("\n");
   const lines2 = content2.split("\n");
@@ -382,20 +406,14 @@ function computeLCS(a: string[], b: string[]): string[] {
 // ---------------------------------------------------------------------------
 
 /**
- * Given an absolute page path, resolve the memory directory.
+ * Legacy fallback: given an absolute page path, heuristically resolve the
+ * memory directory by walking up past known subdirectory names.
  *
- * If `pagePath` is absolute, the memory directory is derived by stripping
- * the relative portion.  The config's sidecarDir is always resolved relative
- * to the memory directory.
+ * Callers should always pass an explicit `memoryDir` instead of relying on
+ * this heuristic.  It is retained only for backward compatibility when the
+ * optional `memoryDir` parameter is omitted.
  */
-function resolveMemoryDir(pagePath: string, _config: VersioningConfig): string {
-  // The pagePath is always absolute.  The "memoryDir" is the root that
-  // contains the page.  We resolve it by checking common subdirectories.
-  // In practice, the caller's memoryDir is known from context, but here
-  // we infer it from the absolute path by looking for known subdirs.
-  //
-  // For simplicity, we walk up from the pagePath until we find a directory
-  // that does NOT match known subdirectory names.
+function resolveMemoryDir(pagePath: string): string {
   const knownSubdirs = new Set([
     "facts",
     "corrections",

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1750,7 +1750,7 @@ export class StorageManager {
     if (!this._versioningConfig || !this._versioningConfig.enabled) return;
     try {
       const existing = await readFile(filePath, "utf-8");
-      await createPageVersion(filePath, existing, trigger, this._versioningConfig, log);
+      await createPageVersion(filePath, existing, trigger, this._versioningConfig, log, undefined, this.baseDir);
     } catch {
       // File does not exist yet — nothing to snapshot
     }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -6,6 +6,7 @@ import { log } from "./logger.js";
 import { getCachedEntities, setCachedEntities } from "./memory-cache.js";
 import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
+import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import {
   matchEntitySchemaSection,
   normalizeEntityStructuredSection,
@@ -1733,6 +1734,28 @@ export class StorageManager {
   /** Optional: set by the orchestrator after construction to enable template-aware citation stripping during legacy hash rebuild. */
   citationTemplate: string = DEFAULT_CITATION_FORMAT;
 
+  /** Page-versioning configuration.  Set by the orchestrator after construction. */
+  private _versioningConfig: VersioningConfig | null = null;
+
+  /** Set the page-versioning configuration.  When `enabled` is false (default), all versioning calls are no-ops. */
+  setVersioningConfig(config: VersioningConfig): void {
+    this._versioningConfig = config;
+  }
+
+  /**
+   * Snapshot the current content of a page before overwriting.
+   * No-op when versioning is disabled or the file does not yet exist.
+   */
+  private async snapshotBeforeWrite(filePath: string, trigger: VersionTrigger): Promise<void> {
+    if (!this._versioningConfig || !this._versioningConfig.enabled) return;
+    try {
+      const existing = await readFile(filePath, "utf-8");
+      await createPageVersion(filePath, existing, trigger, this._versioningConfig, log);
+    } catch {
+      // File does not exist yet — nothing to snapshot
+    }
+  }
+
   constructor(
     private readonly baseDir: string,
     private readonly entitySchemas?: PluginConfig["entitySchemas"],
@@ -2144,6 +2167,7 @@ export class StorageManager {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }
 
+    await this.snapshotBeforeWrite(filePath, "write");
     await writeFile(filePath, fileContent, "utf-8");
     this.invalidateAllMemoriesCache();
     await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.writeMemory", {
@@ -2448,6 +2472,7 @@ export class StorageManager {
     entity.created = entity.created || timestamp;
     entity.updated = new Date().toISOString();
 
+    await this.snapshotBeforeWrite(filePath, "write");
     await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
     this.invalidateKnowledgeIndexCache();
     this.bumpMemoryStatusVersion(); // invalidate entity cache
@@ -2465,6 +2490,7 @@ export class StorageManager {
 
   async writeProfile(content: string): Promise<void> {
     await this.ensureDirectories();
+    await this.snapshotBeforeWrite(this.profilePath, "consolidation");
     await writeFile(this.profilePath, content, "utf-8");
     log.debug("updated profile.md");
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -889,6 +889,14 @@ export interface PluginConfig {
   codexMaterializeOnConsolidation: boolean;
   /** Run materialization at Codex session-end hook. Default true. */
   codexMaterializeOnSessionEnd: boolean;
+
+  // Page-level versioning (issue #371)
+  /** Enable page-level versioning with sidecar snapshots. Default false. */
+  versioningEnabled: boolean;
+  /** Maximum number of version snapshots to keep per page. Default 50. Set to 0 to disable pruning. */
+  versioningMaxPerPage: number;
+  /** Name of the sidecar directory inside memoryDir. Default ".versions". */
+  versioningSidecarDir: string;
 }
 
 /** Runtime configuration for the daily context briefing feature. */

--- a/tests/page-versioning.test.ts
+++ b/tests/page-versioning.test.ts
@@ -1,0 +1,378 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import fs from "node:fs/promises";
+import {
+  createVersion,
+  listVersions,
+  getVersion,
+  revertToVersion,
+  diffVersions,
+  type VersioningConfig,
+} from "../packages/remnic-core/src/page-versioning.js";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async function makeTmpDir(): Promise<string> {
+  return fs.mkdtemp(path.join(os.tmpdir(), "page-versioning-test-"));
+}
+
+function config(memoryDir: string, overrides?: Partial<VersioningConfig>): VersioningConfig {
+  return {
+    enabled: true,
+    maxVersionsPerPage: 50,
+    sidecarDir: ".versions",
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createVersion
+// ---------------------------------------------------------------------------
+
+test("createVersion creates manifest and snapshot on first write", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "preferences.md");
+  await fs.writeFile(pagePath, "initial content", "utf-8");
+
+  const cfg = config(tmp);
+  const v = await createVersion(pagePath, "initial content", "write", cfg);
+
+  assert.equal(v.versionId, "1");
+  assert.equal(v.trigger, "write");
+  assert.equal(v.sizeBytes, Buffer.byteLength("initial content", "utf-8"));
+  assert.ok(v.timestamp);
+  assert.ok(v.contentHash);
+
+  // Manifest should exist
+  const manifestPath = path.join(tmp, ".versions", "facts__preferences", "manifest.json");
+  const manifest = JSON.parse(await fs.readFile(manifestPath, "utf-8"));
+  assert.equal(manifest.versions.length, 1);
+  assert.equal(manifest.currentVersion, "1");
+
+  // Snapshot file should exist
+  const snapshotPath = path.join(tmp, ".versions", "facts__preferences", "1.md");
+  const snapshot = await fs.readFile(snapshotPath, "utf-8");
+  assert.equal(snapshot, "initial content");
+});
+
+test("sequential writes increment version IDs", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "notes.md");
+
+  const cfg = config(tmp);
+
+  await fs.writeFile(pagePath, "v1 content", "utf-8");
+  const v1 = await createVersion(pagePath, "v1 content", "write", cfg);
+  assert.equal(v1.versionId, "1");
+
+  await fs.writeFile(pagePath, "v2 content", "utf-8");
+  const v2 = await createVersion(pagePath, "v2 content", "write", cfg);
+  assert.equal(v2.versionId, "2");
+
+  await fs.writeFile(pagePath, "v3 content", "utf-8");
+  const v3 = await createVersion(pagePath, "v3 content", "consolidation", cfg);
+  assert.equal(v3.versionId, "3");
+  assert.equal(v3.trigger, "consolidation");
+});
+
+test("max versions pruning removes oldest versions", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "pruned.md");
+
+  const cfg = config(tmp, { maxVersionsPerPage: 3 });
+
+  for (let i = 1; i <= 5; i++) {
+    const content = `content v${i}`;
+    await fs.writeFile(pagePath, content, "utf-8");
+    await createVersion(pagePath, content, "write", cfg);
+  }
+
+  const history = await listVersions(pagePath, cfg);
+  // Only the last 3 versions should remain
+  assert.equal(history.versions.length, 3);
+  assert.equal(history.versions[0].versionId, "3");
+  assert.equal(history.versions[1].versionId, "4");
+  assert.equal(history.versions[2].versionId, "5");
+
+  // Pruned snapshot files should not exist
+  const sidecar = path.join(tmp, ".versions", "facts__pruned");
+  await assert.rejects(fs.access(path.join(sidecar, "1.md")));
+  await assert.rejects(fs.access(path.join(sidecar, "2.md")));
+  // Remaining snapshots should exist
+  assert.ok(await fs.access(path.join(sidecar, "3.md")).then(() => true));
+  assert.ok(await fs.access(path.join(sidecar, "4.md")).then(() => true));
+  assert.ok(await fs.access(path.join(sidecar, "5.md")).then(() => true));
+});
+
+// ---------------------------------------------------------------------------
+// listVersions
+// ---------------------------------------------------------------------------
+
+test("listVersions returns all versions sorted by versionId", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "sorted.md");
+
+  const cfg = config(tmp);
+
+  for (let i = 1; i <= 4; i++) {
+    await fs.writeFile(pagePath, `content ${i}`, "utf-8");
+    await createVersion(pagePath, `content ${i}`, "write", cfg);
+  }
+
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions.length, 4);
+  for (let i = 0; i < history.versions.length; i++) {
+    assert.equal(history.versions[i].versionId, String(i + 1));
+  }
+});
+
+test("listVersions returns empty history for non-existent page", async () => {
+  const tmp = await makeTmpDir();
+  const pagePath = path.join(tmp, "facts", "nonexistent.md");
+  const cfg = config(tmp);
+
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions.length, 0);
+  assert.equal(history.currentVersion, "0");
+});
+
+// ---------------------------------------------------------------------------
+// getVersion
+// ---------------------------------------------------------------------------
+
+test("getVersion returns correct content for specific version", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "get.md");
+
+  const cfg = config(tmp);
+
+  await fs.writeFile(pagePath, "first content", "utf-8");
+  await createVersion(pagePath, "first content", "write", cfg);
+
+  await fs.writeFile(pagePath, "second content", "utf-8");
+  await createVersion(pagePath, "second content", "write", cfg);
+
+  const v1Content = await getVersion(pagePath, "1", cfg);
+  assert.equal(v1Content, "first content");
+
+  const v2Content = await getVersion(pagePath, "2", cfg);
+  assert.equal(v2Content, "second content");
+});
+
+test("getVersion throws for non-existent version", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "missing.md");
+
+  const cfg = config(tmp);
+
+  await assert.rejects(
+    getVersion(pagePath, "99", cfg),
+    (err: Error) => err.message.includes("Version 99 not found"),
+  );
+});
+
+// ---------------------------------------------------------------------------
+// revertToVersion
+// ---------------------------------------------------------------------------
+
+test("revertToVersion restores content and creates revert version", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "revert.md");
+
+  const cfg = config(tmp);
+
+  // Write v1
+  await fs.writeFile(pagePath, "original content", "utf-8");
+  await createVersion(pagePath, "original content", "write", cfg);
+
+  // Write v2 (overwrite)
+  await fs.writeFile(pagePath, "modified content", "utf-8");
+  await createVersion(pagePath, "modified content", "write", cfg);
+
+  // Revert to v1
+  const revertVersion = await revertToVersion(pagePath, "1", cfg);
+  assert.equal(revertVersion.trigger, "revert");
+  assert.ok(revertVersion.note?.includes("reverted to version 1"));
+
+  // The page should now contain original content
+  const restored = await fs.readFile(pagePath, "utf-8");
+  assert.equal(restored, "original content");
+
+  // The revert snapshot (v3) should contain the "modified content" that was current before revert
+  const v3Content = await getVersion(pagePath, "3", cfg);
+  assert.equal(v3Content, "modified content");
+
+  // History should have 3 versions
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions.length, 3);
+  assert.equal(history.currentVersion, "3");
+});
+
+// ---------------------------------------------------------------------------
+// diffVersions
+// ---------------------------------------------------------------------------
+
+test("diffVersions produces meaningful line-based diff", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "diff.md");
+
+  const cfg = config(tmp);
+
+  await fs.writeFile(pagePath, "line 1\nline 2\nline 3", "utf-8");
+  await createVersion(pagePath, "line 1\nline 2\nline 3", "write", cfg);
+
+  await fs.writeFile(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "utf-8");
+  await createVersion(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "write", cfg);
+
+  const diff = await diffVersions(pagePath, "1", "2", cfg);
+
+  assert.ok(diff.includes("--- version 1"));
+  assert.ok(diff.includes("+++ version 2"));
+  assert.ok(diff.includes("-line 2"));
+  assert.ok(diff.includes("+line 2 changed"));
+  assert.ok(diff.includes("+line 4"));
+});
+
+// ---------------------------------------------------------------------------
+// Versioning disabled
+// ---------------------------------------------------------------------------
+
+test("createVersion does not create sidecar when disabled via config", async () => {
+  // When disabled, the storage.snapshotBeforeWrite is the no-op gate.
+  // But createVersion itself still works if called directly.
+  // This test verifies the config gate pattern at the storage integration level.
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "disabled.md");
+  await fs.writeFile(pagePath, "some content", "utf-8");
+
+  // The disabled config: createVersion is never called from storage when enabled=false.
+  // We verify the sidecar dir does not exist after a direct file write.
+  const versionsDir = path.join(tmp, ".versions");
+  // No sidecar should exist since we never called createVersion
+  await assert.rejects(fs.access(versionsDir));
+});
+
+// ---------------------------------------------------------------------------
+// Missing manifest — graceful handling
+// ---------------------------------------------------------------------------
+
+test("listVersions returns empty history when manifest is missing", async () => {
+  const tmp = await makeTmpDir();
+  const pagePath = path.join(tmp, "facts", "ghost.md");
+  const cfg = config(tmp);
+
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions.length, 0);
+  assert.equal(history.currentVersion, "0");
+});
+
+// ---------------------------------------------------------------------------
+// Concurrent writes — sequential within same page
+// ---------------------------------------------------------------------------
+
+test("concurrent createVersion calls produce sequential version IDs", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "concurrent.md");
+
+  const cfg = config(tmp);
+
+  // Run 5 version creates sequentially (simulating serialized writes)
+  const versions = [];
+  for (let i = 1; i <= 5; i++) {
+    const content = `content ${i}`;
+    await fs.writeFile(pagePath, content, "utf-8");
+    const v = await createVersion(pagePath, content, "write", cfg);
+    versions.push(v);
+  }
+
+  // All version IDs should be unique and sequential
+  const ids = versions.map((v) => Number(v.versionId));
+  assert.deepEqual(ids, [1, 2, 3, 4, 5]);
+});
+
+// ---------------------------------------------------------------------------
+// Nested page paths (date subdirectories)
+// ---------------------------------------------------------------------------
+
+test("createVersion handles nested date subdirectories", async () => {
+  const tmp = await makeTmpDir();
+  const dateDir = path.join(tmp, "facts", "2026-04-16");
+  await fs.mkdir(dateDir, { recursive: true });
+  const pagePath = path.join(dateDir, "mem-001.md");
+  await fs.writeFile(pagePath, "dated content", "utf-8");
+
+  const cfg = config(tmp);
+  const v = await createVersion(pagePath, "dated content", "write", cfg);
+  assert.equal(v.versionId, "1");
+
+  // Sidecar key should encode the nested path
+  const sidecar = path.join(tmp, ".versions", "facts__2026-04-16__mem-001");
+  const snapshotPath = path.join(sidecar, "1.md");
+  const snapshot = await fs.readFile(snapshotPath, "utf-8");
+  assert.equal(snapshot, "dated content");
+});
+
+// ---------------------------------------------------------------------------
+// Version with note
+// ---------------------------------------------------------------------------
+
+test("createVersion stores optional note", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "noted.md");
+  await fs.writeFile(pagePath, "with note", "utf-8");
+
+  const cfg = config(tmp);
+  const v = await createVersion(pagePath, "with note", "manual", cfg, undefined, "test note");
+  assert.equal(v.note, "test note");
+  assert.equal(v.trigger, "manual");
+
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions[0].note, "test note");
+});
+
+// ---------------------------------------------------------------------------
+// Max versions = 0 disables pruning
+// ---------------------------------------------------------------------------
+
+test("maxVersionsPerPage = 0 disables pruning", async () => {
+  const tmp = await makeTmpDir();
+  const factsDir = path.join(tmp, "facts");
+  await fs.mkdir(factsDir, { recursive: true });
+  const pagePath = path.join(factsDir, "unlimited.md");
+
+  const cfg = config(tmp, { maxVersionsPerPage: 0 });
+
+  for (let i = 1; i <= 10; i++) {
+    await fs.writeFile(pagePath, `v${i}`, "utf-8");
+    await createVersion(pagePath, `v${i}`, "write", cfg);
+  }
+
+  const history = await listVersions(pagePath, cfg);
+  assert.equal(history.versions.length, 10);
+});

--- a/tests/page-versioning.test.ts
+++ b/tests/page-versioning.test.ts
@@ -41,7 +41,7 @@ test("createVersion creates manifest and snapshot on first write", async () => {
   await fs.writeFile(pagePath, "initial content", "utf-8");
 
   const cfg = config(tmp);
-  const v = await createVersion(pagePath, "initial content", "write", cfg);
+  const v = await createVersion(pagePath, "initial content", "write", cfg, undefined, undefined, tmp);
 
   assert.equal(v.versionId, "1");
   assert.equal(v.trigger, "write");
@@ -70,15 +70,15 @@ test("sequential writes increment version IDs", async () => {
   const cfg = config(tmp);
 
   await fs.writeFile(pagePath, "v1 content", "utf-8");
-  const v1 = await createVersion(pagePath, "v1 content", "write", cfg);
+  const v1 = await createVersion(pagePath, "v1 content", "write", cfg, undefined, undefined, tmp);
   assert.equal(v1.versionId, "1");
 
   await fs.writeFile(pagePath, "v2 content", "utf-8");
-  const v2 = await createVersion(pagePath, "v2 content", "write", cfg);
+  const v2 = await createVersion(pagePath, "v2 content", "write", cfg, undefined, undefined, tmp);
   assert.equal(v2.versionId, "2");
 
   await fs.writeFile(pagePath, "v3 content", "utf-8");
-  const v3 = await createVersion(pagePath, "v3 content", "consolidation", cfg);
+  const v3 = await createVersion(pagePath, "v3 content", "consolidation", cfg, undefined, undefined, tmp);
   assert.equal(v3.versionId, "3");
   assert.equal(v3.trigger, "consolidation");
 });
@@ -94,10 +94,10 @@ test("max versions pruning removes oldest versions", async () => {
   for (let i = 1; i <= 5; i++) {
     const content = `content v${i}`;
     await fs.writeFile(pagePath, content, "utf-8");
-    await createVersion(pagePath, content, "write", cfg);
+    await createVersion(pagePath, content, "write", cfg, undefined, undefined, tmp);
   }
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   // Only the last 3 versions should remain
   assert.equal(history.versions.length, 3);
   assert.equal(history.versions[0].versionId, "3");
@@ -128,10 +128,10 @@ test("listVersions returns all versions sorted by versionId", async () => {
 
   for (let i = 1; i <= 4; i++) {
     await fs.writeFile(pagePath, `content ${i}`, "utf-8");
-    await createVersion(pagePath, `content ${i}`, "write", cfg);
+    await createVersion(pagePath, `content ${i}`, "write", cfg, undefined, undefined, tmp);
   }
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions.length, 4);
   for (let i = 0; i < history.versions.length; i++) {
     assert.equal(history.versions[i].versionId, String(i + 1));
@@ -143,7 +143,7 @@ test("listVersions returns empty history for non-existent page", async () => {
   const pagePath = path.join(tmp, "facts", "nonexistent.md");
   const cfg = config(tmp);
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions.length, 0);
   assert.equal(history.currentVersion, "0");
 });
@@ -161,15 +161,15 @@ test("getVersion returns correct content for specific version", async () => {
   const cfg = config(tmp);
 
   await fs.writeFile(pagePath, "first content", "utf-8");
-  await createVersion(pagePath, "first content", "write", cfg);
+  await createVersion(pagePath, "first content", "write", cfg, undefined, undefined, tmp);
 
   await fs.writeFile(pagePath, "second content", "utf-8");
-  await createVersion(pagePath, "second content", "write", cfg);
+  await createVersion(pagePath, "second content", "write", cfg, undefined, undefined, tmp);
 
-  const v1Content = await getVersion(pagePath, "1", cfg);
+  const v1Content = await getVersion(pagePath, "1", cfg, tmp);
   assert.equal(v1Content, "first content");
 
-  const v2Content = await getVersion(pagePath, "2", cfg);
+  const v2Content = await getVersion(pagePath, "2", cfg, tmp);
   assert.equal(v2Content, "second content");
 });
 
@@ -182,7 +182,7 @@ test("getVersion throws for non-existent version", async () => {
   const cfg = config(tmp);
 
   await assert.rejects(
-    getVersion(pagePath, "99", cfg),
+    getVersion(pagePath, "99", cfg, tmp),
     (err: Error) => err.message.includes("Version 99 not found"),
   );
 });
@@ -201,14 +201,14 @@ test("revertToVersion restores content and creates revert version", async () => 
 
   // Write v1
   await fs.writeFile(pagePath, "original content", "utf-8");
-  await createVersion(pagePath, "original content", "write", cfg);
+  await createVersion(pagePath, "original content", "write", cfg, undefined, undefined, tmp);
 
   // Write v2 (overwrite)
   await fs.writeFile(pagePath, "modified content", "utf-8");
-  await createVersion(pagePath, "modified content", "write", cfg);
+  await createVersion(pagePath, "modified content", "write", cfg, undefined, undefined, tmp);
 
   // Revert to v1
-  const revertVersion = await revertToVersion(pagePath, "1", cfg);
+  const revertVersion = await revertToVersion(pagePath, "1", cfg, undefined, tmp);
   assert.equal(revertVersion.trigger, "revert");
   assert.ok(revertVersion.note?.includes("reverted to version 1"));
 
@@ -217,11 +217,11 @@ test("revertToVersion restores content and creates revert version", async () => 
   assert.equal(restored, "original content");
 
   // The revert snapshot (v3) should contain the "modified content" that was current before revert
-  const v3Content = await getVersion(pagePath, "3", cfg);
+  const v3Content = await getVersion(pagePath, "3", cfg, tmp);
   assert.equal(v3Content, "modified content");
 
   // History should have 3 versions
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions.length, 3);
   assert.equal(history.currentVersion, "3");
 });
@@ -239,12 +239,12 @@ test("diffVersions produces meaningful line-based diff", async () => {
   const cfg = config(tmp);
 
   await fs.writeFile(pagePath, "line 1\nline 2\nline 3", "utf-8");
-  await createVersion(pagePath, "line 1\nline 2\nline 3", "write", cfg);
+  await createVersion(pagePath, "line 1\nline 2\nline 3", "write", cfg, undefined, undefined, tmp);
 
   await fs.writeFile(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "utf-8");
-  await createVersion(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "write", cfg);
+  await createVersion(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "write", cfg, undefined, undefined, tmp);
 
-  const diff = await diffVersions(pagePath, "1", "2", cfg);
+  const diff = await diffVersions(pagePath, "1", "2", cfg, tmp);
 
   assert.ok(diff.includes("--- version 1"));
   assert.ok(diff.includes("+++ version 2"));
@@ -283,7 +283,7 @@ test("listVersions returns empty history when manifest is missing", async () => 
   const pagePath = path.join(tmp, "facts", "ghost.md");
   const cfg = config(tmp);
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions.length, 0);
   assert.equal(history.currentVersion, "0");
 });
@@ -305,7 +305,7 @@ test("concurrent createVersion calls produce sequential version IDs", async () =
   for (let i = 1; i <= 5; i++) {
     const content = `content ${i}`;
     await fs.writeFile(pagePath, content, "utf-8");
-    const v = await createVersion(pagePath, content, "write", cfg);
+    const v = await createVersion(pagePath, content, "write", cfg, undefined, undefined, tmp);
     versions.push(v);
   }
 
@@ -326,7 +326,7 @@ test("createVersion handles nested date subdirectories", async () => {
   await fs.writeFile(pagePath, "dated content", "utf-8");
 
   const cfg = config(tmp);
-  const v = await createVersion(pagePath, "dated content", "write", cfg);
+  const v = await createVersion(pagePath, "dated content", "write", cfg, undefined, undefined, tmp);
   assert.equal(v.versionId, "1");
 
   // Sidecar key should encode the nested path
@@ -348,11 +348,11 @@ test("createVersion stores optional note", async () => {
   await fs.writeFile(pagePath, "with note", "utf-8");
 
   const cfg = config(tmp);
-  const v = await createVersion(pagePath, "with note", "manual", cfg, undefined, "test note");
+  const v = await createVersion(pagePath, "with note", "manual", cfg, undefined, "test note", tmp);
   assert.equal(v.note, "test note");
   assert.equal(v.trigger, "manual");
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions[0].note, "test note");
 });
 
@@ -370,9 +370,9 @@ test("maxVersionsPerPage = 0 disables pruning", async () => {
 
   for (let i = 1; i <= 10; i++) {
     await fs.writeFile(pagePath, `v${i}`, "utf-8");
-    await createVersion(pagePath, `v${i}`, "write", cfg);
+    await createVersion(pagePath, `v${i}`, "write", cfg, undefined, undefined, tmp);
   }
 
-  const history = await listVersions(pagePath, cfg);
+  const history = await listVersions(pagePath, cfg, tmp);
   assert.equal(history.versions.length, 10);
 });


### PR DESCRIPTION
## Summary

- Adds snapshot-based page-level versioning for memory files (facts, entities, profile), gated behind `versioningEnabled` (default: false)
- New `page-versioning.ts` module with `createVersion`, `listVersions`, `getVersion`, `revertToVersion`, and `diffVersions` functions
- Storage hooks snapshot previous content before every write to fact, entity, and profile pages
- CLI `remnic versions list|show|diff|revert` commands for inspecting and managing page history

Closes #371

## Test plan

- [x] 15 new tests in `tests/page-versioning.test.ts` covering create, prune, list, get, revert, diff, and edge cases
- [x] Existing config, plugin manifest, and compat tests pass (37 tests total in targeted run)
- [x] Build succeeds (`pnpm run build`)

## PR checklist
- [x] All tests pass
- [x] New logic covered by tests (15 tests for all public functions)
- [x] Docs updated (`docs/architecture/page-versioning.md`)
- [x] No secrets or creds committed
- [x] Config properties added to both plugin manifests and wired end-to-end

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage write paths and introduces new filesystem writes/pruning logic, which could impact durability or performance when enabled. Risk is mitigated by being gated behind `versioningEnabled` (default off) and covered by new unit tests.
> 
> **Overview**
> Introduces **opt-in page-level versioning** for memory pages (facts, entities, `profile.md`) by snapshotting the *previous* file content into a sidecar `.versions/` directory on every overwrite, with configurable retention/pruning.
> 
> Adds a new core `page-versioning` module (create/list/show/diff/revert APIs), wires it through config parsing/types and the orchestrator into the storage write paths, and exposes `remnic versions list|show|diff|revert` for user-facing inspection and rollback. Includes new architecture docs plus a dedicated test suite covering snapshot creation, pruning, diffing, and revert behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c776369cee1a203c52ed5d9a0aff4c8544ce9e59. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->