### PR TITLE
feat(codex): support Codex marketplace installation system

### DIFF
--- a/docs/plugins/codex-marketplace.md
+++ b/docs/plugins/codex-marketplace.md
@@ -1,0 +1,136 @@
+# Codex Marketplace Integration
+
+Remnic supports the Codex CLI marketplace system, allowing users to discover
+and install the Remnic memory plugin through the standard `codex marketplace`
+workflow.
+
+## What is the Codex Marketplace?
+
+The Codex marketplace is a plugin distribution system built into the Codex CLI.
+It allows installing plugins from:
+
+- **GitHub repos** (`codex marketplace add owner/repo`)
+- **Git URLs** (`codex marketplace add https://github.com/owner/repo.git`)
+- **Local directories** (for development)
+- **Direct URLs** (for custom registries)
+
+Each marketplace source provides a `marketplace.json` manifest that describes
+available plugins, their versions, and how to install them.
+
+## Installing Remnic via Codex Marketplace
+
+```bash
+codex marketplace add joshuaswarren/remnic
+```
+
+This fetches the `marketplace.json` from the Remnic repository and installs
+the Codex plugin package located at `packages/plugin-codex`.
+
+## Marketplace Manifest Format
+
+The `marketplace.json` at the repository root describes Remnic as an
+installable plugin:
+
+```json
+{
+  "version": 1,
+  "name": "remnic",
+  "description": "Remnic: Local-first AI memory with semantic search and consolidation",
+  "plugins": [
+    {
+      "name": "remnic",
+      "version": "9.3.11",
+      "description": "Persistent memory plugin for Codex CLI",
+      "repository": "joshuaswarren/remnic",
+      "installType": "github",
+      "entry": "packages/plugin-codex",
+      "configSchema": "openclaw.plugin.json"
+    }
+  ]
+}
+```
+
+### Fields
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `version` | `1` | Yes | Schema version (always 1) |
+| `name` | string | Yes | Marketplace name |
+| `description` | string | Yes | Human-readable description |
+| `plugins` | array | Yes | Available plugins (at least one) |
+| `plugins[].name` | string | Yes | Plugin identifier |
+| `plugins[].version` | string | Yes | Semver version |
+| `plugins[].description` | string | Yes | Plugin description |
+| `plugins[].repository` | string | Yes | Repository reference |
+| `plugins[].installType` | enum | Yes | One of: `github`, `git`, `local`, `url` |
+| `plugins[].entry` | string | No | Entry point path within the repo |
+| `plugins[].configSchema` | string | No | Path to config schema file |
+| `plugins[].manifestUrl` | string | No | Direct URL to plugin manifest |
+
+## CLI Commands
+
+### Generate marketplace.json
+
+```bash
+remnic connectors marketplace generate [--output <dir>]
+```
+
+Generates a `marketplace.json` manifest file from the current configuration.
+Defaults to writing in the current directory.
+
+### Validate marketplace.json
+
+```bash
+remnic connectors marketplace validate [path]
+```
+
+Validates a `marketplace.json` file against the schema. Exits with code 0 if
+valid, non-zero if invalid. Defaults to `./marketplace.json`.
+
+### Install from marketplace
+
+```bash
+remnic connectors marketplace install <source> [--type github|git|local|url]
+```
+
+Install plugins from a marketplace source. The `--type` flag defaults to
+`github` when omitted.
+
+Examples:
+
+```bash
+# Install from GitHub
+remnic connectors marketplace install joshuaswarren/remnic
+
+# Install from a local directory (development)
+remnic connectors marketplace install ./my-plugin --type local
+
+# Install from a URL
+remnic connectors marketplace install https://example.com/marketplace.json --type url
+```
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `codexMarketplaceEnabled` | boolean | `true` | Enable marketplace features |
+
+Set `codexMarketplaceEnabled: false` in your Remnic config to disable
+marketplace install operations.
+
+## How Remnic Participates in the Ecosystem
+
+Remnic exposes itself to the Codex marketplace through:
+
+1. **Root `marketplace.json`** --- discovered by `codex marketplace add`.
+2. **`packages/plugin-codex/`** --- the actual Codex plugin with hooks, skills,
+   and MCP configuration.
+3. **`openclaw.plugin.json`** --- the full config schema referenced by the
+   marketplace entry.
+
+When a user runs `codex marketplace add joshuaswarren/remnic`, the Codex CLI:
+
+1. Fetches `marketplace.json` from the repository.
+2. Reads the plugin entry to find `packages/plugin-codex`.
+3. Installs the plugin and its dependencies.
+4. Registers the plugin in the Codex configuration.

--- a/marketplace.json
+++ b/marketplace.json
@@ -1,0 +1,16 @@
+{
+  "version": 1,
+  "name": "remnic",
+  "description": "Remnic: Local-first AI memory with semantic search and consolidation",
+  "plugins": [
+    {
+      "name": "remnic",
+      "version": "9.3.11",
+      "description": "Persistent memory plugin for Codex CLI",
+      "repository": "joshuaswarren/remnic",
+      "installType": "github",
+      "entry": "packages/plugin-codex",
+      "configSchema": "openclaw.plugin.json"
+    }
+  ]
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -618,6 +618,11 @@
         "default": true,
         "description": "Run Codex memory materialization from the Codex session-end hook."
       },
+      "codexMarketplaceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex marketplace integration for plugin discovery and installation."
+      },
       "versioningEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -615,6 +615,11 @@
         "default": true,
         "description": "Run Codex memory materialization from the Codex session-end hook."
       },
