### PR TITLE
feat: add @remnic/connector-weclone OpenAI-compatible memory proxy

### DIFF
--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -11,10 +11,13 @@
       "types": "./dist/index.d.ts"
     }
   },
+  "bin": {
+    "remnic-weclone-proxy": "dist/cli.js"
+  },
   "files": ["dist"],
   "scripts": {
-    "build": "tsup src/index.ts --format esm --dts",
-    "test": "tsx --test 'src/**/*.test.ts'",
+    "build": "tsup src/index.ts src/cli.ts --format esm --dts",
+    "test": "tsx --test src/*.test.ts",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {

--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@remnic/connector-weclone",
+  "version": "1.0.0",
+  "description": "OpenAI-compatible proxy adding Remnic persistent memory to WeClone avatars",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "test": "tsx --test 'src/**/*.test.ts'",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "typescript": "^5.7.0",
+    "tsx": "^4.0.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/connector-weclone"
+  },
+  "keywords": ["remnic", "memory", "weclone", "proxy", "ai-agent"]
+}

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -1,0 +1,64 @@
+#!/usr/bin/env node
+/**
+ * CLI entrypoint for @remnic/connector-weclone.
+ *
+ * Reads config from ~/.remnic/connectors/weclone.json (or --config path)
+ * and starts the OpenAI-compatible memory proxy.
+ */
+
+import { createWeCloneProxy } from "./proxy.js";
+import { parseConfig } from "./config.js";
+import { readFileSync, existsSync } from "node:fs";
+import { resolve } from "node:path";
+import { homedir } from "node:os";
+
+const args = process.argv.slice(2);
+let configPath = resolve(homedir(), ".remnic/connectors/weclone.json");
+
+for (let i = 0; i < args.length; i++) {
+  if (args[i] === "--config") {
+    if (!args[i + 1]) {
+      console.error("Error: --config requires a path argument");
+      process.exit(1);
+    }
+    configPath = resolve(args[i + 1]);
+    i++;
+  }
+}
+
+if (!existsSync(configPath)) {
+  console.error(`Config not found: ${configPath}`);
+  console.error("Run: remnic connectors install weclone");
+  process.exit(1);
+}
+
+let raw: unknown;
+try {
+  raw = JSON.parse(readFileSync(configPath, "utf-8"));
+} catch (err) {
+  console.error(`Failed to parse config at ${configPath}: ${err instanceof Error ? err.message : String(err)}`);
+  process.exit(1);
+}
+
+if (typeof raw !== "object" || raw === null) {
+  console.error(`Config at ${configPath} must be a JSON object`);
+  process.exit(1);
+}
+
+const config = parseConfig(raw);
+const proxy = createWeCloneProxy(config);
+
+proxy.start().then(() => {
+  console.log(`WeClone memory proxy listening on :${config.proxyPort}`);
+  console.log(`  WeClone API: ${config.wecloneApiUrl}`);
+  console.log(`  Remnic daemon: ${config.remnicDaemonUrl}`);
+});
+
+process.on("SIGINT", () => {
+  proxy.stop();
+  process.exit(0);
+});
+process.on("SIGTERM", () => {
+  proxy.stop();
+  process.exit(0);
+});

--- a/packages/connector-weclone/src/config.test.ts
+++ b/packages/connector-weclone/src/config.test.ts
@@ -1,0 +1,131 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { parseConfig, DEFAULT_CONFIG } from "./config.js";
+
+describe("parseConfig", () => {
+  const validRaw = {
+    wecloneApiUrl: "http://localhost:8000/v1",
+    proxyPort: 8100,
+    remnicDaemonUrl: "http://localhost:4318",
+  };
+
+  it("parses a valid minimal config and applies defaults", () => {
+    const config = parseConfig(validRaw);
+    assert.equal(config.wecloneApiUrl, "http://localhost:8000/v1");
+    assert.equal(config.proxyPort, 8100);
+    assert.equal(config.remnicDaemonUrl, "http://localhost:4318");
+    assert.equal(config.sessionStrategy, DEFAULT_CONFIG.sessionStrategy);
+    assert.equal(config.wecloneModelName, DEFAULT_CONFIG.wecloneModelName);
+    assert.deepStrictEqual(config.memoryInjection, DEFAULT_CONFIG.memoryInjection);
+  });
+
+  it("parses a fully specified config", () => {
+    const full = {
+      ...validRaw,
+      wecloneModelName: "custom-avatar",
+      sessionStrategy: "caller-id",
+      memoryInjection: {
+        maxTokens: 2000,
+        position: "system-prepend",
+        template: "MEMORIES:\n{memories}",
+      },
+    };
+    const config = parseConfig(full);
+    assert.equal(config.wecloneModelName, "custom-avatar");
+    assert.equal(config.sessionStrategy, "caller-id");
+    assert.equal(config.memoryInjection.maxTokens, 2000);
+    assert.equal(config.memoryInjection.position, "system-prepend");
+    assert.equal(config.memoryInjection.template, "MEMORIES:\n{memories}");
+  });
+
+  it("rejects null input", () => {
+    assert.throws(() => parseConfig(null), /non-null object/);
+  });
+
+  it("rejects non-object input", () => {
+    assert.throws(() => parseConfig("string"), /non-null object/);
+  });
+
+  it("rejects missing wecloneApiUrl", () => {
+    const { wecloneApiUrl: _, ...rest } = validRaw;
+    assert.throws(() => parseConfig(rest), /wecloneApiUrl/);
+  });
+
+  it("rejects empty wecloneApiUrl", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, wecloneApiUrl: "" }),
+      /wecloneApiUrl/
+    );
+  });
+
+  it("rejects missing proxyPort", () => {
+    const { proxyPort: _, ...rest } = validRaw;
+    assert.throws(() => parseConfig(rest), /proxyPort/);
+  });
+
+  it("rejects non-integer proxyPort", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, proxyPort: 3.14 }),
+      /proxyPort/
+    );
+  });
+
+  it("rejects zero proxyPort", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, proxyPort: 0 }),
+      /proxyPort/
+    );
+  });
+
+  it("rejects missing remnicDaemonUrl", () => {
+    const { remnicDaemonUrl: _, ...rest } = validRaw;
+    assert.throws(() => parseConfig(rest), /remnicDaemonUrl/);
+  });
+
+  it("rejects invalid sessionStrategy", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, sessionStrategy: "round-robin" }),
+      /sessionStrategy.*must be one of/
+    );
+  });
+
+  it("rejects invalid memoryInjection.position", () => {
+    assert.throws(
+      () =>
+        parseConfig({
+          ...validRaw,
+          memoryInjection: { position: "middle" },
+        }),
+      /memoryInjection\.position.*must be one of/
+    );
+  });
+
+  it("rejects non-object memoryInjection", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, memoryInjection: "bad" }),
+      /memoryInjection.*must be an object/
+    );
+  });
+
+  it("rejects non-positive memoryInjection.maxTokens", () => {
+    assert.throws(
+      () =>
+        parseConfig({
+          ...validRaw,
+          memoryInjection: { maxTokens: -1 },
+        }),
+      /maxTokens.*positive integer/
+    );
+  });
+
+  it("rejects empty memoryInjection.template", () => {
+    assert.throws(
+      () =>
+        parseConfig({
+          ...validRaw,
+          memoryInjection: { template: "" },
+        }),
+      /template.*non-empty string/
+    );
+  });
+});

--- a/packages/connector-weclone/src/config.test.ts
+++ b/packages/connector-weclone/src/config.test.ts
@@ -128,4 +128,31 @@ describe("parseConfig", () => {
       /template.*non-empty string/
     );
   });
+
+  it("accepts remnicAuthToken as optional string", () => {
+    const config = parseConfig({
+      ...validRaw,
+      remnicAuthToken: "my-secret-token",
+    });
+    assert.equal(config.remnicAuthToken, "my-secret-token");
+  });
+
+  it("omits remnicAuthToken when not provided", () => {
+    const config = parseConfig(validRaw);
+    assert.equal(config.remnicAuthToken, undefined);
+  });
+
+  it("rejects empty remnicAuthToken", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, remnicAuthToken: "" }),
+      /remnicAuthToken.*non-empty string/
+    );
+  });
+
+  it("rejects non-string remnicAuthToken", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, remnicAuthToken: 12345 }),
+      /remnicAuthToken.*non-empty string/
+    );
+  });
 });

--- a/packages/connector-weclone/src/config.test.ts
+++ b/packages/connector-weclone/src/config.test.ts
@@ -77,6 +77,30 @@ describe("parseConfig", () => {
     );
   });
 
