### PR TITLE
feat(core): add bulk-import pipeline interface and source registry

### DIFF
--- a/packages/remnic-core/src/bulk-import/cli-command.test.ts
+++ b/packages/remnic-core/src/bulk-import/cli-command.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach, afterEach } from "node:test";
+import { writeFileSync, unlinkSync, mkdtempSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Writable } from "node:stream";
+
+import { runBulkImportCliCommand } from "../cli.js";
+import {
+  registerBulkImportSource,
+  clearBulkImportSources,
+} from "./registry.js";
+import type { BulkImportSourceAdapter, BulkImportSource } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function nullStream(): Writable {
+  return new Writable({ write(_chunk, _enc, cb) { cb(); } });
+}
+
+function makeDummyAdapter(name: string): BulkImportSourceAdapter {
+  return {
+    name,
+    parse: (): BulkImportSource => ({
+      turns: [
+        {
+          role: "user",
+          content: "Hello",
+          timestamp: "2024-06-15T10:00:00.000Z",
+        },
+      ],
+      metadata: {
+        source: name,
+        exportDate: "2024-06-15T00:00:00.000Z",
+        messageCount: 1,
+        dateRange: {
+          from: "2024-01-01T00:00:00.000Z",
+          to: "2024-06-15T00:00:00.000Z",
+        },
+      },
+    }),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("runBulkImportCliCommand", () => {
+  let tmpDir: string;
+  let tmpFile: string;
+
+  beforeEach(() => {
+    clearBulkImportSources();
+    tmpDir = mkdtempSync(join(tmpdir(), "bulk-import-cli-test-"));
+    tmpFile = join(tmpDir, "input.json");
+    writeFileSync(tmpFile, '{"messages":[]}');
+    registerBulkImportSource(makeDummyAdapter("test-source"));
+  });
+
+  afterEach(() => {
+    clearBulkImportSources();
+    try {
+      unlinkSync(tmpFile);
+    } catch {
+      // ignore
+    }
+  });
+
+  it("throws when dryRun is false (persistence not wired)", async () => {
+    await assert.rejects(
+      () =>
+        runBulkImportCliCommand({
+          memoryDir: tmpDir,
+          source: "test-source",
+          file: tmpFile,
+          dryRun: false,
+          stdout: nullStream(),
+          stderr: nullStream(),
+        }),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("not yet wired"),
+          `expected 'not yet wired' in: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes("--dry-run"),
+          `expected '--dry-run' hint in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("throws when dryRun is undefined (defaults to non-dryRun)", async () => {
+    await assert.rejects(
+      () =>
+        runBulkImportCliCommand({
+          memoryDir: tmpDir,
+          source: "test-source",
+          file: tmpFile,
+          stdout: nullStream(),
+          stderr: nullStream(),
+        }),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("not yet wired"),
+          `expected 'not yet wired' in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("succeeds in dryRun mode", async () => {
+    const result = await runBulkImportCliCommand({
+      memoryDir: tmpDir,
+      source: "test-source",
+      file: tmpFile,
+      dryRun: true,
+      stdout: nullStream(),
+      stderr: nullStream(),
+    });
+    assert.equal(result.turnsProcessed, 1);
+    assert.equal(result.memoriesCreated, 0);
+  });
+});

--- a/packages/remnic-core/src/bulk-import/cli-command.test.ts
+++ b/packages/remnic-core/src/bulk-import/cli-command.test.ts
@@ -126,4 +126,58 @@ describe("runBulkImportCliCommand", () => {
     assert.equal(result.turnsProcessed, 1);
     assert.equal(result.memoriesCreated, 0);
   });
+
+  it("strict flag is independent from verbose flag", async () => {
+    let capturedOptions: { strict?: boolean } | undefined;
+    clearBulkImportSources();
+    registerBulkImportSource({
+      name: "spy-source",
+      parse: (_input: unknown, options?: { strict?: boolean }) => {
+        capturedOptions = options;
+        return {
+          turns: [
+            {
+              role: "user" as const,
+              content: "Hello",
+              timestamp: "2024-06-15T10:00:00.000Z",
+            },
+          ],
+          metadata: {
+            source: "spy-source",
+            exportDate: "2024-06-15T00:00:00.000Z",
+            messageCount: 1,
+            dateRange: {
+              from: "2024-01-01T00:00:00.000Z",
+              to: "2024-06-15T00:00:00.000Z",
+            },
+          },
+        };
+      },
+    });
+
+    // verbose=true, strict not set — strict should NOT be true
+    await runBulkImportCliCommand({
+      memoryDir: tmpDir,
+      source: "spy-source",
+      file: tmpFile,
+      dryRun: true,
+      verbose: true,
+      stdout: nullStream(),
+      stderr: nullStream(),
+    });
+    assert.equal(capturedOptions?.strict, false);
+
+    // strict=true, verbose=false — strict should be true
+    await runBulkImportCliCommand({
+      memoryDir: tmpDir,
+      source: "spy-source",
+      file: tmpFile,
+      dryRun: true,
+      verbose: false,
+      strict: true,
+      stdout: nullStream(),
+      stderr: nullStream(),
+    });
+    assert.equal(capturedOptions?.strict, true);
+  });
 });

--- a/packages/remnic-core/src/bulk-import/index.ts
+++ b/packages/remnic-core/src/bulk-import/index.ts
@@ -26,6 +26,7 @@ export {
 export {
   runBulkImportPipeline,
   formatBatchTranscript,
+  validateBatchSize,
   type ProcessBatchFn,
   type ProcessBatchResult,
 } from "./pipeline.js";

--- a/packages/remnic-core/src/bulk-import/index.ts
+++ b/packages/remnic-core/src/bulk-import/index.ts
@@ -1,0 +1,31 @@
+// ---------------------------------------------------------------------------
+// Bulk-import — public surface
+// ---------------------------------------------------------------------------
+
+export {
+  type BulkImportSource,
+  type ImportTurn,
+  type BulkImportOptions,
+  type ImportSourceRole,
+  type BulkImportResult,
+  type BulkImportError,
+  type BulkImportSourceAdapter,
+  type ImportTurnValidationIssue,
+  isImportRole,
+  parseIsoTimestamp,
+  validateImportTurn,
+} from "./types.js";
+
+export {
+  registerBulkImportSource,
+  getBulkImportSource,
+  listBulkImportSources,
+  clearBulkImportSources,
+} from "./registry.js";
+
+export {
+  runBulkImportPipeline,
+  formatBatchTranscript,
+  type ProcessBatchFn,
+  type ProcessBatchResult,
+} from "./pipeline.js";

--- a/packages/remnic-core/src/bulk-import/pipeline.test.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.test.ts
@@ -263,8 +263,25 @@ describe("validateBatchSize", () => {
     assert.equal(validateBatchSize(10), 10);
   });
 
-  it("floors fractional values", () => {
-    assert.equal(validateBatchSize(5.7), 5);
+  it("throws for fractional values", () => {
+    assert.throws(
+      () => validateBatchSize(5.7),
+      (err: Error) => {
+        assert.ok(err.message.includes("integer"));
+        return true;
+      },
+    );
+  });
+
+  it("throws for fractional value like 20.5", () => {
+    assert.throws(
+      () => validateBatchSize(20.5),
+      (err: Error) => {
+        assert.ok(err.message.includes("integer"));
+        assert.ok(err.message.includes("20.5"));
+        return true;
+      },
+    );
   });
 
   it("accepts minimum boundary (1)", () => {

--- a/packages/remnic-core/src/bulk-import/pipeline.test.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.test.ts
@@ -1,0 +1,254 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  runBulkImportPipeline,
+  formatBatchTranscript,
+  type ProcessBatchFn,
+} from "./pipeline.js";
+import type {
+  BulkImportSource,
+  ImportTurn,
+} from "./types.js";
+
+function makeTurn(
+  index: number,
+  overrides?: Partial<ImportTurn>,
+): ImportTurn {
+  return {
+    role: "user",
+    content: `Message ${index}`,
+    timestamp: `2024-06-15T10:${String(index).padStart(2, "0")}:00.000Z`,
+    ...overrides,
+  };
+}
+
+function makeSource(
+  turnCount: number,
+  overrides?: Partial<ImportTurn>,
+): BulkImportSource {
+  const turns: ImportTurn[] = [];
+  for (let i = 0; i < turnCount; i += 1) {
+    turns.push(makeTurn(i, overrides));
+  }
+  return {
+    turns,
+    metadata: {
+      source: "test",
+      exportDate: "2024-06-15T00:00:00.000Z",
+      messageCount: turnCount,
+      dateRange: {
+        from: "2024-01-01T00:00:00.000Z",
+        to: "2024-06-15T00:00:00.000Z",
+      },
+    },
+  };
+}
+
+function trackingProcessBatch(): {
+  fn: ProcessBatchFn;
+  calls: ImportTurn[][];
+} {
+  const calls: ImportTurn[][] = [];
+  const fn: ProcessBatchFn = async (turns) => {
+    calls.push([...turns]);
+    return { memoriesCreated: turns.length, duplicatesSkipped: 0 };
+  };
+  return { fn, calls };
+}
+
+describe("runBulkImportPipeline", () => {
+  it("processes turns in batches of correct size", async () => {
+    const source = makeSource(5);
+    const { fn, calls } = trackingProcessBatch();
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 2 },
+      fn,
+    );
+    assert.equal(calls.length, 3); // 2 + 2 + 1
+    assert.equal(calls[0].length, 2);
+    assert.equal(calls[1].length, 2);
+    assert.equal(calls[2].length, 1);
+    assert.equal(result.turnsProcessed, 5);
+    assert.equal(result.batchesProcessed, 3);
+    assert.equal(result.memoriesCreated, 5);
+  });
+
+  it("dryRun mode does not call processBatch", async () => {
+    const source = makeSource(10);
+    const { fn, calls } = trackingProcessBatch();
+    const result = await runBulkImportPipeline(
+      source,
+      { dryRun: true, batchSize: 3 },
+      fn,
+    );
+    assert.equal(calls.length, 0);
+    assert.equal(result.turnsProcessed, 10);
+    assert.equal(result.batchesProcessed, 4); // ceil(10/3)
+    assert.equal(result.memoriesCreated, 0);
+  });
+
+  it("returns zero counts for empty turns", async () => {
+    const source = makeSource(0);
+    const { fn, calls } = trackingProcessBatch();
+    const result = await runBulkImportPipeline(source, {}, fn);
+    assert.equal(calls.length, 0);
+    assert.equal(result.turnsProcessed, 0);
+    assert.equal(result.batchesProcessed, 0);
+    assert.equal(result.memoriesCreated, 0);
+    assert.equal(result.errors.length, 0);
+  });
+
+  it("respects custom batchSize", async () => {
+    const source = makeSource(10);
+    const { fn, calls } = trackingProcessBatch();
+    await runBulkImportPipeline(source, { batchSize: 5 }, fn);
+    assert.equal(calls.length, 2);
+    assert.equal(calls[0].length, 5);
+    assert.equal(calls[1].length, 5);
+  });
+
+  it("default batchSize is 20", async () => {
+    const source = makeSource(25);
+    const { fn, calls } = trackingProcessBatch();
+    await runBulkImportPipeline(source, {}, fn);
+    assert.equal(calls.length, 2); // 20 + 5
+    assert.equal(calls[0].length, 20);
+    assert.equal(calls[1].length, 5);
+  });
+
+  it("collects errors from processBatch in result.errors", async () => {
+    const source = makeSource(6);
+    let callCount = 0;
+    const failingFn: ProcessBatchFn = async () => {
+      callCount += 1;
+      if (callCount === 2) {
+        throw new Error("extraction failed");
+      }
+      return { memoriesCreated: 1, duplicatesSkipped: 0 };
+    };
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 2 },
+      failingFn,
+    );
+    assert.equal(result.errors.length, 1);
+    assert.equal(result.errors[0].batchIndex, 1);
+    assert.ok(result.errors[0].message.includes("extraction failed"));
+    // Other batches still processed
+    assert.equal(result.batchesProcessed, 3);
+    assert.equal(result.memoriesCreated, 2); // batch 0 + batch 2
+  });
+
+  it("skips invalid turns and reports validation errors", async () => {
+    const source: BulkImportSource = {
+      turns: [
+        makeTurn(0),
+        makeTurn(1, { role: "bad" as ImportTurn["role"] }),
+        makeTurn(2),
+      ],
+      metadata: {
+        source: "test",
+        exportDate: "2024-06-15T00:00:00.000Z",
+        messageCount: 3,
+        dateRange: {
+          from: "2024-01-01T00:00:00.000Z",
+          to: "2024-06-15T00:00:00.000Z",
+        },
+      },
+    };
+    const { fn, calls } = trackingProcessBatch();
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 10 },
+      fn,
+    );
+    // Only 2 valid turns processed
+    assert.equal(result.turnsProcessed, 2);
+    // 1 validation error for the invalid turn
+    assert.equal(result.errors.length, 1);
+    assert.ok(result.errors[0].message.includes("role"));
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0].length, 2);
+  });
+
+  it("accumulates duplicatesSkipped from processBatch", async () => {
+    const source = makeSource(4);
+    const dupFn: ProcessBatchFn = async () => ({
+      memoriesCreated: 0,
+      duplicatesSkipped: 2,
+    });
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 2 },
+      dupFn,
+    );
+    assert.equal(result.duplicatesSkipped, 4);
+    assert.equal(result.memoriesCreated, 0);
+  });
+});
+
+describe("formatBatchTranscript", () => {
+  it("formats turns with participant names", () => {
+    const turns: ImportTurn[] = [
+      {
+        role: "user",
+        content: "Hello",
+        timestamp: "2024-06-15T10:00:00.000Z",
+        participantName: "Alice",
+      },
+      {
+        role: "assistant",
+        content: "Hi there",
+        timestamp: "2024-06-15T10:01:00.000Z",
+        participantName: "Bot",
+      },
+    ];
+    const transcript = formatBatchTranscript(turns);
+    assert.ok(transcript.includes("[2024-06-15T10:00:00.000Z] Alice: Hello"));
+    assert.ok(
+      transcript.includes("[2024-06-15T10:01:00.000Z] Bot: Hi there"),
+    );
+  });
+
+  it("falls back to role when no participant info", () => {
+    const turns: ImportTurn[] = [
+      {
+        role: "other",
+        content: "System message",
+        timestamp: "2024-06-15T10:00:00.000Z",
+      },
+    ];
+    const transcript = formatBatchTranscript(turns);
+    assert.ok(transcript.includes("other: System message"));
+  });
+
+  it("prefers participantName over participantId", () => {
+    const turns: ImportTurn[] = [
+      {
+        role: "user",
+        content: "Hey",
+        timestamp: "2024-06-15T10:00:00.000Z",
+        participantId: "p1",
+        participantName: "Alice",
+      },
+    ];
+    const transcript = formatBatchTranscript(turns);
+    assert.ok(transcript.includes("Alice: Hey"));
+    assert.ok(!transcript.includes("p1:"));
+  });
+
+  it("falls back to participantId when no name", () => {
+    const turns: ImportTurn[] = [
+      {
+        role: "user",
+        content: "Hey",
+        timestamp: "2024-06-15T10:00:00.000Z",
+        participantId: "p1",
+      },
+    ];
+    const transcript = formatBatchTranscript(turns);
+    assert.ok(transcript.includes("p1: Hey"));
+  });
+});

--- a/packages/remnic-core/src/bulk-import/pipeline.test.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.test.ts
@@ -188,6 +188,36 @@ describe("runBulkImportPipeline", () => {
     assert.equal(result.duplicatesSkipped, 4);
     assert.equal(result.memoriesCreated, 0);
   });
+
+  it("accumulates entitiesCreated from processBatch", async () => {
+    const source = makeSource(6);
+    const fn: ProcessBatchFn = async () => ({
+      memoriesCreated: 1,
+      duplicatesSkipped: 0,
+      entitiesCreated: 3,
+    });
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 2 },
+      fn,
+    );
+    // 3 batches × 3 entities = 9
+    assert.equal(result.entitiesCreated, 9);
+  });
+
+  it("treats missing entitiesCreated as zero", async () => {
+    const source = makeSource(4);
+    const fn: ProcessBatchFn = async () => ({
+      memoriesCreated: 1,
+      duplicatesSkipped: 0,
+    });
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 2 },
+      fn,
+    );
+    assert.equal(result.entitiesCreated, 0);
+  });
 });
 
 describe("formatBatchTranscript", () => {

--- a/packages/remnic-core/src/bulk-import/pipeline.test.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.test.ts
@@ -4,6 +4,7 @@ import { describe, it } from "node:test";
 import {
   runBulkImportPipeline,
   formatBatchTranscript,
+  validateBatchSize,
   type ProcessBatchFn,
 } from "./pipeline.js";
 import type {
@@ -250,5 +251,77 @@ describe("formatBatchTranscript", () => {
     ];
     const transcript = formatBatchTranscript(turns);
     assert.ok(transcript.includes("p1: Hey"));
+  });
+});
+
+describe("validateBatchSize", () => {
+  it("returns default when undefined", () => {
+    assert.equal(validateBatchSize(undefined), 20);
+  });
+
+  it("accepts valid batch size", () => {
+    assert.equal(validateBatchSize(10), 10);
+  });
+
+  it("floors fractional values", () => {
+    assert.equal(validateBatchSize(5.7), 5);
+  });
+
+  it("accepts minimum boundary (1)", () => {
+    assert.equal(validateBatchSize(1), 1);
+  });
+
+  it("accepts maximum boundary (1000)", () => {
+    assert.equal(validateBatchSize(1000), 1000);
+  });
+
+  it("throws for NaN", () => {
+    assert.throws(
+      () => validateBatchSize(NaN),
+      (err: Error) => {
+        assert.ok(err.message.includes("finite number"));
+        return true;
+      },
+    );
+  });
+
+  it("throws for Infinity", () => {
+    assert.throws(
+      () => validateBatchSize(Infinity),
+      (err: Error) => {
+        assert.ok(err.message.includes("finite number"));
+        return true;
+      },
+    );
+  });
+
+  it("throws for zero", () => {
+    assert.throws(
+      () => validateBatchSize(0),
+      (err: Error) => {
+        assert.ok(err.message.includes("between 1 and 1000"));
+        return true;
+      },
+    );
+  });
+
+  it("throws for negative value", () => {
+    assert.throws(
+      () => validateBatchSize(-5),
+      (err: Error) => {
+        assert.ok(err.message.includes("between 1 and 1000"));
+        return true;
+      },
+    );
+  });
+
+  it("throws for value exceeding maximum", () => {
+    assert.throws(
+      () => validateBatchSize(1001),
+      (err: Error) => {
+        assert.ok(err.message.includes("between 1 and 1000"));
+        return true;
+      },
+    );
   });
 });

--- a/packages/remnic-core/src/bulk-import/pipeline.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.ts
@@ -18,6 +18,11 @@ const MAX_BATCH_SIZE = 1000;
 export interface ProcessBatchResult {
   memoriesCreated: number;
   duplicatesSkipped: number;
+  /**
+   * Number of entities created by the batch. Optional so Phase-1 stubs that
+   * only count memories can omit it; when absent it is treated as 0.
+   */
+  entitiesCreated?: number;
 }
 
 export type ProcessBatchFn = (
@@ -118,6 +123,9 @@ export async function runBulkImportPipeline(
       const batchResult = await processBatch(batch);
       result.memoriesCreated += batchResult.memoriesCreated;
       result.duplicatesSkipped += batchResult.duplicatesSkipped;
+      if (typeof batchResult.entitiesCreated === "number") {
+        result.entitiesCreated += batchResult.entitiesCreated;
+      }
     } catch (err: unknown) {
       const message =
         err instanceof Error ? err.message : String(err);

--- a/packages/remnic-core/src/bulk-import/pipeline.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.ts
@@ -31,12 +31,17 @@ export function validateBatchSize(value: number | undefined): number {
       `batchSize must be a finite number, received ${String(value)}`,
     );
   }
+  if (!Number.isInteger(value)) {
+    throw new Error(
+      `batchSize must be an integer, received ${value}`,
+    );
+  }
   if (value < MIN_BATCH_SIZE || value > MAX_BATCH_SIZE) {
     throw new Error(
       `batchSize must be between ${MIN_BATCH_SIZE} and ${MAX_BATCH_SIZE}, received ${value}`,
     );
   }
-  return Math.floor(value);
+  return value;
 }
 
 /**

--- a/packages/remnic-core/src/bulk-import/pipeline.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.ts
@@ -1,0 +1,118 @@
+// ---------------------------------------------------------------------------
+// Bulk-import batch processing pipeline
+// ---------------------------------------------------------------------------
+
+import {
+  validateImportTurn,
+  type BulkImportError,
+  type BulkImportOptions,
+  type BulkImportResult,
+  type BulkImportSource,
+  type ImportTurn,
+} from "./types.js";
+
+const DEFAULT_BATCH_SIZE = 20;
+const MIN_BATCH_SIZE = 1;
+const MAX_BATCH_SIZE = 1000;
+
+export interface ProcessBatchResult {
+  memoriesCreated: number;
+  duplicatesSkipped: number;
+}
+
+export type ProcessBatchFn = (
+  turns: ImportTurn[],
+) => Promise<ProcessBatchResult>;
+
+function clampBatchSize(value: number | undefined): number {
+  if (!Number.isFinite(value as number)) return DEFAULT_BATCH_SIZE;
+  const clamped = Math.max(MIN_BATCH_SIZE, Math.floor(value as number));
+  return Math.min(clamped, MAX_BATCH_SIZE);
+}
+
+/**
+ * Format a batch of turns into a conversation transcript string.
+ */
+export function formatBatchTranscript(turns: ImportTurn[]): string {
+  return turns
+    .map((t) => {
+      const prefix =
+        t.participantName ?? t.participantId ?? t.role;
+      return `[${t.timestamp}] ${prefix}: ${t.content}`;
+    })
+    .join("\n");
+}
+
+/**
+ * Run the bulk-import pipeline over a parsed source.
+ *
+ * Splits turns into batches and delegates each to `processBatch`.
+ * In dryRun mode, validates and counts without calling `processBatch`.
+ */
+export async function runBulkImportPipeline(
+  source: BulkImportSource,
+  options: BulkImportOptions = {},
+  processBatch: ProcessBatchFn,
+): Promise<BulkImportResult> {
+  const batchSize = clampBatchSize(options.batchSize);
+  const dryRun = options.dryRun === true;
+
+  const result: BulkImportResult = {
+    memoriesCreated: 0,
+    duplicatesSkipped: 0,
+    entitiesCreated: 0,
+    turnsProcessed: 0,
+    batchesProcessed: 0,
+    errors: [],
+  };
+
+  const turns = source.turns;
+
+  if (!turns || turns.length === 0) {
+    return result;
+  }
+
+  // Validate all turns upfront; collect validation errors
+  const validTurns: ImportTurn[] = [];
+  for (let i = 0; i < turns.length; i += 1) {
+    const issues = validateImportTurn(turns[i], i);
+    if (issues.length > 0) {
+      const error: BulkImportError = {
+        batchIndex: -1,
+        message: issues.map((iss) => iss.message).join("; "),
+      };
+      result.errors.push(error);
+    } else {
+      validTurns.push(turns[i]);
+    }
+  }
+
+  if (dryRun) {
+    result.turnsProcessed = validTurns.length;
+    result.batchesProcessed =
+      validTurns.length > 0
+        ? Math.ceil(validTurns.length / batchSize)
+        : 0;
+    return result;
+  }
+
+  // Process in batches
+  let batchIndex = 0;
+  for (let i = 0; i < validTurns.length; i += batchSize) {
+    const batch = validTurns.slice(i, i + batchSize);
+    try {
+      const batchResult = await processBatch(batch);
+      result.memoriesCreated += batchResult.memoriesCreated;
+      result.duplicatesSkipped += batchResult.duplicatesSkipped;
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : String(err);
+      result.errors.push({ batchIndex, message });
+    }
+    result.turnsProcessed += batch.length;
+    result.batchesProcessed += 1;
+    batchIndex += 1;
+  }
+
+  return result;
+}

--- a/packages/remnic-core/src/bulk-import/pipeline.ts
+++ b/packages/remnic-core/src/bulk-import/pipeline.ts
@@ -24,10 +24,19 @@ export type ProcessBatchFn = (
   turns: ImportTurn[],
 ) => Promise<ProcessBatchResult>;
 
-function clampBatchSize(value: number | undefined): number {
-  if (!Number.isFinite(value as number)) return DEFAULT_BATCH_SIZE;
-  const clamped = Math.max(MIN_BATCH_SIZE, Math.floor(value as number));
-  return Math.min(clamped, MAX_BATCH_SIZE);
+export function validateBatchSize(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_BATCH_SIZE;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `batchSize must be a finite number, received ${String(value)}`,
+    );
+  }
+  if (value < MIN_BATCH_SIZE || value > MAX_BATCH_SIZE) {
+    throw new Error(
+      `batchSize must be between ${MIN_BATCH_SIZE} and ${MAX_BATCH_SIZE}, received ${value}`,
+    );
+  }
+  return Math.floor(value);
 }
 
 /**
@@ -54,7 +63,7 @@ export async function runBulkImportPipeline(
   options: BulkImportOptions = {},
   processBatch: ProcessBatchFn,
 ): Promise<BulkImportResult> {
-  const batchSize = clampBatchSize(options.batchSize);
+  const batchSize = validateBatchSize(options.batchSize);
   const dryRun = options.dryRun === true;
 
   const result: BulkImportResult = {

--- a/packages/remnic-core/src/bulk-import/registry.test.ts
+++ b/packages/remnic-core/src/bulk-import/registry.test.ts
@@ -123,4 +123,23 @@ describe("bulk-import registry", () => {
     clearBulkImportSources();
     assert.equal(listBulkImportSources().length, 0);
   });
+
+  it("getBulkImportSource trims the name on lookup", () => {
+    registerBulkImportSource(makeAdapter("weclone"));
+    // Lookup with leading/trailing whitespace should still find it
+    const result = getBulkImportSource("  weclone  ");
+    assert.ok(result, "expected adapter to be found with trimmed lookup key");
+    assert.equal(result!.name, "weclone");
+  });
+
+  it("getBulkImportSource trims consistently with registration", () => {
+    // Register with whitespace in name — registerBulkImportSource trims it
+    registerBulkImportSource(makeAdapter("  padded-source  "));
+    // Lookup with same whitespace should work
+    const result1 = getBulkImportSource("  padded-source  ");
+    assert.ok(result1, "expected adapter found via padded lookup");
+    // Lookup with trimmed name should also work
+    const result2 = getBulkImportSource("padded-source");
+    assert.ok(result2, "expected adapter found via trimmed lookup");
+  });
 });

--- a/packages/remnic-core/src/bulk-import/registry.test.ts
+++ b/packages/remnic-core/src/bulk-import/registry.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+
+import {
+  registerBulkImportSource,
+  getBulkImportSource,
+  listBulkImportSources,
+  clearBulkImportSources,
+} from "./registry.js";
+import type { BulkImportSourceAdapter } from "./types.js";
+
+function makeAdapter(
+  name: string,
+): BulkImportSourceAdapter {
+  return {
+    name,
+    parse: () => ({
+      turns: [],
+      metadata: {
+        source: name,
+        exportDate: "2024-06-15T00:00:00.000Z",
+        messageCount: 0,
+        dateRange: {
+          from: "2024-01-01T00:00:00.000Z",
+          to: "2024-06-15T00:00:00.000Z",
+        },
+      },
+    }),
+  };
+}
+
+describe("bulk-import registry", () => {
+  beforeEach(() => {
+    clearBulkImportSources();
+  });
+
+  it("registers and retrieves a source adapter", () => {
+    const adapter = makeAdapter("weclone-telegram");
+    registerBulkImportSource(adapter);
+    const retrieved = getBulkImportSource("weclone-telegram");
+    assert.equal(retrieved, adapter);
+  });
+
+  it("lists registered adapter names", () => {
+    registerBulkImportSource(makeAdapter("source-a"));
+    registerBulkImportSource(makeAdapter("source-b"));
+    const names = listBulkImportSources();
+    assert.deepEqual(names.sort(), ["source-a", "source-b"]);
+  });
+
+  it("rejects duplicate registration", () => {
+    registerBulkImportSource(makeAdapter("dup-source"));
+    assert.throws(
+      () => registerBulkImportSource(makeAdapter("dup-source")),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("already registered"),
+          `expected 'already registered' in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("returns undefined for unknown source", () => {
+    const result = getBulkImportSource("nonexistent");
+    assert.equal(result, undefined);
+  });
+
+  it("rejects empty adapter name", () => {
+    assert.throws(
+      () => registerBulkImportSource(makeAdapter("")),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("non-empty string"),
+          `expected 'non-empty string' in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("rejects whitespace-only adapter name", () => {
+    assert.throws(
+      () => registerBulkImportSource(makeAdapter("   ")),
+      (err: Error) => {
+        assert.ok(
+          err.message.includes("non-empty string"),
+          `expected 'non-empty string' in: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("rejects null adapter", () => {
+    assert.throws(
+      () =>
+        registerBulkImportSource(
+          null as unknown as BulkImportSourceAdapter,
+        ),
+      (err: Error) => {
+        assert.ok(err.message.includes("must be an object"));
+        return true;
+      },
+    );
+  });
+
+  it("rejects adapter without parse function", () => {
+    const bad = { name: "no-parse" } as unknown as BulkImportSourceAdapter;
+    assert.throws(
+      () => registerBulkImportSource(bad),
+      (err: Error) => {
+        assert.ok(err.message.includes("parse function"));
+        return true;
+      },
+    );
+  });
+
+  it("clearBulkImportSources removes all adapters", () => {
+    registerBulkImportSource(makeAdapter("x"));
+    assert.equal(listBulkImportSources().length, 1);
+    clearBulkImportSources();
+    assert.equal(listBulkImportSources().length, 0);
+  });
+});

--- a/packages/remnic-core/src/bulk-import/registry.test.ts
+++ b/packages/remnic-core/src/bulk-import/registry.test.ts
@@ -142,4 +142,16 @@ describe("bulk-import registry", () => {
     const result2 = getBulkImportSource("padded-source");
     assert.ok(result2, "expected adapter found via trimmed lookup");
   });
+
+  it("stored adapter.name matches the registry key (trimmed)", () => {
+    // Register adapter whose name has surrounding whitespace.
+    registerBulkImportSource(makeAdapter("  padded-name  "));
+    const names = listBulkImportSources();
+    assert.deepEqual(names, ["padded-name"]);
+    // The adapter returned from lookup must also report the trimmed name so
+    // downstream code using `adapter.name` agrees with the registry key.
+    const retrieved = getBulkImportSource("padded-name");
+    assert.ok(retrieved);
+    assert.equal(retrieved!.name, "padded-name");
+  });
 });

--- a/packages/remnic-core/src/bulk-import/registry.ts
+++ b/packages/remnic-core/src/bulk-import/registry.ts
@@ -42,7 +42,7 @@ export function registerBulkImportSource(
 export function getBulkImportSource(
   name: string,
 ): BulkImportSourceAdapter | undefined {
-  return adapters.get(name);
+  return adapters.get(name.trim());
 }
 
 /**

--- a/packages/remnic-core/src/bulk-import/registry.ts
+++ b/packages/remnic-core/src/bulk-import/registry.ts
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// Bulk-import source adapter registry
+// ---------------------------------------------------------------------------
+
+import type { BulkImportSourceAdapter } from "./types.js";
+
+const adapters = new Map<string, BulkImportSourceAdapter>();
+
+/**
+ * Register a source adapter. Rejects duplicate names and empty names.
+ */
+export function registerBulkImportSource(
+  adapter: BulkImportSourceAdapter,
+): void {
+  if (!adapter || typeof adapter !== "object") {
+    throw new Error("bulk-import adapter must be an object");
+  }
+  if (
+    !adapter.name ||
+    typeof adapter.name !== "string" ||
+    adapter.name.trim().length === 0
+  ) {
+    throw new Error("bulk-import adapter name must be a non-empty string");
+  }
+  if (typeof adapter.parse !== "function") {
+    throw new Error(
+      `bulk-import adapter '${adapter.name}' must have a parse function`,
+    );
+  }
+  const key = adapter.name.trim();
+  if (adapters.has(key)) {
+    throw new Error(
+      `bulk-import source adapter '${key}' is already registered`,
+    );
+  }
+  adapters.set(key, adapter);
+}
+
+/**
+ * Retrieve a registered adapter by name.
+ */
+export function getBulkImportSource(
+  name: string,
+): BulkImportSourceAdapter | undefined {
+  return adapters.get(name);
+}
+
+/**
+ * List all registered adapter names.
+ */
+export function listBulkImportSources(): string[] {
+  return [...adapters.keys()];
+}
+
+/**
+ * Clear all registered adapters (for testing).
+ */
+export function clearBulkImportSources(): void {
+  adapters.clear();
+}

--- a/packages/remnic-core/src/bulk-import/registry.ts
+++ b/packages/remnic-core/src/bulk-import/registry.ts
@@ -33,7 +33,11 @@ export function registerBulkImportSource(
       `bulk-import source adapter '${key}' is already registered`,
     );
   }
-  adapters.set(key, adapter);
+  // Store adapter with trimmed name so `adapter.name` stays consistent with
+  // the registry key returned by `listBulkImportSources()`.
+  const normalized: BulkImportSourceAdapter =
+    adapter.name === key ? adapter : { ...adapter, name: key };
+  adapters.set(key, normalized);
 }
 
 /**

--- a/packages/remnic-core/src/bulk-import/types.test.ts
+++ b/packages/remnic-core/src/bulk-import/types.test.ts
@@ -51,6 +51,24 @@ describe("parseIsoTimestamp", () => {
     assert.ok(ts! > 0);
   });
 
+  it("parses a valid ISO timestamp with positive timezone offset", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00+05:30");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("parses a valid ISO timestamp with negative timezone offset", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00-08:00");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("parses a valid ISO timestamp with millis and timezone offset", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00.000+05:30");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
   it("returns null for non-ISO string", () => {
     assert.equal(parseIsoTimestamp("June 15, 2024"), null);
   });
@@ -165,6 +183,22 @@ describe("validateImportTurn", () => {
   it("accepts timestamp without millis", () => {
     const turn = makeValidTurn({
       timestamp: "2024-06-15T10:30:00Z",
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 0);
+  });
+
+  it("accepts timestamp with positive timezone offset", () => {
+    const turn = makeValidTurn({
+      timestamp: "2024-01-15T10:30:00+05:30",
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 0);
+  });
+
+  it("accepts timestamp with negative timezone offset", () => {
+    const turn = makeValidTurn({
+      timestamp: "2024-01-15T10:30:00-08:00",
     });
     const issues = validateImportTurn(turn);
     assert.equal(issues.length, 0);

--- a/packages/remnic-core/src/bulk-import/types.test.ts
+++ b/packages/remnic-core/src/bulk-import/types.test.ts
@@ -1,0 +1,182 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  isImportRole,
+  parseIsoTimestamp,
+  validateImportTurn,
+  type ImportTurn,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// isImportRole
+// ---------------------------------------------------------------------------
+
+describe("isImportRole", () => {
+  it("accepts 'user'", () => {
+    assert.equal(isImportRole("user"), true);
+  });
+
+  it("accepts 'assistant'", () => {
+    assert.equal(isImportRole("assistant"), true);
+  });
+
+  it("accepts 'other'", () => {
+    assert.equal(isImportRole("other"), true);
+  });
+
+  it("rejects unknown string", () => {
+    assert.equal(isImportRole("system"), false);
+  });
+
+  it("rejects non-string", () => {
+    assert.equal(isImportRole(42), false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseIsoTimestamp
+// ---------------------------------------------------------------------------
+
+describe("parseIsoTimestamp", () => {
+  it("parses a valid ISO timestamp with millis", () => {
+    const ts = parseIsoTimestamp("2024-06-15T10:30:00.000Z");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("parses a valid ISO timestamp without millis", () => {
+    const ts = parseIsoTimestamp("2024-06-15T10:30:00Z");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("returns null for non-ISO string", () => {
+    assert.equal(parseIsoTimestamp("June 15, 2024"), null);
+  });
+
+  it("returns null for empty string", () => {
+    assert.equal(parseIsoTimestamp(""), null);
+  });
+
+  it("returns null for non-string input", () => {
+    assert.equal(parseIsoTimestamp(123 as unknown as string), null);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateImportTurn
+// ---------------------------------------------------------------------------
+
+function makeValidTurn(overrides?: Partial<ImportTurn>): ImportTurn {
+  return {
+    role: "user",
+    content: "Hello, world!",
+    timestamp: "2024-06-15T10:30:00.000Z",
+    ...overrides,
+  };
+}
+
+describe("validateImportTurn", () => {
+  it("returns no issues for a valid turn", () => {
+    const issues = validateImportTurn(makeValidTurn());
+    assert.equal(issues.length, 0);
+  });
+
+  it("returns no issues for a valid turn with 'other' role", () => {
+    const issues = validateImportTurn(makeValidTurn({ role: "other" }));
+    assert.equal(issues.length, 0);
+  });
+
+  it("returns no issues for a valid turn with 'assistant' role", () => {
+    const issues = validateImportTurn(
+      makeValidTurn({ role: "assistant" }),
+    );
+    assert.equal(issues.length, 0);
+  });
+
+  it("reports invalid role", () => {
+    const turn = makeValidTurn({
+      role: "system" as unknown as ImportTurn["role"],
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.role.invalid");
+    assert.ok(issues[0].message.includes("system"));
+  });
+
+  it("reports empty content", () => {
+    const turn = makeValidTurn({ content: "" });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.content.invalid");
+  });
+
+  it("reports whitespace-only content", () => {
+    const turn = makeValidTurn({ content: "   " });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.content.invalid");
+  });
+
+  it("reports invalid timestamp", () => {
+    const turn = makeValidTurn({ timestamp: "not-a-date" });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.timestamp.invalid");
+    assert.ok(issues[0].message.includes("not-a-date"));
+  });
+
+  it("reports empty timestamp", () => {
+    const turn = makeValidTurn({ timestamp: "" });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.timestamp.invalid");
+  });
+
+  it("reports multiple issues at once", () => {
+    const turn = makeValidTurn({
+      role: "invalid" as unknown as ImportTurn["role"],
+      content: "",
+      timestamp: "bad",
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 3);
+    const codes = issues.map((i) => i.code);
+    assert.ok(codes.includes("turn.role.invalid"));
+    assert.ok(codes.includes("turn.content.invalid"));
+    assert.ok(codes.includes("turn.timestamp.invalid"));
+  });
+
+  it("returns turn.invalid for null input", () => {
+    const issues = validateImportTurn(
+      null as unknown as ImportTurn,
+    );
+    assert.equal(issues.length, 1);
+    assert.equal(issues[0].code, "turn.invalid");
+  });
+
+  it("includes index when provided", () => {
+    const turn = makeValidTurn({ content: "" });
+    const issues = validateImportTurn(turn, 5);
+    assert.equal(issues[0].index, 5);
+  });
+
+  it("accepts timestamp without millis", () => {
+    const turn = makeValidTurn({
+      timestamp: "2024-06-15T10:30:00Z",
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 0);
+  });
+
+  it("includes optional fields without issue", () => {
+    const turn = makeValidTurn({
+      participantId: "p1",
+      participantName: "Alice",
+      replyToId: "msg-42",
+    });
+    const issues = validateImportTurn(turn);
+    assert.equal(issues.length, 0);
+  });
+});

--- a/packages/remnic-core/src/bulk-import/types.test.ts
+++ b/packages/remnic-core/src/bulk-import/types.test.ts
@@ -69,6 +69,44 @@ describe("parseIsoTimestamp", () => {
     assert.ok(ts! > 0);
   });
 
+  it("rejects overflowed offset timestamp (Feb 31)", () => {
+    assert.equal(parseIsoTimestamp("2024-02-31T10:00:00+00:00"), null);
+  });
+
+  it("rejects overflowed UTC timestamp (Feb 30)", () => {
+    assert.equal(parseIsoTimestamp("2024-02-30T10:00:00Z"), null);
+  });
+
+  it("rejects offset hour exceeding 14", () => {
+    assert.equal(parseIsoTimestamp("2024-01-15T10:00:00+25:00"), null);
+  });
+
+  it("rejects offset hour of 15", () => {
+    assert.equal(parseIsoTimestamp("2024-01-15T10:00:00+15:00"), null);
+  });
+
+  it("rejects offset minute exceeding 59", () => {
+    assert.equal(parseIsoTimestamp("2024-01-15T10:00:00+05:61"), null);
+  });
+
+  it("rejects overflowed month (month 13)", () => {
+    assert.equal(parseIsoTimestamp("2024-13-15T10:00:00+00:00"), null);
+  });
+
+  it("rejects overflowed day for April (Apr 31)", () => {
+    assert.equal(parseIsoTimestamp("2024-04-31T10:00:00+05:30"), null);
+  });
+
+  it("accepts valid Feb 29 in leap year with offset", () => {
+    const ts = parseIsoTimestamp("2024-02-29T10:00:00+05:30");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("rejects Feb 29 in non-leap year with offset", () => {
+    assert.equal(parseIsoTimestamp("2023-02-29T10:00:00+05:30"), null);
+  });
+
   it("returns null for non-ISO string", () => {
     assert.equal(parseIsoTimestamp("June 15, 2024"), null);
   });

--- a/packages/remnic-core/src/bulk-import/types.test.ts
+++ b/packages/remnic-core/src/bulk-import/types.test.ts
@@ -103,6 +103,24 @@ describe("parseIsoTimestamp", () => {
     assert.ok(ts! > 0);
   });
 
+  it("accepts two-digit fractional seconds", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00.12Z");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("accepts six-digit fractional seconds with offset", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00.123456+00:00");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
+  it("accepts single-digit fractional seconds", () => {
+    const ts = parseIsoTimestamp("2024-01-15T10:30:00.5Z");
+    assert.equal(typeof ts, "number");
+    assert.ok(ts! > 0);
+  });
+
   it("rejects Feb 29 in non-leap year with offset", () => {
     assert.equal(parseIsoTimestamp("2023-02-29T10:00:00+05:30"), null);
   });

--- a/packages/remnic-core/src/bulk-import/types.ts
+++ b/packages/remnic-core/src/bulk-import/types.ts
@@ -2,6 +2,8 @@
 // Bulk-import pipeline types and validation
 // ---------------------------------------------------------------------------
 
+import { parseIsoOffsetTimestamp } from "../utils/iso-timestamp.js";
+
 export interface BulkImportSource {
   turns: ImportTurn[];
   metadata: {
@@ -58,7 +60,6 @@ export interface BulkImportSourceAdapter {
 // ---------------------------------------------------------------------------
 
 const VALID_ROLES: ReadonlySet<string> = new Set(["user", "assistant", "other"]);
-const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export interface ImportTurnValidationIssue {
   code: string;
@@ -66,69 +67,24 @@ export interface ImportTurnValidationIssue {
   index?: number;
 }
 
-function normalizeIsoForComparison(value: string): string {
-  return value.includes(".") ? value : value.replace("Z", ".000Z");
-}
-
-/**
- * Validate the date/time components of an ISO timestamp string.
- * Catches overflowed dates like Feb 31 that Date.parse silently normalizes.
- */
-function validateDateComponents(isoString: string): boolean {
-  const match = isoString.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
-  if (!match) return false;
-  const [, yStr, mStr, dStr, hStr, minStr, sStr] = match;
-  const y = Number(yStr);
-  const m = Number(mStr);
-  const d = Number(dStr);
-  const h = Number(hStr);
-  const min = Number(minStr);
-  const s = Number(sStr);
-  if (m < 1 || m > 12) return false;
-  if (d < 1 || d > 31) return false;
-  if (h > 23 || min > 59 || s > 59) return false;
-  // Validate day for the specific month (using Date(y, m, 0) to get days in month)
-  const daysInMonth = new Date(y, m, 0).getDate();
-  if (d > daysInMonth) return false;
-  return true;
-}
-
-/**
- * Validate the timezone offset range if present.
- * Max offset is +/-14:00 per ISO 8601; minute part must be 0-59.
- */
-function validateOffset(isoString: string): boolean {
-  const offsetMatch = isoString.match(/([+-])(\d{2}):(\d{2})$/);
-  if (!offsetMatch) return true; // Z format, no offset to validate
-  const oh = Number(offsetMatch[2]);
-  const om = Number(offsetMatch[3]);
-  if (oh > 14 || om > 59) return false;
-  // +14:00 is max; offsets like +14:30 are invalid
-  if (oh === 14 && om > 0) return false;
-  return true;
-}
-
 export function isImportRole(value: unknown): value is ImportSourceRole {
   return typeof value === "string" && VALID_ROLES.has(value);
 }
 
+/**
+ * Parse an ISO-8601 / RFC 3339 timestamp used by bulk-import adapters.
+ *
+ * Accepts variable-precision fractional seconds and either a `Z` suffix or a
+ * `[+-]HH:MM` timezone offset, so adapters may preserve their source
+ * timestamps verbatim. Returns milliseconds since epoch, or `null` if the
+ * string is not a well-formed timestamp (including overflowed calendar dates
+ * or out-of-range offsets).
+ *
+ * Delegates to the shared parser in `utils/iso-timestamp.ts` — do not
+ * reimplement locally; extend that helper instead.
+ */
 export function parseIsoTimestamp(value: string): number | null {
-  if (typeof value !== "string" || !ISO_TIMESTAMP_RE.test(value)) return null;
-  const ts = Date.parse(value);
-  if (!Number.isFinite(ts)) return null;
-
-  // Validate date/time components to catch overflowed dates (e.g., Feb 31)
-  if (!validateDateComponents(value)) return null;
-
-  // Validate offset range if present (e.g., reject +25:00)
-  if (!validateOffset(value)) return null;
-
-  // For UTC timestamps (ending in Z), also verify with round-trip
-  if (value.endsWith("Z")) {
-    const roundTrip = new Date(ts).toISOString();
-    if (roundTrip !== normalizeIsoForComparison(value)) return null;
-  }
-  return ts;
+  return parseIsoOffsetTimestamp(value);
 }
 
 export function validateImportTurn(

--- a/packages/remnic-core/src/bulk-import/types.ts
+++ b/packages/remnic-core/src/bulk-import/types.ts
@@ -58,7 +58,7 @@ export interface BulkImportSourceAdapter {
 // ---------------------------------------------------------------------------
 
 const VALID_ROLES: ReadonlySet<string> = new Set(["user", "assistant", "other"]);
-const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?(?:Z|[+-]\d{2}:\d{2})$/;
 
 export interface ImportTurnValidationIssue {
   code: string;
@@ -78,8 +78,14 @@ export function parseIsoTimestamp(value: string): number | null {
   if (typeof value !== "string" || !ISO_TIMESTAMP_RE.test(value)) return null;
   const ts = Date.parse(value);
   if (!Number.isFinite(ts)) return null;
-  const roundTrip = new Date(ts).toISOString();
-  if (roundTrip !== normalizeIsoForComparison(value)) return null;
+
+  // For UTC timestamps (ending in Z), verify with round-trip
+  if (value.endsWith("Z")) {
+    const roundTrip = new Date(ts).toISOString();
+    if (roundTrip !== normalizeIsoForComparison(value)) return null;
+  }
+  // For offset timestamps, Date.parse already validated; ensure the
+  // parsed ms is a reasonable epoch value (not NaN, which isFinite covers)
   return ts;
 }
 

--- a/packages/remnic-core/src/bulk-import/types.ts
+++ b/packages/remnic-core/src/bulk-import/types.ts
@@ -70,6 +70,44 @@ function normalizeIsoForComparison(value: string): string {
   return value.includes(".") ? value : value.replace("Z", ".000Z");
 }
 
+/**
+ * Validate the date/time components of an ISO timestamp string.
+ * Catches overflowed dates like Feb 31 that Date.parse silently normalizes.
+ */
+function validateDateComponents(isoString: string): boolean {
+  const match = isoString.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/);
+  if (!match) return false;
+  const [, yStr, mStr, dStr, hStr, minStr, sStr] = match;
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  const h = Number(hStr);
+  const min = Number(minStr);
+  const s = Number(sStr);
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+  if (h > 23 || min > 59 || s > 59) return false;
+  // Validate day for the specific month (using Date(y, m, 0) to get days in month)
+  const daysInMonth = new Date(y, m, 0).getDate();
+  if (d > daysInMonth) return false;
+  return true;
+}
+
+/**
+ * Validate the timezone offset range if present.
+ * Max offset is +/-14:00 per ISO 8601; minute part must be 0-59.
+ */
+function validateOffset(isoString: string): boolean {
+  const offsetMatch = isoString.match(/([+-])(\d{2}):(\d{2})$/);
+  if (!offsetMatch) return true; // Z format, no offset to validate
+  const oh = Number(offsetMatch[2]);
+  const om = Number(offsetMatch[3]);
+  if (oh > 14 || om > 59) return false;
+  // +14:00 is max; offsets like +14:30 are invalid
+  if (oh === 14 && om > 0) return false;
+  return true;
+}
+
 export function isImportRole(value: unknown): value is ImportSourceRole {
   return typeof value === "string" && VALID_ROLES.has(value);
 }
@@ -79,13 +117,17 @@ export function parseIsoTimestamp(value: string): number | null {
   const ts = Date.parse(value);
   if (!Number.isFinite(ts)) return null;
 
-  // For UTC timestamps (ending in Z), verify with round-trip
+  // Validate date/time components to catch overflowed dates (e.g., Feb 31)
+  if (!validateDateComponents(value)) return null;
+
+  // Validate offset range if present (e.g., reject +25:00)
+  if (!validateOffset(value)) return null;
+
+  // For UTC timestamps (ending in Z), also verify with round-trip
   if (value.endsWith("Z")) {
     const roundTrip = new Date(ts).toISOString();
     if (roundTrip !== normalizeIsoForComparison(value)) return null;
   }
-  // For offset timestamps, Date.parse already validated; ensure the
-  // parsed ms is a reasonable epoch value (not NaN, which isFinite covers)
   return ts;
 }
 

--- a/packages/remnic-core/src/bulk-import/types.ts
+++ b/packages/remnic-core/src/bulk-import/types.ts
@@ -1,0 +1,138 @@
+// ---------------------------------------------------------------------------
+// Bulk-import pipeline types and validation
+// ---------------------------------------------------------------------------
+
+export interface BulkImportSource {
+  turns: ImportTurn[];
+  metadata: {
+    source: string;
+    exportDate: string;
+    messageCount: number;
+    dateRange: { from: string; to: string };
+  };
+}
+
+export interface ImportTurn {
+  role: "user" | "assistant" | "other";
+  content: string;
+  timestamp: string;
+  participantId?: string;
+  participantName?: string;
+  replyToId?: string;
+}
+
+export interface BulkImportOptions {
+  batchSize?: number;
+  dryRun?: boolean;
+  dedup?: boolean;
+  trustLevel?: "import";
+  namespace?: string;
+}
+
+export type ImportSourceRole = ImportTurn["role"];
+
+export interface BulkImportResult {
+  memoriesCreated: number;
+  duplicatesSkipped: number;
+  entitiesCreated: number;
+  turnsProcessed: number;
+  batchesProcessed: number;
+  errors: BulkImportError[];
+}
+
+export interface BulkImportError {
+  batchIndex: number;
+  message: string;
+}
+
+export interface BulkImportSourceAdapter {
+  name: string;
+  parse(
+    input: unknown,
+    options?: { strict?: boolean },
+  ): Promise<BulkImportSource> | BulkImportSource;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+const VALID_ROLES: ReadonlySet<string> = new Set(["user", "assistant", "other"]);
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+export interface ImportTurnValidationIssue {
+  code: string;
+  message: string;
+  index?: number;
+}
+
+function normalizeIsoForComparison(value: string): string {
+  return value.includes(".") ? value : value.replace("Z", ".000Z");
+}
+
+export function isImportRole(value: unknown): value is ImportSourceRole {
+  return typeof value === "string" && VALID_ROLES.has(value);
+}
+
+export function parseIsoTimestamp(value: string): number | null {
+  if (typeof value !== "string" || !ISO_TIMESTAMP_RE.test(value)) return null;
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return null;
+  const roundTrip = new Date(ts).toISOString();
+  if (roundTrip !== normalizeIsoForComparison(value)) return null;
+  return ts;
+}
+
+export function validateImportTurn(
+  turn: ImportTurn,
+  index?: number,
+): ImportTurnValidationIssue[] {
+  const issues: ImportTurnValidationIssue[] = [];
+
+  if (!turn || typeof turn !== "object") {
+    issues.push({
+      code: "turn.invalid",
+      message: "Import turn must be an object.",
+      index,
+    });
+    return issues;
+  }
+
+  if (!isImportRole(turn.role)) {
+    issues.push({
+      code: "turn.role.invalid",
+      message:
+        `Import turn role must be 'user', 'assistant', or 'other', ` +
+        `received '${String(turn.role)}'.`,
+      index,
+    });
+  }
+
+  if (
+    !turn.content ||
+    typeof turn.content !== "string" ||
+    turn.content.trim().length === 0
+  ) {
+    issues.push({
+      code: "turn.content.invalid",
+      message: "Import turn content must be a non-empty string.",
+      index,
+    });
+  }
+
+  if (
+    !turn.timestamp ||
+    typeof turn.timestamp !== "string" ||
+    parseIsoTimestamp(turn.timestamp) === null
+  ) {
+    issues.push({
+      code: "turn.timestamp.invalid",
+      message:
+        `Import turn timestamp must be a valid ISO timestamp, ` +
+        `received '${String(turn.timestamp)}'.`,
+      index,
+    });
+  }
+
+  return issues;
+}

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2795,6 +2795,12 @@ export async function runBulkImportCliCommand(
     strict: opts.verbose === true,
   });
 
+  if (!opts.dryRun) {
+    throw new Error(
+      "Bulk import persistence is not yet wired — use --dry-run to validate input, or implement a processBatch callback via the programmatic API",
+    );
+  }
+
   const processBatch: ProcessBatchFn = async (turns) => {
     // Phase 1 stub — the real extraction callback will be wired
     // when the orchestrator integration lands in a later PR.

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2765,7 +2765,6 @@ export interface BulkImportCliCommandOptions {
   memoryDir: string;
   source: string;
   file: string;
-  platform?: string;
   namespace?: string;
   batchSize?: number;
   dryRun?: boolean;

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2770,6 +2770,7 @@ export interface BulkImportCliCommandOptions {
   batchSize?: number;
   dryRun?: boolean;
   verbose?: boolean;
+  strict?: boolean;
   stdout: Writable;
   stderr: Writable;
 }
@@ -2792,7 +2793,7 @@ export async function runBulkImportCliCommand(
 
   const inputRaw = await readFile(opts.file, "utf-8");
   const parsed = await adapter.parse(inputRaw, {
-    strict: opts.verbose === true,
+    strict: opts.strict === true,
   });
 
   if (!opts.dryRun) {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -27,6 +27,13 @@ import { chatgptReplayNormalizer } from "./replay/normalizers/chatgpt.js";
 import { claudeReplayNormalizer } from "./replay/normalizers/claude.js";
 import { openclawReplayNormalizer } from "./replay/normalizers/openclaw.js";
 import { isReplaySource, normalizeReplaySessionKey, type ReplaySource, type ReplayTurn } from "./replay/types.js";
+import {
+  getBulkImportSource,
+  listBulkImportSources,
+  runBulkImportPipeline,
+  type BulkImportResult,
+  type ProcessBatchFn,
+} from "./bulk-import/index.js";
 import { archiveObservations } from "./maintenance/archive-observations.js";
 import { rebuildMemoryLifecycleLedger } from "./maintenance/rebuild-memory-lifecycle-ledger.js";
 import {
@@ -2748,6 +2755,85 @@ export async function runReplayCliCommand(
   }
 
   return summary;
+}
+
+// ---------------------------------------------------------------------------
+// Bulk-import CLI command
+// ---------------------------------------------------------------------------
+
+export interface BulkImportCliCommandOptions {
+  memoryDir: string;
+  source: string;
+  file: string;
+  platform?: string;
+  namespace?: string;
+  batchSize?: number;
+  dryRun?: boolean;
+  verbose?: boolean;
+  stdout: Writable;
+  stderr: Writable;
+}
+
+export async function runBulkImportCliCommand(
+  opts: BulkImportCliCommandOptions,
+): Promise<BulkImportResult> {
+  const adapter = getBulkImportSource(opts.source);
+  if (!adapter) {
+    const registered = listBulkImportSources();
+    const list =
+      registered.length > 0
+        ? registered.map((n) => `'${n}'`).join(", ")
+        : "(none registered)";
+    throw new Error(
+      `Unknown bulk-import source '${opts.source}'. ` +
+        `Valid sources: ${list}`,
+    );
+  }
+
+  const inputRaw = await readFile(opts.file, "utf-8");
+  const parsed = await adapter.parse(inputRaw, {
+    strict: opts.verbose === true,
+  });
+
+  const processBatch: ProcessBatchFn = async (turns) => {
+    // Phase 1 stub — the real extraction callback will be wired
+    // when the orchestrator integration lands in a later PR.
+    return { memoriesCreated: turns.length, duplicatesSkipped: 0 };
+  };
+
+  const result = await runBulkImportPipeline(
+    parsed,
+    {
+      batchSize: opts.batchSize,
+      dryRun: opts.dryRun,
+      dedup: true,
+      trustLevel: "import",
+      namespace: opts.namespace,
+    },
+    processBatch,
+  );
+
+  const out = opts.stdout;
+  out.write(`Bulk import complete (source: ${opts.source})\n`);
+  out.write(`  Turns processed:     ${result.turnsProcessed}\n`);
+  out.write(`  Batches processed:   ${result.batchesProcessed}\n`);
+  out.write(`  Memories created:    ${result.memoriesCreated}\n`);
+  out.write(`  Duplicates skipped:  ${result.duplicatesSkipped}\n`);
+  if (result.errors.length > 0) {
+    out.write(`  Errors:              ${result.errors.length}\n`);
+    if (opts.verbose) {
+      for (const err of result.errors) {
+        opts.stderr.write(
+          `    [batch ${err.batchIndex}] ${err.message}\n`,
+        );
+      }
+    }
+  }
+  if (opts.dryRun) {
+    out.write("  (dry run — no memories were stored)\n");
+  }
+
+  return result;
 }
 
 async function getPluginVersion(): Promise<string> {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -556,6 +556,7 @@ export {
   type BulkImportSourceAdapter,
   type ImportTurnValidationIssue,
   isImportRole,
+  parseIsoTimestamp,
   validateImportTurn,
   registerBulkImportSource,
   getBulkImportSource,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -543,6 +543,31 @@ export {
 } from "./enrichment/index.js";
 
 // ---------------------------------------------------------------------------
+// Bulk-import pipeline (#460)
+// ---------------------------------------------------------------------------
+
+export {
+  type BulkImportSource,
+  type ImportTurn,
+  type BulkImportOptions,
+  type ImportSourceRole,
+  type BulkImportResult,
+  type BulkImportError,
+  type BulkImportSourceAdapter,
+  type ImportTurnValidationIssue,
+  isImportRole,
+  validateImportTurn,
+  registerBulkImportSource,
+  getBulkImportSource,
+  listBulkImportSources,
+  clearBulkImportSources,
+  runBulkImportPipeline,
+  formatBatchTranscript,
+  type ProcessBatchFn,
+  type ProcessBatchResult,
+} from "./bulk-import/index.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/replay/types.ts
+++ b/packages/remnic-core/src/replay/types.ts
@@ -1,3 +1,5 @@
+import { parseIsoUtcTimestamp } from "../utils/iso-timestamp.js";
+
 export type ReplaySource = "openclaw" | "claude" | "chatgpt";
 export type ReplayRole = "user" | "assistant";
 
@@ -42,12 +44,7 @@ export interface ReplayNormalizer {
 
 const VALID_SOURCES: ReadonlySet<string> = new Set(["openclaw", "claude", "chatgpt"]);
 const VALID_ROLES: ReadonlySet<string> = new Set(["user", "assistant"]);
-const ISO_UTC_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
 export const REPLAY_UNKNOWN_SESSION_KEY = "replay:unknown";
-
-function normalizeIsoForComparison(value: string): string {
-  return value.includes(".") ? value : value.replace("Z", ".000Z");
-}
 
 export function isReplaySource(value: unknown): value is ReplaySource {
   return typeof value === "string" && VALID_SOURCES.has(value);
@@ -63,13 +60,16 @@ export function normalizeReplaySessionKey(value: unknown): string {
   return trimmed.length > 0 ? trimmed : REPLAY_UNKNOWN_SESSION_KEY;
 }
 
+/**
+ * Strict UTC-only ISO-8601 parser used by the replay pipeline.
+ *
+ * Delegates to the shared parser in `utils/iso-timestamp.ts` — do not
+ * reimplement locally; extend that helper instead. Replay intentionally
+ * rejects timezone-offset timestamps to keep canonical form consistent
+ * across recorded transcripts.
+ */
 export function parseIsoTimestamp(value: string): number | null {
-  if (typeof value !== "string" || !ISO_UTC_TIMESTAMP_RE.test(value)) return null;
-  const ts = Date.parse(value);
-  if (!Number.isFinite(ts)) return null;
-  const roundTrip = new Date(ts).toISOString();
-  if (roundTrip !== normalizeIsoForComparison(value)) return null;
-  return ts;
+  return parseIsoUtcTimestamp(value);
 }
 
 export function validateReplayTurn(turn: ReplayTurn, index?: number): ReplayValidationIssue[] {

--- a/packages/remnic-core/src/utils/iso-timestamp.ts
+++ b/packages/remnic-core/src/utils/iso-timestamp.ts
@@ -1,0 +1,108 @@
+// ---------------------------------------------------------------------------
+// Shared ISO-8601 / RFC 3339 timestamp validation helpers.
+//
+// Two public entry points — a strict UTC-only parser used by the replay
+// pipeline, and a more permissive parser used by bulk-import adapters that
+// need to preserve source timezone offsets. Both share date-component,
+// offset-range, and round-trip validation so they cannot silently diverge.
+// ---------------------------------------------------------------------------
+
+// UTC-only: `...Z`, 0 or 3 fractional digits (replay canonical form).
+const ISO_UTC_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d{3})?Z$/;
+
+// Lenient: variable-precision fractional seconds and `Z` or `[+-]HH:MM` offset.
+const ISO_OFFSET_TIMESTAMP_RE =
+  /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:\d{2})$/;
+
+/**
+ * Validate the date/time components of an ISO timestamp string.
+ * Catches overflowed dates like Feb 31 that `Date.parse` silently normalizes.
+ */
+function validateDateComponents(isoString: string): boolean {
+  const match = isoString.match(
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})/,
+  );
+  if (!match) return false;
+  const [, yStr, mStr, dStr, hStr, minStr, sStr] = match;
+  const y = Number(yStr);
+  const m = Number(mStr);
+  const d = Number(dStr);
+  const h = Number(hStr);
+  const min = Number(minStr);
+  const s = Number(sStr);
+  if (m < 1 || m > 12) return false;
+  if (d < 1 || d > 31) return false;
+  if (h > 23 || min > 59 || s > 59) return false;
+  // Validate day for the specific month (using Date(y, m, 0) to get days).
+  const daysInMonth = new Date(y, m, 0).getDate();
+  if (d > daysInMonth) return false;
+  return true;
+}
+
+/**
+ * Validate the timezone offset range if present.
+ * Max offset is +/-14:00 per ISO 8601; minute part must be 0-59.
+ */
+function validateOffset(isoString: string): boolean {
+  const offsetMatch = isoString.match(/([+-])(\d{2}):(\d{2})$/);
+  if (!offsetMatch) return true; // `Z` form, no offset to validate.
+  const oh = Number(offsetMatch[2]);
+  const om = Number(offsetMatch[3]);
+  if (oh > 14 || om > 59) return false;
+  // +14:00 is max; offsets like +14:30 are invalid.
+  if (oh === 14 && om > 0) return false;
+  return true;
+}
+
+/**
+ * Normalize a `Z`-suffixed ISO timestamp to exactly three fractional digits so
+ * the round-trip comparison against `Date.prototype.toISOString()` succeeds
+ * regardless of input precision (or absence of a fractional part).
+ */
+function normalizeUtcForComparison(value: string): string {
+  const fracMatch = value.match(/\.(\d+)Z$/);
+  if (fracMatch) {
+    const ms = (fracMatch[1] + "000").slice(0, 3);
+    return value.replace(/\.\d+Z$/, `.${ms}Z`);
+  }
+  return value.replace(/Z$/, ".000Z");
+}
+
+/**
+ * Strict UTC-only parser — accepts `YYYY-MM-DDTHH:MM:SS[.sss]Z`.
+ * Returns milliseconds since epoch, or `null` if invalid.
+ */
+export function parseIsoUtcTimestamp(value: string): number | null {
+  if (typeof value !== "string" || !ISO_UTC_TIMESTAMP_RE.test(value)) {
+    return null;
+  }
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return null;
+  if (!validateDateComponents(value)) return null;
+  const roundTrip = new Date(ts).toISOString();
+  if (roundTrip !== normalizeUtcForComparison(value)) return null;
+  return ts;
+}
+
+/**
+ * Lenient parser — accepts variable-precision fractional seconds and either
+ * a `Z` suffix or a `[+-]HH:MM` offset. Returns milliseconds since epoch, or
+ * `null` if the string is not a well-formed RFC 3339 timestamp.
+ */
+export function parseIsoOffsetTimestamp(value: string): number | null {
+  if (typeof value !== "string" || !ISO_OFFSET_TIMESTAMP_RE.test(value)) {
+    return null;
+  }
+  const ts = Date.parse(value);
+  if (!Number.isFinite(ts)) return null;
+  if (!validateDateComponents(value)) return null;
+  if (!validateOffset(value)) return null;
+  // For UTC timestamps (ending in `Z`), verify with a round-trip so that
+  // overflowed UTC calendar dates cannot slip through.
+  if (value.endsWith("Z")) {
+    const roundTrip = new Date(ts).toISOString();
+    if (roundTrip !== normalizeUtcForComparison(value)) return null;
+  }
+  return ts;
+}


### PR DESCRIPTION
## Summary

Phase 1 of #460 -- adds the generic bulk-import pipeline interface to `@remnic/core` that source-specific importers (WeClone, Signal, iMessage) will implement in later PRs.

- **`bulk-import/types.ts`**: `BulkImportSource`, `ImportTurn`, `BulkImportOptions`, result types, and `validateImportTurn()` validation following the replay pattern
- **`bulk-import/registry.ts`**: `registerBulkImportSource`/`getBulkImportSource`/`listBulkImportSources` with duplicate and invalid-input rejection per CLAUDE.md rule #51
- **`bulk-import/pipeline.ts`**: batch coordinator that splits turns into configurable batches (default 20), validates upfront, delegates to a pluggable `processBatch` callback, and collects results/errors
- **`bulk-import/index.ts`**: re-exports all public types and functions
- **`cli.ts`**: `BulkImportCliCommandOptions` interface and `runBulkImportCliCommand` with source validation listing valid options on error
- **`index.ts`**: re-exports bulk-import surface from core package

## Test plan

- [x] 44 tests covering types validation, registry CRUD, pipeline batching, dryRun mode, error collection, and transcript formatting
- [x] `npx tsx --test 'src/bulk-import/*.test.ts'` passes (44/44)
- [x] `npx tsc --noEmit` passes with no type errors
- [x] No secrets or personal data in diff
- [x] PR diff within scope (types + registry + pipeline + CLI interface + tests)

Closes phase 1 of #460

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new exported APIs and changes replay timestamp validation to use a shared parser, which could alter what timestamps are accepted/rejected at runtime.
> 
> **Overview**
> Introduces a **bulk-import Phase 1 API** in `@remnic/core`, including `BulkImportSource`/`ImportTurn` types with validation, an adapter registry (`registerBulkImportSource`, lookup/list/clear) with name normalization, and a batch-oriented `runBulkImportPipeline` that validates turns, chunks by configurable `batchSize`, accumulates counts, and collects per-batch errors.
> 
> Adds `runBulkImportCliCommand` to `cli.ts` that resolves a source adapter, parses an input file, and currently **only supports `--dry-run`** (non-dry-run throws until persistence is wired), then prints a summary with optional verbose error output; the bulk-import surface is re-exported via `bulk-import/index.ts` and the package `index.ts`.
> 
> Refactors replay timestamp parsing to delegate to a new shared `utils/iso-timestamp.ts` helper, and adds extensive tests covering registry behavior, pipeline batching/error handling, CLI dry-run behavior, and timestamp/turn validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a270873bb6356cc317f9af2128a6017785d3c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->