### PR TITLE
Fix post-merge enrichment review findings (PR #425)

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -742,6 +742,10 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   let totalPersisted = 0;
   for (const result of results) {
     for (const candidate of result.acceptedCandidates) {
+      // Split persistence and audit into separate try-catch blocks so an
+      // audit-write failure after a successful memory write is logged as a
+      // warning instead of masking the successful persist (PR #425 review).
+      let persisted = false;
       try {
         await storage.writeMemory(candidate.category, candidate.text, {
           confidence: candidate.confidence,
@@ -749,16 +753,8 @@ async function cmdEnrich(rest: string[]): Promise<void> {
           entityRef: result.entityName,
           source: `enrichment:${candidate.source}`,
         });
+        persisted = true;
         totalPersisted++;
-        // Write audit entry for accepted candidate
-        await appendAuditEntry(auditDir, {
-          timestamp: new Date().toISOString(),
-          entityName: result.entityName,
-          provider: result.provider,
-          candidateText: candidate.text,
-          sourceUrl: candidate.sourceUrl,
-          accepted: true,
-        });
       } catch (err) {
         console.error(
           `  Failed to persist candidate for ${result.entityName}: ${err instanceof Error ? err.message : String(err)}`,
@@ -776,6 +772,25 @@ async function cmdEnrich(rest: string[]): Promise<void> {
           });
         } catch {
           // Audit write failure is non-fatal
+        }
+      }
+
+      // Write audit entry for accepted candidate — separate from persist
+      // so audit failures don't mask a successful memory write.
+      if (persisted) {
+        try {
+          await appendAuditEntry(auditDir, {
+            timestamp: new Date().toISOString(),
+            entityName: result.entityName,
+            provider: result.provider,
+            candidateText: candidate.text,
+            sourceUrl: candidate.sourceUrl,
+            accepted: true,
+          });
+        } catch (auditErr) {
+          console.warn(
+            `  Warning: audit write failed for ${result.entityName} (memory was persisted): ${auditErr instanceof Error ? auditErr.message : String(auditErr)}`,
+          );
         }
       }
     }

--- a/packages/remnic-core/src/enrichment/pipeline.ts
+++ b/packages/remnic-core/src/enrichment/pipeline.ts
@@ -138,12 +138,15 @@ export async function runEnrichmentPipeline(
         continue;
       }
 
-      // Run provider
+      // Run provider.
+      // Count every attempt toward rate-limit buckets — including failures —
+      // because the provider may have consumed external quota before throwing
+      // (PR #425 review finding 2).
       let candidates: EnrichmentCandidate[];
       try {
         candidates = await provider.enrich(entity);
-        recordCall(provider.id, rateBuckets);
       } catch (err) {
+        recordCall(provider.id, rateBuckets);
         log.error?.(
           `enrichment: provider ${provider.id} failed for ${entity.name}: ${err instanceof Error ? err.message : String(err)}`,
         );
@@ -158,6 +161,7 @@ export async function runEnrichmentPipeline(
         });
         continue;
       }
+      recordCall(provider.id, rateBuckets);
 
       // Tag each candidate with provider id
       for (const candidate of candidates) {

--- a/tests/enrichment-pipeline.test.ts
+++ b/tests/enrichment-pipeline.test.ts
@@ -489,6 +489,58 @@ test("defaultEnrichmentPipelineConfig returns disabled config", () => {
 // Provider error handling
 // ---------------------------------------------------------------------------
 
+test("Pipeline: failed provider calls count toward rate-limit buckets", async () => {
+  // PR #425 review finding 2: if a provider throws after sending the request,
+  // the attempt must still be counted so the rate limiter stays accurate.
+  let callCount = 0;
+  const provider: EnrichmentProvider = {
+    id: "flaky",
+    costTier: "cheap",
+    async enrich() {
+      callCount++;
+      throw new Error("Transient failure");
+    },
+    async isAvailable() {
+      return true;
+    },
+  };
+
+  const registry = new EnrichmentProviderRegistry();
+  registry.register(provider);
+
+  const config = enabledConfig({
+    providers: [
+      {
+        id: "flaky",
+        enabled: true,
+        costTier: "cheap",
+        rateLimit: { maxPerMinute: 2, maxPerDay: 100 },
+      },
+    ],
+    importanceThresholds: {
+      critical: ["flaky"],
+      high: ["flaky"],
+      normal: ["flaky"],
+      low: ["flaky"],
+    },
+  });
+
+  // 5 entities but maxPerMinute=2 — even though all calls fail, only 2
+  // should be attempted because failures count toward the rate limit.
+  const entities = Array.from({ length: 5 }, (_, i) =>
+    makeEntity({ name: `Entity${i}`, importanceLevel: "normal" }),
+  );
+
+  const results = await runEnrichmentPipeline(entities, registry, config, NOOP_LOG);
+  assert.equal(callCount, 2, "Only 2 provider calls should have been made (failures count toward rate limit)");
+  assert.equal(results.length, 5, "All 5 entities should have result entries");
+
+  // All 5 should report 0 candidates (2 failed, 3 rate-limited)
+  for (const r of results) {
+    assert.equal(r.candidatesFound, 0);
+  }
+});
+
 test("Pipeline: provider that throws is gracefully skipped", async () => {
   const provider: EnrichmentProvider = {
     id: "mock",


### PR DESCRIPTION
## Summary

- **Split audit-write failures from persistence failures** (`packages/remnic-cli/src/index.ts`): The `writeMemory` and `appendAuditEntry` calls were in a single try-catch, so an audit-append failure after a successful memory write jumped to the catch block which logged a misleading "Failed to persist" error. Now they use separate try-catch blocks — audit failures after successful persistence are logged as warnings.

- **Count failed provider calls toward rate-limit buckets** (`packages/remnic-core/src/enrichment/pipeline.ts`): `recordCall` was only invoked after `provider.enrich` resolved, so throwing providers were never counted. If a provider consumed external quota before throwing, the rate limiter would not know. Now `recordCall` is invoked on both the success path and in the catch block.

## Test plan

- [x] Added test: "Pipeline: failed provider calls count toward rate-limit buckets" — verifies that with `maxPerMinute: 2`, only 2 calls are made even when all calls throw
- [x] All 21 enrichment pipeline tests pass (`npx tsx --test tests/enrichment-pipeline.test.ts`)
- [x] `pnpm run check-types` passes
- [x] `pnpm run build` succeeds

## PR Checklist

* [x] **All tests pass** - verified before creating PR
* [x] All new logic is covered by tests
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated (inline comments explain the split)
* [x] No secrets or creds committed
* [x] PR diff <= 400 LOC (82 insertions, 11 deletions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: changes affect enrichment persistence/audit logging and rate-limiting behavior, which could alter how many provider calls run and how failures are reported, but are small and covered by a new test.
> 
> **Overview**
> **Improves enrichment reliability and observability.** The CLI `enrich` flow now separates `writeMemory` persistence errors from audit log append errors so a successful persist is no longer reported as a failure; audit write failures after persist are downgraded to warnings.
> 
> **Fixes rate limiting accuracy on provider errors.** The enrichment pipeline now records a provider call in rate-limit buckets even when `provider.enrich()` throws, and adds a test ensuring failed calls still count toward `maxPerMinute` limits.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d14ed76d0c533679d52e817a46acc0b376a8b4b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->