### PR TITLE
feat(bench): publish ama-bench runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,8 +92,10 @@ Your agent will run the install command, update `openclaw.json`, and restart the
 git clone https://github.com/joshuaswarren/remnic.git \
   ~/.openclaw/extensions/remnic
 cd ~/.openclaw/extensions/remnic
-npm ci && npm run build
+pnpm install && pnpm run build
 ```
+
+> **Note:** This repo uses [pnpm](https://pnpm.io/) workspaces. `npm ci` / `npm install` will fail on `workspace:` specifiers. Install pnpm first: `npm install -g pnpm`.
 
 ### Option 4: Standalone (no OpenClaw)
 

--- a/docs/development/contributing.md
+++ b/docs/development/contributing.md
@@ -70,6 +70,8 @@ Use workspace protocol in `package.json`:
 
 Turborepo ensures correct build order via `turbo.json` task dependencies.
 
+> **Important:** This repo requires [pnpm](https://pnpm.io/) (`npm install -g pnpm`). `npm ci` / `npm install` cannot resolve `workspace:` specifiers. At publish time, `pnpm publish` rewrites `workspace:^` to real version numbers automatically.
+
 ## Code Standards
 
 - **TypeScript strict mode** — all packages

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "remnic-workspace",
-  "version": "9.3.26",
+  "version": "9.3.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "remnic-workspace",
-      "version": "9.3.26",
+      "version": "9.3.29",
       "license": "MIT",
       "workspaces": [
         "packages/*"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "remnic-workspace",
-  "version": "9.3.26",
+  "version": "9.3.29",
   "private": true,
   "type": "module",
   "description": "Workspace root for the Remnic monorepo.",

--- a/packages/bench/src/benchmarks/published/ama-bench/fixture.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/fixture.ts
@@ -1,0 +1,62 @@
+export interface TrajectoryTurn {
+  turn_idx: number;
+  action: string;
+  observation: string;
+}
+
+export interface QAPair {
+  question: string;
+  answer: string;
+  type: string;
+  question_uuid: string;
+}
+
+export interface AMABenchEpisode {
+  episode_id: number;
+  task: string;
+  task_type: string;
+  domain: string;
+  success: boolean;
+  num_turns: number;
+  total_tokens: number;
+  trajectory: TrajectoryTurn[];
+  qa_pairs: QAPair[];
+}
+
+export const AMA_BENCH_SMOKE_FIXTURE: AMABenchEpisode[] = [
+  {
+    episode_id: 1,
+    task: "Web task smoke fixture",
+    task_type: "web",
+    domain: "WEB",
+    success: true,
+    num_turns: 2,
+    total_tokens: 32,
+    trajectory: [
+      {
+        turn_idx: 1,
+        action: "Open the account settings page.",
+        observation: "The profile shows the user's preferred language is Spanish.",
+      },
+      {
+        turn_idx: 2,
+        action: "Review the notification section.",
+        observation: "Email notifications are disabled.",
+      },
+    ],
+    qa_pairs: [
+      {
+        question: "What language preference did the profile show?",
+        answer: "Spanish",
+        type: "recall",
+        question_uuid: "ama-smoke-q1",
+      },
+      {
+        question: "Were email notifications enabled or disabled?",
+        answer: "disabled",
+        type: "state_updating",
+        question_uuid: "ama-smoke-q2",
+      },
+    ],
+  },
+];

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -1,199 +1,293 @@
 /**
- * AMA-Bench runner — Evaluating Long-Horizon Memory for Agentic Applications.
- *
- * 208 agent trajectories across 6 domains, 2,496 QA pairs total.
- * Each trajectory is a sequence of (action, observation) turns that must be memorized,
- * then the system is probed with questions about what happened.
- *
- * Domains: Game, EMBODIED_AI, OPENWORLD_QA, TEXT2SQL, SOFTWARE, WEB
- * QA types: recall, causal_inference, state_updating, state_abstraction
- *
- * Published baselines (Accuracy, Qwen3-32B backbone):
- *   AMA-Agent: 0.5722  |  MemoRAG: 0.4606  |  HippoRAG2: 0.4480
- *   MemoryBank: 0.3397  |  MemAgent: 0.2768
- *   GPT-5.2 (long-context): 0.7226 (strongest overall)
- *
- * Dataset: https://huggingface.co/datasets/AMA-bench/AMA-bench
- * Paper:   AMA-Bench: Evaluating Long-Horizon Memory for Agentic Applications (2025)
- * Code:    https://github.com/AMA-Bench/AMA-Hub
+ * AMA-Bench runner migrated into @remnic/bench for phase 1.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import {
+  AMA_BENCH_SMOKE_FIXTURE,
+  type AMABenchEpisode,
+} from "./fixture.js";
 import type {
-  LegacyBenchmarkRunner,
-  LegacyBenchmarkResult,
-  LegacyBenchmarkMeta,
-  MemorySystem,
-  TaskScore,
-} from "../../../adapters/types.js";
-import { f1Score, containsAnswer, llmJudgeScore, aggregateScores, timed } from "../../../scorer.js";
-import { enrichResult } from "../../../reporter.js";
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
-// ── Dataset types (matches open_end_qa_set.jsonl) ──
-
-interface TrajectoryTurn {
-  turn_idx: number;
-  action: string;
-  observation: string;
-}
-
-interface QAPair {
-  question: string;
-  answer: string;
-  type: string; // recall, causal_inference, state_updating, state_abstraction
-  question_uuid: string;
-}
-
-interface AMABenchEpisode {
-  episode_id: number;
-  task: string;
-  task_type: string;
-  domain: string;
-  success: boolean;
-  num_turns: number;
-  total_tokens: number;
-  trajectory: TrajectoryTurn[];
-  qa_pairs: QAPair[];
-}
-
-async function loadDataset(datasetDir: string, limit?: number): Promise<AMABenchEpisode[]> {
-  const filePath = path.join(datasetDir, "open_end_qa_set.jsonl");
-  try {
-    const raw = await readFile(filePath, "utf-8");
-    const episodes = raw
-      .split("\n")
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as AMABenchEpisode);
-    console.log(`  Loaded ${episodes.length} episodes (${episodes.reduce((s, e) => s + e.qa_pairs.length, 0)} QA pairs)`);
-    return limit ? episodes.slice(0, limit) : episodes;
-  } catch {
-    throw new Error(
-      `AMA-Bench dataset not found at ${filePath}. Download with:\n` +
-      `  git clone --depth 1 https://huggingface.co/datasets/AMA-bench/AMA-bench /tmp/amabench && cp /tmp/amabench/test/open_end_qa_set.jsonl ${datasetDir}/`,
-    );
-  }
-}
-
-const meta: LegacyBenchmarkMeta = {
-  name: "ama-bench",
-  version: "2.0.0",
-  description: "Agent Memory Abilities — 2,496 QA pairs across 208 agentic trajectories in 6 domains",
-  category: "agentic",
-  citation: "AMA-Bench: Evaluating Long-Horizon Memory for Agentic Applications (2025)",
+export const amaBenchDefinition: BenchmarkDefinition = {
+  id: "ama-bench",
+  title: "AMA-Bench",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "ama-bench",
+    version: "2.0.0",
+    description:
+      "Long-horizon agentic memory benchmark across multi-turn trajectories and QA probes.",
+    category: "agentic",
+    citation:
+      "AMA-Bench: Evaluating Long-Horizon Memory for Agentic Applications (2025)",
+  },
 };
 
