### PR TITLE
feat(cli): add bench provider discovery command

### DIFF
--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -39,6 +39,9 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic bench list` | List published benchmark packs |
 | `remnic bench run` | Run one or more published benchmark packs |
 | `remnic bench compare` | Compare two stored benchmark results |
+| `remnic bench baseline` | Save or list named benchmark baselines |
+| `remnic bench export` | Export a stored benchmark result as JSON or CSV |
+| `remnic bench providers discover` | Auto-detect local provider backends |
 
 Run `remnic --help` for the full command list.
 
@@ -52,6 +55,10 @@ remnic bench list
 remnic bench run --quick longmemeval
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
 remnic bench compare base-run candidate-run
+remnic bench baseline save main candidate-run
+remnic bench baseline list
+remnic bench export candidate-run --format csv --output ./candidate.csv
+remnic bench providers discover
 remnic benchmark run --quick longmemeval
 ```
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -9,11 +9,13 @@ export type BenchAction =
   | "results"
   | "baseline"
   | "export"
+  | "providers"
   | "check"
   | "report";
 
 export type BenchBaselineAction = "save" | "list";
 export type BenchExportFormat = "json" | "csv";
+export type BenchProviderAction = "discover";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -27,6 +29,7 @@ export interface ParsedBenchArgs {
   baselinesDir?: string;
   threshold?: number;
   baselineAction?: BenchBaselineAction;
+  providerAction?: BenchProviderAction;
   format?: BenchExportFormat;
   output?: string;
   custom?: string;
@@ -81,6 +84,7 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "results" ||
     first === "baseline" ||
     first === "export" ||
+    first === "providers" ||
     first === "check" ||
     first === "report"
       ? first
@@ -102,11 +106,20 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         ? args[0]
         : undefined
       : undefined;
+  const providerAction =
+    action === "providers"
+      ? args[0] === "discover"
+        ? args[0]
+        : undefined
+      : undefined;
   if (action === "baseline" && baselineAction === undefined) {
     throw new Error("ERROR: baseline requires a subcommand: save or list.");
   }
+  if (action === "providers" && providerAction === undefined) {
+    throw new Error("ERROR: providers requires a subcommand: discover.");
+  }
 
-  const benchmarkArgs = action === "baseline" ? args.slice(1) : args;
+  const benchmarkArgs = action === "baseline" || action === "providers" ? args.slice(1) : args;
   const benchmarks = collectBenchmarks(benchmarkArgs);
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
@@ -144,6 +157,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,
+    providerAction,
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,
   };

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -121,6 +121,7 @@ import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   compareResults,
   defaultBenchmarkBaselineDir,
+  discoverAllProviders,
   listBenchmarkBaselines,
   listBenchmarkResults,
   loadBenchmarkBaseline,
@@ -289,8 +290,8 @@ type PackageBenchModule = {
 };
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|compare|results|baseline|export> [options] [benchmark...]
-       remnic benchmark <list|run|compare|results|baseline|export|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|compare|results|baseline|export|providers> [options] [benchmark...]
+       remnic benchmark <list|run|compare|results|baseline|export|providers|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
@@ -302,6 +303,7 @@ Commands:
   baseline list            List saved baselines
   export <run> --format <json|csv>
                            Export one stored run as JSON or aggregate-metrics CSV
+  providers discover       Auto-detect available local provider backends
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
 
@@ -328,6 +330,7 @@ Examples:
   remnic bench baseline save main candidate-run
   remnic bench baseline list
   remnic bench export candidate-run --format csv --output ./candidate.csv