+  it("rejects proxyPort above 65535", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, proxyPort: 70000 }),
+      /proxyPort.*between 1 and 65535/
+    );
+  });
+
+  it("rejects proxyPort of 65536", () => {
+    assert.throws(
+      () => parseConfig({ ...validRaw, proxyPort: 65536 }),
+      /proxyPort/
+    );
+  });
+
+  it("accepts proxyPort at upper boundary (65535)", () => {
+    const config = parseConfig({ ...validRaw, proxyPort: 65535 });
+    assert.equal(config.proxyPort, 65535);
+  });
+
+  it("accepts proxyPort at lower boundary (1)", () => {
+    const config = parseConfig({ ...validRaw, proxyPort: 1 });
+    assert.equal(config.proxyPort, 1);
+  });
+
   it("rejects missing remnicDaemonUrl", () => {
     const { remnicDaemonUrl: _, ...rest } = validRaw;
     assert.throws(() => parseConfig(rest), /remnicDaemonUrl/);

--- a/packages/connector-weclone/src/config.ts
+++ b/packages/connector-weclone/src/config.ts
@@ -56,9 +56,14 @@ export function parseConfig(raw: unknown): WeCloneConnectorConfig {
     );
   }
 
-  if (typeof obj.proxyPort !== "number" || !Number.isInteger(obj.proxyPort) || obj.proxyPort <= 0) {
+  if (
+    typeof obj.proxyPort !== "number" ||
+    !Number.isInteger(obj.proxyPort) ||
+    obj.proxyPort <= 0 ||
+    obj.proxyPort > 65535
+  ) {
     throw new Error(
-      "Config 'proxyPort' is required and must be a positive integer"
+      "Config 'proxyPort' is required and must be an integer between 1 and 65535"
     );
   }
 

--- a/packages/connector-weclone/src/config.ts
+++ b/packages/connector-weclone/src/config.ts
@@ -1,0 +1,132 @@
+/**
+ * WeClone connector configuration.
+ *
+ * Validates user-provided config and applies defaults for optional fields.
+ */
+
+export interface MemoryInjectionConfig {
+  maxTokens: number;
+  position: "system-append" | "system-prepend";
+  template: string;
+}
+
+export interface WeCloneConnectorConfig {
+  wecloneApiUrl: string;
+  wecloneModelName?: string;
+  proxyPort: number;
+  remnicDaemonUrl: string;
+  sessionStrategy: "caller-id" | "single";
+  memoryInjection: MemoryInjectionConfig;
+}
+
+export const DEFAULT_CONFIG: WeCloneConnectorConfig = {
+  wecloneApiUrl: "http://localhost:8000/v1",
+  wecloneModelName: "weclone-avatar",
+  proxyPort: 8100,
+  remnicDaemonUrl: "http://localhost:4318",
+  sessionStrategy: "single",
+  memoryInjection: {
+    maxTokens: 1500,
+    position: "system-append",
+    template: "[Memory Context]\n{memories}\n[End Memory Context]",
+  },
+};
+
+const VALID_SESSION_STRATEGIES = ["caller-id", "single"] as const;
+const VALID_POSITIONS = ["system-append", "system-prepend"] as const;
+
+/**
+ * Parse and validate a raw config object into a WeCloneConnectorConfig.
+ *
+ * Rejects missing required fields and invalid values with clear messages.
+ * Applies defaults for all optional fields.
+ */
+export function parseConfig(raw: unknown): WeCloneConnectorConfig {
+  if (typeof raw !== "object" || raw === null) {
+    throw new Error("Config must be a non-null object");
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  // --- Required fields ---
+  if (typeof obj.wecloneApiUrl !== "string" || obj.wecloneApiUrl.length === 0) {
+    throw new Error(
+      "Config 'wecloneApiUrl' is required and must be a non-empty string"
+    );
+  }
+
+  if (typeof obj.proxyPort !== "number" || !Number.isInteger(obj.proxyPort) || obj.proxyPort <= 0) {
+    throw new Error(
+      "Config 'proxyPort' is required and must be a positive integer"
+    );
+  }
+
+  if (typeof obj.remnicDaemonUrl !== "string" || obj.remnicDaemonUrl.length === 0) {
+    throw new Error(
+      "Config 'remnicDaemonUrl' is required and must be a non-empty string"
+    );
+  }
+
+  // --- Optional fields with validation ---
+  const wecloneModelName =
+    obj.wecloneModelName !== undefined
+      ? String(obj.wecloneModelName)
+      : DEFAULT_CONFIG.wecloneModelName;
+
+  let sessionStrategy = DEFAULT_CONFIG.sessionStrategy;
+  if (obj.sessionStrategy !== undefined) {
+    if (!VALID_SESSION_STRATEGIES.includes(obj.sessionStrategy as typeof VALID_SESSION_STRATEGIES[number])) {
+      throw new Error(
+        `Config 'sessionStrategy' must be one of: ${VALID_SESSION_STRATEGIES.join(", ")}. ` +
+          `Got: ${JSON.stringify(obj.sessionStrategy)}`
+      );
+    }
+    sessionStrategy = obj.sessionStrategy as typeof sessionStrategy;
+  }
+
+  // --- Memory injection ---
+  let memoryInjection = { ...DEFAULT_CONFIG.memoryInjection };
+  if (obj.memoryInjection !== undefined) {
+    if (typeof obj.memoryInjection !== "object" || obj.memoryInjection === null) {
+      throw new Error("Config 'memoryInjection' must be an object");
+    }
+    const mi = obj.memoryInjection as Record<string, unknown>;
+
+    if (mi.maxTokens !== undefined) {
+      if (typeof mi.maxTokens !== "number" || !Number.isInteger(mi.maxTokens) || mi.maxTokens <= 0) {
+        throw new Error(
+          "Config 'memoryInjection.maxTokens' must be a positive integer"
+        );
+      }
+      memoryInjection.maxTokens = mi.maxTokens;
+    }
+
+    if (mi.position !== undefined) {
+      if (!VALID_POSITIONS.includes(mi.position as typeof VALID_POSITIONS[number])) {
+        throw new Error(
+          `Config 'memoryInjection.position' must be one of: ` +
+            `${VALID_POSITIONS.join(", ")}. Got: ${JSON.stringify(mi.position)}`
+        );
+      }
+      memoryInjection.position = mi.position as typeof memoryInjection.position;
+    }
+
+    if (mi.template !== undefined) {
+      if (typeof mi.template !== "string" || mi.template.length === 0) {
+        throw new Error(
+          "Config 'memoryInjection.template' must be a non-empty string"
+        );
+      }
+      memoryInjection.template = mi.template;
+    }
+  }
+
+  return {
+    wecloneApiUrl: obj.wecloneApiUrl,
+    wecloneModelName,
+    proxyPort: obj.proxyPort,
+    remnicDaemonUrl: obj.remnicDaemonUrl,
+    sessionStrategy,
+    memoryInjection,
+  };
+}

--- a/packages/connector-weclone/src/config.ts
+++ b/packages/connector-weclone/src/config.ts
@@ -15,6 +15,7 @@ export interface WeCloneConnectorConfig {
   wecloneModelName?: string;
   proxyPort: number;
   remnicDaemonUrl: string;
+  remnicAuthToken?: string;
   sessionStrategy: "caller-id" | "single";
   memoryInjection: MemoryInjectionConfig;
 }
@@ -68,6 +69,16 @@ export function parseConfig(raw: unknown): WeCloneConnectorConfig {
   }
 
   // --- Optional fields with validation ---
+  let remnicAuthToken: string | undefined;
+  if (obj.remnicAuthToken !== undefined) {
+    if (typeof obj.remnicAuthToken !== "string" || obj.remnicAuthToken.length === 0) {
+      throw new Error(
+        "Config 'remnicAuthToken' must be a non-empty string when provided"
+      );
+    }
+    remnicAuthToken = obj.remnicAuthToken;
+  }
+
   const wecloneModelName =
     obj.wecloneModelName !== undefined
       ? String(obj.wecloneModelName)
@@ -126,6 +137,7 @@ export function parseConfig(raw: unknown): WeCloneConnectorConfig {
     wecloneModelName,
     proxyPort: obj.proxyPort,
     remnicDaemonUrl: obj.remnicDaemonUrl,
+    remnicAuthToken,
     sessionStrategy,
     memoryInjection,
   };

--- a/packages/connector-weclone/src/format.test.ts
+++ b/packages/connector-weclone/src/format.test.ts
@@ -1,0 +1,86 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { formatMemoryBlock, type RecallResult } from "./format.js";
+
+const TEMPLATE = "[Memory]\n{memories}\n[/Memory]";
+
+describe("formatMemoryBlock", () => {
+  it("returns empty string for empty memories array", () => {
+    const result = formatMemoryBlock([], TEMPLATE, 1500);
+    assert.equal(result, "");
+  });
+
+  it("formats a single memory into the template", () => {
+    const memories: RecallResult[] = [
+      { content: "User likes cats", confidence: 0.9 },
+    ];
+    const result = formatMemoryBlock(memories, TEMPLATE, 1500);
+    assert.equal(result, "[Memory]\nUser likes cats\n[/Memory]");
+  });
+
+  it("formats multiple memories joined by newlines", () => {
+    const memories: RecallResult[] = [
+      { content: "Fact A", confidence: 0.8 },
+      { content: "Fact B", confidence: 0.7 },
+    ];
+    const result = formatMemoryBlock(memories, TEMPLATE, 1500);
+    assert.equal(result, "[Memory]\nFact A\nFact B\n[/Memory]");
+  });
+
+  it("sorts memories by confidence descending", () => {
+    const memories: RecallResult[] = [
+      { content: "Low", confidence: 0.3 },
+      { content: "High", confidence: 0.95 },
+      { content: "Mid", confidence: 0.6 },
+    ];
+    const result = formatMemoryBlock(memories, "{memories}", 1500);
+    assert.equal(result, "High\nMid\nLow");
+  });
+
+  it("places memories without confidence after those with", () => {
+    const memories: RecallResult[] = [
+      { content: "No conf" },
+      { content: "Has conf", confidence: 0.5 },
+    ];
+    const result = formatMemoryBlock(memories, "{memories}", 1500);
+    assert.equal(result, "Has conf\nNo conf");
+  });
+
+  it("truncates to fit within maxTokens", () => {
+    // 4 chars per token, maxTokens = 5 => max 20 chars
+    const memories: RecallResult[] = [
+      { content: "Short text here!", confidence: 0.9 }, // 16 chars
+      { content: "Another fact!!", confidence: 0.8 },    // 14 chars -- would exceed 20
+    ];
+    const result = formatMemoryBlock(memories, "{memories}", 5);
+    assert.equal(result, "Short text here!");
+  });
+
+  it("always includes at least one memory even if it exceeds maxTokens", () => {
+    const memories: RecallResult[] = [
+      { content: "This is a very long memory that exceeds the limit", confidence: 0.9 },
+    ];
+    // maxTokens=1 => max 4 chars, but the single memory is much longer
+    const result = formatMemoryBlock(memories, "{memories}", 1);
+    assert.equal(result, "This is a very long memory that exceeds the limit");
+  });
+
+  it("handles memories with category field", () => {
+    const memories: RecallResult[] = [
+      { content: "City: NYC", confidence: 0.8, category: "location" },
+    ];
+    const result = formatMemoryBlock(memories, "{memories}", 1500);
+    assert.equal(result, "City: NYC");
+  });
+
+  it("handles all memories without confidence scores", () => {
+    const memories: RecallResult[] = [
+      { content: "Fact X" },
+      { content: "Fact Y" },
+    ];
+    const result = formatMemoryBlock(memories, "{memories}", 1500);
+    // Both have confidence -1, so order is stable (original order)
+    assert.ok(result.includes("Fact X"));
+    assert.ok(result.includes("Fact Y"));
+  });
+});

--- a/packages/connector-weclone/src/format.test.ts
+++ b/packages/connector-weclone/src/format.test.ts
@@ -83,4 +83,28 @@ describe("formatMemoryBlock", () => {
     assert.ok(result.includes("Fact X"));
     assert.ok(result.includes("Fact Y"));
   });
+
+  it("does not corrupt output when memory content contains $ patterns", () => {
+    const memories: RecallResult[] = [
+      { content: "Price is $100 and $200", confidence: 0.9 },
+      { content: "Use $& and $` and $' in code", confidence: 0.8 },
+    ];
+    const result = formatMemoryBlock(memories, "[Mem]\n{memories}\n[/Mem]", 1500);
+    assert.ok(
+      result.includes("Price is $100 and $200"),
+      "Dollar signs in content must not be interpreted as replacement patterns"
+    );
+    assert.ok(
+      result.includes("$&"),
+      "$& must appear literally, not as the matched substring"
+    );
+    assert.ok(
+      result.includes("$`"),
+      "$` must appear literally"
+    );
+    assert.ok(
+      result.includes("$'"),
+      "$' must appear literally"
+    );
+  });
 });

--- a/packages/connector-weclone/src/format.ts
+++ b/packages/connector-weclone/src/format.ts
@@ -1,0 +1,59 @@
+/**
+ * Memory format adapter.
+ *
+ * Converts Remnic recall results into system prompt sections that
+ * can be injected into OpenAI-compatible chat completion requests.
+ */
+
+export interface RecallResult {
+  content: string;
+  confidence?: number;
+  category?: string;
+}
+
+const CHARS_PER_TOKEN = 4;
+
+/**
+ * Format recall results into a memory block suitable for prompt injection.
+ *
+ * - Sorts memories by confidence (highest first; missing confidence sorts last)
+ * - Truncates combined content to fit within `maxTokens` (approx 4 chars/token)
+ * - Fills in the template's `{memories}` placeholder
+ * - Returns empty string if no memories are provided
+ */
+export function formatMemoryBlock(
+  memories: RecallResult[],
+  template: string,
+  maxTokens: number
+): string {
+  if (memories.length === 0) {
+    return "";
+  }
+
+  // Sort by confidence descending; undefined confidence sorts last
+  const sorted = [...memories].sort((a, b) => {
+    const aConf = a.confidence ?? -1;
+    const bConf = b.confidence ?? -1;
+    return bConf - aConf;
+  });
+
+  const maxChars = maxTokens * CHARS_PER_TOKEN;
+  let totalChars = 0;
+  const included: string[] = [];
+
+  for (const memory of sorted) {
+    const line = memory.content;
+    if (totalChars + line.length > maxChars && included.length > 0) {
+      break;
+    }
+    included.push(line);
+    totalChars += line.length;
+  }
+
+  if (included.length === 0) {
+    return "";
+  }
+
+  const memoriesText = included.join("\n");
+  return template.replace("{memories}", memoriesText);
+}

--- a/packages/connector-weclone/src/format.ts
+++ b/packages/connector-weclone/src/format.ts
@@ -55,5 +55,5 @@ export function formatMemoryBlock(
   }
 
   const memoriesText = included.join("\n");
-  return template.replace("{memories}", memoriesText);
+  return template.replace("{memories}", () => memoriesText);
 }

--- a/packages/connector-weclone/src/index.ts
+++ b/packages/connector-weclone/src/index.ts
@@ -1,0 +1,25 @@
+/**
+ * @remnic/connector-weclone
+ *
+ * OpenAI-compatible proxy that adds Remnic persistent memory
+ * to deployed WeClone avatars.
+ */
+
+export { createWeCloneProxy, type WeCloneProxy } from "./proxy.js";
+export {
+  type WeCloneConnectorConfig,
+  type MemoryInjectionConfig,
+  DEFAULT_CONFIG,
+  parseConfig,
+} from "./config.js";
+export { formatMemoryBlock, type RecallResult } from "./format.js";
+export {
+  SingleSessionMapper,
+  CallerIdSessionMapper,
+  type SessionMapper,
+  type ChatCompletionRequest,
+} from "./session.js";
+export {
+  generateWeCloneInstructions,
+  type WeCloneInstallResult,
+} from "./installer.js";

--- a/packages/connector-weclone/src/installer.ts
+++ b/packages/connector-weclone/src/installer.ts
@@ -39,12 +39,11 @@ Steps:
    Ensure it is listening at: ${config.remnicDaemonUrl}
 
 3. Start the connector proxy
-   npx @remnic/connector-weclone --port ${config.proxyPort} \\
-     --weclone-api ${config.wecloneApiUrl} \\
-     --remnic-daemon ${config.remnicDaemonUrl}
+   remnic-weclone-proxy --config ~/.remnic/connectors/weclone.json
 
    The proxy will listen on port ${config.proxyPort} and forward
    requests to WeClone after injecting Remnic memory context.
+   (All settings are read from the config file.)
 
 4. Update your bot / client configuration
    Change the API base URL from:

--- a/packages/connector-weclone/src/installer.ts
+++ b/packages/connector-weclone/src/installer.ts
@@ -1,0 +1,66 @@
+/**
+ * WeClone connector installer.
+ *
+ * Generates setup instructions for connecting a WeClone avatar
+ * to Remnic memory through the OpenAI-compatible proxy.
+ */
+
+import type { WeCloneConnectorConfig } from "./config.js";
+
+export interface WeCloneInstallResult {
+  config: WeCloneConnectorConfig;
+  instructions: string;
+}
+
+/**
+ * Generate human-readable setup instructions for the WeClone connector.
+ *
+ * Tells the user how to start each component and reconfigure their
+ * bot to route through the memory-aware proxy.
+ */
+export function generateWeCloneInstructions(
+  config: WeCloneConnectorConfig
+): WeCloneInstallResult {
+  const instructions = `
+WeClone + Remnic Memory Connector Setup
+========================================
+
+Prerequisites:
+  - WeClone avatar API server
+  - Remnic daemon (remnic-server)
+  - Node.js 18+
+
+Steps:
+
+1. Start the WeClone API server
+   Ensure it is listening at: ${config.wecloneApiUrl}
+
+2. Start the Remnic daemon
+   Ensure it is listening at: ${config.remnicDaemonUrl}
+
+3. Start the connector proxy
+   npx @remnic/connector-weclone --port ${config.proxyPort} \\
+     --weclone-api ${config.wecloneApiUrl} \\
+     --remnic-daemon ${config.remnicDaemonUrl}
+
+   The proxy will listen on port ${config.proxyPort} and forward
+   requests to WeClone after injecting Remnic memory context.
+
+4. Update your bot / client configuration
+   Change the API base URL from:
+     ${config.wecloneApiUrl}
+   to:
+     http://localhost:${config.proxyPort}/v1
+
+   All OpenAI-compatible requests will be transparently proxied
+   with memory injection for chat completions.
+
+Session strategy: ${config.sessionStrategy}
+${config.sessionStrategy === "caller-id" ? '  Set X-Caller-Id header or "user" field to scope memory per caller.' : "  All requests share a single memory session."}
+
+Health check:
+  GET http://localhost:${config.proxyPort}/health
+`.trim();
+
+  return { config, instructions };
+}

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1278,6 +1278,156 @@ describe("WeCloneProxy", () => {
     );
   });
 
