### PR TITLE
feat(bench): add static HTML export for benchmark reports

### DIFF
--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -315,6 +315,9 @@ function renderHtmlKeyValueRows(entries: Array<[string, string | number]>): stri
 }
 
 function renderBenchmarkResultHtml(result: BenchmarkResult): string {
+  const seeds = Array.isArray(result.meta.seeds)
+    ? result.meta.seeds.join(", ")
+    : "Unknown";
   const aggregateRows = Object.keys(result.results.aggregates)
     .sort()
     .map((metric) => {
@@ -428,7 +431,7 @@ ${renderHtmlKeyValueRows([
   ["Remnic Version", result.meta.remnicVersion],
   ["Benchmark Version", result.meta.version],
   ["Git SHA", result.meta.gitSha],
-  ["Seeds", result.meta.seeds.join(", ")],
+  ["Seeds", seeds],
 ])}
           </tbody>
         </table>

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -32,7 +32,7 @@ export interface StoredBenchmarkBaselineSummary {
   mode: BenchmarkMode;
 }
 
-export type BenchmarkExportFormat = "json" | "csv";
+export type BenchmarkExportFormat = "json" | "csv" | "html";
 
 const BASELINE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
@@ -301,12 +301,202 @@ function csvEscape(value: string | number): string {
   return text;
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll(`"`, "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+function renderHtmlKeyValueRows(entries: Array<[string, string | number]>): string {
+  return entries.map(([label, value]) => `        <tr><th>${escapeHtml(label)}</th><td>${escapeHtml(String(value))}</td></tr>`).join("\n");
+}
+
+function renderBenchmarkResultHtml(result: BenchmarkResult): string {
+  const aggregateRows = Object.keys(result.results.aggregates)
+    .sort()
+    .map((metric) => {
+      const aggregate = result.results.aggregates[metric]!;
+      return `          <tr><th>${escapeHtml(metric)}</th><td>${escapeHtml(String(aggregate.mean))}</td><td>${escapeHtml(String(aggregate.median))}</td><td>${escapeHtml(String(aggregate.stdDev))}</td><td>${escapeHtml(String(aggregate.min))}</td><td>${escapeHtml(String(aggregate.max))}</td></tr>`;
+    })
+    .join("\n");
+
+  const statisticsBlock = result.results.statistics
+    ? `\n    <section>\n      <h2>Statistics</h2>\n      <pre>${escapeHtml(JSON.stringify(result.results.statistics, null, 2))}</pre>\n    </section>`
+    : "";
+
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Remnic Bench Report: ${escapeHtml(result.meta.benchmark)}</title>
+    <style>
+      :root {
+        color-scheme: light;
+        font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      }
+      body {
+        margin: 0;
+        background: #f5f7fb;
+        color: #18202a;
+      }
+      main {
+        max-width: 1080px;
+        margin: 0 auto;
+        padding: 32px 20px 48px;
+      }
+      header {
+        margin-bottom: 24px;
+      }
+      h1, h2 {
+        margin: 0 0 12px;
+      }
+      p {
+        margin: 0;
+        line-height: 1.5;
+      }
+      section {
+        background: #ffffff;
+        border: 1px solid #d8dee8;
+        border-radius: 12px;
+        padding: 20px;
+        margin-top: 16px;
+        box-shadow: 0 8px 24px rgba(15, 23, 42, 0.05);
+      }
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+      th, td {
+        text-align: left;
+        padding: 10px 12px;
+        border-top: 1px solid #e5eaf1;
+        vertical-align: top;
+      }
+      thead th {
+        border-top: none;
+        font-size: 0.85rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: #526173;
+      }
+      tbody th {
+        width: 30%;
+      }
+      pre {
+        margin: 0;
+        overflow-x: auto;
+        white-space: pre-wrap;
+        word-break: break-word;
+        background: #f5f7fb;
+        border-radius: 10px;
+        padding: 14px;
+        border: 1px solid #e5eaf1;
+      }
+      .muted {
+        color: #526173;
+        margin-top: 6px;
+      }
+      .empty {
+        color: #526173;
+        font-style: italic;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header>
+        <h1>Remnic Bench Report</h1>
+        <p>${escapeHtml(result.meta.benchmark)} · ${escapeHtml(result.meta.id)}</p>
+        <p class="muted">Generated from a stored benchmark result export.</p>
+      </header>
+      <section>
+        <h2>Run Summary</h2>
+        <table>
+          <tbody>
+${renderHtmlKeyValueRows([
+  ["Result ID", result.meta.id],
+  ["Benchmark", result.meta.benchmark],
+  ["Benchmark Tier", result.meta.benchmarkTier],
+  ["Timestamp", result.meta.timestamp],
+  ["Mode", result.meta.mode],
+  ["Run Count", result.meta.runCount],
+  ["Task Count", result.results.tasks.length],
+  ["Remnic Version", result.meta.remnicVersion],
+  ["Benchmark Version", result.meta.version],
+  ["Git SHA", result.meta.gitSha],
+  ["Seeds", result.meta.seeds.join(", ")],
+])}
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Aggregate Metrics</h2>
+${aggregateRows.length > 0
+    ? `        <table>\n          <thead>\n            <tr><th>Metric</th><th>Mean</th><th>Median</th><th>Std Dev</th><th>Min</th><th>Max</th></tr>\n          </thead>\n          <tbody>\n${aggregateRows}\n          </tbody>\n        </table>`
+    : '        <p class="empty">No aggregate metrics recorded for this run.</p>'}
+      </section>
+      <section>
+        <h2>Cost</h2>
+        <table>
+          <tbody>
+${renderHtmlKeyValueRows([
+  ["Total Tokens", result.cost.totalTokens],
+  ["Input Tokens", result.cost.inputTokens],
+  ["Output Tokens", result.cost.outputTokens],
+  ["Estimated Cost (USD)", result.cost.estimatedCostUsd],
+  ["Total Latency (ms)", result.cost.totalLatencyMs],
+  ["Mean Query Latency (ms)", result.cost.meanQueryLatencyMs],
+])}
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Environment</h2>
+        <table>
+          <tbody>
+${renderHtmlKeyValueRows([
+  ["OS", result.environment.os],
+  ["Node Version", result.environment.nodeVersion],
+  ["Hardware", result.environment.hardware ?? "Unknown"],
+])}
+          </tbody>
+        </table>
+      </section>
+      <section>
+        <h2>Configuration</h2>
+        <table>
+          <tbody>
+${renderHtmlKeyValueRows([
+  ["Adapter Mode", result.config.adapterMode],
+])}
+          </tbody>
+        </table>
+        <pre>${escapeHtml(JSON.stringify({
+    systemProvider: result.config.systemProvider,
+    judgeProvider: result.config.judgeProvider,
+    remnicConfig: result.config.remnicConfig,
+  }, null, 2))}</pre>
+      </section>${statisticsBlock}
+    </main>
+  </body>
+</html>
+`;
+}
+
 export function renderBenchmarkResultExport(
   result: BenchmarkResult,
   format: BenchmarkExportFormat,
 ): string {
   if (format === "json") {
     return `${JSON.stringify(result, null, 2)}\n`;
+  }
+
+  if (format === "html") {
+    return renderBenchmarkResultHtml(result);
   }
 
   const rows = [

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -52,6 +52,7 @@ remnic bench list
 remnic bench run --quick longmemeval
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
 remnic bench compare base-run candidate-run
+remnic bench export candidate-run --format html --output ./report.html
 remnic benchmark run --quick longmemeval
 ```
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -14,7 +14,7 @@ export type BenchAction =
   | "report";
 
 export type BenchBaselineAction = "save" | "list";
-export type BenchExportFormat = "json" | "csv";
+export type BenchExportFormat = "json" | "csv" | "html";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -127,8 +127,8 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
 
   let format: BenchExportFormat | undefined;
   if (formatRaw !== undefined) {
-    if (formatRaw !== "json" && formatRaw !== "csv") {
-      throw new Error('ERROR: --format must be "json" or "csv".');
+    if (formatRaw !== "json" && formatRaw !== "csv" && formatRaw !== "html") {
+      throw new Error('ERROR: --format must be "json", "csv", or "html".');
     }
     format = formatRaw;
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -301,8 +301,8 @@ Commands:
   baseline save <name> [run]
                            Save a stored run as a named baseline
   baseline list            List saved baselines
-  export <run> --format <json|csv>
-                           Export one stored run as JSON or aggregate-metrics CSV
+  export <run> --format <json|csv|html>
+                           Export one stored run as JSON, aggregate-metrics CSV, or static HTML
   ui                       Launch the local benchmark overview UI
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
@@ -316,7 +316,7 @@ Options:
   --baselines-dir <path>   Override the named baseline directory
   --threshold <value>      Regression threshold for compare (default: 0.05)
   --detail                 Include per-task details for bench results
-  --format <json|csv>      Output format for bench export
+  --format <json|csv|html> Output format for bench export
   --output <path>          Write bench export output to a file
   --json                   Output JSON for \`list\`
 
@@ -330,6 +330,7 @@ Examples:
   remnic bench baseline save main candidate-run
   remnic bench baseline list
   remnic bench export candidate-run --format csv --output ./candidate.csv
+  remnic bench export candidate-run --format html --output ./report.html
   remnic bench run --custom ./my-bench.yaml
   remnic bench ui --results-dir ~/.remnic/bench/results
   remnic benchmark run --quick longmemeval`;
@@ -782,12 +783,12 @@ async function manageBenchBaselines(parsed: ParsedBenchArgs): Promise<void> {
 async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> {
   if (parsed.benchmarks.length !== 1) {
     console.error(
-      "ERROR: export requires exactly one stored result reference. Usage: remnic bench export <run> --format <json|csv> [--output <path>] [--results-dir <path>]",
+      "ERROR: export requires exactly one stored result reference. Usage: remnic bench export <run> --format <json|csv|html> [--output <path>] [--results-dir <path>]",
     );
     process.exit(1);
   }
   if (!parsed.format) {
-    console.error('ERROR: export requires --format json or --format csv.');
+    console.error('ERROR: export requires --format json, csv, or html.');
     process.exit(1);
   }
 

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -270,3 +270,14 @@ test("renderBenchmarkResultExport returns JSON and aggregate-metric CSV represen
   assert.match(html, /Aggregate Metrics/);
   assert.match(html, /Task Count/);
 });
+
+test("renderBenchmarkResultExport handles older results without seed metadata", () => {
+  const result = buildResult("older-run", "2026-04-18T08:00:00.000Z");
+  delete (result.meta as { seeds?: number[] }).seeds;
+
+  const html = renderBenchmarkResultExport(result, "html");
+
+  assert.match(html, /Older-run|older-run/i);
+  assert.match(html, /Seeds/);
+  assert.match(html, /Unknown/);
+});

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -258,8 +258,15 @@ test("renderBenchmarkResultExport returns JSON and aggregate-metric CSV represen
 
   const json = renderBenchmarkResultExport(result, "json");
   const csv = renderBenchmarkResultExport(result, "csv");
+  const html = renderBenchmarkResultExport(result, "html");
 
   assert.match(json, /"candidate-run"/);
   assert.match(csv, /^result_id,benchmark,timestamp,mode,metric,mean,median,std_dev,min,max$/m);
   assert.match(csv, /candidate-run,longmemeval,2026-04-18T07:00:00.000Z,full,answerAccuracy,0.8,0.8,0.1,0.6,0.9/);
+  assert.match(html, /<!doctype html>/i);
+  assert.match(html, /<title>Remnic Bench Report: longmemeval<\/title>/);
+  assert.match(html, /candidate-run/);
+  assert.match(html, /answerAccuracy/);
+  assert.match(html, /Aggregate Metrics/);
+  assert.match(html, /Task Count/);
 });

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -149,15 +149,17 @@ test("bench results, baseline, and export route through the stored package resul
   assert.match(source, /if \(parsed\.action === "baseline"\) \{\s*await manageBenchBaselines\(parsed\);/s);
   assert.match(source, /if \(parsed\.action === "export"\) \{\s*await exportBenchPackageResult\(parsed\);/s);
   assert.match(source, /baseline save <name> \[run\]/);
-  assert.match(source, /bench export <run> --format <json\|csv>/);
+  assert.match(source, /bench export <run> --format <json\|csv\|html>/);
   assert.match(source, /const baselineDir = parsed\.baselinesDir \?\? resolveBenchBaselineDir\(\)/);
   assert.match(source, /const rendered = renderBenchmarkResultExport\(result, parsed\.format\);/);
+  assert.match(source, /ERROR: export requires --format json, csv, or html\./);
   assert.match(source, /printBenchPackageSummary\(result, summary\.path, "Stored result"\);/);
   assert.match(parserSource, /export type BenchBaselineAction = "save" \| "list";/);
-  assert.match(parserSource, /export type BenchExportFormat = "json" \| "csv";/);
+  assert.match(parserSource, /export type BenchExportFormat = "json" \| "csv" \| "html";/);
   assert.match(parserSource, /const baselinesDir = readBenchOptionValue\(args, "--baselines-dir"\);/);
   assert.match(parserSource, /const formatRaw = readBenchOptionValue\(args, "--format"\);/);
   assert.match(parserSource, /const output = readBenchOptionValue\(args, "--output"\);/);
+  assert.match(parserSource, /ERROR: --format must be "json", "csv", or "html"\./);
   assert.match(parserSource, /detail: args\.includes\("--detail"\),/);
   assert.match(parserSource, /baselinesDir: baselinesDir \? path\.resolve\(expandTilde\(baselinesDir\)\) : undefined/);
   assert.match(parserSource, /output: output \? path\.resolve\(expandTilde\(output\)\) : undefined/);
@@ -236,13 +238,13 @@ test("parseBenchArgs supports results, baseline, and export surfaces", async () 
     "export",
     "candidate-run",
     "--format",
-    "csv",
+    "html",
     "--output",
-    "./candidate.csv",
+    "./report.html",
   ]);
   assert.equal(exportArgs.action, "export");
-  assert.equal(exportArgs.format, "csv");
-  assert.match(exportArgs.output ?? "", /candidate\.csv$/);
+  assert.equal(exportArgs.format, "html");
+  assert.match(exportArgs.output ?? "", /report\.html$/);
 });
 
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {


### PR DESCRIPTION
## Summary
- add static HTML output for 
remnic — Remnic memory CLI

Usage:
  remnic init                  Create config file
  remnic migrate [--rollback] [--json]  Run or undo first-run Engram migration
  remnic status [--json]       Show server status
  remnic query <text> [--json] [--explain] Query memories (use --explain for tier breakdown)

  remnic doctor                Run diagnostics
  remnic config                Show current config
  remnic openclaw install      Configure OpenClaw to use Remnic memory (sets slot + entry)
    --yes / -y / --force       Skip prompts
    --dry-run                  Preview changes without writing
    --memory-dir <path>        Custom memory directory
    --config <path>            Custom OpenClaw config path
  remnic daemon <start|stop|restart|install|uninstall|status>  Manage background server
  remnic token <generate|list|revoke> [connector-id]  Manage auth tokens
  remnic tree <generate|watch|validate>  Generate context tree
  remnic onboard [dir] [--json]     Onboard project directory
  remnic curate <path> [--json]  Curate files into memory
  remnic review <list|approve|dismiss|flag> [id]  Review inbox
  remnic sync <run|watch> [--source <dir>] Diff-aware sync
  remnic dedup [--json]             Find duplicate memories
  remnic connectors <list|install|remove|doctor> [id]  Manage connectors
  remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
    create accepts --parent <id> to set parent-child relationship
  remnic benchmark <run|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
  remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
    Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
    Focus: person:<name>, project:<name>, topic:<name>.

Options:
  --json    Output in JSON format
  --help    Show this help
- extend the bench export CLI surface, help text, and docs to accept 
- cover the renderer and parser changes with focused export tests

Part of #445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `html` export path alongside existing JSON/CSV exports and updates CLI validation/help/docs accordingly, without changing benchmark execution or storage logic.
> 
> **Overview**
> Adds a new `html` option to benchmark result exports, rendering a self-contained static report (run summary, aggregate metrics, cost/env/config, optional statistics) with basic HTML escaping.
> 
> Extends the `remnic bench export` CLI surface (arg parsing, help text, and README examples) to accept `--format html`, and updates tests to cover the new format and backwards-compat behavior when older results lack `meta.seeds`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80b6300b10e271c728bb6f332f4d42714b377b2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->