### PR TITLE
fix(plugin-openclaw): satisfy OpenClaw registerCommand validator

### DIFF
--- a/packages/plugin-openclaw/src/session-command-descriptors.test.ts
+++ b/packages/plugin-openclaw/src/session-command-descriptors.test.ts
@@ -68,3 +68,73 @@ test("buildSessionCommandDescriptors wires toggle and status handlers", async ()
   await clear.handler({ sessionKey: "session-a", agentId: "main" });
   assert.equal(disabled.has("session-a:main"), false);
 });
+
+test("top-level descriptor satisfies OpenClaw registerCommand validator and dispatches subcommands", async () => {
+  const disabled = new Map<string, boolean>();
+  const runtime = {
+    toggles: {
+      async isDisabled() {
+        return false;
+      },
+      async resolve(sessionKey: string, agentId: string) {
+        const key = `${sessionKey}:${agentId}`;
+        return {
+          disabled: disabled.get(key) === true,
+          source: disabled.has(key) ? ("primary" as const) : ("none" as const),
+        };
+      },
+      async setDisabled(sessionKey: string, agentId: string, next: boolean) {
+        disabled.set(`${sessionKey}:${agentId}`, next);
+      },
+      async clear(sessionKey: string, agentId: string) {
+        disabled.delete(`${sessionKey}:${agentId}`);
+      },
+      async list() {
+        return [];
+      },
+    },
+    getLastRecall() {
+      return null;
+    },
+    getLastRecallSummary() {
+      return null;
+    },
+    async flushSession() {},
+  };
+
+  const [group] = buildSessionCommandDescriptors("openclaw-remnic", runtime);
+  const descriptor = group as unknown as {
+    name: string;
+    description: string;
+    acceptsArgs: boolean;
+    handler: (ctx?: { sessionKey?: string; agentId?: string; args?: readonly string[] }) => Promise<string>;
+  };
+
+  // Shape required by openclaw's validatePluginCommandDefinition
+  // (see openclaw/dist/command-registration:*).
+  assert.equal(typeof descriptor.handler, "function");
+  assert.equal(typeof descriptor.description, "string");
+  assert.ok(descriptor.description.trim().length > 0);
+  assert.equal(descriptor.acceptsArgs, true);
+
+  await descriptor.handler({ args: ["off"], sessionKey: "session-b", agentId: "main" });
+  assert.equal(disabled.get("session-b:main"), true);
+
+  const statusText = await descriptor.handler({
+    args: ["status"],
+    sessionKey: "session-b",
+    agentId: "main",
+  });
+  assert.match(statusText, /disabled/);
+
+  const unknownText = await descriptor.handler({
+    args: ["bogus"],
+    sessionKey: "session-b",
+    agentId: "main",
+  });
+  assert.match(unknownText, /Unknown Remnic subcommand "bogus"/);
+
+  // No args => defaults to status.
+  const defaultText = await descriptor.handler({ sessionKey: "session-b", agentId: "main" });
+  assert.match(defaultText, /Remnic recall is/);
+});

