### PR TITLE
Fix 4 post-merge review findings from PR #420 (semantic chunking)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1771,6 +1771,53 @@
         "default": 2,
         "description": "Number of sentences to overlap between chunks"
       },
+      "semanticChunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+      },
+      "semanticChunkingConfig": {
+        "type": "object",
+        "default": {},
+        "description": "Optional overrides for the semantic chunking algorithm",
+        "properties": {
+          "targetTokens": {
+            "type": "number",
+            "default": 200,
+            "description": "Target tokens per chunk"
+          },
+          "minTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Minimum tokens for a segment before merging with neighbor"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 400,
+            "description": "Maximum tokens for a segment before recursive splitting"
+          },
+          "smoothingWindowSize": {
+            "type": "number",
+            "default": 3,
+            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+          },
+          "boundaryThresholdStdDevs": {
+            "type": "number",
+            "default": 1,
+            "description": "Standard deviations below mean for boundary detection"
+          },
+          "embeddingBatchSize": {
+            "type": "number",
+            "default": 32,
+            "description": "Batch size for embedding requests"
+          },
+          "fallbackToRecursive": {
+            "type": "boolean",
+            "default": true,
+            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          }
+        }
+      },
       "contradictionDetectionEnabled": {
         "type": "boolean",
         "default": false,
@@ -3800,6 +3847,15 @@
       "label": "Chunk Overlap Sentences",
       "advanced": true,
       "placeholder": "2"
+    },
+    "semanticChunkingEnabled": {
+      "label": "Semantic Chunking",
+      "help": "Use embedding-based topic detection for more coherent chunks (requires chunking enabled)"
+    },
+    "semanticChunkingConfig": {
+      "label": "Semantic Chunking Config",
+      "advanced": true,
+      "help": "Override defaults for semantic chunking algorithm parameters"
     },
     "contradictionDetectionEnabled": {
       "label": "Contradiction Detection",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1768,6 +1768,53 @@
         "default": 2,
         "description": "Number of sentences to overlap between chunks"
       },
+      "semanticChunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+      },
+      "semanticChunkingConfig": {
+        "type": "object",
+        "default": {},
+        "description": "Optional overrides for the semantic chunking algorithm",
+        "properties": {
+          "targetTokens": {
+            "type": "number",
+            "default": 200,
+            "description": "Target tokens per chunk"
+          },
+          "minTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Minimum tokens for a segment before merging with neighbor"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 400,
+            "description": "Maximum tokens for a segment before recursive splitting"
+          },
+          "smoothingWindowSize": {
+            "type": "number",
+            "default": 3,
+            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+          },
+          "boundaryThresholdStdDevs": {
+            "type": "number",
+            "default": 1.0,
+            "description": "Standard deviations below mean for boundary detection"
+          },
+          "embeddingBatchSize": {
+            "type": "number",
+            "default": 32,
+            "description": "Batch size for embedding requests"
+          },
+          "fallbackToRecursive": {
+            "type": "boolean",
+            "default": true,
+            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          }
+        }
+      },
       "contradictionDetectionEnabled": {
         "type": "boolean",
         "default": false,
@@ -3783,6 +3830,15 @@
       "label": "Chunk Overlap Sentences",
       "advanced": true,
       "placeholder": "2"
+    },
+    "semanticChunkingEnabled": {
+      "label": "Semantic Chunking",
+      "help": "Use embedding-based topic detection for more coherent chunks (requires chunking enabled)"
+    },
+    "semanticChunkingConfig": {
+      "label": "Semantic Chunking Config",
+      "advanced": true,
+      "help": "Override defaults for semantic chunking algorithm parameters"
     },
     "contradictionDetectionEnabled": {
       "label": "Contradiction Detection",

--- a/packages/remnic-core/src/chunking.ts
+++ b/packages/remnic-core/src/chunking.ts
@@ -147,10 +147,17 @@ export function chunkContent(
 
       // Start new chunk with overlap (if not at end)
       if (!isLastSentence) {
-        // Keep last N sentences for overlap
+        // Keep last N sentences for overlap.
+        // Guard: slice(-0) === slice(0), which returns the ENTIRE array
+        // (CLAUDE.md gotcha #27). When overlapSentences is 0, clear fully.
         const overlapCount = Math.min(config.overlapSentences, currentChunkSentences.length);
-        currentChunkSentences = currentChunkSentences.slice(-overlapCount);
-        currentTokens = currentChunkSentences.reduce((sum, s) => sum + estimateTokens(s), 0);
+        if (overlapCount <= 0) {
+          currentChunkSentences = [];
+          currentTokens = 0;
+        } else {
+          currentChunkSentences = currentChunkSentences.slice(-overlapCount);
+          currentTokens = currentChunkSentences.reduce((sum, s) => sum + estimateTokens(s), 0);
+        }
       }
     }
   }

