### PR TITLE
fix(qmd): parse QMD v2 MCP markdown-formatted query results

### DIFF
--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,7 +657,16 @@ class QmdDaemonSession {
   }
 }
 
-const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+?\.\w+)\s+-\s+(.*)$/;
+/** Matches `#<hex-docid> <score>% <rest-of-line>` — rest is split in a second pass. */
+const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)/;
+
+/**
+ * Known file extensions for QMD memory paths. Used to split the "rest" portion
+ * of a markdown result line into path and title. The greedy `.+` before the
+ * extension ensures we match the LAST occurrence (e.g., in
+ * `v1.2 - archived/note.md - Title`, it matches at `note.md`, not `v1.2`).
+ */
+const QMD_PATH_TITLE_RE = /^(.+\.(?:md|txt|json|yaml|yml|html))\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,
@@ -667,9 +676,13 @@ function parseQmdMarkdownResultText(
   for (const line of text.split("\n")) {
     const m = QMD_RESULT_LINE_RE.exec(line.trim());
     if (!m) continue;
+    const rest = m[3]; // "collection/path.md - Title with - dashes"
+    // Find the path by looking for known file extensions followed by " - "
+    const pathTitleSplit = QMD_PATH_TITLE_RE.exec(rest);
+    if (!pathTitleSplit) continue;
     results.push({
       docid: m[1],
-      path: m[3] ?? "unknown",
+      path: pathTitleSplit[1] ?? "unknown",
       snippet: "",
       score: parseInt(m[2], 10) / 100,
       transport,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -661,12 +661,11 @@ class QmdDaemonSession {
 const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)/;
 
 /**
- * Known file extensions for QMD memory paths. Used to split the "rest" portion
- * of a markdown result line into path and title. The greedy `.+` before the
- * extension ensures we match the LAST occurrence (e.g., in
- * `v1.2 - archived/note.md - Title`, it matches at `note.md`, not `v1.2`).
+ * Known file extensions for QMD memory paths. Non-greedy `.+?` finds the
+ * FIRST known extension followed by ` - `, which is safe because version
+ * numbers like `v1.2` don't appear in the extension allow-list.
  */
-const QMD_PATH_TITLE_RE = /^(.+\.(?:md|txt|json|yaml|yml|html))\s+-\s+(.*)$/;
+const QMD_PATH_TITLE_RE = /^(.+?\.(?:md|txt|json|yaml|yml|html))\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,7 +657,7 @@ class QmdDaemonSession {
   }
 }
 
-const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+?)\s+-\s+(.*)$/;
+const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,7 +657,7 @@ class QmdDaemonSession {
   }
 }
 
-const QMD_RESULT_LINE_RE = /^#([0-9a-f]+)\s+(\d+)%\s+(\S+)\s+-\s+(.*)$/;
+const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(\S+)\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,
@@ -669,7 +669,7 @@ function parseQmdMarkdownResultText(
     if (!m) continue;
     results.push({
       docid: m[1],
-      path: `qmd://${m[3]}`,
+      path: m[3] ?? "unknown",
       snippet: "",
       score: parseInt(m[2], 10) / 100,
       transport,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -729,12 +729,13 @@ function parseMcpSearchResult(
           const textResults = parsed?.results ?? parsed?.documents;
           if (Array.isArray(textResults)) pushDocs(textResults);
         } catch {
-          const existingDocids = new Set(results.map((r) => r.docid));
+          const existingDocids = new Set(results.map((r) => r.docid.toLowerCase()));
           const parsed = parseQmdMarkdownResultText(item.text, transport);
           for (const p of parsed) {
-            if (!existingDocids.has(p.docid)) {
+            const key = p.docid.toLowerCase();
+            if (!existingDocids.has(key)) {
               results.push(p);
-              existingDocids.add(p.docid);
+              existingDocids.add(key);
             }
           }
         }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,6 +657,27 @@ class QmdDaemonSession {
   }
 }
 
+const QMD_RESULT_LINE_RE = /^#([0-9a-f]+)\s+(\d+)%\s+(\S+)\s+-\s+(.*)$/;
+
+function parseQmdMarkdownResultText(
+  text: string,
+  transport: QmdSearchResult["transport"],
+): QmdSearchResult[] {
+  const results: QmdSearchResult[] = [];
+  for (const line of text.split("\n")) {
+    const m = QMD_RESULT_LINE_RE.exec(line.trim());
+    if (!m) continue;
+    results.push({
+      docid: m[1],
+      path: `qmd://${m[3]}`,
+      snippet: "",
+      score: parseInt(m[2], 10) / 100,
+      transport,
+    });
+  }
+  return results;
+}
+
 function parseMcpSearchResult(
   result: unknown,
   transport: QmdSearchResult["transport"] = "daemon",
@@ -696,7 +717,10 @@ function parseMcpSearchResult(
           const textResults = parsed?.results ?? parsed?.documents;
           if (Array.isArray(textResults)) pushDocs(textResults);
         } catch {
-          // ignore non-json text
+          const parsed = parseQmdMarkdownResultText(item.text, transport);
+          if (parsed.length > 0) {
+            results.push(...parsed);
+          }
         }
       }
     }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -661,11 +661,12 @@ class QmdDaemonSession {
 const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)/;
 
 /**
- * Known file extensions for QMD memory paths. Non-greedy `.+?` finds the
- * FIRST known extension followed by ` - `, which is safe because version
- * numbers like `v1.2` don't appear in the extension allow-list.
+ * Splits `collection/path.ext - Title text` into path and title.
+ * Non-greedy `.+?` finds the FIRST dot-extension (2+ alphabetic chars)
+ * followed by ` - `, accepting any indexed file type while skipping
+ * version-like segments (e.g. `v1.2` where `.2` is a single digit).
  */
-const QMD_PATH_TITLE_RE = /^(.+?\.(?:md|txt|json|yaml|yml|html))\s+-\s+(.*)$/;
+const QMD_PATH_TITLE_RE = /^(.+?\.[a-zA-Z]{2,10})\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,7 +657,7 @@ class QmdDaemonSession {
   }
 }
 
-const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+)\s+-\s+(.*)$/;
+const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+?\.\w+)\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -657,7 +657,7 @@ class QmdDaemonSession {
   }
 }
 
