### PR TITLE
feat(bench): publish locomo runner

### DIFF
--- a/packages/bench/src/benchmarks/published/locomo/fixture.ts
+++ b/packages/bench/src/benchmarks/published/locomo/fixture.ts
@@ -1,0 +1,69 @@
+export interface LoCoMoTurn {
+  speaker: string;
+  dia_id: string;
+  text: string;
+}
+
+export interface LoCoMoQA {
+  question: string;
+  answer: string;
+  evidence: string[];
+  category: number;
+}
+
+export interface LoCoMoConversation {
+  sample_id: string;
+  conversation: Record<string, unknown>;
+  qa: LoCoMoQA[];
+  event_summary?: unknown;
+  observation?: unknown;
+  session_summary?: unknown;
+}
+
+export const LOCOMO_SMOKE_FIXTURE: LoCoMoConversation[] = [
+  {
+    sample_id: "locomo-smoke-1",
+    conversation: {
+      speaker_a: "Maya",
+      speaker_b: "Assistant",
+      session_1: [
+        {
+          speaker: "Maya",
+          dia_id: "D1:1",
+          text: "I moved to Seattle last spring after accepting the new role.",
+        },
+        {
+          speaker: "Assistant",
+          dia_id: "D1:2",
+          text: "Seattle sounds exciting. I'll remember that move.",
+        },
+      ],
+      session_2: [
+        {
+          speaker: "Maya",
+          dia_id: "D2:1",
+          text: "My favorite tea is jasmine, especially during rainy mornings.",
+        },
+        {
+          speaker: "Assistant",
+          dia_id: "D2:2",
+          text: "Jasmine tea on rainy mornings. Got it.",
+        },
+      ],
+    },
+    qa: [
+      {
+        question: "Which city did Maya move to?",
+        answer: "Seattle",
+        evidence: ["D1:1"],
+        category: 1,
+      },
+      {
+        question: "What tea does Maya prefer on rainy mornings?",
+        answer: "jasmine",
+        evidence: ["D2:1"],
+        category: 2,
+      },
+    ],
+  },
+];

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -1,59 +1,32 @@
 /**
- * LoCoMo runner — Evaluating Very Long-Term Conversational Memory of LLM Agents.
- *
- * 10 long conversations (~300 turns, ~9K tokens each, up to 35 sessions).
- * 1,986 QA pairs across 5 categories.
- *
- * Categories (from paper):
- *   1 = single-hop        (factual retrieval from one turn)
- *   2 = multi-hop          (requires combining info across turns)
- *   3 = temporal           (time-based reasoning)
- *   4 = open-domain        (general questions about the conversation)
- *   5 = adversarial/unanswerable
- *
- * Published baselines (QA F1, from paper Table 2):
- *   GPT-4 + full context:  ~0.62  |  GPT-4 + RAG:  ~0.49
- *   LLaMA-2 70B + RAG:     ~0.36  |  Human:        ~0.86
- *
- * Dataset: https://github.com/snap-research/locomo
- * Paper:   Maharana et al. Evaluating Very Long-Term Conversational Memory of LLM Agents. ACL 2024.
+ * LoCoMo runner migrated into @remnic/bench for phase 1.
  */
 
