### PR TITLE
Fix post-merge citation findings (PR #422)

### DIFF
--- a/packages/remnic-core/src/citations.ts
+++ b/packages/remnic-core/src/citations.ts
@@ -147,6 +147,19 @@ function parseIds(block: string, openTag: string, closeTag: string): string[] | 
 }
 
 // ---------------------------------------------------------------------------
+// Sanitizer
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace newline characters (\n, \r) with spaces so that note values can be
+ * safely embedded in a single citation entry line without corrupting the
+ * line-based parser (`parseEntryLine` splits on `\n`).
+ */
+export function sanitizeNoteForCitation(note: string): string {
+  return note.replace(/[\r\n]+/g, " ").trim();
+}
+
+// ---------------------------------------------------------------------------
 // Formatter
 // ---------------------------------------------------------------------------
 
@@ -155,7 +168,7 @@ function parseIds(block: string, openTag: string, closeTag: string): string[] | 
  */
 export function formatOaiMemCitation(block: CitationBlock): string {
   const entryLines = block.entries
-    .map((e) => `${e.path}:${e.lineStart}-${e.lineEnd}|note=[${e.note}]`)
+    .map((e) => `${e.path}:${e.lineStart}-${e.lineEnd}|note=[${sanitizeNoteForCitation(e.note)}]`)
     .join("\n");
   const idLines = block.rolloutIds.join("\n");
 
@@ -185,7 +198,7 @@ export function buildCitationGuidance(citations: CitationMetadata[]): string {
   if (citations.length === 0) return "";
 
   const entryExamples = citations.map((c) =>
-    `${c.path}:${c.lineStart}-${c.lineEnd}|note=[${c.noteDefault}]`,
+    `${c.path}:${c.lineStart}-${c.lineEnd}|note=[${sanitizeNoteForCitation(c.noteDefault)}]`,
   );
   const rolloutExamples = citations
     .filter((c) => c.rolloutId != null)

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -678,6 +678,8 @@ export interface AccessHttpServeCliCommandOptions {
   principal?: string;
   maxBodyBytes?: number;
   trustPrincipalHeader?: boolean;
+  citationsEnabled?: boolean;
+  citationsAutoDetect?: boolean;
   createServer?: (options: {
     service: EngramAccessService;
     host?: string;
@@ -686,6 +688,8 @@ export interface AccessHttpServeCliCommandOptions {
     principal?: string;
     maxBodyBytes?: number;
     trustPrincipalHeader?: boolean;
+    citationsEnabled?: boolean;
+    citationsAutoDetect?: boolean;
   }) => AccessHttpServerLike;
 }
 
@@ -2396,6 +2400,8 @@ export async function runAccessHttpServeCliCommand(
         principal: input.principal,
         maxBodyBytes: input.maxBodyBytes,
         trustPrincipalHeader: input.trustPrincipalHeader,
+        citationsEnabled: input.citationsEnabled,
+        citationsAutoDetect: input.citationsAutoDetect,
       }));
 
     const server = createServer(options);
@@ -4703,6 +4709,8 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             principal: resolveAccessPrincipalOverride(options.principal, orchestrator.config.agentAccessHttp.principal),
             maxBodyBytes: Number.isFinite(maxBodyBytesRaw) ? maxBodyBytesRaw : 131072,
             trustPrincipalHeader: options.trustPrincipalHeader === true,
+            citationsEnabled: orchestrator.config.citationsEnabled,
+            citationsAutoDetect: orchestrator.config.citationsAutoDetect,
           });
           console.log(JSON.stringify(status, null, 2));
           console.log("OK");

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -248,6 +248,7 @@ export {
   parseOaiMemCitation,
   formatOaiMemCitation,
   buildCitationGuidance,
+  sanitizeNoteForCitation,
   type CitationEntry,
   type CitationBlock,
   type CitationMetadata,

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -136,6 +136,8 @@ export async function startServer(options?: {
     principal: serverConfig.principal,
     maxBodyBytes: serverConfig.maxBodyBytes,
     adminConsoleEnabled: serverConfig.adminConsoleEnabled ?? false,
+    citationsEnabled: config.citationsEnabled,
+    citationsAutoDetect: config.citationsAutoDetect,
   });
 
   const { host, port } = await httpServer.start();

--- a/tests/citations.test.ts
+++ b/tests/citations.test.ts
@@ -4,6 +4,7 @@ import {
   parseOaiMemCitation,
   formatOaiMemCitation,
   buildCitationGuidance,
+  sanitizeNoteForCitation,
   type CitationBlock,
   type CitationMetadata,
 } from "../packages/remnic-core/src/citations.js";
@@ -293,4 +294,86 @@ test("buildCitationGuidance: citations without rolloutId produce empty rollout s
   // The rollout_ids section should be empty (just the tags with nothing between).
   const rolloutSection = guidance.split("<rollout_ids>")[1]?.split("</rollout_ids>")[0] ?? "";
   assert.equal(rolloutSection.trim(), "");
+});
+
+// ---------------------------------------------------------------------------
+// sanitizeNoteForCitation
+// ---------------------------------------------------------------------------
+
+test("sanitizeNoteForCitation: replaces LF with space", () => {
+  assert.equal(sanitizeNoteForCitation("line1\nline2"), "line1 line2");
+});
+
+test("sanitizeNoteForCitation: replaces CR+LF with space", () => {
+  assert.equal(sanitizeNoteForCitation("line1\r\nline2"), "line1 line2");
+});
+
+test("sanitizeNoteForCitation: replaces multiple consecutive newlines with a single space", () => {
+  assert.equal(sanitizeNoteForCitation("line1\n\n\nline2"), "line1 line2");
+});
+
+test("sanitizeNoteForCitation: preserves notes without newlines", () => {
+  assert.equal(sanitizeNoteForCitation("already clean"), "already clean");
+});
+
+test("sanitizeNoteForCitation: empty string stays empty", () => {
+  assert.equal(sanitizeNoteForCitation(""), "");
+});
+
+// ---------------------------------------------------------------------------
+// formatOaiMemCitation: multi-line notes are sanitized
+// ---------------------------------------------------------------------------
+
+test("formatOaiMemCitation: multi-line note is flattened to one line", () => {
+  const block: CitationBlock = {
+    entries: [
+      { path: "facts/f.md", lineStart: 1, lineEnd: 5, note: "line1\nline2\nline3" },
+    ],
+    rolloutIds: ["rollout-1"],
+  };
+
+  const formatted = formatOaiMemCitation(block);
+  // The note should NOT contain literal newlines.
+  assert.ok(formatted.includes("|note=[line1 line2 line3]"));
+  // Round-trip must succeed: parsed note matches sanitized version.
+  const parsed = parseOaiMemCitation(formatted);
+  assert.ok(parsed);
+  assert.equal(parsed.entries.length, 1);
+  assert.equal(parsed.entries[0].note, "line1 line2 line3");
+});
+
+test("formatOaiMemCitation: CR+LF in note is flattened", () => {
+  const block: CitationBlock = {
+    entries: [
+      { path: "facts/f.md", lineStart: 1, lineEnd: 1, note: "a\r\nb" },
+    ],
+    rolloutIds: [],
+  };
+
+  const formatted = formatOaiMemCitation(block);
+  assert.ok(formatted.includes("|note=[a b]"));
+});
+
+// ---------------------------------------------------------------------------
+// buildCitationGuidance: multi-line noteDefault is sanitized
+// ---------------------------------------------------------------------------
+
+test("buildCitationGuidance: multi-line noteDefault is flattened", () => {
+  const citations: CitationMetadata[] = [
+    {
+      memoryId: "fact-1",
+      path: "facts/fact-1.md",
+      lineStart: 1,
+      lineEnd: 1,
+      noteDefault: "first line\nsecond line",
+    },
+  ];
+
+  const guidance = buildCitationGuidance(citations);
+  assert.ok(guidance.includes("|note=[first line second line]"));
+  // Ensure the guidance block can be parsed back correctly.
+  const parsed = parseOaiMemCitation(guidance);
+  assert.ok(parsed);
+  assert.equal(parsed.entries.length, 1);
+  assert.equal(parsed.entries[0].note, "first line second line");
 });


