### PR TITLE
feat(bench-ui): add dashboard pages for local benchmark analysis

### DIFF
--- a/packages/bench-ui/src/App.tsx
+++ b/packages/bench-ui/src/App.tsx
@@ -1,50 +1,61 @@
-import {
-  HashRouter,
-  NavLink,
-  Navigate,
-  Route,
-  Routes,
-  useParams,
-} from "react-router-dom";
+import { useEffect, useState } from "react";
 import type { ReactNode } from "react";
+import { HashRouter, NavLink, Navigate, Route, Routes } from "react-router-dom";
+import type { BenchResultSummaryPayload } from "./bench-data";
+import { listBenchmarks } from "./bench-data";
+import { BenchmarkDetail } from "./pages/BenchmarkDetail";
+import { Compare } from "./pages/Compare";
+import { Overview } from "./pages/Overview";
+import { Providers } from "./pages/Providers";
+import { Runs } from "./pages/Runs";
 
 const navigationItems = [
   { label: "Overview", path: "/" },
   { label: "Runs", path: "/runs" },
   { label: "Compare", path: "/compare" },
-  { label: "Benchmark detail", path: "/benchmark/latency-ladder" },
+  { label: "Benchmark Detail", path: "/benchmark" },
   { label: "Providers", path: "/providers" },
 ];
 
-const overviewCards = [
-  { label: "Tracked runs", value: "12", detail: "Latest benchmark summaries" },
-  { label: "Active providers", value: "4", detail: "Configured adapters" },
-  { label: "Regression delta", value: "0.8%", detail: "Current compare view" },
-];
+const emptyPayload: BenchResultSummaryPayload = {
+  resultsDir: "",
+  summaries: [],
+};
 
-const runRows = [
-  ["longmemeval", "complete", "2m 14s"],
-  ["latency-ladder", "complete", "58s"],
-  ["provider-smoke", "queued", "Pending"],
-];
-
-const providerRows = [
-  ["@remnic/core", "Built-in memory engine"],
-  ["@remnic/server", "Standalone HTTP + MCP server"],
-  ["@remnic/plugin-openclaw", "OpenClaw host adapter"],
-];
-
-function AppShell({ children }: { children: ReactNode }) {
+function AppShell({
+  children,
+  payload,
+  loading,
+  error,
+  onRefresh,
+}: {
+  children: ReactNode;
+  payload: BenchResultSummaryPayload;
+  loading: boolean;
+  error: string | null;
+  onRefresh: () => void;
+}) {
   return (
     <div className="app-shell">
       <aside className="sidebar">
         <div className="brand-lockup">
           <span className="brand-kicker">@remnic/bench-ui</span>
-          <h1>Benchmark shell</h1>
+          <h1>Bench dashboard</h1>
           <p>
-            Routed scaffold for browsing benchmark summaries, comparisons, and
-            provider notes.
+            Local benchmark views for overview, run history, comparison, benchmark
+            diagnosis, and provider drift.
           </p>
+        </div>
+
+        <div className="sidebar-summary">
+          <article>
+            <span>Runs</span>
+            <strong>{payload.summaries.length}</strong>
+          </article>
+          <article>
+            <span>Benchmarks</span>
+            <strong>{listBenchmarks(payload).length}</strong>
+          </article>
         </div>
 
         <nav className="nav-list" aria-label="Bench navigation">
@@ -61,17 +72,22 @@ function AppShell({ children }: { children: ReactNode }) {
             </NavLink>
           ))}
         </nav>
+
+        <button type="button" className="refresh-button" onClick={onRefresh}>
+          {loading ? "Refreshing..." : "Refresh local results"}
+        </button>
       </aside>
 
       <main className="main-panel">
         <header className="topbar">
           <div>
-            <span className="status-chip">local scaffold</span>
+            <span className="status-chip">{loading ? "loading" : "local data"}</span>
             <h2>Remnic benchmark workspace</h2>
           </div>
-          <p className="topbar-copy">
-            Minimal Vite shell, no data wiring, no publish flow.
-          </p>
+          <div className="topbar-copy">
+            <p>{payload.resultsDir || "Awaiting local benchmark result files"}</p>
+            {error ? <p className="error-copy">{error}</p> : null}
+          </div>
         </header>
 
         {children}
@@ -80,170 +96,74 @@ function AppShell({ children }: { children: ReactNode }) {
   );
 }
 
