### PR TITLE
feat(bench): add compare command for stored results

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts",
     "bench:list": "node scripts/run-bench-cli.mjs list",
     "bench:run": "node scripts/run-bench-cli.mjs run",
+    "bench:compare": "node scripts/run-bench-cli.mjs compare",
     "bench:quick": "node scripts/run-bench-cli.mjs run --quick longmemeval",
     "eval:ci-gate": "tsx scripts/eval-ci-gate.ts",
     "eval:run": "tsx evals/run.ts",

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -104,3 +104,8 @@ export {
 } from "./stats/bootstrap.js";
 export { cohensD, interpretEffectSize } from "./stats/effect-size.js";
 export { compareResults } from "./stats/comparison.js";
+export {
+  loadBenchmarkResult,
+  listBenchmarkResults,
+  resolveBenchmarkResultReference,
+} from "./results-store.js";

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -1,0 +1,118 @@
+import { readdir, readFile } from "node:fs/promises";
+import fs from "node:fs";
+import path from "node:path";
+import type { BenchmarkMode, BenchmarkResult } from "./types.js";
+
+export interface StoredBenchmarkResultSummary {
+  id: string;
+  path: string;
+  benchmark: string;
+  timestamp: string;
+  mode: BenchmarkMode;
+}
+
+function compareResultSummaries(
+  left: StoredBenchmarkResultSummary,
+  right: StoredBenchmarkResultSummary,
+): number {
+  if (left.timestamp === right.timestamp) {
+    return left.id.localeCompare(right.id);
+  }
+  return right.timestamp.localeCompare(left.timestamp);
+}
+
+function isBenchmarkMode(value: unknown): value is BenchmarkMode {
+  return value === "quick" || value === "full";
+}
+
+function isBenchmarkResult(value: unknown): value is BenchmarkResult {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const meta = (value as { meta?: Record<string, unknown> }).meta;
+  if (!meta || typeof meta !== "object") {
+    return false;
+  }
+
+  return (
+    typeof meta.id === "string" &&
+    typeof meta.benchmark === "string" &&
+    typeof meta.timestamp === "string" &&
+    isBenchmarkMode(meta.mode)
+  );
+}
+
+function toSummary(
+  result: BenchmarkResult,
+  filePath: string,
+): StoredBenchmarkResultSummary {
+  return {
+    id: result.meta.id,
+    path: filePath,
+    benchmark: result.meta.benchmark,
+    timestamp: result.meta.timestamp,
+    mode: result.meta.mode,
+  };
+}
+
+export async function loadBenchmarkResult(filePath: string): Promise<BenchmarkResult> {
+  const content = await readFile(filePath, "utf8");
+  const parsed: unknown = JSON.parse(content);
+  if (!isBenchmarkResult(parsed)) {
+    throw new Error(`Invalid benchmark result file: ${filePath}`);
+  }
+  return parsed;
+}
+
+export async function listBenchmarkResults(
+  outputDir: string,
+): Promise<StoredBenchmarkResultSummary[]> {
+  if (!fs.existsSync(outputDir)) {
+    return [];
+  }
+
+  const entries = await readdir(outputDir, { withFileTypes: true });
+  const results: StoredBenchmarkResultSummary[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const filePath = path.join(outputDir, entry.name);
+    try {
+      const result = await loadBenchmarkResult(filePath);
+      results.push(toSummary(result, filePath));
+    } catch {
+      continue;
+    }
+  }
+
+  return results.sort(compareResultSummaries);
+}
+
+export async function resolveBenchmarkResultReference(
+  outputDir: string,
+  reference: string,
+): Promise<StoredBenchmarkResultSummary | undefined> {
+  if (fs.existsSync(reference)) {
+    try {
+      const result = await loadBenchmarkResult(reference);
+      return toSummary(result, reference);
+    } catch {
+      return undefined;
+    }
+  }
+
+  const summaries = await listBenchmarkResults(outputDir);
+  const exactIdMatch = summaries.find((summary) => summary.id === reference);
+  if (exactIdMatch) {
+    return exactIdMatch;
+  }
+
+  const basenameMatch = summaries.find(
+    (summary) => path.basename(summary.path) === reference,
+  );
+  return basenameMatch;
+}

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -39,7 +39,18 @@ function isBenchmarkResult(value: unknown): value is BenchmarkResult {
     typeof meta.id === "string" &&
     typeof meta.benchmark === "string" &&
     typeof meta.timestamp === "string" &&
-    isBenchmarkMode(meta.mode)
+    isBenchmarkMode(meta.mode) &&
+    typeof (value as { config?: unknown }).config === "object" &&
+    (value as { config?: unknown }).config !== null &&
+    typeof (value as { cost?: unknown }).cost === "object" &&
+    (value as { cost?: unknown }).cost !== null &&
+    typeof (value as { environment?: unknown }).environment === "object" &&
+    (value as { environment?: unknown }).environment !== null &&
+    typeof (value as { results?: { tasks?: unknown; aggregates?: unknown } }).results === "object" &&
+    (value as { results?: unknown }).results !== null &&
+    Array.isArray((value as { results?: { tasks?: unknown } }).results?.tasks) &&
+    typeof (value as { results?: { aggregates?: unknown } }).results?.aggregates === "object" &&
+    (value as { results?: { aggregates?: unknown } }).results?.aggregates !== null
   );
 }
 
