### PR TITLE
docs: document 10 new features across all project documentation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1067,30 +1067,143 @@ Periodically (every N extractions), the plugin:
 
 ## File Structure
 
+The codebase is a monorepo. Core logic lives in `packages/remnic-core/`;
+host adapters and CLI live in sibling packages.
+
 ```
-~/.openclaw/extensions/openclaw-engram/
-├── package.json
-├── tsconfig.json
-├── tsup.config.ts
-├── openclaw.plugin.json
-├── CLAUDE.md              # Privacy policy
-├── AGENTS.md              # This file
-└── src/
-    ├── index.ts           # Plugin entry, hook registration
-    ├── config.ts          # Config parsing with defaults
-    ├── types.ts           # TypeScript interfaces
-    ├── logger.ts          # Logging wrapper
-    ├── orchestrator.ts    # Core memory coordination
-    ├── storage.ts         # File I/O for memories
-    ├── buffer.ts          # Smart turn buffering
-    ├── extraction.ts      # GPT-5.2 extraction engine
-    ├── qmd.ts             # QMD search client
-    ├── importance.ts      # Importance scoring
-    ├── chunking.ts        # Large content chunking
-    ├── threading.ts       # Conversation threading
-    ├── topics.ts          # Topic extraction
-    ├── tools.ts           # Agent tools
-    └── cli.ts             # CLI commands
+packages/
+├── remnic-core/           # Core memory engine (primary source)
+├── remnic-cli/            # CLI tooling
+├── remnic-server/         # Server runtime
+├── plugin-openclaw/       # OpenClaw host adapter
+├── plugin-claude-code/    # Claude Code host adapter
+├── plugin-codex/          # Codex host adapter
+├── plugin-hermes/         # Hermes host adapter
+├── hermes-provider/       # Hermes provider integration
+├── connector-replit/      # Replit connector
+├── shim-openclaw-engram/  # Legacy engram shim
+└── bench/                 # Benchmarks
+
+packages/remnic-core/src/
+│
+│  ── Core pipeline ──────────────────────────────────
+├── index.ts               # Plugin entry, hook registration
+├── config.ts              # Config parsing with defaults
+├── types.ts               # TypeScript interfaces
+├── logger.ts              # Logging wrapper
+├── orchestrator.ts        # Core memory coordination
+├── storage.ts             # File I/O for memories
+├── buffer.ts              # Smart turn buffering
+├── extraction.ts          # GPT-5.2 extraction engine
+├── qmd.ts                 # QMD search client
+├── importance.ts          # Importance scoring
+├── chunking.ts            # Large content chunking
+├── threading.ts           # Conversation threading
+├── topics.ts              # Topic extraction
+├── tools.ts               # Agent tools
+├── cli.ts                 # CLI commands
+│
+│  ── Recall & retrieval ─────────────────────────────
+├── retrieval.ts           # Recall pipeline implementation
+├── intent.ts              # Intent heuristics (morphology-aware)
+├── signal.ts              # Signal-based flush triggers
+├── recall-qos.ts          # Recall quality-of-service
+├── recall-mmr.ts          # Maximal marginal relevance
+├── recall-query-policy.ts # Query rewrite policy
+├── recall-audit.ts        # Recall audit trail
+├── qmd-recall-cache.ts    # QMD recall caching
+├── rerank.ts              # Re-ranking pipeline
+├── harmonic-retrieval.ts  # Harmonic retrieval scoring
+├── verified-recall.ts     # Verified recall checks
+│
+│  ── Classification & scoring ───────────────────────
+├── himem.ts               # Episode/Note classification (v8.0)
+├── boxes.ts               # Memory Box builder + Trace Weaver (v8.0)
+├── extraction-judge.ts    # LLM-as-judge fact-worthiness gate (#376)
+├── semantic-chunking.ts   # Topic-boundary chunking (#368)
+├── source-attribution.ts  # Citation/attribution helpers (#379)
+├── relevance.ts           # Relevance scoring
+├── calibration.ts         # Score calibration
+│
+│  ── Versioning & lifecycle ─────────────────────────
+├── page-versioning.ts     # Snapshot-based version history (#371)
+├── lifecycle.ts           # Memory lifecycle management
+├── temporal-supersession.ts # Temporal supersession logic
+├── temporal-index.ts      # Temporal indexing
+│
+│  ── Session & context ──────────────────────────────
+├── session-integrity.ts   # Session integrity checks
+├── session-toggles.ts     # Per-session feature toggles
+├── session-observer-bands.ts # Observer band system
+├── session-observer-state.ts # Observer state tracking
+├── profiling.ts           # User profiling
+├── identity-continuity.ts # Identity continuity
+│
+│  ── Causal reasoning ───────────────────────────────
+├── causal-chain.ts        # Causal chain tracking
+├── causal-behavior.ts     # Behavioral causal signals
+├── causal-retrieval.ts    # Causal-aware retrieval
+├── causal-consolidation.ts # Causal consolidation
+├── causal-trajectory.ts   # Trajectory tracking
+├── causal-trajectory-graph.ts # Trajectory graph
+│
+│  ── Graph & dashboard ──────────────────────────────
+├── graph.ts               # Knowledge graph
+├── tmt.ts                 # Tree-of-memory-traces
+├── graph-dashboard-*.ts   # Dashboard rendering (diff, key, parser)
+├── abstraction-nodes.ts   # Abstraction node system
+│
+│  ── Access & MCP ───────────────────────────────────
+├── access-mcp.ts          # MCP access provider
+├── access-cli.ts          # CLI access provider
+├── access-http.ts         # HTTP access provider
+├── access-service.ts      # Access service coordinator
+├── access-schema.ts       # Access schema definitions
+├── access-idempotency.ts  # Idempotent access operations
+│
+│  ── Utilities & support ────────────────────────────
+├── sanitize.ts            # Content sanitization
+├── tokens.ts              # Token counting
+├── json-extract.ts        # JSON extraction helpers
+├── json-store.ts          # JSON-backed storage
+├── whitespace.ts          # Whitespace handling
+├── bootstrap.ts           # Bootstrap/init routines
+├── model-registry.ts      # LLM model registry
+├── fallback-llm.ts        # LLM fallback routing
+├── local-llm.ts           # Local LLM integration
+│
+│  ── Subdirectories ─────────────────────────────────
+├── enrichment/            # External enrichment pipeline (#365)
+├── binary-lifecycle/      # Binary file management (#367)
+├── taxonomy/              # MECE taxonomy resolver (#366)
+├── memory-extension/      # Extension publisher contract (#381, #382)
+├── memory-extension-host/ # Extension host discovery (#381)
+├── compat/                # Provider compatibility checks
+├── adapters/              # Host adapter interfaces
+├── connectors/            # External service connectors
+├── conversation-index/    # Conversation indexing
+├── compounding/           # Compounding memory logic
+├── curation/              # Memory curation pipeline
+├── dedup/                 # Deduplication engine
+├── lcm/                   # Lifecycle management
+├── maintenance/           # Maintenance tasks
+├── migrate/               # Migration scripts
+├── namespaces/            # Multi-tenant namespace logic
+├── network/               # Network transport layer
+├── onboarding/            # Onboarding flows
+├── projection/            # Memory projections
+├── replay/                # Replay/debug tooling
+├── review/                # Review pipeline
+├── routing/               # Routing logic
+├── runtime/               # Runtime services
+├── search/                # Search subsystem
+├── shared-context/        # Shared context management
+├── spaces/                # Memory spaces
+├── surfaces/              # Surface adapters
+├── sync/                  # Sync engine
+├── transfer/              # Data transfer utilities
+├── utils/                 # Shared utility functions
+└── work/                  # Work-product tracking
 
 ~/.openclaw/workspace/memory/local/
 ├── profile.md             # User profile

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,22 +33,96 @@
 
 ### File Structure
 ```
