### PR TITLE
bench: add citation accuracy benchmark for ingestion tier

### DIFF
--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -31,8 +31,29 @@ export const ingestionCitationAccuracyDefinition: BenchmarkDefinition = {
   },
 };
 
-function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourceContent: string }> {
-  const claims: Array<{ claim: string; sourceContent: string }> = [];
+/**
+ * Extract a narrow context window around a sentence within the full text.
+ * Returns up to 2 sentences before and after the target sentence so the judge
+ * sees claim-specific evidence rather than the entire page body.
+ */
+function extractClaimContext(fullText: string, sentence: string): string {
+  const sentences = fullText
+    .split(/(?<=[.!?])\s+/)
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+
+  const idx = sentences.findIndex((s) => s.includes(sentence) || sentence.includes(s));
+  if (idx < 0) return sentence;
+
+  const start = Math.max(0, idx - 2);
+  const end = Math.min(sentences.length, idx + 3);
+  return sentences.slice(start, end).join(" ");
+}
+
+function extractClaims(
+  pages: ExtractedPage[],
+): Array<{ claim: string; claimContext: string; pageRef: string; seeAlso: string[] }> {
+  const claims: Array<{ claim: string; claimContext: string; pageRef: string; seeAlso: string[] }> = [];
   for (const page of pages) {
     if (!page.content) continue;
     const sentences = page.content
@@ -40,10 +61,61 @@ function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourceCon
       .map((s) => s.trim())
       .filter((s) => s.length > 20);
     for (const sentence of sentences) {
-      claims.push({ claim: sentence, sourceContent: page.content });
+      claims.push({
+        claim: sentence,
+        claimContext: extractClaimContext(page.content, sentence),
+        pageRef: page.path,
+        seeAlso: page.seeAlso,
+      });
     }
   }
   return claims;
+}
+
+/**
+ * Build the cited source content for a claim by resolving its page's seeAlso
+ * references against the fixture file map. Falls back to a basename match if
+ * no seeAlso entry resolves directly, and falls back to all sources only if
+ * no narrower match is available. This prevents a misattributed citation from
+ * scoring as valid just because the claim is supported somewhere else in the
+ * merged corpus.
+ */
+function resolveCitedSources(
+  seeAlso: string[],
+  pageRef: string,
+  sourceContentMap: Map<string, string>,
+): string {
+  const resolved: string[] = [];
+
+  for (const ref of seeAlso) {
+    const refBase = path.basename(ref).toLowerCase();
+    for (const [relativePath, content] of sourceContentMap) {
+      if (
+        relativePath === ref ||
+        relativePath.endsWith(ref) ||
+        path.basename(relativePath).toLowerCase() === refBase
+      ) {
+        resolved.push(content);
+        break;
+      }
+    }
+  }
+
+  if (resolved.length > 0) {
+    return resolved.join("\n\n---\n\n");
+  }
+
+  // Fall back to a source whose basename matches the page path
+  const pageBase = path.basename(pageRef).toLowerCase();
+  for (const [relativePath, content] of sourceContentMap) {
+    if (path.basename(relativePath).toLowerCase() === pageBase) {
+      return content;
+    }
+  }
+
+  // Last resort: all sources (equivalent to original behaviour, but only reached
+  // when citation metadata is entirely absent)
+  return Array.from(sourceContentMap.values()).join("\n\n---\n\n");
 }
 
 export async function runIngestionCitationAccuracyBenchmark(
@@ -64,7 +136,9 @@ export async function runIngestionCitationAccuracyBenchmark(
       await writeFile(filePath, file.content, "utf8");
     }
 
-    const { result: ingestionLog, durationMs } = await timed(() =>
+    const benchmarkStart = performance.now();
+
+    const { result: ingestionLog, durationMs: ingestionDurationMs } = await timed(() =>
       options.ingestionAdapter!.ingest(fixtureDir),
     );
 
@@ -73,18 +147,22 @@ export async function runIngestionCitationAccuracyBenchmark(
 
     const judge: BenchJudge | undefined = options.system?.judge;
 
-    const originalSources = fixture.files.map((f) => f.content).join("\n\n---\n\n");
+    // Build a map from relativePath → content for citation-aware source resolution
+    const sourceContentMap = new Map<string, string>(
+      fixture.files.map((f) => [f.relativePath, f.content]),
+    );
 
     let validCitations = 0;
     let scoredClaims = 0;
 
     if (claims.length > 0) {
-      for (const { claim, sourceContent } of claims) {
+      for (const { claim, claimContext, pageRef, seeAlso } of claims) {
+        const citedSources = resolveCitedSources(seeAlso, pageRef, sourceContentMap);
         const score = await llmJudgeScore(
           judge,
-          `Does the page content support this claim with evidence from the original sources? Claim: "${claim}"`,
-          sourceContent,
-          originalSources,
+          `Does the cited source content support this claim? Claim: "${claim}"`,
+          claimContext,
+          citedSources,
         );
         if (score >= 0) {
           scoredClaims += 1;
@@ -94,6 +172,9 @@ export async function runIngestionCitationAccuracyBenchmark(
         }
       }
     }
+
+    // Total latency includes both ingestion and judge scoring time
+    const totalDurationMs = Math.round(performance.now() - benchmarkStart);
 
     const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : -1;
 
@@ -114,7 +195,7 @@ export async function runIngestionCitationAccuracyBenchmark(
           ? `${validCitations}/${scoredClaims} claims cite valid source chunks (${claims.length} total claims)`
           : `No judge available; ${claims.length} claims extracted`,
         scores,
-        latencyMs: durationMs,
+        latencyMs: totalDurationMs,
         tokens: { input: 0, output: 0 },
         details: {
           fixtureId: fixture.id,
@@ -123,6 +204,7 @@ export async function runIngestionCitationAccuracyBenchmark(
           validCitations,
           citationAccuracy,
           judgeAvailable: judge !== undefined,
+          ingestionDurationMs,
           ingestionErrors: ingestionLog.errors,
         },
       },
@@ -153,8 +235,8 @@ export async function runIngestionCitationAccuracyBenchmark(
         inputTokens: 0,
         outputTokens: 0,
         estimatedCostUsd: 0,
-        totalLatencyMs: durationMs,
-        meanQueryLatencyMs: durationMs,
+        totalLatencyMs: totalDurationMs,
+        meanQueryLatencyMs: totalDurationMs,
       },
       results: {
         tasks,

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -73,6 +73,8 @@ export async function runIngestionCitationAccuracyBenchmark(
 
   const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-citation-"));
   try {
+    await options.ingestionAdapter!.reset();
+
     for (const file of fixture.files) {
       const filePath = path.join(fixtureDir, file.relativePath);
       await mkdir(path.dirname(filePath), { recursive: true });
@@ -80,7 +82,7 @@ export async function runIngestionCitationAccuracyBenchmark(
     }
 
     const { result: ingestionLog, durationMs } = await timed(() =>
-      options.ingestionAdapter.ingest(fixtureDir),
+      options.ingestionAdapter!.ingest(fixtureDir),
     );
 
     const graph = await options.ingestionAdapter.getMemoryGraph();
@@ -105,7 +107,7 @@ export async function runIngestionCitationAccuracyBenchmark(
       }
     }
 
-    const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : 0;
+    const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : -1;
 
     const scores: Record<string, number> = {
       citation_accuracy: citationAccuracy,

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -11,7 +11,7 @@ import type {
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,
 } from "../../../types.js";
-import type { IngestionBenchAdapter, ExtractedPage } from "../../../ingestion-types.js";
+import type { ExtractedPage } from "../../../ingestion-types.js";
 import type { BenchJudge } from "../../../adapters/types.js";
 import { aggregateTaskScores, timed } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -64,8 +64,11 @@ async function judgeCitation(
 }
 
 export async function runIngestionCitationAccuracyBenchmark(
-  options: ResolvedRunBenchmarkOptions & { ingestionAdapter: IngestionBenchAdapter },
+  options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
+  if (!options.ingestionAdapter) {
+    throw new Error("ingestionAdapter is required for ingestion benchmarks");
+  }
   const fixture = emailFixture.generate();
 
   const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-citation-"));
@@ -102,7 +105,7 @@ export async function runIngestionCitationAccuracyBenchmark(
       }
     }
 
-    const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : -1;
+    const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : 0;
 
     const scores: Record<string, number> = {
       citation_accuracy: citationAccuracy,

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -13,7 +13,7 @@ import type {
 } from "../../../types.js";
 import type { ExtractedPage } from "../../../ingestion-types.js";
 import type { BenchJudge } from "../../../adapters/types.js";
-import { aggregateTaskScores, timed } from "../../../scorer.js";
+import { aggregateTaskScores, llmJudgeScore, timed } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import { emailFixture } from "../../../fixtures/inbox/email.js";
 
@@ -31,8 +31,8 @@ export const ingestionCitationAccuracyDefinition: BenchmarkDefinition = {
   },
 };
 
-function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourcePage: string; sourceContent: string }> {
-  const claims: Array<{ claim: string; sourcePage: string; sourceContent: string }> = [];
+function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourceContent: string }> {
+  const claims: Array<{ claim: string; sourceContent: string }> = [];
   for (const page of pages) {
     if (!page.content) continue;
     const sentences = page.content
@@ -40,27 +40,10 @@ function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourcePag
       .map((s) => s.trim())
       .filter((s) => s.length > 20);
     for (const sentence of sentences) {
-      claims.push({ claim: sentence, sourcePage: page.path, sourceContent: page.content });
+      claims.push({ claim: sentence, sourceContent: page.content });
     }
   }
   return claims;
-}
-
-async function judgeCitation(
-  judge: BenchJudge,
-  claim: string,
-  pageContent: string,
-  originalSources: string,
-): Promise<number> {
-  try {
-    return await judge.score(
-      `Does the page content support this claim with evidence from the original sources? Claim: "${claim}"`,
-      pageContent,
-      originalSources,
-    );
-  } catch {
-    return -1;
-  }
 }
 
 export async function runIngestionCitationAccuracyBenchmark(
@@ -95,9 +78,14 @@ export async function runIngestionCitationAccuracyBenchmark(
     let validCitations = 0;
     let scoredClaims = 0;
 
-    if (judge && claims.length > 0) {
+    if (claims.length > 0) {
       for (const { claim, sourceContent } of claims) {
-        const score = await judgeCitation(judge, claim, sourceContent, originalSources);
+        const score = await llmJudgeScore(
+          judge,
+          `Does the page content support this claim with evidence from the original sources? Claim: "${claim}"`,
+          sourceContent,
+          originalSources,
+        );
         if (score >= 0) {
           scoredClaims += 1;
           if (score >= 0.5) {
@@ -110,10 +98,10 @@ export async function runIngestionCitationAccuracyBenchmark(
     const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : -1;
 
     const scores: Record<string, number> = {
-      citation_accuracy: citationAccuracy,
       total_claims: claims.length,
       valid_citations: validCitations,
     };
+    if (citationAccuracy >= 0) scores.citation_accuracy = citationAccuracy;
 
     const tasks = [
       {

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -99,9 +99,11 @@ export async function runIngestionCitationAccuracyBenchmark(
 
     const scores: Record<string, number> = {
       total_claims: claims.length,
-      valid_citations: validCitations,
     };
-    if (citationAccuracy >= 0) scores.citation_accuracy = citationAccuracy;
+    if (citationAccuracy >= 0) {
+      scores.valid_citations = validCitations;
+      scores.citation_accuracy = citationAccuracy;
+    }
 
     const tasks = [
       {

--- a/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/ingestion-citation-accuracy/runner.ts
@@ -1,0 +1,177 @@
+/**
+ * Ingestion citation accuracy benchmark.
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, writeFile, rm, mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+} from "../../../types.js";
+import type { IngestionBenchAdapter, ExtractedPage } from "../../../ingestion-types.js";
+import type { BenchJudge } from "../../../adapters/types.js";
+import { aggregateTaskScores, timed } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { emailFixture } from "../../../fixtures/inbox/email.js";
+
+export const ingestionCitationAccuracyDefinition: BenchmarkDefinition = {
+  id: "ingestion-citation-accuracy",
+  title: "Ingestion: Citation Accuracy",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "ingestion-citation-accuracy",
+    version: "1.0.0",
+    description: "Verifies that claims in generated summaries cite valid source chunks via LLM judge.",
+    category: "ingestion",
+  },
+};
+
+function extractClaims(pages: ExtractedPage[]): Array<{ claim: string; sourcePage: string; sourceContent: string }> {
+  const claims: Array<{ claim: string; sourcePage: string; sourceContent: string }> = [];
+  for (const page of pages) {
+    if (!page.content) continue;
+    const sentences = page.content
+      .split(/[.!?]+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 20);
+    for (const sentence of sentences) {
+      claims.push({ claim: sentence, sourcePage: page.path, sourceContent: page.content });
+    }
+  }
+  return claims;
+}
+
+async function judgeCitation(
+  judge: BenchJudge,
+  claim: string,
+  pageContent: string,
+  originalSources: string,
+): Promise<number> {
+  try {
+    return await judge.score(
+      `Does the page content support this claim with evidence from the original sources? Claim: "${claim}"`,
+      pageContent,
+      originalSources,
+    );
+  } catch {
+    return -1;
+  }
+}
+
+export async function runIngestionCitationAccuracyBenchmark(
+  options: ResolvedRunBenchmarkOptions & { ingestionAdapter: IngestionBenchAdapter },
+): Promise<BenchmarkResult> {
+  const fixture = emailFixture.generate();
+
+  const fixtureDir = await mkdtemp(path.join(tmpdir(), "bench-citation-"));
+  try {
+    for (const file of fixture.files) {
+      const filePath = path.join(fixtureDir, file.relativePath);
+      await mkdir(path.dirname(filePath), { recursive: true });
+      await writeFile(filePath, file.content, "utf8");
+    }
+
+    const { result: ingestionLog, durationMs } = await timed(() =>
+      options.ingestionAdapter.ingest(fixtureDir),
+    );
+
+    const graph = await options.ingestionAdapter.getMemoryGraph();
+    const claims = extractClaims(graph.pages);
+
+    const judge: BenchJudge | undefined = options.system?.judge;
+
+    const originalSources = fixture.files.map((f) => f.content).join("\n\n---\n\n");
+
+    let validCitations = 0;
+    let scoredClaims = 0;
+
+    if (judge && claims.length > 0) {
+      for (const { claim, sourceContent } of claims) {
+        const score = await judgeCitation(judge, claim, sourceContent, originalSources);
+        if (score >= 0) {
+          scoredClaims += 1;
+          if (score >= 0.5) {
+            validCitations += 1;
+          }
+        }
+      }
+    }
+
+    const citationAccuracy = scoredClaims > 0 ? validCitations / scoredClaims : -1;
+
+    const scores: Record<string, number> = {
+      citation_accuracy: citationAccuracy,
+      total_claims: claims.length,
+      valid_citations: validCitations,
+    };
+
+    const tasks = [
+      {
+        taskId: `citation-accuracy-${fixture.id}`,
+        question: `Verify citation accuracy for ${fixture.id} fixture`,
+        expected: `All claims cite valid source chunks`,
+        actual: judge
+          ? `${validCitations}/${scoredClaims} claims cite valid source chunks (${claims.length} total claims)`
+          : `No judge available; ${claims.length} claims extracted`,
+        scores,
+        latencyMs: durationMs,
+        tokens: { input: 0, output: 0 },
+        details: {
+          fixtureId: fixture.id,
+          totalClaims: claims.length,
+          scoredClaims,
+          validCitations,
+          citationAccuracy,
+          judgeAvailable: judge !== undefined,
+          ingestionErrors: ingestionLog.errors,
+        },
+      },
+    ];
+
+    const remnicVersion = await getRemnicVersion();
+    return {
+      meta: {
+        id: randomUUID(),
+        benchmark: options.benchmark.id,
+        benchmarkTier: options.benchmark.tier,
+        version: options.benchmark.meta.version,
+        remnicVersion,
+        gitSha: getGitSha(),
+        timestamp: new Date().toISOString(),
+        mode: options.mode,
+        runCount: 1,
+        seeds: [options.seed ?? 0],
+      },
+      config: {
+        systemProvider: options.systemProvider ?? null,
+        judgeProvider: options.judgeProvider ?? null,
+        adapterMode: options.adapterMode ?? "direct",
+        remnicConfig: options.remnicConfig ?? {},
+      },
+      cost: {
+        totalTokens: 0,
+        inputTokens: 0,
+        outputTokens: 0,
+        estimatedCostUsd: 0,
+        totalLatencyMs: durationMs,
+        meanQueryLatencyMs: durationMs,
+      },
+      results: {
+        tasks,
+        aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+      },
+      environment: {
+        os: process.platform,
+        nodeVersion: process.version,
+        hardware: process.arch,
+      },
+    };
+  } finally {
+    await rm(fixtureDir, { recursive: true, force: true });
+  }
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -79,6 +79,10 @@ import {
   ingestionSetupFrictionDefinition,
   runIngestionSetupFrictionBenchmark,
 } from "./benchmarks/remnic/ingestion-setup-friction/runner.js";
+import {
+  ingestionCitationAccuracyDefinition,
+  runIngestionCitationAccuracyBenchmark,
+} from "./benchmarks/remnic/ingestion-citation-accuracy/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -161,6 +165,11 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...ingestionSetupFrictionDefinition,
     run: runIngestionSetupFrictionBenchmark as (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>,
+  },
+  {
+    ...ingestionCitationAccuracyDefinition,
+    runnerAvailable: false,
+    run: runIngestionCitationAccuracyBenchmark,
   },
 ];
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -31,6 +31,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
       "ingestion-setup-friction",
+      "ingestion-citation-accuracy",
     ],
   );
   assert.deepEqual(
@@ -55,15 +56,17 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
     "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,ingestion-entity-recall,ingestion-backlink-f1",
   );
-  // Schema completeness and setup friction remain gated off until their adapter contracts are wired.
+  // Schema completeness, setup friction, and citation accuracy remain gated off until their adapter contracts are wired.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, false);
   assert.equal(getBenchmark("ingestion-setup-friction")?.runnerAvailable, false);
+  assert.equal(getBenchmark("ingestion-citation-accuracy")?.runnerAvailable, false);
 });
 
 test("getBenchmark returns ama-bench metadata with a runnable benchmark entry", () => {
@@ -248,6 +251,17 @@ test("getBenchmark returns ingestion-schema-completeness metadata (not yet runna
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "ingestion-schema-completeness");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, false);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "ingestion");
+});
+
+test("getBenchmark returns ingestion-citation-accuracy metadata (not yet runnable)", () => {
+  const benchmark = getBenchmark("ingestion-citation-accuracy");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "ingestion-citation-accuracy");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, false);
   assert.equal(benchmark?.tier, "remnic");


### PR DESCRIPTION
## Summary

Citation accuracy benchmark for the ingestion tier (issue #449):

- Extracts claims from generated pages (sentences > 20 chars)
- Uses LLM judge to verify each claim cites valid source evidence
- Reports `citation_accuracy`, `total_claims`, `valid_citations`
- Gracefully handles missing judge (returns -1 sentinel)
- Same runner pattern as entity recall

Depends on #495

## Test plan

- [x] `npx tsc --noEmit` passes
- [x] Runner follows entity recall pattern
- [x] Registered in benchmark registry
- [x] Judge absence handled gracefully

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new benchmark runner and registry/test wiring without changing existing benchmark behavior; runner is explicitly gated off (`runnerAvailable: false`) until adapter contracts are ready.
> 
> **Overview**
> Adds a new remnic ingestion benchmark, `ingestion-citation-accuracy`, which ingests the `emailFixture`, extracts sentence-level claims from generated pages, and uses `llmJudgeScore` to compute `citation_accuracy`/`valid_citations` (with a `-1` sentinel when no judge is available).
> 
> Updates the benchmark registry and registry tests to include the new benchmark in the catalog while keeping it **not runnable** via `runnerAvailable: false`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd9bad2d383be871f0c875790c956000fe7e99c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->