### PR TITLE
feat(bench): add MemoryAgentBench runner

### DIFF
--- a/packages/bench/src/benchmarks/published/memoryagentbench/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/fixture.ts
@@ -1,0 +1,102 @@
+import type { Message } from "../../../adapters/types.js";
+
+export type MemoryAgentBenchCompetency =
+  | "accurate_retrieval"
+  | "test_time_learning"
+  | "long_range_understanding"
+  | "conflict_resolution";
+
+export interface MemoryAgentBenchTurn {
+  role: Message["role"];
+  content: string;
+  has_answer?: boolean;
+}
+
+export interface MemoryAgentBenchMetadata {
+  source: string;
+  competency: MemoryAgentBenchCompetency;
+  demo?: string | null;
+  haystack_sessions?: MemoryAgentBenchTurn[][] | null;
+  keypoints?: string[] | null;
+  previous_events?: string[] | null;
+  qa_pair_ids?: string[] | null;
+  question_dates?: string[] | null;
+  question_ids?: string[] | null;
+  question_types?: string[] | null;
+}
+
+export interface MemoryAgentBenchItem {
+  context: string;
+  questions: string[];
+  answers: string[][];
+  metadata: MemoryAgentBenchMetadata;
+}
+
+export const MEMORY_AGENT_BENCH_SMOKE_FIXTURE: MemoryAgentBenchItem[] = [
+  {
+    context: [
+      "Event log:",
+      "1. Maya boarded the blue tram to the museum.",
+      "2. She bought a ticket for the modern art exhibit.",
+      "3. After lunch, she walked to the riverside market.",
+    ].join("\n"),
+    questions: ["After Maya visited the museum, where did she go next?"],
+    answers: [["the riverside market", "riverside market"]],
+    metadata: {
+      source: "eventqa_full",
+      competency: "accurate_retrieval",
+      qa_pair_ids: ["mab-smoke-ar-q1"],
+      question_types: ["event_prediction"],
+    },
+  },
+  {
+    context: [
+      "Example mappings:",
+      "A weather complaint should be labeled label: 12.",
+      "A billing problem should be labeled label: 48.",
+      "A password reset request should be labeled label: 73.",
+    ].join("\n"),
+    questions: ["Classify this request: I need help resetting my password."],
+    answers: [["label: 73", "73"]],
+    metadata: {
+      source: "icl_nlu_8296shot_balance",
+      competency: "test_time_learning",
+      qa_pair_ids: ["mab-smoke-ttl-q1"],
+      question_types: ["classification"],
+    },
+  },
+  {
+    context: [
+      "Case notes:",
+      "Nora found mud on the balcony and a wet umbrella in the hallway.",
+      "The gardener said the balcony door was locked all afternoon.",
+      "A delivery rider remembered Owen arriving soaked just before the alarm.",
+      "The missing ledger was later discovered in Owen's satchel.",
+    ].join("\n"),
+    questions: ["Who most likely took the missing ledger?"],
+    answers: [["Owen"]],
+    metadata: {
+      source: "detective_qa",
+      competency: "long_range_understanding",
+      qa_pair_ids: ["mab-smoke-lru-q1"],
+      question_types: ["inference"],
+      keypoints: ["mud on balcony", "wet umbrella", "ledger in satchel"],
+    },
+  },
+  {
+    context: [
+      "Knowledge pool:",
+      "0. The current project codename is Atlas.",
+      "1. The deployment region is us-east-1.",
+      "2. The current project codename is Zephyr.",
+    ].join("\n"),
+    questions: ["What is the current project codename?"],
+    answers: [["Zephyr"]],
+    metadata: {
+      source: "factconsolidation_sh_6k",
+      competency: "conflict_resolution",
+      qa_pair_ids: ["mab-smoke-cr-q1"],
+      question_types: ["knowledge_conflict"],
+    },
+  },
+];

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -615,11 +615,16 @@ function splitLongChunk(chunk: string, maxLength: number): string[] {
   let remaining = chunk;
   while (remaining.length > maxLength) {
     let splitIndex = remaining.lastIndexOf("\n", maxLength);
+    let keepTrailingPunctuation = false;
     if (splitIndex < maxLength * 0.5) {
       splitIndex = remaining.lastIndexOf(". ", maxLength);
+      keepTrailingPunctuation = splitIndex >= maxLength * 0.5;
     }
     if (splitIndex < maxLength * 0.5) {
       splitIndex = maxLength;
+      keepTrailingPunctuation = false;
+    } else if (keepTrailingPunctuation) {
+      splitIndex += 1;
     }
 
     segments.push(remaining.slice(0, splitIndex).trim());

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -1,0 +1,676 @@
+/**
+ * MemoryAgentBench runner migrated into @remnic/bench for phase 1.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Message } from "../../../adapters/types.js";
+import {
+  MEMORY_AGENT_BENCH_SMOKE_FIXTURE,
+  type MemoryAgentBenchCompetency,
+  type MemoryAgentBenchItem,
+  type MemoryAgentBenchMetadata,
+  type MemoryAgentBenchTurn,
+} from "./fixture.js";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  rougeL,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+
+const DATASET_SPLITS = [
+  {
+    split: "Accurate_Retrieval",
+    competency: "accurate_retrieval" as const,
+    sourcePrefix: "eventqa",
+    candidates: [
+      "Accurate_Retrieval.json",
+      "Accurate_Retrieval.jsonl",
+      "accurate_retrieval.json",
+      "accurate_retrieval.jsonl",
+    ],
+  },
+  {
+    split: "Test_Time_Learning",
+    competency: "test_time_learning" as const,
+    sourcePrefix: "icl_",
+    candidates: [
+      "Test_Time_Learning.json",
+      "Test_Time_Learning.jsonl",
+      "test_time_learning.json",
+      "test_time_learning.jsonl",
+    ],
+  },
+  {
+    split: "Long_Range_Understanding",
+    competency: "long_range_understanding" as const,
+    sourcePrefix: "detective_",
+    candidates: [
+      "Long_Range_Understanding.json",
+      "Long_Range_Understanding.jsonl",
+      "long_range_understanding.json",
+      "long_range_understanding.jsonl",
+    ],
+  },
+  {
+    split: "Conflict_Resolution",
+    competency: "conflict_resolution" as const,
+    sourcePrefix: "factconsolidation",
+    candidates: [
+      "Conflict_Resolution.json",
+      "Conflict_Resolution.jsonl",
+      "conflict_resolution.json",
+      "conflict_resolution.jsonl",
+    ],
+  },
+] as const;
+
+const DATASET_BUNDLE_CANDIDATES = [
+  "memoryagentbench.json",
+  "memoryagentbench.jsonl",
+  "MemoryAgentBench.json",
+  "MemoryAgentBench.jsonl",
+] as const;
+
+export const memoryAgentBenchDefinition: BenchmarkDefinition = {
+  id: "memoryagentbench",
+  title: "MemoryAgentBench",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "memoryagentbench",
+    version: "2.0.0",
+    description:
+      "Incremental multi-turn memory benchmark spanning accurate retrieval, test-time learning, long-range understanding, and conflict resolution.",
+    category: "agentic",
+    citation:
+      "Hu et al. Evaluating Memory in LLM Agents via Incremental Multi-Turn Interactions. ICLR 2026.",
+  },
+};
+
+export async function runMemoryAgentBenchBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const [itemIndex, item] of dataset.entries()) {
+    await options.system.reset();
+
+    const sessionIds = await storeBenchmarkContext(options, item, itemIndex);
+    for (let questionIndex = 0; questionIndex < item.questions.length; questionIndex += 1) {
+      const question = item.questions[questionIndex]!;
+      const answerVariants = item.answers[questionIndex];
+      if (answerVariants === undefined || answerVariants.length === 0) {
+        throw new Error(
+          `MemoryAgentBench sample ${item.metadata.source} is missing answers for question index ${questionIndex}.`,
+        );
+      }
+
+      const { result: recalledText, durationMs } = await timed(async () => {
+        const recalledSessions = await Promise.all(
+          sessionIds.map((sessionId) => options.system.recall(sessionId, question)),
+        );
+        return recalledSessions.filter(Boolean).join("\n\n");
+      });
+      const bestExpectedAnswer = selectBestMatchingAnswer(recalledText, answerVariants);
+      const judgeScore = await llmJudgeScore(
+        options.system.judge,
+        question,
+        recalledText,
+        answerVariants[0]!,
+      );
+
+      const scores: Record<string, number> = {
+        f1: scoreAgainstVariants(recalledText, answerVariants, f1Score),
+        contains_answer: answerVariants.some((variant) =>
+          containsAnswer(recalledText, variant),
+        )
+          ? 1
+          : 0,
+        rouge_l: scoreAgainstVariants(recalledText, answerVariants, rougeL),
+      };
+      if (judgeScore >= 0) {
+        scores.llm_judge = judgeScore;
+      }
+
+      tasks.push({
+        taskId:
+          item.metadata.qa_pair_ids?.[questionIndex] ??
+          `${item.metadata.source}-q${questionIndex}`,
+        question,
+        expected: answerVariants[0]!,
+        actual: recalledText,
+        scores,
+        latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          competency: item.metadata.competency,
+          source: item.metadata.source,
+          questionType: item.metadata.question_types?.[questionIndex],
+          questionId: item.metadata.question_ids?.[questionIndex],
+          questionDate: item.metadata.question_dates?.[questionIndex],
+          previousEvent: item.metadata.previous_events?.[questionIndex],
+          keypoints: item.metadata.keypoints ?? [],
+          answerVariants,
+          bestExpectedAnswer,
+          sessionIds,
+          storedSessionCount: sessionIds.length,
+          recalledLength: recalledText.length,
+        },
+      });
+    }
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<MemoryAgentBenchItem[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetItems = (items: MemoryAgentBenchItem[]): MemoryAgentBenchItem[] => {
+    if (items.length === 0) {
+      throw new Error(
+        "MemoryAgentBench dataset is empty after applying the requested limit.",
+      );
+    }
+    return items;
+  };
+
+  if (datasetDir) {
+    const datasetErrors: string[] = [];
+
+    for (const filename of DATASET_BUNDLE_CANDIDATES) {
+      try {
+        const parsed = await readDatasetFile(path.join(datasetDir, filename), filename);
+        return ensureDatasetItems(applyLimit(parsed, normalizedLimit));
+      } catch (error) {
+        datasetErrors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    const splitItems: MemoryAgentBenchItem[] = [];
+    let remainingLimit = normalizedLimit;
+    for (const splitConfig of DATASET_SPLITS) {
+      if (remainingLimit === 0) {
+        break;
+      }
+
+      let splitData: MemoryAgentBenchItem[] | undefined;
+      for (const filename of splitConfig.candidates) {
+        try {
+          splitData = await readDatasetFile(path.join(datasetDir, filename), filename);
+          break;
+        } catch (error) {
+          datasetErrors.push(
+            `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+      }
+
+      if (!splitData) {
+        continue;
+      }
+
+      const filtered = splitData.filter(
+        (item) =>
+          item.metadata.competency === splitConfig.competency ||
+          item.metadata.source.toLowerCase().startsWith(splitConfig.sourcePrefix),
+      );
+      const limited = applyLimit(filtered, remainingLimit);
+      splitItems.push(...limited);
+      if (remainingLimit !== undefined) {
+        remainingLimit = Math.max(0, remainingLimit - limited.length);
+      }
+    }
+
+    if (splitItems.length > 0) {
+      return ensureDatasetItems(splitItems);
+    }
+
+    throw new Error(
+      `MemoryAgentBench dataset not found under ${datasetDir}. Tried bundle files (${DATASET_BUNDLE_CANDIDATES.join(", ")}) and split files for ${DATASET_SPLITS.map((split) => split.split).join(", ")}. Errors: ${datasetErrors.join(" | ")}`,
+    );
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "MemoryAgentBench full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetItems(applyLimit(MEMORY_AGENT_BENCH_SMOKE_FIXTURE, normalizedLimit));
+}
+
+async function readDatasetFile(
+  filePath: string,
+  filename: string,
+): Promise<MemoryAgentBenchItem[]> {
+  const raw = await readFile(filePath, "utf8");
+  const parsed = filename.endsWith(".jsonl")
+    ? parseJsonLines(raw, filename)
+    : parseJsonArray(raw, filename);
+
+  return parsed.map((item, index) =>
+    parseMemoryAgentBenchItem(item, `${filename} item ${index + 1}`),
+  );
+}
+
+function parseJsonArray(raw: string, filename: string): unknown[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `MemoryAgentBench dataset file ${filename} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `MemoryAgentBench dataset file ${filename} must contain an array of samples.`,
+    );
+  }
+
+  return parsed;
+}
+
+function parseJsonLines(raw: string, filename: string): unknown[] {
+  const rows: unknown[] = [];
+
+  raw.split("\n").forEach((line, lineIndex) => {
+    if (line.trim().length === 0) {
+      return;
+    }
+
+    try {
+      rows.push(JSON.parse(line));
+    } catch (error) {
+      throw new Error(
+        `MemoryAgentBench dataset file ${filename} contains invalid JSON on line ${lineIndex + 1}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+  });
+
+  return rows;
+}
+
+function parseMemoryAgentBenchItem(
+  value: unknown,
+  location: string,
+): MemoryAgentBenchItem {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${location} must be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.context !== "string" || record.context.trim().length === 0) {
+    throw new Error(`${location} must include a non-empty string context.`);
+  }
+
+  const questions = normalizeStringArray(record.questions, `${location}.questions`);
+  const answers = normalizeAnswerVariants(record.answers, `${location}.answers`);
+  if (questions.length === 0) {
+    throw new Error(`${location} must include at least one question.`);
+  }
+  if (questions.length !== answers.length) {
+    throw new Error(
+      `${location} must include the same number of questions and answer groups.`,
+    );
+  }
+
+  return {
+    context: record.context,
+    questions,
+    answers,
+    metadata: parseMetadata(record.metadata, location),
+  };
+}
+
+function parseMetadata(
+  value: unknown,
+  location: string,
+): MemoryAgentBenchMetadata {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${location}.metadata must be an object.`);
+  }
+
+  const record = value as Record<string, unknown>;
+  if (typeof record.source !== "string" || record.source.trim().length === 0) {
+    throw new Error(`${location}.metadata.source must be a non-empty string.`);
+  }
+
+  const competency = inferCompetency(record.source);
+  return {
+    source: record.source,
+    competency,
+    demo: typeof record.demo === "string" || record.demo === null ? (record.demo ?? null) : null,
+    haystack_sessions: normalizeHaystackSessions(
+      record.haystack_sessions,
+      `${location}.metadata.haystack_sessions`,
+    ),
+    keypoints: normalizeOptionalStringArray(record.keypoints, `${location}.metadata.keypoints`),
+    previous_events: normalizeOptionalStringArray(
+      record.previous_events,
+      `${location}.metadata.previous_events`,
+    ),
+    qa_pair_ids: normalizeOptionalStringArray(
+      record.qa_pair_ids,
+      `${location}.metadata.qa_pair_ids`,
+    ),
+    question_dates: normalizeOptionalStringArray(
+      record.question_dates,
+      `${location}.metadata.question_dates`,
+    ),
+    question_ids: normalizeOptionalStringArray(
+      record.question_ids,
+      `${location}.metadata.question_ids`,
+    ),
+    question_types: normalizeOptionalStringArray(
+      record.question_types,
+      `${location}.metadata.question_types`,
+    ),
+  };
+}
+
+function inferCompetency(source: string): MemoryAgentBenchCompetency {
+  const normalizedSource = source.toLowerCase();
+  if (normalizedSource.startsWith("eventqa") || normalizedSource.startsWith("longmemeval")) {
+    return "accurate_retrieval";
+  }
+  if (normalizedSource.startsWith("icl_") || normalizedSource.startsWith("recsys_")) {
+    return "test_time_learning";
+  }
+  if (normalizedSource.startsWith("detective_") || normalizedSource.startsWith("infbench_")) {
+    return "long_range_understanding";
+  }
+  if (normalizedSource.startsWith("factconsolidation")) {
+    return "conflict_resolution";
+  }
+
+  throw new Error(
+    `MemoryAgentBench metadata.source "${source}" does not map to a supported competency.`,
+  );
+}
+
+function normalizeStringArray(value: unknown, location: string): string[] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${location} must be an array of strings.`);
+  }
+
+  return value.map((entry, index) => {
+    if (typeof entry !== "string" || entry.trim().length === 0) {
+      throw new Error(`${location}[${index}] must be a non-empty string.`);
+    }
+    return entry;
+  });
+}
+
+function normalizeOptionalStringArray(
+  value: unknown,
+  location: string,
+): string[] | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  return normalizeStringArray(value, location);
+}
+
+function normalizeAnswerVariants(value: unknown, location: string): string[][] {
+  if (!Array.isArray(value)) {
+    throw new Error(`${location} must be an array of answer groups.`);
+  }
+
+  return value.map((entry, index) => {
+    const answerGroup = Array.isArray(entry) ? entry : [entry];
+    const normalized = answerGroup
+      .map((candidate, candidateIndex) => {
+        if (typeof candidate !== "string" || candidate.trim().length === 0) {
+          throw new Error(
+            `${location}[${index}][${candidateIndex}] must be a non-empty string.`,
+          );
+        }
+        return candidate;
+      })
+      .filter(Boolean);
+
+    if (normalized.length === 0) {
+      throw new Error(`${location}[${index}] must include at least one answer variant.`);
+    }
+
+    return normalized;
+  });
+}
+
+function normalizeHaystackSessions(
+  value: unknown,
+  location: string,
+): MemoryAgentBenchTurn[][] | null {
+  if (value === undefined || value === null) {
+    return null;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${location} must be an array of sessions.`);
+  }
+
+  return value.map((session, sessionIndex) => {
+    if (!Array.isArray(session)) {
+      throw new Error(`${location}[${sessionIndex}] must be an array of turns.`);
+    }
+
+    return session.map((turn, turnIndex) => {
+      if (!turn || typeof turn !== "object" || Array.isArray(turn)) {
+        throw new Error(
+          `${location}[${sessionIndex}][${turnIndex}] must be an object with role/content.`,
+        );
+      }
+
+      const record = turn as Record<string, unknown>;
+      if (
+        record.role !== "user" &&
+        record.role !== "assistant" &&
+        record.role !== "system"
+      ) {
+        throw new Error(
+          `${location}[${sessionIndex}][${turnIndex}].role must be user, assistant, or system.`,
+        );
+      }
+      if (typeof record.content !== "string" || record.content.trim().length === 0) {
+        throw new Error(
+          `${location}[${sessionIndex}][${turnIndex}].content must be a non-empty string.`,
+        );
+      }
+
+      return {
+        role: record.role,
+        content: record.content,
+        has_answer:
+          typeof record.has_answer === "boolean" ? record.has_answer : undefined,
+      };
+    });
+  });
+}
+
+async function storeBenchmarkContext(
+  options: ResolvedRunBenchmarkOptions,
+  item: MemoryAgentBenchItem,
+  itemIndex: number,
+): Promise<string[]> {
+  const sourceSlug = item.metadata.source.replace(/[^a-z0-9]+/gi, "-").toLowerCase();
+  const baseSessionId = `memoryagentbench-${sourceSlug}-${itemIndex}`;
+  const storedSessionIds: string[] = [];
+
+  if (item.metadata.haystack_sessions && item.metadata.haystack_sessions.length > 0) {
+    for (const [sessionIndex, turns] of item.metadata.haystack_sessions.entries()) {
+      const sessionId = `${baseSessionId}-session-${sessionIndex}`;
+      const messages = turns.map<Message>((turn) => ({
+        role: turn.role,
+        content: turn.content,
+      }));
+      if (messages.length > 0) {
+        await storeMessagesInChunks(options, sessionId, messages);
+        storedSessionIds.push(sessionId);
+      }
+    }
+  }
+
+  if (storedSessionIds.length > 0) {
+    return storedSessionIds;
+  }
+
+  const chunkedContext = chunkContext(item.context);
+  const sessionId = `${baseSessionId}-context`;
+  if (chunkedContext.length > 0) {
+    await storeMessagesInChunks(
+      options,
+      sessionId,
+      chunkedContext.map<Message>((content) => ({ role: "user", content })),
+    );
+  }
+  return [sessionId];
+}
+
+async function storeMessagesInChunks(
+  options: ResolvedRunBenchmarkOptions,
+  sessionId: string,
+  messages: Message[],
+): Promise<void> {
+  for (let index = 0; index < messages.length; index += 20) {
+    await options.system.store(sessionId, messages.slice(index, index + 20));
+  }
+}
+
+function chunkContext(context: string): string[] {
+  const paragraphs = context
+    .split(/\n\s*\n+/)
+    .map((paragraph) => paragraph.trim())
+    .filter(Boolean);
+
+  const chunks = paragraphs.length > 0 ? paragraphs : [context.trim()].filter(Boolean);
+  return chunks.flatMap((chunk) => splitLongChunk(chunk, 1_200));
+}
+
+function splitLongChunk(chunk: string, maxLength: number): string[] {
+  if (chunk.length <= maxLength) {
+    return [chunk];
+  }
+
+  const segments: string[] = [];
+  let remaining = chunk;
+  while (remaining.length > maxLength) {
+    let splitIndex = remaining.lastIndexOf("\n", maxLength);
+    if (splitIndex < maxLength * 0.5) {
+      splitIndex = remaining.lastIndexOf(". ", maxLength);
+    }
+    if (splitIndex < maxLength * 0.5) {
+      splitIndex = maxLength;
+    }
+
+    segments.push(remaining.slice(0, splitIndex).trim());
+    remaining = remaining.slice(splitIndex).trim();
+  }
+
+  if (remaining.length > 0) {
+    segments.push(remaining);
+  }
+
+  return segments.filter(Boolean);
+}
+
+function scoreAgainstVariants(
+  actual: string,
+  variants: string[],
+  scorer: (actual: string, expected: string) => number,
+): number {
+  return variants.reduce(
+    (best, variant) => Math.max(best, scorer(actual, variant)),
+    Number.NEGATIVE_INFINITY,
+  );
+}
+
+function selectBestMatchingAnswer(actual: string, variants: string[]): string {
+  return variants.reduce((best, candidate) => {
+    if (!best) {
+      return candidate;
+    }
+
+    const currentScore = scoreAgainstVariants(actual, [best], f1Score);
+    const candidateScore = scoreAgainstVariants(actual, [candidate], f1Score);
+    return candidateScore > currentScore ? candidate : best;
+  }, "");
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      "MemoryAgentBench limit must be a non-negative integer when provided.",
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -235,13 +235,13 @@ async function loadDataset(
     const datasetErrors: string[] = [];
 
     for (const filename of DATASET_BUNDLE_CANDIDATES) {
-      try {
-        const parsed = await readDatasetFile(path.join(datasetDir, filename), filename);
+      const parsed = await tryReadDatasetFile(
+        path.join(datasetDir, filename),
+        filename,
+        datasetErrors,
+      );
+      if (parsed) {
         return ensureDatasetItems(applyLimit(parsed, normalizedLimit));
-      } catch (error) {
-        datasetErrors.push(
-          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
-        );
       }
     }
 
@@ -429,9 +429,28 @@ function parseMetadata(
   };
 }
 
+async function tryReadDatasetFile(
+  filePath: string,
+  filename: string,
+  datasetErrors: string[],
+): Promise<MemoryAgentBenchItem[] | undefined> {
+  try {
+    return await readDatasetFile(filePath, filename);
+  } catch (error) {
+    datasetErrors.push(
+      `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
+}
+
 function inferCompetency(source: string): MemoryAgentBenchCompetency {
   const normalizedSource = source.toLowerCase();
-  if (normalizedSource.startsWith("eventqa") || normalizedSource.startsWith("longmemeval")) {
+  if (
+    normalizedSource.startsWith("eventqa") ||
+    normalizedSource.startsWith("longmemeval") ||
+    normalizedSource.startsWith("ruler_")
+  ) {
     return "accurate_retrieval";
   }
   if (normalizedSource.startsWith("icl_") || normalizedSource.startsWith("recsys_")) {

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -130,7 +130,7 @@ export async function runMemoryAgentBenchBenchmark(
         options.system.judge,
         question,
         recalledText,
-        answerVariants[0]!,
+        bestExpectedAnswer,
       );
 
       const scores: Record<string, number> = {

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -35,6 +35,10 @@ import {
   memBenchDefinition,
   runMemBenchBenchmark,
 } from "./benchmarks/published/membench/runner.js";
+import {
+  memoryAgentBenchDefinition,
+  runMemoryAgentBenchBenchmark,
+} from "./benchmarks/published/memoryagentbench/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -72,6 +76,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...memBenchDefinition,
     run: runMemBenchBenchmark,
+  },
+  {
+    ...memoryAgentBenchDefinition,
+    run: runMemoryAgentBenchBenchmark,
   },
 ];
 

--- a/tests/bench-memoryagentbench-runner.test.ts
+++ b/tests/bench-memoryagentbench-runner.test.ts
@@ -218,6 +218,47 @@ test("runBenchmark uses the best-matching MemoryAgentBench answer variant for ju
   assert.equal(result.results.tasks[0]?.scores.f1 > 0, true);
 });
 
+test("runBenchmark keeps sentence-ending punctuation on the preceding MemoryAgentBench chunk", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-chunking-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter();
+  const longSentence = `${"A".repeat(1_190)}. ${"B".repeat(40)}`;
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: longSentence,
+        questions: ["What token fills the second sentence?"],
+        answers: [["B"]],
+        metadata: {
+          source: "eventqa_sentence_chunking",
+          qa_pair_ids: ["mab-chunk-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+  const storedMessages = [...adapter.sessions.values()][0];
+
+  assert.equal(storedMessages?.length, 2);
+  assert.equal(storedMessages?.[0]?.content.endsWith("."), true);
+  assert.equal(storedMessages?.[1]?.content.startsWith("."), false);
+  assert.equal(
+    result.results.tasks[0]?.actual.includes(`${"A".repeat(1_190)}.\n${"B".repeat(40)}`),
+    true,
+  );
+});
+
 test("runBenchmark rejects memoryagentbench full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 

--- a/tests/bench-memoryagentbench-runner.test.ts
+++ b/tests/bench-memoryagentbench-runner.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchJudge,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -12,6 +13,11 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  readonly judge?: BenchJudge;
+
+  constructor(judge?: BenchJudge) {
+    this.judge = judge;
+  }
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -156,6 +162,60 @@ test("runBenchmark executes memoryagentbench in full mode from split dataset fil
   assert.equal(result.results.tasks[0]?.details.competency, "accurate_retrieval");
   assert.equal(result.results.tasks[1]?.expected, "Aurora");
   assert.equal(result.results.tasks[1]?.details.competency, "conflict_resolution");
+});
+
+test("runBenchmark uses the best-matching MemoryAgentBench answer variant for judge scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-judge-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const judgeCalls: Array<{
+    expected: string;
+    predicted: string;
+    question: string;
+  }> = [];
+  const adapter = new FakeMemoryAdapter({
+    async score(question, predicted, expected) {
+      judgeCalls.push({ question, predicted, expected });
+      return expected === "quarterly roadmap review" ? 0.91 : 0.13;
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context:
+          "Notes:\\nThe team met for the quarterly roadmap review and wrote action items.",
+        questions: ["Which meeting generated the action items?"],
+        answers: [["roadmap meeting", "quarterly roadmap review"]],
+        metadata: {
+          source: "eventqa_judge_variant",
+          qa_pair_ids: ["mab-judge-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(judgeCalls.length, 1);
+  assert.deepEqual(judgeCalls[0], {
+    question: "Which meeting generated the action items?",
+    predicted:
+      "Notes:\\nThe team met for the quarterly roadmap review and wrote action items.",
+    expected: "quarterly roadmap review",
+  });
+  assert.equal(result.results.tasks[0]?.details.bestExpectedAnswer, "quarterly roadmap review");
+  assert.equal(result.results.tasks[0]?.expected, "roadmap meeting");
+  assert.equal(result.results.tasks[0]?.scores.llm_judge, 0.91);
+  assert.equal(result.results.tasks[0]?.scores.f1 > 0, true);
 });
 
 test("runBenchmark rejects memoryagentbench full mode without datasetDir", async () => {

--- a/tests/bench-memoryagentbench-runner.test.ts
+++ b/tests/bench-memoryagentbench-runner.test.ts
@@ -1,0 +1,232 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("runBenchmark executes memoryagentbench in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "memoryagentbench");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 4);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(typeof result.results.aggregates.rouge_l?.mean, "number");
+  assert.equal(result.results.tasks[0]?.details.competency, "accurate_retrieval");
+  assert.equal(result.results.tasks[2]?.details.competency, "long_range_understanding");
+  assert.equal(
+    result.results.tasks[3]?.actual.includes("The current project codename is Zephyr."),
+    true,
+  );
+  assert.deepEqual(result.results.tasks[0]?.details.answerVariants, [
+    "the riverside market",
+    "riverside market",
+  ]);
+});
+
+test("runBenchmark executes memoryagentbench in full mode from split dataset files", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memoryagentbench-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "Accurate_Retrieval.json"),
+    JSON.stringify([
+      {
+        context: "Event log:\\n1. Priya checked in at the library.\\n2. Priya headed to the cafe.",
+        questions: ["Where did Priya go after the library?"],
+        answers: [["the cafe", "cafe"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-full-ar-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(datasetDir, "Conflict_Resolution.json"),
+    JSON.stringify([
+      {
+        context: "0. The active theme is Ember.\\n1. The active theme is Aurora.",
+        questions: ["What is the active theme?"],
+        answers: [["Aurora"]],
+        metadata: {
+          source: "factconsolidation_sh_6k",
+          qa_pair_ids: ["mab-full-cr-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.tasks[0]?.expected, "the cafe");
+  assert.equal(result.results.tasks[0]?.details.competency, "accurate_retrieval");
+  assert.equal(result.results.tasks[1]?.expected, "Aurora");
+  assert.equal(result.results.tasks[1]?.details.competency, "conflict_resolution");
+});
+
+test("runBenchmark rejects memoryagentbench full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memoryagentbench", {
+        mode: "full",
+        system: adapter,
+      }),
+    /MemoryAgentBench full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark fails fast when memoryagentbench full mode is given an explicit missing datasetDir", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memoryagentbench-missing-"));
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memoryagentbench", {
+        mode: "full",
+        datasetDir: path.join(tmpDir, "does-not-exist"),
+        system: adapter,
+      }),
+    /MemoryAgentBench dataset not found under/,
+  );
+});
+
+test("runBenchmark rejects empty memoryagentbench datasets after applying limit", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memoryagentbench", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /MemoryAgentBench dataset is empty after applying the requested limit/,
+  );
+});
+
+test("runBenchmark rejects unsupported memoryagentbench metadata sources with a benchmark-specific error", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memoryagentbench-bad-source-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Bad sample.",
+        questions: ["What happened?"],
+        answers: [["Nothing"]],
+        metadata: {
+          source: "unknown_split",
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memoryagentbench", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /does not map to a supported competency/,
+  );
+});

--- a/tests/bench-memoryagentbench-runner.test.ts
+++ b/tests/bench-memoryagentbench-runner.test.ts
@@ -164,6 +164,42 @@ test("runBenchmark executes memoryagentbench in full mode from split dataset fil
   assert.equal(result.results.tasks[1]?.details.competency, "conflict_resolution");
 });
 
+test("runBenchmark maps current MemoryAgentBench source aliases like ruler_qa1_197K to accurate_retrieval", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-ruler-alias-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "Accurate_Retrieval.json"),
+    JSON.stringify([
+      {
+        context: "Reference notes:\\nNina stored the archive key inside the cedar box.",
+        questions: ["Where did Nina store the archive key?"],
+        answers: [["the cedar box", "cedar box"]],
+        metadata: {
+          source: "ruler_qa1_197K",
+          qa_pair_ids: ["mab-ruler-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "the cedar box");
+  assert.equal(result.results.tasks[0]?.details.competency, "accurate_retrieval");
+  assert.equal(result.results.tasks[0]?.details.source, "ruler_qa1_197K");
+});
+
 test("runBenchmark uses the best-matching MemoryAgentBench answer variant for judge scoring", async () => {
   const tmpDir = await mkdtemp(
     path.join(os.tmpdir(), "remnic-bench-memoryagentbench-judge-"),
@@ -299,6 +335,46 @@ test("runBenchmark rejects empty memoryagentbench datasets after applying limit"
       }),
     /MemoryAgentBench dataset is empty after applying the requested limit/,
   );
+});
+
+test("runBenchmark preserves the empty-after-limit error for MemoryAgentBench bundle files", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-empty-bundle-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Bundle sample.",
+        questions: ["What happened?"],
+        answers: [["A bundle sample was recorded."]],
+        metadata: {
+          source: "eventqa_bundle_limit",
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  await assert.rejects(async () => {
+    await runBenchmark("memoryagentbench", {
+      mode: "full",
+      datasetDir,
+      limit: 0,
+      system: adapter,
+    });
+  }, (error: unknown) => {
+    assert.ok(error instanceof Error);
+    assert.match(
+      error.message,
+      /MemoryAgentBench dataset is empty after applying the requested limit/,
+    );
+    assert.doesNotMatch(error.message, /MemoryAgentBench dataset not found under/);
+    return true;
+  });
 });
 
 test("runBenchmark rejects unsupported memoryagentbench metadata sources with a benchmark-specific error", async () => {

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -11,12 +11,22 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
 
   assert.deepEqual(
     benchmarks.map((benchmark) => benchmark.id),
-    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam", "personamem", "membench"],
+    [
+      "ama-bench",
+      "memory-arena",
+      "amemgym",
+      "longmemeval",
+      "locomo",
+      "beam",
+      "personamem",
+      "membench",
+      "memoryagentbench",
+    ],
   );
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench",
   );
 });
 
@@ -77,6 +87,16 @@ test("getBenchmark returns beam metadata with a runnable benchmark entry", () =>
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns memoryagentbench metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("memoryagentbench");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "memoryagentbench");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "agentic");
 });
 
 test("getBenchmark returns personamem metadata with a runnable benchmark entry", () => {


### PR DESCRIPTION
## Summary
- add the MemoryAgentBench published benchmark runner with quick-mode smoke coverage and full-mode split-dataset loading
- score the current upstream competency splits, including multi-answer variants and benchmark-specific metadata validation
- register MemoryAgentBench in the published benchmark catalog and add focused runner/registry tests

## Verification
- `npx tsx --test tests/bench-memoryagentbench-runner.test.ts tests/bench-registry.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`

Part of #445 (phase 2 MemoryAgentBench slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new published benchmark runner with dataset file loading/parsing and context chunking logic, plus registry exposure; errors or parsing edge cases could affect benchmark execution but changes are isolated to the bench package.
> 
> **Overview**
> Introduces the **published** `memoryagentbench` benchmark to `@remnic/bench`, including a quick-mode smoke fixture and a full-mode runner that loads MemoryAgentBench datasets from either a bundle (`memoryagentbench.json/.jsonl`) or per-split files.
> 
> The runner stores benchmark context (including optional `haystack_sessions`) into the provided memory adapter with chunking, recalls per question across stored sessions, and scores results using *best-of* answer variants (`f1`, `rouge_l`, `contains_answer`, optional `llm_judge`) while validating dataset/schema and mapping `metadata.source` prefixes to competency splits.
> 
> Registers `memoryagentbench` in the published benchmark registry and expands tests to cover catalog exposure plus runner behaviors (dataset resolution, limit/empty and missing-dir errors, source alias mapping, judge variant selection, and chunk punctuation handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d8191967cbaded963a19030aa90c37056be6964f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->