### PR TITLE
feat(bench): complete issue #449 ingestion dashboard and schema docs

### DIFF
--- a/docs/bench-ingestion-schema.md
+++ b/docs/bench-ingestion-schema.md
@@ -1,0 +1,98 @@
+# Ingestion Benchmark: Canonical Page Frontmatter Schema
+
+This document defines the frontmatter schema that the **schema-completeness** rubric scores
+against during ingestion benchmarks. Every generated memory page is evaluated field by field;
+the aggregate score is `passing_field_checks / total_applicable_checks`.
+
+## Required Fields
+
+All generated pages must include the following YAML frontmatter fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Human-readable page title. Must be non-empty. |
+| `type` | string | Memory page type. Common values: `person`, `org`, `project`, `topic`, `event`, `location`. |
+| `state` | string | Lifecycle state. Common values: `active`, `archived`, `superseded`. |
+| `created` | ISO 8601 date string | Date the page was first created (e.g. `2026-01-15`). |
+| `see-also` | list of strings | Cross-references to related pages by title or path. Must be an array (empty array `[]` is acceptable when no related pages exist). |
+
+A page that omits any of these fields contributes a failing check for that field toward the
+completeness score.
+
+## Conditional Fields
+
+These fields are required only for certain entity types. The benchmark gold graph records
+`expectExecSummary` and `expectTimeline` per gold page; the rubric only scores them when the
+flag is set.
+
+### `exec-summary`
+
+**Required when** the page represents a `project`, `org`, or `event` entity.
+
+A prose block that summarises the entity's purpose, status, and key facts in three to five
+sentences. It must appear either as a frontmatter key or as a dedicated heading section
+(`## Executive Summary` / `## Exec Summary`) in the body.
+
+The scorer treats the field as present if `ExtractedPage.hasExecSummary` is `true`.
+
+### `timeline`
+
+**Required when** the page represents a `project` or `event` entity.
+
+An ordered list of milestones or dated entries. It must appear as a frontmatter key or as a
+dedicated heading section (`## Timeline`) in the body.
+
+The scorer treats the field as present if `ExtractedPage.hasTimeline` is `true`.
+
+## Scoring Details
+
+The scorer is implemented in `packages/bench/src/ingestion-scorer.ts` under `schemaCompleteness`.
+
+For each gold page:
+
+1. Every field in `goldPage.requiredFields` is checked. A check passes if the corresponding
+   key exists in `extractedPage.frontmatter` (value may be any non-`undefined` value).
+2. If `goldPage.expectExecSummary` is `true`, `extractedPage.hasExecSummary` must be `true`.
+3. If `goldPage.expectTimeline` is `true`, `extractedPage.hasTimeline` must be `true`.
+4. Each entry in `goldPage.expectSeeAlso` is checked individually; a check passes if the
+   extracted page's `seeAlso` list contains a matching entry after Unicode NFKC normalization
+   and lowercasing.
+
+If no gold pages are defined for a fixture, `schemaCompleteness` returns `1.0` (full score).
+
+The primary metric for the `ingestion-schema-completeness` benchmark is `schema_completeness`,
+which is the `overall` value from `schemaCompleteness`.
+
+## Example
+
+A conforming page for a project entity looks like this:
+
+```markdown
+---
+title: Example Project Alpha
+type: project
+state: active
+created: 2026-01-10
+see-also:
+  - Team Gamma
+  - Q1 Roadmap
+exec-summary: >
+  Example Project Alpha is a synthetic demo project used in ingestion fixtures.
+  It is currently active and involves Team Gamma. Key deliverables land in Q2 2026.
+timeline:
+  - 2026-01-10: Project kicked off
+  - 2026-03-01: Milestone 1 complete
+---
+
+Body content follows...
+```
+
+A page that is missing `state`, `created`, and `see-also` would receive 2 passing checks out of
+5 required (`title` and `type` present), yielding a field-coverage fraction of 0.40 for that page.
+
+## Related
+
+- `packages/bench/src/ingestion-types.ts` — `REQUIRED_FRONTMATTER_FIELDS`, `CONDITIONAL_FRONTMATTER`, `GoldPage`
+- `packages/bench/src/ingestion-scorer.ts` — `schemaCompleteness` implementation
+- `packages/bench/src/benchmarks/remnic/ingestion-schema-completeness/` — benchmark runner
+- `packages/bench-ui/src/pages/Ingestion.tsx` — dashboard view for all five ingestion metrics

