### PR TITLE
feat(bench): add custom YAML benchmarks

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -17,7 +17,8 @@
     "check-types": "tsc --noEmit"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "workspace:*",
+    "yaml": "^2.4.2"
   },
   "devDependencies": {
     "typescript": "^5.9.3",

--- a/packages/bench/src/benchmarks/custom/loader.ts
+++ b/packages/bench/src/benchmarks/custom/loader.ts
@@ -1,0 +1,166 @@
+/**
+ * YAML custom benchmark loader.
+ */
+
+import { readFile } from "node:fs/promises";
+import { parse as parseYaml } from "yaml";
+import type { BenchmarkCategory } from "../../types.js";
+import type {
+  CustomBenchmarkScoring,
+  CustomBenchmarkSpec,
+  CustomBenchmarkTask,
+} from "./types.js";
+
+const CUSTOM_SCORING_VALUES = new Set<CustomBenchmarkScoring>([
+  "exact_match",
+  "f1",
+  "rouge_l",
+  "llm_judge",
+]);
+
+const CUSTOM_CATEGORIES = new Set<BenchmarkCategory>([
+  "agentic",
+  "retrieval",
+  "conversational",
+]);
+
+export function parseCustomBenchmark(source: string): CustomBenchmarkSpec {
+  return normalizeCustomBenchmark(parseYaml(source));
+}
+
+export async function loadCustomBenchmarkFile(
+  filePath: string,
+): Promise<CustomBenchmarkSpec> {
+  let source: string;
+  try {
+    source = await readFile(filePath, "utf8");
+  } catch (error) {
+    throw new Error(
+      `Failed to read custom benchmark file ${filePath}: ${formatError(error)}`,
+    );
+  }
+
+  try {
+    return parseCustomBenchmark(source);
+  } catch (error) {
+    throw new Error(
+      `Custom benchmark file ${filePath} is invalid: ${formatError(error)}`,
+    );
+  }
+}
+
+function normalizeCustomBenchmark(raw: unknown): CustomBenchmarkSpec {
+  const record = expectRecord(raw, "Custom benchmark YAML must parse to an object.");
+  const name = readText(record.name, "Custom benchmark name");
+  const description = readOptionalText(record.description, "Custom benchmark description");
+  const version = readOptionalText(record.version, "Custom benchmark version") ?? "1.0.0";
+  const scoring = readScoring(record.scoring);
+  const category = readCategory(record.category) ?? "retrieval";
+  const citation = readOptionalText(record.citation, "Custom benchmark citation");
+  const tasks = readTasks(record.tasks);
+
+  if (tasks.length === 0) {
+    throw new Error(`Custom benchmark "${name}" must include at least one task.`);
+  }
+
+  return {
+    name,
+    description,
+    version,
+    category,
+    citation,
+    scoring,
+    tasks,
+  };
+}
+
+function readTasks(value: unknown): CustomBenchmarkTask[] {
+  if (!Array.isArray(value)) {
+    throw new Error("Custom benchmark tasks must be an array.");
+  }
+
+  return value.map((task, index) => normalizeTask(task, index));
+}
+
+function normalizeTask(value: unknown, index: number): CustomBenchmarkTask {
+  const label = `Custom benchmark task ${index + 1}`;
+  const record = expectRecord(value, `${label} must be an object.`);
+  const question = readText(record.question, `${label} question`);
+  const expected = readText(record.expected, `${label} expected`);
+  const tags = readOptionalTextArray(record.tags, `${label} tags`);
+
+  return tags ? { question, expected, tags } : { question, expected };
+}
+
+function readScoring(value: unknown): CustomBenchmarkScoring {
+  const scoring = readText(value, "Custom benchmark scoring");
+  if (!CUSTOM_SCORING_VALUES.has(scoring as CustomBenchmarkScoring)) {
+    throw new Error(
+      `Custom benchmark scoring must be one of ${[...CUSTOM_SCORING_VALUES].join(", ")}.`,
+    );
+  }
+  return scoring as CustomBenchmarkScoring;
+}
+
+function readCategory(value: unknown): BenchmarkCategory | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+
+  const category = readText(value, "Custom benchmark category");
+  if (!CUSTOM_CATEGORIES.has(category as BenchmarkCategory)) {
+    throw new Error(
+      `Custom benchmark category must be one of ${[...CUSTOM_CATEGORIES].join(", ")}.`,
+    );
+  }
+  return category as BenchmarkCategory;
+}
+
+function readOptionalTextArray(
+  value: unknown,
+  label: string,
+): string[] | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  if (!Array.isArray(value)) {
+    throw new Error(`${label} must be an array of strings.`);
+  }
+
+  return value.map((item, index) => readText(item, `${label}[${index + 1}]`));
+}
+
+function readOptionalText(value: unknown, label: string): string | undefined {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  return readText(value, label);
+}
+
+function readText(value: unknown, label: string): string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  const normalized = value.trim();
+  if (!normalized) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+
+  return normalized;
+}
+
+function expectRecord(
+  value: unknown,
+  message: string,
+): Record<string, unknown> {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(message);
+  }
+
+  return value as Record<string, unknown>;
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -1,0 +1,202 @@
+/**
+ * Custom benchmark runner.
+ */
+
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import type { RunBenchmarkOptions, BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../types.js";
+import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScore, rougeL, timed } from "../../scorer.js";
+import { orchestrateBenchmarkRuns } from "../../benchmark.js";
+import { getGitSha, getRemnicVersion } from "../../reporter.js";
+import { loadCustomBenchmarkFile } from "./loader.js";
+import type { CustomBenchmarkScoring, CustomBenchmarkSpec } from "./types.js";
+
+export async function runCustomBenchmarkFile(
+  filePath: string,
+  options: RunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const spec = await loadCustomBenchmarkFile(filePath);
+  const benchmark = createCustomBenchmarkDefinition(spec, filePath);
+  return runCustomBenchmark(spec, {
+    ...options,
+    mode: options.mode ?? "quick",
+    benchmark,
+  });
+}
+
+async function runCustomBenchmark(
+  spec: CustomBenchmarkSpec,
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  if (spec.scoring === "llm_judge" && !options.system.judge) {
+    throw new Error(
+      `Custom benchmark "${spec.name}" uses llm_judge scoring but no judge provider is configured.`,
+    );
+  }
+
+  const { runCount, seeds, runs } = await orchestrateBenchmarkRuns(
+    options.mode,
+    async (seed, runIndex) =>
+      runCustomBenchmarkRun(spec, options, seed, runIndex),
+    undefined,
+    options.seed,
+  );
+  const tasks = runs.flat();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion: await getRemnicVersion(),
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount,
+      seeds,
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+async function runCustomBenchmarkRun(
+  benchmark: CustomBenchmarkSpec,
+  options: ResolvedRunBenchmarkOptions,
+  seed: number,
+  runIndex: number,
+): Promise<TaskResult[]> {
+  const tasks = benchmark.tasks.slice(0, normalizeLimit(options.limit) ?? benchmark.tasks.length);
+  if (tasks.length === 0) {
+    throw new Error(
+      `Custom benchmark "${benchmark.name}" is empty after applying the requested limit.`,
+    );
+  }
+
+  const results: TaskResult[] = [];
+  for (const [taskIndex, task] of tasks.entries()) {
+    const { result, durationMs } = await timed(async () => {
+      const searchResults = await options.system.search(task.question, 10);
+      const actual = searchResults.map((entry) => entry.snippet).join("\n\n");
+      const score = await scoreTask(
+        benchmark.scoring,
+        options,
+        task.question,
+        actual,
+        task.expected,
+      );
+      return {
+        actual,
+        score,
+        searchHits: searchResults.length,
+      };
+    });
+
+    results.push({
+      taskId: `${slugify(benchmark.name)}-${runIndex + 1}-${taskIndex + 1}`,
+      question: task.question,
+      expected: task.expected,
+      actual: result.actual,
+      scores: { [benchmark.scoring]: result.score },
+      latencyMs: durationMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        tags: task.tags ?? [],
+        searchHits: result.searchHits,
+        scoring: benchmark.scoring,
+        runIndex,
+        seed,
+      },
+    });
+  }
+
+  return results;
+}
+
+async function scoreTask(
+  scoring: CustomBenchmarkScoring,
+  options: ResolvedRunBenchmarkOptions,
+  question: string,
+  actual: string,
+  expected: string,
+): Promise<number> {
+  switch (scoring) {
+    case "exact_match":
+      return exactMatch(actual, expected);
+    case "f1":
+      return f1Score(actual, expected);
+    case "rouge_l":
+      return rougeL(actual, expected);
+    case "llm_judge":
+      return llmJudgeScore(options.system.judge, question, actual, expected);
+    default:
+      throw new Error(`Unsupported custom benchmark scoring: ${scoring as string}`);
+  }
+}
+
+function createCustomBenchmarkDefinition(
+  benchmark: CustomBenchmarkSpec,
+  filePath: string,
+): BenchmarkDefinition {
+  const id = `custom:${slugify(path.basename(filePath, path.extname(filePath)) || benchmark.name)}`;
+  return {
+    id,
+    title: benchmark.name,
+    tier: "custom",
+    status: "ready",
+    runnerAvailable: true,
+    meta: {
+      name: benchmark.name,
+      version: benchmark.version ?? "1.0.0",
+      description: benchmark.description ?? "",
+      category: benchmark.category ?? "retrieval",
+      citation: benchmark.citation,
+    },
+  };
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      `Custom benchmark limit must be a non-negative integer when provided; received ${limit}.`,
+    );
+  }
+
+  return limit;
+}
+
+function slugify(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .replace(/-+/g, "-") || "custom-benchmark";
+}

