### PR TITLE
feat(recall): emit oai-mem-citation blocks from recall responses

### DIFF
--- a/docs/architecture/citations.md
+++ b/docs/architecture/citations.md
@@ -1,0 +1,133 @@
+# OAI-mem-citation Blocks (Issue #379)
+
+Remnic recall responses can emit `<oai-mem-citation>` blocks that match the
+Codex citation format. This enables Codex-compatible memory attribution and
+usage tracking.
+
+## Citation Block Format
+
+```xml
+<oai-mem-citation>
+<citation_entries>
+facts/fact-abc.md:1-5|note=[user prefers dark mode]
+facts/fact-def.md:10-20|note=[project deadline is Friday]
+</citation_entries>
+<rollout_ids>
+rollout-001
+rollout-002
+</rollout_ids>
+</oai-mem-citation>
+```
+
+### Entry Format
+
+Each line inside `<citation_entries>` follows:
+
+```
+<path>:<line_start>-<line_end>|note=[<short note>]
+```
+
+- **path** -- relative path to the memory file (e.g. `facts/fact-abc.md`)
+- **line_start / line_end** -- line range within the file (1-indexed)
+- **note** -- short human-readable description of the cited memory
+
+### Rollout IDs
+
+The `<rollout_ids>` section contains one ID per line. These are deduplicated
+while preserving insertion order. For legacy compatibility, `<thread_ids>` is
+also accepted during parsing.
+
+## Citation Flow
+
+```
+recall request
+    |
+    v
+Remnic recall pipeline
+    |
+    v
+recall response + citation metadata
+    |
+    v
+citation guidance appended to context
+    |
+    v
+model generates reply with <oai-mem-citation> block
+    |
+    v
+downstream hook extracts citation block
+    |
+    v
+POST /v1/citations/observed
+    |
+    v
+memory usage_count incremented
+```
+
+1. **Recall** -- when the `engram.recall` MCP tool fires, the response
+   includes citation metadata for each recalled memory that has a file path.
+2. **Guidance** -- a `[Remnic citation guidance]` block is appended to the
+   recall context, instructing the model to emit citations in its reply.
+3. **Observation** -- after the model responds, a downstream hook (or the
+   Codex read-path agent) extracts the `<oai-mem-citation>` block and posts
+   it to the usage tracking endpoint.
+4. **Tracking** -- the endpoint parses the citation block, resolves memory
+   IDs from paths, and increments access tracking via the orchestrator.
+
+## Configuration
+
+| Property             | Type    | Default | Description                                                |
+|----------------------|---------|---------|------------------------------------------------------------|
+| `citationsEnabled`   | boolean | `false` | Explicitly enable citation guidance in recall responses.    |
+| `citationsAutoDetect`| boolean | `true`  | Auto-enable when the Codex adapter is detected via MCP.     |
+
+When `citationsAutoDetect` is `true` (the default), citations are
+automatically enabled for MCP sessions where the client identifies as a
+Codex adapter (`codex-mcp-client` or a name containing `codex`).
+
+Set `citationsEnabled: true` to force citations for all recall consumers
+regardless of adapter detection.
+
+## HTTP Endpoint
+
+### POST /v1/citations/observed
+
+Record observed citations from a model's reply.
+
+**Request body:**
+
+```json
+{
+  "sessionId": "session-abc",
+  "namespace": "global",
+  "citations": {
+    "entries": [
+      {
+        "path": "facts/fact-abc.md",
+        "lineStart": 1,
+        "lineEnd": 5,
+        "note": "user prefers dark mode"
+      }
+    ],
+    "rolloutIds": ["rollout-001"]
+  }
+}
+```
+
+**Response (200):**
+
+```json
+{
+  "ok": true,
+  "matched": 1,
+  "entriesReceived": 1,
+  "rolloutIdsReceived": 1
+}
+```
+
+## Integration with Codex
+
+When running behind the Codex CLI, the adapter auto-detection kicks in
+automatically. No manual configuration is needed. The Codex read-path
+agent can parse the model's `<oai-mem-citation>` block and post it back
+to `/v1/citations/observed` to close the loop on usage tracking.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -644,6 +644,16 @@
         "default": true,
         "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
       },
+      "citationsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+      },
+      "citationsAutoDetect": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-enable citations when the Codex adapter is detected."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -641,6 +641,16 @@
         "default": true,
         "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
       },
+      "citationsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+      },
+      "citationsAutoDetect": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-enable citations when the Codex adapter is detected."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -659,17 +659,21 @@ export class EngramAccessHttpServer {
       // Record usage: for each citation entry, try to increment usage on the
       // matching memory. The service exposes recordAccess for this purpose.
       let matched = 0;