+  it("forwards query string on chat completions to upstream", async () => {
+    let receivedUrl = "";
+    const weclone = await createMockServer((req, res) => {
+      receivedUrl = req.url ?? "";
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "ok" } }],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions?api-version=2024-01-01&tenant=abc`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.ok(
+      receivedUrl.includes("api-version=2024-01-01"),
+      "Upstream URL must preserve api-version query param"
+    );
+    assert.ok(
+      receivedUrl.includes("tenant=abc"),
+      "Upstream URL must preserve additional query params"
+    );
+  });
+
+  it("preserves distinct system messages after memory injection", async () => {
+    let receivedBody: Record<string, unknown> | null = null;
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "ok" } }],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          results: [{ preview: "injected-memory", confidence: 0.9 }],
+        })
+      );
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    await fetch(`http://127.0.0.1:${proxy.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "weclone-avatar",
+        messages: [
+          { role: "system", content: "First instruction." },
+          { role: "system", content: "Second instruction." },
+          { role: "user", content: "Hi" },
+        ],
+      }),
+    });
+
+    assert.ok(receivedBody);
+    const messages = (receivedBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const systemMsgs = messages.filter((m) => m.role === "system");
+    assert.equal(systemMsgs.length, 2, "Both system messages must survive");
+    assert.ok(
+      systemMsgs[0].content.includes("First instruction.") &&
+        systemMsgs[0].content.includes("injected-memory"),
+      "First system message must contain original + injected memory"
+    );
+    assert.equal(
+      systemMsgs[1].content,
+      "Second instruction.",
+      "Second system message must be preserved verbatim"
+    );
+  });
+
+  it("returns 400 when messages is not an array", async () => {
+    const weclone = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: "not-an-array",
+        }),
+      }
+    );
+    assert.equal(res.status, 400);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.error, "bad_request");
+    assert.ok(
+      typeof body.detail === "string" && body.detail.includes("array"),
+      "Detail must mention the expected array type"
+    );
+  });
+
   it("preserves configured base path when forwarding to WeClone", async () => {
     let receivedUrl = "";
     const weclone = await createMockServer((req, res) => {

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -685,4 +685,132 @@ describe("WeCloneProxy", () => {
     const body = JSON.parse(await readResponse(res));
     assert.equal(body.error, "bad_request");
   });
+
+  it("trailing slash in wecloneApiUrl does not produce double-slash URLs", async () => {
+    let receivedUrl = "";
+
+    const weclone = await createMockServer((req, res) => {
+      receivedUrl = req.url ?? "";
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              { message: { role: "assistant", content: "OK" } },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    // Config with trailing slash -- should NOT produce /v1//chat/completions
+    const proxy = createWeCloneProxy(
+      testConfig(weclone.port, remnic.port, {
+        wecloneApiUrl: `http://127.0.0.1:${weclone.port}/v1/`,
+      })
+    );
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(
+      receivedUrl,
+      "/v1/chat/completions",
+      "Upstream URL must not contain double slashes"
+    );
+    assert.ok(
+      !receivedUrl.includes("//"),
+      "URL path must not contain double slashes"
+    );
+  });
+
+  it("transparent proxy sets Content-Length and ends response correctly", async () => {
+    const responsePayload = JSON.stringify({
+      data: [{ id: "model-1" }, { id: "model-2" }],
+    });
+
+    const weclone = await createMockServer((_req, res) => {
+      // Simulate upstream with transfer-encoding: chunked
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Transfer-Encoding": "chunked",
+      });
+      res.write(responsePayload.slice(0, 10));
+      res.write(responsePayload.slice(10));
+      res.end();
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/models`);
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/json",
+      "Content-Type should be forwarded"
+    );
+    assert.equal(
+      res.headers.get("content-length"),
+      String(Buffer.byteLength(responsePayload)),
+      "Content-Length should be set to actual body length"
+    );
+    assert.equal(
+      res.headers.get("transfer-encoding"),
+      null,
+      "transfer-encoding hop-by-hop header must be stripped"
+    );
+
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.data.length, 2);
+    assert.equal(body.data[0].id, "model-1");
+  });
+
+  it("transparent proxy returns 502 when upstream is unreachable", async () => {
+    const fakeWeclonePort = 59998;
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(fakeWeclonePort, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/models`);
+    assert.equal(res.status, 502);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.error, "upstream_unreachable");
+  });
 });

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import * as http from "node:http";
+import * as net from "node:net";
 import { gzipSync } from "node:zlib";
 import { createWeCloneProxy } from "./proxy.js";
 import type { WeCloneConnectorConfig } from "./config.js";
@@ -922,6 +923,122 @@ describe("WeCloneProxy", () => {
     );
     const body = JSON.parse(await readResponse(res));
     assert.equal(body.choices[0].message.content, "filtered reply");
+  });
+
+  it("strips hop-by-hop request headers from transparent proxy forwarding", async () => {
+    let receivedHeaders: Record<string, string | string[] | undefined> = {};
+
+    const weclone = await createMockServer((req, res) => {
+      receivedHeaders = { ...req.headers };
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ data: [{ id: "model-1" }] }));
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    // Use a raw HTTP request so we can set hop-by-hop headers that
+    // Node's fetch() / undici would reject (Upgrade, Trailer, TE).
+    // We use a raw TCP socket to bypass Node http.ClientRequest
+    // validation as well (it rejects Trailer without chunked TE).
+    const responseBody = await new Promise<string>((resolve, reject) => {
+      const socket = net.createConnection(proxy.port, "127.0.0.1", () => {
+        const rawRequest = [
+          "GET /v1/models HTTP/1.1",
+          `Host: 127.0.0.1:${proxy.port}`,
+          "Content-Type: application/json",
+          "X-Custom-Header: should-survive",
+          "Proxy-Authorization: Basic secret-proxy-creds",
+          "Proxy-Authenticate: Basic realm=proxy",
+          "TE: trailers",
+          "Trailer: X-Checksum",
+          "Upgrade: websocket",
+          "Keep-Alive: timeout=5",
+          "Connection: close",
+          "",
+          "",
+        ].join("\r\n");
+        socket.write(rawRequest);
+      });
+      socket.setTimeout(5000, () => { socket.destroy(); reject(new Error("socket timeout")); });
+      const chunks: Buffer[] = [];
+      socket.on("data", (c: Buffer) => chunks.push(c));
+      socket.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+      socket.on("error", reject);
+    });
+
+    // Parse HTTP response: skip headers, extract body after blank line
+    const bodyStart = responseBody.indexOf("\r\n\r\n");
+    assert.ok(bodyStart > 0, "Response should have headers and body");
+    // The body might be chunked; extract the JSON payload
+    const rawBody = responseBody.slice(bodyStart + 4);
+    // Handle possible chunked transfer encoding in the response
+    const jsonMatch = rawBody.match(/\{[^]*\}/);
+    assert.ok(jsonMatch, "Response body should contain JSON");
+    const reqBody = JSON.parse(jsonMatch[0]);
+    assert.equal(reqBody.data[0].id, "model-1");
+
+    // Verify hop-by-hop headers were stripped
+    assert.equal(
+      receivedHeaders["proxy-authorization"],
+      undefined,
+      "proxy-authorization must be stripped to prevent credential leakage"
+    );
+    assert.equal(
+      receivedHeaders["proxy-authenticate"],
+      undefined,
+      "proxy-authenticate must be stripped"
+    );
+    assert.equal(
+      receivedHeaders["te"],
+      undefined,
+      "te must be stripped"
+    );
+    assert.equal(
+      receivedHeaders["trailer"],
+      undefined,
+      "trailer must be stripped"
+    );
+    assert.equal(
+      receivedHeaders["upgrade"],
+      undefined,
+      "upgrade must be stripped"
+    );
+    assert.equal(
+      receivedHeaders["keep-alive"],
+      undefined,
+      "keep-alive must be stripped"
+    );
+    // Note: we don't assert connection is absent because fetch() (undici)
+    // adds its own Connection header for transport. The proxy strips the
+    // *original* client Connection header; fetch replaces it with its own.
+
+    // Verify non-hop-by-hop headers survive
+    assert.equal(
+      receivedHeaders["x-custom-header"],
+      "should-survive",
+      "Non-hop-by-hop headers must be forwarded"
+    );
+    assert.equal(
+      receivedHeaders["content-type"],
+      "application/json",
+      "Content-Type must be forwarded"
+    );
+
+    // Host must also be stripped (replaced by fetch with upstream host)
+    assert.notEqual(
+      receivedHeaders["host"],
+      `127.0.0.1:${proxy.port}`,
+      "Original host header must not be forwarded"
+    );
   });
 
   it("strips content-encoding from transparent proxy responses", async () => {

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, afterEach } from "node:test";
 import assert from "node:assert/strict";
 import * as http from "node:http";
+import { gzipSync } from "node:zlib";
 import { createWeCloneProxy } from "./proxy.js";
 import type { WeCloneConnectorConfig } from "./config.js";
 
@@ -812,5 +813,135 @@ describe("WeCloneProxy", () => {
     assert.equal(res.status, 502);
     const body = JSON.parse(await readResponse(res));
     assert.equal(body.error, "upstream_unreachable");
+  });
+
+  it("passes through upstream error body for stream requests instead of SSE headers", async () => {
+    const errorPayload = JSON.stringify({ error: { message: "Unauthorized", type: "auth_error" } });
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        // Return a 401 JSON error, not SSE
+        res.writeHead(401, { "Content-Type": "application/json" });
+        res.end(errorPayload);
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          stream: true,
+          messages: [{ role: "user", content: "Hello" }],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 401, "Upstream error status should be forwarded");
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/json",
+      "Error response should have JSON content-type, not text/event-stream"
+    );
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.error.message, "Unauthorized");
+  });
+
+  it("strips content-encoding from transparent proxy responses", async () => {
+    const payload = JSON.stringify({ data: "test" });
+    const compressed = gzipSync(Buffer.from(payload));
+
+    const weclone = await createMockServer((_req, res) => {
+      // Serve actually-gzipped body with the matching header.
+      // fetch() auto-decompresses, so the proxy receives decoded bytes.
+      // The proxy must NOT forward content-encoding to the client.
+      res.writeHead(200, {
+        "Content-Type": "application/json",
+        "Content-Encoding": "gzip",
+        "Content-Length": String(compressed.length),
+      });
+      res.end(compressed);
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/v1/models`);
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-encoding"),
+      null,
+      "content-encoding must be stripped from buffered proxy responses"
+    );
+    assert.equal(
+      res.headers.get("content-type"),
+      "application/json",
+      "Other headers should still be forwarded"
+    );
+    // Verify the body is readable as decompressed JSON
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.data, "test", "Body should be decompressed and readable");
+  });
+});
+
+describe("WeClone Installer", () => {
+  it("generates instructions with --config flag matching CLI", async () => {
+    // Dynamic import to avoid circular dependency issues
+    const { generateWeCloneInstructions } = await import("./installer.js");
+    const result = generateWeCloneInstructions({
+      wecloneApiUrl: "http://localhost:8000/v1",
+      proxyPort: 8100,
+      remnicDaemonUrl: "http://localhost:4318",
+      sessionStrategy: "single",
+      memoryInjection: {
+        maxTokens: 1500,
+        position: "system-append",
+        template: "[Memory]\n{memories}\n[/Memory]",
+      },
+    });
+
+    assert.ok(
+      result.instructions.includes("--config"),
+      "Instructions should reference the --config flag"
+    );
+    assert.ok(
+      !result.instructions.includes("--port"),
+      "Instructions must not reference unsupported --port flag"
+    );
+    assert.ok(
+      !result.instructions.includes("--weclone-api"),
+      "Instructions must not reference unsupported --weclone-api flag"
+    );
+    assert.ok(
+      !result.instructions.includes("--remnic-daemon"),
+      "Instructions must not reference unsupported --remnic-daemon flag"
+    );
+    assert.ok(
+      result.instructions.includes("remnic-weclone-proxy"),
+      "Instructions should reference the correct binary name"
+    );
   });
 });

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -862,6 +862,68 @@ describe("WeCloneProxy", () => {
     assert.equal(body.error.message, "Unauthorized");
   });
 
+  it("strips hop-by-hop headers from non-streaming chat completions responses", async () => {
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        // Upstream responds with hop-by-hop headers that must be stripped
+        res.writeHead(200, {
+          "Content-Type": "application/json",
+          "Transfer-Encoding": "chunked",
+          "Connection": "keep-alive",
+        });
+        res.end(
+          JSON.stringify({
+            choices: [
+              { message: { role: "assistant", content: "filtered reply" } },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("transfer-encoding"),
+      null,
+      "transfer-encoding hop-by-hop header must be stripped from chat completions responses"
+    );
+    // Note: Node.js HTTP server adds its own Connection header at the
+    // transport layer, so we cannot assert it is absent. The important
+    // guarantee is that upstream hop-by-hop headers like transfer-encoding
+    // and content-encoding do not leak through.
+    assert.ok(
+      res.headers.get("content-length"),
+      "content-length should be set on non-streaming chat completions responses"
+    );
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.choices[0].message.content, "filtered reply");
+  });
+
   it("strips content-encoding from transparent proxy responses", async () => {
     const payload = JSON.stringify({ data: "test" });
     const compressed = gzipSync(Buffer.from(payload));

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -289,6 +289,266 @@ describe("WeCloneProxy", () => {
     assert.equal(body.method, "GET");
   });
 
+  it("sends auth token to Remnic daemon when configured", async () => {
+    let recallAuthHeader: string | undefined;
+    let observeAuthHeader: string | undefined;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: { role: "assistant", content: "Hello!" },
+              },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    let requestCount = 0;
+    const remnic = await createMockServer((req, res) => {
+      requestCount++;
+      if (requestCount === 1) {
+        recallAuthHeader = req.headers["authorization"] as string | undefined;
+      } else {
+        observeAuthHeader = req.headers["authorization"] as string | undefined;
+      }
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [{ preview: "Some memory", confidence: 0.9 }] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(
+      testConfig(weclone.port, remnic.port, {
+        remnicAuthToken: "test-secret-token",
+      })
+    );
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    await fetch(`http://127.0.0.1:${proxy.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "weclone-avatar",
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Hi" },
+        ],
+      }),
+    });
+
+    // Wait briefly for fire-and-forget observe
+    await new Promise((r) => setTimeout(r, 100));
+
+    assert.equal(
+      recallAuthHeader,
+      "Bearer test-secret-token",
+      "Recall request should include auth header"
+    );
+    assert.equal(
+      observeAuthHeader,
+      "Bearer test-secret-token",
+      "Observe request should include auth header"
+    );
+  });
+
+  it("sends observe body in messages array format", async () => {
+    let observeBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: { role: "assistant", content: "I remember you!" },
+              },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    let requestCount = 0;
+    const remnic = await createMockServer((req, res) => {
+      requestCount++;
+      if (requestCount === 1) {
+        // recall request
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ results: [] }));
+      } else {
+        // observe request
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          observeBody = JSON.parse(Buffer.concat(chunks).toString());
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ ok: true }));
+        });
+      }
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    await fetch(`http://127.0.0.1:${proxy.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "weclone-avatar",
+        messages: [
+          { role: "system", content: "You are helpful." },
+          { role: "user", content: "Hello friend" },
+        ],
+      }),
+    });
+
+    // Wait for fire-and-forget observe
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(observeBody, "Observe request should have been sent");
+    assert.ok(
+      Array.isArray((observeBody as Record<string, unknown>).messages),
+      "Observe body should have a messages array"
+    );
+    const messages = (observeBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    assert.equal(messages.length, 2);
+    assert.equal(messages[0].role, "user");
+    assert.equal(messages[0].content, "Hello friend");
+    assert.equal(messages[1].role, "assistant");
+    assert.equal(messages[1].content, "I remember you!");
+    assert.equal(
+      (observeBody as Record<string, unknown>).sessionKey,
+      "weclone-default",
+      "Observe body should include sessionKey"
+    );
+  });
+
+  it("normalizes recall results with preview field to content", async () => {
+    let receivedBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: { role: "assistant", content: "Reply" },
+              },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    // Remnic returns results with preview field (EngramAccessMemorySummary format)
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          results: [
+            { preview: "User likes dogs", confidence: 0.85, category: "preference" },
+            { content: "User lives in NYC", confidence: 0.7 },
+          ],
+        })
+      );
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "What do I like?" },
+          ],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.ok(receivedBody);
+    const messages = (receivedBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const systemMsg = messages.find((m) => m.role === "system");
+    assert.ok(systemMsg);
+    assert.ok(
+      systemMsg.content.includes("User likes dogs"),
+      "preview field should be normalized to content"
+    );
+    assert.ok(
+      systemMsg.content.includes("User lives in NYC"),
+      "content field should still work as fallback"
+    );
+  });
+
+  it("does not expose error details in 502 responses", async () => {
+    // WeClone is unreachable (no mock server started on this port)
+    const fakeWeclonePort = 59999;
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(fakeWeclonePort, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [{ role: "user", content: "Hi" }],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 502);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.error, "upstream_unreachable");
+    assert.equal(
+      body.detail,
+      undefined,
+      "Error response must not expose detail/stack trace"
+    );
+  });
+
   it("returns 400 for invalid JSON body on chat completions", async () => {
     const weclone = await createMockServer((_req, res) => {
       res.writeHead(200);

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1084,6 +1084,267 @@ describe("WeCloneProxy", () => {
     const body = JSON.parse(await readResponse(res));
     assert.equal(body.data, "test", "Body should be decompressed and readable");
   });
+
+  it("matches chat completions route when URL has a query string", async () => {
+    let recallCalled = false;
+    let receivedBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "Hi" } }],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      recallCalled = true;
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ results: [{ preview: "memory X", confidence: 0.9 }] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    // Simulate Azure-OpenAI style query string; route matching must not fall
+    // through to the transparent proxy.
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions?api-version=2024-01-01`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Hello" },
+          ],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.ok(recallCalled, "Recall must be invoked for chat URLs with query strings");
+    const msgs = (receivedBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const sys = msgs.find((m) => m.role === "system");
+    assert.ok(sys && sys.content.includes("memory X"), "Memory must be injected");
+  });
+
+  it("handles multimodal user message content (array of parts)", async () => {
+    let recallQuery: string | undefined;
+    let observeBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "Describing the image." } }],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    let reqCount = 0;
+    const remnic = await createMockServer((req, res) => {
+      reqCount++;
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        const parsed = JSON.parse(Buffer.concat(chunks).toString()) as {
+          query?: string;
+          messages?: Array<{ role: string; content: unknown }>;
+        };
+        if (reqCount === 1) {
+          recallQuery = parsed.query;
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ results: [] }));
+        } else {
+          observeBody = parsed as unknown as Record<string, unknown>;
+          res.writeHead(200);
+          res.end(JSON.stringify({ ok: true }));
+        }
+      });
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    await fetch(`http://127.0.0.1:${proxy.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "weclone-avatar",
+        messages: [
+          { role: "system", content: "You are helpful." },
+          {
+            role: "user",
+            content: [
+              { type: "text", text: "What is in this image?" },
+              { type: "image_url", image_url: { url: "https://example.invalid/i.png" } },
+            ],
+          },
+        ],
+      }),
+    });
+
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.equal(
+      typeof recallQuery,
+      "string",
+      "Recall query must be a string even for multimodal content"
+    );
+    assert.equal(
+      recallQuery,
+      "What is in this image?",
+      "Text parts from multimodal content must be extracted for recall"
+    );
+    assert.ok(observeBody, "Observe must be sent");
+    const messages = (observeBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: unknown;
+    }>;
+    assert.equal(messages[0].role, "user");
+    assert.equal(
+      messages[0].content,
+      "What is in this image?",
+      "Observe user content must be plain text extracted from multimodal parts"
+    );
+  });
+
+  it("normalizes trailing slashes on remnicDaemonUrl", async () => {
+    let recallUrl = "";
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [{ message: { role: "assistant", content: "ok" } }],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((req, res) => {
+      if (!recallUrl) recallUrl = req.url ?? "";
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(
+      testConfig(weclone.port, remnic.port, {
+        // Trailing slash must not produce `//engram/v1/recall`.
+        remnicDaemonUrl: `http://127.0.0.1:${remnic.port}/`,
+      })
+    );
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    await fetch(`http://127.0.0.1:${proxy.port}/v1/chat/completions`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        model: "weclone-avatar",
+        messages: [{ role: "user", content: "hi" }],
+      }),
+    });
+
+    assert.equal(
+      recallUrl,
+      "/engram/v1/recall",
+      "Recall path must not have double-slash from trailing-slash config"
+    );
+  });
+
+  it("preserves configured base path when forwarding to WeClone", async () => {
+    let receivedUrl = "";
+    const weclone = await createMockServer((req, res) => {
+      receivedUrl = req.url ?? "";
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        if (receivedUrl.startsWith("/weclone/v1/chat/completions")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(
+            JSON.stringify({
+              choices: [{ message: { role: "assistant", content: "ok" } }],
+            })
+          );
+        } else if (receivedUrl.startsWith("/weclone/v1/models")) {
+          res.writeHead(200, { "Content-Type": "application/json" });
+          res.end(JSON.stringify({ data: [{ id: "m" }] }));
+        } else {
+          res.writeHead(404);
+          res.end();
+        }
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(
+      testConfig(weclone.port, remnic.port, {
+        wecloneApiUrl: `http://127.0.0.1:${weclone.port}/weclone/v1`,
+      })
+    );
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    // Chat completions: should prepend /weclone/v1.
+    const chatRes = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "m",
+          messages: [{ role: "user", content: "hi" }],
+        }),
+      }
+    );
+    assert.equal(chatRes.status, 200);
+    assert.equal(
+      receivedUrl,
+      "/weclone/v1/chat/completions",
+      "Chat path must be prefixed with configured base path"
+    );
+
+    // Transparent proxy: GET /v1/models should also be prefixed.
+    const modelsRes = await fetch(`http://127.0.0.1:${proxy.port}/v1/models`);
+    assert.equal(modelsRes.status, 200);
+    assert.equal(
+      receivedUrl,
+      "/weclone/v1/models",
+      "Transparent proxy must also preserve base path"
+    );
+  });
 });
 
 describe("WeClone Installer", () => {

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -513,6 +513,113 @@ describe("WeCloneProxy", () => {
     );
   });
 
+  it("streams SSE responses for stream: true requests", async () => {
+    // WeClone mock returns SSE chunks
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        res.writeHead(200, {
+          "Content-Type": "text/event-stream",
+          "Cache-Control": "no-cache",
+          "Connection": "keep-alive",
+        });
+        res.write(
+          'data: {"choices":[{"delta":{"role":"assistant"},"index":0}]}\n\n'
+        );
+        res.write(
+          'data: {"choices":[{"delta":{"content":"Hello"},"index":0}]}\n\n'
+        );
+        res.write(
+          'data: {"choices":[{"delta":{"content":" world"},"index":0}]}\n\n'
+        );
+        res.write("data: [DONE]\n\n");
+        res.end();
+      });
+    });
+    cleanups.push(weclone.close);
+
+    let observeReceived = false;
+    let observeContent = "";
+    let requestCount = 0;
+    const remnic = await createMockServer((req, res) => {
+      requestCount++;
+      if (requestCount === 1) {
+        // recall
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ results: [] }));
+      } else {
+        // observe
+        const chunks: Buffer[] = [];
+        req.on("data", (c: Buffer) => chunks.push(c));
+        req.on("end", () => {
+          observeReceived = true;
+          const body = JSON.parse(Buffer.concat(chunks).toString()) as {
+            messages?: Array<{ role: string; content: string }>;
+          };
+          const assistantMsg = body.messages?.find(
+            (m: { role: string }) => m.role === "assistant"
+          );
+          observeContent = assistantMsg?.content ?? "";
+          res.writeHead(200);
+          res.end(JSON.stringify({ ok: true }));
+        });
+      }
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          stream: true,
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Say hello" },
+          ],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    assert.equal(
+      res.headers.get("content-type"),
+      "text/event-stream",
+      "Response should have SSE content type"
+    );
+
+    // Read the full streamed response
+    const streamedBody = await res.text();
+    assert.ok(
+      streamedBody.includes("data: [DONE]"),
+      "Streamed response should include [DONE] marker"
+    );
+    assert.ok(
+      streamedBody.includes('"content":"Hello"'),
+      "Streamed response should include content chunks"
+    );
+
+    // Wait for fire-and-forget observe
+    await new Promise((r) => setTimeout(r, 200));
+
+    assert.ok(
+      observeReceived,
+      "Observe should be called with reconstructed content"
+    );
+    assert.equal(
+      observeContent,
+      "Hello world",
+      "Observed content should be the concatenated stream deltas"
+    );
+  });
+
   it("does not expose error details in 502 responses", async () => {
     // WeClone is unreachable (no mock server started on this port)
     const fakeWeclonePort = 59999;

--- a/packages/connector-weclone/src/proxy.test.ts
+++ b/packages/connector-weclone/src/proxy.test.ts
@@ -1,0 +1,321 @@
+import { describe, it, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import * as http from "node:http";
+import { createWeCloneProxy } from "./proxy.js";
+import type { WeCloneConnectorConfig } from "./config.js";
+
+/**
+ * Create a mock HTTP server that responds with a fixed body for any request.
+ * Listens on port 0 (OS-assigned) to avoid conflicts.
+ */
+function createMockServer(
+  handler: (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ) => void
+): Promise<{ server: http.Server; port: number; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    server.listen(0, () => {
+      const addr = server.address();
+      const port = typeof addr === "object" && addr !== null ? addr.port : 0;
+      resolve({
+        server,
+        port,
+        close: () =>
+          new Promise<void>((res, rej) =>
+            server.close((err) => (err ? rej(err) : res()))
+          ),
+      });
+    });
+  });
+}
+
+/**
+ * Read a response body as string.
+ */
+async function readResponse(res: Response): Promise<string> {
+  return res.text();
+}
+
+/**
+ * Build a test config pointing at the given mock ports.
+ */
+function testConfig(
+  weclonePort: number,
+  remnicPort: number,
+  overrides: Partial<WeCloneConnectorConfig> = {}
+): WeCloneConnectorConfig {
+  return {
+    wecloneApiUrl: `http://127.0.0.1:${weclonePort}/v1`,
+    proxyPort: 0, // OS-assigned
+    remnicDaemonUrl: `http://127.0.0.1:${remnicPort}`,
+    sessionStrategy: "single",
+    memoryInjection: {
+      maxTokens: 1500,
+      position: "system-append",
+      template: "[Memory]\n{memories}\n[/Memory]",
+    },
+    ...overrides,
+  };
+}
+
+// Track servers to clean up
+const cleanups: Array<() => Promise<void>> = [];
+
+afterEach(async () => {
+  for (const fn of cleanups.splice(0)) {
+    await fn();
+  }
+});
+
+describe("WeCloneProxy", () => {
+  it("starts and stops cleanly", async () => {
+    const weclone = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    assert.ok(proxy.port > 0, "proxy should have a valid port");
+    await proxy.stop();
+    // Remove from cleanups since we already stopped
+    cleanups.pop();
+  });
+
+  it("health endpoint returns 200 with status ok", async () => {
+    const weclone = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const config = testConfig(weclone.port, remnic.port);
+    const proxy = createWeCloneProxy(config);
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(`http://127.0.0.1:${proxy.port}/health`);
+    assert.equal(res.status, 200);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.status, "ok");
+    assert.equal(body.wecloneApi, config.wecloneApiUrl);
+  });
+
+  it("proxies chat completions with memory injection", async () => {
+    let receivedBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: { role: "assistant", content: "Hello from WeClone!" },
+              },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(
+        JSON.stringify({
+          results: [
+            { content: "User prefers formal tone", confidence: 0.9 },
+          ],
+        })
+      );
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Hi there" },
+          ],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    const responseBody = JSON.parse(await readResponse(res));
+    assert.equal(responseBody.choices[0].message.content, "Hello from WeClone!");
+
+    // Verify memory was injected into the forwarded request
+    assert.ok(receivedBody, "WeClone should have received a request");
+    const messages = (receivedBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const systemMsg = messages.find((m) => m.role === "system");
+    assert.ok(systemMsg, "System message should exist");
+    assert.ok(
+      systemMsg.content.includes("User prefers formal tone"),
+      "Memory should be injected into system message"
+    );
+    assert.ok(
+      systemMsg.content.includes("[Memory]"),
+      "Memory template should be used"
+    );
+  });
+
+  it("continues working when Remnic recall fails", async () => {
+    let receivedBody: Record<string, unknown> | null = null;
+
+    const weclone = await createMockServer((req, res) => {
+      const chunks: Buffer[] = [];
+      req.on("data", (c: Buffer) => chunks.push(c));
+      req.on("end", () => {
+        receivedBody = JSON.parse(Buffer.concat(chunks).toString());
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            choices: [
+              {
+                message: { role: "assistant", content: "Response without memory" },
+              },
+            ],
+          })
+        );
+      });
+    });
+    cleanups.push(weclone.close);
+
+    // Remnic returns 500
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(500);
+      res.end("Internal Server Error");
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "weclone-avatar",
+          messages: [
+            { role: "system", content: "You are helpful." },
+            { role: "user", content: "Hello" },
+          ],
+        }),
+      }
+    );
+
+    assert.equal(res.status, 200);
+    const responseBody = JSON.parse(await readResponse(res));
+    assert.equal(
+      responseBody.choices[0].message.content,
+      "Response without memory"
+    );
+
+    // Verify the system message was NOT modified (no memory block)
+    assert.ok(receivedBody);
+    const messages = (receivedBody as Record<string, unknown>).messages as Array<{
+      role: string;
+      content: string;
+    }>;
+    const systemMsg = messages.find((m) => m.role === "system");
+    assert.ok(systemMsg);
+    assert.equal(
+      systemMsg.content,
+      "You are helpful.",
+      "System message should be unmodified when recall fails"
+    );
+  });
+
+  it("transparently proxies non-chat paths", async () => {
+    const weclone = await createMockServer((req, res) => {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ path: req.url, method: req.method }));
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/models`
+    );
+    assert.equal(res.status, 200);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.path, "/v1/models");
+    assert.equal(body.method, "GET");
+  });
+
+  it("returns 400 for invalid JSON body on chat completions", async () => {
+    const weclone = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end("ok");
+    });
+    cleanups.push(weclone.close);
+
+    const remnic = await createMockServer((_req, res) => {
+      res.writeHead(200);
+      res.end(JSON.stringify({ results: [] }));
+    });
+    cleanups.push(remnic.close);
+
+    const proxy = createWeCloneProxy(testConfig(weclone.port, remnic.port));
+    await proxy.start();
+    cleanups.push(() => proxy.stop());
+
+    const res = await fetch(
+      `http://127.0.0.1:${proxy.port}/v1/chat/completions`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: "not json at all{{{",
+      }
+    );
+    assert.equal(res.status, 400);
+    const body = JSON.parse(await readResponse(res));
+    assert.equal(body.error, "bad_request");
+  });
+});

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -27,13 +27,27 @@ interface ChatMessage {
 }
 
 /**
- * Read the entire body of an IncomingMessage as a string.
+ * Read the entire body of an IncomingMessage as a string (UTF-8).
+ * Used for paths that need to parse JSON (e.g. chat completions).
  */
 function readBody(req: http.IncomingMessage): Promise<string> {
   return new Promise((resolve, reject) => {
     const chunks: Buffer[] = [];
     req.on("data", (chunk: Buffer) => chunks.push(chunk));
     req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Read the entire body of an IncomingMessage as raw bytes.
+ * Used for the transparent proxy path to avoid corrupting binary/multipart uploads.
+ */
+function readRawBody(req: http.IncomingMessage): Promise<Buffer> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks)));
     req.on("error", reject);
   });
 }