+      "codexMarketplaceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex marketplace integration for plugin discovery and installation."
+      },
       "versioningEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1235,11 +1235,14 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     }
   } else if (action === "marketplace") {
     const subAction = nonFlagArgs[0];
-    // Strip the subAction token so downstream positional parsing picks up the
-    // real argument (e.g. the install source or validate path), not the
-    // subcommand name itself.  Only the first occurrence is removed.
+    // Use the original `rest` (not strippedRest) because marketplace uses
+    // `--config <path>` for a file path, not `--config key=value` pairs.
+    // `stripConfigArgv` would silently remove that flag, breaking config
+    // overrides for marketplace subcommands.
+    // Strip only the subAction token so downstream positional parsing picks
+    // up the real argument (e.g. the install source or validate path).
     let subActionRemoved = false;
-    const marketplaceRest = strippedRest.filter((a) => {
+    const marketplaceRest = rest.filter((a) => {
       if (!subActionRemoved && a === subAction) {
         subActionRemoved = true;
         return false;
@@ -1264,11 +1267,15 @@ async function cmdConnectorsMarketplace(
   const rawConfig = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))
     : {};
-  const config = parseConfig(rawConfig);
+  // Unwrap the plugin-scoped config block (remnic or engram wrapper) so
+  // parseConfig receives the correct inner object — same pattern used by
+  // other CLI entrypoints (resolveMemoryDir, cmdBriefing, etc.).
+  const pluginConfig = rawConfig.remnic ?? rawConfig.engram ?? rawConfig;
+  const config = parseConfig(pluginConfig);
 
   if (subAction === "generate") {
     const outputDir = resolveFlagStrict(rest, "--output") ?? process.cwd();
-    const manifest = generateMarketplaceManifest(config);
+    const manifest = generateMarketplaceManifest();
     await writeMarketplaceManifest(outputDir, manifest);
     const outPath = path.join(outputDir, "marketplace.json");
     if (json) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -92,6 +92,11 @@ import {
   validateSlug,
   validateTaxonomy,
   getTaxonomyFilePath,
+  generateMarketplaceManifest,
+  checkMarketplaceManifest,
+  writeMarketplaceManifest,
+  installFromMarketplace,
+  type MarketplaceInstallType,
 } from "@remnic/core";
 import type {
   BinaryLifecycleConfig,
@@ -1228,9 +1233,110 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
       }
       console.log(healthy ? "\nConnector healthy" : "\nConnector has issues");
     }
+  } else if (action === "marketplace") {
+    const subAction = nonFlagArgs[0];
+    await cmdConnectorsMarketplace(subAction, strippedRest, json);
   } else {
-    console.log("Usage: remnic connectors <list|install|remove|doctor> [id]");
+    console.log("Usage: remnic connectors <list|install|remove|doctor|marketplace> [id]");
     process.exit(1);
+  }
+}
+
+// ── Marketplace subcommand (connectors marketplace) ────────��────────────────
+
+async function cmdConnectorsMarketplace(
+  subAction: string | undefined,
+  rest: string[],
+  json: boolean,
+): Promise<void> {
+  const configPath = resolveConfigPath(resolveFlagStrict(rest, "--config"));
+  const rawConfig = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const config = parseConfig(rawConfig);
+
+  if (subAction === "generate") {
+    const outputDir = resolveFlagStrict(rest, "--output") ?? process.cwd();
+    const manifest = generateMarketplaceManifest(config);
+    await writeMarketplaceManifest(outputDir, manifest);
+    const outPath = path.join(outputDir, "marketplace.json");
+    if (json) {
+      console.log(JSON.stringify({ status: "generated", path: outPath }, null, 2));
+    } else {
+      console.log(`Generated marketplace.json at ${outPath}`);
+    }
+  } else if (subAction === "validate") {
+    const targetPath = rest.filter((a) => !a.startsWith("--"))[0]
+      ?? path.join(process.cwd(), "marketplace.json");
+    const resolved = path.resolve(targetPath);
+
+    if (!fs.existsSync(resolved)) {
+      console.error(`File not found: ${resolved}`);
+      process.exit(1);
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(fs.readFileSync(resolved, "utf8"));
+    } catch {
+      console.error(`Invalid JSON in ${resolved}`);
+      process.exit(1);
+    }
+
+    const validation = checkMarketplaceManifest(parsed);
+    if (json) {
+      console.log(JSON.stringify(validation, null, 2));
+    }
+    if (validation.valid) {
+      if (!json) console.log(`Valid marketplace manifest: ${resolved}`);
+      // exit 0
+    } else {
+      if (!json) {
+        console.error(`Invalid marketplace manifest: ${resolved}`);
+        for (const err of validation.errors) {
+          console.error(`  - ${err}`);
+        }
+      }
+      process.exit(1);
+    }
+  } else if (subAction === "install") {
+    const source = rest.filter((a) => !a.startsWith("--"))[0];
+    if (!source) {
+      console.error("Usage: remnic connectors marketplace install <source> [--type github|git|local|url]");
+      process.exit(1);
+    }
+
+    const typeFlag = resolveFlagStrict(rest, "--type") ?? "github";
+    const validTypes = new Set(["github", "git", "local", "url"]);
+    if (!validTypes.has(typeFlag)) {
+      console.error(`Invalid --type: "${typeFlag}". Must be one of: ${[...validTypes].join(", ")}`);
+      process.exit(1);
+    }
+
+    const result = await installFromMarketplace(
+      source,
+      typeFlag as MarketplaceInstallType,
+      config,
+    );
+
+    if (json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(result.message);
+      if (result.pluginsFound.length > 0) {
+        console.log(`  Plugins: ${result.pluginsFound.join(", ")}`);
+      }
+    }
+
+    if (!result.ok) process.exit(1);
+  } else {
+    console.log(`Usage: remnic connectors marketplace <generate|validate|install> [args]
+
+  generate [--output <dir>]            Generate marketplace.json
+  validate [path]                      Validate a marketplace.json file
+  install <source> [--type <type>]     Install from marketplace source
+                                       Types: github, git, local, url (default: github)`);
+    if (!subAction) process.exit(1);
   }
 }
 
@@ -2809,7 +2915,10 @@ Usage:
   remnic review <list|approve|dismiss|flag> [id]  Review inbox
   remnic sync <run|watch> [--source <dir>] Diff-aware sync
   remnic dedup [--json]             Find duplicate memories
-  remnic connectors <list|install|remove|doctor> [id]  Manage connectors
+  remnic connectors <list|install|remove|doctor|marketplace> [id]  Manage connectors
+    marketplace generate    Generate marketplace.json for Codex
+    marketplace validate    Validate a marketplace.json file
+    marketplace install     Install from a marketplace source
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
   remnic benchmark <run|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1235,7 +1235,18 @@ async function cmdConnectors(action: string, rest: string[], json: boolean): Pro
     }
   } else if (action === "marketplace") {
     const subAction = nonFlagArgs[0];
-    await cmdConnectorsMarketplace(subAction, strippedRest, json);
+    // Strip the subAction token so downstream positional parsing picks up the
+    // real argument (e.g. the install source or validate path), not the
+    // subcommand name itself.  Only the first occurrence is removed.
+    let subActionRemoved = false;
+    const marketplaceRest = strippedRest.filter((a) => {
+      if (!subActionRemoved && a === subAction) {
+        subActionRemoved = true;
+        return false;
+      }
+      return true;
+    });
+    await cmdConnectorsMarketplace(subAction, marketplaceRest, json);
   } else {
     console.log("Usage: remnic connectors <list|install|remove|doctor|marketplace> [id]");
     process.exit(1);
@@ -1336,7 +1347,7 @@ async function cmdConnectorsMarketplace(
   validate [path]                      Validate a marketplace.json file
   install <source> [--type <type>]     Install from marketplace source
                                        Types: github, git, local, url (default: github)`);
-    if (!subAction) process.exit(1);
+    process.exit(1);
   }
 }
 

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1948,6 +1948,8 @@ export function parseConfig(raw: unknown): PluginConfig {
         : 30,
     codexMaterializeOnConsolidation: cfg.codexMaterializeOnConsolidation !== false,
     codexMaterializeOnSessionEnd: cfg.codexMaterializeOnSessionEnd !== false,
+    // Codex CLI — marketplace integration (#418)
+    codexMarketplaceEnabled: cfg.codexMarketplaceEnabled !== false, // default: true
 
     // Page-level versioning (issue #371)
     versioningEnabled: cfg.versioningEnabled === true,

--- a/packages/remnic-core/src/connectors/codex-marketplace.ts
+++ b/packages/remnic-core/src/connectors/codex-marketplace.ts
@@ -113,7 +113,6 @@ const VALID_INSTALL_TYPES = new Set<string>(["github", "git", "local", "url"]);
  * or falls back to a default version string.
  */
 export function generateMarketplaceManifest(
-  config: PluginConfig,
   options?: { packageVersion?: string },
 ): MarketplaceManifest {
   const version = options?.packageVersion ?? readPackageVersion() ?? "0.0.0";

--- a/packages/remnic-core/src/connectors/codex-marketplace.ts
+++ b/packages/remnic-core/src/connectors/codex-marketplace.ts
@@ -1,5 +1,5 @@
 /**
- * codex/marketplace.ts — Codex marketplace installation support (#418)
+ * codex-marketplace.ts — Codex marketplace installation support (#418)
  *
  * Provides types and functions for integrating Remnic with the Codex CLI
  * marketplace system (`codex marketplace add`). This module handles:
@@ -20,8 +20,8 @@
 import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
 import path from "node:path";
 
-import { log } from "../../logger.js";
-import type { PluginConfig } from "../../types.js";
+import { log } from "../logger.js";
+import type { PluginConfig } from "../types.js";
 
 // ── Types ─────────────────────────────────────────────────────────────────
 
@@ -458,11 +458,11 @@ async function resolveGit(
  */
 function readPackageVersion(): string | undefined {
   // Walk up from this file to find the workspace root package.json
-  // This module lives at packages/remnic-core/src/connectors/codex/marketplace.ts
-  // so workspace root is 5 levels up.
+  // This module lives at packages/remnic-core/src/connectors/codex-marketplace.ts
+  // so workspace root is 4 levels up.
   const candidates = [
+    path.resolve(import.meta.dirname ?? ".", "../../../.."),
     path.resolve(import.meta.dirname ?? ".", "../../../../.."),
-    path.resolve(import.meta.dirname ?? ".", "../../../../../.."),
     path.resolve(import.meta.dirname ?? ".", ".."),
   ];
 

--- a/packages/remnic-core/src/connectors/codex/marketplace.ts
+++ b/packages/remnic-core/src/connectors/codex/marketplace.ts
@@ -1,0 +1,484 @@
+/**
+ * codex/marketplace.ts — Codex marketplace installation support (#418)
+ *
+ * Provides types and functions for integrating Remnic with the Codex CLI
+ * marketplace system (`codex marketplace add`). This module handles:
+ *
+ *  - Generating a `marketplace.json` manifest describing Remnic as an
+ *    installable plugin in the Codex marketplace ecosystem.
+ *  - Validating marketplace manifest files against the expected schema.
+ *  - Writing manifests to disk atomically.
+ *  - Installing plugins from marketplace sources (GitHub, git, local, URL).
+ *
+ * Privacy
+ * -------
+ * This module does not persist any user content. It only reads package
+ * metadata (name, version, description) and writes public marketplace
+ * manifest files.
+ */
+
+import { existsSync, mkdirSync, readFileSync, renameSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+import { log } from "../../logger.js";
+import type { PluginConfig } from "../../types.js";
+
+// ── Types ─────────────────────────────────────────────────────────────────
+
+/** Source type for marketplace installation. */
+export type MarketplaceInstallType = "github" | "git" | "local" | "url";
+
+/** A single plugin entry within a marketplace manifest. */
+export interface MarketplaceEntry {
+  /** Plugin name (e.g. "remnic"). */
+  name: string;
+  /** Semver version string. */
+  version: string;
+  /** Human-readable description. */
+  description: string;
+  /** Repository identifier (e.g. "joshuaswarren/remnic"). */
+  repository: string;
+  /** How this plugin should be installed. */
+  installType: MarketplaceInstallType;
+  /** Optional direct URL to the plugin manifest. */
+  manifestUrl?: string;
+  /** Optional entry point path within the repository. */
+  entry?: string;
+  /** Optional config schema reference. */
+  configSchema?: string;
+}
+
+/** Top-level marketplace manifest. */
+export interface MarketplaceManifest {
+  /** Schema version. Must be 1. */
+  version: 1;
+  /** Marketplace name. */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** Available plugins. */
+  plugins: MarketplaceEntry[];
+}
+
+/** Configuration for the marketplace subsystem. */
+export interface MarketplaceConfig {
+  /** Whether marketplace features are enabled. Default: true. */
+  enabled: boolean;
+  /** Local path where marketplace data is cached. */
+  registryPath: string;
+  /** Whether to auto-update marketplace data on install. Default: false. */
+  autoUpdate: boolean;
+}
+
+/** Result of a marketplace install operation. */
+export interface MarketplaceInstallResult {
+  /** Whether the install succeeded. */
+  ok: boolean;
+  /** Human-readable message. */
+  message: string;
+  /** Source that was installed from. */
+  source: string;
+  /** Source type. */
+  sourceType: MarketplaceInstallType;
+  /** Plugins that were discovered. */
+  pluginsFound: string[];
+  /** Errors encountered (empty on success). */
+  errors: string[];
+}
+
+/** Logger interface accepted by marketplace functions. */
+export interface MarketplaceLogger {
+  info: (msg: string) => void;
+  warn: (msg: string) => void;
+  debug?: (msg: string) => void;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────
+
+/** Current marketplace schema version. */
+export const MARKETPLACE_SCHEMA_VERSION = 1 as const;
+
+/** Default marketplace manifest filename. */
+export const MARKETPLACE_MANIFEST_FILENAME = "marketplace.json";
+
+/** Valid install types for validation. */
+const VALID_INSTALL_TYPES = new Set<string>(["github", "git", "local", "url"]);
+
+// ── Generate ──────────────────────────────────────────────────────────────
+
+/**
+ * Generate a marketplace manifest describing Remnic as an installable plugin.
+ *
+ * Reads version from the workspace root `package.json` at the resolved path,
+ * or falls back to a default version string.
+ */
+export function generateMarketplaceManifest(
+  config: PluginConfig,
+  options?: { packageVersion?: string },
+): MarketplaceManifest {
+  const version = options?.packageVersion ?? readPackageVersion() ?? "0.0.0";
+
+  return {
+    version: MARKETPLACE_SCHEMA_VERSION,
+    name: "remnic",
+    description: "Remnic: Local-first AI memory with semantic search and consolidation",
+    plugins: [
+      {
+        name: "remnic",
+        version,
+        description: "Persistent memory plugin for Codex CLI",
+        repository: "joshuaswarren/remnic",
+        installType: "github",
+        entry: "packages/plugin-codex",
+        configSchema: "openclaw.plugin.json",
+      },
+    ],
+  };
+}
+
+// ── Validate ──────────────────────────────────────────────────────────────
+
+/** Validation result with structured errors. */
+export interface MarketplaceValidation {
+  valid: boolean;
+  errors: string[];
+}
+
+/**
+ * Validate that an unknown value conforms to the MarketplaceManifest schema.
+ *
+ * Returns a typed manifest on success. Throws on invalid input with a
+ * descriptive error message listing all schema violations.
+ */
+export function validateMarketplaceManifest(manifest: unknown): MarketplaceManifest {
+  const validation = checkMarketplaceManifest(manifest);
+  if (!validation.valid) {
+    throw new Error(
+      `Invalid marketplace manifest: ${validation.errors.join("; ")}`,
+    );
+  }
+  return manifest as MarketplaceManifest;
+}
+
+/**
+ * Non-throwing validation. Returns a structured result with error details.
+ */
+export function checkMarketplaceManifest(manifest: unknown): MarketplaceValidation {
+  const errors: string[] = [];
+
+  if (typeof manifest !== "object" || manifest === null) {
+    return { valid: false, errors: ["manifest must be a non-null object"] };
+  }
+
+  const obj = manifest as Record<string, unknown>;
+
+  // version
+  if (obj.version !== MARKETPLACE_SCHEMA_VERSION) {
+    errors.push(`version must be ${MARKETPLACE_SCHEMA_VERSION}, got ${JSON.stringify(obj.version)}`);
+  }
+
+  // name
+  if (typeof obj.name !== "string" || obj.name.trim().length === 0) {
+    errors.push("name must be a non-empty string");
+  }
+
+  // description
+  if (typeof obj.description !== "string" || obj.description.trim().length === 0) {
+    errors.push("description must be a non-empty string");
+  }
+
+  // plugins
+  if (!Array.isArray(obj.plugins)) {
+    errors.push("plugins must be an array");
+  } else if (obj.plugins.length === 0) {
+    errors.push("plugins must contain at least one entry");
+  } else {
+    for (let i = 0; i < obj.plugins.length; i++) {
+      const plugin = obj.plugins[i] as Record<string, unknown>;
+      const prefix = `plugins[${i}]`;
+
+      if (typeof plugin !== "object" || plugin === null) {
+        errors.push(`${prefix} must be a non-null object`);
+        continue;
+      }
+
+      if (typeof plugin.name !== "string" || plugin.name.trim().length === 0) {
+        errors.push(`${prefix}.name must be a non-empty string`);
+      }
+
+      if (typeof plugin.version !== "string" || plugin.version.trim().length === 0) {
+        errors.push(`${prefix}.version must be a non-empty string`);
+      }
+
+      if (typeof plugin.description !== "string" || plugin.description.trim().length === 0) {
+        errors.push(`${prefix}.description must be a non-empty string`);
+      }
+
+      if (typeof plugin.repository !== "string" || plugin.repository.trim().length === 0) {
+        errors.push(`${prefix}.repository must be a non-empty string`);
+      }
+
+      if (typeof plugin.installType !== "string" || !VALID_INSTALL_TYPES.has(plugin.installType)) {
+        errors.push(
+          `${prefix}.installType must be one of: ${[...VALID_INSTALL_TYPES].join(", ")}; ` +
+          `got ${JSON.stringify(plugin.installType)}`,
+        );
+      }
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+// ── Write ─────────────────────────────────────────────────────────────────
+
+/**
+ * Write a marketplace manifest to disk atomically.
+ *
+ * Uses write-to-temp-then-rename to avoid partial writes (CLAUDE.md gotcha #54).
+ */
+export async function writeMarketplaceManifest(
+  outputDir: string,
+  manifest: MarketplaceManifest,
+): Promise<void> {
+  // Validate before writing — never write garbage to disk.
+  const validation = checkMarketplaceManifest(manifest);
+  if (!validation.valid) {
+    throw new Error(
+      `Refusing to write invalid manifest: ${validation.errors.join("; ")}`,
+    );
+  }
+
+  mkdirSync(outputDir, { recursive: true });
+
+  const destPath = path.join(outputDir, MARKETPLACE_MANIFEST_FILENAME);
+  const tmpPath = `${destPath}.tmp.${process.pid}`;
+  const content = JSON.stringify(manifest, null, 2) + "\n";
+
+  writeFileSync(tmpPath, content);
+  renameSync(tmpPath, destPath);
+}
+
+// ── Install ───────────────────────────────────────────────────────────────
+
+/**
+ * Install from a marketplace source.
+ *
+ * Reads the marketplace.json from the given source, validates it, and
+ * returns a result describing what was found.
+ */
+export async function installFromMarketplace(
+  source: string,
+  sourceType: MarketplaceInstallType,
+  config: PluginConfig,
+  logger?: MarketplaceLogger,
+): Promise<MarketplaceInstallResult> {
+  const _log: MarketplaceLogger = logger ?? {
+    info: (msg) => log.info(`[marketplace] ${msg}`),
+    warn: (msg) => log.warn(`[marketplace] ${msg}`),
+    debug: (msg) => log.debug(`[marketplace] ${msg}`),
+  };
+
+  if (!config.codexMarketplaceEnabled) {
+    return {
+      ok: false,
+      message: "Codex marketplace is disabled in config (codexMarketplaceEnabled: false)",
+      source,
+      sourceType,
+      pluginsFound: [],
+      errors: ["marketplace_disabled"],
+    };
+  }
+
+  try {
+    const manifest = await resolveManifest(source, sourceType, _log);
+    const pluginNames = manifest.plugins.map((p) => p.name);
+
+    _log.info(`marketplace install: found ${pluginNames.length} plugin(s) from ${sourceType}://${source}`);
+
+    return {
+      ok: true,
+      message: `Successfully resolved ${pluginNames.length} plugin(s) from marketplace: ${pluginNames.join(", ")}`,
+      source,
+      sourceType,
+      pluginsFound: pluginNames,
+      errors: [],
+    };
+  } catch (err) {
+    const errMsg = err instanceof Error ? err.message : String(err);
+    _log.warn(`marketplace install failed: ${errMsg}`);
+    return {
+      ok: false,
+      message: `Failed to install from marketplace: ${errMsg}`,
+      source,
+      sourceType,
+      pluginsFound: [],
+      errors: [errMsg],
+    };
+  }
+}
+
+// ── Source resolution ─────────────────────────────────────────────────────
+
+/**
+ * Resolve a marketplace manifest from the given source.
+ */
+async function resolveManifest(
+  source: string,
+  sourceType: MarketplaceInstallType,
+  logger: MarketplaceLogger,
+): Promise<MarketplaceManifest> {
+  switch (sourceType) {
+    case "local":
+      return resolveLocal(source, logger);
+    case "url":
+      return resolveUrl(source, logger);
+    case "github":
+      return resolveGithub(source, logger);
+    case "git":
+      return resolveGit(source, logger);
+    default: {
+      // Exhaustive check — CLAUDE.md gotcha #51: reject invalid input.
+      const _: never = sourceType;
+      throw new Error(`Invalid source type: ${String(_)}`);
+    }
+  }
+}
+
+/**
+ * Read marketplace.json from a local directory.
+ */
+function resolveLocal(
+  dirPath: string,
+  logger: MarketplaceLogger,
+): MarketplaceManifest {
+  const manifestPath = path.join(dirPath, MARKETPLACE_MANIFEST_FILENAME);
+
+  if (!existsSync(manifestPath)) {
+    throw new Error(`marketplace.json not found at ${manifestPath}`);
+  }
+
+  logger.debug?.(`reading local marketplace manifest: ${manifestPath}`);
+
+  const raw = readFileSync(manifestPath, "utf-8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error(`Invalid JSON in ${manifestPath}`);
+  }
+
+  // CLAUDE.md gotcha #18: validate parse result type
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`marketplace.json at ${manifestPath} is not a valid object`);
+  }
+
+  return validateMarketplaceManifest(parsed);
+}
+
+/**
+ * Fetch marketplace.json from a URL.
+ */
+async function resolveUrl(
+  url: string,
+  logger: MarketplaceLogger,
+): Promise<MarketplaceManifest> {
+  logger.debug?.(`fetching marketplace manifest from URL: ${url}`);
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    throw new Error(`Invalid URL: ${url}`);
+  }
+
+  if (parsedUrl.protocol !== "https:" && parsedUrl.protocol !== "http:") {
+    throw new Error(`Unsupported URL protocol: ${parsedUrl.protocol} (use https or http)`);
+  }
+
+  const response = await fetch(url);
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status} fetching ${url}`);
+  }
+
+  const body = await response.json() as unknown;
+  return validateMarketplaceManifest(body);
+}
+
+/**
+ * Resolve marketplace.json from a GitHub repository reference (owner/repo).
+ *
+ * Attempts to fetch the raw marketplace.json from the default branch.
+ */
+async function resolveGithub(
+  repo: string,
+  logger: MarketplaceLogger,
+): Promise<MarketplaceManifest> {
+  // Validate format: must be owner/repo
+  if (!/^[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/u.test(repo)) {
+    throw new Error(`Invalid GitHub repo format: "${repo}" (expected owner/repo)`);
+  }
+
+  const rawUrl = `https://raw.githubusercontent.com/${repo}/HEAD/${MARKETPLACE_MANIFEST_FILENAME}`;
+  logger.debug?.(`fetching marketplace manifest from GitHub: ${rawUrl}`);
+
+  return resolveUrl(rawUrl, logger);
+}
+
+/**
+ * Resolve marketplace.json from a git URL.
+ *
+ * For now this delegates to URL-based resolution by constructing a raw URL.
+ * Full git clone support can be added later.
+ */
+async function resolveGit(
+  gitUrl: string,
+  logger: MarketplaceLogger,
+): Promise<MarketplaceManifest> {
+  // For git URLs that look like GitHub HTTPS URLs, extract owner/repo and
+  // delegate to the GitHub resolver.
+  const ghMatch = gitUrl.match(
+    /^(?:https?:\/\/)?github\.com\/([a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+?)(?:\.git)?$/u,
+  );
+  if (ghMatch?.[1]) {
+    logger.debug?.(`git URL looks like GitHub — delegating to github resolver`);
+    return resolveGithub(ghMatch[1], logger);
+  }
+
+  throw new Error(
+    `Git URL resolution requires a GitHub-format URL for now. ` +
+    `Got: ${gitUrl}. Use --type github or --type url instead.`,
+  );
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Read the workspace root package.json version. Returns undefined if not found.
+ */
+function readPackageVersion(): string | undefined {
+  // Walk up from this file to find the workspace root package.json
+  // This module lives at packages/remnic-core/src/connectors/codex/marketplace.ts
+  // so workspace root is 5 levels up.
+  const candidates = [
+    path.resolve(import.meta.dirname ?? ".", "../../../../.."),
+    path.resolve(import.meta.dirname ?? ".", "../../../../../.."),
+    path.resolve(import.meta.dirname ?? ".", ".."),
+  ];
+
+  for (const candidate of candidates) {
+    const pkgPath = path.join(candidate, "package.json");
+    try {
+      if (!existsSync(pkgPath)) continue;
+      const raw = readFileSync(pkgPath, "utf-8");
+      const parsed = JSON.parse(raw);
+      if (typeof parsed === "object" && parsed !== null && typeof parsed.version === "string") {
+        return parsed.version;
+      }
+    } catch {
+      // ignore
+    }
+  }
+
+  return undefined;
+}

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -40,6 +40,22 @@ export {
   runCodexMaterialize,
   type RunMaterializeOptions,
 } from "./codex-materialize-runner.js";
+export {
+  generateMarketplaceManifest,
+  validateMarketplaceManifest,
+  checkMarketplaceManifest,
+  writeMarketplaceManifest,
+  installFromMarketplace,
+  MARKETPLACE_SCHEMA_VERSION,
+  MARKETPLACE_MANIFEST_FILENAME,
+  type MarketplaceManifest,
+  type MarketplaceEntry,
+  type MarketplaceConfig,
+  type MarketplaceInstallType,
+  type MarketplaceInstallResult,
+  type MarketplaceValidation,
+  type MarketplaceLogger,
+} from "./codex/marketplace.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -55,7 +55,7 @@ export {
   type MarketplaceInstallResult,
   type MarketplaceValidation,
   type MarketplaceLogger,
-} from "./codex/marketplace.js";
+} from "./codex-marketplace.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -924,6 +924,8 @@ export interface PluginConfig {
   codexMaterializeOnConsolidation: boolean;
   /** Run materialization at Codex session-end hook. Default true. */
   codexMaterializeOnSessionEnd: boolean;