+      let submitted = 0;
       if (typeof this.service.recordCitationUsage === "function") {
-        matched = await this.service.recordCitationUsage({
+        const result = await this.service.recordCitationUsage({
           sessionId,
           namespace: this.resolveNamespace(req, namespace),
           entries,
           rolloutIds,
         });
+        submitted = result.submitted;
+        matched = result.matched;
       }
 
       this.respondJson(res, 200, {
         ok: true,
+        submitted,
         matched,
         entriesReceived: entries.length,
         rolloutIdsReceived: rolloutIds.length,

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -12,6 +12,7 @@ import { validateRequest, type SchemaName, type SchemaTypeFor } from "./access-s
 import type { RecallPlanMode } from "./types.js";
 import { isTrustZoneName, type TrustZoneName, type TrustZoneRecordKind, type TrustZoneSourceClass } from "./trust-zones.js";
 import { AdapterRegistry, type ResolvedIdentity } from "./adapters/index.js";
+import type { CitationEntry } from "./citations.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -31,6 +32,10 @@ export interface EngramAccessHttpServerOptions {
   enableAdapters?: boolean;
   /** Custom adapter registry (defaults to built-in adapters) */
   adapterRegistry?: AdapterRegistry;
+  /** Enable oai-mem-citation blocks in recall responses (issue #379). */
+  citationsEnabled?: boolean;
+  /** Auto-enable citations for Codex adapter connections (issue #379). */
+  citationsAutoDetect?: boolean;
 }
 
 export interface EngramAccessHttpServerStatus {
@@ -132,7 +137,11 @@ export class EngramAccessHttpServer {
     this.adapterRegistry = options.enableAdapters !== false
       ? (options.adapterRegistry ?? new AdapterRegistry())
       : null;
-    this.mcpServer = new EngramMcpServer(this.service, { principal: options.principal });
+    this.mcpServer = new EngramMcpServer(this.service, {
+      principal: options.principal,
+      citationsEnabled: options.citationsEnabled,
+      citationsAutoDetect: options.citationsAutoDetect,
+    });
   }
 
   async start(): Promise<EngramAccessHttpServerStatus> {
@@ -601,6 +610,70 @@ export class EngramAccessHttpServer {
         this.recordWriteRateLimitHit();
       }
       this.respondJson(res, response.dryRun ? 200 : 201, response);
+      return;
+    }
+
+    // Citation usage tracking (issue #379)
+    if (req.method === "POST" && pathname === "/v1/citations/observed") {
+      const body = await this.readJsonBody(req);
+      if (!body || typeof body !== "object" || Array.isArray(body)) {
+        throw new HttpError(400, "request body must be a JSON object", "invalid_body");
+      }
+      const payload = body as Record<string, unknown>;
+      const sessionId = typeof payload.sessionId === "string" ? payload.sessionId : undefined;
+      const namespace = typeof payload.namespace === "string" ? payload.namespace : undefined;
+      const citationsRaw = payload.citations;
+      if (!citationsRaw || typeof citationsRaw !== "object" || Array.isArray(citationsRaw)) {
+        throw new HttpError(400, "citations must be a JSON object with entries and rolloutIds", "invalid_citations");
+      }
+      const citObj = citationsRaw as Record<string, unknown>;
+      const entries: CitationEntry[] = [];
+      if (Array.isArray(citObj.entries)) {
+        for (const raw of citObj.entries) {
+          if (raw && typeof raw === "object" && !Array.isArray(raw)) {
+            const e = raw as Record<string, unknown>;
+            if (
+              typeof e.path === "string" &&
+              typeof e.lineStart === "number" &&
+              typeof e.lineEnd === "number"
+            ) {
+              entries.push({
+                path: e.path,
+                lineStart: e.lineStart,
+                lineEnd: e.lineEnd,
+                note: typeof e.note === "string" ? e.note : "",
+              });
+            }
+          }
+        }
+      }
+      const rolloutIds: string[] = [];
+      if (Array.isArray(citObj.rolloutIds)) {
+        for (const id of citObj.rolloutIds) {
+          if (typeof id === "string" && id.length > 0) {
+            rolloutIds.push(id);
+          }
+        }
+      }
+
+      // Record usage: for each citation entry, try to increment usage on the
+      // matching memory. The service exposes recordAccess for this purpose.
+      let matched = 0;
+      if (typeof this.service.recordCitationUsage === "function") {
+        matched = await this.service.recordCitationUsage({
+          sessionId,
+          namespace: this.resolveNamespace(req, namespace),
+          entries,
+          rolloutIds,
+        });
+      }
+
+      this.respondJson(res, 200, {
+        ok: true,
+        matched,
+        entriesReceived: entries.length,
+        rolloutIdsReceived: rolloutIds.length,
+      });
       return;
     }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -658,12 +658,15 @@ export class EngramAccessHttpServer {
 
       // Record usage: for each citation entry, try to increment usage on the
       // matching memory. The service exposes recordAccess for this purpose.
+      // Pass authenticatedPrincipal so namespace ACL checks use the same
+      // identity resolution as other write endpoints (Finding #1, issue #379).
       let matched = 0;
       let submitted = 0;
       if (typeof this.service.recordCitationUsage === "function") {
         const result = await this.service.recordCitationUsage({
           sessionId,
           namespace: this.resolveNamespace(req, namespace),
+          authenticatedPrincipal: this.resolveRequestPrincipal(req),
           entries,
           rolloutIds,
         });

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -949,13 +949,35 @@ export class EngramMcpServer {
    * Determine whether oai-mem-citation guidance should be appended to recall.
    * Returns true when explicitly enabled via config OR when auto-detect is
    * active and the current MCP session belongs to a Codex adapter client.
+   *
+   * When no sessionId is provided (e.g., stdio transport where there are no
+   * HTTP headers carrying mcp-session-id), fall back to checking if there is
+   * exactly one known session whose clientInfo matches the Codex pattern.
+   * This covers the common stdio case where a single client connection exists.
    */
   private shouldEmitCitations(mcpSessionId?: string): boolean {
     if (this.citationsEnabled) return true;
     if (!this.citationsAutoDetect) return false;
-    if (!mcpSessionId) return false;
-    const info = this.clientInfoBySession.get(mcpSessionId);
-    if (!info) return false;
+
+    // Direct session lookup (HTTP transport with mcp-session-id header).
+    if (mcpSessionId) {
+      const info = this.clientInfoBySession.get(mcpSessionId);
+      if (!info) return false;
+      return this.isCodexClient(info);
+    }
+
+    // Stdio fallback: no session ID available. If there is exactly one session
+    // registered (the typical stdio pattern), check that session's clientInfo.
+    if (this.clientInfoBySession.size === 1) {
+      const [info] = [...this.clientInfoBySession.values()];
+      if (info) return this.isCodexClient(info);
+    }
+
+    return false;
+  }
+
+  /** Check whether a clientInfo record identifies a Codex adapter client. */
+  private isCodexClient(info: { name: string; version?: string }): boolean {
     const lowerName = info.name.toLowerCase();
     return lowerName === "codex-mcp-client" || lowerName.includes("codex");
   }

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1,10 +1,11 @@
 import type { Readable, Writable } from "node:stream";
 import { readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import type { EngramAccessService } from "./access-service.js";
+import type { EngramAccessService, EngramAccessRecallResponse } from "./access-service.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
+import { buildCitationGuidance, type CitationMetadata } from "./citations.js";
 
 type JsonRpcId = string | number | null;
 
@@ -79,10 +80,17 @@ export class EngramMcpServer {
    */
   private initSessionIds = new Map<string, string>();
 
+  /** Whether oai-mem-citation guidance is explicitly enabled via config. */
+  private readonly citationsEnabled: boolean;
+  /** Whether to auto-enable citations for Codex adapter connections. */
+  private readonly citationsAutoDetect: boolean;
+
   constructor(
     private readonly service: EngramAccessService,
-    options: { principal?: string } = {},
+    options: { principal?: string; citationsEnabled?: boolean; citationsAutoDetect?: boolean } = {},
   ) {
+    this.citationsEnabled = options.citationsEnabled === true;
+    this.citationsAutoDetect = options.citationsAutoDetect !== false;
     this.authenticatedPrincipal =
       options.principal?.trim() ||
       readEnvVar("OPENCLAW_ENGRAM_ACCESS_PRINCIPAL")?.trim() ||
@@ -817,7 +825,7 @@ export class EngramMcpServer {
 
       try {
         const effectivePrincipal = options?.principalOverride ?? this.authenticatedPrincipal;
-        const result = await this.callTool(name, argumentsObject, effectivePrincipal);
+        const result = await this.callTool(name, argumentsObject, effectivePrincipal, options?.sessionId);
         return {
           jsonrpc: "2.0",
           id,
@@ -937,10 +945,41 @@ export class EngramMcpServer {
     output.write(message);
   }
 
-  private async callTool(name: string, args: Record<string, unknown>, effectivePrincipal?: string): Promise<unknown> {
+  /**
+   * Determine whether oai-mem-citation guidance should be appended to recall.
+   * Returns true when explicitly enabled via config OR when auto-detect is
+   * active and the current MCP session belongs to a Codex adapter client.
+   */
+  private shouldEmitCitations(mcpSessionId?: string): boolean {
+    if (this.citationsEnabled) return true;
+    if (!this.citationsAutoDetect) return false;
+    if (!mcpSessionId) return false;
+    const info = this.clientInfoBySession.get(mcpSessionId);
+    if (!info) return false;
+    const lowerName = info.name.toLowerCase();
+    return lowerName === "codex-mcp-client" || lowerName.includes("codex");
+  }
+
+  /**
+   * Build citation metadata for each recall result that has a path.
+   * Line range defaults to 1-1 when not determinable from the summary.
+   */
+  private buildRecallCitations(response: EngramAccessRecallResponse): CitationMetadata[] {
+    return response.results
+      .filter((r) => r.path && r.path.length > 0)
+      .map((r) => ({
+        memoryId: r.id,
+        path: r.path,
+        lineStart: 1,
+        lineEnd: 1,
+        noteDefault: r.preview?.slice(0, 60) || r.id,
+      }));
+  }
+
+  private async callTool(name: string, args: Record<string, unknown>, effectivePrincipal?: string, mcpSessionId?: string): Promise<unknown> {
     switch (toLegacyToolName(name)) {
-      case "engram.recall":
-        return this.service.recall({
+      case "engram.recall": {
+        const response = await this.service.recall({
           query: typeof args.query === "string" ? args.query : "",
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
@@ -948,6 +987,20 @@ export class EngramMcpServer {
           mode: typeof args.mode === "string" ? args.mode as RecallPlanMode | "auto" : undefined,
           includeDebug: args.includeDebug === true,
         });
+
+        if (this.shouldEmitCitations(mcpSessionId)) {
+          const citations = this.buildRecallCitations(response);
+          const guidance = buildCitationGuidance(citations);
+          if (guidance.length > 0) {
+            return {
+              ...response,
+              context: response.context + guidance,
+              citations,
+            };
+          }
+        }
+        return response;
+      }
       case "engram.recall_explain":
         return this.service.recallExplain({
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2705,15 +2705,21 @@ export class EngramAccessService {
    * Record citation usage from an observed oai-mem-citation block.
    * For each citation entry, extract the memory ID from the path and
    * increment its access tracking via the orchestrator. Returns the
-   * count of matched memories.
+   * count of submitted IDs and the count of IDs that matched real memories.
    */
   async recordCitationUsage(request: {
     sessionId?: string;
     namespace?: string;
     entries: Array<{ path: string; lineStart: number; lineEnd: number; note: string }>;
     rolloutIds: string[];
-  }): Promise<number> {
-    if (request.entries.length === 0) return 0;
+  }): Promise<{ submitted: number; matched: number }> {
+    if (request.entries.length === 0) return { submitted: 0, matched: 0 };
+
+    // Enforce namespace ACLs — citation tracking is a write-like operation.
+    const resolvedNamespace = this.resolveWritableNamespace(
+      request.namespace,
+      request.sessionId,
+    );
 
     // Extract memory IDs from citation paths. The path in citations
     // follows the pattern `facts/<id>.md` or just `<id>.md`.
@@ -2727,15 +2733,23 @@ export class EngramAccessService {
       }
     }
 
-    if (memoryIds.length === 0) return 0;
+    if (memoryIds.length === 0) return { submitted: 0, matched: 0 };
 
-    try {
-      this.orchestrator.trackMemoryAccess(memoryIds);
-    } catch {
-      // Fail gracefully — citation usage tracking is best-effort.
-      log.debug("citation usage tracking: failed to record access for cited memories");
+    // Determine which IDs correspond to real memories in storage.
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const allMemories = await storage.readAllMemories();
+    const existingIds = new Set(allMemories.map((m) => m.frontmatter.id));
+    const matchedIds = memoryIds.filter((id) => existingIds.has(id));
+
+    if (matchedIds.length > 0) {
+      try {
+        this.orchestrator.trackMemoryAccess(matchedIds);
+      } catch {
+        // Fail gracefully — citation usage tracking is best-effort.
+        log.debug("citation usage tracking: failed to record access for cited memories");
+      }
     }
 
-    return memoryIds.length;
+    return { submitted: memoryIds.length, matched: matchedIds.length };
   }
 }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2700,4 +2700,42 @@ export class EngramAccessService {
       },
     };
   }
+
+  /**
+   * Record citation usage from an observed oai-mem-citation block.
+   * For each citation entry, extract the memory ID from the path and
+   * increment its access tracking via the orchestrator. Returns the
+   * count of matched memories.
+   */
+  async recordCitationUsage(request: {
+    sessionId?: string;
+    namespace?: string;
+    entries: Array<{ path: string; lineStart: number; lineEnd: number; note: string }>;
+    rolloutIds: string[];
+  }): Promise<number> {
+    if (request.entries.length === 0) return 0;
+
+    // Extract memory IDs from citation paths. The path in citations
+    // follows the pattern `facts/<id>.md` or just `<id>.md`.
+    const memoryIds: string[] = [];
+    for (const entry of request.entries) {
+      // Strip directory prefix and .md extension to derive the memory ID.
+      const basename = entry.path.split("/").pop() ?? entry.path;
+      const id = basename.endsWith(".md") ? basename.slice(0, -3) : basename;
+      if (id.length > 0) {
+        memoryIds.push(id);
+      }
+    }
+
+    if (memoryIds.length === 0) return 0;
+
+    try {
+      this.orchestrator.trackMemoryAccess(memoryIds);
+    } catch {
+      // Fail gracefully — citation usage tracking is best-effort.
+      log.debug("citation usage tracking: failed to record access for cited memories");
+    }
+
+    return memoryIds.length;
+  }
 }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2710,15 +2710,20 @@ export class EngramAccessService {
   async recordCitationUsage(request: {
     sessionId?: string;
     namespace?: string;
+    authenticatedPrincipal?: string;
     entries: Array<{ path: string; lineStart: number; lineEnd: number; note: string }>;
     rolloutIds: string[];
   }): Promise<{ submitted: number; matched: number }> {
     if (request.entries.length === 0) return { submitted: 0, matched: 0 };
 
     // Enforce namespace ACLs — citation tracking is a write-like operation.
+    // Pass authenticatedPrincipal so the principal resolution matches other
+    // write endpoints (gotcha #42: read and write paths must resolve through
+    // the same namespace layer).
     const resolvedNamespace = this.resolveWritableNamespace(
       request.namespace,
       request.sessionId,
+      request.authenticatedPrincipal,
     );
 
     // Extract memory IDs from citation paths. The path in citations
@@ -2735,10 +2740,10 @@ export class EngramAccessService {
 
     if (memoryIds.length === 0) return { submitted: 0, matched: 0 };
 
-    // Determine which IDs correspond to real memories in storage.
+    // Determine which IDs correspond to real memories in storage using a
+    // targeted file-existence scan instead of loading all memories (Finding #2).
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
-    const allMemories = await storage.readAllMemories();
-    const existingIds = new Set(allMemories.map((m) => m.frontmatter.id));
+    const existingIds = await storage.filterExistingMemoryIds(memoryIds);
     const matchedIds = memoryIds.filter((id) => existingIds.has(id));
 
     if (matchedIds.length > 0) {

--- a/packages/remnic-core/src/citations.ts
+++ b/packages/remnic-core/src/citations.ts
@@ -1,0 +1,213 @@
+/**
+ * OAI-mem-citation parser and formatter (issue #379).
+ *
+ * Mirrors the citation block format used by Codex's `citations.rs` so that
+ * Remnic recall responses produce compatible citation blocks. The model
+ * appends these blocks to its final reply, and downstream hooks parse them
+ * to increment memory usage tracking.
+ *
+ * Block format:
+ *
+ *   <oai-mem-citation>
+ *   <citation_entries>
+ *   path/to/file.md:1-5|note=[short explanation]
+ *   </citation_entries>
+ *   <rollout_ids>
+ *   rollout-abc123
+ *   </rollout_ids>
+ *   </oai-mem-citation>
+ */
+
+/** A single citation entry referencing a memory file and line range. */
+export interface CitationEntry {
+  path: string;
+  lineStart: number;
+  lineEnd: number;
+  note: string;
+}
+
+/** Parsed citation block containing entries and rollout/thread IDs. */
+export interface CitationBlock {
+  entries: CitationEntry[];
+  rolloutIds: string[];
+}
+
+/** Metadata attached to a recall result for citation guidance. */
+export interface CitationMetadata {
+  memoryId: string;
+  path: string;
+  lineStart: number;
+  lineEnd: number;
+  rolloutId?: string;
+  noteDefault: string;
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+const OPEN_TAG = "<oai-mem-citation>";
+const CLOSE_TAG = "</oai-mem-citation>";
+const ENTRIES_OPEN = "<citation_entries>";
+const ENTRIES_CLOSE = "</citation_entries>";
+const ROLLOUT_OPEN = "<rollout_ids>";
+const ROLLOUT_CLOSE = "</rollout_ids>";
+/** Legacy alias accepted during parsing (Codex historically used thread_ids). */
+const THREAD_OPEN = "<thread_ids>";
+const THREAD_CLOSE = "</thread_ids>";
+
+/**
+ * Parse an `<oai-mem-citation>` block from arbitrary text.
+ *
+ * Returns `null` when no valid block is found. Malformed entry lines are
+ * silently skipped; only valid lines contribute to the result. Rollout IDs
+ * are deduped while preserving insertion order.
+ */
+export function parseOaiMemCitation(text: string): CitationBlock | null {
+  const openIdx = text.indexOf(OPEN_TAG);
+  if (openIdx < 0) return null;
+  const closeIdx = text.indexOf(CLOSE_TAG, openIdx + OPEN_TAG.length);
+  if (closeIdx < 0) return null;
+
+  const inner = text.slice(openIdx + OPEN_TAG.length, closeIdx);
+
+  const entries = parseEntries(inner);
+  const rolloutIds = parseIds(inner, ROLLOUT_OPEN, ROLLOUT_CLOSE)
+    ?? parseIds(inner, THREAD_OPEN, THREAD_CLOSE)
+    ?? [];
+
+  if (entries.length === 0 && rolloutIds.length === 0) return null;
+
+  return { entries, rolloutIds };
+}
+
+function parseEntries(block: string): CitationEntry[] {
+  const start = block.indexOf(ENTRIES_OPEN);
+  if (start < 0) return [];
+  const end = block.indexOf(ENTRIES_CLOSE, start + ENTRIES_OPEN.length);
+  if (end < 0) return [];
+
+  const raw = block.slice(start + ENTRIES_OPEN.length, end);
+  const lines = raw.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  const results: CitationEntry[] = [];
+  for (const line of lines) {
+    const parsed = parseEntryLine(line);
+    if (parsed) results.push(parsed);
+  }
+  return results;
+}
+
+/**
+ * Parse a single citation entry line:
+ *   `<path>:<line_start>-<line_end>|note=[<note>]`
+ */
+function parseEntryLine(line: string): CitationEntry | null {
+  // Match: path:lineStart-lineEnd|note=[note]
+  const match = line.match(/^(.+?):(\d+)-(\d+)\|note=\[(.*)?\]$/);
+  if (!match) return null;
+  const [, pathRaw, startRaw, endRaw, noteRaw] = match;
+  if (!pathRaw || !startRaw || !endRaw) return null;
+  const lineStart = parseInt(startRaw, 10);
+  const lineEnd = parseInt(endRaw, 10);
+  if (!Number.isFinite(lineStart) || !Number.isFinite(lineEnd)) return null;
+  if (lineStart < 0 || lineEnd < 0) return null;
+  return {
+    path: pathRaw.trim(),
+    lineStart,
+    lineEnd,
+    note: noteRaw ?? "",
+  };
+}
+
+function parseIds(block: string, openTag: string, closeTag: string): string[] | null {
+  const start = block.indexOf(openTag);
+  if (start < 0) return null;
+  const end = block.indexOf(closeTag, start + openTag.length);
+  if (end < 0) return null;
+
+  const raw = block.slice(start + openTag.length, end);
+  const lines = raw.split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+
+  // Deduplicate preserving insertion order.
+  const seen = new Set<string>();
+  const unique: string[] = [];
+  for (const id of lines) {
+    if (!seen.has(id)) {
+      seen.add(id);
+      unique.push(id);
+    }
+  }
+  return unique.length > 0 ? unique : null;
+}
+
+// ---------------------------------------------------------------------------
+// Formatter
+// ---------------------------------------------------------------------------
+
+/**
+ * Format a `CitationBlock` into the canonical `<oai-mem-citation>` XML block.
+ */
+export function formatOaiMemCitation(block: CitationBlock): string {
+  const entryLines = block.entries
+    .map((e) => `${e.path}:${e.lineStart}-${e.lineEnd}|note=[${e.note}]`)
+    .join("\n");
+  const idLines = block.rolloutIds.join("\n");
+
+  return [
+    OPEN_TAG,
+    ENTRIES_OPEN,
+    entryLines,
+    ENTRIES_CLOSE,
+    ROLLOUT_OPEN,
+    idLines,
+    ROLLOUT_CLOSE,
+    CLOSE_TAG,
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Guidance builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Build the citation guidance text appended to recall responses so that the
+ * model knows how to emit a citation block in its reply.
+ *
+ * Returns an empty string when `citations` is empty (no guidance needed).
+ */
+export function buildCitationGuidance(citations: CitationMetadata[]): string {
+  if (citations.length === 0) return "";
+
+  const entryExamples = citations.map((c) =>
+    `${c.path}:${c.lineStart}-${c.lineEnd}|note=[${c.noteDefault}]`,
+  );
+  const rolloutExamples = citations
+    .filter((c) => c.rolloutId != null)
+    .map((c) => c.rolloutId!);
+
+  // Dedupe rollout IDs preserving order.
+  const seenRollouts = new Set<string>();
+  const uniqueRollouts: string[] = [];
+  for (const id of rolloutExamples) {
+    if (!seenRollouts.has(id)) {
+      seenRollouts.add(id);
+      uniqueRollouts.push(id);
+    }
+  }
+
+  const lines = [
+    "",
+    "[Remnic citation guidance]",
+    "If you used any of the memories above, append the following to the END of your final reply:",
+    OPEN_TAG,
+    ENTRIES_OPEN,
+    ...entryExamples,
+    ENTRIES_CLOSE,
+    ROLLOUT_OPEN,
+    ...uniqueRollouts,
+    ROLLOUT_CLOSE,
+    CLOSE_TAG,
+  ];
+
+  return lines.join("\n");
+}

--- a/packages/remnic-core/src/citations.ts
+++ b/packages/remnic-core/src/citations.ts
@@ -100,10 +100,16 @@ function parseEntries(block: string): CitationEntry[] {
 /**
  * Parse a single citation entry line:
  *   `<path>:<line_start>-<line_end>|note=[<note>]`
+ *
+ * Splits on the LAST `:` before the range pattern, not the first, because
+ * file paths can contain colons on some systems (e.g., Windows drive letters
+ * like `C:\` or macOS resource forks).
  */
 function parseEntryLine(line: string): CitationEntry | null {
-  // Match: path:lineStart-lineEnd|note=[note]
-  const match = line.match(/^(.+?):(\d+)-(\d+)\|note=\[(.*)?\]$/);
+  // Match the range+note suffix anchored at the end, allowing the path prefix
+  // to contain colons. The (.+) is greedy so it consumes everything up to the
+  // LAST `:` before the `\d+-\d+|note=[...]` suffix.
+  const match = line.match(/^(.+):(\d+)-(\d+)\|note=\[(.*)?\]$/);
   if (!match) return null;
   const [, pathRaw, startRaw, endRaw, noteRaw] = match;
   if (!pathRaw || !startRaw || !endRaw) return null;

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1978,6 +1978,10 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.binaryLifecycleBackendPath === "string"
         ? cfg.binaryLifecycleBackendPath.trim()
         : "",
+
+    // Codex citation parity (issue #379)
+    citationsEnabled: cfg.citationsEnabled === true,
+    citationsAutoDetect: cfg.citationsAutoDetect !== false,
   };
 }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -241,6 +241,19 @@ export {
 } from "./page-versioning.js";
 
 // ---------------------------------------------------------------------------
+// OAI-mem-citation blocks (issue #379)
+// ---------------------------------------------------------------------------
+
+export {
+  parseOaiMemCitation,
+  formatOaiMemCitation,
+  buildCitationGuidance,
+  type CitationEntry,
+  type CitationBlock,
+  type CitationMetadata,
+} from "./citations.js";
+
+// ---------------------------------------------------------------------------
 // Logger
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -5176,6 +5176,31 @@ export class StorageManager {
     return memories.find((m) => m.frontmatter.id === id) ?? null;
   }
 
+  /**
+   * Check which of the given memory IDs actually exist on disk.
+   *
+   * Uses a lightweight directory scan (collectActiveMemoryPaths) that reads
+   * file names without parsing frontmatter — much cheaper than readAllMemories()
+   * for simple existence checks like citation usage tracking.
+   *
+   * Returns the subset of `ids` that correspond to real memory files.
+   */
+  async filterExistingMemoryIds(ids: string[]): Promise<Set<string>> {
+    if (ids.length === 0) return new Set();
+    const wantedIds = new Set(ids);
+    const filePaths = await this.collectActiveMemoryPaths();
+    const foundIds = new Set<string>();
+    for (const filePath of filePaths) {
+      const basename = path.basename(filePath, ".md");
+      if (wantedIds.has(basename)) {
+        foundIds.add(basename);
+        // Short-circuit once all requested IDs are found.
+        if (foundIds.size === wantedIds.size) break;
+      }
+    }
+    return foundIds;
+  }
+
   async getProjectedMemoryState(id: string): Promise<MemoryProjectionCurrentState | null> {
     const projected = readProjectedMemoryState(this.baseDir, id);
     if (projected) return projected;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -942,6 +942,12 @@ export interface PluginConfig {
   binaryLifecycleBackendType: "filesystem" | "s3" | "none";
   /** Base path for the filesystem backend. Required when backendType is "filesystem". */
   binaryLifecycleBackendPath: string;
+
+  // Codex citation parity (issue #379)
+  /** Enable oai-mem-citation blocks in recall responses. Default false. */
+  citationsEnabled: boolean;
+  /** Auto-enable citations when the Codex adapter is detected. Default true. */
+  citationsAutoDetect: boolean;
 }
 
 /** Runtime configuration for the daily context briefing feature. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -603,6 +603,8 @@ const pluginDefinition = {
             authToken: cfg.agentAccessHttp.authToken,
             principal: cfg.agentAccessHttp.principal,
             maxBodyBytes: cfg.agentAccessHttp.maxBodyBytes,
+            citationsEnabled: cfg.citationsEnabled,
+            citationsAutoDetect: cfg.citationsAutoDetect,
           });
     (globalThis as any)[keys.ACCESS_HTTP_SERVER] = accessHttpServer;
 

--- a/tests/citations.test.ts
+++ b/tests/citations.test.ts
@@ -134,6 +134,46 @@ id-1
   assert.equal(result.entries[0].note, "");
 });
 
+test("parseOaiMemCitation: path with colons splits on the LAST colon before range", () => {
+  // File paths can contain colons on some systems (e.g., Windows drive letters,
+  // macOS resource forks). The parser must split on the last `:` before the
+  // digit range, not the first.
+  const text = `<oai-mem-citation>
+<citation_entries>
+C:\\Users\\data:facts/fact-1.md:10-20|note=[colon in path]
+</citation_entries>
+<rollout_ids>
+id-1
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].path, "C:\\Users\\data:facts/fact-1.md");
+  assert.equal(result.entries[0].lineStart, 10);
+  assert.equal(result.entries[0].lineEnd, 20);
+  assert.equal(result.entries[0].note, "colon in path");
+});
+
+test("parseOaiMemCitation: simple path still parses correctly after regex change", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+facts/simple.md:5-15|note=[simple test]
+</citation_entries>
+<rollout_ids>
+id-1
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].path, "facts/simple.md");
+  assert.equal(result.entries[0].lineStart, 5);
+  assert.equal(result.entries[0].lineEnd, 15);
+});
+
 // ---------------------------------------------------------------------------
 // formatOaiMemCitation
 // ---------------------------------------------------------------------------

--- a/tests/citations.test.ts
+++ b/tests/citations.test.ts
@@ -1,0 +1,256 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  parseOaiMemCitation,
+  formatOaiMemCitation,
+  buildCitationGuidance,
+  type CitationBlock,
+  type CitationMetadata,
+} from "../packages/remnic-core/src/citations.js";
+
+// ---------------------------------------------------------------------------
+// parseOaiMemCitation
+// ---------------------------------------------------------------------------
+
+test("parseOaiMemCitation: valid block with entries and rollout IDs", () => {
+  const text = `Some preamble
+<oai-mem-citation>
+<citation_entries>
+facts/fact-abc.md:1-5|note=[user prefers dark mode]
+facts/fact-def.md:10-20|note=[project deadline is Friday]
+</citation_entries>
+<rollout_ids>
+rollout-001
+rollout-002
+</rollout_ids>
+</oai-mem-citation>
+Some epilogue`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 2);
+  assert.deepStrictEqual(result.entries[0], {
+    path: "facts/fact-abc.md",
+    lineStart: 1,
+    lineEnd: 5,
+    note: "user prefers dark mode",
+  });
+  assert.deepStrictEqual(result.entries[1], {
+    path: "facts/fact-def.md",
+    lineStart: 10,
+    lineEnd: 20,
+    note: "project deadline is Friday",
+  });
+  assert.deepStrictEqual(result.rolloutIds, ["rollout-001", "rollout-002"]);
+});
+
+test("parseOaiMemCitation: legacy <thread_ids> tag works like <rollout_ids>", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+facts/fact-1.md:1-1|note=[test]
+</citation_entries>
+<thread_ids>
+thread-abc
+thread-def
+</thread_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 1);
+  assert.deepStrictEqual(result.rolloutIds, ["thread-abc", "thread-def"]);
+});
+
+test("parseOaiMemCitation: no citation block returns null", () => {
+  const text = "This is just regular text with no citation block.";
+  const result = parseOaiMemCitation(text);
+  assert.equal(result, null);
+});
+
+test("parseOaiMemCitation: malformed entries are skipped, valid ones kept", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+facts/good.md:1-5|note=[valid entry]
+bad line with no structure
+also:bad
+facts/good2.md:3-7|note=[another valid]
+</citation_entries>
+<rollout_ids>
+id-1
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 2);
+  assert.equal(result.entries[0].path, "facts/good.md");
+  assert.equal(result.entries[1].path, "facts/good2.md");
+});
+
+test("parseOaiMemCitation: deduplicates rollout IDs preserving order", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+facts/f.md:1-1|note=[x]
+</citation_entries>
+<rollout_ids>
+rollout-a
+rollout-b
+rollout-a
+rollout-c
+rollout-b
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.deepStrictEqual(result.rolloutIds, ["rollout-a", "rollout-b", "rollout-c"]);
+});
+
+test("parseOaiMemCitation: empty block with no entries and no IDs returns null", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+</citation_entries>
+<rollout_ids>
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.equal(result, null);
+});
+
+test("parseOaiMemCitation: entry with empty note is valid", () => {
+  const text = `<oai-mem-citation>
+<citation_entries>
+facts/f.md:1-1|note=[]
+</citation_entries>
+<rollout_ids>
+id-1
+</rollout_ids>
+</oai-mem-citation>`;
+
+  const result = parseOaiMemCitation(text);
+  assert.ok(result);
+  assert.equal(result.entries.length, 1);
+  assert.equal(result.entries[0].note, "");
+});
+
+// ---------------------------------------------------------------------------
+// formatOaiMemCitation
+// ---------------------------------------------------------------------------
+
+test("formatOaiMemCitation: produces well-formed XML block", () => {
+  const block: CitationBlock = {
+    entries: [
+      { path: "facts/fact-1.md", lineStart: 1, lineEnd: 5, note: "test note" },
+    ],
+    rolloutIds: ["rollout-abc"],
+  };
+
+  const formatted = formatOaiMemCitation(block);
+  assert.ok(formatted.includes("<oai-mem-citation>"));
+  assert.ok(formatted.includes("</oai-mem-citation>"));
+  assert.ok(formatted.includes("<citation_entries>"));
+  assert.ok(formatted.includes("facts/fact-1.md:1-5|note=[test note]"));
+  assert.ok(formatted.includes("<rollout_ids>"));
+  assert.ok(formatted.includes("rollout-abc"));
+});
+
+test("formatOaiMemCitation: round-trip parse(format(block)) preserves data", () => {
+  const original: CitationBlock = {
+    entries: [
+      { path: "facts/fact-a.md", lineStart: 1, lineEnd: 10, note: "memory about dogs" },
+      { path: "facts/fact-b.md", lineStart: 3, lineEnd: 7, note: "project deadline" },
+    ],
+    rolloutIds: ["rollout-001", "rollout-002"],
+  };
+
+  const formatted = formatOaiMemCitation(original);
+  const parsed = parseOaiMemCitation(formatted);
+
+  assert.ok(parsed);
+  assert.deepStrictEqual(parsed.entries, original.entries);
+  assert.deepStrictEqual(parsed.rolloutIds, original.rolloutIds);
+});
+
+// ---------------------------------------------------------------------------
+// buildCitationGuidance
+// ---------------------------------------------------------------------------
+
+test("buildCitationGuidance: contains template with citation entries", () => {
+  const citations: CitationMetadata[] = [
+    {
+      memoryId: "fact-1",
+      path: "facts/fact-1.md",
+      lineStart: 1,
+      lineEnd: 1,
+      rolloutId: "rollout-abc",
+      noteDefault: "user likes coffee",
+    },
+    {
+      memoryId: "fact-2",
+      path: "facts/fact-2.md",
+      lineStart: 1,
+      lineEnd: 1,
+      noteDefault: "project uses TypeScript",
+    },
+  ];
+
+  const guidance = buildCitationGuidance(citations);
+  assert.ok(guidance.includes("[Remnic citation guidance]"));
+  assert.ok(guidance.includes("<oai-mem-citation>"));
+  assert.ok(guidance.includes("facts/fact-1.md:1-1|note=[user likes coffee]"));
+  assert.ok(guidance.includes("facts/fact-2.md:1-1|note=[project uses TypeScript]"));
+  assert.ok(guidance.includes("rollout-abc"));
+  assert.ok(guidance.includes("<rollout_ids>"));
+  assert.ok(guidance.includes("</oai-mem-citation>"));
+});
+
+test("buildCitationGuidance: empty citations returns empty string", () => {
+  const guidance = buildCitationGuidance([]);
+  assert.equal(guidance, "");
+});
+
+test("buildCitationGuidance: deduplicates rollout IDs", () => {
+  const citations: CitationMetadata[] = [
+    {
+      memoryId: "fact-1",
+      path: "facts/fact-1.md",
+      lineStart: 1,
+      lineEnd: 1,
+      rolloutId: "rollout-shared",
+      noteDefault: "first",
+    },
+    {
+      memoryId: "fact-2",
+      path: "facts/fact-2.md",
+      lineStart: 1,
+      lineEnd: 1,
+      rolloutId: "rollout-shared",
+      noteDefault: "second",
+    },
+  ];
+
+  const guidance = buildCitationGuidance(citations);
+  // Count occurrences of "rollout-shared" within the rollout_ids section.
+  const rolloutSection = guidance.split("<rollout_ids>")[1]?.split("</rollout_ids>")[0] ?? "";
+  const occurrences = rolloutSection.split("rollout-shared").length - 1;
+  assert.equal(occurrences, 1, "rollout ID should appear only once after dedup");
+});
+
+test("buildCitationGuidance: citations without rolloutId produce empty rollout section", () => {
+  const citations: CitationMetadata[] = [
+    {
+      memoryId: "fact-1",
+      path: "facts/fact-1.md",
+      lineStart: 1,
+      lineEnd: 1,
+      noteDefault: "no rollout",
+    },
+  ];
+
+  const guidance = buildCitationGuidance(citations);
+  assert.ok(guidance.includes("<rollout_ids>"));
+  // The rollout_ids section should be empty (just the tags with nothing between).
+  const rolloutSection = guidance.split("<rollout_ids>")[1]?.split("</rollout_ids>")[0] ?? "";
+  assert.equal(rolloutSection.trim(), "");
+});


### PR DESCRIPTION
## Summary
- Add `citations.ts` with parser/formatter mirroring Codex `citations.rs` (supports `<oai-mem-citation>`, `<thread_ids>` legacy compat, dedupe)
- Recall tool appends citation metadata + guidance block when enabled
- `POST /v1/citations/observed` endpoint for usage tracking
- Auto-detect Codex adapter to enable citations automatically
- New config: `citationsEnabled`, `citationsAutoDetect`

## Test plan
- [ ] 13 citation parser/formatter/guidance tests pass
- [ ] Round-trip parse(format(block)) preserves data
- [ ] Legacy `<thread_ids>` tag accepted
- [ ] Build succeeds with no type errors

Closes #379

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated write-like HTTP endpoint and modifies recall responses conditionally, which can affect downstream integrations and access-tracking behavior if parsing/identity resolution is incorrect.
> 
> **Overview**
> Adds **Codex-compatible citation support** by introducing `citations.ts` (parse/format/guidance for `<oai-mem-citation>`, including legacy `<thread_ids>` parsing and rollout ID dedupe) and exporting it from the core package.
> 
> Updates the `engram.recall` MCP tool to optionally attach citation metadata and append a `[Remnic citation guidance]` block to the returned context, gated by new config (`citationsEnabled`) or auto-detection of Codex clients (`citationsAutoDetect`) using MCP `clientInfo`/session tracking.
> 
> Introduces `POST /v1/citations/observed` on the access HTTP server to accept observed citation entries/rollout IDs and best-effort increment memory access tracking via a new `recordCitationUsage` service method, including a storage helper (`filterExistingMemoryIds`) to avoid expensive full-memory loads. Configuration schema/types are extended accordingly, and docs/tests are added for the citation block format and parser/guidance behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb458bd7d0c54ac947a01c415cc67fb1042ef461. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->