@@ -192,9 +206,14 @@ function getOrigin(urlStr: string): string {
  * Headers that must not be forwarded from the upstream response.
  * These are hop-by-hop headers that apply to a single transport connection
  * and would conflict with our fully-buffered response write.
+ *
+ * `content-encoding` is included because fetch() auto-decompresses the body.
+ * When we buffer with arrayBuffer() and relay, the bytes are already decoded;
+ * forwarding `content-encoding: gzip` would label decompressed bytes as gzip.
  */
 const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
   "transfer-encoding",
+  "content-encoding",
   "connection",
   "keep-alive",
   "upgrade",
@@ -217,7 +236,7 @@ async function transparentProxy(
   method: string,
   path: string,
   headers: Record<string, string>,
-  body: string | null,
+  body: Buffer | null,
   res: http.ServerResponse
 ): Promise<void> {
   const origin = getOrigin(wecloneApiUrl);
@@ -371,6 +390,16 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
 
         // --- Streaming path ---
         if (parsed.stream === true) {
+          // If upstream returned an error, pass through as-is (don't force SSE headers)
+          if (!upstream.ok) {
+            const errBody = await upstream.arrayBuffer();
+            res.writeHead(upstream.status, {
+              "content-type": upstream.headers.get("content-type") || "application/json",
+            });
+            res.end(Buffer.from(errBody));
+            return;
+          }
+
           res.writeHead(upstream.status, {
             "Content-Type": "text/event-stream",
             "Cache-Control": "no-cache",
@@ -459,7 +488,8 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     }
 
     // --- All other paths: transparent proxy ---
-    const body = method !== "GET" && method !== "HEAD" ? await readBody(req) : null;
+    // Use raw bytes to avoid corrupting binary/multipart uploads
+    const body = method !== "GET" && method !== "HEAD" ? await readRawBody(req) : null;
     const flat = flattenHeaders(req.headers);
     await transparentProxy(wecloneApiUrl, method, url, flat, body, res);
   };

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -21,11 +21,6 @@ export interface WeCloneProxy {
   port: number;
 }
 
-interface ChatMessage {
-  role: string;
-  content: string;
-}
-
 /**
  * Read the entire body of an IncomingMessage as a string (UTF-8).
  * Used for paths that need to parse JSON (e.g. chat completions).
@@ -186,33 +181,6 @@ function extractAssistantReply(responseBody: Record<string, unknown>): string {
     return choices[0]?.message?.content ?? "";
   }
   return "";
-}
-
-/**
- * Inject memories into the messages array by modifying the system message.
- */
-function injectMemories(
-  messages: ChatMessage[],
-  memoryBlock: string,
-  position: "system-append" | "system-prepend"
-): ChatMessage[] {
-  if (memoryBlock.length === 0) return messages;
-
-  const result = messages.map((m) => ({ ...m }));
-  const systemIdx = result.findIndex((m) => m.role === "system");
-
-  if (systemIdx >= 0) {
-    const existing = result[systemIdx].content;
-    result[systemIdx].content =
-      position === "system-prepend"
-        ? `${memoryBlock}\n\n${existing}`
-        : `${existing}\n\n${memoryBlock}`;
-  } else {
-    // No system message exists -- prepend one
-    result.unshift({ role: "system", content: memoryBlock });
-  }
-
-  return result;
 }
 
 /**
@@ -461,12 +429,31 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
 
       const headers = req.headers as Record<string, string | string[] | undefined>;
       const sessionKey = sessionMapper.resolve(headers, parsed);
+      // Validate `messages` is an array with object entries before use so
+      // malformed payloads (`messages: "..."`, `messages: {}`, etc.) return
+      // a structured 400 instead of surfacing as a 500 internal error.
+      if (parsed.messages !== undefined && !Array.isArray(parsed.messages)) {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            error: "bad_request",
+            detail: "messages must be an array",
+          })
+        );
+        return;
+      }
       // Messages may contain multimodal content-parts arrays; keep them
-      // untyped and validate strings at each use site.
-      const rawMessages = (parsed.messages ?? []) as Array<{
-        role: string;
-        content: unknown;
-      }>;
+      // untyped and validate strings at each use site. Drop entries that
+      // are not plain objects so downstream `.map()` cannot throw.
+      const rawMessages: Array<{ role: string; content: unknown }> = [];
+      for (const raw of parsed.messages ?? []) {
+        if (raw === null || typeof raw !== "object") continue;
+        const entry = raw as { role?: unknown; content?: unknown };
+        rawMessages.push({
+          role: typeof entry.role === "string" ? entry.role : "",
+          content: entry.content,
+        });
+      }
       const query = lastUserMessage(rawMessages);
 
       // Recall memories (graceful degradation on failure)
@@ -489,40 +476,37 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
         }
       }
 
-      // Build a string-content view for memory injection only. The
-      // forwarded payload preserves the original message shapes so
-      // multimodal parts are not flattened on the way to WeClone.
-      const stringMessages: ChatMessage[] = rawMessages.map((m) => ({
-        role: m.role,
-        content: extractTextContent(m.content),
-      }));
-      const modifiedStringMessages = injectMemories(
-        stringMessages,
-        memoryBlock,
-        config.memoryInjection.position
-      );
-
-      // Merge: keep original (possibly multimodal) messages, but use the
-      // modified system prompt text from the injection step.
+      // Build the forwarded messages array. Only the *first* system message
+      // is rewritten with injected memory (or, if no system exists, a
+      // synthetic system message is prepended). Subsequent system messages
+      // are forwarded verbatim so distinct system instructions are not
+      // silently overwritten.
       const outMessages: Array<{ role: string; content: unknown }> = [];
-      // If injection added a leading synthetic system message (no original
-      // system existed), surface it as a string-content message.
-      const hadSystem = rawMessages.some((m) => m.role === "system");
-      if (!hadSystem && modifiedStringMessages[0]?.role === "system") {
-        outMessages.push({
-          role: "system",
-          content: modifiedStringMessages[0].content,
-        });
-      }
-      for (const m of rawMessages) {
-        if (m.role === "system") {
-          const updated = modifiedStringMessages.find((s) => s.role === "system");
-          outMessages.push({
-            role: "system",
-            content: updated ? updated.content : extractTextContent(m.content),
-          });
-        } else {
-          outMessages.push(m);
+      const firstSystemIdx = rawMessages.findIndex((m) => m.role === "system");
+      const position = config.memoryInjection.position;
+
+      if (memoryBlock.length === 0) {
+        // No memory to inject — forward original messages unchanged.
+        for (const m of rawMessages) outMessages.push(m);
+      } else if (firstSystemIdx === -1) {
+        // No existing system message: prepend a synthetic one.
+        outMessages.push({ role: "system", content: memoryBlock });
+        for (const m of rawMessages) outMessages.push(m);
+      } else {
+        for (let i = 0; i < rawMessages.length; i++) {
+          const m = rawMessages[i];
+          if (i === firstSystemIdx) {
+            const existing = extractTextContent(m.content);
+            outMessages.push({
+              role: "system",
+              content:
+                position === "system-prepend"
+                  ? `${memoryBlock}\n\n${existing}`
+                  : `${existing}\n\n${memoryBlock}`,
+            });
+          } else {
+            outMessages.push(m);
+          }
         }
       }
 
@@ -535,10 +519,16 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
       // common `/v1` or custom mounts like `/weclone/v1`), forward to
       // `${basePath}/chat/completions`. If the configured URL has no
       // base path at all, default to the standard OpenAI `/v1/chat/completions`.
+      // Preserve any query string on the incoming request (e.g. Azure's
+      // `?api-version=...`) so version selectors and tenant hints reach
+      // upstream unchanged.
       const chatBase = wecloneParts.basePath.length > 0
         ? wecloneParts.basePath
         : "/v1";
-      const targetUrl = `${wecloneParts.origin}${chatBase}/chat/completions`;
+      const qIdx = url.indexOf("?");
+      const querySuffix = qIdx === -1 ? "" : url.slice(qIdx);
+      const targetUrl =
+        `${wecloneParts.origin}${chatBase}/chat/completions${querySuffix}`;
       const forwardHeaders: Record<string, string> = {
         "Content-Type": "application/json",
       };

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -203,6 +203,27 @@ function getOrigin(urlStr: string): string {
 }
 
 /**
+ * Hop-by-hop request headers that must not be forwarded to upstream.
+ * Per RFC 2616 §13.5.1 / RFC 7230 §6.1 these apply only to the
+ * immediate transport connection. `proxy-authorization` is the most
+ * critical — leaking it would send proxy credentials to the origin.
+ *
+ * `host` is deliberately excluded from this set because it is
+ * always replaced (not just stripped) with the upstream origin
+ * and is handled separately below.
+ */
+const HOP_BY_HOP_REQUEST_HEADERS = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+]);
+
+/**
  * Headers that must not be forwarded from the upstream response.
  * These are hop-by-hop headers that apply to a single transport connection
  * and would conflict with our fully-buffered response write.
@@ -242,10 +263,12 @@ async function transparentProxy(
   const origin = getOrigin(wecloneApiUrl);
   const targetUrl = `${origin}${path}`;
 
-  // Remove hop-by-hop request headers
-  const forwardHeaders = { ...headers };
-  delete forwardHeaders["host"];
-  delete forwardHeaders["connection"];
+  // Remove hop-by-hop request headers and replace host with upstream origin
+  const forwardHeaders: Record<string, string> = {};
+  for (const [key, value] of Object.entries(headers)) {
+    if (key === "host" || HOP_BY_HOP_REQUEST_HEADERS.has(key)) continue;
+    forwardHeaders[key] = value;
+  }
 
   const fetchInit: RequestInit = {
     method,

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -54,17 +54,30 @@ function flattenHeaders(
 }
 
 /**
+ * Build standard headers for Remnic daemon requests.
+ * Includes Authorization if an auth token is configured.
+ */
+function remnicHeaders(authToken?: string): Record<string, string> {
+  const headers: Record<string, string> = { "Content-Type": "application/json" };
+  if (authToken) {
+    headers["Authorization"] = `Bearer ${authToken}`;
+  }
+  return headers;
+}
+
+/**
  * Call Remnic daemon recall endpoint for the given session and query.
  */
 async function recallMemories(
   daemonUrl: string,
   sessionKey: string,
-  query: string
+  query: string,
+  authToken?: string
 ): Promise<RecallResult[]> {
   const url = `${daemonUrl}/engram/v1/recall`;
   const res = await fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: remnicHeaders(authToken),
     body: JSON.stringify({ sessionKey, query }),
   });
 
