### PR TITLE
[codex] wire remnic auth through codex-cli connector

### DIFF
--- a/packages/plugin-codex/hooks/bin/post-tool-observe.sh
+++ b/packages/plugin-codex/hooks/bin/post-tool-observe.sh
@@ -38,10 +38,11 @@ for TOKEN_FILE in "${HOME}/.remnic/tokens.json" "${HOME}/.engram/tokens.json"; d
     const tokenFile = process.argv[1];
     const store = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
     const tokens = store.tokens || [];
+    const cxc = tokens.find(t => t.connector === 'codex-cli');
     const cx = tokens.find(t => t.connector === 'codex');
     const oc = tokens.find(t => t.connector === 'openclaw');
-    let tok = (cx && cx.token) || (oc && oc.token) || '';
-    if (!tok) { tok = store['codex'] || store['openclaw'] || ''; }
+    let tok = (cxc && cxc.token) || (cx && cx.token) || (oc && oc.token) || '';
+    if (!tok) { tok = store['codex-cli'] || store['codex'] || store['openclaw'] || ''; }
     process.stdout.write(tok);
   " "$TOKEN_FILE" 2>/dev/null || echo "")"
   [ -n "$REMNIC_TOKEN" ] && break

--- a/packages/plugin-codex/hooks/bin/session-end.sh
+++ b/packages/plugin-codex/hooks/bin/session-end.sh
@@ -36,10 +36,11 @@ for TOKEN_FILE in "${HOME}/.remnic/tokens.json" "${HOME}/.engram/tokens.json"; d
     const tokenFile = process.argv[1];
     const store = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
     const tokens = store.tokens || [];
+    const cxc = tokens.find(t => t.connector === 'codex-cli');
     const cx = tokens.find(t => t.connector === 'codex');
     const oc = tokens.find(t => t.connector === 'openclaw');
-    let tok = (cx && cx.token) || (oc && oc.token) || '';
-    if (!tok) { tok = store['codex'] || store['openclaw'] || ''; }
+    let tok = (cxc && cxc.token) || (cx && cx.token) || (oc && oc.token) || '';
+    if (!tok) { tok = store['codex-cli'] || store['codex'] || store['openclaw'] || ''; }
     process.stdout.write(tok);
   " "$TOKEN_FILE" 2>/dev/null || echo "")"
   [ -n "$REMNIC_TOKEN" ] && break

--- a/packages/plugin-codex/hooks/bin/session-start.sh
+++ b/packages/plugin-codex/hooks/bin/session-start.sh
@@ -39,10 +39,11 @@ for TOKEN_FILE in "${TOKEN_FILES[@]}"; do
   REMNIC_TOKEN="$(node -e "
     const store = JSON.parse(require('fs').readFileSync(process.argv[1],'utf8'));
     const tokens = store.tokens || [];
+    const cxc = tokens.find(t => t.connector === 'codex-cli');
     const cx = tokens.find(t => t.connector === 'codex');
     const oc = tokens.find(t => t.connector === 'openclaw');
-    let tok = (cx && cx.token) || (oc && oc.token) || '';
-    if (!tok) { tok = store['codex'] || store['openclaw'] || ''; }
+    let tok = (cxc && cxc.token) || (cx && cx.token) || (oc && oc.token) || '';
+    if (!tok) { tok = store['codex-cli'] || store['codex'] || store['openclaw'] || ''; }
     process.stdout.write(tok);
   " "$TOKEN_FILE" 2>/dev/null || echo "")"
   [ -n "$REMNIC_TOKEN" ] && break
@@ -76,7 +77,7 @@ fi
 
 if [ -z "$REMNIC_TOKEN" ]; then
   log "skipping: no token found"
-  echo '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"[Remnic: no auth token — run: remnic connectors install codex]"}}'
+  echo '{"continue":true,"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"[Remnic: no auth token — run: remnic connectors install codex-cli]"}}'
   exit 0
 fi
 

--- a/packages/plugin-codex/hooks/bin/user-prompt-recall.sh
+++ b/packages/plugin-codex/hooks/bin/user-prompt-recall.sh
@@ -38,10 +38,11 @@ for TOKEN_FILE in "${HOME}/.remnic/tokens.json" "${HOME}/.engram/tokens.json"; d
     const tokenFile = process.argv[1];
     const store = JSON.parse(fs.readFileSync(tokenFile, 'utf8'));
     const tokens = store.tokens || [];
+    const cxc = tokens.find(t => t.connector === 'codex-cli');
     const cx = tokens.find(t => t.connector === 'codex');
     const oc = tokens.find(t => t.connector === 'openclaw');
-    let tok = (cx && cx.token) || (oc && oc.token) || '';
-    if (!tok) { tok = store['codex'] || store['openclaw'] || ''; }
+    let tok = (cxc && cxc.token) || (cx && cx.token) || (oc && oc.token) || '';
+    if (!tok) { tok = store['codex-cli'] || store['codex'] || store['openclaw'] || ''; }
     process.stdout.write(tok);
   " "$TOKEN_FILE" 2>/dev/null || echo "")"
   [ -n "$REMNIC_TOKEN" ] && break

--- a/packages/remnic-core/src/connectors/index.test.ts
+++ b/packages/remnic-core/src/connectors/index.test.ts
@@ -1202,15 +1202,14 @@ test(
   },
 );
 
-// ── PR #400 PRRT_kwDORJXyws56U9U0 round 6: non-token connectors must not write to tokens.json ──
+// ── Codex CLI token auth regression coverage ────────────────────────────────
 //
