### PR TITLE
feat(bench): add stateful remnic benchmark runners

### DIFF
--- a/packages/bench/src/benchmarks/remnic/entity-consolidation/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/entity-consolidation/fixture.ts
@@ -1,0 +1,68 @@
+export interface EntityConsolidationExpectation {
+  canonicalName: string;
+  timelineCount: number;
+  structuredFactCount: number;
+  stale: boolean;
+  synthesis: string;
+}
+
+export type EntityConsolidationScenario =
+  | "timeline-staleness"
+  | "structured-merge"
+  | "duplicate-dedupe";
+
+export interface EntityConsolidationCase {
+  id: string;
+  title: string;
+  scenario: EntityConsolidationScenario;
+  entityName: string;
+  entityType: string;
+  expected: EntityConsolidationExpectation;
+}
+
+export const ENTITY_CONSOLIDATION_FIXTURE: EntityConsolidationCase[] = [
+  {
+    id: "timeline-staleness-after-new-fact",
+    title: "Timeline evidence makes an older synthesis stale",
+    scenario: "timeline-staleness",
+    entityName: "Jane Doe",
+    entityType: "person",
+    expected: {
+      canonicalName: "person-jane-doe",
+      timelineCount: 2,
+      structuredFactCount: 0,
+      stale: true,
+      synthesis: "Jane Doe leads the roadmap.",
+    },
+  },
+  {
+    id: "structured-section-merge",
+    title: "Structured sections merge under the schema key and stale synthesis",
+    scenario: "structured-merge",
+    entityName: "Jane Doe",
+    entityType: "person",
+    expected: {
+      canonicalName: "person-jane-doe",
+      timelineCount: 0,
+      structuredFactCount: 2,
+      stale: true,
+      synthesis: "Jane Doe prefers small, decisive teams.",
+    },
+  },
+  {
+    id: "duplicate-fact-dedupes",
+    title: "Duplicate fact writes do not inflate the entity timeline",
+    scenario: "duplicate-dedupe",
+    entityName: "Project Atlas",
+    entityType: "project",
+    expected: {
+      canonicalName: "project-project-atlas",
+      timelineCount: 1,
+      structuredFactCount: 0,
+      stale: false,
+      synthesis: "Project Atlas keeps weekly notes.",
+    },
+  },
+];
+
+export const ENTITY_CONSOLIDATION_SMOKE_FIXTURE = ENTITY_CONSOLIDATION_FIXTURE;