-function PageFrame({
-  title,
-  description,
-  children,
-}: {
-  title: string;
-  description: string;
-  children?: ReactNode;
-}) {
+function NotFoundPage() {
   return (
     <section className="page">
       <header className="page-header">
         <div>
           <span className="section-kicker">Bench UI</span>
-          <h3>{title}</h3>
+          <h3>Page not found</h3>
         </div>
-        <p>{description}</p>
+        <p>Use the dashboard navigation to move between the available views.</p>
       </header>
-
-      {children}
     </section>
   );
 }
 
-function OverviewPage() {
-  return (
-    <PageFrame
-      title="Overview"
-      description="A compact entrypoint for benchmark runs, trend snapshots, and status notes."
-    >
-      <div className="card-grid">
-        {overviewCards.map((card) => (
-          <article className="stat-card" key={card.label}>
-            <span>{card.label}</span>
-            <strong>{card.value}</strong>
-            <p>{card.detail}</p>
-          </article>
-        ))}
-      </div>
-    </PageFrame>
-  );
-}
-
-function RunsPage() {
-  return (
-    <PageFrame
-      title="Runs"
-      description="Placeholder list for queued and completed benchmark executions."
-    >
-      <div className="panel">
-        <table className="table">
-          <thead>
-            <tr>
-              <th>Benchmark</th>
-              <th>Status</th>
-              <th>Duration</th>
-            </tr>
-          </thead>
-          <tbody>
-            {runRows.map(([benchmark, status, duration]) => (
-              <tr key={benchmark}>
-                <td>{benchmark}</td>
-                <td>{status}</td>
-                <td>{duration}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      </div>
-    </PageFrame>
-  );
-}
-
-function ComparePage() {
-  return (
-    <PageFrame
-      title="Compare"
-      description="Reserved for side-by-side run comparison once data wiring lands."
-    >
-      <div className="panel compare-grid">
-        <div>
-          <span className="section-kicker">Baseline</span>
-          <p>Previous run set</p>
-        </div>
-        <div>
-          <span className="section-kicker">Current</span>
-          <p>Latest run set</p>
-        </div>
-        <div>
-          <span className="section-kicker">Delta</span>
-          <p>Comparison summary placeholder</p>
-        </div>
-      </div>
-    </PageFrame>
-  );
-}
-
-function BenchmarkDetailPage() {
-  const { benchmarkId } = useParams();
-
-  return (
-    <PageFrame
-      title="Benchmark detail"
-      description="Route scaffold for an individual benchmark run."
-    >
-      <div className="panel detail-card">
-        <span className="section-kicker">Benchmark</span>
-        <h4>{benchmarkId ?? "unknown"}</h4>
-        <p>
-          This page is intentionally lightweight. It exists so downstream work
-          can attach real benchmark metadata later.
-        </p>
-      </div>
-    </PageFrame>
-  );
-}
-
-function ProvidersPage() {
-  return (
-    <PageFrame
-      title="Providers"
-      description="Placeholder registry for benchmark provider backends and adapters."
-    >
-      <div className="panel">
-        <ul className="provider-list">
-          {providerRows.map(([name, detail]) => (
-            <li key={name}>
-              <strong>{name}</strong>
-              <span>{detail}</span>
-            </li>
-          ))}
-        </ul>
-      </div>
-    </PageFrame>
-  );
-}
-
-function NotFoundPage() {
-  return (
-    <PageFrame
-      title="Page not found"
-      description="This route is not part of the current bench UI scaffold."
-    >
-      <div className="panel">
-        <p>Use the navigation to move between the scaffolded routes.</p>
-      </div>
-    </PageFrame>
-  );
-}
-
 export function App() {
+  const [payload, setPayload] = useState<BenchResultSummaryPayload>(emptyPayload);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  async function loadPayload(): Promise<void> {
+    setLoading(true);
+    setError(null);
+
+    try {
+      const response = await fetch("/api/results");
+      if (!response.ok) {
+        throw new Error(`Failed to load bench results: ${response.status}`);
+      }
+
+      const next = (await response.json()) as BenchResultSummaryPayload;
+      setPayload(next);
+    } catch (cause) {
+      setError(cause instanceof Error ? cause.message : String(cause));
+      setPayload(emptyPayload);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void loadPayload();
+  }, []);
+
+  const defaultBenchmark = listBenchmarks(payload)[0] ?? "longmemeval";
+
   return (
     <HashRouter>
-      <AppShell>
+      <AppShell
+        payload={payload}
+        loading={loading}
+        error={error}
+        onRefresh={() => {
+          void loadPayload();
+        }}
+      >
         <Routes>
-          <Route path="/" element={<OverviewPage />} />
-          <Route path="/runs" element={<RunsPage />} />
-          <Route path="/compare" element={<ComparePage />} />
+          <Route path="/" element={<Overview payload={payload} />} />
+          <Route path="/runs" element={<Runs payload={payload} />} />
+          <Route path="/compare" element={<Compare payload={payload} />} />
           <Route
             path="/benchmark/:benchmarkId"
-            element={<BenchmarkDetailPage />}
+            element={<BenchmarkDetail payload={payload} />}
           />
-          <Route path="/providers" element={<ProvidersPage />} />
-          <Route path="/benchmark" element={<Navigate to="/benchmark/latency-ladder" replace />} />
+          <Route path="/providers" element={<Providers payload={payload} />} />
+          <Route
+            path="/benchmark"
+            element={<Navigate to={`/benchmark/${defaultBenchmark}`} replace />}
+          />
           <Route path="*" element={<NotFoundPage />} />
         </Routes>
       </AppShell>

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -1,0 +1,527 @@
+export interface BenchMetricHighlight {
+  name: string;
+  mean: number;
+}
+
+export interface BenchAggregateMetric {
+  name: string;
+  mean: number | null;
+  median: number | null;
+  stdDev: number | null;
+  min: number | null;
+  max: number | null;
+  ciLower: number | null;
+  ciUpper: number | null;
+  ciLevel: number | null;
+  effectSize: number | null;
+  effectInterpretation: string | null;
+}
+
+export interface BenchTaskScoreEntry {
+  name: string;
+  value: number;
+}
+
+export interface BenchTaskSummary {
+  taskId: string;
+  question: string;
+  expected: string;
+  actual: string;
+  latencyMs: number | null;
+  totalTokens: number;
+  primaryScore: number | null;
+  scoreEntries: BenchTaskScoreEntry[];
+}
+
+export interface BenchResultSummary {
+  id: string;
+  benchmark: string;
+  benchmarkTier: string;
+  timestamp: string;
+  mode: "quick" | "full";
+  totalLatencyMs: number | null;
+  meanQueryLatencyMs: number | null;
+  taskCount: number;
+  metricHighlights: BenchMetricHighlight[];
+  primaryMetric: string | null;
+  primaryScore: number | null;
+  runCount: number;
+  estimatedCostUsd: number | null;
+  totalTokens: number | null;
+  inputTokens: number | null;
+  outputTokens: number | null;
+  systemProvider: string;
+  judgeProvider: string;
+  providerKey: string;
+  adapterMode: string;
+  aggregateMetrics: BenchAggregateMetric[];
+  taskSummaries: BenchTaskSummary[];
+  filePath: string;
+}
+
+export interface BenchResultSummaryPayload {
+  resultsDir: string;
+  summaries: BenchResultSummary[];
+}
+
+export type TrendRange = "7d" | "30d" | "90d" | "all";
+
+export interface BenchmarkCard {
+  benchmark: string;
+  latest: BenchResultSummary;
+  previous: BenchResultSummary | null;
+  delta: number | null;
+}
+
+export interface TrendPoint {
+  runId: string;
+  benchmark: string;
+  label: string;
+  timestamp: string;
+  score: number;
+}
+
+export interface RunFilters {
+  benchmark: string;
+  systemProvider: string;
+  judgeProvider: string;
+  mode: string;
+  range: TrendRange;
+}
+
+export interface CompareMetricRow {
+  name: string;
+  baseline: number | null;
+  candidate: number | null;
+  delta: number | null;
+  percentChange: number | null;
+  ciLower: number | null;
+  ciUpper: number | null;
+  effectSize: number | null;
+  effectInterpretation: string | null;
+}
+
+export interface TaskDeltaRow {
+  taskId: string;
+  baseline: number | null;
+  candidate: number | null;
+  delta: number | null;
+  question: string;
+  latencyMs: number | null;
+}
+
+export interface CompareModel {
+  baseline: BenchResultSummary;
+  candidate: BenchResultSummary;
+  metricRows: CompareMetricRow[];
+  taskRows: TaskDeltaRow[];
+}
+
+export interface HistogramBucket {
+  label: string;
+  count: number;
+}
+
+export interface ProviderRow {
+  providerKey: string;
+  systemProvider: string;
+  judgeProvider: string;
+  runCount: number;
+  benchmarks: string[];
+  averageScore: number | null;
+  averageCostUsd: number | null;
+  benchmarkScores: Record<string, number | null>;
+}
+
+const metricPriority = [
+  "score",
+  "accuracy",
+  "f1",
+  "exact_match",
+  "llm_judge",
+  "semantic_similarity",
+  "precision",
+  "recall",
+];
+
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function compareRuns(left: BenchResultSummary, right: BenchResultSummary): number {
+  if (left.timestamp === right.timestamp) {
+    return compareStrings(left.id, right.id);
+  }
+
+  return right.timestamp.localeCompare(left.timestamp);
+}
+
+function compareMetricNames(left: string, right: string): number {
+  const leftIndex = metricPriority.indexOf(left);
+  const rightIndex = metricPriority.indexOf(right);
+
+  if (leftIndex !== rightIndex) {
+    if (leftIndex === -1) return 1;
+    if (rightIndex === -1) return -1;
+    return leftIndex - rightIndex;
+  }
+
+  return compareStrings(left, right);
+}
+
+function latestTimestamp(runs: BenchResultSummary[]): number {
+  const newest = runs[0];
+  return newest ? Date.parse(newest.timestamp) : 0;
+}
+
+function withinRange(timestamp: string, range: TrendRange, anchor: number): boolean {
+  if (range === "all") {
+    return true;
+  }
+
+  const days = range === "7d" ? 7 : range === "30d" ? 30 : 90;
+  const value = Date.parse(timestamp);
+  return value >= anchor - days * 24 * 60 * 60 * 1000;
+}
+
+export function humanizeIdentifier(value: string): string {
+  return value
+    .split(/[-_/]+/u)
+    .filter((segment) => segment.length > 0)
+    .map((segment) => segment[0]!.toUpperCase() + segment.slice(1))
+    .join(" ");
+}
+
+export function formatMetricValue(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+
+  if (Math.abs(value) <= 1.25) {
+    return `${(value * 100).toFixed(1)}%`;
+  }
+
+  return value.toFixed(2);
+}
+
+export function formatDelta(value: number | null): string {
+  if (value === null) {
+    return "No baseline";
+  }
+
+  const prefix = value > 0 ? "+" : "";
+  return `${prefix}${formatMetricValue(value)}`;
+}
+
+export function formatDuration(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+
+  if (value < 1000) {
+    return `${Math.round(value)} ms`;
+  }
+
+  return `${(value / 1000).toFixed(2)} s`;
+}
+
+export function formatCurrency(value: number | null): string {
+  if (value === null) {
+    return "n/a";
+  }
+
+  return `$${value.toFixed(3)}`;
+}
+
+export function formatTimestamp(value: string): string {
+  const timestamp = Date.parse(value);
+  if (Number.isNaN(timestamp)) {
+    return value;
+  }
+
+  return new Date(timestamp).toLocaleString("en-US", {
+    month: "short",
+    day: "numeric",
+    hour: "numeric",
+    minute: "2-digit",
+  });
+}
+
+export function listBenchmarks(payload: BenchResultSummaryPayload): string[] {
+  return Array.from(new Set(payload.summaries.map((summary) => summary.benchmark))).sort(compareStrings);
+}
+
+export function listProviders(
+  payload: BenchResultSummaryPayload,
+  field: "systemProvider" | "judgeProvider",
+): string[] {
+  return Array.from(new Set(payload.summaries.map((summary) => summary[field]))).sort(compareStrings);
+}
+
+export function getBenchmarkCards(payload: BenchResultSummaryPayload): BenchmarkCard[] {
+  const cards: BenchmarkCard[] = [];
+
+  for (const benchmark of listBenchmarks(payload)) {
+    const runs = payload.summaries.filter((summary) => summary.benchmark === benchmark);
+    const latest = runs[0];
+    if (!latest) {
+      continue;
+    }
+
+    const previous = runs[1] ?? null;
+    cards.push({
+      benchmark,
+      latest,
+      previous,
+      delta:
+        latest.primaryScore !== null &&
+        previous !== null &&
+        previous.primaryScore !== null
+          ? latest.primaryScore - previous.primaryScore
+          : null,
+    });
+  }
+
+  return cards.sort((left, right) => compareStrings(left.benchmark, right.benchmark));
+}
+
+export function getTrendPoints(
+  payload: BenchResultSummaryPayload,
+  benchmark: string,
+  range: TrendRange,
+): TrendPoint[] {
+  const anchor = latestTimestamp(payload.summaries);
+  const runs = payload.summaries
+    .filter((summary) => summary.primaryScore !== null)
+    .filter((summary) => benchmark === "all" || summary.benchmark === benchmark)
+    .filter((summary) => withinRange(summary.timestamp, range, anchor))
+    .slice()
+    .sort((left, right) => left.timestamp.localeCompare(right.timestamp));
+
+  return runs.map((summary) => ({
+    runId: summary.id,
+    benchmark: summary.benchmark,
+    label: formatTimestamp(summary.timestamp),
+    timestamp: summary.timestamp,
+    score: summary.primaryScore ?? 0,
+  }));
+}
+
+export function filterRuns(
+  payload: BenchResultSummaryPayload,
+  filters: RunFilters,
+): BenchResultSummary[] {
+  const anchor = latestTimestamp(payload.summaries);
+
+  return payload.summaries.filter((summary) => {
+    if (filters.benchmark !== "all" && summary.benchmark !== filters.benchmark) {
+      return false;
+    }
+    if (
+      filters.systemProvider !== "all" &&
+      summary.systemProvider !== filters.systemProvider
+    ) {
+      return false;
+    }
+    if (filters.judgeProvider !== "all" && summary.judgeProvider !== filters.judgeProvider) {
+      return false;
+    }
+    if (filters.mode !== "all" && summary.mode !== filters.mode) {
+      return false;
+    }
+    if (!withinRange(summary.timestamp, filters.range, anchor)) {
+      return false;
+    }
+
+    return true;
+  });
+}
+
+function metricValue(summary: BenchResultSummary, name: string): BenchAggregateMetric | undefined {
+  return summary.aggregateMetrics.find((metric) => metric.name === name);
+}
+
+export function buildCompareModel(
+  payload: BenchResultSummaryPayload,
+  baselineId: string,
+  candidateId: string,
+): CompareModel | null {
+  const baseline = payload.summaries.find((summary) => summary.id === baselineId);
+  const candidate = payload.summaries.find((summary) => summary.id === candidateId);
+
+  if (!baseline || !candidate) {
+    return null;
+  }
+
+  const metricNames = Array.from(
+    new Set([
+      ...baseline.aggregateMetrics.map((metric) => metric.name),
+      ...candidate.aggregateMetrics.map((metric) => metric.name),
+    ]),
+  ).sort(compareMetricNames);
+
+  const metricRows = metricNames.map((name) => {
+    const left = metricValue(baseline, name);
+    const right = metricValue(candidate, name);
+    const baselineValue = left?.mean ?? null;
+    const candidateValue = right?.mean ?? null;
+    const delta =
+      baselineValue !== null && candidateValue !== null ? candidateValue - baselineValue : null;
+
+    return {
+      name,
+      baseline: baselineValue,
+      candidate: candidateValue,
+      delta,
+      percentChange:
+        delta !== null && baselineValue !== null && baselineValue !== 0
+          ? (delta / baselineValue) * 100
+          : null,
+      ciLower: right?.ciLower ?? null,
+      ciUpper: right?.ciUpper ?? null,
+      effectSize: right?.effectSize ?? null,
+      effectInterpretation: right?.effectInterpretation ?? null,
+    };
+  });
+
+  const baselineTasks = new Map(baseline.taskSummaries.map((task) => [task.taskId, task]));
+  const candidateTasks = new Map(candidate.taskSummaries.map((task) => [task.taskId, task]));
+  const taskIds = Array.from(new Set([...baselineTasks.keys(), ...candidateTasks.keys()])).sort(
+    compareStrings,
+  );
+
+  const taskRows = taskIds
+    .map((taskId) => {
+      const left = baselineTasks.get(taskId) ?? null;
+      const right = candidateTasks.get(taskId) ?? null;
+      const baselineValue = left?.primaryScore ?? null;
+      const candidateValue = right?.primaryScore ?? null;
+
+      return {
+        taskId,
+        baseline: baselineValue,
+        candidate: candidateValue,
+        delta:
+          baselineValue !== null && candidateValue !== null
+            ? candidateValue - baselineValue
+            : null,
+        question: right?.question || left?.question || "Task prompt unavailable",
+        latencyMs: right?.latencyMs ?? left?.latencyMs ?? null,
+      };
+    })
+    .sort((left, right) => {
+      const leftDelta = left.delta ?? Number.POSITIVE_INFINITY;
+      const rightDelta = right.delta ?? Number.POSITIVE_INFINITY;
+      if (leftDelta === rightDelta) {
+        return compareStrings(left.taskId, right.taskId);
+      }
+      return leftDelta - rightDelta;
+    });
+
+  return {
+    baseline,
+    candidate,
+    metricRows,
+    taskRows,
+  };
+}
+
+export function buildHistogram(summary: BenchResultSummary): HistogramBucket[] {
+  const buckets = [
+    { label: "0-19", count: 0 },
+    { label: "20-39", count: 0 },
+    { label: "40-59", count: 0 },
+    { label: "60-79", count: 0 },
+    { label: "80-100", count: 0 },
+  ];
+
+  for (const task of summary.taskSummaries) {
+    if (task.primaryScore === null) {
+      continue;
+    }
+
+    const value = Math.max(0, Math.min(100, Math.round(task.primaryScore * 100)));
+    const index = Math.min(Math.floor(value / 20), buckets.length - 1);
+    const bucket = buckets[index];
+    if (bucket) {
+      bucket.count += 1;
+    }
+  }
+
+  return buckets;
+}
+
+export function buildProviderRows(payload: BenchResultSummaryPayload): ProviderRow[] {
+  const grouped = new Map<string, ProviderRow>();
+
+  for (const summary of payload.summaries) {
+    const existing = grouped.get(summary.providerKey);
+    if (existing) {
+      existing.runCount += 1;
+      if (!existing.benchmarks.includes(summary.benchmark)) {
+        existing.benchmarks.push(summary.benchmark);
+        existing.benchmarks.sort(compareStrings);
+      }
+      if (!(summary.benchmark in existing.benchmarkScores)) {
+        existing.benchmarkScores[summary.benchmark] = summary.primaryScore;
+      }
+      continue;
+    }
+
+    grouped.set(summary.providerKey, {
+      providerKey: summary.providerKey,
+      systemProvider: summary.systemProvider,
+      judgeProvider: summary.judgeProvider,
+      runCount: 1,
+      benchmarks: [summary.benchmark],
+      averageScore: summary.primaryScore,
+      averageCostUsd: summary.estimatedCostUsd,
+      benchmarkScores: { [summary.benchmark]: summary.primaryScore },
+    });
+  }
+
+  return Array.from(grouped.values())
+    .map((row) => {
+      const scoreValues = payload.summaries
+        .filter((summary) => summary.providerKey === row.providerKey)
+        .map((summary) => summary.primaryScore)
+        .filter((value): value is number => value !== null);
+      const costValues = payload.summaries
+        .filter((summary) => summary.providerKey === row.providerKey)
+        .map((summary) => summary.estimatedCostUsd)
+        .filter((value): value is number => value !== null);
+
+      return {
+        ...row,
+        averageScore:
+          scoreValues.length > 0
+            ? scoreValues.reduce((sum, value) => sum + value, 0) / scoreValues.length
+            : null,
+        averageCostUsd:
+          costValues.length > 0
+            ? costValues.reduce((sum, value) => sum + value, 0) / costValues.length
+            : null,
+      };
+    })
+    .sort((left, right) => compareStrings(left.providerKey, right.providerKey));
+}
+
+export function pickDefaultCompareIds(payload: BenchResultSummaryPayload): {
+  baselineId: string | null;
+  candidateId: string | null;
+} {
+  return {
+    candidateId: payload.summaries[0]?.id ?? null,
+    baselineId: payload.summaries[1]?.id ?? null,
+  };
+}
+
+export function benchmarkRuns(
+  payload: BenchResultSummaryPayload,
+  benchmark: string,
+): BenchResultSummary[] {
+  return payload.summaries
+    .filter((summary) => summary.benchmark === benchmark)
+    .slice()
+    .sort(compareRuns);
+}

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -143,11 +143,6 @@ function compareRuns(left: BenchResultSummary, right: BenchResultSummary): numbe
   return right.timestamp.localeCompare(left.timestamp);
 }
 
-function latestTimestamp(runs: BenchResultSummary[]): number {
-  const newest = runs[0];
-  return newest ? Date.parse(newest.timestamp) : 0;
-}
-
 function withinRange(timestamp: string, range: TrendRange, anchor: number): boolean {
   if (range === "all") {
     return true;
@@ -279,7 +274,7 @@ export function getTrendPoints(
   benchmark: string,
   range: TrendRange,
 ): TrendPoint[] {
-  const anchor = latestTimestamp(payload.summaries);
+  const anchor = Date.now();
   const runs = payload.summaries
     .filter((summary) => summary.primaryScore !== null)
     .filter((summary) => benchmark === "all" || summary.benchmark === benchmark)
@@ -300,7 +295,7 @@ export function filterRuns(
   payload: BenchResultSummaryPayload,
   filters: RunFilters,
 ): BenchResultSummary[] {
-  const anchor = latestTimestamp(payload.summaries);
+  const anchor = Date.now();
 
   return payload.summaries.filter((summary) => {
     if (filters.benchmark !== "all" && summary.benchmark !== filters.benchmark) {

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -1,4 +1,4 @@
-import { compareMetricNames, compareStrings } from "./sort-utils";
+import { compareMetricNames, compareStrings, compareTimestampedRuns } from "./sort-utils";
 
 export interface BenchMetricHighlight {
   name: string;
@@ -135,21 +135,17 @@ export interface ProviderRow {
   benchmarkScores: Record<string, number | null>;
 }
 
-function compareRuns(left: BenchResultSummary, right: BenchResultSummary): number {
-  if (left.timestamp === right.timestamp) {
-    return compareStrings(left.id, right.id);
+function withinRange(timestamp: string, range: TrendRange, anchor: number): boolean {
+  const value = Date.parse(timestamp);
+  if (Number.isNaN(value) || value > anchor) {
+    return false;
   }
 
-  return right.timestamp.localeCompare(left.timestamp);
-}
-
-function withinRange(timestamp: string, range: TrendRange, anchor: number): boolean {
   if (range === "all") {
     return true;
   }
 
   const days = range === "7d" ? 7 : range === "30d" ? 30 : 90;
-  const value = Date.parse(timestamp);
   return value >= anchor - days * 24 * 60 * 60 * 1000;
 }
 
@@ -246,7 +242,7 @@ export function getBenchmarkCards(payload: BenchResultSummaryPayload): Benchmark
     const runs = payload.summaries
       .filter((summary) => summary.benchmark === benchmark)
       .slice()
-      .sort(compareRuns);
+      .sort(compareTimestampedRuns);
     const latest = runs[0];
     if (!latest) {
       continue;
@@ -424,8 +420,9 @@ export function buildHistogram(summary: BenchResultSummary): HistogramBucket[] {
       continue;
     }
 
-    const value = Math.max(0, Math.min(100, Math.round(task.primaryScore * 100)));
-    const index = Math.min(Math.floor(value / 20), buckets.length - 1);
+    const clampedScore = Math.max(0, Math.min(1, task.primaryScore));
+    const index =
+      clampedScore === 1 ? buckets.length - 1 : Math.floor(clampedScore * buckets.length);
     const bucket = buckets[index];
     if (bucket) {
       bucket.count += 1;
@@ -507,5 +504,5 @@ export function benchmarkRuns(
   return payload.summaries
     .filter((summary) => summary.benchmark === benchmark)
     .slice()
-    .sort(compareRuns);
+    .sort(compareTimestampedRuns);
 }

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -1,3 +1,5 @@
+import { compareMetricNames, compareStrings } from "./sort-utils";
+
 export interface BenchMetricHighlight {
   name: string;
   mean: number;
@@ -133,40 +135,12 @@ export interface ProviderRow {
   benchmarkScores: Record<string, number | null>;
 }
 
-const metricPriority = [
-  "score",
-  "accuracy",
-  "f1",
-  "exact_match",
-  "llm_judge",
-  "semantic_similarity",
-  "precision",
-  "recall",
-];
-
-function compareStrings(left: string, right: string): number {
-  return left.localeCompare(right);
-}
-
 function compareRuns(left: BenchResultSummary, right: BenchResultSummary): number {
   if (left.timestamp === right.timestamp) {
     return compareStrings(left.id, right.id);
   }
 
   return right.timestamp.localeCompare(left.timestamp);
-}
-
-function compareMetricNames(left: string, right: string): number {
-  const leftIndex = metricPriority.indexOf(left);
-  const rightIndex = metricPriority.indexOf(right);
-
-  if (leftIndex !== rightIndex) {
-    if (leftIndex === -1) return 1;
-    if (rightIndex === -1) return -1;
-    return leftIndex - rightIndex;
-  }
-
-  return compareStrings(left, right);
 }
 
 function latestTimestamp(runs: BenchResultSummary[]): number {

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -166,9 +166,21 @@ export function humanizeIdentifier(value: string): string {
     .join(" ");
 }
 
-export function formatMetricValue(value: number | null): string {
+const rawCountMetrics = new Set([
+  "search_hits",
+]);
+
+function isRawCountMetric(metricName?: string): boolean {
+  return typeof metricName === "string" && rawCountMetrics.has(metricName);
+}
+
+export function formatMetricValue(value: number | null, metricName?: string): string {
   if (value === null) {
     return "n/a";
+  }
+
+  if (isRawCountMetric(metricName)) {
+    return Number.isInteger(value) ? value.toString() : value.toFixed(2);
   }
 
   if (Math.abs(value) <= 1.25) {
@@ -236,7 +248,10 @@ export function getBenchmarkCards(payload: BenchResultSummaryPayload): Benchmark
   const cards: BenchmarkCard[] = [];
 
   for (const benchmark of listBenchmarks(payload)) {
-    const runs = payload.summaries.filter((summary) => summary.benchmark === benchmark);
+    const runs = payload.summaries
+      .filter((summary) => summary.benchmark === benchmark)
+      .slice()
+      .sort(compareRuns);
     const latest = runs[0];
     if (!latest) {
       continue;

--- a/packages/bench-ui/src/components/ComparisonTable.tsx
+++ b/packages/bench-ui/src/components/ComparisonTable.tsx
@@ -27,12 +27,12 @@ export function ComparisonTable({ rows }: { rows: CompareMetricRow[] }) {
           {rows.map((row) => (
             <tr key={row.name}>
               <td>{row.name}</td>
-              <td>{formatMetricValue(row.baseline)}</td>
-              <td>{formatMetricValue(row.candidate)}</td>
-              <td>{formatMetricValue(row.delta)}</td>
+              <td>{formatMetricValue(row.baseline, row.name)}</td>
+              <td>{formatMetricValue(row.candidate, row.name)}</td>
+              <td>{formatMetricValue(row.delta, row.name)}</td>
               <td>
                 {row.ciLower !== null && row.ciUpper !== null
-                  ? `${formatMetricValue(row.ciLower)} to ${formatMetricValue(row.ciUpper)}`
+                  ? `${formatMetricValue(row.ciLower, row.name)} to ${formatMetricValue(row.ciUpper, row.name)}`
                   : "n/a"}
               </td>
               <td>

--- a/packages/bench-ui/src/components/ComparisonTable.tsx
+++ b/packages/bench-ui/src/components/ComparisonTable.tsx
@@ -1,0 +1,49 @@
+import type { CompareMetricRow } from "../bench-data";
+import { formatMetricValue } from "../bench-data";
+
+export function ComparisonTable({ rows }: { rows: CompareMetricRow[] }) {
+  if (rows.length === 0) {
+    return (
+      <div className="panel panel--empty">
+        <p>No overlapping benchmark metrics were found for this run pair.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <table className="table">
+        <thead>
+          <tr>
+            <th>Metric</th>
+            <th>Baseline</th>
+            <th>Candidate</th>
+            <th>Delta</th>
+            <th>CI</th>
+            <th>Effect</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={row.name}>
+              <td>{row.name}</td>
+              <td>{formatMetricValue(row.baseline)}</td>
+              <td>{formatMetricValue(row.candidate)}</td>
+              <td>{formatMetricValue(row.delta)}</td>
+              <td>
+                {row.ciLower !== null && row.ciUpper !== null
+                  ? `${formatMetricValue(row.ciLower)} to ${formatMetricValue(row.ciUpper)}`
+                  : "n/a"}
+              </td>
+              <td>
+                {row.effectSize !== null
+                  ? `${row.effectSize.toFixed(2)} ${row.effectInterpretation ?? ""}`.trim()
+                  : "n/a"}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/bench-ui/src/components/CostSummary.tsx
+++ b/packages/bench-ui/src/components/CostSummary.tsx
@@ -1,0 +1,24 @@
+import type { BenchResultSummary } from "../bench-data";
+import { formatCurrency, formatDuration } from "../bench-data";
+
+export function CostSummary({ summary }: { summary: BenchResultSummary }) {
+  return (
+    <section className="cost-summary">
+      <article className="stat-card stat-card--compact">
+        <span>Estimated cost</span>
+        <strong>{formatCurrency(summary.estimatedCostUsd)}</strong>
+        <p>{summary.totalTokens ?? 0} total tokens</p>
+      </article>
+      <article className="stat-card stat-card--compact">
+        <span>Total latency</span>
+        <strong>{formatDuration(summary.totalLatencyMs)}</strong>
+        <p>{summary.taskCount} task evaluations</p>
+      </article>
+      <article className="stat-card stat-card--compact">
+        <span>Mean query latency</span>
+        <strong>{formatDuration(summary.meanQueryLatencyMs)}</strong>
+        <p>{summary.adapterMode} adapter mode</p>
+      </article>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/components/RunTable.tsx
+++ b/packages/bench-ui/src/components/RunTable.tsx
@@ -1,0 +1,74 @@
+import { Link } from "react-router-dom";
+import type { BenchResultSummary } from "../bench-data";
+import {
+  formatCurrency,
+  formatDelta,
+  formatDuration,
+  formatMetricValue,
+  formatTimestamp,
+  humanizeIdentifier,
+} from "../bench-data";
+
+export function RunTable({
+  runs,
+  showDelta = true,
+}: {
+  runs: Array<BenchResultSummary & { delta?: number | null }>;
+  showDelta?: boolean;
+}) {
+  if (runs.length === 0) {
+    return (
+      <div className="panel panel--empty">
+        <p>No runs match the current filters.</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      <table className="table table--runs">
+        <thead>
+          <tr>
+            <th>Run</th>
+            <th>Benchmark</th>
+            <th>Providers</th>
+            <th>Score</th>
+            {showDelta ? <th>Delta</th> : null}
+            <th>Latency</th>
+            <th>Cost</th>
+          </tr>
+        </thead>
+        <tbody>
+          {runs.map((run) => (
+            <tr key={run.id}>
+              <td>
+                <div className="run-cell">
+                  <strong>{run.id}</strong>
+                  <span>{formatTimestamp(run.timestamp)}</span>
+                </div>
+              </td>
+              <td>
+                <div className="run-cell">
+                  <Link className="inline-link" to={`/benchmark/${run.benchmark}`}>
+                    {humanizeIdentifier(run.benchmark)}
+                  </Link>
+                  <span>{run.mode}</span>
+                </div>
+              </td>
+              <td>
+                <div className="run-cell">
+                  <strong>{run.systemProvider}</strong>
+                  <span>{run.judgeProvider}</span>
+                </div>
+              </td>
+              <td>{formatMetricValue(run.primaryScore)}</td>
+              {showDelta ? <td>{formatDelta(run.delta ?? null)}</td> : null}
+              <td>{formatDuration(run.totalLatencyMs)}</td>
+              <td>{formatCurrency(run.estimatedCostUsd)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/packages/bench-ui/src/components/ScoreCard.tsx
+++ b/packages/bench-ui/src/components/ScoreCard.tsx
@@ -1,0 +1,51 @@
+import type { BenchmarkCard } from "../bench-data";
+import {
+  formatDelta,
+  formatMetricValue,
+  formatTimestamp,
+  humanizeIdentifier,
+} from "../bench-data";
+
+export function ScoreCard({ card }: { card: BenchmarkCard }) {
+  return (
+    <article className="score-card">
+      <div className="score-card__header">
+        <div>
+          <span className="section-kicker">{card.latest.benchmarkTier}</span>
+          <h4>{humanizeIdentifier(card.benchmark)}</h4>
+        </div>
+        <span className="score-card__timestamp">{formatTimestamp(card.latest.timestamp)}</span>
+      </div>
+
+      <div className="score-card__score-row">
+        <strong>{formatMetricValue(card.latest.primaryScore)}</strong>
+        <span
+          className={`delta-pill${
+            card.delta !== null && card.delta > 0
+              ? " delta-pill--positive"
+              : card.delta !== null && card.delta < 0
+                ? " delta-pill--negative"
+                : ""
+          }`}
+        >
+          {formatDelta(card.delta)}
+        </span>
+      </div>
+
+      <dl className="score-card__meta">
+        <div>
+          <dt>Metric</dt>
+          <dd>{card.latest.primaryMetric ?? "n/a"}</dd>
+        </div>
+        <div>
+          <dt>System</dt>
+          <dd>{card.latest.systemProvider}</dd>
+        </div>
+        <div>
+          <dt>Judge</dt>
+          <dd>{card.latest.judgeProvider}</dd>
+        </div>
+      </dl>
+    </article>
+  );
+}

--- a/packages/bench-ui/src/components/TaskBreakdown.tsx
+++ b/packages/bench-ui/src/components/TaskBreakdown.tsx
@@ -1,0 +1,43 @@
+import type { TaskDeltaRow } from "../bench-data";
+import { formatDuration, formatMetricValue } from "../bench-data";
+
+export function TaskBreakdown({
+  rows,
+  title,
+}: {
+  rows: TaskDeltaRow[];
+  title: string;
+}) {
+  if (rows.length === 0) {
+    return (
+      <div className="panel panel--empty">
+        <p>No task-level data was available for this benchmark run.</p>
+      </div>
+    );
+  }
+
+  return (
+    <section className="panel">
+      <div className="section-title">
+        <span className="section-kicker">Tasks</span>
+        <h4>{title}</h4>
+      </div>
+      <div className="task-stack">
+        {rows.slice(0, 8).map((row) => (
+          <article className="task-card" key={row.taskId}>
+            <div className="task-card__header">
+              <strong>{row.taskId}</strong>
+              <span>{formatDuration(row.latencyMs)}</span>
+            </div>
+            <p>{row.question}</p>
+            <div className="task-card__scores">
+              <span>Baseline {formatMetricValue(row.baseline)}</span>
+              <span>Candidate {formatMetricValue(row.candidate)}</span>
+              <span>Delta {formatMetricValue(row.delta)}</span>
+            </div>
+          </article>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/components/TrendChart.tsx
+++ b/packages/bench-ui/src/components/TrendChart.tsx
@@ -1,0 +1,75 @@
+import type { TrendPoint } from "../bench-data";
+import { formatMetricValue } from "../bench-data";
+
+function pathForPoints(points: TrendPoint[], width: number, height: number): string {
+  if (points.length === 0) {
+    return "";
+  }
+
+  const max = Math.max(...points.map((point) => point.score));
+  const min = Math.min(...points.map((point) => point.score));
+  const span = max === min ? 1 : max - min;
+
+  return points
+    .map((point, index) => {
+      const x = (index / Math.max(points.length - 1, 1)) * width;
+      const normalized = (point.score - min) / span;
+      const y = height - normalized * height;
+      return `${index === 0 ? "M" : "L"} ${x.toFixed(2)} ${y.toFixed(2)}`;
+    })
+    .join(" ");
+}
+
+export function TrendChart({ points }: { points: TrendPoint[] }) {
+  if (points.length === 0) {
+    return (
+      <div className="panel panel--empty">
+        <p>No benchmark runs match the selected trend range yet.</p>
+      </div>
+    );
+  }
+
+  const width = 720;
+  const height = 220;
+  const path = pathForPoints(points, width, height);
+
+  return (
+    <section className="panel trend-chart">
+      <div className="trend-chart__header">
+        <div>
+          <span className="section-kicker">Trend</span>
+          <h4>Score movement over time</h4>
+        </div>
+        <span className="trend-chart__summary">
+          {formatMetricValue(points[points.length - 1]?.score ?? null)} latest
+        </span>
+      </div>
+
+      <svg viewBox={`0 0 ${width} ${height}`} className="trend-chart__canvas" role="img">
+        <defs>
+          <linearGradient id="trendStroke" x1="0%" x2="100%" y1="0%" y2="0%">
+            <stop offset="0%" stopColor="#8fd6ff" />
+            <stop offset="100%" stopColor="#ffab78" />
+          </linearGradient>
+        </defs>
+        <path d={path} fill="none" stroke="url(#trendStroke)" strokeWidth="4" />
+        {points.map((point, index) => {
+          const x = (index / Math.max(points.length - 1, 1)) * width;
+          const values = points.map((entry) => entry.score);
+          const max = Math.max(...values);
+          const min = Math.min(...values);
+          const span = max === min ? 1 : max - min;
+          const normalized = (point.score - min) / span;
+          const y = height - normalized * height;
+
+          return <circle key={point.runId} cx={x} cy={y} r="5" fill="#0f1721" stroke="#d7f3ff" strokeWidth="2" />;
+        })}
+      </svg>
+
+      <div className="trend-chart__labels">
+        <span>{points[0]?.label}</span>
+        <span>{points[points.length - 1]?.label}</span>
+      </div>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/components/TrendChart.tsx
+++ b/packages/bench-ui/src/components/TrendChart.tsx
@@ -32,6 +32,10 @@ export function TrendChart({ points }: { points: TrendPoint[] }) {
   const width = 720;
   const height = 220;
   const path = pathForPoints(points, width, height);
+  const scores = points.map((point) => point.score);
+  const max = Math.max(...scores);
+  const min = Math.min(...scores);
+  const span = max === min ? 1 : max - min;
 
   return (
     <section className="panel trend-chart">
@@ -55,10 +59,6 @@ export function TrendChart({ points }: { points: TrendPoint[] }) {
         <path d={path} fill="none" stroke="url(#trendStroke)" strokeWidth="4" />
         {points.map((point, index) => {
           const x = (index / Math.max(points.length - 1, 1)) * width;
-          const values = points.map((entry) => entry.score);
-          const max = Math.max(...values);
-          const min = Math.min(...values);
-          const span = max === min ? 1 : max - min;
           const normalized = (point.score - min) / span;
           const y = height - normalized * height;
 

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { useParams } from "react-router-dom";
-import type { BenchResultSummaryPayload } from "../bench-data";
+import type { BenchResultSummary, BenchResultSummaryPayload, TaskDeltaRow } from "../bench-data";
 import {
   benchmarkRuns,
   buildHistogram,
@@ -10,6 +10,25 @@ import {
 } from "../bench-data";
 import { CostSummary } from "../components/CostSummary";
 import { TaskBreakdown } from "../components/TaskBreakdown";
+
+export function buildBenchmarkDetailTaskRows(selected: BenchResultSummary): TaskDeltaRow[] {
+  return selected.taskSummaries.map((task) => ({
+    taskId: task.taskId,
+    baseline: null,
+    candidate: task.primaryScore,
+    delta: null,
+    question: task.question,
+    latencyMs: task.latencyMs,
+  }));
+}
+
+export function selectLowestScoringTasks(taskRows: TaskDeltaRow[], limit = 5): TaskDeltaRow[] {
+  return taskRows
+    .filter((task) => (task.candidate ?? 1) < 0.6)
+    .slice()
+    .sort((left, right) => (left.candidate ?? 1) - (right.candidate ?? 1))
+    .slice(0, limit);
+}
 
 export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayload }) {
   const { benchmarkId } = useParams();
@@ -32,17 +51,8 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
   }
 
   const histogram = buildHistogram(selected);
-  const taskRows = selected.taskSummaries.map((task) => ({
-    taskId: task.taskId,
-    baseline: null,
-    candidate: task.primaryScore,
-    delta: null,
-    question: task.question,
-    latencyMs: task.latencyMs,
-  }));
-  const lowScoring = taskRows
-    .filter((task) => (task.candidate ?? 1) < 0.6)
-    .sort((left, right) => (left.candidate ?? 1) - (right.candidate ?? 1));
+  const taskRows = buildBenchmarkDetailTaskRows(selected);
+  const lowScoring = selectLowestScoringTasks(taskRows);
 
   return (
     <section className="page">
@@ -111,7 +121,7 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
         </div>
         {lowScoring.length > 0 ? (
           <ul className="failure-list">
-            {lowScoring.slice(0, 5).map((task) => (
+            {lowScoring.map((task) => (
               <li key={task.taskId}>
                 <strong>{task.taskId}</strong>
                 <span>{formatMetricValue(task.candidate)}</span>

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -40,7 +40,9 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
     question: task.question,
     latencyMs: task.latencyMs,
   }));
-  const lowScoring = taskRows.filter((task) => (task.candidate ?? 1) < 0.6);
+  const lowScoring = taskRows
+    .filter((task) => (task.candidate ?? 1) < 0.6)
+    .sort((left, right) => (left.candidate ?? 1) - (right.candidate ?? 1));
 
   return (
     <section className="page">

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -36,7 +36,7 @@ export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayloa
     taskId: task.taskId,
     baseline: null,
     candidate: task.primaryScore,
-    delta: task.primaryScore,
+    delta: null,
     question: task.question,
     latencyMs: task.latencyMs,
   }));

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -1,0 +1,126 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import type { BenchResultSummaryPayload } from "../bench-data";
+import {
+  benchmarkRuns,
+  buildHistogram,
+  formatMetricValue,
+  formatTimestamp,
+  humanizeIdentifier,
+} from "../bench-data";
+import { CostSummary } from "../components/CostSummary";
+import { TaskBreakdown } from "../components/TaskBreakdown";
+
+export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayload }) {
+  const { benchmarkId } = useParams();
+  const runs = benchmarkId ? benchmarkRuns(payload, benchmarkId) : [];
+  const [selectedRunId, setSelectedRunId] = useState<string>(runs[0]?.id ?? "");
+  const selected = runs.find((run) => run.id === selectedRunId) ?? runs[0] ?? null;
+
+  if (!benchmarkId || !selected) {
+    return (
+      <section className="page">
+        <header className="page-header">
+          <div>
+            <span className="section-kicker">Benchmark detail</span>
+            <h3>Benchmark not found</h3>
+          </div>
+          <p>Choose a benchmark from Overview or Runs to inspect its task-level detail.</p>
+        </header>
+      </section>
+    );
+  }
+
+  const histogram = buildHistogram(selected);
+  const taskRows = selected.taskSummaries.map((task) => ({
+    taskId: task.taskId,
+    baseline: null,
+    candidate: task.primaryScore,
+    delta: task.primaryScore,
+    question: task.question,
+    latencyMs: task.latencyMs,
+  }));
+  const lowScoring = taskRows.filter((task) => (task.candidate ?? 1) < 0.6);
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Benchmark detail</span>
+          <h3>{humanizeIdentifier(benchmarkId)}</h3>
+        </div>
+        <p>
+          Latest local metrics, task score distribution, and failure analysis for this benchmark family.
+        </p>
+      </header>
+
+      <section className="panel controls-grid">
+        <label>
+          <span>Inspect run</span>
+          <select value={selected.id} onChange={(event) => setSelectedRunId(event.target.value)}>
+            {runs.map((run) => (
+              <option key={run.id} value={run.id}>
+                {run.id} · {formatTimestamp(run.timestamp)}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <div className="detail-hero">
+        <article className="stat-card">
+          <span>Primary score</span>
+          <strong>{formatMetricValue(selected.primaryScore)}</strong>
+          <p>{selected.primaryMetric ?? "No primary metric"}</p>
+        </article>
+        <article className="stat-card">
+          <span>Metric stack</span>
+          <strong>{selected.aggregateMetrics.length}</strong>
+          <p>{selected.aggregateMetrics.map((metric) => metric.name).slice(0, 4).join(", ") || "No aggregates"}</p>
+        </article>
+      </div>
+
+      <CostSummary summary={selected} />
+
+      <section className="panel">
+        <div className="section-title">
+          <span className="section-kicker">Distribution</span>
+          <h4>Task score histogram</h4>
+        </div>
+        <div className="histogram">
+          {histogram.map((bucket) => (
+            <div className="histogram__bucket" key={bucket.label}>
+              <div className="histogram__bar-wrap">
+                <div className="histogram__bar" style={{ height: `${Math.max(bucket.count * 18, 12)}px` }} />
+              </div>
+              <strong>{bucket.count}</strong>
+              <span>{bucket.label}</span>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <TaskBreakdown rows={taskRows} title="Task-level score breakdown" />
+
+      <section className="panel">
+        <div className="section-title">
+          <span className="section-kicker">Failure analysis</span>
+          <h4>Lowest-scoring tasks</h4>
+        </div>
+        {lowScoring.length > 0 ? (
+          <ul className="failure-list">
+            {lowScoring.slice(0, 5).map((task) => (
+              <li key={task.taskId}>
+                <strong>{task.taskId}</strong>
+                <span>{formatMetricValue(task.candidate)}</span>
+                <p>{task.question}</p>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="muted-copy">No low-scoring task cluster was detected for the selected run.</p>
+        )}
+      </section>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/pages/BenchmarkDetail.tsx
+++ b/packages/bench-ui/src/pages/BenchmarkDetail.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import type { BenchResultSummary, BenchResultSummaryPayload, TaskDeltaRow } from "../bench-data";
 import {
@@ -30,11 +30,30 @@ export function selectLowestScoringTasks(taskRows: TaskDeltaRow[], limit = 5): T
     .slice(0, limit);
 }
 
+export function resolveSelectedRunId(
+  runs: BenchResultSummary[],
+  selectedRunId: string,
+): string {
+  if (runs.some((run) => run.id === selectedRunId)) {
+    return selectedRunId;
+  }
+
+  return runs[0]?.id ?? "";
+}
+
 export function BenchmarkDetail({ payload }: { payload: BenchResultSummaryPayload }) {
   const { benchmarkId } = useParams();
   const runs = benchmarkId ? benchmarkRuns(payload, benchmarkId) : [];
   const [selectedRunId, setSelectedRunId] = useState<string>(runs[0]?.id ?? "");
-  const selected = runs.find((run) => run.id === selectedRunId) ?? runs[0] ?? null;
+  const resolvedSelectedRunId = resolveSelectedRunId(runs, selectedRunId);
+
+  useEffect(() => {
+    if (selectedRunId !== resolvedSelectedRunId) {
+      setSelectedRunId(resolvedSelectedRunId);
+    }
+  }, [resolvedSelectedRunId, selectedRunId]);
+
+  const selected = runs.find((run) => run.id === resolvedSelectedRunId) ?? runs[0] ?? null;
 
   if (!benchmarkId || !selected) {
     return (

--- a/packages/bench-ui/src/pages/Compare.tsx
+++ b/packages/bench-ui/src/pages/Compare.tsx
@@ -14,8 +14,31 @@ export function Compare({ payload }: { payload: BenchResultSummaryPayload }) {
     setCandidateId(defaults.candidateId ?? "");
   }, [defaults.baselineId, defaults.candidateId]);
 
+  const baselineSummary =
+    payload.summaries.find((summary) => summary.id === baselineId) ?? null;
+  const candidateSummary =
+    payload.summaries.find((summary) => summary.id === candidateId) ?? null;
+
+  useEffect(() => {
+    if (
+      baselineSummary &&
+      candidateSummary &&
+      baselineSummary.benchmark !== candidateSummary.benchmark
+    ) {
+      setCandidateId("");
+    }
+  }, [baselineSummary, candidateSummary]);
+
+  const candidateOptions = baselineSummary
+    ? payload.summaries.filter(
+        (summary) => summary.benchmark === baselineSummary.benchmark,
+      )
+    : payload.summaries;
+
   const comparison =
-    baselineId.length > 0 && candidateId.length > 0
+    baselineSummary &&
+    candidateSummary &&
+    baselineSummary.benchmark === candidateSummary.benchmark
       ? buildCompareModel(payload, baselineId, candidateId)
       : null;
 
@@ -45,7 +68,7 @@ export function Compare({ payload }: { payload: BenchResultSummaryPayload }) {
           <span>Candidate run</span>
           <select value={candidateId} onChange={(event) => setCandidateId(event.target.value)}>
             <option value="">Select candidate</option>
-            {payload.summaries.map((summary) => (
+            {candidateOptions.map((summary) => (
               <option key={summary.id} value={summary.id}>
                 {summary.id} · {summary.benchmark}
               </option>

--- a/packages/bench-ui/src/pages/Compare.tsx
+++ b/packages/bench-ui/src/pages/Compare.tsx
@@ -1,0 +1,84 @@
+import { useEffect, useState } from "react";
+import type { BenchResultSummaryPayload } from "../bench-data";
+import { buildCompareModel, pickDefaultCompareIds } from "../bench-data";
+import { ComparisonTable } from "../components/ComparisonTable";
+import { TaskBreakdown } from "../components/TaskBreakdown";
+
+export function Compare({ payload }: { payload: BenchResultSummaryPayload }) {
+  const defaults = pickDefaultCompareIds(payload);
+  const [baselineId, setBaselineId] = useState<string>(defaults.baselineId ?? "");
+  const [candidateId, setCandidateId] = useState<string>(defaults.candidateId ?? "");
+
+  useEffect(() => {
+    setBaselineId(defaults.baselineId ?? "");
+    setCandidateId(defaults.candidateId ?? "");
+  }, [defaults.baselineId, defaults.candidateId]);
+
+  const comparison =
+    baselineId.length > 0 && candidateId.length > 0
+      ? buildCompareModel(payload, baselineId, candidateId)
+      : null;
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Compare</span>
+          <h3>Run-versus-run inspection</h3>
+        </div>
+        <p>Choose two local runs and compare aggregate movement, confidence intervals, and task deltas.</p>
+      </header>
+
+      <section className="panel controls-grid">
+        <label>
+          <span>Baseline run</span>
+          <select value={baselineId} onChange={(event) => setBaselineId(event.target.value)}>
+            <option value="">Select baseline</option>
+            {payload.summaries.map((summary) => (
+              <option key={summary.id} value={summary.id}>
+                {summary.id} · {summary.benchmark}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Candidate run</span>
+          <select value={candidateId} onChange={(event) => setCandidateId(event.target.value)}>
+            <option value="">Select candidate</option>
+            {payload.summaries.map((summary) => (
+              <option key={summary.id} value={summary.id}>
+                {summary.id} · {summary.benchmark}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      {comparison ? (
+        <>
+          <section className="compare-summary">
+            <article className="stat-card stat-card--compact">
+              <span>Baseline</span>
+              <strong>{comparison.baseline.id}</strong>
+              <p>{comparison.baseline.benchmark}</p>
+            </article>
+            <article className="stat-card stat-card--compact">
+              <span>Candidate</span>
+              <strong>{comparison.candidate.id}</strong>
+              <p>{comparison.candidate.benchmark}</p>
+            </article>
+          </section>
+          <ComparisonTable rows={comparison.metricRows} />
+          <TaskBreakdown
+            rows={comparison.taskRows}
+            title="Largest task-level shifts"
+          />
+        </>
+      ) : (
+        <div className="panel panel--empty">
+          <p>Select two runs to unlock the comparison view.</p>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/bench-ui/src/pages/Compare.tsx
+++ b/packages/bench-ui/src/pages/Compare.tsx
@@ -1,8 +1,32 @@
 import { useEffect, useState } from "react";
-import type { BenchResultSummaryPayload } from "../bench-data";
+import type { BenchResultSummary, BenchResultSummaryPayload } from "../bench-data";
 import { buildCompareModel, pickDefaultCompareIds } from "../bench-data";
 import { ComparisonTable } from "../components/ComparisonTable";
 import { TaskBreakdown } from "../components/TaskBreakdown";
+
+export function canCompareBenchRuns(
+  baselineSummary: BenchResultSummary | null,
+  candidateSummary: BenchResultSummary | null,
+): boolean {
+  return (
+    baselineSummary !== null &&
+    candidateSummary !== null &&
+    baselineSummary.benchmark === candidateSummary.benchmark
+  );
+}
+
+export function filterComparableCandidateRuns(
+  payload: BenchResultSummaryPayload,
+  baselineSummary: BenchResultSummary | null,
+): BenchResultSummary[] {
+  if (!baselineSummary) {
+    return payload.summaries;
+  }
+
+  return payload.summaries.filter(
+    (summary) => summary.benchmark === baselineSummary.benchmark,
+  );
+}
 
 export function Compare({ payload }: { payload: BenchResultSummaryPayload }) {
   const defaults = pickDefaultCompareIds(payload);
@@ -20,27 +44,16 @@ export function Compare({ payload }: { payload: BenchResultSummaryPayload }) {
     payload.summaries.find((summary) => summary.id === candidateId) ?? null;
 
   useEffect(() => {
-    if (
-      baselineSummary &&
-      candidateSummary &&
-      baselineSummary.benchmark !== candidateSummary.benchmark
-    ) {
+    if (baselineSummary && candidateSummary && !canCompareBenchRuns(baselineSummary, candidateSummary)) {
       setCandidateId("");
     }
   }, [baselineSummary, candidateSummary]);
 
-  const candidateOptions = baselineSummary
-    ? payload.summaries.filter(
-        (summary) => summary.benchmark === baselineSummary.benchmark,
-      )
-    : payload.summaries;
+  const candidateOptions = filterComparableCandidateRuns(payload, baselineSummary);
 
-  const comparison =
-    baselineSummary &&
-    candidateSummary &&
-    baselineSummary.benchmark === candidateSummary.benchmark
-      ? buildCompareModel(payload, baselineId, candidateId)
-      : null;
+  const comparison = canCompareBenchRuns(baselineSummary, candidateSummary)
+    ? buildCompareModel(payload, baselineId, candidateId)
+    : null;
 
   return (
     <section className="page">

--- a/packages/bench-ui/src/pages/Overview.tsx
+++ b/packages/bench-ui/src/pages/Overview.tsx
@@ -1,0 +1,80 @@
+import { Link } from "react-router-dom";
+import { useState } from "react";
+import type { BenchResultSummaryPayload, TrendRange } from "../bench-data";
+import { getBenchmarkCards, getTrendPoints } from "../bench-data";
+import { RunTable } from "../components/RunTable";
+import { ScoreCard } from "../components/ScoreCard";
+import { TrendChart } from "../components/TrendChart";
+
+const ranges: TrendRange[] = ["7d", "30d", "90d", "all"];
+
+export function Overview({ payload }: { payload: BenchResultSummaryPayload }) {
+  const cards = getBenchmarkCards(payload);
+  const [range, setRange] = useState<TrendRange>("30d");
+  const [benchmark, setBenchmark] = useState<string>("all");
+  const trendPoints = getTrendPoints(payload, benchmark, range);
+  const recentRuns = cards
+    .map((card) => ({ ...card.latest, delta: card.delta }))
+    .sort((left, right) => right.timestamp.localeCompare(left.timestamp))
+    .slice(0, 6);
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Overview</span>
+          <h3>Local benchmark command center</h3>
+        </div>
+        <p>Latest scores, trend movement, and the most recent run activity pulled from local result files.</p>
+      </header>
+
+      <div className="score-grid">
+        {cards.map((card) => (
+          <Link key={card.benchmark} to={`/benchmark/${card.benchmark}`}>
+            <ScoreCard card={card} />
+          </Link>
+        ))}
+      </div>
+
+      <section className="panel controls-panel">
+        <div className="control-group">
+          <label htmlFor="trend-benchmark">Trend benchmark</label>
+          <select
+            id="trend-benchmark"
+            value={benchmark}
+            onChange={(event) => setBenchmark(event.target.value)}
+          >
+            <option value="all">All benchmarks</option>
+            {cards.map((card) => (
+              <option key={card.benchmark} value={card.benchmark}>
+                {card.benchmark}
+              </option>
+            ))}
+          </select>
+        </div>
+        <div className="range-group" role="tablist" aria-label="Trend range">
+          {ranges.map((option) => (
+            <button
+              key={option}
+              type="button"
+              className={`range-pill${range === option ? " range-pill--active" : ""}`}
+              onClick={() => setRange(option)}
+            >
+              {option}
+            </button>
+          ))}
+        </div>
+      </section>
+
+      <TrendChart points={trendPoints} />
+
+      <section className="page-block">
+        <div className="section-title">
+          <span className="section-kicker">Recent runs</span>
+          <h4>Latest benchmark executions</h4>
+        </div>
+        <RunTable runs={recentRuns} />
+      </section>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/pages/Providers.tsx
+++ b/packages/bench-ui/src/pages/Providers.tsx
@@ -1,0 +1,67 @@
+import type { BenchResultSummaryPayload } from "../bench-data";
+import {
+  buildProviderRows,
+  formatCurrency,
+  formatMetricValue,
+  listBenchmarks,
+  humanizeIdentifier,
+} from "../bench-data";
+
+export function Providers({ payload }: { payload: BenchResultSummaryPayload }) {
+  const rows = buildProviderRows(payload);
+  const benchmarks = listBenchmarks(payload);
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Providers</span>
+          <h3>System and judge performance matrix</h3>
+        </div>
+        <p>See how provider pairings influence scores and cost across the local benchmark set.</p>
+      </header>
+
+      {rows.length === 0 ? (
+        <div className="panel panel--empty">
+          <p>No provider data has been observed yet.</p>
+        </div>
+      ) : (
+        <div className="panel">
+          <table className="table table--providers">
+            <thead>
+              <tr>
+                <th>Provider pair</th>
+                <th>Runs</th>
+                <th>Avg score</th>
+                <th>Avg cost</th>
+                {benchmarks.map((benchmark) => (
+                  <th key={benchmark}>{humanizeIdentifier(benchmark)}</th>
+                ))}
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map((row) => (
+                <tr key={row.providerKey}>
+                  <td>
+                    <div className="run-cell">
+                      <strong>{row.systemProvider}</strong>
+                      <span>{row.judgeProvider}</span>
+                    </div>
+                  </td>
+                  <td>{row.runCount}</td>
+                  <td>{formatMetricValue(row.averageScore)}</td>
+                  <td>{formatCurrency(row.averageCostUsd)}</td>
+                  {benchmarks.map((benchmark) => (
+                    <td key={`${row.providerKey}-${benchmark}`}>
+                      {formatMetricValue(row.benchmarkScores[benchmark] ?? null)}
+                    </td>
+                  ))}
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/packages/bench-ui/src/pages/Runs.tsx
+++ b/packages/bench-ui/src/pages/Runs.tsx
@@ -1,0 +1,106 @@
+import { useState } from "react";
+import type { BenchResultSummaryPayload, RunFilters, TrendRange } from "../bench-data";
+import { filterRuns, listBenchmarks, listProviders } from "../bench-data";
+import { RunTable } from "../components/RunTable";
+
+const ranges: TrendRange[] = ["7d", "30d", "90d", "all"];
+
+export function Runs({ payload }: { payload: BenchResultSummaryPayload }) {
+  const [filters, setFilters] = useState<RunFilters>({
+    benchmark: "all",
+    systemProvider: "all",
+    judgeProvider: "all",
+    mode: "all",
+    range: "all",
+  });
+  const filtered = filterRuns(payload, filters);
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Runs</span>
+          <h3>Filterable run history</h3>
+        </div>
+        <p>Slice the local result set by benchmark, provider stack, mode, and recency window.</p>
+      </header>
+
+      <section className="panel controls-grid">
+        <label>
+          <span>Benchmark</span>
+          <select
+            value={filters.benchmark}
+            onChange={(event) => setFilters((current) => ({ ...current, benchmark: event.target.value }))}
+          >
+            <option value="all">All benchmarks</option>
+            {listBenchmarks(payload).map((benchmark) => (
+              <option key={benchmark} value={benchmark}>
+                {benchmark}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>System provider</span>
+          <select
+            value={filters.systemProvider}
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, systemProvider: event.target.value }))
+            }
+          >
+            <option value="all">All systems</option>
+            {listProviders(payload, "systemProvider").map((provider) => (
+              <option key={provider} value={provider}>
+                {provider}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Judge provider</span>
+          <select
+            value={filters.judgeProvider}
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, judgeProvider: event.target.value }))
+            }
+          >
+            <option value="all">All judges</option>
+            {listProviders(payload, "judgeProvider").map((provider) => (
+              <option key={provider} value={provider}>
+                {provider}
+              </option>
+            ))}
+          </select>
+        </label>
+        <label>
+          <span>Mode</span>
+          <select
+            value={filters.mode}
+            onChange={(event) => setFilters((current) => ({ ...current, mode: event.target.value }))}
+          >
+            <option value="all">All modes</option>
+            <option value="quick">quick</option>
+            <option value="full">full</option>
+          </select>
+        </label>
+        <label>
+          <span>Range</span>
+          <select
+            value={filters.range}
+            onChange={(event) =>
+              setFilters((current) => ({ ...current, range: event.target.value as TrendRange }))
+            }
+          >
+            {ranges.map((range) => (
+              <option key={range} value={range}>
+                {range}
+              </option>
+            ))}
+          </select>
+        </label>
+      </section>
+
+      <RunTable runs={filtered} showDelta={false} />
+    </section>
+  );
+}

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -9,7 +9,7 @@ import type {
   BenchTaskScoreEntry,
   BenchTaskSummary,
 } from "./bench-data.js";
-import { compareMetricNames, compareStrings } from "./sort-utils.js";
+import { compareMetricNames, compareStrings, compareTimestampedRuns } from "./sort-utils.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -19,14 +19,6 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function compareSummaries(left: BenchResultSummary, right: BenchResultSummary): number {
-  if (left.timestamp === right.timestamp) {
-    return compareStrings(left.id, right.id);
-  }
-
-  return right.timestamp.localeCompare(left.timestamp);
 }
 
 function providerLabel(value: unknown): string {
@@ -230,7 +222,7 @@ export async function loadBenchResultSummaries(
     }
   }
 
-  summaries.sort(compareSummaries);
+  summaries.sort(compareTimestampedRuns);
 
   return {
     resultsDir,

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -1,86 +1,227 @@
 import fs from "node:fs";
 import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
+import type {
+  BenchAggregateMetric,
+  BenchMetricHighlight,
+  BenchResultSummary,
+  BenchResultSummaryPayload,
+  BenchTaskScoreEntry,
+  BenchTaskSummary,
+} from "./bench-data.js";
 
-export interface BenchMetricHighlight {
-  name: string;
-  mean: number;
-}
+const metricPriority = [
+  "score",
+  "accuracy",
+  "f1",
+  "exact_match",
+  "llm_judge",
+  "semantic_similarity",
+  "precision",
+  "recall",
+];
 
-export interface BenchResultSummary {
-  id: string;
-  benchmark: string;
-  timestamp: string;
-  mode: "quick" | "full";
-  totalLatencyMs: number | null;
-  meanQueryLatencyMs: number | null;
-  taskCount: number;
-  metricHighlights: BenchMetricHighlight[];
-  filePath: string;
-}
+type JsonRecord = Record<string, unknown>;
 
-export interface BenchResultSummaryPayload {
-  resultsDir: string;
-  summaries: BenchResultSummary[];
-}
-
-function isRecord(value: unknown): value is Record<string, unknown> {
+function isRecord(value: unknown): value is JsonRecord {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
 
-function toNumber(value: unknown): number | null {
+function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
 }
 
-function summarizeMetricHighlights(aggregates: unknown): BenchMetricHighlight[] {
-  if (!isRecord(aggregates)) {
-    return [];
+function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+function compareMetricNames(left: string, right: string): number {
+  const leftIndex = metricPriority.indexOf(left);
+  const rightIndex = metricPriority.indexOf(right);
+
+  if (leftIndex !== rightIndex) {
+    if (leftIndex === -1) return 1;
+    if (rightIndex === -1) return -1;
+    return leftIndex - rightIndex;
   }
 
-  return Object.entries(aggregates)
-    .map(([name, metric]) => ({
-      name,
-      mean: isRecord(metric) ? toNumber(metric.mean) : null,
-    }))
-    .filter((metric): metric is BenchMetricHighlight => metric.mean !== null)
-    .sort((left, right) => left.name.localeCompare(right.name))
-    .slice(0, 3);
+  return compareStrings(left, right);
 }
 
 function compareSummaries(left: BenchResultSummary, right: BenchResultSummary): number {
   if (left.timestamp === right.timestamp) {
-    return left.id.localeCompare(right.id);
+    return compareStrings(left.id, right.id);
   }
 
   return right.timestamp.localeCompare(left.timestamp);
+}
+
+function providerLabel(value: unknown): string {
+  if (!isRecord(value)) {
+    return "unconfigured";
+  }
+
+  const provider = typeof value.provider === "string" ? value.provider : null;
+  const model = typeof value.model === "string" ? value.model : null;
+
+  if (provider && model) {
+    return `${provider}/${model}`;
+  }
+  if (provider) {
+    return provider;
+  }
+  if (model) {
+    return model;
+  }
+
+  return "unconfigured";
+}
+
+function scoreEntries(scores: unknown): BenchTaskScoreEntry[] {
+  if (!isRecord(scores)) {
+    return [];
+  }
+
+  return Object.entries(scores)
+    .map(([name, value]) => ({ name, value: toFiniteNumber(value) }))
+    .filter((entry): entry is { name: string; value: number } => entry.value !== null)
+    .sort((left, right) => compareMetricNames(left.name, right.name))
+    .map(({ name, value }) => ({ name, value }));
+}
+
+function primaryMetricNameFromEntries(entries: Array<{ name: string }>): string | null {
+  return entries[0]?.name ?? null;
+}
+
+function aggregateMetrics(result: JsonRecord): BenchAggregateMetric[] {
+  const results = isRecord(result.results) ? result.results : {};
+  const aggregates = isRecord(results.aggregates) ? results.aggregates : {};
+  const statistics = isRecord(results.statistics) ? results.statistics : {};
+  const confidenceIntervals = isRecord(statistics.confidenceIntervals)
+    ? statistics.confidenceIntervals
+    : {};
+  const effectSizes = isRecord(statistics.effectSizes) ? statistics.effectSizes : {};
+
+  return Object.entries(aggregates)
+    .map(([name, aggregate]): BenchAggregateMetric | null => {
+      if (!isRecord(aggregate)) {
+        return null;
+      }
+
+      const interval = isRecord(confidenceIntervals[name]) ? confidenceIntervals[name] : {};
+      const effect = isRecord(effectSizes[name]) ? effectSizes[name] : {};
+
+      return {
+        name,
+        mean: toFiniteNumber(aggregate.mean),
+        median: toFiniteNumber(aggregate.median),
+        stdDev: toFiniteNumber(aggregate.stdDev),
+        min: toFiniteNumber(aggregate.min),
+        max: toFiniteNumber(aggregate.max),
+        ciLower: toFiniteNumber(interval.lower),
+        ciUpper: toFiniteNumber(interval.upper),
+        ciLevel: toFiniteNumber(interval.level),
+        effectSize: toFiniteNumber(effect.cohensD),
+        effectInterpretation:
+          typeof effect.interpretation === "string" ? effect.interpretation : null,
+      };
+    })
+    .filter((metric): metric is BenchAggregateMetric => metric !== null)
+    .sort((left, right) => compareMetricNames(left.name, right.name));
+}
+
+function metricHighlights(metrics: BenchAggregateMetric[]): BenchMetricHighlight[] {
+  return metrics
+    .filter((metric): metric is BenchAggregateMetric & { mean: number } => metric.mean !== null)
+    .slice(0, 3)
+    .map((metric) => ({ name: metric.name, mean: metric.mean }));
+}
+
+function taskSummaries(result: JsonRecord): BenchTaskSummary[] {
+  const results = isRecord(result.results) ? result.results : {};
+  const tasks = Array.isArray(results.tasks) ? results.tasks : [];
+
+  return tasks
+    .map((task): BenchTaskSummary | null => {
+      if (!isRecord(task) || typeof task.taskId !== "string") {
+        return null;
+      }
+
+      const entries = scoreEntries(task.scores);
+      const tokens = isRecord(task.tokens) ? task.tokens : {};
+      const primaryMetric = primaryMetricNameFromEntries(entries);
+      const primaryEntry = primaryMetric
+        ? entries.find((entry) => entry.name === primaryMetric) ?? null
+        : null;
+
+      return {
+        taskId: task.taskId,
+        question: typeof task.question === "string" ? task.question : "",
+        expected: typeof task.expected === "string" ? task.expected : "",
+        actual: typeof task.actual === "string" ? task.actual : "",
+        latencyMs: toFiniteNumber(task.latencyMs),
+        totalTokens:
+          (toFiniteNumber(tokens.input) ?? 0) + (toFiniteNumber(tokens.output) ?? 0),
+        primaryScore: primaryEntry?.value ?? null,
+        scoreEntries: entries,
+      };
+    })
+    .filter((task): task is BenchTaskSummary => task !== null)
+    .sort((left, right) => compareStrings(left.taskId, right.taskId));
 }
 
 export function summarizeBenchmarkResult(
   result: unknown,
   filePath: string,
 ): BenchResultSummary | null {
-  const root = isRecord(result) ? result : {};
-  const meta = isRecord(root.meta) ? root.meta : {};
-  const cost = isRecord(root.cost) ? root.cost : {};
-  const results = isRecord(root.results) ? root.results : {};
-  const tasks = Array.isArray(results.tasks) ? results.tasks : [];
-
-  if (typeof meta.id !== "string" || typeof meta.benchmark !== "string") {
+  if (!isRecord(result)) {
     return null;
   }
+
+  const meta = isRecord(result.meta) ? result.meta : {};
+  const config = isRecord(result.config) ? result.config : {};
+  const cost = isRecord(result.cost) ? result.cost : {};
+  const metrics = aggregateMetrics(result);
+  const tasks = taskSummaries(result);
+  const primaryMetric = metrics[0]?.name ?? null;
+  const primaryScore = metrics[0]?.mean ?? null;
+
+  if (
+    typeof meta.id !== "string" ||
+    typeof meta.benchmark !== "string" ||
+    typeof meta.timestamp !== "string"
+  ) {
+    return null;
+  }
+
+  const systemProvider = providerLabel(config.systemProvider);
+  const judgeProvider = providerLabel(config.judgeProvider);
 
   return {
     id: meta.id,
     benchmark: meta.benchmark,
-    timestamp:
-      typeof meta.timestamp === "string"
-        ? meta.timestamp
-        : new Date(0).toISOString(),
+    benchmarkTier:
+      typeof meta.benchmarkTier === "string" ? meta.benchmarkTier : "custom",
+    timestamp: meta.timestamp,
     mode: meta.mode === "full" ? "full" : "quick",
-    totalLatencyMs: toNumber(cost.totalLatencyMs),
-    meanQueryLatencyMs: toNumber(cost.meanQueryLatencyMs),
+    totalLatencyMs: toFiniteNumber(cost.totalLatencyMs),
+    meanQueryLatencyMs: toFiniteNumber(cost.meanQueryLatencyMs),
     taskCount: tasks.length,
-    metricHighlights: summarizeMetricHighlights(results.aggregates),
+    metricHighlights: metricHighlights(metrics),
+    primaryMetric,
+    primaryScore,
+    runCount: toFiniteNumber(meta.runCount) ?? tasks.length,
+    estimatedCostUsd: toFiniteNumber(cost.estimatedCostUsd),
+    totalTokens: toFiniteNumber(cost.totalTokens),
+    inputTokens: toFiniteNumber(cost.inputTokens),
+    outputTokens: toFiniteNumber(cost.outputTokens),
+    systemProvider,
+    judgeProvider,
+    providerKey: `${systemProvider}__${judgeProvider}`,
+    adapterMode:
+      typeof config.adapterMode === "string" ? config.adapterMode : "unknown",
+    aggregateMetrics: metrics,
+    taskSummaries: tasks,
     filePath,
   };
 }
@@ -107,8 +248,7 @@ export async function loadBenchResultSummaries(
 
     try {
       const raw = await readFile(filePath, "utf8");
-      const parsed = JSON.parse(raw) as unknown;
-      const summary = summarizeBenchmarkResult(parsed, filePath);
+      const summary = summarizeBenchmarkResult(JSON.parse(raw) as unknown, filePath);
       if (summary) {
         summaries.push(summary);
       }

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -9,17 +9,7 @@ import type {
   BenchTaskScoreEntry,
   BenchTaskSummary,
 } from "./bench-data.js";
-
-const metricPriority = [
-  "score",
-  "accuracy",
-  "f1",
-  "exact_match",
-  "llm_judge",
-  "semantic_similarity",
-  "precision",
-  "recall",
-];
+import { compareMetricNames, compareStrings } from "./sort-utils.js";
 
 type JsonRecord = Record<string, unknown>;
 
@@ -29,23 +19,6 @@ function isRecord(value: unknown): value is JsonRecord {
 
 function toFiniteNumber(value: unknown): number | null {
   return typeof value === "number" && Number.isFinite(value) ? value : null;
-}
-
-function compareStrings(left: string, right: string): number {
-  return left.localeCompare(right);
-}
-
-function compareMetricNames(left: string, right: string): number {
-  const leftIndex = metricPriority.indexOf(left);
-  const rightIndex = metricPriority.indexOf(right);
-
-  if (leftIndex !== rightIndex) {
-    if (leftIndex === -1) return 1;
-    if (rightIndex === -1) return -1;
-    return leftIndex - rightIndex;
-  }
-
-  return compareStrings(left, right);
 }
 
 function compareSummaries(left: BenchResultSummary, right: BenchResultSummary): number {

--- a/packages/bench-ui/src/sort-utils.ts
+++ b/packages/bench-ui/src/sort-utils.ts
@@ -25,3 +25,14 @@ export function compareMetricNames(left: string, right: string): number {
 
   return compareStrings(left, right);
 }
+
+export function compareTimestampedRuns<T extends { timestamp: string; id: string }>(
+  left: T,
+  right: T,
+): number {
+  if (left.timestamp === right.timestamp) {
+    return compareStrings(left.id, right.id);
+  }
+
+  return right.timestamp.localeCompare(left.timestamp);
+}

--- a/packages/bench-ui/src/sort-utils.ts
+++ b/packages/bench-ui/src/sort-utils.ts
@@ -1,0 +1,27 @@
+const metricPriority = [
+  "score",
+  "accuracy",
+  "f1",
+  "exact_match",
+  "llm_judge",
+  "semantic_similarity",
+  "precision",
+  "recall",
+];
+
+export function compareStrings(left: string, right: string): number {
+  return left.localeCompare(right);
+}
+
+export function compareMetricNames(left: string, right: string): number {
+  const leftIndex = metricPriority.indexOf(left);
+  const rightIndex = metricPriority.indexOf(right);
+
+  if (leftIndex !== rightIndex) {
+    if (leftIndex === -1) return 1;
+    if (rightIndex === -1) return -1;
+    return leftIndex - rightIndex;
+  }
+
+  return compareStrings(left, right);
+}

--- a/packages/bench-ui/tsconfig.json
+++ b/packages/bench-ui/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "jsx": "react-jsx",
-    "types": ["vite/client"]
+    "types": ["vite/client", "node"]
   },
   "include": ["src"]
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -462,6 +462,7 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
   const child = childProcess.spawn(pnpmCmd, ["exec", "vite", "--host", "127.0.0.1"], {
     cwd: benchUiDir,
     stdio: "inherit",
+    shell: process.platform === "win32",
     env: {
       ...process.env,
       REMNIC_BENCH_RESULTS_DIR: resultsDir,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -462,7 +462,6 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
   const child = childProcess.spawn(pnpmCmd, ["exec", "vite", "--host", "127.0.0.1"], {
     cwd: benchUiDir,
     stdio: "inherit",
-    shell: process.platform === "win32",
     env: {
       ...process.env,
       REMNIC_BENCH_RESULTS_DIR: resultsDir,

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -1,14 +1,18 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
   formatMetricValue,
   buildProviderRows,
+  filterRuns,
   getBenchmarkCards,
+  getTrendPoints,
   type BenchResultSummaryPayload,
 } from "../packages/bench-ui/src/bench-data.js";
+import { buildBenchmarkDetailTaskRows, selectLowestScoringTasks } from "../packages/bench-ui/src/pages/BenchmarkDetail.js";
+import { canCompareBenchRuns, filterComparableCandidateRuns } from "../packages/bench-ui/src/pages/Compare.js";
 import { loadBenchResultSummaries } from "../packages/bench-ui/src/results.js";
 
 test("bench UI loader summarizes valid benchmark JSON files and ignores invalid entries", async () => {
@@ -193,25 +197,219 @@ test("getBenchmarkCards sorts benchmark runs before choosing latest and previous
   assert.equal(cards[0]?.previous?.id, "older-run");
 });
 
-test("benchmark detail renders single-run task deltas as null", async () => {
-  const source = await readFile("packages/bench-ui/src/pages/BenchmarkDetail.tsx", "utf8");
+test("filterRuns uses wall-clock time for recency windows", async (t) => {
+  t.mock.method(Date, "now", () => Date.parse("2026-04-18T12:00:00.000Z"));
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "stale-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-03-01T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.75,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/stale-run.json",
+      },
+    ],
+  };
 
-  assert.match(source, /delta:\s*null,/);
+  const runs = filterRuns(payload, {
+    benchmark: "all",
+    systemProvider: "all",
+    judgeProvider: "all",
+    mode: "all",
+    range: "7d",
+  });
+
+  assert.deepEqual(runs, []);
 });
 
-test("benchmark detail sorts low scorers ascending before slicing", async () => {
-  const source = await readFile("packages/bench-ui/src/pages/BenchmarkDetail.tsx", "utf8");
+test("getTrendPoints uses wall-clock time for recency windows", async (t) => {
+  t.mock.method(Date, "now", () => Date.parse("2026-04-18T12:00:00.000Z"));
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "stale-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-03-01T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.75,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/stale-run.json",
+      },
+    ],
+  };
 
-  assert.match(source, /\.sort\(\(left, right\) => \(left\.candidate \?\? 1\) - \(right\.candidate \?\? 1\)\)/);
-  assert.match(source, /lowScoring\.slice\(0, 5\)/);
+  assert.deepEqual(getTrendPoints(payload, "all", "7d"), []);
 });
 
-test("compare view guards against cross-benchmark run pairs", async () => {
-  const source = await readFile("packages/bench-ui/src/pages/Compare.tsx", "utf8");
+test("benchmark detail helpers keep single-run deltas null and sort low scorers ascending", () => {
+  const taskRows = buildBenchmarkDetailTaskRows({
+    id: "latest-run",
+    benchmark: "longmemeval",
+    benchmarkTier: "published",
+    timestamp: "2026-04-18T10:00:00.000Z",
+    mode: "quick",
+    totalLatencyMs: 1234,
+    meanQueryLatencyMs: 617,
+    taskCount: 6,
+    metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+    primaryMetric: "accuracy",
+    primaryScore: 0.75,
+    runCount: 1,
+    estimatedCostUsd: 0.12,
+    totalTokens: 100,
+    inputTokens: 60,
+    outputTokens: 40,
+    systemProvider: "openai/gpt-5.4",
+    judgeProvider: "openai/gpt-5.4-mini",
+    providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+    adapterMode: "standalone",
+    aggregateMetrics: [],
+    taskSummaries: [
+      { taskId: "task-1", question: "Q1", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.55, scoreEntries: [] },
+      { taskId: "task-2", question: "Q2", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.11, scoreEntries: [] },
+      { taskId: "task-3", question: "Q3", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.44, scoreEntries: [] },
+      { taskId: "task-4", question: "Q4", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.25, scoreEntries: [] },
+      { taskId: "task-5", question: "Q5", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.35, scoreEntries: [] },
+      { taskId: "task-6", question: "Q6", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.05, scoreEntries: [] },
+    ],
+    filePath: "/tmp/results/latest-run.json",
+  });
 
-  assert.match(source, /summary\.benchmark === baselineSummary\.benchmark/);
-  assert.match(source, /baselineSummary\.benchmark === candidateSummary\.benchmark/);
-  assert.match(source, /setCandidateId\(""\)/);
+  assert(taskRows.every((row) => row.delta === null));
+  assert.deepEqual(
+    selectLowestScoringTasks(taskRows).map((row) => row.taskId),
+    ["task-6", "task-2", "task-4", "task-5", "task-3"],
+  );
+});
+
+test("compare helpers constrain candidate options to the selected benchmark", () => {
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "baseline-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.75,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/baseline-run.json",
+      },
+      {
+        id: "candidate-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-17T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.80 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.80,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/candidate-run.json",
+      },
+      {
+        id: "other-run",
+        benchmark: "ama-bench",
+        benchmarkTier: "published",
+        timestamp: "2026-04-17T09:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.33 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.33,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/other-run.json",
+      },
+    ],
+  };
+
+  const baselineSummary = payload.summaries[0] ?? null;
+  const candidateSummary = payload.summaries[1] ?? null;
+  const otherSummary = payload.summaries[2] ?? null;
+
+  assert.deepEqual(
+    filterComparableCandidateRuns(payload, baselineSummary).map((summary) => summary.id),
+    ["baseline-run", "candidate-run"],
+  );
+  assert.equal(canCompareBenchRuns(baselineSummary, candidateSummary), true);
+  assert.equal(canCompareBenchRuns(baselineSummary, otherSummary), false);
 });
 
 test("buildProviderRows keeps the newest benchmark score for each provider", () => {

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  formatMetricValue,
   buildProviderRows,
   getBenchmarkCards,
   type BenchResultSummaryPayload,
@@ -124,10 +125,85 @@ test("getBenchmarkCards keeps delta null when a benchmark has only one run", () 
   assert.equal(cards[0]?.delta, null);
 });
 
+test("formatMetricValue keeps raw count metrics as counts", () => {
+  assert.equal(formatMetricValue(7, "search_hits"), "7");
+  assert.equal(formatMetricValue(0.75, "accuracy"), "75.0%");
+});
+
+test("getBenchmarkCards sorts benchmark runs before choosing latest and previous", () => {
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "older-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-17T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1400,
+        meanQueryLatencyMs: 700,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.42 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.42,
+        runCount: 1,
+        estimatedCostUsd: 0.18,
+        totalTokens: 120,
+        inputTokens: 75,
+        outputTokens: 45,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/older-run.json",
+      },
+      {
+        id: "latest-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.91 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.91,
+        runCount: 1,
+        estimatedCostUsd: 0.14,
+        totalTokens: 110,
+        inputTokens: 70,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/latest-run.json",
+      },
+    ],
+  };
+
+  const cards = getBenchmarkCards(payload);
+
+  assert.equal(cards[0]?.latest.id, "latest-run");
+  assert.equal(cards[0]?.previous?.id, "older-run");
+});
+
 test("benchmark detail renders single-run task deltas as null", async () => {
   const source = await readFile("packages/bench-ui/src/pages/BenchmarkDetail.tsx", "utf8");
 
   assert.match(source, /delta:\s*null,/);
+});
+
+test("benchmark detail sorts low scorers ascending before slicing", async () => {
+  const source = await readFile("packages/bench-ui/src/pages/BenchmarkDetail.tsx", "utf8");
+
+  assert.match(source, /\.sort\(\(left, right\) => \(left\.candidate \?\? 1\) - \(right\.candidate \?\? 1\)\)/);
+  assert.match(source, /lowScoring\.slice\(0, 5\)/);
 });
 
 test("compare view guards against cross-benchmark run pairs", async () => {

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -4,6 +4,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
+  buildHistogram,
   formatMetricValue,
   buildProviderRows,
   filterRuns,
@@ -11,7 +12,11 @@ import {
   getTrendPoints,
   type BenchResultSummaryPayload,
 } from "../packages/bench-ui/src/bench-data.js";
-import { buildBenchmarkDetailTaskRows, selectLowestScoringTasks } from "../packages/bench-ui/src/pages/BenchmarkDetail.js";
+import {
+  buildBenchmarkDetailTaskRows,
+  resolveSelectedRunId,
+  selectLowestScoringTasks,
+} from "../packages/bench-ui/src/pages/BenchmarkDetail.js";
 import { canCompareBenchRuns, filterComparableCandidateRuns } from "../packages/bench-ui/src/pages/Compare.js";
 import { loadBenchResultSummaries } from "../packages/bench-ui/src/results.js";
 
@@ -277,6 +282,52 @@ test("getTrendPoints uses wall-clock time for recency windows", async (t) => {
   assert.deepEqual(getTrendPoints(payload, "all", "7d"), []);
 });
 
+test("recency filters exclude future runs beyond the current wall-clock anchor", async (t) => {
+  t.mock.method(Date, "now", () => Date.parse("2026-04-18T12:00:00.000Z"));
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "future-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-19T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.75,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/future-run.json",
+      },
+    ],
+  };
+
+  assert.deepEqual(
+    filterRuns(payload, {
+      benchmark: "all",
+      systemProvider: "all",
+      judgeProvider: "all",
+      mode: "all",
+      range: "7d",
+    }),
+    [],
+  );
+  assert.deepEqual(getTrendPoints(payload, "all", "7d"), []);
+});
+
 test("benchmark detail helpers keep single-run deltas null and sort low scorers ascending", () => {
   const taskRows = buildBenchmarkDetailTaskRows({
     id: "latest-run",
@@ -315,6 +366,105 @@ test("benchmark detail helpers keep single-run deltas null and sort low scorers 
   assert.deepEqual(
     selectLowestScoringTasks(taskRows).map((row) => row.taskId),
     ["task-6", "task-2", "task-4", "task-5", "task-3"],
+  );
+});
+
+test("resolveSelectedRunId falls back to the current benchmark run list", () => {
+  const runs = [
+    {
+      id: "run-b",
+      benchmark: "longmemeval",
+      benchmarkTier: "published",
+      timestamp: "2026-04-18T10:00:00.000Z",
+      mode: "quick" as const,
+      totalLatencyMs: 1234,
+      meanQueryLatencyMs: 617,
+      taskCount: 1,
+      metricHighlights: [],
+      primaryMetric: "accuracy",
+      primaryScore: 0.75,
+      runCount: 1,
+      estimatedCostUsd: 0.12,
+      totalTokens: 100,
+      inputTokens: 60,
+      outputTokens: 40,
+      systemProvider: "openai/gpt-5.4",
+      judgeProvider: "openai/gpt-5.4-mini",
+      providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+      adapterMode: "standalone",
+      aggregateMetrics: [],
+      taskSummaries: [],
+      filePath: "/tmp/results/run-b.json",
+    },
+    {
+      id: "run-a",
+      benchmark: "longmemeval",
+      benchmarkTier: "published",
+      timestamp: "2026-04-17T10:00:00.000Z",
+      mode: "quick" as const,
+      totalLatencyMs: 1234,
+      meanQueryLatencyMs: 617,
+      taskCount: 1,
+      metricHighlights: [],
+      primaryMetric: "accuracy",
+      primaryScore: 0.6,
+      runCount: 1,
+      estimatedCostUsd: 0.12,
+      totalTokens: 100,
+      inputTokens: 60,
+      outputTokens: 40,
+      systemProvider: "openai/gpt-5.4",
+      judgeProvider: "openai/gpt-5.4-mini",
+      providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+      adapterMode: "standalone",
+      aggregateMetrics: [],
+      taskSummaries: [],
+      filePath: "/tmp/results/run-a.json",
+    },
+  ];
+
+  assert.equal(resolveSelectedRunId(runs, "missing-run"), "run-b");
+  assert.equal(resolveSelectedRunId(runs, "run-a"), "run-a");
+  assert.equal(resolveSelectedRunId([], "missing-run"), "");
+});
+
+test("buildHistogram buckets boundary scores by floor semantics", () => {
+  const summary = {
+    id: "latest-run",
+    benchmark: "longmemeval",
+    benchmarkTier: "published",
+    timestamp: "2026-04-18T10:00:00.000Z",
+    mode: "quick" as const,
+    totalLatencyMs: 1234,
+    meanQueryLatencyMs: 617,
+    taskCount: 6,
+    metricHighlights: [],
+    primaryMetric: "accuracy",
+    primaryScore: 0.75,
+    runCount: 1,
+    estimatedCostUsd: 0.12,
+    totalTokens: 100,
+    inputTokens: 60,
+    outputTokens: 40,
+    systemProvider: "openai/gpt-5.4",
+    judgeProvider: "openai/gpt-5.4-mini",
+    providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+    adapterMode: "standalone",
+    aggregateMetrics: [],
+    taskSummaries: [
+      { taskId: "task-1", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.199, scoreEntries: [] },
+      { taskId: "task-2", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.2, scoreEntries: [] },
+      { taskId: "task-3", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.399, scoreEntries: [] },
+      { taskId: "task-4", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.4, scoreEntries: [] },
+      { taskId: "task-5", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.8, scoreEntries: [] },
+      { taskId: "task-6", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 1, scoreEntries: [] },
+    ],
+    filePath: "/tmp/results/latest-run.json",
+  };
+
+  assert.deepEqual(
+    buildHistogram(summary).map((bucket) => bucket.count),
+    [1, 2, 1, 0, 2],
   );
 });
 

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -122,6 +122,20 @@ test("getBenchmarkCards keeps delta null when a benchmark has only one run", () 
   assert.equal(cards.length, 1);
   assert.equal(cards[0]?.previous, null);
   assert.equal(cards[0]?.delta, null);
+});
+
+test("benchmark detail renders single-run task deltas as null", async () => {
+  const source = await readFile("packages/bench-ui/src/pages/BenchmarkDetail.tsx", "utf8");
+
+  assert.match(source, /delta:\s*null,/);
+});
+
+test("compare view guards against cross-benchmark run pairs", async () => {
+  const source = await readFile("packages/bench-ui/src/pages/Compare.tsx", "utf8");
+
+  assert.match(source, /summary\.benchmark === baselineSummary\.benchmark/);
+  assert.match(source, /baselineSummary\.benchmark === candidateSummary\.benchmark/);
+  assert.match(source, /setCandidateId\(""\)/);
 });
 
 test("buildProviderRows keeps the newest benchmark score for each provider", () => {

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -3,6 +3,11 @@ import assert from "node:assert/strict";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
+import {
+  buildProviderRows,
+  getBenchmarkCards,
+  type BenchResultSummaryPayload,
+} from "../packages/bench-ui/src/bench-data.js";
 import { loadBenchResultSummaries } from "../packages/bench-ui/src/results.js";
 
 test("bench UI loader summarizes valid benchmark JSON files and ignores invalid entries", async () => {
@@ -22,7 +27,7 @@ test("bench UI loader summarizes valid benchmark JSON files and ignores invalid 
         meanQueryLatencyMs: 617,
       },
       results: {
-        tasks: [{ id: "task-1" }, { id: "task-2" }],
+        tasks: [{ taskId: "task-1" }, { taskId: "task-2" }],
         aggregates: {
           accuracy: { mean: 0.75 },
           f1: { mean: 0.63 },
@@ -78,4 +83,109 @@ test("bench UI loader returns an empty payload when the results directory is mis
 
   assert.equal(payload.resultsDir, resultsDir);
   assert.deepEqual(payload.summaries, []);
+});
+
+test("getBenchmarkCards keeps delta null when a benchmark has only one run", () => {
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "latest-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.75 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.75,
+        runCount: 1,
+        estimatedCostUsd: 0.12,
+        totalTokens: 100,
+        inputTokens: 60,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/latest-run.json",
+      },
+    ],
+  };
+
+  const cards = getBenchmarkCards(payload);
+
+  assert.equal(cards.length, 1);
+  assert.equal(cards[0]?.previous, null);
+  assert.equal(cards[0]?.delta, null);
+});
+
+test("buildProviderRows keeps the newest benchmark score for each provider", () => {
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [
+      {
+        id: "latest-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1234,
+        meanQueryLatencyMs: 617,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.91 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.91,
+        runCount: 1,
+        estimatedCostUsd: 0.14,
+        totalTokens: 110,
+        inputTokens: 70,
+        outputTokens: 40,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/latest-run.json",
+      },
+      {
+        id: "older-run",
+        benchmark: "longmemeval",
+        benchmarkTier: "published",
+        timestamp: "2026-04-17T10:00:00.000Z",
+        mode: "quick",
+        totalLatencyMs: 1400,
+        meanQueryLatencyMs: 700,
+        taskCount: 2,
+        metricHighlights: [{ name: "accuracy", mean: 0.42 }],
+        primaryMetric: "accuracy",
+        primaryScore: 0.42,
+        runCount: 1,
+        estimatedCostUsd: 0.18,
+        totalTokens: 120,
+        inputTokens: 75,
+        outputTokens: 45,
+        systemProvider: "openai/gpt-5.4",
+        judgeProvider: "openai/gpt-5.4-mini",
+        providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+        adapterMode: "standalone",
+        aggregateMetrics: [],
+        taskSummaries: [],
+        filePath: "/tmp/results/older-run.json",
+      },
+    ],
+  };
+
+  const rows = buildProviderRows(payload);
+
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]?.benchmarkScores.longmemeval, 0.91);
+  assert.equal(rows[0]?.runCount, 2);
+  assert.equal(rows[0]?.averageScore, (0.91 + 0.42) / 2);
+  assert.equal(rows[0]?.averageCostUsd, (0.14 + 0.18) / 2);
 });

--- a/tests/remnic-cli-bench-ui-surface.test.ts
+++ b/tests/remnic-cli-bench-ui-surface.test.ts
@@ -27,5 +27,6 @@ test("CLI source wires remnic bench ui to the local bench-ui package", async () 
   assert.match(source, /async function launchBenchUi\(resultsDir: string\): Promise<void>/);
   assert.match(source, /const benchUiDir = path\.join\(CLI_REPO_ROOT, "packages", "bench-ui"\);/);
   assert.match(source, /REMNIC_BENCH_RESULTS_DIR: resultsDir/);
+  assert.match(source, /shell:\s*process\.platform === "win32"/);
   assert.match(source, /childProcess\.spawn\(pnpmCmd, \["exec", "vite", "--host", "127\.0\.0\.1"\]/);
 });


### PR DESCRIPTION
Part of #445.

## Summary
- replace the bench UI placeholders with real Overview, Runs, Compare, Benchmark Detail, and Providers dashboard pages
- restore the local results loader with the richer summary payload the new pages need
- typecheck and build the bench UI package with the updated data plumbing

## Verification
- `pnpm --filter @remnic/bench-ui exec tsc --noEmit`
- `pnpm --filter @remnic/bench-ui build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it replaces the bench UI scaffold with real data-driven views and significantly expands the benchmark JSON parsing/summary model used across the UI and Vite API middleware.
> 
> **Overview**
> **Bench UI is now a real local-results dashboard instead of placeholders.** `App.tsx` now fetches `GET /api/results`, tracks loading/error state, shows run/benchmark counts, supports manual refresh, and routes to new pages (`Overview`, `Runs`, `Compare`, `BenchmarkDetail`, `Providers`) with a `/benchmark` redirect to the first available benchmark.
> 
> **Adds a typed data/model layer and UI components for analysis.** New `bench-data.ts` defines the richer `BenchResultSummary` payload and utilities for formatting, filtering by recency/providers/mode, building trend points, compare models (metrics + task deltas), histograms, and provider rollups; new components render run tables, trend chart, comparison tables, task breakdowns, score cards, and cost/latency summaries.
> 
> **Result loading is upgraded to emit the richer payload and is more robust.** `results.ts` now parses provider/config metadata, aggregate statistics (including confidence intervals/effect sizes), and per-task score/tokens, sorts runs by timestamp via new `sort-utils.ts`, and `tsconfig.json` enables DOM libs + Node types; tests are expanded to cover the new helpers and ensure CLI bench-ui spawning uses Windows-safe `shell` behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b9dd2d57752c584173ac12a608b5a575e45ffe4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->