### PR TITLE
feat(extensions): discover third-party memory extensions (#382)

### DIFF
--- a/docs/architecture/memory-extensions.md
+++ b/docs/architecture/memory-extensions.md
@@ -1,0 +1,122 @@
+# Memory Extensions Architecture
+
+Third-party memory extensions allow external tools and integrations to provide
+structured instructions that influence how Remnic's consolidation engine
+interprets, groups, and synthesizes memories.
+
+## Directory Layout
+
+Extensions live under the memory extensions root directory, which defaults to
+`<memoryDir>/../memory_extensions/` (typically `~/.openclaw/workspace/memory/memory_extensions/`).
+The root can be overridden with the `memoryExtensionsRoot` config property.
+
+```
+memory_extensions/
+  github-issues/
+    instructions.md      # REQUIRED: how to interpret these memories
+    schema.json           # OPTIONAL: memory types, grouping hints, version
+    examples/             # OPTIONAL: up to 10 example .md files
+      issue-closed.md
+      issue-opened.md
+    scripts/              # NEVER read by Remnic (read-only contract)
+      install.sh
+  slack-archive/
+    instructions.md
+    schema.json
+```
+
+## Naming Rules
+
+Each extension lives in a subdirectory whose name is a **slug**:
+
+- Lowercase letters, digits, and hyphens only (`[a-z0-9-]`)
+- 1 to 64 characters
+- Must start with a letter or digit (not a hyphen)
+
+Invalid slugs are skipped with a warning.
+
+## instructions.md
+
+The only required file. Contains free-form markdown that tells the consolidation
+LLM how to interpret memories this extension produces or curates. This content
+is injected into consolidation prompts wrapped in a fenced code block.
+
+Keep instructions concise. The total token budget across all extensions is
+**5,000 tokens** (estimated at ~4 chars per token). Extensions are inlined in
+alphabetical order until the budget is exhausted; remaining extensions are listed
+in a truncation footer.
+
+## schema.json
+
+Optional JSON file with the following shape:
+
+```json
+{
+  "memoryTypes": ["fact", "preference", "procedure", "reference"],
+  "groupingHints": ["repository", "issue-number"],
+  "version": "1.0.0"
+}
+```
+
+All fields are optional. Invalid fields are silently ignored; a completely
+malformed file causes the schema to be `undefined` (the extension still loads).
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `memoryTypes` | `string[]` | Which memory categories this extension produces. Valid values: `fact`, `preference`, `procedure`, `reference`. |
+| `groupingHints` | `string[]` | Suggested grouping dimensions for consolidation clustering. |
+| `version` | `string` | Semantic version of the extension. |
+
+## Examples Directory
+
+Up to 10 `.md` files in `examples/` are collected (sorted alphabetically) and
+made available as `examplesPaths` on the discovered extension object. These are
+not currently injected into prompts but reserved for future use (e.g., few-shot
+examples for extraction).
+
+## Read-Only Contract
+
+Remnic **never** reads or executes files under any extension's `scripts/`
+directory. The discovery process only touches:
+
+- The extension root directory listing
+- `instructions.md`
+- `schema.json`
+- `examples/*.md` file listing
+
+## Token Budget
+
+The total budget for all extension instructions combined is 5,000 tokens
+(constant `REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT`). Token estimation uses the
+4 chars = 1 token heuristic.
+
+Extensions are rendered in alphabetical order. Once the budget is exhausted,
+remaining extensions are listed by name in a truncation footer but their
+instructions are not included.
+
+## Configuration
+
+| Property | Type | Default | Description |
+|----------|------|---------|-------------|
+| `memoryExtensionsEnabled` | `boolean` | `true` | Master switch for extension discovery. |
+| `memoryExtensionsRoot` | `string` | `""` | Override root directory. Empty = derive from `memoryDir`. |
+
+## Injection Points
+
+- **Semantic consolidation** (`semantic-consolidation.ts`): Full extensions block appended to the synthesis prompt.
+- **Causal consolidation** (`causal-consolidation.ts`): Full extensions block appended to the causal context.
+- **Day summary** (`day-summary.ts`): One-line footer only (`Active extensions: ext1, ext2`).
+- **Summary snapshot** (`summary-snapshot.ts`): One-line footer only.
+
+## CLI Commands
+
+```
+remnic extensions list        # List discovered extensions
+remnic extensions show <name> # Print instructions.md content
+remnic extensions validate    # Validate all, exit non-zero on error
+remnic extensions reload      # No-op stub, reserved for future caching
+```
+
+The `remnic daemon status` command also shows a memory extensions summary line.

--- a/docs/extensions/example-github-issues/README.md
+++ b/docs/extensions/example-github-issues/README.md
@@ -1,0 +1,86 @@
+# Publishing a Memory Extension
+
+This directory is an example of a third-party Remnic memory extension.
+
+## Directory Structure
+
+A memory extension is a directory placed under `~/.remnic/memory_extensions/`
+(or the configured `memoryExtensionsRoot`) with the following layout:
+
+```
+your-extension-name/
+  instructions.md       # REQUIRED
+  schema.json           # OPTIONAL
+  examples/             # OPTIONAL (up to 10 .md files)
+    example-01.md
+  scripts/              # OPTIONAL (never read by Remnic)
+    install.sh
+```
+
+## Required: instructions.md
+
+This file tells Remnic's consolidation engine how to interpret the memories
+your extension produces. Write it as if you are briefing an LLM that will be
+synthesizing and merging these memories.
+
+Include:
+- What each memory represents
+- How memories should be grouped during consolidation
+- What information must be preserved vs. can be summarized
+- Any importance signals or priority rules
+
+## Optional: schema.json
+
+Declares metadata about what your extension produces:
+
+```json
+{
+  "memoryTypes": ["fact", "preference", "procedure", "reference"],
+  "groupingHints": ["project-name", "category"],
+  "version": "1.0.0"
+}
+```
+
+- `memoryTypes`: Which Remnic memory categories your extension produces.
+  Valid values: `fact`, `preference`, `procedure`, `reference`.
+- `groupingHints`: Suggested dimensions for clustering during consolidation.
+- `version`: Semantic version of your extension.
+
+## Optional: examples/
+
+Place up to 10 `.md` files showing example memories. These are reserved for
+future use (e.g., few-shot prompting) but help document your extension.
+
+## Naming Your Extension
+
+The directory name must be a valid slug:
+- Lowercase letters, digits, and hyphens only
+- 1 to 64 characters
+- Cannot start with a hyphen
+
+## Token Budget
+
+All extensions share a 5,000 token budget for their instructions. Keep your
+`instructions.md` concise. Extensions are loaded alphabetically; if the budget
+is exhausted, later extensions are omitted with a note.
+
+## Read-Only Contract
+
+Remnic will **never** execute or read files in your `scripts/` directory. The
+discovery process only reads `instructions.md`, `schema.json`, and lists files
+in `examples/`.
+
+## Installation
+
+Copy your extension directory into `~/.remnic/memory_extensions/`:
+
+```bash
+cp -r your-extension-name ~/.remnic/memory_extensions/
+```
+
+Verify with:
+
+```bash
+remnic extensions list
+remnic extensions validate
+```

--- a/docs/extensions/example-github-issues/instructions.md
+++ b/docs/extensions/example-github-issues/instructions.md
@@ -1,0 +1,30 @@
+# GitHub Issues Memory Extension
+
+This extension produces **reference** memories from GitHub issues.
+
+## Memory Format
+
+Each memory represents a single GitHub issue or pull request and contains:
+
+- **Title**: The issue title
+- **State**: open, closed, or merged
+- **Labels**: Comma-separated label names
+- **Repository**: owner/repo format
+- **Body excerpt**: First 500 characters of the issue body
+
+## Consolidation Guidance
+
+When consolidating memories from this extension:
+
+1. Group by repository first, then by label similarity
+2. Closed/merged issues with the same root cause should merge into a single
+   "resolved pattern" memory
+3. Open issues should remain as individual reference memories
+4. Preserve issue numbers in consolidated memories for traceability
+
+## Importance Signals
+
+- Issues with "critical" or "security" labels: high importance
+- Issues with "bug" label: medium importance
+- Feature requests and enhancements: low importance
+- Stale issues (no activity > 90 days): candidate for archival

--- a/docs/extensions/example-github-issues/schema.json
+++ b/docs/extensions/example-github-issues/schema.json
@@ -1,0 +1,5 @@
+{
+  "memoryTypes": ["reference"],
+  "groupingHints": ["repository", "label", "issue-state"],
+  "version": "1.0.0"
+}

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -659,6 +659,16 @@
         "default": true,
         "description": "Auto-enable citations when the Codex adapter is detected."
       },
