### PR TITLE
feat(bench): add remnic.ai benchmark feed publishing

### DIFF
--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -110,7 +110,9 @@ export {
 export { cohensD, interpretEffectSize } from "./stats/effect-size.js";
 export { compareResults } from "./stats/comparison.js";
 export {
+  buildBenchmarkPublishFeed,
   defaultBenchmarkBaselineDir,
+  defaultBenchmarkPublishPath,
   loadBenchmarkResult,
   loadBenchmarkBaseline,
   listBenchmarkBaselines,
@@ -118,6 +120,7 @@ export {
   renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
   saveBenchmarkBaseline,
+  writeBenchmarkPublishFeed,
 } from "./results-store.js";
 export {
   loadCustomBenchmarkFile,

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -33,12 +33,45 @@ export interface StoredBenchmarkBaselineSummary {
 }
 
 export type BenchmarkExportFormat = "json" | "csv" | "html";
+export type BenchmarkPublishTarget = "remnic-ai";
+
+export interface PublishedBenchmarkFeedEntry {
+  benchmark: string;
+  benchmarkTier: BenchmarkResult["meta"]["benchmarkTier"];
+  resultId: string;
+  timestamp: string;
+  mode: BenchmarkMode;
+  remnicVersion: string;
+  gitSha: string;
+  taskCount: number;
+  aggregateMetrics: BenchmarkResult["results"]["aggregates"];
+  cost: BenchmarkResult["cost"];
+  environment: BenchmarkResult["environment"];
+  source: {
+    path: string;
+  };
+}
+
+export interface PublishedBenchmarkFeed {
+  target: BenchmarkPublishTarget;
+  generatedAt: string;
+  sourceResultsDir: string;
+  benchmarks: PublishedBenchmarkFeedEntry[];
+}
 
 const BASELINE_NAME_PATTERN = /^[A-Za-z0-9_-]+$/;
 
 export function defaultBenchmarkBaselineDir(): string {
   const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
   return path.join(homeDir, ".remnic", "bench", "baselines");
+}
+
+export function defaultBenchmarkPublishPath(target: BenchmarkPublishTarget): string {
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  switch (target) {
+    case "remnic-ai":
+      return path.join(homeDir, ".remnic", "published", "benchmarks.json");
+  }
 }
 
 function compareResultSummaries(
@@ -291,6 +324,74 @@ export async function resolveBenchmarkResultReference(
     (summary) => path.basename(summary.path) === reference,
   );
   return basenameMatch;
+}
+
+function comparePublishedBenchmarkEntries(
+  left: PublishedBenchmarkFeedEntry,
+  right: PublishedBenchmarkFeedEntry,
+): number {
+  if (left.timestamp === right.timestamp) {
+    return left.benchmark.localeCompare(right.benchmark);
+  }
+  return right.timestamp.localeCompare(left.timestamp);
+}
+
+function toPublishedBenchmarkFeedEntry(
+  result: BenchmarkResult,
+  filePath: string,
+): PublishedBenchmarkFeedEntry {
+  return {
+    benchmark: result.meta.benchmark,
+    benchmarkTier: result.meta.benchmarkTier,
+    resultId: result.meta.id,
+    timestamp: result.meta.timestamp,
+    mode: result.meta.mode,
+    remnicVersion: result.meta.remnicVersion,
+    gitSha: result.meta.gitSha,
+    taskCount: result.results.tasks.length,
+    aggregateMetrics: result.results.aggregates,
+    cost: result.cost,
+    environment: result.environment,
+    source: {
+      path: filePath,
+    },
+  };
+}
+
+export async function buildBenchmarkPublishFeed(
+  outputDir: string,
+  target: BenchmarkPublishTarget,
+): Promise<PublishedBenchmarkFeed> {
+  const summaries = await listBenchmarkResults(outputDir);
+  const latestByBenchmark = new Map<string, PublishedBenchmarkFeedEntry>();
+
+  for (const summary of summaries) {
+    if (latestByBenchmark.has(summary.benchmark)) {
+      continue;
+    }
+
+    const result = await loadBenchmarkResult(summary.path);
+    latestByBenchmark.set(
+      summary.benchmark,
+      toPublishedBenchmarkFeedEntry(result, summary.path),
+    );
+  }
+
+  return {
+    target,
+    generatedAt: new Date().toISOString(),
+    sourceResultsDir: outputDir,
+    benchmarks: [...latestByBenchmark.values()].sort(comparePublishedBenchmarkEntries),
+  };
+}
+
+export async function writeBenchmarkPublishFeed(
+  feed: PublishedBenchmarkFeed,
+  outputPath: string,
+): Promise<string> {
+  await mkdir(path.dirname(outputPath), { recursive: true });
+  await writeFile(outputPath, `${JSON.stringify(feed, null, 2)}\n`);
+  return outputPath;
 }
 
 function csvEscape(value: string | number): string {

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -47,15 +47,11 @@ export interface PublishedBenchmarkFeedEntry {
   aggregateMetrics: BenchmarkResult["results"]["aggregates"];
   cost: BenchmarkResult["cost"];
   environment: BenchmarkResult["environment"];
-  source: {
-    path: string;
-  };
 }
 
 export interface PublishedBenchmarkFeed {
   target: BenchmarkPublishTarget;
   generatedAt: string;
-  sourceResultsDir: string;
   benchmarks: PublishedBenchmarkFeedEntry[];
 }
 
@@ -336,9 +332,18 @@ function comparePublishedBenchmarkEntries(
   return right.timestamp.localeCompare(left.timestamp);
 }
 
+function isPublishableResultForTarget(
+  result: BenchmarkResult,
+  target: BenchmarkPublishTarget,
+): boolean {
+  switch (target) {
+    case "remnic-ai":
+      return result.meta.benchmarkTier === "published" && result.meta.mode === "full";
+  }
+}
+
 function toPublishedBenchmarkFeedEntry(
   result: BenchmarkResult,
-  filePath: string,
 ): PublishedBenchmarkFeedEntry {
   return {
     benchmark: result.meta.benchmark,
@@ -352,9 +357,6 @@ function toPublishedBenchmarkFeedEntry(
     aggregateMetrics: result.results.aggregates,
     cost: result.cost,
     environment: result.environment,
-    source: {
-      path: filePath,
-    },
   };
 }
 
@@ -371,16 +373,18 @@ export async function buildBenchmarkPublishFeed(
     }
 
     const result = await loadBenchmarkResult(summary.path);
+    if (!isPublishableResultForTarget(result, target)) {
+      continue;
+    }
     latestByBenchmark.set(
       summary.benchmark,
-      toPublishedBenchmarkFeedEntry(result, summary.path),
+      toPublishedBenchmarkFeedEntry(result),
     );
   }
 
   return {
     target,
     generatedAt: new Date().toISOString(),
-    sourceResultsDir: outputDir,
     benchmarks: [...latestByBenchmark.values()].sort(comparePublishedBenchmarkEntries),
   };
 }
@@ -430,6 +434,15 @@ function renderBenchmarkResultHtml(result: BenchmarkResult): string {
   const statisticsBlock = result.results.statistics
     ? `\n    <section>\n      <h2>Statistics</h2>\n      <pre>${escapeHtml(JSON.stringify(result.results.statistics, null, 2))}</pre>\n    </section>`
     : "";
+  const remnicConfigKeyCount = Object.keys(result.config.remnicConfig ?? {}).length;
+  const renderedConfig = {
+    systemProvider: result.config.systemProvider,
+    judgeProvider: result.config.judgeProvider,
+    remnicConfig:
+      remnicConfigKeyCount === 0
+        ? "[empty]"
+        : `[redacted ${remnicConfigKeyCount} key${remnicConfigKeyCount === 1 ? "" : "s"}]`,
+  };
 
   return `<!doctype html>
 <html lang="en">
@@ -579,11 +592,7 @@ ${renderHtmlKeyValueRows([
 ])}
           </tbody>
         </table>
-        <pre>${escapeHtml(JSON.stringify({
-    systemProvider: result.config.systemProvider,
-    judgeProvider: result.config.judgeProvider,
-    remnicConfig: result.config.remnicConfig,
-  }, null, 2))}</pre>
+        <pre>${escapeHtml(JSON.stringify(renderedConfig, null, 2))}</pre>
       </section>${statisticsBlock}
     </main>
   </body>

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -40,8 +40,9 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic bench run` | Run one or more published benchmark packs |
 | `remnic bench compare` | Compare two stored benchmark results |
 | `remnic bench baseline` | Save or list named benchmark baselines |
-| `remnic bench export` | Export a stored benchmark result as JSON or CSV |
+| `remnic bench export` | Export a stored benchmark result as JSON, CSV, or HTML |
 | `remnic bench providers discover` | Auto-detect local provider backends |
+| `remnic bench publish --target remnic-ai` | Build the Remnic.ai benchmark feed from stored results |
 
 Run `remnic --help` for the full command list.
 
@@ -60,6 +61,7 @@ remnic bench baseline list
 remnic bench export candidate-run --format csv --output ./candidate.csv
 remnic bench export candidate-run --format html --output ./report.html
 remnic bench providers discover
+remnic bench publish --target remnic-ai
 remnic benchmark run --quick longmemeval
 ```
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -11,12 +11,14 @@ export type BenchAction =
   | "baseline"
   | "export"
   | "providers"
+  | "publish"
   | "check"
   | "report";
 
 export type BenchBaselineAction = "save" | "list";
 export type BenchExportFormat = "json" | "csv" | "html";
 export type BenchProviderAction = "discover";
+export type BenchPublishTarget = "remnic-ai";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -34,6 +36,7 @@ export interface ParsedBenchArgs {
   format?: BenchExportFormat;
   output?: string;
   custom?: string;
+  target?: BenchPublishTarget;
 }
 
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
@@ -61,7 +64,8 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--threshold" ||
       arg === "--custom" ||
       arg === "--format" ||
-      arg === "--output"
+      arg === "--output" ||
+      arg === "--target"
     ) {
       index += 1;
       continue;
@@ -87,6 +91,7 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "baseline" ||
     first === "export" ||
     first === "providers" ||
+    first === "publish" ||
     first === "check" ||
     first === "report"
       ? first
@@ -130,6 +135,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const customRaw = readBenchOptionValue(args, "--custom");
   const formatRaw = readBenchOptionValue(args, "--format");
   const output = readBenchOptionValue(args, "--output");
+  const targetRaw = readBenchOptionValue(args, "--target");
   let threshold: number | undefined;
   if (thresholdRaw !== undefined) {
     threshold = Number(thresholdRaw);
@@ -144,6 +150,14 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       throw new Error('ERROR: --format must be "json", "csv", or "html".');
     }
     format = formatRaw;
+  }
+
+  let target: BenchPublishTarget | undefined;
+  if (targetRaw !== undefined) {
+    if (targetRaw !== "remnic-ai") {
+      throw new Error('ERROR: --target must be "remnic-ai".');
+    }
+    target = targetRaw;
   }
 
   return {
@@ -162,5 +176,6 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     providerAction,
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,
+    target,
   };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -876,6 +876,12 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
 
   const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
   const feed = await buildBenchmarkPublishFeed(resultsDir, parsed.target);
+  if (feed.benchmarks.length === 0) {
+    console.error(
+      `ERROR: no publishable benchmark results found in ${resultsDir}. remnic-ai requires stored full runs for published benchmarks.`,
+    );
+    process.exit(1);
+  }
   const outputPath = parsed.output ?? defaultBenchmarkPublishPath(parsed.target);
   const writtenPath = await writeBenchmarkPublishFeed(feed, outputPath);
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -20,6 +20,7 @@
  *   token revoke      Revoke auth token for a connector
  *   bench list        List published benchmark packs
  *   bench run         Run published benchmark packs
+ *   bench publish     Generate the Remnic.ai benchmark feed
  *   bench ui          Launch the local benchmark overview UI
  *   tree              Generate context tree
  *   onboard [dir]     Onboard project directory
@@ -120,9 +121,11 @@ import type {
 } from "@remnic/core";
 import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
+  buildBenchmarkPublishFeed,
   compareResults,
   defaultBenchmarkBaselineDir,
   discoverAllProviders,
+  defaultBenchmarkPublishPath,
   listBenchmarkBaselines,
   listBenchmarkResults,
   loadBenchmarkBaseline,
@@ -135,6 +138,7 @@ import {
   renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
   saveBenchmarkBaseline,
+  writeBenchmarkPublishFeed,
   type BenchConfig,
   type BenchmarkDefinition,
 } from "@remnic/bench";
@@ -291,8 +295,8 @@ type PackageBenchModule = {
 };
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|compare|results|baseline|export|ui|providers> [options] [benchmark...]
-       remnic benchmark <list|run|compare|results|baseline|export|ui|providers|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
+       remnic benchmark <list|run|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
@@ -304,6 +308,8 @@ Commands:
   baseline list            List saved baselines
   export <run> --format <json|csv|html>
                            Export one stored run as JSON, aggregate-metrics CSV, or static HTML
+  publish --target remnic-ai
+                           Generate the Remnic.ai benchmark feed from stored runs
   ui                       Launch the local benchmark overview UI
   providers discover       Auto-detect available local provider backends
   check                    Legacy latency regression gate (compatibility)
@@ -320,6 +326,7 @@ Options:
   --detail                 Include per-task details for bench results
   --format <json|csv|html> Output format for bench export
   --output <path>          Write bench export output to a file
+  --target <name>          Publish target for bench publish (remnic-ai)
   --json                   Output JSON for \`list\`
 
 Examples:
@@ -333,6 +340,7 @@ Examples:
   remnic bench baseline list
   remnic bench export candidate-run --format csv --output ./candidate.csv
   remnic bench export candidate-run --format html --output ./report.html
+  remnic bench publish --target remnic-ai
   remnic bench providers discover
   remnic bench run --custom ./my-bench.yaml
   remnic benchmark run --quick longmemeval`;
@@ -851,6 +859,39 @@ async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
       );
     }
   }
+}
+
+async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
+  if (parsed.benchmarks.length > 0) {
+    console.error(
+      "ERROR: publish does not accept positional result references. Usage: remnic bench publish --target remnic-ai [--results-dir <path>] [--output <path>] [--json]",
+    );
+    process.exit(1);
+  }
+
+  if (parsed.target !== "remnic-ai") {
+    console.error('ERROR: publish requires --target remnic-ai.');
+    process.exit(1);
+  }
+
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const feed = await buildBenchmarkPublishFeed(resultsDir, parsed.target);
+  const outputPath = parsed.output ?? defaultBenchmarkPublishPath(parsed.target);
+  const writtenPath = await writeBenchmarkPublishFeed(feed, outputPath);
+
+  if (parsed.json) {
+    console.log(JSON.stringify({
+      target: parsed.target,
+      outputPath: writtenPath,
+      benchmarkCount: feed.benchmarks.length,
+      feed,
+    }, null, 2));
+    return;
+  }
+
+  console.log(
+    `Published ${feed.benchmarks.length} benchmark entries for ${parsed.target} to ${writtenPath}`,
+  );
 }
 
 async function runBenchViaPackage(
@@ -2775,6 +2816,11 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "publish") {
+    await publishBenchPackageResults(parsed);
+    return;
+  }
+
   if (parsed.action === "ui") {
     await launchBenchUi(parsed.resultsDir ?? resolveBenchOutputDir());
     return;
@@ -4231,9 +4277,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare|results|baseline|export|ui|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv>] [--output <path>] [--json]
+  remnic bench <list|run|compare|results|baseline|export|publish|ui|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv|html>] [--output <path>] [--target remnic-ai] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|compare|results|baseline|export|ui|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|compare|results|baseline|export|publish|ui|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/tests/bench-package-surface.test.ts
+++ b/tests/bench-package-surface.test.ts
@@ -58,8 +58,11 @@ test("@remnic/bench index exports the phase-2 stats helpers", async () => {
   assert.match(source, /loadBenchmarkResult/);
   assert.match(source, /listBenchmarkResults/);
   assert.match(source, /renderBenchmarkResultExport/);
+  assert.match(source, /buildBenchmarkPublishFeed/);
+  assert.match(source, /defaultBenchmarkPublishPath/);
   assert.match(source, /resolveBenchmarkResultReference/);
   assert.match(source, /saveBenchmarkBaseline/);
+  assert.match(source, /writeBenchmarkPublishFeed/);
   assert.match(source, /buildBenchmarkRunSeeds/);
   assert.match(source, /orchestrateBenchmarkRuns/);
   assert.match(source, /resolveBenchmarkRunCount/);

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import {
+  buildBenchmarkPublishFeed,
   defaultBenchmarkBaselineDir,
+  defaultBenchmarkPublishPath,
   listBenchmarkBaselines,
   listBenchmarkResults,
   loadBenchmarkBaseline,
@@ -12,6 +14,7 @@ import {
   renderBenchmarkResultExport,
   resolveBenchmarkResultReference,
   saveBenchmarkBaseline,
+  writeBenchmarkPublishFeed,
 } from "../packages/bench/src/results-store.ts";
 import type { BenchmarkResult } from "../packages/bench/src/types.ts";
 
@@ -280,4 +283,82 @@ test("renderBenchmarkResultExport handles older results without seed metadata", 
   assert.match(html, /Older-run|older-run/i);
   assert.match(html, /Seeds/);
   assert.match(html, /Unknown/);
+});
+
+test("buildBenchmarkPublishFeed keeps only the latest stored result per benchmark", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-publish-"));
+  const olderLongMemEval = buildResult("run-old", "2026-04-18T07:00:00.000Z");
+  olderLongMemEval.results.aggregates = {
+    answerAccuracy: { mean: 0.5, median: 0.5, stdDev: 0, min: 0.5, max: 0.5 },
+  };
+
+  const newerLongMemEval = buildResult("run-new", "2026-04-18T08:00:00.000Z");
+  newerLongMemEval.results.aggregates = {
+    answerAccuracy: { mean: 0.8, median: 0.8, stdDev: 0, min: 0.8, max: 0.8 },
+  };
+
+  const locomo = buildResult("run-locomo", "2026-04-18T06:00:00.000Z", "locomo");
+  locomo.results.tasks = [{ taskId: "1", question: "q", expected: "e", actual: "a", scores: { exactMatch: 1 }, latencyMs: 10, tokens: { input: 1, output: 1 } }];
+
+  await writeFile(path.join(root, "old.json"), `${JSON.stringify(olderLongMemEval)}\n`);
+  await writeFile(path.join(root, "new.json"), `${JSON.stringify(newerLongMemEval)}\n`);
+  await writeFile(path.join(root, "locomo.json"), `${JSON.stringify(locomo)}\n`);
+
+  const feed = await buildBenchmarkPublishFeed(root, "remnic-ai");
+
+  assert.equal(feed.target, "remnic-ai");
+  assert.equal(feed.sourceResultsDir, root);
+  assert.deepEqual(
+    feed.benchmarks.map((entry) => [entry.benchmark, entry.resultId]),
+    [["longmemeval", "run-new"], ["locomo", "run-locomo"]],
+  );
+  assert.equal(feed.benchmarks[0]?.aggregateMetrics.answerAccuracy?.mean, 0.8);
+  assert.equal(feed.benchmarks[1]?.taskCount, 1);
+});
+
+test("defaultBenchmarkPublishPath resolves under the Remnic published directory", () => {
+  const originalHome = process.env.HOME;
+  const originalUserProfile = process.env.USERPROFILE;
+  const customHomeDir = path.join(path.sep, "tmp", "remnic-publish-home");
+
+  process.env.HOME = customHomeDir;
+  delete process.env.USERPROFILE;
+
+  try {
+    const publishPath = defaultBenchmarkPublishPath("remnic-ai");
+    assert.equal(
+      publishPath,
+      path.join(customHomeDir, ".remnic", "published", "benchmarks.json"),
+    );
+  } finally {
+    if (originalHome === undefined) {
+      delete process.env.HOME;
+    } else {
+      process.env.HOME = originalHome;
+    }
+
+    if (originalUserProfile === undefined) {
+      delete process.env.USERPROFILE;
+    } else {
+      process.env.USERPROFILE = originalUserProfile;
+    }
+  }
+});
+
+test("writeBenchmarkPublishFeed persists the generated feed as JSON", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-feed-write-"));
+  const feed = {
+    target: "remnic-ai" as const,
+    generatedAt: "2026-04-18T09:00:00.000Z",
+    sourceResultsDir: "/tmp/results",
+    benchmarks: [],
+  };
+
+  const outputPath = path.join(root, "published", "benchmarks.json");
+  const writtenPath = await writeBenchmarkPublishFeed(feed, outputPath);
+  const written = JSON.parse(await readFile(writtenPath, "utf8")) as typeof feed;
+
+  assert.equal(writtenPath, outputPath);
+  assert.equal(written.target, "remnic-ai");
+  assert.deepEqual(written.benchmarks, []);
 });

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -277,43 +277,58 @@ test("renderBenchmarkResultExport returns JSON and aggregate-metric CSV represen
 test("renderBenchmarkResultExport handles older results without seed metadata", () => {
   const result = buildResult("older-run", "2026-04-18T08:00:00.000Z");
   delete (result.meta as { seeds?: number[] }).seeds;
+  result.config.remnicConfig = {
+    authToken: "secret-token",
+    endpoint: "https://internal.example.com",
+  };
 
   const html = renderBenchmarkResultExport(result, "html");
 
   assert.match(html, /Older-run|older-run/i);
   assert.match(html, /Seeds/);
   assert.match(html, /Unknown/);
+  assert.match(html, /\[redacted 2 keys\]/);
+  assert.doesNotMatch(html, /secret-token/);
+  assert.doesNotMatch(html, /internal\.example\.com/);
 });
 
-test("buildBenchmarkPublishFeed keeps only the latest stored result per benchmark", async () => {
+test("buildBenchmarkPublishFeed keeps only the latest full published result per benchmark", async () => {
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-publish-"));
   const olderLongMemEval = buildResult("run-old", "2026-04-18T07:00:00.000Z");
   olderLongMemEval.results.aggregates = {
     answerAccuracy: { mean: 0.5, median: 0.5, stdDev: 0, min: 0.5, max: 0.5 },
   };
 
-  const newerLongMemEval = buildResult("run-new", "2026-04-18T08:00:00.000Z");
-  newerLongMemEval.results.aggregates = {
+  const newerPublishedQuick = buildResult("run-quick", "2026-04-18T09:00:00.000Z");
+  newerPublishedQuick.meta.mode = "quick";
+  newerPublishedQuick.results.aggregates = {
     answerAccuracy: { mean: 0.8, median: 0.8, stdDev: 0, min: 0.8, max: 0.8 },
+  };
+
+  const newerRemnicFull = buildResult("run-remnic", "2026-04-18T10:00:00.000Z");
+  newerRemnicFull.meta.benchmarkTier = "remnic";
+  newerRemnicFull.results.aggregates = {
+    answerAccuracy: { mean: 0.9, median: 0.9, stdDev: 0, min: 0.9, max: 0.9 },
   };
 
   const locomo = buildResult("run-locomo", "2026-04-18T06:00:00.000Z", "locomo");
   locomo.results.tasks = [{ taskId: "1", question: "q", expected: "e", actual: "a", scores: { exactMatch: 1 }, latencyMs: 10, tokens: { input: 1, output: 1 } }];
 
   await writeFile(path.join(root, "old.json"), `${JSON.stringify(olderLongMemEval)}\n`);
-  await writeFile(path.join(root, "new.json"), `${JSON.stringify(newerLongMemEval)}\n`);
+  await writeFile(path.join(root, "new-quick.json"), `${JSON.stringify(newerPublishedQuick)}\n`);
+  await writeFile(path.join(root, "new-remnic.json"), `${JSON.stringify(newerRemnicFull)}\n`);
   await writeFile(path.join(root, "locomo.json"), `${JSON.stringify(locomo)}\n`);
 
   const feed = await buildBenchmarkPublishFeed(root, "remnic-ai");
 
   assert.equal(feed.target, "remnic-ai");
-  assert.equal(feed.sourceResultsDir, root);
   assert.deepEqual(
     feed.benchmarks.map((entry) => [entry.benchmark, entry.resultId]),
-    [["longmemeval", "run-new"], ["locomo", "run-locomo"]],
+    [["longmemeval", "run-old"], ["locomo", "run-locomo"]],
   );
-  assert.equal(feed.benchmarks[0]?.aggregateMetrics.answerAccuracy?.mean, 0.8);
+  assert.equal(feed.benchmarks[0]?.aggregateMetrics.answerAccuracy?.mean, 0.5);
   assert.equal(feed.benchmarks[1]?.taskCount, 1);
+  assert.equal("source" in (feed.benchmarks[0] ?? {}), false);
 });
 
 test("defaultBenchmarkPublishPath resolves under the Remnic published directory", () => {
@@ -350,7 +365,6 @@ test("writeBenchmarkPublishFeed persists the generated feed as JSON", async () =
   const feed = {
     target: "remnic-ai" as const,
     generatedAt: "2026-04-18T09:00:00.000Z",
-    sourceResultsDir: "/tmp/results",
     benchmarks: [],
   };
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -12,7 +12,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -52,6 +52,7 @@ test("CLI README documents bench list and quick-run examples", async () => {
   assert.match(readme, /remnic bench run --quick longmemeval/);
   assert.match(readme, /--dataset-dir ~\/datasets\/longmemeval/);
   assert.match(readme, /remnic bench compare base-run candidate-run/);
+  assert.match(readme, /remnic bench publish --target remnic-ai/);
   assert.match(readme, /remnic benchmark run --quick longmemeval/);
   assert.match(readme, /bundled smoke fixture/i);
   assert.match(readme, /full runs need a real benchmark dataset/i);
@@ -127,7 +128,7 @@ test("bench compare routes through stored package results with threshold and res
   assert.match(source, /parsed\.resultsDir \?\? resolveBenchOutputDir\(\)/);
   assert.match(source, /compareResults\(\s*baseline,\s*candidate,\s*parsed\.threshold \?\? 0\.05/s);
   assert.match(source, /benchmark mismatch: \$\{baseline\.meta\.benchmark\} vs \$\{candidate\.meta\.benchmark\}/);
-  assert.match(parserSource, /export type BenchAction =[\s\S]*"results"[\s\S]*"baseline"[\s\S]*"export"[\s\S]*"check"[\s\S]*"report";/);
+  assert.match(parserSource, /export type BenchAction =[\s\S]*"results"[\s\S]*"baseline"[\s\S]*"export"[\s\S]*"publish"[\s\S]*"check"[\s\S]*"report";/);
   assert.match(parserSource, /const resultsDir = readBenchOptionValue\(args, "--results-dir"\);/);
   assert.match(parserSource, /const thresholdRaw = readBenchOptionValue\(args, "--threshold"\);/);
   assert.match(parserSource, /ERROR: --threshold must be a non-negative number\./);
@@ -382,6 +383,45 @@ test("parseBenchArgs supports results, baseline, and export surfaces", async () 
   assert.equal(exportArgs.action, "export");
   assert.equal(exportArgs.format, "html");
   assert.match(exportArgs.output ?? "", /report\.html$/);
+
+  const publishArgs = parseBenchArgs([
+    "publish",
+    "--target",
+    "remnic-ai",
+    "--output",
+    "./benchmarks.json",
+  ]);
+  assert.equal(publishArgs.action, "publish");
+  assert.equal(publishArgs.target, "remnic-ai");
+  assert.deepEqual(publishArgs.benchmarks, []);
+  assert.match(publishArgs.output ?? "", /benchmarks\.json$/);
+});
+
+test("bench publish routes through the stored package feed helpers", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+
+  assert.match(source, /buildBenchmarkPublishFeed,/);
+  assert.match(source, /defaultBenchmarkPublishPath,/);
+  assert.match(source, /writeBenchmarkPublishFeed,/);
+  assert.match(source, /async function publishBenchPackageResults\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /publish requires --target remnic-ai/);
+  assert.match(source, /Published \$\{feed\.benchmarks\.length\} benchmark entries for \$\{parsed\.target\} to \$\{writtenPath\}/);
+  assert.match(source, /if \(parsed\.action === "publish"\) \{\s*await publishBenchPackageResults\(parsed\);/s);
+  assert.match(parserSource, /export type BenchPublishTarget = "remnic-ai";/);
+  assert.match(parserSource, /arg === "--target"/);
+  assert.match(parserSource, /const targetRaw = readBenchOptionValue\(args, "--target"\);/);
+  assert.match(parserSource, /ERROR: --target must be "remnic-ai"\./);
+  assert.match(parserSource, /target,\s*\n\s*\};/s);
+});
+
+test("parseBenchArgs rejects unknown bench publish targets", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  assert.throws(
+    () => parseBenchArgs(["publish", "--target", "somewhere-else"]),
+    /ERROR: --target must be "remnic-ai"\./,
+  );
 });
 
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -175,7 +175,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
   assert.match(source, /discoverAllProviders,/);
-  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
+  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /providers discover does not accept positional arguments/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -253,8 +253,10 @@ test("bench providers discover rejects unexpected trailing positional args", asy
       benchModuleEntry,
       `
 export function compareResults() {}
+export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai", generatedAt: new Date(0).toISOString(), benchmarks: [] }; }
 export function checkRegression() { return null; }
 export function defaultBenchmarkBaselineDir() { return ""; }
+export function defaultBenchmarkPublishPath() { return ""; }
 export async function discoverAllProviders() { return []; }
 export async function listBenchmarkBaselines() { return []; }
 export async function listBenchmarkResults() { return []; }
@@ -267,6 +269,7 @@ export async function loadBenchmarkResult() { return null; }
 export function renderBenchmarkResultExport() { return ""; }
 export async function resolveBenchmarkResultReference() { return null; }
 export async function saveBenchmarkBaseline() { return null; }
+export async function writeBenchmarkPublishFeed() { return ""; }
 `,
     );
   }

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -406,6 +406,9 @@ test("bench publish routes through the stored package feed helpers", async () =>
   assert.match(source, /writeBenchmarkPublishFeed,/);
   assert.match(source, /async function publishBenchPackageResults\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /publish requires --target remnic-ai/);
+  assert.match(source, /if \(feed\.benchmarks\.length === 0\) \{/);
+  assert.match(source, /no publishable benchmark results found in \$\{resultsDir\}/);
+  assert.match(source, /remnic-ai requires stored full runs for published benchmarks/);
   assert.match(source, /Published \$\{feed\.benchmarks\.length\} benchmark entries for \$\{parsed\.target\} to \$\{writtenPath\}/);
   assert.match(source, /if \(parsed\.action === "publish"\) \{\s*await publishBenchPackageResults\(parsed\);/s);
   assert.match(parserSource, /export type BenchPublishTarget = "remnic-ai";/);

--- a/tests/remnic-cli-bench-ui-surface.test.ts
+++ b/tests/remnic-cli-bench-ui-surface.test.ts
@@ -21,7 +21,7 @@ test("CLI source wires remnic bench ui to the local bench-ui package", async () 
 
   assert.match(parserSource, /\| "ui"/);
   assert.match(parserSource, /first === "ui"/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|ui\|providers>/);
+  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /ui\s+Launch the local benchmark overview UI/);
   assert.match(source, /if \(parsed\.action === "ui"\) \{\s*await launchBenchUi\(parsed\.resultsDir \?\? resolveBenchOutputDir\(\)\);\s*return;\s*\}/s);
   assert.match(source, /async function launchBenchUi\(resultsDir: string\): Promise<void>/);


### PR DESCRIPTION
## Summary
- add a Remnic.ai benchmark feed writer in `@remnic/bench`
- add `remnic bench publish --target remnic-ai` to the CLI
- cover the publish/feed surface with focused tests and a smoke-run path

Part of #445

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI command that reads stored benchmark JSON and writes a published feed file under the user home directory; incorrect filtering/paths could publish wrong data or fail in automation. Also changes HTML export to redact `remnicConfig`, reducing accidental secret leakage but altering report output.
> 
> **Overview**
> Adds **benchmark feed publishing** for Remnic.ai: `@remnic/bench` can now build a `PublishedBenchmarkFeed` by selecting the latest *full + published-tier* result per benchmark and writing it as JSON (with a default output path under `~/.remnic/published/benchmarks.json`).
> 
> Extends the CLI with `remnic bench publish --target remnic-ai` (arg parsing, usage/docs, and JSON/non-JSON output), and updates the HTML export to **redact `config.remnicConfig` contents** (showing only key count) to avoid leaking secrets. Tests are expanded to cover the new exports, publish/feed behavior, default path resolution, persistence, and redaction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f37ed3b6c20382547071012353ac2b012e0bae91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->