### PR TITLE
feat(bench): publish amemgym runner

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/fixture.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/fixture.ts
@@ -1,0 +1,125 @@
+export interface UserProfile {
+  uuid: string;
+  name: string;
+  age: number;
+  gender: string;
+  [key: string]: unknown;
+}
+
+export interface AMemGymSessionMessage {
+  role: string;
+  content: string;
+}
+
+export interface AMemGymSession {
+  event: string | null;
+  exposed_states: Record<string, string>;
+  query: string;
+  messages: AMemGymSessionMessage[];
+  session_time: string;
+}
+
+export interface AMemGymPeriod {
+  period_start: string;
+  period_end: string;
+  period_summary: string;
+  sessions: AMemGymSession[];
+  state: Record<string, string>;
+  updates: Record<string, string>;
+  update_cnts: Record<string, number>;
+}
+
+export interface AnswerChoice {
+  state: string[];
+  answer: string;
+}
+
+export interface AMemGymQA {
+  query: string;
+  required_info: string[];
+  answer_choices: AnswerChoice[];
+}
+
+export interface AMemGymProfile {
+  id: string;
+  start_time: string;
+  user_profile: UserProfile;
+  state_schema: Record<string, unknown>;
+  periods: AMemGymPeriod[];
+  qas: AMemGymQA[];
+}
+
+export const AMEMGYM_SMOKE_FIXTURE: AMemGymProfile[] = [
+  {
+    id: "smoke-profile-1",
+    start_time: "2025-01-01T00:00:00Z",
+    user_profile: {
+      uuid: "smoke-user-1",
+      name: "Maya",
+      age: 29,
+      gender: "female",
+    },
+    state_schema: {
+      city: { type: "string" },
+      favorite_snack: { type: "string" },
+    },
+    periods: [
+      {
+        period_start: "2025-01-01T00:00:00Z",
+        period_end: "2025-01-31T23:59:59Z",
+        period_summary: "Maya moved and updated her travel snack preference.",
+        sessions: [
+          {
+            event: "Maya relocated to Chicago for a new job.",
+            exposed_states: { city: "Chicago" },
+            query: "I moved to Chicago last month and I am still getting used to the cold.",
+            messages: [
+              {
+                role: "assistant",
+                content: "Chicago winters can be intense. I will remember that you live there now.",
+              },
+            ],
+            session_time: "2025-01-10T09:00:00Z",
+          },
+          {
+            event: null,
+            exposed_states: { favorite_snack: "trail mix" },
+            query: "For train rides I always pack trail mix because it is easy to carry.",
+            messages: [],
+            session_time: "2025-01-12T13:00:00Z",
+          },
+        ],
+        state: {
+          city: "Chicago",
+          favorite_snack: "trail mix",
+        },
+        updates: {
+          city: "Chicago",
+          favorite_snack: "trail mix",
+        },
+        update_cnts: {
+          city: 1,
+          favorite_snack: 1,
+        },
+      },
+    ],
+    qas: [
+      {
+        query: "What city does Maya live in now?",
+        required_info: ["city"],
+        answer_choices: [
+          { state: ["Chicago"], answer: "Chicago" },
+          { state: ["Austin"], answer: "Austin" },
+        ],
+      },
+      {
+        query: "Which snack should Maya pack for the train ride?",
+        required_info: ["favorite_snack"],
+        answer_choices: [
+          { state: ["trail mix"], answer: "trail mix" },
+          { state: ["pretzels"], answer: "pretzels" },
+        ],
+      },
+    ],
+  },
+];

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -1,96 +1,37 @@
 /**
- * AMemGym runner — Interactive Memory Benchmarking for Assistants in Long-Horizon Conversations.
- *
- * 20 user profiles, each with ~10 evolution periods and 10 evaluation questions.
- * 200 total QA pairs testing memory-driven personalization.
- *
- * Sessions contain user queries that expose latent state variables (preferences, life events).
- * QA pairs test whether the system captured state changes across periods.
- *
- * Published baselines (Memory Score, on-policy):
- *   Claude Sonnet 4:  0.336  |  GPT-4.1-mini: 0.203
- *   AWE (best agent):  0.291  |  Native LLMs: < 50% of upper bound
- *
- * Dataset: https://huggingface.co/datasets/AGI-Eval/AMemGym
- * Paper:   AMemGym: Interactive Memory Benchmarking for Assistants in Long-Horizon Conversations (2025)
+ * AMemGym runner migrated into @remnic/bench for phase 1.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import type { Message } from "../../../adapters/types.js";
+import {
+  AMEMGYM_SMOKE_FIXTURE,
+  type AMemGymProfile,
+  type AMemGymQA,
+  type AMemGymSession,
+} from "./fixture.js";
 import type {
-  LegacyBenchmarkRunner,
-  LegacyBenchmarkResult,
-  LegacyBenchmarkMeta,
-  MemorySystem,
-  TaskScore,
-} from "../../../adapters/types.js";
-import { f1Score, containsAnswer, llmJudgeScore, aggregateScores, timed } from "../../../scorer.js";
-import { enrichResult } from "../../../reporter.js";
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
-// ── Dataset types (matches amemgym-v1-base.json) ──
-
-interface UserProfile {
-  uuid: string;
-  name: string;
-  age: number;
-  gender: string;
-  [key: string]: unknown;
-}
-
-interface AMemGymSession {
-  event: string | null;
-  exposed_states: Record<string, string>;
-  query: string;
-  messages: Array<{ role: string; content: string }>;
-  session_time: string;
-}
-
-interface AMemGymPeriod {
-  period_start: string;
-  period_end: string;
-  period_summary: string;
-  sessions: AMemGymSession[];
-  state: Record<string, string>;
-  updates: Record<string, string>;
-  update_cnts: Record<string, number>;
-}
-
-interface AnswerChoice {
-  state: string[];
-  answer: string;
-}
-
-interface AMemGymQA {
-  query: string;
-  required_info: string[];
-  answer_choices: AnswerChoice[];
-}
-
-interface AMemGymProfile {
-  id: string;
-  start_time: string;
-  user_profile: UserProfile;
-  state_schema: Record<string, any>;
-  periods: AMemGymPeriod[];
-  qas: AMemGymQA[];
-}
-
-async function loadDataset(datasetDir: string, limit?: number): Promise<AMemGymProfile[]> {
-  for (const filename of ["amemgym-v1-base.json", "amemgym-tasks.json", "data.json"]) {
-    try {
-      const raw = await readFile(path.join(datasetDir, filename), "utf-8");
-      const data: AMemGymProfile[] = JSON.parse(raw);
-      console.log(`  Loaded ${data.length} user profiles (${data.reduce((s, p) => s + p.qas.length, 0)} QA pairs)`);
-      return limit ? data.slice(0, limit) : data;
-    } catch {
-      continue;
-    }
-  }
-  throw new Error(
-    `AMemGym dataset not found at ${datasetDir}. Download with:\n` +
-    `  git clone --depth 1 https://huggingface.co/datasets/AGI-Eval/AMemGym /tmp/amemgym && cp /tmp/amemgym/v1.base/data.json ${datasetDir}/amemgym-v1-base.json`,
-  );
-}
+const DATASET_FILENAMES = [
+  "amemgym-v1-base.json",
+  "amemgym-tasks.json",
+  "data.json",
+] as const;
 
 /**
  * For each QA, find the correct answer based on the final state.
@@ -98,151 +39,269 @@ async function loadDataset(datasetDir: string, limit?: number): Promise<AMemGymP
  * We pick the one matching the user's final state.
  */
 function findBestAnswer(qa: AMemGymQA, finalState: Record<string, string>): string {
-  // Check each answer choice against the final state
   for (const choice of qa.answer_choices) {
     const requiredStates = choice.state;
     const matchValues = qa.required_info.map((key) => finalState[key]);
-    // Check if this choice's state matches the final state
     if (requiredStates.length === matchValues.length &&
       requiredStates.every((s, i) => s === matchValues[i])) {
       return choice.answer;
     }
   }
-  // Fallback: return the first answer choice
   return qa.answer_choices[0]?.answer ?? "";
 }
 