--- a/packages/bench/src/benchmarks/remnic/entity-consolidation/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/entity-consolidation/runner.ts
@@ -1,0 +1,365 @@
+/**
+ * Stateful entity consolidation benchmark for Remnic's file-backed entity store.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import { StorageManager } from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores, exactMatch } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  ENTITY_CONSOLIDATION_FIXTURE,
+  ENTITY_CONSOLIDATION_SMOKE_FIXTURE,
+  type EntityConsolidationCase,
+  type EntityConsolidationExpectation,
+} from "./fixture.js";
+
+const BUILT_IN_SECTIONS = new Set([
+  "facts",
+  "timeline",
+  "summary",
+  "synthesis",
+  "connected to",
+  "activity",
+  "aliases",
+]);
+
+export const entityConsolidationDefinition: BenchmarkDefinition = {
+  id: "entity-consolidation",
+  title: "Entity Consolidation",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "entity-consolidation",
+    version: "1.0.0",
+    description:
+      "File-backed benchmark covering entity timeline consolidation, structured section merges, and duplicate-write dedupe.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #445",
+  },
+};
+
+export async function runEntityConsolidationBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const sample of cases) {
+    const startedAt = performance.now();
+    const actual = await executeCase(sample);
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const expectedJson = JSON.stringify(sample.expected);
+    const actualJson = JSON.stringify(actual);
+
+    tasks.push({
+      taskId: sample.id,
+      question: sample.title,
+      expected: expectedJson,
+      actual: actualJson,
+      scores: {
+        exact_match: exactMatch(actualJson, expectedJson),
+        canonical_match: exactMatch(actual.canonicalName, sample.expected.canonicalName),
+        timeline_count_match: exactMatch(String(actual.timelineCount), sample.expected.timelineCount),
+        structured_fact_count_match: exactMatch(
+          String(actual.structuredFactCount),
+          sample.expected.structuredFactCount,
+        ),
+        stale_flag_match: exactMatch(String(actual.stale), String(sample.expected.stale)),
+        synthesis_match: exactMatch(actual.synthesis, sample.expected.synthesis),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        scenario: sample.scenario,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): EntityConsolidationCase[] {
+  const baseCases = mode === "quick"
+    ? ENTITY_CONSOLIDATION_SMOKE_FIXTURE
+    : ENTITY_CONSOLIDATION_FIXTURE;
+
+  if (limit === undefined) {
+    return baseCases;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("entity-consolidation limit must be a positive integer");
+  }
+
+  const limited = baseCases.slice(0, limit);
+  if (limited.length === 0) {
+    throw new Error("entity-consolidation fixture is empty after applying the requested limit.");
+  }
+  return limited;
+}
+
+async function executeCase(
+  sample: EntityConsolidationCase,
+): Promise<EntityConsolidationExpectation> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-entity-consolidation-"));
+
+  try {
+    const storage = new StorageManager(tmpDir);
+    await storage.ensureDirectories();
+
+    const canonicalName = await applyScenario(storage, sample);
+    const rawEntity = await storage.readEntity(canonicalName);
+
+    return summarizeEntity(rawEntity, canonicalName);
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+async function applyScenario(
+  storage: StorageManager,
+  sample: EntityConsolidationCase,
+): Promise<string> {
+  switch (sample.scenario) {
+    case "timeline-staleness": {
+      const firstTimestamp = "2026-04-13T10:00:00.000Z";
+      const secondTimestamp = "2026-04-13T11:00:00.000Z";
+      const canonicalName = await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        ["Leads the roadmap."],
+        {
+          timestamp: firstTimestamp,
+          source: "extraction",
+          sessionKey: "session-1",
+        },
+      );
+      await storage.updateEntitySynthesis(canonicalName, sample.expected.synthesis, {
+        updatedAt: firstTimestamp,
+        entityUpdatedAt: firstTimestamp,
+        synthesisTimelineCount: 1,
+      });
+      await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        ["Owns release approvals now."],
+        {
+          timestamp: secondTimestamp,
+          source: "extraction",
+          sessionKey: "session-2",
+        },
+      );
+      return canonicalName;
+    }
+    case "structured-merge": {
+      const timestamp = "2026-04-13T10:00:00.000Z";
+      const canonicalName = await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        [],
+        {
+          timestamp,
+          source: "extraction",
+          structuredSections: [
+            {
+              key: "beliefs",
+              title: "Beliefs",
+              facts: ["Small teams move faster than committees."],
+            },
+          ],
+        },
+      );
+      await storage.updateEntitySynthesis(canonicalName, sample.expected.synthesis, {
+        updatedAt: timestamp,
+        entityUpdatedAt: timestamp,
+        synthesisTimelineCount: 0,
+        synthesisStructuredFactCount: 1,
+      });
+      await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        [],
+        {
+          timestamp,
+          source: "extraction",
+          structuredSections: [
+            {
+              key: "Beliefs",
+              title: "Beliefs",
+              facts: ["Roadmaps should stay legible to the team."],
+            },
+          ],
+        },
+      );
+      return canonicalName;
+    }
+    case "duplicate-dedupe": {
+      const timestamp = "2026-04-14T09:00:00.000Z";
+      const canonicalName = await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        ["Keeps weekly notes."],
+        {
+          timestamp,
+          source: "extraction",
+          sessionKey: "session-1",
+        },
+      );
+      await storage.updateEntitySynthesis(canonicalName, sample.expected.synthesis, {
+        updatedAt: timestamp,
+        entityUpdatedAt: timestamp,
+        synthesisTimelineCount: 1,
+      });
+      await storage.writeEntity(
+        sample.entityName,
+        sample.entityType,
+        ["Keeps weekly notes."],
+        {
+          timestamp,
+          source: "extraction",
+          sessionKey: "session-1",
+        },
+      );
+      return canonicalName;
+    }
+  }
+}
+
+function summarizeEntity(
+  rawEntity: string,
+  canonicalName: string,
+): EntityConsolidationExpectation {
+  const frontmatter = parseFrontmatter(rawEntity);
+  const sections = parseSections(rawEntity);
+  const synthesis = (sections.get("synthesis") ?? [])
+    .join("\n")
+    .trim();
+  const timelineCount = countBullets(sections.get("timeline"));
+  const structuredFactCount = [...sections.entries()]
+    .filter(([title]) => !BUILT_IN_SECTIONS.has(title))
+    .reduce((sum, [, lines]) => sum + countBullets(lines), 0);
+
+  return {
+    canonicalName,
+    timelineCount,
+    structuredFactCount,
+    stale: deriveStaleState(frontmatter, timelineCount, structuredFactCount, synthesis),
+    synthesis,
+  };
+}
+
+function parseFrontmatter(rawEntity: string): Record<string, string> {
+  const match = rawEntity.match(/^---\n([\s\S]*?)\n---\n?/);
+  if (!match) return {};
+  const frontmatter: Record<string, string> = {};
+
+  for (const line of match[1].split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line.slice(colonIndex + 1).trim();
+    frontmatter[key] = value;
+  }
+
+  return frontmatter;
+}
+
+function parseSections(rawEntity: string): Map<string, string[]> {
+  const body = rawEntity.replace(/^---\n[\s\S]*?\n---\n?/, "");
+  const sections = new Map<string, string[]>();
+  let activeSection: string | null = null;
+
+  for (const line of body.split("\n")) {
+    if (line.startsWith("## ")) {
+      activeSection = line.slice(3).trim().toLowerCase();
+      sections.set(activeSection, []);
+      continue;
+    }
+    if (activeSection) {
+      sections.get(activeSection)?.push(line);
+    }
+  }
+
+  return sections;
+}
+
+function countBullets(lines: string[] | undefined): number {
+  return (lines ?? []).filter((line) => line.startsWith("- ")).length;
+}
+
+function deriveStaleState(
+  frontmatter: Record<string, string>,
+  timelineCount: number,
+  structuredFactCount: number,
+  synthesis: string,
+): boolean {
+  if (timelineCount === 0 && structuredFactCount === 0) return false;
+  if (!synthesis) return true;
+
+  const synthesisTimelineCount = parseNonNegativeInt(frontmatter.synthesis_timeline_count);
+  const synthesisStructuredFactCount = parseNonNegativeInt(frontmatter.synthesis_structured_fact_count);
+
+  if (synthesisTimelineCount === undefined) return true;
+  if (structuredFactCount > 0 && synthesisStructuredFactCount === undefined) return true;
+
+  return timelineCount > synthesisTimelineCount
+    || structuredFactCount > (synthesisStructuredFactCount ?? 0);
+}
+
+function parseNonNegativeInt(rawValue: string | undefined): number | undefined {
+  if (!rawValue) return undefined;
+  const parsed = Number.parseInt(rawValue, 10);
+  return Number.isInteger(parsed) && parsed >= 0 ? parsed : undefined;
+}

--- a/packages/bench/src/benchmarks/remnic/page-versioning/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/page-versioning/fixture.ts
@@ -1,0 +1,56 @@
+export interface PageVersioningExpectation {
+  versionIds: string[];
+  currentVersion: string;
+  pageContent: string;
+  observed: string;
+}
+
+export type PageVersioningScenario =
+  | "revert-flow"
+  | "prune-window"
+  | "diff-output";
+
+export interface PageVersioningCase {
+  id: string;
+  title: string;
+  scenario: PageVersioningScenario;
+  expected: PageVersioningExpectation;
+}
+
+export const PAGE_VERSIONING_FIXTURE: PageVersioningCase[] = [
+  {
+    id: "revert-restores-content",
+    title: "Revert restores the earlier page and snapshots the replaced content",
+    scenario: "revert-flow",
+    expected: {
+      versionIds: ["1", "2", "3"],
+      currentVersion: "3",
+      pageContent: "original content",
+      observed: "modified content",
+    },
+  },
+  {
+    id: "prune-retains-latest-window",
+    title: "Pruning keeps only the newest page versions in the sidecar manifest",
+    scenario: "prune-window",
+    expected: {
+      versionIds: ["3", "4"],
+      currentVersion: "4",
+      pageContent: "content v4",
+      observed: "pruned:1,2",
+    },
+  },
+  {
+    id: "diff-captures-line-edits",
+    title: "Diff output reflects the inserted and replaced lines between versions",
+    scenario: "diff-output",
+    expected: {
+      versionIds: ["1", "2"],
+      currentVersion: "2",
+      pageContent: "line 1\nline 2 changed\nline 3\nline 4",
+      observed: "-line 2|+line 2 changed|+line 4",
+    },
+  },
+];
+
+export const PAGE_VERSIONING_SMOKE_FIXTURE = PAGE_VERSIONING_FIXTURE;

--- a/packages/bench/src/benchmarks/remnic/page-versioning/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/page-versioning/runner.ts
@@ -1,0 +1,255 @@
+/**
+ * Stateful page versioning benchmark for Remnic's snapshot sidecars.
+ */
+
+import os from "node:os";
+import path from "node:path";
+import { randomUUID } from "node:crypto";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import {
+  createVersion,
+  diffVersions,
+  getVersion,
+  listVersions,
+  revertToVersion,
+  type VersioningConfig,
+} from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores, exactMatch } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  PAGE_VERSIONING_FIXTURE,
+  PAGE_VERSIONING_SMOKE_FIXTURE,
+  type PageVersioningCase,
+  type PageVersioningExpectation,
+} from "./fixture.js";
+
+export const pageVersioningDefinition: BenchmarkDefinition = {
+  id: "page-versioning",
+  title: "Page Versioning",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "page-versioning",
+    version: "1.0.0",
+    description:
+      "File-backed benchmark covering sequential snapshots, revert behavior, pruning, and line diffs.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #445",
+  },
+};
+
+export async function runPageVersioningBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const sample of cases) {
+    const startedAt = performance.now();
+    const actual = await executeCase(sample);
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const expectedJson = JSON.stringify(sample.expected);
+    const actualJson = JSON.stringify(actual);
+
+    tasks.push({
+      taskId: sample.id,
+      question: sample.title,
+      expected: expectedJson,
+      actual: actualJson,
+      scores: {
+        exact_match: exactMatch(actualJson, expectedJson),
+        history_match: exactMatch(
+          JSON.stringify({
+            versionIds: actual.versionIds,
+            currentVersion: actual.currentVersion,
+          }),
+          JSON.stringify({
+            versionIds: sample.expected.versionIds,
+            currentVersion: sample.expected.currentVersion,
+          }),
+        ),
+        page_content_match: exactMatch(actual.pageContent, sample.expected.pageContent),
+        observed_match: exactMatch(actual.observed, sample.expected.observed),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        scenario: sample.scenario,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): PageVersioningCase[] {
+  const baseCases = mode === "quick"
+    ? PAGE_VERSIONING_SMOKE_FIXTURE
+    : PAGE_VERSIONING_FIXTURE;
+
+  if (limit === undefined) {
+    return baseCases;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("page-versioning limit must be a positive integer");
+  }
+
+  const limited = baseCases.slice(0, limit);
+  if (limited.length === 0) {
+    throw new Error("page-versioning fixture is empty after applying the requested limit.");
+  }
+  return limited;
+}
+
+async function executeCase(
+  sample: PageVersioningCase,
+): Promise<PageVersioningExpectation> {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-page-versioning-"));
+
+  try {
+    const factsDir = path.join(tmpDir, "facts");
+    const pagePath = path.join(factsDir, `${sample.id}.md`);
+    await mkdir(factsDir, { recursive: true });
+    const config = versioningConfig();
+
+    switch (sample.scenario) {
+      case "revert-flow": {
+        await writeFile(pagePath, "original content", "utf-8");
+        await createVersion(pagePath, "original content", "write", config, undefined, undefined, tmpDir);
+        await writeFile(pagePath, "modified content", "utf-8");
+        await createVersion(pagePath, "modified content", "write", config, undefined, undefined, tmpDir);
+        await revertToVersion(pagePath, "1", config, undefined, tmpDir);
+        const history = await listVersions(pagePath, config, tmpDir);
+        const pageContent = await readFile(pagePath, "utf-8");
+        const observed = await getVersion(pagePath, "3", config, tmpDir);
+        return {
+          versionIds: history.versions.map((version) => version.versionId),
+          currentVersion: history.currentVersion,
+          pageContent,
+          observed,
+        };
+      }
+      case "prune-window": {
+        const pruningConfig = versioningConfig({ maxVersionsPerPage: 2 });
+        for (let index = 1; index <= 4; index += 1) {
+          const content = `content v${index}`;
+          await writeFile(pagePath, content, "utf-8");
+          await createVersion(pagePath, content, "write", pruningConfig, undefined, undefined, tmpDir);
+        }
+        const history = await listVersions(pagePath, pruningConfig, tmpDir);
+        const pageContent = await readFile(pagePath, "utf-8");
+        const prunedIds: string[] = [];
+        for (const versionId of ["1", "2"]) {
+          try {
+            await getVersion(pagePath, versionId, pruningConfig, tmpDir);
+          } catch {
+            prunedIds.push(versionId);
+          }
+        }
+        return {
+          versionIds: history.versions.map((version) => version.versionId),
+          currentVersion: history.currentVersion,
+          pageContent,
+          observed: `pruned:${prunedIds.join(",")}`,
+        };
+      }
+      case "diff-output": {
+        await writeFile(pagePath, "line 1\nline 2\nline 3", "utf-8");
+        await createVersion(
+          pagePath,
+          "line 1\nline 2\nline 3",
+          "write",
+          config,
+          undefined,
+          undefined,
+          tmpDir,
+        );
+        await writeFile(pagePath, "line 1\nline 2 changed\nline 3\nline 4", "utf-8");
+        await createVersion(
+          pagePath,
+          "line 1\nline 2 changed\nline 3\nline 4",
+          "write",
+          config,
+          undefined,
+          undefined,
+          tmpDir,
+        );
+        const history = await listVersions(pagePath, config, tmpDir);
+        const pageContent = await readFile(pagePath, "utf-8");
+        const diff = await diffVersions(pagePath, "1", "2", config, tmpDir);
+        const observedLines = ["-line 2", "+line 2 changed", "+line 4"]
+          .filter((line) => diff.includes(line))
+          .join("|");
+        return {
+          versionIds: history.versions.map((version) => version.versionId),
+          currentVersion: history.currentVersion,
+          pageContent,
+          observed: observedLines,
+        };
+      }
+    }
+  } finally {
+    await rm(tmpDir, { recursive: true, force: true });
+  }
+}
+
+function versioningConfig(
+  overrides?: Partial<VersioningConfig>,
+): VersioningConfig {
+  return {
+    enabled: true,
+    maxVersionsPerPage: 50,
+    sidecarDir: ".versions",
+    ...overrides,
+  };
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -51,6 +51,14 @@ import {
   enrichmentFidelityDefinition,
   runEnrichmentFidelityBenchmark,
 } from "./benchmarks/remnic/enrichment-fidelity/runner.js";
+import {
+  entityConsolidationDefinition,
+  runEntityConsolidationBenchmark,
+} from "./benchmarks/remnic/entity-consolidation/runner.js";
+import {
+  pageVersioningDefinition,
+  runPageVersioningBenchmark,
+} from "./benchmarks/remnic/page-versioning/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -104,6 +112,14 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...enrichmentFidelityDefinition,
     run: runEnrichmentFidelityBenchmark,
+  },
+  {
+    ...entityConsolidationDefinition,
+    run: runEntityConsolidationBenchmark,
+  },
+  {
+    ...pageVersioningDefinition,
+    run: runPageVersioningBenchmark,
   },
 ];
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -24,6 +24,8 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "taxonomy-accuracy",
       "extraction-judge-calibration",
       "enrichment-fidelity",
+      "entity-consolidation",
+      "page-versioning",
     ],
   );
   assert.deepEqual(
@@ -41,11 +43,13 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning",
   );
 });
 