+  remnic bench providers discover
   remnic bench run --custom ./my-bench.yaml
   remnic benchmark run --quick longmemeval`;
 }
@@ -772,6 +775,37 @@ async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> 
   }
 
   process.stdout.write(rendered);
+}
+
+async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
+  const discovered = await discoverAllProviders();
+
+  if (parsed.json) {
+    console.log(JSON.stringify(discovered, null, 2));
+    return;
+  }
+
+  if (discovered.length === 0) {
+    console.log("No local bench providers were discovered.");
+    return;
+  }
+
+  console.log("Discovered bench providers:");
+  for (const entry of discovered) {
+    console.log(`  ${entry.provider}`);
+    for (const model of entry.models) {
+      const capabilities = model.capabilities.join(", ");
+      const details = [
+        model.contextLength > 0 ? `context=${model.contextLength}` : undefined,
+        model.parameterCount ? `params=${model.parameterCount}` : undefined,
+        model.quantization ? `quant=${model.quantization}` : undefined,
+        capabilities.length > 0 ? `caps=${capabilities}` : undefined,
+      ].filter((value): value is string => Boolean(value));
+      console.log(
+        `    - ${model.id}${details.length > 0 ? ` (${details.join(", ")})` : ""}`,
+      );
+    }
+  }
 }
 
 async function runBenchViaPackage(
@@ -2696,6 +2730,11 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "providers") {
+    await discoverBenchProviders(parsed);
+    return;
+  }
+
   if (parsed.action === "list") {
     const catalog = await listBenchmarksFromPackage() ?? BENCHMARK_CATALOG;
     if (parsed.json) {
@@ -4142,9 +4181,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare|results|baseline|export> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
+  remnic bench <list|run|compare|results|baseline|export|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|compare|results|baseline|export|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|compare|results|baseline|export|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -9,7 +9,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -87,7 +87,7 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /async function runCustomBenchViaPackage\(parsed: ParsedBenchArgs\): Promise<boolean>/);
   assert.match(parserSource, /function readBenchOptionValue\(argv: string\[\], flag: string\)/);
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
-  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \? args\.slice\(1\) : args;/);
+  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \|\| action === "providers" \? args\.slice\(1\) : args;/);
   assert.match(parserSource, /const benchmarks = collectBenchmarks\(benchmarkArgs\);/);
   assert.match(parserSource, /requires a value\./);
   assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--custom"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
@@ -161,6 +161,35 @@ test("bench results, baseline, and export route through the stored package resul
   assert.match(parserSource, /detail: args\.includes\("--detail"\),/);
   assert.match(parserSource, /baselinesDir: baselinesDir \? path\.resolve\(expandTilde\(baselinesDir\)\) : undefined/);
   assert.match(parserSource, /output: output \? path\.resolve\(expandTilde\(output\)\) : undefined/);
+});
+
+test("bench providers discovery is exposed as a package-backed CLI surface", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+  const readme = await readFile("packages/remnic-cli/README.md", "utf8");
+
+  assert.match(source, /discoverAllProviders,/);
+  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
+  assert.match(source, /remnic bench providers discover/);
+  assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /if \(parsed\.action === "providers"\) \{\s*await discoverBenchProviders\(parsed\);/s);
+  assert.match(parserSource, /export type BenchAction =[\s\S]*"providers"[\s\S]*"check"[\s\S]*"report";/);
+  assert.match(parserSource, /export type BenchProviderAction = "discover";/);
+  assert.match(parserSource, /providerAction\?: BenchProviderAction;/);
+  assert.match(parserSource, /first === "providers"/);
+  assert.match(parserSource, /const providerAction =[\s\S]*args\[0\] === "discover"/);
+  assert.match(readme, /remnic bench providers discover/);
+});
+
+test("parseBenchArgs supports the providers discovery surface", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs(["providers", "discover", "--json"]);
+
+  assert.equal(parsed.action, "providers");
+  assert.equal(parsed.providerAction, "discover");
+  assert.equal(parsed.json, true);
+  assert.deepEqual(parsed.benchmarks, []);
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {


### PR DESCRIPTION
Superseded by a non-draft recreation of the same branch to avoid the broken draft->ready transition path during this rollout.