+import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
+import type { Message } from "../../../adapters/types.js";
+import {
+  LOCOMO_SMOKE_FIXTURE,
+  type LoCoMoConversation,
+  type LoCoMoQA,
+  type LoCoMoTurn,
+} from "./fixture.js";
 import type {
-  LegacyBenchmarkRunner,
-  LegacyBenchmarkResult,
-  LegacyBenchmarkMeta,
-  MemorySystem,
-  TaskScore,
-} from "../../../adapters/types.js";
-import { f1Score, containsAnswer, rougeL, llmJudgeScore, aggregateScores, timed } from "../../../scorer.js";
-import { enrichResult } from "../../../reporter.js";
-
-// ── Dataset types (matches locomo10.json) ──
-
-interface LoCoMoTurn {
-  speaker: string;
-  dia_id: string;
-  text: string;
-}
-
-interface LoCoMoQA {
-  question: string;
-  answer: string;
-  evidence: string[]; // e.g. ["D1:3", "D5:12"]
-  category: number;   // 1-5
-}
-
-interface LoCoMoConversation {
-  sample_id: string;
-  conversation: Record<string, any>; // speaker_a, speaker_b, session_1, session_1_date_time, etc.
-  qa: LoCoMoQA[];
-  event_summary: any;
-  observation: any;
-  session_summary: any;
-}
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  rougeL,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
 const CATEGORY_NAMES: Record<number, string> = {
   1: "single_hop",
@@ -63,164 +36,316 @@ const CATEGORY_NAMES: Record<number, string> = {
   5: "adversarial",
 };
 
-async function loadDataset(datasetDir: string): Promise<LoCoMoConversation[]> {
-  for (const filename of ["locomo10.json", "locomo.json"]) {
-    try {
-      const raw = await readFile(path.join(datasetDir, filename), "utf-8");
-      const data: LoCoMoConversation[] = JSON.parse(raw);
-      console.log(`  Loaded ${data.length} conversations from ${filename}`);
-      return data;
-    } catch {
-      continue;
-    }
-  }
-  throw new Error(
-    `LoCoMo dataset not found at ${datasetDir}. Download with:\n` +
-    `  git clone --depth 1 https://github.com/snap-research/locomo.git /tmp/locomo && cp /tmp/locomo/data/locomo10.json ${datasetDir}/`,
-  );
-}
-
 /** Extract sessions from the conversation dict as ordered (sessionId, turns) pairs. */
-function extractSessions(conv: Record<string, any>): Array<{ sessionId: string; turns: LoCoMoTurn[] }> {
+function extractSessions(
+  conversation: Record<string, unknown>,
+): Array<{ sessionId: string; turns: LoCoMoTurn[] }> {
   const sessions: Array<{ sessionId: string; turns: LoCoMoTurn[] }> = [];
-  const sessionKeys = Object.keys(conv)
-    .filter((k) => k.match(/^session_\d+$/) && Array.isArray(conv[k]))
+  const sessionKeys = Object.keys(conversation)
+    .filter(
+      (key) =>
+        /^session_\d+$/.test(key) && Array.isArray(conversation[key]),
+    )
     .sort((a, b) => {
-      const na = parseInt(a.replace("session_", ""));
-      const nb = parseInt(b.replace("session_", ""));
-      return na - nb;
+      const leftIndex = Number.parseInt(a.replace("session_", ""), 10);
+      const rightIndex = Number.parseInt(b.replace("session_", ""), 10);
+      return leftIndex - rightIndex;
     });
 
   for (const key of sessionKeys) {
     sessions.push({
       sessionId: key,
-      turns: conv[key] as LoCoMoTurn[],
+      turns: conversation[key] as LoCoMoTurn[],
     });
   }
   return sessions;
 }
 
-const meta: LegacyBenchmarkMeta = {
-  name: "locomo",
-  version: "2.0.0",
-  description: "Long conversation memory — 1,986 QA pairs across 10 multi-session conversations (ACL 2024)",
-  category: "conversational",
-  citation: "Maharana et al. Evaluating Very Long-Term Conversational Memory of LLM Agents. ACL 2024.",
+function buildMessages(
+  turns: LoCoMoTurn[],
+  speakerA: string,
+): Message[] {
+  return turns.map((turn) => ({
+    role: turn.speaker === speakerA ? "user" : "assistant",
+    content: turn.text,
+  }));
+}
+
+export const locomoDefinition: BenchmarkDefinition = {
+  id: "locomo",
+  title: "LoCoMo",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "locomo",
+    version: "2.0.0",
+    description:
+      "Long conversation memory benchmark across multi-session dialogue transcripts and QA probes.",
+    category: "conversational",
+    citation:
+      "Maharana et al. Evaluating Very Long-Term Conversational Memory of LLM Agents. ACL 2024.",
+  },
 };
 
-async function run(
-  system: MemorySystem,
-  options: { limit?: number; datasetDir: string },
-): Promise<LegacyBenchmarkResult> {
-  const conversations = await loadDataset(options.datasetDir);
-  const scores: TaskScore[] = [];
-  const overallStart = performance.now();
+export async function runLoCoMoBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const conversations = await loadDataset(
+    options.mode,
+    options.datasetDir,
+    options.limit,
+  );
+  const tasks: TaskResult[] = [];
 
-  // Limit applies to conversations (each has ~200 QA pairs)
-  const convsToRun = options.limit ? conversations.slice(0, options.limit) : conversations;
+  for (const conversation of conversations) {
+    await options.system.reset();
 
-  for (let ci = 0; ci < convsToRun.length; ci++) {
-    const conv = convsToRun[ci];
-    await system.reset();
-
-    console.log(`  [locomo] Conversation ${ci + 1}/${convsToRun.length} (${conv.sample_id}): ${conv.qa.length} QA pairs`);
-
-    // Phase 1: Ingest all sessions
-    const sessions = extractSessions(conv.conversation);
-    const speakerA = conv.conversation.speaker_a ?? "Speaker A";
-    const speakerB = conv.conversation.speaker_b ?? "Speaker B";
+    const sessions = extractSessions(conversation.conversation);
+    const speakerA =
+      typeof conversation.conversation.speaker_a === "string"
+        ? conversation.conversation.speaker_a
+        : "Speaker A";
+    const sessionIds: string[] = [];
 
     for (const session of sessions) {
-      // Map speaker turns to user/assistant roles
-      // speakerA → user, speakerB → assistant (convention from paper)
-      const messages = session.turns.map((t) => ({
-        role: (t.speaker === speakerA ? "user" : "assistant") as "user" | "assistant",
-        content: t.text,
-      }));
+      const sessionId = `${conversation.sample_id}-${session.sessionId}`;
+      const messages = buildMessages(session.turns, speakerA);
+      sessionIds.push(sessionId);
       if (messages.length > 0) {
-        await system.store(`${conv.sample_id}-${session.sessionId}`, messages);
+        await options.system.store(sessionId, messages);
       }
     }
 
-    // Phase 2: Query each QA pair
-    const sessionIds = sessions.map((s) => `${conv.sample_id}-${s.sessionId}`);
-
-    for (let qi = 0; qi < conv.qa.length; qi++) {
-      const qa = conv.qa[qi];
-      const catName = CATEGORY_NAMES[qa.category] ?? `cat_${qa.category}`;
-
-      const { result: recallText, durationMs } = await timed(async () => {
-        // Recall from all sessions
-        const parts: string[] = [];
-        for (const sid of sessionIds) {
-          const r = await system.recall(sid, qa.question);
-          if (r && r.trim().length > 0) parts.push(r);
-        }
-        return parts.join("\n\n");
+    for (
+      let questionIndex = 0;
+      questionIndex < conversation.qa.length;
+      questionIndex += 1
+    ) {
+      const qa = conversation.qa[questionIndex]!;
+      const categoryName =
+        CATEGORY_NAMES[qa.category] ?? `category_${qa.category}`;
+      const { result: recalledText, durationMs } = await timed(async () => {
+        const recalledSessions = await Promise.all(
+          sessionIds.map((sessionId) =>
+            options.system.recall(sessionId, qa.question),
+          ),
+        );
+        return recalledSessions.filter(Boolean).join("\n\n");
       });
+      const judgeScore = await llmJudgeScore(
+        options.system.judge,
+        qa.question,
+        recalledText,
+        qa.answer,
+      );
 
-      const f1 = f1Score(recallText, qa.answer);
-      const contains = containsAnswer(recallText, qa.answer);
-      const rouge = rougeL(recallText, qa.answer);
-      const judgeScore = await llmJudgeScore(system.judge, qa.question, recallText, qa.answer);
-
-      const metrics: Record<string, number> = {
-        f1,
-        contains_answer: contains,
-        rouge_l: rouge,
+      const scores: Record<string, number> = {
+        f1: f1Score(recalledText, qa.answer),
+        contains_answer: containsAnswer(recalledText, qa.answer),
+        rouge_l: rougeL(recalledText, qa.answer),
       };
-      if (judgeScore >= 0) metrics.llm_judge = judgeScore;
+      if (judgeScore >= 0) {
+        scores.llm_judge = judgeScore;
+      }
 
-      scores.push({
-        taskId: `${conv.sample_id}-q${qi}-${catName}`,
-        metrics,
-        details: {
-          question: qa.question,
-          expected: qa.answer,
-          category: qa.category,
-          category_name: catName,
-          evidence: qa.evidence,
-          conversation_id: conv.sample_id,
-          recalled_length: recallText.length,
-        },
+      tasks.push({
+        taskId: `${conversation.sample_id}-q${questionIndex}-${categoryName}`,
+        question: qa.question,
+        expected: qa.answer,
+        actual: recalledText,
+        scores,
         latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          category: qa.category,
+          categoryName,
+          evidence: qa.evidence,
+          conversationId: conversation.sample_id,
+          sessionIds,
+          recalledLength: recalledText.length,
+        },
       });
     }
   }
 
-  const durationMs = Math.round(performance.now() - overallStart);
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
 
-  // Overall aggregate
-  const aggregate = aggregateScores(scores.map((s) => s.metrics));
-
-  // Per-category aggregates
-  for (const [catNum, catName] of Object.entries(CATEGORY_NAMES)) {
-    const catScores = scores.filter((s) => (s.details as any)?.category === parseInt(catNum));
-    if (catScores.length > 0) {
-      const catF1 = catScores.map((s) => s.metrics.f1);
-      const catContains = catScores.map((s) => s.metrics.contains_answer);
-      aggregate[`${catName}_f1`] = catF1.reduce((a, b) => a + b, 0) / catF1.length;
-      aggregate[`${catName}_accuracy`] = catContains.reduce((a, b) => a + b, 0) / catContains.length;
-      aggregate[`${catName}_count`] = catScores.length;
-    }
-  }
-
-  return enrichResult({
-    meta,
-    engramVersion: "",
-    gitSha: "",
-    timestamp: "",
-    adapterMode: "direct",
-    taskCount: scores.length,
-    scores,
-    aggregate,
-    config: {
-      limit: options.limit,
-      datasetDir: options.datasetDir,
-      conversations_run: convsToRun.length,
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
     },
-    durationMs,
-  });
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
-export const locomoRunner: LegacyBenchmarkRunner = { meta, run };
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<LoCoMoConversation[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetConversations = (
+    conversations: LoCoMoConversation[],
+  ): LoCoMoConversation[] => {
+    if (conversations.length === 0) {
+      throw new Error(
+        "LoCoMo dataset is empty after applying the requested limit.",
+      );
+    }
+    return conversations;
+  };
+
+  if (datasetDir) {
+    const datasetErrors: string[] = [];
+    for (const filename of ["locomo10.json", "locomo.json"]) {
+      try {
+        const raw = await readFile(path.join(datasetDir, filename), "utf8");
+        const parsed = parseDataset(raw, filename);
+        return ensureDatasetConversations(
+          applyLimit(parsed, normalizedLimit),
+        );
+      } catch (error) {
+        datasetErrors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `LoCoMo dataset not found under ${datasetDir}. Tried locomo10.json and locomo.json. Errors: ${datasetErrors.join(" | ")}`,
+    );
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetConversations(
+    applyLimit(LOCOMO_SMOKE_FIXTURE, normalizedLimit),
+  );
+}
+
+function parseDataset(
+  raw: string,
+  filename: string,
+): LoCoMoConversation[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `LoCoMo dataset file ${filename} must contain an array of conversations.`,
+    );
+  }
+
+  return parsed.map((entry, index) => parseConversation(entry, filename, index));
+}
+
+function parseConversation(
+  entry: unknown,
+  filename: string,
+  index: number,
+): LoCoMoConversation {
+  const location = `LoCoMo dataset file ${filename} conversation ${index + 1}`;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(`${location} must be an object.`);
+  }
+
+  const record = entry as Record<string, unknown>;
+  if (typeof record.sample_id !== "string") {
+    throw new Error(`${location} must include a string sample_id.`);
+  }
+  if (
+    !record.conversation ||
+    typeof record.conversation !== "object" ||
+    Array.isArray(record.conversation)
+  ) {
+    throw new Error(`${location} must include a conversation object.`);
+  }
+  if (!isValidQaArray(record.qa)) {
+    throw new Error(
+      `${location} must include a qa array with question/answer/evidence/category fields.`,
+    );
+  }
+
+  return {
+    sample_id: record.sample_id,
+    conversation: record.conversation as Record<string, unknown>,
+    qa: record.qa as LoCoMoQA[],
+    event_summary: record.event_summary,
+    observation: record.observation,
+    session_summary: record.session_summary,
+  };
+}
+
+function isValidQaArray(value: unknown): value is LoCoMoQA[] {
+  return Array.isArray(value) && value.every(isValidQa);
+}
+
+function isValidQa(value: unknown): value is LoCoMoQA {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  const record = value as Record<string, unknown>;
+  return (
+    typeof record.question === "string" &&
+    typeof record.answer === "string" &&
+    Number.isInteger(record.category) &&
+    Array.isArray(record.evidence) &&
+    record.evidence.every((item) => typeof item === "string")
+  );
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      "LoCoMo limit must be a non-negative integer when provided.",
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -19,6 +19,10 @@ import {
   longMemEvalDefinition,
   runLongMemEvalBenchmark,
 } from "./benchmarks/published/longmemeval/runner.js";
+import {
+  locomoDefinition,
+  runLoCoMoBenchmark,
+} from "./benchmarks/published/locomo/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -42,17 +46,8 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     run: runLongMemEvalBenchmark,
   },
   {
-    id: "locomo",
-    title: "LoCoMo",
-    tier: "published",
-    status: "planned",
-    runnerAvailable: false,
-    meta: {
-      name: "locomo",
-      version: "1.0.0",
-      description: "Long conversation memory benchmark.",
-      category: "conversational",
-    },
+    ...locomoDefinition,
+    run: runLoCoMoBenchmark,
   },
 ];
 

--- a/tests/bench-locomo-runner.test.ts
+++ b/tests/bench-locomo-runner.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function createDatasetConversation() {
+  return [
+    {
+      sample_id: "locomo-dataset-1",
+      conversation: {
+        speaker_a: "Jordan",
+        speaker_b: "Assistant",
+        session_1: [
+          {
+            speaker: "Jordan",
+            dia_id: "D1:1",
+            text: "I moved to Austin in January for the new project.",
+          },
+          {
+            speaker: "Assistant",
+            dia_id: "D1:2",
+            text: "Austin in January. I'll keep that in mind.",
+          },
+        ],
+      },
+      qa: [
+        {
+          question: "Which city did Jordan move to?",
+          answer: "Austin",
+          evidence: ["D1:1"],
+          category: 1,
+        },
+      ],
+    },
+  ];
+}
+
+test("runBenchmark executes locomo in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("locomo", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "locomo");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(typeof result.results.aggregates.rouge_l?.mean, "number");
+  assert.equal(result.results.tasks[0]?.expected, "Seattle");
+  assert.equal(result.results.tasks[0]?.actual.includes("Seattle"), true);
+  assert.equal(result.results.tasks[0]?.details.categoryName, "single_hop");
+});
+
+test("runBenchmark executes locomo in full mode from an explicit dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-locomo-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "locomo");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "locomo10.json"),
+    JSON.stringify(createDatasetConversation()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("locomo", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Austin");
+});
+
+test("runBenchmark rejects locomo full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("locomo", {
+        mode: "full",
+        system: adapter,
+      }),
+    /LoCoMo full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when locomo full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-locomo-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("locomo", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /LoCoMo dataset not found under/,
+  );
+});
+
+test("runBenchmark fails fast when locomo full mode is given an explicit unreadable dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-locomo-bad-"));
+  const datasetDir = path.join(tmpDir, "datasets", "locomo");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "locomo10.json"), "{not json");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("locomo", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /LoCoMo dataset not found under/,
+  );
+});
+
+test("runBenchmark rejects empty locomo datasets", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-locomo-empty-"));
+  const datasetDir = path.join(tmpDir, "datasets", "locomo");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "locomo10.json"), "[]", "utf8");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("locomo", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /LoCoMo dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark treats locomo limit zero as an empty run instead of falling back to all conversations", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("locomo", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /LoCoMo dataset is empty after applying the requested limit/,
+  );
+});

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -16,7 +16,7 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo",
   );
 });
 