+      "memoryExtensionsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+      },
+      "memoryExtensionsRoot": {
+        "type": "string",
+        "default": "",
+        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -656,6 +656,16 @@
         "default": true,
         "description": "Auto-enable citations when the Codex adapter is detected."
       },
+      "memoryExtensionsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+      },
+      "memoryExtensionsRoot": {
+        "type": "string",
+        "default": "",
+        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -103,6 +103,8 @@ import {
   appendAuditEntry,
   readAuditLog,
   defaultEnrichmentPipelineConfig,
+  discoverMemoryExtensions,
+  resolveExtensionsRoot,
 } from "@remnic/core";
 import type {
   BinaryLifecycleConfig,
@@ -147,7 +149,8 @@ type CommandName =
   | "binary"
   | "taxonomy"
   | "enrich"
-  | "openclaw";
+  | "openclaw"
+  | "extensions";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -794,6 +797,107 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   }
   if (totalPersisted > 0) {
     console.log(`\n  ${totalPersisted} candidate(s) persisted to memory store.`);
+  }
+}
+
+async function cmdExtensions(action: string, rest: string[]): Promise<void> {
+  initLogger();
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const config = parseConfig(remnicCfg);
+
+  const root = resolveExtensionsRoot(config);
+  const noopLog = { warn: () => {}, debug: () => {} };
+  const warnLog = {
+    warn: (msg: string) => console.warn(msg),
+    debug: () => {},
+  };
+
+  switch (action) {
+    case "list": {
+      const extensions = await discoverMemoryExtensions(root, noopLog);
+      if (extensions.length === 0) {
+        console.log("No memory extensions found.");
+        console.log(`  Scanned: ${root}`);
+        return;
+      }
+      console.log(`Memory extensions (${extensions.length}):`);
+      for (const ext of extensions) {
+        const schemaInfo = ext.schema?.version ? ` v${ext.schema.version}` : "";
+        const types = ext.schema?.memoryTypes?.join(", ") ?? "any";
+        console.log(`  ${ext.name}${schemaInfo}  (types: ${types})`);
+      }
+      console.log(`\nRoot: ${root}`);
+      break;
+    }
+
+    case "show": {
+      const name = rest[0];
+      if (!name) {
+        console.error("Usage: remnic extensions show <name>");
+        process.exitCode = 1;
+        return;
+      }
+      const extensions = await discoverMemoryExtensions(root, noopLog);
+      const ext = extensions.find((e) => e.name === name);
+      if (!ext) {
+        console.error(`Extension "${name}" not found in ${root}`);
+        process.exitCode = 1;
+        return;
+      }
+      console.log(ext.instructions);
+      break;
+    }
+
+    case "validate": {
+      const extensions = await discoverMemoryExtensions(root, warnLog);
+      // Re-scan to detect skipped entries
+      let entries: string[] = [];
+      try {
+        entries = fs.readdirSync(root);
+      } catch {
+        console.log(`Extensions root does not exist: ${root}`);
+        process.exitCode = 0;
+        return;
+      }
+      const validNames = new Set(extensions.map((e) => e.name));
+      let errors = 0;
+      for (const entry of entries) {
+        const entryPath = path.join(root, entry);
+        try {
+          if (!fs.statSync(entryPath).isDirectory()) continue;
+        } catch {
+          continue;
+        }
+        if (!validNames.has(entry)) {
+          errors++;
+        }
+      }
+      console.log(`Validated: ${extensions.length} valid, ${errors} skipped`);
+      if (errors > 0) {
+        process.exitCode = 1;
+      }
+      break;
+    }
+
+    case "reload": {
+      // No-op stub reserved for future caching
+      console.log("Extension cache reloaded (no-op: caching not yet implemented).");
+      break;
+    }
+
+    default:
+      console.log(`Usage: remnic extensions <list|show|validate|reload>
+
+  list                 List discovered extensions
+  show <name>          Print instructions.md content
+  validate             Validate all extensions, exit non-zero on errors
+  reload               Reserved for future caching (no-op)
+`);
+      break;
   }
 }
 
@@ -2056,7 +2160,7 @@ function isServiceRunning(): { running: boolean; pid?: number } {
   return { running: false };
 }
 