-const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(\S+)\s+-\s+(.*)$/;
+const QMD_RESULT_LINE_RE = /^#([0-9a-fA-F]+)\s+(\d+)%\s+(.+?)\s+-\s+(.*)$/;
 
 function parseQmdMarkdownResultText(
   text: string,
@@ -717,9 +717,13 @@ function parseMcpSearchResult(
           const textResults = parsed?.results ?? parsed?.documents;
           if (Array.isArray(textResults)) pushDocs(textResults);
         } catch {
+          const existingDocids = new Set(results.map((r) => r.docid));
           const parsed = parseQmdMarkdownResultText(item.text, transport);
-          if (parsed.length > 0) {
-            results.push(...parsed);
+          for (const p of parsed) {
+            if (!existingDocids.has(p.docid)) {
+              results.push(p);
+              existingDocids.add(p.docid);
+            }
           }
         }
       }

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -729,13 +729,13 @@ function parseMcpSearchResult(
           const textResults = parsed?.results ?? parsed?.documents;
           if (Array.isArray(textResults)) pushDocs(textResults);
         } catch {
-          const existingDocids = new Set(results.map((r) => r.docid.toLowerCase()));
+          const existingKeys = new Set(results.map((r) => `${r.docid.toLowerCase()}|${r.path}`));
           const parsed = parseQmdMarkdownResultText(item.text, transport);
           for (const p of parsed) {
-            const key = p.docid.toLowerCase();
-            if (!existingDocids.has(key)) {
+            const key = `${p.docid.toLowerCase()}|${p.path}`;
+            if (!existingKeys.has(key)) {
               results.push(p);
-              existingDocids.add(key);
+              existingKeys.add(key);
             }
           }
         }

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -377,6 +377,50 @@ test("daemon parses QMD v2 markdown results with titles containing ` - ` separat
   assert.equal(out[2]?.path, "openclaw-engram-hot-facts/2026-02-15/report.txt");
 });
 
+test("daemon parses QMD v2 markdown results with version-like dots in path segments", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 3 results for "version path test":',
+            "",
+            // Path contains "v1.2" which looks like a file extension to a naive regex
+            "#aa1100 88% openclaw-engram-hot-facts/v1.2 - archived/note.md - Archived v1.2 note",
+            // Path contains multiple dot-segments before the real extension
+            "#bb2200 75% openclaw-engram-hot-facts/api.v2.0/config.yaml - API v2 config",
+            // Path with version in directory AND dashes in title
+            "#cc3300 60% openclaw-engram-hot-facts/release-3.1/2026-04-01/summary.txt - Release 3.1 - final notes",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("version path test", undefined, 5);
+  assert.equal(out.length, 3);
+
+  // "v1.2" should NOT be treated as the path — the greedy match finds "note.md"
+  assert.equal(out[0]?.docid, "aa1100");
+  assert.equal(out[0]?.score, 0.88);
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/v1.2 - archived/note.md");
+
+  // Multiple dots in path resolved correctly to the real .yaml extension
+  assert.equal(out[1]?.docid, "bb2200");
+  assert.equal(out[1]?.score, 0.75);
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/api.v2.0/config.yaml");
+
+  // Version in directory + dash in title
+  assert.equal(out[2]?.docid, "cc3300");
+  assert.equal(out[2]?.score, 0.60);
+  assert.equal(out[2]?.path, "openclaw-engram-hot-facts/release-3.1/2026-04-01/summary.txt");
+});
+
 test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {
   const client = new QmdClient("openclaw-engram", 5) as any;
   client.available = true;

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -274,6 +274,81 @@ test("daemon parses QMD v2 markdown results with uppercase hex docids", async ()
   assert.equal(out[1]?.path, "openclaw-engram-hot-facts/namespaces/work/2026-03-01/mixed-2.md");
 });
 
