### PR TITLE
feat(enrichment): add external enrichment pipeline with importance-tiered spend

### DIFF
--- a/docs/architecture/enrichment-pipeline.md
+++ b/docs/architecture/enrichment-pipeline.md
@@ -1,0 +1,185 @@
+# External Enrichment Pipeline
+
+Issue #365 — Importance-tiered API spend for entity enrichment.
+
+## Overview
+
+The enrichment pipeline enables Remnic to enrich entity pages with
+information from external sources (web search, APIs, knowledge bases)
+while controlling cost through importance-based provider tiering.
+
+The pipeline is **opt-in and disabled by default**. When enabled, it
+evaluates each entity's importance level and selects which providers to
+run based on configurable thresholds. Critical entities may justify
+expensive API calls; low-importance entities skip enrichment entirely.
+
+## Architecture
+
+```
+Entity page
+  |
+  v
+Importance level  ->  Provider selection  ->  Provider execution
+  |                                               |
+  v                                               v
+  "critical" -> [web-search, gpt-enricher]   Candidates[]
+  "high"     -> [web-search]                     |
+  "normal"   -> [web-search]                     v
+  "low"      -> []                          Cap & tag
+  "trivial"  -> [] (always empty)                |
+                                                 v
+                                           EnrichmentResult
+                                           + Audit trail
+```
+
+### Key components
+
+| Module | Purpose |
+|--------|---------|
+| `enrichment/types.ts` | Interfaces for providers, candidates, config |
+| `enrichment/provider-registry.ts` | Central registry; resolves providers for importance tiers |
+| `enrichment/pipeline.ts` | Orchestrator: iterates entities, runs providers, rate-limits |
+| `enrichment/web-search-provider.ts` | Stub provider backed by an injected search function |
+| `enrichment/audit.ts` | Append-only JSONL audit log |
+
+## Configuration
+
+Add these to your Remnic config:
+
+```json
+{
+  "enrichmentEnabled": false,
+  "enrichmentAutoOnCreate": false,
+  "enrichmentMaxCandidatesPerEntity": 20
+}
+```
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `enrichmentEnabled` | boolean | `false` | Enable the enrichment pipeline |
+| `enrichmentAutoOnCreate` | boolean | `false` | Auto-enrich new entities on creation |
+| `enrichmentMaxCandidatesPerEntity` | integer | `20` | Max candidates accepted per entity per run |
+
+### Pipeline config (programmatic)
+
+When building a pipeline programmatically, use `defaultEnrichmentPipelineConfig()`
+and override fields as needed:
+
+```ts
+import {
+  defaultEnrichmentPipelineConfig,
+  EnrichmentProviderRegistry,
+  WebSearchProvider,
+  runEnrichmentPipeline,
+} from "@remnic/core";
+
+const config = defaultEnrichmentPipelineConfig();
+config.enabled = true;
+config.importanceThresholds.critical = ["web-search"];
+config.providers = [{ id: "web-search", enabled: true, costTier: "cheap" }];
+
+const registry = new EnrichmentProviderRegistry();
+registry.register(new WebSearchProvider({ searchFn: mySearchFn }));
+
+const results = await runEnrichmentPipeline(entities, registry, config, logger);
+```
+
+## Writing a Custom Provider
+
+Implement the `EnrichmentProvider` interface:
+
+```ts
+import type {
+  EnrichmentProvider,
+  EnrichmentCandidate,
+  EntityEnrichmentInput,
+  EnrichmentCostTier,
+} from "@remnic/core";
+
+export class MyProvider implements EnrichmentProvider {
+  readonly id = "my-provider";
+  readonly costTier: EnrichmentCostTier = "expensive";
+
+  async isAvailable(): Promise<boolean> {
+    // Check if API key is configured, service is reachable, etc.
+    return true;
+  }
+
+  async enrich(entity: EntityEnrichmentInput): Promise<EnrichmentCandidate[]> {
+    // Call your API, parse results, return candidates
+    return [
+      {
+        text: "Discovered fact about " + entity.name,
+        source: this.id,
+        sourceUrl: "https://api.example.com/...",
+        confidence: 0.85,
+        category: "fact",
+        tags: ["external", "my-provider"],
+      },
+    ];
+  }
+}
+```
+
+Then register it:
+
+```ts
+registry.register(new MyProvider());
+```
+
+And add it to the pipeline config providers list and importance thresholds.
+
+## Audit Trail
+
+Every enrichment candidate evaluation is recorded in an append-only
+JSONL file at `<memoryDir>/enrichment/enrichment-audit.jsonl`.
+
+Each line is a JSON object:
+
+```json
+{
+  "timestamp": "2026-04-16T10:00:00.000Z",
+  "entityName": "Acme Corp",
+  "provider": "web-search",
+  "candidateText": "Acme Corp founded in 2015",
+  "sourceUrl": "https://example.com",
+  "accepted": true,
+  "reason": null
+}
+```
+
+Read the audit log programmatically:
+
+```ts
+import { readAuditLog } from "@remnic/core";
+
+const entries = await readAuditLog(auditDir);
+const recent = await readAuditLog(auditDir, "2026-04-16T00:00:00Z");
+```
+
+## CLI Commands
+
+```
+remnic enrich <entity-name>    # Manually enrich a specific entity
+remnic enrich --all            # Enrich all entities
+remnic enrich --dry-run        # Preview what would be enriched
+remnic enrich audit            # Show recent enrichment audit log
+remnic enrich providers        # List registered providers and their status
+```
+
+## Rate Limiting
+
+Each provider config can specify rate limits:
+
+```json
+{
+  "id": "web-search",
+  "enabled": true,
+  "costTier": "cheap",
+  "rateLimit": { "maxPerMinute": 10, "maxPerDay": 500 }
+}
+```
+
+The pipeline tracks per-provider call counts per minute and per day.
+When a limit is reached, subsequent calls for that provider are skipped
+(not queued) and the result records zero candidates found.

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3517,6 +3517,22 @@
           "llmFollowups": true
         },
         "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
+      },
+      "enrichmentEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+      },
+      "enrichmentAutoOnCreate": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+      },
+      "enrichmentMaxCandidatesPerEntity": {
+        "type": "integer",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
       }
     }
   },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3500,6 +3500,22 @@
           "llmFollowups": true
         },
         "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
