### PR TITLE
feat(bench): add provider discovery layer

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -46,14 +46,27 @@ export {
   createRemnicAdapter,
 } from "./adapters/remnic-adapter.js";
 export type {
+  AnthropicProviderConfig,
   CompletionOpts,
   CompletionResult,
   DiscoveredModel,
   TokenUsage,
   LlmProvider,
+  OllamaProviderConfig,
+  OpenAiCompatibleProviderConfig,
+  ProviderBaseConfig,
+  ProviderDiscoveryResult,
+  ProviderFactoryConfig,
 } from "./providers/types.js";
 
 export { BENCHMARK_RESULT_SCHEMA } from "./schema.js";
+export { createAnthropicProvider } from "./providers/anthropic.js";
+export {
+  createProvider,
+  discoverAllProviders,
+} from "./providers/factory.js";
+export { createLiteLlmProvider } from "./providers/litellm.js";
+export { createOllamaProvider } from "./providers/ollama.js";
 export { createOpenAiCompatibleProvider } from "./providers/openai-compatible.js";
 export {
   runBenchmark,

--- a/packages/bench/src/providers/anthropic.ts
+++ b/packages/bench/src/providers/anthropic.ts
@@ -1,0 +1,126 @@
+import type {
+  AnthropicProviderConfig,
+  CompletionOpts,
+  CompletionResult,
+  LlmProvider,
+  TokenUsage,
+} from "./types.js";
+
+interface AnthropicMessageResponse {
+  model?: string;
+  content?: Array<{ type?: string; text?: string }>;
+  usage?: {
+    input_tokens?: number;
+    output_tokens?: number;
+  };
+}
+
+class AnthropicProvider implements LlmProvider {
+  readonly provider = "anthropic" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: AnthropicProviderConfig;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: AnthropicProviderConfig) {
+    this.config = config;
+    this.id = `anthropic:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(
+    prompt: string,
+    opts: CompletionOpts = {},
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const response = await fetch(this.urlFor("messages"), {
+      method: "POST",
+      headers: this.headers(opts.headers),
+      body: JSON.stringify({
+        model: this.config.model,
+        system: opts.systemPrompt,
+        max_tokens: opts.maxTokens ?? 1_024,
+        temperature: opts.temperature,
+        messages: [{ role: "user", content: prompt }],
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Anthropic completion failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const payload = (await response.json()) as AnthropicMessageResponse;
+    const inputTokens = payload.usage?.input_tokens ?? 0;
+    const outputTokens = payload.usage?.output_tokens ?? 0;
+    this.recordUsage(inputTokens, outputTokens);
+
+    return {
+      text: (payload.content ?? [])
+        .filter((part) => part.type === "text")
+        .map((part) => part.text ?? "")
+        .join("")
+        .trim(),
+      tokens: {
+        input: inputTokens,
+        output: outputTokens,
+      },
+      latencyMs: Math.round(performance.now() - startedAt),
+      model: payload.model ?? this.config.model,
+    };
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private headers(extraHeaders: Record<string, string> = {}): Record<string, string> {
+    return {
+      "content-type": "application/json",
+      "anthropic-version": this.config.anthropicVersion ?? "2023-06-01",
+      ...(this.config.apiKey ? { "x-api-key": this.config.apiKey } : {}),
+      ...(this.config.headers ?? {}),
+      ...extraHeaders,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  private urlFor(pathname: string): string {
+    const baseUrl = this.config.baseUrl ?? "https://api.anthropic.com/v1";
+    const normalizedBase = baseUrl.endsWith("/")
+      ? baseUrl.slice(0, -1)
+      : baseUrl;
+    const normalizedPath = pathname.startsWith("/")
+      ? pathname.slice(1)
+      : pathname;
+
+    return `${normalizedBase}/${normalizedPath}`;
+  }
+}
+
+export function createAnthropicProvider(
+  config: AnthropicProviderConfig,
+): LlmProvider {
+  return new AnthropicProvider(config);
+}

--- a/packages/bench/src/providers/factory.ts
+++ b/packages/bench/src/providers/factory.ts
@@ -1,0 +1,70 @@
+import type {
+  LlmProvider,
+  ProviderDiscoveryResult,
+  ProviderFactoryConfig,
+} from "./types.js";
+import { createAnthropicProvider } from "./anthropic.js";
+import { createLiteLlmProvider } from "./litellm.js";
+import { createOllamaProvider } from "./ollama.js";
+import { createOpenAiCompatibleProvider } from "./openai-compatible.js";
+
+export function createProvider(config: ProviderFactoryConfig): LlmProvider {
+  switch (config.provider) {
+    case "openai":
+      return createOpenAiCompatibleProvider(config);
+    case "anthropic":
+      return createAnthropicProvider(config);
+    case "ollama":
+      return createOllamaProvider(config);
+    case "litellm":
+      return createLiteLlmProvider(config);
+    default: {
+      const exhaustive: never = config;
+      throw new Error(`Unknown provider: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+export async function discoverAllProviders(): Promise<ProviderDiscoveryResult[]> {
+  const discoveryTargets = [
+    {
+      provider: "ollama" as const,
+      create: () => createOllamaProvider({ provider: "ollama", model: "probe" }),
+    },
+    {
+      provider: "openai" as const,
+      create: () =>
+        createOpenAiCompatibleProvider({
+          provider: "openai",
+          model: "probe",
+          baseUrl: "http://localhost:1234/v1",
+        }),
+    },
+    {
+      provider: "litellm" as const,
+      create: () =>
+        createLiteLlmProvider({
+          provider: "litellm",
+          model: "probe",
+        }),
+    },
+  ];
+
+  const results: ProviderDiscoveryResult[] = [];
+  for (const target of discoveryTargets) {
+    try {
+      const provider = target.create();
+      const models = provider.discover ? await provider.discover() : [];
+      if (models.length > 0) {
+        results.push({
+          provider: target.provider,
+          models,
+        });
+      }
+    } catch {
+      // Missing local provider endpoints should not fail discovery for others.
+    }
+  }
+
+  return results;
+}

--- a/packages/bench/src/providers/litellm.ts
+++ b/packages/bench/src/providers/litellm.ts
@@ -1,0 +1,12 @@
+import type { LlmProvider, OpenAiCompatibleProviderConfig } from "./types.js";
+import { createOpenAiCompatibleProvider } from "./openai-compatible.js";
+
+export function createLiteLlmProvider(
+  config: OpenAiCompatibleProviderConfig,
+): LlmProvider {
+  return createOpenAiCompatibleProvider({
+    ...config,
+    provider: "litellm",
+    baseUrl: config.baseUrl ?? "http://localhost:4000",
+  });
+}

--- a/packages/bench/src/providers/ollama.ts
+++ b/packages/bench/src/providers/ollama.ts
@@ -1,0 +1,159 @@
+import type {
+  CompletionOpts,
+  CompletionResult,
+  DiscoveredModel,
+  LlmProvider,
+  OllamaProviderConfig,
+  TokenUsage,
+} from "./types.js";
+
+interface OllamaGenerateResponse {
+  model?: string;
+  response?: string;
+  prompt_eval_count?: number;
+  eval_count?: number;
+}
+
+interface OllamaTagsResponse {
+  models?: Array<{
+    name: string;
+    details?: {
+      parameter_size?: string;
+      quantization_level?: string;
+    };
+  }>;
+}
+
+class OllamaProvider implements LlmProvider {
+  readonly provider = "ollama" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: OllamaProviderConfig;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: OllamaProviderConfig) {
+    this.config = config;
+    this.id = `ollama:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(
+    prompt: string,
+    opts: CompletionOpts = {},
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const response = await fetch(this.urlFor("generate"), {
+      method: "POST",
+      headers: this.headers(opts.headers),
+      body: JSON.stringify({
+        model: this.config.model,
+        prompt,
+        system: opts.systemPrompt,
+        stream: false,
+        options: {
+          temperature: opts.temperature,
+          num_predict: opts.maxTokens,
+        },
+      }),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Ollama completion failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const payload = (await response.json()) as OllamaGenerateResponse;
+    const inputTokens = payload.prompt_eval_count ?? 0;
+    const outputTokens = payload.eval_count ?? 0;
+    this.recordUsage(inputTokens, outputTokens);
+
+    return {
+      text: payload.response?.trim() ?? "",
+      tokens: {
+        input: inputTokens,
+        output: outputTokens,
+      },
+      latencyMs: Math.round(performance.now() - startedAt),
+      model: payload.model ?? this.config.model,
+    };
+  }
+
+  async discover(): Promise<DiscoveredModel[]> {
+    const response = await fetch(this.urlFor("tags"), {
+      method: "GET",
+      headers: this.headers(),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Ollama model discovery failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const payload = (await response.json()) as OllamaTagsResponse;
+    return (payload.models ?? []).map((model) => ({
+      id: model.name,
+      name: model.name,
+      contextLength: 0,
+      capabilities: ["completion"],
+      ...(model.details?.quantization_level
+        ? { quantization: model.details.quantization_level }
+        : {}),
+      ...(model.details?.parameter_size
+        ? { parameterCount: model.details.parameter_size }
+        : {}),
+    }));
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private headers(extraHeaders: Record<string, string> = {}): Record<string, string> {
+    return {
+      "content-type": "application/json",
+      ...(this.config.headers ?? {}),
+      ...extraHeaders,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  private urlFor(pathname: string): string {
+    const baseUrl = this.config.baseUrl ?? "http://localhost:11434/api";
+    const normalizedBase = baseUrl.endsWith("/")
+      ? baseUrl.slice(0, -1)
+      : baseUrl;
+    const normalizedPath = pathname.startsWith("/")
+      ? pathname.slice(1)
+      : pathname;
+
+    return `${normalizedBase}/${normalizedPath}`;
+  }
+}
+
+export function createOllamaProvider(
+  config: OllamaProviderConfig,
+): LlmProvider {
+  return new OllamaProvider(config);
+}

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -7,15 +7,9 @@ import type {
   CompletionResult,
   DiscoveredModel,
   LlmProvider,
+  OpenAiCompatibleProviderConfig,
   TokenUsage,
 } from "./types.js";
-
-export interface OpenAiCompatibleProviderConfig {
-  model: string;
-  baseUrl?: string;
-  apiKey?: string;
-  headers?: Record<string, string>;
-}
 
 interface ChatCompletionResponse {
   model?: string;
@@ -42,7 +36,7 @@ interface ModelsResponse {
 }
 
 class OpenAiCompatibleProvider implements LlmProvider {
-  readonly provider = "openai" as const;
+  readonly provider: "openai" | "litellm";
   readonly id: string;
   readonly name: string;
 
@@ -56,7 +50,8 @@ class OpenAiCompatibleProvider implements LlmProvider {
 
   constructor(config: OpenAiCompatibleProviderConfig) {
     this.config = config;
-    this.id = `openai:${config.model}`;
+    this.provider = config.provider ?? "openai";
+    this.id = `${this.provider}:${config.model}`;
     this.name = config.model;
   }
 

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -27,6 +27,36 @@ export interface DiscoveredModel {
   parameterCount?: string;
 }
 
+export interface ProviderBaseConfig {
+  model: string;
+  baseUrl?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+
+export interface OpenAiCompatibleProviderConfig extends ProviderBaseConfig {
+  provider?: "openai" | "litellm";
+}
+
+export interface AnthropicProviderConfig extends ProviderBaseConfig {
+  provider?: "anthropic";
+  anthropicVersion?: string;
+}
+
+export interface OllamaProviderConfig extends ProviderBaseConfig {
+  provider?: "ollama";
+}
+
+export type ProviderFactoryConfig =
+  | (OpenAiCompatibleProviderConfig & { provider: "openai" | "litellm" })
+  | (AnthropicProviderConfig & { provider: "anthropic" })
+  | (OllamaProviderConfig & { provider: "ollama" });
+
+export interface ProviderDiscoveryResult {
+  provider: BuiltInProvider;
+  models: DiscoveredModel[];
+}
+
 export interface TokenUsage {
   inputTokens: number;
   outputTokens: number;

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -43,3 +43,13 @@ test("legacy adapter benchmark types use explicit Legacy* names to avoid collidi
   assert.doesNotMatch(source, /export interface BenchmarkResult/);
   assert.doesNotMatch(source, /export interface BenchmarkRunner/);
 });
+
+test("@remnic/bench index exports provider factory and discovery helpers", async () => {
+  const source = await readFile("packages/bench/src/index.ts", "utf8");
+
+  assert.match(source, /createAnthropicProvider/);
+  assert.match(source, /createLiteLlmProvider/);
+  assert.match(source, /createOllamaProvider/);
+  assert.match(source, /createProvider/);
+  assert.match(source, /discoverAllProviders/);
+});

--- a/tests/bench-providers.test.ts
+++ b/tests/bench-providers.test.ts
@@ -1,0 +1,199 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  createAnthropicProvider,
+  createLiteLlmProvider,
+  createOllamaProvider,
+  createProvider,
+  createOpenAiCompatibleProvider,
+  discoverAllProviders,
+} from "../packages/bench/src/index.ts";
+
+type FetchCall = {
+  url: string;
+  init?: RequestInit;
+};
+
+function withFetchStub(
+  implementation: (input: string | URL | Request, init?: RequestInit) => Promise<Response>,
+) {
+  const originalFetch = globalThis.fetch;
+  const calls: FetchCall[] = [];
+  globalThis.fetch = (async (input: string | URL | Request, init?: RequestInit) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+    calls.push({ url, init });
+    return implementation(input, init);
+  }) as typeof fetch;
+
+  return {
+    calls,
+    restore() {
+      globalThis.fetch = originalFetch;
+    },
+  };
+}
+
+test("Anthropic provider maps responses and usage counters", async () => {
+  const stub = withFetchStub(async () =>
+    new Response(
+      JSON.stringify({
+        model: "claude-3-7-sonnet",
+        content: [{ type: "text", text: "done" }],
+        usage: { input_tokens: 12, output_tokens: 5 },
+      }),
+      { status: 200 },
+    ));
+
+  try {
+    const provider = createAnthropicProvider({
+      model: "claude-3-7-sonnet",
+      apiKey: "secret",
+    });
+    const result = await provider.complete("hello");
+
+    assert.equal(result.text, "done");
+    assert.equal(result.tokens.input, 12);
+    assert.equal(result.tokens.output, 5);
+    assert.equal(provider.getUsage().totalTokens, 17);
+    assert.match(stub.calls[0]!.url, /api\.anthropic\.com\/v1\/messages$/);
+  } finally {
+    stub.restore();
+  }
+});
+
+test("Ollama provider supports local model discovery", async () => {
+  const stub = withFetchStub(async () =>
+    new Response(
+      JSON.stringify({
+        models: [
+          {
+            name: "llama3.2",
+            details: {
+              parameter_size: "8B",
+              quantization_level: "Q4_K_M",
+            },
+          },
+        ],
+      }),
+      { status: 200 },
+    ));
+
+  try {
+    const provider = createOllamaProvider({ model: "llama3.2" });
+    const models = await provider.discover?.();
+
+    assert.deepEqual(models, [
+      {
+        id: "llama3.2",
+        name: "llama3.2",
+        contextLength: 0,
+        capabilities: ["completion"],
+        quantization: "Q4_K_M",
+        parameterCount: "8B",
+      },
+    ]);
+    assert.match(stub.calls[0]!.url, /localhost:11434\/api\/tags$/);
+  } finally {
+    stub.restore();
+  }
+});
+
+test("LiteLLM provider uses the LiteLLM local default base URL", async () => {
+  const stub = withFetchStub(async () =>
+    new Response(
+      JSON.stringify({
+        model: "gpt-4o-mini",
+        usage: { prompt_tokens: 3, completion_tokens: 2 },
+        choices: [{ message: { content: "ok" } }],
+      }),
+      { status: 200 },
+    ));
+
+  try {
+    const provider = createLiteLlmProvider({ model: "gpt-4o-mini" });
+    const result = await provider.complete("ping");
+
+    assert.equal(result.text, "ok");
+    assert.match(stub.calls[0]!.url, /localhost:4000\/chat\/completions$/);
+  } finally {
+    stub.restore();
+  }
+});
+
+test("provider factory returns concrete providers for each supported backend", async () => {
+  const openai = createProvider({ provider: "openai", model: "gpt-5.4" });
+  const litellm = createProvider({ provider: "litellm", model: "gpt-4o-mini" });
+  const anthropic = createProvider({ provider: "anthropic", model: "claude-3-7-sonnet" });
+  const ollama = createProvider({ provider: "ollama", model: "llama3.2" });
+
+  assert.equal(openai.provider, "openai");
+  assert.equal(litellm.provider, "litellm");
+  assert.equal(anthropic.provider, "anthropic");
+  assert.equal(ollama.provider, "ollama");
+});
+
+test("discoverAllProviders skips unavailable endpoints and returns successful discoveries", async () => {
+  const stub = withFetchStub(async (input) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    if (url.includes("11434")) {
+      return new Response(
+        JSON.stringify({
+          models: [{ name: "llama3.2" }],
+        }),
+        { status: 200 },
+      );
+    }
+
+    if (url.includes("1234")) {
+      return new Response(
+        JSON.stringify({
+          data: [{ id: "local-model", context_length: 32768 }],
+        }),
+        { status: 200 },
+      );
+    }
+
+    return new Response("unavailable", { status: 503 });
+  });
+
+  try {
+    const discovered = await discoverAllProviders();
+    assert.deepEqual(
+      discovered.map((entry) => entry.provider),
+      ["ollama", "openai"],
+    );
+  } finally {
+    stub.restore();
+  }
+});
+
+test("OpenAI-compatible provider still tracks usage through the shared config type", async () => {
+  const stub = withFetchStub(async () =>
+    new Response(
+      JSON.stringify({
+        model: "gpt-5.4",
+        usage: { prompt_tokens: 9, completion_tokens: 4 },
+        choices: [{ message: { content: "done" } }],
+      }),
+      { status: 200 },
+    ));
+
+  try {
+    const provider = createOpenAiCompatibleProvider({ model: "gpt-5.4" });
+    const result = await provider.complete("hello");
+
+    assert.equal(result.text, "done");
+    assert.equal(provider.getUsage().totalTokens, 13);
+  } finally {
+    stub.restore();
+  }
+});


### PR DESCRIPTION
## Summary
- add Anthropic, Ollama, and LiteLLM providers that match the existing bench provider contract
- add a provider factory plus lightweight discovery across local provider endpoints
- cover the new provider surface with focused fetch-stub tests and package-surface assertions

## Verification
- `cd /Users/joshuawarren/src/remnic/.worktrees/bench-provider-discovery-445 && pnpm install --frozen-lockfile`
- `cd /Users/joshuawarren/src/remnic/.worktrees/bench-provider-discovery-445 && npx tsx --test tests/bench-providers.test.ts tests/bench-package-surface.test.ts`
- `cd /Users/joshuawarren/src/remnic/.worktrees/bench-provider-discovery-445 && pnpm --filter @remnic/bench check-types`
- `cd /Users/joshuawarren/src/remnic/.worktrees/bench-provider-discovery-445 && pnpm --filter @remnic/bench build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new provider implementations and a factory/discovery layer that changes the public `@remnic/bench` API surface and adds new HTTP integration paths that could affect benchmark execution if misconfigured.
> 
> **Overview**
> Adds first-class provider support for **Anthropic**, **Ollama**, and **LiteLLM**, including usage accounting and (for Ollama/OpenAI-compatible) model discovery.
> 
> Introduces a `createProvider` factory plus `discoverAllProviders` to probe common local endpoints and return available models without failing when a backend is unreachable. Updates shared provider config typing (`ProviderBaseConfig` + `ProviderFactoryConfig`) and extends the OpenAI-compatible provider to support `litellm` identity/default base URL.
> 
> Expands `packages/bench` exports to include the new providers/factory/discovery helpers and adds fetch-stubbed tests covering response mapping, discovery behavior, and package surface exports.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b6f1b6938ef49ee96af7acd9e0ac0da721ba86. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->