--- a/packages/plugin-openclaw/src/session-command-descriptors.ts
+++ b/packages/plugin-openclaw/src/session-command-descriptors.ts
@@ -4,6 +4,7 @@ import type { LastRecallSnapshot } from "../../remnic-core/src/recall-state.js";
 export interface SessionCommandContext {
   sessionKey?: string;
   agentId?: string;
+  args?: readonly string[];
 }
 
 export interface SessionCommandRuntime {
@@ -30,92 +31,113 @@ export function buildSessionCommandDescriptors(
   pluginId: string,
   runtime: SessionCommandRuntime,
 ) {
+  const subcommands = [
+    {
+      name: "off",
+      description: "Disable Remnic recall for this session",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey, agentId } = resolveSession(commandCtx);
+        await runtime.toggles.setDisabled(sessionKey, agentId, true);
+        return `Remnic recall disabled for session ${sessionKey}.`;
+      },
+    },
+    {
+      name: "on",
+      description: "Re-enable Remnic recall for this session",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey, agentId } = resolveSession(commandCtx);
+        await runtime.toggles.setDisabled(sessionKey, agentId, false);
+        return `Remnic recall re-enabled for session ${sessionKey}.`;
+      },
+    },
+    {
+      name: "status",
+      description: "Show Remnic recall status and last injected summary",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey, agentId } = resolveSession(commandCtx);
+        const resolved = await runtime.toggles.resolve(sessionKey, agentId);
+        const lastRecall = runtime.getLastRecall(sessionKey);
+        const summaryText = runtime.getLastRecallSummary(sessionKey);
+        const summary = summaryText && summaryText.length > 0
+          ? summaryText
+          : lastRecall && lastRecall.memoryIds.length > 0
+            ? `${lastRecall.memoryIds.length} memory item(s), latency ${lastRecall.latencyMs ?? "?"}ms`
+            : "NONE";
+        return [
+          `Remnic recall is ${resolved.disabled ? "disabled" : "enabled"} for session ${sessionKey}.`,
+          `Source: ${describeToggleSource(resolved.source)}.`,
+          `Last recall: ${summary}.`,
+        ].join(" ");
+      },
+    },
+    {
+      name: "clear",
+      description: "Clear the session override and use global config again",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey, agentId } = resolveSession(commandCtx);
+        await runtime.toggles.clear(sessionKey, agentId);
+        return `Cleared the Remnic session override for ${sessionKey}.`;
+      },
+    },
+    {
+      name: "stats",
+      description: "Show Remnic extraction and recall stats for this session",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey } = resolveSession(commandCtx);
+        const lastRecall = runtime.getLastRecall(sessionKey);
+        if (!lastRecall) {
+          return `No Remnic recall stats are available for session ${sessionKey} yet.`;
+        }
+        return [
+          `Session ${sessionKey}.`,
+          `Planner mode: ${lastRecall.plannerMode ?? "unknown"}.`,
+          `Latency: ${lastRecall.latencyMs ?? "?"}ms.`,
+          `Memories: ${lastRecall.memoryIds.length}.`,
+        ].join(" ");
+      },
+    },
+    {
+      name: "flush",
+      description: "Force-flush the extraction buffer now",
+      args: [],
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const { sessionKey } = resolveSession(commandCtx);
+        await runtime.flushSession(sessionKey);
+        return `Flushed the Remnic buffer for session ${sessionKey}.`;
+      },
+    },
+  ];
+
+  // Top-level handler + description + acceptsArgs let the OpenClaw host
+  // registerPluginCommand validator accept this descriptor. The validator
+  // (openclaw/dist/command-registration:validatePluginCommandDefinition)
+  // requires a function `handler` and a non-empty string `description` on the
+  // registered command itself; it does not walk a `subcommands` array. The
+  // dispatcher below routes `/remnic <sub>` to the matching subcommand while
+  // keeping the `subcommands` array available for command-discovery surfaces
+  // that introspect it.
+  const subcommandNames = subcommands.map((entry) => entry.name).join(", ");
   return [
     {
       name: "remnic",
+      description: `Remnic memory controls (${subcommandNames})`,
       category: "memory",
       pluginId,
-      subcommands: [
-        {
-          name: "off",
-          description: "Disable Remnic recall for this session",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey, agentId } = resolveSession(commandCtx);
-            await runtime.toggles.setDisabled(sessionKey, agentId, true);
-            return `Remnic recall disabled for session ${sessionKey}.`;
-          },
-        },
-        {
-          name: "on",
-          description: "Re-enable Remnic recall for this session",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey, agentId } = resolveSession(commandCtx);
-            await runtime.toggles.setDisabled(sessionKey, agentId, false);
-            return `Remnic recall re-enabled for session ${sessionKey}.`;
-          },
-        },
-        {
-          name: "status",
-          description: "Show Remnic recall status and last injected summary",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey, agentId } = resolveSession(commandCtx);
-            const resolved = await runtime.toggles.resolve(sessionKey, agentId);
-            const lastRecall = runtime.getLastRecall(sessionKey);
-            const summaryText = runtime.getLastRecallSummary(sessionKey);
-            const summary = summaryText && summaryText.length > 0
-              ? summaryText
-              : lastRecall && lastRecall.memoryIds.length > 0
-                ? `${lastRecall.memoryIds.length} memory item(s), latency ${lastRecall.latencyMs ?? "?"}ms`
-                : "NONE";
-            return [
-              `Remnic recall is ${resolved.disabled ? "disabled" : "enabled"} for session ${sessionKey}.`,
-              `Source: ${describeToggleSource(resolved.source)}.`,
-              `Last recall: ${summary}.`,
-            ].join(" ");
-          },
-        },
-        {
-          name: "clear",
-          description: "Clear the session override and use global config again",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey, agentId } = resolveSession(commandCtx);
-            await runtime.toggles.clear(sessionKey, agentId);
-            return `Cleared the Remnic session override for ${sessionKey}.`;
-          },
-        },
-        {
-          name: "stats",
-          description: "Show Remnic extraction and recall stats for this session",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey } = resolveSession(commandCtx);
-            const lastRecall = runtime.getLastRecall(sessionKey);
-            if (!lastRecall) {
-              return `No Remnic recall stats are available for session ${sessionKey} yet.`;
-            }
-            return [
-              `Session ${sessionKey}.`,
-              `Planner mode: ${lastRecall.plannerMode ?? "unknown"}.`,
-              `Latency: ${lastRecall.latencyMs ?? "?"}ms.`,
-              `Memories: ${lastRecall.memoryIds.length}.`,
-            ].join(" ");
-          },
-        },
-        {
-          name: "flush",
-          description: "Force-flush the extraction buffer now",
-          args: [],
-          handler: async (commandCtx: SessionCommandContext = {}) => {
-            const { sessionKey } = resolveSession(commandCtx);
-            await runtime.flushSession(sessionKey);
-            return `Flushed the Remnic buffer for session ${sessionKey}.`;
-          },
-        },
-      ],
+      acceptsArgs: true,
+      subcommands,
+      handler: async (commandCtx: SessionCommandContext = {}) => {
+        const requested = commandCtx.args?.[0]?.trim().toLowerCase() ?? "status";
+        const match = subcommands.find((entry) => entry.name === requested);
+        if (!match) {
+          return `Unknown Remnic subcommand "${requested}". Try one of: ${subcommandNames}.`;
+        }
+        return match.handler(commandCtx);
+      },
     },
   ];
 }


