### PR TITLE
fix(extensions): normalize parent path in symlink containment check

### DIFF
--- a/packages/remnic-core/src/memory-extension-host/host-discovery.ts
+++ b/packages/remnic-core/src/memory-extension-host/host-discovery.ts
@@ -58,7 +58,16 @@ export async function discoverMemoryExtensions(
     } catch {
       return [];
     }
-    const expectedParent = path.dirname(root);
+    // Normalize the parent path through realpath so that:
+    // 1. Relative roots (e.g. "memory_extensions") become absolute (#431 Finding 1)
+    // 2. Intermediate symlinks (e.g. macOS /var -> /private/var) are resolved (#431 Finding 2)
+    let expectedParent: string;
+    try {
+      expectedParent = await realpath(path.resolve(path.dirname(root)));
+    } catch {
+      // Parent directory doesn't exist or is inaccessible — reject.
+      return [];
+    }
     if (!resolved.startsWith(expectedParent + path.sep) && resolved !== expectedParent) {
       log.warn?.(
         `[memory-extensions] root "${root}" is a symlink resolving outside the expected parent directory, skipping`,

--- a/tests/memory-extension-discovery.test.ts
+++ b/tests/memory-extension-discovery.test.ts
@@ -519,6 +519,87 @@ test("symlinked root directory within expected parent is allowed (#428 P2)", asy
   fs.rmSync(parentDir, { recursive: true });
 });
 
+// ── Symlink root normalization (#431) ─────────────────────────────────────
+
+test("symlinked root with intermediate parent symlink is accepted (#431 Finding 2)", async () => {
+  // Simulates macOS /var -> /private/var: the parent itself contains a symlink
+  // so path.dirname(root) != realpath(path.dirname(root)).
+  const base = makeTempDir();
+
+  // Create a real parent directory
+  const realParent = path.join(base, "real-parent");
+  fs.mkdirSync(realParent, { recursive: true });
+
+  // Create a symlink that acts as an intermediate directory symlink
+  // (like /var -> /private/var on macOS)
+  const symlinkParent = path.join(base, "symlink-parent");
+  fs.symlinkSync(realParent, symlinkParent);
+
+  // Create a real extensions directory under the real parent
+  const realExtDir = path.join(realParent, "memory_extensions");
+  fs.mkdirSync(realExtDir, { recursive: true });
+  createExtension(realExtDir, "ok-ext", {
+    instructions: "Should be discovered despite intermediate symlink",
+  });
+
+  // Create symlink root under the symlink-parent path
+  // root = <base>/symlink-parent/memory_extensions -> <base>/real-parent/memory_extensions
+  // path.dirname(root) = <base>/symlink-parent (unresolved)
+  // realpath(root) = <base>/real-parent/memory_extensions (resolved)
+  // Without the fix, containment check fails because resolved path starts with
+  // real-parent but expectedParent is symlink-parent.
+  const symlinkRoot = path.join(symlinkParent, "memory_extensions");
+  // symlinkRoot is not itself a symlink — it's a real dir accessed through a symlinked parent.
+  // But we need the root to be a symlink for the guard to trigger, so create one.
+  const symlinkRootLink = path.join(symlinkParent, "ext-link");
+  fs.symlinkSync(realExtDir, symlinkRootLink);
+
+  const { log, warnings } = collectWarnings();
+  const result = await discoverMemoryExtensions(symlinkRootLink, log);
+
+  // Should be allowed: realpath of both root and parent resolve consistently
+  assert.equal(result.length, 1);
+  assert.equal(result[0].name, "ok-ext");
+  assert.equal(warnings.filter((w) => w.includes("symlink resolving outside")).length, 0);
+
+  fs.rmSync(base, { recursive: true });
+});
+
+test("symlinked root with relative path is handled correctly (#431 Finding 1)", async () => {
+  // When root is relative like "./memory_extensions", path.dirname returns "."
+  // which without normalization can't match the absolute resolved path.
+  const base = makeTempDir();
+
+  // Create a real extensions dir and a symlink to it
+  const realExtDir = path.join(base, "real_exts");
+  fs.mkdirSync(realExtDir, { recursive: true });
+  createExtension(realExtDir, "rel-ext", {
+    instructions: "Should be discovered via relative symlink root",
+  });
+
+  const symlinkRoot = path.join(base, "link-exts");
+  fs.symlinkSync(realExtDir, symlinkRoot);
+
+  // Use a relative path for the symlink root by changing to the base dir
+  const originalCwd = process.cwd();
+  try {
+    process.chdir(base);
+    const relativeRoot = "./link-exts";
+
+    const { log, warnings } = collectWarnings();
+    const result = await discoverMemoryExtensions(relativeRoot, log);
+
+    // Should be accepted: both sides normalize through path.resolve + realpath
+    assert.equal(result.length, 1);
+    assert.equal(result[0].name, "rel-ext");
+    assert.equal(warnings.filter((w) => w.includes("symlink resolving outside")).length, 0);
+  } finally {
+    process.chdir(originalCwd);
+  }
+
+  fs.rmSync(base, { recursive: true });
+});
+
 // ── buildExtensionsFooterForSummary wiring (#382) ──────────────────────────
 
 test("buildExtensionsFooterForSummary returns footer when extensions exist", async () => {


### PR DESCRIPTION
## Summary

Fixes 2 unresolved review findings from the already-merged PR #431 (extensions symlink hardening):

- **Finding 1 (P2)**: Relative roots like `"memory_extensions"` produced `expectedParent = "."` from `path.dirname()`, but `realpath(root)` returned an absolute path. The containment check always failed for relative paths. Fixed by running `path.resolve()` before comparison.

- **Finding 2 (High)**: On macOS, `os.tmpdir()` returns `/var/folders/...` where `/var` is a symlink to `/private/var`. `realpath()` resolved all symlinks on the root side (producing `/private/var/...`), but `path.dirname()` preserved the unresolved `/var/...` path. The containment check failed because the two paths diverged. Fixed by running `fs.realpath()` on the parent so both sides go through the same symlink resolution.

The combined fix on line 66 of `host-discovery.ts`:
```typescript
expectedParent = await realpath(path.resolve(path.dirname(root)));
```

## Test plan

- [x] New test: symlinked root with intermediate parent symlink is accepted (#431 Finding 2)
- [x] New test: symlinked root with relative path is handled correctly (#431 Finding 1)
- [x] All 33 extension discovery tests pass
- [x] `pnpm run build` succeeds
- [x] `pnpm run check-types` succeeds

## PR Checklist

* [x] All tests pass (`pytest`/`npm test`)
* [x] All new logic is covered by tests
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff <= 400 LOC

Resolves review threads:
- `PRRT_kwDORJXyws57s1o0`
- `PRRT_kwDORJXyws57s3sc`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches security-adjacent filesystem path validation for symlinked extension roots; subtle path/realpath edge cases could change which roots are accepted or rejected across platforms.
> 
> **Overview**
> Improves the **symlink containment guard** in `discoverMemoryExtensions` by normalizing the expected parent directory via `path.resolve()` + `realpath()`, so relative roots and intermediate parent symlinks (e.g. macOS `/var` -> `/private/var`) don’t cause false rejections.
> 
> Adds regression tests covering acceptance of a symlinked root when the parent path itself is symlinked, and when the root is provided as a relative path, ensuring no “resolving outside” warnings are emitted in these valid cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 075a6ded37051e2dfb8a51636343a552e62c49dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->