-// Regression test: installing a connector that does NOT require token auth
-// (e.g. "codex-cli", connectionType "mcp") must leave tokens.json with NO
-// entry for that connector. Only connectors with requiresToken:true may write
-// to the token store.
+// Codex CLI hook auth depends on a dedicated bearer token entry in tokens.json.
+// Installing codex-cli must therefore mint a token, but still keep that token
+// out of the saved connector config file.
 
 test(
-  "installConnector does NOT write a token entry for connectors that do not require token auth (PRRT_kwDORJXyws56U9U0 r6)",
+  "installConnector writes a remnic_cx_ token entry for codex-cli and keeps connector config token-free",
   async (t) => {
     const sandbox = makeSandbox(t);
 
@@ -1222,7 +1221,6 @@ test(
         CODEX_HOME: sandbox.codexHome,
       },
       () => {
-        // codex-cli is an MCP connector with requiresToken: false (default).
         const result = installConnector({
           connectorId: "codex-cli",
           config: { installExtension: false },
@@ -1230,22 +1228,25 @@ test(
 
         assert.equal(result.status, "installed", `expected status "installed", got: "${result.status}"`);
 
-        // tokens.json must contain NO entry for codex-cli.
+        // tokens.json must contain a codex-cli entry.
         const store = loadTokenStore();
         const codexEntry = store.tokens.find((e) => e.connector === "codex-cli");
-        assert.equal(
+        assert.ok(
           codexEntry,
-          undefined,
-          "tokens.json must NOT contain an entry for a non-token-auth connector (codex-cli)",
+          "tokens.json must contain a token entry for codex-cli after install",
+        );
+        assert.ok(
+          codexEntry!.token.startsWith("remnic_cx_"),
+          `codex-cli token must start with \"remnic_cx_\", got: \"${codexEntry!.token.slice(0, 20)}...\"`,
         );
 
-        // The saved connector.json must also not contain a token field.
+        // The saved connector.json must not contain a token field.
         assert.ok(result.configPath, "configPath should be set");
         const saved = JSON.parse(fs.readFileSync(result.configPath as string, "utf8")) as Record<string, unknown>;
         assert.equal(
           "token" in saved,
           false,
-          "connector.json must NOT contain a 'token' field",
+          "codex-cli connector.json must NOT contain a 'token' field",
         );
       },
     );

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -245,6 +245,7 @@ const BUILTIN_CONNECTORS: ConnectorManifest[] = [
     homepage: "https://openai.com/codex",
     author: "OpenAI",
     tags: ["official", "ai", "codex"],
+    requiresToken: true,
   },
   {
     id: "cursor",

--- a/packages/remnic-core/src/tokens.ts
+++ b/packages/remnic-core/src/tokens.ts
@@ -22,6 +22,7 @@ export interface TokenStore {
 const TOKEN_PREFIXES: Record<string, string> = {
   "openclaw": "remnic_oc_",
   "claude-code": "remnic_cc_",
+  "codex-cli": "remnic_cx_",
   "codex": "remnic_cx_",
   "hermes": "remnic_hm_",
   "replit": "remnic_rl_",

--- a/tests/integration/plugin-structure.test.ts
+++ b/tests/integration/plugin-structure.test.ts
@@ -203,5 +203,6 @@ test("Codex hooks prefer ~/.remnic/tokens.json with Engram fallback", () => {
   assert.ok(content.includes("tokens.json"), "Must read from token file");
   assert.ok(content.includes(".remnic"), "Must prefer Remnic token path");
   assert.ok(content.includes(".engram"), "Must preserve Engram token fallback");
-  assert.ok(content.includes("codex"), "Must look for codex token key");
+  assert.ok(content.includes("codex-cli"), "Must look for codex-cli token key");
+  assert.ok(content.includes("codex"), "Must preserve legacy codex token fallback");
 });


### PR DESCRIPTION
## Summary
- require a token for the built-in `codex-cli` connector
- mint `remnic_cx_` tokens for Codex installs and keep connector config token-free
- update Codex hook scripts and integration coverage to prefer `codex-cli` with legacy `codex` fallback

## Why
Codex-side Remnic startup wiring was still depending on legacy token assumptions while the live install had moved to the `codex-cli` connector identity. That left the startup hook path and install guidance out of sync.

## Validation
- `pnpm exec tsx --test tests/integration/plugin-structure.test.ts tests/session-start-hook.test.ts tests/user-prompt-recall-hook.test.ts tests/post-tool-observe-hook.test.ts tests/codex-session-end-hook.test.ts packages/remnic-core/src/connectors/index.test.ts`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes connector installation/auth token generation and updates Codex hook scripts to use a new token identity, which could break Codex recall/observe flows if token minting or lookup mismatches existing installs.
> 
> **Overview**
> Codex hooks now **prefer a dedicated `codex-cli` bearer token** from `~/.remnic/tokens.json` (with legacy `codex` and `openclaw` fallback), and the SessionStart guidance message is updated to instruct `remnic connectors install codex-cli`.
> 
> In `@remnic/core`, the built-in `codex-cli` connector is switched to `requiresToken: true` and token minting is updated to support a `codex-cli` entry with the `remnic_cx_` prefix while keeping the saved connector config token-free.
> 
> Tests are updated to assert `codex-cli` token presence/prefix and to validate Codex hook scripts look for `codex-cli` first while preserving the `codex` fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc9f73700567ce272d5144d50814b49cee202f98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->