--- a/packages/bench-ui/src/App.tsx
+++ b/packages/bench-ui/src/App.tsx
@@ -5,12 +5,14 @@ import type { BenchResultSummaryPayload } from "./bench-data";
 import { listBenchmarks } from "./bench-data";
 import { BenchmarkDetail } from "./pages/BenchmarkDetail";
 import { Compare } from "./pages/Compare";
+import { Ingestion } from "./pages/Ingestion";
 import { Overview } from "./pages/Overview";
 import { Providers } from "./pages/Providers";
 import { Runs } from "./pages/Runs";
 
 const navigationItems = [
   { label: "Overview", path: "/" },
+  { label: "Ingestion", path: "/ingestion" },
   { label: "Runs", path: "/runs" },
   { label: "Compare", path: "/compare" },
   { label: "Benchmark Detail", path: "/benchmark" },
@@ -153,6 +155,7 @@ export function App() {
       >
         <Routes>
           <Route path="/" element={<Overview payload={payload} />} />
+          <Route path="/ingestion" element={<Ingestion payload={payload} />} />
           <Route path="/runs" element={<Runs payload={payload} />} />
           <Route path="/compare" element={<Compare payload={payload} />} />
           <Route

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -181,13 +181,13 @@ export function formatMetricValue(value: number | null, metricName?: string): st
   return value.toFixed(2);
 }
 
-export function formatDelta(value: number | null): string {
+export function formatDelta(value: number | null, metricName?: string): string {
   if (value === null) {
     return "No baseline";
   }
 
   const prefix = value > 0 ? "+" : "";
-  return `${prefix}${formatMetricValue(value)}`;
+  return `${prefix}${formatMetricValue(value, metricName)}`;
 }
 
 export function formatDuration(value: number | null): string {

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -159,6 +159,11 @@ export function humanizeIdentifier(value: string): string {
 
 const rawCountMetrics = new Set([
   "search_hits",
+  // ingestion-setup-friction raw count metrics — lower is better
+  "setup_friction",
+  "commands_count",
+  "prompts_count",
+  "errors_count",
 ]);
 
 function isRawCountMetric(metricName?: string): boolean {

--- a/packages/bench-ui/src/components/ScoreCard.tsx
+++ b/packages/bench-ui/src/components/ScoreCard.tsx
@@ -18,7 +18,7 @@ export function ScoreCard({ card }: { card: BenchmarkCard }) {
       </div>
 
       <div className="score-card__score-row">
-        <strong>{formatMetricValue(card.latest.primaryScore)}</strong>
+        <strong>{formatMetricValue(card.latest.primaryScore, card.latest.primaryMetric ?? undefined)}</strong>
         <span
           className={`delta-pill${
             card.delta !== null && card.delta > 0
@@ -28,7 +28,7 @@ export function ScoreCard({ card }: { card: BenchmarkCard }) {
                 : ""
           }`}
         >
-          {formatDelta(card.delta)}
+          {formatDelta(card.delta, card.latest.primaryMetric ?? undefined)}
         </span>
       </div>
 

--- a/packages/bench-ui/src/pages/Ingestion.tsx
+++ b/packages/bench-ui/src/pages/Ingestion.tsx
@@ -3,10 +3,10 @@ import type { BenchResultSummaryPayload } from "../bench-data";
 import {
   formatDelta,
   formatMetricValue,
-  formatTimestamp,
   getBenchmarkCards,
   humanizeIdentifier,
 } from "../bench-data";
+import { ScoreCard } from "../components/ScoreCard";
 
 const INGESTION_BENCHMARKS = [
   "ingestion-entity-recall",
@@ -65,47 +65,7 @@ export function Ingestion({ payload }: { payload: BenchResultSummaryPayload }) {
           <div className="score-grid">
             {ingestionCards.map((card) => (
               <Link key={card.benchmark} to={`/benchmark/${card.benchmark}`}>
-                <article className="score-card">
-                  <div className="score-card__header">
-                    <div>
-                      <span className="section-kicker">ingestion</span>
-                      <h4>{humanizeIdentifier(card.benchmark)}</h4>
-                    </div>
-                    <span className="score-card__timestamp">
-                      {formatTimestamp(card.latest.timestamp)}
-                    </span>
-                  </div>
-
-                  <div className="score-card__score-row">
-                    <strong>{formatMetricValue(card.latest.primaryScore)}</strong>
-                    <span
-                      className={`delta-pill${
-                        card.delta !== null && card.delta > 0
-                          ? " delta-pill--positive"
-                          : card.delta !== null && card.delta < 0
-                            ? " delta-pill--negative"
-                            : ""
-                      }`}
-                    >
-                      {formatDelta(card.delta)}
-                    </span>
-                  </div>
-
-                  <dl className="score-card__meta">
-                    <div>
-                      <dt>Metric</dt>
-                      <dd>{card.latest.primaryMetric ?? "n/a"}</dd>
-                    </div>
-                    <div>
-                      <dt>System</dt>
-                      <dd>{card.latest.systemProvider}</dd>
-                    </div>
-                  </dl>
-
-                  <p className="score-card__desc">
-                    {INGESTION_DESCRIPTIONS[card.benchmark] ?? ""}
-                  </p>
-                </article>
+                <ScoreCard card={card} />
               </Link>
             ))}
           </div>

--- a/packages/bench-ui/src/pages/Ingestion.tsx
+++ b/packages/bench-ui/src/pages/Ingestion.tsx
@@ -117,7 +117,7 @@ export function Ingestion({ payload }: { payload: BenchResultSummaryPayload }) {
                   </td>
                   <td>{card?.latest.primaryMetric ?? <span className="muted-copy">—</span>}</td>
                   <td>{card ? formatMetricValue(card.latest.primaryScore, card.latest.primaryMetric ?? undefined) : <span className="muted-copy">—</span>}</td>
-                  <td>{card ? formatDelta(card.delta) : <span className="muted-copy">—</span>}</td>
+                  <td>{card ? formatDelta(card.delta, card.latest.primaryMetric ?? undefined) : <span className="muted-copy">—</span>}</td>
                 </tr>
               );
             })}

--- a/packages/bench-ui/src/pages/Ingestion.tsx
+++ b/packages/bench-ui/src/pages/Ingestion.tsx
@@ -116,7 +116,7 @@ export function Ingestion({ payload }: { payload: BenchResultSummaryPayload }) {
                     )}
                   </td>
                   <td>{card?.latest.primaryMetric ?? <span className="muted-copy">—</span>}</td>
-                  <td>{card ? formatMetricValue(card.latest.primaryScore) : <span className="muted-copy">—</span>}</td>
+                  <td>{card ? formatMetricValue(card.latest.primaryScore, card.latest.primaryMetric ?? undefined) : <span className="muted-copy">—</span>}</td>
                   <td>{card ? formatDelta(card.delta) : <span className="muted-copy">—</span>}</td>
                 </tr>
               );

--- a/packages/bench-ui/src/pages/Ingestion.tsx
+++ b/packages/bench-ui/src/pages/Ingestion.tsx
@@ -1,0 +1,169 @@
+import { Link } from "react-router-dom";
+import type { BenchResultSummaryPayload } from "../bench-data";
+import {
+  formatDelta,
+  formatMetricValue,
+  formatTimestamp,
+  getBenchmarkCards,
+  humanizeIdentifier,
+} from "../bench-data";
+
+const INGESTION_BENCHMARKS = [
+  "ingestion-entity-recall",
+  "ingestion-backlink-f1",
+  "ingestion-citation-accuracy",
+  "ingestion-schema-completeness",
+  "ingestion-setup-friction",
+] as const;
+
+const INGESTION_DESCRIPTIONS: Record<string, string> = {
+  "ingestion-entity-recall":
+    "Recall of people, orgs, projects, topics, and events extracted from raw inbox fixtures against a curated gold entity set.",
+  "ingestion-backlink-f1":
+    "Precision and F1 of the extracted bidirectional link graph compared to the gold link set.",
+  "ingestion-citation-accuracy":
+    "Fraction of claims in generated summaries that carry a valid source-chunk citation, verified by the judge.",
+  "ingestion-schema-completeness":
+    "Pass rate across required frontmatter fields (title, type, state, created, see-also), exec-summary, and timeline on generated pages.",
+  "ingestion-setup-friction":
+    "Number of commands and prompts required for a human to make the ingested inbox useful. Lower is better.",
+};
+
+export function Ingestion({ payload }: { payload: BenchResultSummaryPayload }) {
+  const allCards = getBenchmarkCards(payload);
+  const ingestionCards = allCards.filter((card) =>
+    (INGESTION_BENCHMARKS as readonly string[]).includes(card.benchmark),
+  );
+
+  const missingBenchmarks = (INGESTION_BENCHMARKS as readonly string[]).filter(
+    (id) => !ingestionCards.some((card) => card.benchmark === id),
+  );
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Ingestion</span>
+          <h3>Ingestion tier benchmark suite</h3>
+        </div>
+        <p>
+          Five metrics that measure whether Remnic can turn raw input (emails, calendars, project
+          folders, chat transcripts) into a well-structured memory graph. Covers entity recall,
+          backlink fidelity, citation accuracy, frontmatter schema completeness, and setup friction.
+        </p>
+      </header>
+
+      {ingestionCards.length === 0 && missingBenchmarks.length === INGESTION_BENCHMARKS.length ? (
+        <div className="panel panel--empty">
+          <p>
+            No ingestion benchmark results found. Run one or more ingestion benchmarks to populate
+            this view.
+          </p>
+        </div>
+      ) : (
+        <>
+          <div className="score-grid">
+            {ingestionCards.map((card) => (
+              <Link key={card.benchmark} to={`/benchmark/${card.benchmark}`}>
+                <article className="score-card">
+                  <div className="score-card__header">
+                    <div>
+                      <span className="section-kicker">ingestion</span>
+                      <h4>{humanizeIdentifier(card.benchmark)}</h4>
+                    </div>
+                    <span className="score-card__timestamp">
+                      {formatTimestamp(card.latest.timestamp)}
+                    </span>
+                  </div>
+
+                  <div className="score-card__score-row">
+                    <strong>{formatMetricValue(card.latest.primaryScore)}</strong>
+                    <span
+                      className={`delta-pill${
+                        card.delta !== null && card.delta > 0
+                          ? " delta-pill--positive"
+                          : card.delta !== null && card.delta < 0
+                            ? " delta-pill--negative"
+                            : ""
+                      }`}
+                    >
+                      {formatDelta(card.delta)}
+                    </span>
+                  </div>
+
+                  <dl className="score-card__meta">
+                    <div>
+                      <dt>Metric</dt>
+                      <dd>{card.latest.primaryMetric ?? "n/a"}</dd>
+                    </div>
+                    <div>
+                      <dt>System</dt>
+                      <dd>{card.latest.systemProvider}</dd>
+                    </div>
+                  </dl>
+
+                  <p className="score-card__desc">
+                    {INGESTION_DESCRIPTIONS[card.benchmark] ?? ""}
+                  </p>
+                </article>
+              </Link>
+            ))}
+          </div>
+
+          {missingBenchmarks.length > 0 && (
+            <section className="panel">
+              <div className="section-title">
+                <span className="section-kicker">Pending</span>
+                <h4>Benchmarks not yet run</h4>
+              </div>
+              <ul className="failure-list">
+                {missingBenchmarks.map((id) => (
+                  <li key={id}>
+                    <strong>{humanizeIdentifier(id)}</strong>
+                    <p>{INGESTION_DESCRIPTIONS[id] ?? ""}</p>
+                  </li>
+                ))}
+              </ul>
+            </section>
+          )}
+        </>
+      )}
+
+      <section className="panel">
+        <div className="section-title">
+          <span className="section-kicker">Reference</span>
+          <h4>Ingestion benchmark axis</h4>
+        </div>
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Benchmark</th>
+              <th>Primary metric</th>
+              <th>Latest score</th>
+              <th>vs. prior</th>
+            </tr>
+          </thead>
+          <tbody>
+            {(INGESTION_BENCHMARKS as readonly string[]).map((id) => {
+              const card = ingestionCards.find((c) => c.benchmark === id);
+              return (
+                <tr key={id}>
+                  <td>
+                    {card ? (
+                      <Link to={`/benchmark/${id}`}>{humanizeIdentifier(id)}</Link>
+                    ) : (
+                      <span className="muted-copy">{humanizeIdentifier(id)}</span>
+                    )}
+                  </td>
+                  <td>{card?.latest.primaryMetric ?? <span className="muted-copy">—</span>}</td>
+                  <td>{card ? formatMetricValue(card.latest.primaryScore) : <span className="muted-copy">—</span>}</td>
+                  <td>{card ? formatDelta(card.delta) : <span className="muted-copy">—</span>}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </section>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- Adds `/ingestion` route to `packages/bench-ui/` surfacing all five ingestion benchmark metrics (entity-recall, backlink-f1, citation-accuracy, schema-completeness, setup-friction) with score cards, delta pills, a pending-benchmarks panel, and a reference summary table
- Wires the new page into `App.tsx` navigation and router
- Adds `docs/bench-ingestion-schema.md` documenting the canonical YAML frontmatter schema (required fields: title, type, state, created, see-also; conditional fields: exec-summary and timeline) and explaining how `schemaCompleteness` in `ingestion-scorer.ts` scores each field

## Test plan

- [ ] Open bench-ui dev server; confirm "Ingestion" nav item appears and routes to `/ingestion`
- [ ] With no ingestion results loaded, confirm the empty-state panel renders
- [ ] With ingestion benchmark result files present, confirm score cards, delta pills, and the reference table populate correctly
- [ ] Confirm clicking a score card navigates to the matching `/benchmark/:id` detail page
- [ ] Review `docs/bench-ingestion-schema.md` for accuracy against `REQUIRED_FRONTMATTER_FIELDS` in `ingestion-types.ts`

Closes #449

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds a new UI route/page and documentation; small formatting logic tweaks could slightly change how some metric values/deltas display but do not affect underlying benchmark data.
> 
> **Overview**
> Adds a new `bench-ui` **Ingestion** view at `/ingestion` that surfaces the five ingestion-tier benchmarks, including an empty state, a grid of clickable score cards, a “pending benchmarks” panel, and a reference table.
> 
> Updates metric rendering so ingestion setup-friction *raw count* metrics (`setup_friction`, `commands_count`, `prompts_count`, `errors_count`) and their deltas are formatted as counts (not percentages), and wires the metric name through `ScoreCard` formatting.
> 
> Adds `docs/bench-ingestion-schema.md` describing the required/conditional YAML frontmatter fields and how `schemaCompleteness` scores them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b735e9630b0aa79b1d7ba0e72c34c0cdae434667. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->