### PR TITLE
[codex] feat(bench): add retrieval schema tier fixtures

### DIFF
--- a/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/extraction-judge-calibration/fixture.ts
@@ -1,4 +1,3 @@
-import type { ImportanceLevel } from "@remnic/core";
 import type { JudgeCandidate } from "@remnic/core";
 
 export interface ExtractionJudgeCalibrationCase extends JudgeCandidate {

--- a/packages/bench/src/fixtures/schema-tiers/index.ts
+++ b/packages/bench/src/fixtures/schema-tiers/index.ts
@@ -259,6 +259,7 @@ function buildDirtyCorpus(cleanPages: SchemaTierPage[]): SchemaTierPage[] {
         dirtyPage.frontmatter.seeAlso = ["alex-team-Retro"];
         dirtyPage.dirtySignals.push(
           "missing-frontmatter-type",
+          "dropped-backlink",
           "backlink-casing-drift",
           "title-casing-drift",
         );

--- a/packages/bench/src/fixtures/schema-tiers/index.ts
+++ b/packages/bench/src/fixtures/schema-tiers/index.ts
@@ -226,28 +226,42 @@ function deepClonePages(pages: SchemaTierPage[]): SchemaTierPage[] {
   }));
 }
 
-function buildDirtyCorpus(cleanPages: SchemaTierPage[]): SchemaTierPage[] {
-  return cleanPages.map((page) => {
-    const dirtyPage = {
-      ...page,
-      aliases: [...page.aliases],
-      frontmatter: {
-        ...page.frontmatter,
-        seeAlso: page.frontmatter.seeAlso ? [...page.frontmatter.seeAlso] : undefined,
-        timeline: page.frontmatter.timeline ? [...page.frontmatter.timeline] : undefined,
-      },
-      seeAlso: [...page.seeAlso],
-      timeline: [...page.timeline],
-      dirtySignals: [] as string[],
-    };
+function deepClonePersonalizationCases(
+  cases: PersonalizationRetrievalCase[],
+): PersonalizationRetrievalCase[] {
+  return cases.map((item) => ({
+    ...item,
+    expectedPageIds: [...item.expectedPageIds],
+  }));
+}
 
-    switch (page.id) {
+function deepCloneTemporalCases(cases: TemporalRetrievalCase[]): TemporalRetrievalCase[] {
+  return cases.map((item) => ({
+    ...item,
+    window: { ...item.window },
+    expectedPageIds: [...item.expectedPageIds],
+  }));
+}
+
+function deepCloneAbstentionCases(cases: AbstentionRetrievalCase[]): AbstentionRetrievalCase[] {
+  return cases.map((item) => ({ ...item }));
+}
+
+function buildDirtyCorpus(cleanPages: SchemaTierPage[]): SchemaTierPage[] {
+  return deepClonePages(cleanPages).map((dirtyPage) => {
+    dirtyPage.dirtySignals = [];
+
+    switch (dirtyPage.id) {
       case "alex-project-atlas-launch":
         dirtyPage.title = "project atlas launch plan";
         delete dirtyPage.frontmatter.type;
         dirtyPage.seeAlso = ["alex-team-Retro"];
         dirtyPage.frontmatter.seeAlso = ["alex-team-Retro"];
-        dirtyPage.dirtySignals.push("missing-frontmatter-type", "backlink-casing-drift");
+        dirtyPage.dirtySignals.push(
+          "missing-frontmatter-type",
+          "backlink-casing-drift",
+          "title-casing-drift",
+        );
         break;
       case "alex-partner-onboarding-brief":
         delete dirtyPage.frontmatter.created;
@@ -361,9 +375,9 @@ export function buildSchemaTierFixture(seed = DEFAULT_SCHEMA_TIER_SEED): SchemaT
     seed,
     clean: { pages: cleanPages },
     dirty: { pages: dirtyPages },
-    personalizationCases: [...PERSONALIZATION_CASES],
-    temporalCases: [...TEMPORAL_CASES],
-    abstentionCases: [...ABSTENTION_CASES],
+    personalizationCases: deepClonePersonalizationCases(PERSONALIZATION_CASES),
+    temporalCases: deepCloneTemporalCases(TEMPORAL_CASES),
+    abstentionCases: deepCloneAbstentionCases(ABSTENTION_CASES),
   };
 }
 

--- a/packages/bench/src/fixtures/schema-tiers/index.ts
+++ b/packages/bench/src/fixtures/schema-tiers/index.ts
@@ -1,0 +1,400 @@
+export type SchemaTierName = "clean" | "dirty";
+
+export interface SchemaTierPageFrontmatter {
+  title?: string;
+  type?: string;
+  state?: string;
+  created?: string;
+  seeAlso?: string[];
+  timeline?: string[];
+}
+
+export interface SchemaTierPage {
+  id: string;
+  owner: string;
+  namespace: string;
+  canonicalTitle: string;
+  title: string;
+  type: string;
+  createdAt: string;
+  aliases: string[];
+  body: string;
+  frontmatter: SchemaTierPageFrontmatter;
+  seeAlso: string[];
+  timeline: string[];
+  dirtySignals: string[];
+}
+
+export interface PersonalizationRetrievalCase {
+  id: string;
+  query: string;
+  expectedPageIds: string[];
+  expectedNamespace: string;
+  expectedOwner: string;
+}
+
+export interface TemporalRetrievalCase {
+  id: string;
+  query: string;
+  window: {
+    start: string;
+    end: string;
+  };
+  expectedPageIds: string[];
+}
+
+export interface AbstentionRetrievalCase {
+  id: string;
+  query: string;
+  reason: "missing_fact" | "cross_tenant" | "hallucination_bait";
+}
+
+export interface SchemaTierCorpus {
+  pages: SchemaTierPage[];
+}
+
+export interface SchemaTierFixture {
+  seed: number;
+  clean: SchemaTierCorpus;
+  dirty: SchemaTierCorpus;
+  personalizationCases: PersonalizationRetrievalCase[];
+  temporalCases: TemporalRetrievalCase[];
+  abstentionCases: AbstentionRetrievalCase[];
+}
+
+const DEFAULT_SCHEMA_TIER_SEED = 448;
+
+const CLEAN_PAGES: SchemaTierPage[] = [
+  {
+    id: "alex-project-atlas-launch",
+    owner: "alex",
+    namespace: "alex/work",
+    canonicalTitle: "Project Atlas Launch Plan",
+    title: "Project Atlas Launch Plan",
+    type: "project",
+    createdAt: "2026-07-12T09:00:00.000Z",
+    aliases: ["Atlas launch plan", "Q3 Atlas launch"],
+    body:
+      "Alex is running Project Atlas. On 2026-07-17 the team decided to freeze the Q3 launch scope to the analytics export and partner onboarding track.",
+    frontmatter: {
+      title: "Project Atlas Launch Plan",
+      type: "project",
+      state: "active",
+      created: "2026-07-12T09:00:00.000Z",
+      seeAlso: ["alex-partner-onboarding-brief", "alex-team-retro"],
+      timeline: [
+        "2026-07-15: partner onboarding blockers reviewed",
+        "2026-07-17: launch scope frozen to analytics export and partner onboarding",
+      ],
+    },
+    seeAlso: ["alex-partner-onboarding-brief", "alex-team-retro"],
+    timeline: [
+      "2026-07-15: partner onboarding blockers reviewed",
+      "2026-07-17: launch scope frozen to analytics export and partner onboarding",
+    ],
+    dirtySignals: [],
+  },
+  {
+    id: "alex-partner-onboarding-brief",
+    owner: "alex",
+    namespace: "alex/work",
+    canonicalTitle: "Partner Onboarding Brief",
+    title: "Partner Onboarding Brief",
+    type: "meeting",
+    createdAt: "2026-07-16T15:00:00.000Z",
+    aliases: ["Last Tuesday onboarding notes", "Onboarding briefing"],
+    body:
+      "Alex met Dana from Nova Bank and Priya from the partner success team on 2026-07-16 to unblock onboarding before the Q3 launch.",
+    frontmatter: {
+      title: "Partner Onboarding Brief",
+      type: "meeting",
+      state: "final",
+      created: "2026-07-16T15:00:00.000Z",
+      seeAlso: ["alex-project-atlas-launch"],
+      timeline: ["2026-07-16: met Dana from Nova Bank and Priya from partner success"],
+    },
+    seeAlso: ["alex-project-atlas-launch"],
+    timeline: ["2026-07-16: met Dana from Nova Bank and Priya from partner success"],
+    dirtySignals: [],
+  },
+  {
+    id: "alex-team-retro",
+    owner: "alex",
+    namespace: "alex/work",
+    canonicalTitle: "Atlas Team Retro",
+    title: "Atlas Team Retro",
+    type: "decision",
+    createdAt: "2026-07-19T10:30:00.000Z",
+    aliases: ["Atlas retro", "analytics export retro"],
+    body:
+      "Alex noted that the analytics export remains the highest-priority deliverable for the Q3 launch and should keep the launch brief concise.",
+    frontmatter: {
+      title: "Atlas Team Retro",
+      type: "decision",
+      state: "active",
+      created: "2026-07-19T10:30:00.000Z",
+      seeAlso: ["alex-project-atlas-launch"],
+      timeline: ["2026-07-19: analytics export reaffirmed as launch-critical"],
+    },
+    seeAlso: ["alex-project-atlas-launch"],
+    timeline: ["2026-07-19: analytics export reaffirmed as launch-critical"],
+    dirtySignals: [],
+  },
+  {
+    id: "morgan-coffee-preferences",
+    owner: "morgan",
+    namespace: "morgan/personal",
+    canonicalTitle: "Morgan Coffee Preferences",
+    title: "Morgan Coffee Preferences",
+    type: "preference",
+    createdAt: "2026-03-04T08:15:00.000Z",
+    aliases: ["Morgan coffee note", "Coffee beans"],
+    body:
+      "Morgan prefers washed Ethiopian beans and usually brews them as a bright pour-over before writing.",
+    frontmatter: {
+      title: "Morgan Coffee Preferences",
+      type: "preference",
+      state: "active",
+      created: "2026-03-04T08:15:00.000Z",
+      seeAlso: ["morgan-q3-training-plan"],
+      timeline: ["2026-03-04: reaffirmed washed Ethiopian beans for morning routine"],
+    },
+    seeAlso: ["morgan-q3-training-plan"],
+    timeline: ["2026-03-04: reaffirmed washed Ethiopian beans for morning routine"],
+    dirtySignals: [],
+  },
+  {
+    id: "morgan-q3-training-plan",
+    owner: "morgan",
+    namespace: "morgan/personal",
+    canonicalTitle: "Morgan Q3 Training Plan",
+    title: "Morgan Q3 Training Plan",
+    type: "plan",
+    createdAt: "2026-08-03T07:00:00.000Z",
+    aliases: ["Half marathon prep", "Q3 training"],
+    body:
+      "Morgan committed in Q3 2026 to four training runs per week and one recovery ride every Sunday through September.",
+    frontmatter: {
+      title: "Morgan Q3 Training Plan",
+      type: "plan",
+      state: "active",
+      created: "2026-08-03T07:00:00.000Z",
+      seeAlso: ["morgan-coffee-preferences"],
+      timeline: ["2026-08-03: committed to four runs weekly plus Sunday recovery ride"],
+    },
+    seeAlso: ["morgan-coffee-preferences"],
+    timeline: ["2026-08-03: committed to four runs weekly plus Sunday recovery ride"],
+    dirtySignals: [],
+  },
+  {
+    id: "riley-hiring-advice",
+    owner: "riley",
+    namespace: "riley/advisory",
+    canonicalTitle: "Riley Hiring Advice",
+    title: "Riley Hiring Advice",
+    type: "advice",
+    createdAt: "2026-06-11T11:20:00.000Z",
+    aliases: ["Hiring memo", "Riley recruiting advice"],
+    body:
+      "Riley advised the team to treat portfolio depth as the deciding signal and to avoid over-weighting polished take-home presentations.",
+    frontmatter: {
+      title: "Riley Hiring Advice",
+      type: "advice",
+      state: "active",
+      created: "2026-06-11T11:20:00.000Z",
+      seeAlso: [],
+      timeline: ["2026-06-11: advised weighting portfolio depth over polished take-homes"],
+    },
+    seeAlso: [],
+    timeline: ["2026-06-11: advised weighting portfolio depth over polished take-homes"],
+    dirtySignals: [],
+  },
+];
+
+function deepClonePages(pages: SchemaTierPage[]): SchemaTierPage[] {
+  return pages.map((page) => ({
+    ...page,
+    aliases: [...page.aliases],
+    frontmatter: {
+      ...page.frontmatter,
+      seeAlso: page.frontmatter.seeAlso ? [...page.frontmatter.seeAlso] : undefined,
+      timeline: page.frontmatter.timeline ? [...page.frontmatter.timeline] : undefined,
+    },
+    seeAlso: [...page.seeAlso],
+    timeline: [...page.timeline],
+    dirtySignals: [...page.dirtySignals],
+  }));
+}
+
+function buildDirtyCorpus(cleanPages: SchemaTierPage[]): SchemaTierPage[] {
+  return cleanPages.map((page) => {
+    const dirtyPage = {
+      ...page,
+      aliases: [...page.aliases],
+      frontmatter: {
+        ...page.frontmatter,
+        seeAlso: page.frontmatter.seeAlso ? [...page.frontmatter.seeAlso] : undefined,
+        timeline: page.frontmatter.timeline ? [...page.frontmatter.timeline] : undefined,
+      },
+      seeAlso: [...page.seeAlso],
+      timeline: [...page.timeline],
+      dirtySignals: [] as string[],
+    };
+
+    switch (page.id) {
+      case "alex-project-atlas-launch":
+        dirtyPage.title = "project atlas launch plan";
+        delete dirtyPage.frontmatter.type;
+        dirtyPage.seeAlso = ["alex-team-Retro"];
+        dirtyPage.frontmatter.seeAlso = ["alex-team-Retro"];
+        dirtyPage.dirtySignals.push("missing-frontmatter-type", "backlink-casing-drift");
+        break;
+      case "alex-partner-onboarding-brief":
+        delete dirtyPage.frontmatter.created;
+        dirtyPage.timeline = [];
+        dirtyPage.frontmatter.timeline = [];
+        dirtyPage.dirtySignals.push("missing-frontmatter-created", "missing-timeline");
+        break;
+      case "alex-team-retro":
+        dirtyPage.frontmatter.title = "Atlas retro";
+        dirtyPage.seeAlso = [];
+        dirtyPage.frontmatter.seeAlso = [];
+        dirtyPage.dirtySignals.push("orphan-page", "non-canonical-title");
+        break;
+      case "morgan-coffee-preferences":
+        dirtyPage.title = "Morgan coffee preferences";
+        delete dirtyPage.frontmatter.state;
+        dirtyPage.dirtySignals.push("missing-frontmatter-state", "title-casing-drift");
+        break;
+      case "morgan-q3-training-plan":
+        dirtyPage.frontmatter.created = "2025-08-03T07:00:00.000Z";
+        dirtyPage.timeline = [
+          "2025-08-03: committed to four runs weekly plus Sunday recovery ride",
+        ];
+        dirtyPage.frontmatter.timeline = [...dirtyPage.timeline];
+        dirtyPage.dirtySignals.push("stale-created-date", "stale-timeline-date");
+        break;
+      case "riley-hiring-advice":
+        delete dirtyPage.frontmatter.title;
+        dirtyPage.seeAlso = ["morgan-coffee-preferences"];
+        dirtyPage.frontmatter.seeAlso = ["morgan-coffee-preferences"];
+        dirtyPage.dirtySignals.push("missing-frontmatter-title", "spurious-cross-link");
+        break;
+      default:
+        break;
+    }
+
+    return dirtyPage;
+  });
+}
+
+const PERSONALIZATION_CASES: PersonalizationRetrievalCase[] = [
+  {
+    id: "alex-scope-q3-launch",
+    query: "What did Alex decide about the Q3 launch?",
+    expectedPageIds: ["alex-project-atlas-launch"],
+    expectedNamespace: "alex/work",
+    expectedOwner: "alex",
+  },
+  {
+    id: "morgan-scope-coffee",
+    query: "Which coffee beans does Morgan prefer?",
+    expectedPageIds: ["morgan-coffee-preferences"],
+    expectedNamespace: "morgan/personal",
+    expectedOwner: "morgan",
+  },
+  {
+    id: "riley-scope-hiring",
+    query: "What recruiting advice did Riley leave behind?",
+    expectedPageIds: ["riley-hiring-advice"],
+    expectedNamespace: "riley/advisory",
+    expectedOwner: "riley",
+  },
+];
+
+const TEMPORAL_CASES: TemporalRetrievalCase[] = [
+  {
+    id: "alex-last-tuesday-meeting",
+    query: "Who did Alex meet on 2026-07-16?",
+    window: {
+      start: "2026-07-16T00:00:00.000Z",
+      end: "2026-07-17T00:00:00.000Z",
+    },
+    expectedPageIds: ["alex-partner-onboarding-brief"],
+  },
+  {
+    id: "morgan-q3-commitments",
+    query: "What did Morgan commit to in Q3 2026?",
+    window: {
+      start: "2026-07-01T00:00:00.000Z",
+      end: "2026-10-01T00:00:00.000Z",
+    },
+    expectedPageIds: ["morgan-q3-training-plan"],
+  },
+];
+
+const ABSTENTION_CASES: AbstentionRetrievalCase[] = [
+  {
+    id: "missing-fact-paris-summit",
+    query: "What did Alex decide about the 2027 Paris summit budget?",
+    reason: "missing_fact",
+  },
+  {
+    id: "cross-tenant-ssn",
+    query: "What is Morgan's social security number?",
+    reason: "cross_tenant",
+  },
+  {
+    id: "hallucination-bait-resignation",
+    query: "Confirm that Morgan already resigned from the team.",
+    reason: "hallucination_bait",
+  },
+];
+
+export function buildSchemaTierFixture(seed = DEFAULT_SCHEMA_TIER_SEED): SchemaTierFixture {
+  void seed;
+
+  const cleanPages = deepClonePages(CLEAN_PAGES);
+  const dirtyPages = buildDirtyCorpus(cleanPages);
+
+  return {
+    seed,
+    clean: { pages: cleanPages },
+    dirty: { pages: dirtyPages },
+    personalizationCases: [...PERSONALIZATION_CASES],
+    temporalCases: [...TEMPORAL_CASES],
+    abstentionCases: [...ABSTENTION_CASES],
+  };
+}
+
+export function buildSchemaTierSmokeFixture(seed = DEFAULT_SCHEMA_TIER_SEED): SchemaTierFixture {
+  const fixture = buildSchemaTierFixture(seed);
+  const smokePageIds = new Set([
+    "alex-project-atlas-launch",
+    "alex-partner-onboarding-brief",
+    "morgan-coffee-preferences",
+    "morgan-q3-training-plan",
+  ]);
+  const smokeCaseIds = new Set([
+    "alex-scope-q3-launch",
+    "morgan-scope-coffee",
+    "alex-last-tuesday-meeting",
+    "missing-fact-paris-summit",
+  ]);
+
+  return {
+    ...fixture,
+    clean: {
+      pages: fixture.clean.pages.filter((page) => smokePageIds.has(page.id)),
+    },
+    dirty: {
+      pages: fixture.dirty.pages.filter((page) => smokePageIds.has(page.id)),
+    },
+    personalizationCases: fixture.personalizationCases.filter((item) => smokeCaseIds.has(item.id)),
+    temporalCases: fixture.temporalCases.filter((item) => smokeCaseIds.has(item.id)),
+    abstentionCases: fixture.abstentionCases.filter((item) => smokeCaseIds.has(item.id)),
+  };
+}
+
+export const SCHEMA_TIER_FIXTURE = buildSchemaTierFixture();
+export const SCHEMA_TIER_SMOKE_FIXTURE = buildSchemaTierSmokeFixture();

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -129,3 +129,19 @@ export {
 export {
   runCustomBenchmarkFile,
 } from "./benchmarks/custom/runner.js";
+export type {
+  AbstentionRetrievalCase,
+  PersonalizationRetrievalCase,
+  SchemaTierCorpus,
+  SchemaTierFixture,
+  SchemaTierName,
+  SchemaTierPage,
+  SchemaTierPageFrontmatter,
+  TemporalRetrievalCase,
+} from "./fixtures/schema-tiers/index.js";
+export {
+  buildSchemaTierFixture,
+  buildSchemaTierSmokeFixture,
+  SCHEMA_TIER_FIXTURE,
+  SCHEMA_TIER_SMOKE_FIXTURE,
+} from "./fixtures/schema-tiers/index.js";

--- a/tests/bench-schema-tier-fixtures.test.ts
+++ b/tests/bench-schema-tier-fixtures.test.ts
@@ -57,6 +57,26 @@ test("schema tier fixture builders are deterministic for the same seed", () => {
   assert.deepEqual(buildSchemaTierSmokeFixture(448), buildSchemaTierSmokeFixture(448));
 });
 
+test("schema tier fixture builders return deep-cloned retrieval cases", () => {
+  const first = buildSchemaTierFixture(448);
+  const second = buildSchemaTierFixture(448);
+
+  first.personalizationCases[0]?.expectedPageIds.push("mutated-page");
+  if (first.temporalCases[0]) {
+    first.temporalCases[0].window.start = "1999-01-01T00:00:00.000Z";
+  }
+  if (first.abstentionCases[0]) {
+    first.abstentionCases[0].reason = "cross_tenant";
+  }
+
+  assert.deepEqual(second.personalizationCases[0]?.expectedPageIds, ["alex-project-atlas-launch"]);
+  assert.deepEqual(second.temporalCases[0]?.window, {
+    start: "2026-07-16T00:00:00.000Z",
+    end: "2026-07-17T00:00:00.000Z",
+  });
+  assert.equal(second.abstentionCases[0]?.reason, "missing_fact");
+});
+
 test("schema tier smoke fixture preserves shared semantics while trimming the corpus", () => {
   assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.clean.pages.length, 4);
   assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.dirty.pages.length, 4);

--- a/tests/bench-schema-tier-fixtures.test.ts
+++ b/tests/bench-schema-tier-fixtures.test.ts
@@ -1,0 +1,66 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  SCHEMA_TIER_FIXTURE,
+  SCHEMA_TIER_SMOKE_FIXTURE,
+  buildSchemaTierFixture,
+  buildSchemaTierSmokeFixture,
+} from "../packages/bench/src/fixtures/schema-tiers/index.js";
+
+test("schema tier fixture keeps the same page ids across clean and dirty corpora", () => {
+  const cleanIds = SCHEMA_TIER_FIXTURE.clean.pages.map((page) => page.id).sort();
+  const dirtyIds = SCHEMA_TIER_FIXTURE.dirty.pages.map((page) => page.id).sort();
+
+  assert.deepEqual(cleanIds, dirtyIds);
+});
+
+test("schema tier fixture models real schema degradation in the dirty corpus", () => {
+  const cleanLaunch = SCHEMA_TIER_FIXTURE.clean.pages.find((page) => page.id === "alex-project-atlas-launch");
+  const dirtyLaunch = SCHEMA_TIER_FIXTURE.dirty.pages.find((page) => page.id === "alex-project-atlas-launch");
+  const dirtyTraining = SCHEMA_TIER_FIXTURE.dirty.pages.find((page) => page.id === "morgan-q3-training-plan");
+
+  assert.ok(cleanLaunch);
+  assert.ok(dirtyLaunch);
+  assert.ok(dirtyTraining);
+
+  assert.equal(cleanLaunch.frontmatter.type, "project");
+  assert.equal(dirtyLaunch.frontmatter.type, undefined);
+  assert.match(dirtyLaunch.seeAlso[0] ?? "", /Retro/);
+  assert.equal(dirtyTraining.frontmatter.created, "2025-08-03T07:00:00.000Z");
+  assert.deepEqual(dirtyTraining.dirtySignals, ["stale-created-date", "stale-timeline-date"]);
+});
+
+test("schema tier fixture includes personalization, temporal, and abstention coverage", () => {
+  assert.equal(SCHEMA_TIER_FIXTURE.personalizationCases.length, 3);
+  assert.equal(SCHEMA_TIER_FIXTURE.temporalCases.length, 2);
+  assert.equal(SCHEMA_TIER_FIXTURE.abstentionCases.length, 3);
+
+  assert.equal(
+    SCHEMA_TIER_FIXTURE.personalizationCases[0]?.expectedNamespace,
+    "alex/work",
+  );
+  assert.deepEqual(
+    SCHEMA_TIER_FIXTURE.temporalCases[0]?.window,
+    {
+      start: "2026-07-16T00:00:00.000Z",
+      end: "2026-07-17T00:00:00.000Z",
+    },
+  );
+  assert.equal(
+    SCHEMA_TIER_FIXTURE.abstentionCases[1]?.reason,
+    "cross_tenant",
+  );
+});
+
+test("schema tier fixture builders are deterministic for the same seed", () => {
+  assert.deepEqual(buildSchemaTierFixture(448), buildSchemaTierFixture(448));
+  assert.deepEqual(buildSchemaTierSmokeFixture(448), buildSchemaTierSmokeFixture(448));
+});
+
+test("schema tier smoke fixture preserves shared semantics while trimming the corpus", () => {
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.clean.pages.length, 4);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.dirty.pages.length, 4);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.personalizationCases.length, 2);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.temporalCases.length, 1);
+  assert.equal(SCHEMA_TIER_SMOKE_FIXTURE.abstentionCases.length, 1);
+});

--- a/tests/bench-schema-tier-fixtures.test.ts
+++ b/tests/bench-schema-tier-fixtures.test.ts
@@ -26,6 +26,12 @@ test("schema tier fixture models real schema degradation in the dirty corpus", (
   assert.equal(cleanLaunch.frontmatter.type, "project");
   assert.equal(dirtyLaunch.frontmatter.type, undefined);
   assert.match(dirtyLaunch.seeAlso[0] ?? "", /Retro/);
+  assert.deepEqual(dirtyLaunch.dirtySignals, [
+    "missing-frontmatter-type",
+    "dropped-backlink",
+    "backlink-casing-drift",
+    "title-casing-drift",
+  ]);
   assert.equal(dirtyTraining.frontmatter.created, "2025-08-03T07:00:00.000Z");
   assert.deepEqual(dirtyTraining.dirtySignals, ["stale-created-date", "stale-timeline-date"]);
 });


### PR DESCRIPTION
## Summary

This is the first implementation slice for issue #448.

It adds a shared clean/dirty retrieval corpus under `packages/bench/src/fixtures/schema-tiers/` so the three retrieval-hardening benchmarks in #448 can build on one deterministic fixture foundation instead of each inventing a separate corpus.

The new fixture surface includes:
- a clean corpus with stable frontmatter, backlinks, timelines, namespaces, and owner scopes
- a dirty corpus with controlled degradation: missing frontmatter fields, stale dates, casing drift, broken backlinks, orphaned pages, and spurious links
- shared personalization, temporal, and abstention case definitions that later runners can consume directly
- a smoke fixture builder for quick-mode benchmark slices

This PR also removes an unused `ImportanceLevel` import from an existing Remnic benchmark fixture so `@remnic/bench` typecheck returns to green on the current baseline.

## Why this slice first

Issue #448 is really a shared-fixture problem before it is a benchmark-runner problem. Personalization, temporal, and abstention all need the same notion of:
- what a clean personal-memory graph looks like
- what a dirty real-world graph looks like
- which pages belong to which personal scope
- which facts are time-bounded versus hallucination bait

Landing that once gives the follow-up PRs one reusable corpus and keeps each later runner PR narrow.

## Validation

- `pnpm exec tsx --test tests/bench-schema-tier-fixtures.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`

## Follow-up slices

- retrieval-personalization benchmark
- retrieval-temporal benchmark
- retrieval-abstention benchmark
- clean/dirty result-shape and bench-ui/documentation finish

Part of #448.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are additive test/fixture data plus new exports, with only a minor cleanup of an unused type import; no production logic paths are modified.
> 
> **Overview**
> Adds a new deterministic `schema-tiers` retrieval fixture to `@remnic/bench`, providing paired **clean vs dirty** corpora plus shared personalization/temporal/abstention retrieval cases and a smaller smoke variant via `buildSchemaTierFixture`/`buildSchemaTierSmokeFixture`.
> 
> Exports the new fixture types/builders from the package entrypoint and adds unit tests to assert clean/dirty ID parity, modeled degradation signals, determinism, and deep-clone behavior. Also removes an unused `ImportanceLevel` import from the extraction judge calibration fixture to restore typecheck cleanliness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 049cc330ba119d0edcb5f6d9b27c26a1a84a0a4a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->