+test("daemon parses QMD v2 markdown results with paths containing spaces", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 2 results for "spaced path test":',
+            "",
+            "#aa1122 85% openclaw-engram-hot-facts/2026-04-12/my folder/preference-1.md - Preference with spaces",
+            "#bb3344 60% openclaw-engram-hot-facts/2026-03-01/some path with spaces/work-2.md - Work item in spaced dir",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("spaced path test", undefined, 5);
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.docid, "aa1122");
+  assert.equal(out[0]?.score, 0.85);
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/my folder/preference-1.md");
+  assert.equal(out[1]?.docid, "bb3344");
+  assert.equal(out[1]?.score, 0.60);
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/some path with spaces/work-2.md");
+});
+
+test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      // Structured results AND markdown text for the same query
+      structuredContent: {
+        results: [
+          {
+            docid: "ca5902",
+            file: "openclaw-engram-hot-facts/2026-04-12/preference-123.md",
+            snippet: "structured snippet",
+            score: 0.93,
+          },
+        ],
+      },
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 2 results for "dedup test":',
+            "",
+            // Duplicate of the structured result above
+            "#ca5902 93% openclaw-engram-hot-facts/2026-04-12/preference-123.md - User prefers dark mode",
+            // Unique result only in markdown
+            "#fbcb6e 50% openclaw-engram-hot-facts/2026-02-05/honcho-456.md - Honcho integration details",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("dedup test", undefined, 5);
+  // Should have 2 results: one from structured, one unique from markdown.
+  // The duplicate ca5902 from markdown should be skipped.
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.docid, "ca5902");
+  assert.equal(out[0]?.snippet, "structured snippet"); // from structured, not markdown
+  assert.equal(out[1]?.docid, "fbcb6e");
+  assert.equal(out[1]?.score, 0.50);
+});
+
 test("probe attempts daemon connectivity even when CLI probe fails", async () => {
   const client = new QmdClient("openclaw-engram", 5, { daemonUrl: "http://127.0.0.1:9020" }) as any;
   let cliCalls = 0;

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -336,6 +336,47 @@ test("daemon parses QMD v2 markdown results with paths containing ` - ` separato
   assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/some - path - with - dashes/work-2.md");
 });
 
+test("daemon parses QMD v2 markdown results with titles containing ` - ` separators", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 3 results for "title dash test":',
+            "",
+            "#aabb11 90% openclaw-engram-hot-facts/2026-04-12/fact.md - API notes - follow-up",
+            "#ccdd22 75% openclaw-engram-hot-facts/2026-03-01/my - folder/config.json - Settings - production - v2",
+            "#eeff33 60% openclaw-engram-hot-facts/2026-02-15/report.txt - Summary - Q1 2026",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("title dash test", undefined, 5);
+  assert.equal(out.length, 3);
+
+  // Path ends at .md, title gets the rest including ` - `
+  assert.equal(out[0]?.docid, "aabb11");
+  assert.equal(out[0]?.score, 0.90);
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/fact.md");
+
+  // Path with ` - ` in directory AND ` - ` in title
+  assert.equal(out[1]?.docid, "ccdd22");
+  assert.equal(out[1]?.score, 0.75);
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/my - folder/config.json");
+
+  // Non-.md extension (.txt) also works
+  assert.equal(out[2]?.docid, "eeff33");
+  assert.equal(out[2]?.score, 0.60);
+  assert.equal(out[2]?.path, "openclaw-engram-hot-facts/2026-02-15/report.txt");
+});
+
 test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {
   const client = new QmdClient("openclaw-engram", 5) as any;
   client.available = true;

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -405,7 +405,7 @@ test("daemon parses QMD v2 markdown results with version-like dots in path segme
   const out = await client.search("version path test", undefined, 5);
   assert.equal(out.length, 3);
 
-  // "v1.2" should NOT be treated as the path — the greedy match finds "note.md"
+  // "v1.2" is skipped because "2" isn't in the known-extension list
   assert.equal(out[0]?.docid, "aa1100");
   assert.equal(out[0]?.score, 0.88);
   assert.equal(out[0]?.path, "openclaw-engram-hot-facts/v1.2 - archived/note.md");
@@ -419,6 +419,37 @@ test("daemon parses QMD v2 markdown results with version-like dots in path segme
   assert.equal(out[2]?.docid, "cc3300");
   assert.equal(out[2]?.score, 0.60);
   assert.equal(out[2]?.path, "openclaw-engram-hot-facts/release-3.1/2026-04-01/summary.txt");
+});
+
+test("daemon parses QMD v2 markdown results when title contains a filename", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 2 results for "title filename test":',
+            "",
+            "#aabb11 90% openclaw-engram-hot-facts/2026-04-12/fact.md - mentions config.json - follow-up",
+            "#ccdd22 75% openclaw-engram-hot-facts/2026-03-01/note.txt - see also report.html - final draft",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("title filename test", undefined, 5);
+  assert.equal(out.length, 2);
+
+  assert.equal(out[0]?.docid, "aabb11");
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/fact.md");
+
+  assert.equal(out[1]?.docid, "ccdd22");
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/note.txt");
 });
 
 test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -305,6 +305,37 @@ test("daemon parses QMD v2 markdown results with paths containing spaces", async
   assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/some path with spaces/work-2.md");
 });
 
