### PR TITLE
fix(taxonomy): exercise real flag parser in resolve tests

### DIFF
--- a/packages/remnic-cli/src/cli-args.ts
+++ b/packages/remnic-cli/src/cli-args.ts
@@ -24,3 +24,34 @@ export function resolveFlag(args: string[], flag: string): string | undefined {
 export function hasFlag(args: string[], flag: string): boolean {
   return args.indexOf(flag) !== -1;
 }
+
+/**
+ * Set of flags for `taxonomy resolve` that are boolean (no trailing value).
+ * Key-value flags (like `--category`) consume the next token as their value.
+ */
+export const TAXONOMY_RESOLVE_BOOLEAN_FLAGS = new Set(["--json"]);
+
+/**
+ * Strip CLI flags from `taxonomy resolve` argument tokens, returning only
+ * the text parts. Boolean flags (e.g. `--json`) skip only the flag itself;
+ * key-value flags (e.g. `--category preference`) skip the flag and its
+ * following value token.
+ */
+export function stripResolveFlags(
+  args: string[],
+  booleanFlags: ReadonlySet<string> = TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
+): string[] {
+  const textParts: string[] = [];
+  for (let i = 0; i < args.length; i++) {
+    if (args[i].startsWith("--")) {
+      // Boolean flags have no trailing value — skip only the flag itself
+      if (!booleanFlags.has(args[i])) {
+        // Key-value flag: skip the flag and its value (next token)
+        i++;
+      }
+      continue;
+    }
+    textParts.push(args[i]);
+  }
+  return textParts;
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -124,8 +124,8 @@ import {
   type BenchConfig,
 } from "@remnic/bench";
 import { firstSuccessfulCandidate, firstSuccessfulResult } from "./service-candidates.js";
-export { hasFlag, resolveFlag } from "./cli-args.js";
-import { hasFlag, resolveFlag } from "./cli-args.js";
+export { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
+import { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
 import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.js";
 
 export { parseConnectorConfig, stripConfigArgv };
@@ -2973,20 +2973,8 @@ async function cmdTaxonomy(rest: string[]): Promise<void> {
       // Strip --flag and its following value token together so flag values
       // (e.g. "preference" in `--category preference`) don't leak into text.
       // Boolean flags (like --json) don't consume a following value token.
-      const BOOLEAN_FLAGS = new Set(["--json"]);
       const resolveArgs = rest.slice(1);
-      const textParts: string[] = [];
-      for (let i = 0; i < resolveArgs.length; i++) {
-        if (resolveArgs[i].startsWith("--")) {
-          // Boolean flags have no trailing value — skip only the flag itself
-          if (!BOOLEAN_FLAGS.has(resolveArgs[i])) {
-            // Key-value flag: skip the flag and its value (next token)
-            i++;
-          }
-          continue;
-        }
-        textParts.push(resolveArgs[i]);
-      }
+      const textParts = stripResolveFlags(resolveArgs, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
       const text = textParts.join(" ");
       if (!text) {
         console.error("Usage: remnic taxonomy resolve <text>");

--- a/tests/taxonomy-cli-boolean-flag.test.ts
+++ b/tests/taxonomy-cli-boolean-flag.test.ts
@@ -3,78 +3,59 @@
  * text argument in the `taxonomy resolve` flag-stripping loop.
  *
  * Also tests the generic coerceBool helper (Finding 3).
+ *
+ * Exercises the REAL stripResolveFlags implementation from cli-args.ts
+ * (not a local copy) so regressions in the CLI are caught by these tests.
  */
 
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { coerceBool, coerceInstallExtension } from "../packages/remnic-core/src/connectors/coerce.js";
-
-// ── Boolean flag stripping logic (Finding 1) ───────────────────────────────
-//
-// The resolve case strips --flag <value> pairs before joining remaining tokens
-// as the input text. Boolean flags like --json have no trailing value, so the
-// loop must not skip the token after them.
-//
-// We replicate the exact stripping logic here so the test stays self-contained
-// and doesn't need to import the full CLI entry.
-
-const BOOLEAN_FLAGS = new Set(["--json"]);
-
-function stripFlags(args: string[]): string[] {
-  const textParts: string[] = [];
-  for (let i = 0; i < args.length; i++) {
-    if (args[i].startsWith("--")) {
-      if (!BOOLEAN_FLAGS.has(args[i])) {
-        // Key-value flag: skip the flag and its value (next token)
-        i++;
-      }
-      continue;
-    }
-    textParts.push(args[i]);
-  }
-  return textParts;
-}
+import {
+  stripResolveFlags,
+  TAXONOMY_RESOLVE_BOOLEAN_FLAGS,
+} from "../packages/remnic-cli/src/cli-args.js";
 
 describe("taxonomy resolve flag stripping", () => {
   it("--json does not eat the following text argument", () => {
     const args = ["--json", "hello", "world"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["hello", "world"]);
   });
 
   it("--category (key-value) correctly skips the value", () => {
     const args = ["--category", "preference", "my", "text"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["my", "text"]);
   });
 
   it("--json before --category works correctly", () => {
     const args = ["--json", "--category", "fact", "some", "input"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["some", "input"]);
   });
 
   it("--category before --json works correctly", () => {
     const args = ["--category", "fact", "--json", "some", "input"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["some", "input"]);
   });
 
   it("--json at the end does not cause out-of-bounds", () => {
     const args = ["hello", "--json"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["hello"]);
   });
 
   it("no flags returns all tokens", () => {
     const args = ["hello", "world"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, ["hello", "world"]);
   });
 
   it("only --json returns empty", () => {
     const args = ["--json"];
-    const result = stripFlags(args);
+    const result = stripResolveFlags(args, TAXONOMY_RESOLVE_BOOLEAN_FLAGS);
     assert.deepStrictEqual(result, []);
   });
 });


### PR DESCRIPTION
## Summary

- Extracted the flag-stripping loop from `cmdTaxonomy`'s `resolve` case into a standalone `stripResolveFlags()` function in `packages/remnic-cli/src/cli-args.ts`
- Updated `tests/taxonomy-cli-boolean-flag.test.ts` to import and call the real `stripResolveFlags` instead of a reimplemented local copy
- Both the CLI and tests now share the same implementation, so a regression in flag parsing will be caught by the test suite

Addresses unresolved P1 finding from PR #433 (thread `PRRT_kwDORJXyws57s46h`): tests were reimplementing the flag-stripping algorithm locally, meaning they could stay green even if `cmdTaxonomy` regressed differently.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run check-types` passes
- [x] `npm run test` passes (all 214 tests, 0 failures)
- [x] Specific test file `tests/taxonomy-cli-boolean-flag.test.ts` passes (18/18 tests)

## PR checklist

* [x] **All tests pass (`pytest`)** - RUN BEFORE CREATING PR
* [x] All new logic is covered by tests (>= 90% overall)
* [x] Pre-commit hooks pass locally
* [x] Docs or comments updated
* [x] No secrets or creds committed
* [x] PR diff <= 400 LOC (or justified)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes `taxonomy resolve` flag-stripping logic and updates tests to cover the shared implementation; behavior should remain the same aside from better regression detection.
> 
> **Overview**
> Extracts the `taxonomy resolve` argument flag-stripping loop into `stripResolveFlags()` in `cli-args.ts` (with a shared `TAXONOMY_RESOLVE_BOOLEAN_FLAGS` set) and updates the CLI `resolve` path to call it.
> 
> Updates `tests/taxonomy-cli-boolean-flag.test.ts` to import and exercise the real `stripResolveFlags` implementation instead of a locally reimplemented copy, ensuring regressions in boolean vs key/value flag handling (e.g. `--json` not consuming the next token) are caught.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7366595c7daf9d998ab606eee4769c18153634e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->