@@ -101,7 +112,7 @@ export async function resolveBenchmarkResultReference(
       const result = await loadBenchmarkResult(reference);
       return toSummary(result, reference);
     } catch {
-      return undefined;
+      // Fall through to id/basename matching under the results directory.
     }
   }
 

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -38,6 +38,7 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic spaces` | Manage memory namespaces |
 | `remnic bench list` | List published benchmark packs |
 | `remnic bench run` | Run one or more published benchmark packs |
+| `remnic bench compare` | Compare two stored benchmark results |
 
 Run `remnic --help` for the full command list.
 
@@ -50,6 +51,7 @@ kept as a compatibility alias.
 remnic bench list
 remnic bench run --quick longmemeval
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
+remnic bench compare base-run candidate-run
 remnic benchmark run --quick longmemeval
 ```
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import { expandTilde } from "./path-utils.js";
 
-export type BenchAction = "help" | "list" | "run" | "check" | "report";
+export type BenchAction = "help" | "list" | "run" | "compare" | "check" | "report";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -10,6 +10,8 @@ export interface ParsedBenchArgs {
   all: boolean;
   json: boolean;
   datasetDir?: string;
+  resultsDir?: string;
+  threshold?: number;
 }
 
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
@@ -30,7 +32,7 @@ export function collectBenchmarks(argv: string[]): string[] {
   const benchmarks: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === "--dataset-dir") {
+    if (arg === "--dataset-dir" || arg === "--results-dir" || arg === "--threshold") {
       index += 1;
       continue;
     }
@@ -47,7 +49,7 @@ export function parseBenchActionArgs(argv: string[]): {
 } {
   const [first, ...rest] = argv;
   const action: BenchAction =
-    first === "list" || first === "run" || first === "check" || first === "report"
+    first === "list" || first === "run" || first === "compare" || first === "check" || first === "report"
       ? first
       : first === undefined || first === "--help" || first === "-h"
         ? "help"
@@ -63,6 +65,15 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const { action, args } = parseBenchActionArgs(argv);
   const benchmarks = collectBenchmarks(args);
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
+  const resultsDir = readBenchOptionValue(args, "--results-dir");
+  const thresholdRaw = readBenchOptionValue(args, "--threshold");
+  let threshold: number | undefined;
+  if (thresholdRaw !== undefined) {
+    threshold = Number(thresholdRaw);
+    if (!Number.isFinite(threshold) || threshold < 0) {
+      throw new Error("ERROR: --threshold must be a non-negative number.");
+    }
+  }
 
   return {
     action,
@@ -71,5 +82,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     all: args.includes("--all"),
     json: args.includes("--json"),
     datasetDir: datasetDir ? path.resolve(expandTilde(datasetDir)) : undefined,
+    resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
+    threshold,
   };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -119,11 +119,14 @@ import type {
 } from "@remnic/core";
 import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
+  compareResults,
   runBenchSuite,
   runExplain,
   loadBaseline,
   saveBaseline,
   checkRegression,
+  loadBenchmarkResult,
+  resolveBenchmarkResultReference,
   type BenchConfig,
   type BenchmarkDefinition,
 } from "@remnic/bench";
@@ -244,12 +247,13 @@ export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
 const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run> [options] [benchmark...]
-       remnic benchmark <list|run|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|compare> [options] [benchmark...]
+       remnic benchmark <list|run|compare|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
   run [benchmark...]       Run one or more benchmark packs
+  compare <base> <cand>    Compare two stored benchmark runs by id or file path
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
 
@@ -257,12 +261,15 @@ Options:
   --quick                  Run a lightweight quick pass (maps to --lightweight --limit 1)
   --all                    Run every published benchmark
   --dataset-dir <path>     Override the benchmark dataset directory for full runs
+  --results-dir <path>     Override the stored benchmark results directory
+  --threshold <value>      Regression threshold for compare (default: 0.05)
   --json                   Output JSON for \`list\`
 
 Examples:
   remnic bench list
   remnic bench run --quick longmemeval
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
+  remnic bench compare base-run candidate-run
   remnic benchmark run --quick longmemeval`;
 }
 
