### PR TITLE
feat(cli): add bench provider discovery command

### DIFF
--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -39,6 +39,9 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic bench list` | List published benchmark packs |
 | `remnic bench run` | Run one or more published benchmark packs |
 | `remnic bench compare` | Compare two stored benchmark results |
+| `remnic bench baseline` | Save or list named benchmark baselines |
+| `remnic bench export` | Export a stored benchmark result as JSON or CSV |
+| `remnic bench providers discover` | Auto-detect local provider backends |
 
 Run `remnic --help` for the full command list.
 
@@ -52,7 +55,11 @@ remnic bench list
 remnic bench run --quick longmemeval
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
 remnic bench compare base-run candidate-run
+remnic bench baseline save main candidate-run
+remnic bench baseline list
+remnic bench export candidate-run --format csv --output ./candidate.csv
 remnic bench export candidate-run --format html --output ./report.html
+remnic bench providers discover
 remnic benchmark run --quick longmemeval
 ```
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -6,6 +6,7 @@ export type BenchAction =
   | "list"
   | "run"
   | "compare"
+  | "ui"
   | "results"
   | "baseline"
   | "export"
@@ -82,6 +83,7 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "list" ||
     first === "run" ||
     first === "compare" ||
+    first === "ui" ||
     first === "results" ||
     first === "baseline" ||
     first === "export" ||

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -6,15 +6,17 @@ export type BenchAction =
   | "list"
   | "run"
   | "compare"
-  | "ui"
   | "results"
   | "baseline"
   | "export"
+  | "ui"
+  | "providers"
   | "check"
   | "report";
 
 export type BenchBaselineAction = "save" | "list";
 export type BenchExportFormat = "json" | "csv" | "html";
+export type BenchProviderAction = "discover";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -28,6 +30,7 @@ export interface ParsedBenchArgs {
   baselinesDir?: string;
   threshold?: number;
   baselineAction?: BenchBaselineAction;
+  providerAction?: BenchProviderAction;
   format?: BenchExportFormat;
   output?: string;
   custom?: string;
@@ -79,10 +82,11 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "list" ||
     first === "run" ||
     first === "compare" ||
-    first === "ui" ||
     first === "results" ||
     first === "baseline" ||
     first === "export" ||
+    first === "ui" ||
+    first === "providers" ||
     first === "check" ||
     first === "report"
       ? first
@@ -104,11 +108,20 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         ? args[0]
         : undefined
       : undefined;
+  const providerAction =
+    action === "providers"
+      ? args[0] === "discover"
+        ? args[0]
+        : undefined
+      : undefined;
   if (action === "baseline" && baselineAction === undefined) {
     throw new Error("ERROR: baseline requires a subcommand: save or list.");
   }
+  if (action === "providers" && providerAction === undefined) {
+    throw new Error("ERROR: providers requires a subcommand: discover.");
+  }
 
-  const benchmarkArgs = action === "baseline" ? args.slice(1) : args;
+  const benchmarkArgs = action === "baseline" || action === "providers" ? args.slice(1) : args;
   const benchmarks = collectBenchmarks(benchmarkArgs);
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
@@ -146,6 +159,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,
+    providerAction,
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,
   };

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -10,7 +10,6 @@ export type BenchAction =
   | "results"
   | "baseline"
   | "export"
-  | "ui"
   | "providers"
   | "check"
   | "report";
@@ -87,7 +86,6 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "results" ||
     first === "baseline" ||
     first === "export" ||
-    first === "ui" ||
     first === "providers" ||
     first === "check" ||
     first === "report"

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -816,6 +816,13 @@ async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> 
 }
 
 async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
+  if (parsed.benchmarks.length > 0) {
+    console.error(
+      "ERROR: providers discover does not accept positional arguments. Usage: remnic bench providers discover [--json]",
+    );
+    process.exit(1);
+  }
+
   const discovered = await discoverAllProviders();
 
   if (parsed.json) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -20,6 +20,7 @@
  *   token revoke      Revoke auth token for a connector
  *   bench list        List published benchmark packs
  *   bench run         Run published benchmark packs
+ *   bench ui          Launch the local benchmark overview UI
  *   tree              Generate context tree
  *   onboard [dir]     Onboard project directory
  *   curate <path>     Curate files into memory