-src/
-├── index.ts              # Plugin entry point, hook registration
-├── config.ts             # Config parsing with defaults
-├── types.ts              # TypeScript interfaces
-├── logger.ts             # Logging wrapper
-├── orchestrator.ts       # Core memory coordination
-├── storage.ts            # File I/O for memories
-├── buffer.ts             # Smart turn buffering
-├── extraction.ts         # GPT-5.2 extraction engine
-├── qmd.ts                # QMD search client
-├── importance.ts         # Importance scoring
-├── chunking.ts           # Large content chunking
-├── threading.ts          # Conversation threading
-├── topics.ts             # Topic extraction
-├── tools.ts              # Agent tools
-└── cli.ts                # CLI commands
+packages/remnic-core/src/
+│
+│ ── Core lifecycle ──────────────────────────────────────
+├── index.ts                    # Plugin entry point, hook registration
+├── config.ts                   # Config parsing with defaults
+├── types.ts                    # TypeScript interfaces
+├── logger.ts                   # Logging wrapper
+├── orchestrator.ts             # Core memory coordination
+├── storage.ts                  # File I/O for memories
+├── buffer.ts                   # Smart turn buffering
+├── lifecycle.ts                # Session and service lifecycle management
+├── bootstrap.ts                # Plugin bootstrap / init sequence
+│
+│ ── Extraction & scoring ────────────────────────────────
+├── extraction.ts               # GPT-5.2 extraction engine
+├── extraction-judge.ts         # LLM-as-judge fact-worthiness gate
+├── importance.ts               # Importance scoring
+├── calibration.ts              # Score calibration helpers
+├── topics.ts                   # Topic extraction
+│
+│ ── Chunking & storage format ───────────────────────────
+├── chunking.ts                 # Recursive large-content chunking
+├── semantic-chunking.ts        # Topic-boundary chunking (embedding-based)
+├── page-versioning.ts          # Snapshot-based version history for memory files
+├── citations.ts                # OAI-mem-citation block generation
+│
+│ ── Recall & retrieval ──────────────────────────────────
+├── qmd.ts                      # QMD search client
+├── qmd-recall-cache.ts         # Recall result caching
+├── retrieval.ts                # Primary retrieval orchestration
+├── recall-audit.ts             # Recall audit trail
+├── recall-mmr.ts               # Maximal marginal relevance diversification
+├── recall-qos.ts               # Recall quality-of-service enforcement
+├── recall-query-policy.ts      # Query rewriting / policy
+├── recall-state.ts             # Recall state tracking
+├── rerank.ts                   # Result reranking
+├── source-attribution.ts       # Source attribution for recalled facts
+│
+│ ── Dedup & consolidation ───────────────────────────────
+├── dedup/                      # Semantic deduplication pipeline
+├── semantic-consolidation.ts   # Embedding-aware memory merging
+├── summarizer.ts               # Summary generation
+├── summary-snapshot.ts         # Point-in-time summary snapshots
+│
+│ ── Taxonomy & classification ───────────────────────────
+├── taxonomy/                   # MECE taxonomy resolver, loader, defaults
+├── entity-retrieval.ts         # Entity-aware retrieval
+├── entity-schema.ts            # Entity type definitions
+│
+│ ── Extensions & publishers ─────────────────────────────
+├── memory-extension/           # Third-party extension discovery + publishers
+├── memory-extension-host/      # Host-side extension rendering + discovery
+│
+│ ── Enrichment ──────────────────────────────────────────
+├── enrichment/                 # External enrichment pipeline, provider registry
+│
+│ ── Binary lifecycle ────────────────────────────────────
+├── binary-lifecycle/           # Mirror/redirect/clean pipeline for binary files
+│
+│ ── Access surfaces ─────────────────────────────────────
+├── cli.ts                      # CLI commands
+├── access-mcp.ts               # MCP server surface
+├── access-http.ts              # HTTP API surface
+├── access-cli.ts               # CLI access helpers
+├── surfaces/                   # Heartbeat, dreams, and other surface integrations
+│
+│ ── Maintenance & governance ────────────────────────────
+├── maintenance/                # Governance crons, archive, backup, observation ledger
+├── hygiene.ts                  # Memory hygiene checks
+├── memory-cache.ts             # Multi-layer memory cache
+│
+│ ── Compatibility & migration ───────────────────────────
+├── compat/                     # Provider compatibility checks (Codex, etc.)
+├── migrate/                    # Legacy data migration utilities
+├── sdk-compat.ts               # SDK compatibility shims
+│
+│ ── Session & threading ─────────────────────────────────
+├── threading.ts                # Conversation threading
+├── session-integrity.ts        # Session identity validation
+├── session-toggles.ts          # Per-session feature toggles
+├── namespaces/                 # Multi-tenant namespace resolution
+│
+│ ── Supporting subsystems ───────────────────────────────
+├── routing/                    # Tier and model routing
+├── sync/                       # Cross-device sync
+├── network/                    # Network transport helpers
+├── profiling.ts                # Runtime profiling
+├── intent.ts                   # User intent classification
+├── tokens.ts                   # Token counting utilities
+└── utils/                      # Shared utility functions
 ```
 
 ### Key Patterns
@@ -59,6 +133,14 @@ src/
 4. **QMD for search** — hybrid BM25 + vector + reranking
 5. **Markdown + YAML frontmatter** — human-readable storage format
 6. **Consolidation** — periodic merging, cleaning, and summarization
+7. **Extraction judge** — optional LLM-as-judge post-filter evaluates fact durability before writes
+8. **Semantic chunking** — sentence-embedding-based topic boundary detection alternative to recursive chunking
+9. **Page versioning** — every memory file overwrite saves a numbered snapshot; list/diff/revert via CLI
+10. **Citation blocks** — recall responses emit `<oai-mem-citation>` blocks for Codex-compatible attribution
+11. **Publisher contract** — pluggable `MemoryExtensionPublisher` interface for host-specific extension installation
+12. **MECE taxonomy** — deterministic categorization via mutually exclusive, collectively exhaustive directory
+13. **Enrichment pipeline** — importance-tiered external enrichment with provider registry and audit trail
+14. **Binary lifecycle** — three-stage mirror/redirect/clean pipeline for binary files in memory directory
 
 ### Integration Points
 

--- a/README.md
+++ b/README.md
@@ -517,6 +517,7 @@ Start with zero config. Enable features as your needs grow:
 | **+ Memory OS** | Memory boxes, graph reasoning, compounding, shared context, identity continuity |
 | **+ LCM** | Lossless Context Management — never lose conversation context to compaction |
 | **+ Parallel retrieval** | Three specialized agents (DirectFact, Contextual, Temporal) run in parallel — same latency, broader coverage |
+| **+ Quality gates** | Extraction judge, semantic chunking, MECE taxonomy, page versioning |
 | **+ Advanced** | Trust zones, causal trajectories, harmonic retrieval, evaluation harness, poisoning defense |
 
 Use a preset to jump to a recommended level: `conservative`, `balanced`, `research-max`, or `local-llm-heavy`.
@@ -551,6 +552,28 @@ Run Engram as a standalone HTTP server that multiple agent harnesses share. Isol
 - **Entity tracking** — People, projects, tools, companies tracked as structured entities
 - **Lifecycle management** — Memories age through active, validated, stale, archived states
 - **Episode/Note model** — Memories classified as time-specific events or stable beliefs
+
+### Extraction & Processing (opt-in)
+
+- **Extraction Judge** — LLM-as-judge post-extraction filter that evaluates fact durability before write. Has shadow mode for calibration. Opt-in via `extractionJudgeEnabled`. (issue #376)
+- **Semantic Chunking** — Smoothing-based topic boundary detection using sentence embeddings and cosine similarity, as an alternative to recursive chunking. Opt-in via `semanticChunkingEnabled`. (issue #368)
+- **OAI-mem-citation Blocks** — Recall responses emit `<oai-mem-citation>` blocks matching the Codex citation format for memory attribution and usage tracking. Opt-in via `citationsEnabled`. (issue #379)
+
+### Organization & Taxonomy (opt-in)
+
+- **MECE Taxonomy** — Mutually Exclusive, Collectively Exhaustive knowledge directory with resolver decision tree for deterministic memory categorization. Opt-in via `taxonomyEnabled`. (issue #366)
+- **Enrichment Pipeline** — Importance-tiered API spend for entity enrichment from external sources with a provider registry. Opt-in via `enrichmentEnabled`. (issue #365)
+
+### Storage & Lifecycle (opt-in)
+
+- **Page Versioning** — Snapshot-based history for memory files. Every overwrite saves a numbered snapshot in a sidecar directory. List, inspect, diff, and revert. Opt-in via `versioningEnabled`. (issue #371)
+- **Binary Lifecycle Management** — Three-stage pipeline (mirror, redirect, clean) for binary files in the memory directory with configurable storage backends. Opt-in via `binaryLifecycleEnabled`. (issue #367)
+
+### Integrations & Extensions
+
+- **Codex Marketplace** — Install Remnic via `codex marketplace add joshuaswarren/remnic`. Marketplace manifest at repo root. (issue #418)
+- **Memory Extension Publisher Contract** — Pluggable contract for installing host-specific instruction files into any AI agent host's extension directory. Generalizes the pattern previously hard-coded for Codex. (issue #381)
+- **Memory Extension Discovery** — Third-party memory extensions provide structured instructions that influence consolidation, auto-discovered from extension directories. (issue #382)
 
 ### Search Backends
 
@@ -779,6 +802,28 @@ remnic briefing                                  # Yesterday's briefing (markdow
 remnic briefing --since 3d --focus project:alpha # Focused 3-day lookback
 remnic briefing --format json --save             # JSON + dated file in $REMNIC_HOME/briefings
 
+# Page versioning
+remnic versions list [file]                       # List version history for a memory file
+remnic versions show [file] [version]             # Show a specific version snapshot
+remnic versions diff [file] [version]             # Diff a version against current
+remnic versions revert [file] [version]           # Revert a file to a previous version
+
+# MECE taxonomy
+remnic taxonomy list                              # List taxonomy categories
+remnic taxonomy add [category]                    # Add a taxonomy category
+remnic taxonomy remove [category]                 # Remove a taxonomy category
+remnic taxonomy resolve [query]                   # Resolve a query to a taxonomy category
+
+# Entity enrichment
+remnic enrichment run [entity]                    # Run enrichment for an entity
+remnic enrichment status [entity]                 # Check enrichment status
+
+# Binary lifecycle
+remnic binary scan                                # Scan for binary files in memory directory
+remnic binary mirror                              # Mirror binaries to configured backend
+remnic binary clean                               # Clean up mirrored/redirected binaries
+remnic binary status                              # Show binary lifecycle status
+
 # Access layer
 remnic daemon start                # Start HTTP API + managed daemon
 openclaw engram access mcp-serve   # Start OpenClaw-hosted stdio MCP server
@@ -827,6 +872,13 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | `semanticConsolidationEnabled` | `false` | Enable periodic semantic dedup of similar memories |
 | `semanticConsolidationThreshold` | `0.8` | Token overlap threshold (0.8=conservative, 0.6=aggressive) |
 | `semanticConsolidationModel` | `"auto"` | LLM for synthesis: `"auto"`, `"fast"`, or specific model |
+| `extractionJudgeEnabled` | `false` | LLM-as-judge post-extraction durability filter |
+| `semanticChunkingEnabled` | `false` | Topic-boundary chunking via sentence embeddings |
+| `versioningEnabled` | `false` | Snapshot-based page versioning with history and revert |
+| `citationsEnabled` | `false` | Emit `oai-mem-citation` blocks in recall responses |
+| `taxonomyEnabled` | `false` | MECE knowledge directory with resolver decision tree |
+| `enrichmentEnabled` | `false` | External entity enrichment pipeline |
+| `binaryLifecycleEnabled` | `false` | Binary file lifecycle management (mirror/redirect/clean) |
 
 **[See the full config reference for all 60+ settings](docs/config-reference.md)** including search backend configuration, namespace policies, Memory OS features, governance, evaluation harness, trust zones, causal trajectories, and more.
 
@@ -856,6 +908,16 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Platform Migration Guide](docs/guides/platform-migration.md) — Migrating to the monorepo architecture (v9.1.36+)
 - [Hermes Setup](docs/integration/hermes-setup.md) — HTTP client for remote Remnic instances
 - [Deployment Topologies](docs/integration/deployment-topologies.md) — Localhost, LAN, remote, containerized, standalone
+- [Extraction Judge](docs/architecture/extraction-judge.md) — LLM-as-judge fact-worthiness gate
+- [Semantic Chunking](docs/architecture/semantic-chunking.md) — Topic-boundary detection
+- [Page Versioning](docs/architecture/page-versioning.md) — Snapshot-based history and revert
+- [Citations](docs/architecture/citations.md) — OAI-mem-citation block format
+- [Memory Extension Publishers](docs/architecture/memory-extension-publishers.md) — Pluggable publisher contract
+- [MECE Taxonomy](docs/architecture/mece-taxonomy.md) — Knowledge directory with resolver
+- [Enrichment Pipeline](docs/architecture/enrichment-pipeline.md) — Entity enrichment from external sources
+- [Binary Lifecycle](docs/architecture/binary-lifecycle.md) — Binary file management
+- [Memory Extensions](docs/architecture/memory-extensions.md) — Third-party extension discovery
+- [Codex Marketplace](docs/plugins/codex-marketplace.md) — Marketplace installation
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ remnic enrich <entity-name|--all|audit|providers> [--dry-run]   # Run enrichment
 remnic binary scan                                # Scan for binary files in memory directory
 remnic binary status                              # Show binary lifecycle status
 remnic binary run [--dry-run]                     # Run lifecycle (redirect/clean) for binaries
-remnic binary clean [--dry-run]                   # Clean up mirrored/redirected binaries
+remnic binary clean --force                       # Force-clean binaries past grace period
 
 # Access layer
 remnic daemon start                # Start HTTP API + managed daemon

--- a/README.md
+++ b/README.md
@@ -809,20 +809,19 @@ remnic versions diff [file] [version]             # Diff a version against curre
 remnic versions revert [file] [version]           # Revert a file to a previous version
 
 # MECE taxonomy
-remnic taxonomy list                              # List taxonomy categories
-remnic taxonomy add [category]                    # Add a taxonomy category
-remnic taxonomy remove [category]                 # Remove a taxonomy category
-remnic taxonomy resolve [query]                   # Resolve a query to a taxonomy category
+remnic taxonomy show                              # Show taxonomy categories and priorities
+remnic taxonomy resolver                          # Generate or display resolver decision tree
+remnic taxonomy add <id> <name>                   # Add a taxonomy category
+remnic taxonomy remove <id>                       # Remove a taxonomy category
 
 # Entity enrichment
-remnic enrichment run [entity]                    # Run enrichment for an entity
-remnic enrichment status [entity]                 # Check enrichment status
+remnic enrich <entity-name|--all|audit|providers> [--dry-run]   # Run enrichment pipeline
 
 # Binary lifecycle
 remnic binary scan                                # Scan for binary files in memory directory
-remnic binary mirror                              # Mirror binaries to configured backend
-remnic binary clean                               # Clean up mirrored/redirected binaries
 remnic binary status                              # Show binary lifecycle status
+remnic binary run [--dry-run]                     # Run lifecycle (redirect/clean) for binaries
+remnic binary clean [--dry-run]                   # Clean up mirrored/redirected binaries
 
 # Access layer
 remnic daemon start                # Start HTTP API + managed daemon

--- a/README.md
+++ b/README.md
@@ -803,10 +803,10 @@ remnic briefing --since 3d --focus project:alpha # Focused 3-day lookback
 remnic briefing --format json --save             # JSON + dated file in $REMNIC_HOME/briefings
 
 # Page versioning
-remnic versions list [file]                       # List version history for a memory file
-remnic versions show [file] [version]             # Show a specific version snapshot
-remnic versions diff [file] [version]             # Diff a version against current
-remnic versions revert [file] [version]           # Revert a file to a previous version
+remnic versions list <page-path>                  # List version history for a memory file
+remnic versions show <page-path> <version-id>     # Show a specific version snapshot
+remnic versions diff <page-path> <v1> <v2>        # Diff two versions of a memory file
+remnic versions revert <page-path> <version-id>   # Revert a file to a previous version
 
 # MECE taxonomy
 remnic taxonomy show                              # Show taxonomy categories and priorities

--- a/docs/api.md
+++ b/docs/api.md
@@ -22,9 +22,9 @@ The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder
 | `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
 | `remnic benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
 | `remnic versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
