### PR TITLE
feat(bench): add stored baseline and export surfaces

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -105,7 +105,12 @@ export {
 export { cohensD, interpretEffectSize } from "./stats/effect-size.js";
 export { compareResults } from "./stats/comparison.js";
 export {
+  defaultBenchmarkBaselineDir,
   loadBenchmarkResult,
+  loadBenchmarkBaseline,
+  listBenchmarkBaselines,
   listBenchmarkResults,
+  renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
+  saveBenchmarkBaseline,
 } from "./results-store.js";

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -127,6 +127,19 @@ function assertValidBaselineName(name: string): void {
   }
 }
 
+function assertUsableBaselineDir(baselineDir: string): void {
+  if (!fs.existsSync(baselineDir)) {
+    return;
+  }
+
+  const stats = fs.statSync(baselineDir);
+  if (!stats.isDirectory()) {
+    throw new Error(
+      `Invalid benchmark baseline directory: ${baselineDir} is not a directory.`,
+    );
+  }
+}
+
 function toSummary(
   result: BenchmarkResult,
   filePath: string,
@@ -201,6 +214,7 @@ export async function saveBenchmarkBaseline(
   },
 ): Promise<string> {
   assertValidBaselineName(name);
+  assertUsableBaselineDir(baselineDir);
   await mkdir(baselineDir, { recursive: true });
 
   const filePath = path.join(baselineDir, `${name}.json`);
@@ -232,6 +246,7 @@ export async function listBenchmarkBaselines(
     return [];
   }
 
+  assertUsableBaselineDir(baselineDir);
   const entries = await readdir(baselineDir, { withFileTypes: true });
   const baselines: StoredBenchmarkBaselineSummary[] = [];
 

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -37,7 +37,8 @@ export type BenchmarkExportFormat = "json" | "csv";
 const BASELINE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export function defaultBenchmarkBaselineDir(): string {
-  return path.join(os.homedir(), ".remnic", "bench", "baselines");
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  return path.join(homeDir, ".remnic", "bench", "baselines");
 }
 
 function compareResultSummaries(

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -1,5 +1,6 @@
-import { readdir, readFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import type { BenchmarkMode, BenchmarkResult } from "./types.js";
 
@@ -11,12 +12,50 @@ export interface StoredBenchmarkResultSummary {
   mode: BenchmarkMode;
 }
 
+export interface StoredBenchmarkBaseline {
+  name: string;
+  savedAt: string;
+  result: BenchmarkResult;
+  source?: {
+    id: string;
+    path: string;
+  };
+}
+
+export interface StoredBenchmarkBaselineSummary {
+  name: string;
+  path: string;
+  benchmark: string;
+  timestamp: string;
+  resultId: string;
+  resultTimestamp: string;
+  mode: BenchmarkMode;
+}
+
+export type BenchmarkExportFormat = "json" | "csv";
+
+const BASELINE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
+
+export function defaultBenchmarkBaselineDir(): string {
+  return path.join(os.homedir(), ".remnic", "bench", "baselines");
+}
+
 function compareResultSummaries(
   left: StoredBenchmarkResultSummary,
   right: StoredBenchmarkResultSummary,
 ): number {
   if (left.timestamp === right.timestamp) {
     return left.id.localeCompare(right.id);
+  }
+  return right.timestamp.localeCompare(left.timestamp);
+}
+
+function compareBaselineSummaries(
+  left: StoredBenchmarkBaselineSummary,
+  right: StoredBenchmarkBaselineSummary,
+): number {
+  if (left.timestamp === right.timestamp) {
+    return left.name.localeCompare(right.name);
   }
   return right.timestamp.localeCompare(left.timestamp);
 }
@@ -54,6 +93,40 @@ function isBenchmarkResult(value: unknown): value is BenchmarkResult {
   );
 }
 
+function isStoredBenchmarkBaseline(value: unknown): value is StoredBenchmarkBaseline {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+
+  const baseline = value as StoredBenchmarkBaseline;
+  if (
+    typeof baseline.name !== "string" ||
+    typeof baseline.savedAt !== "string" ||
+    !isBenchmarkResult(baseline.result)
+  ) {
+    return false;
+  }
+
+  if (baseline.source === undefined) {
+    return true;
+  }
+
+  return (
+    typeof baseline.source === "object" &&
+    baseline.source !== null &&
+    typeof baseline.source.id === "string" &&
+    typeof baseline.source.path === "string"
+  );
+}
+
+function assertValidBaselineName(name: string): void {
+  if (!BASELINE_NAME_PATTERN.test(name)) {
+    throw new Error(
+      `Invalid baseline name "${name}". Use only letters, numbers, "_" and "-".`,
+    );
+  }
+}
+
 function toSummary(
   result: BenchmarkResult,
   filePath: string,
@@ -64,6 +137,21 @@ function toSummary(
     benchmark: result.meta.benchmark,
     timestamp: result.meta.timestamp,
     mode: result.meta.mode,
+  };
+}
+
+function toBaselineSummary(
+  baseline: StoredBenchmarkBaseline,
+  filePath: string,
+): StoredBenchmarkBaselineSummary {
+  return {
+    name: baseline.name,
+    path: filePath,
+    benchmark: baseline.result.meta.benchmark,
+    timestamp: baseline.savedAt,
+    resultId: baseline.result.meta.id,
+    resultTimestamp: baseline.result.meta.timestamp,
+    mode: baseline.result.meta.mode,
   };
 }
 
@@ -103,6 +191,67 @@ export async function listBenchmarkResults(
   return results.sort(compareResultSummaries);
 }
 
+export async function saveBenchmarkBaseline(
+  baselineDir: string,
+  name: string,
+  result: BenchmarkResult,
+  source?: {
+    id: string;
+    path: string;
+  },
+): Promise<string> {
+  assertValidBaselineName(name);
+  await mkdir(baselineDir, { recursive: true });
+
+  const filePath = path.join(baselineDir, `${name}.json`);
+  const payload: StoredBenchmarkBaseline = {
+    name,
+    savedAt: new Date().toISOString(),
+    result,
+    source,
+  };
+  await writeFile(filePath, `${JSON.stringify(payload, null, 2)}\n`);
+  return filePath;
+}
+
+export async function loadBenchmarkBaseline(
+  filePath: string,
+): Promise<StoredBenchmarkBaseline> {
+  const content = await readFile(filePath, "utf8");
+  const parsed: unknown = JSON.parse(content);
+  if (!isStoredBenchmarkBaseline(parsed)) {
+    throw new Error(`Invalid benchmark baseline file: ${filePath}`);
+  }
+  return parsed;
+}
+
+export async function listBenchmarkBaselines(
+  baselineDir: string,
+): Promise<StoredBenchmarkBaselineSummary[]> {
+  if (!fs.existsSync(baselineDir)) {
+    return [];
+  }
+
+  const entries = await readdir(baselineDir, { withFileTypes: true });
+  const baselines: StoredBenchmarkBaselineSummary[] = [];
+
+  for (const entry of entries) {
+    if (!entry.isFile() || !entry.name.endsWith(".json")) {
+      continue;
+    }
+
+    const filePath = path.join(baselineDir, entry.name);
+    try {
+      const baseline = await loadBenchmarkBaseline(filePath);
+      baselines.push(toBaselineSummary(baseline, filePath));
+    } catch {
+      continue;
+    }
+  }
+
+  return baselines.sort(compareBaselineSummaries);
+}
+
 export async function resolveBenchmarkResultReference(
   outputDir: string,
   reference: string,
@@ -126,4 +275,54 @@ export async function resolveBenchmarkResultReference(
     (summary) => path.basename(summary.path) === reference,
   );
   return basenameMatch;
+}
+
+function csvEscape(value: string | number): string {
+  const text = String(value);
+  if (/[",\n]/.test(text)) {
+    return `"${text.replaceAll(`"`, `""`)}"`;
+  }
+  return text;
+}
+
+export function renderBenchmarkResultExport(
+  result: BenchmarkResult,
+  format: BenchmarkExportFormat,
+): string {
+  if (format === "json") {
+    return `${JSON.stringify(result, null, 2)}\n`;
+  }
+
+  const rows = [
+    [
+      "result_id",
+      "benchmark",
+      "timestamp",
+      "mode",
+      "metric",
+      "mean",
+      "median",
+      "std_dev",
+      "min",
+      "max",
+    ].join(","),
+  ];
+
+  for (const metric of Object.keys(result.results.aggregates).sort()) {
+    const aggregate = result.results.aggregates[metric]!;
+    rows.push([
+      result.meta.id,
+      result.meta.benchmark,
+      result.meta.timestamp,
+      result.meta.mode,
+      metric,
+      aggregate.mean,
+      aggregate.median,
+      aggregate.stdDev,
+      aggregate.min,
+      aggregate.max,
+    ].map(csvEscape).join(","));
+  }
+
+  return `${rows.join("\n")}\n`;
 }

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -1,7 +1,19 @@
 import path from "node:path";
 import { expandTilde } from "./path-utils.js";
 
-export type BenchAction = "help" | "list" | "run" | "compare" | "check" | "report";
+export type BenchAction =
+  | "help"
+  | "list"
+  | "run"
+  | "compare"
+  | "results"
+  | "baseline"
+  | "export"
+  | "check"
+  | "report";
+
+export type BenchBaselineAction = "save" | "list";
+export type BenchExportFormat = "json" | "csv";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -9,9 +21,14 @@ export interface ParsedBenchArgs {
   quick: boolean;
   all: boolean;
   json: boolean;
+  detail: boolean;
   datasetDir?: string;
   resultsDir?: string;
+  baselinesDir?: string;
   threshold?: number;
+  baselineAction?: BenchBaselineAction;
+  format?: BenchExportFormat;
+  output?: string;
 }
 
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
@@ -32,7 +49,14 @@ export function collectBenchmarks(argv: string[]): string[] {
   const benchmarks: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index];
-    if (arg === "--dataset-dir" || arg === "--results-dir" || arg === "--threshold") {
+    if (
+      arg === "--dataset-dir" ||
+      arg === "--results-dir" ||
+      arg === "--baselines-dir" ||
+      arg === "--threshold" ||
+      arg === "--format" ||
+      arg === "--output"
+    ) {
       index += 1;
       continue;
     }
@@ -49,7 +73,14 @@ export function parseBenchActionArgs(argv: string[]): {
 } {
   const [first, ...rest] = argv;
   const action: BenchAction =
-    first === "list" || first === "run" || first === "compare" || first === "check" || first === "report"
+    first === "list" ||
+    first === "run" ||
+    first === "compare" ||
+    first === "results" ||
+    first === "baseline" ||
+    first === "export" ||
+    first === "check" ||
+    first === "report"
       ? first
       : first === undefined || first === "--help" || first === "-h"
         ? "help"
@@ -63,10 +94,24 @@ export function parseBenchActionArgs(argv: string[]): {
 
 export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const { action, args } = parseBenchActionArgs(argv);
-  const benchmarks = collectBenchmarks(args);
+  const baselineAction =
+    action === "baseline"
+      ? args[0] === "save" || args[0] === "list"
+        ? args[0]
+        : undefined
+      : undefined;
+  if (action === "baseline" && baselineAction === undefined) {
+    throw new Error("ERROR: baseline requires a subcommand: save or list.");
+  }
+
+  const benchmarkArgs = action === "baseline" ? args.slice(1) : args;
+  const benchmarks = collectBenchmarks(benchmarkArgs);
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
+  const baselinesDir = readBenchOptionValue(args, "--baselines-dir");
   const thresholdRaw = readBenchOptionValue(args, "--threshold");
+  const formatRaw = readBenchOptionValue(args, "--format");
+  const output = readBenchOptionValue(args, "--output");
   let threshold: number | undefined;
   if (thresholdRaw !== undefined) {
     threshold = Number(thresholdRaw);
@@ -75,14 +120,27 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     }
   }
 
+  let format: BenchExportFormat | undefined;
+  if (formatRaw !== undefined) {
+    if (formatRaw !== "json" && formatRaw !== "csv") {
+      throw new Error('ERROR: --format must be "json" or "csv".');
+    }
+    format = formatRaw;
+  }
+
   return {
     action,
     benchmarks,
     quick: args.includes("--quick"),
     all: args.includes("--all"),
     json: args.includes("--json"),
+    detail: args.includes("--detail"),
     datasetDir: datasetDir ? path.resolve(expandTilde(datasetDir)) : undefined,
     resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
+    baselinesDir: baselinesDir ? path.resolve(expandTilde(baselinesDir)) : undefined,
     threshold,
+    baselineAction,
+    format,
+    output: output ? path.resolve(expandTilde(output)) : undefined,
   };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -120,13 +120,19 @@ import type {
 import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   compareResults,
+  defaultBenchmarkBaselineDir,
+  listBenchmarkBaselines,
+  listBenchmarkResults,
+  loadBenchmarkBaseline,
   runBenchSuite,
   runExplain,
   loadBaseline,
   saveBaseline,
   checkRegression,
   loadBenchmarkResult,
+  renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
+  saveBenchmarkBaseline,
   type BenchConfig,
   type BenchmarkDefinition,
 } from "@remnic/bench";
@@ -247,13 +253,19 @@ export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
 const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|compare> [options] [benchmark...]
-       remnic benchmark <list|run|compare|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|compare|results|baseline|export> [options] [benchmark...]
+       remnic benchmark <list|run|compare|results|baseline|export|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
   run [benchmark...]       Run one or more benchmark packs
   compare <base> <cand>    Compare two stored benchmark runs by id or file path
+  results [run]            List stored runs or inspect a stored run
+  baseline save <name> [run]
+                           Save a stored run as a named baseline
+  baseline list            List saved baselines
+  export <run> --format <json|csv>
+                           Export one stored run as JSON or aggregate-metrics CSV
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
 
@@ -262,7 +274,11 @@ Options:
   --all                    Run every published benchmark
   --dataset-dir <path>     Override the benchmark dataset directory for full runs
   --results-dir <path>     Override the stored benchmark results directory
+  --baselines-dir <path>   Override the named baseline directory
   --threshold <value>      Regression threshold for compare (default: 0.05)
+  --detail                 Include per-task details for bench results
+  --format <json|csv>      Output format for bench export
+  --output <path>          Write bench export output to a file
   --json                   Output JSON for \`list\`
 
 Examples:
@@ -270,6 +286,11 @@ Examples:
   remnic bench run --quick longmemeval
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
   remnic bench compare base-run candidate-run
+  remnic bench results
+  remnic bench results candidate-run --detail
+  remnic bench baseline save main candidate-run
+  remnic bench baseline list
+  remnic bench export candidate-run --format csv --output ./candidate.csv
   remnic benchmark run --quick longmemeval`;
 }
 
@@ -384,6 +405,10 @@ function resolveBenchOutputDir(): string {
   return path.join(resolveHomeDir(), ".remnic", "bench", "results");
 }
 
+function resolveBenchBaselineDir(): string {
+  return defaultBenchmarkBaselineDir();
+}
+
 function resolveBenchDatasetDir(
   benchmarkId: string,
   quick: boolean,
@@ -421,6 +446,37 @@ function printBenchPackageSummary(
     console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
   }
   console.log(`Results saved: ${outputPath}`);
+}
+
+function printStoredBenchResultSummary(
+  result: Awaited<ReturnType<typeof loadBenchmarkResult>>,
+  summary: { id: string; path: string },
+): void {
+  printBenchPackageSummary(result, summary.path);
+  console.log(`Run id: ${summary.id}`);
+}
+
+function printStoredBenchResultDetails(
+  result: Awaited<ReturnType<typeof loadBenchmarkResult>>,
+  summary: { id: string; path: string },
+): void {
+  printStoredBenchResultSummary(result, summary);
+  if (result.results.tasks.length === 0) {
+    console.log("Tasks: none");
+    return;
+  }
+
+  console.log("Task breakdown:");
+  for (const task of result.results.tasks) {
+    const scores = Object.entries(task.scores)
+      .sort(([left], [right]) => left.localeCompare(right))
+      .map(([metric, value]) => `${metric}=${value.toFixed(4)}`)
+      .join(", ");
+    console.log(
+      `  ${task.taskId}: ${task.latencyMs.toFixed(1)}ms` +
+      `${scores.length > 0 ? ` [${scores}]` : ""}`,
+    );
+  }
 }
 
 function printBenchComparisonSummary(
@@ -513,6 +569,170 @@ async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
   if (comparison.verdict === "regression") {
     process.exit(1);
   }
+}
+
+async function showBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+
+  if (parsed.benchmarks.length === 0) {
+    const summaries = await listBenchmarkResults(resultsDir);
+    if (parsed.json) {
+      console.log(JSON.stringify(summaries, null, 2));
+      return;
+    }
+    if (summaries.length === 0) {
+      console.log(`No stored benchmark runs found in ${resultsDir}`);
+      return;
+    }
+
+    console.log("Stored benchmark runs:");
+    for (const summary of summaries) {
+      console.log(
+        `  ${summary.id.padEnd(24)} ${summary.benchmark.padEnd(16)} ${summary.mode.padEnd(5)} ${summary.timestamp}`,
+      );
+    }
+    return;
+  }
+
+  if (parsed.benchmarks.length !== 1) {
+    console.error(
+      "ERROR: results accepts at most one stored result reference. Usage: remnic bench results [run] [--detail] [--results-dir <path>] [--json]",
+    );
+    process.exit(1);
+  }
+
+  const reference = parsed.benchmarks[0]!;
+  const summary = await resolveBenchmarkResultReference(resultsDir, reference);
+  if (!summary) {
+    console.error(`ERROR: benchmark result not found: ${reference}`);
+    process.exit(1);
+  }
+
+  const result = await loadBenchmarkResult(summary.path);
+  if (parsed.json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+
+  if (parsed.detail) {
+    printStoredBenchResultDetails(result, summary);
+  } else {
+    printStoredBenchResultSummary(result, summary);
+  }
+}
+
+async function manageBenchBaselines(parsed: ParsedBenchArgs): Promise<void> {
+  const baselineDir = parsed.baselinesDir ?? resolveBenchBaselineDir();
+
+  if (parsed.baselineAction === "list") {
+    const baselines = await listBenchmarkBaselines(baselineDir);
+    if (parsed.json) {
+      console.log(JSON.stringify(baselines, null, 2));
+      return;
+    }
+    if (baselines.length === 0) {
+      console.log(`No saved baselines found in ${baselineDir}`);
+      return;
+    }
+
+    console.log("Saved baselines:");
+    for (const baseline of baselines) {
+      console.log(
+        `  ${baseline.name.padEnd(20)} ${baseline.benchmark.padEnd(16)} ${baseline.mode.padEnd(5)} ${baseline.timestamp}`,
+      );
+    }
+    return;
+  }
+
+  if (parsed.baselineAction !== "save") {
+    console.error("ERROR: baseline requires a subcommand: save or list.");
+    process.exit(1);
+  }
+
+  if (parsed.benchmarks.length < 1 || parsed.benchmarks.length > 2) {
+    console.error(
+      "ERROR: baseline save requires a name and optionally one stored result reference. Usage: remnic bench baseline save <name> [run] [--results-dir <path>] [--baselines-dir <path>] [--json]",
+    );
+    process.exit(1);
+  }
+
+  const [name, explicitReference] = parsed.benchmarks;
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const sourceSummary = explicitReference
+    ? await resolveBenchmarkResultReference(resultsDir, explicitReference)
+    : (await listBenchmarkResults(resultsDir))[0];
+
+  if (!sourceSummary) {
+    console.error(
+      explicitReference
+        ? `ERROR: benchmark result not found: ${explicitReference}`
+        : `ERROR: no stored benchmark runs found in ${resultsDir}`,
+    );
+    process.exit(1);
+  }
+
+  const result = await loadBenchmarkResult(sourceSummary.path);
+  let writtenPath: string;
+  try {
+    writtenPath = await saveBenchmarkBaseline(
+      baselineDir,
+      name!,
+      result,
+      { id: sourceSummary.id, path: sourceSummary.path },
+    );
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+
+  if (parsed.json) {
+    const baseline = await loadBenchmarkBaseline(writtenPath);
+    console.log(JSON.stringify({
+      name: baseline.name,
+      path: writtenPath,
+      source: baseline.source,
+      benchmark: baseline.result.meta.benchmark,
+      timestamp: baseline.savedAt,
+    }, null, 2));
+    return;
+  }
+
+  console.log(`Saved baseline "${name}" to ${writtenPath}`);
+  console.log(`  Source run: ${sourceSummary.id}`);
+  console.log(`  Benchmark: ${result.meta.benchmark}`);
+}
+
+async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> {
+  if (parsed.benchmarks.length !== 1) {
+    console.error(
+      "ERROR: export requires exactly one stored result reference. Usage: remnic bench export <run> --format <json|csv> [--output <path>] [--results-dir <path>]",
+    );
+    process.exit(1);
+  }
+  if (!parsed.format) {
+    console.error('ERROR: export requires --format json or --format csv.');
+    process.exit(1);
+  }
+
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const reference = parsed.benchmarks[0]!;
+  const summary = await resolveBenchmarkResultReference(resultsDir, reference);
+  if (!summary) {
+    console.error(`ERROR: benchmark result not found: ${reference}`);
+    process.exit(1);
+  }
+
+  const result = await loadBenchmarkResult(summary.path);
+  const rendered = renderBenchmarkResultExport(result, parsed.format);
+
+  if (parsed.output) {
+    fs.mkdirSync(path.dirname(parsed.output), { recursive: true });
+    fs.writeFileSync(parsed.output, rendered);
+    console.log(`Exported ${summary.id} as ${parsed.format} to ${parsed.output}`);
+    return;
+  }
+
+  process.stdout.write(rendered);
 }
 
 async function runBenchViaPackage(
@@ -2400,6 +2620,21 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "results") {
+    await showBenchPackageResults(parsed);
+    return;
+  }
+
+  if (parsed.action === "baseline") {
+    await manageBenchBaselines(parsed);
+    return;
+  }
+
+  if (parsed.action === "export") {
+    await exportBenchPackageResult(parsed);
+    return;
+  }
+
   if (parsed.action === "list") {
     const catalog = await listBenchmarksFromPackage() ?? BENCHMARK_CATALOG;
     if (parsed.json) {
@@ -3830,9 +4065,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--threshold <value>] [--json]
+  remnic bench <list|run|compare|results|baseline|export> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|compare|results|baseline|export|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -437,6 +437,7 @@ function printBenchPackageSummary(
     cost: { meanQueryLatencyMs: number };
   },
   outputPath: string,
+  outputLabel = "Results saved",
 ): void {
   console.log(`Benchmark: ${result.meta.benchmark}`);
   console.log(`Mode: ${result.meta.mode}`);
@@ -445,14 +446,14 @@ function printBenchPackageSummary(
   for (const [metric, aggregate] of Object.entries(result.results.aggregates).sort()) {
     console.log(`  ${metric.padEnd(20)} ${aggregate.mean.toFixed(4)}`);
   }
-  console.log(`Results saved: ${outputPath}`);
+  console.log(`${outputLabel}: ${outputPath}`);
 }
 
 function printStoredBenchResultSummary(
   result: Awaited<ReturnType<typeof loadBenchmarkResult>>,
   summary: { id: string; path: string },
 ): void {
-  printBenchPackageSummary(result, summary.path);
+  printBenchPackageSummary(result, summary.path, "Stored result");
   console.log(`Run id: ${summary.id}`);
 }
 

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -52,9 +52,14 @@ test("@remnic/bench index exports the phase-2 stats helpers", async () => {
   assert.match(source, /cohensD/);
   assert.match(source, /interpretEffectSize/);
   assert.match(source, /compareResults/);
+  assert.match(source, /defaultBenchmarkBaselineDir/);
+  assert.match(source, /loadBenchmarkBaseline/);
+  assert.match(source, /listBenchmarkBaselines/);
   assert.match(source, /loadBenchmarkResult/);
   assert.match(source, /listBenchmarkResults/);
+  assert.match(source, /renderBenchmarkResultExport/);
   assert.match(source, /resolveBenchmarkResultReference/);
+  assert.match(source, /saveBenchmarkBaseline/);
   assert.match(source, /buildBenchmarkRunSeeds/);
   assert.match(source, /orchestrateBenchmarkRuns/);
   assert.match(source, /resolveBenchmarkRunCount/);

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -4,9 +4,14 @@ import os from "node:os";
 import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import {
+  defaultBenchmarkBaselineDir,
+  listBenchmarkBaselines,
   listBenchmarkResults,
+  loadBenchmarkBaseline,
   loadBenchmarkResult,
+  renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
+  saveBenchmarkBaseline,
 } from "../packages/bench/src/results-store.ts";
 import type { BenchmarkResult } from "../packages/bench/src/types.ts";
 
@@ -145,4 +150,66 @@ test("resolveBenchmarkResultReference falls back to id matching when a same-name
   } finally {
     process.chdir(cwd);
   }
+});
+
+test("saveBenchmarkBaseline persists a named baseline and listBenchmarkBaselines returns newest first", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-baselines-"));
+  const firstPath = await saveBenchmarkBaseline(
+    root,
+    "main",
+    buildResult("run-main", "2026-04-18T04:00:00.000Z"),
+    { id: "run-main", path: "/tmp/run-main.json" },
+  );
+
+  await new Promise((resolve) => setTimeout(resolve, 5));
+
+  const secondPath = await saveBenchmarkBaseline(
+    root,
+    "candidate",
+    buildResult("run-candidate", "2026-04-18T05:00:00.000Z"),
+    { id: "run-candidate", path: "/tmp/run-candidate.json" },
+  );
+
+  const stored = await loadBenchmarkBaseline(firstPath);
+  const listed = await listBenchmarkBaselines(root);
+
+  assert.equal(stored.name, "main");
+  assert.equal(stored.source?.id, "run-main");
+  assert.equal(listed[0]?.name, "candidate");
+  assert.equal(listed[0]?.path, secondPath);
+  assert.equal(listed[1]?.name, "main");
+});
+
+test("saveBenchmarkBaseline rejects invalid baseline names instead of sanitizing them", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-baseline-invalid-"));
+
+  await assert.rejects(
+    () => saveBenchmarkBaseline(root, "main branch", buildResult("run-main", "2026-04-18T06:00:00.000Z")),
+    /Invalid baseline name/,
+  );
+});
+
+test("defaultBenchmarkBaselineDir resolves under the Remnic home directory", () => {
+  const baselineDir = defaultBenchmarkBaselineDir();
+  assert.match(baselineDir, /\.remnic[\/\\]bench[\/\\]baselines$/);
+});
+
+test("renderBenchmarkResultExport returns JSON and aggregate-metric CSV representations", () => {
+  const result = buildResult("candidate-run", "2026-04-18T07:00:00.000Z");
+  result.results.aggregates = {
+    answerAccuracy: {
+      mean: 0.8,
+      median: 0.8,
+      stdDev: 0.1,
+      min: 0.6,
+      max: 0.9,
+    },
+  };
+
+  const json = renderBenchmarkResultExport(result, "json");
+  const csv = renderBenchmarkResultExport(result, "csv");
+
+  assert.match(json, /"candidate-run"/);
+  assert.match(csv, /^result_id,benchmark,timestamp,mode,metric,mean,median,std_dev,min,max$/m);
+  assert.match(csv, /candidate-run,longmemeval,2026-04-18T07:00:00.000Z,full,answerAccuracy,0.8,0.8,0.1,0.6,0.9/);
 });

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -216,8 +216,32 @@ test("saveBenchmarkBaseline rejects baseline paths that exist as files", async (
 });
 
 test("defaultBenchmarkBaselineDir resolves under the Remnic home directory", () => {
-  const baselineDir = defaultBenchmarkBaselineDir();
-  assert.match(baselineDir, /\.remnic[\/\\]bench[\/\\]baselines$/);
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const customHomeDir = path.join(path.sep, "tmp", "remnic-home");
+
+  process.env.HOME = customHomeDir;
+  delete process.env.USERPROFILE;
+
+  try {
+    const baselineDir = defaultBenchmarkBaselineDir();
+    assert.equal(
+      baselineDir,
+      path.join(customHomeDir, ".remnic", "bench", "baselines"),
+    );
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
+    }
+  }
 });
 
 test("renderBenchmarkResultExport returns JSON and aggregate-metric CSV representations", () => {

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -189,6 +189,32 @@ test("saveBenchmarkBaseline rejects invalid baseline names instead of sanitizing
   );
 });
 
+test("listBenchmarkBaselines rejects baseline paths that exist as files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-baseline-file-list-"));
+  const baselinePath = path.join(root, "baselines.json");
+  await writeFile(baselinePath, "not a directory");
+
+  await assert.rejects(
+    () => listBenchmarkBaselines(baselinePath),
+    /Invalid benchmark baseline directory: .* is not a directory\./,
+  );
+});
+
+test("saveBenchmarkBaseline rejects baseline paths that exist as files", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-baseline-file-save-"));
+  const baselinePath = path.join(root, "baselines.json");
+  await writeFile(baselinePath, "not a directory");
+
+  await assert.rejects(
+    () => saveBenchmarkBaseline(
+      baselinePath,
+      "main",
+      buildResult("run-main", "2026-04-18T06:30:00.000Z"),
+    ),
+    /Invalid benchmark baseline directory: .* is not a directory\./,
+  );
+});
+
 test("defaultBenchmarkBaselineDir resolves under the Remnic home directory", () => {
   const baselineDir = defaultBenchmarkBaselineDir();
   assert.match(baselineDir, /\.remnic[\/\\]bench[\/\\]baselines$/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -139,6 +139,7 @@ test("bench results, baseline, and export route through the stored package resul
   assert.match(source, /bench export <run> --format <json\|csv>/);
   assert.match(source, /const baselineDir = parsed\.baselinesDir \?\? resolveBenchBaselineDir\(\)/);
   assert.match(source, /const rendered = renderBenchmarkResultExport\(result, parsed\.format\);/);
+  assert.match(source, /printBenchPackageSummary\(result, summary\.path, "Stored result"\);/);
   assert.match(parserSource, /export type BenchBaselineAction = "save" \| "list";/);
   assert.match(parserSource, /export type BenchExportFormat = "json" \| "csv";/);
   assert.match(parserSource, /const baselinesDir = readBenchOptionValue\(args, "--baselines-dir"\);/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -9,7 +9,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -85,9 +85,10 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /from "\.\/bench-args\.js";/);
   assert.match(parserSource, /function readBenchOptionValue\(argv: string\[\], flag: string\)/);
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
-  assert.match(parserSource, /const benchmarks = collectBenchmarks\(args\);/);
+  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \? args\.slice\(1\) : args;/);
+  assert.match(parserSource, /const benchmarks = collectBenchmarks\(benchmarkArgs\);/);
   assert.match(parserSource, /requires a value\./);
-  assert.match(parserSource, /if \(arg === "--dataset-dir" \|\| arg === "--results-dir" \|\| arg === "--threshold"\) \{\s*index \+= 1;\s*continue;\s*\}/s);
+  assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
   assert.match(parserSource, /datasetDir: datasetDir \? path\.resolve\(expandTilde\(datasetDir\)\) : undefined/);
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
   assert.match(source, /const outputDir = resolveBenchOutputDir\(\);/);
@@ -110,12 +111,42 @@ test("bench compare routes through stored package results with threshold and res
   assert.match(source, /parsed\.resultsDir \?\? resolveBenchOutputDir\(\)/);
   assert.match(source, /compareResults\(\s*baseline,\s*candidate,\s*parsed\.threshold \?\? 0\.05/s);
   assert.match(source, /benchmark mismatch: \$\{baseline\.meta\.benchmark\} vs \$\{candidate\.meta\.benchmark\}/);
-  assert.match(parserSource, /export type BenchAction = "help" \| "list" \| "run" \| "compare" \| "check" \| "report";/);
+  assert.match(parserSource, /export type BenchAction =[\s\S]*"results"[\s\S]*"baseline"[\s\S]*"export"[\s\S]*"check"[\s\S]*"report";/);
   assert.match(parserSource, /const resultsDir = readBenchOptionValue\(args, "--results-dir"\);/);
   assert.match(parserSource, /const thresholdRaw = readBenchOptionValue\(args, "--threshold"\);/);
   assert.match(parserSource, /ERROR: --threshold must be a non-negative number\./);
   assert.match(parserSource, /resultsDir: resultsDir \? path\.resolve\(expandTilde\(resultsDir\)\) : undefined/);
   assert.match(parserSource, /threshold,/);
+});
+
+test("bench results, baseline, and export route through the stored package results helpers", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+
+  assert.match(source, /defaultBenchmarkBaselineDir,/);
+  assert.match(source, /listBenchmarkBaselines,/);
+  assert.match(source, /loadBenchmarkBaseline,/);
+  assert.match(source, /listBenchmarkResults,/);
+  assert.match(source, /renderBenchmarkResultExport,/);
+  assert.match(source, /saveBenchmarkBaseline,/);
+  assert.match(source, /async function showBenchPackageResults\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /async function manageBenchBaselines\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /async function exportBenchPackageResult\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /if \(parsed\.action === "results"\) \{\s*await showBenchPackageResults\(parsed\);/s);
+  assert.match(source, /if \(parsed\.action === "baseline"\) \{\s*await manageBenchBaselines\(parsed\);/s);
+  assert.match(source, /if \(parsed\.action === "export"\) \{\s*await exportBenchPackageResult\(parsed\);/s);
+  assert.match(source, /baseline save <name> \[run\]/);
+  assert.match(source, /bench export <run> --format <json\|csv>/);
+  assert.match(source, /const baselineDir = parsed\.baselinesDir \?\? resolveBenchBaselineDir\(\)/);
+  assert.match(source, /const rendered = renderBenchmarkResultExport\(result, parsed\.format\);/);
+  assert.match(parserSource, /export type BenchBaselineAction = "save" \| "list";/);
+  assert.match(parserSource, /export type BenchExportFormat = "json" \| "csv";/);
+  assert.match(parserSource, /const baselinesDir = readBenchOptionValue\(args, "--baselines-dir"\);/);
+  assert.match(parserSource, /const formatRaw = readBenchOptionValue\(args, "--format"\);/);
+  assert.match(parserSource, /const output = readBenchOptionValue\(args, "--output"\);/);
+  assert.match(parserSource, /detail: args\.includes\("--detail"\),/);
+  assert.match(parserSource, /baselinesDir: baselinesDir \? path\.resolve\(expandTilde\(baselinesDir\)\) : undefined/);
+  assert.match(parserSource, /output: output \? path\.resolve\(expandTilde\(output\)\) : undefined/);
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {
@@ -157,6 +188,47 @@ test("parseBenchArgs supports compare-specific results-dir and threshold options
   assert.deepEqual(parsed.benchmarks, ["base-run", "candidate-run"]);
   assert.match(parsed.resultsDir ?? "", /bench-results$/);
   assert.equal(parsed.threshold, 0.2);
+});
+
+test("parseBenchArgs supports results, baseline, and export surfaces", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const resultsArgs = parseBenchArgs([
+    "results",
+    "candidate-run",
+    "--detail",
+    "--results-dir",
+    "~/bench-results",
+  ]);
+  assert.equal(resultsArgs.action, "results");
+  assert.deepEqual(resultsArgs.benchmarks, ["candidate-run"]);
+  assert.equal(resultsArgs.detail, true);
+  assert.match(resultsArgs.resultsDir ?? "", /bench-results$/);
+
+  const baselineArgs = parseBenchArgs([
+    "baseline",
+    "save",
+    "main",
+    "candidate-run",
+    "--baselines-dir",
+    "~/bench-baselines",
+  ]);
+  assert.equal(baselineArgs.action, "baseline");
+  assert.equal(baselineArgs.baselineAction, "save");
+  assert.deepEqual(baselineArgs.benchmarks, ["main", "candidate-run"]);
+  assert.match(baselineArgs.baselinesDir ?? "", /bench-baselines$/);
+
+  const exportArgs = parseBenchArgs([
+    "export",
+    "candidate-run",
+    "--format",
+    "csv",
+    "--output",
+    "./candidate.csv",
+  ]);
+  assert.equal(exportArgs.action, "export");
+  assert.equal(exportArgs.format, "csv");
+  assert.match(exportArgs.output ?? "", /candidate\.csv$/);
 });
 
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {


### PR DESCRIPTION
## Summary
- add stored benchmark result helpers for named baselines plus JSON and CSV exports
- extend the bench CLI with `results`, `baseline save|list`, and `export` surfaces
- cover the new package and CLI behavior with focused bench-store and surface tests

## Verification
- `npx tsx --test tests/bench-results-store.test.ts tests/bench-package-surface.test.ts tests/remnic-cli-bench-surface.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/cli check-types`
- `pnpm --filter @remnic/bench build && pnpm --filter @remnic/cli build`

Part of #445 (phase 3 stored-results slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI subcommands that read/write benchmark artifacts on disk and introduces new serialization/validation paths for baselines and CSV exports; main risk is incorrect file handling or format/validation edge cases.
> 
> **Overview**
> **Adds stored benchmark baseline + export support.** `@remnic/bench` now supports saving/loading/listing named baselines (with name validation and a default `~/.remnic/bench/baselines` location) alongside existing stored-run helpers.
> 
> **Extends `remnic bench` CLI surface.** Introduces `results` (list/inspect runs with optional `--detail`), `baseline save|list` (with `--baselines-dir`), and `export` (JSON or aggregate-metrics CSV via `--format`, optionally `--output`).
> 
> **Tests updated/added** to assert new package exports, baseline directory/name error handling, and CSV/JSON export rendering behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1704d9580fb5197c636ba436a042a42bd9fa936. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->