@@ -446,6 +447,41 @@ async function runBenchViaFallback(
 
 function resolveBenchOutputDir(): string {
   return path.join(resolveHomeDir(), ".remnic", "bench", "results");
+}
+
+async function launchBenchUi(resultsDir: string): Promise<void> {
+  const benchUiDir = path.join(CLI_REPO_ROOT, "packages", "bench-ui");
+  const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+  if (!fs.existsSync(path.join(benchUiDir, "package.json"))) {
+    console.error("ERROR: @remnic/bench-ui is not available in this checkout.");
+    process.exit(1);
+  }
+
+  console.log(`Launching bench UI with results from ${resultsDir}`);
+  console.log("Press Ctrl+C to stop the local server.");
+
+  const child = childProcess.spawn(pnpmCmd, ["exec", "vite", "--host", "127.0.0.1"], {
+    cwd: benchUiDir,
+    stdio: "inherit",
+    shell: process.platform === "win32",
+    env: {
+      ...process.env,
+      REMNIC_BENCH_RESULTS_DIR: resultsDir,
+    },
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    child.on("error", reject);
+    child.on("close", (code, signal) => {
+      if (code === 0 || signal === "SIGINT" || signal === "SIGTERM") {
+        resolve();
+        return;
+      }
+
+      reject(new Error(`bench UI exited with code ${code ?? "unknown"}`));
+    });
+  });
 }
 
 function resolveBenchBaselineDir(): string {
@@ -2732,6 +2768,11 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "ui") {
+    await launchBenchUi(parsed.resultsDir ?? resolveBenchOutputDir());
+    return;
+  }
+
   if (parsed.action === "providers") {
     await discoverBenchProviders(parsed);
     return;
@@ -4183,9 +4224,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare|results|baseline|export|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
+  remnic bench <list|run|compare|results|baseline|export|ui|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|compare|results|baseline|export|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|compare|results|baseline|export|ui|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -20,7 +20,6 @@
  *   token revoke      Revoke auth token for a connector
  *   bench list        List published benchmark packs
  *   bench run         Run published benchmark packs
- *   bench ui          Launch the local benchmark overview UI
  *   tree              Generate context tree
  *   onboard [dir]     Onboard project directory
  *   curate <path>     Curate files into memory
@@ -122,6 +121,7 @@ import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   compareResults,
   defaultBenchmarkBaselineDir,
+  discoverAllProviders,
   listBenchmarkBaselines,
   listBenchmarkResults,
   loadBenchmarkBaseline,
@@ -290,8 +290,8 @@ type PackageBenchModule = {
 };
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|compare|results|baseline|export|ui> [options] [benchmark...]
-       remnic benchmark <list|run|compare|results|baseline|export|ui|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|compare|results|baseline|export|ui|providers> [options] [benchmark...]
+       remnic benchmark <list|run|compare|results|baseline|export|ui|providers|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
@@ -304,6 +304,7 @@ Commands:
   export <run> --format <json|csv|html>
                            Export one stored run as JSON, aggregate-metrics CSV, or static HTML
   ui                       Launch the local benchmark overview UI
+  providers discover       Auto-detect available local provider backends
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
 
@@ -331,8 +332,8 @@ Examples:
   remnic bench baseline list
   remnic bench export candidate-run --format csv --output ./candidate.csv
   remnic bench export candidate-run --format html --output ./report.html
+  remnic bench providers discover
   remnic bench run --custom ./my-bench.yaml
-  remnic bench ui --results-dir ~/.remnic/bench/results
   remnic benchmark run --quick longmemeval`;
 }
 
@@ -445,41 +446,6 @@ async function runBenchViaFallback(
 
 function resolveBenchOutputDir(): string {
   return path.join(resolveHomeDir(), ".remnic", "bench", "results");
-}
-
-async function launchBenchUi(resultsDir: string): Promise<void> {
-  const benchUiDir = path.join(CLI_REPO_ROOT, "packages", "bench-ui");
-  const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-
-  if (!fs.existsSync(path.join(benchUiDir, "package.json"))) {
-    console.error("ERROR: @remnic/bench-ui is not available in this checkout.");
-    process.exit(1);
-  }
-
-  console.log(`Launching bench UI with results from ${resultsDir}`);
-  console.log("Press Ctrl+C to stop the local server.");
-
-  const child = childProcess.spawn(pnpmCmd, ["exec", "vite", "--host", "127.0.0.1"], {
-    cwd: benchUiDir,
-    stdio: "inherit",
-    shell: process.platform === "win32",
-    env: {
-      ...process.env,
-      REMNIC_BENCH_RESULTS_DIR: resultsDir,
-    },
-  });
-
-  await new Promise<void>((resolve, reject) => {
-    child.on("error", reject);
-    child.on("close", (code, signal) => {
-      if (code === 0 || signal === "SIGINT" || signal === "SIGTERM") {
-        resolve();
-        return;
-      }
-
-      reject(new Error(`bench UI exited with code ${code ?? "unknown"}`));
-    });
-  });
 }
 
 function resolveBenchBaselineDir(): string {
@@ -811,6 +777,37 @@ async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> 
   }
 
   process.stdout.write(rendered);
+}
+
+async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
+  const discovered = await discoverAllProviders();
+
+  if (parsed.json) {
+    console.log(JSON.stringify(discovered, null, 2));
+    return;
+  }
+
+  if (discovered.length === 0) {
+    console.log("No local bench providers were discovered.");
+    return;
+  }
+
+  console.log("Discovered bench providers:");
+  for (const entry of discovered) {
+    console.log(`  ${entry.provider}`);
+    for (const model of entry.models) {
+      const capabilities = model.capabilities.join(", ");
+      const details = [
+        model.contextLength > 0 ? `context=${model.contextLength}` : undefined,
+        model.parameterCount ? `params=${model.parameterCount}` : undefined,
+        model.quantization ? `quant=${model.quantization}` : undefined,
+        capabilities.length > 0 ? `caps=${capabilities}` : undefined,
+      ].filter((value): value is string => Boolean(value));
+      console.log(
+        `    - ${model.id}${details.length > 0 ? ` (${details.join(", ")})` : ""}`,
+      );
+    }
+  }
 }
 
 async function runBenchViaPackage(
@@ -2735,8 +2732,8 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
-  if (parsed.action === "ui") {
-    await launchBenchUi(parsed.resultsDir ?? resolveBenchOutputDir());
+  if (parsed.action === "providers") {
+    await discoverBenchProviders(parsed);
     return;
   }
 
@@ -4186,9 +4183,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare|results|baseline|export> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
+  remnic bench <list|run|compare|results|baseline|export|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|compare|results|baseline|export|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|compare|results|baseline|export|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -9,7 +9,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -87,7 +87,7 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /async function runCustomBenchViaPackage\(parsed: ParsedBenchArgs\): Promise<boolean>/);
   assert.match(parserSource, /function readBenchOptionValue\(argv: string\[\], flag: string\)/);
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
-  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \? args\.slice\(1\) : args;/);
+  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \|\| action === "providers" \? args\.slice\(1\) : args;/);
   assert.match(parserSource, /const benchmarks = collectBenchmarks\(benchmarkArgs\);/);
   assert.match(parserSource, /requires a value\./);
   assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--custom"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
@@ -163,6 +163,35 @@ test("bench results, baseline, and export route through the stored package resul
   assert.match(parserSource, /detail: args\.includes\("--detail"\),/);
   assert.match(parserSource, /baselinesDir: baselinesDir \? path\.resolve\(expandTilde\(baselinesDir\)\) : undefined/);
   assert.match(parserSource, /output: output \? path\.resolve\(expandTilde\(output\)\) : undefined/);
+});
+
+test("bench providers discovery is exposed as a package-backed CLI surface", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+  const readme = await readFile("packages/remnic-cli/README.md", "utf8");
+
+  assert.match(source, /discoverAllProviders,/);
+  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
+  assert.match(source, /remnic bench providers discover/);
+  assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /if \(parsed\.action === "providers"\) \{\s*await discoverBenchProviders\(parsed\);/s);
+  assert.match(parserSource, /export type BenchAction =[\s\S]*"providers"[\s\S]*"check"[\s\S]*"report";/);
+  assert.match(parserSource, /export type BenchProviderAction = "discover";/);
+  assert.match(parserSource, /providerAction\?: BenchProviderAction;/);
+  assert.match(parserSource, /first === "providers"/);
+  assert.match(parserSource, /const providerAction =[\s\S]*args\[0\] === "discover"/);
+  assert.match(readme, /remnic bench providers discover/);
+});
+
+test("parseBenchArgs supports the providers discovery surface", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs(["providers", "discover", "--json"]);
+
+  assert.equal(parsed.action, "providers");
+  assert.equal(parsed.providerAction, "discover");
+  assert.equal(parsed.json, true);
+  assert.deepEqual(parsed.benchmarks, []);
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -252,6 +252,7 @@ test("bench providers discover rejects unexpected trailing positional args", asy
       benchModuleEntry,
       `
 export function compareResults() {}
+export function checkRegression() { return null; }
 export function defaultBenchmarkBaselineDir() { return ""; }
 export async function discoverAllProviders() { return []; }
 export async function listBenchmarkBaselines() { return []; }

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync } from "node:fs";
 import { readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 test("remnic CLI source wires the new bench command and keeps benchmark as an alias", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
@@ -174,6 +179,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /providers discover does not accept positional arguments/);
   assert.match(source, /if \(parsed\.action === "providers"\) \{\s*await discoverBenchProviders\(parsed\);/s);
   assert.match(parserSource, /export type BenchAction =[\s\S]*"providers"[\s\S]*"check"[\s\S]*"report";/);
   assert.match(parserSource, /export type BenchProviderAction = "discover";/);
@@ -202,6 +208,50 @@ test("parseBenchArgs supports the providers discovery surface", async () => {
   assert.equal(parsed.providerAction, "discover");
   assert.equal(parsed.json, true);
   assert.deepEqual(parsed.benchmarks, []);
+});
+
+test("parseBenchArgs preserves unexpected trailing providers args for CLI validation", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs(["providers", "discover", "foo"]);
+
+  assert.equal(parsed.action, "providers");
+  assert.equal(parsed.providerAction, "discover");
+  assert.deepEqual(parsed.benchmarks, ["foo"]);
+});
+
+test("bench providers discover rejects unexpected trailing positional args", () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const tsxBin = join(__dirname, "../node_modules/.bin/tsx");
+  const cliEntry = pathToFileURL(join(__dirname, "../packages/remnic-cli/src/index.ts")).href;
+  const isolatedHome = mkdtempSync(join(tmpdir(), "remnic-bench-providers-"));
+  const script = `
+import { main } from ${JSON.stringify(cliEntry)};
+await main(["bench", "providers", "discover", "foo"]);
+`;
+
+  const result = spawnSync(tsxBin, ["--input-type=module"], {
+    input: script,
+    encoding: "utf8",
+    timeout: 20_000,
+    cwd: join(__dirname, ".."),
+    env: {
+      ...process.env,
+      HOME: isolatedHome,
+    },
+  });
+
+  if (result.error) throw result.error;
+
+  assert.equal(
+    result.status,
+    1,
+    `Expected providers discover to fail with trailing args.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
+  );
+  assert.match(
+    `${result.stdout}\n${result.stderr}`,
+    /providers discover does not accept positional arguments/,
+  );
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, realpathSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -221,25 +221,35 @@ test("parseBenchArgs preserves unexpected trailing providers args for CLI valida
 test("bench providers discover rejects unexpected trailing positional args", async () => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
   const repoRoot = join(__dirname, "..");
-  const benchModuleRoot = join(repoRoot, "packages/remnic-cli/node_modules/@remnic/bench");
+  const benchModuleLinkRoot = join(repoRoot, "packages/remnic-cli/node_modules/@remnic/bench");
+  const benchModuleRoot = existsSync(benchModuleLinkRoot)
+    ? realpathSync(benchModuleLinkRoot)
+    : benchModuleLinkRoot;
   const benchModuleDist = join(benchModuleRoot, "dist");
+  const benchModuleEntry = join(benchModuleDist, "index.js");
+  const benchPackageJson = join(benchModuleRoot, "package.json");
   const cliEntry = pathToFileURL(join(repoRoot, "packages/remnic-cli/src/index.ts")).href;
-  const stubbedBenchModule = !existsSync(join(benchModuleDist, "index.js"));
+  const stubbedBenchModule = !existsSync(benchModuleEntry);
+  const createdModuleRoot = !existsSync(benchModuleLinkRoot);
+  const createdPackageJson = stubbedBenchModule && !existsSync(benchPackageJson);
+  const createdDistDir = stubbedBenchModule && !existsSync(benchModuleDist);
 
   if (stubbedBenchModule) {
     mkdirSync(benchModuleDist, { recursive: true });
+    if (createdPackageJson) {
+      writeFileSync(
+        benchPackageJson,
+        JSON.stringify({
+          name: "@remnic/bench",
+          type: "module",
+          exports: {
+            ".": "./dist/index.js",
+          },
+        }),
+      );
+    }
     writeFileSync(
-      join(benchModuleRoot, "package.json"),
-      JSON.stringify({
-        name: "@remnic/bench",
-        type: "module",
-        exports: {
-          ".": "./dist/index.js",
-        },
-      }),
-    );
-    writeFileSync(
-      join(benchModuleDist, "index.js"),
+      benchModuleEntry,
       `
 export function compareResults() {}
 export function defaultBenchmarkBaselineDir() { return ""; }
@@ -277,7 +287,16 @@ export async function saveBenchmarkBaseline() { return null; }
   } finally {
     process.exit = originalExit;
     if (stubbedBenchModule) {
-      rmSync(benchModuleRoot, { recursive: true, force: true });
+      rmSync(benchModuleEntry, { force: true });
+      if (createdDistDir) {
+        rmSync(benchModuleDist, { recursive: true, force: true });
+      }
+      if (createdPackageJson) {
+        rmSync(benchPackageJson, { force: true });
+      }
+      if (createdModuleRoot) {
+        rmSync(benchModuleRoot, { recursive: true, force: true });
+      }
     }
   }
 });

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -5,7 +5,7 @@ import { mkdtempSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath, pathToFileURL } from "node:url";
+import { fileURLToPath } from "node:url";
 
 test("remnic CLI source wires the new bench command and keeps benchmark as an alias", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
@@ -222,16 +222,11 @@ test("parseBenchArgs preserves unexpected trailing providers args for CLI valida
 
 test("bench providers discover rejects unexpected trailing positional args", () => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  const tsxBin = join(__dirname, "../node_modules/.bin/tsx");
-  const cliEntry = pathToFileURL(join(__dirname, "../packages/remnic-cli/src/index.ts")).href;
+  const nodeBin = process.execPath;
+  const helperPath = join(__dirname, "../scripts/run-bench-cli.mjs");
   const isolatedHome = mkdtempSync(join(tmpdir(), "remnic-bench-providers-"));
-  const script = `
-import { main } from ${JSON.stringify(cliEntry)};
-await main(["bench", "providers", "discover", "foo"]);
-`;
 
-  const result = spawnSync(tsxBin, ["--input-type=module"], {
-    input: script,
+  const result = spawnSync(nodeBin, [helperPath, "providers", "discover", "foo"], {
     encoding: "utf8",
     timeout: 20_000,
     cwd: join(__dirname, ".."),

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -9,7 +9,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -171,7 +171,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
   assert.match(source, /discoverAllProviders,/);
-  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|providers>/);
+  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /if \(parsed\.action === "providers"\) \{\s*await discoverBenchProviders\(parsed\);/s);
@@ -181,6 +181,16 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   assert.match(parserSource, /first === "providers"/);
   assert.match(parserSource, /const providerAction =[\s\S]*args\[0\] === "discover"/);
   assert.match(readme, /remnic bench providers discover/);
+});
+
+test("bench surface retains local UI compatibility alongside providers discovery", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+
+  assert.match(parserSource, /\| "ui"/);
+  assert.match(parserSource, /first === "ui"/);
+  assert.match(source, /ui\s+Launch the local benchmark overview UI/);
+  assert.match(source, /if \(parsed\.action === "ui"\) \{\s*await launchBenchUi\(parsed\.resultsDir \?\? resolveBenchOutputDir\(\)\);\s*return;\s*\}/s);
 });
 
 test("parseBenchArgs supports the providers discovery surface", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1,11 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { spawnSync } from "node:child_process";
-import { mkdtempSync } from "node:fs";
+import { existsSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
 import { readFile } from "node:fs/promises";
-import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
+import { fileURLToPath, pathToFileURL } from "node:url";
 
 test("remnic CLI source wires the new bench command and keeps benchmark as an alias", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
@@ -220,33 +218,68 @@ test("parseBenchArgs preserves unexpected trailing providers args for CLI valida
   assert.deepEqual(parsed.benchmarks, ["foo"]);
 });
 
-test("bench providers discover rejects unexpected trailing positional args", () => {
+test("bench providers discover rejects unexpected trailing positional args", async () => {
   const __dirname = dirname(fileURLToPath(import.meta.url));
-  const nodeBin = process.execPath;
-  const helperPath = join(__dirname, "../scripts/run-bench-cli.mjs");
-  const isolatedHome = mkdtempSync(join(tmpdir(), "remnic-bench-providers-"));
+  const repoRoot = join(__dirname, "..");
+  const benchModuleRoot = join(repoRoot, "packages/remnic-cli/node_modules/@remnic/bench");
+  const benchModuleDist = join(benchModuleRoot, "dist");
+  const cliEntry = pathToFileURL(join(repoRoot, "packages/remnic-cli/src/index.ts")).href;
+  const stubbedBenchModule = !existsSync(join(benchModuleDist, "index.js"));
 
-  const result = spawnSync(nodeBin, [helperPath, "providers", "discover", "foo"], {
-    encoding: "utf8",
-    timeout: 20_000,
-    cwd: join(__dirname, ".."),
-    env: {
-      ...process.env,
-      HOME: isolatedHome,
-    },
-  });
+  if (stubbedBenchModule) {
+    mkdirSync(benchModuleDist, { recursive: true });
+    writeFileSync(
+      join(benchModuleRoot, "package.json"),
+      JSON.stringify({
+        name: "@remnic/bench",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+        },
+      }),
+    );
+    writeFileSync(
+      join(benchModuleDist, "index.js"),
+      `
+export function compareResults() {}
+export function defaultBenchmarkBaselineDir() { return ""; }
+export async function discoverAllProviders() { return []; }
+export async function listBenchmarkBaselines() { return []; }
+export async function listBenchmarkResults() { return []; }
+export async function loadBenchmarkBaseline() { return null; }
+export async function runBenchSuite() { return null; }
+export async function runExplain() { return null; }
+export async function loadBaseline() { return null; }
+export async function saveBaseline() { return null; }
+export async function loadBenchmarkResult() { return null; }
+export function renderBenchmarkResultExport() { return ""; }
+export async function resolveBenchmarkResultReference() { return null; }
+export async function saveBenchmarkBaseline() { return null; }
+`,
+    );
+  }
 
-  if (result.error) throw result.error;
+  const originalExit = process.exit;
+  const exitCalls: number[] = [];
 
-  assert.equal(
-    result.status,
-    1,
-    `Expected providers discover to fail with trailing args.\nstdout: ${result.stdout}\nstderr: ${result.stderr}`,
-  );
-  assert.match(
-    `${result.stdout}\n${result.stderr}`,
-    /providers discover does not accept positional arguments/,
-  );
+  process.exit = ((code?: number) => {
+    exitCalls.push(code ?? 0);
+    throw new Error(`PROCESS_EXIT:${code ?? 0}`);
+  }) as typeof process.exit;
+
+  try {
+    const { main } = await import(`${cliEntry}?test=${Date.now()}`);
+    await assert.rejects(
+      () => main(["bench", "providers", "discover", "foo"]),
+      /PROCESS_EXIT:1/,
+    );
+    assert.deepEqual(exitCalls, [1]);
+  } finally {
+    process.exit = originalExit;
+    if (stubbedBenchModule) {
+      rmSync(benchModuleRoot, { recursive: true, force: true });
+    }
+  }
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {

--- a/tests/remnic-cli-bench-ui-surface.test.ts
+++ b/tests/remnic-cli-bench-ui-surface.test.ts
@@ -21,7 +21,7 @@ test("CLI source wires remnic bench ui to the local bench-ui package", async () 
 
   assert.match(parserSource, /\| "ui"/);
   assert.match(parserSource, /first === "ui"/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|ui>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
   assert.match(source, /ui\s+Launch the local benchmark overview UI/);
   assert.match(source, /if \(parsed\.action === "ui"\) \{\s*await launchBenchUi\(parsed\.resultsDir \?\? resolveBenchOutputDir\(\)\);\s*return;\s*\}/s);
   assert.match(source, /async function launchBenchUi\(resultsDir: string\): Promise<void>/);


### PR DESCRIPTION
Part of #445.

## Summary
- add `remnic bench providers discover` on top of the provider discovery support already exposed by `@remnic/bench`
- wire the new providers action into CLI parsing, help text, and package-backed dispatch
- document the bench baseline/export/provider surfaces in the CLI README and extend bench surface tests accordingly

## Verification
- `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/bench-results-store.test.ts tests/bench-providers.test.ts`
- `pnpm --filter @remnic/bench build`
- `pnpm --filter @remnic/cli build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI subcommand and related argument parsing/help/test updates without changing benchmark execution or core data/auth paths.
> 
> **Overview**
> Adds a new benchmark subcommand, `remnic bench providers discover`, which calls through to `@remnic/bench`’s `discoverAllProviders()` and supports `--json` output plus human-readable printing.
> 
> Extends bench argument parsing and help/usage text to include the new `providers` action (with required `discover` subcommand), updates the CLI README examples, and expands bench surface tests to cover parsing and to assert positional-arg rejection behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 147ee1c6c0a9539987212281f4968ac8712c0e71. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->