### PR TITLE
fix(plugin-openclaw): bump to 1.0.4 — unblock Clawhub install

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

- Published v1.0.3 on npm contains `"@remnic/core": "workspace:^"` in `dependencies` — a pnpm workspace protocol specifier that npm cannot resolve at install time
- When Clawhub runs `npm install` inside the extension directory, this unresolvable dep causes the install to fail; Clawhub then falls back to hook-pack mode which also fails (`package.json missing openclaw.hooks`)
- The fix was already applied locally (`dependencies: {}` since dist bundles everything via tsup), but was never published
- This bumps to 1.0.4 so the fixed package can be published, also shipping the corrected manifest id (`openclaw-remnic` instead of `openclaw-engram`)

## Root cause

`@remnic/core` was listed as a runtime dependency with `workspace:^` specifier. When published via `npm publish` (rather than `pnpm publish`), the workspace protocol was not resolved to a real version. Since tsup bundles all of `@remnic/core` into `dist/`, the dependency entry is unnecessary.

## Test plan

- [ ] `npm pack --dry-run` shows `dependencies: {}` — no workspace specifiers
- [ ] `npm publish` succeeds for v1.0.4
- [ ] `clawhub install @remnic/plugin-openclaw` completes without error on a clean OpenClaw instance
- [ ] Plugin loads and memory hooks fire after install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only updates the published package version for `@remnic/plugin-openclaw`, with no functional code or dependency changes in this PR.
> 
> **Overview**
> Updates `packages/plugin-openclaw/package.json` to bump the `@remnic/plugin-openclaw` version from `1.0.3` to `1.0.4` to publish a new release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f778ee2fcf01f26b274ee39cb9cca46f9d004e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->