-const meta: LegacyBenchmarkMeta = {
-  name: "amemgym",
-  version: "2.0.0",
-  description: "Interactive memory benchmarking — 200 QA pairs across 20 user profiles with state evolution",
-  category: "agentic",
-  citation: "AMemGym: Interactive Memory Benchmarking for Assistants in Long-Horizon Conversations (2025)",
+export const amemGymDefinition: BenchmarkDefinition = {
+  id: "amemgym",
+  title: "AMemGym",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "amemgym",
+    version: "2.0.0",
+    description:
+      "Interactive personalization benchmark across evolving user profiles and memory probes.",
+    category: "agentic",
+    citation:
+      "AMemGym: Interactive Memory Benchmarking for Assistants in Long-Horizon Conversations (2025)",
+  },
 };
 
-async function run(
-  system: MemorySystem,
-  options: { limit?: number; datasetDir: string },
-): Promise<LegacyBenchmarkResult> {
-  const profiles = await loadDataset(options.datasetDir, options.limit);
-  const scores: TaskScore[] = [];
-  const overallStart = performance.now();
+export async function runAMemGymBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const profiles = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
 
-  for (let pi = 0; pi < profiles.length; pi++) {
-    const profile = profiles[pi];
-    await system.reset();
-
-    console.log(`  [amemgym] Profile ${pi + 1}/${profiles.length} (${profile.user_profile.name}): ${profile.periods.length} periods, ${profile.qas.length} QA`);
+  for (let profileIndex = 0; profileIndex < profiles.length; profileIndex += 1) {
+    const profile = profiles[profileIndex]!;
+    await options.system.reset();
 
     const sessionId = `amemgym-${profile.id}`;
-
-    // Phase 1: Ingest all periods' sessions chronologically
-    // Build up the final state across all periods
-    let finalState: Record<string, string> = {};
+    const finalState: Record<string, string> = {};
 
     for (const period of profile.periods) {
-      // Update final state with this period's state
       Object.assign(finalState, period.state);
 
       for (const session of period.sessions) {
-        const messages: Array<{ role: "user" | "assistant"; content: string }> = [];
-
-        // If there's an event (life change), add it as context
-        if (session.event) {
-          messages.push({
-            role: "assistant",
-            content: `[Context update]: ${session.event}`,
-          });
-        }
-
-        // Add the user query
-        if (session.query) {
-          messages.push({
-            role: "user",
-            content: session.query,
-          });
-        }
-
-        // Add any existing messages from the session
-        for (const m of session.messages) {
-          messages.push({
-            role: m.role as "user" | "assistant",
-            content: m.content,
-          });
-        }
-
-        // If no messages but we have exposed states, create a context message
-        if (messages.length === 0 && Object.keys(session.exposed_states).length > 0) {
-          const stateDesc = Object.entries(session.exposed_states)
-            .map(([k, v]) => `${k}: ${v}`)
-            .join(", ");
-          messages.push({
-            role: "user",
-            content: `[User state]: ${stateDesc}`,
-          });
-        }
-
+        const messages = buildSessionMessages(session);
         if (messages.length > 0) {
-          await system.store(sessionId, messages);
+          await options.system.store(sessionId, messages);
         }
       }
     }
 
-    // Phase 2: Evaluate QA pairs
-    for (let qi = 0; qi < profile.qas.length; qi++) {
-      const qa = profile.qas[qi];
+    for (
+      let questionIndex = 0;
+      questionIndex < profile.qas.length;
+      questionIndex += 1
+    ) {
+      const qa = profile.qas[questionIndex]!;
       const expectedAnswer = findBestAnswer(qa, finalState);
 
       const { result: recallText, durationMs } = await timed(async () => {
-        return system.recall(sessionId, qa.query);
+        return options.system.recall(sessionId, qa.query);
       });
 
-      const f1 = f1Score(recallText, expectedAnswer);
-      const contains = containsAnswer(recallText, expectedAnswer);
-      const judgeScore = await llmJudgeScore(system.judge, qa.query, recallText, expectedAnswer);
-
-      const metrics: Record<string, number> = {
-        f1,
-        contains_answer: contains,
+      const scores: Record<string, number> = {
+        f1: f1Score(recallText, expectedAnswer),
+        contains_answer: containsAnswer(recallText, expectedAnswer),
       };
-      if (judgeScore >= 0) metrics.llm_judge = judgeScore;
+      const judgeScore = await llmJudgeScore(
+        options.system.judge,
+        qa.query,
+        recallText,
+        expectedAnswer,
+      );
+      if (judgeScore >= 0) {
+        scores.llm_judge = judgeScore;
+      }
 
-      scores.push({
-        taskId: `${profile.id}-q${qi}`,
-        metrics,
-        details: {
-          question: qa.query,
-          expected: expectedAnswer.slice(0, 200),
-          required_info: qa.required_info,
-          profile_name: profile.user_profile.name,
-          num_periods: profile.periods.length,
-          recalled_length: recallText.length,
-        },
+      tasks.push({
+        taskId: `${profile.id}-q${questionIndex}`,
+        question: qa.query,
+        expected: expectedAnswer,
+        actual: recallText,
+        scores,
         latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          profileId: profile.id,
+          profileName: profile.user_profile.name,
+          questionIndex,
+          periodCount: profile.periods.length,
+          requiredInfo: qa.required_info,
+          recalledLength: recallText.length,
+        },
       });
     }
   }
 
-  const durationMs = Math.round(performance.now() - overallStart);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce(
+    (sum, task) => sum + task.tokens.input,
+    0,
+  );
+  const totalOutputTokens = tasks.reduce(
+    (sum, task) => sum + task.tokens.output,
+    0,
+  );
 
-  const aggregate = aggregateScores(scores.map((s) => s.metrics));
-
-  return enrichResult({
-    meta,
-    engramVersion: "",
-    gitSha: "",
-    timestamp: "",
-    adapterMode: "direct",
-    taskCount: scores.length,
-    scores,
-    aggregate,
-    config: {
-      limit: options.limit,
-      datasetDir: options.datasetDir,
-      profiles_run: profiles.length,
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
     },
-    durationMs,
-  });
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
-export const amemGymRunner: LegacyBenchmarkRunner = { meta, run };
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<AMemGymProfile[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetProfiles = (
+    profiles: AMemGymProfile[],
+  ): AMemGymProfile[] => {
+    if (profiles.length === 0) {
+      throw new Error(
+        "AMemGym dataset is empty after applying the requested limit.",
+      );
+    }
+    return profiles;
+  };
+
+  if (datasetDir) {
+    const datasetErrors: string[] = [];
+    for (const filename of DATASET_FILENAMES) {
+      try {
+        const raw = await readFile(path.join(datasetDir, filename), "utf8");
+        const parsed = parseDataset(raw, filename);
+        return ensureDatasetProfiles(applyLimit(parsed, normalizedLimit));
+      } catch (error) {
+        datasetErrors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `AMemGym dataset not found under ${datasetDir}. Tried ${DATASET_FILENAMES.join(", ")}. Errors: ${datasetErrors.join(" | ")}`,
+    );
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "AMemGym full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetProfiles(applyLimit(AMEMGYM_SMOKE_FIXTURE, normalizedLimit));
+}
+
+function parseDataset(raw: string, filename: string): AMemGymProfile[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `AMemGym dataset file ${filename} must contain an array of user profiles.`,
+    );
+  }
+  return parsed as AMemGymProfile[];
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      "AMemGym limit must be a non-negative integer when provided.",
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return items;
+  }
+  return items.slice(0, limit);
+}
+
+function buildSessionMessages(session: AMemGymSession): Message[] {
+  const messages: Message[] = [];
+
+  if (session.event) {
+    messages.push({
+      role: "assistant",
+      content: `[Context update]: ${session.event}`,
+    });
+  }
+
+  if (session.query) {
+    messages.push({
+      role: "user",
+      content: session.query,
+    });
+  }
+
+  for (const message of session.messages) {
+    messages.push({
+      role: normalizeRole(message.role),
+      content: message.content,
+    });
+  }
+
+  if (messages.length === 0 && Object.keys(session.exposed_states).length > 0) {
+    const stateDescription = Object.entries(session.exposed_states)
+      .map(([key, value]) => `${key}: ${value}`)
+      .join(", ");
+    messages.push({
+      role: "user",
+      content: `[User state]: ${stateDescription}`,
+    });
+  }
+
+  return messages;
+}
+
+function normalizeRole(role: string): Message["role"] {
+  if (role === "assistant" || role === "system") {
+    return role;
+  }
+  return "user";
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -8,6 +8,10 @@ import {
   runAmaBenchBenchmark,
 } from "./benchmarks/published/ama-bench/runner.js";
 import {
+  amemGymDefinition,
+  runAMemGymBenchmark,
+} from "./benchmarks/published/amemgym/runner.js";
+import {
   memoryArenaDefinition,
   runMemoryArenaBenchmark,
 } from "./benchmarks/published/memory-arena/runner.js";
@@ -30,17 +34,8 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     run: runMemoryArenaBenchmark,
   },
   {
-    id: "amemgym",
-    title: "AMemGym",
-    tier: "published",
-    status: "planned",
-    runnerAvailable: false,
-    meta: {
-      name: "amemgym",
-      version: "1.0.0",
-      description: "Interactive personalization benchmark.",
-      category: "agentic",
-    },
+    ...amemGymDefinition,
+    run: runAMemGymBenchmark,
   },
   {
     ...longMemEvalDefinition,

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -1,0 +1,246 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function createDatasetProfile() {
+  return [
+    {
+      id: "dataset-profile-1",
+      start_time: "2025-02-01T00:00:00Z",
+      user_profile: {
+        uuid: "dataset-user-1",
+        name: "Jordan",
+        age: 34,
+        gender: "nonbinary",
+      },
+      state_schema: {
+        city: { type: "string" },
+      },
+      periods: [
+        {
+          period_start: "2025-02-01T00:00:00Z",
+          period_end: "2025-02-28T23:59:59Z",
+          period_summary: "Jordan moved cities.",
+          sessions: [
+            {
+              event: "Jordan moved to Seattle.",
+              exposed_states: { city: "Seattle" },
+              query: "I live in Seattle now after the move.",
+              messages: [],
+              session_time: "2025-02-12T08:00:00Z",
+            },
+          ],
+          state: { city: "Seattle" },
+          updates: { city: "Seattle" },
+          update_cnts: { city: 1 },
+        },
+      ],
+      qas: [
+        {
+          query: "Where does Jordan live now?",
+          required_info: ["city"],
+          answer_choices: [
+            { state: ["Seattle"], answer: "Seattle" },
+            { state: ["Denver"], answer: "Denver" },
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+test("runBenchmark executes amemgym in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("amemgym", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "amemgym");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(result.results.tasks[0]?.expected, "Chicago");
+  assert.equal(result.results.tasks[1]?.expected, "trail mix");
+  assert.equal(result.results.tasks[1]?.actual.includes("trail mix"), true);
+});
+
+test("runBenchmark executes amemgym in full mode from an explicit dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Seattle");
+});
+
+test("runBenchmark rejects amemgym full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("amemgym", {
+        mode: "full",
+        system: adapter,
+      }),
+    /AMemGym full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when amemgym full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("amemgym", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /AMemGym dataset not found under/,
+  );
+});
+
+test("runBenchmark fails fast when amemgym full mode is given an explicit unreadable dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bad-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "data.json"), "{not json");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("amemgym", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /AMemGym dataset not found under/,
+  );
+});
+
+test("runBenchmark rejects empty amemgym datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-empty-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    "[]",
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("amemgym", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /AMemGym dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark treats amemgym limit zero as an empty run instead of falling back to all profiles", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("amemgym", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /AMemGym dataset is empty after applying the requested limit/,
+  );
+});

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -16,7 +16,7 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,longmemeval",
+    "ama-bench,memory-arena,amemgym,longmemeval",
   );
 });
 
