### PR TITLE
fix(extensions): harden symlink checks and relocate resolveExtensionsRoot (#428)

### DIFF
--- a/packages/remnic-core/src/day-summary.ts
+++ b/packages/remnic-core/src/day-summary.ts
@@ -4,8 +4,7 @@ import path from "node:path";
 import { fileURLToPath } from "node:url";
 import { log } from "./logger.js";
 import type { MemoryFile, PluginConfig } from "./types.js";
-import { discoverMemoryExtensions, renderExtensionsFooter } from "./memory-extension-host/index.js";
-import { resolveExtensionsRoot } from "./semantic-consolidation.js";
+import { discoverMemoryExtensions, renderExtensionsFooter, resolveExtensionsRoot } from "./memory-extension-host/index.js";
 
 const PROMPT_RELATIVE_PATH = path.join("prompts", "day_summary.prompt.md");
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -357,13 +357,13 @@ export {
   discoverMemoryExtensions,
   renderExtensionsBlock,
   renderExtensionsFooter,
+  resolveExtensionsRoot,
   REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT,
   type DiscoveredExtension,
   type ExtensionSchema,
 } from "./memory-extension-host/index.js";
 
 export {
-  resolveExtensionsRoot,
   buildExtensionsBlockForConsolidation,
 } from "./semantic-consolidation.js";
 

--- a/packages/remnic-core/src/memory-extension-host/host-discovery.ts
+++ b/packages/remnic-core/src/memory-extension-host/host-discovery.ts
@@ -7,9 +7,10 @@
  * any extension's scripts/ directory.
  */
 
-import { readdir, readFile, lstat, stat } from "node:fs/promises";
+import { readdir, readFile, lstat, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { LoggerBackend } from "../logger.js";
+import type { PluginConfig } from "../types.js";
 import type { DiscoveredExtension, ExtensionSchema } from "./types.js";
 
 /** Total token budget for all discovered extension instructions combined. */
@@ -38,14 +39,38 @@ export async function discoverMemoryExtensions(
   log: Pick<LoggerBackend, "warn" | "debug">,
 ): Promise<DiscoveredExtension[]> {
   // If root doesn't exist, return empty silently (not even a warning).
-  // Use stat() for root — the user configures this path, so following a
-  // symlink here is intentional.  Child entries use lstat() to block
-  // symlink traversal that could escape the extensions directory.
+  // Use lstat() for root — a symlinked extensions root could redirect
+  // discovery to an untrusted directory tree (#428 P2).  When the root
+  // IS a symlink, resolve it and verify it still lives under the parent
+  // memory directory so that an attacker-controlled symlink can't point
+  // discovery at /etc or another user's home.
   let rootStat;
   try {
-    rootStat = await stat(root);
+    rootStat = await lstat(root);
   } catch {
     return [];
+  }
+  if (rootStat.isSymbolicLink()) {
+    // Resolve and verify the real path is inside the expected parent.
+    let resolved: string;
+    try {
+      resolved = await realpath(root);
+    } catch {
+      return [];
+    }
+    const expectedParent = path.dirname(root);
+    if (!resolved.startsWith(expectedParent + path.sep) && resolved !== expectedParent) {
+      log.warn?.(
+        `[memory-extensions] root "${root}" is a symlink resolving outside the expected parent directory, skipping`,
+      );
+      return [];
+    }
+    // Re-check the resolved path is a directory.
+    try {
+      rootStat = await lstat(resolved);
+    } catch {
+      return [];
+    }
   }
   if (!rootStat.isDirectory()) {
     return [];
@@ -87,8 +112,14 @@ export async function discoverMemoryExtensions(
       continue;
     }
 
-    // Require instructions.md
+    // Require instructions.md — reject symlinked files (#428 P1)
     const instructionsPath = path.join(entryPath, "instructions.md");
+    if (await isSymlink(instructionsPath)) {
+      log.warn?.(
+        `[memory-extensions] skipping "${entry}": instructions.md is a symlink`,
+      );
+      continue;
+    }
     let instructions: string;
     try {
       instructions = await readFile(instructionsPath, "utf-8");
@@ -99,27 +130,33 @@ export async function discoverMemoryExtensions(
       continue;
     }
 
-    // Read optional schema.json
+    // Read optional schema.json — reject symlinked files (#428 P1)
     let schema: ExtensionSchema | undefined;
     const schemaPath = path.join(entryPath, "schema.json");
-    try {
-      const schemaRaw = await readFile(schemaPath, "utf-8");
-      const parsed = JSON.parse(schemaRaw);
-      if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
-        schema = validateSchema(parsed);
-      } else {
-        log.warn?.(
-          `[memory-extensions] "${entry}": schema.json is not a valid object, ignoring schema`,
-        );
-      }
-    } catch (err) {
-      // File doesn't exist → fine, no warning needed
-      if (isFileNotFoundError(err)) {
-        // schema remains undefined
-      } else {
-        log.warn?.(
-          `[memory-extensions] "${entry}": malformed schema.json, ignoring schema`,
-        );
+    if (await isSymlink(schemaPath)) {
+      log.warn?.(
+        `[memory-extensions] "${entry}": schema.json is a symlink, ignoring schema`,
+      );
+    } else {
+      try {
+        const schemaRaw = await readFile(schemaPath, "utf-8");
+        const parsed = JSON.parse(schemaRaw);
+        if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+          schema = validateSchema(parsed);
+        } else {
+          log.warn?.(
+            `[memory-extensions] "${entry}": schema.json is not a valid object, ignoring schema`,
+          );
+        }
+      } catch (err) {
+        // File doesn't exist → fine, no warning needed
+        if (isFileNotFoundError(err)) {
+          // schema remains undefined
+        } else {
+          log.warn?.(
+            `[memory-extensions] "${entry}": malformed schema.json, ignoring schema`,
+          );
+        }
       }
     }
 
@@ -197,4 +234,34 @@ function isFileNotFoundError(err: unknown): boolean {
     "code" in err &&
     (err as { code: string }).code === "ENOENT"
   );
+}
+
+/**
+ * Returns true if the path exists and is a symlink.
+ * Returns false if the path does not exist or is not a symlink.
+ */
+async function isSymlink(filePath: string): Promise<boolean> {
+  try {
+    const s = await lstat(filePath);
+    return s.isSymbolicLink();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the memory extensions root directory from config.
+ * If memoryExtensionsRoot is empty, derive from memoryDir by going up to
+ * the Remnic home dir and appending memory_extensions.
+ *
+ * Moved here from semantic-consolidation.ts (#428 Finding 3) because this
+ * is a generic config-to-path resolver with no consolidation logic.
+ */
+export function resolveExtensionsRoot(config: PluginConfig): string {
+  if (config.memoryExtensionsRoot.length > 0) {
+    return config.memoryExtensionsRoot;
+  }
+  // Default: memoryDir is typically ~/.openclaw/workspace/memory/local
+  // Go up to the parent that owns the memory tree and append memory_extensions
+  return path.join(path.dirname(config.memoryDir), "memory_extensions");
 }

--- a/packages/remnic-core/src/memory-extension-host/index.ts
+++ b/packages/remnic-core/src/memory-extension-host/index.ts
@@ -5,6 +5,7 @@
 export type { DiscoveredExtension, ExtensionSchema } from "./types.js";
 export {
   discoverMemoryExtensions,
+  resolveExtensionsRoot,
   REMNIC_EXTENSIONS_TOTAL_TOKEN_LIMIT,
 } from "./host-discovery.js";
 export {

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -6,13 +6,16 @@
  * Reduces memory store bloat while preserving all unique information.
  */
 
-import path from "node:path";
 import type { MemoryFile, PluginConfig } from "./types.js";
 import { normalizeRecallTokens, countRecallTokenOverlap } from "./recall-tokenization.js";
 import { runPostConsolidationMaterialize } from "./connectors/codex-materialize-runner.js";
 import type { MaterializeResult, RolloutSummaryInput } from "./connectors/codex-materialize.js";
-import { discoverMemoryExtensions, renderExtensionsBlock } from "./memory-extension-host/index.js";
+import { discoverMemoryExtensions, renderExtensionsBlock, resolveExtensionsRoot } from "./memory-extension-host/index.js";
 import { log } from "./logger.js";
+
+// Re-export resolveExtensionsRoot for backward compatibility — existing
+// consumers that import from semantic-consolidation.ts continue to work.
+export { resolveExtensionsRoot } from "./memory-extension-host/index.js";
 
 export interface ConsolidationCluster {
   category: string;
@@ -142,20 +145,6 @@ Write ONLY the consolidated memory content (no metadata, no explanation, no prea
  */
 export function parseConsolidationResponse(response: string): string {
   return response.trim();
-}
-
-/**
- * Resolve the memory extensions root directory from config.
- * If memoryExtensionsRoot is empty, derive from memoryDir by going up to
- * the Remnic home dir and appending memory_extensions.
- */
-export function resolveExtensionsRoot(config: PluginConfig): string {
-  if (config.memoryExtensionsRoot.length > 0) {
-    return config.memoryExtensionsRoot;
-  }
-  // Default: memoryDir is typically ~/.openclaw/workspace/memory/local
-  // Go up to the parent that owns the memory tree and append memory_extensions
-  return path.join(path.dirname(config.memoryDir), "memory_extensions");
 }
 
 /**

--- a/tests/memory-extension-discovery.test.ts
+++ b/tests/memory-extension-discovery.test.ts
@@ -419,6 +419,106 @@ test("symlink extension entry is skipped with warning", async () => {
   fs.rmSync(root, { recursive: true });
 });
 
+// ── Symlinked extension files (#428 P1) ────────────────────────────────────
+
+test("symlinked instructions.md is skipped with warning (#428 P1)", async () => {
+  const root = makeTempDir();
+
+  // Create a real instructions.md outside the extension dir
+  const targetFile = path.join(root, "_target-instructions.md");
+  fs.writeFileSync(targetFile, "Should not be read via symlink", "utf-8");
+
+  // Create extension dir with symlinked instructions.md
+  const extDir = path.join(root, "symlink-file-ext");
+  fs.mkdirSync(extDir, { recursive: true });
+  fs.symlinkSync(targetFile, path.join(extDir, "instructions.md"));
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+
+  assert.equal(result.length, 0);
+  assert.ok(warnings.some((w) => w.includes("instructions.md is a symlink")));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+test("symlinked schema.json is ignored with warning (#428 P1)", async () => {
+  const root = makeTempDir();
+
+  // Create a real schema.json outside the extension dir
+  const targetFile = path.join(root, "_target-schema.json");
+  fs.writeFileSync(targetFile, JSON.stringify({ memoryTypes: ["fact"] }), "utf-8");
+
+  // Create extension with real instructions.md but symlinked schema.json
+  const extDir = path.join(root, "symlink-schema-ext");
+  fs.mkdirSync(extDir, { recursive: true });
+  fs.writeFileSync(path.join(extDir, "instructions.md"), "Real instructions", "utf-8");
+  fs.symlinkSync(targetFile, path.join(extDir, "schema.json"));
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(root, log);
+
+  // Extension should still be discovered but schema should be undefined
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, "symlink-schema-ext");
+  assert.equal(result[0].schema, undefined);
+  assert.ok(warnings.some((w) => w.includes("schema.json is a symlink")));
+
+  fs.rmSync(root, { recursive: true });
+});
+
+// ── Symlinked root directory (#428 P2) ─────────────────────────────────────
+
+test("symlinked root directory outside expected parent is rejected (#428 P2)", async () => {
+  const parentDir = makeTempDir();
+  const outsideDir = makeTempDir();
+
+  // Create a real extensions directory outside the expected parent
+  const realExtensionsDir = path.join(outsideDir, "memory_extensions");
+  fs.mkdirSync(realExtensionsDir, { recursive: true });
+  createExtension(realExtensionsDir, "sneaky-ext", {
+    instructions: "Should not be discovered",
+  });
+
+  // Create a symlink inside parentDir pointing to the outside location
+  const symlinkRoot = path.join(parentDir, "memory_extensions");
+  fs.symlinkSync(realExtensionsDir, symlinkRoot);
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(symlinkRoot, log);
+
+  // Should reject because realpath resolves outside the expected parent
+  assert.equal(result.length, 0);
+  assert.ok(warnings.some((w) => w.includes("symlink resolving outside")));
+
+  fs.rmSync(parentDir, { recursive: true });
+  fs.rmSync(outsideDir, { recursive: true });
+});
+
+test("symlinked root directory within expected parent is allowed (#428 P2)", async () => {
+  const parentDir = makeTempDir();
+
+  // Create a real extensions directory under the parent
+  const realExtensionsDir = path.join(parentDir, "real_extensions");
+  fs.mkdirSync(realExtensionsDir, { recursive: true });
+  createExtension(realExtensionsDir, "ok-ext", {
+    instructions: "Should be discovered",
+  });
+
+  // Create a symlink under the same parent
+  const symlinkRoot = path.join(parentDir, "memory_extensions");
+  fs.symlinkSync(realExtensionsDir, symlinkRoot);
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(symlinkRoot, log);
+
+  // Should be allowed because realpath resolves within the expected parent
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, "ok-ext");
+
+  fs.rmSync(parentDir, { recursive: true });
+});
+
 // ── buildExtensionsFooterForSummary wiring (#382) ──────────────────────────
 
 test("buildExtensionsFooterForSummary returns footer when extensions exist", async () => {


### PR DESCRIPTION
## Summary

Addresses 3 post-merge review findings from PR #428 (extension discovery):

- **P1**: Reject symlinked `instructions.md` and `schema.json` files before reading. After the directory-level `lstat` fix, individual files within valid extension directories could still be symlinks pointing outside the trusted tree. Added `lstat()` checks before `readFile()` for both files.
- **P2**: Reject symlinked extension root directories that resolve outside the expected parent. Replaced `stat()` with `lstat()` for root validation and added `realpath()` verification to detect when the resolved path escapes the memory directory tree.
- **Low**: Moved `resolveExtensionsRoot` from `semantic-consolidation.ts` to the `memory-extension-host` module where it semantically belongs. Added backward-compatible re-export from `semantic-consolidation.ts` so existing consumers continue to work.

## Test plan

- [x] 4 new tests added covering all 3 findings
- [x] `pnpm run check-types` passes
- [x] `pnpm run build` passes
- [x] `npx tsx --test tests/memory-extension-discovery.test.ts` passes (31/31)

## PR checklist

* [x] **All tests pass (`pytest`)** - RUN BEFORE CREATING PR
* [x] All new logic is covered by tests
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff ≤ 400 LOC (or justified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens filesystem path validation in extension discovery, which could change which extensions are detected/loaded in real deployments. Also moves a small public API surface (`resolveExtensionsRoot`) requiring careful compatibility/export review.
> 
> **Overview**
> **Hardens memory extension discovery against symlink attacks.** `discoverMemoryExtensions` now rejects symlinked extension roots that resolve outside the expected parent directory (via `lstat` + `realpath` checks), and skips/ignores symlinked `instructions.md` and `schema.json` files before reading them.
> 
> **Refactors extension-path resolution.** `resolveExtensionsRoot` is moved from `semantic-consolidation.ts` into `memory-extension-host` (and re-exported for backward compatibility), with call sites updated (including day-summary) and new tests added to cover the new symlink behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 836329638845dbff746b98240884d4732b0fe9e9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->