### PR TITLE
bench: add schema completeness benchmark for ingestion tier

### DIFF
--- a/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-entity-recall/runner.ts
@@ -1,0 +1,122 @@
+/**
+ * Ingestion entity recall benchmark.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+} from "../../../types.js";
+import { entityRecall } from "../../../ingestion-scorer.js";
+import { aggregateTaskScores, timed } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { emailFixture } from "../../../fixtures/inbox/email.js";
+
+export const ingestionEntityRecallDefinition: BenchmarkDefinition = {
+  id: "ingestion-entity-recall",
+  title: "Ingestion: Entity Recall",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "ingestion-entity-recall",
+    version: "1.0.0",
+    description: "Measures entity extraction recall against a curated gold graph after ingesting synthetic inbox data.",
+    category: "ingestion",
+  },
+};
+
+export async function runIngestionEntityRecallBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  if (!options.ingestionAdapter) {
+    throw new Error("ingestionAdapter is required for ingestion benchmarks");
+  }
+  const fixture = emailFixture.generate();
+
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-email-"));
+  try {
+    await options.ingestionAdapter!.reset();
+
+    for (const file of fixture.files) {
+      const filePath = path.join(fixtureDir, file.relativePath);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, file.content, "utf8");
+    }
+
+    const { result: ingestionLog, durationMs } = await timed(() =>
+      options.ingestionAdapter!.ingest(fixtureDir),
+    );
+
+    const graph = await options.ingestionAdapter.getMemoryGraph();
+    const { overall, byType } = entityRecall(graph.entities, fixture.goldGraph.entities);
+
+    const scores: Record<string, number> = {
+      entity_recall: overall,
+      ...byType,
+    };
+
+    const tasks = [
+      {
+        taskId: `entity-recall-${fixture.id}`,
+        question: `Extract entities from ${fixture.id} fixture`,
+        expected: `${fixture.goldGraph.entities.length} entities`,
+        actual: `${graph.entities.length} entities extracted`,
+        scores,
+        latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          fixtureId: fixture.id,
+          goldEntityCount: fixture.goldGraph.entities.length,
+          extractedEntityCount: graph.entities.length,
+          ingestionErrors: ingestionLog.errors,
+        },
+      },
+    ];
+
+    const remnicVersion = await getRemnicVersion();
+    return {
+      meta: {
+        id: randomUUID(),
+        benchmark: options.benchmark.id,
+        benchmarkTier: options.benchmark.tier,
+        version: options.benchmark.meta.version,
+        remnicVersion,
+        gitSha: getGitSha(),
+        timestamp: new Date().toISOString(),
+        mode: options.mode,
+        runCount: 1,
+        seeds: [options.seed ?? 0],
+      },
+      config: {
+        systemProvider: options.systemProvider ?? null,
+        judgeProvider: options.judgeProvider ?? null,
+        adapterMode: options.adapterMode ?? "direct",
+        remnicConfig: options.remnicConfig ?? {},
+      },
+      cost: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+        totalLatencyMs: durationMs,
+        meanQueryLatencyMs: durationMs,
+      },
+      results: {
+        tasks,
+        aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+      },
+      environment: {
+        os: process.platform,
+        nodeVersion: process.version,
+        hardware: process.arch,
+      },
+    };
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/runner.ts
@@ -1,0 +1,134 @@
+/**
+ * Ingestion schema completeness benchmark.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+} from "../../../types.js";
+import { REQUIRED_FRONTMATTER_FIELDS } from "../../../ingestion-types.js";
+import { schemaCompleteness } from "../../../ingestion-scorer.js";
+import { aggregateTaskScores, timed } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { emailFixture } from "../../../fixtures/inbox/email.js";
+
+export const ingestionSchemaCompletenessDefinition: BenchmarkDefinition = {
+  id: "ingestion-schema-completeness",
+  title: "Ingestion: Schema Completeness",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "ingestion-schema-completeness",
+    version: "1.0.0",
+    description: "Measures frontmatter schema completeness of generated pages against the canonical required fields after ingesting synthetic inbox data.",
+    category: "ingestion",
+  },
+};
+
+export async function runIngestionSchemaCompletenessBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  if (!options.ingestionAdapter) {
+    throw new Error("ingestionAdapter is required for ingestion benchmarks");
+  }
+  const fixture = emailFixture.generate();
+
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-email-"));
+  try {
+    await options.ingestionAdapter!.reset();
+
+    for (const file of fixture.files) {
+      const filePath = path.join(fixtureDir, file.relativePath);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, file.content, "utf8");
+    }
+
+    const { result: ingestionLog, durationMs } = await timed(() =>
+      options.ingestionAdapter!.ingest(fixtureDir),
+    );
+
+    const graph = await options.ingestionAdapter.getMemoryGraph();
+    const { overall, fieldCoverage } = schemaCompleteness(
+      graph.pages,
+      fixture.goldGraph.pages,
+      REQUIRED_FRONTMATTER_FIELDS,
+    );
+
+    const perFieldScores: Record<string, number> = {};
+    for (const [field, coverage] of Object.entries(fieldCoverage)) {
+      const key = `field_${field.replace(/-/g, "_")}`;
+      perFieldScores[key] = coverage;
+    }
+
+    const scores: Record<string, number> = {
+      schema_completeness: overall,
+      ...perFieldScores,
+    };
+
+    const tasks = [
+      {
+        taskId: `schema-completeness-${fixture.id}`,
+        question: `Check frontmatter schema completeness from ${fixture.id} fixture`,
+        expected: `${fixture.goldGraph.pages.length} pages with required frontmatter fields`,
+        actual: `${graph.pages.length} pages extracted`,
+        scores,
+        latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          fixtureId: fixture.id,
+          goldPageCount: fixture.goldGraph.pages.length,
+          extractedPageCount: graph.pages.length,
+          fieldCoverage,
+          ingestionErrors: ingestionLog.errors,
+        },
+      },
+    ];
+
+    const remnicVersion = await getRemnicVersion();
+    return {
+      meta: {
+        id: randomUUID(),
+        benchmark: options.benchmark.id,
+        benchmarkTier: options.benchmark.tier,
+        version: options.benchmark.meta.version,
+        remnicVersion,
+        gitSha: getGitSha(),
+        timestamp: new Date().toISOString(),
+        mode: options.mode,
+        runCount: 1,
+        seeds: [options.seed ?? 0],
+      },
+      config: {
+        systemProvider: options.systemProvider ?? null,
+        judgeProvider: options.judgeProvider ?? null,
+        adapterMode: options.adapterMode ?? "direct",
+        remnicConfig: options.remnicConfig ?? {},
+      },
+      cost: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+        totalLatencyMs: durationMs,
+        meanQueryLatencyMs: durationMs,
+      },
+      results: {
+        tasks,
+        aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+      },
+      environment: {
+        os: process.platform,
+        nodeVersion: process.version,
+        hardware: process.arch,
+      },
+    };
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench/src/fixtures/inbox/email-gold.ts
+++ b/packages/bench/src/fixtures/inbox/email-gold.ts
@@ -1,0 +1,58 @@
+/**
+ * Gold graph for the synthetic inbox email fixture.
+ *
+ * Entities and links are fully synthetic — no real person or organisation data.
+ */
+
+import type { GoldGraph } from "../../ingestion-types.js";
+
+export const EMAIL_GOLD_GRAPH: GoldGraph = {
+  entities: [
+    // People
+    { id: "person-alice", name: "Alice Nakamura", type: "person", aliases: ["Alice"] },
+    { id: "person-bob", name: "Bob Chen", type: "person", aliases: ["Bob"] },
+    { id: "person-carol", name: "Carol Osei", type: "person", aliases: ["Carol"] },
+    // Orgs
+    { id: "org-acme", name: "Acme Corp", type: "org", aliases: ["Acme"] },
+    { id: "org-betaworks", name: "Betaworks Ltd", type: "org", aliases: ["Betaworks"] },
+    // Projects
+    { id: "project-atlas", name: "Project Atlas", type: "project", aliases: ["Atlas"] },
+    // Topics
+    { id: "topic-budget", name: "Q3 Budget Review", type: "topic", aliases: ["budget review", "Q3 budget"] },
+    { id: "topic-onboarding", name: "Onboarding", type: "topic", aliases: ["onboard"] },
+    // Events
+    { id: "event-kickoff", name: "Atlas Kickoff Meeting", type: "event", aliases: ["kickoff"] },
+  ],
+  links: [
+    { source: "Alice Nakamura", target: "Acme Corp", relation: "works-at", bidirectional: false },
+    { source: "Bob Chen", target: "Acme Corp", relation: "works-at", bidirectional: false },
+    { source: "Carol Osei", target: "Betaworks Ltd", relation: "works-at", bidirectional: false },
+    { source: "Alice Nakamura", target: "Project Atlas", relation: "leads", bidirectional: false },
+    { source: "Bob Chen", target: "Project Atlas", relation: "contributes-to", bidirectional: false },
+    { source: "Alice Nakamura", target: "Bob Chen", relation: "collaborates-with", bidirectional: true },
+    { source: "Atlas Kickoff Meeting", target: "Project Atlas", relation: "relates-to", bidirectional: false },
+  ],
+  pages: [
+    {
+      title: "Project Atlas",
+      requiredFields: ["title", "type", "state", "created", "see-also"],
+      expectTimeline: true,
+      expectExecSummary: true,
+      expectSeeAlso: ["Alice Nakamura", "Acme Corp"],
+    },
+    {
+      title: "Alice Nakamura",
+      requiredFields: ["title", "type", "state", "created", "see-also"],
+      expectTimeline: false,
+      expectExecSummary: false,
+      expectSeeAlso: ["Project Atlas", "Acme Corp"],
+    },
+    {
+      title: "Acme Corp",
+      requiredFields: ["title", "type", "state", "created", "see-also"],
+      expectTimeline: false,
+      expectExecSummary: true,
+      expectSeeAlso: ["Project Atlas"],
+    },
+  ],
+};