-| `remnic taxonomy <list\|add\|remove\|resolve> [args]` | MECE taxonomy knowledge directory management |
-| `remnic enrichment <run\|status> [entity]` | External entity enrichment pipeline |
-| `remnic binary <scan\|mirror\|clean\|status>` | Binary file lifecycle operations |
+| `remnic taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
+| `remnic enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
+| `remnic binary <scan\|status\|run\|clean> [--dry-run]` | Binary file lifecycle operations |
 
 All commands accept `--json` for machine-readable output. The CLI resolves configuration from:
 
@@ -64,7 +64,7 @@ Core routes:
 - `POST /engram/v1/observe` — feed conversation messages into LCM archive and extraction pipeline
 - `POST /engram/v1/lcm/search` — full-text search over LCM-archived conversations
 - `GET /engram/v1/lcm/status` — LCM availability and stats
-- `POST /engram/v1/citations/observed` — Record observed citation usage for attribution tracking
+- `POST /v1/citations/observed` — Record observed citation usage for attribution tracking
 
 Recall request fields:
 
@@ -194,19 +194,25 @@ Response (HTTP 200):
 - `archiveAvailable` — whether the LCM archive is accessible
 - `stats` (optional) — `{ totalTurns }` when LCM is enabled
 
-#### `POST /engram/v1/citations/observed`
+#### `POST /v1/citations/observed`
 