@@ -47,6 +47,16 @@ test("getBenchmark returns longmemeval metadata with a runnable benchmark entry"
   assert.equal(benchmark?.id, "longmemeval");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns amemgym metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("amemgym");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "amemgym");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "agentic");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary
- migrate AMemGym into the phase-1 `@remnic/bench` contract
- add a bundled quick fixture and make `amemgym` runnable in the published registry
- cover the runner, registry surface, and quick CLI path with focused tests

## Verification
- `npx tsx --test tests/bench-amemgym-runner.test.ts tests/bench-ama-bench-runner.test.ts tests/bench-registry.test.ts tests/bench-memory-arena-runner.test.ts tests/bench-longmemeval-quick.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `node scripts/run-bench-cli.mjs run --quick amemgym`

## Stack
- stacked on #461

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new benchmark runners and dataset loading/validation paths (including file I/O and JSON parsing) and wires them into the published registry, which could affect CLI/package behavior if edge cases are missed; changes are isolated to `@remnic/bench` and covered by new tests.
> 
> **Overview**
> Publishes **runnable phase-1 implementations** of the `amemgym` and `ama-bench` benchmarks in `@remnic/bench`, including bundled *quick-mode smoke fixtures* and `full`-mode dataset loading.
> 
> Both runners are migrated to the phase-1 `BenchmarkResult` contract (task-level `scores`, aggregates, meta/config/cost/environment fields), add dataset validation/fail-fast errors (missing datasetDir, empty datasets, malformed JSON/records), and are now marked `ready`/`runnerAvailable` and executable via the benchmark registry.
> 
> Adds focused tests for the new runners (quick + full dataset cases and error handling) and updates registry tests to assert `ama-bench`/`amemgym` are runnable. Also bumps workspace version `9.3.29` → `9.3.30`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5f8b9f26bbb043b42cc3df605dcc7dbeb59de40d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->