### PR DESCRIPTION
## Summary

Fixes two post-merge review findings from PR #422 (oai-mem-citation support):

- **Sanitize newlines in citation notes**: formatOaiMemCitation and buildCitationGuidance now call sanitizeNoteForCitation() to replace newlines with spaces before embedding note values in entry lines. Without this, a note containing newlines breaks the line-based parseEntryLine parser.
- **Propagate citation config to non-plugin startup paths**: citationsEnabled and citationsAutoDetect are now forwarded to EngramAccessHttpServer from the standalone @remnic/server package and the CLI serve command, matching the existing plugin bootstrap path in src/index.ts.

## Test plan

- [x] pnpm run check-types passes
- [x] pnpm run build succeeds
- [x] All 23 citation tests pass (15 existing + 8 new)
- [x] New tests cover: LF, CRLF, multi-newline, clean input, empty string, round-trip formatting, and guidance builder with multi-line notes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes how citation notes are serialized (newline flattening) and wires citation feature flags into additional HTTP server startup paths, which could subtly affect citation parsing/behavior in production.
> 
> **Overview**
> Prevents multi-line citation notes from corrupting the line-based citation parser by introducing `sanitizeNoteForCitation()` and applying it when generating citation entry lines in both `formatOaiMemCitation()` and `buildCitationGuidance()`.
> 
> Propagates `citationsEnabled` and `citationsAutoDetect` through the non-plugin startup paths by passing them into `EngramAccessHttpServer` from the core CLI serve command and the standalone `@remnic/server` bootstrap. Adds focused tests covering newline sanitization and round-trip parsing for formatted blocks and guidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0306703d2837e5980ae75319776d358d50d7d8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->