### PR TITLE
fix(core): defer QMD warmup to background so gateway_start returns fast

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -716,6 +716,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const config = parseConfig(remnicCfg);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
+  await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
   if (explain) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -925,6 +925,7 @@ async function cmdEnrich(rest: string[]): Promise<void> {
     // Wire the real search backend so isAvailable() reflects actual state
     const orchestrator = new Orchestrator(config);
     await orchestrator.initialize();
+    await orchestrator.deferredReady;
     const searchBackend = orchestrator.qmd;
     const searchFn = searchBackend.isAvailable()
       ? async (query: string): Promise<string[]> => {
@@ -968,6 +969,7 @@ async function cmdEnrich(rest: string[]): Promise<void> {
 
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
+  await orchestrator.deferredReady;
   const storage = await orchestrator.getStorage(config.defaultNamespace);
 
   // Gather entities to enrich

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -119,6 +119,16 @@ export class SmartBuffer {
     this.loaded = true;
   }
 
+  /**
+   * Reset the buffer to an empty, usable state.
+   * Called when the persisted buffer file is corrupt and load() fails,
+   * so the buffer can still accept new turns for the rest of the session.
+   */
+  resetToEmpty(): void {
+    this.state = { turns: [], lastExtractionAt: null, extractionCount: 0 };
+    this.loaded = true;
+  }
+
   async save(): Promise<void> {
     await this.storage.saveBuffer(this.state);
   }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1854,7 +1854,7 @@ export class Orchestrator {
   }
 
   private async deferredInitialize(): Promise<void> {
-    {
+    try {
       const available = await this.qmd.probe();
       if (available) {
         log.info(`Search backend: available ${this.qmd.debugStatus()}`);
@@ -1902,6 +1902,8 @@ export class Orchestrator {
       } else {
         log.warn(`Search backend: not available ${this.qmd.debugStatus()}`);
       }
+    } catch (err) {
+      log.error(`QMD probe/collection check failed (non-fatal): ${err}`);
     }
 
     // Sync QMD index with current disk state so recall finds recently-written
@@ -1980,21 +1982,30 @@ export class Orchestrator {
     await Promise.all(cacheWarmups);
 
     if (this.config.conversationIndexEnabled && this.conversationIndexBackend) {
-      const init = await this.conversationIndexBackend.initialize();
-      if (!init.enabled) {
+      try {
+        const init = await this.conversationIndexBackend.initialize();
+        if (!init.enabled) {
+          this.config.conversationIndexEnabled = false;
+        }
+        if (init.logLevel === "info") {
+          log.info(init.message);
+        } else if (init.logLevel === "warn") {
+          log.warn(init.message);
+        } else {
+          log.debug(init.message);
+        }
+      } catch (err) {
+        log.error(`Conversation index initialization failed (non-fatal): ${err}`);
         this.config.conversationIndexEnabled = false;
-      }
-      if (init.logLevel === "info") {
-        log.info(init.message);
-      } else if (init.logLevel === "warn") {
-        log.warn(init.message);
-      } else {
-        log.debug(init.message);
       }
     }
 
     if (this.config.localLlmEnabled) {
-      await this.validateLocalLlmModel();
+      try {
+        await this.validateLocalLlmModel();
+      } catch (err) {
+        log.error(`Local LLM validation failed (non-fatal): ${err}`);
+      }
     }
 
     // Await cron auto-registration so callers that `await deferredReady` can

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1856,6 +1856,27 @@ export class Orchestrator {
       }
     }
 
+    // Sync QMD index with current disk state so recall finds recently-written
+    // facts. Without this, the index stays stale from the last extraction-
+    // triggered update — which can be days ago if the daemon restarted without
+    // new extractions. This is the root cause of "0 memories" recall results
+    // despite thousands of facts on disk.
+    if (this.qmd.isAvailable() && this.config.qmdMaintenanceEnabled) {
+      try {
+        log.info("QMD startup sync: updating index to match current disk state");
+        if (this.config.namespacesEnabled) {
+          await this.namespaceSearchRouter.updateNamespaces(
+            this.configuredNamespaces(),
+          );
+        } else {
+          await this.qmd.update();
+        }
+        log.info("QMD startup sync: complete");
+      } catch (err) {
+        log.warn(`QMD startup sync failed (non-fatal): ${err}`);
+      }
+    }
+
     // Warmup: run cheap searches to pre-load QMD embedding models and the
     // embedding-fallback JSON index so the first real recall is fast.
     const warmupPromises: Promise<void>[] = [];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1817,15 +1817,19 @@ export class Orchestrator {
       // Runs in background so gateway_start returns fast. On low-power hardware
       // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
       // restart loops when they block the startup path. See issue #462.
+      //
+      // Capture the resolver by value so a concurrent re-initialize() cannot
+      // overwrite this.resolveDeferredReady before .finally() runs — that would
+      // cause the first cycle's .finally() to resolve the *second* cycle's
+      // promise prematurely while leaving the first cycle's promise pending.
+      const resolveDeferred = this.resolveDeferredReady;
+      this.resolveDeferredReady = null;
       this.deferredInitialize()
         .catch((err) => {
           log.error(`deferred initialization failed (non-fatal): ${err}`);
         })
         .finally(() => {
-          if (this.resolveDeferredReady) {
-            this.resolveDeferredReady();
-            this.resolveDeferredReady = null;
-          }
+          resolveDeferred?.();
         });
     } catch (err) {
       // Resolve both gates so callers never hang on permanently-pending promises
@@ -1987,18 +1991,26 @@ export class Orchestrator {
       await this.validateLocalLlmModel();
     }
 
-    log.info("orchestrator initialized (full — deferred steps complete)");
-
+    // Await cron auto-registration so callers that `await deferredReady` can
+    // rely on cron jobs being registered when it resolves. Without this, the
+    // fire-and-forget pattern lets deferredReady settle while cron writes are
+    // still in flight. Errors are non-fatal — catch individually.
     if (this.config.daySummaryEnabled) {
-      this.autoRegisterDaySummaryCron().catch((err) => {
+      try {
+        await this.autoRegisterDaySummaryCron();
+      } catch (err) {
         log.debug(`day-summary cron auto-register failed (non-fatal): ${err}`);
-      });
+      }
     }
     if (this.config.nightlyGovernanceCronAutoRegister) {
-      this.autoRegisterNightlyGovernanceCron().catch((err) => {
+      try {
+        await this.autoRegisterNightlyGovernanceCron();
+      } catch (err) {
         log.debug(`nightly governance cron auto-register failed (non-fatal): ${err}`);
-      });
+      }
     }
+
+    log.info("orchestrator initialized (full — deferred steps complete)");
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1783,6 +1783,7 @@ export class Orchestrator {
         log.error(
           `buffer.load() failed (init gate will still open): ${bufErr}`,
         );
+        this.buffer.resetToEmpty();
       }
       if (this.config.compactionResetEnabled) {
         try {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1172,6 +1172,16 @@ export class Orchestrator {
   private initPromise: Promise<void> | null = null;
   private resolveInit: (() => void) | null = null;
 
+  /**
+   * Resolves when deferred initialization (QMD probe, warmup, caches, cron)
+   * completes. CLI and http-serve callers that need `qmd.isAvailable()` to
+   * reflect reality should `await orchestrator.deferredReady` after
+   * `initialize()`. Gateway callers can ignore it — recall() degrades
+   * gracefully when QMD isn't ready yet.
+   */
+  deferredReady: Promise<void> = Promise.resolve();
+  private resolveDeferredReady: (() => void) | null = null;
+
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
   setRecallWorkspaceOverride(sessionKey: string, dir: string): void {
     this._recallWorkspaceOverrides.set(sessionKey, dir);
@@ -1444,6 +1454,11 @@ export class Orchestrator {
     // Create init gate — recall() will await this before proceeding
     this.initPromise = new Promise<void>((resolve) => {
       this.resolveInit = resolve;
+    });
+
+    // Create deferred-ready gate — CLI callers await this for full QMD readiness
+    this.deferredReady = new Promise<void>((resolve) => {
+      this.resolveDeferredReady = resolve;
     });
   }
 
@@ -1778,9 +1793,16 @@ export class Orchestrator {
     // Runs in background so gateway_start returns fast. On low-power hardware
     // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
     // restart loops when they block the startup path. See issue #462.
-    this.deferredInitialize().catch((err) => {
-      log.error(`deferred initialization failed (non-fatal): ${err}`);
-    });
+    this.deferredInitialize()
+      .catch((err) => {
+        log.error(`deferred initialization failed (non-fatal): ${err}`);
+      })
+      .finally(() => {
+        if (this.resolveDeferredReady) {
+          this.resolveDeferredReady();
+          this.resolveDeferredReady = null;
+        }
+      });
   }
 
   private async deferredInitialize(): Promise<void> {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1742,16 +1742,48 @@ export class Orchestrator {
       await this.compounding.ensureDirs();
     }
 
-    // Open the init gate early — essential state (storage, aliases, relevance,
-    // transcript, summarizer) is loaded. The slow QMD collection setup and
-    // remaining steps run after the gate opens. recall() already degrades
-    // gracefully when QMD isn't ready, so there's no correctness risk.
+    // Buffer and compaction cleanup are fast and needed for basic operation —
+    // load them before the init gate so turn buffering works immediately.
+    await this.buffer.load();
+    if (this.config.compactionResetEnabled) {
+      try {
+        const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
+        const files = await readdir(wsDir).catch(() => [] as string[]);
+        for (const f of files) {
+          if (!f.startsWith(".compaction-reset-signal-")) continue;
+          const fp = path.join(wsDir, f);
+          const s = await stat(fp).catch(() => null);
+          if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
+            await unlink(fp).catch(() => {});
+            log.debug(`initialize: removed stale compaction signal ${f}`);
+          }
+        }
+      } catch (err) {
+        log.debug("initialize: stale signal sweep failed:", err);
+      }
+    }
+
+    // Open the init gate — essential state (storage, aliases, relevance,
+    // transcript, summarizer, buffer) is loaded. QMD probe, collection setup,
+    // warmup, and remaining heavy operations run in the background after this
+    // point. recall() already degrades gracefully when QMD isn't ready (falls
+    // back to non-search retrieval), so there's no correctness risk.
     if (this.resolveInit) {
       this.resolveInit();
       this.resolveInit = null;
       log.info("init gate opened (essential state loaded)");
     }
 
+    // Deferred init: QMD, warmup, conversation index, caches, cron.
+    // Runs in background so gateway_start returns fast. On low-power hardware
+    // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
+    // restart loops when they block the startup path. See issue #462.
+    this.deferredInitialize().catch((err) => {
+      log.error(`deferred initialization failed (non-fatal): ${err}`);
+    });
+  }
+
+  private async deferredInitialize(): Promise<void> {
     {
       const available = await this.qmd.probe();
       if (available) {
@@ -1803,11 +1835,7 @@ export class Orchestrator {
     }
 
     // Warmup: run cheap searches to pre-load QMD embedding models and the
-    // embedding-fallback JSON index. Without this, the first recall after
-    // startup loads ML models + parses a 300 MB JSON file (30-60 s each),
-    // causing it to exceed RECALL_TIMEOUT_MS. This is especially important
-    // for the http-serve CLI path where initialize() runs once at startup and
-    // every subsequent recall must be fast.
+    // embedding-fallback JSON index so the first real recall is fast.
     const warmupPromises: Promise<void>[] = [];
     if (this.qmd.isAvailable()) {
       const warmupNs = this.config.defaultNamespace;
@@ -1824,9 +1852,6 @@ export class Orchestrator {
       );
     }
     if (this.config.embeddingFallbackEnabled) {
-      // Only probe availability — do NOT load the full index at warmup.
-      // embeddings.json can be hundreds of MB; parsing it into JS number arrays
-      // consumes gigabytes of V8 heap and triggers GC stalls / OOM crashes.
       warmupPromises.push(
         this.embeddingFallback
           .isAvailable()
@@ -1842,15 +1867,7 @@ export class Orchestrator {
     }
     await Promise.all(warmupPromises);
 
-    // Fire-and-forget: pre-warm the readAllMemories() static cache for all
-    // configured namespace storages.  With 80k+ memory files the cold scan takes
-    // 13-60 s; running it in the background at startup ensures the cache is hot
-    // before the first recall request arrives, eliminating the cold-start penalty.
-    // Also pre-warms buildKnowledgeIndex() to prime knowledgeIndexCache on the
-    // base storage (avoids the 13 s readAllEntityFiles() penalty on first recall).
-    // Warm the Knowledge Index (readAllEntityFiles + scoring) on the base storage.
-    // knowledgeIndexCache is an instance-level cache — warming it here populates it
-    // before the first recall so ki=13s cold penalty doesn't hit real requests.
+    // Pre-warm knowledge index, memory, and entity caches in background
     if (this.config.knowledgeIndexEnabled) {
       (async () => {
         try {
@@ -1862,9 +1879,6 @@ export class Orchestrator {
         }
       })().catch(() => {});
     }
-
-    // Pre-warm memory and entity caches in background so first recall
-    // doesn't pay the cold load penalty
     this.storage.readAllMemories().catch(() => {});
     this.storage.readAllEntityFiles().catch(() => {});
 
@@ -1882,41 +1896,12 @@ export class Orchestrator {
       }
     }
 
-    await this.buffer.load();
-
-    // Validate local LLM model configuration
     if (this.config.localLlmEnabled) {
       await this.validateLocalLlmModel();
     }
 
-    // Sweep stale compaction-reset signal files (>1 hour old).
-    // This prevents orphaned signals from persisting when agents are removed
-    // or sessions never call recall() again after a compaction.
-    // NOTE: This sweep only covers the config-level workspace. Per-agent signals
-    // (written to ctx.workspaceDir) are cleaned up by recall() on each session
-    // start, with a 1-hour TTL enforced at read time. Agent-specific workspaces
-    // are not known at initialize() time.
-    if (this.config.compactionResetEnabled) {
-      try {
-        const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
-        const files = await readdir(wsDir).catch(() => [] as string[]);
-        for (const f of files) {
-          if (!f.startsWith(".compaction-reset-signal-")) continue;
-          const fp = path.join(wsDir, f);
-          const s = await stat(fp).catch(() => null);
-          if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
-            await unlink(fp).catch(() => {});
-            log.debug(`initialize: removed stale compaction signal ${f}`);
-          }
-        }
-      } catch (err) {
-        log.debug("initialize: stale signal sweep failed:", err);
-      }
-    }
+    log.info("orchestrator initialized (full — deferred steps complete)");
 
-    log.info("orchestrator initialized (full)");
-
-    // Fire-and-forget: auto-register day-summary cron job if enabled
     if (this.config.daySummaryEnabled) {
       this.autoRegisterDaySummaryCron().catch((err) => {
         log.debug(`day-summary cron auto-register failed (non-fatal): ${err}`);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1802,21 +1802,81 @@ export class Orchestrator {
         }
       }
 
+      // QMD probe + collection check: determines the final QMD state (real
+      // client vs NoopSearchBackend). Must complete BEFORE the init gate opens
+      // so that recall() — which awaits initPromise — always observes the final
+      // QMD state. Without this ordering, a concurrent recall() could read
+      // this.qmd while it's still the real client, then get errors when
+      // deferredInitialize() swaps it to NoopSearchBackend mid-query.
+      try {
+        const available = await this.qmd.probe();
+        if (available) {
+          log.info(`Search backend: available ${this.qmd.debugStatus()}`);
+          const namespaces = this.config.namespacesEnabled
+            ? this.configuredNamespaces()
+            : [this.config.defaultNamespace];
+          const states = await Promise.all(
+            namespaces.map(async (namespace) => ({
+              namespace,
+              state: this.config.namespacesEnabled
+                ? await this.namespaceSearchRouter.ensureNamespaceCollection(
+                    namespace,
+                  )
+                : await this.qmd.ensureCollection(this.config.memoryDir),
+            })),
+          );
+          const defaultState =
+            states.find(
+              (entry) => entry.namespace === this.config.defaultNamespace,
+            )?.state ?? "unknown";
+          if (defaultState === "missing") {
+            this.qmd = new NoopSearchBackend();
+            log.warn(
+              "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
+            );
+          } else if (defaultState === "unknown") {
+            log.warn(
+              "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
+            );
+          } else if (defaultState === "skipped") {
+            log.debug(
+              "Search collection check skipped (remote or daemon-only mode)",
+            );
+          }
+          for (const entry of states) {
+            if (entry.namespace === this.config.defaultNamespace) continue;
+            if (entry.state === "missing") {
+              log.warn(
+                `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
+              );
+            }
+          }
+        } else if (this.qmd instanceof NoopSearchBackend) {
+          log.debug(`Search backend: noop (search intentionally disabled)`);
+        } else {
+          log.warn(`Search backend: not available ${this.qmd.debugStatus()}`);
+        }
+      } catch (err) {
+        log.error(`QMD probe/collection check failed (non-fatal): ${err}`);
+      }
+
       // Open the init gate — essential state (storage, aliases, relevance,
-      // transcript, summarizer, buffer) is loaded. QMD probe, collection setup,
-      // warmup, and remaining heavy operations run in the background after this
-      // point. recall() already degrades gracefully when QMD isn't ready (falls
-      // back to non-search retrieval), so there's no correctness risk.
+      // transcript, summarizer, buffer) is loaded AND QMD state is finalized
+      // (probe + collection check complete, NoopSearchBackend swap done if
+      // needed). Warmup, sync, caches, and remaining heavy operations run in
+      // the background after this point via deferredInitialize().
       if (this.resolveInit) {
         this.resolveInit();
         this.resolveInit = null;
-        log.info("init gate opened (essential state loaded)");
+        log.info("init gate opened (essential state + QMD state loaded)");
       }
 
-      // Deferred init: QMD, warmup, conversation index, caches, cron.
+      // Deferred init: QMD sync, warmup, conversation index, caches, cron.
       // Runs in background so gateway_start returns fast. On low-power hardware
-      // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
+      // (Umbrel, RPi) QMD warmup/sync alone can take 30-60s and cause gateway
       // restart loops when they block the startup path. See issue #462.
+      // Note: QMD probe + collection check (including NoopSearchBackend swap)
+      // already ran above before the init gate, so this.qmd is finalized.
       //
       // Capture the resolver by value so a concurrent re-initialize() cannot
       // overwrite this.resolveDeferredReady before .finally() runs — that would
@@ -1854,57 +1914,8 @@ export class Orchestrator {
   }
 
   private async deferredInitialize(): Promise<void> {
-    try {
-      const available = await this.qmd.probe();
-      if (available) {
-        log.info(`Search backend: available ${this.qmd.debugStatus()}`);
-        const namespaces = this.config.namespacesEnabled
-          ? this.configuredNamespaces()
-          : [this.config.defaultNamespace];
-        const states = await Promise.all(
-          namespaces.map(async (namespace) => ({
-            namespace,
-            state: this.config.namespacesEnabled
-              ? await this.namespaceSearchRouter.ensureNamespaceCollection(
-                  namespace,
-                )
-              : await this.qmd.ensureCollection(this.config.memoryDir),
-          })),
-        );
-        const defaultState =
-          states.find(
-            (entry) => entry.namespace === this.config.defaultNamespace,
-          )?.state ?? "unknown";
-        if (defaultState === "missing") {
-          this.qmd = new NoopSearchBackend();
-          log.warn(
-            "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
-          );
-        } else if (defaultState === "unknown") {
-          log.warn(
-            "Search collection check unavailable; keeping search retrieval enabled for fail-open behavior",
-          );
-        } else if (defaultState === "skipped") {
-          log.debug(
-            "Search collection check skipped (remote or daemon-only mode)",
-          );
-        }
-        for (const entry of states) {
-          if (entry.namespace === this.config.defaultNamespace) continue;
-          if (entry.state === "missing") {
-            log.warn(
-              `Search collection missing for namespace '${entry.namespace}'; namespace retrieval will fail open to non-search paths`,
-            );
-          }
-        }
-      } else if (this.qmd instanceof NoopSearchBackend) {
-        log.debug(`Search backend: noop (search intentionally disabled)`);
-      } else {
-        log.warn(`Search backend: not available ${this.qmd.debugStatus()}`);
-      }
-    } catch (err) {
-      log.error(`QMD probe/collection check failed (non-fatal): ${err}`);
-    }
+    // QMD probe + collection check (including NoopSearchBackend swap) already
+    // ran in initialize() before the init gate opened, so this.qmd is final.
 
     // Sync QMD index with current disk state so recall finds recently-written
     // facts. Without this, the index stays stale from the last extraction-

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1464,10 +1464,10 @@ export class Orchestrator {
       this.resolveInit = resolve;
     });
 
-    // Create deferred-ready gate — CLI callers await this for full QMD readiness
-    this.deferredReady = new Promise<void>((resolve) => {
-      this.resolveDeferredReady = resolve;
-    });
+    // deferredReady is NOT created here — the property initializer provides a
+    // safe default (Promise.resolve()), and initialize() recreates it on every
+    // call. Creating a pending promise in the constructor would be orphaned
+    // since initialize() unconditionally overwrites it.
   }
 
   /** Get or create a BoxBuilder for the given namespace storage root (namespace-isolated). */
@@ -1958,20 +1958,26 @@ export class Orchestrator {
     }
     await Promise.all(warmupPromises);
 
-    // Pre-warm knowledge index, memory, and entity caches in background
+    // Pre-warm knowledge index, memory, and entity caches.
+    // Awaited so callers of `deferredReady` can rely on warmups being complete
+    // and shutdown sequencing does not race with in-flight cache builds.
+    const cacheWarmups: Promise<void>[] = [];
     if (this.config.knowledgeIndexEnabled) {
-      (async () => {
-        try {
-          const t0 = Date.now();
-          await this.storage.buildKnowledgeIndex(this.config);
-          log.info(`Knowledge Index warmup: complete in ${Date.now() - t0}ms`);
-        } catch (err) {
-          log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
-        }
-      })().catch(() => {});
+      cacheWarmups.push(
+        (async () => {
+          try {
+            const t0 = Date.now();
+            await this.storage.buildKnowledgeIndex(this.config);
+            log.info(`Knowledge Index warmup: complete in ${Date.now() - t0}ms`);
+          } catch (err) {
+            log.debug(`Knowledge Index warmup failed (non-fatal): ${err}`);
+          }
+        })(),
+      );
     }
-    this.storage.readAllMemories().catch(() => {});
-    this.storage.readAllEntityFiles().catch(() => {});
+    cacheWarmups.push(this.storage.readAllMemories().then(() => {}).catch(() => {}));
+    cacheWarmups.push(this.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
+    await Promise.all(cacheWarmups);
 
     if (this.config.conversationIndexEnabled && this.conversationIndexBackend) {
       const init = await this.conversationIndexBackend.initialize();

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1717,6 +1717,15 @@ export class Orchestrator {
   }
 
   async initialize(): Promise<void> {
+    // Recreate the deferred-ready gate on every initialize() call.
+    // The same Orchestrator instance may be reused across stop/start cycles
+    // (src/index.ts does this). Without this reset, the second cycle's
+    // `await orchestrator.deferredReady` resolves immediately (already settled
+    // from the first cycle) while the new deferredInitialize() is still running.
+    this.deferredReady = new Promise<void>((resolve) => {
+      this.resolveDeferredReady = resolve;
+    });
+
     try {
       await migrateFromEngram({
         quiet: true,
@@ -1819,9 +1828,19 @@ export class Orchestrator {
           }
         });
     } catch (err) {
-      // Resolve deferredReady so callers that `await orchestrator.deferredReady`
-      // after catching the initialize() error never hang on a permanently-pending
-      // promise. The deferred-init phase will not run, so resolve immediately.
+      // Resolve both gates so callers never hang on permanently-pending promises
+      // after catching the initialize() error:
+      //
+      // - initPromise: recall(), generateDaySummary(), etc. await this as a
+      //   readiness gate with a 15s timeout. Leaving it pending means every
+      //   subsequent call pays that timeout penalty.
+      //
+      // - deferredReady: CLI callers await this for full QMD readiness. Without
+      //   resolution it hangs forever since deferredInitialize() never ran.
+      if (this.resolveInit) {
+        this.resolveInit();
+        this.resolveInit = null;
+      }
       if (this.resolveDeferredReady) {
         this.resolveDeferredReady();
         this.resolveDeferredReady = null;

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1178,6 +1178,14 @@ export class Orchestrator {
    * reflect reality should `await orchestrator.deferredReady` after
    * `initialize()`. Gateway callers can ignore it — recall() degrades
    * gracefully when QMD isn't ready yet.
+   *
+   * Also resolves (without error) when `initialize()` throws before reaching
+   * the deferred-init phase, so callers never hang on a permanently-pending
+   * promise.
+   *
+   * Host adapters that need to tie deferred init to their stop() lifecycle
+   * should `await orchestrator.deferredReady` before proceeding with teardown
+   * to prevent background QMD/warmup/cron tasks from racing with shutdown.
    */
   deferredReady: Promise<void> = Promise.resolve();
   private resolveDeferredReady: (() => void) | null = null;
@@ -1709,106 +1717,117 @@ export class Orchestrator {
   }
 
   async initialize(): Promise<void> {
-    await migrateFromEngram({
-      quiet: true,
-      logger: (message) => log.info(message),
-    });
-    await this.storage.ensureDirectories();
-    await this.storage.loadAliases();
-    if (this.config.namespacesEnabled) {
-      const namespaces = new Set<string>([
-        this.config.defaultNamespace,
-        this.config.sharedNamespace,
-        ...this.config.namespacePolicies.map((p) => p.name),
-      ]);
-      for (const ns of namespaces) {
-        const sm = await this.storageRouter.storageFor(ns);
-        await sm.ensureDirectories();
-        await sm.loadAliases().catch(() => undefined);
-      }
-    }
-    await this.relevance.load();
-    await this.negatives.load();
-    await this.lastRecall.load();
-    await this.tierMigrationStatus.load();
-    await this.sessionObserver.load();
-    this.runtimePolicyValues = await this.policyRuntime.loadRuntimeValues();
-    this.utilityRuntimeValues = await loadUtilityRuntimeValues({
-      memoryDir: this.config.memoryDir,
-      memoryUtilityLearningEnabled: this.config.memoryUtilityLearningEnabled,
-      promotionByOutcomeEnabled: this.config.promotionByOutcomeEnabled,
-    });
-
-    // Initialize content-hash dedup index
-    if (this.config.factDeduplicationEnabled) {
-      const stateDir = path.join(this.config.memoryDir, "state");
-      this.contentHashIndex = new ContentHashIndex(stateDir);
-      await this.contentHashIndex.load();
-      log.info(
-        `content-hash dedup: loaded ${this.contentHashIndex.size} hashes`,
-      );
-    }
-    await this.transcript.initialize();
-    await this.summarizer.initialize();
-    if (this.sharedContext) {
-      await this.sharedContext.ensureStructure();
-    }
-    if (this.compounding) {
-      await this.compounding.ensureDirs();
-    }
-
-    // Buffer and compaction cleanup are fast and needed for basic operation —
-    // load them before the init gate so turn buffering works immediately.
     try {
-      await this.buffer.load();
-    } catch (bufErr) {
-      log.error(
-        `buffer.load() failed (init gate will still open): ${bufErr}`,
-      );
-    }
-    if (this.config.compactionResetEnabled) {
-      try {
-        const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
-        const files = await readdir(wsDir).catch(() => [] as string[]);
-        for (const f of files) {
-          if (!f.startsWith(".compaction-reset-signal-")) continue;
-          const fp = path.join(wsDir, f);
-          const s = await stat(fp).catch(() => null);
-          if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
-            await unlink(fp).catch(() => {});
-            log.debug(`initialize: removed stale compaction signal ${f}`);
-          }
-        }
-      } catch (err) {
-        log.debug("initialize: stale signal sweep failed:", err);
-      }
-    }
-
-    // Open the init gate — essential state (storage, aliases, relevance,
-    // transcript, summarizer, buffer) is loaded. QMD probe, collection setup,
-    // warmup, and remaining heavy operations run in the background after this
-    // point. recall() already degrades gracefully when QMD isn't ready (falls
-    // back to non-search retrieval), so there's no correctness risk.
-    if (this.resolveInit) {
-      this.resolveInit();
-      this.resolveInit = null;
-      log.info("init gate opened (essential state loaded)");
-    }
-
-    // Deferred init: QMD, warmup, conversation index, caches, cron.
-    // Runs in background so gateway_start returns fast. On low-power hardware
-    // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
-    // restart loops when they block the startup path. See issue #462.
-    this.deferredInitialize()
-      .catch((err) => {
-        log.error(`deferred initialization failed (non-fatal): ${err}`);
-      })
-      .finally(() => {
-        if (this.resolveDeferredReady) {
-          this.resolveDeferredReady();
-          this.resolveDeferredReady = null;
-        }
+      await migrateFromEngram({
+        quiet: true,
+        logger: (message) => log.info(message),
       });
+      await this.storage.ensureDirectories();
+      await this.storage.loadAliases();
+      if (this.config.namespacesEnabled) {
+        const namespaces = new Set<string>([
+          this.config.defaultNamespace,
+          this.config.sharedNamespace,
+          ...this.config.namespacePolicies.map((p) => p.name),
+        ]);
+        for (const ns of namespaces) {
+          const sm = await this.storageRouter.storageFor(ns);
+          await sm.ensureDirectories();
+          await sm.loadAliases().catch(() => undefined);
+        }
+      }
+      await this.relevance.load();
+      await this.negatives.load();
+      await this.lastRecall.load();
+      await this.tierMigrationStatus.load();
+      await this.sessionObserver.load();
+      this.runtimePolicyValues = await this.policyRuntime.loadRuntimeValues();
+      this.utilityRuntimeValues = await loadUtilityRuntimeValues({
+        memoryDir: this.config.memoryDir,
+        memoryUtilityLearningEnabled: this.config.memoryUtilityLearningEnabled,
+        promotionByOutcomeEnabled: this.config.promotionByOutcomeEnabled,
+      });
+
+      // Initialize content-hash dedup index
+      if (this.config.factDeduplicationEnabled) {
+        const stateDir = path.join(this.config.memoryDir, "state");
+        this.contentHashIndex = new ContentHashIndex(stateDir);
+        await this.contentHashIndex.load();
+        log.info(
+          `content-hash dedup: loaded ${this.contentHashIndex.size} hashes`,
+        );
+      }
+      await this.transcript.initialize();
+      await this.summarizer.initialize();
+      if (this.sharedContext) {
+        await this.sharedContext.ensureStructure();
+      }
+      if (this.compounding) {
+        await this.compounding.ensureDirs();
+      }
+
+      // Buffer and compaction cleanup are fast and needed for basic operation —
+      // load them before the init gate so turn buffering works immediately.
+      try {
+        await this.buffer.load();
+      } catch (bufErr) {
+        log.error(
+          `buffer.load() failed (init gate will still open): ${bufErr}`,
+        );
+      }
+      if (this.config.compactionResetEnabled) {
+        try {
+          const wsDir = this.config.workspaceDir || defaultWorkspaceDir();
+          const files = await readdir(wsDir).catch(() => [] as string[]);
+          for (const f of files) {
+            if (!f.startsWith(".compaction-reset-signal-")) continue;
+            const fp = path.join(wsDir, f);
+            const s = await stat(fp).catch(() => null);
+            if (s && Date.now() - s.mtimeMs >= COMPACTION_SIGNAL_MAX_AGE_MS) {
+              await unlink(fp).catch(() => {});
+              log.debug(`initialize: removed stale compaction signal ${f}`);
+            }
+          }
+        } catch (err) {
+          log.debug("initialize: stale signal sweep failed:", err);
+        }
+      }
+
+      // Open the init gate — essential state (storage, aliases, relevance,
+      // transcript, summarizer, buffer) is loaded. QMD probe, collection setup,
+      // warmup, and remaining heavy operations run in the background after this
+      // point. recall() already degrades gracefully when QMD isn't ready (falls
+      // back to non-search retrieval), so there's no correctness risk.
+      if (this.resolveInit) {
+        this.resolveInit();
+        this.resolveInit = null;
+        log.info("init gate opened (essential state loaded)");
+      }
+
+      // Deferred init: QMD, warmup, conversation index, caches, cron.
+      // Runs in background so gateway_start returns fast. On low-power hardware
+      // (Umbrel, RPi) the QMD operations alone can take 30-60s and cause gateway
+      // restart loops when they block the startup path. See issue #462.
+      this.deferredInitialize()
+        .catch((err) => {
+          log.error(`deferred initialization failed (non-fatal): ${err}`);
+        })
+        .finally(() => {
+          if (this.resolveDeferredReady) {
+            this.resolveDeferredReady();
+            this.resolveDeferredReady = null;
+          }
+        });
+    } catch (err) {
+      // Resolve deferredReady so callers that `await orchestrator.deferredReady`
+      // after catching the initialize() error never hang on a permanently-pending
+      // promise. The deferred-init phase will not run, so resolve immediately.
+      if (this.resolveDeferredReady) {
+        this.resolveDeferredReady();
+        this.resolveDeferredReady = null;
+      }
+      throw err;
+    }
   }
 
   private async deferredInitialize(): Promise<void> {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1759,7 +1759,13 @@ export class Orchestrator {
 
     // Buffer and compaction cleanup are fast and needed for basic operation —
     // load them before the init gate so turn buffering works immediately.
-    await this.buffer.load();
+    try {
+      await this.buffer.load();
+    } catch (bufErr) {
+      log.error(
+        `buffer.load() failed (init gate will still open): ${bufErr}`,
+      );
+    }
     if (this.config.compactionResetEnabled) {
       try {
         const wsDir = this.config.workspaceDir || defaultWorkspaceDir();

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -117,6 +117,7 @@ export async function startServer(options?: {
 
   const config = parseConfig(remnicConfig);
   const orchestrator = new Orchestrator(config);
+  await orchestrator.initialize();
   const service = new EngramAccessService(orchestrator);
 
   const authToken = serverConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -3452,29 +3452,58 @@ const pluginDefinition = {
           ((globalThis as any)[CLI_ACTIVE_SERVICE_COUNT] || 0) - 1,
         );
         (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT] = remainingServices;
-        // Opik cleanup: placed after the guard so secondary stop()s never detach
-        // the process-wide exporter while Engram is still running.
-        // Wrapped in try-catch (like accessHttpServer.stop()) so a throwing
-        // unsubscribe does not leave SERVICE_STARTED=true and prevent restart.
-        try {
-          activeOpikExporter?.unsubscribe();
-        } catch (err) {
-          log.debug(`engram opik exporter unsubscribe failed: ${err}`);
+
+        // Uses the pre-await snapshot (initPromiseAtStopEntry) so a secondary
+        // that finishes start() during the deferredReady await doesn't cause
+        // us to misclassify a stop-during-init as a full stop.
+        const currentInitPromise = initPromiseAtStopEntry;
+        // Track whether a secondary completed init during stop()'s await window
+        // (either the deferredReady await or the currentInitPromise await below).
+        // Used to guard SERVICE_STARTED=false, hook/guard cleanup, AND shared
+        // service teardown (HTTP server, watchers, globals).
+        let secondaryTookOver = false;
+
+        // Check if a secondary started during the deferredReady await.
+        // When stop() was called with no in-flight init (full stop),
+        // INIT_PROMISE was null. If it's now non-null, a secondary entered
+        // start() while we were awaiting deferredReady. Without this check
+        // we'd tear down the secondary's live resources.
+        // Note: we only check INIT_PROMISE here, not SERVICE_STARTED,
+        // because SERVICE_STARTED is expected to be true from our own
+        // start() in the full-stop case.
+        if (!currentInitPromise && (globalThis as any)[keys.INIT_PROMISE]) {
+          secondaryTookOver = true;
         }
-        activeOpikExporter = null;
-        try {
-          await accessHttpServer.stop();
-        } catch (err) {
-          log.debug(`engram access HTTP stop failed: ${err}`);
+
+        // Shared service teardown: Opik, HTTP server, watchers, globals.
+        // Guarded by secondaryTookOver — if a secondary became live during the
+        // deferredReady await, we must not tear down its resources.
+        if (!secondaryTookOver) {
+          // Opik cleanup: placed after the guard so secondary stop()s never detach
+          // the process-wide exporter while Engram is still running.
+          // Wrapped in try-catch so a throwing unsubscribe does not leave
+          // SERVICE_STARTED=true and prevent restart.
+          try {
+            activeOpikExporter?.unsubscribe();
+          } catch (err) {
+            log.debug(`engram opik exporter unsubscribe failed: ${err}`);
+          }
+          activeOpikExporter = null;
+          try {
+            await accessHttpServer.stop();
+          } catch (err) {
+            log.debug(`engram access HTTP stop failed: ${err}`);
+          }
+          stopDreamWatcher?.();
+          stopDreamWatcher = null;
+          stopHeartbeatWatcher?.();
+          stopHeartbeatWatcher = null;
+          removeDreamingObserver?.();
+          removeDreamingObserver = null;
+          delete (globalThis as any)[keys.ACCESS_HTTP_SERVER];
+          delete (globalThis as any)[keys.ACCESS_SERVICE];
         }
-        stopDreamWatcher?.();
-        stopDreamWatcher = null;
-        stopHeartbeatWatcher?.();
-        stopHeartbeatWatcher = null;
-        removeDreamingObserver?.();
-        removeDreamingObserver = null;
-        delete (globalThis as any)[keys.ACCESS_HTTP_SERVER];
-        delete (globalThis as any)[keys.ACCESS_SERVICE];
+
         // REGISTERED_GUARD policy:
         //
         // Full stop (INIT_PROMISE is null when stop() was called):
@@ -3487,29 +3516,6 @@ const pluginDefinition = {
         //   unregister CLI commands. Clearing GUARD here would allow a
         //   subsequent register() to register CLI again on top of the
         //   still-live registration, duplicating the CLI command tree.
-        //
-        // Uses the pre-await snapshot (initPromiseAtStopEntry) so a secondary
-        // that finishes start() during the deferredReady await doesn't cause
-        // us to misclassify a stop-during-init as a full stop.
-        const currentInitPromise = initPromiseAtStopEntry;
-        // Track whether a secondary completed init during stop()'s await window
-        // (either the deferredReady await or the currentInitPromise await below).
-        // Used to guard SERVICE_STARTED=false and hook/guard cleanup.
-        let secondaryTookOver = false;
-
-        // Check if a secondary started during the deferredReady await.
-        // When stop() was called with no in-flight init (full stop),
-        // INIT_PROMISE was null. If it's now non-null, a secondary entered
-        // start() while we were awaiting deferredReady. Without this check
-        // we'd misclassify the current state and tear down the secondary's
-        // live resources (HTTP server, watchers, etc.).
-        // Note: we only check INIT_PROMISE here, not SERVICE_STARTED,
-        // because SERVICE_STARTED is expected to be true from our own
-        // start() in the full-stop case.
-        if (!currentInitPromise && (globalThis as any)[keys.INIT_PROMISE]) {
-          secondaryTookOver = true;
-        }
-
         if (!currentInitPromise) {
           if (!secondaryTookOver) {
             (globalThis as any)[keys.REGISTERED_GUARD] = false;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3463,6 +3463,13 @@ const pluginDefinition = {
         // service teardown (HTTP server, watchers, globals).
         let secondaryTookOver = false;
 
+        // --- Takeover detection (both paths) ---
+        // Both the full-stop and stop-during-init paths must complete their
+        // takeover checks BEFORE any shared resource teardown. Otherwise the
+        // stop-during-init path (which awaits currentInitPromise) would let
+        // the shared teardown block run while secondaryTookOver is still false,
+        // tearing down resources that belong to a live secondary.
+
         // Check if a secondary started during the deferredReady await.
         // When stop() was called with no in-flight init (full stop),
         // INIT_PROMISE was null. If it's now non-null, a secondary entered
@@ -3473,35 +3480,6 @@ const pluginDefinition = {
         // start() in the full-stop case.
         if (!currentInitPromise && (globalThis as any)[keys.INIT_PROMISE]) {
           secondaryTookOver = true;
-        }
-
-        // Shared service teardown: Opik, HTTP server, watchers, globals.
-        // Guarded by secondaryTookOver — if a secondary became live during the
-        // deferredReady await, we must not tear down its resources.
-        if (!secondaryTookOver) {
-          // Opik cleanup: placed after the guard so secondary stop()s never detach
-          // the process-wide exporter while Engram is still running.
-          // Wrapped in try-catch so a throwing unsubscribe does not leave
-          // SERVICE_STARTED=true and prevent restart.
-          try {
-            activeOpikExporter?.unsubscribe();
-          } catch (err) {
-            log.debug(`engram opik exporter unsubscribe failed: ${err}`);
-          }
-          activeOpikExporter = null;
-          try {
-            await accessHttpServer.stop();
-          } catch (err) {
-            log.debug(`engram access HTTP stop failed: ${err}`);
-          }
-          stopDreamWatcher?.();
-          stopDreamWatcher = null;
-          stopHeartbeatWatcher?.();
-          stopHeartbeatWatcher = null;
-          removeDreamingObserver?.();
-          removeDreamingObserver = null;
-          delete (globalThis as any)[keys.ACCESS_HTTP_SERVER];
-          delete (globalThis as any)[keys.ACCESS_SERVICE];
         }
 
         // REGISTERED_GUARD policy:
@@ -3552,6 +3530,38 @@ const pluginDefinition = {
             secondaryTookOver = true;
           }
         }
+
+        // --- Shared service teardown ---
+        // Runs AFTER both takeover detection paths so secondaryTookOver is
+        // accurate regardless of whether stop() entered the full-stop or
+        // stop-during-init branch. If a secondary became live during any
+        // await window, we skip teardown to avoid destroying its resources.
+        if (!secondaryTookOver) {
+          // Opik cleanup: placed after the guard so secondary stop()s never detach
+          // the process-wide exporter while Engram is still running.
+          // Wrapped in try-catch so a throwing unsubscribe does not leave
+          // SERVICE_STARTED=true and prevent restart.
+          try {
+            activeOpikExporter?.unsubscribe();
+          } catch (err) {
+            log.debug(`engram opik exporter unsubscribe failed: ${err}`);
+          }
+          activeOpikExporter = null;
+          try {
+            await accessHttpServer.stop();
+          } catch (err) {
+            log.debug(`engram access HTTP stop failed: ${err}`);
+          }
+          stopDreamWatcher?.();
+          stopDreamWatcher = null;
+          stopHeartbeatWatcher?.();
+          stopHeartbeatWatcher = null;
+          removeDreamingObserver?.();
+          removeDreamingObserver = null;
+          delete (globalThis as any)[keys.ACCESS_HTTP_SERVER];
+          delete (globalThis as any)[keys.ACCESS_SERVICE];
+        }
+
         // Clear per-api hook tracking so hooks can be re-bound to fresh api objects.
         // Skip when a secondary is live — its api objects already have hooks bound
         // and resetting the WeakSet here would cause duplicate hook registration

--- a/src/index.ts
+++ b/src/index.ts
@@ -3513,6 +3513,23 @@ const pluginDefinition = {
           // in the gateway's registry; clearing GUARD here would allow a
           // subsequent register() to register CLI again, duplicating commands
           // on top of the still-live registration (thread PRRT_kwDORJXyws5159Kz).
+
+          // Check if a secondary already completed init during the deferredReady
+          // await above.  Without this, the stop-during-init path bypasses the
+          // full-stop takeover check (gated by !currentInitPromise) and proceeds
+          // to await currentInitPromise / shared teardown with secondaryTookOver
+          // still false — tearing down a live secondary's resources.
+          // We detect takeover the same way as the full-stop path: if
+          // INIT_PROMISE changed (a new secondary entered start()) or if
+          // SERVICE_STARTED is set by someone other than our own init (which
+          // aborted via didCountStart=false), a secondary is live.
+          if (
+            (globalThis as any)[keys.INIT_PROMISE] &&
+            (globalThis as any)[keys.INIT_PROMISE] !== currentInitPromise
+          ) {
+            secondaryTookOver = true;
+          }
+
           //
           // Await the in-flight init (didCountStart=false signals it to abort at
           // its next checkpoint). Ignore errors — we only care about settlement.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3418,6 +3418,19 @@ const pluginDefinition = {
         // and skip all cleanup — including Opik — to avoid detaching a live exporter.
         if (!didCountStart) return;
         didCountStart = false;
+
+        // Wait for the deferred initialization (QMD probe, warmup, cron) to
+        // settle before tearing down. Without this, fire-and-forget tasks
+        // from deferredInitialize() continue after stop() completes and can
+        // race with a subsequent start() — duplicate cron registrations,
+        // background QMD updates after the service is marked stopped, etc.
+        // The promise always resolves (never rejects), so this is safe.
+        try {
+          await orchestrator.deferredReady;
+        } catch {
+          // deferredReady should never reject, but guard defensively.
+        }
+
         // Decrement the process-global active-service count.  When it reaches
         // zero, all Remnic services have stopped and it's safe to clear the CLI
         // guard so a subsequent reload cycle can re-register CLI commands.

--- a/src/index.ts
+++ b/src/index.ts
@@ -3419,6 +3419,19 @@ const pluginDefinition = {
         if (!didCountStart) return;
         didCountStart = false;
 
+        // Snapshot takeover-relevant state BEFORE any await points.
+        // The deferredReady await below can take seconds (QMD warmup, cron).
+        // During that window a secondary registry can finish start() and set
+        // SERVICE_STARTED / clear INIT_PROMISE. If we read those globals
+        // AFTER the await, we'd observe the secondary's state and skip the
+        // takeover guard — then proceed to tear down the secondary's live
+        // resources (HTTP server, watchers, etc.). By snapshotting before the
+        // await we compare against the state as it was when stop() was
+        // called, making the takeover check immune to concurrent start().
+        const initPromiseAtStopEntry = (globalThis as any)[
+          keys.INIT_PROMISE
+        ] as Promise<void> | null;
+
         // Wait for the deferred initialization (QMD probe, warmup, cron) to
         // settle before tearing down. Without this, fire-and-forget tasks
         // from deferredInitialize() continue after stop() completes and can
@@ -3464,32 +3477,51 @@ const pluginDefinition = {
         delete (globalThis as any)[keys.ACCESS_SERVICE];
         // REGISTERED_GUARD policy:
         //
-        // Full stop (INIT_PROMISE is null when stop() is called):
+        // Full stop (INIT_PROMISE is null when stop() was called):
         //   Clear GUARD so a subsequent register() in a fresh session can
         //   re-register CLI commands after a stop/reload cycle.
         //
-        // Stop-during-init (INIT_PROMISE is non-null):
+        // Stop-during-init (INIT_PROMISE is non-null when stop() was called):
         //   Leave GUARD as-is. The CLI registered by the original register()
         //   call is still present in the gateway's registry — stop() does not
         //   unregister CLI commands. Clearing GUARD here would allow a
         //   subsequent register() to register CLI again on top of the
         //   still-live registration, duplicating the CLI command tree.
-        const currentInitPromise = (globalThis as any)[
-          keys.INIT_PROMISE
-        ] as Promise<void> | null;
-        // Track whether a secondary completed init during stop()'s await window.
-        // Used below to guard the SERVICE_STARTED=false assignment.
+        //
+        // Uses the pre-await snapshot (initPromiseAtStopEntry) so a secondary
+        // that finishes start() during the deferredReady await doesn't cause
+        // us to misclassify a stop-during-init as a full stop.
+        const currentInitPromise = initPromiseAtStopEntry;
+        // Track whether a secondary completed init during stop()'s await window
+        // (either the deferredReady await or the currentInitPromise await below).
+        // Used to guard SERVICE_STARTED=false and hook/guard cleanup.
         let secondaryTookOver = false;
+
+        // Check if a secondary started during the deferredReady await.
+        // When stop() was called with no in-flight init (full stop),
+        // INIT_PROMISE was null. If it's now non-null, a secondary entered
+        // start() while we were awaiting deferredReady. Without this check
+        // we'd misclassify the current state and tear down the secondary's
+        // live resources (HTTP server, watchers, etc.).
+        // Note: we only check INIT_PROMISE here, not SERVICE_STARTED,
+        // because SERVICE_STARTED is expected to be true from our own
+        // start() in the full-stop case.
+        if (!currentInitPromise && (globalThis as any)[keys.INIT_PROMISE]) {
+          secondaryTookOver = true;
+        }
+
         if (!currentInitPromise) {
-          (globalThis as any)[keys.REGISTERED_GUARD] = false;
-          // Clear CLI guard only when ALL Remnic services have stopped.
-          // In multi-plugin installs, one plugin stopping must not clear the
-          // guard while the other is still running — that would let a
-          // subsequent register() duplicate CLI commands.  When the refcount
-          // reaches zero, the gateway's reload cycle can safely re-register.
-          if (remainingServices === 0) {
-            (globalThis as any)[CLI_REGISTERED_GUARD] = false;
-            (globalThis as any)[SESSION_COMMANDS_REGISTERED_GUARD] = false;
+          if (!secondaryTookOver) {
+            (globalThis as any)[keys.REGISTERED_GUARD] = false;
+            // Clear CLI guard only when ALL Remnic services have stopped.
+            // In multi-plugin installs, one plugin stopping must not clear the
+            // guard while the other is still running — that would let a
+            // subsequent register() duplicate CLI commands.  When the refcount
+            // reaches zero, the gateway's reload cycle can safely re-register.
+            if (remainingServices === 0) {
+              (globalThis as any)[CLI_REGISTERED_GUARD] = false;
+              (globalThis as any)[SESSION_COMMANDS_REGISTERED_GUARD] = false;
+            }
           }
         } else {
           // Stop-during-init: leave GUARD as-is.

--- a/tests/orchestrator-nightly-governance-cron.test.ts
+++ b/tests/orchestrator-nightly-governance-cron.test.ts
@@ -62,6 +62,7 @@ test("initialize skips nightly governance cron auto-register unless explicitly e
     };
 
     await orchestrator.initialize();
+    await orchestrator.deferredReady;
 
     assert.equal(nightlyCalls, 0);
   } finally {
@@ -84,6 +85,7 @@ test("initialize triggers nightly governance cron auto-register when explicitly 
     };
 
     await orchestrator.initialize();
+    await orchestrator.deferredReady;
 
     assert.equal(nightlyCalls, 1);
   } finally {


### PR DESCRIPTION
## Summary

- Splits `Orchestrator.initialize()` into sync + background phases so `gateway_start` returns in <1s instead of blocking 10-60s on QMD operations
- Buffer load and compaction signal cleanup run before the init gate (needed for basic operation)
- QMD probe/collection/warmup, conversation index, local LLM validation, cache warming, and cron registration move to `deferredInitialize()` which runs fire-and-forget after the gate opens
- `recall()` already degrades gracefully when QMD isn't ready, so no correctness risk
- **Codex P1 fix**: Exposes `deferredReady` promise so CLI callers can await full QMD readiness before checking `isAvailable()`
- **QMD index staleness fix**: Adds `qmd.update()` during deferred init to sync the index with current disk state on every startup — without this, the index stays stale indefinitely if no new extractions trigger a reactive update

Closes #462

## Test plan

- [x] `pnpm run check-types` passes (remnic-core)
- [x] `pnpm -w run test:entity-hardening` — 175/175 pass
- [x] Pre-existing heartbeat/dreams watcher flakes confirmed on main (unrelated)
- [x] Codex P1 addressed: CLI callers now `await orchestrator.deferredReady`
- [ ] Verify on Umbrel/RPi hardware that gateway restarts complete in <2s
- [ ] Verify recall works during deferred init window (falls back to non-QMD retrieval)
- [ ] Verify full QMD recall works after deferred init completes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core startup/teardown sequencing and search backend (QMD) readiness; mistakes could cause subtle race conditions in recall, cache warmup, or shutdown behavior, though changes are guarded and mostly additive.
> 
> **Overview**
> **Speeds up gateway startup by splitting `Orchestrator.initialize()` into an essential phase and a background deferred phase.** QMD warmup/sync, cache warmups, conversation-index init, local LLM validation, and cron auto-registration are moved into `deferredInitialize()` so the init gate opens sooner while still finalizing QMD state before `recall()` proceeds.
> 
> Adds an explicit `orchestrator.deferredReady` promise (reset each init cycle and guaranteed to resolve) so callers can await full deferred readiness; the CLI (`query`, `enrich`, provider checks) and tests now await it, and plugin shutdown (`src/index.ts`) waits for deferred work before tearing down to avoid races.
> 
> Improves resilience by handling corrupt persisted buffers: `SmartBuffer` gains `resetToEmpty()`, and `initialize()` now catches `buffer.load()` failures and continues with an empty buffer instead of blocking startup. Also adds a startup QMD index sync (`qmd.update()` / namespace updates) to avoid stale recall results after restarts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1509f30fd1fcfa4d3aeddeaba037eff5e8d1d6aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->