### PR TITLE
fix(server): initialize orchestrator on daemon startup

### DIFF
--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -125,6 +125,11 @@ export class NamespaceSearchRouter {
     return record.collectionState;
   }
 
+  /** Clear cached backend records so the next access re-probes availability. */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
   private async backendRecordFor(namespace: string): Promise<NamespaceBackendRecord> {
     const key = namespace.trim() || this.config.defaultNamespace;
     const existing = this.cache.get(key);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2082,14 +2082,27 @@ export class Orchestrator {
       return false;
     }
 
-    // Run index update — namespace-aware when enabled
+    // Run index update — namespace-aware when enabled.
+    // qmd.update() swallows errors internally (logs + records fail timestamp),
+    // so we snapshot lastUpdateFailedAtMs before the call and compare after
+    // to detect silent failures that would otherwise be misclassified as success.
     if (this.config.qmdMaintenanceEnabled) {
       try {
+        const failTsBefore = "lastUpdateFailedAtMs" in this.qmd
+          ? (this.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
         log.info("startupSearchSync: updating index to match current disk state");
         if (this.config.namespacesEnabled) {
           await this.namespaceSearchRouter.updateNamespaces(namespaces);
         } else {
           await this.qmd.update();
+        }
+        const failTsAfter = "lastUpdateFailedAtMs" in this.qmd
+          ? (this.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
+        if (failTsAfter !== null && failTsAfter !== failTsBefore) {
+          log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
+          return false;
         }
         log.info("startupSearchSync: sync complete");
       } catch (err) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2133,7 +2133,7 @@ export class Orchestrator {
           log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
           return false;
         }
-        if (!this.config.namespacesEnabled && runTsAfter === runTsBefore) {
+        if (!this.config.namespacesEnabled && runTsBefore !== null && runTsAfter === runTsBefore) {
           log.warn("startupSearchSync: update was throttled/skipped (no run timestamp change)");
           return false;
         }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2102,21 +2102,19 @@ export class Orchestrator {
     }
 
     // Run index update — namespace-aware when enabled.
-    // qmd.update() swallows errors internally, so we: (1) reset throttles to
-    // ensure the update actually runs (not skipped by stale backoff from a
-    // previous failed attempt), and (2) verify both timestamps to confirm the
-    // update executed and didn't fail silently.
+    // qmd.update() swallows errors internally, so we: (1) snapshot fail/run
+    // timestamps, (2) reset throttles so the update isn't skipped by stale
+    // backoff, and (3) verify timestamps after update to confirm it executed
+    // and didn't fail silently.
     if (this.config.qmdMaintenanceEnabled) {
       try {
-        if ("resetUpdateThrottles" in this.qmd) {
-          (this.qmd as any).resetUpdateThrottles();
-        }
         const failTsBefore = "lastUpdateFailedAtMs" in this.qmd
           ? (this.qmd as any).lastUpdateFailedAtMs as number | null
           : null;
-        const runTsBefore = "lastUpdateRanAtMs" in this.qmd
-          ? (this.qmd as any).lastUpdateRanAtMs as number | null
-          : null;
+        const hasRunTs = "lastUpdateRanAtMs" in this.qmd;
+        if ("resetUpdateThrottles" in this.qmd) {
+          (this.qmd as any).resetUpdateThrottles();
+        }
         log.info("startupSearchSync: updating index to match current disk state");
         if (this.config.namespacesEnabled) {
           await this.namespaceSearchRouter.updateNamespaces(namespaces);
@@ -2126,15 +2124,15 @@ export class Orchestrator {
         const failTsAfter = "lastUpdateFailedAtMs" in this.qmd
           ? (this.qmd as any).lastUpdateFailedAtMs as number | null
           : null;
-        const runTsAfter = "lastUpdateRanAtMs" in this.qmd
+        const runTsAfter = hasRunTs
           ? (this.qmd as any).lastUpdateRanAtMs as number | null
           : null;
         if (failTsAfter !== null && failTsAfter !== failTsBefore) {
           log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
           return false;
         }
-        if (!this.config.namespacesEnabled && runTsBefore !== null && runTsAfter === runTsBefore) {
-          log.warn("startupSearchSync: update was throttled/skipped (no run timestamp change)");
+        if (!this.config.namespacesEnabled && hasRunTs && runTsAfter === null) {
+          log.warn("startupSearchSync: update was throttled/skipped (run timestamp is null after reset + update)");
           return false;
         }
         log.info("startupSearchSync: sync complete");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2043,6 +2043,72 @@ export class Orchestrator {
   }
 
   /**
+   * Namespace-aware startup search sync. Re-probes QMD, ensures collections
+   * (namespace-aware when namespacesEnabled), runs update, and warms up search.
+   * Designed for server retry paths that run after the deferred init completes
+   * when QMD was not available during initial startup.
+   *
+   * Returns true if the sync succeeded (QMD now available), false otherwise.
+   */
+  async startupSearchSync(): Promise<boolean> {
+    const available = await this.qmd.probe();
+    if (!available) return false;
+
+    log.info(`startupSearchSync: backend now available ${this.qmd.debugStatus()}`);
+
+    // Clear namespace router cache so re-probe picks up newly available backends
+    if (this.config.namespacesEnabled) {
+      this.namespaceSearchRouter.clearCache();
+    }
+
+    // Ensure collections — namespace-aware when enabled
+    const namespaces = this.config.namespacesEnabled
+      ? this.configuredNamespaces()
+      : [this.config.defaultNamespace];
+
+    const states = await Promise.all(
+      namespaces.map(async (namespace) => ({
+        namespace,
+        state: this.config.namespacesEnabled
+          ? await this.namespaceSearchRouter.ensureNamespaceCollection(namespace)
+          : await this.qmd.ensureCollection(this.config.memoryDir),
+      })),
+    );
+
+    const defaultState =
+      states.find((e) => e.namespace === this.config.defaultNamespace)?.state ?? "unknown";
+    if (defaultState === "missing") {
+      log.warn("startupSearchSync: search collection missing; skipping sync");
+      return false;
+    }
+
+    // Run index update — namespace-aware when enabled
+    if (this.config.qmdMaintenanceEnabled) {
+      try {
+        log.info("startupSearchSync: updating index to match current disk state");
+        if (this.config.namespacesEnabled) {
+          await this.namespaceSearchRouter.updateNamespaces(namespaces);
+        } else {
+          await this.qmd.update();
+        }
+        log.info("startupSearchSync: sync complete");
+      } catch (err) {
+        log.warn(`startupSearchSync: update failed (non-fatal): ${err}`);
+      }
+    }
+
+    // Warmup search to pre-load embedding models
+    try {
+      await this.qmd.search("warmup", this.config.defaultNamespace, 1);
+      log.info("startupSearchSync: warmup complete");
+    } catch (err) {
+      log.debug(`startupSearchSync: warmup search failed (non-fatal): ${err}`);
+    }
+
+    return true;
+  }
+
+  /**
    * Auto-register the engram-day-summary cron job in OpenClaw if it doesn't exist.
    * Fire-and-forget — never blocks init or crashes on failure.
    */

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2083,13 +2083,20 @@ export class Orchestrator {
     }
 
     // Run index update — namespace-aware when enabled.
-    // qmd.update() swallows errors internally (logs + records fail timestamp),
-    // so we snapshot lastUpdateFailedAtMs before the call and compare after
-    // to detect silent failures that would otherwise be misclassified as success.
+    // qmd.update() swallows errors internally, so we: (1) reset throttles to
+    // ensure the update actually runs (not skipped by stale backoff from a
+    // previous failed attempt), and (2) verify both timestamps to confirm the
+    // update executed and didn't fail silently.
     if (this.config.qmdMaintenanceEnabled) {
       try {
+        if ("resetUpdateThrottles" in this.qmd) {
+          (this.qmd as any).resetUpdateThrottles();
+        }
         const failTsBefore = "lastUpdateFailedAtMs" in this.qmd
           ? (this.qmd as any).lastUpdateFailedAtMs as number | null
+          : null;
+        const runTsBefore = "lastUpdateRanAtMs" in this.qmd
+          ? (this.qmd as any).lastUpdateRanAtMs as number | null
           : null;
         log.info("startupSearchSync: updating index to match current disk state");
         if (this.config.namespacesEnabled) {
@@ -2100,8 +2107,15 @@ export class Orchestrator {
         const failTsAfter = "lastUpdateFailedAtMs" in this.qmd
           ? (this.qmd as any).lastUpdateFailedAtMs as number | null
           : null;
+        const runTsAfter = "lastUpdateRanAtMs" in this.qmd
+          ? (this.qmd as any).lastUpdateRanAtMs as number | null
+          : null;
         if (failTsAfter !== null && failTsAfter !== failTsBefore) {
           log.warn("startupSearchSync: update silently failed (detected via fail timestamp)");
+          return false;
+        }
+        if (!this.config.namespacesEnabled && runTsAfter === runTsBefore) {
+          log.warn("startupSearchSync: update was throttled/skipped (no run timestamp change)");
           return false;
         }
         log.info("startupSearchSync: sync complete");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1192,6 +1192,14 @@ export class Orchestrator {
   private deferredInitAbort: AbortController | null = null;
 
   /**
+   * Whether the deferred init's QMD startup sync completed successfully.
+   * When false after deferredReady resolves, the server retry loop should
+   * attempt startupSearchSync() even if `qmd.isAvailable()` is true —
+   * availability only means probe succeeded, not that the index is current.
+   */
+  deferredSyncSucceeded = false;
+
+  /**
    * Abort deferred initialization so background QMD sync/warmup stops
    * promptly on shutdown. Safe to call multiple times or before init.
    */
@@ -1947,9 +1955,16 @@ export class Orchestrator {
           await this.qmd.update();
         }
         log.info("QMD startup sync: complete");
+        this.deferredSyncSucceeded = true;
       } catch (err) {
         log.warn(`QMD startup sync failed (non-fatal): ${err}`);
+        // deferredSyncSucceeded stays false — server retry will attempt sync
       }
+    } else if (!(this.qmd.isAvailable())) {
+      // QMD not available at deferred init time — server retry will handle it
+    } else {
+      // QMD available but maintenance disabled — consider sync not needed
+      this.deferredSyncSucceeded = true;
     }
 
     if (signal.aborted) return;
@@ -2009,6 +2024,8 @@ export class Orchestrator {
     cacheWarmups.push(this.storage.readAllEntityFiles().then(() => {}).catch(() => {}));
     await Promise.all(cacheWarmups);
 
+    if (signal.aborted) return;
+
     if (this.config.conversationIndexEnabled && this.conversationIndexBackend) {
       try {
         const init = await this.conversationIndexBackend.initialize();
@@ -2027,6 +2044,8 @@ export class Orchestrator {
         this.config.conversationIndexEnabled = false;
       }
     }
+
+    if (signal.aborted) return;
 
     if (this.config.localLlmEnabled) {
       try {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1189,6 +1189,18 @@ export class Orchestrator {
    */
   deferredReady: Promise<void> = Promise.resolve();
   private resolveDeferredReady: (() => void) | null = null;
+  private deferredInitAbort: AbortController | null = null;
+
+  /**
+   * Abort deferred initialization so background QMD sync/warmup stops
+   * promptly on shutdown. Safe to call multiple times or before init.
+   */
+  abortDeferredInit(): void {
+    if (this.deferredInitAbort) {
+      this.deferredInitAbort.abort();
+      this.deferredInitAbort = null;
+    }
+  }
 
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
   setRecallWorkspaceOverride(sessionKey: string, dir: string): void {
@@ -1885,7 +1897,8 @@ export class Orchestrator {
       // promise prematurely while leaving the first cycle's promise pending.
       const resolveDeferred = this.resolveDeferredReady;
       this.resolveDeferredReady = null;
-      this.deferredInitialize()
+      this.deferredInitAbort = new AbortController();
+      this.deferredInitialize(this.deferredInitAbort.signal)
         .catch((err) => {
           log.error(`deferred initialization failed (non-fatal): ${err}`);
         })
@@ -1914,9 +1927,9 @@ export class Orchestrator {
     }
   }
 
-  private async deferredInitialize(): Promise<void> {
-    // QMD probe + collection check (including NoopSearchBackend swap) already
-    // ran in initialize() before the init gate opened, so this.qmd is final.
+  private async deferredInitialize(signal: AbortSignal): Promise<void> {
+
+    if (signal.aborted) return;
 
     // Sync QMD index with current disk state so recall finds recently-written
     // facts. Without this, the index stays stale from the last extraction-
@@ -1938,6 +1951,8 @@ export class Orchestrator {
         log.warn(`QMD startup sync failed (non-fatal): ${err}`);
       }
     }
+
+    if (signal.aborted) return;
 
     // Warmup: run cheap searches to pre-load QMD embedding models and the
     // embedding-fallback JSON index so the first real recall is fast.
@@ -1971,6 +1986,7 @@ export class Orchestrator {
       );
     }
     await Promise.all(warmupPromises);
+    if (signal.aborted) return;
 
     // Pre-warm knowledge index, memory, and entity caches.
     // Awaited so callers of `deferredReady` can rely on warmups being complete
@@ -2019,6 +2035,8 @@ export class Orchestrator {
         log.error(`Local LLM validation failed (non-fatal): ${err}`);
       }
     }
+
+    if (signal.aborted) return;
 
     // Await cron auto-registration so callers that `await deferredReady` can
     // rely on cron jobs being registered when it resolves. Without this, the
@@ -2078,7 +2096,8 @@ export class Orchestrator {
     const defaultState =
       states.find((e) => e.namespace === this.config.defaultNamespace)?.state ?? "unknown";
     if (defaultState === "missing") {
-      log.warn("startupSearchSync: search collection missing; skipping sync");
+      this.qmd = new NoopSearchBackend();
+      log.warn("startupSearchSync: search collection missing; disabling search (fallback retrieval remains enabled)");
       return false;
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2093,7 +2093,8 @@ export class Orchestrator {
         }
         log.info("startupSearchSync: sync complete");
       } catch (err) {
-        log.warn(`startupSearchSync: update failed (non-fatal): ${err}`);
+        log.warn(`startupSearchSync: update failed: ${err}`);
+        return false;
       }
     }
 

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -800,6 +800,19 @@ export class QmdClient implements SearchBackend {
   get lastUpdateFailedAtMs(): number | null {
     return this._lastUpdateFailAtMs;
   }
+
+  get lastUpdateRanAtMs(): number | null {
+    return this.lastUpdateRunAtMs;
+  }
+
+  resetUpdateThrottles(): void {
+    this._lastUpdateFailAtMs = null;
+    this.lastUpdateRunAtMs = null;
+    const gs = getGlobalQmdState();
+    gs.lastGlobalUpdateRunAtMs = null;
+    gs.lastGlobalUpdateFailAtMs = null;
+  }
+
   private readonly updateTimeoutMs: number;
   private readonly updateMinIntervalMs: number;
   private readonly slowLog?: { enabled: boolean; thresholdMs: number };

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -793,9 +793,13 @@ function getSharedDaemonSession(qmdPath: string): QmdDaemonSession {
 
 export class QmdClient implements SearchBackend {
   private available: boolean | null = null;
-  private lastUpdateFailAtMs: number | null = null;
+  private _lastUpdateFailAtMs: number | null = null;
   private lastEmbedFailAtMs: number | null = null;
   private lastUpdateRunAtMs: number | null = null;
+
+  get lastUpdateFailedAtMs(): number | null {
+    return this._lastUpdateFailAtMs;
+  }
   private readonly updateTimeoutMs: number;
   private readonly updateMinIntervalMs: number;
   private readonly slowLog?: { enabled: boolean; thresholdMs: number };
@@ -1663,8 +1667,8 @@ export class QmdClient implements SearchBackend {
         return;
       }
       if (
-        this.lastUpdateFailAtMs &&
-        now - this.lastUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
+        this._lastUpdateFailAtMs &&
+        now - this._lastUpdateFailAtMs < QMD_UPDATE_BACKOFF_MS
       ) {
         log.debug("QMD update: suppressed due to recent failures (backoff)");
         return;
@@ -1712,7 +1716,7 @@ export class QmdClient implements SearchBackend {
         globalState.lastUpdateFailByCollectionMs[name] = at;
         globalState.lastGlobalUpdateFailAtMs = at;
       } else {
-        this.lastUpdateFailAtMs = at;
+        this._lastUpdateFailAtMs = at;
         globalState.lastGlobalUpdateFailAtMs = at;
       }
       const msg = err instanceof Error ? err.message : String(err);

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -174,7 +174,7 @@ export async function startServer(options?: {
   const startupSyncAbort = new AbortController();
 
   orchestrator.deferredReady.then(() => {
-    if (!orchestrator.qmd.isAvailable()) {
+    if (!orchestrator.qmd.isAvailable() && orchestrator.qmd.debugStatus() !== "backend=noop") {
       const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
       (async () => {
         for (const delay of RETRY_DELAYS_MS) {

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -80,6 +80,25 @@ function envOverrides(): Partial<ServerConfig["server"]> & { remnic?: Record<str
   return { ...overrides, ...(Object.keys(remnic).length > 0 ? { remnic } : {}) };
 }
 
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Like `setTimeout` wrapped in a Promise, but respects an `AbortSignal`.
+ * Resolves immediately (without throwing) when the signal fires so the
+ * caller can check `signal.aborted` and exit cleanly.
+ */
+function abortableDelay(ms: number, signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise<void>((resolve) => {
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      resolve();
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 // ── Server startup ──────────────────────────────────────────────────────────
 
 export interface ServerResult {
@@ -88,6 +107,8 @@ export interface ServerResult {
   httpServer: EngramAccessHttpServer;
   host: string;
   port: number;
+  /** Cancel any pending startup-sync retry timers. Called automatically on shutdown. */
+  cancelStartupSync: () => void;
 }
 
 export async function startServer(options?: {
@@ -149,12 +170,20 @@ export async function startServer(options?: {
   // Fire-and-forget: wait for deferred init (QMD probe, collection setup,
   // warmup) then check QMD availability and retry if needed. This does NOT
   // block the server listener — connections are accepted immediately above.
+  // An AbortController allows the shutdown handler to cancel pending retries.
+  const startupSyncAbort = new AbortController();
+
   orchestrator.deferredReady.then(() => {
     if (!orchestrator.qmd.isAvailable()) {
       const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
       (async () => {
         for (const delay of RETRY_DELAYS_MS) {
-          await new Promise<void>((r) => setTimeout(r, delay));
+          await abortableDelay(delay, startupSyncAbort.signal);
+
+          if (startupSyncAbort.signal.aborted) {
+            log.debug("QMD startup-sync retry: cancelled by shutdown");
+            return;
+          }
 
           const synced = await orchestrator.startupSearchSync();
           if (!synced) {
@@ -174,7 +203,7 @@ export async function startServer(options?: {
     log.warn(`Deferred init error: ${err}`);
   });
 
-  return { config, service, httpServer, host, port };
+  return { config, service, httpServer, host, port, cancelStartupSync: () => startupSyncAbort.abort() };
 }
 
 // ── CLI entry point ──────────────────────────────────────────────────────────
@@ -237,6 +266,7 @@ Environment:
   // Graceful shutdown
   const shutdown = async (signal: string) => {
     console.log(`\nReceived ${signal}, shutting down...`);
+    result.cancelStartupSync();
     await result.httpServer.stop();
     process.exit(0);
   };

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -119,37 +119,8 @@ export async function startServer(options?: {
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
 
-  // Wait for the deferred portion of init (QMD probe, collection setup,
-  // warmup) to complete before checking availability. Without this,
-  // isAvailable() returns false because the QMD probe hasn't run yet
-  // and the retry always fires unnecessarily.
-  await orchestrator.deferredReady;
-
-  // If QMD wasn't available after deferred init completes (e.g. daemon still
-  // loading on cold start), schedule background retries so the search index is
-  // synced once QMD becomes ready. Uses the orchestrator's namespace-aware
-  // startupSearchSync() so namespace-specific collections are also synced.
-  if (!orchestrator.qmd.isAvailable()) {
-    const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
-    (async () => {
-      for (const delay of RETRY_DELAYS_MS) {
-        await new Promise<void>((r) => setTimeout(r, delay));
-
-        const synced = await orchestrator.startupSearchSync();
-        if (!synced) {
-          log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
-          continue;
-        }
-
-        return; // sync succeeded, stop retrying
-      }
-
-      log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
-    })().catch((err) => {
-      log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
-    });
-  }
-
+  // Start the HTTP server immediately so health checks, MCP handshakes,
+  // and liveness probes can connect while deferred init is still running.
   const service = new EngramAccessService(orchestrator);
 
   const authToken = serverConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";
@@ -174,6 +145,34 @@ export async function startServer(options?: {
   });
 
   const { host, port } = await httpServer.start();
+
+  // Fire-and-forget: wait for deferred init (QMD probe, collection setup,
+  // warmup) then check QMD availability and retry if needed. This does NOT
+  // block the server listener — connections are accepted immediately above.
+  orchestrator.deferredReady.then(() => {
+    if (!orchestrator.qmd.isAvailable()) {
+      const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
+      (async () => {
+        for (const delay of RETRY_DELAYS_MS) {
+          await new Promise<void>((r) => setTimeout(r, delay));
+
+          const synced = await orchestrator.startupSearchSync();
+          if (!synced) {
+            log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
+            continue;
+          }
+
+          return; // sync succeeded, stop retrying
+        }
+
+        log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
+      })().catch((err) => {
+        log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
+      });
+    }
+  }).catch((err) => {
+    log.warn(`Deferred init error: ${err}`);
+  });
 
   return { config, service, httpServer, host, port };
 }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -109,6 +109,8 @@ export interface ServerResult {
   port: number;
   /** Cancel any pending startup-sync retry timers. Called automatically on shutdown. */
   cancelStartupSync: () => void;
+  /** Abort deferred orchestrator initialization (QMD sync, warmup, cache). */
+  abortDeferredInit: () => void;
 }
 
 export async function startServer(options?: {
@@ -207,7 +209,7 @@ export async function startServer(options?: {
     log.warn(`Deferred init error: ${err}`);
   });
 
-  return { config, service, httpServer, host, port, cancelStartupSync: () => startupSyncAbort.abort() };
+  return { config, service, httpServer, host, port, cancelStartupSync: () => startupSyncAbort.abort(), abortDeferredInit: () => orchestrator.abortDeferredInit() };
 }
 
 // ── CLI entry point ──────────────────────────────────────────────────────────
@@ -271,6 +273,7 @@ Environment:
   const shutdown = async (signal: string) => {
     console.log(`\nReceived ${signal}, shutting down...`);
     result.cancelStartupSync();
+    result.abortDeferredInit();
     await result.httpServer.stop();
     process.exit(0);
   };

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -118,6 +118,65 @@ export async function startServer(options?: {
   const config = parseConfig(remnicConfig);
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
+
+  // If QMD wasn't available during initialize() (e.g. daemon still loading on
+  // cold start), schedule background retries so the search index is synced once
+  // QMD becomes ready.  Without this, the server would run with a stale/empty
+  // search index for its entire lifetime.
+  if (!orchestrator.qmd.isAvailable()) {
+    const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
+    (async () => {
+      for (const delay of RETRY_DELAYS_MS) {
+        await new Promise<void>((r) => setTimeout(r, delay));
+
+        const available = await orchestrator.qmd.probe();
+        if (!available) {
+          log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
+          continue;
+        }
+
+        log.info(`QMD startup-sync retry: backend now available ${orchestrator.qmd.debugStatus()}`);
+
+        // Ensure collection exists
+        try {
+          const collectionState = await orchestrator.qmd.ensureCollection(config.memoryDir);
+          if (collectionState === "missing") {
+            log.warn("QMD startup-sync retry: search collection missing; skipping sync");
+            return;
+          }
+        } catch (err) {
+          log.warn(`QMD startup-sync retry: ensureCollection failed: ${err}`);
+          return;
+        }
+
+        // Run the startup sync (update index to match disk)
+        if (config.qmdMaintenanceEnabled) {
+          try {
+            log.info("QMD startup-sync retry: updating index to match current disk state");
+            await orchestrator.qmd.update();
+            log.info("QMD startup-sync retry: sync complete");
+          } catch (err) {
+            log.warn(`QMD startup-sync retry: update failed (non-fatal): ${err}`);
+          }
+        }
+
+        // Warmup search to pre-load embedding models
+        try {
+          await orchestrator.qmd.search("warmup", config.defaultNamespace, 1);
+          log.info("QMD startup-sync retry: warmup complete");
+        } catch (err) {
+          log.debug(`QMD startup-sync retry: warmup search failed (non-fatal): ${err}`);
+        }
+
+        return; // sync succeeded, stop retrying
+      }
+
+      log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
+    })().catch((err) => {
+      log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
+    });
+  }
+
   const service = new EngramAccessService(orchestrator);
 
   const authToken = serverConfig.authToken ?? readCompatEnv("REMNIC_AUTH_TOKEN", "ENGRAM_AUTH_TOKEN") ?? "";

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -119,53 +119,26 @@ export async function startServer(options?: {
   const orchestrator = new Orchestrator(config);
   await orchestrator.initialize();
 
-  // If QMD wasn't available during initialize() (e.g. daemon still loading on
-  // cold start), schedule background retries so the search index is synced once
-  // QMD becomes ready.  Without this, the server would run with a stale/empty
-  // search index for its entire lifetime.
+  // Wait for the deferred portion of init (QMD probe, collection setup,
+  // warmup) to complete before checking availability. Without this,
+  // isAvailable() returns false because the QMD probe hasn't run yet
+  // and the retry always fires unnecessarily.
+  await orchestrator.deferredReady;
+
+  // If QMD wasn't available after deferred init completes (e.g. daemon still
+  // loading on cold start), schedule background retries so the search index is
+  // synced once QMD becomes ready. Uses the orchestrator's namespace-aware
+  // startupSearchSync() so namespace-specific collections are also synced.
   if (!orchestrator.qmd.isAvailable()) {
     const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
     (async () => {
       for (const delay of RETRY_DELAYS_MS) {
         await new Promise<void>((r) => setTimeout(r, delay));
 
-        const available = await orchestrator.qmd.probe();
-        if (!available) {
+        const synced = await orchestrator.startupSearchSync();
+        if (!synced) {
           log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
           continue;
-        }
-
-        log.info(`QMD startup-sync retry: backend now available ${orchestrator.qmd.debugStatus()}`);
-
-        // Ensure collection exists
-        try {
-          const collectionState = await orchestrator.qmd.ensureCollection(config.memoryDir);
-          if (collectionState === "missing") {
-            log.warn("QMD startup-sync retry: search collection missing; skipping sync");
-            return;
-          }
-        } catch (err) {
-          log.warn(`QMD startup-sync retry: ensureCollection failed: ${err}`);
-          return;
-        }
-
-        // Run the startup sync (update index to match disk)
-        if (config.qmdMaintenanceEnabled) {
-          try {
-            log.info("QMD startup-sync retry: updating index to match current disk state");
-            await orchestrator.qmd.update();
-            log.info("QMD startup-sync retry: sync complete");
-          } catch (err) {
-            log.warn(`QMD startup-sync retry: update failed (non-fatal): ${err}`);
-          }
-        }
-
-        // Warmup search to pre-load embedding models
-        try {
-          await orchestrator.qmd.search("warmup", config.defaultNamespace, 1);
-          log.info("QMD startup-sync retry: warmup complete");
-        } catch (err) {
-          log.debug(`QMD startup-sync retry: warmup search failed (non-fatal): ${err}`);
         }
 
         return; // sync succeeded, stop retrying

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -187,6 +187,10 @@ export async function startServer(options?: {
 
           const synced = await orchestrator.startupSearchSync();
           if (!synced) {
+            if (orchestrator.qmd.debugStatus() === "backend=noop") {
+              log.debug("QMD startup-sync retry: search intentionally disabled; stopping retries");
+              return;
+            }
             log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
             continue;
           }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -176,35 +176,50 @@ export async function startServer(options?: {
   const startupSyncAbort = new AbortController();
 
   orchestrator.deferredReady.then(() => {
-    if (!orchestrator.qmd.isAvailable() && orchestrator.qmd.debugStatus() !== "backend=noop") {
-      const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
-      (async () => {
-        for (const delay of RETRY_DELAYS_MS) {
-          await abortableDelay(delay, startupSyncAbort.signal);
+    // Skip retries when search is intentionally disabled (noop backend).
+    if (orchestrator.qmd.debugStatus() === "backend=noop") {
+      log.debug("QMD startup-sync: search backend is noop, skipping retries");
+      return;
+    }
 
-          if (startupSyncAbort.signal.aborted) {
-            log.debug("QMD startup-sync retry: cancelled by shutdown");
-            return;
-          }
+    // Retry when either: (a) QMD is not available yet (cold-start race), or
+    // (b) QMD is available but the deferred init sync step failed silently
+    // (e.g., update errors swallowed by backend, throttle skip, transient
+    // network failure). Without (b), the daemon permanently serves stale
+    // recall after a failed sync despite healthy QMD probe.
+    const needsRetry = !orchestrator.qmd.isAvailable() || !orchestrator.deferredSyncSucceeded;
+    if (!needsRetry) {
+      log.debug("QMD startup-sync: deferred init completed successfully, no retries needed");
+      return;
+    }
 
-          const synced = await orchestrator.startupSearchSync();
-          if (!synced) {
-            if (orchestrator.qmd.debugStatus() === "backend=noop") {
-              log.debug("QMD startup-sync retry: search intentionally disabled; stopping retries");
-              return;
-            }
-            log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
-            continue;
-          }
+    const RETRY_DELAYS_MS = [5_000, 15_000, 30_000, 60_000, 120_000];
+    (async () => {
+      for (const delay of RETRY_DELAYS_MS) {
+        await abortableDelay(delay, startupSyncAbort.signal);
 
-          return; // sync succeeded, stop retrying
+        if (startupSyncAbort.signal.aborted) {
+          log.debug("QMD startup-sync retry: cancelled by shutdown");
+          return;
         }
 
-        log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
-      })().catch((err) => {
-        log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
-      });
-    }
+        const synced = await orchestrator.startupSearchSync();
+        if (!synced) {
+          if (orchestrator.qmd.debugStatus() === "backend=noop") {
+            log.debug("QMD startup-sync retry: search intentionally disabled; stopping retries");
+            return;
+          }
+          log.debug(`QMD startup-sync retry: not available yet (next retry in ${RETRY_DELAYS_MS[RETRY_DELAYS_MS.indexOf(delay) + 1] ?? "n/a"}ms)`);
+          continue;
+        }
+
+        return; // sync succeeded, stop retrying
+      }
+
+      log.warn("QMD startup-sync retry: exhausted all retries; search index may be stale");
+    })().catch((err) => {
+      log.warn(`QMD startup-sync retry: unexpected error: ${err}`);
+    });
   }).catch((err) => {
     log.warn(`Deferred init error: ${err}`);
   });

--- a/tests/orchestrator-nightly-governance-cron.test.ts
+++ b/tests/orchestrator-nightly-governance-cron.test.ts
@@ -93,3 +93,27 @@ test("initialize triggers nightly governance cron auto-register when explicitly 
     await rm(workspaceDir, { recursive: true, force: true });
   }
 });
+
+test("abortDeferredInit stops deferred initialization before cron registration", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-abort-deferred-memory-"));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "engram-abort-deferred-workspace-"));
+  try {
+    const orchestrator = new Orchestrator(buildConfig(memoryDir, workspaceDir, true)) as any;
+    stubInitializeDependencies(orchestrator);
+
+    let nightlyCalls = 0;
+    orchestrator.autoRegisterNightlyGovernanceCron = () => {
+      nightlyCalls += 1;
+      return Promise.resolve();
+    };
+
+    await orchestrator.initialize();
+    orchestrator.abortDeferredInit();
+    await orchestrator.deferredReady;
+
+    assert.equal(nightlyCalls, 0);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- The standalone `remnic-server` daemon created an `Orchestrator` but never called `initialize()`, so the init gate never resolved, `qmd.probe()` never ran, and every recall timed out after 15s with zero results.
- Adds the missing `await orchestrator.initialize()` call in `startServer()` between Orchestrator construction and `EngramAccessService` creation.

## Root cause

`startServer()` in `packages/remnic-server/src/index.ts` was missing the `initialize()` call that the OpenClaw plugin path performs via the `gateway_start` hook. Without it:
1. `initPromise` never resolves → 15s timeout on every recall
2. `qmd.probe()` (in `deferredInitialize()`) never runs → `isAvailable()` returns false
3. `qmd.search()` returns `[]` immediately
4. All memory recall returns 0 results

## Test plan

- [x] `tsc --noEmit` passes
- [x] `tsup` build succeeds
- [ ] Start daemon with `npx remnic-server`, verify QMD probe runs in logs
- [ ] `remnic recall` returns actual memory results instead of empty array

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches daemon startup and deferred initialization flow, adding retry logic and new abort paths; mistakes could lead to missed indexing syncs or background work not stopping cleanly.
> 
> **Overview**
> Fixes daemon startup by ensuring the `Orchestrator` is initialized before serving requests, and by adding a post-start *startup search sync* path that retries QMD probe/collection setup/index update after deferred init when the backend isn’t ready or the initial sync didn’t complete.
> 
> Makes deferred initialization controllable: adds an abort mechanism to stop deferred QMD sync/warmups/cache/cron work on shutdown, tracks whether the deferred sync succeeded, and exposes QMD update throttle timestamps/reset hooks to detect and recover from silently skipped/failed updates. Also adds a namespace router cache clear to force re-probing backends when they become available, plus a test covering `abortDeferredInit()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b9b2bdd217dc6efd367f405bc519fb5ffdfd244. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->