### PR TITLE
fix(plugin-openclaw): externalize openai SDK to pass Clawhub security scan

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",
@@ -28,7 +28,9 @@
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },
-  "dependencies": {},
+  "dependencies": {
+    "openai": "^6.0.0"
+  },
   "peerDependencies": {
     "openclaw": ">=2026.4.8"
   },

--- a/packages/plugin-openclaw/tsup.config.ts
+++ b/packages/plugin-openclaw/tsup.config.ts
@@ -9,6 +9,7 @@ export default defineConfig({
   clean: true,
   external: [
     "openclaw",
+    "openai",
     "@remnic/core",
     "@lancedb/lancedb",
     "meilisearch",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,10 @@ importers:
         version: link:../remnic-core
 
   packages/plugin-openclaw:
+    dependencies:
+      openai:
+        specifier: ^6.0.0
+        version: 6.33.0(zod@4.0.0)
     devDependencies:
       tsup:
         specifier: ^8.5.1
@@ -1539,6 +1543,10 @@ snapshots:
   openai@6.33.0(zod@3.25.76):
     optionalDependencies:
       zod: 3.25.76
+
+  openai@6.33.0(zod@4.0.0):
+    optionalDependencies:
+      zod: 4.0.0
 
   pathe@2.0.3: {}
 


### PR DESCRIPTION
## Summary

- Clawhub's security scanner blocks install when it detects env var access + network requests in the same bundle chunk — flags it as "possible credential harvesting"
- The bundled OpenAI SDK (`chunk-NJG4HPAL.js`) contains `readEnv()` (API key lookup) and HTTP fetch (API calls) in the same file, triggering the block
- Fix: mark `openai` as external in tsup and add it as a real dependency (`^6.0.0`) so it's installed via npm rather than bundled into the plugin dist
- Bumps to v1.0.5

## Changes

- `tsup.config.ts`: add `"openai"` to external list
- `package.json`: add `"openai": "^6.0.0"` to dependencies, bump version to 1.0.5
- `pnpm-lock.yaml`: sync

## Test plan

- [ ] `npm pack --dry-run` shows no OpenAI SDK code in dist chunks
- [ ] `grep 'globalThis.process.env' dist/` returns 0 matches
- [ ] `npm publish` succeeds for v1.0.5
- [ ] `clawhub install @remnic/plugin-openclaw` completes without security block
- [ ] Plugin loads, openai SDK resolves at runtime, memory hooks fire

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: packaging-only changes that affect how `openai` is bundled/installed; main risk is a runtime install/resolve issue if consumers don’t get the dependency.
> 
> **Overview**
> Updates `@remnic/plugin-openclaw` to stop bundling the OpenAI SDK by **adding `openai` to `tsup` externals** and **declaring `openai@^6.0.0` as a direct dependency**, so it’s resolved at runtime instead of included in dist.
> 
> Bumps the plugin version to `1.0.5` and refreshes `pnpm-lock.yaml` accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cd0e1deb49d3ba0a12784a5256653cd76c734f89. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->