@@ -72,8 +85,13 @@ async function recallMemories(
     throw new Error(`Remnic recall returned ${res.status}: ${await res.text()}`);
   }
 
-  const data = (await res.json()) as { results?: RecallResult[] };
-  return data.results ?? [];
+  const data = (await res.json()) as { results?: Array<{ preview?: string; content?: string; confidence?: number; category?: string }> };
+  const memories: RecallResult[] = (data.results ?? []).map((r) => ({
+    content: r.preview || r.content || "",
+    confidence: r.confidence,
+    category: r.category,
+  }));
+  return memories;
 }
 
 /**
@@ -84,13 +102,20 @@ function observeTurn(
   daemonUrl: string,
   sessionKey: string,
   userMessage: string,
-  assistantMessage: string
+  assistantMessage: string,
+  authToken?: string
 ): void {
   const url = `${daemonUrl}/engram/v1/observe`;
   fetch(url, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({ sessionKey, userMessage, assistantMessage }),
+    headers: remnicHeaders(authToken),
+    body: JSON.stringify({
+      sessionKey,
+      messages: [
+        { role: "user", content: userMessage },
+        { role: "assistant", content: assistantMessage },
+      ],
+    }),
   }).catch(() => {
     // Intentionally swallowed -- observation must not affect the response path
   });
@@ -197,9 +222,9 @@ async function transparentProxy(
     res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
     const responseBody = await upstream.arrayBuffer();
     res.end(Buffer.from(responseBody));
-  } catch (err) {
+  } catch (_err) {
     res.writeHead(502, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({ error: "upstream_unreachable", detail: String(err) }));
+    res.end(JSON.stringify({ error: "upstream_unreachable" }));
   }
 }
 
@@ -264,7 +289,8 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
           const memories = await recallMemories(
             config.remnicDaemonUrl,
             sessionKey,
-            query
+            query,
+            config.remnicAuthToken
           );
           memoryBlock = formatMemoryBlock(
             memories,
@@ -323,17 +349,16 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
 
         // Fire-and-forget observe
         if (query.length > 0 && assistantReply.length > 0) {
-          observeTurn(config.remnicDaemonUrl, sessionKey, query, assistantReply);
+          observeTurn(config.remnicDaemonUrl, sessionKey, query, assistantReply, config.remnicAuthToken);
         }
 
         // Return upstream response to caller
         res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
         res.end(responseBytes);
-      } catch (err) {
+      } catch (_err) {
         res.writeHead(502, { "Content-Type": "application/json" });
         res.end(JSON.stringify({
           error: "upstream_unreachable",
-          detail: String(err),
         }));
       }
       return;
@@ -353,10 +378,10 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     start(): Promise<void> {
       return new Promise((resolve, reject) => {
         server = http.createServer((req, res) => {
-          requestHandler(req, res).catch((err) => {
+          requestHandler(req, res).catch((_err) => {
             if (!res.headersSent) {
               res.writeHead(500, { "Content-Type": "application/json" });
-              res.end(JSON.stringify({ error: "internal", detail: String(err) }));
+              res.end(JSON.stringify({ error: "internal_proxy_error" }));
             }
           });
         });

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -189,9 +189,28 @@ function getOrigin(urlStr: string): string {
 }
 
 /**
+ * Headers that must not be forwarded from the upstream response.
+ * These are hop-by-hop headers that apply to a single transport connection
+ * and would conflict with our fully-buffered response write.
+ */
+const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
+  "transfer-encoding",
+  "connection",
+  "keep-alive",
+  "upgrade",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+]);
+
+/**
  * Forward a request transparently to the WeClone API.
  * Uses the origin of wecloneApiUrl so that incoming paths
  * (e.g. /v1/models) map 1:1 to upstream paths.
+ *
+ * Reads the full upstream response before writing to the client
+ * to avoid partial-header or hanging-body issues.
  */
 async function transparentProxy(
   wecloneApiUrl: string,
@@ -204,7 +223,7 @@ async function transparentProxy(
   const origin = getOrigin(wecloneApiUrl);
   const targetUrl = `${origin}${path}`;
 
-  // Remove hop-by-hop headers
+  // Remove hop-by-hop request headers
   const forwardHeaders = { ...headers };
   delete forwardHeaders["host"];
   delete forwardHeaders["connection"];
@@ -219,9 +238,22 @@ async function transparentProxy(
 
   try {
     const upstream = await fetch(targetUrl, fetchInit);
-    res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
+
+    // Read full body before sending any headers to the client
     const responseBody = await upstream.arrayBuffer();
-    res.end(Buffer.from(responseBody));
+    const responseBuffer = Buffer.from(responseBody);
+
+    // Build response headers, filtering hop-by-hop and setting Content-Length
+    const responseHeaders: Record<string, string> = {};
+    for (const [key, value] of upstream.headers.entries()) {
+      if (!HOP_BY_HOP_RESPONSE_HEADERS.has(key.toLowerCase())) {
+        responseHeaders[key] = value;
+      }
+    }
+    responseHeaders["content-length"] = String(responseBuffer.length);
+
+    res.writeHead(upstream.status, responseHeaders);
+    res.end(responseBuffer);
   } catch (_err) {
     res.writeHead(502, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ error: "upstream_unreachable" }));
@@ -232,6 +264,10 @@ async function transparentProxy(
  * Create a WeClone proxy instance.
  */
 export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy {
+  // Normalize wecloneApiUrl: strip trailing slashes to prevent double-slash
+  // when appending path segments like /chat/completions.
+  const wecloneApiUrl = config.wecloneApiUrl.replace(/\/+$/, "");
+
   const sessionMapper: SessionMapper =
     config.sessionStrategy === "caller-id"
       ? new CallerIdSessionMapper()
@@ -315,7 +351,7 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
       };
 
       // Forward to WeClone
-      const targetUrl = `${config.wecloneApiUrl}/chat/completions`;
+      const targetUrl = `${wecloneApiUrl}/chat/completions`;
       const forwardHeaders: Record<string, string> = {
         "Content-Type": "application/json",
       };
@@ -425,7 +461,7 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     // --- All other paths: transparent proxy ---
     const body = method !== "GET" && method !== "HEAD" ? await readBody(req) : null;
     const flat = flattenHeaders(req.headers);
-    await transparentProxy(config.wecloneApiUrl, method, url, flat, body, res);
+    await transparentProxy(wecloneApiUrl, method, url, flat, body, res);
   };
 
   return {

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -1,0 +1,390 @@
+/**
+ * OpenAI-compatible HTTP proxy for WeClone with Remnic memory injection.
+ *
+ * Intercepts POST /v1/chat/completions to inject recalled memories,
+ * forwards all other requests transparently to the WeClone API.
+ */
+
+import * as http from "node:http";
+import type { WeCloneConnectorConfig } from "./config.js";
+import { formatMemoryBlock, type RecallResult } from "./format.js";
+import {
+  SingleSessionMapper,
+  CallerIdSessionMapper,
+  type SessionMapper,
+  type ChatCompletionRequest,
+} from "./session.js";
+
+export interface WeCloneProxy {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+  port: number;
+}
+
+interface ChatMessage {
+  role: string;
+  content: string;
+}
+
+/**
+ * Read the entire body of an IncomingMessage as a string.
+ */
+function readBody(req: http.IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (chunk: Buffer) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf-8")));
+    req.on("error", reject);
+  });
+}
+
+/**
+ * Build a flat headers record from IncomingHttpHeaders,
+ * normalizing array values to comma-separated strings.
+ */
+function flattenHeaders(
+  raw: http.IncomingHttpHeaders
+): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [key, val] of Object.entries(raw)) {
+    if (val === undefined) continue;
+    result[key] = Array.isArray(val) ? val.join(", ") : val;
+  }
+  return result;
+}
+
+/**
+ * Call Remnic daemon recall endpoint for the given session and query.
+ */
+async function recallMemories(
+  daemonUrl: string,
+  sessionKey: string,
+  query: string
+): Promise<RecallResult[]> {
+  const url = `${daemonUrl}/engram/v1/recall`;
+  const res = await fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionKey, query }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`Remnic recall returned ${res.status}: ${await res.text()}`);
+  }
+
+  const data = (await res.json()) as { results?: RecallResult[] };
+  return data.results ?? [];
+}
+
+/**
+ * Fire-and-forget observation to the Remnic daemon.
+ * Errors are caught and silently discarded to avoid adding latency.
+ */
+function observeTurn(
+  daemonUrl: string,
+  sessionKey: string,
+  userMessage: string,
+  assistantMessage: string
+): void {
+  const url = `${daemonUrl}/engram/v1/observe`;
+  fetch(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ sessionKey, userMessage, assistantMessage }),
+  }).catch(() => {
+    // Intentionally swallowed -- observation must not affect the response path
+  });
+}
+
+/**
+ * Extract the last user message from a chat completion messages array.
+ */
+function lastUserMessage(messages: ChatMessage[]): string {
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if (messages[i].role === "user") {
+      return messages[i].content;
+    }
+  }
+  return "";
+}
+
+/**
+ * Extract the assistant reply from a WeClone chat completion response.
+ */
+function extractAssistantReply(responseBody: Record<string, unknown>): string {
+  const choices = responseBody.choices as
+    | Array<{ message?: { content?: string } }>
+    | undefined;
+  if (choices && choices.length > 0) {
+    return choices[0]?.message?.content ?? "";
+  }
+  return "";
+}
+
+/**
+ * Inject memories into the messages array by modifying the system message.
+ */
+function injectMemories(
+  messages: ChatMessage[],
+  memoryBlock: string,
+  position: "system-append" | "system-prepend"
+): ChatMessage[] {
+  if (memoryBlock.length === 0) return messages;
+
+  const result = messages.map((m) => ({ ...m }));
+  const systemIdx = result.findIndex((m) => m.role === "system");
+
+  if (systemIdx >= 0) {
+    const existing = result[systemIdx].content;
+    result[systemIdx].content =
+      position === "system-prepend"
+        ? `${memoryBlock}\n\n${existing}`
+        : `${existing}\n\n${memoryBlock}`;
+  } else {
+    // No system message exists -- prepend one
+    result.unshift({ role: "system", content: memoryBlock });
+  }
+
+  return result;
+}
+
+/**
+ * Derive the origin (scheme + host + port) from a URL string.
+ * e.g. "http://localhost:8000/v1" -> "http://localhost:8000"
+ */
+function getOrigin(urlStr: string): string {
+  try {
+    const parsed = new URL(urlStr);
+    return parsed.origin;
+  } catch {
+    // Fallback: strip trailing path components
+    const match = urlStr.match(/^(https?:\/\/[^/]+)/);
+    return match ? match[1] : urlStr;
+  }
+}
+
+/**
+ * Forward a request transparently to the WeClone API.
+ * Uses the origin of wecloneApiUrl so that incoming paths
+ * (e.g. /v1/models) map 1:1 to upstream paths.
+ */
+async function transparentProxy(
+  wecloneApiUrl: string,
+  method: string,
+  path: string,
+  headers: Record<string, string>,
+  body: string | null,
+  res: http.ServerResponse
+): Promise<void> {
+  const origin = getOrigin(wecloneApiUrl);
+  const targetUrl = `${origin}${path}`;
+
+  // Remove hop-by-hop headers
+  const forwardHeaders = { ...headers };
+  delete forwardHeaders["host"];
+  delete forwardHeaders["connection"];
+
+  const fetchInit: RequestInit = {
+    method,
+    headers: forwardHeaders,
+  };
+  if (body && method !== "GET" && method !== "HEAD") {
+    fetchInit.body = body;
+  }
+
+  try {
+    const upstream = await fetch(targetUrl, fetchInit);
+    res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
+    const responseBody = await upstream.arrayBuffer();
+    res.end(Buffer.from(responseBody));
+  } catch (err) {
+    res.writeHead(502, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ error: "upstream_unreachable", detail: String(err) }));
+  }
+}
+
+/**
+ * Create a WeClone proxy instance.
+ */
+export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy {
+  const sessionMapper: SessionMapper =
+    config.sessionStrategy === "caller-id"
+      ? new CallerIdSessionMapper()
+      : new SingleSessionMapper();
+
+  let server: http.Server | null = null;
+  let resolvedPort = config.proxyPort;
+
+  const requestHandler = async (
+    req: http.IncomingMessage,
+    res: http.ServerResponse
+  ): Promise<void> => {
+    const url = req.url ?? "/";
+    const method = (req.method ?? "GET").toUpperCase();
+
+    // --- Health check ---
+    if (url === "/health" && method === "GET") {
+      res.writeHead(200, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        status: "ok",
+        wecloneApi: config.wecloneApiUrl,
+      }));
+      return;
+    }
+
+    // --- Chat completions with memory injection ---
+    if (url === "/v1/chat/completions" && method === "POST") {
+      let bodyStr: string;
+      try {
+        bodyStr = await readBody(req);
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "bad_request", detail: "Could not read request body" }));
+        return;
+      }
+
+      let parsed: ChatCompletionRequest;
+      try {
+        parsed = JSON.parse(bodyStr) as ChatCompletionRequest;
+      } catch {
+        res.writeHead(400, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({ error: "bad_request", detail: "Invalid JSON body" }));
+        return;
+      }
+
+      const headers = req.headers as Record<string, string | string[] | undefined>;
+      const sessionKey = sessionMapper.resolve(headers, parsed);
+      const messages = (parsed.messages ?? []) as ChatMessage[];
+      const query = lastUserMessage(messages);
+
+      // Recall memories (graceful degradation on failure)
+      let memoryBlock = "";
+      if (query.length > 0) {
+        try {
+          const memories = await recallMemories(
+            config.remnicDaemonUrl,
+            sessionKey,
+            query
+          );
+          memoryBlock = formatMemoryBlock(
+            memories,
+            config.memoryInjection.template,
+            config.memoryInjection.maxTokens
+          );
+        } catch {
+          // Remnic recall failed -- proceed without memory injection
+        }
+      }
+
+      // Inject memories into messages
+      const modifiedMessages = injectMemories(
+        messages,
+        memoryBlock,
+        config.memoryInjection.position
+      );
+
+      const modifiedBody = {
+        ...parsed,
+        messages: modifiedMessages,
+      };
+
+      // Forward to WeClone
+      const targetUrl = `${config.wecloneApiUrl}/chat/completions`;
+      const forwardHeaders: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+
+      // Preserve authorization if present
+      const authHeader = req.headers["authorization"];
+      if (typeof authHeader === "string") {
+        forwardHeaders["Authorization"] = authHeader;
+      }
+
+      try {
+        const upstream = await fetch(targetUrl, {
+          method: "POST",
+          headers: forwardHeaders,
+          body: JSON.stringify(modifiedBody),
+        });
+
+        const responseBuffer = await upstream.arrayBuffer();
+        const responseBytes = Buffer.from(responseBuffer);
+
+        // Parse response for observation (best-effort)
+        let assistantReply = "";
+        try {
+          const responseJson = JSON.parse(
+            responseBytes.toString("utf-8")
+          ) as Record<string, unknown>;
+          assistantReply = extractAssistantReply(responseJson);
+        } catch {
+          // Non-JSON response -- skip observation
+        }
+
+        // Fire-and-forget observe
+        if (query.length > 0 && assistantReply.length > 0) {
+          observeTurn(config.remnicDaemonUrl, sessionKey, query, assistantReply);
+        }
+
+        // Return upstream response to caller
+        res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
+        res.end(responseBytes);
+      } catch (err) {
+        res.writeHead(502, { "Content-Type": "application/json" });
+        res.end(JSON.stringify({
+          error: "upstream_unreachable",
+          detail: String(err),
+        }));
+      }
+      return;
+    }
+
+    // --- All other paths: transparent proxy ---
+    const body = method !== "GET" && method !== "HEAD" ? await readBody(req) : null;
+    const flat = flattenHeaders(req.headers);
+    await transparentProxy(config.wecloneApiUrl, method, url, flat, body, res);
+  };
+
+  return {
+    get port() {
+      return resolvedPort;
+    },
+
+    start(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        server = http.createServer((req, res) => {
+          requestHandler(req, res).catch((err) => {
+            if (!res.headersSent) {
+              res.writeHead(500, { "Content-Type": "application/json" });
+              res.end(JSON.stringify({ error: "internal", detail: String(err) }));
+            }
+          });
+        });
+
+        server.on("error", reject);
+
+        server.listen(config.proxyPort, () => {
+          const addr = server!.address();
+          if (typeof addr === "object" && addr !== null) {
+            resolvedPort = addr.port;
+          }
+          resolve();
+        });
+      });
+    },
+
+    stop(): Promise<void> {
+      return new Promise((resolve, reject) => {
+        if (!server) {
+          resolve();
+          return;
+        }
+        server.close((err) => {
+          server = null;
+          if (err) reject(err);
+          else resolve();
+        });
+      });
+    },
+  };
+}

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -252,7 +252,7 @@ async function transparentProxy(
     headers: forwardHeaders,
   };
   if (body && method !== "GET" && method !== "HEAD") {
-    fetchInit.body = body;
+    fetchInit.body = body as unknown as BodyInit;
   }
 
   try {
@@ -475,8 +475,15 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
           observeTurn(config.remnicDaemonUrl, sessionKey, query, assistantReply, config.remnicAuthToken);
         }
 
