### PR TITLE
bench: add setup friction benchmark for ingestion tier

### DIFF
--- a/packages/bench/src/benchmark.ts
+++ b/packages/bench/src/benchmark.ts
@@ -135,10 +135,19 @@ export async function runBenchmark(
     );
   }
 
+  const definition = benchmarkDefinition(registeredBenchmark.id);
+  if (definition.meta.category === "ingestion" && !options.ingestionAdapter) {
+    throw new Error(
+      `Benchmark "${benchmarkId}" requires an ingestion adapter. ` +
+      `Pass ingestionAdapter via RunBenchmarkOptions or use the programmatic API. ` +
+      `The CLI does not yet support ingestion benchmarks.`,
+    );
+  }
+
   return registeredBenchmark.run({
     ...options,
     mode: options.mode ?? "quick",
-    benchmark: benchmarkDefinition(registeredBenchmark.id),
+    benchmark: definition,
   });
 }
 

--- a/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
@@ -40,6 +40,8 @@ export async function runIngestionSetupFrictionBenchmark(
 
   const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-friction-"));
   try {
+    await options.ingestionAdapter!.reset();
+
     for (const file of fixture.files) {
       const filePath = path.join(fixtureDir, file.relativePath);
       await mkdir(path.dirname(filePath), { recursive: true });
@@ -47,7 +49,7 @@ export async function runIngestionSetupFrictionBenchmark(
     }
 
     const { result: ingestionLog, durationMs } = await timed(() =>
-      options.ingestionAdapter.ingest(fixtureDir),
+      options.ingestionAdapter!.ingest(fixtureDir),
     );
 
     const commandsCount = ingestionLog.commandsIssued.length;

--- a/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
@@ -19,6 +19,13 @@ import { aggregateTaskScores, timed } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import { emailFixture } from "../../../fixtures/inbox/email.js";
 
+/**
+ * Metrics where a lower value represents better performance.
+ * Pass this set to `compareResults` so regressions are detected correctly.
+ */
+export const INGESTION_SETUP_FRICTION_LOWER_IS_BETTER: ReadonlySet<string> =
+  new Set(["setup_friction", "commands_count", "prompts_count", "errors_count"]);
+
 export const ingestionSetupFrictionDefinition: BenchmarkDefinition = {
   id: "ingestion-setup-friction",
   title: "Ingestion: Setup Friction",

--- a/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-setup-friction/runner.ts
@@ -1,0 +1,124 @@
+/**
+ * Ingestion setup friction benchmark.
+ *
+ * Counts commands issued, prompts shown, and errors produced during ingestion.
+ * Lower setup_friction (commands + prompts) is better.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+} from "../../../types.js";
+import type { IngestionBenchAdapter } from "../../../ingestion-types.js";
+import { aggregateTaskScores, timed } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { emailFixture } from "../../../fixtures/inbox/email.js";
+
+export const ingestionSetupFrictionDefinition: BenchmarkDefinition = {
+  id: "ingestion-setup-friction",
+  title: "Ingestion: Setup Friction",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "ingestion-setup-friction",
+    version: "1.0.0",
+    description: "Counts commands and prompts required during ingestion. Lower setup_friction is better.",
+    category: "ingestion",
+  },
+};
+
+export async function runIngestionSetupFrictionBenchmark(
+  options: ResolvedRunBenchmarkOptions & { ingestionAdapter: IngestionBenchAdapter },
+): Promise<BenchmarkResult> {
+  const fixture = emailFixture.generate();
+
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-friction-"));
+  try {
+    for (const file of fixture.files) {
+      const filePath = path.join(fixtureDir, file.relativePath);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, file.content, "utf8");
+    }
+
+    const { result: ingestionLog, durationMs } = await timed(() =>
+      options.ingestionAdapter.ingest(fixtureDir),
+    );
+
+    const commandsCount = ingestionLog.commandsIssued.length;
+    const promptsCount = ingestionLog.promptsShown.length;
+    const errorsCount = ingestionLog.errors.length;
+    const setupFriction = commandsCount + promptsCount;
+
+    const scores: Record<string, number> = {
+      setup_friction: setupFriction,
+      commands_count: commandsCount,
+      prompts_count: promptsCount,
+      errors_count: errorsCount,
+    };
+
+    const tasks = [
+      {
+        taskId: `setup-friction-${fixture.id}`,
+        question: `Measure setup friction for ${fixture.id} fixture`,
+        expected: "0 commands, 0 prompts",
+        actual: `${commandsCount} commands, ${promptsCount} prompts, ${errorsCount} errors`,
+        scores,
+        latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          fixtureId: fixture.id,
+          commandsIssued: ingestionLog.commandsIssued,
+          promptsShown: ingestionLog.promptsShown,
+          errors: ingestionLog.errors,
+        },
+      },
+    ];
+
+    const remnicVersion = await getRemnicVersion();
+    return {
+      meta: {
+        id: randomUUID(),
+        benchmark: options.benchmark.id,
+        benchmarkTier: options.benchmark.tier,
+        version: options.benchmark.meta.version,
+        remnicVersion,
+        gitSha: getGitSha(),
+        timestamp: new Date().toISOString(),
+        mode: options.mode,
+        runCount: 1,
+        seeds: [options.seed ?? 0],
+      },
+      config: {
+        systemProvider: options.systemProvider ?? null,
+        judgeProvider: options.judgeProvider ?? null,
+        adapterMode: options.adapterMode ?? "direct",
+        remnicConfig: options.remnicConfig ?? {},
+      },
+      cost: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+        totalLatencyMs: durationMs,
+        meanQueryLatencyMs: durationMs,
+      },
+      results: {
+        tasks,
+        aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+      },
+      environment: {
+        os: process.platform,
+        nodeVersion: process.version,
+        hardware: process.arch,
+      },
+    };
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -131,7 +131,7 @@ export {
   pairedDeltaConfidenceInterval,
 } from "./stats/bootstrap.js";
 export { cohensD, interpretEffectSize } from "./stats/effect-size.js";
-export { compareResults } from "./stats/comparison.js";
+export { compareResults, getBenchmarkLowerIsBetter } from "./stats/comparison.js";
 export {
   buildBenchmarkPublishFeed,
   defaultBenchmarkBaselineDir,

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -72,9 +72,9 @@ import {
   runIngestionSchemaCompletenessBenchmark,
 } from "./benchmarks/remnic/ingestion-schema-completeness/runner.js";
 import {
-  ingestionBacklinkF1Definition,
-  runIngestionBacklinkF1Benchmark,
-} from "./benchmarks/remnic/ingestion-backlink-f1/runner.js";
+  ingestionSetupFrictionDefinition,
+  runIngestionSetupFrictionBenchmark,
+} from "./benchmarks/remnic/ingestion-setup-friction/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -151,8 +151,8 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     run: runIngestionSchemaCompletenessBenchmark,
   },
   {
-    ...ingestionBacklinkF1Definition,
-    run: runIngestionBacklinkF1Benchmark,
+    ...ingestionSetupFrictionDefinition,
+    run: runIngestionSetupFrictionBenchmark as (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>,
   },
 ];
 

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -72,6 +72,10 @@ import {
   runIngestionSchemaCompletenessBenchmark,
 } from "./benchmarks/remnic/ingestion-schema-completeness/runner.js";
 import {
+  ingestionBacklinkF1Definition,
+  runIngestionBacklinkF1Benchmark,
+} from "./benchmarks/remnic/ingestion-backlink-f1/runner.js";
+import {
   ingestionSetupFrictionDefinition,
   runIngestionSetupFrictionBenchmark,
 } from "./benchmarks/remnic/ingestion-setup-friction/runner.js";
@@ -149,6 +153,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
     ...ingestionSchemaCompletenessDefinition,
     runnerAvailable: false,
     run: runIngestionSchemaCompletenessBenchmark,
+  },
+  {
+    ...ingestionBacklinkF1Definition,
+    run: runIngestionBacklinkF1Benchmark,
   },
   {
     ...ingestionSetupFrictionDefinition,

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -16,15 +16,20 @@ function percentChange(candidateValue: number, baselineValue: number): number {
 function verdictFromMetricDeltas(
   metricDeltas: Record<string, ComparisonMetricDelta>,
   threshold: number,
+  lowerIsBetter: ReadonlySet<string>,
 ): ComparisonResult["verdict"] {
   let hasImprovement = false;
   let hasRegression = false;
 
-  for (const metric of Object.values(metricDeltas)) {
-    if (metric.percentChange > threshold) {
+  for (const [metricName, metric] of Object.entries(metricDeltas)) {
+    // For lower-is-better metrics, a positive percent change is a regression.
+    const directedChange = lowerIsBetter.has(metricName)
+      ? -metric.percentChange
+      : metric.percentChange;
+    if (directedChange > threshold) {
       hasImprovement = true;
     }
-    if (metric.percentChange < -threshold) {
+    if (directedChange < -threshold) {
       hasRegression = true;
     }
   }
@@ -38,6 +43,7 @@ export function compareResults(
   baseline: BenchmarkResult,
   candidate: BenchmarkResult,
   threshold = 0.05,
+  lowerIsBetter: ReadonlySet<string> = new Set(),
 ): ComparisonResult {
   const metricDeltas: Record<string, ComparisonMetricDelta> = {};
 
@@ -85,6 +91,6 @@ export function compareResults(
   return {
     benchmark: candidate.meta.benchmark,
     metricDeltas,
-    verdict: verdictFromMetricDeltas(metricDeltas, threshold),
+    verdict: verdictFromMetricDeltas(metricDeltas, threshold, lowerIsBetter),
   };
 }

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -94,3 +94,19 @@ export function compareResults(
     verdict: verdictFromMetricDeltas(metricDeltas, threshold, lowerIsBetter),
   };
 }
+
+/**
+ * Registry of lower-is-better metric sets keyed by benchmark id.  Callers
+ * (such as the CLI comparison command) can look up the appropriate set and
+ * pass it to compareResults so verdicts correctly treat friction/error-style
+ * metrics as regressions when they increase.
+ */
+import { INGESTION_SETUP_FRICTION_LOWER_IS_BETTER } from "../benchmarks/remnic/ingestion-setup-friction/runner.js";
+
+const LOWER_IS_BETTER_BY_BENCHMARK: Record<string, ReadonlySet<string>> = {
+  "ingestion-setup-friction": INGESTION_SETUP_FRICTION_LOWER_IS_BETTER,
+};
+
+export function getBenchmarkLowerIsBetter(benchmarkId: string): ReadonlySet<string> {
+  return LOWER_IS_BETTER_BY_BENCHMARK[benchmarkId] ?? new Set<string>();
+}

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -123,6 +123,7 @@ import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   buildBenchmarkPublishFeed,
   compareResults,
+  getBenchmarkLowerIsBetter,
   defaultBenchmarkBaselineDir,
   discoverAllProviders,
   defaultBenchmarkPublishPath,
@@ -641,6 +642,7 @@ async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
     baseline,
     candidate,
     parsed.threshold ?? 0.05,
+    getBenchmarkLowerIsBetter(candidate.meta.benchmark),
   );
 
   if (parsed.json) {

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -30,6 +30,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
+      "ingestion-setup-friction",
     ],
   );
   assert.deepEqual(
@@ -53,14 +54,16 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
     "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,ingestion-entity-recall,ingestion-backlink-f1",
   );
-  // Schema completeness remains gated off until its adapter contract is wired.
+  // Schema completeness and setup friction remain gated off until their adapter contracts are wired.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, false);
+  assert.equal(getBenchmark("ingestion-setup-friction")?.runnerAvailable, false);
 });
 
 test("getBenchmark returns ama-bench metadata with a runnable benchmark entry", () => {


### PR DESCRIPTION
## Summary

Setup friction benchmark for the ingestion tier (issue #449):

- Counts commands + prompts required during ingestion (lower = better)
- Reports `setup_friction`, `commands_count`, `prompts_count`, `errors_count`
- Pure bookkeeping from `IngestionLog` — no scorer dependency
- Details include raw command/prompt/error arrays

Depends on #495

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Runner follows entity recall pattern
- [x] Registered in benchmark registry

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new ingestion benchmark runner plus changes comparison verdict logic to account for lower-is-better metrics, which can change regression/improvement outcomes in the CLI compare command. Also adds a runtime guard requiring an `ingestionAdapter` for ingestion-category benchmarks.
> 
> **Overview**
> Adds a new `ingestion-setup-friction` ingestion-tier benchmark that runs ingestion on a generated email fixture and reports bookkeeping metrics (`setup_friction`, `commands_count`, `prompts_count`, `errors_count`) along with per-task details.
> 
> Updates benchmark execution to hard-fail ingestion-category runs when no `ingestionAdapter` is provided, and extends result comparison to support *lower-is-better* metrics via `getBenchmarkLowerIsBetter`, which the CLI now passes into `compareResults` so verdicts treat increases in friction/error metrics as regressions. Registry/tests are updated to include the new benchmark while keeping it gated as not CLI-runnable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 939f2a85e65d869be574746622f227e7df9bb334. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->