### PR DESCRIPTION
## Summary

- `/remnic off|on|status|clear|stats|flush` slash commands currently fail to register on OpenClaw hosts, because `buildSessionCommandDescriptors` returns a descriptor with only a `subcommands:` array — no top-level `handler` or `description`.
- OpenClaw's `validatePluginCommandDefinition` (`openclaw/dist/command-registration`) requires both, and has no `subcommands` concept. Registration aborts with `command registration failed: Command handler must be a function`.
- This PR adds a top-level `handler`, `description`, and `acceptsArgs: true` to the `remnic` descriptor. The new handler dispatches on `args[0]` to the existing subcommand handlers, which are preserved unchanged.

## Reproduction (before)

Plugin `@remnic/plugin-openclaw@1.0.5` on `openclaw 2026.4.15`:

```
$ openclaw plugins inspect openclaw-remnic
…
Diagnostics:
WARN: unknown typed hook "commands.list" ignored
```

At session start: `command registration failed: Command handler must be a function`. `/remnic status` and friends are not dispatchable.

Host-side enforcement is at `openclaw/dist/command-registration-*.js`, `validatePluginCommandDefinition`:

```js
if (typeof command.handler !== "function") return "Command handler must be a function";
if (typeof command.description !== "string") return "Command description must be a string";
```

The validator does not recurse into `subcommands`.

## Fix

`packages/plugin-openclaw/src/session-command-descriptors.ts`:

- Extract the six per-sub handler objects into a local `subcommands` array (verbatim behavior, unchanged).
- Return a single descriptor with:
  - `name: "remnic"`
  - `description: "Remnic memory controls (off, on, status, clear, stats, flush)"`
  - `acceptsArgs: true`
  - `subcommands` (same contents as before — kept for discovery surfaces that introspect it, and for the existing tests that assert on it)
  - `handler` — dispatches `commandCtx.args?.[0]` (lower-cased) to the matching subcommand. No args defaults to `status`. Unknown sub returns a short usage string.
- `SessionCommandContext` gains `args?: readonly string[]` to reflect the real host-provided ctx (`openclaw/dist/commands-*.js` passes `args: sanitizedArgs` to plugin command handlers).

## What is *not* in this PR

- The `api.on("commands.list", …)` call in `src/index.ts:2785` still produces `WARN: unknown typed hook "commands.list" ignored` on current OpenClaw hosts, because `commands.list` is not a name accepted by OpenClaw's `isPluginHookName` gate (see `openclaw/dist/loader-*.js`, `registerTypedHook` path). It is non-fatal: command listing is already populated by `api.registerCommand()` calls, which after this PR succeed. The AGENTS.md rule against reinventing host-native features (§"Do not reinvent host-native features") suggests removing the `commands.list` block and its associated `commandsListEnabled` flag in a follow-up PR, but that touches docs, schema, `remnic-core`, and several integration tests, so I kept it out of scope here to keep this change minimal and reviewable. Happy to follow up if you'd like.

## Test plan

- [x] `pnpm run check-types` — passes
- [x] `pnpm exec tsx --test packages/plugin-openclaw/src/session-command-descriptors.test.ts` — 2/2 pass (existing test + new dispatcher test)
- [x] `pnpm exec tsx --test --test-name-pattern="commands.list" tests/sdk-compat-hook-handlers.test.ts` — 2/2 pass (existing `commands.list` shape tests unchanged)
- [x] `pnpm exec tsx --test --test-name-pattern="before_prompt_build respects the primary session toggle" tests/sdk-compat-hook-handlers.test.ts` — passes (uses `commands.list` → `subcommands.find(off)` path; still works because `subcommands` is preserved)
- [x] `pnpm exec tsx --test --test-name-pattern="commands.list" tests/sdk-compat-integration.test.ts` — passes

## New test

`packages/plugin-openclaw/src/session-command-descriptors.test.ts` gains a second case that asserts:

- Top-level `handler` is a function
- Top-level `description` is a non-empty string
- `acceptsArgs === true`
- `/remnic off` → sets disabled
- `/remnic status` → reports disabled
- `/remnic bogus` → returns unknown-subcommand message
- `/remnic` (no args) → defaults to status

This is exactly the shape contract `validatePluginCommandDefinition` enforces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)