+  /** Enable Codex marketplace integration. Default true. */
+  codexMarketplaceEnabled: boolean;
 
   // Page-level versioning (issue #371)
   /** Enable page-level versioning with sidecar snapshots. Default false. */

--- a/scripts/sync-marketplace-version.mjs
+++ b/scripts/sync-marketplace-version.mjs
@@ -1,0 +1,30 @@
+/**
+ * sync-marketplace-version.mjs
+ *
+ * Reads the version from the root package.json and updates the version field
+ * in the root marketplace.json to keep them in sync during releases.
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, "..");
+
+const pkgPath = path.resolve(repoRoot, "package.json");
+const marketplacePath = path.resolve(repoRoot, "marketplace.json");
+
+const pkg = JSON.parse(await readFile(pkgPath, "utf-8"));
+const marketplace = JSON.parse(await readFile(marketplacePath, "utf-8"));
+
+if (Array.isArray(marketplace.plugins)) {
+  for (const plugin of marketplace.plugins) {
+    if (plugin.name === "remnic") {
+      plugin.version = pkg.version;
+    }
+  }
+}
+
+await writeFile(marketplacePath, `${JSON.stringify(marketplace, null, 2)}\n`);
+console.log(`marketplace.json updated to version ${pkg.version}`);

--- a/tests/codex-marketplace.test.ts
+++ b/tests/codex-marketplace.test.ts
@@ -1,0 +1,443 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+import {
+  generateMarketplaceManifest,
+  validateMarketplaceManifest,
+  checkMarketplaceManifest,
+  writeMarketplaceManifest,
+  installFromMarketplace,
+  MARKETPLACE_SCHEMA_VERSION,
+  MARKETPLACE_MANIFEST_FILENAME,
+} from "../packages/remnic-core/src/connectors/codex/marketplace.js";
+import { parseConfig } from "../packages/remnic-core/src/config.js";
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeConfig(overrides?: Record<string, unknown>) {
+  return parseConfig({ ...overrides });
+}
+
+function makeTmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remnic-marketplace-test-"));
+}
+
+function cleanupDir(dir: string) {
+  try {
+    fs.rmSync(dir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+}
+
+// ── generateMarketplaceManifest ─────────────────────────────────────────────
+
+test("generateMarketplaceManifest produces valid manifest with correct version", () => {
+  const config = makeConfig();
+  const manifest = generateMarketplaceManifest(config, { packageVersion: "9.3.11" });
+
+  assert.equal(manifest.version, MARKETPLACE_SCHEMA_VERSION);
+  assert.equal(manifest.name, "remnic");
+  assert.ok(manifest.description.length > 0);
+  assert.equal(manifest.plugins.length, 1);
+
+  const plugin = manifest.plugins[0];
+  assert.equal(plugin.name, "remnic");
+  assert.equal(plugin.version, "9.3.11");
+  assert.equal(plugin.repository, "joshuaswarren/remnic");
+  assert.equal(plugin.installType, "github");
+  assert.equal(plugin.entry, "packages/plugin-codex");
+  assert.equal(plugin.configSchema, "openclaw.plugin.json");
+});
+
+test("generateMarketplaceManifest defaults to 0.0.0 when no version supplied", () => {
+  const config = makeConfig();
+  // Force no version discovery by passing undefined
+  const manifest = generateMarketplaceManifest(config, { packageVersion: undefined });
+
+  // Should fall back to readPackageVersion() or 0.0.0
+  assert.ok(typeof manifest.plugins[0].version === "string");
+  assert.ok(manifest.plugins[0].version.length > 0);
+});
+
+test("generateMarketplaceManifest output passes validation", () => {
+  const config = makeConfig();
+  const manifest = generateMarketplaceManifest(config, { packageVersion: "1.0.0" });
+  const validation = checkMarketplaceManifest(manifest);
+
+  assert.ok(validation.valid, `validation failed: ${validation.errors.join("; ")}`);
+});
+
+// ── validateMarketplaceManifest ─────────────────────────────────────────────
+
+test("validateMarketplaceManifest accepts valid manifest", () => {
+  const valid = {
+    version: 1,
+    name: "test-marketplace",
+    description: "Test marketplace",
+    plugins: [
+      {
+        name: "test-plugin",
+        version: "1.0.0",
+        description: "A test plugin",
+        repository: "owner/repo",
+        installType: "github",
+      },
+    ],
+  };
+
+  const result = validateMarketplaceManifest(valid);
+  assert.equal(result.version, 1);
+  assert.equal(result.name, "test-marketplace");
+  assert.equal(result.plugins.length, 1);
+});
+
+test("validateMarketplaceManifest rejects missing fields", () => {
+  const cases = [
+    { input: { version: 1, description: "d", plugins: [{ name: "n", version: "1", description: "d", repository: "r", installType: "github" }] }, missing: "name" },
+    { input: { version: 1, name: "n", plugins: [{ name: "n", version: "1", description: "d", repository: "r", installType: "github" }] }, missing: "description" },
+    { input: { version: 1, name: "n", description: "d" }, missing: "plugins" },
+    { input: { version: 1, name: "n", description: "d", plugins: [] }, missing: "plugins (empty)" },
+  ];
+
+  for (const { input, missing } of cases) {
+    assert.throws(
+      () => validateMarketplaceManifest(input),
+      (err: Error) => {
+        assert.ok(err.message.includes("Invalid marketplace manifest"), `Expected validation error for missing ${missing}`);
+        return true;
+      },
+    );
+  }
+});
+
+test("validateMarketplaceManifest rejects invalid version", () => {
+  const invalid = {
+    version: 2,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "r",
+        installType: "github",
+      },
+    ],
+  };
+
+  assert.throws(
+    () => validateMarketplaceManifest(invalid),
+    (err: Error) => {
+      assert.ok(err.message.includes("version must be 1"));
+      return true;
+    },
+  );
+});
+
+test("validateMarketplaceManifest rejects invalid installType", () => {
+  const invalid = {
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "r",
+        installType: "ftp",
+      },
+    ],
+  };
+
+  assert.throws(
+    () => validateMarketplaceManifest(invalid),
+    (err: Error) => {
+      assert.ok(err.message.includes("installType"));
+      return true;
+    },
+  );
+});
+
+test("validateMarketplaceManifest rejects null input", () => {
+  assert.throws(
+    () => validateMarketplaceManifest(null),
+    (err: Error) => {
+      assert.ok(err.message.includes("non-null object"));
+      return true;
+    },
+  );
+});
+
+test("validateMarketplaceManifest rejects string input", () => {
+  assert.throws(
+    () => validateMarketplaceManifest("not an object"),
+    (err: Error) => {
+      assert.ok(err.message.includes("non-null object"));
+      return true;
+    },
+  );
+});
+
+// ── checkMarketplaceManifest ────────────────────────────────────────────────
+
+test("checkMarketplaceManifest returns structured errors without throwing", () => {
+  const result = checkMarketplaceManifest({
+    version: 99,
+    name: "",
+    description: "",
+    plugins: "not-an-array",
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.length >= 3);
+  assert.ok(result.errors.some((e) => e.includes("version")));
+  assert.ok(result.errors.some((e) => e.includes("name")));
+  assert.ok(result.errors.some((e) => e.includes("plugins")));
+});
+
+test("checkMarketplaceManifest validates plugin entry fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "",
+        version: "",
+        description: "",
+        repository: "",
+        installType: "invalid",
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.length >= 4);
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].name")));
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].version")));
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].installType")));
+});
+
+// ── writeMarketplaceManifest ────────────────────────────────────────────────
+
+test("writeMarketplaceManifest writes valid JSON to disk", async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const manifest = {
+      version: 1 as const,
+      name: "write-test",
+      description: "Test write",
+      plugins: [
+        {
+          name: "test-plugin",
+          version: "1.0.0",
+          description: "Test plugin",
+          repository: "owner/repo",
+          installType: "github" as const,
+        },
+      ],
+    };
+
+    await writeMarketplaceManifest(tmpDir, manifest);
+
+    const outPath = path.join(tmpDir, MARKETPLACE_MANIFEST_FILENAME);
+    assert.ok(fs.existsSync(outPath), "marketplace.json should exist");
+
+    const written = JSON.parse(fs.readFileSync(outPath, "utf-8"));
+    assert.equal(written.version, 1);
+    assert.equal(written.name, "write-test");
+    assert.equal(written.plugins.length, 1);
+    assert.equal(written.plugins[0].name, "test-plugin");
+  } finally {
+    cleanupDir(tmpDir);
+  }
+});
+
+test("writeMarketplaceManifest rejects invalid manifest", async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const invalid = {
+      version: 99 as any,
+      name: "bad",
+      description: "bad",
+      plugins: [],
+    };
+
+    await assert.rejects(
+      () => writeMarketplaceManifest(tmpDir, invalid as any),
+      (err: Error) => {
+        assert.ok(err.message.includes("Refusing to write invalid manifest"));
+        return true;
+      },
+    );
+  } finally {
+    cleanupDir(tmpDir);
+  }
+});
+
+test("writeMarketplaceManifest creates parent directories", async () => {
+  const tmpDir = makeTmpDir();
+  const nested = path.join(tmpDir, "a", "b", "c");
+  try {
+    const manifest = {
+      version: 1 as const,
+      name: "nested-test",
+      description: "Nested dir test",
+      plugins: [
+        {
+          name: "p",
+          version: "1.0.0",
+          description: "d",
+          repository: "o/r",
+          installType: "github" as const,
+        },
+      ],
+    };
+
+    await writeMarketplaceManifest(nested, manifest);
+    assert.ok(fs.existsSync(path.join(nested, MARKETPLACE_MANIFEST_FILENAME)));
+  } finally {
+    cleanupDir(tmpDir);
+  }
+});
+
+// ── installFromMarketplace — local ─────────────────────────────────────────
+
+test("installFromMarketplace reads local marketplace.json correctly", async () => {
+  const tmpDir = makeTmpDir();
+  try {
+    const manifest = {
+      version: 1,
+      name: "local-test",
+      description: "Local marketplace test",
+      plugins: [
+        {
+          name: "local-plugin",
+          version: "2.0.0",
+          description: "A local plugin",
+          repository: "local/repo",
+          installType: "local",
+        },
+      ],
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, "marketplace.json"),
+      JSON.stringify(manifest, null, 2),
+    );
+
+    const config = makeConfig();
+    const result = await installFromMarketplace(tmpDir, "local", config);
+
+    assert.equal(result.ok, true);
+    assert.equal(result.sourceType, "local");
+    assert.deepEqual(result.pluginsFound, ["local-plugin"]);
+    assert.equal(result.errors.length, 0);
+  } finally {
+    cleanupDir(tmpDir);
+  }
+});
+
+test("installFromMarketplace fails for missing local directory", async () => {
+  const config = makeConfig();
+  const result = await installFromMarketplace(
+    "/nonexistent/path",
+    "local",
+    config,
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.length > 0);
+  assert.ok(result.message.includes("Failed"));
+});
+
+test("installFromMarketplace fails when marketplace disabled", async () => {
+  const config = makeConfig({ codexMarketplaceEnabled: false });
+  const result = await installFromMarketplace(
+    "/some/path",
+    "local",
+    config,
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.message.includes("disabled"));
+  assert.deepEqual(result.pluginsFound, []);
+});
+
+// ── installFromMarketplace — URL (mock) ─────────────────────────────────────
+
+test("installFromMarketplace handles invalid URL", async () => {
+  const config = makeConfig();
+  const result = await installFromMarketplace(
+    "not-a-url",
+    "url",
+    config,
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.length > 0);
+});
+
+// ── installFromMarketplace — GitHub (format check) ─────────────────────────
+
+test("installFromMarketplace rejects invalid GitHub repo format", async () => {
+  const config = makeConfig();
+  const result = await installFromMarketplace(
+    "not-a-valid-repo",
+    "github",
+    config,
+  );
+
+  assert.equal(result.ok, false);
+  assert.ok(result.errors.length > 0);
+  assert.ok(result.message.includes("Invalid GitHub repo format"));
+});
+
+// ── Root marketplace.json validity ──────────────────────────────────────────
+
+test("root marketplace.json is valid per the marketplace schema", () => {
+  const rootDir = path.resolve(import.meta.dirname ?? ".", "..");
+  const manifestPath = path.join(rootDir, "marketplace.json");
+
+  assert.ok(fs.existsSync(manifestPath), "root marketplace.json should exist");
+
+  const raw = fs.readFileSync(manifestPath, "utf-8");
+  const parsed = JSON.parse(raw);
+
+  const validation = checkMarketplaceManifest(parsed);
+  if (!validation.valid) {
+    assert.fail(`root marketplace.json validation failed: ${validation.errors.join("; ")}`);
+  }
+
+  assert.equal(parsed.version, 1);
+  assert.equal(parsed.name, "remnic");
+  assert.ok(parsed.plugins.length >= 1);
+  assert.equal(parsed.plugins[0].name, "remnic");
+});
+
+// ── Config integration ──────────────────────────────────────────────────────
+
+test("parseConfig defaults codexMarketplaceEnabled to true", () => {
+  const config = parseConfig({});
+  assert.equal(config.codexMarketplaceEnabled, true);
+});
+
+test("parseConfig respects codexMarketplaceEnabled: false", () => {
+  const config = parseConfig({ codexMarketplaceEnabled: false });
+  assert.equal(config.codexMarketplaceEnabled, false);
+});
+
+// ── MARKETPLACE_MANIFEST_FILENAME constant ──────────────────────────────────
+
+test("MARKETPLACE_MANIFEST_FILENAME is marketplace.json", () => {
+  assert.equal(MARKETPLACE_MANIFEST_FILENAME, "marketplace.json");
+});
+
+test("MARKETPLACE_SCHEMA_VERSION is 1", () => {
+  assert.equal(MARKETPLACE_SCHEMA_VERSION, 1);
+});

--- a/tests/codex-marketplace.test.ts
+++ b/tests/codex-marketplace.test.ts
@@ -12,7 +12,7 @@ import {
   installFromMarketplace,
   MARKETPLACE_SCHEMA_VERSION,
   MARKETPLACE_MANIFEST_FILENAME,
-} from "../packages/remnic-core/src/connectors/codex/marketplace.js";
+} from "../packages/remnic-core/src/connectors/codex-marketplace.js";
 import { parseConfig } from "../packages/remnic-core/src/config.js";
 
 // ── Helpers ─────────────────────────────────────────────────────────────────

--- a/tests/codex-marketplace.test.ts
+++ b/tests/codex-marketplace.test.ts
@@ -36,8 +36,7 @@ function cleanupDir(dir: string) {
 // ── generateMarketplaceManifest ─────────────────────────────────────────────
 
 test("generateMarketplaceManifest produces valid manifest with correct version", () => {
-  const config = makeConfig();
-  const manifest = generateMarketplaceManifest(config, { packageVersion: "9.3.11" });
+  const manifest = generateMarketplaceManifest({ packageVersion: "9.3.11" });
 
   assert.equal(manifest.version, MARKETPLACE_SCHEMA_VERSION);
   assert.equal(manifest.name, "remnic");
@@ -54,9 +53,8 @@ test("generateMarketplaceManifest produces valid manifest with correct version",
 });
 
 test("generateMarketplaceManifest defaults to 0.0.0 when no version supplied", () => {
-  const config = makeConfig();
   // Force no version discovery by passing undefined
-  const manifest = generateMarketplaceManifest(config, { packageVersion: undefined });
+  const manifest = generateMarketplaceManifest({ packageVersion: undefined });
 
   // Should fall back to readPackageVersion() or 0.0.0
   assert.ok(typeof manifest.plugins[0].version === "string");
@@ -64,8 +62,7 @@ test("generateMarketplaceManifest defaults to 0.0.0 when no version supplied", (
 });
 
 test("generateMarketplaceManifest output passes validation", () => {
-  const config = makeConfig();
-  const manifest = generateMarketplaceManifest(config, { packageVersion: "1.0.0" });
+  const manifest = generateMarketplaceManifest({ packageVersion: "1.0.0" });
   const validation = checkMarketplaceManifest(manifest);
 
   assert.ok(validation.valid, `validation failed: ${validation.errors.join("; ")}`);


### PR DESCRIPTION
## Summary

- Add Codex marketplace support so Remnic can be discovered and installed via `codex marketplace add joshuaswarren/remnic`
- New `marketplace.json` at repo root describes Remnic as an installable plugin in the Codex marketplace ecosystem
- New CLI commands under `remnic connectors marketplace` for generate, validate, and install operations
- New `codexMarketplaceEnabled` config property (default: true) with full schema/config/type wiring

## Changes

### New files
- `packages/remnic-core/src/connectors/codex/marketplace.ts` — core marketplace module with types, generate, validate, write, and install functions
- `marketplace.json` — root marketplace manifest for Codex discovery
- `tests/codex-marketplace.test.ts` — 24 tests covering all marketplace operations
- `docs/plugins/codex-marketplace.md` — documentation for the integration
- `scripts/sync-marketplace-version.mjs` — version sync script for releases

### Modified files
- `packages/remnic-core/src/types.ts` — added `codexMarketplaceEnabled` to PluginConfig
- `packages/remnic-core/src/config.ts` — parse `codexMarketplaceEnabled` (default: true)
- `packages/remnic-core/src/connectors/index.ts` — export marketplace functions and types
- `packages/plugin-openclaw/openclaw.plugin.json` + `openclaw.plugin.json` — config schema entry
- `packages/remnic-cli/src/index.ts` — `connectors marketplace` subcommands

## Test plan

- [x] All 24 new marketplace tests pass
- [x] `generateMarketplaceManifest` produces valid manifest with correct version
- [x] `validateMarketplaceManifest` accepts valid manifests, rejects invalid ones (missing fields, invalid version, invalid installType, null/string input)
- [x] `writeMarketplaceManifest` writes valid JSON atomically, rejects invalid manifests, creates parent dirs
- [x] `installFromMarketplace` reads local marketplace.json, handles invalid URLs, rejects invalid GitHub format, respects disabled config
- [x] Root `marketplace.json` validates against schema
- [x] Config contract validation passes (513/513/512 with expected `gatewayConfig` exclusion)
- [x] Existing codex-materialize tests pass (no regressions)
- [x] TypeScript compiles cleanly (`tsc --noEmit`)
- [x] Build succeeds (`pnpm run build`)

Closes #418

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI surface area and network-based manifest fetching/validation paths, plus a new config flag that gates install behavior; failures could affect connector UX but are largely additive and well-tested.
> 
> **Overview**
> Adds **Codex CLI marketplace integration** so Remnic can be discovered/installed via a repository-root `marketplace.json` and new `remnic connectors marketplace` CLI subcommands to `generate`, `validate`, and `install` marketplace manifests.
> 
> Introduces a core `codex-marketplace` module (manifest generation/validation, atomic writes, and source resolution for `github`/`url`/`local`/limited `git`), wires it through core exports, and adds a config guard `codexMarketplaceEnabled` (default `true`) to schemas/types/config parsing. Includes docs, a release helper script to sync manifest version, and comprehensive tests for the marketplace workflow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 794167e8fa62293936ba90d200ecac344cfbc97c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->