### PR TITLE
feat(bench): add BEAM published benchmark runner

### DIFF
--- a/packages/bench/src/benchmarks/published/beam/fixture.ts
+++ b/packages/bench/src/benchmarks/published/beam/fixture.ts
@@ -1,0 +1,171 @@
+/**
+ * Small BEAM smoke fixture for quick-mode benchmark validation.
+ */
+
+export interface BeamChatTurn {
+  content: string;
+  role: string;
+  id?: number | string;
+  index?: string;
+  question_type?: string;
+  time_anchor?: string;
+}
+
+export interface BeamQuestion {
+  question: string;
+  rubric?: string[];
+  difficulty?: string;
+  answer?: string;
+  ideal_answer?: string;
+  ideal_response?: string;
+  ideal_summary?: string;
+  expected_compliance?: string;
+  instruction_being_tested?: string;
+  preference_being_tested?: string;
+  plan_reference?: string;
+  source_chat_ids?: unknown;
+  [key: string]: unknown;
+}
+
+export type BeamQuestionMap = Record<string, BeamQuestion[]>;
+
+export interface BeamPlan {
+  plan_id?: number | string;
+  chat?: BeamChatTurn[][] | BeamChatTurn[];
+  [key: string]: unknown;
+}
+
+export interface BeamConversation {
+  conversation_id: string | number;
+  chat: BeamChatTurn[][] | BeamChatTurn[];
+  probing_questions: BeamQuestionMap | string;
+  plans?: BeamPlan[];
+  [key: string]: unknown;
+}
+
+export const BEAM_SMOKE_FIXTURE: BeamConversation[] = [
+  {
+    conversation_id: "beam-smoke-1",
+    chat: [
+      [
+        {
+          id: 1,
+          index: "1,1",
+          question_type: "main_question",
+          role: "user",
+          content:
+            "Please help me ship the first sprint of my budget tracker. I want sprint one to end on March 29.",
+          time_anchor: "March-15-2024",
+        },
+        {
+          id: 2,
+          index: "1,2",
+          question_type: "assistant_response",
+          role: "assistant",
+          content:
+            "Sprint one ending on March 29 sounds reasonable. We can stage auth, expenses, and analytics before then.",
+          time_anchor: "March-15-2024",
+        },
+      ],
+      [
+        {
+          id: 3,
+          index: "2,1",
+          question_type: "main_question",
+          role: "user",
+          content:
+            "For the transactions table, I want to add two new columns: category and notes.",
+          time_anchor: "March-20-2024",
+        },
+        {
+          id: 4,
+          index: "2,2",
+          question_type: "assistant_response",
+          role: "assistant",
+          content:
+            "Got it. I will treat category and notes as the two new transaction columns.",
+          time_anchor: "March-20-2024",
+        },
+      ],
+      [
+        {
+          id: 5,
+          index: "3,1",
+          question_type: "main_question",
+          role: "user",
+          content:
+            "Please remember this instruction: whenever I ask about implementation, format the answer with syntax-highlighted code blocks.",
+          time_anchor: "March-22-2024",
+        },
+        {
+          id: 6,
+          index: "3,2",
+          question_type: "assistant_response",
+          role: "assistant",
+          content:
+            "Understood. I'll use syntax-highlighted code blocks for implementation guidance.",
+          time_anchor: "March-22-2024",
+        },
+        {
+          id: 7,
+          index: "3,3",
+          question_type: "main_question",
+          role: "user",
+          content:
+            "After the caching work, the dashboard API now averages around 250ms.",
+          time_anchor: "March-24-2024",
+        },
+      ],
+    ],
+    probing_questions: {
+      information_extraction: [
+        {
+          question: "When does my first sprint end?",
+          answer: "March 29",
+          difficulty: "easy",
+          rubric: ["LLM response should state: March 29"],
+          plan_reference: "Batch 1, Bullet 1",
+          source_chat_ids: [1, 2],
+        },
+      ],
+      knowledge_update: [
+        {
+          question: "What is the average response time of the dashboard API now?",
+          answer: "250ms",
+          difficulty: "easy",
+          rubric: ["LLM response should state: 250ms"],
+          plan_reference: "Batch 3, Bullet 3",
+          source_chat_ids: [7],
+        },
+      ],
+      multi_session_reasoning: [
+        {
+          question: "How many new columns did I want to add to the transactions table?",
+          answer: "Two columns: category and notes.",
+          difficulty: "easy",
+          rubric: [
+            "LLM response should state: Two columns",
+            "LLM response should state: category and notes",
+          ],
+          plan_reference: "Batch 2, Bullet 1",
+          source_chat_ids: [3, 4],
+        },
+      ],
+      instruction_following: [
+        {
+          question: "Could you show me how to implement a login feature?",
+          instruction_being_tested:
+            "Always format implementation help with syntax-highlighted code blocks.",
+          expected_compliance:
+            "Response should include code blocks with syntax highlighting.",
+          difficulty: "medium",
+          rubric: [
+            "LLM response should contain: code blocks with syntax highlighting",
+          ],
+          plan_reference: "Batch 3, Bullet 1",
+          source_chat_ids: [5, 6],
+        },
+      ],
+    },
+  },
+];

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -1,0 +1,755 @@
+/**
+ * BEAM runner migrated into @remnic/bench for phase 2.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile, readdir } from "node:fs/promises";
+import path from "node:path";
+import type { Message } from "../../../adapters/types.js";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  rougeL,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  BEAM_SMOKE_FIXTURE,
+  type BeamChatTurn,
+  type BeamConversation,
+  type BeamPlan,
+  type BeamQuestion,
+  type BeamQuestionMap,
+} from "./fixture.js";
+
+const SPLIT_ORDER: Record<string, number> = {
+  "100K": 0,
+  "500K": 1,
+  "1M": 2,
+  "10M": 3,
+};
+
+export const beamDefinition: BenchmarkDefinition = {
+  id: "beam",
+  title: "BEAM",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "beam",
+    version: "2.0.0",
+    description:
+      "Beyond a Million Tokens benchmark across 128K/500K/1M/10M conversational memory probes and 10 memory abilities.",
+    category: "retrieval",
+    citation:
+      "Tavakoli et al. Beyond a Million Tokens: Benchmarking and Enhancing Long-Term Memory in LLMs. ICLR 2026.",
+  },
+};
+
+interface BeamDatasetEntry {
+  scale: string;
+  conversation: BeamConversation;
+}
+
+interface BeamSession {
+  sessionId: string;
+  messages: Message[];
+}
+
+export async function runBeamBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const entry of dataset) {
+    await options.system.reset();
+
+    const questionMap = normalizeQuestionMap(entry.conversation.probing_questions);
+    const sessions = collectSessions(entry.conversation, entry.scale);
+    const sessionIds = sessions
+      .filter((session) => session.messages.length > 0)
+      .map((session) => session.sessionId);
+
+    for (const session of sessions) {
+      if (session.messages.length > 0) {
+        await options.system.store(session.sessionId, session.messages);
+      }
+    }
+
+    let taskIndex = 0;
+    for (const [ability, questions] of Object.entries(questionMap)) {
+      for (const probe of questions) {
+        const expected = buildExpectedAnswer(probe);
+        const rubricTargets = normalizeRubricTargets(probe.rubric);
+        const { result: recalledText, durationMs } = await timed(async () => {
+          const recalledSessions = await Promise.all(
+            sessionIds.map((sessionId) =>
+              options.system.recall(sessionId, probe.question),
+            ),
+          );
+          return recalledSessions.filter(Boolean).join("\n\n");
+        });
+        const searchResults = await options.system.search(probe.question, 10);
+        const judgeScore = await llmJudgeScore(
+          options.system.judge,
+          probe.question,
+          recalledText,
+          expected,
+        );
+
+        const scores: Record<string, number> = {
+          f1: f1Score(recalledText, expected),
+          contains_answer: containsAnswer(recalledText, expected),
+          rouge_l: rougeL(recalledText, expected),
+          search_hits: searchResults.length,
+        };
+        if (rubricTargets.length > 0) {
+          scores.rubric_coverage = computeRubricCoverage(
+            recalledText,
+            rubricTargets,
+          );
+        }
+        if (judgeScore >= 0) {
+          scores.llm_judge = judgeScore;
+        }
+
+        tasks.push({
+          taskId: `${entry.scale}-${entry.conversation.conversation_id}-${ability}-${taskIndex}`,
+          question: probe.question,
+          expected,
+          actual: recalledText,
+          scores,
+          latencyMs: durationMs,
+          tokens: { input: 0, output: 0 },
+          details: {
+            ability,
+            scale: entry.scale,
+            difficulty: probe.difficulty,
+            conversationId: entry.conversation.conversation_id,
+            sessionCount: sessionIds.length,
+            planReference: probe.plan_reference,
+            sourceChatIds: probe.source_chat_ids,
+            rubric: probe.rubric,
+            recalledLength: recalledText.length,
+          },
+        });
+        taskIndex += 1;
+      }
+    }
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<BeamDatasetEntry[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetEntries = (entries: BeamDatasetEntry[]): BeamDatasetEntry[] => {
+    if (entries.length === 0) {
+      throw new Error("BEAM dataset is empty after applying the requested limit.");
+    }
+    return entries;
+  };
+
+  if (datasetDir) {
+    let filenames: string[];
+    try {
+      filenames = await readdir(datasetDir);
+    } catch (error) {
+      throw new Error(
+        `BEAM dataset not found under ${datasetDir}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    const datasetFiles = filenames
+      .filter((filename) => filename.endsWith(".json") || filename.endsWith(".jsonl"))
+      .sort((left, right) => compareDatasetFiles(left, right));
+
+    if (datasetFiles.length === 0) {
+      throw new Error(
+        `BEAM dataset not found under ${datasetDir}: no .json or .jsonl files were found.`,
+      );
+    }
+
+    const entries: BeamDatasetEntry[] = [];
+    let remainingLimit = normalizedLimit;
+    for (const filename of datasetFiles) {
+      if (remainingLimit === 0) {
+        break;
+      }
+
+      const raw = await readFile(path.join(datasetDir, filename), "utf8");
+      const scale = inferScaleFromFilename(filename);
+      const conversations = filename.endsWith(".jsonl")
+        ? parseJsonlDataset(raw, filename)
+        : parseJsonDataset(raw, filename);
+
+      const limitedConversations = applyLimit(conversations, remainingLimit);
+      entries.push(
+        ...limitedConversations.map((conversation) => ({
+          scale,
+          conversation,
+        })),
+      );
+      if (remainingLimit !== undefined) {
+        remainingLimit = Math.max(0, remainingLimit - limitedConversations.length);
+      }
+    }
+
+    return ensureDatasetEntries(entries);
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "BEAM full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetEntries(
+    applyLimit(BEAM_SMOKE_FIXTURE, normalizedLimit).map((conversation) => ({
+      scale: "100K",
+      conversation,
+    })),
+  );
+}
+
+function compareDatasetFiles(left: string, right: string): number {
+  const scaleDelta =
+    (SPLIT_ORDER[inferScaleFromFilename(left)] ?? Number.MAX_SAFE_INTEGER) -
+    (SPLIT_ORDER[inferScaleFromFilename(right)] ?? Number.MAX_SAFE_INTEGER);
+  if (scaleDelta !== 0) {
+    return scaleDelta;
+  }
+  return left.localeCompare(right);
+}
+
+function inferScaleFromFilename(filename: string): string {
+  const normalized = filename.toLowerCase();
+  if (normalized.includes("10m")) return "10M";
+  if (normalized.includes("1m")) return "1M";
+  if (normalized.includes("500k")) return "500K";
+  if (normalized.includes("100k") || normalized.includes("128k")) return "100K";
+  return "unknown";
+}
+
+function parseJsonDataset(raw: string, filename: string): BeamConversation[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `BEAM dataset file ${filename} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(`BEAM dataset file ${filename} must contain an array of conversations.`);
+  }
+
+  return parsed.map((conversation, index) =>
+    validateConversation(conversation, `${filename}[${index}]`),
+  );
+}
+
+function parseJsonlDataset(raw: string, filename: string): BeamConversation[] {
+  const conversations: BeamConversation[] = [];
+  raw.split("\n").forEach((line, lineIndex) => {
+    if (line.trim().length === 0) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch (error) {
+      throw new Error(
+        `BEAM dataset file ${filename} contains invalid JSON on line ${lineIndex + 1}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+    conversations.push(
+      validateConversation(parsed, `${filename}:${lineIndex + 1}`),
+    );
+  });
+
+  return conversations;
+}
+
+function validateConversation(
+  value: unknown,
+  location: string,
+): BeamConversation {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`BEAM conversation ${location} must be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.conversation_id !== "string" &&
+    !Number.isInteger(record.conversation_id)
+  ) {
+    throw new Error(
+      `BEAM conversation ${location} must include a string or integer conversation_id.`,
+    );
+  }
+  if (!isChatCollection(record.chat)) {
+    throw new Error(
+      `BEAM conversation ${location} must include chat data as a list of turns or turn batches.`,
+    );
+  }
+  if (
+    typeof record.probing_questions !== "string" &&
+    !isQuestionMap(record.probing_questions)
+  ) {
+    throw new Error(
+      `BEAM conversation ${location} must include probing_questions as a string or question map.`,
+    );
+  }
+  if (record.plans !== undefined && !isValidPlans(record.plans)) {
+    throw new Error(
+      `BEAM conversation ${location} has an invalid plans array.`,
+    );
+  }
+
+  return record as unknown as BeamConversation;
+}
+
+function isChatCollection(value: unknown): value is BeamConversation["chat"] {
+  if (!Array.isArray(value)) {
+    return false;
+  }
+  return value.every((entry) => isChatTurn(entry) || isChatBatch(entry));
+}
+
+function isChatBatch(value: unknown): value is BeamChatTurn[] {
+  return Array.isArray(value) && value.every((entry) => isChatTurn(entry));
+}
+
+function isChatTurn(value: unknown): value is BeamChatTurn {
+  return !!value && typeof value === "object" && typeof (value as BeamChatTurn).content === "string";
+}
+
+function isQuestionMap(value: unknown): value is BeamQuestionMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    (questions) =>
+      Array.isArray(questions) &&
+      questions.every(
+        (question) =>
+          !!question &&
+          typeof question === "object" &&
+          typeof (question as BeamQuestion).question === "string",
+      ),
+  );
+}
+
+function isValidPlans(value: unknown): value is BeamPlan[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (plan) =>
+        !!plan &&
+        typeof plan === "object" &&
+        (plan.chat === undefined || isChatCollection(plan.chat)),
+    )
+  );
+}
+
+function normalizeQuestionMap(raw: BeamConversation["probing_questions"]): BeamQuestionMap {
+  if (typeof raw !== "string") {
+    return raw;
+  }
+
+  const parsed = parseStructuredLiteral(raw);
+  if (!isQuestionMap(parsed)) {
+    throw new Error("BEAM probing_questions did not parse into a valid question map.");
+  }
+  return parsed;
+}
+
+function collectSessions(
+  conversation: BeamConversation,
+  scale: string,
+): BeamSession[] {
+  const conversationId = String(conversation.conversation_id);
+  const sessions: BeamSession[] = [];
+
+  flattenChatCollection(conversation.chat).forEach((batch, batchIndex) => {
+    sessions.push({
+      sessionId: `beam-${scale}-${conversationId}-main-${batchIndex + 1}`,
+      messages: buildMessages(batch),
+    });
+  });
+
+  (conversation.plans ?? []).forEach((plan, planIndex) => {
+    if (!plan.chat) {
+      return;
+    }
+    flattenChatCollection(plan.chat).forEach((batch, batchIndex) => {
+      sessions.push({
+        sessionId:
+          `beam-${scale}-${conversationId}-plan-${String(plan.plan_id ?? planIndex)}-${batchIndex + 1}`,
+        messages: buildMessages(batch),
+      });
+    });
+  });
+
+  return sessions;
+}
+
+function flattenChatCollection(
+  chat: BeamConversation["chat"],
+): BeamChatTurn[][] {
+  if (chat.length === 0) {
+    return [];
+  }
+  return isChatTurn(chat[0]) ? [chat as BeamChatTurn[]] : (chat as BeamChatTurn[][]);
+}
+
+function buildMessages(turns: BeamChatTurn[]): Message[] {
+  return turns.map((turn) => ({
+    role: normalizeRole(turn.role),
+    content: turn.content,
+  }));
+}
+
+function normalizeRole(role: string): Message["role"] {
+  if (role === "assistant" || role === "system") {
+    return role;
+  }
+  return "user";
+}
+
+function buildExpectedAnswer(question: BeamQuestion): string {
+  for (const candidate of [
+    question.ideal_response,
+    question.ideal_answer,
+    question.ideal_summary,
+    question.answer,
+    question.instruction_being_tested,
+    question.preference_being_tested,
+    question.expected_compliance,
+  ]) {
+    if (typeof candidate === "string" && candidate.trim().length > 0) {
+      return candidate.trim();
+    }
+  }
+
+  const rubricTargets = normalizeRubricTargets(question.rubric);
+  if (rubricTargets.length > 0) {
+    return rubricTargets.join(" ");
+  }
+
+  return question.question;
+}
+
+function normalizeRubricTargets(rubric: BeamQuestion["rubric"]): string[] {
+  if (!Array.isArray(rubric)) {
+    return [];
+  }
+
+  return rubric
+    .map((item) => {
+      if (typeof item !== "string") {
+        return "";
+      }
+      return item.replace(/^LLM response should (?:contain|state|mention):\s*/i, "").trim();
+    })
+    .filter((item) => item.length > 0);
+}
+
+function computeRubricCoverage(actual: string, rubricTargets: string[]): number {
+  if (rubricTargets.length === 0) {
+    return 0;
+  }
+
+  const matches = rubricTargets.filter((target) =>
+    containsAnswer(actual, target) === 1,
+  ).length;
+  return matches / rubricTargets.length;
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `BEAM limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}
+
+function parseStructuredLiteral(input: string): unknown {
+  const parser = new StructuredLiteralParser(input);
+  const result = parser.parseValue();
+  parser.skipWhitespace();
+  if (!parser.isDone()) {
+    throw new Error("Unexpected trailing content in BEAM probing_questions literal.");
+  }
+  return result;
+}
+
+class StructuredLiteralParser {
+  private index = 0;
+
+  constructor(private readonly source: string) {}
+
+  parseValue(): unknown {
+    this.skipWhitespace();
+    const current = this.peek();
+
+    if (current === "{") {
+      return this.parseObject();
+    }
+    if (current === "[") {
+      return this.parseArray();
+    }
+    if (current === "'" || current === "\"") {
+      return this.parseString();
+    }
+    if (current === "-" || this.isDigit(current)) {
+      return this.parseNumber();
+    }
+    return this.parseKeyword();
+  }
+
+  skipWhitespace(): void {
+    while (!this.isDone() && /\s/.test(this.peek())) {
+      this.index += 1;
+    }
+  }
+
+  isDone(): boolean {
+    return this.index >= this.source.length;
+  }
+
+  private parseObject(): Record<string, unknown> {
+    const result: Record<string, unknown> = {};
+    this.expect("{");
+    this.skipWhitespace();
+    if (this.peek() === "}") {
+      this.index += 1;
+      return result;
+    }
+
+    while (!this.isDone()) {
+      const keyValue = this.parseValue();
+      if (typeof keyValue !== "string") {
+        throw new Error("BEAM probing_questions object keys must be strings.");
+      }
+      this.skipWhitespace();
+      this.expect(":");
+      const value = this.parseValue();
+      result[keyValue] = value;
+      this.skipWhitespace();
+      const current = this.peek();
+      if (current === "}") {
+        this.index += 1;
+        return result;
+      }
+      this.expect(",");
+    }
+
+    throw new Error("Unterminated object literal in BEAM probing_questions.");
+  }
+
+  private parseArray(): unknown[] {
+    const result: unknown[] = [];
+    this.expect("[");
+    this.skipWhitespace();
+    if (this.peek() === "]") {
+      this.index += 1;
+      return result;
+    }
+
+    while (!this.isDone()) {
+      result.push(this.parseValue());
+      this.skipWhitespace();
+      const current = this.peek();
+      if (current === "]") {
+        this.index += 1;
+        return result;
+      }
+      this.expect(",");
+    }
+
+    throw new Error("Unterminated array literal in BEAM probing_questions.");
+  }
+
+  private parseString(): string {
+    const quote = this.peek();
+    this.index += 1;
+    let result = "";
+
+    while (!this.isDone()) {
+      const current = this.peek();
+      this.index += 1;
+
+      if (current === "\\") {
+        if (this.isDone()) {
+          throw new Error("Invalid escape sequence in BEAM probing_questions.");
+        }
+        const escaped = this.peek();
+        this.index += 1;
+        result += this.decodeEscape(escaped);
+        continue;
+      }
+
+      if (current === quote) {
+        return result;
+      }
+
+      result += current;
+    }
+
+    throw new Error("Unterminated string literal in BEAM probing_questions.");
+  }
+
+  private parseNumber(): number {
+    const start = this.index;
+    if (this.peek() === "-") {
+      this.index += 1;
+    }
+    while (this.isDigit(this.peek())) {
+      this.index += 1;
+    }
+    if (this.peek() === ".") {
+      this.index += 1;
+      while (this.isDigit(this.peek())) {
+        this.index += 1;
+      }
+    }
+    const raw = this.source.slice(start, this.index);
+    const parsed = Number(raw);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(`Invalid numeric literal "${raw}" in BEAM probing_questions.`);
+    }
+    return parsed;
+  }
+
+  private parseKeyword(): unknown {
+    const start = this.index;
+    while (!this.isDone() && /[A-Za-z_]/.test(this.peek())) {
+      this.index += 1;
+    }
+    const keyword = this.source.slice(start, this.index);
+    switch (keyword) {
+      case "True":
+      case "true":
+        return true;
+      case "False":
+      case "false":
+        return false;
+      case "None":
+      case "null":
+        return null;
+      default:
+        throw new Error(`Unsupported keyword "${keyword}" in BEAM probing_questions.`);
+    }
+  }
+
+  private decodeEscape(value: string): string {
+    switch (value) {
+      case "'":
+      case "\"":
+      case "\\":
+        return value;
+      case "n":
+        return "\n";
+      case "r":
+        return "\r";
+      case "t":
+        return "\t";
+      case "u": {
+        const hex = this.source.slice(this.index, this.index + 4);
+        if (!/^[0-9a-fA-F]{4}$/.test(hex)) {
+          throw new Error("Invalid unicode escape in BEAM probing_questions.");
+        }
+        this.index += 4;
+        return String.fromCodePoint(Number.parseInt(hex, 16));
+      }
+      default:
+        return value;
+    }
+  }
+
+  private expect(expected: string): void {
+    this.skipWhitespace();
+    if (this.peek() !== expected) {
+      throw new Error(
+        `Expected "${expected}" in BEAM probing_questions but found "${this.peek()}".`,
+      );
+    }
+    this.index += 1;
+  }
+
+  private peek(): string {
+    return this.source[this.index] ?? "";
+  }
+
+  private isDigit(value: string): boolean {
+    return value >= "0" && value <= "9";
+  }
+}

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -369,7 +369,19 @@ function isChatCollection(value: unknown): value is BeamConversation["chat"] {
   if (!Array.isArray(value)) {
     return false;
   }
-  return value.every((entry) => isChatTurn(entry) || isChatBatch(entry));
+  if (value.length === 0) {
+    return true;
+  }
+
+  if (isChatTurn(value[0])) {
+    return value.every((entry) => isChatTurn(entry));
+  }
+
+  if (isChatBatch(value[0])) {
+    return value.every((entry) => isChatBatch(entry));
+  }
+
+  return false;
 }
 
 function isChatBatch(value: unknown): value is BeamChatTurn[] {

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -23,6 +23,10 @@ import {
   locomoDefinition,
   runLoCoMoBenchmark,
 } from "./benchmarks/published/locomo/runner.js";
+import {
+  beamDefinition,
+  runBeamBenchmark,
+} from "./benchmarks/published/beam/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -48,6 +52,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...locomoDefinition,
     run: runLoCoMoBenchmark,
+  },
+  {
+    ...beamDefinition,
+    run: runBeamBenchmark,
   },
 ];
 

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -1,0 +1,183 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("runBenchmark executes beam in quick mode with the bundled smoke fixture", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("beam", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "beam");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 4);
+  assert.equal(result.results.tasks[0]?.expected, "March 29");
+  assert.equal(result.results.tasks[0]?.actual.includes("March 29"), true);
+  assert.equal(result.results.tasks[0]?.details.ability, "information_extraction");
+  assert.equal(result.results.tasks[0]?.details.scale, "100K");
+  assert.equal(typeof result.results.aggregates.rouge_l?.mean, "number");
+  assert.equal(typeof result.results.aggregates.search_hits?.mean, "number");
+});
+
+test("runBenchmark loads beam full-mode datasets and includes 10M plan chats in recall", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  const conversation = [
+    {
+      conversation_id: "beam-full-10m-1",
+      chat: [
+        [
+          {
+            id: 1,
+            role: "user",
+            content: "The main thread is about preparing the release checklist.",
+          },
+        ],
+      ],
+      plans: [
+        {
+          plan_id: "plan-0",
+          chat: [
+            [
+              {
+                id: 101,
+                role: "user",
+                content: "Micah owns the final deployment sign-off for the 10M plan.",
+              },
+            ],
+          ],
+        },
+      ],
+      probing_questions:
+        "{'knowledge_update': [{'question': 'Who owns the final deployment sign-off?', 'answer': 'Micah', 'difficulty': 'easy', 'rubric': ['LLM response should state: Micah']}]}",
+    },
+  ];
+
+  await writeFile(
+    path.join(datasetDir, "10M.json"),
+    JSON.stringify(conversation),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Micah");
+  assert.equal(result.results.tasks[0]?.actual.includes("Micah"), true);
+  assert.equal(result.results.tasks[0]?.details.scale, "10M");
+  assert.equal(result.results.tasks[0]?.details.sessionCount, 2);
+});
+
+test("runBenchmark rejects beam full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("beam", {
+        mode: "full",
+        system: adapter,
+      }),
+    /BEAM full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark rejects empty beam datasets after applying limit", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("beam", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /BEAM dataset is empty after applying the requested limit/,
+  );
+});

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -181,3 +181,52 @@ test("runBenchmark rejects empty beam datasets after applying limit", async () =
     /BEAM dataset is empty after applying the requested limit/,
   );
 });
+
+test("runBenchmark rejects beam datasets with mixed chat nesting", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-mixed-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-mixed-1",
+        chat: [
+          {
+            id: 1,
+            role: "user",
+            content: "This top-level array mixes turns and batches.",
+          },
+          [
+            {
+              id: 2,
+              role: "assistant",
+              content: "This nested batch should be rejected.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Who spoke in the second turn?",
+              answer: "assistant",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("beam", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must include chat data as a list of turns or turn batches/,
+  );
+});

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -11,12 +11,12 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
 
   assert.deepEqual(
     benchmarks.map((benchmark) => benchmark.id),
-    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo"],
+    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam"],
   );
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam",
   );
 });
 
@@ -67,6 +67,16 @@ test("getBenchmark returns locomo metadata with a runnable benchmark entry", () 
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "conversational");
+});
+
+test("getBenchmark returns beam metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("beam");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "beam");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "retrieval");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary
- add the BEAM published benchmark runner with quick-mode smoke coverage and full-mode dataset loading
- include 10M plan-chat sessions in recall so multi-session BEAM prompts can hit plan memory
- register BEAM in the published benchmark catalog and add focused runner/registry tests

## Verification
- `/Users/joshuawarren/src/remnic/node_modules/.bin/tsx --test tests/bench-beam-runner.test.ts tests/bench-registry.test.ts`
- `/Users/joshuawarren/src/remnic/node_modules/.bin/tsc --noEmit -p packages/bench/tsconfig.json`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @remnic/bench build`

Closes #445 (phase 2 BEAM slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new benchmark runner with filesystem dataset loading/parsing and custom literal parsing, which could affect reliability/perf and error handling when pointed at real datasets. Changes are otherwise isolated to the bench package and covered by new runner/registry tests.
> 
> **Overview**
> Adds the **published `beam` benchmark** to `@remnic/bench`, including a new runner that can execute in *quick mode* using a bundled smoke fixture or in *full mode* by loading `.json`/`.jsonl` datasets from `datasetDir`.
> 
> The runner validates dataset structure (chat nesting, question maps, optional plan chats), parses `probing_questions` when supplied as a structured string literal, stores conversation + plan sessions for recall, and emits per-probe scores (`f1`, `rouge_l`, `contains_answer`, `search_hits`, optional rubric coverage and `llm_judge`).
> 
> Registers `beam` in the benchmark catalog and adds targeted tests covering quick execution, full-mode dataset loading (including plan-chat recall), and key failure cases (missing datasetDir, empty-after-limit, invalid chat nesting).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e8fe148e4bee5606f357866807fe63eec8b3564. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->