### PR TITLE
feat(bench): add stats and comparison primitives

### DIFF
--- a/packages/bench/src/benchmark.ts
+++ b/packages/bench/src/benchmark.ts
@@ -10,6 +10,7 @@ import type {
   BenchConfig,
   BenchTier,
   BenchmarkDefinition,
+  BenchmarkMode,
   BenchmarkReport,
   BenchmarkResult,
   BenchmarkSuiteResult,
@@ -29,6 +30,7 @@ const DEFAULT_BASELINE_PATH = path.join(process.cwd(), "benchmarks", "baseline.j
 const DEFAULT_REPORT_PATH = path.join(process.cwd(), "benchmarks", "report.json");
 const BASELINE_VERSION = 1;
 const DEFAULT_TOLERANCE = 10;
+const DEFAULT_FULL_RUN_COUNT = 5;
 
 const DEFAULT_QUERIES = [
   "What is the storage?",
@@ -56,6 +58,62 @@ interface RecallResponse {
 function hrTimeMs(): number {
   const [seconds, nanos] = process.hrtime();
   return seconds * 1_000 + Math.round(nanos / 1_000_000);
+}
+
+export function resolveBenchmarkRunCount(
+  mode: BenchmarkMode,
+  requestedIterations?: number,
+): number {
+  if (mode === "quick") {
+    return 1;
+  }
+
+  if (requestedIterations === undefined) {
+    return DEFAULT_FULL_RUN_COUNT;
+  }
+
+  if (!Number.isInteger(requestedIterations) || requestedIterations <= 0) {
+    throw new Error("benchmark iterations must be a positive integer");
+  }
+
+  return requestedIterations;
+}
+
+export function buildBenchmarkRunSeeds(
+  runCount: number,
+  baseSeed?: number,
+): number[] {
+  if (!Number.isInteger(runCount) || runCount <= 0) {
+    throw new Error("benchmark run count must be a positive integer");
+  }
+
+  const firstSeed = baseSeed ?? 0;
+  if (!Number.isInteger(firstSeed) || firstSeed < 0) {
+    throw new Error("benchmark seed must be a non-negative integer");
+  }
+
+  return Array.from({ length: runCount }, (_, index) => firstSeed + index);
+}
+
+export async function orchestrateBenchmarkRuns<T>(
+  mode: BenchmarkMode,
+  executeRun: (seed: number, runIndex: number) => Promise<T>,
+  requestedIterations?: number,
+  baseSeed?: number,
+): Promise<{ runCount: number; seeds: number[]; runs: T[] }> {
+  const runCount = resolveBenchmarkRunCount(mode, requestedIterations);
+  const seeds = buildBenchmarkRunSeeds(runCount, baseSeed);
+  const runs: T[] = [];
+
+  for (const [runIndex, seed] of seeds.entries()) {
+    runs.push(await executeRun(seed, runIndex));
+  }
+
+  return {
+    runCount,
+    seeds,
+    runs,
+  };
 }
 
 export async function runBenchmark(

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -23,6 +23,11 @@ export type {
   TaskResult,
   MetricAggregate,
   AggregateMetrics,
+  ComparisonMetricDelta,
+  ComparisonResult,
+  ConfidenceInterval,
+  EffectSizeInterpretation,
+  EffectSizeSummary,
   StatisticalReport,
   BenchmarkResult,
   BenchmarkMeta,
@@ -56,6 +61,9 @@ export type {
 export { BENCHMARK_RESULT_SCHEMA } from "./schema.js";
 export { createOpenAiCompatibleProvider } from "./providers/openai-compatible.js";
 export {
+  buildBenchmarkRunSeeds,
+  orchestrateBenchmarkRuns,
+  resolveBenchmarkRunCount,
   runBenchmark,
   listBenchmarks,
   getBenchmark,
@@ -77,3 +85,9 @@ export {
   timed,
   aggregateTaskScores,
 } from "./scorer.js";
+export {
+  bootstrapMeanConfidenceInterval,
+  pairedDeltaConfidenceInterval,
+} from "./stats/bootstrap.js";
+export { cohensD, interpretEffectSize } from "./stats/effect-size.js";
+export { compareResults } from "./stats/comparison.js";

--- a/packages/bench/src/stats/bootstrap.ts
+++ b/packages/bench/src/stats/bootstrap.ts
@@ -1,0 +1,100 @@
+import type { ConfidenceInterval } from "../types.js";
+
+export interface BootstrapOptions {
+  iterations?: number;
+  level?: number;
+  random?: () => number;
+}
+
+const DEFAULT_ITERATIONS = 1_000;
+const DEFAULT_LEVEL = 0.95;
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("bootstrap requires at least one value");
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function percentile(sortedValues: number[], percentileValue: number): number {
+  if (sortedValues.length === 0) {
+    throw new Error("percentile requires at least one value");
+  }
+
+  const clamped = Math.min(1, Math.max(0, percentileValue));
+  const index = (sortedValues.length - 1) * clamped;
+  const lowerIndex = Math.floor(index);
+  const upperIndex = Math.ceil(index);
+
+  if (lowerIndex === upperIndex) {
+    return sortedValues[lowerIndex]!;
+  }
+
+  const weight = index - lowerIndex;
+  const lower = sortedValues[lowerIndex]!;
+  const upper = sortedValues[upperIndex]!;
+  return lower + (upper - lower) * weight;
+}
+
+function createBootstrapMeans(
+  values: number[],
+  {
+    iterations = DEFAULT_ITERATIONS,
+    random = Math.random,
+  }: Pick<BootstrapOptions, "iterations" | "random">,
+): number[] {
+  if (values.length === 0) {
+    throw new Error("bootstrap requires at least one value");
+  }
+  if (!Number.isInteger(iterations) || iterations <= 0) {
+    throw new Error("bootstrap iterations must be a positive integer");
+  }
+
+  const samples: number[] = [];
+  for (let iteration = 0; iteration < iterations; iteration += 1) {
+    const sample: number[] = [];
+    for (let index = 0; index < values.length; index += 1) {
+      const pickedIndex = Math.floor(random() * values.length);
+      sample.push(values[pickedIndex]!);
+    }
+    samples.push(mean(sample));
+  }
+
+  return samples;
+}
+
+export function bootstrapMeanConfidenceInterval(
+  values: number[],
+  options: BootstrapOptions = {},
+): ConfidenceInterval {
+  const level = options.level ?? DEFAULT_LEVEL;
+  if (!(level > 0 && level < 1)) {
+    throw new Error("bootstrap confidence level must be between 0 and 1");
+  }
+
+  const bootstrappedMeans = createBootstrapMeans(values, options).sort(
+    (left, right) => left - right,
+  );
+  const tail = (1 - level) / 2;
+
+  return {
+    lower: percentile(bootstrappedMeans, tail),
+    upper: percentile(bootstrappedMeans, 1 - tail),
+    level,
+  };
+}
+
+export function pairedDeltaConfidenceInterval(
+  candidateValues: number[],
+  baselineValues: number[],
+  options: BootstrapOptions = {},
+): ConfidenceInterval {
+  if (candidateValues.length !== baselineValues.length) {
+    throw new Error("paired delta confidence intervals require equal-length arrays");
+  }
+
+  const deltas = candidateValues.map(
+    (candidate, index) => candidate - baselineValues[index]!,
+  );
+  return bootstrapMeanConfidenceInterval(deltas, options);
+}

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -61,11 +61,15 @@ export function compareResults(
       delta,
       percentChange: percentChange(aggregate.mean, baselineAggregate.mean),
       effectSize: {
-        cohensD: cohensD(candidateScores, baselineScores),
-        interpretation: interpretEffectSize(
-          cohensD(candidateScores, baselineScores),
-        ),
+        cohensD: 0,
+        interpretation: "negligible",
       },
+    };
+
+    const effectSizeValue = cohensD(candidateScores, baselineScores);
+    metricDelta.effectSize = {
+      cohensD: effectSizeValue,
+      interpretation: interpretEffectSize(effectSizeValue),
     };
 
     if (candidateScores.length === baselineScores.length && candidateScores.length > 0) {

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -1,0 +1,86 @@
+import type {
+  BenchmarkResult,
+  ComparisonResult,
+  ComparisonMetricDelta,
+} from "../types.js";
+import { pairedDeltaConfidenceInterval } from "./bootstrap.js";
+import { cohensD, interpretEffectSize } from "./effect-size.js";
+
+function percentChange(candidateValue: number, baselineValue: number): number {
+  if (baselineValue === 0) {
+    return candidateValue === 0 ? 0 : Math.sign(candidateValue) * Infinity;
+  }
+  return (candidateValue - baselineValue) / baselineValue;
+}
+
+function verdictFromMetricDeltas(
+  metricDeltas: Record<string, ComparisonMetricDelta>,
+  threshold: number,
+): ComparisonResult["verdict"] {
+  let hasImprovement = false;
+  let hasRegression = false;
+
+  for (const metric of Object.values(metricDeltas)) {
+    if (metric.percentChange > threshold) {
+      hasImprovement = true;
+    }
+    if (metric.percentChange < -threshold) {
+      hasRegression = true;
+    }
+  }
+
+  if (hasRegression) return "regression";
+  if (hasImprovement) return "improvement";
+  return "pass";
+}
+
+export function compareResults(
+  baseline: BenchmarkResult,
+  candidate: BenchmarkResult,
+  threshold = 0.05,
+): ComparisonResult {
+  const metricDeltas: Record<string, ComparisonMetricDelta> = {};
+
+  for (const [metricName, aggregate] of Object.entries(candidate.results.aggregates)) {
+    const baselineAggregate = baseline.results.aggregates[metricName];
+    if (!baselineAggregate) {
+      continue;
+    }
+
+    const baselineScores = baseline.results.tasks.map(
+      (task) => task.scores[metricName] ?? 0,
+    );
+    const candidateScores = candidate.results.tasks.map(
+      (task) => task.scores[metricName] ?? 0,
+    );
+
+    const delta = aggregate.mean - baselineAggregate.mean;
+    const metricDelta: ComparisonMetricDelta = {
+      baseline: baselineAggregate.mean,
+      candidate: aggregate.mean,
+      delta,
+      percentChange: percentChange(aggregate.mean, baselineAggregate.mean),
+      effectSize: {
+        cohensD: cohensD(candidateScores, baselineScores),
+        interpretation: interpretEffectSize(
+          cohensD(candidateScores, baselineScores),
+        ),
+      },
+    };
+
+    if (candidateScores.length === baselineScores.length && candidateScores.length > 0) {
+      metricDelta.ciOnDelta = pairedDeltaConfidenceInterval(
+        candidateScores,
+        baselineScores,
+      );
+    }
+
+    metricDeltas[metricName] = metricDelta;
+  }
+
+  return {
+    benchmark: candidate.meta.benchmark,
+    metricDeltas,
+    verdict: verdictFromMetricDeltas(metricDeltas, threshold),
+  };
+}

--- a/packages/bench/src/stats/effect-size.ts
+++ b/packages/bench/src/stats/effect-size.ts
@@ -1,0 +1,51 @@
+import type { EffectSizeInterpretation } from "../types.js";
+
+function mean(values: number[]): number {
+  if (values.length === 0) {
+    throw new Error("effect size requires at least one value");
+  }
+  return values.reduce((sum, value) => sum + value, 0) / values.length;
+}
+
+function sampleVariance(values: number[], avg: number): number {
+  if (values.length <= 1) {
+    return 0;
+  }
+  return values.reduce((sum, value) => sum + (value - avg) ** 2, 0) / (values.length - 1);
+}
+
+export function cohensD(
+  candidateValues: number[],
+  baselineValues: number[],
+): number {
+  if (candidateValues.length === 0 || baselineValues.length === 0) {
+    throw new Error("effect size requires non-empty candidate and baseline arrays");
+  }
+
+  const candidateMean = mean(candidateValues);
+  const baselineMean = mean(baselineValues);
+  const candidateVariance = sampleVariance(candidateValues, candidateMean);
+  const baselineVariance = sampleVariance(baselineValues, baselineMean);
+  const pooledVariance =
+    ((candidateValues.length - 1) * candidateVariance +
+      (baselineValues.length - 1) * baselineVariance) /
+    (candidateValues.length + baselineValues.length - 2);
+
+  if (pooledVariance === 0) {
+    return candidateMean === baselineMean
+      ? 0
+      : Math.sign(candidateMean - baselineMean) * Infinity;
+  }
+
+  return (candidateMean - baselineMean) / Math.sqrt(pooledVariance);
+}
+
+export function interpretEffectSize(
+  cohensDValue: number,
+): EffectSizeInterpretation {
+  const absolute = Math.abs(cohensDValue);
+  if (absolute < 0.2) return "negligible";
+  if (absolute < 0.5) return "small";
+  if (absolute < 0.8) return "medium";
+  return "large";
+}

--- a/packages/bench/src/stats/effect-size.ts
+++ b/packages/bench/src/stats/effect-size.ts
@@ -26,12 +26,21 @@ export function cohensD(
   const baselineMean = mean(baselineValues);
   const candidateVariance = sampleVariance(candidateValues, candidateMean);
   const baselineVariance = sampleVariance(baselineValues, baselineMean);
+  const pooledDegreesOfFreedom =
+    candidateValues.length + baselineValues.length - 2;
+
+  if (pooledDegreesOfFreedom <= 0) {
+    return candidateMean === baselineMean
+      ? 0
+      : Math.sign(candidateMean - baselineMean) * Infinity;
+  }
+
   const pooledVariance =
     ((candidateValues.length - 1) * candidateVariance +
       (baselineValues.length - 1) * baselineVariance) /
-    (candidateValues.length + baselineValues.length - 2);
+    pooledDegreesOfFreedom;
 
-  if (pooledVariance === 0) {
+  if (!Number.isFinite(pooledVariance) || pooledVariance === 0) {
     return candidateMean === baselineMean
       ? 0
       : Math.sign(candidateMean - baselineMean) * Infinity;
@@ -43,6 +52,9 @@ export function cohensD(
 export function interpretEffectSize(
   cohensDValue: number,
 ): EffectSizeInterpretation {
+  if (Number.isNaN(cohensDValue)) {
+    throw new Error("effect size interpretation requires a numeric value");
+  }
   const absolute = Math.abs(cohensDValue);
   if (absolute < 0.2) return "negligible";
   if (absolute < 0.5) return "small";

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -40,23 +40,52 @@ export interface MetricAggregate {
 
 export type AggregateMetrics = Record<string, MetricAggregate>;
 
+export interface ConfidenceInterval {
+  lower: number;
+  upper: number;
+  level: number;
+}
+
+export type EffectSizeInterpretation =
+  | "negligible"
+  | "small"
+  | "medium"
+  | "large";
+
+export interface EffectSizeSummary {
+  cohensD: number;
+  interpretation: EffectSizeInterpretation;
+}
+
+export interface ComparisonMetricDelta {
+  baseline: number;
+  candidate: number;
+  delta: number;
+  percentChange: number;
+  effectSize: EffectSizeSummary;
+  ciOnDelta?: ConfidenceInterval;
+}
+
+export interface ComparisonResult {
+  benchmark: string;
+  metricDeltas: Record<string, ComparisonMetricDelta>;
+  verdict: "pass" | "regression" | "improvement";
+}
+
 export interface StatisticalReport {
   confidenceIntervals: Record<
     string,
-    { lower: number; upper: number; level: 0.95 }
+    ConfidenceInterval
   >;
   bootstrapSamples: number;
   effectSizes?: Record<
     string,
-    {
-      cohensD: number;
-      interpretation: "negligible" | "small" | "medium" | "large";
-    }
+    EffectSizeSummary
   >;
   pairedComparison?: {
     baselineId: string;
     pValue: number;
-    ciOnDelta: { lower: number; upper: number };
+    ciOnDelta: ConfidenceInterval;
   };
 }
 

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -43,3 +43,16 @@ test("legacy adapter benchmark types use explicit Legacy* names to avoid collidi
   assert.doesNotMatch(source, /export interface BenchmarkResult/);
   assert.doesNotMatch(source, /export interface BenchmarkRunner/);
 });
+
+test("@remnic/bench index exports the phase-2 stats helpers", async () => {
+  const source = await readFile("packages/bench/src/index.ts", "utf8");
+
+  assert.match(source, /bootstrapMeanConfidenceInterval/);
+  assert.match(source, /pairedDeltaConfidenceInterval/);
+  assert.match(source, /cohensD/);
+  assert.match(source, /interpretEffectSize/);
+  assert.match(source, /compareResults/);
+  assert.match(source, /buildBenchmarkRunSeeds/);
+  assert.match(source, /orchestrateBenchmarkRuns/);
+  assert.match(source, /resolveBenchmarkRunCount/);
+});

--- a/tests/bench-stats.test.ts
+++ b/tests/bench-stats.test.ts
@@ -150,6 +150,15 @@ test("cohensD and interpretEffectSize classify large separations", () => {
   assert.equal(interpretEffectSize(d), "large");
 });
 
+test("cohensD handles singleton samples without producing NaN", () => {
+  const equalSingletons = cohensD([0.5], [0.5]);
+  const shiftedSingletons = cohensD([0.9], [0.1]);
+
+  assert.equal(equalSingletons, 0);
+  assert.equal(shiftedSingletons, Infinity);
+  assert.equal(interpretEffectSize(shiftedSingletons), "large");
+});
+
 test("compareResults reports improvements with effect sizes and paired delta intervals", () => {
   const baseline = buildBenchmarkResult("longmemeval", [0.2, 0.3, 0.4]);
   const candidate = buildBenchmarkResult("longmemeval", [0.6, 0.7, 0.8]);

--- a/tests/bench-stats.test.ts
+++ b/tests/bench-stats.test.ts
@@ -1,0 +1,165 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  bootstrapMeanConfidenceInterval,
+  pairedDeltaConfidenceInterval,
+} from "../packages/bench/src/stats/bootstrap.ts";
+import {
+  cohensD,
+  interpretEffectSize,
+} from "../packages/bench/src/stats/effect-size.ts";
+import { compareResults } from "../packages/bench/src/stats/comparison.ts";
+import {
+  buildBenchmarkRunSeeds,
+  orchestrateBenchmarkRuns,
+  resolveBenchmarkRunCount,
+} from "../packages/bench/src/benchmark.ts";
+import type { BenchmarkResult } from "../packages/bench/src/types.ts";
+
+function makeDeterministicRandom(seed = 7): () => number {
+  let state = seed;
+  return () => {
+    state = (state * 48271) % 0x7fffffff;
+    return state / 0x7fffffff;
+  };
+}
+
+function buildBenchmarkResult(
+  benchmark: string,
+  scoreValues: number[],
+): BenchmarkResult {
+  return {
+    meta: {
+      id: `${benchmark}-run`,
+      benchmark,
+      benchmarkTier: "published",
+      version: "1.0.0",
+      remnicVersion: "9.3.32",
+      gitSha: "abc123",
+      timestamp: "2026-04-18T00:00:00.000Z",
+      mode: "full",
+      runCount: 5,
+      seeds: [0, 1, 2, 3, 4],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "lightweight",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: scoreValues.map((value, index) => ({
+        taskId: `task-${index}`,
+        question: `Question ${index}`,
+        expected: `Expected ${index}`,
+        actual: `Actual ${index}`,
+        scores: {
+          f1: value,
+        },
+        latencyMs: 10,
+        tokens: {
+          input: 0,
+          output: 0,
+        },
+      })),
+      aggregates: {
+        f1: {
+          mean: scoreValues.reduce((sum, value) => sum + value, 0) / scoreValues.length,
+          median: scoreValues[Math.floor(scoreValues.length / 2)] ?? 0,
+          stdDev: 0,
+          min: Math.min(...scoreValues),
+          max: Math.max(...scoreValues),
+        },
+      },
+    },
+    environment: {
+      os: "darwin",
+      nodeVersion: process.version,
+    },
+  };
+}
+
+test("resolveBenchmarkRunCount keeps quick mode single-run and defaults full mode to five runs", () => {
+  assert.equal(resolveBenchmarkRunCount("quick", 99), 1);
+  assert.equal(resolveBenchmarkRunCount("full"), 5);
+  assert.equal(resolveBenchmarkRunCount("full", 3), 3);
+  assert.throws(() => resolveBenchmarkRunCount("full", 0), /positive integer/);
+});
+
+test("buildBenchmarkRunSeeds produces deterministic sequential seeds", () => {
+  assert.deepEqual(buildBenchmarkRunSeeds(4), [0, 1, 2, 3]);
+  assert.deepEqual(buildBenchmarkRunSeeds(3, 11), [11, 12, 13]);
+  assert.throws(() => buildBenchmarkRunSeeds(0), /positive integer/);
+});
+
+test("orchestrateBenchmarkRuns executes once per planned seed", async () => {
+  const seen: Array<{ seed: number; runIndex: number }> = [];
+  const batch = await orchestrateBenchmarkRuns(
+    "full",
+    async (seed, runIndex) => {
+      seen.push({ seed, runIndex });
+      return `${seed}:${runIndex}`;
+    },
+    3,
+    5,
+  );
+
+  assert.equal(batch.runCount, 3);
+  assert.deepEqual(batch.seeds, [5, 6, 7]);
+  assert.deepEqual(batch.runs, ["5:0", "6:1", "7:2"]);
+  assert.deepEqual(seen, [
+    { seed: 5, runIndex: 0 },
+    { seed: 6, runIndex: 1 },
+    { seed: 7, runIndex: 2 },
+  ]);
+});
+
+test("bootstrapMeanConfidenceInterval returns an ordered interval around the sample mean", () => {
+  const interval = bootstrapMeanConfidenceInterval(
+    [0.2, 0.4, 0.6, 0.8],
+    {
+      iterations: 200,
+      random: makeDeterministicRandom(17),
+    },
+  );
+
+  assert.equal(interval.level, 0.95);
+  assert.ok(interval.lower <= interval.upper);
+  assert.ok(interval.lower <= 0.5);
+  assert.ok(interval.upper >= 0.5);
+});
+
+test("pairedDeltaConfidenceInterval rejects mismatched sample sizes", () => {
+  assert.throws(
+    () => pairedDeltaConfidenceInterval([1, 2], [1]),
+    /equal-length arrays/,
+  );
+});
+
+test("cohensD and interpretEffectSize classify large separations", () => {
+  const d = cohensD([0.9, 0.95, 1.0], [0.1, 0.15, 0.2]);
+  assert.ok(d > 0.8);
+  assert.equal(interpretEffectSize(d), "large");
+});
+
+test("compareResults reports improvements with effect sizes and paired delta intervals", () => {
+  const baseline = buildBenchmarkResult("longmemeval", [0.2, 0.3, 0.4]);
+  const candidate = buildBenchmarkResult("longmemeval", [0.6, 0.7, 0.8]);
+
+  const comparison = compareResults(baseline, candidate, 0.05);
+
+  assert.equal(comparison.benchmark, "longmemeval");
+  assert.equal(comparison.verdict, "improvement");
+  assert.ok(comparison.metricDeltas.f1);
+  assert.ok(comparison.metricDeltas.f1!.delta > 0);
+  assert.equal(comparison.metricDeltas.f1!.effectSize.interpretation, "large");
+  assert.ok(comparison.metricDeltas.f1!.ciOnDelta);
+});


### PR DESCRIPTION
## Summary
- add deterministic run-planning helpers for quick/full benchmark execution
- add bootstrap confidence-interval, effect-size, and benchmark-comparison primitives under `@remnic/bench`
- cover the new stats surface with focused tests and package-surface assertions

## Verification
- `cd /Users/joshuawarren/src/remnic/.worktrees/issue-445-bench-stats && npx tsx --test tests/bench-stats.test.ts tests/bench-package-surface.test.ts tests/bench-scorer.test.ts`
- `cd /Users/joshuawarren/src/remnic/.worktrees/issue-445-bench-stats && pnpm install --frozen-lockfile`
- `cd /Users/joshuawarren/src/remnic/.worktrees/issue-445-bench-stats && pnpm --filter @remnic/bench check-types`
- `cd /Users/joshuawarren/src/remnic/.worktrees/issue-445-bench-stats && pnpm --filter @remnic/bench build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive utilities/types in the benchmark package plus new tests, with no modifications to production runtime paths beyond new exports.
> 
> **Overview**
> Adds *phase-2 benchmarking primitives* to `@remnic/bench`: deterministic run planning (`resolveBenchmarkRunCount`, `buildBenchmarkRunSeeds`) and an `orchestrateBenchmarkRuns` helper that standardizes multi-run execution for `quick` vs `full` modes.
> 
> Introduces statistical utilities for result analysis, including bootstrap mean/paired-delta confidence intervals, Cohen’s d effect size + interpretation, and a `compareResults` helper that computes per-metric deltas (percent change, effect size, optional CI) and returns a pass/improvement/regression verdict.
> 
> Extends public types (`ConfidenceInterval`, effect-size and comparison result shapes) and re-exports the new helpers from `packages/bench/src/index.ts`, with new unit tests and package-surface assertions to lock in the API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b8b3d01b3862675a116c4ecae3f3eabd4ce8f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->