### PR TITLE
fix(publish): republish cli/server/shim with resolved workspace: deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ Your agent will run the install command, update `openclaw.json`, and restart the
 git clone https://github.com/joshuaswarren/remnic.git \
   ~/.openclaw/extensions/remnic
 cd ~/.openclaw/extensions/remnic
-npm ci && npm run build
+pnpm install && pnpm run build
 ```
+
+> **Note:** This repo uses [pnpm](https://pnpm.io/) workspaces. `npm ci` / `npm install` will fail on `workspace:` specifiers. Install pnpm first: `npm install -g pnpm`.
 
 ### Option 4: Standalone (no OpenClaw)
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -70,6 +70,8 @@ Use workspace protocol in `package.json`:
 
 Turborepo ensures correct build order via `turbo.json` task dependencies.
 
+> **Important:** This repo requires [pnpm](https://pnpm.io/) (`npm install -g pnpm`). `npm ci` / `npm install` cannot resolve `workspace:` specifiers. At publish time, `pnpm publish` rewrites `workspace:^` to real version numbers automatically.
+
 ## Code Standards
 
 - **TypeScript strict mode** — all packages

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Standalone Remnic memory server — HTTP + MCP without OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary

Published versions of three packages contain pnpm `workspace:^` specifiers that npm cannot resolve, blocking all npm-based installs:

| Package | Broken version | Fixed version |
|---------|---------------|---------------|
| `@remnic/cli` | 1.0.3 | 1.0.4 |
| `@remnic/server` | 1.0.3 | 1.0.4 |
| `@joshuaswarren/openclaw-engram` | 9.3.3 | 9.3.4 |

These were published before the CI was updated to use `pnpm publish` (which rewrites `workspace:^` to real version numbers at pack time). The version bumps trigger CI to republish with properly resolved deps.

## Doc changes

- **README.md**: Option 3 (developer install from source) now uses `pnpm install && pnpm run build` instead of `npm ci && npm run build`, with a note explaining why pnpm is required
- **docs/development/contributing.md**: Added note that pnpm is required and that `workspace:` specifiers are rewritten at publish time

## Test plan

- [ ] CI publishes all three packages successfully
- [ ] `npm install -g @remnic/cli` succeeds (no EUNSUPPORTEDPROTOCOL error)
- [ ] `npm view @remnic/cli@1.0.4 dependencies` shows `@remnic/core: ^1.0.2` (not `workspace:^`)
- [ ] `npm view @remnic/server@1.0.4 dependencies` shows resolved version
- [ ] `npm view @joshuaswarren/openclaw-engram@9.3.4 dependencies` shows resolved versions
- [ ] `remnic --help` works after global install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only documentation updates and package version bumps to trigger republishing; no runtime code or dependency graph changes beyond the published versions.
> 
> **Overview**
> Updates install/contributing docs to require `pnpm` for workspace-based installs (replacing `npm ci` in the source install instructions) and explains why `npm` fails on `workspace:` specifiers.
> 
> Bumps published versions for `@remnic/cli` (1.0.4), `@remnic/server` (1.0.4), and `@joshuaswarren/openclaw-engram` (9.3.4) to trigger republishing with resolved `workspace:^` dependencies.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 984aab148bd071764f57fa043f656c7ec184d090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->