@@ -414,6 +421,98 @@ function printBenchPackageSummary(
     console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
   }
   console.log(`Results saved: ${outputPath}`);
+}
+
+function printBenchComparisonSummary(
+  comparison: ReturnType<typeof compareResults>,
+  baseline: { id: string; path: string },
+  candidate: { id: string; path: string },
+): void {
+  console.log(`Benchmark: ${comparison.benchmark}`);
+  console.log(`Baseline: ${baseline.id} (${baseline.path})`);
+  console.log(`Candidate: ${candidate.id} (${candidate.path})`);
+  console.log(`Verdict: ${comparison.verdict}`);
+
+  const metrics = Object.entries(comparison.metricDeltas).sort(([left], [right]) =>
+    left.localeCompare(right),
+  );
+  if (metrics.length === 0) {
+    console.log("No overlapping metrics were found between the two results.");
+    return;
+  }
+
+  console.log("Metrics:");
+  for (const [metric, delta] of metrics) {
+    const percent = Number.isFinite(delta.percentChange)
+      ? `${(delta.percentChange * 100).toFixed(2)}%`
+      : delta.percentChange > 0
+        ? "+Infinity%"
+        : "-Infinity%";
+    const direction = delta.delta >= 0 ? "+" : "";
+    console.log(
+      `  ${metric.padEnd(18)} ${delta.baseline.toFixed(4)} -> ${delta.candidate.toFixed(4)} (${direction}${delta.delta.toFixed(4)}, ${percent}, d=${delta.effectSize.cohensD.toFixed(3)} ${delta.effectSize.interpretation})`,
+    );
+    if (delta.ciOnDelta) {
+      console.log(
+        `    CI95 delta: [${delta.ciOnDelta.lower.toFixed(4)}, ${delta.ciOnDelta.upper.toFixed(4)}]`,
+      );
+    }
+  }
+}
+
+async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
+  const refs = parsed.benchmarks;
+  if (refs.length !== 2) {
+    console.error(
+      "ERROR: compare requires exactly two stored result references. Usage: remnic bench compare <baseline> <candidate> [--results-dir <path>] [--threshold <value>] [--json]",
+    );
+    process.exit(1);
+  }
+
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const [baselineRef, candidateRef] = refs;
+  const baselineSummary = await resolveBenchmarkResultReference(resultsDir, baselineRef);
+  const candidateSummary = await resolveBenchmarkResultReference(resultsDir, candidateRef);
+
+  if (!baselineSummary) {
+    console.error(`ERROR: benchmark result not found: ${baselineRef}`);
+    process.exit(1);
+  }
+  if (!candidateSummary) {
+    console.error(`ERROR: benchmark result not found: ${candidateRef}`);
+    process.exit(1);
+  }
+
+  const baseline = await loadBenchmarkResult(baselineSummary.path);
+  const candidate = await loadBenchmarkResult(candidateSummary.path);
+
+  if (baseline.meta.benchmark !== candidate.meta.benchmark) {
+    console.error(
+      `ERROR: benchmark mismatch: ${baseline.meta.benchmark} vs ${candidate.meta.benchmark}. Compare runs from the same benchmark.`,
+    );
+    process.exit(1);
+  }
+
+  const comparison = compareResults(
+    baseline,
+    candidate,
+    parsed.threshold ?? 0.05,
+  );
+
+  if (parsed.json) {
+    console.log(JSON.stringify({
+      benchmark: comparison.benchmark,
+      baseline: baselineSummary,
+      candidate: candidateSummary,
+      comparison,
+    }, null, 2));
+  } else {
+    printBenchComparisonSummary(comparison, baselineSummary, candidateSummary);
+  }
+
+  if (comparison.verdict === "regression") {
+    process.exit(1);
+  }
 }
 
 async function runBenchViaPackage(
@@ -2296,6 +2395,11 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "compare") {
+    await compareBenchPackageResults(parsed);
+    return;
+  }
+
   if (parsed.action === "list") {
     const catalog = await listBenchmarksFromPackage() ?? BENCHMARK_CATALOG;
     if (parsed.json) {
@@ -3726,7 +3830,7 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--json]
+  remnic bench <list|run|compare> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--threshold <value>] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
   remnic benchmark <list|run|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -52,6 +52,9 @@ test("@remnic/bench index exports the phase-2 stats helpers", async () => {
   assert.match(source, /cohensD/);
   assert.match(source, /interpretEffectSize/);
   assert.match(source, /compareResults/);
+  assert.match(source, /loadBenchmarkResult/);
+  assert.match(source, /listBenchmarkResults/);
+  assert.match(source, /resolveBenchmarkResultReference/);
   assert.match(source, /buildBenchmarkRunSeeds/);
   assert.match(source, /orchestrateBenchmarkRuns/);
   assert.match(source, /resolveBenchmarkRunCount/);

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -1,0 +1,105 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import {
+  listBenchmarkResults,
+  loadBenchmarkResult,
+  resolveBenchmarkResultReference,
+} from "../packages/bench/src/results-store.ts";
+import type { BenchmarkResult } from "../packages/bench/src/types.ts";
+
+function buildResult(
+  id: string,
+  timestamp: string,
+  benchmark = "longmemeval",
+): BenchmarkResult {
+  return {
+    meta: {
+      id,
+      benchmark,
+      benchmarkTier: "published",
+      version: "1.0.0",
+      remnicVersion: "9.3.35",
+      gitSha: "abc1234",
+      timestamp,
+      mode: "full",
+      runCount: 5,
+      seeds: [0, 1, 2, 3, 4],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "lightweight",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [],
+      aggregates: {},
+    },
+    environment: {
+      os: "darwin",
+      nodeVersion: process.version,
+    },
+  };
+}
+
+test("listBenchmarkResults sorts valid result files newest first and skips invalid JSON", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-results-"));
+  await mkdir(root, { recursive: true });
+
+  const olderPath = path.join(root, "older.json");
+  const newerPath = path.join(root, "newer.json");
+  await writeFile(
+    olderPath,
+    `${JSON.stringify(buildResult("run-older", "2026-04-18T00:00:00.000Z"))}\n`,
+  );
+  await writeFile(
+    newerPath,
+    `${JSON.stringify(buildResult("run-newer", "2026-04-18T01:00:00.000Z"))}\n`,
+  );
+  await writeFile(path.join(root, "broken.json"), "{not json\n");
+
+  const listed = await listBenchmarkResults(root);
+  assert.deepEqual(
+    listed.map((entry) => entry.id),
+    ["run-newer", "run-older"],
+  );
+});
+
+test("loadBenchmarkResult rejects invalid benchmark result files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-load-"));
+  const invalidPath = path.join(root, "invalid.json");
+  await writeFile(invalidPath, JSON.stringify({ hello: "world" }));
+
+  await assert.rejects(
+    () => loadBenchmarkResult(invalidPath),
+    /Invalid benchmark result file/,
+  );
+});
+
+test("resolveBenchmarkResultReference matches by id, basename, or direct path", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-resolve-"));
+  const filePath = path.join(root, "candidate.json");
+  await writeFile(
+    filePath,
+    `${JSON.stringify(buildResult("candidate-run", "2026-04-18T02:00:00.000Z"))}\n`,
+  );
+
+  const byId = await resolveBenchmarkResultReference(root, "candidate-run");
+  const byBasename = await resolveBenchmarkResultReference(root, "candidate.json");
+  const byPath = await resolveBenchmarkResultReference(root, filePath);
+
+  assert.equal(byId?.id, "candidate-run");
+  assert.equal(byBasename?.id, "candidate-run");
+  assert.equal(byPath?.path, filePath);
+});

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -87,6 +87,27 @@ test("loadBenchmarkResult rejects invalid benchmark result files", async () => {
   );
 });
 