--- a/packages/bench/src/benchmarks/custom/types.ts
+++ b/packages/bench/src/benchmarks/custom/types.ts
@@ -1,0 +1,27 @@
+/**
+ * Custom benchmark schema types.
+ */
+
+import type { BenchmarkCategory } from "../../types.js";
+
+export type CustomBenchmarkScoring =
+  | "exact_match"
+  | "f1"
+  | "rouge_l"
+  | "llm_judge";
+
+export interface CustomBenchmarkTask {
+  question: string;
+  expected: string;
+  tags?: string[];
+}
+
+export interface CustomBenchmarkSpec {
+  name: string;
+  description?: string;
+  version?: string;
+  category?: BenchmarkCategory;
+  citation?: string;
+  scoring: CustomBenchmarkScoring;
+  tasks: CustomBenchmarkTask[];
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -35,6 +35,11 @@ export type {
   RunBenchmarkOptions,
   ResolvedRunBenchmarkOptions,
 } from "./types.js";
+export type {
+  CustomBenchmarkScoring,
+  CustomBenchmarkSpec,
+  CustomBenchmarkTask,
+} from "./benchmarks/custom/types.js";
 
 export type {
   Message,
@@ -114,3 +119,10 @@ export {
   resolveBenchmarkResultReference,
   saveBenchmarkBaseline,
 } from "./results-store.js";
+export {
+  loadCustomBenchmarkFile,
+  parseCustomBenchmark,
+} from "./benchmarks/custom/loader.js";
+export {
+  runCustomBenchmarkFile,
+} from "./benchmarks/custom/runner.js";

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -22,6 +22,7 @@
     "src/scorer.ts",
     "src/adapters/**/*.ts",
     "src/providers/**/*.ts",
-    "src/benchmarks/published/**/*.ts"
+    "src/benchmarks/published/**/*.ts",
+    "src/benchmarks/custom/**/*.ts"
   ]
 }

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -29,6 +29,7 @@ export interface ParsedBenchArgs {
   baselineAction?: BenchBaselineAction;
   format?: BenchExportFormat;
   output?: string;
+  custom?: string;
 }
 
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
@@ -54,6 +55,7 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--results-dir" ||
       arg === "--baselines-dir" ||
       arg === "--threshold" ||