--- a/packages/bench/src/fixtures/inbox/email.ts
+++ b/packages/bench/src/fixtures/inbox/email.ts
@@ -1,0 +1,85 @@
+/**
+ * Synthetic inbox email fixture for ingestion benchmarks.
+ *
+ * All names, organisations, and content are entirely fictional.
+ */
+
+import type { FixtureGenerator, FixtureOutput } from "./types.js";
+import { EMAIL_GOLD_GRAPH } from "./email-gold.js";
+
+const EMAIL_FILES = [
+  {
+    relativePath: "emails/001-project-atlas-kickoff.txt",
+    content: `From: Alice Nakamura <alice@acmecorp.example>
+To: Bob Chen <bob@acmecorp.example>
+Subject: Project Atlas Kickoff Meeting
+Date: Mon, 10 Mar 2025 09:00:00 +0000
+
+Hi Bob,
+
+I wanted to confirm the details for the Atlas Kickoff Meeting scheduled for
+next Friday. As the lead on Project Atlas, I'll be presenting the roadmap and
+the Q3 Budget Review slides.
+
+Could you please prepare a summary of your contributions so far?
+
+Thanks,
+Alice Nakamura
+Acme Corp
+`,
+  },
+  {
+    relativePath: "emails/002-budget-review-notes.txt",
+    content: `From: Bob Chen <bob@acmecorp.example>
+To: Alice Nakamura <alice@acmecorp.example>, Carol Osei <carol@betaworks.example>
+Subject: RE: Q3 Budget Review — notes
+Date: Tue, 11 Mar 2025 14:30:00 +0000
+
+Hi Alice, Carol,
+
+Attaching my notes from the Q3 budget review discussion. Carol, since
+Betaworks Ltd is a partner on Project Atlas, I thought it would be useful
+to loop you in.
+
+Key points:
+- Atlas is on track for the Q3 milestone
+- Onboarding of new team members starts next week
+
+Best,
+Bob Chen
+Acme Corp
+`,
+  },
+  {
+    relativePath: "emails/003-onboarding-schedule.txt",
+    content: `From: Carol Osei <carol@betaworks.example>
+To: Bob Chen <bob@acmecorp.example>
+Subject: Onboarding schedule for Atlas contributors
+Date: Wed, 12 Mar 2025 10:15:00 +0000
+
+Bob,
+
+Thanks for the heads-up. Betaworks Ltd will have two engineers joining the
+Project Atlas onboarding next week. Please share the onboarding materials
+with them beforehand.
+
+Regards,
+Carol Osei
+Betaworks Ltd
+`,
+  },
+];
+
+export const emailFixture: FixtureGenerator = {
+  id: "inbox-email-v1",
+  description: "Synthetic three-email inbox spanning two organisations and one shared project.",
+
+  generate(): FixtureOutput {
+    return {
+      id: "inbox-email-v1",
+      description: emailFixture.description,
+      files: EMAIL_FILES,
+      goldGraph: EMAIL_GOLD_GRAPH,
+    };
+  },
+};

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -65,7 +65,7 @@ export type {
   IngestionBenchAdapter,
 } from "./ingestion-types.js";
 