-        // Return upstream response to caller
-        res.writeHead(upstream.status, Object.fromEntries(upstream.headers.entries()));
+        // Return upstream response to caller, stripping hop-by-hop headers
+        const chatResponseHeaders: Record<string, string> = {};
+        for (const [key, value] of upstream.headers.entries()) {
+          if (!HOP_BY_HOP_RESPONSE_HEADERS.has(key.toLowerCase())) {
+            chatResponseHeaders[key] = value;
+          }
+        }
+        chatResponseHeaders["content-length"] = String(responseBytes.length);
+        res.writeHead(upstream.status, chatResponseHeaders);
         res.end(responseBytes);
       } catch (_err) {
         res.writeHead(502, { "Content-Type": "application/json" });

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -333,6 +333,64 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
           body: JSON.stringify(modifiedBody),
         });
 
+        // --- Streaming path ---
+        if (parsed.stream === true) {
+          res.writeHead(upstream.status, {
+            "Content-Type": "text/event-stream",
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+          });
+
+          const reader = upstream.body?.getReader();
+          if (!reader) {
+            res.end();
+            return;
+          }
+
+          const chunks: Uint8Array[] = [];
+          try {
+            while (true) {
+              const { done, value } = await reader.read();
+              if (done) break;
+              chunks.push(value);
+              res.write(value);
+            }
+          } finally {
+            res.end();
+          }
+
+          // Best-effort: reconstruct assistant content for observation
+          try {
+            const fullText = Buffer.concat(chunks).toString("utf-8");
+            const contentParts: string[] = [];
+            for (const line of fullText.split("\n")) {
+              if (!line.startsWith("data: ") || line === "data: [DONE]") continue;
+              try {
+                const event = JSON.parse(line.slice(6)) as {
+                  choices?: Array<{ delta?: { content?: string } }>;
+                };
+                const delta = event.choices?.[0]?.delta?.content;
+                if (delta) contentParts.push(delta);
+              } catch {
+                // Malformed SSE chunk -- skip
+              }
+            }
+            if (contentParts.length > 0 && query.length > 0) {
+              observeTurn(
+                config.remnicDaemonUrl,
+                sessionKey,
+                query,
+                contentParts.join(""),
+                config.remnicAuthToken
+              );
+            }
+          } catch {
+            // Observation reconstruction failed -- non-critical
+          }
+          return;
+        }
+
+        // --- Non-streaming path ---
         const responseBuffer = await upstream.arrayBuffer();
         const responseBytes = Buffer.from(responseBuffer);
 

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -136,12 +136,40 @@ function observeTurn(
 }
 
 /**
- * Extract the last user message from a chat completion messages array.
+ * Coerce an OpenAI chat message `content` into a plain text string.
+ *
+ * OpenAI chat messages can be either a string or an array of content
+ * parts (e.g. `[{type:"text",text:"..."},{type:"image_url",...}]`) for
+ * multimodal inputs. Recall/observe only operate on text, so we extract
+ * and concatenate the `text` parts. Returns an empty string if no text
+ * is present (e.g. image-only turn) so we skip recall rather than sending
+ * non-string payloads to the Remnic daemon.
  */
