### PR TITLE
feat(bench): publish memory-arena runner

### DIFF
--- a/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
@@ -1,0 +1,39 @@
+export interface ArenaAnswer {
+  target_asin?: string;
+  attributes?: string[];
+  [key: string]: unknown;
+}
+
+export type ArenaExpectedAnswer = ArenaAnswer | string;
+
+export interface ArenaTask {
+  id: number;
+  questions: string[];
+  answers: ArenaExpectedAnswer[];
+  category: string;
+}
+
+export interface DomainData {
+  domain: string;
+  tasks: ArenaTask[];
+}
+
+export const MEMORY_ARENA_SMOKE_FIXTURE: DomainData[] = [
+  {
+    domain: "bundled_shopping",
+    tasks: [
+      {
+        id: 1,
+        category: "bundled_shopping",
+        questions: [
+          "What snack did we decide to buy for the train ride?",
+          "Which snack from earlier should I pack in the bag now?",
+        ],
+        answers: [
+          { attributes: ["trail mix"] },
+          { attributes: ["trail mix"] },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
@@ -4,7 +4,10 @@ export interface ArenaAnswer {
   [key: string]: unknown;
 }
 
-export type ArenaExpectedAnswer = ArenaAnswer | string;
+export type ArenaExpectedAnswer =
+  | ArenaAnswer
+  | string
+  | Array<ArenaAnswer | string>;
 
 export interface ArenaTask {
   id: number;

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -205,10 +205,13 @@ async function loadDataset(
     const domains: DomainData[] = [];
     for (const filename of domainFiles) {
       const raw = await readFile(path.join(datasetDir, filename), "utf8");
-      const parsedTasks = raw
-        .split("\n")
-        .filter((line) => line.trim().length > 0)
-        .map((line, lineIndex) => parseTask(line, filename, lineIndex + 1));
+      const parsedTasks: ArenaTask[] = [];
+      raw.split("\n").forEach((line, lineIndex) => {
+        if (line.trim().length === 0) {
+          return;
+        }
+        parsedTasks.push(parseTask(line, filename, lineIndex + 1));
+      });
       const tasks = limit ? parsedTasks.slice(0, limit) : parsedTasks;
       domains.push({
         domain: filename.replace(/\.jsonl$/, ""),
@@ -265,14 +268,11 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
     !Array.isArray(record.answers)
     || record.answers.some(
       (answer) =>
-        !(
-          typeof answer === "string"
-          || (!!answer && typeof answer === "object" && !Array.isArray(answer))
-        ),
+        !isValidExpectedAnswer(answer),
     )
   ) {
     throw new Error(
-      `${location} must include an answers array of strings or objects.`,
+      `${location} must include an answers array of strings, objects, or arrays of those values.`,
     );
   }
 
@@ -288,6 +288,9 @@ function answerToString(answer: ArenaExpectedAnswer): string {
   if (typeof answer === "string") {
     return answer;
   }
+  if (Array.isArray(answer)) {
+    return answer.map(answerToString).join(" | ");
+  }
 
   const parts: string[] = [];
   if (answer.target_asin) {
@@ -302,4 +305,18 @@ function answerToString(answer: ArenaExpectedAnswer): string {
     }
   }
   return parts.join(" | ");
+}
+
+function isValidExpectedAnswer(answer: unknown): answer is ArenaExpectedAnswer {
+  if (typeof answer === "string") {
+    return true;
+  }
+  if (Array.isArray(answer)) {
+    return answer.every(
+      (item) =>
+        typeof item === "string"
+        || (!!item && typeof item === "object" && !Array.isArray(item)),
+    );
+  }
+  return !!answer && typeof answer === "object";
 }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -204,6 +204,7 @@ async function loadDataset(
     }
 
     const domains: DomainData[] = [];
+    let remainingLimit = normalizedLimit;
     for (const filename of domainFiles) {
       const raw = await readFile(path.join(datasetDir, filename), "utf8");
       const parsedTasks: ArenaTask[] = [];
@@ -213,7 +214,10 @@ async function loadDataset(
         }
         parsedTasks.push(parseTask(line, filename, lineIndex + 1));
       });
-      const tasks = applyLimit(parsedTasks, normalizedLimit);
+      const tasks = applyLimit(parsedTasks, remainingLimit);
+      if (remainingLimit !== undefined) {
+        remainingLimit = Math.max(0, remainingLimit - tasks.length);
+      }
       domains.push({
         domain: filename.replace(/\.jsonl$/, ""),
         tasks,
@@ -229,10 +233,22 @@ async function loadDataset(
     );
   }
 
-  const bundledFixture = MEMORY_ARENA_SMOKE_FIXTURE.map((domain) => ({
+  const bundledFixture: DomainData[] = MEMORY_ARENA_SMOKE_FIXTURE.map((domain) => ({
     ...domain,
-    tasks: applyLimit(domain.tasks, normalizedLimit),
+    tasks: [] as ArenaTask[],
   }));
+  let remainingLimit = normalizedLimit;
+  for (let index = 0; index < bundledFixture.length; index += 1) {
+    const sourceDomain = MEMORY_ARENA_SMOKE_FIXTURE[index]!;
+    const limitedTasks = applyLimit(sourceDomain.tasks, remainingLimit);
+    bundledFixture[index] = {
+      ...bundledFixture[index]!,
+      tasks: limitedTasks,
+    };
+    if (remainingLimit !== undefined) {
+      remainingLimit = Math.max(0, remainingLimit - limitedTasks.length);
+    }
+  }
   return ensureDatasetTasks(bundledFixture);
 }
 
@@ -332,11 +348,30 @@ function isValidExpectedAnswer(answer: unknown): answer is ArenaExpectedAnswer {
     return true;
   }
   if (Array.isArray(answer)) {
-    return answer.every(
-      (item) =>
-        typeof item === "string"
-        || (!!item && typeof item === "object" && !Array.isArray(item)),
-    );
+    return answer.every((item) => typeof item === "string" || isValidArenaAnswerObject(item));
   }
-  return !!answer && typeof answer === "object";
+  return isValidArenaAnswerObject(answer);
+}
+
+function isValidArenaAnswerObject(answer: unknown): answer is ArenaAnswer {
+  if (!answer || typeof answer !== "object" || Array.isArray(answer)) {
+    return false;
+  }
+  const record = answer as Record<string, unknown>;
+  if (
+    "target_asin" in record
+    && record.target_asin !== undefined
+    && typeof record.target_asin !== "string"
+  ) {
+    return false;
+  }
+  if (
+    "attributes" in record
+    && record.attributes !== undefined
+    && (!Array.isArray(record.attributes)
+      || record.attributes.some((item) => typeof item !== "string"))
+  ) {
+    return false;
+  }
+  return true;
 }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -206,6 +206,9 @@ async function loadDataset(
     const domains: DomainData[] = [];
     let remainingLimit = normalizedLimit;
     for (const filename of domainFiles) {
+      if (remainingLimit === 0) {
+        break;
+      }
       const raw = await readFile(path.join(datasetDir, filename), "utf8");
       const parsedTasks: ArenaTask[] = [];
       raw.split("\n").forEach((line, lineIndex) => {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -1,203 +1,305 @@
 /**
- * MemoryArena runner — Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks.
- *
- * 701 tasks across 5 domains, each with sequential interdependent questions.
- * The agent must store context from earlier subtasks to solve later ones.
- *
- * Domains:
- *   bundled_shopping (150)  |  progressive_search (221)  |  group_travel_planner (270)
- *   formal_reasoning_math (40)  |  formal_reasoning_phys (20)
- *
- * Published baselines: Agents perform poorly despite near-saturated performance
- * on existing long-context memory benchmarks.
- *
- * Dataset: https://huggingface.co/datasets/ZexueHe/memoryarena
- * Paper:   MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)
+ * MemoryArena runner migrated into @remnic/bench for phase 1.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import {
+  MEMORY_ARENA_SMOKE_FIXTURE,
+  type ArenaAnswer,
+  type ArenaExpectedAnswer,
+  type ArenaTask,
+  type DomainData,
+} from "./fixture.js";
 import type {
-  LegacyBenchmarkRunner,
-  LegacyBenchmarkResult,
-  LegacyBenchmarkMeta,
-  MemorySystem,
-  TaskScore,
-} from "../../../adapters/types.js";
-import { f1Score, containsAnswer, llmJudgeScore, aggregateScores, timed } from "../../../scorer.js";
-import { enrichResult } from "../../../reporter.js";
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
-// ── Dataset types (matches data.jsonl per domain) ──
-
-interface ArenaAnswer {
-  target_asin?: string;
-  attributes?: string[];
-  [key: string]: unknown;
-}
-
-interface ArenaTask {
-  id: number;
-  questions: string[];    // Sequential subtask prompts
-  answers: ArenaAnswer[]; // Expected answers (one per question)
-  category: string;
-}
-
-interface DomainData {
-  domain: string;
-  tasks: ArenaTask[];
-}
-
-async function loadDataset(datasetDir: string, limit?: number): Promise<DomainData[]> {
-  const domainFiles = (await readdir(datasetDir)).filter((f) => f.endsWith(".jsonl"));
-  if (domainFiles.length === 0) {
-    throw new Error(
-      `MemoryArena dataset not found at ${datasetDir}. Download with:\n` +
-      `  git clone --depth 1 https://huggingface.co/datasets/ZexueHe/memoryarena /tmp/memoryarena\n` +
-      `  for d in /tmp/memoryarena/*/; do cp "$d/data.jsonl" "${datasetDir}/$(basename $d).jsonl"; done`,
-    );
-  }
-
-  const domains: DomainData[] = [];
-  for (const file of domainFiles.sort()) {
-    const domain = file.replace(".jsonl", "");
-    const raw = await readFile(path.join(datasetDir, file), "utf-8");
-    let tasks = raw
-      .split("\n")
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as ArenaTask);
-    if (limit) tasks = tasks.slice(0, limit);
-    domains.push({ domain, tasks });
-    console.log(`  [memory-arena] ${domain}: ${tasks.length} tasks`);
-  }
-  return domains;
-}
-
-/** Serialize an answer object into a comparable string. */
-function answerToString(answer: ArenaAnswer): string {
-  if (typeof answer === "string") return answer;
-  const parts: string[] = [];
-  if (answer.target_asin) parts.push(answer.target_asin);
-  if (answer.attributes) parts.push(answer.attributes.join(", "));
-  // For other answer formats, serialize relevant fields
-  for (const [key, val] of Object.entries(answer)) {
-    if (key !== "target_asin" && key !== "attributes" && val !== undefined) {
-      parts.push(`${key}: ${typeof val === "string" ? val : JSON.stringify(val)}`);
-    }
-  }
-  return parts.join(" | ");
-}
-
-const meta: LegacyBenchmarkMeta = {
-  name: "memory-arena",
-  version: "2.0.0",
-  description: "Interdependent multi-session agentic memory — 701 tasks across 5 domains",
-  category: "agentic",
-  citation: "MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)",
+export const memoryArenaDefinition: BenchmarkDefinition = {
+  id: "memory-arena",
+  title: "MemoryArena",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "memory-arena",
+    version: "2.0.0",
+    description:
+      "Interdependent multi-session agentic memory benchmark across sequential tasks and domains.",
+    category: "agentic",
+    citation:
+      "MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)",
+  },
 };
 
-async function run(
-  system: MemorySystem,
-  options: { limit?: number; datasetDir: string },
-): Promise<LegacyBenchmarkResult> {
-  const domains = await loadDataset(options.datasetDir, options.limit);
-  const scores: TaskScore[] = [];
-  const overallStart = performance.now();
+export async function runMemoryArenaBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
 
-  for (const { domain, tasks } of domains) {
-    for (let ti = 0; ti < tasks.length; ti++) {
-      const task = tasks[ti];
-      await system.reset();
+  for (const { domain, tasks: domainTasks } of dataset) {
+    for (const task of domainTasks) {
+      await options.system.reset();
 
       const sessionId = `arena-${domain}-${task.id}`;
-
-      // Process subtasks sequentially — each builds on the previous
-      for (let qi = 0; qi < task.questions.length; qi++) {
-        const question = task.questions[qi];
-        const expectedAnswer = task.answers[qi];
+      for (
+        let questionIndex = 0;
+        questionIndex < task.questions.length;
+        questionIndex += 1
+      ) {
+        const question = task.questions[questionIndex]!;
+        const expectedAnswer = task.answers[questionIndex];
         if (expectedAnswer === undefined) {
           throw new Error(
-            `MemoryArena task ${domain}:${task.id} is missing answer index ${qi} for question "${question.slice(0, 120)}"`,
+            `MemoryArena task ${domain}:${task.id} is missing answer index ${questionIndex} for question "${question.slice(0, 120)}"`,
           );
         }
-        const expectedStr = answerToString(expectedAnswer);
 
-        // Store the question as context (simulates the agent receiving the task)
-        await system.store(sessionId, [
+        const expected = answerToString(expectedAnswer);
+        await options.system.store(sessionId, [
           { role: "user", content: question },
-          { role: "assistant", content: `Processing subtask ${qi + 1}: ${question.slice(0, 100)}...` },
+          {
+            role: "assistant",
+            content: `Processing subtask ${questionIndex + 1}: ${question.slice(0, 100)}...`,
+          },
         ]);
 
-        // Recall relevant context from previous subtasks
-        const { result: recallText, durationMs } = await timed(async () => {
-          return system.recall(sessionId, question);
-        });
+        const { result: recalledText, durationMs } = await timed(async () =>
+          options.system.recall(sessionId, question),
+        );
+        const judgeScore = await llmJudgeScore(
+          options.system.judge,
+          question,
+          recalledText,
+          expected,
+        );
 
-        const f1 = f1Score(recallText, expectedStr);
-        const contains = containsAnswer(recallText, expectedStr);
-        const judgeScore = await llmJudgeScore(system.judge, question, recallText, expectedStr);
-
-        const metrics: Record<string, number> = {
-          f1,
-          contains_answer: contains,
+        const scores: Record<string, number> = {
+          f1: f1Score(recalledText, expected),
+          contains_answer: containsAnswer(recalledText, expected),
         };
-        if (judgeScore >= 0) metrics.llm_judge = judgeScore;
+        if (judgeScore >= 0) {
+          scores.llm_judge = judgeScore;
+        }
 
-        scores.push({
-          taskId: `${domain}-t${task.id}-q${qi}`,
-          metrics,
+        tasks.push({
+          taskId: `${domain}-t${task.id}-q${questionIndex}`,
+          question,
+          expected,
+          actual: recalledText,
+          scores,
+          latencyMs: durationMs,
+          tokens: { input: 0, output: 0 },
           details: {
             domain,
-            task_id: task.id,
-            subtask_index: qi,
+            taskId: task.id,
+            subtaskIndex: questionIndex,
             category: task.category,
-            question: question.slice(0, 200),
-            expected: expectedStr.slice(0, 200),
-            recalled_length: recallText.length,
+            recalledLength: recalledText.length,
           },
-          latencyMs: durationMs,
         });
 
-        // Store the answer as context for subsequent subtasks
-        await system.store(sessionId, [
-          { role: "assistant", content: `Answer for subtask ${qi + 1}: ${expectedStr}` },
+        await options.system.store(sessionId, [
+          {
+            role: "assistant",
+            content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
+          },
         ]);
       }
     }
   }
 
-  const durationMs = Math.round(performance.now() - overallStart);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
 
-  // Overall aggregate
-  const aggregate = aggregateScores(scores.map((s) => s.metrics));
-
-  // Per-domain aggregates
-  for (const { domain } of domains) {
-    const domainScores = scores.filter((s) => (s.details as any)?.domain === domain);
-    if (domainScores.length > 0) {
-      const domF1 = domainScores.map((s) => s.metrics.f1);
-      const domContains = domainScores.map((s) => s.metrics.contains_answer);
-      aggregate[`${domain}_f1`] = domF1.reduce((a, b) => a + b, 0) / domF1.length;
-      aggregate[`${domain}_accuracy`] = domContains.reduce((a, b) => a + b, 0) / domContains.length;
-      aggregate[`${domain}_count`] = domainScores.length;
-    }
-  }
-
-  return enrichResult({
-    meta,
-    engramVersion: "",
-    gitSha: "",
-    timestamp: "",
-    adapterMode: "direct",
-    taskCount: scores.length,
-    scores,
-    aggregate,
-    config: {
-      limit: options.limit,
-      datasetDir: options.datasetDir,
-      domains_run: domains.map((d) => d.domain),
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
     },
-    durationMs,
-  });
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
-export const memoryArenaRunner: LegacyBenchmarkRunner = { meta, run };
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<DomainData[]> {
+  const ensureDatasetTasks = (domains: DomainData[]): DomainData[] => {
+    const taskCount = domains.reduce(
+      (sum, domain) => sum + domain.tasks.length,
+      0,
+    );
+    if (taskCount === 0) {
+      throw new Error(
+        "MemoryArena dataset is empty after applying the requested limit.",
+      );
+    }
+    return domains;
+  };
+
+  if (datasetDir) {
+    let directoryEntries: string[];
+    try {
+      directoryEntries = await readdir(datasetDir);
+    } catch (error) {
+      throw new Error(
+        `MemoryArena dataset not found under ${datasetDir}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const domainFiles = directoryEntries
+      .filter((filename) => filename.endsWith(".jsonl"))
+      .sort();
+    if (domainFiles.length === 0) {
+      throw new Error(
+        `MemoryArena dataset not found under ${datasetDir}: no .jsonl domain files were found.`,
+      );
+    }
+
+    const domains: DomainData[] = [];
+    for (const filename of domainFiles) {
+      const raw = await readFile(path.join(datasetDir, filename), "utf8");
+      const parsedTasks = raw
+        .split("\n")
+        .filter((line) => line.trim().length > 0)
+        .map((line, lineIndex) => parseTask(line, filename, lineIndex + 1));
+      const tasks = limit ? parsedTasks.slice(0, limit) : parsedTasks;
+      domains.push({
+        domain: filename.replace(/\.jsonl$/, ""),
+        tasks,
+      });
+    }
+
+    return ensureDatasetTasks(domains);
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "MemoryArena full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  const bundledFixture = MEMORY_ARENA_SMOKE_FIXTURE.map((domain) => ({
+    ...domain,
+    tasks: limit ? domain.tasks.slice(0, limit) : [...domain.tasks],
+  }));
+  return ensureDatasetTasks(bundledFixture);
+}
+
+function parseTask(line: string, filename: string, lineNumber: number): ArenaTask {
+  const location = `MemoryArena dataset file ${filename} line ${lineNumber}`;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (error) {
+    throw new Error(
+      `MemoryArena dataset file ${filename} contains invalid JSON on line ${lineNumber}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${location} must be an object.`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (!Number.isInteger(record.id)) {
+    throw new Error(`${location} must include an integer id.`);
+  }
+  if (typeof record.category !== "string") {
+    throw new Error(`${location} must include a string category.`);
+  }
+  if (
+    !Array.isArray(record.questions)
+    || record.questions.some((question) => typeof question !== "string")
+  ) {
+    throw new Error(`${location} must include a questions array of strings.`);
+  }
+  if (
+    !Array.isArray(record.answers)
+    || record.answers.some(
+      (answer) =>
+        !(
+          typeof answer === "string"
+          || (!!answer && typeof answer === "object" && !Array.isArray(answer))
+        ),
+    )
+  ) {
+    throw new Error(
+      `${location} must include an answers array of strings or objects.`,
+    );
+  }
+
+  return {
+    id: record.id as number,
+    category: record.category as string,
+    questions: record.questions as string[],
+    answers: record.answers as ArenaExpectedAnswer[],
+  };
+}
+
+function answerToString(answer: ArenaExpectedAnswer): string {
+  if (typeof answer === "string") {
+    return answer;
+  }
+
+  const parts: string[] = [];
+  if (answer.target_asin) {
+    parts.push(answer.target_asin);
+  }
+  if (answer.attributes) {
+    parts.push(answer.attributes.join(", "));
+  }
+  for (const [key, value] of Object.entries(answer)) {
+    if (key !== "target_asin" && key !== "attributes" && value !== undefined) {
+      parts.push(`${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`);
+    }
+  }
+  return parts.join(" | ");
+}

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -170,6 +170,7 @@ async function loadDataset(
   datasetDir: string | undefined,
   limit?: number,
 ): Promise<DomainData[]> {
+  const normalizedLimit = normalizeLimit(limit);
   const ensureDatasetTasks = (domains: DomainData[]): DomainData[] => {
     const taskCount = domains.reduce(
       (sum, domain) => sum + domain.tasks.length,
@@ -212,7 +213,7 @@ async function loadDataset(
         }
         parsedTasks.push(parseTask(line, filename, lineIndex + 1));
       });
-      const tasks = limit ? parsedTasks.slice(0, limit) : parsedTasks;
+      const tasks = applyLimit(parsedTasks, normalizedLimit);
       domains.push({
         domain: filename.replace(/\.jsonl$/, ""),
         tasks,
@@ -230,9 +231,28 @@ async function loadDataset(
 
   const bundledFixture = MEMORY_ARENA_SMOKE_FIXTURE.map((domain) => ({
     ...domain,
-    tasks: limit ? domain.tasks.slice(0, limit) : [...domain.tasks],
+    tasks: applyLimit(domain.tasks, normalizedLimit),
   }));
   return ensureDatasetTasks(bundledFixture);
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `MemoryArena limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
 }
 
 function parseTask(line: string, filename: string, lineNumber: number): ArenaTask {

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -4,6 +4,10 @@
 
 import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions } from "./types.js";
 import {
+  memoryArenaDefinition,
+  runMemoryArenaBenchmark,
+} from "./benchmarks/published/memory-arena/runner.js";
+import {
   longMemEvalDefinition,
   runLongMemEvalBenchmark,
 } from "./benchmarks/published/longmemeval/runner.js";
@@ -27,17 +31,8 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     },
   },
   {
-    id: "memory-arena",
-    title: "MemoryArena",
-    tier: "published",
-    status: "planned",
-    runnerAvailable: false,
-    meta: {
-      name: "memory-arena",
-      version: "1.0.0",
-      description: "Interdependent multi-session task benchmark.",
-      category: "agentic",
-    },
+    ...memoryArenaDefinition,
+    run: runMemoryArenaBenchmark,
   },
   {
     id: "amemgym",

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -122,6 +122,34 @@ test("runBenchmark preserves string-form memory-arena answers in full mode datas
   assert.equal(result.results.tasks[0]?.expected, "trail mix");
 });
 
+test("runBenchmark preserves array-form memory-arena answers in full mode datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-array-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "group_travel_planner",
+      questions: ["Which museum stop should we keep in the itinerary?"],
+      answers: [[{ name: "Art Institute" }, { day: "Saturday" }]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(
+    result.results.tasks[0]?.expected,
+    "name: Art Institute | day: Saturday",
+  );
+});
+
 test("runBenchmark rejects memory-arena full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -240,7 +268,34 @@ test("runBenchmark rejects malformed memory-arena answers arrays with a benchmar
         datasetDir,
         system: adapter,
       }),
-    /must include an answers array of strings or objects/,
+    /must include an answers array of strings, objects, or arrays of those values/,
+  );
+});
+
+test("runBenchmark reports original JSONL line numbers when blank lines precede malformed memory-arena rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-lines-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `\n${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [{ attributes: ["trail mix"] }],
+    })}\n\n{not json}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /contains invalid JSON on line 4/,
   );
 });
 

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -187,6 +187,38 @@ test("runBenchmark applies the memory-arena limit across the full benchmark, not
   assert.equal(result.results.tasks[0]?.taskId, "bundled_shopping-t1-q0");
 });
 
+test("runBenchmark stops reading later memory-arena domain files once the global limit is exhausted", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-stop-after-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    "{not json}\n",
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "bundled_shopping-t1-q0");
+});
+
 test("runBenchmark rejects memory-arena full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -150,6 +150,43 @@ test("runBenchmark preserves array-form memory-arena answers in full mode datase
   );
 });
 
+test("runBenchmark applies the memory-arena limit across the full benchmark, not once per domain file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-global-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 2,
+      category: "group_travel_planner",
+      questions: ["Which museum stop should we keep in the itinerary?"],
+      answers: [["Art Institute"]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "bundled_shopping-t1-q0");
+});
+
 test("runBenchmark rejects memory-arena full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -271,6 +308,33 @@ test("runBenchmark rejects malformed memory-arena answers arrays with a benchmar
       category: "bundled_shopping",
       questions: ["What snack should I pack?"],
       answers: [null],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include an answers array of strings, objects, or arrays of those values/,
+  );
+});
+
+test("runBenchmark rejects memory-arena answer objects with non-array attributes", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-attributes-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [{ attributes: "trail mix" }],
     })}\n`,
     "utf8",
   );

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -218,6 +218,20 @@ test("runBenchmark rejects empty memory-arena datasets", async () => {
   );
 });
 
+test("runBenchmark treats memory-arena limit zero as an empty run instead of falling back to all tasks", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /MemoryArena dataset is empty after applying the requested limit/,
+  );
+});
+
 test("runBenchmark rejects malformed memory-arena questions arrays with a benchmark-specific error", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-questions-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -3,9 +3,248 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
-import { memoryArenaRunner } from "../packages/bench/src/benchmarks/published/memory-arena/runner.ts";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
 
-test("memoryArenaRunner fails fast when a question is missing a matching answer entry", async () => {
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("runBenchmark executes memory-arena in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "memory-arena");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(
+    result.results.tasks[1]?.actual.includes("Answer for subtask 1: trail mix"),
+    true,
+  );
+  assert.equal(result.results.tasks[1]?.expected, "trail mix");
+});
+
+test("runBenchmark preserves string-form memory-arena answers in full mode datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.expected, "trail mix");
+});
+
+test("runBenchmark rejects memory-arena full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        system: adapter,
+      }),
+    /MemoryArena full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when memory-arena full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /MemoryArena dataset not found under/,
+  );
+});
+
+test("runBenchmark fails fast when memory-arena full mode is given an explicit unreadable dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "bundled_shopping.jsonl"), "{not json");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /MemoryArena dataset file bundled_shopping\.jsonl contains invalid JSON on line 1/,
+  );
+});
+
+test("runBenchmark rejects empty memory-arena datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-empty-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    "",
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /MemoryArena dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark rejects malformed memory-arena questions arrays with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-questions-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: [42],
+      answers: [{ attributes: ["trail mix"] }],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include a questions array of strings/,
+  );
+});
+
+test("runBenchmark rejects malformed memory-arena answers arrays with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-answers-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [null],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include an answers array of strings or objects/,
+  );
+});
+
+test("runBenchmark fails fast when a memory-arena question is missing a matching answer entry", async () => {
   const tmpDir = await mkdtemp(
     path.join(os.tmpdir(), "remnic-bench-memory-arena-"),
   );
@@ -23,48 +262,23 @@ test("memoryArenaRunner fails fast when a question is missing a matching answer 
     "utf8",
   );
 
-  const storedTurns: Array<{ sessionId: string; content: string }> = [];
-  const system = {
-    async reset(): Promise<void> {},
-    async store(
-      sessionId: string,
-      messages: Array<{ role: string; content: string }>,
-    ): Promise<void> {
-      for (const message of messages) {
-        storedTurns.push({ sessionId, content: message.content });
-      }
-    },
-    async recall(): Promise<string> {
-      return "";
-    },
-    async search(): Promise<Array<unknown>> {
-      return [];
-    },
-    async getStats(): Promise<{
-      totalMessages: number;
-      totalSummaryNodes: number;
-      maxDepth: number;
-    }> {
-      return {
-        totalMessages: storedTurns.length,
-        totalSummaryNodes: 0,
-        maxDepth: 1,
-      };
-    },
-    async destroy(): Promise<void> {},
-  };
+  const adapter = new FakeMemoryAdapter();
 
   await assert.rejects(
     () =>
-      memoryArenaRunner.run(system as never, {
+      runBenchmark("memory-arena", {
+        mode: "full",
         datasetDir,
         limit: 1,
+        system: adapter,
       }),
     /MemoryArena task bundled_shopping:1 is missing answer index 0/,
   );
 
   assert.equal(
-    storedTurns.some((turn) => /Answer for subtask/.test(turn.content)),
+    [...adapter.sessions.values()].some((messages) =>
+      messages.some((message) => /Answer for subtask/.test(message.content)),
+    ),
     false,
   );
 });

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -16,8 +16,18 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "longmemeval",
+    "memory-arena,longmemeval",
   );
+});
+
+test("getBenchmark returns memory-arena metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("memory-arena");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "memory-arena");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "agentic");
 });
 
 test("getBenchmark returns longmemeval metadata with a runnable benchmark entry", () => {


### PR DESCRIPTION
## Summary
- migrate `memory-arena` onto the phase-1 `@remnic/bench` benchmark contract
- add a bundled quick fixture and publish the runner through the benchmark registry
- cover runnable registry metadata, string/object answer parsing, and dataset validation in targeted tests

## Verification
- `npx tsx --test tests/bench-registry.test.ts tests/bench-memory-arena-runner.test.ts tests/bench-longmemeval-quick.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `node scripts/run-bench-cli.mjs run --quick memory-arena`

Refs #445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runnable published benchmark with dataset loading/parsing and result shaping, which could affect `runBenchmark` consumers and benchmark stability if parsing/limits behave unexpectedly.
> 
> **Overview**
> Publishes **MemoryArena** as a runnable phase-1 benchmark: introduces `memoryArenaDefinition` + `runMemoryArenaBenchmark` that emits the new `BenchmarkResult` contract (task-level `question/expected/actual/scores/latency`, plus run metadata/cost/environment).
> 
> Adds dataset handling for `full` mode via JSONL domain files with **strict validation**, global `limit` applied across domains (and early stop once exhausted), and a `quick` mode that runs a bundled smoke fixture (`MEMORY_ARENA_SMOKE_FIXTURE`).
> 
> Updates the published benchmark `registry` to mark `memory-arena` as `ready`/`runnerAvailable` and wires `runBenchmark("memory-arena")`, with new tests covering registry metadata, quick-mode execution, answer serialization (string/object/array), limit semantics, and dataset error cases (missing dir/files, invalid JSON, empty dataset, malformed rows, missing answers).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 449ba2aabb090f5db9cc752f43f0fdbb3b753b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->