@@ -165,6 +169,28 @@ test("getBenchmark returns enrichment-fidelity metadata with a runnable benchmar
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "enrichment-fidelity");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns entity-consolidation metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("entity-consolidation");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "entity-consolidation");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns page-versioning metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("page-versioning");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "page-versioning");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");

--- a/tests/bench-remnic-stateful-runners.test.ts
+++ b/tests/bench-remnic-stateful-runners.test.ts
@@ -1,0 +1,60 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import type { BenchMemoryAdapter, Message, SearchResult } from "../packages/bench/src/index.js";
+import { runBenchmark } from "../packages/bench/src/index.js";
+
+class NoopMemoryAdapter implements BenchMemoryAdapter {
+  async store(_sessionId: string, _messages: Message[]): Promise<void> {}
+
+  async recall(_sessionId: string, _query: string): Promise<string> {
+    return "";
+  }
+
+  async search(
+    _query: string,
+    _limit: number,
+    _sessionId?: string,
+  ): Promise<SearchResult[]> {
+    return [];
+  }
+
+  async reset(_sessionId?: string): Promise<void> {}
+
+  async getStats() {
+    return {
+      totalMessages: 0,
+      totalSummaryNodes: 0,
+      maxDepth: 0,
+    };
+  }
+
+  async destroy(): Promise<void> {}
+}
+
+const adapter = new NoopMemoryAdapter();
+
+test("runBenchmark executes entity-consolidation in quick mode", async () => {
+  const result = await runBenchmark("entity-consolidation", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "entity-consolidation");
+  assert.equal(result.meta.benchmarkTier, "remnic");
+  assert.equal(result.results.tasks.length, 3);
+  assert.equal(result.results.aggregates.exact_match.mean, 1);
+  assert.equal(result.results.aggregates.stale_flag_match.mean, 1);
+});
+
+test("runBenchmark executes page-versioning in quick mode", async () => {
+  const result = await runBenchmark("page-versioning", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "page-versioning");
+  assert.equal(result.meta.benchmarkTier, "remnic");
+  assert.equal(result.results.tasks.length, 3);
+  assert.equal(result.results.aggregates.exact_match.mean, 1);
+  assert.equal(result.results.aggregates.history_match.mean, 1);
+});


### PR DESCRIPTION
Part of #445.

## Summary
- add deterministic, temp-dir-backed `entity-consolidation` and `page-versioning` benchmark runners under the Remnic benchmark tier
- register both new runners in `@remnic/bench` and extend registry assertions accordingly
- cover the new stateful runners with focused quick-mode tests that exercise file-backed benchmark behavior without external services

## Verification
- `pnpm exec tsx --test tests/bench-registry.test.ts tests/bench-remnic-stateful-runners.test.ts`
- `pnpm --filter @remnic/bench build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are isolated to the `@remnic/bench` benchmark suite, adding new file-backed runners and tests without touching core runtime or production code paths.
> 
> **Overview**
> Adds two new *stateful* Remnic benchmarks—`entity-consolidation` and `page-versioning`—that run deterministically in temp directories and score results by inspecting file-backed outputs (entity markdown sections/frontmatter and snapshot sidecars).
> 
> Registers both benchmarks in the `@remnic/bench` registry and extends test coverage to assert the updated catalog plus quick-mode execution via `runBenchmark`, ensuring the new runners produce expected aggregate scores.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f4136d5b13d0ee47d7668c545ba93d7763cbd92a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->