@@ -57,6 +57,16 @@ test("getBenchmark returns amemgym metadata with a runnable benchmark entry", ()
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "agentic");
+});
+
+test("getBenchmark returns locomo metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("locomo");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "locomo");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "conversational");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary
- migrate LoCoMo into the phase-1 `@remnic/bench` contract
- add a bundled quick fixture and make `locomo` runnable in the published registry
- cover the runner, registry surface, and quick CLI path with focused tests

## Verification
- `npx tsx --test tests/bench-locomo-runner.test.ts tests/bench-amemgym-runner.test.ts tests/bench-ama-bench-runner.test.ts tests/bench-registry.test.ts tests/bench-memory-arena-runner.test.ts tests/bench-longmemeval-quick.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `node scripts/run-bench-cli.mjs run --quick locomo`

## Notes
- final phase-1 published benchmark slice for issue #445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runnable published benchmark with filesystem dataset loading/parsing and result generation, which could impact bench execution and error handling paths. Changes are localized to the bench package and covered by new tests, keeping overall risk moderate.
> 
> **Overview**
> Publishes the **LoCoMo** benchmark as a runnable entry in `@remnic/bench`, including a new `locomoDefinition` and `runLoCoMoBenchmark` that stores session turns, recalls across sessions per question, and reports per-task scores (`f1`, `rouge_l`, `contains_answer`, optional `llm_judge`) with phase-1 `BenchmarkResult` metadata.
> 
> Adds a bundled *quick-mode* smoke fixture (`LOCOMO_SMOKE_FIXTURE`) and implements dataset loading for *full mode* via `datasetDir` with stricter parsing/validation, limit handling (including `limit: 0` as empty), and clearer error messages. Updates the published registry to mark `locomo` as **ready/runnable**, and adds focused tests covering quick/full runs plus failure cases and registry exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba761584be910bd0c82491194ccd82b862423a9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->