### PR TITLE
fix(codex): address unresolved review findings from #427

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1664,8 +1664,16 @@ async function cmdConnectorsMarketplace(
       process.exit(1);
     }
 
-    const typeFlag = resolveFlagStrict(rest, "--type") ?? "github";
+    // CLAUDE.md gotcha #14 / #51: distinguish "flag not provided" from
+    // "flag provided without a value" — the latter must be a hard error.
     const validTypes = new Set(["github", "git", "local", "url"]);
+    const typeFlagPresent = rest.includes("--type");
+    const typeFlagValue = resolveFlagStrict(rest, "--type");
+    if (typeFlagPresent && typeFlagValue === undefined) {
+      console.error(`--type requires a value (${[...validTypes].join(", ")})`);
+      process.exit(1);
+    }
+    const typeFlag = typeFlagValue ?? "github";
     if (!validTypes.has(typeFlag)) {
       console.error(`Invalid --type: "${typeFlag}". Must be one of: ${[...validTypes].join(", ")}`);
       process.exit(1);

--- a/packages/remnic-core/src/connectors/codex-marketplace.ts
+++ b/packages/remnic-core/src/connectors/codex-marketplace.ts
@@ -223,6 +223,17 @@ export function checkMarketplaceManifest(manifest: unknown): MarketplaceValidati
           `got ${JSON.stringify(plugin.installType)}`,
         );
       }
+
+      // Validate optional string fields — reject present-but-wrong-type values
+      // so they fail here rather than causing runtime errors downstream.
+      const optionalStringFields = ["entry", "manifestUrl", "configSchema", "author"] as const;
+      for (const field of optionalStringFields) {
+        if (field in plugin && typeof plugin[field] !== "string") {
+          errors.push(
+            `${prefix}.${field} must be a string if provided; got ${typeof plugin[field]}`,
+          );
+        }
+      }
     }
   }
 

--- a/tests/codex-marketplace.test.ts
+++ b/tests/codex-marketplace.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import fs from "node:fs";
 import path from "node:path";
 import os from "node:os";
+import { fileURLToPath } from "node:url";
 
 import {
   generateMarketplaceManifest,
@@ -437,4 +438,194 @@ test("MARKETPLACE_MANIFEST_FILENAME is marketplace.json", () => {
 
 test("MARKETPLACE_SCHEMA_VERSION is 1", () => {
   assert.equal(MARKETPLACE_SCHEMA_VERSION, 1);
+});
+
+// ── Optional field type validation (Finding 1 — PR #427) ─────────────────────
+
+test("checkMarketplaceManifest rejects non-string entry field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: 123,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("entry") && e.includes("string")));
+});
+
+test("checkMarketplaceManifest rejects non-string manifestUrl field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        manifestUrl: { url: "bad" },
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("manifestUrl") && e.includes("string")));
+});
+
+test("checkMarketplaceManifest rejects non-string configSchema field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        configSchema: 42,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("configSchema") && e.includes("string")));
+});
+
+test("checkMarketplaceManifest rejects non-string author field", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        author: ["not", "a", "string"],
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  assert.ok(result.errors.some((e) => e.includes("author") && e.includes("string")));
+});
+
+test("checkMarketplaceManifest accepts valid optional string fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: "packages/plugin",
+        manifestUrl: "https://example.com/manifest.json",
+        configSchema: "plugin.json",
+        author: "tester",
+      },
+    ],
+  });
+
+  assert.ok(result.valid, `unexpected errors: ${result.errors.join("; ")}`);
+});
+
+test("checkMarketplaceManifest accepts absent optional fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+      },
+    ],
+  });
+
+  assert.ok(result.valid, `unexpected errors: ${result.errors.join("; ")}`);
+});
+
+test("checkMarketplaceManifest reports multiple malformed optional fields", () => {
+  const result = checkMarketplaceManifest({
+    version: 1,
+    name: "test",
+    description: "test",
+    plugins: [
+      {
+        name: "p",
+        version: "1.0.0",
+        description: "d",
+        repository: "o/r",
+        installType: "github",
+        entry: 123,
+        manifestUrl: false,
+        configSchema: null,
+      },
+    ],
+  });
+
+  assert.equal(result.valid, false);
+  // Should report an error for each malformed optional field
+  assert.ok(result.errors.some((e) => e.includes("entry")));
+  assert.ok(result.errors.some((e) => e.includes("manifestUrl")));
+  assert.ok(result.errors.some((e) => e.includes("configSchema")));
+});
+
+// ── --type flag fail-fast validation (Finding 2 — PR #427) ────────────────────
+
+const CLI_SRC_PATH = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "packages",
+  "remnic-cli",
+  "src",
+  "index.ts",
+);
+
+test("CLI marketplace install guards --type present-without-value", async () => {
+  const src = fs.readFileSync(CLI_SRC_PATH, "utf-8");
+
+  // The guard must check whether --type is present in the args array
+  // and error if resolveFlagStrict returns undefined for a present flag.
+  assert.ok(
+    src.includes('rest.includes("--type")'),
+    "CLI must check for --type presence in rest args",
+  );
+  assert.ok(
+    src.includes('--type requires a value'),
+    "CLI must emit an error message when --type is present without a value",
+  );
+});
+
+test("CLI marketplace install still defaults to github when --type is omitted", async () => {
+  const src = fs.readFileSync(CLI_SRC_PATH, "utf-8");
+
+  // When --type is not provided at all, the default should be "github".
+  assert.ok(
+    src.includes('?? "github"'),
+    "CLI must default typeFlag to 'github' when --type is absent",
+  );
 });


### PR DESCRIPTION
## Summary

Fixes two unresolved P2 review findings from the Codex marketplace PR #427:

- **Validate optional manifest fields**: `checkMarketplaceManifest` now type-checks optional plugin fields (`entry`, `manifestUrl`, `configSchema`, `author`). If present, they must be strings; malformed values (e.g., `entry: 123`, `manifestUrl: {}`) now produce clear validation errors instead of passing validation and causing runtime failures downstream.

- **Fail fast on `--type` without value**: `remnic connectors marketplace install` now distinguishes "flag not provided" (defaults to `github`) from "flag provided without a trailing value" (hard error: `--type requires a value`). Previously both cases silently defaulted to `github`, which could eat the next positional argument.

## Test plan

- [x] 7 new tests for optional field type validation (entry, manifestUrl, configSchema, author — reject wrong types, accept correct types, accept absent fields, multi-field error reporting)
- [x] 2 new tests for `--type` flag guard (source-code structure tests verifying the presence guard and the default-when-absent behavior)
- [x] Build passes (`pnpm run build`)
- [x] Type check passes (`pnpm run check-types`)
- [x] All 33 marketplace tests pass

Closes review threads on #427.

## PR checklist

* [x] All tests pass
* [x] All new logic is covered by tests
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff < 400 LOC

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds stricter validation and fail-fast CLI argument handling, with behavior changes limited to previously-invalid manifests and malformed `--type` usage.
> 
> **Overview**
> Improves robustness of Codex marketplace support by making `checkMarketplaceManifest` reject *present-but-non-string* optional plugin fields (`entry`, `manifestUrl`, `configSchema`, `author`) instead of letting them through to fail later.
> 
> Updates `remnic connectors marketplace install` to distinguish omitted `--type` (still defaults to `github`) from `--type` provided without a value (now a hard error), and adds tests covering both the new manifest validation and the CLI guard.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a72068d5ba6434ae03576efc4c41984217171fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->