+test("loadBenchmarkResult rejects incomplete benchmark result payloads", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-incomplete-"));
+  const invalidPath = path.join(root, "incomplete.json");
+  await writeFile(
+    invalidPath,
+    JSON.stringify({
+      meta: {
+        id: "incomplete-run",
+        benchmark: "longmemeval",
+        timestamp: "2026-04-18T00:00:00.000Z",
+        mode: "full",
+      },
+    }),
+  );
+
+  await assert.rejects(
+    () => loadBenchmarkResult(invalidPath),
+    /Invalid benchmark result file/,
+  );
+});
+
 test("resolveBenchmarkResultReference matches by id, basename, or direct path", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-resolve-"));
   const filePath = path.join(root, "candidate.json");
@@ -102,4 +123,26 @@ test("resolveBenchmarkResultReference matches by id, basename, or direct path", 
   assert.equal(byId?.id, "candidate-run");
   assert.equal(byBasename?.id, "candidate-run");
   assert.equal(byPath?.path, filePath);
+});
+
+test("resolveBenchmarkResultReference falls back to id matching when a same-named direct path is invalid", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-fallback-"));
+  const storedPath = path.join(root, "stored.json");
+  await writeFile(
+    storedPath,
+    `${JSON.stringify(buildResult("candidate-run", "2026-04-18T03:00:00.000Z"))}\n`,
+  );
+
+  const cwd = process.cwd();
+  const conflictingPath = path.join(root, "candidate-run");
+  await writeFile(conflictingPath, "not benchmark json");
+
+  try {
+    process.chdir(root);
+    const resolved = await resolveBenchmarkResultReference(root, "candidate-run");
+    assert.equal(resolved?.id, "candidate-run");
+    assert.equal(resolved?.path, storedPath);
+  } finally {
+    process.chdir(cwd);
+  }
 });

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -9,7 +9,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run>/);
+  assert.match(source, /remnic bench <list\|run\|compare>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -32,6 +32,7 @@ test("workspace scripts expose bench list, bench run, and a quick smoke path", a
 
   assert.equal(pkg.scripts?.["bench:list"], "node scripts/run-bench-cli.mjs list");
   assert.equal(pkg.scripts?.["bench:run"], "node scripts/run-bench-cli.mjs run");
+  assert.equal(pkg.scripts?.["bench:compare"], "node scripts/run-bench-cli.mjs compare");
   assert.equal(pkg.scripts?.["bench:quick"], "node scripts/run-bench-cli.mjs run --quick longmemeval");
 
   assert.match(helper, /packages", "remnic-core", "dist", "index\.js"/);
@@ -47,6 +48,7 @@ test("CLI README documents bench list and quick-run examples", async () => {
   assert.match(readme, /remnic bench list/);
   assert.match(readme, /remnic bench run --quick longmemeval/);
   assert.match(readme, /--dataset-dir ~\/datasets\/longmemeval/);
+  assert.match(readme, /remnic bench compare base-run candidate-run/);
   assert.match(readme, /remnic benchmark run --quick longmemeval/);
   assert.match(readme, /bundled smoke fixture/i);
   assert.match(readme, /full runs need a real benchmark dataset/i);
@@ -85,7 +87,7 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
   assert.match(parserSource, /const benchmarks = collectBenchmarks\(args\);/);
   assert.match(parserSource, /requires a value\./);
-  assert.match(parserSource, /if \(arg === "--dataset-dir"\) \{\s*index \+= 1;\s*continue;\s*\}/s);
+  assert.match(parserSource, /if \(arg === "--dataset-dir" \|\| arg === "--results-dir" \|\| arg === "--threshold"\) \{\s*index \+= 1;\s*continue;\s*\}/s);
   assert.match(parserSource, /datasetDir: datasetDir \? path\.resolve\(expandTilde\(datasetDir\)\) : undefined/);
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
   assert.match(source, /const outputDir = resolveBenchOutputDir\(\);/);
@@ -93,6 +95,27 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /if \(!parsed\.quick && !datasetDir\) \{\s*throw new Error\(/s);
   assert.match(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const system = await createAdapter\(\);/);
+});
+
+test("bench compare routes through stored package results with threshold and results-dir options", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+
+  assert.match(source, /compareResults,/);
+  assert.match(source, /loadBenchmarkResult,/);
+  assert.match(source, /resolveBenchmarkResultReference,/);
+  assert.match(source, /async function compareBenchPackageResults\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /if \(parsed\.action === "compare"\) \{\s*await compareBenchPackageResults\(parsed\);/s);
+  assert.match(source, /compare requires exactly two stored result references/i);
+  assert.match(source, /parsed\.resultsDir \?\? resolveBenchOutputDir\(\)/);
+  assert.match(source, /compareResults\(\s*baseline,\s*candidate,\s*parsed\.threshold \?\? 0\.05/s);
+  assert.match(source, /benchmark mismatch: \$\{baseline\.meta\.benchmark\} vs \$\{candidate\.meta\.benchmark\}/);
+  assert.match(parserSource, /export type BenchAction = "help" \| "list" \| "run" \| "compare" \| "check" \| "report";/);
+  assert.match(parserSource, /const resultsDir = readBenchOptionValue\(args, "--results-dir"\);/);
+  assert.match(parserSource, /const thresholdRaw = readBenchOptionValue\(args, "--threshold"\);/);
+  assert.match(parserSource, /ERROR: --threshold must be a non-negative number\./);
+  assert.match(parserSource, /resultsDir: resultsDir \? path\.resolve\(expandTilde\(resultsDir\)\) : undefined/);
+  assert.match(parserSource, /threshold,/);
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {
@@ -115,6 +138,25 @@ test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async ()
   ]);
   assert.deepEqual(optionFirst.benchmarks, ["longmemeval"]);
   assert.equal(optionFirst.datasetDir, "/tmp/bench-dataset");
+});
+
+test("parseBenchArgs supports compare-specific results-dir and threshold options", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs([
+    "compare",
+    "base-run",
+    "candidate-run",
+    "--results-dir",
+    "~/bench-results",
+    "--threshold",
+    "0.2",
+  ]);
+
+  assert.equal(parsed.action, "compare");
+  assert.deepEqual(parsed.benchmarks, ["base-run", "candidate-run"]);
+  assert.match(parsed.resultsDir ?? "", /bench-results$/);
+  assert.equal(parsed.threshold, 0.2);
 });
 
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {


### PR DESCRIPTION
## Summary
- add a result-store module to load and resolve stored benchmark results by id or file path
- add `remnic bench compare` with threshold gating, JSON output, and results-dir override
- document and test the new compare surface across the CLI and bench package

## Verification
- `npx tsx --test tests/bench-results-store.test.ts tests/bench-package-surface.test.ts tests/remnic-cli-bench-surface.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `pnpm --filter @remnic/cli check-types`
- `pnpm --filter @remnic/cli build`
- `npx tsx packages/remnic-cli/src/index.ts bench compare base-run candidate-run --results-dir <tmpdir> --json`

Closes #445 (phase 2 compare slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI behavior that reads and validates JSON benchmark artifacts from disk and can exit non-zero based on regression verdicts, which could affect automation and users’ workflows.
> 
> **Overview**
> Adds a new `remnic bench compare` command to diff two previously saved benchmark runs (by id, filename, or direct path), with optional `--results-dir`, `--threshold` gating (default `0.05`), and `--json` output; regressions cause a non-zero exit.
> 
> Introduces a `@remnic/bench` `results-store` module to load/validate stored benchmark result JSON, list/sort results, and resolve references, and exports these helpers from the package index. Updates workspace scripts/docs and adds tests covering the new exports, result-store behaviors, and CLI parsing/routing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49f314e9c328a8c7afc929aaddec2f69bf289d83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->