### PR TITLE
feat(bench): add PersonaMem-v2 runner

### DIFF
--- a/packages/bench/src/benchmarks/published/personamem/fixture.ts
+++ b/packages/bench/src/benchmarks/published/personamem/fixture.ts
@@ -1,0 +1,83 @@
+export interface PersonaMemChatMessage {
+  role: string;
+  content: string;
+}
+
+export interface PersonaMemChatHistory {
+  metadata?: Record<string, unknown>;
+  chat_history: PersonaMemChatMessage[];
+}
+
+export interface PersonaMemSample {
+  personaId: string;
+  userQuery: string;
+  correctAnswer: string;
+  chatHistory: PersonaMemChatHistory;
+  topicQuery?: string;
+  preference?: string;
+  topicPreference?: string;
+  prefType?: string;
+  relatedConversationSnippet?: string;
+  who?: string;
+  updated?: string;
+  prevPref?: string;
+  chatHistory32kLink?: string;
+  chatHistory128kLink?: string;
+}
+
+export const PERSONAMEM_SMOKE_FIXTURE: PersonaMemSample[] = [
+  {
+    personaId: "personamem-smoke-1",
+    userQuery: "Which tea do I usually drink while journaling in the morning?",
+    correctAnswer: "Earl Grey",
+    preference: "Earl Grey while journaling",
+    prefType: "implicit_preference",
+    relatedConversationSnippet:
+      "I like to journal every morning with a mug of Earl Grey tea.",
+    chatHistory: {
+      metadata: { persona_id: "personamem-smoke-1" },
+      chat_history: [
+        {
+          role: "system",
+          content: "You are a personalized assistant helping a user over time.",
+        },
+        {
+          role: "user",
+          content: "I like to journal every morning with a mug of Earl Grey tea.",
+        },
+        {
+          role: "assistant",
+          content: "Noted: journaling pairs with Earl Grey tea for you.",
+        },
+      ],
+    },
+  },
+  {
+    personaId: "personamem-smoke-1",
+    userQuery: "What music do I tend to put on when I cook on Sunday evenings?",
+    correctAnswer: "jazz piano",
+    preference: "jazz piano while cooking on Sunday evenings",
+    prefType: "implicit_preference",
+    relatedConversationSnippet:
+      "On Sunday evenings I usually cook pasta with soft jazz piano playing in the background.",
+    chatHistory: {
+      metadata: { persona_id: "personamem-smoke-1" },
+      chat_history: [
+        {
+          role: "system",
+          content: "You are a personalized assistant helping a user over time.",
+        },
+        {
+          role: "user",
+          content:
+            "On Sunday evenings I usually cook pasta with soft jazz piano playing in the background.",
+        },
+        {
+          role: "assistant",
+          content:
+            "Got it. Sunday evening cooking means pasta and jazz piano for you.",
+        },
+      ],
+    },
+  },
+];

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -1,0 +1,548 @@
+/**
+ * PersonaMem-v2 runner migrated into @remnic/bench for phase 1.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Message } from "../../../adapters/types.js";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  PERSONAMEM_SMOKE_FIXTURE,
+  type PersonaMemChatHistory,
+  type PersonaMemSample,
+} from "./fixture.js";
+
+const DATASET_FILE_CANDIDATES = [
+  "benchmark/text/benchmark.csv",
+  "benchmark/benchmark.csv",
+  "benchmark.csv",
+] as const;
+
+interface RawPersonaMemRow {
+  persona_id: string;
+  chat_history_32k_link: string;
+  chat_history_128k_link?: string;
+  user_query: string;
+  correct_answer: string;
+  topic_query?: string;
+  preference?: string;
+  topic_preference?: string;
+  pref_type?: string;
+  related_conversation_snippet?: string;
+  who?: string;
+  updated?: string;
+  prev_pref?: string;
+}
+
+export const personaMemDefinition: BenchmarkDefinition = {
+  id: "personamem",
+  title: "PersonaMem-v2",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "personamem",
+    version: "2.0.0",
+    description:
+      "Implicit preference-learning benchmark over long user-chatbot histories and personalized response probes.",
+    category: "conversational",
+    citation:
+      "PersonaMem-v2: Towards Personalized Intelligence via Learning Implicit User Personas and Agentic Memory (2025)",
+  },
+};
+
+export async function runPersonaMemBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const samples = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex += 1) {
+    const sample = samples[sampleIndex]!;
+    await options.system.reset();
+
+    const sessionId = `personamem-${sample.personaId}`;
+    const messages = buildMessages(sample.chatHistory.chat_history);
+    if (messages.length > 0) {
+      await options.system.store(sessionId, messages);
+    }
+
+    const { result: recalledText, durationMs } = await timed(async () =>
+      options.system.recall(sessionId, sample.userQuery),
+    );
+    const searchResults = await options.system.search(
+      sample.userQuery,
+      10,
+      sessionId,
+    );
+    const judgeScore = await llmJudgeScore(
+      options.system.judge,
+      sample.userQuery,
+      recalledText,
+      sample.correctAnswer,
+    );
+
+    const scores: Record<string, number> = {
+      f1: f1Score(recalledText, sample.correctAnswer),
+      contains_answer: containsAnswer(recalledText, sample.correctAnswer),
+      search_hits: searchResults.length,
+    };
+    if (judgeScore >= 0) {
+      scores.llm_judge = judgeScore;
+    }
+
+    tasks.push({
+      taskId: `${sample.personaId}-q${sampleIndex}`,
+      question: sample.userQuery,
+      expected: sample.correctAnswer,
+      actual: recalledText,
+      scores,
+      latencyMs: durationMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        personaId: sample.personaId,
+        topicQuery: sample.topicQuery,
+        preference: sample.preference,
+        topicPreference: sample.topicPreference,
+        prefType: sample.prefType,
+        relatedConversationSnippet: sample.relatedConversationSnippet,
+        who: sample.who,
+        updated: sample.updated,
+        prevPref: sample.prevPref,
+        chatHistoryMessageCount: sample.chatHistory.chat_history.length,
+        chatHistory32kLink: sample.chatHistory32kLink,
+        chatHistory128kLink: sample.chatHistory128kLink,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<PersonaMemSample[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetSamples = (
+    samples: PersonaMemSample[],
+  ): PersonaMemSample[] => {
+    if (samples.length === 0) {
+      throw new Error(
+        "PersonaMem-v2 dataset is empty after applying the requested limit.",
+      );
+    }
+    return samples;
+  };
+
+  if (datasetDir) {
+    const datasetErrors: string[] = [];
+    for (const relativePath of DATASET_FILE_CANDIDATES) {
+      const datasetPath = path.join(datasetDir, relativePath);
+      try {
+        const raw = await readFile(datasetPath, "utf8");
+        const rows = parseCsvRows(raw, relativePath);
+        const limitedRows = applyLimit(rows, normalizedLimit);
+        const datasetRoot = resolveDatasetRoot(datasetDir, relativePath);
+        const samples: PersonaMemSample[] = [];
+
+        for (const row of limitedRows) {
+          samples.push(await hydrateSample(row, datasetRoot));
+        }
+
+        return ensureDatasetSamples(samples);
+      } catch (error) {
+        datasetErrors.push(
+          `${relativePath}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `PersonaMem-v2 dataset not found under ${datasetDir}. Tried ${DATASET_FILE_CANDIDATES.join(", ")}. Errors: ${datasetErrors.join(" | ")}`,
+    );
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "PersonaMem-v2 full mode requires datasetDir. Pass a dataset root or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetSamples(
+    applyLimit(PERSONAMEM_SMOKE_FIXTURE, normalizedLimit),
+  );
+}
+
+function resolveDatasetRoot(datasetDir: string, relativePath: string): string {
+  if (relativePath === "benchmark/text/benchmark.csv") {
+    return datasetDir;
+  }
+  if (relativePath === "benchmark/benchmark.csv") {
+    return datasetDir;
+  }
+  return datasetDir;
+}
+
+async function hydrateSample(
+  row: RawPersonaMemRow,
+  datasetRoot: string,
+): Promise<PersonaMemSample> {
+  if (row.persona_id.trim().length === 0) {
+    throw new Error("PersonaMem-v2 row is missing persona_id.");
+  }
+  if (row.chat_history_32k_link.trim().length === 0) {
+    throw new Error(
+      `PersonaMem-v2 row for persona ${row.persona_id} is missing chat_history_32k_link.`,
+    );
+  }
+  if (row.correct_answer.trim().length === 0) {
+    throw new Error(
+      `PersonaMem-v2 row for persona ${row.persona_id} is missing correct_answer.`,
+    );
+  }
+
+  const userQuery = extractLooseObjectValue(row.user_query, "content")
+    ?? row.user_query.trim();
+  if (userQuery.length === 0) {
+    throw new Error(
+      `PersonaMem-v2 row for persona ${row.persona_id} is missing user_query content.`,
+    );
+  }
+
+  const chatHistoryRaw = await readFile(
+    path.resolve(datasetRoot, row.chat_history_32k_link),
+    "utf8",
+  );
+  const chatHistory = parseChatHistory(
+    chatHistoryRaw,
+    row.chat_history_32k_link,
+  );
+
+  return {
+    personaId: row.persona_id,
+    userQuery,
+    correctAnswer: row.correct_answer,
+    topicQuery: row.topic_query,
+    preference: row.preference,
+    topicPreference: row.topic_preference,
+    prefType: row.pref_type,
+    relatedConversationSnippet: row.related_conversation_snippet,
+    who: row.who,
+    updated: row.updated,
+    prevPref: row.prev_pref,
+    chatHistory,
+    chatHistory32kLink: row.chat_history_32k_link,
+    chatHistory128kLink: row.chat_history_128k_link,
+  };
+}
+
+function parseCsvRows(
+  raw: string,
+  filename: string,
+): RawPersonaMemRow[] {
+  const rows = parseCsv(raw);
+  if (rows.length < 2) {
+    throw new Error(
+      `PersonaMem-v2 dataset file ${filename} must contain a header row and at least one data row.`,
+    );
+  }
+
+  const [header, ...dataRows] = rows;
+  const headerIndex = new Map<string, number>();
+  header!.forEach((name, index) => {
+    headerIndex.set(name, index);
+  });
+
+  const requiredColumns = [
+    "persona_id",
+    "chat_history_32k_link",
+    "user_query",
+    "correct_answer",
+  ] as const;
+  for (const column of requiredColumns) {
+    if (!headerIndex.has(column)) {
+      throw new Error(
+        `PersonaMem-v2 dataset file ${filename} is missing required column "${column}".`,
+      );
+    }
+  }
+
+  return dataRows
+    .filter((row) => row.some((value) => value.trim().length > 0))
+    .map((row, rowIndex) => {
+      const valueAt = (column: string): string => {
+        const index = headerIndex.get(column);
+        return index === undefined ? "" : (row[index] ?? "");
+      };
+
+      const record: RawPersonaMemRow = {
+        persona_id: valueAt("persona_id"),
+        chat_history_32k_link: valueAt("chat_history_32k_link"),
+        chat_history_128k_link: valueAt("chat_history_128k_link") || undefined,
+        user_query: valueAt("user_query"),
+        correct_answer: valueAt("correct_answer"),
+        topic_query: valueAt("topic_query") || undefined,
+        preference: valueAt("preference") || undefined,
+        topic_preference: valueAt("topic_preference") || undefined,
+        pref_type: valueAt("pref_type") || undefined,
+        related_conversation_snippet:
+          valueAt("related_conversation_snippet") || undefined,
+        who: valueAt("who") || undefined,
+        updated: valueAt("updated") || undefined,
+        prev_pref: valueAt("prev_pref") || undefined,
+      };
+
+      if (record.persona_id.trim().length === 0) {
+        throw new Error(
+          `PersonaMem-v2 dataset file ${filename} row ${rowIndex + 2} is missing persona_id.`,
+        );
+      }
+      return record;
+    });
+}
+
+function parseCsv(raw: string): string[][] {
+  const rows: string[][] = [];
+  let currentRow: string[] = [];
+  let currentField = "";
+  let inQuotes = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index]!;
+    const next = raw[index + 1];
+
+    if (char === "\"") {
+      if (inQuotes && next === "\"") {
+        currentField += "\"";
+        index += 1;
+      } else {
+        inQuotes = !inQuotes;
+      }
+      continue;
+    }
+
+    if (!inQuotes && char === ",") {
+      currentRow.push(currentField);
+      currentField = "";
+      continue;
+    }
+
+    if (!inQuotes && (char === "\n" || char === "\r")) {
+      if (char === "\r" && next === "\n") {
+        index += 1;
+      }
+      currentRow.push(currentField);
+      rows.push(currentRow);
+      currentRow = [];
+      currentField = "";
+      continue;
+    }
+
+    currentField += char;
+  }
+
+  if (currentField.length > 0 || currentRow.length > 0) {
+    currentRow.push(currentField);
+    rows.push(currentRow);
+  }
+
+  return rows;
+}
+
+function extractLooseObjectValue(
+  raw: string,
+  key: string,
+): string | undefined {
+  const patterns = [`'${key}'`, `"${key}"`];
+  for (const pattern of patterns) {
+    const start = raw.indexOf(pattern);
+    if (start < 0) {
+      continue;
+    }
+
+    let index = start + pattern.length;
+    while (index < raw.length && /\s/.test(raw[index]!)) {
+      index += 1;
+    }
+    if (raw[index] !== ":") {
+      continue;
+    }
+    index += 1;
+    while (index < raw.length && /\s/.test(raw[index]!)) {
+      index += 1;
+    }
+
+    const quote = raw[index];
+    if (quote !== "'" && quote !== "\"") {
+      continue;
+    }
+
+    const parsed = readQuotedValue(raw, index);
+    if (parsed) {
+      return parsed.value;
+    }
+  }
+
+  return undefined;
+}
+
+function readQuotedValue(
+  raw: string,
+  start: number,
+): { value: string; end: number } | undefined {
+  const quote = raw[start];
+  if (quote !== "'" && quote !== "\"") {
+    return undefined;
+  }
+
+  let value = "";
+  for (let index = start + 1; index < raw.length; index += 1) {
+    const char = raw[index]!;
+    if (char === "\\") {
+      const next = raw[index + 1];
+      if (next !== undefined) {
+        value += next;
+        index += 1;
+      }
+      continue;
+    }
+    if (char === quote) {
+      return { value, end: index + 1 };
+    }
+    value += char;
+  }
+
+  return undefined;
+}
+
+function parseChatHistory(
+  raw: string,
+  filename: string,
+): PersonaMemChatHistory {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    throw new Error(
+      `PersonaMem-v2 chat history ${filename} must contain an object with a chat_history array.`,
+    );
+  }
+
+  const chatHistory = (parsed as { chat_history?: unknown }).chat_history;
+  if (!Array.isArray(chatHistory)) {
+    throw new Error(
+      `PersonaMem-v2 chat history ${filename} is missing the chat_history array.`,
+    );
+  }
+
+  return {
+    metadata:
+      "metadata" in parsed && typeof parsed.metadata === "object"
+        ? (parsed.metadata as Record<string, unknown>)
+        : undefined,
+    chat_history: chatHistory.map((entry, index) => {
+      if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+        throw new Error(
+          `PersonaMem-v2 chat history ${filename} contains a malformed message at index ${index}.`,
+        );
+      }
+
+      const role = typeof entry.role === "string" ? entry.role : "assistant";
+      const content =
+        typeof entry.content === "string" ? entry.content : String(entry.content ?? "");
+      return { role, content };
+    }),
+  };
+}
+
+function buildMessages(chatHistory: PersonaMemChatHistory["chat_history"]): Message[] {
+  return chatHistory
+    .filter((message) => message.content.trim().length > 0)
+    .map((message) => ({
+      role: normalizeRole(message.role),
+      content: message.content,
+    }));
+}
+
+function normalizeRole(role: string): Message["role"] {
+  switch (role) {
+    case "user":
+    case "assistant":
+    case "system":
+      return role;
+    default:
+      return "assistant";
+  }
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `PersonaMem-v2 limit must be a non-negative integer. Received ${limit}.`,
+    );
+  }
+
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  return limit === undefined ? items : items.slice(0, limit);
+}

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import type {
@@ -46,6 +46,11 @@ interface RawPersonaMemRow {
   who?: string;
   updated?: string;
   prev_pref?: string;
+}
+
+interface CsvRowRecord {
+  values: string[];
+  rowNumber: number;
 }
 
 export const personaMemDefinition: BenchmarkDefinition = {
@@ -196,13 +201,11 @@ async function loadDataset(
       const datasetPath = path.join(datasetDir, relativePath);
       try {
         const raw = await readFile(datasetPath, "utf8");
-        const rows = parseCsvRows(raw, relativePath);
-        const limitedRows = applyLimit(rows, normalizedLimit);
-        const datasetRoot = resolveDatasetRoot(datasetDir, relativePath);
+        const rows = parseCsvRows(raw, relativePath, normalizedLimit);
         const samples: PersonaMemSample[] = [];
 
-        for (const row of limitedRows) {
-          samples.push(await hydrateSample(row, datasetRoot));
+        for (const row of rows) {
+          samples.push(await hydrateSample(row, datasetDir));
         }
 
         return ensureDatasetSamples(samples);
@@ -227,16 +230,6 @@ async function loadDataset(
   return ensureDatasetSamples(
     applyLimit(PERSONAMEM_SMOKE_FIXTURE, normalizedLimit),
   );
-}
-
-function resolveDatasetRoot(datasetDir: string, relativePath: string): string {
-  if (relativePath === "benchmark/text/benchmark.csv") {
-    return datasetDir;
-  }
-  if (relativePath === "benchmark/benchmark.csv") {
-    return datasetDir;
-  }
-  return datasetDir;
 }
 
 async function hydrateSample(
@@ -265,10 +258,11 @@ async function hydrateSample(
     );
   }
 
-  const chatHistoryRaw = await readFile(
-    path.resolve(datasetRoot, row.chat_history_32k_link),
-    "utf8",
+  const chatHistoryPath = await resolveDatasetFilePath(
+    datasetRoot,
+    row.chat_history_32k_link,
   );
+  const chatHistoryRaw = await readFile(chatHistoryPath, "utf8");
   const chatHistory = parseChatHistory(
     chatHistoryRaw,
     row.chat_history_32k_link,
@@ -295,8 +289,9 @@ async function hydrateSample(
 function parseCsvRows(
   raw: string,
   filename: string,
+  limit: number | undefined,
 ): RawPersonaMemRow[] {
-  const rows = parseCsv(raw);
+  const rows = parseCsv(raw, limit);
   if (rows.length < 2) {
     throw new Error(
       `PersonaMem-v2 dataset file ${filename} must contain a header row and at least one data row.`,
@@ -305,7 +300,7 @@ function parseCsvRows(
 
   const [header, ...dataRows] = rows;
   const headerIndex = new Map<string, number>();
-  header!.forEach((name, index) => {
+  header.values.forEach((name, index) => {
     headerIndex.set(name, index);
   });
 
@@ -323,12 +318,10 @@ function parseCsvRows(
     }
   }
 
-  return dataRows
-    .filter((row) => row.some((value) => value.trim().length > 0))
-    .map((row, rowIndex) => {
+  return dataRows.map((row) => {
       const valueAt = (column: string): string => {
         const index = headerIndex.get(column);
-        return index === undefined ? "" : (row[index] ?? "");
+        return index === undefined ? "" : (row.values[index] ?? "");
       };
 
       const record: RawPersonaMemRow = {
@@ -350,18 +343,39 @@ function parseCsvRows(
 
       if (record.persona_id.trim().length === 0) {
         throw new Error(
-          `PersonaMem-v2 dataset file ${filename} row ${rowIndex + 2} is missing persona_id.`,
+          `PersonaMem-v2 dataset file ${filename} row ${row.rowNumber} is missing persona_id.`,
         );
       }
       return record;
     });
 }
 
-function parseCsv(raw: string): string[][] {
-  const rows: string[][] = [];
+function parseCsv(raw: string, limit: number | undefined): CsvRowRecord[] {
+  const rows: CsvRowRecord[] = [];
   let currentRow: string[] = [];
   let currentField = "";
   let inQuotes = false;
+  let rowNumber = 1;
+  let dataRowCount = 0;
+
+  const pushRow = (): boolean => {
+    const values = [...currentRow, currentField];
+    const isHeader = rows.length === 0;
+    const isBlank = values.every((value) => value.trim().length === 0);
+
+    if (isHeader || !isBlank) {
+      rows.push({ values, rowNumber });
+      if (!isHeader) {
+        dataRowCount += 1;
+      }
+    }
+
+    currentRow = [];
+    currentField = "";
+    rowNumber += 1;
+
+    return limit !== undefined && dataRowCount >= limit;
+  };
 
   for (let index = 0; index < raw.length; index += 1) {
     const char = raw[index]!;
@@ -387,10 +401,9 @@ function parseCsv(raw: string): string[][] {
       if (char === "\r" && next === "\n") {
         index += 1;
       }
-      currentRow.push(currentField);
-      rows.push(currentRow);
-      currentRow = [];
-      currentField = "";
+      if (pushRow()) {
+        return rows;
+      }
       continue;
     }
 
@@ -398,11 +411,32 @@ function parseCsv(raw: string): string[][] {
   }
 
   if (currentField.length > 0 || currentRow.length > 0) {
-    currentRow.push(currentField);
-    rows.push(currentRow);
+    pushRow();
   }
 
   return rows;
+}
+
+async function resolveDatasetFilePath(
+  datasetRoot: string,
+  relativePath: string,
+): Promise<string> {
+  const rootPath = path.resolve(datasetRoot);
+  const rootRealPath = await realpath(rootPath);
+  const candidatePath = path.resolve(rootPath, relativePath);
+  const candidateRealPath = await realpath(candidatePath);
+  const relativeToRoot = path.relative(rootRealPath, candidateRealPath);
+
+  if (
+    relativeToRoot.startsWith("..")
+    || path.isAbsolute(relativeToRoot)
+  ) {
+    throw new Error(
+      `PersonaMem-v2 dataset file reference "${relativePath}" must stay within datasetDir.`,
+    );
+  }
+
+  return candidateRealPath;
 }
 
 function extractLooseObjectValue(

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -27,6 +27,10 @@ import {
   beamDefinition,
   runBeamBenchmark,
 } from "./benchmarks/published/beam/runner.js";
+import {
+  personaMemDefinition,
+  runPersonaMemBenchmark,
+} from "./benchmarks/published/personamem/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -56,6 +60,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...beamDefinition,
     run: runBeamBenchmark,
+  },
+  {
+    ...personaMemDefinition,
+    run: runPersonaMemBenchmark,
   },
 ];
 

--- a/tests/bench-personamem-runner.test.ts
+++ b/tests/bench-personamem-runner.test.ts
@@ -193,3 +193,131 @@ test("runBenchmark rejects personamem full mode without datasetDir", async () =>
     /PersonaMem-v2 full mode requires datasetDir/,
   );
 });
+
+test("runBenchmark rejects personamem chat history links that escape the dataset root", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-escape-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const outsideDir = path.join(tmpDir, "outside");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(outsideDir, { recursive: true });
+
+  await writeFile(
+    path.join(outsideDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [{ role: "user", content: "I prefer oolong tea." }],
+    }),
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "user_query",
+        "correct_answer",
+      ],
+      [
+        "persona-1",
+        "../../outside/persona-1.json",
+        "{'role': 'user', 'content': 'Which tea do I prefer?'}",
+        "oolong tea",
+      ],
+    ),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("personamem", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /must stay within datasetDir/,
+  );
+});
+
+test("runBenchmark honors personamem limit before parsing later CSV rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [{ role: "user", content: "I always order Earl Grey tea." }],
+    }),
+    "utf8",
+  );
+
+  const headers = [
+    "persona_id",
+    "chat_history_32k_link",
+    "user_query",
+    "correct_answer",
+  ];
+  const validRow = [
+    "persona-1",
+    "data/chat_history_32k/persona-1.json",
+    "{'role': 'user', 'content': 'Which tea do I order?'}",
+    "Earl Grey tea",
+  ];
+  const invalidRow = [
+    "",
+    "data/chat_history_32k/persona-1.json",
+    "{'role': 'user', 'content': 'Which tea do I order?'}",
+    "Earl Grey tea",
+  ];
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    `${headers.join(",")}\n${validRow.map(escapeCsvField).join(",")}\n${invalidRow.map(escapeCsvField).join(",")}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Earl Grey tea");
+});
+
+test("runBenchmark preserves original CSV row numbers after blank personamem rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-rows-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(benchmarkDir, { recursive: true });
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    [
+      "persona_id,chat_history_32k_link,user_query,correct_answer",
+      "",
+      ",data/chat_history_32k/persona-1.json,\"{'role': 'user', 'content': 'Which tea do I order?'}\",Earl Grey tea",
+    ].join("\n"),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("personamem", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /row 3 is missing persona_id/,
+  );
+});

--- a/tests/bench-personamem-runner.test.ts
+++ b/tests/bench-personamem-runner.test.ts
@@ -1,0 +1,195 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function escapeCsvField(value: string): string {
+  if (/[",\n]/.test(value)) {
+    return `"${value.replaceAll("\"", "\"\"")}"`;
+  }
+  return value;
+}
+
+function toCsv(headers: string[], values: string[]): string {
+  return `${headers.join(",")}\n${values.map(escapeCsvField).join(",")}\n`;
+}
+
+test("runBenchmark executes personamem in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("personamem", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "personamem");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(
+    result.results.tasks[0]?.actual.includes("Earl Grey"),
+    true,
+  );
+  assert.equal(result.results.tasks[0]?.expected, "Earl Grey");
+});
+
+test("runBenchmark executes personamem in full mode from an explicit dataset root", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      metadata: { persona_id: "persona-1" },
+      chat_history: [
+        {
+          role: "system",
+          content: "You are a personalized assistant.",
+        },
+        {
+          role: "user",
+          content: "I like to journal every morning with a mug of Earl Grey tea.",
+        },
+        {
+          role: "assistant",
+          content: "Noted: journaling pairs with Earl Grey tea for you.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "expanded_persona",
+        "user_query",
+        "correct_answer",
+      ],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{\n  \"preferences\": [\"tea\", \"journaling\"],\n  \"note\": \"contains a comma, too\"\n}",
+        "{'role': 'user', 'content': 'Which tea do I usually drink while journaling in the morning?'}",
+        "Earl Grey",
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(
+    result.results.tasks[0]?.question,
+    "Which tea do I usually drink while journaling in the morning?",
+  );
+  assert.equal(result.results.tasks[0]?.expected, "Earl Grey");
+  assert.equal(
+    result.results.tasks[0]?.actual.includes("Earl Grey"),
+    true,
+  );
+});
+
+test("runBenchmark rejects personamem full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("personamem", {
+        mode: "full",
+        system: adapter,
+      }),
+    /PersonaMem-v2 full mode requires datasetDir/,
+  );
+});

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -11,12 +11,12 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
 
   assert.deepEqual(
     benchmarks.map((benchmark) => benchmark.id),
-    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam"],
+    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam", "personamem"],
   );
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem",
   );
 });
 
@@ -77,6 +77,16 @@ test("getBenchmark returns beam metadata with a runnable benchmark entry", () =>
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns personamem metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("personamem");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "personamem");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "conversational");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary
- add the PersonaMem-v2 published benchmark runner with quick-mode smoke coverage and full-mode dataset loading
- hydrate linked chat-history files and parse the dataset's loose object-literal prompt field into runnable queries
- register PersonaMem in the published benchmark catalog and add focused runner/registry tests

## Verification
- `npx tsx --test tests/bench-personamem-runner.test.ts tests/bench-registry.test.ts`
- `npx tsc --noEmit -p packages/bench/tsconfig.json`
- `pnpm install --frozen-lockfile`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`

Closes #445 (phase 2 PersonaMem slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new published benchmark with custom CSV/JSON dataset parsing and filesystem reads, which can affect benchmark execution and introduces input-handling edge cases despite added path traversal checks and tests.
> 
> **Overview**
> Adds a new published benchmark, **`PersonaMem-v2`**, exposing `personamem` via `runBenchmark` and registering it in the published benchmark catalog.
> 
> The new runner supports *quick mode* via a bundled smoke fixture and *full mode* by loading a CSV dataset plus linked chat-history JSON files (with limit support, basic loose object-literal extraction for `user_query`, and validation that linked files remain within `datasetDir`).
> 
> Updates tests to cover quick/full execution paths, dataset error handling (missing datasetDir, path escape), CSV row/limit behavior, and registry exposure for the new benchmark.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 352a5c66748183e690bf11abe1ec95f7f17b36e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->