### PR TITLE
fix(codex): finish remnic runtime rename

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3060,7 +3060,7 @@ const pluginDefinition = {
           id: jobId,
           agentId: "generalist",
           model,
-          name: "Engram Hourly Summary",
+          name: "Remnic Hourly Summary",
           enabled: true,
           createdAtMs: Date.now(),
           updatedAtMs: Date.now(),
@@ -3077,7 +3077,7 @@ const pluginDefinition = {
             thinking: "off" as const,
             message:
               "You are OpenClaw automation.\n\n" +
-              "Task: Generate Engram hourly summaries.\n\n" +
+              "Task: Generate Remnic hourly summaries.\n\n" +
               "Call the tool `memory_summarize_hourly` with empty params.\n\n" +
               "Output policy:\n" +
               "- If you generated summaries successfully: output exactly NO_REPLY.\n" +
@@ -3112,7 +3112,7 @@ const pluginDefinition = {
     // vs. reply contexts), each registry gets its own api object and must have
     // tools registered against it. Skipping registration on secondary calls
     // leaves those registries with hooks but zero tools, making
-    // memory_summarize_hourly (and all other Engram tools) invisible to the LLM.
+    // memory_summarize_hourly (and all other Remnic tools) invisible to the LLM.
     //
     // CLI commands, by contrast, live in the central plugin registry (not in
     // per-registry api state), so registering them more than once would create

--- a/tests/remnic-runtime-labels.test.ts
+++ b/tests/remnic-runtime-labels.test.ts
@@ -1,0 +1,12 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+
+test("runtime-facing hourly summary labels use Remnic naming", async () => {
+  const source = await readFile("src/index.ts", "utf8");
+
+  assert.match(source, /name: "Remnic Hourly Summary"/);
+  assert.match(source, /Task: Generate Remnic hourly summaries/);
+  assert.doesNotMatch(source, /name: "Engram Hourly Summary"/);
+  assert.doesNotMatch(source, /Task: Generate Engram hourly summaries/);
+});


### PR DESCRIPTION
## Summary
- rename the remaining active Codex runtime hourly-summary strings from Engram to Remnic
- add a small regression test so the runtime-facing labels do not drift back
- update the local QMD collection descriptions to describe Remnic rather than Engram

## Verification
- `npx tsx --test tests/remnic-runtime-labels.test.ts tests/user-message-cleaning.test.ts tests/sdk-compat-integration.test.ts`
- `rg -n "Engram Hourly Summary|Generate Engram hourly summaries|Remnic Hourly Summary|Generate Remnic hourly summaries" src tests`
- `rg -n "Engram memory plugin|Engram transcript conversation chunks|Remnic memory plugin|Remnic transcript conversation chunks" ~/.config/qmd/index.yml`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates human-facing cron job labels/prompt strings and adds a regression test; no behavior, data handling, or scheduling logic changes.
> 
> **Overview**
> Updates the auto-registered hourly summary cron job’s runtime-facing `name` and task prompt text from **Engram** to **Remnic**.
> 
> Adds `tests/remnic-runtime-labels.test.ts` to prevent these hourly-summary labels from drifting back to Engram wording.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffac8c3c0a15b47d416b297fc04aa572fc8d4eab. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->