### PR TITLE
feat(bench): add published MemBench runner

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/fixture.ts
+++ b/packages/bench/src/benchmarks/published/membench/fixture.ts
@@ -1,0 +1,50 @@
+import type { Message } from "../../../adapters/types.js";
+
+export interface MemBenchCase {
+  id: string;
+  memoryType: "factual" | "reflective";
+  scenario: "participant" | "observation";
+  level: string;
+  turns: Message[];
+  question: string;
+  answer: string;
+}
+
+export const MEMBENCH_SMOKE_FIXTURE: MemBenchCase[] = [
+  {
+    id: "factual-participant-1",
+    memoryType: "factual",
+    scenario: "participant",
+    level: "surface",
+    turns: [
+      {
+        role: "user",
+        content: "I moved to Lisbon last spring to work from the waterfront.",
+      },
+      {
+        role: "assistant",
+        content: "Lisbon by the waterfront, noted.",
+      },
+    ],
+    question: "Which city did I move to last spring?",
+    answer: "Lisbon",
+  },
+  {
+    id: "reflective-observation-1",
+    memoryType: "reflective",
+    scenario: "observation",
+    level: "insight",
+    turns: [
+      {
+        role: "user",
+        content: "During the retro, Avery paused, reflected on every concern, and reframed the conflict before answering.",
+      },
+      {
+        role: "assistant",
+        content: "That pattern suggests Avery handles conflict by pausing, reflecting, and reframing concerns before responding.",
+      },
+    ],
+    question: "How does Avery tend to handle conflict?",
+    answer: "pausing, reflecting, and reframing concerns",
+  },
+];

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import {
   MEMBENCH_SMOKE_FIXTURE,
@@ -30,6 +30,17 @@ const DATASET_FILENAMES = [
   "membench.jsonl",
   "data.json",
 ] as const;
+
+const UPSTREAM_DATASET_FILENAME_PATTERNS = [
+  /^(?:First|Third)Agent(?:Data)?(?:High|Low)Level\.jsonl?$/i,
+  /^(?:First|Third)Agent(?:High|Low)Level\.jsonl?$/i,
+] as const;
+
+interface MemBenchHints {
+  memoryType?: MemBenchCase["memoryType"];
+  scenario?: MemBenchCase["scenario"];
+  level?: string;
+}
 
 export const memBenchDefinition: BenchmarkDefinition = {
   id: "membench",
@@ -157,14 +168,29 @@ async function loadDataset(
   };
 
   if (datasetDir) {
+    const { filenames, scanError } = await discoverDatasetFiles(datasetDir);
+    if (filenames.length === 0) {
+      throw new Error(buildDatasetNotFoundError(datasetDir, scanError, []));
+    }
+
     const datasetErrors: string[] = [];
-    for (const filename of DATASET_FILENAMES) {
+    const cases: MemBenchCase[] = [];
+    let remainingLimit = normalizedLimit;
+    for (const filename of filenames) {
+      if (remainingLimit === 0) {
+        break;
+      }
+
       try {
         const raw = await readFile(path.join(datasetDir, filename), "utf8");
         const parsed = filename.endsWith(".jsonl")
           ? parseJsonlDataset(raw, filename)
           : parseJsonDataset(raw, filename);
-        return ensureDatasetCases(applyLimit(parsed, normalizedLimit));
+        const limitedCases = applyLimit(parsed, remainingLimit);
+        cases.push(...limitedCases);
+        if (remainingLimit !== undefined) {
+          remainingLimit = Math.max(remainingLimit - limitedCases.length, 0);
+        }
       } catch (error) {
         datasetErrors.push(
           `${filename}: ${error instanceof Error ? error.message : String(error)}`,
@@ -172,9 +198,11 @@ async function loadDataset(
       }
     }
 
-    throw new Error(
-      `MemBench dataset not found under ${datasetDir}. Tried ${DATASET_FILENAMES.join(", ")}. Errors: ${datasetErrors.join(" | ")}`,
-    );
+    if (cases.length > 0) {
+      return ensureDatasetCases(cases);
+    }
+
+    throw new Error(buildDatasetNotFoundError(datasetDir, undefined, datasetErrors));
   }
 
   if (mode === "full") {
@@ -197,9 +225,19 @@ function parseJsonDataset(raw: string, filename: string): MemBenchCase[] {
   }
 
   if (!Array.isArray(parsed)) {
+    const normalizedCases = normalizePublishedDataset(parsed, filename);
+    if (normalizedCases.length > 0) {
+      return normalizedCases;
+    }
+
     throw new Error(
-      `MemBench dataset file ${filename} must contain an array of cases.`,
+      `MemBench dataset file ${filename} must contain an array of cases or a nested published dataset structure.`,
     );
+  }
+
+  const normalizedCases = normalizePublishedDataset(parsed, filename);
+  if (normalizedCases.length > 0) {
+    return normalizedCases;
   }
 
   return parsed.map((entry, index) => parseCase(entry, `${filename}[${index}]`));
@@ -282,6 +320,337 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     question,
     answer,
   };
+}
+
+async function discoverDatasetFiles(
+  datasetDir: string,
+): Promise<{ filenames: string[]; scanError?: string }> {
+  let directoryEntries: string[];
+  try {
+    directoryEntries = await readdir(datasetDir);
+  } catch (error) {
+    return {
+      filenames: [],
+      scanError: error instanceof Error ? error.message : String(error),
+    };
+  }
+
+  const filenames = directoryEntries
+    .filter((filename) => isRecognizedDatasetFilename(filename))
+    .sort((left, right) => left.localeCompare(right));
+
+  return { filenames };
+}
+
+function isRecognizedDatasetFilename(filename: string): boolean {
+  if (DATASET_FILENAMES.includes(filename as (typeof DATASET_FILENAMES)[number])) {
+    return true;
+  }
+
+  return UPSTREAM_DATASET_FILENAME_PATTERNS.some((pattern) => pattern.test(filename));
+}
+
+function buildDatasetNotFoundError(
+  datasetDir: string,
+  scanError: string | undefined,
+  datasetErrors: string[],
+): string {
+  const tried = [
+    ...DATASET_FILENAMES,
+    "FirstAgentDataLowLevel.json",
+    "FirstAgentDataHighLevel.json",
+    "ThirdAgentDataLowLevel.json",
+    "ThirdAgentDataHighLevel.json",
+  ].join(", ");
+  const details = [scanError, ...datasetErrors].filter(Boolean).join(" | ");
+  return details.length > 0
+    ? `MemBench dataset not found under ${datasetDir}. Tried ${tried}. Errors: ${details}`
+    : `MemBench dataset not found under ${datasetDir}. Tried ${tried}.`;
+}
+
+function normalizePublishedDataset(
+  parsed: unknown,
+  filename: string,
+): MemBenchCase[] {
+  const hints = inferHintsFromLabel(filename, {});
+  return normalizePublishedNode(parsed, hints, filename);
+}
+
+function normalizePublishedNode(
+  node: unknown,
+  hints: MemBenchHints,
+  location: string,
+): MemBenchCase[] {
+  if (Array.isArray(node)) {
+    return node.flatMap((entry, index) =>
+      normalizePublishedNode(entry, hints, `${location}[${index}]`),
+    );
+  }
+
+  if (!isPlainObject(node)) {
+    return [];
+  }
+
+  const flatCase = normalizeFlatCase(node, hints, location);
+  if (flatCase) {
+    return [flatCase];
+  }
+
+  const leafCases = normalizeTrajectoryQaRecord(node, hints, location);
+  if (leafCases.length > 0) {
+    return leafCases;
+  }
+
+  return Object.entries(node).flatMap(([key, value]) =>
+    normalizePublishedNode(
+      value,
+      inferHintsFromLabel(key, hints),
+      `${location}.${key}`,
+    ),
+  );
+}
+
+function normalizeFlatCase(
+  record: Record<string, unknown>,
+  hints: MemBenchHints,
+  location: string,
+): MemBenchCase | null {
+  if (!("turns" in record) || !("question" in record) || !("answer" in record)) {
+    return null;
+  }
+
+  return parseCase(
+    {
+      id: resolveCaseId(record, location, 0),
+      memoryType: resolveMemoryType(record.memoryType, hints),
+      scenario: resolveScenario(record.scenario, hints),
+      level: resolveLevel(record.level, hints),
+      turns: record.turns,
+      question: record.question,
+      answer: record.answer,
+    },
+    location,
+  );
+}
+
+function normalizeTrajectoryQaRecord(
+  record: Record<string, unknown>,
+  hints: MemBenchHints,
+  location: string,
+): MemBenchCase[] {
+  const trajectory = record.trajectory;
+  const qa = record.qa ?? record.qas ?? record.qa_pairs ?? record.question_answers;
+
+  if (!Array.isArray(trajectory) || !Array.isArray(qa) || qa.length === 0) {
+    return [];
+  }
+
+  const turns = normalizeTrajectoryTurns(trajectory, `${location}.trajectory`);
+  if (!turns) {
+    return [];
+  }
+
+  const qaPairs = normalizeQaPairs(qa, `${location}.qa`);
+  if (qaPairs.length === 0) {
+    return [];
+  }
+
+  return qaPairs.map((pair, index) =>
+    parseCase(
+      {
+        id: pair.id ?? resolveCaseId(record, location, index),
+        memoryType: resolveMemoryType(record.memoryType, hints),
+        scenario: resolveScenario(record.scenario, hints),
+        level: resolveLevel(record.level, hints),
+        turns,
+        question: pair.question,
+        answer: pair.answer,
+      },
+      `${location}.qa[${index}]`,
+    ),
+  );
+}
+
+function normalizeTrajectoryTurns(
+  trajectory: unknown[],
+  location: string,
+): Message[] | null {
+  if (trajectory.length === 0) {
+    return null;
+  }
+
+  const speakerRoles = new Map<string, Message["role"]>();
+  let distinctSpeakers = 0;
+  const turns: Message[] = [];
+
+  for (let index = 0; index < trajectory.length; index += 1) {
+    const turn = trajectory[index];
+    if (!isPlainObject(turn)) {
+      return null;
+    }
+
+    const directMessage = parseDirectMessageTurn(turn);
+    if (directMessage) {
+      turns.push(directMessage);
+      continue;
+    }
+
+    const speaker = typeof turn.speaker === "string" ? turn.speaker : undefined;
+    const text = typeof turn.text === "string"
+      ? turn.text
+      : typeof turn.content === "string"
+        ? turn.content
+        : undefined;
+    if (!speaker || !text) {
+      return null;
+    }
+
+    let role = speakerRoles.get(speaker);
+    if (!role) {
+      role = distinctSpeakers === 0 ? "user" : "assistant";
+      speakerRoles.set(speaker, role);
+      distinctSpeakers += 1;
+    }
+
+    turns.push({ role, content: text });
+  }
+
+  return turns.length > 0 ? turns : null;
+}
+
+function parseDirectMessageTurn(turn: Record<string, unknown>): Message | null {
+  const { role, content } = turn;
+  if ((role === "user" || role === "assistant") && typeof content === "string") {
+    return { role, content };
+  }
+  return null;
+}
+
+function normalizeQaPairs(
+  qa: unknown[],
+  location: string,
+): Array<{ id?: string; question: string; answer: string }> {
+  const pairs: Array<{ id?: string; question: string; answer: string }> = [];
+
+  for (let index = 0; index < qa.length; index += 1) {
+    const item = qa[index];
+    if (!isPlainObject(item)) {
+      continue;
+    }
+
+    const question = firstString(item.question, item.query, item.prompt);
+    const answer = firstString(item.answer, item.expected, item.gold, item.reference);
+    if (!question || !answer) {
+      continue;
+    }
+
+    const id = firstString(item.id, item.qid, item.question_id);
+    pairs.push({ id: id ?? undefined, question, answer });
+  }
+
+  return pairs;
+}
+
+function resolveCaseId(
+  record: Record<string, unknown>,
+  location: string,
+  index: number,
+): string {
+  return firstString(record.id, record.case_id, record.sample_id)
+    ?? `${sanitizeCaseId(location)}-${index}`;
+}
+
+function resolveMemoryType(
+  value: unknown,
+  hints: MemBenchHints,
+): MemBenchCase["memoryType"] {
+  const normalized = normalizeLabel(value);
+  if (normalized.includes("reflective") || normalized.includes("highlevel")) {
+    return "reflective";
+  }
+  if (normalized.includes("factual") || normalized.includes("lowlevel")) {
+    return "factual";
+  }
+  return hints.memoryType ?? "factual";
+}
+
+function resolveScenario(
+  value: unknown,
+  hints: MemBenchHints,
+): MemBenchCase["scenario"] {
+  const normalized = normalizeLabel(value);
+  if (normalized.includes("participant") || normalized.includes("participation") || normalized.includes("firstagent")) {
+    return "participant";
+  }
+  if (normalized.includes("observation") || normalized.includes("thirdagent")) {
+    return "observation";
+  }
+  return hints.scenario ?? "participant";
+}
+
+function resolveLevel(value: unknown, hints: MemBenchHints): string {
+  const direct = typeof value === "string" && value.trim().length > 0
+    ? value
+    : undefined;
+  return direct ?? hints.level ?? "published";
+}
+
+function inferHintsFromLabel(
+  label: string,
+  current: MemBenchHints,
+): MemBenchHints {
+  const normalized = normalizeLabel(label);
+  const next: MemBenchHints = { ...current };
+
+  if (
+    normalized.includes("firstagent")
+    || normalized.includes("participation")
+    || normalized.includes("participant")
+  ) {
+    next.scenario = "participant";
+  } else if (
+    normalized.includes("thirdagent")
+    || normalized.includes("observation")
+  ) {
+    next.scenario = "observation";
+  }
+
+  if (
+    normalized.includes("highlevel")
+    || normalized.includes("reflective")
+  ) {
+    next.memoryType = "reflective";
+    next.level ??= "high_level";
+  } else if (
+    normalized.includes("lowlevel")
+    || normalized.includes("factual")
+  ) {
+    next.memoryType = "factual";
+    next.level ??= "low_level";
+  }
+
+  return next;
+}
+
+function normalizeLabel(value: unknown): string {
+  return String(value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "");
+}
+
+function sanitizeCaseId(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(-80);
+}
+
+function firstString(...values: unknown[]): string | null {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) {
+      return value;
+    }
+  }
+  return null;
 }
 
 function parseTurn(turn: unknown, location: string): Message {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -1,0 +1,322 @@
+/**
+ * MemBench runner migrated into @remnic/bench for phase 1.
+ */
+
+import { randomUUID } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  MEMBENCH_SMOKE_FIXTURE,
+  type MemBenchCase,
+} from "./fixture.js";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScore,
+  timed,
+} from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+
+const DATASET_FILENAMES = [
+  "membench.json",
+  "membench.jsonl",
+  "data.json",
+] as const;
+
+export const memBenchDefinition: BenchmarkDefinition = {
+  id: "membench",
+  title: "MemBench",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "membench",
+    version: "2.0.0",
+    description:
+      "Factual versus reflective memory benchmark across participant and observer scenarios.",
+    category: "retrieval",
+    citation:
+      "MemBench: Evaluating Factual and Reflective Memory in Long-Context Assistants (ACL 2025).",
+  },
+};
+
+export async function runMemBenchBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const testCase of dataset) {
+    await options.system.reset();
+
+    const sessionId = `membench-${testCase.id}`;
+    if (testCase.turns.length > 0) {
+      await options.system.store(sessionId, testCase.turns);
+    }
+
+    const { result: recalledText, durationMs } = await timed(async () =>
+      options.system.recall(sessionId, testCase.question),
+    );
+    const judgeScore = await llmJudgeScore(
+      options.system.judge,
+      testCase.question,
+      recalledText,
+      testCase.answer,
+    );
+
+    const scores: Record<string, number> = {
+      f1: f1Score(recalledText, testCase.answer),
+      contains_answer: containsAnswer(recalledText, testCase.answer),
+    };
+    if (judgeScore >= 0) {
+      scores.llm_judge = judgeScore;
+    }
+
+    tasks.push({
+      taskId: testCase.id,
+      question: testCase.question,
+      expected: testCase.answer,
+      actual: recalledText,
+      scores,
+      latencyMs: durationMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        memoryType: testCase.memoryType,
+        scenario: testCase.scenario,
+        level: testCase.level,
+        turnCount: testCase.turns.length,
+        recalledLength: recalledText.length,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+async function loadDataset(
+  mode: "full" | "quick",
+  datasetDir: string | undefined,
+  limit?: number,
+): Promise<MemBenchCase[]> {
+  const normalizedLimit = normalizeLimit(limit);
+  const ensureDatasetCases = (cases: MemBenchCase[]): MemBenchCase[] => {
+    if (cases.length === 0) {
+      throw new Error(
+        "MemBench dataset is empty after applying the requested limit.",
+      );
+    }
+    return cases;
+  };
+
+  if (datasetDir) {
+    const datasetErrors: string[] = [];
+    for (const filename of DATASET_FILENAMES) {
+      try {
+        const raw = await readFile(path.join(datasetDir, filename), "utf8");
+        const parsed = filename.endsWith(".jsonl")
+          ? parseJsonlDataset(raw, filename)
+          : parseJsonDataset(raw, filename);
+        return ensureDatasetCases(applyLimit(parsed, normalizedLimit));
+      } catch (error) {
+        datasetErrors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+
+    throw new Error(
+      `MemBench dataset not found under ${datasetDir}. Tried ${DATASET_FILENAMES.join(", ")}. Errors: ${datasetErrors.join(" | ")}`,
+    );
+  }
+
+  if (mode === "full") {
+    throw new Error(
+      "MemBench full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+    );
+  }
+
+  return ensureDatasetCases(applyLimit(MEMBENCH_SMOKE_FIXTURE, normalizedLimit));
+}
+
+function parseJsonDataset(raw: string, filename: string): MemBenchCase[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error) {
+    throw new Error(
+      `MemBench dataset file ${filename} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
+    );
+  }
+
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `MemBench dataset file ${filename} must contain an array of cases.`,
+    );
+  }
+
+  return parsed.map((entry, index) => parseCase(entry, `${filename}[${index}]`));
+}
+
+function parseJsonlDataset(raw: string, filename: string): MemBenchCase[] {
+  const cases: MemBenchCase[] = [];
+  raw.split("\n").forEach((line, lineIndex) => {
+    if (line.trim().length === 0) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line) as unknown;
+    } catch (error) {
+      throw new Error(
+        `MemBench dataset file ${filename} contains invalid JSON on line ${lineIndex + 1}: ${error instanceof Error ? error.message : String(error)}`,
+      );
+    }
+
+    cases.push(parseCase(parsed, `${filename}:${lineIndex + 1}`));
+  });
+  return cases;
+}
+
+function parseCase(entry: unknown, location: string): MemBenchCase {
+  if (!isPlainObject(entry)) {
+    throw new Error(`MemBench case ${location} must be an object.`);
+  }
+
+  const {
+    id,
+    memoryType,
+    scenario,
+    level,
+    turns,
+    question,
+    answer,
+  } = entry;
+
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error(`MemBench case ${location} must include a non-empty id string.`);
+  }
+
+  if (memoryType !== "factual" && memoryType !== "reflective") {
+    throw new Error(
+      `MemBench case ${location} must include memoryType as "factual" or "reflective".`,
+    );
+  }
+
+  if (scenario !== "participant" && scenario !== "observation") {
+    throw new Error(
+      `MemBench case ${location} must include scenario as "participant" or "observation".`,
+    );
+  }
+
+  if (typeof level !== "string" || level.length === 0) {
+    throw new Error(`MemBench case ${location} must include a non-empty level string.`);
+  }
+
+  if (typeof question !== "string" || question.length === 0) {
+    throw new Error(`MemBench case ${location} must include a non-empty question string.`);
+  }
+
+  if (typeof answer !== "string" || answer.length === 0) {
+    throw new Error(`MemBench case ${location} must include a non-empty answer string.`);
+  }
+
+  if (!Array.isArray(turns) || turns.length === 0) {
+    throw new Error(`MemBench case ${location} must include a non-empty turns array.`);
+  }
+
+  return {
+    id,
+    memoryType,
+    scenario,
+    level,
+    turns: turns.map((turn, index) => parseTurn(turn, `${location}.turns[${index}]`)),
+    question,
+    answer,
+  };
+}
+
+function parseTurn(turn: unknown, location: string) {
+  if (!isPlainObject(turn)) {
+    throw new Error(`MemBench turn ${location} must be an object.`);
+  }
+
+  const { role, content } = turn;
+  if ((role !== "user" && role !== "assistant") || typeof content !== "string") {
+    throw new Error(
+      `MemBench turn ${location} must include role/content fields compatible with bench messages.`,
+    );
+  }
+
+  return { role, content };
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `MemBench limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return [...items];
+  }
+  return items.slice(0, limit);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -9,6 +9,7 @@ import {
   MEMBENCH_SMOKE_FIXTURE,
   type MemBenchCase,
 } from "./fixture.js";
+import type { Message } from "../../../adapters/types.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -283,7 +284,7 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
   };
 }
 
-function parseTurn(turn: unknown, location: string) {
+function parseTurn(turn: unknown, location: string): Message {
   if (!isPlainObject(turn)) {
     throw new Error(`MemBench turn ${location} must be an object.`);
   }

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -31,6 +31,10 @@ import {
   personaMemDefinition,
   runPersonaMemBenchmark,
 } from "./benchmarks/published/personamem/runner.js";
+import {
+  memBenchDefinition,
+  runMemBenchBenchmark,
+} from "./benchmarks/published/membench/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -64,6 +68,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...personaMemDefinition,
     run: runPersonaMemBenchmark,
+  },
+  {
+    ...memBenchDefinition,
+    run: runMemBenchBenchmark,
   },
 ];
 

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -102,6 +102,31 @@ function createDatasetCases() {
   ];
 }
 
+function createNestedPublishedDataset() {
+  return {
+    conflict_patterns: [
+      {
+        trajectory: [
+          {
+            speaker: "Avery",
+            text: "I moved to Porto last year to be closer to the river walk.",
+          },
+          {
+            speaker: "Morgan",
+            text: "Porto by the river walk. I'll remember that.",
+          },
+        ],
+        qa: [
+          {
+            question: "Which city did Avery move to last year?",
+            answer: "Porto",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 test("runBenchmark executes membench in quick mode through the phase-1 package API", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -143,6 +168,53 @@ test("runBenchmark executes membench in full mode from an explicit dataset file"
   assert.equal(result.results.tasks.length, 1);
   assert.equal(result.results.tasks[0]?.expected, "Lisbon");
   assert.equal(result.results.tasks[0]?.details.scenario, "participant");
+});
+
+test("runBenchmark accepts upstream MemBench export filenames in full mode", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-upstream-name-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "FirstAgentDataLowLevel.json"),
+    JSON.stringify(createDatasetCases()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Lisbon");
+  assert.equal(result.results.tasks[0]?.details.memoryType, "factual");
+  assert.equal(result.results.tasks[0]?.details.scenario, "participant");
+});
+
+test("runBenchmark normalizes nested published MemBench trajectory and qa structures", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-nested-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataHighLevel.json"),
+    JSON.stringify(createNestedPublishedDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Porto");
+  assert.equal(result.results.tasks[0]?.question, "Which city did Avery move to last year?");
+  assert.equal(result.results.tasks[0]?.details.memoryType, "reflective");
+  assert.equal(result.results.tasks[0]?.details.scenario, "observation");
 });
 
 test("runBenchmark rejects membench full mode without datasetDir", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -1,0 +1,173 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(sessionId: string, _query: string): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+function createDatasetCases() {
+  return [
+    {
+      id: "membench-dataset-1",
+      memoryType: "factual",
+      scenario: "participant",
+      level: "surface",
+      turns: [
+        {
+          role: "user",
+          content: "I moved to Lisbon last spring to work from the waterfront.",
+        },
+        {
+          role: "assistant",
+          content: "Lisbon by the waterfront, noted.",
+        },
+      ],
+      question: "Which city did I move to last spring?",
+      answer: "Lisbon",
+    },
+  ];
+}
+
+test("runBenchmark executes membench in quick mode through the phase-1 package API", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  const result = await runBenchmark("membench", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "membench");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.benchmarkTier, "published");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.statistics, undefined);
+  assert.equal(typeof result.results.aggregates.f1?.mean, "number");
+  assert.equal(typeof result.results.aggregates.contains_answer?.mean, "number");
+  assert.equal(result.results.tasks[0]?.expected, "Lisbon");
+  assert.equal(result.results.tasks[0]?.actual.includes("Lisbon"), true);
+  assert.equal(result.results.tasks[0]?.details.memoryType, "factual");
+  assert.equal(result.results.tasks[1]?.details.memoryType, "reflective");
+});
+
+test("runBenchmark executes membench in full mode from an explicit dataset file", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-full-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "membench.json"),
+    JSON.stringify(createDatasetCases()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.expected, "Lisbon");
+  assert.equal(result.results.tasks[0]?.details.scenario, "participant");
+});
+
+test("runBenchmark rejects membench full mode without datasetDir", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("membench", {
+        mode: "full",
+        system: adapter,
+      }),
+    /MemBench full mode requires datasetDir/,
+  );
+});
+
+test("runBenchmark treats membench limit zero as an empty run instead of falling back to all cases", async () => {
+  const adapter = new FakeMemoryAdapter();
+
+  await assert.rejects(
+    () =>
+      runBenchmark("membench", {
+        mode: "quick",
+        limit: 0,
+        system: adapter,
+      }),
+    /MemBench dataset is empty after applying the requested limit/,
+  );
+});

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -11,12 +11,12 @@ test("listBenchmarks exposes the published benchmark catalog from @remnic/bench"
 
   assert.deepEqual(
     benchmarks.map((benchmark) => benchmark.id),
-    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam", "personamem"],
+    ["ama-bench", "memory-arena", "amemgym", "longmemeval", "locomo", "beam", "personamem", "membench"],
   );
   assert.ok(benchmarks.every((benchmark) => benchmark.tier === "published"));
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench",
   );
 });
 
@@ -87,6 +87,16 @@ test("getBenchmark returns personamem metadata with a runnable benchmark entry",
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.meta.category, "conversational");
+});
+
+test("getBenchmark returns membench metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("membench");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "membench");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.meta.category, "retrieval");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary
- add the MemBench published benchmark runner with quick-mode smoke coverage and full-mode dataset-file loading
- score factual and reflective recall cases with benchmark-specific limit and dataset validation behavior
- register MemBench in the published benchmark catalog and add focused runner/registry tests

## Verification
- `npx tsx --test tests/bench-membench-runner.test.ts tests/bench-registry.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`

Part of #445 (phase 2 MemBench slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new published benchmark with fairly complex dataset discovery/parsing (JSON/JSONL and nested upstream formats), which could affect benchmark execution and error handling but is isolated to the bench package.
> 
> **Overview**
> Adds **published MemBench support** to `@remnic/bench`, including a new `membench` benchmark definition/runner and a bundled quick-mode smoke fixture.
> 
> The runner supports **full-mode dataset loading** from a `datasetDir`, including JSON/JSONL parsing, filename discovery (including upstream export naming patterns), normalization of nested `trajectory` + `qa` dataset structures, and strict validation/limit behavior (e.g., `limit: 0` yields an empty-dataset error rather than defaulting).
> 
> Registers `membench` in the published benchmark catalog and adds targeted tests covering quick/full execution paths, dataset normalization, and registry exposure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cef2d611e8153416d7084947af911a626de9840. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->