### PR TITLE
[codex] feat(bench): add retrieval personalization benchmark

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/fixture.ts
@@ -1,0 +1,59 @@
+import {
+  SCHEMA_TIER_FIXTURE,
+  SCHEMA_TIER_SMOKE_FIXTURE,
+  type PersonalizationRetrievalCase,
+  type SchemaTierName,
+  type SchemaTierPage,
+} from "../../../fixtures/schema-tiers/index.js";
+
+export interface RetrievalPersonalizationCase {
+  id: string;
+  title: string;
+  tier: SchemaTierName;
+  query: string;
+  expectedPageIds: string[];
+  expectedNamespace: string;
+  expectedOwner: string;
+  pages: SchemaTierPage[];
+}
+
+function buildCases(
+  sourceCases: PersonalizationRetrievalCase[],
+  cleanPages: SchemaTierPage[],
+  dirtyPages: SchemaTierPage[],
+): RetrievalPersonalizationCase[] {
+  return sourceCases.flatMap((sample) => [
+    {
+      id: `clean:${sample.id}`,
+      title: `[clean] ${sample.query}`,
+      tier: "clean" as const,
+      query: sample.query,
+      expectedPageIds: [...sample.expectedPageIds],
+      expectedNamespace: sample.expectedNamespace,
+      expectedOwner: sample.expectedOwner,
+      pages: cleanPages,
+    },
+    {
+      id: `dirty:${sample.id}`,
+      title: `[dirty] ${sample.query}`,
+      tier: "dirty" as const,
+      query: sample.query,
+      expectedPageIds: [...sample.expectedPageIds],
+      expectedNamespace: sample.expectedNamespace,
+      expectedOwner: sample.expectedOwner,
+      pages: dirtyPages,
+    },
+  ]);
+}
+
+export const RETRIEVAL_PERSONALIZATION_FIXTURE = buildCases(
+  SCHEMA_TIER_FIXTURE.personalizationCases,
+  SCHEMA_TIER_FIXTURE.clean.pages,
+  SCHEMA_TIER_FIXTURE.dirty.pages,
+);
+
+export const RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE = buildCases(
+  SCHEMA_TIER_SMOKE_FIXTURE.personalizationCases,
+  SCHEMA_TIER_SMOKE_FIXTURE.clean.pages,
+  SCHEMA_TIER_SMOKE_FIXTURE.dirty.pages,
+);

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -10,7 +10,7 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
-import { aggregateTaskScores, recallAtK } from "../../../scorer.js";
+import { aggregateTaskScores, precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
@@ -54,9 +54,9 @@ export async function runRetrievalPersonalizationBenchmark(
       expected: expectedJson,
       actual: actualJson,
       scores: {
-        p_at_1: recallAtK(rankedPageIds, sample.expectedPageIds, 1),
-        p_at_3: recallAtK(rankedPageIds, sample.expectedPageIds, 3),
-        p_at_5: recallAtK(rankedPageIds, sample.expectedPageIds, 5),
+        p_at_1: precisionAtK(rankedPageIds, sample.expectedPageIds, 1),
+        p_at_3: precisionAtK(rankedPageIds, sample.expectedPageIds, 3),
+        p_at_5: precisionAtK(rankedPageIds, sample.expectedPageIds, 5),
       },
       latencyMs,
       tokens: { input: 0, output: 0 },
@@ -127,8 +127,7 @@ function loadCases(
     throw new Error("retrieval-personalization limit must be a positive integer");
   }
 
-  const groupedLimit = limit * 2;
-  const limited = baseCases.slice(0, groupedLimit);
+  const limited = baseCases.slice(0, limit);
   if (limited.length === 0) {
     throw new Error("retrieval-personalization fixture is empty after applying the requested limit.");
   }

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -1,0 +1,222 @@
+/**
+ * Deterministic personalization retrieval benchmark over the schema-tier corpus.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  AggregateMetrics,
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores, recallAtK } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
+import {
+  RETRIEVAL_PERSONALIZATION_FIXTURE,
+  RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE,
+  type RetrievalPersonalizationCase,
+} from "./fixture.js";
+
+export const retrievalPersonalizationDefinition: BenchmarkDefinition = {
+  id: "retrieval-personalization",
+  title: "Retrieval Personalization",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retrieval-personalization",
+    version: "1.0.0",
+    description:
+      "Deterministic clean-vs-dirty retrieval benchmark for personal-scope ranking precision.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #448",
+  },
+};
+
+export async function runRetrievalPersonalizationBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const sample of cases) {
+    const startedAt = performance.now();
+    const rankedPageIds = rankPages(sample.query, sample.pages).map((page) => page.id);
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const expectedJson = JSON.stringify(sample.expectedPageIds);
+    const actualJson = JSON.stringify(rankedPageIds.slice(0, 5));
+
+    tasks.push({
+      taskId: sample.id,
+      question: sample.title,
+      expected: expectedJson,
+      actual: actualJson,
+      scores: {
+        p_at_1: recallAtK(rankedPageIds, sample.expectedPageIds, 1),
+        p_at_3: recallAtK(rankedPageIds, sample.expectedPageIds, 3),
+        p_at_5: recallAtK(rankedPageIds, sample.expectedPageIds, 5),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        tier: sample.tier,
+        expectedOwner: sample.expectedOwner,
+        expectedNamespace: sample.expectedNamespace,
+        retrievedPageIds: rankedPageIds.slice(0, 5),
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: buildTieredAggregates(tasks),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): RetrievalPersonalizationCase[] {
+  const baseCases = mode === "quick"
+    ? RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE
+    : RETRIEVAL_PERSONALIZATION_FIXTURE;
+
+  if (limit === undefined) {
+    return baseCases;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("retrieval-personalization limit must be a positive integer");
+  }
+
+  const groupedLimit = limit * 2;
+  const limited = baseCases.slice(0, groupedLimit);
+  if (limited.length === 0) {
+    throw new Error("retrieval-personalization fixture is empty after applying the requested limit.");
+  }
+  return limited;
+}
+
+function rankPages(query: string, pages: SchemaTierPage[]): SchemaTierPage[] {
+  return [...pages].sort((left, right) => {
+    const scoreDelta = scorePage(query, right) - scorePage(query, left);
+    if (scoreDelta !== 0) return scoreDelta;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function scorePage(query: string, page: SchemaTierPage): number {
+  const queryTokens = tokenize(query);
+  const ownerHit = queryTokens.has(page.owner.toLowerCase()) ? 3 : 0;
+  const titleScore = overlapCount(queryTokens, tokenize(page.title)) * 4;
+  const canonicalTitleScore = overlapCount(queryTokens, tokenize(page.canonicalTitle)) * 3;
+  const aliasScore = overlapCount(queryTokens, tokenize(page.aliases.join(" "))) * 2;
+  const bodyScore = overlapCount(queryTokens, tokenize(page.body)) * 2;
+  const timelineScore = overlapCount(queryTokens, tokenize(page.timeline.join(" "))) * 1.5;
+  const penalty = schemaPenalty(queryTokens, page);
+
+  return ownerHit + titleScore + canonicalTitleScore + aliasScore + bodyScore + timelineScore - penalty;
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9]+/g)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3),
+  );
+}
+
+function overlapCount(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const token of right) {
+    if (left.has(token)) count += 1;
+  }
+  return count;
+}
+
+function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
+  let penalty = 0;
+
+  if (page.title !== page.canonicalTitle) penalty += 2;
+  if (!page.frontmatter.type) penalty += 2.5;
+  if (!page.frontmatter.created) penalty += 1;
+  if (page.timeline.length === 0) penalty += 1;
+  if (page.type === "project" && page.seeAlso.length < 2) penalty += 1.5;
+  if ((queryTokens.has("decide") || queryTokens.has("decision")) && !page.frontmatter.type) {
+    penalty += 7;
+  }
+
+  return penalty;
+}
+
+function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
+  const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
+  const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
+  const pairedDeltas = cleanTasks.map((task, index) => {
+    const dirtyTask = dirtyTasks[index];
+    return {
+      p_at_1: (task.scores.p_at_1 ?? 0) - (dirtyTask?.scores.p_at_1 ?? 0),
+      p_at_3: (task.scores.p_at_3 ?? 0) - (dirtyTask?.scores.p_at_3 ?? 0),
+      p_at_5: (task.scores.p_at_5 ?? 0) - (dirtyTask?.scores.p_at_5 ?? 0),
+    };
+  });
+
+  return {
+    ...prefixAggregates("clean", aggregateTaskScores(cleanTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
+  };
+}
+
+function prefixAggregates(
+  prefix: string,
+  aggregates: AggregateMetrics,
+): AggregateMetrics {
+  const prefixed: AggregateMetrics = {};
+
+  for (const [metric, aggregate] of Object.entries(aggregates)) {
+    prefixed[`${prefix}.${metric}`] = aggregate;
+  }
+
+  return prefixed;
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -191,13 +191,18 @@ function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
 function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
   const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
   const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
-  const pairedDeltas = cleanTasks.map((task, index) => {
-    const dirtyTask = dirtyTasks[index];
-    return {
-      p_at_1: (task.scores.p_at_1 ?? 0) - (dirtyTask?.scores.p_at_1 ?? 0),
-      p_at_3: (task.scores.p_at_3 ?? 0) - (dirtyTask?.scores.p_at_3 ?? 0),
-      p_at_5: (task.scores.p_at_5 ?? 0) - (dirtyTask?.scores.p_at_5 ?? 0),
-    };
+  const dirtyTasksByPairId = new Map(
+    dirtyTasks.map((task) => [pairId(task.taskId), task]),
+  );
+  const pairedDeltas = cleanTasks.flatMap((task) => {
+    const dirtyTask = dirtyTasksByPairId.get(pairId(task.taskId));
+    if (!dirtyTask) return [];
+
+    return [{
+      p_at_1: (task.scores.p_at_1 ?? 0) - (dirtyTask.scores.p_at_1 ?? 0),
+      p_at_3: (task.scores.p_at_3 ?? 0) - (dirtyTask.scores.p_at_3 ?? 0),
+      p_at_5: (task.scores.p_at_5 ?? 0) - (dirtyTask.scores.p_at_5 ?? 0),
+    }];
   });
 
   return {
@@ -218,4 +223,8 @@ function prefixAggregates(
   }
 
   return prefixed;
+}
+
+function pairId(taskId: string): string {
+  return taskId.replace(/^(clean|dirty):/, "");
 }

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -98,6 +98,7 @@ export {
   f1Score,
   rougeL,
   recallAtK,
+  precisionAtK,
   containsAnswer,
   llmJudgeScore,
   timed,

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -59,6 +59,10 @@ import {
   pageVersioningDefinition,
   runPageVersioningBenchmark,
 } from "./benchmarks/remnic/page-versioning/runner.js";
+import {
+  retrievalPersonalizationDefinition,
+  runRetrievalPersonalizationBenchmark,
+} from "./benchmarks/remnic/retrieval-personalization/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -120,6 +124,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...pageVersioningDefinition,
     run: runPageVersioningBenchmark,
+  },
+  {
+    ...retrievalPersonalizationDefinition,
+    run: runRetrievalPersonalizationBenchmark,
   },
 ];
 

--- a/packages/bench/src/scorer.ts
+++ b/packages/bench/src/scorer.ts
@@ -71,6 +71,24 @@ export function recallAtK(
   return hits / relevantSet.size;
 }
 
+export function precisionAtK(
+  retrieved: string[],
+  relevant: string[],
+  k: number,
+): number {
+  if (!Number.isInteger(k) || k <= 0) return 0;
+
+  const topK = retrieved.slice(0, k).map(normalizeText);
+  if (topK.length === 0) return 0;
+
+  const relevantSet = new Set(relevant.map(normalizeText));
+  const hits = new Set(
+    topK.filter((candidate) => relevantSet.has(candidate)),
+  ).size;
+
+  return hits / k;
+}
+
 export function containsAnswer(
   predicted: string,
   expected: string | number | unknown,

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -26,6 +26,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "enrichment-fidelity",
       "entity-consolidation",
       "page-versioning",
+      "retrieval-personalization",
     ],
   );
   assert.deepEqual(
@@ -45,11 +46,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization",
   );
 });
 
@@ -191,6 +193,17 @@ test("getBenchmark returns page-versioning metadata with a runnable benchmark en
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "page-versioning");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns retrieval-personalization metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("retrieval-personalization");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "retrieval-personalization");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -71,3 +71,17 @@ test("runBenchmark executes enrichment-fidelity in quick mode", async () => {
   assert.ok(result.results.aggregates.accepted_precision.mean >= 0.66);
   assert.equal(result.results.aggregates.exact_count_match.mean, 1);
 });
+
+test("runBenchmark executes retrieval-personalization in quick mode", async () => {
+  const result = await runBenchmark("retrieval-personalization", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "retrieval-personalization");
+  assert.equal(result.meta.benchmarkTier, "remnic");
+  assert.equal(result.results.tasks.length, 4);
+  assert.equal(result.results.aggregates["clean.p_at_1"].mean, 1);
+  assert.equal(result.results.aggregates["dirty.p_at_1"].mean, 0.5);
+  assert.equal(result.results.aggregates["dirty_penalty.p_at_1"].mean, 0.5);
+});

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -95,4 +95,5 @@ test("runBenchmark applies retrieval-personalization limit as an exact task cap"
 
   assert.equal(result.results.tasks.length, 1);
   assert.equal(result.results.tasks[0]?.taskId, "clean:alex-scope-q3-launch");
+  assert.equal(result.results.aggregates["dirty_penalty.p_at_1"], undefined);
 });

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -85,3 +85,14 @@ test("runBenchmark executes retrieval-personalization in quick mode", async () =
   assert.equal(result.results.aggregates["dirty.p_at_1"].mean, 0.5);
   assert.equal(result.results.aggregates["dirty_penalty.p_at_1"].mean, 0.5);
 });
+
+test("runBenchmark applies retrieval-personalization limit as an exact task cap", async () => {
+  const result = await runBenchmark("retrieval-personalization", {
+    mode: "quick",
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "clean:alex-scope-q3-launch");
+});

--- a/tests/bench-scorer.test.ts
+++ b/tests/bench-scorer.test.ts
@@ -3,6 +3,7 @@ import assert from "node:assert/strict";
 import {
   aggregateScores,
   aggregateTaskScores,
+  precisionAtK,
   recallAtK,
 } from "../packages/bench/src/scorer.ts";
 
@@ -30,4 +31,12 @@ test("aggregateScores and aggregateTaskScores both handle empty input", () => {
 
 test("recallAtK deduplicates repeated hits so recall does not exceed 1.0", () => {
   assert.equal(recallAtK(["a", "a"], ["a"], 2), 1.0);
+});
+
+test("precisionAtK divides hits by K instead of relevant set size", () => {
+  assert.equal(precisionAtK(["a", "b", "c"], ["a"], 3), 1 / 3);
+});
+
+test("precisionAtK deduplicates repeated hits so precision does not double-count duplicates", () => {
+  assert.equal(precisionAtK(["a", "a"], ["a"], 2), 0.5);
 });


### PR DESCRIPTION
## Summary

This is slice 2 of issue #448. The shared clean/dirty schema-tier fixtures are
already on `main`; this PR adds the first retrieval runner that actually uses
them.

The benchmark suite had no runnable retrieval metric for personal-scope ranking
yet, so `#448` still had no direct coverage for whether degraded schema quality
hurts personalized retrieval. This PR adds a narrow `retrieval-personalization`
benchmark that stays inside `@remnic/bench` and avoids the broader aggregate
schema, dashboard, and docs work that belong to later slices.

## What Changed

- added `packages/bench/src/benchmarks/remnic/retrieval-personalization/`
  with a benchmark-local fixture wrapper built on top of the shared
  `schema-tiers` corpus
- added a deterministic personalization runner that evaluates the clean and
  dirty tiers separately and emits paired aggregate metrics
- registered the new benchmark in the public bench registry
- extended the public bench smoke tests to cover registry lookup and
  `runBenchmark("retrieval-personalization")`

## Why This Shape

The generic `BenchMemoryAdapter` contract does not naturally carry page owners,
namespaces, backlinks, and frontmatter-rich schema. The existing Remnic-tier
benchmarks already use deterministic internal runners where that produces a
cleaner contract, so this slice follows the same pattern instead of forcing a
premature adapter expansion.

The runner emits flat paired aggregate keys such as `clean.p_at_1`,
`dirty.p_at_1`, and `dirty_penalty.p_at_1`. That keeps this PR narrow while
still making the clean-vs-dirty split visible in the result JSON. The richer
aggregate-schema and dashboard work remains for later `#448` slices.

## Validation

- `pnpm exec tsx --test tests/bench-registry.test.ts tests/bench-remnic-deterministic-runners.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive: introduces a new deterministic `retrieval-personalization` benchmark plus a new `precisionAtK` scorer, with minimal impact beyond bench output metrics and exports.
> 
> **Overview**
> Adds a new Remnic-tier **deterministic `retrieval-personalization` benchmark** that runs paired clean/dirty schema-tier cases, ranks pages via a local heuristic scorer, and reports `p_at_1/3/5` plus prefixed aggregates (`clean.*`, `dirty.*`, `dirty_penalty.*`).
> 
> Extends `scorer.ts` with `precisionAtK` (and re-exports it from `packages/bench/src/index.ts`), registers the new benchmark in `registry.ts`, and updates tests to cover registry listing/lookup and `runBenchmark("retrieval-personalization")` behavior (including `limit` handling).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 643c0733aa3d52250047a693236f0207cd93d3de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->