+      },
+      "enrichmentEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+      },
+      "enrichmentAutoOnCreate": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+      },
+      "enrichmentMaxCandidatesPerEntity": {
+        "type": "integer",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
       }
     }
   },

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -608,9 +608,24 @@ async function cmdEnrich(rest: string[]): Promise<void> {
     pipelineConfig.enabled = config.enrichmentEnabled;
     pipelineConfig.maxCandidatesPerEntity = config.enrichmentMaxCandidatesPerEntity;
     pipelineConfig.autoEnrichOnCreate = config.enrichmentAutoOnCreate;
+    // Populate the provider config list so listEnabled() can match registered providers
+    pipelineConfig.providers = [
+      { id: "web-search", enabled: true, costTier: "cheap" },
+    ];
+
+    // Wire the real search backend so isAvailable() reflects actual state
+    const orchestrator = new Orchestrator(config);
+    await orchestrator.initialize();
+    const searchBackend = orchestrator.qmd;
+    const searchFn = searchBackend.isAvailable()
+      ? async (query: string): Promise<string[]> => {
+          const results = await searchBackend.search(query, undefined, 10);
+          return results.map((r) => r.snippet);
+        }
+      : undefined;
 
     const registry = new EnrichmentProviderRegistry();
-    registry.register(new WebSearchProvider());
+    registry.register(new WebSearchProvider({ searchFn }));
 
     const allEnabled = registry.listEnabled(pipelineConfig);
     console.log(`Pipeline enabled: ${pipelineConfig.enabled}`);
@@ -679,8 +694,17 @@ async function cmdEnrich(rest: string[]): Promise<void> {
     low: [],
   };
 
+  // Wire the real search backend into the web-search provider (issue #425 P1)
+  const searchBackend = orchestrator.qmd;
+  const searchFn = searchBackend.isAvailable()
+    ? async (query: string): Promise<string[]> => {
+        const results = await searchBackend.search(query, undefined, 10);
+        return results.map((r) => r.snippet);
+      }
+    : undefined;
+
   const registry = new EnrichmentProviderRegistry();
-  registry.register(new WebSearchProvider());
+  registry.register(new WebSearchProvider({ searchFn }));
 
   // Map entity files to enrichment inputs
   const inputs = targets.map((ef) => ({
@@ -708,10 +732,68 @@ async function cmdEnrich(rest: string[]): Promise<void> {
     return;
   }
 
+  // Persist accepted candidates to storage (issue #425 P1).
+  // Gotcha #43: direct-write paths must trigger reindex.
+  const memoryDir = expandTilde(config.memoryDir);
+  const auditDir = path.join(memoryDir, "enrichment");
+  let totalPersisted = 0;
+  for (const result of results) {
+    for (const candidate of result.acceptedCandidates) {
+      try {
+        await storage.writeMemory(candidate.category, candidate.text, {
+          confidence: candidate.confidence,
+          tags: [...(candidate.tags ?? []), "enrichment", candidate.source],
+          entityRef: result.entityName,
+          source: `enrichment:${candidate.source}`,
+        });
+        totalPersisted++;
+        // Write audit entry for accepted candidate
+        await appendAuditEntry(auditDir, {
+          timestamp: new Date().toISOString(),
+          entityName: result.entityName,
+          provider: result.provider,
+          candidateText: candidate.text,
+          sourceUrl: candidate.sourceUrl,
+          accepted: true,
+        });
+      } catch (err) {
+        console.error(
+          `  Failed to persist candidate for ${result.entityName}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        // Audit rejected-due-to-error candidate
+        try {
+          await appendAuditEntry(auditDir, {
+            timestamp: new Date().toISOString(),
+            entityName: result.entityName,
+            provider: result.provider,
+            candidateText: candidate.text,
+            sourceUrl: candidate.sourceUrl,
+            accepted: false,
+            reason: `persist failed: ${err instanceof Error ? err.message : String(err)}`,
+          });
+        } catch {
+          // Audit write failure is non-fatal
+        }
+      }
+    }
+  }
+
+  // Trigger reindex after direct writes (gotcha #43)
+  if (totalPersisted > 0 && searchBackend.isAvailable()) {
+    try {
+      await searchBackend.update();
+    } catch {
+      // Reindex failure is non-fatal for CLI
+    }
+  }
+
   for (const result of results) {
     console.log(
       `  ${result.entityName} via ${result.provider}: ${result.candidatesAccepted} accepted, ${result.candidatesRejected} rejected (${result.elapsed}ms)`,
     );
+  }
+  if (totalPersisted > 0) {
+    console.log(`\n  ${totalPersisted} candidate(s) persisted to memory store.`);
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -97,6 +97,12 @@ import {
   writeMarketplaceManifest,
   installFromMarketplace,
   type MarketplaceInstallType,
+  EnrichmentProviderRegistry,
+  WebSearchProvider,
+  runEnrichmentPipeline,
+  appendAuditEntry,
+  readAuditLog,
+  defaultEnrichmentPipelineConfig,
 } from "@remnic/core";
 import type {
   BinaryLifecycleConfig,
@@ -140,6 +146,7 @@ type CommandName =
   | "briefing"
   | "binary"
   | "taxonomy"
+  | "enrich"
   | "openclaw";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
@@ -558,6 +565,144 @@ Options:
   --json    Output in JSON format
 `);
       break;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// enrich command (issue #365)
+// ---------------------------------------------------------------------------
+
+async function cmdEnrich(rest: string[]): Promise<void> {
+  initLogger();
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const config = parseConfig(remnicCfg);
+
+  const subcommand = rest[0];
+
+  // Sub-commands that don't need an entity name
+  if (subcommand === "audit") {
+    const memoryDir = expandTilde(config.memoryDir);
+    const auditDir = path.join(memoryDir, "enrichment");
+    const sinceFlag = resolveFlag(rest.slice(1), "--since");
+    const entries = await readAuditLog(auditDir, sinceFlag ?? undefined);
+    if (entries.length === 0) {
+      console.log("No enrichment audit entries found.");
+      return;
+    }
+    for (const entry of entries) {
+      const status = entry.accepted ? "ACCEPTED" : "REJECTED";
+      const url = entry.sourceUrl ? ` (${entry.sourceUrl})` : "";
+      console.log(
+        `[${entry.timestamp}] ${status} ${entry.entityName} via ${entry.provider}: ${entry.candidateText}${url}`,
+      );
+    }
+    return;
+  }
+
+  if (subcommand === "providers") {
+    const pipelineConfig = defaultEnrichmentPipelineConfig();
+    pipelineConfig.enabled = config.enrichmentEnabled;
+    pipelineConfig.maxCandidatesPerEntity = config.enrichmentMaxCandidatesPerEntity;
+    pipelineConfig.autoEnrichOnCreate = config.enrichmentAutoOnCreate;
+
+    const registry = new EnrichmentProviderRegistry();
+    registry.register(new WebSearchProvider());
+
+    const allEnabled = registry.listEnabled(pipelineConfig);
+    console.log(`Pipeline enabled: ${pipelineConfig.enabled}`);
+    console.log(`Auto-enrich on create: ${pipelineConfig.autoEnrichOnCreate}`);
+    console.log(`Max candidates per entity: ${pipelineConfig.maxCandidatesPerEntity}`);
+    console.log(`\nRegistered providers:`);
+
+    const webSearch = registry.get("web-search");
+    if (webSearch) {
+      const available = await webSearch.isAvailable();
+      console.log(`  - web-search (${webSearch.costTier}) — ${available ? "available" : "unavailable (no searchFn configured)"}`);
+    }
+    if (allEnabled.length === 0) {
+      console.log("\n  No providers are currently enabled in config.");
+    }
+    return;
+  }
+
+  if (!config.enrichmentEnabled) {
+    console.error("Enrichment pipeline is disabled (enrichmentEnabled = false).");
+    process.exit(1);
+  }
+
+  const dryRun = rest.includes("--dry-run");
+  const all = rest.includes("--all");
+
+  if (!all && (!subcommand || subcommand.startsWith("--"))) {
+    console.error("Usage: remnic enrich <entity-name> | --all | --dry-run | audit | providers");
+    process.exit(1);
+  }
+
+  const orchestrator = new Orchestrator(config);
+  await orchestrator.initialize();
+  const storage = await orchestrator.getStorage(config.defaultNamespace);
+
+  // Gather entities to enrich
+  const entityFiles = await storage.listEntities();
+  let targets = entityFiles;
+  if (!all && subcommand && !subcommand.startsWith("--")) {
+    const match = entityFiles.find(
+      (e) => e.name.toLowerCase() === subcommand.toLowerCase(),
+    );
+    if (!match) {
+      console.error(`Entity not found: ${subcommand}`);
+      process.exit(1);
+    }
+    targets = [match];
+  }
+
+  if (targets.length === 0) {
+    console.log("No entities to enrich.");
+    return;
+  }
+
+  // Build pipeline config and registry
+  const pipelineConfig = defaultEnrichmentPipelineConfig();
+  pipelineConfig.enabled = true;
+  pipelineConfig.maxCandidatesPerEntity = config.enrichmentMaxCandidatesPerEntity;
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(new WebSearchProvider());
+
+  // Map entity files to enrichment inputs
+  const inputs = targets.map((ef) => ({
+    name: ef.name,
+    type: ef.type,
+    knownFacts: ef.facts,
+    importanceLevel: "normal" as const,
+  }));
+
+  if (dryRun) {
+    console.log(`Dry run: would enrich ${inputs.length} entity(ies):`);
+    for (const input of inputs) {
+      const providers = registry.getForImportance(input.importanceLevel, pipelineConfig);
+      console.log(`  - ${input.name} (${input.type}) — ${providers.length} provider(s)`);
+    }
+    return;
+  }
+
+  console.log(`Enriching ${inputs.length} entity(ies)...`);
+  const noopLog = { info() {}, warn() {}, error() {}, debug() {} };
+  const results = await runEnrichmentPipeline(inputs, registry, pipelineConfig, noopLog);
+
+  if (results.length === 0) {
+    console.log("No enrichment results (no providers matched).");
+    return;
+  }
+
+  for (const result of results) {
+    console.log(
+      `  ${result.entityName} via ${result.provider}: ${result.candidatesAccepted} accepted, ${result.candidatesRejected} rejected (${result.elapsed}ms)`,
+    );
   }
 }
 
@@ -2883,6 +3028,11 @@ Options:
       break;
     }
 
+    case "enrich": {
+      await cmdEnrich(rest);
+      break;
+    }
+
     case "openclaw": {
       const subAction = rest[0] ?? "help";
       if (subAction === "install") {
@@ -2955,6 +3105,11 @@ Usage:
     add <id> <name> [--priority N]    Add custom category
     remove <id>                       Remove custom category
     resolve <text> [--category <cat>] Test resolver on sample text
+  remnic enrich <entity-name>    Manually enrich a specific entity
+  remnic enrich --all            Enrich all entities
+  remnic enrich --dry-run        Preview what would be enriched
+  remnic enrich audit            Show recent enrichment audit log
+  remnic enrich providers        List registered providers and their status
 
 Options:
   --json    Output in JSON format

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -647,7 +647,7 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   const storage = await orchestrator.getStorage(config.defaultNamespace);
 
   // Gather entities to enrich
-  const entityFiles = await storage.listEntities();
+  const entityFiles = await storage.readAllEntityFiles();
   let targets = entityFiles;
   if (!all && subcommand && !subcommand.startsWith("--")) {
     const match = entityFiles.find(
@@ -669,6 +669,15 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   const pipelineConfig = defaultEnrichmentPipelineConfig();
   pipelineConfig.enabled = true;
   pipelineConfig.maxCandidatesPerEntity = config.enrichmentMaxCandidatesPerEntity;
+  pipelineConfig.providers = [
+    { id: "web-search", enabled: true, costTier: "cheap" },
+  ];
+  pipelineConfig.importanceThresholds = {
+    critical: ["web-search"],
+    high: ["web-search"],
+    normal: ["web-search"],
+    low: [],
+  };
 
   const registry = new EnrichmentProviderRegistry();
   registry.register(new WebSearchProvider());

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1984,6 +1984,14 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Codex citation parity (issue #379)
     citationsEnabled: cfg.citationsEnabled === true,
     citationsAutoDetect: cfg.citationsAutoDetect !== false,
+
+    // External enrichment pipeline (issue #365)
+    enrichmentEnabled: cfg.enrichmentEnabled === true,
+    enrichmentAutoOnCreate: cfg.enrichmentAutoOnCreate === true,
+    enrichmentMaxCandidatesPerEntity:
+      typeof cfg.enrichmentMaxCandidatesPerEntity === "number"
+        ? Math.max(0, Math.floor(cfg.enrichmentMaxCandidatesPerEntity))
+        : 20,
   };
 }
 

--- a/packages/remnic-core/src/enrichment/audit.ts
+++ b/packages/remnic-core/src/enrichment/audit.ts
@@ -1,0 +1,89 @@
+/**
+ * Enrichment audit trail (issue #365).
+ *
+ * Append-only JSONL log for every enrichment candidate that was evaluated.
+ * Each entry records whether the candidate was accepted or rejected, the
+ * provider that produced it, and an optional reason string.
+ */
+
+import { mkdir, readFile, appendFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import path from "node:path";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EnrichmentAuditEntry {
+  timestamp: string;
+  entityName: string;
+  provider: string;
+  candidateText: string;
+  sourceUrl?: string;
+  accepted: boolean;
+  reason?: string;
+}
+
+// ---------------------------------------------------------------------------
+// File helpers
+// ---------------------------------------------------------------------------
+
+const AUDIT_FILENAME = "enrichment-audit.jsonl";
+
+function auditFilePath(auditDir: string): string {
+  return path.join(auditDir, AUDIT_FILENAME);
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Append a single audit entry to the JSONL log. Creates the audit directory
+ * and file if they do not exist.
+ */
+export async function appendAuditEntry(
+  auditDir: string,
+  entry: EnrichmentAuditEntry,
+): Promise<void> {
+  await mkdir(auditDir, { recursive: true });
+  const line = JSON.stringify(entry) + "\n";
+  await appendFile(auditFilePath(auditDir), line, "utf-8");
+}
+
+/**
+ * Read the audit log and return entries, optionally filtered to entries at
+ * or after `since` (ISO 8601 timestamp, half-open interval).
+ */
+export async function readAuditLog(
+  auditDir: string,
+  since?: string,
+): Promise<EnrichmentAuditEntry[]> {
+  const filePath = auditFilePath(auditDir);
+  if (!existsSync(filePath)) return [];
+
+  const raw = await readFile(filePath, "utf-8");
+  const entries: EnrichmentAuditEntry[] = [];
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.length === 0) continue;
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "timestamp" in parsed &&
+        "entityName" in parsed
+      ) {
+        const entry = parsed as EnrichmentAuditEntry;
+        if (since && entry.timestamp < since) continue;
+        entries.push(entry);
+      }
+    } catch {
+      // Skip malformed lines
+    }
+  }
+
+  return entries;
+}

--- a/packages/remnic-core/src/enrichment/index.ts
+++ b/packages/remnic-core/src/enrichment/index.ts
@@ -1,0 +1,27 @@
+/**
+ * Enrichment pipeline barrel export (issue #365).
+ */
+
+export type {
+  EnrichmentCandidate,
+  EnrichmentCostTier,
+  EnrichmentPipelineConfig,
+  EnrichmentProvider,
+  EnrichmentProviderConfig,
+  EnrichmentResult,
+  EntityEnrichmentInput,
+} from "./types.js";
+
+export { defaultEnrichmentPipelineConfig } from "./types.js";
+
+export { EnrichmentProviderRegistry } from "./provider-registry.js";
+
+export { WebSearchProvider, type WebSearchFn, type WebSearchProviderOptions } from "./web-search-provider.js";
+
+export { runEnrichmentPipeline } from "./pipeline.js";
+
+export {
+  appendAuditEntry,
+  readAuditLog,
+  type EnrichmentAuditEntry,
+} from "./audit.js";

--- a/packages/remnic-core/src/enrichment/pipeline.ts
+++ b/packages/remnic-core/src/enrichment/pipeline.ts
@@ -1,0 +1,183 @@
+/**
+ * Enrichment pipeline orchestrator (issue #365).
+ *
+ * For each entity, determines the importance tier, resolves the providers
+ * to run, executes them in sequence (respecting rate limits), tags
+ * candidates, and caps at `maxCandidatesPerEntity`.
+ *
+ * Actual persistence of accepted candidates is the caller's responsibility.
+ */
+
+import type { LoggerBackend } from "../logger.js";
+import type { EnrichmentProviderRegistry } from "./provider-registry.js";
+import type {
+  EnrichmentCandidate,
+  EnrichmentPipelineConfig,
+  EnrichmentProvider,
+  EnrichmentResult,
+  EntityEnrichmentInput,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Rate-limit tracking
+// ---------------------------------------------------------------------------
+
+interface RateLimitBucket {
+  minuteCount: number;
+  minuteReset: number;
+  dayCount: number;
+  dayReset: number;
+}
+
+function isRateLimited(
+  provider: EnrichmentProvider,
+  config: EnrichmentPipelineConfig,
+  buckets: Map<string, RateLimitBucket>,
+): boolean {
+  const providerCfg = config.providers.find((p) => p.id === provider.id);
+  if (!providerCfg?.rateLimit) return false;
+
+  const now = Date.now();
+  let bucket = buckets.get(provider.id);
+  if (!bucket) {
+    bucket = {
+      minuteCount: 0,
+      minuteReset: now + 60_000,
+      dayCount: 0,
+      dayReset: now + 86_400_000,
+    };
+    buckets.set(provider.id, bucket);
+  }
+
+  // Reset windows if expired
+  if (now >= bucket.minuteReset) {
+    bucket.minuteCount = 0;
+    bucket.minuteReset = now + 60_000;
+  }
+  if (now >= bucket.dayReset) {
+    bucket.dayCount = 0;
+    bucket.dayReset = now + 86_400_000;
+  }
+
+  const { maxPerMinute, maxPerDay } = providerCfg.rateLimit;
+  return bucket.minuteCount >= maxPerMinute || bucket.dayCount >= maxPerDay;
+}
+
+function recordCall(
+  providerId: string,
+  buckets: Map<string, RateLimitBucket>,
+): void {
+  const bucket = buckets.get(providerId);
+  if (bucket) {
+    bucket.minuteCount += 1;
+    bucket.dayCount += 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline
+// ---------------------------------------------------------------------------
+
+export async function runEnrichmentPipeline(
+  entities: EntityEnrichmentInput[],
+  registry: EnrichmentProviderRegistry,
+  config: EnrichmentPipelineConfig,
+  log: LoggerBackend,
+): Promise<EnrichmentResult[]> {
+  if (!config.enabled) return [];
+  if (entities.length === 0) return [];
+
+  const rateBuckets = new Map<string, RateLimitBucket>();
+  const results: EnrichmentResult[] = [];
+
+  for (const entity of entities) {
+    const providers = registry.getForImportance(entity.importanceLevel, config);
+
+    for (const provider of providers) {
+      const start = Date.now();
+
+      // Check availability
+      let available: boolean;
+      try {
+        available = await provider.isAvailable();
+      } catch {
+        available = false;
+      }
+
+      if (!available) {
+        log.debug?.(
+          `enrichment: skipping provider ${provider.id} for ${entity.name} — unavailable`,
+        );
+        results.push({
+          entityName: entity.name,
+          provider: provider.id,
+          candidatesFound: 0,
+          candidatesAccepted: 0,
+          candidatesRejected: 0,
+          elapsed: Date.now() - start,
+        });
+        continue;
+      }
+
+      // Check rate limit
+      if (isRateLimited(provider, config, rateBuckets)) {
+        log.debug?.(
+          `enrichment: skipping provider ${provider.id} for ${entity.name} — rate limited`,
+        );
+        results.push({
+          entityName: entity.name,
+          provider: provider.id,
+          candidatesFound: 0,
+          candidatesAccepted: 0,
+          candidatesRejected: 0,
+          elapsed: Date.now() - start,
+        });
+        continue;
+      }
+
+      // Run provider
+      let candidates: EnrichmentCandidate[];
+      try {
+        candidates = await provider.enrich(entity);
+        recordCall(provider.id, rateBuckets);
+      } catch (err) {
+        log.error?.(
+          `enrichment: provider ${provider.id} failed for ${entity.name}: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        results.push({
+          entityName: entity.name,
+          provider: provider.id,
+          candidatesFound: 0,
+          candidatesAccepted: 0,
+          candidatesRejected: 0,
+          elapsed: Date.now() - start,
+        });
+        continue;
+      }
+
+      // Tag each candidate with provider id
+      for (const candidate of candidates) {
+        candidate.source = provider.id;
+      }
+
+      // Cap at maxCandidatesPerEntity
+      const maxCandidates = config.maxCandidatesPerEntity;
+      const accepted =
+        maxCandidates > 0 && candidates.length > maxCandidates
+          ? candidates.slice(0, maxCandidates)
+          : candidates;
+      const rejected = candidates.length - accepted.length;
+
+      results.push({
+        entityName: entity.name,
+        provider: provider.id,
+        candidatesFound: candidates.length,
+        candidatesAccepted: accepted.length,
+        candidatesRejected: rejected,
+        elapsed: Date.now() - start,
+      });
+    }
+  }
+
+  return results;
+}

--- a/packages/remnic-core/src/enrichment/pipeline.ts
+++ b/packages/remnic-core/src/enrichment/pipeline.ts
@@ -5,7 +5,8 @@
  * to run, executes them in sequence (respecting rate limits), tags
  * candidates, and caps at `maxCandidatesPerEntity`.
  *
- * Actual persistence of accepted candidates is the caller's responsibility.
+ * Accepted candidates are returned in each `EnrichmentResult` via the
+ * `acceptedCandidates` field so that callers can persist them.
  */
 
 import type { LoggerBackend } from "../logger.js";
@@ -114,6 +115,7 @@ export async function runEnrichmentPipeline(
           candidatesFound: 0,
           candidatesAccepted: 0,
           candidatesRejected: 0,
+          acceptedCandidates: [],
           elapsed: Date.now() - start,
         });
         continue;
@@ -130,6 +132,7 @@ export async function runEnrichmentPipeline(
           candidatesFound: 0,
           candidatesAccepted: 0,
           candidatesRejected: 0,
+          acceptedCandidates: [],
           elapsed: Date.now() - start,
         });
         continue;
@@ -150,6 +153,7 @@ export async function runEnrichmentPipeline(
           candidatesFound: 0,
           candidatesAccepted: 0,
           candidatesRejected: 0,
+          acceptedCandidates: [],
           elapsed: Date.now() - start,
         });
         continue;
@@ -179,6 +183,7 @@ export async function runEnrichmentPipeline(
         candidatesFound: candidates.length,
         candidatesAccepted: accepted.length,
         candidatesRejected: rejected,
+        acceptedCandidates: accepted,
         elapsed: Date.now() - start,
       });
     }

--- a/packages/remnic-core/src/enrichment/pipeline.ts
+++ b/packages/remnic-core/src/enrichment/pipeline.ts
@@ -160,12 +160,17 @@ export async function runEnrichmentPipeline(
         candidate.source = provider.id;
       }
 
-      // Cap at maxCandidatesPerEntity
+      // Cap at maxCandidatesPerEntity.
+      // 0 means "accept none"; undefined/negative means "no cap".
       const maxCandidates = config.maxCandidatesPerEntity;
-      const accepted =
-        maxCandidates > 0 && candidates.length > maxCandidates
-          ? candidates.slice(0, maxCandidates)
-          : candidates;
+      let accepted: EnrichmentCandidate[];
+      if (maxCandidates === 0) {
+        accepted = [];
+      } else if (maxCandidates > 0 && candidates.length > maxCandidates) {
+        accepted = candidates.slice(0, maxCandidates);
+      } else {
+        accepted = candidates;
+      }
       const rejected = candidates.length - accepted.length;
 
       results.push({

--- a/packages/remnic-core/src/enrichment/provider-registry.ts
+++ b/packages/remnic-core/src/enrichment/provider-registry.ts
@@ -1,0 +1,85 @@
+/**
+ * Enrichment provider registry (issue #365).
+ *
+ * Central registry for enrichment providers. Providers register themselves
+ * at startup; the pipeline queries the registry to determine which providers
+ * to run for a given importance tier.
+ */
+
+import type { ImportanceLevel } from "../types.js";
+import type {
+  EnrichmentPipelineConfig,
+  EnrichmentProvider,
+} from "./types.js";
+
+export class EnrichmentProviderRegistry {
+  private readonly providers = new Map<string, EnrichmentProvider>();
+
+  /** Register a provider. Overwrites any existing provider with the same id. */
+  register(provider: EnrichmentProvider): void {
+    this.providers.set(provider.id, provider);
+  }
+
+  /** Look up a single provider by id. */
+  get(id: string): EnrichmentProvider | undefined {
+    return this.providers.get(id);
+  }
+
+  /**
+   * Return all registered providers whose id appears in the config's
+   * `providers` list with `enabled: true`.
+   */
+  listEnabled(config: EnrichmentPipelineConfig): EnrichmentProvider[] {
+    const enabledIds = new Set(
+      config.providers
+        .filter((p) => p.enabled)
+        .map((p) => p.id),
+    );
+    const result: EnrichmentProvider[] = [];
+    for (const [id, provider] of this.providers.entries()) {
+      if (enabledIds.has(id)) {
+        result.push(provider);
+      }
+    }
+    return result;
+  }
+
+  /**
+   * Return providers that should run for a given importance level.
+   * Providers are resolved from `config.importanceThresholds[level]` and
+   * filtered to only those that are both registered and enabled.
+   */
+  getForImportance(
+    level: ImportanceLevel,
+    config: EnrichmentPipelineConfig,
+  ): EnrichmentProvider[] {
+    // "trivial" entities never get enrichment providers
+    if (level === "trivial") return [];
+
+    const thresholds = config.importanceThresholds;
+    const providerIds: string[] =
+      level === "critical"
+        ? thresholds.critical
+        : level === "high"
+          ? thresholds.high
+          : level === "normal"
+            ? thresholds.normal
+            : thresholds.low;
+
+    const enabledIds = new Set(
+      config.providers
+        .filter((p) => p.enabled)
+        .map((p) => p.id),
+    );
+
+    const result: EnrichmentProvider[] = [];
+    for (const id of providerIds) {
+      if (!enabledIds.has(id)) continue;
+      const provider = this.providers.get(id);
+      if (provider) {
+        result.push(provider);
+      }
+    }
+    return result;
+  }
+}

--- a/packages/remnic-core/src/enrichment/types.ts
+++ b/packages/remnic-core/src/enrichment/types.ts
@@ -1,0 +1,99 @@
+/**
+ * Enrichment pipeline types (issue #365).
+ *
+ * Defines the provider interface, candidate shape, pipeline config,
+ * and result types for the external enrichment subsystem.
+ */
+
+import type { ImportanceLevel, MemoryCategory } from "../types.js";
+
+// ---------------------------------------------------------------------------
+// Provider config & interface
+// ---------------------------------------------------------------------------
+
+export type EnrichmentCostTier = "free" | "cheap" | "expensive";
+
+export interface EnrichmentProviderConfig {
+  id: string;
+  enabled: boolean;
+  costTier: EnrichmentCostTier;
+  rateLimit?: { maxPerMinute: number; maxPerDay: number };
+}
+
+export interface EnrichmentCandidate {
+  text: string;
+  source: string;
+  sourceUrl?: string;
+  confidence: number;
+  category: MemoryCategory;
+  tags?: string[];
+}
+
+export interface EnrichmentProvider {
+  readonly id: string;
+  readonly costTier: EnrichmentCostTier;
+  enrich(entity: EntityEnrichmentInput): Promise<EnrichmentCandidate[]>;
+  isAvailable(): Promise<boolean>;
+}
+
+// ---------------------------------------------------------------------------
+// Entity enrichment input
+// ---------------------------------------------------------------------------
+
+export interface EntityEnrichmentInput {
+  name: string;
+  type: string;
+  knownFacts: string[];
+  importanceLevel: ImportanceLevel;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline result
+// ---------------------------------------------------------------------------
+
+export interface EnrichmentResult {
+  entityName: string;
+  provider: string;
+  candidatesFound: number;
+  candidatesAccepted: number;
+  candidatesRejected: number;
+  elapsed: number;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline config
+// ---------------------------------------------------------------------------
+
+export interface EnrichmentPipelineConfig {
+  enabled: boolean;
+  providers: EnrichmentProviderConfig[];
+  importanceThresholds: {
+    critical: string[];
+    high: string[];
+    normal: string[];
+    low: string[];
+  };
+  maxCandidatesPerEntity: number;
+  autoEnrichOnCreate: boolean;
+  scheduleIntervalMs: number;
+}
+
+/**
+ * Build a default (disabled) pipeline config. Every consumer that needs a
+ * config object should call this rather than duplicating the defaults.
+ */
+export function defaultEnrichmentPipelineConfig(): EnrichmentPipelineConfig {
+  return {
+    enabled: false,
+    providers: [],
+    importanceThresholds: {
+      critical: [],
+      high: [],
+      normal: [],
+      low: [],
+    },
+    maxCandidatesPerEntity: 20,
+    autoEnrichOnCreate: false,
+    scheduleIntervalMs: 3_600_000,
+  };
+}

--- a/packages/remnic-core/src/enrichment/types.ts
+++ b/packages/remnic-core/src/enrichment/types.ts
@@ -57,6 +57,7 @@ export interface EnrichmentResult {
   candidatesFound: number;
   candidatesAccepted: number;
   candidatesRejected: number;
+  acceptedCandidates: EnrichmentCandidate[];
   elapsed: number;
 }
 

--- a/packages/remnic-core/src/enrichment/web-search-provider.ts
+++ b/packages/remnic-core/src/enrichment/web-search-provider.ts
@@ -1,0 +1,63 @@
+/**
+ * Web search enrichment provider stub (issue #365).
+ *
+ * A basic provider backed by web search. Since this is opt-in and we do not
+ * want to hard-code an API key, the provider accepts an optional `searchFn`
+ * injection point. When no search function is configured it returns empty
+ * results, making it safe to register unconditionally.
+ */
+
+import type {
+  EnrichmentCandidate,
+  EnrichmentCostTier,
+  EnrichmentProvider,
+  EntityEnrichmentInput,
+} from "./types.js";
+
+export type WebSearchFn = (query: string) => Promise<string[]>;
+
+export interface WebSearchProviderOptions {
+  /**
+   * Injected search function. Each returned string is treated as a raw
+   * snippet. When `undefined` the provider returns empty results.
+   */
+  searchFn?: WebSearchFn;
+}
+
+export class WebSearchProvider implements EnrichmentProvider {
+  readonly id = "web-search";
+  readonly costTier: EnrichmentCostTier = "cheap";
+
+  private readonly searchFn: WebSearchFn | undefined;
+
+  constructor(options: WebSearchProviderOptions = {}) {
+    this.searchFn = options.searchFn;
+  }
+
+  async isAvailable(): Promise<boolean> {
+    return this.searchFn !== undefined;
+  }
+
+  async enrich(entity: EntityEnrichmentInput): Promise<EnrichmentCandidate[]> {
+    if (!this.searchFn) return [];
+
+    const query = `${entity.name} ${entity.type}`;
+    let snippets: string[];
+    try {
+      snippets = await this.searchFn(query);
+    } catch {
+      return [];
+    }
+
+    return snippets
+      .filter((s) => typeof s === "string" && s.trim().length > 0)
+      .map((snippet) => ({
+        text: snippet.trim(),
+        source: this.id,
+        sourceUrl: undefined,
+        confidence: 0.5,
+        category: "fact" as const,
+        tags: ["web-search"],
+      }));
+  }
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -484,6 +484,29 @@ export {
 } from "./taxonomy/index.js";
 
 // ---------------------------------------------------------------------------
+// Enrichment pipeline (issue #365)
+// ---------------------------------------------------------------------------
+
+export {
+  EnrichmentProviderRegistry,
+  WebSearchProvider,
+  runEnrichmentPipeline,
+  appendAuditEntry,
+  readAuditLog,
+  defaultEnrichmentPipelineConfig,
+  type EnrichmentCandidate,
+  type EnrichmentCostTier,
+  type EnrichmentPipelineConfig,
+  type EnrichmentProvider,
+  type EnrichmentProviderConfig,
+  type EnrichmentResult,
+  type EntityEnrichmentInput,
+  type EnrichmentAuditEntry,
+  type WebSearchFn,
+  type WebSearchProviderOptions,
+} from "./enrichment/index.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -950,6 +950,14 @@ export interface PluginConfig {
   citationsEnabled: boolean;
   /** Auto-enable citations when the Codex adapter is detected. Default true. */
   citationsAutoDetect: boolean;
+
+  // External enrichment pipeline (issue #365)
+  /** Enable the external enrichment pipeline. Default false. */
+  enrichmentEnabled: boolean;
+  /** Automatically enrich new entities on creation. Default false. */
+  enrichmentAutoOnCreate: boolean;
+  /** Max candidates accepted per entity per enrichment run. Default 20. */
+  enrichmentMaxCandidatesPerEntity: number;
 }
 
 /** Runtime configuration for the daily context briefing feature. */

--- a/src/enrichment.ts
+++ b/src/enrichment.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/enrichment/index.js";

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -205,6 +205,11 @@ test("Pipeline: mock provider returns candidates and pipeline processes them", a
   assert.equal(results[0].candidatesAccepted, 2);
   assert.equal(results[0].candidatesRejected, 0);
   assert.ok(results[0].elapsed >= 0);
+
+  // acceptedCandidates must contain the actual candidate objects (issue #425 P1)
+  assert.equal(results[0].acceptedCandidates.length, 2);
+  assert.equal(results[0].acceptedCandidates[0].text, "Entity was founded in 2020");
+  assert.equal(results[0].acceptedCandidates[1].text, "Entity has 50 employees");
 });
 
 test("Pipeline: rate limiting prevents calls beyond limit", async () => {
@@ -275,6 +280,11 @@ test("Pipeline: max candidates trims excess", async () => {
   assert.equal(results[0].candidatesFound, 30);
   assert.equal(results[0].candidatesAccepted, 10);
   assert.equal(results[0].candidatesRejected, 20);
+
+  // acceptedCandidates length must match accepted count
+  assert.equal(results[0].acceptedCandidates.length, 10);
+  assert.equal(results[0].acceptedCandidates[0].text, "Fact 0");
+  assert.equal(results[0].acceptedCandidates[9].text, "Fact 9");
 });
 
 test("Pipeline: maxCandidatesPerEntity = 0 rejects all candidates", async () => {
@@ -295,6 +305,7 @@ test("Pipeline: maxCandidatesPerEntity = 0 rejects all candidates", async () => 
   assert.equal(results[0].candidatesFound, 5);
   assert.equal(results[0].candidatesAccepted, 0);
   assert.equal(results[0].candidatesRejected, 5);
+  assert.equal(results[0].acceptedCandidates.length, 0);
 });
 
 test("Pipeline: disabled config returns empty results", async () => {
@@ -315,6 +326,7 @@ test("Pipeline: provider unavailable is gracefully skipped", async () => {
   assert.equal(results.length, 1);
   assert.equal(results[0].candidatesFound, 0);
   assert.equal(results[0].candidatesAccepted, 0);
+  assert.equal(results[0].acceptedCandidates.length, 0);
 });
 
 test("Pipeline: empty entities list returns empty results", async () => {
@@ -497,4 +509,5 @@ test("Pipeline: provider that throws is gracefully skipped", async () => {
   assert.equal(results.length, 1);
   assert.equal(results[0].candidatesFound, 0);
   assert.equal(results[0].candidatesAccepted, 0);
+  assert.equal(results[0].acceptedCandidates.length, 0);
 });

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -277,6 +277,26 @@ test("Pipeline: max candidates trims excess", async () => {
   assert.equal(results[0].candidatesRejected, 20);
 });
 
+test("Pipeline: maxCandidatesPerEntity = 0 rejects all candidates", async () => {
+  const candidates: EnrichmentCandidate[] = Array.from({ length: 5 }, (_, i) => ({
+    text: `Fact ${i}`,
+    source: "mock",
+    confidence: 0.5,
+    category: "fact" as const,
+  }));
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock", "cheap", candidates));
+
+  const config = enabledConfig({ maxCandidatesPerEntity: 0 });
+  const entity = makeEntity();
+
+  const results = await runEnrichmentPipeline([entity], registry, config, NOOP_LOG);
+  assert.equal(results[0].candidatesFound, 5);
+  assert.equal(results[0].candidatesAccepted, 0);
+  assert.equal(results[0].candidatesRejected, 5);
+});
+
 test("Pipeline: disabled config returns empty results", async () => {
   const registry = new EnrichmentProviderRegistry();
   registry.register(makeMockProvider("mock"));

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -1,0 +1,480 @@
+/**
+ * Enrichment pipeline tests (issue #365).
+ *
+ * Covers: registry, importance tiering, pipeline orchestration, rate limiting,
+ * audit trail, max candidates, disabled config, provider unavailability,
+ * empty entity lists, and tag/sourceUrl preservation.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import {
+  EnrichmentProviderRegistry,
+  WebSearchProvider,
+  runEnrichmentPipeline,
+  appendAuditEntry,
+  readAuditLog,
+  defaultEnrichmentPipelineConfig,
+} from "../src/enrichment.js";
+import type {
+  EnrichmentCandidate,
+  EnrichmentPipelineConfig,
+  EnrichmentProvider,
+  EntityEnrichmentInput,
+} from "../src/enrichment.js";
+import type { ImportanceLevel } from "../src/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const NOOP_LOG = {
+  info() {},
+  warn() {},
+  error() {},
+  debug() {},
+};
+
+function makeEntity(overrides: Partial<EntityEnrichmentInput> = {}): EntityEnrichmentInput {
+  return {
+    name: overrides.name ?? "TestEntity",
+    type: overrides.type ?? "project",
+    knownFacts: overrides.knownFacts ?? ["fact-1"],
+    importanceLevel: overrides.importanceLevel ?? "normal",
+  };
+}
+
+/** A mock provider that returns a fixed list of candidates. */
+function makeMockProvider(
+  id: string,
+  costTier: "free" | "cheap" | "expensive" = "cheap",
+  candidates: EnrichmentCandidate[] = [],
+  available = true,
+): EnrichmentProvider {
+  return {
+    id,
+    costTier,
+    async enrich() {
+      return candidates;
+    },
+    async isAvailable() {
+      return available;
+    },
+  };
+}
+
+function enabledConfig(
+  overrides: Partial<EnrichmentPipelineConfig> = {},
+): EnrichmentPipelineConfig {
+  return {
+    ...defaultEnrichmentPipelineConfig(),
+    enabled: true,
+    providers: [{ id: "mock", enabled: true, costTier: "cheap" }],
+    importanceThresholds: {
+      critical: ["mock"],
+      high: ["mock"],
+      normal: ["mock"],
+      low: [],
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Registry tests
+// ---------------------------------------------------------------------------
+
+test("Registry: register and get provider", () => {
+  const registry = new EnrichmentProviderRegistry();
+  const provider = makeMockProvider("alpha");
+  registry.register(provider);
+
+  assert.equal(registry.get("alpha"), provider);
+  assert.equal(registry.get("nonexistent"), undefined);
+});
+
+test("Registry: listEnabled filters to enabled providers", () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("a"));
+  registry.register(makeMockProvider("b"));
+  registry.register(makeMockProvider("c"));
+
+  const config = enabledConfig({
+    providers: [
+      { id: "a", enabled: true, costTier: "free" },
+      { id: "b", enabled: false, costTier: "cheap" },
+      { id: "c", enabled: true, costTier: "expensive" },
+    ],
+  });
+
+  const enabled = registry.listEnabled(config);
+  const ids = enabled.map((p) => p.id).sort();
+  assert.deepEqual(ids, ["a", "c"]);
+});
+
+// ---------------------------------------------------------------------------
+// Importance tiering tests
+// ---------------------------------------------------------------------------
+
+test("Importance tiering: critical entities get expensive providers", () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("cheap-provider", "cheap"));
+  registry.register(makeMockProvider("expensive-provider", "expensive"));
+
+  const config = enabledConfig({
+    providers: [
+      { id: "cheap-provider", enabled: true, costTier: "cheap" },
+      { id: "expensive-provider", enabled: true, costTier: "expensive" },
+    ],
+    importanceThresholds: {
+      critical: ["cheap-provider", "expensive-provider"],
+      high: ["cheap-provider"],
+      normal: ["cheap-provider"],
+      low: [],
+    },
+  });
+
+  const criticalProviders = registry.getForImportance("critical", config);
+  assert.equal(criticalProviders.length, 2);
+  assert.ok(criticalProviders.some((p) => p.id === "expensive-provider"));
+
+  const highProviders = registry.getForImportance("high", config);
+  assert.equal(highProviders.length, 1);
+  assert.equal(highProviders[0].id, "cheap-provider");
+});
+
+test("Importance tiering: low entities get no providers when low is empty", () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock"));
+
+  const config = enabledConfig({
+    importanceThresholds: {
+      critical: ["mock"],
+      high: ["mock"],
+      normal: ["mock"],
+      low: [],
+    },
+  });
+
+  const providers = registry.getForImportance("low", config);
+  assert.equal(providers.length, 0);
+});
+
+test("Importance tiering: trivial entities always get no providers", () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock"));
+
+  const config = enabledConfig({
+    importanceThresholds: {
+      critical: ["mock"],
+      high: ["mock"],
+      normal: ["mock"],
+      low: ["mock"],
+    },
+  });
+
+  const providers = registry.getForImportance("trivial", config);
+  assert.equal(providers.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Pipeline tests
+// ---------------------------------------------------------------------------
+
+test("Pipeline: mock provider returns candidates and pipeline processes them", async () => {
+  const candidates: EnrichmentCandidate[] = [
+    { text: "Entity was founded in 2020", source: "mock", confidence: 0.8, category: "fact" },
+    { text: "Entity has 50 employees", source: "mock", confidence: 0.7, category: "fact" },
+  ];
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock", "cheap", candidates));
+
+  const config = enabledConfig();
+  const entity = makeEntity();
+
+  const results = await runEnrichmentPipeline([entity], registry, config, NOOP_LOG);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].entityName, "TestEntity");
+  assert.equal(results[0].provider, "mock");
+  assert.equal(results[0].candidatesFound, 2);
+  assert.equal(results[0].candidatesAccepted, 2);
+  assert.equal(results[0].candidatesRejected, 0);
+  assert.ok(results[0].elapsed >= 0);
+});
+
+test("Pipeline: rate limiting prevents calls beyond limit", async () => {
+  let callCount = 0;
+  const provider: EnrichmentProvider = {
+    id: "limited",
+    costTier: "cheap",
+    async enrich() {
+      callCount++;
+      return [{ text: "fact", source: "limited", confidence: 0.5, category: "fact" }];
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(provider);
+
+  const config = enabledConfig({
+    providers: [
+      {
+        id: "limited",
+        enabled: true,
+        costTier: "cheap",
+        rateLimit: { maxPerMinute: 2, maxPerDay: 100 },
+      },
+    ],
+    importanceThresholds: {
+      critical: ["limited"],
+      high: ["limited"],
+      normal: ["limited"],
+      low: ["limited"],
+    },
+  });
+
+  // Create 5 entities — only 2 should get calls due to maxPerMinute=2
+  const entities = Array.from({ length: 5 }, (_, i) =>
+    makeEntity({ name: `Entity${i}`, importanceLevel: "normal" }),
+  );
+
+  const results = await runEnrichmentPipeline(entities, registry, config, NOOP_LOG);
+  assert.equal(callCount, 2, "Only 2 provider calls should have been made");
+  assert.equal(results.length, 5, "All 5 entities should have result entries");
+
+  // 2 with actual results, 3 rate-limited (0 candidates)
+  const withResults = results.filter((r) => r.candidatesFound > 0);
+  const rateLimited = results.filter((r) => r.candidatesFound === 0);
+  assert.equal(withResults.length, 2);
+  assert.equal(rateLimited.length, 3);
+});
+
+test("Pipeline: max candidates trims excess", async () => {
+  const candidates: EnrichmentCandidate[] = Array.from({ length: 30 }, (_, i) => ({
+    text: `Fact ${i}`,
+    source: "mock",
+    confidence: 0.5,
+    category: "fact" as const,
+  }));
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock", "cheap", candidates));
+
+  const config = enabledConfig({ maxCandidatesPerEntity: 10 });
+  const entity = makeEntity();
+
+  const results = await runEnrichmentPipeline([entity], registry, config, NOOP_LOG);
+  assert.equal(results[0].candidatesFound, 30);
+  assert.equal(results[0].candidatesAccepted, 10);
+  assert.equal(results[0].candidatesRejected, 20);
+});
+
+test("Pipeline: disabled config returns empty results", async () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock"));
+
+  const config = enabledConfig({ enabled: false });
+  const results = await runEnrichmentPipeline([makeEntity()], registry, config, NOOP_LOG);
+  assert.equal(results.length, 0);
+});
+
+test("Pipeline: provider unavailable is gracefully skipped", async () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock", "cheap", [], /* available */ false));
+
+  const config = enabledConfig();
+  const results = await runEnrichmentPipeline([makeEntity()], registry, config, NOOP_LOG);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].candidatesFound, 0);
+  assert.equal(results[0].candidatesAccepted, 0);
+});
+
+test("Pipeline: empty entities list returns empty results", async () => {
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(makeMockProvider("mock"));
+
+  const config = enabledConfig();
+  const results = await runEnrichmentPipeline([], registry, config, NOOP_LOG);
+  assert.equal(results.length, 0);
+});
+
+test("Pipeline: tags and sourceUrl preserved through pipeline", async () => {
+  const candidates: EnrichmentCandidate[] = [
+    {
+      text: "Tagged fact",
+      source: "will-be-overwritten",
+      sourceUrl: "https://example.com/page",
+      confidence: 0.9,
+      category: "fact",
+      tags: ["external", "verified"],
+    },
+  ];
+
+  // Verify the candidates retain their tags and sourceUrl after pipeline processing
+  let capturedCandidates: EnrichmentCandidate[] = [];
+  const provider: EnrichmentProvider = {
+    id: "mock",
+    costTier: "cheap",
+    async enrich() {
+      // Return deep copies so we can verify the pipeline doesn't strip fields
+      const results = candidates.map((c) => ({ ...c }));
+      capturedCandidates = results;
+      return results;
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(provider);
+
+  const config = enabledConfig();
+  await runEnrichmentPipeline([makeEntity()], registry, config, NOOP_LOG);
+
+  // The pipeline tags candidates with the provider ID
+  assert.equal(capturedCandidates[0].source, "mock");
+  assert.equal(capturedCandidates[0].sourceUrl, "https://example.com/page");
+  assert.deepEqual(capturedCandidates[0].tags, ["external", "verified"]);
+});
+
+// ---------------------------------------------------------------------------
+// Audit tests
+// ---------------------------------------------------------------------------
+
+test("Audit: entries written and readable", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "enrichment-audit-"));
+  try {
+    const entry1 = {
+      timestamp: "2026-04-16T10:00:00.000Z",
+      entityName: "Acme Corp",
+      provider: "web-search",
+      candidateText: "Acme Corp founded in 2015",
+      sourceUrl: "https://example.com",
+      accepted: true,
+    };
+    const entry2 = {
+      timestamp: "2026-04-16T11:00:00.000Z",
+      entityName: "Acme Corp",
+      provider: "web-search",
+      candidateText: "Acme Corp has 1000 employees",
+      accepted: false,
+      reason: "Low confidence",
+    };
+
+    await appendAuditEntry(tmpDir, entry1);
+    await appendAuditEntry(tmpDir, entry2);
+
+    const all = await readAuditLog(tmpDir);
+    assert.equal(all.length, 2);
+    assert.equal(all[0].entityName, "Acme Corp");
+    assert.equal(all[0].accepted, true);
+    assert.equal(all[1].accepted, false);
+    assert.equal(all[1].reason, "Low confidence");
+
+    // Filter by since
+    const filtered = await readAuditLog(tmpDir, "2026-04-16T10:30:00.000Z");
+    assert.equal(filtered.length, 1);
+    assert.equal(filtered[0].candidateText, "Acme Corp has 1000 employees");
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+});
+
+test("Audit: reading from nonexistent directory returns empty", async () => {
+  const entries = await readAuditLog("/tmp/nonexistent-enrichment-audit-dir-" + Date.now());
+  assert.equal(entries.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// WebSearchProvider tests
+// ---------------------------------------------------------------------------
+
+test("WebSearchProvider: returns empty when no searchFn configured", async () => {
+  const provider = new WebSearchProvider();
+  assert.equal(provider.id, "web-search");
+  assert.equal(provider.costTier, "cheap");
+  assert.equal(await provider.isAvailable(), false);
+
+  const results = await provider.enrich(makeEntity());
+  assert.equal(results.length, 0);
+});
+
+test("WebSearchProvider: returns candidates from injected searchFn", async () => {
+  const provider = new WebSearchProvider({
+    searchFn: async (query: string) => [
+      `Result for ${query}: snippet one`,
+      `Result for ${query}: snippet two`,
+    ],
+  });
+
+  assert.equal(await provider.isAvailable(), true);
+
+  const results = await provider.enrich(makeEntity({ name: "Acme", type: "company" }));
+  assert.equal(results.length, 2);
+  assert.ok(results[0].text.includes("Acme company"));
+  assert.equal(results[0].source, "web-search");
+  assert.deepEqual(results[0].tags, ["web-search"]);
+});
+
+test("WebSearchProvider: gracefully handles searchFn throwing", async () => {
+  const provider = new WebSearchProvider({
+    searchFn: async () => {
+      throw new Error("Network error");
+    },
+  });
+
+  assert.equal(await provider.isAvailable(), true);
+
+  const results = await provider.enrich(makeEntity());
+  assert.equal(results.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Default config tests
+// ---------------------------------------------------------------------------
+
+test("defaultEnrichmentPipelineConfig returns disabled config", () => {
+  const config = defaultEnrichmentPipelineConfig();
+  assert.equal(config.enabled, false);
+  assert.equal(config.providers.length, 0);
+  assert.equal(config.maxCandidatesPerEntity, 20);
+  assert.equal(config.autoEnrichOnCreate, false);
+  assert.equal(config.scheduleIntervalMs, 3_600_000);
+  assert.deepEqual(config.importanceThresholds.critical, []);
+  assert.deepEqual(config.importanceThresholds.low, []);
+});
+
+// ---------------------------------------------------------------------------
+// Provider error handling
+// ---------------------------------------------------------------------------
+
+test("Pipeline: provider that throws is gracefully skipped", async () => {
+  const provider: EnrichmentProvider = {
+    id: "mock",
+    costTier: "cheap",
+    async enrich() {
+      throw new Error("Provider crashed");
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(provider);
+
+  const config = enabledConfig();
+  const results = await runEnrichmentPipeline([makeEntity()], registry, config, NOOP_LOG);
+  assert.equal(results.length, 1);
+  assert.equal(results[0].candidatesFound, 0);
+  assert.equal(results[0].candidatesAccepted, 0);
+});


### PR DESCRIPTION
## Summary

Closes #365

- Add a new enrichment subsystem (`packages/remnic-core/src/enrichment/`) that enables Remnic to enrich entity pages with external provider data while controlling API cost through importance-based provider tiering
- Implement provider registry with importance-tier resolution, rate limiting, candidate capping, and an append-only JSONL audit trail
- Add CLI commands (`remnic enrich <entity|--all|--dry-run|audit|providers>`) and three new config properties (`enrichmentEnabled`, `enrichmentAutoOnCreate`, `enrichmentMaxCandidatesPerEntity`), all opt-in and disabled by default
- Include a web-search stub provider with injectable `searchFn` for extensibility without hard-coded API keys

## Test plan

- [x] 19 tests covering registry registration/lookup, importance tiering, pipeline orchestration, rate limiting, audit read/write, max candidates trimming, disabled config no-op, provider unavailability graceful skip, empty entities, tag/sourceUrl preservation, provider error handling
- [x] `npm run build` passes
- [x] Config tests pass (enrichment properties parsed correctly)
- [ ] All new logic covered by tests (>= 90% overall)
- [ ] Pre-commit hooks pass locally
- [ ] Docs updated (docs/architecture/enrichment-pipeline.md)
- [ ] No secrets or creds committed
- [ ] PR diff reviewed for personal data

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Although disabled by default, this adds new code paths that can write to the memory store, touch the search backend for reindexing, and create on-disk audit logs, so regressions could affect data integrity or CLI behavior when enabled.
> 
> **Overview**
> Adds an **opt-in external enrichment pipeline** to `@remnic/core`, including provider interfaces, a provider registry with importance-tier selection, a pipeline runner with per-provider rate limiting and candidate capping, a stub `WebSearchProvider`, and a JSONL audit trail (`appendAuditEntry`/`readAuditLog`).
> 
> Wires the feature into the product surface by exporting the new APIs, adding config parsing + schema keys (`enrichmentEnabled`, `enrichmentAutoOnCreate`, `enrichmentMaxCandidatesPerEntity`), and introducing a new `remnic enrich` CLI with `--all/--dry-run`, `audit`, and `providers` subcommands that can persist accepted candidates to the memory store and trigger a search reindex.
> 
> Includes new architecture docs and a comprehensive test suite for the enrichment subsystem (tiering, rate limits, audit IO, disabled/no-op behavior, and error/unavailable-provider handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b9b076877882904175c35861ff9a323371e6ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->