--- a/packages/remnic-core/src/embedding-fallback.ts
+++ b/packages/remnic-core/src/embedding-fallback.ts
@@ -141,6 +141,32 @@ export class EmbeddingFallback {
   }
 
   /**
+   * Embed an array of texts and return their embedding vectors.
+   *
+   * This is the public batch-embed interface used by semantic chunking
+   * (Finding 1, PR #420 post-merge).  Each text is embedded individually
+   * through the existing embed() private method.  If the provider is
+   * unavailable or any single embedding fails, the method throws so the
+   * caller can fall back to recursive chunking.
+   */
+  async embedTexts(texts: string[]): Promise<number[][]> {
+    const provider = await this.resolveProvider();
+    if (!provider) {
+      throw new Error("Embedding provider is not available");
+    }
+
+    const vectors: number[][] = [];
+    for (const text of texts) {
+      const vec = await this.embed(text, provider, { mode: "lookup" });
+      if (!vec) {
+        throw new Error("Embedding returned null for input text");
+      }
+      vectors.push(vec);
+    }
+    return vectors;
+  }
+
+  /**
    * Nearest-neighbor search against the embedding index.
    *
    * @param query         The query string to embed and search for.

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -16,6 +16,7 @@ import { resolveHomeDir } from "./runtime/env.js";
 import { migrateFromEngram } from "./migrate/from-engram.js";
 import { SmartBuffer } from "./buffer.js";
 import { chunkContent, type ChunkingConfig } from "./chunking.js";
+import { semanticChunkContent, type SemanticChunkResult } from "./semantic-chunking.js";
 import { ExtractionEngine } from "./extraction.js";
 import { isAboveImportanceThreshold, scoreImportance } from "./importance.js";
 import {
@@ -9771,9 +9772,31 @@ export class Orchestrator {
         continue;
       }
 
-      // Check if chunking is enabled and content should be chunked
+      // Check if chunking is enabled and content should be chunked.
+      // When semanticChunkingEnabled is true, prefer the embedding-based
+      // semantic chunker which produces more coherent topic-aligned segments.
+      // Falls back to the recursive sentence-boundary chunker on failure.
       if (this.config.chunkingEnabled) {
-        const chunkResult = chunkContent(fact.content, chunkingConfig);
+        let chunkResult: { chunked: boolean; chunks: { content: string; index: number; tokenCount: number }[] };
+
+        if (this.config.semanticChunkingEnabled) {
+          try {
+            const embedFn = this.embeddingFallback.embedTexts.bind(this.embeddingFallback);
+            const semanticResult: SemanticChunkResult = await semanticChunkContent(
+              fact.content,
+              embedFn,
+              this.config.semanticChunkingConfig,
+            );
+            chunkResult = semanticResult;
+          } catch (err) {
+            log.debug(
+              `semantic chunking failed, falling back to recursive chunker: ${err}`,
+            );
+            chunkResult = chunkContent(fact.content, chunkingConfig);
+          }
+        } else {
+          chunkResult = chunkContent(fact.content, chunkingConfig);
+        }
 
         if (chunkResult.chunked && chunkResult.chunks.length > 1) {
           // Classify memory kind (v8.0 Phase 2B: HiMem episode/note dual store)

--- a/packages/remnic-core/src/semantic-chunking.ts
+++ b/packages/remnic-core/src/semantic-chunking.ts
@@ -129,10 +129,15 @@ export function stddev(series: number[]): number {
  * Simple moving average over a 1D series.
  * The window is centered: for window size W, each output[i] averages
  * series[i - floor(W/2) .. i + floor(W/2)], clamped to bounds.
+ *
+ * Even window sizes are rounded up to the next odd value so the window
+ * is symmetric around the center point (Finding 4, PR #420).
  */
 export function movingAverage(series: number[], windowSize: number): number[] {
   if (series.length === 0) return [];
   if (windowSize < 1) windowSize = 1;
+  // Round even values up to the next odd so the window is symmetric.
+  if (windowSize % 2 === 0) windowSize = windowSize + 1;
 
   const halfW = Math.floor(windowSize / 2);
   const result: number[] = new Array(series.length);
@@ -310,9 +315,12 @@ function splitLongSegment(
   targetTokens: number,
 ): SemanticChunk[] {
   const text = segment.join(" ");
+  // Cap targetTokens to maxTokens so recursive splitting never produces
+  // segments larger than the configured maximum (Finding 2, PR #420).
+  const cappedTarget = Math.min(targetTokens, maxTokens);
   const result: ChunkResult = chunkContent(text, {
-    targetTokens,
-    minTokens: Math.min(targetTokens, maxTokens),
+    targetTokens: cappedTarget,
+    minTokens: Math.min(cappedTarget, maxTokens),
     overlapSentences: 0,
   });
 

--- a/tests/semantic-chunking.test.ts
+++ b/tests/semantic-chunking.test.ts
@@ -489,3 +489,70 @@ test("semanticChunkContent: two sentences exceeding maxTokens triggers recursive
   assert.equal(result.method, "recursive-fallback");
   assert.ok(result.chunks.length >= 2, `Expected multiple chunks, got ${result.chunks.length}`);
 });
+
+// ---------------------------------------------------------------------------
+// Finding 2 (PR #420): splitLongSegment caps targetTokens to maxTokens
+// ---------------------------------------------------------------------------
+
+test("semanticChunkContent: recursive split respects maxTokens when targetTokens is larger", async () => {
+  // Create a long single-topic text that will be split recursively.
+  // targetTokens=500 with maxTokens=100 should produce chunks much
+  // smaller than 500 tokens because splitLongSegment now caps
+  // targetTokens to maxTokens.
+  const longSentences = Array.from(
+    { length: 40 },
+    (_, i) =>
+      `This is sentence number ${i} and it contributes to the total count.`,
+  );
+  const text = longSentences.join(" ");
+
+  const result = await semanticChunkContent(text, uniformEmbedFn, {
+    targetTokens: 500,
+    minTokens: 10,
+    maxTokens: 100,
+  });
+
+  // Without the maxTokens cap, splitLongSegment would forward
+  // targetTokens=500 to the recursive chunker, producing 1-2 huge chunks.
+  // With the cap, it uses targetTokens=100 instead, producing many smaller
+  // chunks.  Verify that we got multiple chunks and none approaches 500.
+  assert.ok(
+    result.chunks.length >= 3,
+    `Expected >= 3 chunks when maxTokens caps targetTokens, got ${result.chunks.length}`,
+  );
+  for (const chunk of result.chunks) {
+    assert.ok(
+      chunk.tokenCount < 400,
+      `Chunk token count ${chunk.tokenCount} is near uncapped targetTokens (500). ` +
+        `splitLongSegment should have capped targetTokens to maxTokens=100.`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Finding 4 (PR #420): even window sizes are rounded up to odd
+// ---------------------------------------------------------------------------
+
+test("movingAverage: even windowSize is rounded up to next odd", () => {
+  // With windowSize=4, it should be treated as windowSize=5 (halfW=2).
+  // With windowSize=5, halfW=2, so the two should produce identical results.
+  const series = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+  const resultEven = movingAverage(series, 4);
+  const resultOdd = movingAverage(series, 5);
+  assert.deepEqual(
+    resultEven,
+    resultOdd,
+    "Even windowSize=4 should produce the same result as odd windowSize=5",
+  );
+});
+
+test("movingAverage: windowSize=2 behaves as windowSize=3", () => {
+  const series = [10, 20, 30, 40, 50];
+  const resultTwo = movingAverage(series, 2);
+  const resultThree = movingAverage(series, 3);
+  assert.deepEqual(
+    resultTwo,
+    resultThree,
+    "Even windowSize=2 should be rounded to 3",
+  );
+});


### PR DESCRIPTION
## Summary

Fixes 4 post-merge review findings from the semantic chunking PR (#420):

- **Finding 1 (P1):** Route `semanticChunkingEnabled` config into the production chunking flow. Added `EmbeddingFallback.embedTexts()` as a public batch-embed method and wired `semanticChunkContent` into the orchestrator's chunking path with fallback to the recursive chunker on error.
- **Finding 2 (P1):** Added `semanticChunkingEnabled` and `semanticChunkingConfig` properties to the `configSchema` in both `openclaw.plugin.json` files, along with `uiHints` entries. Without this, the gateway schema rejected these config fields.
- **Finding 3 (P2):** Enforce `maxTokens` as a hard cap during recursive splitting in `splitLongSegment`. Previously, `targetTokens` was forwarded unchanged, so `targetTokens: 500` with `maxTokens: 100` produced oversized segments. Also fixed the `slice(-0)` gotcha (CLAUDE.md #27) in the recursive chunker's overlap logic.
- **Finding 4 (Low):** `movingAverage` now auto-rounds even `windowSize` values up to the next odd value so the window is symmetric. Documented the behavior in JSDoc.

## Test plan

- [x] `pnpm run check-types` passes
- [x] `pnpm run build` succeeds
- [x] `npx tsx --test tests/semantic-chunking.test.ts` — all 37 tests pass (including 3 new tests for Findings 3 and 4)
- [ ] All new logic is covered by tests (>= 90% overall)
- [ ] Pre-commit hooks pass locally
- [ ] No secrets or creds committed
- [ ] PR diff <= 400 LOC (or justified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the core extraction/write chunking flow and introduces embedding-dependent behavior with fallback; failures could impact how memories are segmented and stored.
> 
> **Overview**
> **Enables semantic chunking in the actual memory write path.** When `chunkingEnabled` is on and `semanticChunkingEnabled` is true, the orchestrator now calls `semanticChunkContent` using a new batch embedding API and falls back to the recursive chunker on errors.
> 
> **Makes semantic chunking configurable end-to-end.** Both `openclaw.plugin.json` schemas (and UI hints) now accept `semanticChunkingEnabled` plus a `semanticChunkingConfig` object of algorithm overrides.
> 
> **Fixes chunking correctness edge cases.** Recursive chunking now avoids the `slice(-0)` overlap bug when overlap is 0, semantic splitting enforces `maxTokens` by capping `targetTokens`, and `movingAverage` rounds even window sizes up to odd; tests add coverage for these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c523a8aacaea11af048bcb117d2c1046405b209. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->