-function daemonStatus(): void {
+async function daemonStatus(): Promise<void> {
   const { running, pid } = isServiceRunning();
   const port = inferPort();
   const serviceInstalled = isMacOS()
@@ -2072,6 +2176,27 @@ function daemonStatus(): void {
   console.log(`  Platform:  ${process.platform}`);
   console.log(`  PID file:  ${fs.existsSync(PID_FILE) ? PID_FILE : LEGACY_PID_FILE}`);
   console.log(`  Log file:  ${fs.existsSync(LOG_FILE) ? LOG_FILE : LEGACY_LOG_FILE}`);
+
+  // Memory extensions status (#382)
+  try {
+    const configPath = resolveConfigPath();
+    const raw = fs.existsSync(configPath)
+      ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+      : {};
+    const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+    const config = parseConfig(remnicCfg);
+    const extRoot = resolveExtensionsRoot(config);
+    const noopLog = { warn: () => {}, debug: () => {} };
+    const exts = await discoverMemoryExtensions(extRoot, noopLog);
+    if (exts.length > 0) {
+      const names = exts.map((e) => e.name).join(", ");
+      console.log(`  Memory extensions: ${exts.length} active (${names})`);
+    } else {
+      console.log(`  Memory extensions: none`);
+    }
+  } catch {
+    console.log(`  Memory extensions: unknown (config error)`);
+  }
 }
 
 function daemonStart(): void {
@@ -2904,7 +3029,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
           daemonUninstall();
           break;
         case "status":
-          daemonStatus();
+          await daemonStatus();
           break;
         default:
           console.log("Usage: remnic daemon <start|stop|restart|install|uninstall|status>");
@@ -3126,6 +3251,12 @@ Options:
       break;
     }
 
+    case "extensions": {
+      const action = rest[0] ?? "help";
+      await cmdExtensions(action, rest.slice(1));
+      break;
+    }
+
     case "openclaw": {
       const subAction = rest[0] ?? "help";
       if (subAction === "install") {
@@ -3180,6 +3311,7 @@ Usage:
     marketplace generate    Generate marketplace.json for Codex
     marketplace validate    Validate a marketplace.json file
     marketplace install     Install from a marketplace source
+  remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
   remnic benchmark <run|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]

--- a/packages/remnic-core/src/causal-consolidation.ts
+++ b/packages/remnic-core/src/causal-consolidation.ts
@@ -23,6 +23,7 @@ import path from "node:path";
 import { log } from "./logger.js";
 import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
 import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
+import { buildExtensionsBlockForConsolidation } from "./semantic-consolidation.js";
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -259,6 +260,7 @@ export async function deriveCausalPromotionCandidates(options: {
   config: ConsolidationConfig;
   gatewayConfig?: GatewayConfig;
   gatewayAgentId?: string;
+  pluginConfig?: PluginConfig;
 }): Promise<CausalPatternCandidate[]> {
   try {
     const trajectories = await readAllTrajectories(options.memoryDir, options.causalTrajectoryStoreDir);
@@ -268,7 +270,15 @@ export async function deriveCausalPromotionCandidates(options: {
     const chainIndex = await readChainIndex(chainsDir);
 
     // Format the causal context for the LLM
-    const context = formatCausalContext(trajectories, chainIndex);
+    let context = formatCausalContext(trajectories, chainIndex);
+
+    // Append memory extensions block if available (#382)
+    if (options.pluginConfig) {
+      const extBlock = await buildExtensionsBlockForConsolidation(options.pluginConfig);
+      if (extBlock.length > 0) {
+        context += "\n\n" + extBlock;
+      }
+    }
 
     // If no LLM available, fall back to empty (no deterministic fallback)
     const llm = new FallbackLlmClient(options.gatewayConfig);

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -504,6 +504,7 @@ export class CompoundingEngine {
           causalTrajectoryStoreDir: this.config.causalTrajectoryStoreDir,
           gatewayConfig: this.config.gatewayConfig,
           gatewayAgentId: this.config.modelSource === "gateway" ? (this.config.gatewayAgentId || undefined) : undefined,
+          pluginConfig: this.config,
           config: {
             minRecurrence: this.config.cmcConsolidationMinRecurrence,
             minSessions: this.config.cmcConsolidationMinSessions,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1992,6 +1992,13 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.enrichmentMaxCandidatesPerEntity === "number"
         ? Math.max(0, Math.floor(cfg.enrichmentMaxCandidatesPerEntity))
         : 20,
+
+    // Memory extensions discovery (#382)
+    memoryExtensionsEnabled: cfg.memoryExtensionsEnabled !== false,
+    memoryExtensionsRoot:
+      typeof cfg.memoryExtensionsRoot === "string" && cfg.memoryExtensionsRoot.trim().length > 0
+        ? cfg.memoryExtensionsRoot.trim()
+        : "",
   };
 }
 

--- a/packages/remnic-core/src/day-summary.ts
+++ b/packages/remnic-core/src/day-summary.ts
@@ -3,7 +3,9 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { log } from "./logger.js";
-import type { MemoryFile } from "./types.js";
+import type { MemoryFile, PluginConfig } from "./types.js";
+import { discoverMemoryExtensions, renderExtensionsFooter } from "./memory-extension-host/index.js";
+import { resolveExtensionsRoot } from "./semantic-consolidation.js";
 
 const PROMPT_RELATIVE_PATH = path.join("prompts", "day_summary.prompt.md");
 
@@ -104,4 +106,18 @@ export function formatDaySummaryMemories(memories: string | MemoryFile[]): strin
     })
     .join("\n\n")
     .trim();
+}
+
+/**
+ * Build a one-line extension footer for day-summary and summary-snapshot contexts.
+ * Returns "" when extensions are disabled or none are found.
+ */
+export async function buildExtensionsFooterForSummary(
+  config: PluginConfig,
+): Promise<string> {
+  if (!config.memoryExtensionsEnabled) return "";
+  const root = resolveExtensionsRoot(config);
+  const extensions = await discoverMemoryExtensions(root, log);
+  if (extensions.length === 0) return "";
+  return renderExtensionsFooter(extensions);
 }

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -32,7 +32,7 @@ import { extractJsonCandidates } from "./json-extract.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { applyWorkExtractionBoundary } from "./work/boundary.js";
 import { buildChatCompletionTokenLimit, shouldAssumeOpenAiChatCompletions } from "./openai-chat-compat.js";
-import { formatDaySummaryMemories, loadDaySummaryPrompt } from "./day-summary.js";
+import { formatDaySummaryMemories, loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-summary.js";
 import { ProfilingCollector } from "./profiling.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
@@ -2369,9 +2369,18 @@ Respond with valid JSON matching this schema:
     if (memoryContext.length === 0) return null;
 
     const systemPrompt = await loadDaySummaryPrompt();
+
+    // Append extension footer when extensions are active (#382)
+    let extensionsFooter = "";
+    try {
+      extensionsFooter = await buildExtensionsFooterForSummary(this.config);
+    } catch {
+      // Non-fatal: skip extension footer if discovery fails
+    }
+
     const userPrompt = `Generate an end-of-day summary from this Remnic memory context:
 
-${memoryContext}`;
+${memoryContext}${extensionsFooter.length > 0 ? `\n\n${extensionsFooter}` : ""}`;
     const traceId = crypto.randomUUID();
     const startedAt = Date.now();
     this.emit({ kind: "llm_start", traceId, model: this.config.model, operation: "day_summary", input: memoryContext.slice(0, 4000) });

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -144,7 +144,7 @@ export {
 // Day summary / LCM
 // ---------------------------------------------------------------------------
 
-export { loadDaySummaryPrompt } from "./day-summary.js";
+export { loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-summary.js";
 
 // ---------------------------------------------------------------------------
 // Active memory bridge
@@ -348,6 +348,24 @@ export {
   type FileChange,
   type SyncState,
 } from "./sync/index.js";
+
+// ---------------------------------------------------------------------------
+// Memory Extension Host (#382)
+// ---------------------------------------------------------------------------
+
+export {
+  discoverMemoryExtensions,
+  renderExtensionsBlock,
+  renderExtensionsFooter,
+  REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT,
+  type DiscoveredExtension,
+  type ExtensionSchema,
+} from "./memory-extension-host/index.js";
+
+export {
+  resolveExtensionsRoot,
+  buildExtensionsBlockForConsolidation,
+} from "./semantic-consolidation.js";
 
 // ---------------------------------------------------------------------------
 // Connector Manager

--- a/packages/remnic-core/src/memory-extension-host/host-discovery.ts
+++ b/packages/remnic-core/src/memory-extension-host/host-discovery.ts
@@ -1,0 +1,189 @@
+/**
+ * memory-extension-host/host-discovery.ts — Discover third-party memory extensions.
+ *
+ * Scans a root directory (typically ~/.remnic/memory_extensions/) for valid
+ * extension subdirectories. Each extension must contain an instructions.md.
+ * The discovery process is read-only and NEVER reads or executes files under
+ * any extension's scripts/ directory.
+ */
+
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import type { LoggerBackend } from "../logger.js";
+import type { DiscoveredExtension, ExtensionSchema } from "./types.js";
+
+/** Total token budget for all discovered extension instructions combined. */
+export const REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT = 5_000;
+
+/** Maximum number of example files collected per extension. */
+const MAX_EXAMPLES_PER_EXTENSION = 10;
+
+/** Slug validation: lowercase letters, digits, hyphens, 1-64 chars. */
+const VALID_SLUG_RE = /^[a-z0-9][a-z0-9-]{0,63}$/;
+
+const VALID_MEMORY_TYPES = new Set(["fact", "preference", "procedure", "reference"]);
+
+/**
+ * Discover all valid memory extensions under the given root directory.
+ *
+ * Returns extensions sorted by name. Skips entries with warnings when:
+ * - The slug is invalid (not lowercase alphanumeric + hyphens, or > 64 chars)
+ * - instructions.md is missing
+ * - schema.json is malformed (extension still returned but schema is undefined)
+ *
+ * NEVER reads files under any extension's scripts/ directory.
+ */
+export async function discoverMemoryExtensions(
+  root: string,
+  log: Pick<LoggerBackend, "warn" | "debug">,
+): Promise<DiscoveredExtension[]> {
+  // If root doesn't exist, return empty silently (not even a warning)
+  let rootStat;
+  try {
+    rootStat = await stat(root);
+  } catch {
+    return [];
+  }
+  if (!rootStat.isDirectory()) {
+    return [];
+  }
+
+  let entries: string[];
+  try {
+    entries = await readdir(root);
+  } catch {
+    return [];
+  }
+
+  const extensions: DiscoveredExtension[] = [];
+
+  for (const entry of entries) {
+    const entryPath = path.join(root, entry);
+
+    // Must be a directory
+    let entryStat;
+    try {
+      entryStat = await stat(entryPath);
+    } catch {
+      continue;
+    }
+    if (!entryStat.isDirectory()) continue;
+
+    // Validate slug
+    if (!VALID_SLUG_RE.test(entry)) {
+      log.warn?.(
+        `[memory-extensions] skipping "${entry}": invalid slug (must be lowercase alphanumeric + hyphens, 1-64 chars)`,
+      );
+      continue;
+    }
+
+    // Require instructions.md
+    const instructionsPath = path.join(entryPath, "instructions.md");
+    let instructions: string;
+    try {
+      instructions = await readFile(instructionsPath, "utf-8");
+    } catch {
+      log.warn?.(
+        `[memory-extensions] skipping "${entry}": missing instructions.md`,
+      );
+      continue;
+    }
+
+    // Read optional schema.json
+    let schema: ExtensionSchema | undefined;
+    const schemaPath = path.join(entryPath, "schema.json");
+    try {
+      const schemaRaw = await readFile(schemaPath, "utf-8");
+      const parsed = JSON.parse(schemaRaw);
+      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+        schema = validateSchema(parsed);
+      } else {
+        log.warn?.(
+          `[memory-extensions] "${entry}": schema.json is not a valid object, ignoring schema`,
+        );
+      }
+    } catch (err) {
+      // File doesn't exist → fine, no warning needed
+      if (isFileNotFoundError(err)) {
+        // schema remains undefined
+      } else {
+        log.warn?.(
+          `[memory-extensions] "${entry}": malformed schema.json, ignoring schema`,
+        );
+      }
+    }
+
+    // Collect examples/*.md (cap at MAX_EXAMPLES_PER_EXTENSION)
+    // NEVER read from scripts/ directory
+    const examplesPaths: string[] = [];
+    const examplesDir = path.join(entryPath, "examples");
+    try {
+      const exampleEntries = await readdir(examplesDir);
+      const mdFiles = exampleEntries
+        .filter((f) => f.endsWith(".md"))
+        .sort()
+        .slice(0, MAX_EXAMPLES_PER_EXTENSION);
+      for (const f of mdFiles) {
+        examplesPaths.push(path.join(examplesDir, f));
+      }
+    } catch {
+      // No examples dir — fine
+    }
+
+    extensions.push({
+      name: entry,
+      root: entryPath,
+      instructionsPath,
+      instructions,
+      schema,
+      examplesPaths,
+    });
+  }
+
+  // Sort by name for deterministic ordering
+  extensions.sort((a, b) => {
+    if (a.name < b.name) return -1;
+    if (a.name > b.name) return 1;
+    return 0;
+  });
+
+  return extensions;
+}
+
+function validateSchema(raw: Record<string, unknown>): ExtensionSchema {
+  const result: ExtensionSchema = {};
+
+  if (Array.isArray(raw.memoryTypes)) {
+    const validTypes = raw.memoryTypes.filter(
+      (t): t is "fact" | "preference" | "procedure" | "reference" =>
+        typeof t === "string" && VALID_MEMORY_TYPES.has(t),
+    );
+    if (validTypes.length > 0) {
+      result.memoryTypes = validTypes;
+    }
+  }
+
+  if (Array.isArray(raw.groupingHints)) {
+    const validHints = raw.groupingHints.filter(
+      (h): h is string => typeof h === "string" && h.length > 0,
+    );
+    if (validHints.length > 0) {
+      result.groupingHints = validHints;
+    }
+  }
+
+  if (typeof raw.version === "string" && raw.version.length > 0) {
+    result.version = raw.version;
+  }
+
+  return result;
+}
+
+function isFileNotFoundError(err: unknown): boolean {
+  return (
+    typeof err === "object" &&
+    err !== null &&
+    "code" in err &&
+    (err as { code: string }).code === "ENOENT"
+  );
+}

--- a/packages/remnic-core/src/memory-extension-host/host-discovery.ts
+++ b/packages/remnic-core/src/memory-extension-host/host-discovery.ts
@@ -7,7 +7,7 @@
  * any extension's scripts/ directory.
  */
 
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, readFile, lstat, stat } from "node:fs/promises";
 import path from "node:path";
 import type { LoggerBackend } from "../logger.js";
 import type { DiscoveredExtension, ExtensionSchema } from "./types.js";
@@ -37,7 +37,10 @@ export async function discoverMemoryExtensions(
   root: string,
   log: Pick<LoggerBackend, "warn" | "debug">,
 ): Promise<DiscoveredExtension[]> {
-  // If root doesn't exist, return empty silently (not even a warning)
+  // If root doesn't exist, return empty silently (not even a warning).
+  // Use stat() for root — the user configures this path, so following a
+  // symlink here is intentional.  Child entries use lstat() to block
+  // symlink traversal that could escape the extensions directory.
   let rootStat;
   try {
     rootStat = await stat(root);
@@ -60,11 +63,18 @@ export async function discoverMemoryExtensions(
   for (const entry of entries) {
     const entryPath = path.join(root, entry);
 
-    // Must be a directory
+    // Must be a real directory (not a symlink) — lstat() blocks symlink
+    // traversal that could escape the extensions root (#382 P2).
     let entryStat;
     try {
-      entryStat = await stat(entryPath);
+      entryStat = await lstat(entryPath);
     } catch {
+      continue;
+    }
+    if (entryStat.isSymbolicLink()) {
+      log.warn?.(
+        `[memory-extensions] skipping "${entry}": symlinks are not followed for security`,
+      );
       continue;
     }
     if (!entryStat.isDirectory()) continue;

--- a/packages/remnic-core/src/memory-extension-host/host-discovery.ts
+++ b/packages/remnic-core/src/memory-extension-host/host-discovery.ts
@@ -161,32 +161,33 @@ export async function discoverMemoryExtensions(
 }
 
 function validateSchema(raw: Record<string, unknown>): ExtensionSchema {
-  const result: ExtensionSchema = {};
-
-  if (Array.isArray(raw.memoryTypes)) {
-    const validTypes = raw.memoryTypes.filter(
+  const memoryTypes: ExtensionSchema["memoryTypes"] = (() => {
+    if (!Array.isArray(raw.memoryTypes)) return undefined;
+    const valid = raw.memoryTypes.filter(
       (t): t is "fact" | "preference" | "procedure" | "reference" =>
         typeof t === "string" && VALID_MEMORY_TYPES.has(t),
     );
-    if (validTypes.length > 0) {
-      result.memoryTypes = validTypes;
-    }
-  }
+    return valid.length > 0 ? valid : undefined;
+  })();
 
-  if (Array.isArray(raw.groupingHints)) {
-    const validHints = raw.groupingHints.filter(
+  const groupingHints: ExtensionSchema["groupingHints"] = (() => {
+    if (!Array.isArray(raw.groupingHints)) return undefined;
+    const valid = raw.groupingHints.filter(
       (h): h is string => typeof h === "string" && h.length > 0,
     );
-    if (validHints.length > 0) {
-      result.groupingHints = validHints;
-    }
-  }
+    return valid.length > 0 ? valid : undefined;
+  })();
 
-  if (typeof raw.version === "string" && raw.version.length > 0) {
-    result.version = raw.version;
-  }
+  const version: ExtensionSchema["version"] =
+    typeof raw.version === "string" && raw.version.length > 0
+      ? raw.version
+      : undefined;
 
-  return result;
+  return {
+    ...(memoryTypes ? { memoryTypes } : {}),
+    ...(groupingHints ? { groupingHints } : {}),
+    ...(version ? { version } : {}),
+  };
 }
 
 function isFileNotFoundError(err: unknown): boolean {

--- a/packages/remnic-core/src/memory-extension-host/index.ts
+++ b/packages/remnic-core/src/memory-extension-host/index.ts
@@ -1,0 +1,13 @@
+/**
+ * memory-extension-host/index.ts — Public API for memory extension discovery.
+ */
+
+export type { DiscoveredExtension, ExtensionSchema } from "./types.js";
+export {
+  discoverMemoryExtensions,
+  REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT,
+} from "./host-discovery.js";
+export {
+  renderExtensionsBlock,
+  renderExtensionsFooter,
+} from "./render-extensions-block.js";

--- a/packages/remnic-core/src/memory-extension-host/render-extensions-block.ts
+++ b/packages/remnic-core/src/memory-extension-host/render-extensions-block.ts
@@ -1,0 +1,73 @@
+/**
+ * memory-extension-host/render-extensions-block.ts — Render discovered extensions
+ * into a markdown block for injection into consolidation prompts.
+ *
+ * Respects the global token budget (REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT) and
+ * truncates with a footer listing omitted extensions when over budget.
+ */
+
+import { REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT } from "./host-discovery.js";
+import type { DiscoveredExtension } from "./types.js";
+
+/**
+ * Approximate token count using the 4 chars per token heuristic.
+ */
+function estimateTokens(text: string): number {
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Render a markdown block containing extension instructions for injection
+ * into consolidation prompts.
+ *
+ * If the list is empty, returns "".
+ * Inlines extensions in name order until the token budget is exhausted.
+ * If the budget is exceeded, appends a truncation footer listing omitted extensions.
+ */
+export function renderExtensionsBlock(extensions: DiscoveredExtension[]): string {
+  if (extensions.length === 0) return "";
+
+  const header = `## Active memory extensions
+
+You are running with the following third-party memory extensions. Each
+extension's \`instructions.md\` tells you how to interpret memories that
+extension produces or curates.
+
+`;
+
+  let budget = REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT;
+  budget -= estimateTokens(header);
+
+  const inlined: string[] = [];
+  const omitted: string[] = [];
+
+  for (const ext of extensions) {
+    const block = `### remnic-extension/${ext.name}\n\`\`\`\n${ext.instructions}\n\`\`\`\n\n`;
+    const cost = estimateTokens(block);
+    if (cost <= budget) {
+      inlined.push(block);
+      budget -= cost;
+    } else {
+      omitted.push(ext.name);
+    }
+  }
+
+  let result = header;
+  result += inlined.join("");
+
+  if (omitted.length > 0) {
+    result += `> **Note:** ${omitted.length} extension(s) omitted due to token budget: ${omitted.join(", ")}\n`;
+  }
+
+  return result;
+}
+
+/**
+ * Render a compact one-line footer listing active extension names.
+ * Used by day-summary and summary-snapshot where full instructions are not needed.
+ */
+export function renderExtensionsFooter(extensions: DiscoveredExtension[]): string {
+  if (extensions.length === 0) return "";
+  const names = extensions.map((ext) => ext.name).join(", ");
+  return `Active extensions: ${names}`;
+}

--- a/packages/remnic-core/src/memory-extension-host/types.ts
+++ b/packages/remnic-core/src/memory-extension-host/types.ts
@@ -1,0 +1,21 @@
+/**
+ * memory-extension-host/types.ts — Types for third-party memory extension discovery.
+ *
+ * Memory extensions live under ~/.remnic/memory_extensions/<slug>/ and provide
+ * instructions.md (required), schema.json (optional), and examples/*.md (optional).
+ */
+
+export interface DiscoveredExtension {
+  readonly name: string;
+  readonly root: string;
+  readonly instructionsPath: string;
+  readonly instructions: string;
+  readonly schema?: ExtensionSchema;
+  readonly examplesPaths: string[];
+}
+
+export interface ExtensionSchema {
+  readonly memoryTypes?: Array<"fact" | "preference" | "procedure" | "reference">;
+  readonly groupingHints?: string[];
+  readonly version?: string;
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -199,6 +199,7 @@ import {
   findSimilarClusters,
   buildConsolidationPrompt,
   parseConsolidationResponse,
+  buildExtensionsBlockForConsolidation,
   materializeAfterSemanticConsolidation,
   type SemanticConsolidationResult,
 } from "./semantic-consolidation.js";
@@ -2183,9 +2184,20 @@ export class Orchestrator {
       return result;
     }
 
+    // Discover memory extensions once for all clusters (#382)
+    let extensionsBlock = "";
+    try {
+      extensionsBlock = await buildExtensionsBlockForConsolidation(this.config);
+    } catch (err) {
+      log.warn(`[semantic-consolidation] extension discovery failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`);
+    }
+
     for (const cluster of clusters) {
       try {
-        const prompt = buildConsolidationPrompt(cluster);
+        let prompt = buildConsolidationPrompt(cluster);
+        if (extensionsBlock.length > 0) {
+          prompt += "\n\n" + extensionsBlock;
+        }
         const messages = [
           {
             role: "system" as const,

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -6,10 +6,13 @@
  * Reduces memory store bloat while preserving all unique information.
  */
 
+import path from "node:path";
 import type { MemoryFile, PluginConfig } from "./types.js";
 import { normalizeRecallTokens, countRecallTokenOverlap } from "./recall-tokenization.js";
 import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
 import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
+import { discoverMemoryExtensions, renderExtensionsBlock } from "./memory-extension-host/index.js";
+import { log } from "./logger.js";
 
 export interface ConsolidationCluster {
   category: string;
@@ -139,6 +142,34 @@ Write ONLY the consolidated memory content (no metadata, no explanation, no prea
  */
 export function parseConsolidationResponse(response: string): string {
   return response.trim();
+}
+
+/**
+ * Resolve the memory extensions root directory from config.
+ * If memoryExtensionsRoot is empty, derive from memoryDir by going up to
+ * the Remnic home dir and appending memory_extensions.
+ */
+export function resolveExtensionsRoot(config: PluginConfig): string {
+  if (config.memoryExtensionsRoot.length > 0) {
+    return config.memoryExtensionsRoot;
+  }
+  // Default: memoryDir is typically ~/.openclaw/workspace/memory/local
+  // Go up to the parent that owns the memory tree and append memory_extensions
+  return path.join(path.dirname(config.memoryDir), "memory_extensions");
+}
+
+/**
+ * Discover extensions and build the block to append to a consolidation prompt.
+ * Returns "" when extensions are disabled or none are found.
+ */
+export async function buildExtensionsBlockForConsolidation(
+  config: PluginConfig,
+): Promise<string> {
+  if (!config.memoryExtensionsEnabled) return "";
+  const root = resolveExtensionsRoot(config);
+  const extensions = await discoverMemoryExtensions(root, log);
+  if (extensions.length === 0) return "";
+  return renderExtensionsBlock(extensions);
 }
 
 /**

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -958,6 +958,15 @@ export interface PluginConfig {
   enrichmentAutoOnCreate: boolean;
   /** Max candidates accepted per entity per enrichment run. Default 20. */
   enrichmentMaxCandidatesPerEntity: number;
+
+  // Memory extensions discovery (#382)
+  /** Whether third-party memory extensions are discovered and injected into consolidation. Default true. */
+  memoryExtensionsEnabled: boolean;
+  /**
+   * Root directory for memory extensions. Empty string means derive from
+   * memoryDir: go up to the Remnic home dir and append memory_extensions.
+   */
+  memoryExtensionsRoot: string;
 }
 
 /** Runtime configuration for the daily context briefing feature. */

--- a/tests/memory-extension-discovery.test.ts
+++ b/tests/memory-extension-discovery.test.ts
@@ -1,0 +1,395 @@
+/**
+ * Tests for memory extension discovery (#382).
+ *
+ * Covers: discovery, slug validation, instructions.md requirement,
+ * schema.json parsing, example capping, sorting, scripts/ safety,
+ * renderExtensionsBlock token budget, and consolidation wiring.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import {
+  discoverMemoryExtensions,
+  renderExtensionsBlock,
+  renderExtensionsFooter,
+  REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT,
+} from "../packages/remnic-core/src/memory-extension-host/index.ts";
+import type { DiscoveredExtension } from "../packages/remnic-core/src/memory-extension-host/types.ts";
+import {
+  buildConsolidationPrompt,
+  buildExtensionsBlockForConsolidation,
+  resolveExtensionsRoot,
+} from "../packages/remnic-core/src/semantic-consolidation.ts";
+import type { PluginConfig } from "../packages/remnic-core/src/types.ts";
+import { parseConfig } from "../packages/remnic-core/src/config.ts";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeTempDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "remnic-ext-test-"));
+}
+
+function createExtension(
+  root: string,
+  name: string,
+  opts: {
+    instructions?: string;
+    schema?: Record<string, unknown>;
+    exampleCount?: number;
+    includeScripts?: boolean;
+  } = {},
+): void {
+  const dir = path.join(root, name);
+  fs.mkdirSync(dir, { recursive: true });
+
+  if (opts.instructions !== undefined) {
+    fs.writeFileSync(path.join(dir, "instructions.md"), opts.instructions, "utf-8");
+  }
+
+  if (opts.schema !== undefined) {
+    fs.writeFileSync(path.join(dir, "schema.json"), JSON.stringify(opts.schema), "utf-8");
+  }
+
+  if (opts.exampleCount && opts.exampleCount > 0) {
+    const exDir = path.join(dir, "examples");
+    fs.mkdirSync(exDir, { recursive: true });
+    for (let i = 0; i < opts.exampleCount; i++) {
+      fs.writeFileSync(
+        path.join(exDir, `example-${String(i).padStart(3, "0")}.md`),
+        `Example ${i}`,
+        "utf-8",
+      );
+    }
+  }
+
+  if (opts.includeScripts) {
+    const scriptsDir = path.join(dir, "scripts");
+    fs.mkdirSync(scriptsDir, { recursive: true });
+    fs.writeFileSync(path.join(scriptsDir, "install.sh"), "#!/bin/bash\necho hi", "utf-8");
+  }
+}
+
+const silentLog = { warn: () => {}, debug: () => {} };
+
+function collectWarnings(): { log: { warn: (msg: string) => void; debug: () => void }; warnings: string[] } {
+  const warnings: string[] = [];
+  return {
+    log: {
+      warn: (msg: string) => warnings.push(msg),
+      debug: () => {},
+    },
+    warnings,
+  };
+}
+
+// ── discoverMemoryExtensions ─────────────────────────────────────────────────
+
+test("empty root returns []", async () => {
+  const root = makeTempDir();
+  const result = await discoverMemoryExtensions(root, silentLog);
+  assert.deepStrictEqual(result, []);
+  fs.rmSync(root, { recursive: true });
+});
+
+test("missing root returns [] without warning", async () => {
+  const root = path.join(os.tmpdir(), `nonexistent-${Date.now()}`);
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+  assert.deepStrictEqual(result, []);
+  assert.equal(warnings.length, 0);
+});
+
+test("one valid extension returns one entry with correct fields", async () => {
+  const root = makeTempDir();
+  createExtension(root, "github-issues", {
+    instructions: "Track GitHub issues as reference memories.",
+    schema: {
+      memoryTypes: ["reference"],
+      groupingHints: ["repository"],
+      version: "1.0.0",
+    },
+    exampleCount: 2,
+  });
+
+  const result = await discoverMemoryExtensions(root, silentLog);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, "github-issues");
+  assert.equal(result[0].root, path.join(root, "github-issues"));
+  assert.equal(result[0].instructionsPath, path.join(root, "github-issues", "instructions.md"));
+  assert.equal(result[0].instructions, "Track GitHub issues as reference memories.");
+  assert.deepStrictEqual(result[0].schema, {
+    memoryTypes: ["reference"],
+    groupingHints: ["repository"],
+    version: "1.0.0",
+  });
+  assert.equal(result[0].examplesPaths.length, 2);
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("extension missing instructions.md is skipped with warning", async () => {
+  const root = makeTempDir();
+  // Create directory but no instructions.md
+  fs.mkdirSync(path.join(root, "no-instructions"), { recursive: true });
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+  assert.equal(result.length, 0);
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes("missing instructions.md"));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("invalid slug is skipped with warning", async () => {
+  const root = makeTempDir();
+  // Capital letters are invalid
+  createExtension(root, "BadSlug", { instructions: "test" });
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+  assert.equal(result.length, 0);
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes("invalid slug"));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("malformed schema.json results in entry with schema undefined", async () => {
+  const root = makeTempDir();
+  const dir = path.join(root, "bad-schema");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "instructions.md"), "Test", "utf-8");
+  fs.writeFileSync(path.join(dir, "schema.json"), "not valid json{{{", "utf-8");
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].schema, undefined);
+  assert.equal(warnings.length, 1);
+  assert.ok(warnings[0].includes("malformed schema.json"));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("15 example files: only first 10 collected", async () => {
+  const root = makeTempDir();
+  createExtension(root, "many-examples", {
+    instructions: "Test",
+    exampleCount: 15,
+  });
+
+  const result = await discoverMemoryExtensions(root, silentLog);
+  assert.equal(result.length, 1);
+  assert.equal(result[0].examplesPaths.length, 10);
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("discovery results sorted by name", async () => {
+  const root = makeTempDir();
+  createExtension(root, "zeta-ext", { instructions: "Zeta" });
+  createExtension(root, "alpha-ext", { instructions: "Alpha" });
+  createExtension(root, "middle-ext", { instructions: "Middle" });
+
+  const result = await discoverMemoryExtensions(root, silentLog);
+  assert.equal(result.length, 3);
+  assert.equal(result[0].name, "alpha-ext");
+  assert.equal(result[1].name, "middle-ext");
+  assert.equal(result[2].name, "zeta-ext");
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("discovery never reads scripts/ directory", async () => {
+  const root = makeTempDir();
+  createExtension(root, "has-scripts", {
+    instructions: "Test",
+    includeScripts: true,
+  });
+
+  // Track all readFile/readdir calls via spying on fs
+  const originalReadFile = fs.promises.readFile;
+  const readPaths: string[] = [];
+  // @ts-expect-error -- spy override for test
+  fs.promises.readFile = async function (filePath: string, ...args: unknown[]) {
+    readPaths.push(String(filePath));
+    return (originalReadFile as Function).call(fs.promises, filePath, ...args);
+  };
+
+  try {
+    await discoverMemoryExtensions(root, silentLog);
+    // Verify no path under scripts/ was read
+    const scriptsReads = readPaths.filter((p) => p.includes("/scripts/"));
+    assert.equal(scriptsReads.length, 0, `Unexpected reads from scripts/: ${scriptsReads.join(", ")}`);
+  } finally {
+    fs.promises.readFile = originalReadFile;
+  }
+
+  fs.rmSync(root, { recursive: true });
+});
+
+// ── renderExtensionsBlock ────────────────────────────────────────────────────
+
+test("renderExtensionsBlock: empty list returns empty string", () => {
+  const result = renderExtensionsBlock([]);
+  assert.equal(result, "");
+});
+
+test("renderExtensionsBlock: two small extensions both inlined", () => {
+  const extensions: DiscoveredExtension[] = [
+    {
+      name: "alpha",
+      root: "/tmp/alpha",
+      instructionsPath: "/tmp/alpha/instructions.md",
+      instructions: "Alpha extension instructions.",
+      examplesPaths: [],
+    },
+    {
+      name: "beta",
+      root: "/tmp/beta",
+      instructionsPath: "/tmp/beta/instructions.md",
+      instructions: "Beta extension instructions.",
+      examplesPaths: [],
+    },
+  ];
+
+  const result = renderExtensionsBlock(extensions);
+  assert.ok(result.includes("## Active memory extensions"));
+  assert.ok(result.includes("### remnic-extension/alpha"));
+  assert.ok(result.includes("### remnic-extension/beta"));
+  assert.ok(result.includes("Alpha extension instructions."));
+  assert.ok(result.includes("Beta extension instructions."));
+  assert.ok(!result.includes("omitted"));
+});
+
+test("renderExtensionsBlock: exceeds token budget adds truncation footer", () => {
+  // Create extensions that collectively exceed the budget
+  const bigInstruction = "x".repeat(REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT * 4);
+  const extensions: DiscoveredExtension[] = [
+    {
+      name: "big-one",
+      root: "/tmp/big-one",
+      instructionsPath: "/tmp/big-one/instructions.md",
+      instructions: bigInstruction,
+      examplesPaths: [],
+    },
+    {
+      name: "small-one",
+      root: "/tmp/small-one",
+      instructionsPath: "/tmp/small-one/instructions.md",
+      instructions: "Small extension.",
+      examplesPaths: [],
+    },
+  ];
+
+  const result = renderExtensionsBlock(extensions);
+  // Big one takes all budget, small one is omitted (or vice versa depending on order)
+  assert.ok(result.includes("omitted"));
+});
+
+// ── renderExtensionsFooter ──────────────────────────────────────────────────
+
+test("renderExtensionsFooter: empty list returns empty string", () => {
+  assert.equal(renderExtensionsFooter([]), "");
+});
+
+test("renderExtensionsFooter: returns comma-separated names", () => {
+  const exts: DiscoveredExtension[] = [
+    { name: "alpha", root: "", instructionsPath: "", instructions: "", examplesPaths: [] },
+    { name: "beta", root: "", instructionsPath: "", instructions: "", examplesPaths: [] },
+  ];
+  const footer = renderExtensionsFooter(exts);
+  assert.equal(footer, "Active extensions: alpha, beta");
+});
+
+// ── resolveExtensionsRoot ────────────────────────────────────────────────────
+
+test("resolveExtensionsRoot: uses memoryExtensionsRoot when set", () => {
+  const config = parseConfig({ memoryExtensionsRoot: "/custom/extensions" });
+  const root = resolveExtensionsRoot(config);
+  assert.equal(root, "/custom/extensions");
+});
+
+test("resolveExtensionsRoot: derives from memoryDir when empty", () => {
+  const config = parseConfig({ memoryDir: "/home/user/.openclaw/workspace/memory/local" });
+  const root = resolveExtensionsRoot(config);
+  assert.equal(root, "/home/user/.openclaw/workspace/memory/memory_extensions");
+});
+
+// ── Config parsing ──────────────────────────────────────────────────────────
+
+test("parseConfig: memoryExtensionsEnabled defaults to true", () => {
+  const config = parseConfig({});
+  assert.equal(config.memoryExtensionsEnabled, true);
+});
+
+test("parseConfig: memoryExtensionsEnabled can be set to false", () => {
+  const config = parseConfig({ memoryExtensionsEnabled: false });
+  assert.equal(config.memoryExtensionsEnabled, false);
+});
+
+test("parseConfig: memoryExtensionsRoot defaults to empty string", () => {
+  const config = parseConfig({});
+  assert.equal(config.memoryExtensionsRoot, "");
+});
+
+test("parseConfig: memoryExtensionsRoot preserves custom value", () => {
+  const config = parseConfig({ memoryExtensionsRoot: "/my/extensions" });
+  assert.equal(config.memoryExtensionsRoot, "/my/extensions");
+});
+
+// ── Consolidation wiring ────────────────────────────────────────────────────
+
+test("consolidation prompt includes extensions block when extensions exist", async () => {
+  const root = makeTempDir();
+  createExtension(root, "test-ext", {
+    instructions: "Test extension for consolidation wiring.",
+  });
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: true,
+    memoryExtensionsRoot: root,
+  });
+
+  const block = await buildExtensionsBlockForConsolidation(config);
+  assert.ok(block.includes("## Active memory extensions"));
+  assert.ok(block.includes("### remnic-extension/test-ext"));
+  assert.ok(block.includes("Test extension for consolidation wiring."));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("consolidation prompt unchanged when no extensions", async () => {
+  const root = makeTempDir();
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: true,
+    memoryExtensionsRoot: root,
+  });
+
+  const block = await buildExtensionsBlockForConsolidation(config);
+  assert.equal(block, "");
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("consolidation prompt empty when extensions disabled", async () => {
+  const root = makeTempDir();
+  createExtension(root, "test-ext", {
+    instructions: "Should not appear.",
+  });
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: false,
+    memoryExtensionsRoot: root,
+  });
+
+  const block = await buildExtensionsBlockForConsolidation(config);
+  assert.equal(block, "");
+
+  fs.rmSync(root, { recursive: true });
+});

--- a/tests/memory-extension-discovery.test.ts
+++ b/tests/memory-extension-discovery.test.ts
@@ -23,6 +23,7 @@ import {
   buildExtensionsBlockForConsolidation,
   resolveExtensionsRoot,
 } from "../packages/remnic-core/src/semantic-consolidation.ts";
+import { buildExtensionsFooterForSummary } from "../packages/remnic-core/src/day-summary.ts";
 import type { PluginConfig } from "../packages/remnic-core/src/types.ts";
 import { parseConfig } from "../packages/remnic-core/src/config.ts";
 
@@ -390,6 +391,80 @@ test("consolidation prompt empty when extensions disabled", async () => {
 
   const block = await buildExtensionsBlockForConsolidation(config);
   assert.equal(block, "");
+
+  fs.rmSync(root, { recursive: true });
+});
+
+// ── Symlink traversal blocking (#382 P2) ───────────────────────────────────
+
+test("symlink extension entry is skipped with warning", async () => {
+  const root = makeTempDir();
+
+  // Create a real extension to be the symlink target
+  const targetDir = path.join(root, "_real-target");
+  fs.mkdirSync(targetDir, { recursive: true });
+  fs.writeFileSync(path.join(targetDir, "instructions.md"), "Should not be discovered via symlink", "utf-8");
+
+  // Create a symlink inside the extensions root
+  const symlinkPath = path.join(root, "symlink-ext");
+  fs.symlinkSync(targetDir, symlinkPath);
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+
+  // The symlink should NOT be discovered
+  assert.equal(result.length, 0);
+  assert.ok(warnings.some((w) => w.includes("symlinks are not followed")));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+// ── buildExtensionsFooterForSummary wiring (#382) ──────────────────────────
+
+test("buildExtensionsFooterForSummary returns footer when extensions exist", async () => {
+  const root = makeTempDir();
+  createExtension(root, "day-ext", {
+    instructions: "Day summary extension.",
+  });
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: true,
+    memoryExtensionsRoot: root,
+  });
+
+  const footer = await buildExtensionsFooterForSummary(config);
+  assert.ok(footer.includes("Active extensions: day-ext"));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("buildExtensionsFooterForSummary returns empty when disabled", async () => {
+  const root = makeTempDir();
+  createExtension(root, "day-ext", {
+    instructions: "Should not appear.",
+  });
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: false,
+    memoryExtensionsRoot: root,
+  });
+
+  const footer = await buildExtensionsFooterForSummary(config);
+  assert.equal(footer, "");
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("buildExtensionsFooterForSummary returns empty when no extensions", async () => {
+  const root = makeTempDir();
+
+  const config = parseConfig({
+    memoryExtensionsEnabled: true,
+    memoryExtensionsRoot: root,
+  });
+
+  const footer = await buildExtensionsFooterForSummary(config);
+  assert.equal(footer, "");
 
   fs.rmSync(root, { recursive: true });
 });


### PR DESCRIPTION
## Summary
- Adds `discoverMemoryExtensions()` to scan `extensions/` directory for third-party memory extensions
- Each extension requires `instructions.md`, optional `schema.json` and `examples/*.md` (capped at 10)
- Slug validation: lowercase alphanumeric + hyphens, 1-64 chars
- Read-only contract: never reads `scripts/` directory
- Token-budgeted rendering (5,000 tokens) with truncation footer for omitted extensions
- Consolidation wiring: semantic, causal, and day-summary pipelines inject extension context
- Config: `memoryExtensionsEnabled` (default true), `memoryExtensionsRoot` (default derives from memoryDir)
- CLI: `remnic extensions list|show|validate|reload`
- Daemon status integration shows active extension count

## Test plan
- [x] 23 new tests in `tests/memory-extension-discovery.test.ts`
- [x] Covers: empty/missing root, valid fields, missing instructions.md, invalid slug, malformed schema.json, example capping, name sorting, scripts/ safety, render block/footer, config parsing, consolidation wiring
- [x] 15 semantic consolidation tests pass
- [x] 5 causal consolidation tests pass  
- [x] 16 config tests pass
- [x] Build succeeds

Closes #382

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches consolidation prompt construction and adds filesystem-based discovery, so misconfiguration or unexpected extension content could change LLM behavior; mitigations include strict slug checks, symlink blocking, and token-budget truncation.
> 
> **Overview**
> Adds a *memory extensions* feature that discovers third-party extension directories (validated slugs, required `instructions.md`, optional `schema.json`/`examples/`, token-budgeted rendering, and symlink traversal blocking) and exposes it via a new `memory-extension-host` API.
> 
> Wires discovered extension instructions into **semantic** and **causal** consolidation prompts, and adds a lightweight “Active extensions …” footer to day-summary generation; also surfaces extensions via new config fields (`memoryExtensionsEnabled`, `memoryExtensionsRoot`), a new `remnic extensions` CLI, and an extra line in `remnic daemon status`.
> 
> Includes new docs (architecture + example extension) and a comprehensive test suite covering discovery rules, rendering/token budget behavior, config parsing, and consolidation/footer wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4233e5e9c11230dd7e3ff7cb806236e2cad7cd2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->