### PR TITLE
bench: add retrieval temporal benchmark

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -4,7 +4,6 @@
 
 import { randomUUID } from "node:crypto";
 import type {
-  AggregateMetrics,
   BenchmarkDefinition,
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -14,6 +14,11 @@ import { aggregateTaskScores, precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
+  overlapCount,
+  pairIdFromTaskId,
+  prefixAggregates,
+} from "../retrieval-shared.js";
+import {
   RETRIEVAL_PERSONALIZATION_FIXTURE,
   RETRIEVAL_PERSONALIZATION_SMOKE_FIXTURE,
   type RetrievalPersonalizationCase,
@@ -165,14 +170,6 @@ function tokenize(value: string): Set<string> {
   );
 }
 
-function overlapCount(left: Set<string>, right: Set<string>): number {
-  let count = 0;
-  for (const token of right) {
-    if (left.has(token)) count += 1;
-  }
-  return count;
-}
-
 function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
   let penalty = 0;
 
@@ -192,10 +189,10 @@ function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
   const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
   const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
   const dirtyTasksByPairId = new Map(
-    dirtyTasks.map((task) => [pairId(task.taskId), task]),
+    dirtyTasks.map((task) => [pairIdFromTaskId(task.taskId), task]),
   );
   const pairedDeltas = cleanTasks.flatMap((task) => {
-    const dirtyTask = dirtyTasksByPairId.get(pairId(task.taskId));
+    const dirtyTask = dirtyTasksByPairId.get(pairIdFromTaskId(task.taskId));
     if (!dirtyTask) return [];
 
     return [{
@@ -210,21 +207,4 @@ function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
     ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
     ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
   };
-}
-
-function prefixAggregates(
-  prefix: string,
-  aggregates: AggregateMetrics,
-): AggregateMetrics {
-  const prefixed: AggregateMetrics = {};
-
-  for (const [metric, aggregate] of Object.entries(aggregates)) {
-    prefixed[`${prefix}.${metric}`] = aggregate;
-  }
-
-  return prefixed;
-}
-
-function pairId(taskId: string): string {
-  return taskId.replace(/^(clean|dirty):/, "");
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -10,7 +10,7 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
-import { aggregateTaskScores, precisionAtK } from "../../../scorer.js";
+import { precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {

--- a/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-personalization/runner.ts
@@ -14,9 +14,8 @@ import { aggregateTaskScores, precisionAtK } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
+  buildTieredAggregates,
   overlapCount,
-  pairIdFromTaskId,
-  prefixAggregates,
 } from "../retrieval-shared.js";
 import {
   RETRIEVAL_PERSONALIZATION_FIXTURE,
@@ -183,28 +182,4 @@ function schemaPenalty(queryTokens: Set<string>, page: SchemaTierPage): number {
   }
 
   return penalty;
-}
-
-function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
-  const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
-  const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
-  const dirtyTasksByPairId = new Map(
-    dirtyTasks.map((task) => [pairIdFromTaskId(task.taskId), task]),
-  );
-  const pairedDeltas = cleanTasks.flatMap((task) => {
-    const dirtyTask = dirtyTasksByPairId.get(pairIdFromTaskId(task.taskId));
-    if (!dirtyTask) return [];
-
-    return [{
-      p_at_1: (task.scores.p_at_1 ?? 0) - (dirtyTask.scores.p_at_1 ?? 0),
-      p_at_3: (task.scores.p_at_3 ?? 0) - (dirtyTask.scores.p_at_3 ?? 0),
-      p_at_5: (task.scores.p_at_5 ?? 0) - (dirtyTask.scores.p_at_5 ?? 0),
-    }];
-  });
-
-  return {
-    ...prefixAggregates("clean", aggregateTaskScores(cleanTasks.map((task) => task.scores))),
-    ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
-    ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
-  };
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
@@ -1,0 +1,26 @@
+import type { AggregateMetrics } from "../../types.js";
+
+export function overlapCount(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const token of right) {
+    if (left.has(token)) count += 1;
+  }
+  return count;
+}
+
+export function prefixAggregates(
+  prefix: string,
+  aggregates: AggregateMetrics,
+): AggregateMetrics {
+  const prefixed: AggregateMetrics = {};
+
+  for (const [metric, aggregate] of Object.entries(aggregates)) {
+    prefixed[`${prefix}.${metric}`] = aggregate;
+  }
+
+  return prefixed;
+}
+
+export function pairIdFromTaskId(taskId: string): string {
+  return taskId.replace(/^(clean|dirty):/, "");
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
@@ -1,4 +1,5 @@
-import type { AggregateMetrics } from "../../types.js";
+import { aggregateTaskScores } from "../../scorer.js";
+import type { AggregateMetrics, TaskResult } from "../../types.js";
 
 export function overlapCount(left: Set<string>, right: Set<string>): number {
   let count = 0;
@@ -23,4 +24,35 @@ export function prefixAggregates(
 
 export function pairIdFromTaskId(taskId: string): string {
   return taskId.replace(/^(clean|dirty):/, "");
+}
+
+export function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
+  const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
+  const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
+  const dirtyTasksByPairId = new Map(
+    dirtyTasks.map((task) => [pairIdFromTaskId(task.taskId), task]),
+  );
+  const pairedDeltas = cleanTasks.flatMap((task) => {
+    const dirtyTask = dirtyTasksByPairId.get(pairIdFromTaskId(task.taskId));
+    if (!dirtyTask) return [];
+
+    const metricNames = new Set([
+      ...Object.keys(task.scores),
+      ...Object.keys(dirtyTask.scores),
+    ]);
+    const deltaScores: Record<string, number> = {};
+
+    for (const metricName of metricNames) {
+      deltaScores[metricName] =
+        (task.scores[metricName] ?? 0) - (dirtyTask.scores[metricName] ?? 0);
+    }
+
+    return [deltaScores];
+  });
+
+  return {
+    ...prefixAggregates("clean", aggregateTaskScores(cleanTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
+  };
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-shared.ts
@@ -9,7 +9,7 @@ export function overlapCount(left: Set<string>, right: Set<string>): number {
   return count;
 }
 
-export function prefixAggregates(
+function prefixAggregates(
   prefix: string,
   aggregates: AggregateMetrics,
 ): AggregateMetrics {
@@ -22,7 +22,7 @@ export function prefixAggregates(
   return prefixed;
 }
 
-export function pairIdFromTaskId(taskId: string): string {
+function pairIdFromTaskId(taskId: string): string {
   return taskId.replace(/^(clean|dirty):/, "");
 }
 

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.ts
@@ -1,0 +1,63 @@
+import {
+  SCHEMA_TIER_FIXTURE,
+  SCHEMA_TIER_SMOKE_FIXTURE,
+  type SchemaTierName,
+  type SchemaTierPage,
+  type TemporalRetrievalCase,
+} from "../../../fixtures/schema-tiers/index.js";
+
+export interface RetrievalTemporalCase {
+  id: string;
+  pairId: string;
+  title: string;
+  tier: SchemaTierName;
+  query: string;
+  window: {
+    start: string;
+    end: string;
+  };
+  expectedPageIds: string[];
+  pages: SchemaTierPage[];
+}
+
+export const RETRIEVAL_TEMPORAL_FIXTURE = buildFixture(SCHEMA_TIER_FIXTURE);
+export const RETRIEVAL_TEMPORAL_SMOKE_FIXTURE = buildFixture(SCHEMA_TIER_SMOKE_FIXTURE);
+
+function buildFixture(source: typeof SCHEMA_TIER_FIXTURE): RetrievalTemporalCase[] {
+  const cases: RetrievalTemporalCase[] = [];
+
+  for (const sample of source.temporalCases) {
+    cases.push(buildCase(sample, "clean", source.clean.pages));
+    cases.push(buildCase(sample, "dirty", source.dirty.pages));
+  }
+
+  return cases;
+}
+
+function buildCase(
+  sample: TemporalRetrievalCase,
+  tier: SchemaTierName,
+  pages: SchemaTierPage[],
+): RetrievalTemporalCase {
+  return {
+    id: `${tier}:${sample.id}`,
+    pairId: sample.id,
+    title: `${sample.id} (${tier})`,
+    tier,
+    query: sample.query,
+    window: { ...sample.window },
+    expectedPageIds: [...sample.expectedPageIds],
+    pages: pages.map((page) => ({
+      ...page,
+      aliases: [...page.aliases],
+      frontmatter: {
+        ...page.frontmatter,
+        seeAlso: page.frontmatter.seeAlso ? [...page.frontmatter.seeAlso] : undefined,
+        timeline: page.frontmatter.timeline ? [...page.frontmatter.timeline] : undefined,
+      },
+      seeAlso: [...page.seeAlso],
+      timeline: [...page.timeline],
+      dirtySignals: [...page.dirtySignals],
+    })),
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.ts
@@ -8,7 +8,6 @@ import {
 
 export interface RetrievalTemporalCase {
   id: string;
-  pairId: string;
   title: string;
   tier: SchemaTierName;
   query: string;
@@ -41,7 +40,6 @@ function buildCase(
 ): RetrievalTemporalCase {
   return {
     id: `${tier}:${sample.id}`,
-    pairId: sample.id,
     title: `${sample.id} (${tier})`,
     tier,
     query: sample.query,

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -4,7 +4,6 @@
 
 import { randomUUID } from "node:crypto";
 import type {
-  AggregateMetrics,
   BenchmarkDefinition,
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -232,7 +232,7 @@ function tokenize(value: string): Set<string> {
       .toLowerCase()
       .split(/[^a-z0-9]+/g)
       .map((token) => token.trim())
-      .filter((token) => token.length >= 3),
+      .filter((token) => token.length >= 3 || (token.length >= 2 && /\d/.test(token))),
   );
 }
 

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -211,10 +211,23 @@ function parseTimestamp(value: string | undefined): number | null {
 }
 
 function parseTimelineEntry(entry: string): number | null {
-  const match = entry.match(/^(\d{4}-\d{2}-\d{2})/);
+  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})/);
   if (!match) return null;
-  const timestamp = Date.parse(`${match[1]}T00:00:00.000Z`);
-  return Number.isFinite(timestamp) ? timestamp : null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const date = new Date(Date.UTC(year, month - 1, day));
+
+  if (
+    date.getUTCFullYear() !== year ||
+    date.getUTCMonth() !== month - 1 ||
+    date.getUTCDate() !== day
+  ) {
+    return null;
+  }
+
+  return date.getTime();
 }
 
 function matchingPageIds(

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -1,0 +1,286 @@
+/**
+ * Deterministic temporal retrieval benchmark over the schema-tier corpus.
+ */
+
+import { randomUUID } from "node:crypto";
+import type {
+  AggregateMetrics,
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
+import {
+  RETRIEVAL_TEMPORAL_FIXTURE,
+  RETRIEVAL_TEMPORAL_SMOKE_FIXTURE,
+  type RetrievalTemporalCase,
+} from "./fixture.js";
+
+export const retrievalTemporalDefinition: BenchmarkDefinition = {
+  id: "retrieval-temporal",
+  title: "Retrieval Temporal",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retrieval-temporal",
+    version: "1.0.0",
+    description:
+      "Deterministic clean-vs-dirty retrieval benchmark for temporal qrels under half-open windows.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #448",
+  },
+};
+
+export async function runRetrievalTemporalBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const sample of cases) {
+    const startedAt = performance.now();
+    const rankedPages = rankPages(sample.query, sample.pages);
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const expectedJson = JSON.stringify({
+      expectedPageIds: sample.expectedPageIds,
+      window: sample.window,
+    });
+    const actualJson = JSON.stringify({
+      retrievedPageIds: rankedPages.slice(0, 5).map((page) => page.id),
+      matchingPageIds: matchingPageIds(rankedPages, sample),
+    });
+
+    tasks.push({
+      taskId: sample.id,
+      question: sample.title,
+      expected: expectedJson,
+      actual: actualJson,
+      scores: {
+        qrel_at_1: temporalQrelAtK(rankedPages, sample, 1),
+        qrel_at_3: temporalQrelAtK(rankedPages, sample, 3),
+        qrel_at_5: temporalQrelAtK(rankedPages, sample, 5),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        tier: sample.tier,
+        window: sample.window,
+        retrievedPageIds: rankedPages.slice(0, 5).map((page) => page.id),
+        matchingPageIds: matchingPageIds(rankedPages, sample),
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: buildTieredAggregates(tasks),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): RetrievalTemporalCase[] {
+  const baseCases = mode === "quick"
+    ? RETRIEVAL_TEMPORAL_SMOKE_FIXTURE
+    : RETRIEVAL_TEMPORAL_FIXTURE;
+
+  if (limit === undefined) {
+    return baseCases;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("retrieval-temporal limit must be a positive integer");
+  }
+
+  const limited = baseCases.slice(0, limit);
+  if (limited.length === 0) {
+    throw new Error("retrieval-temporal fixture is empty after applying the requested limit.");
+  }
+  return limited;
+}
+
+function rankPages(query: string, pages: SchemaTierPage[]): SchemaTierPage[] {
+  return [...pages].sort((left, right) => {
+    const scoreDelta = scorePage(query, right) - scorePage(query, left);
+    if (scoreDelta !== 0) return scoreDelta;
+    return left.id.localeCompare(right.id);
+  });
+}
+
+function scorePage(query: string, page: SchemaTierPage): number {
+  const queryTokens = tokenize(query);
+  const ownerHit = queryTokens.has(page.owner.toLowerCase()) ? 3 : 0;
+  const titleScore = overlapCount(queryTokens, tokenize(page.title)) * 4;
+  const canonicalTitleScore = overlapCount(queryTokens, tokenize(page.canonicalTitle)) * 3;
+  const aliasScore = overlapCount(queryTokens, tokenize(page.aliases.join(" "))) * 2;
+  const bodyScore = overlapCount(queryTokens, tokenize(page.body)) * 2;
+  const timelineScore = overlapCount(queryTokens, tokenize(page.timeline.join(" "))) * 1.5;
+
+  return ownerHit + titleScore + canonicalTitleScore + aliasScore + bodyScore + timelineScore;
+}
+
+function temporalQrelAtK(
+  rankedPages: SchemaTierPage[],
+  sample: RetrievalTemporalCase,
+  k: number,
+): number {
+  const topK = rankedPages.slice(0, k);
+  return topK.some((page) => pageQualifies(page, sample)) ? 1 : 0;
+}
+
+function pageQualifies(page: SchemaTierPage, sample: RetrievalTemporalCase): boolean {
+  if (!sample.expectedPageIds.includes(page.id)) return false;
+  return pageHasTemporalEvidenceInWindow(page, sample.window.start, sample.window.end);
+}
+
+function pageHasTemporalEvidenceInWindow(
+  page: SchemaTierPage,
+  startIso: string,
+  endIso: string,
+): boolean {
+  const startMs = Date.parse(startIso);
+  const endMs = Date.parse(endIso);
+
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs >= endMs) {
+    throw new Error("retrieval-temporal window must use valid half-open ISO timestamps");
+  }
+
+  const evidenceTimestamps = collectEvidenceTimestamps(page);
+  return evidenceTimestamps.some((timestamp) => timestamp >= startMs && timestamp < endMs);
+}
+
+function collectEvidenceTimestamps(page: SchemaTierPage): number[] {
+  const timestamps = new Set<number>();
+
+  const created = parseTimestamp(page.frontmatter.created);
+  if (created !== null) timestamps.add(created);
+
+  for (const entry of page.frontmatter.timeline ?? []) {
+    const timestamp = parseTimelineEntry(entry);
+    if (timestamp !== null) timestamps.add(timestamp);
+  }
+
+  return [...timestamps];
+}
+
+function parseTimestamp(value: string | undefined): number | null {
+  if (!value) return null;
+  const timestamp = Date.parse(value);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function parseTimelineEntry(entry: string): number | null {
+  const match = entry.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (!match) return null;
+  const timestamp = Date.parse(`${match[1]}T00:00:00.000Z`);
+  return Number.isFinite(timestamp) ? timestamp : null;
+}
+
+function matchingPageIds(
+  rankedPages: SchemaTierPage[],
+  sample: RetrievalTemporalCase,
+): string[] {
+  return rankedPages
+    .filter((page) => pageQualifies(page, sample))
+    .map((page) => page.id);
+}
+
+function tokenize(value: string): Set<string> {
+  return new Set(
+    value
+      .toLowerCase()
+      .split(/[^a-z0-9]+/g)
+      .map((token) => token.trim())
+      .filter((token) => token.length >= 3),
+  );
+}
+
+function overlapCount(left: Set<string>, right: Set<string>): number {
+  let count = 0;
+  for (const token of right) {
+    if (left.has(token)) count += 1;
+  }
+  return count;
+}
+
+function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
+  const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
+  const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
+  const dirtyTasksByPairId = new Map(
+    dirtyTasks.map((task) => [pairId(task.taskId), task]),
+  );
+  const pairedDeltas = cleanTasks.flatMap((task) => {
+    const dirtyTask = dirtyTasksByPairId.get(pairId(task.taskId));
+    if (!dirtyTask) return [];
+
+    return [{
+      qrel_at_1: (task.scores.qrel_at_1 ?? 0) - (dirtyTask.scores.qrel_at_1 ?? 0),
+      qrel_at_3: (task.scores.qrel_at_3 ?? 0) - (dirtyTask.scores.qrel_at_3 ?? 0),
+      qrel_at_5: (task.scores.qrel_at_5 ?? 0) - (dirtyTask.scores.qrel_at_5 ?? 0),
+    }];
+  });
+
+  return {
+    ...prefixAggregates("clean", aggregateTaskScores(cleanTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
+    ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
+  };
+}
+
+function prefixAggregates(
+  prefix: string,
+  aggregates: AggregateMetrics,
+): AggregateMetrics {
+  const prefixed: AggregateMetrics = {};
+
+  for (const [metric, aggregate] of Object.entries(aggregates)) {
+    prefixed[`${prefix}.${metric}`] = aggregate;
+  }
+
+  return prefixed;
+}
+
+function pairId(taskId: string): string {
+  return taskId.replace(/^(clean|dirty):/, "");
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -45,6 +45,7 @@ export async function runRetrievalTemporalBenchmark(
 
   for (const sample of cases) {
     validateHalfOpenWindow(sample.window.start, sample.window.end);
+    validateExpectedPageIds(sample);
     const startedAt = performance.now();
     const rankedPages = rankPages(sample.query, sample.pages);
     const latencyMs = Math.round(performance.now() - startedAt);
@@ -202,6 +203,17 @@ function validateHalfOpenWindow(
   }
 
   return { startMs, endMs };
+}
+
+function validateExpectedPageIds(sample: RetrievalTemporalCase): void {
+  const pageIds = new Set(sample.pages.map((page) => page.id));
+  const missingPageIds = sample.expectedPageIds.filter((pageId) => !pageIds.has(pageId));
+
+  if (missingPageIds.length > 0) {
+    throw new Error(
+      `retrieval-temporal expectedPageIds must reference pages present in the fixture: ${sample.id} -> ${missingPageIds.join(", ")}`,
+    );
+  }
 }
 
 function collectEvidenceTimestamps(page: SchemaTierPage): number[] {

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -215,7 +215,7 @@ function parseTimestamp(value: string | undefined): number | null {
 }
 
 function parseTimelineEntry(entry: string): number | null {
-  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})/);
+  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})(?=$|\D)/);
   if (!match) return null;
 
   const year = Number(match[1]);

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -10,7 +10,6 @@ import type {
   ResolvedRunBenchmarkOptions,
   TaskResult,
 } from "../../../types.js";
-import { aggregateTaskScores } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -14,6 +14,11 @@ import { aggregateTaskScores } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
+  overlapCount,
+  pairIdFromTaskId,
+  prefixAggregates,
+} from "../retrieval-shared.js";
+import {
   RETRIEVAL_TEMPORAL_FIXTURE,
   RETRIEVAL_TEMPORAL_SMOKE_FIXTURE,
   type RetrievalTemporalCase,
@@ -179,10 +184,10 @@ function pageHasTemporalEvidenceInWindow(
   startIso: string,
   endIso: string,
 ): boolean {
-  const startMs = Date.parse(startIso);
-  const endMs = Date.parse(endIso);
+  const startMs = parseStrictIsoTimestamp(startIso);
+  const endMs = parseStrictIsoTimestamp(endIso);
 
-  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || startMs >= endMs) {
+  if (startMs === null || endMs === null || startMs >= endMs) {
     throw new Error("retrieval-temporal window must use valid half-open ISO timestamps");
   }
 
@@ -206,8 +211,7 @@ function collectEvidenceTimestamps(page: SchemaTierPage): number[] {
 
 function parseTimestamp(value: string | undefined): number | null {
   if (!value) return null;
-  const timestamp = Date.parse(value);
-  return Number.isFinite(timestamp) ? timestamp : null;
+  return parseStrictIsoTimestamp(value);
 }
 
 function parseTimelineEntry(entry: string): number | null {
@@ -230,6 +234,19 @@ function parseTimelineEntry(entry: string): number | null {
   return date.getTime();
 }
 
+function parseStrictIsoTimestamp(value: string): number | null {
+  if (!/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/.test(value)) {
+    return null;
+  }
+
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return null;
+  }
+
+  return date.toISOString() === value ? date.getTime() : null;
+}
+
 function matchingPageIds(
   rankedPages: SchemaTierPage[],
   sample: RetrievalTemporalCase,
@@ -249,22 +266,14 @@ function tokenize(value: string): Set<string> {
   );
 }
 
-function overlapCount(left: Set<string>, right: Set<string>): number {
-  let count = 0;
-  for (const token of right) {
-    if (left.has(token)) count += 1;
-  }
-  return count;
-}
-
 function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
   const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
   const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
   const dirtyTasksByPairId = new Map(
-    dirtyTasks.map((task) => [pairId(task.taskId), task]),
+    dirtyTasks.map((task) => [pairIdFromTaskId(task.taskId), task]),
   );
   const pairedDeltas = cleanTasks.flatMap((task) => {
-    const dirtyTask = dirtyTasksByPairId.get(pairId(task.taskId));
+    const dirtyTask = dirtyTasksByPairId.get(pairIdFromTaskId(task.taskId));
     if (!dirtyTask) return [];
 
     return [{
@@ -279,21 +288,4 @@ function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
     ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
     ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
   };
-}
-
-function prefixAggregates(
-  prefix: string,
-  aggregates: AggregateMetrics,
-): AggregateMetrics {
-  const prefixed: AggregateMetrics = {};
-
-  for (const [metric, aggregate] of Object.entries(aggregates)) {
-    prefixed[`${prefix}.${metric}`] = aggregate;
-  }
-
-  return prefixed;
-}
-
-function pairId(taskId: string): string {
-  return taskId.replace(/^(clean|dirty):/, "");
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -14,9 +14,8 @@ import { aggregateTaskScores } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 import type { SchemaTierPage } from "../../../fixtures/schema-tiers/index.js";
 import {
+  buildTieredAggregates,
   overlapCount,
-  pairIdFromTaskId,
-  prefixAggregates,
 } from "../retrieval-shared.js";
 import {
   RETRIEVAL_TEMPORAL_FIXTURE,
@@ -215,7 +214,7 @@ function parseTimestamp(value: string | undefined): number | null {
 }
 
 function parseTimelineEntry(entry: string): number | null {
-  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})(?=$|\D)/);
+  const match = entry.match(/^(\d{4})-(\d{2})-(\d{2})(?=$|[:\s])/);
   if (!match) return null;
 
   const year = Number(match[1]);
@@ -264,28 +263,4 @@ function tokenize(value: string): Set<string> {
       .map((token) => token.trim())
       .filter((token) => token.length >= 3 || (token.length >= 2 && /\d/.test(token))),
   );
-}
-
-function buildTieredAggregates(tasks: TaskResult[]): AggregateMetrics {
-  const cleanTasks = tasks.filter((task) => task.details?.tier === "clean");
-  const dirtyTasks = tasks.filter((task) => task.details?.tier === "dirty");
-  const dirtyTasksByPairId = new Map(
-    dirtyTasks.map((task) => [pairIdFromTaskId(task.taskId), task]),
-  );
-  const pairedDeltas = cleanTasks.flatMap((task) => {
-    const dirtyTask = dirtyTasksByPairId.get(pairIdFromTaskId(task.taskId));
-    if (!dirtyTask) return [];
-
-    return [{
-      qrel_at_1: (task.scores.qrel_at_1 ?? 0) - (dirtyTask.scores.qrel_at_1 ?? 0),
-      qrel_at_3: (task.scores.qrel_at_3 ?? 0) - (dirtyTask.scores.qrel_at_3 ?? 0),
-      qrel_at_5: (task.scores.qrel_at_5 ?? 0) - (dirtyTask.scores.qrel_at_5 ?? 0),
-    }];
-  });
-
-  return {
-    ...prefixAggregates("clean", aggregateTaskScores(cleanTasks.map((task) => task.scores))),
-    ...prefixAggregates("dirty", aggregateTaskScores(dirtyTasks.map((task) => task.scores))),
-    ...prefixAggregates("dirty_penalty", aggregateTaskScores(pairedDeltas)),
-  };
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -48,13 +48,15 @@ export async function runRetrievalTemporalBenchmark(
     const startedAt = performance.now();
     const rankedPages = rankPages(sample.query, sample.pages);
     const latencyMs = Math.round(performance.now() - startedAt);
+    const topRetrievedPageIds = rankedPages.slice(0, 5).map((page) => page.id);
+    const matchedPageIds = matchingPageIds(rankedPages, sample);
     const expectedJson = JSON.stringify({
       expectedPageIds: sample.expectedPageIds,
       window: sample.window,
     });
     const actualJson = JSON.stringify({
-      retrievedPageIds: rankedPages.slice(0, 5).map((page) => page.id),
-      matchingPageIds: matchingPageIds(rankedPages, sample),
+      retrievedPageIds: topRetrievedPageIds,
+      matchingPageIds: matchedPageIds,
     });
 
     tasks.push({
@@ -72,8 +74,8 @@ export async function runRetrievalTemporalBenchmark(
       details: {
         tier: sample.tier,
         window: sample.window,
-        retrievedPageIds: rankedPages.slice(0, 5).map((page) => page.id),
-        matchingPageIds: matchingPageIds(rankedPages, sample),
+        retrievedPageIds: topRetrievedPageIds,
+        matchingPageIds: matchedPageIds,
       },
     });
   }

--- a/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-temporal/runner.ts
@@ -45,6 +45,7 @@ export async function runRetrievalTemporalBenchmark(
   const tasks: TaskResult[] = [];
 
   for (const sample of cases) {
+    validateHalfOpenWindow(sample.window.start, sample.window.end);
     const startedAt = performance.now();
     const rankedPages = rankPages(sample.query, sample.pages);
     const latencyMs = Math.round(performance.now() - startedAt);
@@ -182,6 +183,16 @@ function pageHasTemporalEvidenceInWindow(
   startIso: string,
   endIso: string,
 ): boolean {
+  const { startMs, endMs } = validateHalfOpenWindow(startIso, endIso);
+
+  const evidenceTimestamps = collectEvidenceTimestamps(page);
+  return evidenceTimestamps.some((timestamp) => timestamp >= startMs && timestamp < endMs);
+}
+
+function validateHalfOpenWindow(
+  startIso: string,
+  endIso: string,
+): { startMs: number; endMs: number } {
   const startMs = parseStrictIsoTimestamp(startIso);
   const endMs = parseStrictIsoTimestamp(endIso);
 
@@ -189,8 +200,7 @@ function pageHasTemporalEvidenceInWindow(
     throw new Error("retrieval-temporal window must use valid half-open ISO timestamps");
   }
 
-  const evidenceTimestamps = collectEvidenceTimestamps(page);
-  return evidenceTimestamps.some((timestamp) => timestamp >= startMs && timestamp < endMs);
+  return { startMs, endMs };
 }
 
 function collectEvidenceTimestamps(page: SchemaTierPage): number[] {

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -63,6 +63,10 @@ import {
   retrievalPersonalizationDefinition,
   runRetrievalPersonalizationBenchmark,
 } from "./benchmarks/remnic/retrieval-personalization/runner.js";
+import {
+  retrievalTemporalDefinition,
+  runRetrievalTemporalBenchmark,
+} from "./benchmarks/remnic/retrieval-temporal/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -128,6 +132,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalPersonalizationDefinition,
     run: runRetrievalPersonalizationBenchmark,
+  },
+  {
+    ...retrievalTemporalDefinition,
+    run: runRetrievalTemporalBenchmark,
   },
 ];
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -27,6 +27,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "entity-consolidation",
       "page-versioning",
       "retrieval-personalization",
+      "retrieval-temporal",
     ],
   );
   assert.deepEqual(
@@ -47,11 +48,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal",
   );
 });
 
@@ -204,6 +206,17 @@ test("getBenchmark returns retrieval-personalization metadata with a runnable be
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "retrieval-personalization");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns retrieval-temporal metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("retrieval-temporal");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "retrieval-temporal");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -189,6 +189,30 @@ test("runBenchmark rejects overflowed window timestamps in retrieval-temporal ca
   }
 });
 
+test("runBenchmark rejects overflowed window timestamps even without expected temporal pages", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:alex-last-tuesday-meeting");
+  assert.ok(temporalCase);
+
+  const originalWindow = { ...temporalCase.window };
+  const originalExpectedPageIds = [...temporalCase.expectedPageIds];
+
+  try {
+    temporalCase.window.start = "2026-06-31T00:00:00.000Z";
+    temporalCase.expectedPageIds = [];
+
+    await assert.rejects(
+      () => runBenchmark("retrieval-temporal", {
+        mode: "full",
+        system: adapter,
+      }),
+      /retrieval-temporal window must use valid half-open ISO timestamps/,
+    );
+  } finally {
+    temporalCase.window = originalWindow;
+    temporalCase.expectedPageIds = originalExpectedPageIds;
+  }
+});
+
 test("runBenchmark rejects overflowed created timestamps in retrieval-temporal evidence", async () => {
   const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
   assert.ok(temporalCase);

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -213,6 +213,27 @@ test("runBenchmark rejects overflowed window timestamps even without expected te
   }
 });
 
+test("runBenchmark rejects retrieval-temporal cases whose expectedPageIds do not exist in fixture pages", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:alex-last-tuesday-meeting");
+  assert.ok(temporalCase);
+
+  const originalExpectedPageIds = [...temporalCase.expectedPageIds];
+
+  try {
+    temporalCase.expectedPageIds = ["missing-page-id"];
+
+    await assert.rejects(
+      () => runBenchmark("retrieval-temporal", {
+        mode: "full",
+        system: adapter,
+      }),
+      /retrieval-temporal expectedPageIds must reference pages present in the fixture/,
+    );
+  } finally {
+    temporalCase.expectedPageIds = originalExpectedPageIds;
+  }
+});
+
 test("runBenchmark rejects overflowed created timestamps in retrieval-temporal evidence", async () => {
   const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
   assert.ok(temporalCase);

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -123,3 +123,18 @@ test("runBenchmark applies retrieval-temporal limit as an exact task cap", async
   assert.equal(result.results.tasks[0]?.taskId, "clean:alex-last-tuesday-meeting");
   assert.equal(result.results.aggregates["dirty_penalty.qrel_at_1"], undefined);
 });
+
+test("runBenchmark preserves quarter tokens for full retrieval-temporal cases", async () => {
+  const result = await runBenchmark("retrieval-temporal", {
+    mode: "full",
+    system: adapter,
+  });
+
+  const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
+  assert.ok(task);
+  assert.equal(task.scores.qrel_at_1, 1);
+  assert.deepEqual(
+    task.details?.retrievedPageIds?.slice(0, 2),
+    ["morgan-q3-training-plan", "morgan-coffee-preferences"],
+  );
+});

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -244,3 +244,31 @@ test("runBenchmark rejects timeline entries with extra day digits in retrieval-t
     targetPage.frontmatter.timeline = originalTimeline;
   }
 });
+
+test("runBenchmark rejects timeline entries with trailing alpha suffixes in retrieval-temporal evidence", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
+  assert.ok(temporalCase);
+
+  const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
+  assert.ok(targetPage);
+
+  const originalCreated = targetPage.frontmatter.created;
+  const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+
+  try {
+    targetPage.frontmatter.created = undefined;
+    targetPage.frontmatter.timeline = ["2026-08-03x malformed day token"];
+
+    const result = await runBenchmark("retrieval-temporal", {
+      mode: "full",
+      system: adapter,
+    });
+
+    const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
+    assert.ok(task);
+    assert.equal(task.scores.qrel_at_1, 0);
+  } finally {
+    targetPage.frontmatter.created = originalCreated;
+    targetPage.frontmatter.timeline = originalTimeline;
+  }
+});

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -167,3 +167,52 @@ test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evide
     targetPage.frontmatter.timeline = originalTimeline;
   }
 });
+
+test("runBenchmark rejects overflowed window timestamps in retrieval-temporal cases", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:alex-last-tuesday-meeting");
+  assert.ok(temporalCase);
+
+  const originalWindow = { ...temporalCase.window };
+
+  try {
+    temporalCase.window.start = "2026-06-31T00:00:00.000Z";
+
+    await assert.rejects(
+      () => runBenchmark("retrieval-temporal", {
+        mode: "full",
+        system: adapter,
+      }),
+      /retrieval-temporal window must use valid half-open ISO timestamps/,
+    );
+  } finally {
+    temporalCase.window = originalWindow;
+  }
+});
+
+test("runBenchmark rejects overflowed created timestamps in retrieval-temporal evidence", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
+  assert.ok(temporalCase);
+
+  const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
+  assert.ok(targetPage);
+
+  const originalCreated = targetPage.frontmatter.created;
+  const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+
+  try {
+    targetPage.frontmatter.created = "2026-06-31T07:00:00.000Z";
+    targetPage.frontmatter.timeline = [];
+
+    const result = await runBenchmark("retrieval-temporal", {
+      mode: "full",
+      system: adapter,
+    });
+
+    const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
+    assert.ok(task);
+    assert.equal(task.scores.qrel_at_1, 0);
+  } finally {
+    targetPage.frontmatter.created = originalCreated;
+    targetPage.frontmatter.timeline = originalTimeline;
+  }
+});

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import type { BenchMemoryAdapter, SearchResult, Message } from "../packages/bench/src/index.js";
 import { runBenchmark } from "../packages/bench/src/index.js";
+import { RETRIEVAL_TEMPORAL_FIXTURE } from "../packages/bench/src/benchmarks/remnic/retrieval-temporal/fixture.js";
 
 class NoopMemoryAdapter implements BenchMemoryAdapter {
   async store(_sessionId: string, _messages: Message[]): Promise<void> {}
@@ -137,4 +138,32 @@ test("runBenchmark preserves quarter tokens for full retrieval-temporal cases", 
     task.details?.retrievedPageIds?.slice(0, 2),
     ["morgan-q3-training-plan", "morgan-coffee-preferences"],
   );
+});
+
+test("runBenchmark rejects overflowed timeline dates in retrieval-temporal evidence", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
+  assert.ok(temporalCase);
+
+  const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
+  assert.ok(targetPage);
+
+  const originalCreated = targetPage.frontmatter.created;
+  const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+
+  try {
+    targetPage.frontmatter.created = undefined;
+    targetPage.frontmatter.timeline = ["2026-08-32 impossible training block"];
+
+    const result = await runBenchmark("retrieval-temporal", {
+      mode: "full",
+      system: adapter,
+    });
+
+    const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
+    assert.ok(task);
+    assert.equal(task.scores.qrel_at_1, 0);
+  } finally {
+    targetPage.frontmatter.created = originalCreated;
+    targetPage.frontmatter.timeline = originalTimeline;
+  }
 });

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -216,3 +216,31 @@ test("runBenchmark rejects overflowed created timestamps in retrieval-temporal e
     targetPage.frontmatter.timeline = originalTimeline;
   }
 });
+
+test("runBenchmark rejects timeline entries with extra day digits in retrieval-temporal evidence", async () => {
+  const temporalCase = RETRIEVAL_TEMPORAL_FIXTURE.find((entry) => entry.id === "clean:morgan-q3-commitments");
+  assert.ok(temporalCase);
+
+  const targetPage = temporalCase.pages.find((page) => page.id === "morgan-q3-training-plan");
+  assert.ok(targetPage);
+
+  const originalCreated = targetPage.frontmatter.created;
+  const originalTimeline = targetPage.frontmatter.timeline ? [...targetPage.frontmatter.timeline] : undefined;
+
+  try {
+    targetPage.frontmatter.created = undefined;
+    targetPage.frontmatter.timeline = ["2026-08-032 malformed day"];
+
+    const result = await runBenchmark("retrieval-temporal", {
+      mode: "full",
+      system: adapter,
+    });
+
+    const task = result.results.tasks.find((entry) => entry.taskId === "clean:morgan-q3-commitments");
+    assert.ok(task);
+    assert.equal(task.scores.qrel_at_1, 0);
+  } finally {
+    targetPage.frontmatter.created = originalCreated;
+    targetPage.frontmatter.timeline = originalTimeline;
+  }
+});

--- a/tests/bench-remnic-deterministic-runners.test.ts
+++ b/tests/bench-remnic-deterministic-runners.test.ts
@@ -97,3 +97,29 @@ test("runBenchmark applies retrieval-personalization limit as an exact task cap"
   assert.equal(result.results.tasks[0]?.taskId, "clean:alex-scope-q3-launch");
   assert.equal(result.results.aggregates["dirty_penalty.p_at_1"], undefined);
 });
+
+test("runBenchmark executes retrieval-temporal in quick mode", async () => {
+  const result = await runBenchmark("retrieval-temporal", {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.meta.benchmark, "retrieval-temporal");
+  assert.equal(result.meta.benchmarkTier, "remnic");
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.aggregates["clean.qrel_at_1"].mean, 1);
+  assert.equal(result.results.aggregates["dirty.qrel_at_1"].mean, 0);
+  assert.equal(result.results.aggregates["dirty_penalty.qrel_at_1"].mean, 1);
+});
+
+test("runBenchmark applies retrieval-temporal limit as an exact task cap", async () => {
+  const result = await runBenchmark("retrieval-temporal", {
+    mode: "quick",
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.taskId, "clean:alex-last-tuesday-meeting");
+  assert.equal(result.results.aggregates["dirty_penalty.qrel_at_1"], undefined);
+});

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -268,6 +268,7 @@ export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai"
 export function checkRegression() { return null; }
 export function defaultBenchmarkBaselineDir() { return ""; }
 export function defaultBenchmarkPublishPath() { return ""; }
+export function getBenchmarkLowerIsBetter() { return false; }
 export async function discoverAllProviders() { return []; }
 export async function listBenchmarkBaselines() { return []; }
 export async function listBenchmarkResults() { return []; }

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -229,11 +229,22 @@ test("bench providers discover rejects unexpected trailing positional args", asy
   const benchModuleDist = join(benchModuleRoot, "dist");
   const benchModuleEntry = join(benchModuleDist, "index.js");
   const benchPackageJson = join(benchModuleRoot, "package.json");
+  const exportModuleLinkRoot = join(repoRoot, "packages/remnic-cli/node_modules/@remnic/export-weclone");
+  const exportModuleRoot = existsSync(exportModuleLinkRoot)
+    ? realpathSync(exportModuleLinkRoot)
+    : exportModuleLinkRoot;
+  const exportModuleDist = join(exportModuleRoot, "dist");
+  const exportModuleEntry = join(exportModuleDist, "index.js");
+  const exportPackageJson = join(exportModuleRoot, "package.json");
   const cliEntry = pathToFileURL(join(repoRoot, "packages/remnic-cli/src/index.ts")).href;
   const stubbedBenchModule = !existsSync(benchModuleEntry);
+  const stubbedExportModule = !existsSync(exportModuleEntry);
   const createdModuleRoot = !existsSync(benchModuleLinkRoot);
   const createdPackageJson = stubbedBenchModule && !existsSync(benchPackageJson);
   const createdDistDir = stubbedBenchModule && !existsSync(benchModuleDist);
+  const createdExportModuleRoot = !existsSync(exportModuleLinkRoot);
+  const createdExportPackageJson = stubbedExportModule && !existsSync(exportPackageJson);
+  const createdExportDistDir = stubbedExportModule && !existsSync(exportModuleDist);
 
   if (stubbedBenchModule) {
     mkdirSync(benchModuleDist, { recursive: true });
@@ -274,6 +285,30 @@ export async function writeBenchmarkPublishFeed() { return ""; }
     );
   }
 
+  if (stubbedExportModule) {
+    mkdirSync(exportModuleDist, { recursive: true });
+    if (createdExportPackageJson) {
+      writeFileSync(
+        exportPackageJson,
+        JSON.stringify({
+          name: "@remnic/export-weclone",
+          type: "module",
+          exports: {
+            ".": "./dist/index.js",
+          },
+        }),
+      );
+    }
+    writeFileSync(
+      exportModuleEntry,
+      `
+export function ensureWecloneExportAdapterRegistered() { return false; }
+export function synthesizeTrainingPairs() { return []; }
+export function sweepPii(records) { return { records, redactions: [] }; }
+`,
+    );
+  }
+
   const originalExit = process.exit;
   const exitCalls: number[] = [];
 
@@ -291,6 +326,18 @@ export async function writeBenchmarkPublishFeed() { return ""; }
     assert.deepEqual(exitCalls, [1]);
   } finally {
     process.exit = originalExit;
+    if (stubbedExportModule) {
+      rmSync(exportModuleEntry, { force: true });
+      if (createdExportDistDir) {
+        rmSync(exportModuleDist, { recursive: true, force: true });
+      }
+      if (createdExportPackageJson) {
+        rmSync(exportPackageJson, { force: true });
+      }
+      if (createdExportModuleRoot) {
+        rmSync(exportModuleRoot, { recursive: true, force: true });
+      }
+    }
     if (stubbedBenchModule) {
       rmSync(benchModuleEntry, { force: true });
       if (createdDistDir) {


### PR DESCRIPTION
## Summary
- add the deterministic `retrieval-temporal` remnic benchmark slice
- score temporal qrels against schema evidence under half-open `[start, end)` windows
- cover registry wiring and exact `limit` behavior in the bench tests

## Testing
- pnpm exec tsx --test tests/bench-registry.test.ts tests/bench-remnic-deterministic-runners.test.ts
- pnpm --filter @remnic/bench check-types
- pnpm --filter @remnic/bench build
- pnpm exec tsx --eval '(async () => { const { runBenchmark } = await import("./packages/bench/src/index.ts"); const noop = { store: async () => {}, recall: async () => "", search: async () => [], reset: async () => {}, getStats: async () => ({ totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 }), destroy: async () => {} }; const result = await runBenchmark("retrieval-temporal", { mode: "quick", system: noop }); console.log(JSON.stringify(result.results.aggregates, null, 2)); })()'

Closes #448 (temporal slice only).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk: adds a new benchmark runner plus shared aggregation logic that changes how tiered metrics deltas are computed (now for arbitrary score keys), which could affect reported aggregates across benchmarks.
> 
> **Overview**
> Adds a new deterministic Remnic benchmark, `retrieval-temporal`, that scores whether expected pages are retrieved *and* have qualifying schema evidence within a validated half-open time window, producing `qrel_at_{1,3,5}` metrics.
> 
> Refactors shared retrieval utilities by extracting `overlapCount` and tiered aggregate computation into `retrieval-shared.ts`, and generalizes `dirty_penalty` aggregation to delta **all** score metrics present in clean/dirty task pairs. Wires the new benchmark into the bench registry and expands tests to cover registry exposure, `limit` behavior, and strict timestamp/timeline validation, plus updates CLI surface tests to stub `@remnic/export-weclone` when absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 830045d02f324fcac62d62dda609c7c2d4efd594. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->