### PR TITLE
fix: validate optional marketplace fields and reject --type without value

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1664,8 +1664,15 @@ async function cmdConnectorsMarketplace(
       process.exit(1);
     }
 
-    const typeFlag = resolveFlagStrict(rest, "--type") ?? "github";
+    // CLAUDE.md gotcha #14 & #51: reject --type without a value instead of
+    // silently defaulting to "github".
     const validTypes = new Set(["github", "git", "local", "url"]);
+    const hasTypeFlag = rest.includes("--type");
+    const typeFlag = resolveFlagStrict(rest, "--type") ?? (hasTypeFlag ? undefined : "github");
+    if (typeFlag === undefined) {
+      console.error(`--type requires a value. Must be one of: ${[...validTypes].join(", ")}`);
+      process.exit(1);
+    }
     if (!validTypes.has(typeFlag)) {
       console.error(`Invalid --type: "${typeFlag}". Must be one of: ${[...validTypes].join(", ")}`);
       process.exit(1);

--- a/packages/remnic-core/src/connectors/codex-marketplace.ts
+++ b/packages/remnic-core/src/connectors/codex-marketplace.ts
@@ -223,6 +223,23 @@ export function checkMarketplaceManifest(manifest: unknown): MarketplaceValidati
           `got ${JSON.stringify(plugin.installType)}`,
         );
       }
+
+      // Optional fields — validate type when present (PR #427 post-merge fix).
+      if ("manifestUrl" in plugin && plugin.manifestUrl !== undefined) {
+        if (typeof plugin.manifestUrl !== "string" || (plugin.manifestUrl as string).trim().length === 0) {
+          errors.push(`${prefix}.manifestUrl must be a non-empty string when provided`);
+        }
+      }
+      if ("entry" in plugin && plugin.entry !== undefined) {
+        if (typeof plugin.entry !== "string" || (plugin.entry as string).trim().length === 0) {
+          errors.push(`${prefix}.entry must be a non-empty string when provided`);
+        }
+      }
+      if ("configSchema" in plugin && plugin.configSchema !== undefined) {
+        if (typeof plugin.configSchema !== "string" || (plugin.configSchema as string).trim().length === 0) {
+          errors.push(`${prefix}.configSchema must be a non-empty string when provided`);
+        }
+      }
     }
   }
 

--- a/tests/codex-marketplace.test.ts
+++ b/tests/codex-marketplace.test.ts
@@ -221,6 +221,139 @@ test("checkMarketplaceManifest validates plugin entry fields", () => {
   assert.ok(result.errors.some((e) => e.includes("plugins[0].installType")));
 });
 
+// ── Optional field type validation (PR #427 post-merge) ───────────────────
+
+test("checkMarketplaceManifest rejects malformed optional entry field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: 123,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].entry")));
+});
+
+test("checkMarketplaceManifest rejects malformed optional manifestUrl field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        manifestUrl: {},
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].manifestUrl")));
+});
+
+test("checkMarketplaceManifest rejects malformed optional configSchema field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        configSchema: false,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].configSchema")));
+});
+
+test("checkMarketplaceManifest rejects empty-string optional fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: "",
+        manifestUrl: "  ",
+        configSchema: "",
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].entry")));
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].manifestUrl")));
+  assert.ok(result.errors.some((e) => e.includes("plugins[0].configSchema")));
+});
+
+test("checkMarketplaceManifest accepts valid optional fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: "packages/plugin",
+        manifestUrl: "https://example.com/manifest.json",
+        configSchema: "plugin.json",
+      },
+    ],
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
+test("checkMarketplaceManifest accepts absent optional fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+      },
+    ],
+  });
+
+  assert.equal(result.valid, true);
+  assert.equal(result.errors.length, 0);
+});
+
 // ── writeMarketplaceManifest ────────────────────────────────────────────────
 
 test("writeMarketplaceManifest writes valid JSON to disk", async () => {


### PR DESCRIPTION
## Summary

Two post-merge review findings from PR #427 (codex marketplace):

- **P2: Validate optional marketplace plugin fields** — `checkMarketplaceManifest` now type-checks `manifestUrl`, `entry`, and `configSchema` when present. Manifests with malformed optional fields (e.g., `entry: 123` or `manifestUrl: {}`) are now rejected with descriptive errors.
- **P2: Fail fast when `--type` is present without a value** — The `marketplace install` CLI path now errors when `--type` is passed without a following argument, per CLAUDE.md gotchas #14 and #51, instead of silently defaulting to `"github"`.

## Test plan

- [x] 6 new tests in `tests/codex-marketplace.test.ts` covering malformed optional fields, empty strings, valid optional fields, and absent optional fields
- [x] All 30 marketplace tests pass (`npx tsx --test tests/codex-marketplace.test.ts`)
- [x] `pnpm run check-types` passes
- [x] `pnpm run build` passes

## PR checklist

* [x] **All tests pass (`pytest`)** - RUN BEFORE CREATING PR
* [x] All new logic is covered by tests (>= 90% overall)
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff <= 400 LOC (or justified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CLI argument handling (scripts passing bare `--type` will now error) and makes previously-accepted marketplace manifests invalid when optional fields are malformed.
> 
> **Overview**
> Improves robustness of the Codex marketplace flow by **failing fast on invalid inputs**.
> 
> `checkMarketplaceManifest` now validates optional plugin fields (`manifestUrl`, `entry`, `configSchema`) when present, rejecting non-strings and empty/whitespace values, with new tests covering these cases. The CLI `connectors marketplace install` path now errors if `--type` is supplied without a value instead of silently defaulting to `github`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edc17f87c2f1acff1f5af40a04df13d929c874a5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->