-export { REQUIRED_FRONTMATTER_FIELDS } from "./ingestion-types.js";
+export { REQUIRED_FRONTMATTER_FIELDS, CONDITIONAL_FRONTMATTER } from "./ingestion-types.js";
 
 export type {
   GeneratedFile,
@@ -168,3 +168,11 @@ export {
   SCHEMA_TIER_FIXTURE,
   SCHEMA_TIER_SMOKE_FIXTURE,
 } from "./fixtures/schema-tiers/index.js";
+
+export {
+  matchEntity,
+  entityRecall,
+  linkMatches,
+  backlinkF1,
+  schemaCompleteness,
+} from "./ingestion-scorer.js";

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -172,7 +172,5 @@ export {
 export {
   matchEntity,
   entityRecall,
-  linkMatches,
-  backlinkF1,
   schemaCompleteness,
 } from "./ingestion-scorer.js";

--- a/packages/bench/src/ingestion-scorer.ts
+++ b/packages/bench/src/ingestion-scorer.ts
@@ -134,19 +134,24 @@ export function schemaCompleteness(
       totalApplicable++;
       const passes = matchedPage ? matchedPage.frontmatter[field] !== undefined : false;
       if (passes) totalPassing++;
-      fieldPasses[field]?.push(passes ? 1 : 0);
+      if (!(field in fieldPasses)) fieldPasses[field] = [];
+      fieldPasses[field]!.push(passes ? 1 : 0);
     }
 
     if (gp.expectExecSummary) {
       totalApplicable++;
       const passes = matchedPage?.hasExecSummary ?? false;
       if (passes) totalPassing++;
+      if (!("field_exec_summary" in fieldPasses)) fieldPasses["field_exec_summary"] = [];
+      fieldPasses["field_exec_summary"]!.push(passes ? 1 : 0);
     }
 
     if (gp.expectTimeline) {
       totalApplicable++;
       const passes = matchedPage?.hasTimeline ?? false;
       if (passes) totalPassing++;
+      if (!("field_timeline" in fieldPasses)) fieldPasses["field_timeline"] = [];
+      fieldPasses["field_timeline"]!.push(passes ? 1 : 0);
     }
 
     if (gp.expectSeeAlso && gp.expectSeeAlso.length > 0) {

--- a/packages/bench/src/ingestion-scorer.ts
+++ b/packages/bench/src/ingestion-scorer.ts
@@ -1,0 +1,171 @@
+/**
+ * Scoring utilities for ingestion benchmarks.
+ */
+
+import type {
+  ExtractedEntity,
+  ExtractedLink,
+  ExtractedPage,
+  GoldEntity,
+  GoldLink,
+  GoldPage,
+} from "./ingestion-types.js";
+
+function normalize(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9\s]/g, "");
+}
+
+function entityNameMatches(extracted: string, gold: GoldEntity): boolean {
+  const normalizedExtracted = normalize(extracted);
+  if (normalizedExtracted === normalize(gold.name)) return true;
+  if (gold.aliases) {
+    return gold.aliases.some((alias) => normalize(alias) === normalizedExtracted);
+  }
+  return false;
+}
+
+export function matchEntity(extracted: ExtractedEntity, gold: GoldEntity): boolean {
+  return (
+    normalize(extracted.type) === normalize(gold.type) &&
+    entityNameMatches(extracted.name, gold)
+  );
+}
+
+export function entityRecall(
+  extracted: ExtractedEntity[],
+  gold: GoldEntity[],
+): { overall: number; byType: Record<string, number> } {
+  if (gold.length === 0) return { overall: 1, byType: {} };
+
+  const matched = new Set<string>();
+  const consumedExtracted = new Set<number>();
+  for (const ge of gold) {
+    const idx = extracted.findIndex((ee, i) => !consumedExtracted.has(i) && matchEntity(ee, ge));
+    if (idx >= 0) {
+      matched.add(ge.id);
+      consumedExtracted.add(idx);
+    }
+  }
+
+  const overall = matched.size / gold.length;
+
+  const typeGroups = new Map<string, GoldEntity[]>();
+  for (const ge of gold) {
+    const group = typeGroups.get(ge.type) ?? [];
+    group.push(ge);
+    typeGroups.set(ge.type, group);
+  }
+
+  const byType: Record<string, number> = {};
+  for (const [type, entities] of typeGroups) {
+    const typeMatched = entities.filter((ge) => matched.has(ge.id)).length;
+    byType[`${type}_recall`] = typeMatched / entities.length;
+  }
+
+  return { overall, byType };
+}
+
+export function linkMatches(extracted: ExtractedLink, gold: GoldLink): boolean {
+  if (gold.bidirectional) {
+    const directMatch =
+      normalize(extracted.source) === normalize(gold.source) &&
+      normalize(extracted.target) === normalize(gold.target);
+    const reverseMatch =
+      normalize(extracted.source) === normalize(gold.target) &&
+      normalize(extracted.target) === normalize(gold.source);
+    return (directMatch || reverseMatch) && normalize(extracted.relation) === normalize(gold.relation);
+  }
+
+  return (
+    normalize(extracted.source) === normalize(gold.source) &&
+    normalize(extracted.target) === normalize(gold.target) &&
+    normalize(extracted.relation) === normalize(gold.relation)
+  );
+}
+
+export function backlinkF1(
+  extracted: ExtractedLink[],
+  gold: GoldLink[],
+): { precision: number; recall: number; f1: number } {
+  if (gold.length === 0 && extracted.length === 0) {
+    return { precision: 1, recall: 1, f1: 1 };
+  }
+  if (extracted.length === 0) return { precision: 0, recall: 0, f1: 0 };
+  if (gold.length === 0) return { precision: 0, recall: 0, f1: 0 };
+
+  const matchedGold = new Set<number>();
+  let correctExtracted = 0;
+  for (const el of extracted) {
+    for (let gi = 0; gi < gold.length; gi++) {
+      if (!matchedGold.has(gi) && linkMatches(el, gold[gi]!)) {
+        matchedGold.add(gi);
+        correctExtracted++;
+        break;
+      }
+    }
+  }
+
+  const precision = correctExtracted / extracted.length;
+  const recall = matchedGold.size / gold.length;
+  const f1 = precision + recall > 0 ? (2 * precision * recall) / (precision + recall) : 0;
+
+  return { precision, recall, f1 };
+}
+
+export function schemaCompleteness(
+  pages: ExtractedPage[],
+  goldPages: GoldPage[],
+  requiredFields: readonly string[],
+): { overall: number; fieldCoverage: Record<string, number> } {
+  if (goldPages.length === 0) return { overall: 1, fieldCoverage: {} };
+
+  const fieldPasses: Record<string, number[]> = {};
+  for (const field of requiredFields) {
+    fieldPasses[field] = [];
+  }
+
+  let totalApplicable = 0;
+  let totalPassing = 0;
+
+  for (const gp of goldPages) {
+    const matchedPage = pages.find((p) => normalize(p.title) === normalize(gp.title));
+
+    for (const field of gp.requiredFields) {
+      totalApplicable++;
+      const passes = matchedPage ? matchedPage.frontmatter[field] !== undefined : false;
+      if (passes) totalPassing++;
+      fieldPasses[field]?.push(passes ? 1 : 0);
+    }
+
+    if (gp.expectExecSummary) {
+      totalApplicable++;
+      const passes = matchedPage?.hasExecSummary ?? false;
+      if (passes) totalPassing++;
+    }
+
+    if (gp.expectTimeline) {
+      totalApplicable++;
+      const passes = matchedPage?.hasTimeline ?? false;
+      if (passes) totalPassing++;
+    }
+
+    if (gp.expectSeeAlso && gp.expectSeeAlso.length > 0) {
+      for (const expected of gp.expectSeeAlso) {
+        totalApplicable++;
+        const passes = matchedPage?.seeAlso.some((sa) => normalize(sa) === normalize(expected)) ?? false;
+        if (passes) totalPassing++;
+      }
+    }
+  }
+
+  const overall = totalApplicable > 0 ? totalPassing / totalApplicable : 1;
+
+  const fieldCoverage: Record<string, number> = {};
+  for (const [field, values] of Object.entries(fieldPasses)) {
+    if (values.length > 0) {
+      fieldCoverage[field] = values.reduce((s, v) => s + v, 0) / values.length;
+    }
+  }
+
+  return { overall, fieldCoverage };
+}

--- a/packages/bench/src/ingestion-types.ts
+++ b/packages/bench/src/ingestion-types.ts
@@ -75,3 +75,8 @@ export interface IngestionBenchAdapter {
 }
 
 export const REQUIRED_FRONTMATTER_FIELDS = ["title", "type", "state", "created", "see-also"] as const;
+
+export const CONDITIONAL_FRONTMATTER: Record<string, { field: string; requiredWhen: GoldEntityType[] }[]> = {
+  "exec-summary": [{ field: "exec-summary", requiredWhen: ["project", "org", "event"] }],
+  timeline: [{ field: "timeline", requiredWhen: ["project", "event"] }],
+};

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -63,6 +63,14 @@ import {
   retrievalPersonalizationDefinition,
   runRetrievalPersonalizationBenchmark,
 } from "./benchmarks/remnic/retrieval-personalization/runner.js";
+import {
+  ingestionEntityRecallDefinition,
+  runIngestionEntityRecallBenchmark,
+} from "./benchmarks/remnic/ingestion-entity-recall/runner.js";
+import {
+  ingestionSchemaCompletenessDefinition,
+  runIngestionSchemaCompletenessBenchmark,
+} from "./benchmarks/remnic/ingestion-schema-completeness/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -128,6 +136,16 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalPersonalizationDefinition,
     run: runRetrievalPersonalizationBenchmark,
+  },
+  {
+    ...ingestionEntityRecallDefinition,
+    runnerAvailable: false,
+    run: runIngestionEntityRecallBenchmark,
+  },
+  {
+    ...ingestionSchemaCompletenessDefinition,
+    runnerAvailable: false,
+    run: runIngestionSchemaCompletenessBenchmark,
   },
 ];
 