-Record that a cited memory was used by the agent. Used for citation attribution tracking.
+Record that cited memories were used by the agent. Used for citation attribution tracking.
 
 Request fields:
 
-- `rolloutIds` (string[], required) — Rollout IDs from the oai-mem-citation block
-- `sessionKey` (string, optional) — Session identifier
+- `sessionId` (string, optional) — Session identifier
 - `namespace` (string, optional) — Target namespace
+- `citations` (object, required) — Citation data containing:
+  - `entries` (array, optional) — Array of `{ path: string, lineStart: number, lineEnd: number, note?: string }` objects
+  - `rolloutIds` (string[], optional) — Rollout IDs from the oai-mem-citation block
 
 Response (HTTP 200):
 
-- `accepted` — Number of rollout IDs accepted
+- `ok` (boolean) — Whether the request succeeded
+- `submitted` (number) — Number of citation entries submitted
+- `matched` (number) — Number of entries matched to existing memories
+- `entriesReceived` (number) — Number of citation entries in the request
+- `rolloutIdsReceived` (number) — Number of rollout IDs in the request
 
 #### `X-Engram-Principal` Header
 
@@ -529,9 +535,9 @@ Run via `openclaw engram <command>`:
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
 | `trust-zone-demo-seed [--scenario enterprise-buyer-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed the opt-in trust-zone buyer demo dataset |
 | `versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
-| `taxonomy <list\|add\|remove\|resolve> [args]` | MECE taxonomy knowledge directory management |
-| `enrichment <run\|status> [entity]` | External entity enrichment pipeline |
-| `binary <scan\|mirror\|clean\|status>` | Binary file lifecycle operations |
+| `taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
+| `enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
+| `binary <scan\|status\|run\|clean> [--dry-run]` | Binary file lifecycle operations |
 
 ## Error Responses
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -24,7 +24,7 @@ The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder
 | `remnic versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
 | `remnic taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
 | `remnic enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
-| `remnic binary <scan\|status\|run\|clean> [--dry-run]` | Binary file lifecycle operations |
+| `remnic binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |
 
 All commands accept `--json` for machine-readable output. The CLI resolves configuration from:
 
@@ -273,7 +273,8 @@ Search the LCM conversation archive for matching content using full-text search.
 Generate a structured end-of-day summary from memory content.
 
 **Parameters:**
-- `date` (string, optional) — ISO date string (defaults to today)
+- `memories` (string, optional) — Pre-collected memory text; when omitted or empty, auto-gathers today's facts and hourly summaries from storage
+- `sessionKey` (string, optional) — Session identifier
 - `namespace` (string, optional) — Target namespace
 
 **Returns:** Structured summary of the day's memory activity.
@@ -537,7 +538,7 @@ Run via `openclaw engram <command>`:
 | `versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
 | `taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
 | `enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
-| `binary <scan\|status\|run\|clean> [--dry-run]` | Binary file lifecycle operations |
+| `binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |
 
 ## Error Responses
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,6 +21,10 @@ The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder
 | `remnic connectors <list\|install\|remove\|doctor> [id]` | Manage host adapter connectors |
 | `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
 | `remnic benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
