### PR TITLE
feat(connectors): generalize memory-extension publisher contract

### DIFF
--- a/docs/architecture/memory-extension-publishers.md
+++ b/docs/architecture/memory-extension-publishers.md
@@ -1,0 +1,138 @@
+# Memory Extension Publishers
+
+## Overview
+
+Memory extension publishers are the mechanism Remnic uses to install
+host-specific instruction files into each AI agent host's extension
+directory. Each publisher knows:
+
+- Where the host stores extensions on disk.
+- Whether the host is installed locally.
+- How to render and write Remnic-specific instructions.
+- How to clean up (unpublish) those artefacts.
+
+This design generalises the pattern previously hard-coded for Codex into
+a pluggable contract that any host can implement.
+
+## Publisher Interface
+
+Every publisher implements `MemoryExtensionPublisher`:
+
+```ts
+interface MemoryExtensionPublisher {
+  readonly hostId: string;
+  resolveExtensionRoot(env?: NodeJS.ProcessEnv): Promise<string>;
+  isHostAvailable(): Promise<boolean>;
+  renderInstructions(ctx: PublishContext): Promise<string>;
+  publish(ctx: PublishContext): Promise<PublishResult>;
+  unpublish(): Promise<void>;
+}
+```
+
+### PublishContext
+
+```ts
+interface PublishContext {
+  readonly config: { memoryDir: string; daemonPort?: number; namespace?: string };
+  readonly skillsRoot: string;
+  readonly log: { info, warn, error };
+}
+```
+
+### PublishResult
+
+```ts
+interface PublishResult {
+  readonly hostId: string;
+  readonly extensionRoot: string;
+  readonly filesWritten: string[];
+  readonly skipped: string[];
+}
+```
+
+### PublisherCapabilities
+
+Static capability flags that describe what a publisher can produce:
+
+```ts
+interface PublisherCapabilities {
+  readonly instructionsMd: boolean;
+  readonly skillsFolder: boolean;
+  readonly citationFormat: boolean;
+  readonly readPathTemplate: boolean;
+}
+```
+
+## Host Implementations
+
+### Codex (`codex-publisher.ts`)
+
+**Status:** Fully implemented.
+
+- Extension root: `~/.codex/memories_extensions/remnic/`
+- Writes `instructions.md` with shared blocks + Codex-specific sandbox rules.
+- Uses atomic write (temp file + rename) per CLAUDE.md guideline #54.
+- `isHostAvailable()` checks for `~/.codex/` directory existence.
+
+### Claude Code (`claude-code-publisher.ts`)
+
+**Status:** Stub. Claude Code does not yet support file-based memory
+extension directories. All methods are safe no-ops.
+
+### Hermes (`hermes-publisher.ts`)
+
+**Status:** Stub. Hermes uses daemon-based transport. All methods are
+safe no-ops.
+
+## Shared Instruction Blocks
+
+`shared-instructions.ts` exports four reusable markdown fragments:
+
+| Export | Content |
+|--------|---------|
+| `REMNIC_SEMANTIC_OVERVIEW` | Table of memory types (fact, preference, decision, etc.) |
+| `REMNIC_CITATION_FORMAT` | `<oai-mem-citation>` block format and examples |
+| `REMNIC_MCP_TOOL_INVENTORY` | Table of all MCP tools the daemon exposes |
+| `REMNIC_RECALL_DECISION_RULES` | When to use MCP recall vs direct file reads |
+
+Each publisher composes these blocks into its host-specific
+`renderInstructions()` output, adding host-specific sections (e.g.
+Codex sandbox rules) as needed.
+
+## Registry
+
+`index.ts` exports:
+
+```ts
+const PUBLISHERS: Record<string, () => MemoryExtensionPublisher>;
+function publisherFor(hostId: string): MemoryExtensionPublisher | undefined;
+```
+
+`publisherFor()` returns `undefined` for unknown host IDs rather than
+throwing, so callers can gracefully skip unknown hosts.
+
+## CLI Integration
+
+### `connectors install`
+
+After a successful connector install, the CLI calls
+`publisherFor(connectorId)` and, if the host is available, publishes
+the memory extension automatically.
+
+### `connectors doctor`
+
+The doctor command iterates all registered publishers and reports:
+
+- Whether each host is installed locally.
+- Whether the extension directory exists.
+- Remediation advice if the extension is missing.
+
+## Adding a New Host Publisher
+
+1. Create `packages/remnic-core/src/memory-extension/<host>-publisher.ts`.
+2. Implement `MemoryExtensionPublisher`.
+3. Define static `capabilities: PublisherCapabilities`.
+4. Register it in `index.ts`'s `PUBLISHERS` map.
+5. Export the class from `index.ts`.
+6. Add it to the main `packages/remnic-core/src/index.ts` exports.
+7. Write tests in `tests/memory-extension-publisher.test.ts`.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -81,6 +81,8 @@ import {
   DEFAULT_SCAN_PATTERNS,
   DEFAULT_MAX_BINARY_SIZE_BYTES,
   DEFAULT_GRACE_PERIOD_DAYS,
+  publisherFor,
+  PUBLISHERS,
 } from "@remnic/core";
 import type {
   BinaryLifecycleConfig,
@@ -1115,6 +1117,33 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     if (result.configPath) console.log(`  Config: ${result.configPath}`);
     if (result.status === "already_installed") console.log("Use --force to reinstall.");
     if (result.status === "config_required") console.log("Set config with --config <key>=<value>");
+
+    // Publish memory extension if the connector has a publisher and the
+    // install was successful (not error/already_installed/config_required).
+    if (result.status === "installed") {
+      const pub = publisherFor(connectorId);
+      if (pub) {
+        try {
+          const available = await pub.isHostAvailable();
+          if (available) {
+            const memoryDir = resolveMemoryDir();
+            const pubResult = await pub.publish({
+              config: { memoryDir },
+              skillsRoot: path.join(memoryDir, "skills"),
+              log: { info: console.log, warn: console.warn, error: console.error },
+            });
+            if (pubResult.filesWritten.length > 0) {
+              console.log(`  Published memory extension to ${pubResult.extensionRoot}`);
+            }
+          }
+        } catch (err) {
+          // Per CLAUDE.md #13: external service calls must not crash the
+          // primary install flow. Surface a user-facing note instead.
+          const msg = err instanceof Error ? err.message : String(err);
+          console.warn(`  Warning: memory extension publish failed: ${msg}`);
+        }
+      }
+    }
   } else if (action === "remove") {
     if (!connectorId) {
       console.error("Usage: remnic connectors remove <id>");
@@ -1142,14 +1171,47 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       process.exit(1);
     }
     const result = await doctorConnector(connectorId);
+
+    // Append memory extension publisher health for each registered publisher.
+    const publisherChecks: Array<{ name: string; ok: boolean; detail: string }> = [];
+    for (const [hostId, factory] of Object.entries(PUBLISHERS)) {
+      try {
+        const pub = factory();
+        const available = await pub.isHostAvailable();
+        const extRoot = available ? await pub.resolveExtensionRoot() : "(host not installed)";
+        const extensionExists = available && extRoot
+          ? fs.existsSync(extRoot)
+          : false;
+        publisherChecks.push({
+          name: `Publisher: ${hostId}`,
+          ok: !available || extensionExists,
+          detail: !available
+            ? "host not installed (skip)"
+            : extensionExists
+            ? `extension at ${extRoot}`
+            : `extension missing at ${extRoot} — run \`remnic connectors install ${connectorId}\``,
+        });
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        publisherChecks.push({
+          name: `Publisher: ${hostId}`,
+          ok: false,
+          detail: `error: ${msg}`,
+        });
+      }
+    }
+
+    const allChecks = [...result.checks, ...publisherChecks];
+    const healthy = allChecks.every((c) => c.ok);
+
     if (json) {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify({ ...result, checks: allChecks, healthy }, null, 2));
     } else {
-      for (const check of result.checks) {
+      for (const check of allChecks) {
         const icon = check.ok ? "✓" : "✗";
         console.log(`  ${icon} ${check.name}: ${check.detail}`);
       }
-      console.log(result.healthy ? "\nConnector healthy" : "\nConnector has issues");
+      console.log(healthy ? "\nConnector healthy" : "\nConnector has issues");
     }
   } else {
     console.log("Usage: remnic connectors <list|install|remove|doctor> [id]");

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -81,7 +81,8 @@ import {
   DEFAULT_SCAN_PATTERNS,
   DEFAULT_MAX_BINARY_SIZE_BYTES,
   DEFAULT_GRACE_PERIOD_DAYS,
-  publisherFor,
+  publisherForConnector,
+  hostIdForConnector,
   PUBLISHERS,
 } from "@remnic/core";
 import type {
@@ -1121,7 +1122,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     // Publish memory extension if the connector has a publisher and the
     // install was successful (not error/already_installed/config_required).
     if (result.status === "installed") {
-      const pub = publisherFor(connectorId);
+      const pub = publisherForConnector(connectorId);
       if (pub) {
         try {
           const available = await pub.isHostAvailable();
@@ -1172,9 +1173,13 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     }
     const result = await doctorConnector(connectorId);
 
-    // Append memory extension publisher health for each registered publisher.
+    // Append memory extension publisher health only for the requested
+    // connector's host, not all registered publishers. This prevents
+    // unrelated hosts from polluting the health status.
     const publisherChecks: Array<{ name: string; ok: boolean; detail: string }> = [];
-    for (const [hostId, factory] of Object.entries(PUBLISHERS)) {
+    const targetHostId = hostIdForConnector(connectorId);
+    const factory = PUBLISHERS[targetHostId];
+    if (factory) {
       try {
         const pub = factory();
         const available = await pub.isHostAvailable();
@@ -1183,7 +1188,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
           ? fs.existsSync(extRoot)
           : false;
         publisherChecks.push({
-          name: `Publisher: ${hostId}`,
+          name: `Publisher: ${targetHostId}`,
           ok: !available || extensionExists,
           detail: !available
             ? "host not installed (skip)"
@@ -1194,7 +1199,7 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         publisherChecks.push({
-          name: `Publisher: ${hostId}`,
+          name: `Publisher: ${targetHostId}`,
           ok: false,
           detail: `error: ${msg}`,
         });

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -435,6 +435,8 @@ export {
 
 export {
   publisherFor,
+  publisherForConnector,
+  hostIdForConnector,
   PUBLISHERS,
   CodexMemoryExtensionPublisher,
   ClaudeCodeMemoryExtensionPublisher,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -430,6 +430,26 @@ export {
 } from "./connectors/codex-materialize.js";
 
 // ---------------------------------------------------------------------------
+// Memory Extension Publishers (#381)
+// ---------------------------------------------------------------------------
+
+export {
+  publisherFor,
+  PUBLISHERS,
+  CodexMemoryExtensionPublisher,
+  ClaudeCodeMemoryExtensionPublisher,
+  HermesMemoryExtensionPublisher,
+  REMNIC_SEMANTIC_OVERVIEW,
+  REMNIC_CITATION_FORMAT,
+  REMNIC_MCP_TOOL_INVENTORY,
+  REMNIC_RECALL_DECISION_RULES,
+  type MemoryExtensionPublisher,
+  type PublishContext,
+  type PublishResult,
+  type PublisherCapabilities,
+} from "./memory-extension/index.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/memory-extension/claude-code-publisher.ts
+++ b/packages/remnic-core/src/memory-extension/claude-code-publisher.ts
@@ -1,0 +1,51 @@
+/**
+ * @remnic/core — Claude Code Memory Extension Publisher (stub)
+ *
+ * Placeholder publisher for Claude Code. Claude Code does not yet
+ * support a file-based memory extension directory, so all methods are
+ * no-ops that return safe defaults.
+ */
+
+import type {
+  MemoryExtensionPublisher,
+  PublishContext,
+  PublishResult,
+  PublisherCapabilities,
+} from "./types.js";
+
+export class ClaudeCodeMemoryExtensionPublisher implements MemoryExtensionPublisher {
+  readonly hostId = "claude-code";
+
+  static readonly capabilities: PublisherCapabilities = {
+    instructionsMd: false,
+    skillsFolder: false,
+    citationFormat: false,
+    readPathTemplate: false,
+  };
+
+  async resolveExtensionRoot(): Promise<string> {
+    // Claude Code does not have an extension directory yet.
+    return "";
+  }
+
+  async isHostAvailable(): Promise<boolean> {
+    return false;
+  }
+
+  async renderInstructions(_ctx: PublishContext): Promise<string> {
+    return "";
+  }
+
+  async publish(_ctx: PublishContext): Promise<PublishResult> {
+    return {
+      hostId: this.hostId,
+      extensionRoot: "",
+      filesWritten: [],
+      skipped: [],
+    };
+  }
+
+  async unpublish(): Promise<void> {
+    // no-op
+  }
+}

--- a/packages/remnic-core/src/memory-extension/codex-publisher.ts
+++ b/packages/remnic-core/src/memory-extension/codex-publisher.ts
@@ -1,0 +1,148 @@
+/**
+ * @remnic/core — Codex Memory Extension Publisher
+ *
+ * Writes Remnic instructions into ~/.codex/memories_extensions/remnic/
+ * so the Codex agent can discover and use Remnic memories during its
+ * consolidation phase.
+ */
+
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+
+import type {
+  MemoryExtensionPublisher,
+  PublishContext,
+  PublishResult,
+  PublisherCapabilities,
+} from "./types.js";
+
+import {
+  REMNIC_SEMANTIC_OVERVIEW,
+  REMNIC_CITATION_FORMAT,
+  REMNIC_MCP_TOOL_INVENTORY,
+  REMNIC_RECALL_DECISION_RULES,
+} from "./shared-instructions.js";
+
+/** Folder name Remnic installs its extension under inside memories_extensions/. */
+const REMNIC_EXTENSION_DIR_NAME = "remnic";
+
+/**
+ * Codex-specific publisher that knows the Codex extension layout:
+ *   ~/.codex/memories_extensions/remnic/instructions.md
+ */
+export class CodexMemoryExtensionPublisher implements MemoryExtensionPublisher {
+  readonly hostId = "codex";
+
+  static readonly capabilities: PublisherCapabilities = {
+    instructionsMd: true,
+    skillsFolder: true,
+    citationFormat: true,
+    readPathTemplate: true,
+  };
+
+  async resolveExtensionRoot(
+    env?: NodeJS.ProcessEnv,
+  ): Promise<string> {
+    const e = env ?? process.env;
+    const codexHome =
+      e.CODEX_HOME?.trim() || path.join(e.HOME ?? os.homedir(), ".codex");
+    return path.join(codexHome, "memories_extensions", REMNIC_EXTENSION_DIR_NAME);
+  }
+
+  async isHostAvailable(): Promise<boolean> {
+    try {
+      const home = process.env.CODEX_HOME?.trim() ||
+        path.join(process.env.HOME ?? os.homedir(), ".codex");
+      return fs.existsSync(home);
+    } catch {
+      return false;
+    }
+  }
+
+  async renderInstructions(ctx: PublishContext): Promise<string> {
+    const memDir = ctx.config.memoryDir;
+    const ns = ctx.config.namespace ?? "default";
+
+    const sections: string[] = [
+      `# Remnic Memory Extension for Codex\n`,
+      `This document tells you how to use Remnic as an authoritative local ` +
+        `memory source. Remnic is a local-first, file-backed memory system. ` +
+        `All Remnic content lives on disk as plain Markdown.\n`,
+      REMNIC_SEMANTIC_OVERVIEW,
+      `## Where Remnic Content Lives\n\n` +
+        `Memory base directory: \`${memDir}\`\n\n` +
+        `Namespace: \`${ns}\`\n\n` +
+        `Under the base directory, memories are organized by namespace:\n\n` +
+        "```\n" +
+        `${memDir}/<namespace>/\n` +
+        `  MEMORY.md               # compact top-of-mind memory\n` +
+        `  memory_summary.md       # optional longer summary\n` +
+        `  skills/\n` +
+        `    <skill-name>/SKILL.md # reusable workflows\n` +
+        `  rollout_summaries/\n` +
+        `    *.md                  # per-session rollup notes\n` +
+        "```\n",
+      REMNIC_CITATION_FORMAT,
+      REMNIC_MCP_TOOL_INVENTORY,
+      REMNIC_RECALL_DECISION_RULES,
+      `## Sandboxing Rules (Codex Phase-2)\n\n` +
+        `When running inside the Codex phase-2 consolidation sandbox:\n\n` +
+        `- **No network.** Do not attempt HTTP calls or MCP connections.\n` +
+        `- **No CLI invocation.** Do not shell out to \`remnic\` or \`engram\`.\n` +
+        `- **No MCP tool calls.** Use filesystem reads only.\n` +
+        `- **Local writes** are allowed only where Codex's sandbox policy permits.\n` +
+        `- **Respect missing files.** If a file does not exist, move on silently.\n`,
+    ];
+
+    return sections.join("\n");
+  }
+
+  async publish(ctx: PublishContext): Promise<PublishResult> {
+    const extensionRoot = await this.resolveExtensionRoot();
+    const instructionsPath = path.join(extensionRoot, "instructions.md");
+    const filesWritten: string[] = [];
+    const skipped: string[] = [];
+
+    ctx.log.info(`Publishing Codex memory extension to ${extensionRoot}`);
+
+    // Ensure the extension root exists.
+    fs.mkdirSync(extensionRoot, { recursive: true });
+
+    // Render and write instructions.md using atomic write (temp + rename).
+    // Per CLAUDE.md #54: never delete before write in file replace operations.
+    const content = await this.renderInstructions(ctx);
+    const tmpPath = `${instructionsPath}.tmp-${process.pid}-${Date.now()}`;
+
+    try {
+      fs.writeFileSync(tmpPath, content, "utf-8");
+      fs.renameSync(tmpPath, instructionsPath);
+      filesWritten.push(instructionsPath);
+      ctx.log.info(`Wrote ${instructionsPath}`);
+    } catch (err) {
+      // Clean up temp file on failure.
+      try {
+        if (fs.existsSync(tmpPath)) {
+          fs.unlinkSync(tmpPath);
+        }
+      } catch {
+        // swallow cleanup error
+      }
+      throw err;
+    }
+
+    return {
+      hostId: this.hostId,
+      extensionRoot,
+      filesWritten,
+      skipped,
+    };
+  }
+
+  async unpublish(): Promise<void> {
+    const extensionRoot = await this.resolveExtensionRoot();
+    if (fs.existsSync(extensionRoot)) {
+      fs.rmSync(extensionRoot, { recursive: true, force: true });
+    }
+  }
+}

--- a/packages/remnic-core/src/memory-extension/hermes-publisher.ts
+++ b/packages/remnic-core/src/memory-extension/hermes-publisher.ts
@@ -1,0 +1,51 @@
+/**
+ * @remnic/core — Hermes Memory Extension Publisher (stub)
+ *
+ * Placeholder publisher for Hermes. Hermes uses a daemon-based
+ * transport and does not currently consume file-based memory
+ * extensions, so all methods are no-ops.
+ */
+
+import type {
+  MemoryExtensionPublisher,
+  PublishContext,
+  PublishResult,
+  PublisherCapabilities,
+} from "./types.js";
+
+export class HermesMemoryExtensionPublisher implements MemoryExtensionPublisher {
+  readonly hostId = "hermes";
+
+  static readonly capabilities: PublisherCapabilities = {
+    instructionsMd: false,
+    skillsFolder: false,
+    citationFormat: false,
+    readPathTemplate: false,
+  };
+
+  async resolveExtensionRoot(): Promise<string> {
+    // Hermes does not have an extension directory.
+    return "";
+  }
+
+  async isHostAvailable(): Promise<boolean> {
+    return false;
+  }
+
+  async renderInstructions(_ctx: PublishContext): Promise<string> {
+    return "";
+  }
+
+  async publish(_ctx: PublishContext): Promise<PublishResult> {
+    return {
+      hostId: this.hostId,
+      extensionRoot: "",
+      filesWritten: [],
+      skipped: [],
+    };
+  }
+
+  async unpublish(): Promise<void> {
+    // no-op
+  }
+}

--- a/packages/remnic-core/src/memory-extension/index.ts
+++ b/packages/remnic-core/src/memory-extension/index.ts
@@ -1,0 +1,54 @@
+/**
+ * @remnic/core — Memory Extension Publisher Registry
+ *
+ * Central registry of host-specific publishers. Each publisher knows
+ * how to write Remnic instruction artefacts into a host's extension
+ * directory.
+ *
+ * Usage:
+ *   import { publisherFor } from "../memory-extension/index.js";
+ *   const pub = publisherFor("codex");
+ *   if (pub && await pub.isHostAvailable()) { ... }
+ */
+
+export type {
+  MemoryExtensionPublisher,
+  PublishContext,
+  PublishResult,
+  PublisherCapabilities,
+} from "./types.js";
+
+export {
+  REMNIC_SEMANTIC_OVERVIEW,
+  REMNIC_CITATION_FORMAT,
+  REMNIC_MCP_TOOL_INVENTORY,
+  REMNIC_RECALL_DECISION_RULES,
+} from "./shared-instructions.js";
+
+export { CodexMemoryExtensionPublisher } from "./codex-publisher.js";
+export { ClaudeCodeMemoryExtensionPublisher } from "./claude-code-publisher.js";
+export { HermesMemoryExtensionPublisher } from "./hermes-publisher.js";
+
+import type { MemoryExtensionPublisher } from "./types.js";
+import { CodexMemoryExtensionPublisher } from "./codex-publisher.js";
+import { ClaudeCodeMemoryExtensionPublisher } from "./claude-code-publisher.js";
+import { HermesMemoryExtensionPublisher } from "./hermes-publisher.js";
+
+/**
+ * Factory registry keyed by host ID. Each value is a zero-argument
+ * factory that returns a fresh publisher instance.
+ */
+export const PUBLISHERS: Record<string, () => MemoryExtensionPublisher> = {
+  "codex": () => new CodexMemoryExtensionPublisher(),
+  "claude-code": () => new ClaudeCodeMemoryExtensionPublisher(),
+  "hermes": () => new HermesMemoryExtensionPublisher(),
+};
+
+/**
+ * Look up a publisher by host ID.
+ * Returns undefined for unknown host IDs rather than throwing.
+ */
+export function publisherFor(hostId: string): MemoryExtensionPublisher | undefined {
+  const factory = PUBLISHERS[hostId];
+  return factory ? factory() : undefined;
+}

--- a/packages/remnic-core/src/memory-extension/index.ts
+++ b/packages/remnic-core/src/memory-extension/index.ts
@@ -45,10 +45,45 @@ export const PUBLISHERS: Record<string, () => MemoryExtensionPublisher> = {
 };
 
 /**
+ * Maps connector IDs to publisher host IDs.
+ *
+ * Most connector IDs match their publisher host ID exactly (e.g.
+ * "claude-code" -> "claude-code", "hermes" -> "hermes").
+ * This map only needs entries for connector IDs that differ from
+ * their publisher host ID. Connectors without a publisher (e.g.
+ * "cursor", "cline") are intentionally absent.
+ */
+const CONNECTOR_TO_HOST: Record<string, string> = {
+  "codex-cli": "codex",
+};
+
+/**
+ * Resolve a connector ID to its publisher host ID.
+ *
+ * Returns the explicit mapping if one exists, otherwise returns
+ * the connector ID itself (identity mapping covers the common case
+ * where connector ID === host ID).
+ */
+export function hostIdForConnector(connectorId: string): string {
+  return CONNECTOR_TO_HOST[connectorId] ?? connectorId;
+}
+
+/**
  * Look up a publisher by host ID.
  * Returns undefined for unknown host IDs rather than throwing.
  */
 export function publisherFor(hostId: string): MemoryExtensionPublisher | undefined {
   const factory = PUBLISHERS[hostId];
   return factory ? factory() : undefined;
+}
+
+/**
+ * Look up a publisher by connector ID.
+ *
+ * Resolves the connector ID to its host ID first (e.g. "codex-cli" -> "codex"),
+ * then looks up the publisher. Returns undefined if no publisher exists for
+ * the resolved host ID.
+ */
+export function publisherForConnector(connectorId: string): MemoryExtensionPublisher | undefined {
+  return publisherFor(hostIdForConnector(connectorId));
 }

--- a/packages/remnic-core/src/memory-extension/shared-instructions.ts
+++ b/packages/remnic-core/src/memory-extension/shared-instructions.ts
@@ -1,0 +1,133 @@
+/**
+ * @remnic/core — Shared Instruction Blocks
+ *
+ * Reusable markdown fragments that every host-specific publisher can
+ * compose into its instructions.md file. Keeping them here avoids
+ * per-host copy-paste drift.
+ */
+
+/**
+ * Describes the Remnic memory types a host agent may encounter.
+ */
+export const REMNIC_SEMANTIC_OVERVIEW = `\
+## Remnic Memory Types
+
+Remnic stores memories as plain Markdown files with YAML front-matter.
+Each memory has a **type** that describes its semantic role:
+
+| Type | Description |
+|------|-------------|
+| \`fact\` | An objective piece of knowledge the user confirmed or that was extracted from a session. |
+| \`preference\` | A stated or inferred user preference (e.g. coding style, tool choice). |
+| \`decision\` | An explicit decision or trade-off the user made. |
+| \`entity\` | A named thing the user cares about (project, service, person, API). |
+| \`skill\` | A reusable workflow or procedure documented for future sessions. |
+| \`correction\` | A fix or amendment to a previously stored memory. |
+| \`question\` | An open question or uncertainty flagged for future resolution. |
+| \`observation\` | A pattern noticed across sessions (e.g. "user always runs tests before commits"). |
+| \`summary\` | A condensed roll-up of recent sessions or a topic area. |
+
+When reading Remnic content, the front-matter \`type\` field tells you what
+kind of knowledge you are looking at and how much weight to give it.
+`;
+
+/**
+ * Explains the oai-mem-citation block format hosts should use when
+ * referencing Remnic-sourced content.
+ */
+export const REMNIC_CITATION_FORMAT = `\
+## Citing Remnic Memories
+
+When a piece of your output draws on a Remnic file, cite it using the
+memory citation block format so the user can trace the source:
+
+\`\`\`
+<oai-mem-citation path="<path-relative-to-remnic-memory-base>" />
+\`\`\`
+
+The path must be **relative to the Remnic memory base** (the directory
+named \`memories/\` under \`<remnic-home>\`), not absolute. Examples:
+
+- \`<oai-mem-citation path="default/MEMORY.md" />\`
+- \`<oai-mem-citation path="my-project/skills/deploy/SKILL.md" />\`
+- \`<oai-mem-citation path="shared/memory_summary.md" />\`
+
+Cite each distinct source once near the fact it supports. Do not invent
+citations for files you have not actually read.
+`;
+
+/**
+ * Table of MCP tools the Remnic daemon exposes. Hosts that can reach
+ * the MCP server should prefer these over raw file reads.
+ *
+ * Tool names use the canonical `remnic.*` prefix. Legacy `engram.*`
+ * aliases are also accepted by the server for backward compatibility.
+ */
+export const REMNIC_MCP_TOOL_INVENTORY = `\
+## Remnic MCP Tools
+
+When the Remnic MCP server is reachable, the following tools are
+available. Prefer MCP tools over direct file reads when the host
+supports MCP connections.
+
+| Tool | Purpose |
+|------|---------|
+| \`remnic.recall\` | Retrieve contextually relevant memories for the current session. |
+| \`remnic.recall_explain\` | Like recall, but includes an explanation of why each memory was selected. |
+| \`remnic.memory_store\` | Persist a new memory (fact, preference, decision, etc.). |
+| \`remnic.memory_get\` | Fetch a specific memory by ID. |
+| \`remnic.memory_search\` | Full-text + semantic search across all memories. |
+| \`remnic.memory_timeline\` | Retrieve memories in chronological order within a time range. |
+| \`remnic.observe\` | Record an observation from the current conversation turn. |
+| \`remnic.entity_get\` | Look up a named entity and its relationships. |
+| \`remnic.memory_entities_list\` | List all known entities. |
+| \`remnic.memory_profile\` | Retrieve the user profile summary. |
+| \`remnic.day_summary\` | Generate a summary of memories from a specific day. |
+| \`remnic.briefing\` | Generate a structured briefing for an upcoming session. |
+| \`remnic.memory_feedback\` | Submit feedback on a recalled memory (useful, outdated, wrong). |
+| \`remnic.memory_promote\` | Promote a memory to a higher confidence tier. |
+| \`remnic.context_checkpoint\` | Save a conversation checkpoint for continuity. |
+| \`remnic.suggestion_submit\` | Submit a suggestion for a new memory to the review queue. |
+| \`remnic.review_queue_list\` | List pending suggestions in the review queue. |
+| \`remnic.work_task\` | Create or update a work task. |
+| \`remnic.work_project\` | Create or update a work project. |
+| \`remnic.work_board\` | View the work board. |
+
+Legacy \`engram.*\` prefixed names are accepted as aliases for all tools.
+`;
+
+/**
+ * Decision rules for when a host agent should use MCP recall vs
+ * reading Remnic files directly from disk.
+ */
+export const REMNIC_RECALL_DECISION_RULES = `\
+## When to Use Recall vs Direct Read
+
+### Use \`remnic.recall\` (MCP) when:
+
+- The Remnic MCP server is reachable (the host has an active MCP
+  connection to the Remnic daemon).
+- You want contextually relevant memories ranked by the recall planner
+  (semantic search + reranking + importance scoring).
+- You need memories across multiple namespaces or topics.
+- The conversation benefits from Remnic's intent detection and
+  adaptive recall depth.
+
+### Use direct file reads when:
+
+- You are in a sandboxed environment with no network or MCP access
+  (e.g. Codex phase-2 consolidation).
+- You need a specific file you already know the path to.
+- The MCP server is unavailable or unhealthy.
+- You are operating on the raw memory files for maintenance or
+  migration purposes.
+
+### General guidance:
+
+- Prefer MCP tools when available — they provide ranked, deduplicated,
+  and context-aware results.
+- Fall back to file reads gracefully — never block on a failed MCP call
+  when the data is also on disk.
+- Never write directly to the Remnic memory directory unless you are an
+  authorized extraction or consolidation process.
+`;

--- a/packages/remnic-core/src/memory-extension/types.ts
+++ b/packages/remnic-core/src/memory-extension/types.ts
@@ -1,0 +1,77 @@
+/**
+ * @remnic/core — Memory Extension Publisher Contract
+ *
+ * Defines the interface that every host-specific publisher must implement.
+ * Each publisher knows how to write Remnic instruction files into the
+ * host's extension directory so the host agent can discover and use
+ * Remnic memories.
+ */
+
+/**
+ * A publisher that can install (and remove) Remnic memory-extension
+ * artefacts into a specific host's extension directory.
+ */
+export interface MemoryExtensionPublisher {
+  /** Unique host identifier (e.g. "codex", "claude-code", "hermes"). */
+  readonly hostId: string;
+
+  /**
+   * Resolve the absolute path to the extension root for this host.
+   * @param env Optional environment to read HOME / host-specific vars from.
+   */
+  resolveExtensionRoot(env?: NodeJS.ProcessEnv): Promise<string>;
+
+  /** Return true when the host toolchain appears to be installed locally. */
+  isHostAvailable(): Promise<boolean>;
+
+  /** Render the full instructions markdown that will be written to disk. */
+  renderInstructions(ctx: PublishContext): Promise<string>;
+
+  /** Write extension artefacts to the host's extension directory. */
+  publish(ctx: PublishContext): Promise<PublishResult>;
+
+  /** Remove extension artefacts previously written by publish(). */
+  unpublish(): Promise<void>;
+}
+
+/**
+ * Context passed to every publisher method that needs configuration,
+ * paths, or logging.
+ */
+export interface PublishContext {
+  readonly config: {
+    memoryDir: string;
+    daemonPort?: number;
+    namespace?: string;
+  };
+  readonly skillsRoot: string;
+  readonly log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string) => void;
+  };
+}
+
+/** Result returned by a successful publish() call. */
+export interface PublishResult {
+  readonly hostId: string;
+  readonly extensionRoot: string;
+  readonly filesWritten: string[];
+  readonly skipped: string[];
+}
+
+/**
+ * Declarative capability flags that describe what a given publisher
+ * can produce. Useful for feature-gating UI or doctor output without
+ * instantiating the publisher.
+ */
+export interface PublisherCapabilities {
+  /** Whether the publisher writes an instructions.md file. */
+  readonly instructionsMd: boolean;
+  /** Whether the publisher populates a skills folder. */
+  readonly skillsFolder: boolean;
+  /** Whether the publisher embeds citation format guidance. */
+  readonly citationFormat: boolean;
+  /** Whether the publisher includes a read-path template for the host. */
+  readonly readPathTemplate: boolean;
+}

--- a/tests/memory-extension-publisher.test.ts
+++ b/tests/memory-extension-publisher.test.ts
@@ -1,0 +1,298 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import {
+  publisherFor,
+  PUBLISHERS,
+  CodexMemoryExtensionPublisher,
+  ClaudeCodeMemoryExtensionPublisher,
+  HermesMemoryExtensionPublisher,
+  REMNIC_SEMANTIC_OVERVIEW,
+  REMNIC_CITATION_FORMAT,
+  REMNIC_MCP_TOOL_INVENTORY,
+  REMNIC_RECALL_DECISION_RULES,
+} from "../packages/remnic-core/src/memory-extension/index.js";
+
+import type { PublishContext } from "../packages/remnic-core/src/memory-extension/types.js";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function makeTestContext(overrides: Partial<PublishContext> = {}): PublishContext {
+  return {
+    config: {
+      memoryDir: "/tmp/test-remnic-memory",
+      daemonPort: 4242,
+      namespace: "test-ns",
+    },
+    skillsRoot: "/tmp/test-remnic-memory/skills",
+    log: {
+      info: () => {},
+      warn: () => {},
+      error: () => {},
+    },
+    ...overrides,
+  };
+}
+
+// ── Registry tests ─────────────────────────────────────────────────────────
+
+test("publisherFor('codex') returns CodexMemoryExtensionPublisher", () => {
+  const pub = publisherFor("codex");
+  assert.ok(pub, "expected a publisher for codex");
+  assert.equal(pub.hostId, "codex");
+  assert.ok(pub instanceof CodexMemoryExtensionPublisher);
+});
+
+test("publisherFor('claude-code') returns stub with isHostAvailable() === false", async () => {
+  const pub = publisherFor("claude-code");
+  assert.ok(pub, "expected a publisher for claude-code");
+  assert.equal(pub.hostId, "claude-code");
+  assert.ok(pub instanceof ClaudeCodeMemoryExtensionPublisher);
+  const available = await pub.isHostAvailable();
+  assert.equal(available, false);
+});
+
+test("publisherFor('hermes') returns stub with isHostAvailable() === false", async () => {
+  const pub = publisherFor("hermes");
+  assert.ok(pub, "expected a publisher for hermes");
+  assert.equal(pub.hostId, "hermes");
+  assert.ok(pub instanceof HermesMemoryExtensionPublisher);
+  const available = await pub.isHostAvailable();
+  assert.equal(available, false);
+});
+
+test("publisherFor('unknown') returns undefined", () => {
+  const pub = publisherFor("unknown-host-xyz");
+  assert.equal(pub, undefined);
+});
+
+test("PUBLISHERS registry has entries for codex, claude-code, hermes", () => {
+  assert.ok("codex" in PUBLISHERS);
+  assert.ok("claude-code" in PUBLISHERS);
+  assert.ok("hermes" in PUBLISHERS);
+});
+
+// ── Codex publisher ────────────────────────────────────────────────────────
+
+test("Codex publisher: resolveExtensionRoot uses CODEX_HOME env", async () => {
+  const pub = new CodexMemoryExtensionPublisher();
+  const root = await pub.resolveExtensionRoot({
+    HOME: "/home/test",
+    CODEX_HOME: "/custom/codex",
+  });
+  assert.equal(root, path.join("/custom/codex", "memories_extensions", "remnic"));
+});
+
+test("Codex publisher: resolveExtensionRoot falls back to ~/.codex", async () => {
+  const pub = new CodexMemoryExtensionPublisher();
+  const root = await pub.resolveExtensionRoot({ HOME: "/home/test" });
+  assert.equal(root, path.join("/home/test", ".codex", "memories_extensions", "remnic"));
+});
+
+test("Codex publisher: publish writes instructions.md to tmp dir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-pub-test-"));
+  const codexHome = path.join(tmpDir, ".codex");
+
+  // Save and override CODEX_HOME so the publisher writes to our temp dir.
+  const prevCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+
+  try {
+    // Create the .codex dir so isHostAvailable returns true.
+    fs.mkdirSync(codexHome, { recursive: true });
+
+    const pub = new CodexMemoryExtensionPublisher();
+    const ctx = makeTestContext();
+    const result = await pub.publish(ctx);
+
+    assert.equal(result.hostId, "codex");
+    assert.ok(result.extensionRoot.includes("memories_extensions"));
+    assert.ok(result.filesWritten.length > 0, "expected at least one file written");
+
+    const instructionsPath = result.filesWritten.find((f) => f.endsWith("instructions.md"));
+    assert.ok(instructionsPath, "expected instructions.md in filesWritten");
+    assert.ok(fs.existsSync(instructionsPath), "instructions.md should exist on disk");
+
+    const content = fs.readFileSync(instructionsPath, "utf-8");
+    assert.ok(content.includes("Remnic Memory Extension"), "should contain title");
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex publisher: instructions contain shared blocks", async () => {
+  const pub = new CodexMemoryExtensionPublisher();
+  const ctx = makeTestContext();
+  const instructions = await pub.renderInstructions(ctx);
+
+  // REMNIC_SEMANTIC_OVERVIEW
+  assert.ok(instructions.includes("Memory Types"), "should contain semantic overview header");
+  assert.ok(instructions.includes("fact"), "should mention 'fact' memory type");
+  assert.ok(instructions.includes("preference"), "should mention 'preference' memory type");
+  assert.ok(instructions.includes("decision"), "should mention 'decision' memory type");
+  assert.ok(instructions.includes("entity"), "should mention 'entity' memory type");
+  assert.ok(instructions.includes("skill"), "should mention 'skill' memory type");
+  assert.ok(instructions.includes("correction"), "should mention 'correction' memory type");
+  assert.ok(instructions.includes("observation"), "should mention 'observation' memory type");
+  assert.ok(instructions.includes("summary"), "should mention 'summary' memory type");
+
+  // REMNIC_CITATION_FORMAT
+  assert.ok(instructions.includes("oai-mem-citation"), "should contain citation format");
+
+  // REMNIC_MCP_TOOL_INVENTORY
+  assert.ok(instructions.includes("remnic.recall"), "should list remnic.recall tool");
+  assert.ok(instructions.includes("remnic.memory_store"), "should list remnic.memory_store tool");
+
+  // REMNIC_RECALL_DECISION_RULES
+  assert.ok(
+    instructions.includes("When to Use Recall"),
+    "should contain recall decision rules",
+  );
+
+  // Codex-specific sandbox rules
+  assert.ok(instructions.includes("Sandboxing Rules"), "should contain sandbox rules");
+});
+
+test("Codex publisher: unpublish removes the extension folder", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-pub-unpub-"));
+  const codexHome = path.join(tmpDir, ".codex");
+
+  const prevCodexHome = process.env.CODEX_HOME;
+  process.env.CODEX_HOME = codexHome;
+
+  try {
+    fs.mkdirSync(codexHome, { recursive: true });
+
+    const pub = new CodexMemoryExtensionPublisher();
+    const ctx = makeTestContext();
+
+    // Publish first so there is something to remove.
+    const result = await pub.publish(ctx);
+    assert.ok(fs.existsSync(result.extensionRoot), "extension dir should exist after publish");
+
+    // Now unpublish.
+    await pub.unpublish();
+    assert.ok(!fs.existsSync(result.extensionRoot), "extension dir should be removed after unpublish");
+  } finally {
+    if (prevCodexHome === undefined) delete process.env.CODEX_HOME;
+    else process.env.CODEX_HOME = prevCodexHome;
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("Codex publisher: capabilities are set correctly", () => {
+  assert.equal(CodexMemoryExtensionPublisher.capabilities.instructionsMd, true);
+  assert.equal(CodexMemoryExtensionPublisher.capabilities.skillsFolder, true);
+  assert.equal(CodexMemoryExtensionPublisher.capabilities.citationFormat, true);
+  assert.equal(CodexMemoryExtensionPublisher.capabilities.readPathTemplate, true);
+});
+
+// ── Claude Code stub ───────────────────────────────────────────────────────
+
+test("Claude Code stub: publish is no-op, returns empty filesWritten", async () => {
+  const pub = new ClaudeCodeMemoryExtensionPublisher();
+  const ctx = makeTestContext();
+  const result = await pub.publish(ctx);
+
+  assert.equal(result.hostId, "claude-code");
+  assert.equal(result.extensionRoot, "");
+  assert.deepEqual(result.filesWritten, []);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("Claude Code stub: renderInstructions returns empty string", async () => {
+  const pub = new ClaudeCodeMemoryExtensionPublisher();
+  const ctx = makeTestContext();
+  const instructions = await pub.renderInstructions(ctx);
+  assert.equal(instructions, "");
+});
+
+test("Claude Code stub: capabilities are all false", () => {
+  assert.equal(ClaudeCodeMemoryExtensionPublisher.capabilities.instructionsMd, false);
+  assert.equal(ClaudeCodeMemoryExtensionPublisher.capabilities.skillsFolder, false);
+  assert.equal(ClaudeCodeMemoryExtensionPublisher.capabilities.citationFormat, false);
+  assert.equal(ClaudeCodeMemoryExtensionPublisher.capabilities.readPathTemplate, false);
+});
+
+// ── Hermes stub ────────────────────────────────────────────────────────────
+
+test("Hermes stub: publish is no-op", async () => {
+  const pub = new HermesMemoryExtensionPublisher();
+  const ctx = makeTestContext();
+  const result = await pub.publish(ctx);
+
+  assert.equal(result.hostId, "hermes");
+  assert.equal(result.extensionRoot, "");
+  assert.deepEqual(result.filesWritten, []);
+  assert.deepEqual(result.skipped, []);
+});
+
+test("Hermes stub: isHostAvailable returns false", async () => {
+  const pub = new HermesMemoryExtensionPublisher();
+  const available = await pub.isHostAvailable();
+  assert.equal(available, false);
+});
+
+test("Hermes stub: capabilities are all false", () => {
+  assert.equal(HermesMemoryExtensionPublisher.capabilities.instructionsMd, false);
+  assert.equal(HermesMemoryExtensionPublisher.capabilities.skillsFolder, false);
+  assert.equal(HermesMemoryExtensionPublisher.capabilities.citationFormat, false);
+  assert.equal(HermesMemoryExtensionPublisher.capabilities.readPathTemplate, false);
+});
+
+// ── Shared instructions content ────────────────────────────────────────────
+
+test("REMNIC_SEMANTIC_OVERVIEW mentions all memory types", () => {
+  const types = [
+    "fact", "preference", "decision", "entity", "skill",
+    "correction", "question", "observation", "summary",
+  ];
+  for (const t of types) {
+    assert.ok(
+      REMNIC_SEMANTIC_OVERVIEW.includes(t),
+      `REMNIC_SEMANTIC_OVERVIEW should mention memory type '${t}'`,
+    );
+  }
+});
+
+test("REMNIC_CITATION_FORMAT includes oai-mem-citation", () => {
+  assert.ok(REMNIC_CITATION_FORMAT.includes("oai-mem-citation"));
+});
+
+test("REMNIC_MCP_TOOL_INVENTORY lists core tools", () => {
+  const expectedTools = [
+    "remnic.recall",
+    "remnic.memory_store",
+    "remnic.memory_search",
+    "remnic.memory_get",
+    "remnic.observe",
+    "remnic.entity_get",
+    "remnic.briefing",
+  ];
+  for (const tool of expectedTools) {
+    assert.ok(
+      REMNIC_MCP_TOOL_INVENTORY.includes(tool),
+      `REMNIC_MCP_TOOL_INVENTORY should list tool '${tool}'`,
+    );
+  }
+});
+
+test("REMNIC_RECALL_DECISION_RULES covers MCP vs direct read", () => {
+  assert.ok(REMNIC_RECALL_DECISION_RULES.includes("remnic.recall"));
+  assert.ok(REMNIC_RECALL_DECISION_RULES.includes("direct file reads"));
+  assert.ok(REMNIC_RECALL_DECISION_RULES.includes("MCP"));
+});
+
+// ── Each publisher factory produces distinct instances ──────────────────────
+
+test("publisherFor returns fresh instances each call", () => {
+  const a = publisherFor("codex");
+  const b = publisherFor("codex");
+  assert.ok(a !== b, "each call should return a distinct instance");
+});

--- a/tests/memory-extension-publisher.test.ts
+++ b/tests/memory-extension-publisher.test.ts
@@ -7,6 +7,8 @@ import { mkdtemp, rm } from "node:fs/promises";
 
 import {
   publisherFor,
+  publisherForConnector,
+  hostIdForConnector,
   PUBLISHERS,
   CodexMemoryExtensionPublisher,
   ClaudeCodeMemoryExtensionPublisher,
@@ -295,4 +297,50 @@ test("publisherFor returns fresh instances each call", () => {
   const a = publisherFor("codex");
   const b = publisherFor("codex");
   assert.ok(a !== b, "each call should return a distinct instance");
+});
+
+// ── hostIdForConnector mapping ────────────────────────────────────────────
+
+test("hostIdForConnector maps 'codex-cli' to 'codex'", () => {
+  assert.equal(hostIdForConnector("codex-cli"), "codex");
+});
+
+test("hostIdForConnector returns identity for matching IDs", () => {
+  assert.equal(hostIdForConnector("claude-code"), "claude-code");
+  assert.equal(hostIdForConnector("hermes"), "hermes");
+  assert.equal(hostIdForConnector("codex"), "codex");
+});
+
+test("hostIdForConnector returns identity for unknown connectors", () => {
+  assert.equal(hostIdForConnector("cursor"), "cursor");
+  assert.equal(hostIdForConnector("unknown-xyz"), "unknown-xyz");
+});
+
+// ── publisherForConnector ─────────────────────────────────────────────────
+
+test("publisherForConnector('codex-cli') resolves to Codex publisher", () => {
+  const pub = publisherForConnector("codex-cli");
+  assert.ok(pub, "expected a publisher for codex-cli");
+  assert.equal(pub.hostId, "codex");
+  assert.ok(pub instanceof CodexMemoryExtensionPublisher);
+});
+
+test("publisherForConnector('claude-code') returns Claude Code publisher", () => {
+  const pub = publisherForConnector("claude-code");
+  assert.ok(pub, "expected a publisher for claude-code");
+  assert.equal(pub.hostId, "claude-code");
+  assert.ok(pub instanceof ClaudeCodeMemoryExtensionPublisher);
+});
+
+test("publisherForConnector('hermes') returns Hermes publisher", () => {
+  const pub = publisherForConnector("hermes");
+  assert.ok(pub, "expected a publisher for hermes");
+  assert.equal(pub.hostId, "hermes");
+  assert.ok(pub instanceof HermesMemoryExtensionPublisher);
+});
+
+test("publisherForConnector returns undefined for connectors without a publisher", () => {
+  assert.equal(publisherForConnector("cursor"), undefined);
+  assert.equal(publisherForConnector("cline"), undefined);
+  assert.equal(publisherForConnector("unknown-xyz"), undefined);
 });


### PR DESCRIPTION
## Summary

- Introduces the `MemoryExtensionPublisher` interface and a host-keyed registry (`publisherFor()`) that generalizes how Remnic installs instruction artefacts into each AI agent host's extension directory.
- Implements a fully functional **Codex publisher** that writes `instructions.md` into `~/.codex/memories_extensions/remnic/` using shared markdown blocks (semantic overview, citation format, MCP tool inventory, recall decision rules). Claude Code and Hermes are stubs pending host support.
- Integrates publishing into the CLI: `connectors install` auto-publishes when the host is available; `connectors doctor` reports publisher health for all registered hosts.

Closes #381

## Test plan

- [x] 22 new tests in `tests/memory-extension-publisher.test.ts` covering:
  - Registry lookup for all hosts + unknown hosts
  - Codex publish writes instructions.md to temp dir with correct content
  - Codex unpublish removes the extension folder
  - Claude Code and Hermes stubs return no-op results
  - Shared instruction blocks contain all expected memory types and tools
  - Each `publisherFor()` call returns a fresh instance
- [x] Related existing tests (`codex-memory-extension-install`, `codex-memory-extension-content`) still pass (46/46)
- [x] Build succeeds (`pnpm run build`)
- [x] Type check passes (`tsc --noEmit`)

## PR Checklist

* [x] **All tests pass (`pytest`)** - RUN BEFORE CREATING PR
* [x] All new logic is covered by tests
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff ~1035 LOC (new subsystem — types, 3 publishers, registry, shared blocks, tests, docs)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the connector install/doctor CLI paths and introduces new filesystem writes under host-specific extension directories, which could affect local installs if paths/permissions are wrong, though failures are handled best-effort and covered by tests.
> 
> **Overview**
> Adds a new **memory extension publisher** subsystem to `@remnic/core`, including the `MemoryExtensionPublisher` contract, shared instruction blocks, and a host-keyed registry (`PUBLISHERS`, `publisherFor*`, `hostIdForConnector`) with Codex implemented and Claude Code/Hermes as safe no-op stubs.
> 
> Updates `remnic connectors install` to automatically publish the host’s memory extension after a successful install (best-effort, non-fatal on failure), and extends `remnic connectors doctor` to report publisher/extension presence for the requested connector’s host.
> 
> Adds architecture docs plus comprehensive tests covering registry lookup, Codex publish/unpublish behavior (including atomic write), stub behavior, and shared instruction content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e8c57cb31c99ffd4282b23983c0063e7d7b90d3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->