+      arg === "--custom" ||
       arg === "--format" ||
       arg === "--output"
     ) {
@@ -110,6 +112,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const resultsDir = readBenchOptionValue(args, "--results-dir");
   const baselinesDir = readBenchOptionValue(args, "--baselines-dir");
   const thresholdRaw = readBenchOptionValue(args, "--threshold");
+  const customRaw = readBenchOptionValue(args, "--custom");
   const formatRaw = readBenchOptionValue(args, "--format");
   const output = readBenchOptionValue(args, "--output");
   let threshold: number | undefined;
@@ -139,6 +142,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
     baselinesDir: baselinesDir ? path.resolve(expandTilde(baselinesDir)) : undefined,
     threshold,
+    custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -252,6 +252,42 @@ export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
 
 const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 
+type PackageBenchModule = {
+  getBenchmark?: (id: string) => {
+    runnerAvailable?: boolean;
+  } | undefined;
+  runBenchmark?: (id: string, options: {
+    mode?: "full" | "quick";
+    datasetDir?: string;
+    outputDir?: string;
+    limit?: number;
+    adapterMode?: string;
+    system: {
+      destroy(): Promise<void>;
+    };
+  }) => Promise<{
+    meta: { benchmark: string; mode: string };
+    results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
+    cost: { meanQueryLatencyMs: number };
+  }>;
+  runCustomBenchmarkFile?: (filePath: string, options: {
+    mode?: "full" | "quick";
+    outputDir?: string;
+    limit?: number;
+    adapterMode?: string;
+    system: {
+      destroy(): Promise<void>;
+    };
+  }) => Promise<{
+    meta: { benchmark: string; mode: string };
+    results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
+    cost: { meanQueryLatencyMs: number };
+  }>;
+  writeBenchmarkResult?: (result: unknown, outputDir: string) => Promise<string>;
+  createLightweightAdapter?: () => Promise<{ destroy(): Promise<void> }>;
+  createRemnicAdapter?: () => Promise<{ destroy(): Promise<void> }>;
+};
+
 export function getBenchUsageText(): string {
   return `Usage: remnic bench <list|run|compare|results|baseline|export> [options] [benchmark...]
        remnic benchmark <list|run|compare|results|baseline|export|check|report> [options] [benchmark...]
@@ -273,6 +309,7 @@ Options:
   --quick                  Run a lightweight quick pass (maps to --lightweight --limit 1)
   --all                    Run every published benchmark
   --dataset-dir <path>     Override the benchmark dataset directory for full runs
+  --custom <path>          Run a YAML-defined custom benchmark file
   --results-dir <path>     Override the stored benchmark results directory
   --baselines-dir <path>   Override the named baseline directory
   --threshold <value>      Regression threshold for compare (default: 0.05)
@@ -291,6 +328,7 @@ Examples:
   remnic bench baseline save main candidate-run
   remnic bench baseline list
   remnic bench export candidate-run --format csv --output ./candidate.csv
+  remnic bench run --custom ./my-bench.yaml
   remnic benchmark run --quick longmemeval`;
 }
 
@@ -740,30 +778,9 @@ async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
 ): Promise<boolean> {
-  let benchModule: {
-    getBenchmark?: (id: string) => {
-      runnerAvailable?: boolean;
-    } | undefined;
-    runBenchmark?: (id: string, options: {
-      mode?: "full" | "quick";
-      datasetDir?: string;
-      outputDir?: string;
-      limit?: number;
-      adapterMode?: string;
-      system: {
-        destroy(): Promise<void>;
-      };
-    }) => Promise<{
-      meta: { benchmark: string; mode: string };
-      results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
-      cost: { meanQueryLatencyMs: number };
-    }>;
-    writeBenchmarkResult?: (result: unknown, outputDir: string) => Promise<string>;
-    createLightweightAdapter?: () => Promise<{ destroy(): Promise<void> }>;
-    createRemnicAdapter?: () => Promise<{ destroy(): Promise<void> }>;
-  };
+  let benchModule: PackageBenchModule;
   try {
-    benchModule = await import("@remnic/bench") as unknown as typeof benchModule;
+    benchModule = await import("@remnic/bench") as unknown as PackageBenchModule;
   } catch {
     return false;
   }
@@ -799,6 +816,49 @@ async function runBenchViaPackage(
     const result = await benchModule.runBenchmark(benchmarkId, {
       mode: parsed.quick ? "quick" : "full",
       datasetDir,
+      outputDir,
+      limit: parsed.quick ? 1 : undefined,
+      adapterMode: parsed.quick ? "lightweight" : "direct",
+      system,
+    });
+    const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
+    if (parsed.json) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      printBenchPackageSummary(result, writtenPath);
+    }
+    return true;
+  } finally {
+    await system.destroy();
+  }
+}
+
+async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolean> {
+  let benchModule: PackageBenchModule;
+  try {
+    benchModule = await import("@remnic/bench") as unknown as PackageBenchModule;
+  } catch {
+    return false;
+  }
+
+  if (!benchModule.runCustomBenchmarkFile || !benchModule.writeBenchmarkResult) {
+    return false;
+  }
+
+  const createAdapter = parsed.quick
+    ? benchModule.createLightweightAdapter
+    : benchModule.createRemnicAdapter;
+
+  if (!createAdapter) {
+    return false;
+  }
+
+  const outputDir = resolveBenchOutputDir();
+  const system = await createAdapter();
+
+  try {
+    const result = await benchModule.runCustomBenchmarkFile(parsed.custom!, {
+      mode: parsed.quick ? "quick" : "full",
       outputDir,
       limit: parsed.quick ? 1 : undefined,
       adapterMode: parsed.quick ? "lightweight" : "direct",
@@ -2646,6 +2706,22 @@ async function cmdBench(rest: string[]): Promise<void> {
     console.log("Published benchmarks:");
     for (const entry of catalog) {
       console.log(`  ${entry.id.padEnd(14)} ${entry.category.padEnd(14)} ${entry.summary}`);
+    }
+    return;
+  }
+
+  if (parsed.custom) {
+    if (parsed.all || parsed.benchmarks.length > 0) {
+      console.error("ERROR: --custom cannot be combined with benchmark names or --all.");
+      process.exit(1);
+    }
+
+    const handledByPackage = await runCustomBenchViaPackage(parsed);
+    if (!handledByPackage) {
+      console.error(
+        "Benchmark runner not found. Expected a phase-1 @remnic/bench runtime export for custom benchmarks.",
+      );
+      process.exit(1);
     }
     return;
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,7 +47,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       tsx:
         specifier: ^4.0.0
         version: 4.21.0
@@ -70,10 +70,13 @@ importers:
       '@remnic/core':
         specifier: workspace:*
         version: link:../remnic-core
+      yaml:
+        specifier: ^2.4.2
+        version: 2.8.3
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -84,7 +87,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.0.0
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.7.0
         version: 5.9.3
@@ -105,7 +108,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -121,7 +124,7 @@ importers:
         version: link:../bench
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -164,7 +167,7 @@ importers:
         version: 7.6.13
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -187,7 +190,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -203,7 +206,7 @@ importers:
     devDependencies:
       tsup:
         specifier: ^8.5.1
-        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)
+        version: 8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -1061,6 +1064,11 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  yaml@2.8.3:
+    resolution: {integrity: sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
@@ -1562,11 +1570,12 @@ snapshots:
       mlly: 1.8.2
       pathe: 2.0.3
 
-  postcss-load-config@6.0.1(tsx@4.21.0):
+  postcss-load-config@6.0.1(tsx@4.21.0)(yaml@2.8.3):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       tsx: 4.21.0
+      yaml: 2.8.3
 
   prebuild-install@7.1.3:
     dependencies:
@@ -1717,7 +1726,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3):
+  tsup@8.5.1(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.27.7)
       cac: 6.7.14
@@ -1728,7 +1737,7 @@ snapshots:
       fix-dts-default-cjs-exports: 1.0.1
       joycon: 3.1.1
       picocolors: 1.1.1
-      postcss-load-config: 6.0.1(tsx@4.21.0)
+      postcss-load-config: 6.0.1(tsx@4.21.0)(yaml@2.8.3)
       resolve-from: 5.0.0
       rollup: 4.60.1
       source-map: 0.7.6
@@ -1772,6 +1781,8 @@ snapshots:
   wordwrapjs@5.1.1: {}
 
   wrappy@1.0.2: {}
+
+  yaml@2.8.3: {}
 
   zod@3.25.76: {}
 

--- a/tests/bench-custom-benchmark.test.ts
+++ b/tests/bench-custom-benchmark.test.ts
@@ -1,0 +1,176 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import type {
+  BenchMemoryAdapter,
+  Message,
+  SearchResult,
+} from "../packages/bench/src/index.js";
+import {
+  parseCustomBenchmark,
+} from "../packages/bench/src/benchmarks/custom/loader.js";
+import { runCustomBenchmarkFile } from "../packages/bench/src/benchmarks/custom/runner.js";
+
+class FakeMemoryAdapter implements BenchMemoryAdapter {
+  readonly sessions = new Map<string, Message[]>();
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    const existing = this.sessions.get(sessionId) ?? [];
+    this.sessions.set(sessionId, [...existing, ...messages]);
+  }
+
+  async recall(
+    sessionId: string,
+    _query: string,
+    _budgetChars?: number,
+  ): Promise<string> {
+    return (this.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  }
+
+  async search(
+    query: string,
+    limit: number,
+    sessionId?: string,
+  ): Promise<SearchResult[]> {
+    const haystack = sessionId
+      ? [[sessionId, this.sessions.get(sessionId) ?? []] as const]
+      : [...this.sessions.entries()];
+    const tokens = query
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((token) => token.length > 2);
+
+    const results: SearchResult[] = [];
+    for (const [currentSessionId, messages] of haystack) {
+      messages.forEach((message, index) => {
+        const content = message.content.toLowerCase();
+        if (tokens.some((token) => content.includes(token))) {
+          results.push({
+            turnIndex: index,
+            role: message.role,
+            snippet: message.content,
+            sessionId: currentSessionId,
+            score: 1,
+          });
+        }
+      });
+    }
+
+    return results.slice(0, limit);
+  }
+
+  async reset(sessionId?: string): Promise<void> {
+    if (sessionId) {
+      this.sessions.delete(sessionId);
+      return;
+    }
+    this.sessions.clear();
+  }
+
+  async getStats(_sessionId?: string): Promise<{
+    totalMessages: number;
+    totalSummaryNodes: number;
+    maxDepth: number;
+  }> {
+    const totalMessages = [...this.sessions.values()].reduce(
+      (sum, messages) => sum + messages.length,
+      0,
+    );
+
+    return {
+      totalMessages,
+      totalSummaryNodes: 0,
+      maxDepth: 1,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+test("parseCustomBenchmark normalizes a valid YAML benchmark definition", () => {
+  const benchmark = parseCustomBenchmark(`
+name: Sky Check
+description: Custom benchmark for a single memory fact
+version: 2.0.0
+category: retrieval
+scoring: exact_match
+tasks:
+  - question: What color is the sky?
+    expected: The sky is blue.
+    tags: [nature, weather]
+`);
+
+  assert.equal(benchmark.name, "Sky Check");
+  assert.equal(benchmark.description, "Custom benchmark for a single memory fact");
+  assert.equal(benchmark.version, "2.0.0");
+  assert.equal(benchmark.category, "retrieval");
+  assert.equal(benchmark.scoring, "exact_match");
+  assert.equal(benchmark.tasks.length, 1);
+  assert.deepEqual(benchmark.tasks[0]?.tags, ["nature", "weather"]);
+});
+
+test("parseCustomBenchmark rejects custom benchmarks without tasks", () => {
+  assert.throws(
+    () =>
+      parseCustomBenchmark(`
+name: Empty
+scoring: f1
+tasks: []
+`),
+    /must include at least one task/,
+  );
+});
+
+test("parseCustomBenchmark rejects unsupported scoring values", () => {
+  assert.throws(
+    () =>
+      parseCustomBenchmark(`
+name: Invalid
+scoring: made_up
+tasks:
+  - question: What is stored here?
+    expected: A fact
+`),
+    /must be one of exact_match, f1, rouge_l, llm_judge/,
+  );
+});
+
+test("runCustomBenchmarkFile executes a custom YAML benchmark against the adapter", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-custom-bench-"));
+  const filePath = path.join(tmpDir, "sky-check.yaml");
+  await writeFile(
+    filePath,
+    `
+name: Sky Check
+description: Custom benchmark for a single memory fact
+scoring: exact_match
+tasks:
+  - question: What color is the sky?
+    expected: The sky is blue.
+    tags: [nature, weather]
+`,
+  );
+
+  const adapter = new FakeMemoryAdapter();
+  await adapter.store("memory", [
+    { role: "assistant", content: "The sky is blue." },
+  ]);
+
+  const result = await runCustomBenchmarkFile(filePath, {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "custom:sky-check");
+  assert.equal(result.meta.benchmarkTier, "custom");
+  assert.equal(result.meta.mode, "quick");
+  assert.equal(result.meta.runCount, 1);
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.actual, "The sky is blue.");
+  assert.equal(result.results.tasks[0]?.scores.exact_match, 1);
+  assert.equal(result.results.aggregates.exact_match?.mean, 1);
+});

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -65,6 +65,15 @@ test("@remnic/bench index exports the phase-2 stats helpers", async () => {
   assert.match(source, /resolveBenchmarkRunCount/);
 });
 
+test("@remnic/bench index exports the custom benchmark loader and runner", async () => {
+  const source = await readFile("packages/bench/src/index.ts", "utf8");
+
+  assert.match(source, /CustomBenchmarkScoring/);
+  assert.match(source, /loadCustomBenchmarkFile/);
+  assert.match(source, /parseCustomBenchmark/);
+  assert.match(source, /runCustomBenchmarkFile/);
+});
+
 test("@remnic/bench index exports provider factory and discovery helpers", async () => {
   const source = await readFile("packages/bench/src/index.ts", "utf8");
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -82,20 +82,33 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
 
   assert.match(source, /--dataset-dir <path>\s+Override the benchmark dataset directory for full runs/);
+  assert.match(source, /--custom <path>\s+Run a YAML-defined custom benchmark file/);
   assert.match(source, /from "\.\/bench-args\.js";/);
+  assert.match(source, /async function runCustomBenchViaPackage\(parsed: ParsedBenchArgs\): Promise<boolean>/);
   assert.match(parserSource, /function readBenchOptionValue\(argv: string\[\], flag: string\)/);
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
   assert.match(parserSource, /const benchmarkArgs = action === "baseline" \? args\.slice\(1\) : args;/);
   assert.match(parserSource, /const benchmarks = collectBenchmarks\(benchmarkArgs\);/);
   assert.match(parserSource, /requires a value\./);
-  assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
+  assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--custom"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
   assert.match(parserSource, /datasetDir: datasetDir \? path\.resolve\(expandTilde\(datasetDir\)\) : undefined/);
+  assert.match(parserSource, /custom: customRaw \? path\.resolve\(expandTilde\(customRaw\)\) : undefined/);
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
+  assert.match(source, /if \(parsed\.custom\) \{/);
   assert.match(source, /const outputDir = resolveBenchOutputDir\(\);/);
   assert.match(source, /const datasetDir = resolveBenchDatasetDir\(/);
   assert.match(source, /if \(!parsed\.quick && !datasetDir\) \{\s*throw new Error\(/s);
   assert.match(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const system = await createAdapter\(\);/);
+});
+
+test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs(["run", "--custom", "~/benchmarks/custom.yaml"]);
+
+  assert.match(parsed.custom ?? "", /benchmarks[\/\\]custom\.yaml$/);
+  assert.deepEqual(parsed.benchmarks, []);
 });
 
 test("bench compare routes through stored package results with threshold and results-dir options", async () => {


### PR DESCRIPTION
Part of #445.

## Summary
- add a YAML-backed custom benchmark loader and runner under `@remnic/bench`
- wire a narrow `remnic bench run --custom <path>` CLI surface into the existing bench flow
- add focused parsing, run-path, and CLI surface tests for the custom benchmark slice

## Verification
- `pnpm --filter @remnic/bench build`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/cli check-types`
- `pnpm exec tsx --test tests/bench-custom-benchmark.test.ts tests/bench-package-surface.test.ts tests/remnic-cli-bench-surface.test.ts`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new YAML parsing/execution path and a new CLI mode (`--custom`) that writes benchmark results, so failures or schema/score edge cases could affect bench runs and output handling.
> 
> **Overview**
> Adds a **custom benchmark** capability to `@remnic/bench`, including a YAML loader/validator (`parseCustomBenchmark`/`loadCustomBenchmarkFile`) and a runner (`runCustomBenchmarkFile`) that executes tasks via adapter `search` and scores them with `exact_match`, `f1`, `rouge_l`, or `llm_judge`.
> 
> Exposes this through the CLI with `remnic bench run --custom <path>`, including argument parsing, mutual-exclusion validation with `--all`/named benchmarks, and package-export wiring; updates `@remnic/bench` public exports/types, build includes, and adds the `yaml` dependency plus tests covering parsing, execution, and CLI surface.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15d5de94fb63e7b573a588e9d00d72a2a9c4d801. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->