+test("daemon parses QMD v2 markdown results with paths containing ` - ` separator", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 2 results for "dash path test":',
+            "",
+            "#dd1122 90% openclaw-engram-hot-facts/2026-04-12/my - folder/preference-1.md - Preference in dash dir",
+            "#ee3344 75% openclaw-engram-hot-facts/2026-03-01/some - path - with - dashes/work-2.md - Work item in dashed dir",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("dash path test", undefined, 5);
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.docid, "dd1122");
+  assert.equal(out[0]?.score, 0.90);
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/my - folder/preference-1.md");
+  assert.equal(out[1]?.docid, "ee3344");
+  assert.equal(out[1]?.score, 0.75);
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/some - path - with - dashes/work-2.md");
+});
+
 test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {
   const client = new QmdClient("openclaw-engram", 5) as any;
   client.available = true;

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -235,11 +235,43 @@ test("daemon parses QMD v2 markdown-formatted text results", async () => {
   assert.equal(out.length, 3);
   assert.equal(out[0]?.docid, "ca5902");
   assert.equal(out[0]?.score, 0.93);
-  assert.equal(out[0]?.path, "qmd://openclaw-engram-hot-facts/2026-04-12/preference-123.md");
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/preference-123.md");
   assert.equal(out[1]?.docid, "fbcb6e");
   assert.equal(out[1]?.score, 0.50);
   assert.equal(out[2]?.docid, "abc123");
   assert.equal(out[2]?.score, 0.72);
+});
+
+test("daemon parses QMD v2 markdown results with uppercase hex docids", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 2 results for "uppercase test":',
+            "",
+            "#CA5902 88% openclaw-engram-hot-facts/2026-04-12/upper-1.md - Uppercase hex docid",
+            "#FbCb6E 45% openclaw-engram-hot-facts/namespaces/work/2026-03-01/mixed-2.md - Mixed case hex docid",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("uppercase test", undefined, 5);
+  assert.equal(out.length, 2);
+  assert.equal(out[0]?.docid, "CA5902");
+  assert.equal(out[0]?.score, 0.88);
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-12/upper-1.md");
+  assert.equal(out[1]?.docid, "FbCb6E");
+  assert.equal(out[1]?.score, 0.45);
+  // Namespace info is preserved in the path for downstream namespace filtering
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/namespaces/work/2026-03-01/mixed-2.md");
 });
 
 test("probe attempts daemon connectivity even when CLI probe fails", async () => {

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -202,6 +202,46 @@ test("daemon parser uses path field when file is absent", async () => {
   assert.equal(out[0]?.path, "/tmp/facts/fact-daemon-path.md");
 });
 
+test("daemon parses QMD v2 markdown-formatted text results", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 3 results for "test query":',
+            "",
+            "#ca5902 93% openclaw-engram-hot-facts/2026-04-12/preference-123.md - User prefers dark mode",
+            "#fbcb6e 50% openclaw-engram-hot-facts/2026-02-05/honcho-456.md - Honcho integration details",
+            "#abc123 72% openclaw-engram-hot-facts/2026-03-15/work-789.md - Work schedule preferences",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  let subprocessCalls = 0;
+  client.searchViaSubprocess = async () => {
+    subprocessCalls += 1;
+    return [];
+  };
+
+  const out = await client.search("test query", undefined, 5);
+  assert.equal(subprocessCalls, 0);
+  assert.equal(out.length, 3);
+  assert.equal(out[0]?.docid, "ca5902");
+  assert.equal(out[0]?.score, 0.93);
+  assert.equal(out[0]?.path, "qmd://openclaw-engram-hot-facts/2026-04-12/preference-123.md");
+  assert.equal(out[1]?.docid, "fbcb6e");
+  assert.equal(out[1]?.score, 0.50);
+  assert.equal(out[2]?.docid, "abc123");
+  assert.equal(out[2]?.score, 0.72);
+});
+
 test("probe attempts daemon connectivity even when CLI probe fails", async () => {
   const client = new QmdClient("openclaw-engram", 5, { daemonUrl: "http://127.0.0.1:9020" }) as any;
   let cliCalls = 0;

--- a/tests/qmd-daemon-empty-fallback.test.ts
+++ b/tests/qmd-daemon-empty-fallback.test.ts
@@ -452,6 +452,41 @@ test("daemon parses QMD v2 markdown results when title contains a filename", asy
   assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-01/note.txt");
 });
 
+test("daemon parses QMD v2 markdown results with non-standard file extensions", async () => {
+  const client = new QmdClient("openclaw-engram", 5) as any;
+  client.available = true;
+  client.daemonAvailable = true;
+  client.maybeProbeDaemon = async () => {};
+  client.daemonSession = {
+    callTool: async () => ({
+      content: [
+        {
+          type: "text",
+          text: [
+            'Found 3 results for "extension test":',
+            "",
+            "#aa1122 88% openclaw-engram-hot-facts/2026-04-10/helper.ts - TypeScript utility",
+            "#bb3344 72% openclaw-engram-hot-facts/2026-03-15/analysis.py - Python analysis script",
+            "#cc5566 65% openclaw-engram-hot-facts/2026-02-20/guide.mdx - MDX documentation",
+          ].join("\n"),
+        },
+      ],
+    }),
+  };
+
+  const out = await client.search("extension test", undefined, 5);
+  assert.equal(out.length, 3);
+
+  assert.equal(out[0]?.docid, "aa1122");
+  assert.equal(out[0]?.path, "openclaw-engram-hot-facts/2026-04-10/helper.ts");
+
+  assert.equal(out[1]?.docid, "bb3344");
+  assert.equal(out[1]?.path, "openclaw-engram-hot-facts/2026-03-15/analysis.py");
+
+  assert.equal(out[2]?.docid, "cc5566");
+  assert.equal(out[2]?.path, "openclaw-engram-hot-facts/2026-02-20/guide.mdx");
+});
+
 test("parseMcpSearchResult deduplicates markdown fallback hits against structured results", async () => {
   const client = new QmdClient("openclaw-engram", 5) as any;
   client.available = true;


### PR DESCRIPTION
## Summary

- **Root cause of 0 recall results**: QMD v2's MCP `query` tool returns results as markdown-formatted text (`#<docid> <score>% <collection>/<path> - <title>`) instead of JSON `structuredContent`. The existing `parseMcpSearchResult()` silently dropped these non-JSON text items in the catch block, causing every daemon-session search to return empty results despite 82k+ facts on disk.
- Adds `parseQmdMarkdownResultText()` as a fallback parser that extracts docid, score, and path from the markdown lines when JSON parsing fails.
- Fixes recall for all QMD v2 daemon-session users — the subprocess path (`--json` flag) was unaffected.

## Test plan

- [x] All 31 QMD-related tests pass (`qmd-daemon-empty-fallback`, `qmd-sync-after-store`, `qmd-recall-cache`)
- [x] `tsc --noEmit` passes clean
- [x] `pnpm run build` succeeds
- [ ] Verify recall returns non-zero results after deploying to gateway

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes daemon search result parsing logic to accept a new output format; mistakes could drop/duplicate recall hits or mis-parse paths/scores, but the change is localized and covered by focused tests.
> 
> **Overview**
> Fixes QMD v2 daemon-mode searches returning empty results by adding a markdown-text fallback parser for MCP `query` output (`#<docid> <score>% <path> - <title>`) when JSON parsing fails.
> 
> The new parser extracts `docid`, `score`, and `path` (handling spaces, embedded ` - `, mixed-case hex ids, and non-`.md` extensions) and **deduplicates** markdown-derived hits against any structured results. Extensive new tests validate parsing edge cases and dedup behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c70f81c1c0e5bcfbe5fa4770bc5bbfe2d29eda22. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->