--- a/packages/bench/tsconfig.json
+++ b/packages/bench/tsconfig.json
@@ -21,10 +21,12 @@
     "src/registry.ts",
     "src/reporter.ts",
     "src/scorer.ts",
+    "src/ingestion-scorer.ts",
     "src/adapters/**/*.ts",
     "src/fixtures/**/*.ts",
     "src/providers/**/*.ts",
     "src/benchmarks/published/**/*.ts",
-    "src/benchmarks/custom/**/*.ts"
+    "src/benchmarks/custom/**/*.ts",
+    "src/benchmarks/remnic/**/*.ts"
   ]
 }

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -27,6 +27,8 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "entity-consolidation",
       "page-versioning",
       "retrieval-personalization",
+      "ingestion-entity-recall",
+      "ingestion-schema-completeness",
     ],
   );
   assert.deepEqual(
@@ -47,12 +49,17 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
     "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization",
   );
+  // Ingestion benchmarks are registered but not runnable until ingestionAdapter is wired through CLI
+  assert.equal(getBenchmark("ingestion-entity-recall")?.runnerAvailable, false);
+  assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, false);
 });
 
 test("getBenchmark returns ama-bench metadata with a runnable benchmark entry", () => {
@@ -208,6 +215,28 @@ test("getBenchmark returns retrieval-personalization metadata with a runnable be
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");
   assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns ingestion-entity-recall metadata (not yet runnable)", () => {
+  const benchmark = getBenchmark("ingestion-entity-recall");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "ingestion-entity-recall");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, false);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "ingestion");
+});
+
+test("getBenchmark returns ingestion-schema-completeness metadata (not yet runnable)", () => {
+  const benchmark = getBenchmark("ingestion-schema-completeness");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "ingestion-schema-completeness");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, false);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "ingestion");
 });
 
 test("BenchmarkResult schema captures the phase-1 package contract", () => {


### PR DESCRIPTION
## Summary

Schema completeness benchmark for the ingestion tier (issue #449):

- Scores generated page frontmatter against canonical schema
- Checks: title, type, state, created, see-also, plus conditional exec-summary and timeline
- Reports `schema_completeness` (overall) plus per-field pass rates
- Same runner pattern as entity recall

Depends on #495

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Runner follows entity recall pattern
- [x] Registered in benchmark registry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive (new fixtures, scoring helpers, and benchmark registrations) and the new ingestion benchmarks are registered as `runnerAvailable: false`, so they won’t run via the CLI yet.
> 
> **Overview**
> Adds two new *ingestion-tier* benchmarks: `ingestion-entity-recall` and `ingestion-schema-completeness`, each ingesting a synthetic email inbox fixture and scoring the resulting in-memory graph.
> 
> Introduces `ingestion-scorer.ts` with reusable match/metric helpers (`entityRecall`, `schemaCompleteness`, plus link matching/F1 utilities) and adds a new synthetic inbox fixture + gold graph used by the runners.
> 
> Updates package exports/tsconfig and the benchmark registry/tests to include the new benchmark metadata while explicitly marking them not runnable until an `ingestionAdapter` is wired through the CLI.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e89187f46bde88853fc5aeea25cce8b3fc902b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->