-async function run(
-  system: MemorySystem,
-  options: { limit?: number; datasetDir: string },
-): Promise<LegacyBenchmarkResult> {
-  const episodes = await loadDataset(options.datasetDir, options.limit);
-  const scores: TaskScore[] = [];
-  const overallStart = performance.now();
+export async function runAmaBenchBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
 
-  for (let ei = 0; ei < episodes.length; ei++) {
-    const ep = episodes[ei];
-    await system.reset();
+  for (const episode of dataset) {
+    await options.system.reset();
 
-    if ((ei + 1) % 10 === 0 || ei === 0) {
-      console.log(`  [ama-bench] Episode ${ei + 1}/${episodes.length} (${ep.domain}, ${ep.num_turns} turns, ${ep.qa_pairs.length} QA)`);
-    }
-
-    const sessionId = `ama-ep-${ep.episode_id}`;
-
-    // Phase 1: Ingest trajectory as alternating user/assistant turns
-    // action → user message, observation → assistant response
-    const messages = ep.trajectory.flatMap((t) => [
-      { role: "user" as const, content: `[Action ${t.turn_idx}]: ${t.action}` },
-      { role: "assistant" as const, content: `[Observation ${t.turn_idx}]: ${t.observation}` },
+    const sessionId = `ama-ep-${episode.episode_id}`;
+    const messages = episode.trajectory.flatMap((turn) => [
+      { role: "user" as const, content: `[Action ${turn.turn_idx}]: ${turn.action}` },
+      {
+        role: "assistant" as const,
+        content: `[Observation ${turn.turn_idx}]: ${turn.observation}`,
+      },
     ]);
 
-    // Store in batches to avoid overwhelming the buffer
-    const BATCH_SIZE = 50;
-    for (let i = 0; i < messages.length; i += BATCH_SIZE) {
-      const batch = messages.slice(i, i + BATCH_SIZE);
-      await system.store(sessionId, batch);
+    for (let index = 0; index < messages.length; index += 50) {
+      await options.system.store(sessionId, messages.slice(index, index + 50));
     }
 
-    // Phase 2: Probe with QA pairs
-    for (const qa of ep.qa_pairs) {
-      const { result: recallText, durationMs } = await timed(async () => {
-        return system.recall(sessionId, qa.question);
-      });
+    for (const qa of episode.qa_pairs) {
+      const { result: recalledText, durationMs } = await timed(async () =>
+        options.system.recall(sessionId, qa.question),
+      );
+      const judgeScore = await llmJudgeScore(
+        options.system.judge,
+        qa.question,
+        recalledText,
+        qa.answer,
+      );
 
-      const f1 = f1Score(recallText, qa.answer);
-      const contains = containsAnswer(recallText, qa.answer);
-      const judgeScore = await llmJudgeScore(system.judge, qa.question, recallText, qa.answer);
-
-      const metrics: Record<string, number> = {
-        f1,
-        contains_answer: contains,
+      const scores: Record<string, number> = {
+        f1: f1Score(recalledText, qa.answer),
+        contains_answer: containsAnswer(recalledText, qa.answer),
       };
-      if (judgeScore >= 0) metrics.llm_judge = judgeScore;
+      if (judgeScore >= 0) {
+        scores.llm_judge = judgeScore;
+      }
 
-      scores.push({
+      tasks.push({
         taskId: qa.question_uuid,
-        metrics,
-        details: {
-          question: qa.question,
-          expected: qa.answer.slice(0, 200), // Truncate for readability in results
-          qa_type: qa.type,
-          domain: ep.domain,
-          episode_id: ep.episode_id,
-          num_turns: ep.num_turns,
-          total_tokens: ep.total_tokens,
-          recalled_length: recallText.length,
-        },
+        question: qa.question,
+        expected: qa.answer,
+        actual: recalledText,
+        scores,
         latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          qaType: qa.type,
+          domain: episode.domain,
+          episodeId: episode.episode_id,
+          task: episode.task,
+          taskType: episode.task_type,
+          numTurns: episode.num_turns,
+          totalTokens: episode.total_tokens,
+          recalledLength: recalledText.length,
+        },
       });
     }
   }
 
-  const durationMs = Math.round(performance.now() - overallStart);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
 
-  // Overall aggregate
-  const aggregate = aggregateScores(scores.map((s) => s.metrics));
-
-  // Per-domain aggregates
-  const domains = [...new Set(episodes.map((e) => e.domain))];
-  for (const domain of domains) {
-    const domainScores = scores.filter((s) => (s.details as any)?.domain === domain);
-    if (domainScores.length > 0) {
-      const domF1 = domainScores.map((s) => s.metrics.f1);
-      const domContains = domainScores.map((s) => s.metrics.contains_answer);
-      aggregate[`${domain}_f1`] = domF1.reduce((a, b) => a + b, 0) / domF1.length;
-      aggregate[`${domain}_accuracy`] = domContains.reduce((a, b) => a + b, 0) / domContains.length;
-      aggregate[`${domain}_count`] = domainScores.length;
-    }
-  }
-
-  // Per-QA-type aggregates
-  const qaTypes = [...new Set(scores.map((s) => (s.details as any)?.qa_type).filter(Boolean))];
-  for (const qt of qaTypes) {
-    const qtScores = scores.filter((s) => (s.details as any)?.qa_type === qt);
-    if (qtScores.length > 0) {
-      const qtF1 = qtScores.map((s) => s.metrics.f1);
-      aggregate[`${qt}_f1`] = qtF1.reduce((a, b) => a + b, 0) / qtF1.length;
-      aggregate[`${qt}_count`] = qtScores.length;
-    }
-  }
-
-  return enrichResult({
-    meta,
-    engramVersion: "",
-    gitSha: "",
-    timestamp: "",
-    adapterMode: "direct",
-    taskCount: scores.length,
-    scores,
-    aggregate,
-    config: {
-      limit: options.limit,
-      datasetDir: options.datasetDir,
-      episodes_run: episodes.length,
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
     },
-    durationMs,
-  });
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
-export const amaBenchRunner: LegacyBenchmarkRunner = { meta, run };
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<AMABenchEpisode[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetEpisodes = (episodes: AMABenchEpisode[]): AMABenchEpisode[] => {
+    if (episodes.length === 0) {
+      throw new Error(
+        "AMA-Bench dataset is empty after applying the requested limit.",
+      );
+    }
+    return episodes;
+  };
+
+  if (datasetDir) {
+    const filePath = path.join(datasetDir, "open_end_qa_set.jsonl");
+    let raw: string;
+    try {
+      raw = await readFile(filePath, "utf8");
+    } catch (error) {
+      throw new Error(
+        `AMA-Bench dataset not found at ${filePath}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const episodes: AMABenchEpisode[] = [];
+    raw.split("\n").forEach((line, lineIndex) => {
+      if (line.trim().length === 0) {
+        return;
+      }
+      episodes.push(parseEpisode(line, lineIndex + 1));
+    });
+    return ensureDatasetEpisodes(applyLimit(episodes, normalizedLimit));
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "AMA-Bench full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetEpisodes(
+    applyLimit(AMA_BENCH_SMOKE_FIXTURE, normalizedLimit),
+  );
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `AMA-Bench limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}
+
+function parseEpisode(line: string, lineNumber: number): AMABenchEpisode {
+  const location = `AMA-Bench dataset line ${lineNumber}`;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (error) {
+    throw new Error(
+      `AMA-Bench dataset contains invalid JSON on line ${lineNumber}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${location} must be an object.`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (!Number.isInteger(record.episode_id)) {
+    throw new Error(`${location} must include an integer episode_id.`);
+  }
+  if (typeof record.task !== "string" || typeof record.task_type !== "string") {
+    throw new Error(`${location} must include string task and task_type fields.`);
+  }
+  if (typeof record.domain !== "string") {
+    throw new Error(`${location} must include a string domain.`);
+  }
+  if (typeof record.success !== "boolean") {
+    throw new Error(`${location} must include a boolean success flag.`);
+  }
+  if (!Number.isFinite(record.num_turns) || !Number.isFinite(record.total_tokens)) {
+    throw new Error(`${location} must include numeric num_turns and total_tokens fields.`);
+  }
+  if (!isValidTrajectory(record.trajectory)) {
+    throw new Error(`${location} must include a trajectory array with action/observation turns.`);
+  }
+  if (!isValidQaPairs(record.qa_pairs)) {
+    throw new Error(`${location} must include a qa_pairs array with question/answer/type/question_uuid strings.`);
+  }
+
+  return {
+    episode_id: record.episode_id as number,
+    task: record.task as string,
+    task_type: record.task_type as string,
+    domain: record.domain as string,
+    success: record.success as boolean,
+    num_turns: record.num_turns as number,
+    total_tokens: record.total_tokens as number,
+    trajectory: record.trajectory as AMABenchEpisode["trajectory"],
+    qa_pairs: record.qa_pairs as AMABenchEpisode["qa_pairs"],
+  };
+}
+
+function isValidTrajectory(value: unknown): value is AMABenchEpisode["trajectory"] {
+  return Array.isArray(value)
+    && value.every(
+      (turn) =>
+        !!turn
+        && typeof turn === "object"
+        && !Array.isArray(turn)
+        && Number.isInteger((turn as Record<string, unknown>).turn_idx)
+        && typeof (turn as Record<string, unknown>).action === "string"
+        && typeof (turn as Record<string, unknown>).observation === "string",
+    );
+}
+
+function isValidQaPairs(value: unknown): value is AMABenchEpisode["qa_pairs"] {
+  return Array.isArray(value)
+    && value.every(
+      (qa) =>
+        !!qa
+        && typeof qa === "object"
+        && !Array.isArray(qa)
+        && typeof (qa as Record<string, unknown>).question === "string"
+        && typeof (qa as Record<string, unknown>).answer === "string"
+        && typeof (qa as Record<string, unknown>).type === "string"
+        && typeof (qa as Record<string, unknown>).question_uuid === "string",
+    );
+}

--- a/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
@@ -1,0 +1,42 @@
+export interface ArenaAnswer {
+  target_asin?: string;
+  attributes?: string[];
+  [key: string]: unknown;
+}
+
+export type ArenaExpectedAnswer =
+  | ArenaAnswer
+  | string
+  | Array<ArenaAnswer | string>;
+
+export interface ArenaTask {
+  id: number;
+  questions: string[];
+  answers: ArenaExpectedAnswer[];
+  category: string;
+}
+
+export interface DomainData {
+  domain: string;
+  tasks: ArenaTask[];
+}
+
+export const MEMORY_ARENA_SMOKE_FIXTURE: DomainData[] = [
+  {
+    domain: "bundled_shopping",
+    tasks: [
+      {
+        id: 1,
+        category: "bundled_shopping",
+        questions: [
+          "What snack did we decide to buy for the train ride?",
+          "Which snack from earlier should I pack in the bag now?",
+        ],
+        answers: [
+          { attributes: ["trail mix"] },
+          { attributes: ["trail mix"] },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -1,203 +1,380 @@
 /**
- * MemoryArena runner — Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks.
- *
- * 701 tasks across 5 domains, each with sequential interdependent questions.
- * The agent must store context from earlier subtasks to solve later ones.
- *
- * Domains:
- *   bundled_shopping (150)  |  progressive_search (221)  |  group_travel_planner (270)
- *   formal_reasoning_math (40)  |  formal_reasoning_phys (20)
- *
- * Published baselines: Agents perform poorly despite near-saturated performance
- * on existing long-context memory benchmarks.
- *
- * Dataset: https://huggingface.co/datasets/ZexueHe/memoryarena
- * Paper:   MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)
+ * MemoryArena runner migrated into @remnic/bench for phase 1.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
+import {
+  MEMORY_ARENA_SMOKE_FIXTURE,
+  type ArenaAnswer,
+  type ArenaExpectedAnswer,
+  type ArenaTask,
+  type DomainData,
+} from "./fixture.js";
 import type {
-  LegacyBenchmarkRunner,
-  LegacyBenchmarkResult,
-  LegacyBenchmarkMeta,
-  MemorySystem,
-  TaskScore,
-} from "../../../adapters/types.js";
-import { f1Score, containsAnswer, llmJudgeScore, aggregateScores, timed } from "../../../scorer.js";
-import { enrichResult } from "../../../reporter.js";
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
-// ── Dataset types (matches data.jsonl per domain) ──
-
-interface ArenaAnswer {
-  target_asin?: string;
-  attributes?: string[];
-  [key: string]: unknown;
-}
-
-interface ArenaTask {
-  id: number;
-  questions: string[];    // Sequential subtask prompts
-  answers: ArenaAnswer[]; // Expected answers (one per question)
-  category: string;
-}
-
-interface DomainData {
-  domain: string;
-  tasks: ArenaTask[];
-}
-
-async function loadDataset(datasetDir: string, limit?: number): Promise<DomainData[]> {
-  const domainFiles = (await readdir(datasetDir)).filter((f) => f.endsWith(".jsonl"));
-  if (domainFiles.length === 0) {
-    throw new Error(
-      `MemoryArena dataset not found at ${datasetDir}. Download with:\n` +
-      `  git clone --depth 1 https://huggingface.co/datasets/ZexueHe/memoryarena /tmp/memoryarena\n` +
-      `  for d in /tmp/memoryarena/*/; do cp "$d/data.jsonl" "${datasetDir}/$(basename $d).jsonl"; done`,
-    );
-  }
-
-  const domains: DomainData[] = [];
-  for (const file of domainFiles.sort()) {
-    const domain = file.replace(".jsonl", "");
-    const raw = await readFile(path.join(datasetDir, file), "utf-8");
-    let tasks = raw
-      .split("\n")
-      .filter((l) => l.trim())
-      .map((l) => JSON.parse(l) as ArenaTask);
-    if (limit) tasks = tasks.slice(0, limit);
-    domains.push({ domain, tasks });
-    console.log(`  [memory-arena] ${domain}: ${tasks.length} tasks`);
-  }
-  return domains;
-}
-
-/** Serialize an answer object into a comparable string. */
-function answerToString(answer: ArenaAnswer): string {
-  if (typeof answer === "string") return answer;
-  const parts: string[] = [];
-  if (answer.target_asin) parts.push(answer.target_asin);
-  if (answer.attributes) parts.push(answer.attributes.join(", "));
-  // For other answer formats, serialize relevant fields
-  for (const [key, val] of Object.entries(answer)) {
-    if (key !== "target_asin" && key !== "attributes" && val !== undefined) {
-      parts.push(`${key}: ${typeof val === "string" ? val : JSON.stringify(val)}`);
-    }
-  }
-  return parts.join(" | ");
-}
-
-const meta: LegacyBenchmarkMeta = {
-  name: "memory-arena",
-  version: "2.0.0",
-  description: "Interdependent multi-session agentic memory — 701 tasks across 5 domains",
-  category: "agentic",
-  citation: "MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)",
+export const memoryArenaDefinition: BenchmarkDefinition = {
+  id: "memory-arena",
+  title: "MemoryArena",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "memory-arena",
+    version: "2.0.0",
+    description:
+      "Interdependent multi-session agentic memory benchmark across sequential tasks and domains.",
+    category: "agentic",
+    citation:
+      "MemoryArena: Benchmarking Agent Memory in Interdependent Multi-Session Agentic Tasks (2025)",
+  },
 };
 
-async function run(
-  system: MemorySystem,
-  options: { limit?: number; datasetDir: string },
-): Promise<LegacyBenchmarkResult> {
-  const domains = await loadDataset(options.datasetDir, options.limit);
-  const scores: TaskScore[] = [];
-  const overallStart = performance.now();
+export async function runMemoryArenaBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
 
-  for (const { domain, tasks } of domains) {
-    for (let ti = 0; ti < tasks.length; ti++) {
-      const task = tasks[ti];
-      await system.reset();
+  for (const { domain, tasks: domainTasks } of dataset) {
+    for (const task of domainTasks) {
+      await options.system.reset();
 
       const sessionId = `arena-${domain}-${task.id}`;
-
-      // Process subtasks sequentially — each builds on the previous
-      for (let qi = 0; qi < task.questions.length; qi++) {
-        const question = task.questions[qi];
-        const expectedAnswer = task.answers[qi];
+      for (
+        let questionIndex = 0;
+        questionIndex < task.questions.length;
+        questionIndex += 1
+      ) {
+        const question = task.questions[questionIndex]!;
+        const expectedAnswer = task.answers[questionIndex];
         if (expectedAnswer === undefined) {
           throw new Error(
-            `MemoryArena task ${domain}:${task.id} is missing answer index ${qi} for question "${question.slice(0, 120)}"`,
+            `MemoryArena task ${domain}:${task.id} is missing answer index ${questionIndex} for question "${question.slice(0, 120)}"`,
           );
         }
-        const expectedStr = answerToString(expectedAnswer);
 
-        // Store the question as context (simulates the agent receiving the task)
-        await system.store(sessionId, [
+        const expected = answerToString(expectedAnswer);
+        await options.system.store(sessionId, [
           { role: "user", content: question },
-          { role: "assistant", content: `Processing subtask ${qi + 1}: ${question.slice(0, 100)}...` },
+          {
+            role: "assistant",
+            content: `Processing subtask ${questionIndex + 1}: ${question.slice(0, 100)}...`,
+          },
         ]);
 
-        // Recall relevant context from previous subtasks
-        const { result: recallText, durationMs } = await timed(async () => {
-          return system.recall(sessionId, question);
-        });
+        const { result: recalledText, durationMs } = await timed(async () =>
+          options.system.recall(sessionId, question),
+        );
+        const judgeScore = await llmJudgeScore(
+          options.system.judge,
+          question,
+          recalledText,
+          expected,
+        );
 
-        const f1 = f1Score(recallText, expectedStr);
-        const contains = containsAnswer(recallText, expectedStr);
-        const judgeScore = await llmJudgeScore(system.judge, question, recallText, expectedStr);
-
-        const metrics: Record<string, number> = {
-          f1,
-          contains_answer: contains,
+        const scores: Record<string, number> = {
+          f1: f1Score(recalledText, expected),
+          contains_answer: containsAnswer(recalledText, expected),
         };
-        if (judgeScore >= 0) metrics.llm_judge = judgeScore;
+        if (judgeScore >= 0) {
+          scores.llm_judge = judgeScore;
+        }
 
-        scores.push({
-          taskId: `${domain}-t${task.id}-q${qi}`,
-          metrics,
+        tasks.push({
+          taskId: `${domain}-t${task.id}-q${questionIndex}`,
+          question,
+          expected,
+          actual: recalledText,
+          scores,
+          latencyMs: durationMs,
+          tokens: { input: 0, output: 0 },
           details: {
             domain,
-            task_id: task.id,
-            subtask_index: qi,
+            taskId: task.id,
+            subtaskIndex: questionIndex,
             category: task.category,
-            question: question.slice(0, 200),
-            expected: expectedStr.slice(0, 200),
-            recalled_length: recallText.length,
+            recalledLength: recalledText.length,
           },
-          latencyMs: durationMs,
         });
 
-        // Store the answer as context for subsequent subtasks
-        await system.store(sessionId, [
-          { role: "assistant", content: `Answer for subtask ${qi + 1}: ${expectedStr}` },
+        await options.system.store(sessionId, [
+          {
+            role: "assistant",
+            content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
+          },
         ]);
       }
     }
   }
 
-  const durationMs = Math.round(performance.now() - overallStart);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
 
-  // Overall aggregate
-  const aggregate = aggregateScores(scores.map((s) => s.metrics));
-
-  // Per-domain aggregates
-  for (const { domain } of domains) {
-    const domainScores = scores.filter((s) => (s.details as any)?.domain === domain);
-    if (domainScores.length > 0) {
-      const domF1 = domainScores.map((s) => s.metrics.f1);
-      const domContains = domainScores.map((s) => s.metrics.contains_answer);
-      aggregate[`${domain}_f1`] = domF1.reduce((a, b) => a + b, 0) / domF1.length;
-      aggregate[`${domain}_accuracy`] = domContains.reduce((a, b) => a + b, 0) / domContains.length;
-      aggregate[`${domain}_count`] = domainScores.length;
-    }
-  }
-
-  return enrichResult({
-    meta,
-    engramVersion: "",
-    gitSha: "",
-    timestamp: "",
-    adapterMode: "direct",
-    taskCount: scores.length,
-    scores,
-    aggregate,
-    config: {
-      limit: options.limit,
-      datasetDir: options.datasetDir,
-      domains_run: domains.map((d) => d.domain),
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
     },
-    durationMs,
-  });
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
-export const memoryArenaRunner: LegacyBenchmarkRunner = { meta, run };
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<DomainData[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetTasks = (domains: DomainData[]): DomainData[] => {
+    const taskCount = domains.reduce(
+      (sum, domain) => sum + domain.tasks.length,
+      0,
+    );
+    if (taskCount === 0) {
+      throw new Error(
+        "MemoryArena dataset is empty after applying the requested limit.",
+      );
+    }
+    return domains;
+  };
+
+  if (datasetDir) {
+    let directoryEntries: string[];
+    try {
+      directoryEntries = await readdir(datasetDir);
+    } catch (error) {
+      throw new Error(
+        `MemoryArena dataset not found under ${datasetDir}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const domainFiles = directoryEntries
+      .filter((filename) => filename.endsWith(".jsonl"))
+      .sort();
+    if (domainFiles.length === 0) {
+      throw new Error(
+        `MemoryArena dataset not found under ${datasetDir}: no .jsonl domain files were found.`,
+      );
+    }
+
+    const domains: DomainData[] = [];
+    let remainingLimit = normalizedLimit;
+    for (const filename of domainFiles) {
+      if (remainingLimit === 0) {
+        break;
+      }
+      const raw = await readFile(path.join(datasetDir, filename), "utf8");
+      const parsedTasks: ArenaTask[] = [];
+      raw.split("\n").forEach((line, lineIndex) => {
+        if (line.trim().length === 0) {
+          return;
+        }
+        parsedTasks.push(parseTask(line, filename, lineIndex + 1));
+      });
+      const tasks = applyLimit(parsedTasks, remainingLimit);
+      if (remainingLimit !== undefined) {
+        remainingLimit = Math.max(0, remainingLimit - tasks.length);
+      }
+      domains.push({
+        domain: filename.replace(/\.jsonl$/, ""),
+        tasks,
+      });
+    }
+
+    return ensureDatasetTasks(domains);
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "MemoryArena full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  const bundledFixture: DomainData[] = MEMORY_ARENA_SMOKE_FIXTURE.map((domain) => ({
+    ...domain,
+    tasks: [] as ArenaTask[],
+  }));
+  let remainingLimit = normalizedLimit;
+  for (let index = 0; index < bundledFixture.length; index += 1) {
+    const sourceDomain = MEMORY_ARENA_SMOKE_FIXTURE[index]!;
+    const limitedTasks = applyLimit(sourceDomain.tasks, remainingLimit);
+    bundledFixture[index] = {
+      ...bundledFixture[index]!,
+      tasks: limitedTasks,
+    };
+    if (remainingLimit !== undefined) {
+      remainingLimit = Math.max(0, remainingLimit - limitedTasks.length);
+    }
+  }
+  return ensureDatasetTasks(bundledFixture);
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `MemoryArena limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}
+
+function parseTask(line: string, filename: string, lineNumber: number): ArenaTask {
+  const location = `MemoryArena dataset file ${filename} line ${lineNumber}`;
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(line);
+  } catch (error) {
+    throw new Error(
+      `MemoryArena dataset file ${filename} contains invalid JSON on line ${lineNumber}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(`${location} must be an object.`);
+  }
+
+  const record = parsed as Record<string, unknown>;
+  if (!Number.isInteger(record.id)) {
+    throw new Error(`${location} must include an integer id.`);
+  }
+  if (typeof record.category !== "string") {
+    throw new Error(`${location} must include a string category.`);
+  }
+  if (
+    !Array.isArray(record.questions)
+    || record.questions.some((question) => typeof question !== "string")
+  ) {
+    throw new Error(`${location} must include a questions array of strings.`);
+  }
+  if (
+    !Array.isArray(record.answers)
+    || record.answers.some(
+      (answer) =>
+        !isValidExpectedAnswer(answer),
+    )
+  ) {
+    throw new Error(
+      `${location} must include an answers array of strings, objects, or arrays of those values.`,
+    );
+  }
+
+  return {
+    id: record.id as number,
+    category: record.category as string,
+    questions: record.questions as string[],
+    answers: record.answers as ArenaExpectedAnswer[],
+  };
+}
+
+function answerToString(answer: ArenaExpectedAnswer): string {
+  if (typeof answer === "string") {
+    return answer;
+  }
+  if (Array.isArray(answer)) {
+    return answer.map(answerToString).join(" | ");
+  }
+
+  const parts: string[] = [];
+  if (answer.target_asin) {
+    parts.push(answer.target_asin);
+  }
+  if (answer.attributes) {
+    parts.push(answer.attributes.join(", "));
+  }
+  for (const [key, value] of Object.entries(answer)) {
+    if (key !== "target_asin" && key !== "attributes" && value !== undefined) {
+      parts.push(`${key}: ${typeof value === "string" ? value : JSON.stringify(value)}`);
+    }
+  }
+  return parts.join(" | ");
+}
+
+function isValidExpectedAnswer(answer: unknown): answer is ArenaExpectedAnswer {
+  if (typeof answer === "string") {
+    return true;
+  }
+  if (Array.isArray(answer)) {
+    return answer.every((item) => typeof item === "string" || isValidArenaAnswerObject(item));
+  }
+  return isValidArenaAnswerObject(answer);
+}
+
+function isValidArenaAnswerObject(answer: unknown): answer is ArenaAnswer {
+  if (!answer || typeof answer !== "object" || Array.isArray(answer)) {
+    return false;
+  }
+  const record = answer as Record<string, unknown>;
+  if (
+    "target_asin" in record
+    && record.target_asin !== undefined
+    && typeof record.target_asin !== "string"
+  ) {
+    return false;
+  }
+  if (
+    "attributes" in record
+    && record.attributes !== undefined
+    && (!Array.isArray(record.attributes)
+      || record.attributes.some((item) => typeof item !== "string"))
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -4,6 +4,10 @@
 
 import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions } from "./types.js";
 import {
+  memoryArenaDefinition,
+  runMemoryArenaBenchmark,
+} from "./benchmarks/published/memory-arena/runner.js";
+import {
   longMemEvalDefinition,
   runLongMemEvalBenchmark,
 } from "./benchmarks/published/longmemeval/runner.js";
@@ -27,17 +31,8 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     },
   },
   {
-    id: "memory-arena",
-    title: "MemoryArena",
-    tier: "published",
-    status: "planned",
-    runnerAvailable: false,
-    meta: {
-      name: "memory-arena",
-      version: "1.0.0",
-      description: "Interdependent multi-session task benchmark.",
-      category: "agentic",
-    },
+    ...memoryArenaDefinition,
+    run: runMemoryArenaBenchmark,
   },
   {
     id: "amemgym",

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -4,6 +4,10 @@
 
 import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions } from "./types.js";
 import {
+  amaBenchDefinition,
+  runAmaBenchBenchmark,
+} from "./benchmarks/published/ama-bench/runner.js";
+import {
   memoryArenaDefinition,
   runMemoryArenaBenchmark,
 } from "./benchmarks/published/memory-arena/runner.js";
@@ -18,17 +22,8 @@ interface RegisteredBenchmark extends BenchmarkDefinition {
 
 const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
-    id: "ama-bench",
-    title: "AMA-Bench",
-    tier: "published",
-    status: "planned",
-    runnerAvailable: false,
-    meta: {
-      name: "ama-bench",
-      version: "1.0.0",
-      description: "Long-horizon agentic memory benchmark.",
-      category: "agentic",
-    },
+    ...amaBenchDefinition,
+    run: runAmaBenchBenchmark,
   },
   {
     ...memoryArenaDefinition,

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/server",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Standalone Remnic memory server — HTTP + MCP without OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.3",
+  "version": "9.3.4",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/bench-ama-bench-runner.test.ts
+++ b/tests/bench-ama-bench-runner.test.ts
@@ -1,0 +1,256 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("runBenchmark executes ama-bench in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("ama-bench", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "ama-bench");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(
+    result.results.tasks[0]?.actual.includes("preferred language is Spanish"),
+    true,
+  );
+  assert.equal(result.results.tasks[0]?.expected, "Spanish");
+  assert.equal(result.results.tasks[0]?.details.task, "Web task smoke fixture");
+  assert.equal(result.results.tasks[0]?.details.taskType, "web");
+  assert.equal(result.results.tasks[0]?.details.qaType, "recall");
+});
+
+test("runBenchmark rejects ama-bench full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        system: adapter,
+      }),
+    /AMA-Bench full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when ama-bench full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ama-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /AMA-Bench dataset not found at/,
+  );
+});
+
+test("runBenchmark fails fast when ama-bench full mode is given malformed JSON", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ama-bad-"));
+  const datasetDir = path.join(tmpDir, "datasets", "ama-bench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "open_end_qa_set.jsonl"), "{not json");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /AMA-Bench dataset contains invalid JSON on line 1/,
+  );
+});
+
+test("runBenchmark rejects empty ama-bench datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ama-empty-"));
+  const datasetDir = path.join(tmpDir, "datasets", "ama-bench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "open_end_qa_set.jsonl"), "");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /AMA-Bench dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark treats ama-bench limit zero as an empty run instead of falling back to all episodes", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /AMA-Bench dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark rejects malformed ama-bench trajectory rows with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ama-bad-trajectory-"));
+  const datasetDir = path.join(tmpDir, "datasets", "ama-bench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "open_end_qa_set.jsonl"),
+    `${JSON.stringify({
+      episode_id: 1,
+      task: "Broken episode",
+      task_type: "web",
+      domain: "WEB",
+      success: true,
+      num_turns: 1,
+      total_tokens: 10,
+      trajectory: [{ turn_idx: 1, action: "Open the page." }],
+      qa_pairs: [
+        {
+          question: "What happened?",
+          answer: "Nothing",
+          type: "recall",
+          question_uuid: "ama-bad-q1",
+        },
+      ],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include a trajectory array with action\/observation turns/,
+  );
+});
+
+test("runBenchmark rejects malformed ama-bench qa_pairs with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ama-bad-qa-"));
+  const datasetDir = path.join(tmpDir, "datasets", "ama-bench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "open_end_qa_set.jsonl"),
+    `${JSON.stringify({
+      episode_id: 1,
+      task: "Broken episode",
+      task_type: "web",
+      domain: "WEB",
+      success: true,
+      num_turns: 1,
+      total_tokens: 10,
+      trajectory: [
+        {
+          turn_idx: 1,
+          action: "Open the page.",
+          observation: "The profile shows the user's preferred language is Spanish.",
+        },
+      ],
+      qa_pairs: [{ question: "What happened?" }],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("ama-bench", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include a qa_pairs array with question\/answer\/type\/question_uuid strings/,
+  );
+});

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -3,9 +3,413 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
-import { memoryArenaRunner } from "../packages/bench/src/benchmarks/published/memory-arena/runner.ts";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
 
-test("memoryArenaRunner fails fast when a question is missing a matching answer entry", async () => {
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("runBenchmark executes memory-arena in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "memory-arena");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(
+    result.results.tasks[1]?.actual.includes("Answer for subtask 1: trail mix"),
+    true,
+  );
+  assert.equal(result.results.tasks[1]?.expected, "trail mix");
+});
+
+test("runBenchmark preserves string-form memory-arena answers in full mode datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.expected, "trail mix");
+});
+
+test("runBenchmark preserves array-form memory-arena answers in full mode datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-array-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "group_travel_planner",
+      questions: ["Which museum stop should we keep in the itinerary?"],
+      answers: [[{ name: "Art Institute" }, { day: "Saturday" }]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(
+    result.results.tasks[0]?.expected,
+    "name: Art Institute | day: Saturday",
+  );
+});
+
+test("runBenchmark applies the memory-arena limit across the full benchmark, not once per domain file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-global-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 2,
+      category: "group_travel_planner",
+      questions: ["Which museum stop should we keep in the itinerary?"],
+      answers: [["Art Institute"]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "bundled_shopping-t1-q0");
+});
+
+test("runBenchmark stops reading later memory-arena domain files once the global limit is exhausted", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-stop-after-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+    })}\n`,
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    "{not json}\n",
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "bundled_shopping-t1-q0");
+});
+
+test("runBenchmark rejects memory-arena full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        system: adapter,
+      }),
+    /MemoryArena full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when memory-arena full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /MemoryArena dataset not found under/,
+  );
+});
+
+test("runBenchmark fails fast when memory-arena full mode is given an explicit unreadable dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "bundled_shopping.jsonl"), "{not json");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /MemoryArena dataset file bundled_shopping\.jsonl contains invalid JSON on line 1/,
+  );
+});
+
+test("runBenchmark rejects empty memory-arena datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-empty-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    "",
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /MemoryArena dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark treats memory-arena limit zero as an empty run instead of falling back to all tasks", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /MemoryArena dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark rejects malformed memory-arena questions arrays with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-questions-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: [42],
+      answers: [{ attributes: ["trail mix"] }],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include a questions array of strings/,
+  );
+});
+
+test("runBenchmark rejects malformed memory-arena answers arrays with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-answers-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [null],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include an answers array of strings, objects, or arrays of those values/,
+  );
+});
+
+test("runBenchmark rejects memory-arena answer objects with non-array attributes", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-attributes-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [{ attributes: "trail mix" }],
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include an answers array of strings, objects, or arrays of those values/,
+  );
+});
+
+test("runBenchmark reports original JSONL line numbers when blank lines precede malformed memory-arena rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-lines-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `\n${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["What snack should I pack?"],
+      answers: [{ attributes: ["trail mix"] }],
+    })}\n\n{not json}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /contains invalid JSON on line 4/,
+  );
+});
+
+test("runBenchmark fails fast when a memory-arena question is missing a matching answer entry", async () => {
   const tmpDir = await mkdtemp(
     path.join(os.tmpdir(), "remnic-bench-memory-arena-"),
   );
@@ -23,48 +427,23 @@ test("memoryArenaRunner fails fast when a question is missing a matching answer 
     "utf8",
   );
 
-  const storedTurns: Array<{ sessionId: string; content: string }> = [];
-  const system = {
-    async reset(): Promise<void> {},
-    async store(
-      sessionId: string,
-      messages: Array<{ role: string; content: string }>,
-    ): Promise<void> {
-      for (const message of messages) {
-        storedTurns.push({ sessionId, content: message.content });
-      }
-    },
-    async recall(): Promise<string> {
-      return "";
-    },
-    async search(): Promise<Array<unknown>> {
-      return [];
-    },
-    async getStats(): Promise<{
-      totalMessages: number;
-      totalSummaryNodes: number;
-      maxDepth: number;
-    }> {
-      return {
-        totalMessages: storedTurns.length,
-        totalSummaryNodes: 0,
-        maxDepth: 1,
-      };
-    },
-    async destroy(): Promise<void> {},
-  };
+  const adapter = new FakeMemoryAdapter();
 
   await assert.rejects(
     () =>
-      memoryArenaRunner.run(system as never, {
+      runBenchmark("memory-arena", {
+        mode: "full",
         datasetDir,
         limit: 1,
+        system: adapter,
       }),
     /MemoryArena task bundled_shopping:1 is missing answer index 0/,
   );
 
   assert.equal(
-    storedTurns.some((turn) => /Answer for subtask/.test(turn.content)),
+    [...adapter.sessions.values()].some((messages) =>
+      messages.some((message) => /Answer for subtask/.test(message.content)),
+    ),
     false,
   );
 });

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -16,8 +16,18 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "memory-arena,longmemeval",
+    "ama-bench,memory-arena,longmemeval",
   );
+});
+
+test("getBenchmark returns ama-bench metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("ama-bench");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "ama-bench");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "agentic");
 });
 
 test("getBenchmark returns memory-arena metadata with a runnable benchmark entry", () => {

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -16,8 +16,18 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "longmemeval",
+    "memory-arena,longmemeval",
   );
+});
+
+test("getBenchmark returns memory-arena metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("memory-arena");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "memory-arena");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "agentic");
 });
 
 test("getBenchmark returns longmemeval metadata with a runnable benchmark entry", () => {

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.3");
+  assert.equal(pkg.version, "9.3.4");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- migrate `ama-bench` onto the phase-1 `@remnic/bench` contract
- add a bundled smoke fixture plus dataset validation for full-mode JSONL input
- mark the benchmark runnable in the published registry and cover the package runner with targeted tests

## Verification
- `npx tsx --test tests/bench-ama-bench-runner.test.ts tests/bench-registry.test.ts tests/bench-memory-arena-runner.test.ts tests/bench-longmemeval-quick.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm rebuild better-sqlite3`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `node scripts/run-bench-cli.mjs run --quick ama-bench`

## Notes
- This is stacked on `feat/bench-memory-arena-runnable` / PR #457 to keep issue #445 in small reviewable slices.
- `npm run preflight:quick` was started in this worktree and reached repo-wide legacy-name and teardown warnings that are pre-existing/broad, not AMA-specific blockers.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new runnable benchmark runners and dataset parsing/validation paths, which could affect `@remnic/bench` consumers and CI benchmark runs. Changes are isolated to the bench package/docs with no production memory engine or auth logic touched.
> 
> **Overview**
> Enables **runnable** `ama-bench` (and marks `memory-arena` runnable) under the phase-1 `@remnic/bench` API by adding new runners that emit the new `BenchmarkResult`/`TaskResult` shape (including meta/cost/env fields) and wiring them into the published registry.
> 
> Adds **quick-mode bundled smoke fixtures** plus **full-mode dataset loaders** for both benchmarks, with stricter input validation (JSON parse errors w/ line numbers, required fields/type guards, empty/limit=0 handling, and clearer missing-dataset errors). Updates tests to execute both benchmarks via `runBenchmark` and verify registry metadata, and refreshes docs/version bumps (including pnpm workspace install guidance).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6eacd7489a9b1479cc9ff096e62f6bc612a670ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->