### PR TITLE
fix(taxonomy): address unresolved review findings from #424

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2911,12 +2911,17 @@ async function cmdTaxonomy(rest: string[]): Promise<void> {
     case "resolve": {
       // Strip --flag and its following value token together so flag values
       // (e.g. "preference" in `--category preference`) don't leak into text.
+      // Boolean flags (like --json) don't consume a following value token.
+      const BOOLEAN_FLAGS = new Set(["--json"]);
       const resolveArgs = rest.slice(1);
       const textParts: string[] = [];
       for (let i = 0; i < resolveArgs.length; i++) {
         if (resolveArgs[i].startsWith("--")) {
-          // Skip the flag and its value (next token)
-          i++;
+          // Boolean flags have no trailing value — skip only the flag itself
+          if (!BOOLEAN_FLAGS.has(resolveArgs[i])) {
+            // Key-value flag: skip the flag and its value (next token)
+            i++;
+          }
           continue;
         }
         textParts.push(resolveArgs[i]);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -25,7 +25,7 @@ import { normalizeEntitySchemas } from "./entity-schema.js";
 // boolean-coercion logic that connectors/index.ts already exports. The helper
 // lives in connectors/coerce.ts (a tiny, dependency-free module) so neither
 // config.ts → connectors/index.ts nor the reverse circular import arises.
-import { coerceInstallExtension } from "./connectors/coerce.js";
+import { coerceBool, coerceInstallExtension } from "./connectors/coerce.js";
 
 const DEFAULT_MEMORY_DIR = path.join(
   resolveHomeDir(),
@@ -1929,8 +1929,9 @@ export function parseConfig(raw: unknown): PluginConfig {
     })(),
 
     // MECE Taxonomy (#366)
-    taxonomyEnabled: cfg.taxonomyEnabled === true,
-    taxonomyAutoGenResolver: cfg.taxonomyAutoGenResolver !== false,
+    // Coerce string booleans from CLI (e.g. --config taxonomyEnabled=true) — gotcha #36
+    taxonomyEnabled: coerceBool(cfg.taxonomyEnabled) ?? false,
+    taxonomyAutoGenResolver: coerceBool(cfg.taxonomyAutoGenResolver) ?? true,
 
     // Codex CLI — native memory materialization (#378)
     codexMaterializeMemories: cfg.codexMaterializeMemories !== false,

--- a/packages/remnic-core/src/connectors/coerce.ts
+++ b/packages/remnic-core/src/connectors/coerce.ts
@@ -1,19 +1,22 @@
 /**
- * Shared coercion helper for the `installExtension` config field.
+ * Shared boolean coercion helpers.
  *
  * Extracted from connectors/index.ts so that both config.ts and
- * connectors/index.ts can import it without creating a circular dependency.
+ * connectors/index.ts can import them without creating a circular dependency.
  */
 
 /**
- * Coerce the `installExtension` config value from a string (e.g. from CLI
- * `--config installExtension=false`) to a proper boolean.  Accepts the same
- * truthy/falsy strings that common shells and env vars use.
+ * Generic boolean coercion: converts string representations of booleans
+ * (e.g. from CLI `--config someFlag=false`) to proper boolean values.
+ * Accepts the same truthy/falsy strings that common shells and env vars use.
  *
  * Returns `undefined` when the value is neither a boolean nor a recognised
  * string, so callers can fall back to a default.
+ *
+ * CLAUDE.md gotcha #36: String "false" is truthy in JavaScript.
+ * CLAUDE.md gotcha #28: Coerce CLI values to expected types at input boundaries.
  */
-export function coerceInstallExtension(value: unknown): boolean | undefined {
+export function coerceBool(value: unknown): boolean | undefined {
   if (typeof value === "boolean") return value;
   if (typeof value === "string") {
     const v = value.trim().toLowerCase();
@@ -21,4 +24,14 @@ export function coerceInstallExtension(value: unknown): boolean | undefined {
     if (["true", "1", "yes", "on"].includes(v)) return true;
   }
   return undefined;
+}
+
+/**
+ * Coerce the `installExtension` config value from a string (e.g. from CLI
+ * `--config installExtension=false`) to a proper boolean.
+ *
+ * Delegates to the generic `coerceBool` helper. Kept for backward compatibility.
+ */
+export function coerceInstallExtension(value: unknown): boolean | undefined {
+  return coerceBool(value);
 }

--- a/packages/remnic-core/src/taxonomy/taxonomy-loader.ts
+++ b/packages/remnic-core/src/taxonomy/taxonomy-loader.ts
@@ -122,6 +122,23 @@ export async function loadTaxonomy(memoryDir: string): Promise<Taxonomy> {
     ? (obj.categories as TaxonomyCategory[])
     : [];
 
+  // Validate: reject duplicate IDs in user categories before merging.
+  // Without this check, duplicates are silently collapsed with last-write-wins
+  // semantics when inserted into the Map.
+  const userIdCounts = new Map<string, number>();
+  for (const cat of userCategories) {
+    const id = typeof cat.id === "string" ? cat.id : String(cat.id);
+    userIdCounts.set(id, (userIdCounts.get(id) ?? 0) + 1);
+  }
+  const duplicateIds = [...userIdCounts.entries()]
+    .filter(([, count]) => count > 1)
+    .map(([id]) => id);
+  if (duplicateIds.length > 0) {
+    throw new Error(
+      `Duplicate category IDs in taxonomy.json: ${duplicateIds.map((id) => `"${id}"`).join(", ")}`,
+    );
+  }
+
   // Merge: user categories override defaults by ID
   const mergedMap = new Map<string, TaxonomyCategory>();
   for (const cat of DEFAULT_TAXONOMY.categories) {

--- a/tests/mece-taxonomy.test.ts
+++ b/tests/mece-taxonomy.test.ts
@@ -499,4 +499,106 @@ describe("Config integration", () => {
     assert.equal(config.taxonomyEnabled, true);
     assert.equal(config.taxonomyAutoGenResolver, false);
   });
+
+  // Finding 3: String booleans from CLI must be coerced (gotcha #36)
+  it("parseConfig coerces string 'true' to boolean true for taxonomyEnabled", () => {
+    const config = parseConfig({ taxonomyEnabled: "true" });
+    assert.equal(config.taxonomyEnabled, true);
+  });
+
+  it("parseConfig coerces string 'false' to boolean false for taxonomyEnabled", () => {
+    const config = parseConfig({ taxonomyEnabled: "false" });
+    assert.equal(config.taxonomyEnabled, false);
+  });
+
+  it("parseConfig coerces string 'false' to boolean false for taxonomyAutoGenResolver", () => {
+    const config = parseConfig({ taxonomyAutoGenResolver: "false" });
+    assert.equal(config.taxonomyAutoGenResolver, false);
+  });
+
+  it("parseConfig coerces string 'true' to boolean true for taxonomyAutoGenResolver", () => {
+    const config = parseConfig({ taxonomyAutoGenResolver: "true" });
+    assert.equal(config.taxonomyAutoGenResolver, true);
+  });
+
+  it("parseConfig coerces '0'/'1' for taxonomy flags", () => {
+    const config = parseConfig({ taxonomyEnabled: "1", taxonomyAutoGenResolver: "0" });
+    assert.equal(config.taxonomyEnabled, true);
+    assert.equal(config.taxonomyAutoGenResolver, false);
+  });
+});
+
+// ── Duplicate ID detection in loadTaxonomy (Finding 2) ─────────────────────
+
+describe("loadTaxonomy duplicate ID detection", () => {
+  it("rejects duplicate category IDs in user taxonomy.json before map merge", async () => {
+    const custom = {
+      version: 1,
+      categories: [
+        {
+          id: "my-cat",
+          name: "My Cat",
+          description: "First instance",
+          filingRules: ["rule"],
+          priority: 10,
+          memoryCategories: [],
+        },
+        {
+          id: "my-cat",
+          name: "My Cat Dupe",
+          description: "Duplicate instance",
+          filingRules: ["rule2"],
+          priority: 20,
+          memoryCategories: [],
+        },
+      ],
+    };
+    const taxonomyDir = path.join(tmpDir, ".taxonomy");
+    fs.mkdirSync(taxonomyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(taxonomyDir, "taxonomy.json"),
+      JSON.stringify(custom),
+    );
+
+    await assert.rejects(
+      () => loadTaxonomy(tmpDir),
+      (err: Error) => {
+        return err.message.includes("Duplicate category IDs") && err.message.includes("my-cat");
+      },
+    );
+  });
+
+  it("allows unique category IDs in user taxonomy.json", async () => {
+    const custom = {
+      version: 1,
+      categories: [
+        {
+          id: "alpha",
+          name: "Alpha",
+          description: "First",
+          filingRules: ["rule"],
+          priority: 10,
+          memoryCategories: [],
+        },
+        {
+          id: "beta",
+          name: "Beta",
+          description: "Second",
+          filingRules: ["rule"],
+          priority: 20,
+          memoryCategories: [],
+        },
+      ],
+    };
+    const taxonomyDir = path.join(tmpDir, ".taxonomy");
+    fs.mkdirSync(taxonomyDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(taxonomyDir, "taxonomy.json"),
+      JSON.stringify(custom),
+    );
+
+    const loaded = await loadTaxonomy(tmpDir);
+    assert.ok(loaded.categories.some((c) => c.id === "alpha"));
+    assert.ok(loaded.categories.some((c) => c.id === "beta"));
+  });
 });

--- a/tests/taxonomy-cli-boolean-flag.test.ts
+++ b/tests/taxonomy-cli-boolean-flag.test.ts
@@ -1,0 +1,148 @@
+/**
+ * Tests for Finding 1 (PR #424): boolean --json flag must not eat the next
+ * text argument in the `taxonomy resolve` flag-stripping loop.
+ *
+ * Also tests the generic coerceBool helper (Finding 3).
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { coerceBool, coerceInstallExtension } from "../packages/remnic-core/src/connectors/coerce.js";
+
+// ── Boolean flag stripping logic (Finding 1) ───────────────────────────────
+//
+// The resolve case strips --flag <value> pairs before joining remaining tokens
+// as the input text. Boolean flags like --json have no trailing value, so the
+// loop must not skip the token after them.
+//
+// We replicate the exact stripping logic here so the test stays self-contained
+// and doesn't need to import the full CLI entry.
+
+const BOOLEAN_FLAGS = new Set(["--json"]);
+
+function stripFlags(args: string[]): string[] {
+  const textParts: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--")) {
+      if (!BOOLEAN_FLAGS.has(args[i])) {
+        // Key-value flag: skip the flag and its value (next token)
+        i++;
+      }
+      continue;
+    }
+    textParts.push(args[i]);
+  }
+  return textParts;
+}
+
+describe("taxonomy resolve flag stripping", () => {
+  it("--json does not eat the following text argument", () => {
+    const args = ["--json", "hello", "world"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["hello", "world"]);
+  });
+
+  it("--category (key-value) correctly skips the value", () => {
+    const args = ["--category", "preference", "my", "text"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["my", "text"]);
+  });
+
+  it("--json before --category works correctly", () => {
+    const args = ["--json", "--category", "fact", "some", "input"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["some", "input"]);
+  });
+
+  it("--category before --json works correctly", () => {
+    const args = ["--category", "fact", "--json", "some", "input"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["some", "input"]);
+  });
+
+  it("--json at the end does not cause out-of-bounds", () => {
+    const args = ["hello", "--json"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["hello"]);
+  });
+
+  it("no flags returns all tokens", () => {
+    const args = ["hello", "world"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, ["hello", "world"]);
+  });
+
+  it("only --json returns empty", () => {
+    const args = ["--json"];
+    const result = stripFlags(args);
+    assert.deepStrictEqual(result, []);
+  });
+});
+
+// ── coerceBool generic helper (Finding 3) ──────────────────────────────────
+
+describe("coerceBool", () => {
+  it("passes through boolean true", () => {
+    assert.equal(coerceBool(true), true);
+  });
+
+  it("passes through boolean false", () => {
+    assert.equal(coerceBool(false), false);
+  });
+
+  it("coerces string 'true' to true", () => {
+    assert.equal(coerceBool("true"), true);
+  });
+
+  it("coerces string 'false' to false", () => {
+    assert.equal(coerceBool("false"), false);
+  });
+
+  it("coerces '1' to true", () => {
+    assert.equal(coerceBool("1"), true);
+  });
+
+  it("coerces '0' to false", () => {
+    assert.equal(coerceBool("0"), false);
+  });
+
+  it("coerces 'yes'/'no' correctly", () => {
+    assert.equal(coerceBool("yes"), true);
+    assert.equal(coerceBool("no"), false);
+  });
+
+  it("coerces 'on'/'off' correctly", () => {
+    assert.equal(coerceBool("on"), true);
+    assert.equal(coerceBool("off"), false);
+  });
+
+  it("handles whitespace and case", () => {
+    assert.equal(coerceBool("  TRUE  "), true);
+    assert.equal(coerceBool("  FALSE  "), false);
+    assert.equal(coerceBool("True"), true);
+    assert.equal(coerceBool("False"), false);
+  });
+
+  it("returns undefined for unrecognized values", () => {
+    assert.equal(coerceBool(undefined), undefined);
+    assert.equal(coerceBool(null), undefined);
+    assert.equal(coerceBool("maybe"), undefined);
+    assert.equal(coerceBool(42), undefined);
+    assert.equal(coerceBool({}), undefined);
+  });
+});
+
+// ── coerceInstallExtension backward compat ─────────────────────────────────
+
+describe("coerceInstallExtension delegates to coerceBool", () => {
+  it("behaves identically to coerceBool", () => {
+    const cases: unknown[] = [true, false, "true", "false", "1", "0", "yes", "no", undefined, null, "maybe", 42];
+    for (const input of cases) {
+      assert.equal(
+        coerceInstallExtension(input),
+        coerceBool(input),
+        `mismatch for input ${JSON.stringify(input)}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- **Finding 1 (Medium):** Boolean `--json` flag in `taxonomy resolve` no longer silently eats the next text argument. Added a `BOOLEAN_FLAGS` set so the flag-stripping loop skips only the flag itself (not the following token) for boolean flags.
- **Finding 2 (P2):** `loadTaxonomy()` now validates for duplicate IDs in user categories **before** merging into the Map, so last-write-wins collapsing is surfaced as an error listing the duplicate IDs.
- **Finding 3 (P2):** Taxonomy boolean config flags (`taxonomyEnabled`, `taxonomyAutoGenResolver`) now use the generic `coerceBool()` helper instead of strict `=== true` / `!== false` checks, so CLI string values like `"true"`/`"false"` from `--config` are handled correctly (CLAUDE.md gotcha #36).

## Test plan

- [x] `pnpm run check-types` passes
- [x] `pnpm run build` succeeds
- [x] `npx tsx --test tests/mece-taxonomy.test.ts` — 45 tests pass (6 new)
- [x] `npx tsx --test tests/taxonomy-cli-boolean-flag.test.ts` — 18 tests pass (new file)
- [x] All new logic is covered by tests
- [x] Pre-commit hooks pass locally
- [x] No secrets or creds committed
- [x] PR diff under 400 LOC