+| `remnic versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
+| `remnic taxonomy <list\|add\|remove\|resolve> [args]` | MECE taxonomy knowledge directory management |
+| `remnic enrichment <run\|status> [entity]` | External entity enrichment pipeline |
+| `remnic binary <scan\|mirror\|clean\|status>` | Binary file lifecycle operations |
 
 All commands accept `--json` for machine-readable output. The CLI resolves configuration from:
 
@@ -60,6 +64,7 @@ Core routes:
 - `POST /engram/v1/observe` — feed conversation messages into LCM archive and extraction pipeline
 - `POST /engram/v1/lcm/search` — full-text search over LCM-archived conversations
 - `GET /engram/v1/lcm/status` — LCM availability and stats
+- `POST /engram/v1/citations/observed` — Record observed citation usage for attribution tracking
 
 Recall request fields:
 
@@ -189,6 +194,20 @@ Response (HTTP 200):
 - `archiveAvailable` — whether the LCM archive is accessible
 - `stats` (optional) — `{ totalTurns }` when LCM is enabled
 
+#### `POST /engram/v1/citations/observed`
+
+Record that a cited memory was used by the agent. Used for citation attribution tracking.
+
+Request fields:
+
+- `rolloutIds` (string[], required) — Rollout IDs from the oai-mem-citation block
+- `sessionKey` (string, optional) — Session identifier
+- `namespace` (string, optional) — Target namespace
+
+Response (HTTP 200):
+
+- `accepted` — Number of rollout IDs accepted
+
 #### `X-Engram-Principal` Header
 
 When the server is started with `--trust-principal-header`, requests can include an `X-Engram-Principal` header to override the authenticated principal for that request. This determines namespace read/write access. Without `--trust-principal-header`, the header is silently ignored.
@@ -213,6 +232,7 @@ Available MCP tools:
 - `remnic.review_queue_list`
 - `remnic.observe`
 - `remnic.lcm_search`
+- `remnic.day_summary`
 
 The legacy `engram.*` aliases remain available through the v1.x compatibility window.
 
@@ -241,6 +261,16 @@ Search the LCM conversation archive for matching content using full-text search.
 - `limit` (number, optional) — max results to return
 
 **Returns:** `{ query, namespace, results: [{ sessionId, content, turnIndex }], count, lcmEnabled }`
+
+#### `remnic.day_summary`
+
+Generate a structured end-of-day summary from memory content.
+
+**Parameters:**
+- `date` (string, optional) — ISO date string (defaults to today)
+- `namespace` (string, optional) — Target namespace
+
+**Returns:** Structured summary of the day's memory activity.
 
 ### MCP over HTTP
 
@@ -498,6 +528,10 @@ Run via `openclaw engram <command>`:
 | `trust-zone-status` | Show trust-zone store status and aggregate counts |
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
 | `trust-zone-demo-seed [--scenario enterprise-buyer-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed the opt-in trust-zone buyer demo dataset |
+| `versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
+| `taxonomy <list\|add\|remove\|resolve> [args]` | MECE taxonomy knowledge directory management |
+| `enrichment <run\|status> [entity]` | External entity enrichment pipeline |
+| `binary <scan\|mirror\|clean\|status>` | Binary file lifecycle operations |
 
 ## Error Responses
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -21,7 +21,7 @@ The canonical CLI is `remnic`. The legacy `engram` binary remains as a forwarder
 | `remnic connectors <list\|install\|remove\|doctor> [id]` | Manage host adapter connectors |
 | `remnic space <list\|switch\|create\|delete\|push\|pull\|share\|promote\|audit>` | Manage personal, project, and team memory spaces |
 | `remnic benchmark <run\|check\|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]` | Run benchmarks, check for regressions, generate reports |
-| `remnic versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
+| `remnic versions <list\|show\|diff\|revert> <page-path> [version-id(s)]` | Page version history management |
 | `remnic taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
 | `remnic enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
 | `remnic binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |
@@ -535,7 +535,7 @@ Run via `openclaw engram <command>`:
 | `trust-zone-status` | Show trust-zone store status and aggregate counts |
 | `trust-zone-promote --record-id <id> --target-zone <zone> --reason <text> [--dry-run]` | Preview or apply a trust-zone promotion |
 | `trust-zone-demo-seed [--scenario enterprise-buyer-v1] [--recorded-at <iso>] [--dry-run]` | Explicitly preview or seed the opt-in trust-zone buyer demo dataset |
-| `versions <list\|show\|diff\|revert> [file] [version]` | Page version history management |
+| `versions <list\|show\|diff\|revert> <page-path> [version-id(s)]` | Page version history management |
 | `taxonomy <show\|resolver\|add\|remove> [args]` | MECE taxonomy knowledge directory management |
 | `enrich <entity-name\|--all\|audit\|providers> [--dry-run]` | External entity enrichment pipeline |
 | `binary <scan\|status\|run\|clean> [--dry-run\|--force]` | Binary file lifecycle operations |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -938,7 +938,7 @@ of truth for similarity logic across read-time and write-time code paths.
 |---------|---------|-------------|
 | `enrichmentEnabled` | `false` | Enable external entity enrichment pipeline |
 | `enrichmentAutoOnCreate` | `false` | Auto-enrich newly created entities |
-| `enrichmentMaxCandidatesPerEntity` | `5` | Max enrichment candidates per entity per run |
+| `enrichmentMaxCandidatesPerEntity` | `20` | Max enrichment candidates per entity per run |
 
 ## Binary Lifecycle (issue #367)
 
@@ -1460,7 +1460,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `taxonomyAutoGenResolver` | `true` | `true` |
 | `enrichmentEnabled` | `false` | `false` |
 | `enrichmentAutoOnCreate` | `false` | `false` |
-| `enrichmentMaxCandidatesPerEntity` | `5` | `5` |
+| `enrichmentMaxCandidatesPerEntity` | `20` | `20` |
 | `binaryLifecycleEnabled` | `false` | `false` |
 | `binaryLifecycleGracePeriodDays` | `7` | `7` |
 | `binaryLifecycleBackendType` | `"none"` | `"none"` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -916,7 +916,7 @@ of truth for similarity logic across read-time and write-time code paths.
 |---------|---------|-------------|
 | `versioningEnabled` | `false` | Enable page-level versioning |
 | `versioningMaxPerPage` | `50` | Max snapshots per page (0 = unlimited) |
-| `versioningSidecarDir` | `""` | Override sidecar directory path (empty = default `.versions/` next to memoryDir) |
+| `versioningSidecarDir` | `".versions"` | Override sidecar directory path (`.versions/` relative to memoryDir when unset) |
 
 ## Citations (issue #379)
 
@@ -1453,7 +1453,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `semanticChunkingConfig.fallbackToRecursive` | `true` | `true` |
 | `versioningEnabled` | `false` | `false` |
 | `versioningMaxPerPage` | `50` | `50` |
-| `versioningSidecarDir` | `""` | `""` |
+| `versioningSidecarDir` | `".versions"` | `".versions"` |
 | `citationsEnabled` | `false` | `false` |
 | `citationsAutoDetect` | `true` | `true` |
 | `taxonomyEnabled` | `false` | `false` |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -882,6 +882,86 @@ of truth for similarity logic across read-time and write-time code paths.
 | `summarizationEnabled` | `false` | Summarize old memories when count exceeds threshold |
 | `summarizationTriggerCount` | `1000` | Memory count that triggers summarization |
 
+## Extraction Judge (issue #376)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `extractionJudgeEnabled` | `false` | Enable the LLM-as-judge post-extraction durability filter |
+| `extractionJudgeModel` | `""` | Model override for judge; empty = use configured local model |
+| `extractionJudgeBatchSize` | `20` | Max candidates per LLM batch call |
+| `extractionJudgeShadow` | `false` | Shadow mode: log verdicts without filtering |
+
+## Semantic Chunking (issue #368)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `semanticChunkingEnabled` | `false` | Enable topic-boundary chunking via sentence embeddings |
+| `semanticChunkingConfig` | `(see below)` | Sub-object with chunking parameters |
+
+### `semanticChunkingConfig` keys
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `targetTokens` | `number` | `200` | Target token count per chunk |
+| `minTokens` | `number` | `100` | Minimum token count per chunk |
+| `maxTokens` | `number` | `400` | Maximum token count per chunk |
+| `smoothingWindowSize` | `number` | `3` | Sliding window size for similarity smoothing |
+| `boundaryThresholdStdDevs` | `number` | `1.0` | Standard deviations below mean similarity to trigger a boundary |
+| `embeddingBatchSize` | `number` | `32` | Batch size for sentence embedding calls |
+| `fallbackToRecursive` | `boolean` | `true` | Fall back to recursive character chunking when embeddings are unavailable |
+
+## Page Versioning (issue #371)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `versioningEnabled` | `false` | Enable page-level versioning |
+| `versioningMaxPerPage` | `50` | Max snapshots per page (0 = unlimited) |
+| `versioningSidecarDir` | `""` | Override sidecar directory path (empty = default `.versions/` next to memoryDir) |
+
+## Citations (issue #379)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `citationsEnabled` | `false` | Emit oai-mem-citation blocks in recall responses |
+| `citationsAutoDetect` | `true` | Auto-detect Codex citation context |
+
+## MECE Taxonomy (issue #366)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `taxonomyEnabled` | `false` | Enable the MECE knowledge directory |
+| `taxonomyAutoGenResolver` | `true` | Auto-regenerate RESOLVER.md when taxonomy changes |
+
+## Enrichment Pipeline (issue #365)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `enrichmentEnabled` | `false` | Enable external entity enrichment pipeline |
+| `enrichmentAutoOnCreate` | `false` | Auto-enrich newly created entities |
+| `enrichmentMaxCandidatesPerEntity` | `5` | Max enrichment candidates per entity per run |
+
+## Binary Lifecycle (issue #367)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `binaryLifecycleEnabled` | `false` | Enable binary file lifecycle management |
+| `binaryLifecycleGracePeriodDays` | `7` | Days before local cleanup of mirrored files |
+| `binaryLifecycleBackendType` | `"none"` | Storage backend: `"none"`, `"filesystem"`, `"s3"` |
+| `binaryLifecycleBackendPath` | `""` | Base path for filesystem backend |
+
+## Codex Marketplace (issue #418)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `codexMarketplaceEnabled` | `true` | Enable Codex marketplace installation support |
+
+## Memory Extensions (issue #382)
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `memoryExtensionsEnabled` | `true` | Enable third-party memory extension discovery |
+| `memoryExtensionsRoot` | `""` | Override memory extensions root directory |
+
 
 ## Schema-Complete Default and Recommended Settings
 
@@ -1358,3 +1438,33 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `recallPipeline[].topK` | (unset) | (unset) |
 | `recallPipeline[].timeoutMs` | (unset) | (unset) |
 | `recallPipeline[].maxPatterns` | (unset) | (unset) |
+| `extractionJudgeEnabled` | `false` | `false` |
+| `extractionJudgeModel` | `""` | `""` |
+| `extractionJudgeBatchSize` | `20` | `20` |
+| `extractionJudgeShadow` | `false` | `false` |
+| `semanticChunkingEnabled` | `false` | `false` |
+| `semanticChunkingConfig` | `{"targetTokens":200,"minTokens":100,"maxTokens":400,"smoothingWindowSize":3,"boundaryThresholdStdDevs":1.0,"embeddingBatchSize":32,"fallbackToRecursive":true}` | `{"targetTokens":200,"minTokens":100,"maxTokens":400,"smoothingWindowSize":3,"boundaryThresholdStdDevs":1.0,"embeddingBatchSize":32,"fallbackToRecursive":true}` |
+| `semanticChunkingConfig.targetTokens` | `200` | `200` |
+| `semanticChunkingConfig.minTokens` | `100` | `100` |
+| `semanticChunkingConfig.maxTokens` | `400` | `400` |
+| `semanticChunkingConfig.smoothingWindowSize` | `3` | `3` |
+| `semanticChunkingConfig.boundaryThresholdStdDevs` | `1.0` | `1.0` |
+| `semanticChunkingConfig.embeddingBatchSize` | `32` | `32` |
+| `semanticChunkingConfig.fallbackToRecursive` | `true` | `true` |
+| `versioningEnabled` | `false` | `false` |
+| `versioningMaxPerPage` | `50` | `50` |
+| `versioningSidecarDir` | `""` | `""` |
+| `citationsEnabled` | `false` | `false` |
+| `citationsAutoDetect` | `true` | `true` |
+| `taxonomyEnabled` | `false` | `false` |
+| `taxonomyAutoGenResolver` | `true` | `true` |
+| `enrichmentEnabled` | `false` | `false` |
+| `enrichmentAutoOnCreate` | `false` | `false` |
+| `enrichmentMaxCandidatesPerEntity` | `5` | `5` |
+| `binaryLifecycleEnabled` | `false` | `false` |
+| `binaryLifecycleGracePeriodDays` | `7` | `7` |
+| `binaryLifecycleBackendType` | `"none"` | `"none"` |
+| `binaryLifecycleBackendPath` | `""` | `""` |
+| `codexMarketplaceEnabled` | `true` | `true` |
+| `memoryExtensionsEnabled` | `true` | `true` |
+| `memoryExtensionsRoot` | `""` | `""` |

--- a/llms.txt
+++ b/llms.txt
@@ -1,66 +1,197 @@
-# openclaw-engram
+Remnic (formerly Engram)
+Persistent, private, local-first memory for AI agents.
+Open source, MIT licensed. https://github.com/joshuaswarren/remnic
 
-> Local-first memory plugin for OpenClaw. Gives AI agents persistent, searchable long-term memory using LLM-powered extraction, plain markdown storage, and hybrid search.
+All data stays on the user's machine as plain markdown files with YAML
+frontmatter. No cloud services, no external databases, no subscriptions.
 
-## What it does
+Works with OpenClaw, Claude Code, Codex CLI, Hermes Agent, Replit, Cursor,
+and any MCP-compatible client. Tell one agent a preference — every agent
+remembers it.
 
-Engram hooks into the OpenClaw gateway to:
+ARCHITECTURE
 
-1. **Recall** relevant memories before each agent session and inject them into the system prompt.
-2. **Buffer** conversation turns after each agent response.
-3. **Extract** facts, preferences, decisions, and entities periodically via a single LLM call.
-4. **Consolidate** memories periodically: merge duplicates, resolve contradictions, expire stale entries.
-5. **Store** everything as plain markdown files with YAML frontmatter — no external database.
+TypeScript ESM monorepo. pnpm workspaces. Node 22+.
 
-## Key files
+Packages:
+  @remnic/core            Engine (orchestrator, storage, search, extraction,
+                          graph, trust zones, LCM). Framework-agnostic.
+  @remnic/cli             Standalone CLI binary, 20+ commands.
+  @remnic/server          HTTP + MCP server with multi-token auth, daemon mode.
+  @remnic/bench           Latency benchmarks with CI regression gates.
+  @remnic/plugin-openclaw OpenClaw adapter (embedded or delegate mode).
+  @remnic/plugin-codex    Codex CLI adapter (hooks + MCP + memory extension).
+  @remnic/hermes-provider TypeScript HTTP client for remote Remnic instances.
+  remnic-hermes           Python PyPI package, MemoryProvider for Hermes Agent.
 
-- `src/orchestrator.ts` — coordinates all phases; main integration point
-- `src/storage.ts` — reads and writes memory files
-- `src/extraction.ts` — LLM extraction engine (OpenAI Responses API)
-- `src/retrieval.ts` — recall pipeline: filter → rerank → cap → format
-- `src/qmd.ts` — hybrid search client wrapping the `qmd` CLI
-- `src/config.ts` — config parsing with defaults
-- `src/types.ts` — TypeScript interfaces for all memory types
-- `openclaw.plugin.json` — plugin manifest and config schema
+Three-phase flow:
+  1. Recall   Before each agent turn, inject relevant memories into context.
+  2. Buffer   After each turn, accumulate content until a trigger fires.
+  3. Extract  Periodically, extract structured memories via an LLM call.
 
-## Memory categories
+Storage: plain markdown + YAML frontmatter. Categories include fact,
+decision, preference, correction, relationship, principle, commitment,
+moment, skill, rule, entity, and more.
 
-`fact`, `preference`, `correction`, `entity`, `decision`, `relationship`, `principle`, `commitment`, `moment`, `skill`
+Search: hybrid BM25 + vector + reranking via QMD. Six backend options:
+QMD (default), Orama (embedded JS), LanceDB (embedded native Arrow),
+Meilisearch (server), Remote (HTTP REST), Noop (extraction only).
 
-## Configuration
+KEY FEATURES
 
-Key options in `openclaw.json`:
+Core (enabled by default):
+  - Automatic extraction and recall injection
+  - Entity tracking and relationship graph
+  - Memory lifecycle (active -> validated -> stale -> archived)
+  - Episode/note model (time-specific events vs stable beliefs)
+  - Importance-gated extraction (trivial content never hits disk)
+  - Inline source attribution (provenance tags in fact body)
 
-```jsonc
-{
-  "plugins": {
-    "openclaw-engram": {
-      "openaiApiKey": "${OPENAI_API_KEY}",
-      "memoryDir": "~/.openclaw/workspace/memory/local",
-      "recallBudgetChars": 64000,
-      "qmdEnabled": true,
-      "consolidateEveryN": 10
-    }
-  }
-}
-```
+Lossless Context Management (LCM):
+  Proactive session archive into local SQLite + hierarchical summary DAG.
+  When context gets compacted, LCM injects compressed history back into
+  recall. Three-level summarization with guaranteed convergence. Full-text
+  search over archived messages. Zero data loss.
 
-**Important:** `recallBudgetChars` controls the total character budget for recall context. The default (8,000 chars) is too small for most deployments — profile and shared context consume the entire budget, leaving zero room for actual memories. Set to 64,000 for large-context models or 32,000 for smaller ones.
+Parallel Specialized Retrieval:
+  Three agents run in parallel (latency = max, not sum):
+    DirectFact  Scans entity filenames for keyword overlap (<5ms).
+    Contextual  Existing hybrid BM25+vector search.
+    Temporal    Reads date index with recency decay scoring (<10ms).
+  Zero additional LLM cost. Graceful per-agent degradation.
 
-Full reference: [docs/config-reference.md](docs/config-reference.md)
+Semantic Consolidation:
+  Finds clusters of similar memories via token overlap, synthesizes a
+  canonical version via LLM, archives originals. Conservative threshold
+  (80%+), corrections and commitments excluded by default.
 
-## Docs
+Trust Zones:
+  Quarantine -> working -> trusted tiers with promotion rules and
+  poisoning defense. Provenance tracking and corroboration scoring.
 
-- [Getting Started](docs/getting-started.md)
-- [Architecture Overview](docs/architecture/overview.md)
-- [Config Reference](docs/config-reference.md)
-- [Operations Guide](docs/operations.md)
-- [Import / Export](docs/import-export.md)
-- [Namespaces](docs/namespaces.md)
+Extraction Judge (issue #376):
+  LLM-as-judge post-extraction durability filter. Shadow mode available
+  for calibration before enabling gating.
 
-## Requirements
+Semantic Chunking (issue #368):
+  Topic-boundary detection via sentence embeddings and cosine similarity
+  with smoothing. Alternative to recursive chunking.
 
-- Node.js ≥ 22.12.0
-- OpenClaw gateway
-- OpenAI API key (for extraction; retrieval works without it)
-- `qmd` CLI (optional but recommended for hybrid search)
+Page Versioning (issue #371):
+  Snapshot-based history for memory files. Every overwrite saves a
+  numbered snapshot. List, inspect, diff, and revert via CLI or API.
+
+OAI-mem-citation Blocks (issue #379):
+  Recall responses emit <oai-mem-citation> blocks matching the Codex
+  citation format for memory attribution and usage tracking.
+
+Memory Extension Publisher Contract (issue #381):
+  Pluggable contract for installing host-specific instruction files into
+  any AI agent host's extension directory. Generalizes Codex extension
+  pattern.
+
+Memory Extension Discovery (issue #382):
+  Third-party memory extensions provide structured instructions that
+  influence consolidation, auto-discovered from extension directories.
+
+MECE Taxonomy (issue #366):
+  Mutually Exclusive, Collectively Exhaustive knowledge directory with
+  resolver decision tree for deterministic memory categorization.
+
+Enrichment Pipeline (issue #365):
+  Importance-tiered API spend for entity enrichment from external sources
+  with a provider registry.
+
+Binary Lifecycle (issue #367):
+  Three-stage pipeline (mirror, redirect, clean) for binary files in the
+  memory directory with configurable storage backends.
+
+Codex Marketplace (issue #418):
+  Install via: codex marketplace add joshuaswarren/remnic
+
+Memory OS (progressive opt-in):
+  Memory boxes, graph recall, compounding (weekly synthesis), shared
+  context (cross-agent), identity continuity, hot/cold tiering, native
+  knowledge search, behavior loop tuning.
+
+Advanced (opt-in):
+  Objective-state recall, causal trajectories, harmonic retrieval,
+  verified recall, semantic rule promotion, creation memory, commitment
+  lifecycle.
+
+BUILD / TEST / DEVELOP
+
+  Build:        pnpm run build
+  Test:         npm run test        (node:test with tsx, 672+ tests)
+  Typecheck:    pnpm run check-types
+  Quality gate: npm run preflight:quick
+  Eval suite:   npm run eval:run
+
+ACCESS LAYER
+
+HTTP API:
+  Base path /engram/v1/... (v1.x compatibility window).
+  Bearer-token auth, binds to loopback by default.
+  Routes: health, recall, recall/explain, memories (CRUD), entities,
+  observe, lcm/search, lcm/status, trust-zones/status, trust-zones/records,
+  trust-zones/promote, review-queue, maintenance, citations/observed,
+  suggestions, review-disposition.
+
+MCP tools:
+  Exposed via stdio and HTTP transports. 14+ tools covering recall, store,
+  entity lookup, memory search, LCM expansion, trust zone inspection, and
+  observation.
+
+Standalone CLI (20+ commands):
+  init, status, query, doctor, config, daemon, tree, onboard, curate,
+  review, sync, dedup, connectors, space, benchmark, versions, taxonomy,
+  enrichment, binary.
+
+Operator UI:
+  http://127.0.0.1:4318/engram/ui/
+
+DOCUMENTATION
+
+  README.md                    Full installation guide, feature list, architecture
+  CLAUDE.md                    Project instructions and privacy policy
+  AGENTS.md                    Agent guide with 43 review prevention patterns
+  docs/config-reference.md     90+ configuration properties
+  docs/api.md                  HTTP, MCP, and CLI reference
+  docs/architecture/           Per-feature architecture docs
+  docs/guides/                 Standalone, Codex, Claude Code, local LLM, etc.
+  docs/getting-started.md      Quick start
+  docs/operations.md           Operations guide
+  docs/search-backends.md      Search backend comparison
+  docs/namespaces.md           Namespace isolation
+  docs/import-export.md        Data portability
+
+CONFIGURATION
+
+Config resolved from: REMNIC_CONFIG_PATH env var -> ./remnic.config.json ->
+~/.config/remnic/config.json. Presets: conservative, balanced, research-max,
+local-llm-heavy. 90+ properties. LLM routing: OpenAI API, local LLM (Ollama,
+LM Studio), or gateway model chain with multi-provider fallback.
+
+QUICK START (STANDALONE)
+
+  npm install -g @remnic/cli
+  remnic init
+  export OPENAI_API_KEY=sk-...
+  export REMNIC_AUTH_TOKEN=$(openssl rand -hex 32)
+  remnic daemon start
+  remnic status
+  remnic query "hello" --explain
+
+QUICK START (OPENCLAW)
+
+  openclaw plugins install @remnic/plugin-openclaw --pin
+  remnic openclaw install
+  launchctl kickstart -k gui/$(id -u)/ai.openclaw.gateway
+  remnic doctor
+
+CONNECTING OTHER AGENTS
+
+  remnic connectors install claude-code
+  remnic connectors install codex-cli
+  remnic connectors install replit
+  pip install remnic-hermes

--- a/llms.txt
+++ b/llms.txt
@@ -130,12 +130,13 @@ BUILD / TEST / DEVELOP
 ACCESS LAYER
 
 HTTP API:
-  Base path /engram/v1/... (v1.x compatibility window).
+  Most routes under /engram/v1/... (v1.x compatibility window).
   Bearer-token auth, binds to loopback by default.
   Routes: health, recall, recall/explain, memories (CRUD), entities,
   observe, lcm/search, lcm/status, trust-zones/status, trust-zones/records,
-  trust-zones/promote, review-queue, maintenance, citations/observed,
-  suggestions, review-disposition.
+  trust-zones/promote, review-queue, maintenance, suggestions,
+  review-disposition.
+  Exception: POST /v1/citations/observed (no /engram prefix).
 
 MCP tools:
   Exposed via stdio and HTTP transports. 14+ tools covering recall, store,
@@ -145,7 +146,7 @@ MCP tools:
 Standalone CLI (20+ commands):
   init, status, query, doctor, config, daemon, tree, onboard, curate,
   review, sync, dedup, connectors, space, benchmark, versions, taxonomy,
-  enrichment, binary.
+  enrich, binary.
 
 Operator UI:
   http://127.0.0.1:4318/engram/ui/

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -669,6 +669,28 @@
         "default": "",
         "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
       },
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+      },
+      "binaryLifecycleGracePeriodDays": {
+        "type": "number",
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "binaryLifecycleBackendType": {
+        "type": "string",
+        "enum": ["none", "filesystem", "s3"],
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -577,7 +577,10 @@
             "description": "Install the Remnic Codex memory extension during Codex connector setup."
           },
           "codexHome": {
-            "type": ["string", "null"],
+            "type": [
+              "string",
+              "null"
+            ],
             "default": null,
             "description": "Optional Codex home directory override used for connector install and materialization."
           }
@@ -665,6 +668,28 @@
         "type": "string",
         "default": "",
         "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+      },
+      "binaryLifecycleGracePeriodDays": {
+        "type": "number",
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "binaryLifecycleBackendType": {
+        "type": "string",
+        "enum": ["none", "filesystem", "s3"],
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
       },
       "codexCompat": {
         "type": "object",
@@ -1214,7 +1239,7 @@
       "recallPlannerShadowMode": {
         "type": "boolean",
         "default": false,
-        "description": "Run recall planner in shadow mode \u2014 evaluate but do not apply results."
+        "description": "Run recall planner in shadow mode — evaluate but do not apply results."
       },
       "recallPlannerTelemetryEnabled": {
         "type": "boolean",
@@ -1289,7 +1314,7 @@
       "boxTopicShiftThreshold": {
         "type": "number",
         "default": 0.35,
-        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0\u20131)."
+        "description": "Jaccard overlap threshold below which a topic shift seals the current box (0–1)."
       },
       "boxTimeGapMs": {
         "type": "number",
@@ -1314,7 +1339,7 @@
       "traceWeaverOverlapThreshold": {
         "type": "number",
         "default": 0.4,
-        "description": "Minimum Jaccard topic overlap to assign the same traceId (0\u20131)."
+        "description": "Minimum Jaccard topic overlap to assign the same traceId (0–1)."
       },
       "boxRecallDays": {
         "type": "number",
@@ -1414,7 +1439,7 @@
       "graphRecallShadowEnabled": {
         "type": "boolean",
         "default": false,
-        "description": "Run graph recall in shadow mode \u2014 evaluate but do not inject results."
+        "description": "Run graph recall in shadow mode — evaluate but do not inject results."
       },
       "graphRecallSnapshotEnabled": {
         "type": "boolean",
@@ -1800,7 +1825,7 @@
           },
           "boundaryThresholdStdDevs": {
             "type": "number",
-            "default": 1.0,
+            "default": 1,
             "description": "Standard deviations below mean for boundary detection"
           },
           "embeddingBatchSize": {
@@ -1989,7 +2014,10 @@
       },
       "modelSource": {
         "type": "string",
-        "enum": ["plugin", "gateway"],
+        "enum": [
+          "plugin",
+          "gateway"
+        ],
         "default": "plugin",
         "description": "LLM source: 'plugin' uses Engram's own openai/localLlm config; 'gateway' delegates to a gateway agent's model chain (agents.list[])."
       },
@@ -2069,7 +2097,7 @@
       "traceRecallContent": {
         "type": "boolean",
         "default": false,
-        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default \u2014 only enable when you want external trace collectors to capture injected memory context."
+        "description": "If true, include the full recalled memory text in RecallTraceEvent.recalledContent emitted to __openclawEngramTrace subscribers (e.g. Langfuse). Disabled by default — only enable when you want external trace collectors to capture injected memory context."
       },
       "profilingEnabled": {
         "type": "boolean",
@@ -2103,7 +2131,13 @@
       },
       "extractionMinImportanceLevel": {
         "type": "string",
-        "enum": ["trivial", "low", "normal", "high", "critical"],
+        "enum": [
+          "trivial",
+          "low",
+          "normal",
+          "high",
+          "critical"
+        ],
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
@@ -2517,8 +2551,13 @@
       },
       "semanticConsolidationExcludeCategories": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["correction", "commitment"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "correction",
+          "commitment"
+        ],
         "description": "Memory categories excluded from semantic consolidation."
       },
       "semanticConsolidationIntervalHours": {
@@ -3533,7 +3572,7 @@
       "parallelAgentWeights": {
         "type": "object",
         "default": {
-          "direct": 1.0,
+          "direct": 1,
           "contextual": 0.7,
           "temporal": 0.85
         },
@@ -3573,28 +3612,6 @@
         "default": 20,
         "minimum": 0,
         "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
-      },
-      "binaryLifecycleEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
-      },
-      "binaryLifecycleGracePeriodDays": {
-        "type": "number",
-        "default": 7,
-        "minimum": 0,
-        "description": "Days to wait before cleaning local copies of mirrored binary files."
-      },
-      "binaryLifecycleBackendType": {
-        "type": "string",
-        "enum": ["none", "filesystem", "s3"],
-        "default": "none",
-        "description": "Storage backend for binary lifecycle mirror stage."
-      },
-      "binaryLifecycleBackendPath": {
-        "type": "string",
-        "default": "",
-        "description": "Base path for the filesystem storage backend."
       }
     }
   },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3573,6 +3573,28 @@
         "default": 20,
         "minimum": 0,
         "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
+      },
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+      },
+      "binaryLifecycleGracePeriodDays": {
+        "type": "number",
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "binaryLifecycleBackendType": {
+        "type": "string",
+        "enum": ["none", "filesystem", "s3"],
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
       }
     }
   },

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -45,6 +45,23 @@ See `AGENTS.md` (root) for the full list. Key reminders:
 | `orchestrator.ts` | Core coordination | Active development (v8.2) |
 | `tools.ts` | Agent-callable tool implementations | Stable |
 | `cli.ts` | CLI command implementations | Stable |
+| `extraction-judge.ts` | LLM-as-judge fact-worthiness gate (#376) | Stable |
+| `semantic-chunking.ts` | Topic-boundary chunking (#368) | Stable |
+| `page-versioning.ts` | Snapshot-based version history (#371) | Stable |
+| `source-attribution.ts` | Citation/attribution helpers (#379) | Stable |
+| `enrichment/` | External enrichment pipeline (#365) | Stable |
+| `binary-lifecycle/` | Binary file management (#367) | Stable |
+| `taxonomy/` | MECE taxonomy resolver (#366) | Stable |
+| `memory-extension/` | Extension publisher contract (#381, #382) | Stable |
+| `memory-extension-host/` | Extension host discovery (#381) | Stable |
+| `recall-mmr.ts` | Maximal marginal relevance reranking | Stable |
+| `recall-qos.ts` | Recall quality-of-service | Stable |
+| `recall-audit.ts` | Recall audit trail | Stable |
+| `session-integrity.ts` | Session integrity checks | Stable |
+| `session-toggles.ts` | Per-session feature toggles | Stable |
+| `compat/` | Provider compatibility checks | Stable |
+| `dedup/` | Deduplication engine | Stable |
+| `curation/` | Memory curation pipeline | Stable |
 
 ## Testing
 


### PR DESCRIPTION
## Summary

- **README.md**: Added all 10 new features in 4 organized subsections (Extraction & Processing, Organization & Taxonomy, Storage & Lifecycle, Integrations & Extensions), 7 new config keys to the summary table, 4 new CLI command groups, 10 architecture doc links, and a "Quality gates" row in the progressive complexity table
- **CLAUDE.md**: Replaced outdated flat 15-file `src/` listing with grouped monorepo-aware structure of ~45 entries across 11 subsystems; added 8 new key patterns (#7-#14)
- **AGENTS.md**: Replaced flat `src/` file structure with monorepo layout showing all 11 packages and grouped `packages/remnic-core/src/` listing; preserved all 43 review prevention patterns untouched
- **src/AGENTS.md**: Extended File Ownership table with 17 new entries for shipped feature modules
- **docs/config-reference.md**: Added 31 new config properties across 9 feature sections with full type/default/description tables, plus appendix entries
- **docs/api.md**: Added 4 new CLI command groups, `POST /engram/v1/citations/observed` endpoint, and `remnic.day_summary` MCP tool
- **openclaw.plugin.json**: Added 4 missing `binaryLifecycle*` config properties to schema (violates gotcha #4 without this fix)
- **llms.txt**: Full rewrite from outdated "openclaw-engram" description to current Remnic project state covering all features, architecture, and access layer

Features documented: Extraction Judge (#376), Semantic Chunking (#368), Page Versioning (#371), OAI-mem-citation Blocks (#379), Memory Extension Publisher Contract (#381), MECE Taxonomy (#366), Enrichment Pipeline (#365), Binary Lifecycle (#367), Codex Marketplace (#418), Memory Extension Discovery (#382).

## Test plan

- [x] `python3 -c "import json; json.load(open('openclaw.plugin.json'))"` — JSON valid
- [x] `pnpm run check-types` — passes (documentation-only changes + JSON schema addition)
- [x] `npx tsx --test tests/semantic-chunking.test.ts` — 38/38 pass
- [x] `npx tsx --test tests/binary-lifecycle*.test.ts` — 25/25 pass
- [ ] Verify new doc links in README resolve to existing files
- [ ] Verify config-reference.md new sections render correctly in GitHub markdown

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and schema-description updates; runtime behavior is unchanged aside from exposing previously-missing `binaryLifecycle*` config keys in the plugin JSON schema.
> 
> **Overview**
> **Documents a large set of recently shipped opt-in capabilities** (extraction judge, semantic chunking, citations, MECE taxonomy, enrichment, page versioning, binary lifecycle, extension publishers/discovery, Codex marketplace) across `README.md`, `CLAUDE.md`, `AGENTS.md`, and `llms.txt`, including updated monorepo-aware file structure and new config/CLI sections.
> 
> **Extends reference docs** by adding new CLI command groups and endpoints/tools to `docs/api.md` (including `POST /v1/citations/observed` and `remnic.day_summary`), and by adding corresponding config flags/sections to `docs/config-reference.md`.
> 
> **Updates config schemas** in `openclaw.plugin.json` and `packages/plugin-openclaw/openclaw.plugin.json` to include the missing `binaryLifecycle*` properties so the documented settings are accepted by schema validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 649b9e6533a9642c892825916dee02690e40c863. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->