-function lastUserMessage(messages: ChatMessage[]): string {
+function extractTextContent(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  const parts: string[] = [];
+  for (const part of content) {
+    if (
+      part &&
+      typeof part === "object" &&
+      (part as { type?: unknown }).type === "text"
+    ) {
+      const text = (part as { text?: unknown }).text;
+      if (typeof text === "string") parts.push(text);
+    }
+  }
+  return parts.join("\n");
+}
+
+/**
+ * Extract the last user message's text content from a chat completion
+ * messages array. Handles both string and multimodal array content.
+ */
+function lastUserMessage(messages: Array<{ role: string; content: unknown }>): string {
   for (let i = messages.length - 1; i >= 0; i--) {
     if (messages[i].role === "user") {
-      return messages[i].content;
+      return extractTextContent(messages[i].content);
     }
   }
   return "";
@@ -188,17 +216,43 @@ function injectMemories(
 }
 
 /**
- * Derive the origin (scheme + host + port) from a URL string.
- * e.g. "http://localhost:8000/v1" -> "http://localhost:8000"
+ * Strip trailing slashes from a URL without using a regex quantifier
+ * on the same character, which CodeQL flags as polynomial ReDoS
+ * (`js/polynomial-redos`). A simple loop is O(n) and cannot backtrack.
  */
-function getOrigin(urlStr: string): string {
+function stripTrailingSlashes(s: string): string {
+  let end = s.length;
+  while (end > 0 && s.charCodeAt(end - 1) === 47 /* '/' */) {
+    end--;
+  }
+  return end === s.length ? s : s.slice(0, end);
+}
+
+/**
+ * Parse a URL string into { origin, basePath } where `basePath` is the
+ * configured path prefix (e.g. "/weclone/v1") with any trailing slashes
+ * stripped. Falls back safely for malformed inputs.
+ */
+function splitBaseUrl(urlStr: string): { origin: string; basePath: string } {
   try {
     const parsed = new URL(urlStr);
-    return parsed.origin;
+    const basePath = stripTrailingSlashes(parsed.pathname);
+    return { origin: parsed.origin, basePath };
   } catch {
-    // Fallback: strip trailing path components
-    const match = urlStr.match(/^(https?:\/\/[^/]+)/);
-    return match ? match[1] : urlStr;
+    // Fallback: strip trailing path components without ReDoS-prone regex.
+    // Split on the first "/" after the scheme.
+    const schemeEnd = urlStr.indexOf("://");
+    if (schemeEnd === -1) {
+      return { origin: stripTrailingSlashes(urlStr), basePath: "" };
+    }
+    const afterScheme = urlStr.slice(schemeEnd + 3);
+    const pathStart = afterScheme.indexOf("/");
+    if (pathStart === -1) {
+      return { origin: urlStr, basePath: "" };
+    }
+    const origin = urlStr.slice(0, schemeEnd + 3 + pathStart);
+    const basePath = stripTrailingSlashes(afterScheme.slice(pathStart));
+    return { origin, basePath };
   }
 }
 
@@ -246,27 +300,57 @@ const HOP_BY_HOP_RESPONSE_HEADERS = new Set([
 
 /**
  * Forward a request transparently to the WeClone API.
- * Uses the origin of wecloneApiUrl so that incoming paths
- * (e.g. /v1/models) map 1:1 to upstream paths.
+ *
+ * If the configured WeClone URL has a non-empty base path (e.g.
+ * "https://host/weclone/v1"), the proxy forwards incoming request paths
+ * such that "/v1/models" maps to "https://host/weclone/v1/models". For
+ * URLs without a base path, paths map 1:1 to the upstream origin.
+ *
+ * The request body (if any) is forwarded as raw bytes via Uint8Array so
+ * that multipart/binary uploads are not corrupted.
  *
  * Reads the full upstream response before writing to the client
  * to avoid partial-header or hanging-body issues.
  */
 async function transparentProxy(
-  wecloneApiUrl: string,
+  weclone: { origin: string; basePath: string },
   method: string,
   path: string,
   headers: Record<string, string>,
   body: Buffer | null,
   res: http.ServerResponse
 ): Promise<void> {
-  const origin = getOrigin(wecloneApiUrl);
-  const targetUrl = `${origin}${path}`;
+  // Map the client-facing path into an upstream path.
+  //
+  // The proxy exposes an OpenAI-compatible `/v1/...` surface. When the
+  // configured `wecloneApiUrl` itself already ends in `/v1` (or any
+  // path prefix), treat the configured prefix as the upstream mount
+  // point and rewrite `/v1/<rest>` to `<basePath>/<rest>`.
+  //
+  // - basePath "" (no prefix): forward path as-is.
+  // - basePath "/v1": "/v1/models" -> "/v1/models" (no change).
+  // - basePath "/weclone/v1": "/v1/models" -> "/weclone/v1/models".
+  //
+  // Split off any query string so rewriting operates on the pathname only.
+  const qIdx = path.indexOf("?");
+  const rawPath = qIdx === -1 ? path : path.slice(0, qIdx);
+  const querySuffix = qIdx === -1 ? "" : path.slice(qIdx);
+  let upstreamPathname = rawPath;
+  if (weclone.basePath.length > 0) {
+    if (rawPath === "/v1" || rawPath.startsWith("/v1/")) {
+      upstreamPathname = `${weclone.basePath}${rawPath.slice(3)}`;
+    } else if (!rawPath.startsWith(weclone.basePath)) {
+      upstreamPathname = `${weclone.basePath}${rawPath}`;
+    }
+  }
+  const targetUrl = `${weclone.origin}${upstreamPathname}${querySuffix}`;
 
   // Remove hop-by-hop request headers and replace host with upstream origin
   const forwardHeaders: Record<string, string> = {};
   for (const [key, value] of Object.entries(headers)) {
     if (key === "host" || HOP_BY_HOP_REQUEST_HEADERS.has(key)) continue;
+    // content-length is recomputed by fetch() for the forwarded body
+    if (key === "content-length") continue;
     forwardHeaders[key] = value;
   }
 
@@ -275,7 +359,9 @@ async function transparentProxy(
     headers: forwardHeaders,
   };
   if (body && method !== "GET" && method !== "HEAD") {
-    fetchInit.body = body as unknown as BodyInit;
+    // Use Uint8Array (a valid BodyInit) instead of Buffer to satisfy
+    // RequestInit typing and forward raw bytes verbatim.
+    fetchInit.body = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
   }
 
   try {
@@ -306,9 +392,14 @@ async function transparentProxy(
  * Create a WeClone proxy instance.
  */
 export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy {
-  // Normalize wecloneApiUrl: strip trailing slashes to prevent double-slash
-  // when appending path segments like /chat/completions.
-  const wecloneApiUrl = config.wecloneApiUrl.replace(/\/+$/, "");
+  // Normalize upstream URLs: strip trailing slashes to prevent double-slash
+  // when appending path segments. Use a loop (not regex) to avoid the
+  // polynomial-ReDoS class flagged by CodeQL for `/\/+$/`.
+  const wecloneApiUrl = stripTrailingSlashes(config.wecloneApiUrl);
+  const remnicDaemonUrl = stripTrailingSlashes(config.remnicDaemonUrl);
+  // Pre-split the WeClone URL so transparentProxy and the chat path can
+  // honor a configured base path (e.g. "/weclone/v1").
+  const wecloneParts = splitBaseUrl(wecloneApiUrl);
 
   const sessionMapper: SessionMapper =
     config.sessionStrategy === "caller-id"
@@ -325,8 +416,21 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     const url = req.url ?? "/";
     const method = (req.method ?? "GET").toUpperCase();
 
+    // Parse the request URL into a pathname (stripping query string and
+    // normalizing trailing slash). Using pathname for route matching avoids
+    // silently falling through when clients append query params like
+    // `?api-version=2023-05-15` (common with Azure OpenAI-compatible SDKs).
+    let pathname = url;
+    const queryStart = url.indexOf("?");
+    if (queryStart !== -1) pathname = url.slice(0, queryStart);
+    // Normalize trailing slash for route matching only (not for forwarding).
+    const normalizedPathname =
+      pathname.length > 1 && pathname.endsWith("/")
+        ? pathname.slice(0, -1)
+        : pathname;
+
     // --- Health check ---
-    if (url === "/health" && method === "GET") {
+    if (normalizedPathname === "/health" && method === "GET") {
       res.writeHead(200, { "Content-Type": "application/json" });
       res.end(JSON.stringify({
         status: "ok",
@@ -336,7 +440,7 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     }
 
     // --- Chat completions with memory injection ---
-    if (url === "/v1/chat/completions" && method === "POST") {
+    if (normalizedPathname === "/v1/chat/completions" && method === "POST") {
       let bodyStr: string;
       try {
         bodyStr = await readBody(req);
@@ -357,15 +461,20 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
 
       const headers = req.headers as Record<string, string | string[] | undefined>;
       const sessionKey = sessionMapper.resolve(headers, parsed);
-      const messages = (parsed.messages ?? []) as ChatMessage[];
-      const query = lastUserMessage(messages);
+      // Messages may contain multimodal content-parts arrays; keep them
+      // untyped and validate strings at each use site.
+      const rawMessages = (parsed.messages ?? []) as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const query = lastUserMessage(rawMessages);
 
       // Recall memories (graceful degradation on failure)
       let memoryBlock = "";
       if (query.length > 0) {
         try {
           const memories = await recallMemories(
-            config.remnicDaemonUrl,
+            remnicDaemonUrl,
             sessionKey,
             query,
             config.remnicAuthToken
@@ -380,20 +489,56 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
         }
       }
 
-      // Inject memories into messages
-      const modifiedMessages = injectMemories(
-        messages,
+      // Build a string-content view for memory injection only. The
+      // forwarded payload preserves the original message shapes so
+      // multimodal parts are not flattened on the way to WeClone.
+      const stringMessages: ChatMessage[] = rawMessages.map((m) => ({
+        role: m.role,
+        content: extractTextContent(m.content),
+      }));
+      const modifiedStringMessages = injectMemories(
+        stringMessages,
         memoryBlock,
         config.memoryInjection.position
       );
 
+      // Merge: keep original (possibly multimodal) messages, but use the
+      // modified system prompt text from the injection step.
+      const outMessages: Array<{ role: string; content: unknown }> = [];
+      // If injection added a leading synthetic system message (no original
+      // system existed), surface it as a string-content message.
+      const hadSystem = rawMessages.some((m) => m.role === "system");
+      if (!hadSystem && modifiedStringMessages[0]?.role === "system") {
+        outMessages.push({
+          role: "system",
+          content: modifiedStringMessages[0].content,
+        });
+      }
+      for (const m of rawMessages) {
+        if (m.role === "system") {
+          const updated = modifiedStringMessages.find((s) => s.role === "system");
+          outMessages.push({
+            role: "system",
+            content: updated ? updated.content : extractTextContent(m.content),
+          });
+        } else {
+          outMessages.push(m);
+        }
+      }
+
       const modifiedBody = {
         ...parsed,
-        messages: modifiedMessages,
+        messages: outMessages,
       };
 
-      // Forward to WeClone
-      const targetUrl = `${wecloneApiUrl}/chat/completions`;
+      // Forward to WeClone. If `wecloneApiUrl` has a path prefix (the
+      // common `/v1` or custom mounts like `/weclone/v1`), forward to
+      // `${basePath}/chat/completions`. If the configured URL has no
+      // base path at all, default to the standard OpenAI `/v1/chat/completions`.
+      const chatBase = wecloneParts.basePath.length > 0
+        ? wecloneParts.basePath
+        : "/v1";
+      const targetUrl = `${wecloneParts.origin}${chatBase}/chat/completions`;
       const forwardHeaders: Record<string, string> = {
         "Content-Type": "application/json",
       };
@@ -465,7 +610,7 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
             }
             if (contentParts.length > 0 && query.length > 0) {
               observeTurn(
-                config.remnicDaemonUrl,
+                remnicDaemonUrl,
                 sessionKey,
                 query,
                 contentParts.join(""),
@@ -495,7 +640,7 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
 
         // Fire-and-forget observe
         if (query.length > 0 && assistantReply.length > 0) {
-          observeTurn(config.remnicDaemonUrl, sessionKey, query, assistantReply, config.remnicAuthToken);
+          observeTurn(remnicDaemonUrl, sessionKey, query, assistantReply, config.remnicAuthToken);
         }
 
         // Return upstream response to caller, stripping hop-by-hop headers
@@ -518,10 +663,10 @@ export function createWeCloneProxy(config: WeCloneConnectorConfig): WeCloneProxy
     }
 
     // --- All other paths: transparent proxy ---
-    // Use raw bytes to avoid corrupting binary/multipart uploads
+    // Use raw bytes to avoid corrupting binary/multipart uploads.
     const body = method !== "GET" && method !== "HEAD" ? await readRawBody(req) : null;
     const flat = flattenHeaders(req.headers);
-    await transparentProxy(wecloneApiUrl, method, url, flat, body, res);
+    await transparentProxy(wecloneParts, method, url, flat, body, res);
   };
 
   return {

--- a/packages/connector-weclone/src/session.test.ts
+++ b/packages/connector-weclone/src/session.test.ts
@@ -1,0 +1,79 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { SingleSessionMapper, CallerIdSessionMapper } from "./session.js";
+
+describe("SingleSessionMapper", () => {
+  it("returns the default fixed key", () => {
+    const mapper = new SingleSessionMapper();
+    const key = mapper.resolve({}, {});
+    assert.equal(key, "weclone-default");
+  });
+
+  it("returns a custom fixed key", () => {
+    const mapper = new SingleSessionMapper("my-session");
+    const key = mapper.resolve({}, { user: "ignored" });
+    assert.equal(key, "my-session");
+  });
+
+  it("ignores headers and body", () => {
+    const mapper = new SingleSessionMapper("fixed");
+    const key = mapper.resolve(
+      { "x-caller-id": "alice" },
+      { user: "bob" }
+    );
+    assert.equal(key, "fixed");
+  });
+});
+
+describe("CallerIdSessionMapper", () => {
+  it("extracts from X-Caller-Id header", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve(
+      { "x-caller-id": "alice" },
+      { user: "bob" }
+    );
+    assert.equal(key, "alice");
+  });
+
+  it("extracts from body.user when header is absent", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve({}, { user: "charlie" });
+    assert.equal(key, "charlie");
+  });
+
+  it("falls back to default when neither is present", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve({}, {});
+    assert.equal(key, "default");
+  });
+
+  it("uses custom fallback", () => {
+    const mapper = new CallerIdSessionMapper("anonymous");
+    const key = mapper.resolve({}, {});
+    assert.equal(key, "anonymous");
+  });
+
+  it("prefers header over body.user", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve(
+      { "x-caller-id": "from-header" },
+      { user: "from-body" }
+    );
+    assert.equal(key, "from-header");
+  });
+
+  it("ignores empty header and falls through to body", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve(
+      { "x-caller-id": "" },
+      { user: "from-body" }
+    );
+    assert.equal(key, "from-body");
+  });
+
+  it("ignores empty body.user and falls back to default", () => {
+    const mapper = new CallerIdSessionMapper();
+    const key = mapper.resolve({}, { user: "" });
+    assert.equal(key, "default");
+  });
+});

--- a/packages/connector-weclone/src/session.ts
+++ b/packages/connector-weclone/src/session.ts
@@ -1,0 +1,70 @@
+/**
+ * Session mapping strategies.
+ *
+ * Maps caller identity to Remnic session keys so memory is scoped
+ * appropriately per user or shared across all callers.
+ */
+
+export interface ChatCompletionRequest {
+  model?: string;
+  messages?: Array<{ role: string; content: string }>;
+  user?: string;
+  [key: string]: unknown;
+}
+
+export interface SessionMapper {
+  resolve(
+    headers: Record<string, string | string[] | undefined>,
+    body: ChatCompletionRequest
+  ): string;
+}
+
+/**
+ * Returns a fixed session key for single-user setups.
+ */
+export class SingleSessionMapper implements SessionMapper {
+  private readonly key: string;
+
+  constructor(key = "weclone-default") {
+    this.key = key;
+  }
+
+  resolve(
+    _headers: Record<string, string | string[] | undefined>,
+    _body: ChatCompletionRequest
+  ): string {
+    return this.key;
+  }
+}
+
+/**
+ * Extracts caller identity from request metadata.
+ *
+ * Resolution order:
+ * 1. `X-Caller-Id` header
+ * 2. `user` field in the request body
+ * 3. Falls back to "default"
+ */
+export class CallerIdSessionMapper implements SessionMapper {
+  private readonly fallback: string;
+
+  constructor(fallback = "default") {
+    this.fallback = fallback;
+  }
+
+  resolve(
+    headers: Record<string, string | string[] | undefined>,
+    body: ChatCompletionRequest
+  ): string {
+    const headerValue = headers["x-caller-id"];
+    if (typeof headerValue === "string" && headerValue.length > 0) {
+      return headerValue;
+    }
+
+    if (typeof body.user === "string" && body.user.length > 0) {
+      return body.user;
+    }
+
+    return this.fallback;
+  }
+}

--- a/packages/connector-weclone/tsconfig.json
+++ b/packages/connector-weclone/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,6 +111,18 @@ importers:
 
   packages/connector-replit: {}
 
+  packages/connector-weclone:
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/hermes-provider:
     devDependencies:
       tsup:


### PR DESCRIPTION
## Summary

Scaffolds the `@remnic/connector-weclone` package -- an OpenAI-compatible HTTP proxy that adds Remnic persistent memory to deployed WeClone avatars. Phase 1 of #458.

- **Config** (`config.ts`): Validates connector configuration with clear error messages on invalid input; applies defaults for optional fields
- **Session mapping** (`session.ts`): Two strategies -- `SingleSessionMapper` (fixed key) and `CallerIdSessionMapper` (from header/body/fallback)
- **Format adapter** (`format.ts`): Converts recall results into system prompt sections with confidence sorting and token truncation
- **Proxy server** (`proxy.ts`): Node `http` server intercepting `POST /v1/chat/completions` to recall memories, inject into system message, forward to WeClone, and fire-and-forget observe. Graceful degradation when Remnic is unavailable. Health endpoint and transparent pass-through for all other paths.
- **Installer** (`installer.ts`): Generates human-readable setup instructions
- **40 tests** across all modules using `node:test` runner

## Test plan

- [x] `npx tsx --test 'src/**/*.test.ts'` -- all 40 tests pass
- [ ] Manual: start WeClone API + Remnic daemon + proxy, verify memory injection in chat completions
- [ ] Manual: verify graceful degradation when Remnic daemon is down
- [ ] Manual: verify transparent proxy for non-chat endpoints (e.g. `/v1/models`)

Closes phase 1 of #458

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new network-facing HTTP proxy that rewrites and forwards chat completion traffic, including header/body manipulation and fire-and-forget calls to the Remnic daemon, so misrouting or subtle protocol/header handling bugs could impact reliability/security.
> 
> **Overview**
> Introduces a new `@remnic/connector-weclone` package that runs an OpenAI-compatible HTTP proxy in front of WeClone, **injecting Remnic recall results into chat completion requests** and sending best-effort observations back to the Remnic daemon.
> 
> Includes a config parser with defaults + validation (including optional `remnicAuthToken`), session scoping strategies (`single` vs `caller-id`), memory formatting/truncation utilities, and a CLI (`remnic-weclone-proxy`) that loads JSON config and manages proxy lifecycle.
> 
> Proxy behavior covers streaming (SSE) and non-streaming chat completions, graceful degradation when Remnic is unavailable, a `/health` endpoint, and transparent pass-through for other `/v1/*` routes with base-path support and hop-by-hop header stripping. Extensive `node:test` coverage and lockfile updates are included.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f7f53aa3fe5fdcfaad6a8b88a0fd099bc3815c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->