### PR TITLE
feat(connector-weclone): complete issue #458 (installer, CLI, docs)

### DIFF
--- a/docs/integration/connector-setup.md
+++ b/docs/integration/connector-setup.md
@@ -271,6 +271,60 @@ See the [Hermes plugin reference](../plugins/hermes.md) for the `remnic-hermes` 
 
 ---
 
+## WeClone Avatar
+
+[WeClone](https://github.com/xming521/weclone) fine-tunes a model on your chat
+history, then serves it via an OpenAI-compatible API. Remnic's `weclone`
+connector adds persistent memory on top, so the deployed avatar remembers
+prior conversations instead of being stateless at inference time.
+
+### Install
+
+```bash
+remnic connectors install weclone \
+  --config wecloneApiUrl=http://localhost:8000/v1 \
+  --config proxyPort=8100
+```
+
+This writes two files:
+
+- `~/.config/engram/.engram-connectors/connectors/weclone.json` — registry entry
+  used by `remnic connectors list / remove / doctor`.
+- `~/.remnic/connectors/weclone.json` — proxy config read by
+  `remnic-weclone-proxy` at startup. A Remnic daemon auth token is minted and
+  stored here so the proxy can authenticate without additional setup.
+
+### Run
+
+```bash
+remnic-weclone-proxy
+```
+
+Point your bot/client at `http://localhost:8100/v1` (or whichever `proxyPort`
+you chose). All OpenAI-compatible requests are transparently proxied, with
+memory injection applied only to `POST /v1/chat/completions`.
+
+### Per-caller session isolation
+
+For multi-user avatars, install with `sessionStrategy=caller-id`:
+
+```bash
+remnic connectors install weclone --force \
+  --config sessionStrategy=caller-id
+```
+
+Callers should pass their identity via the `X-Caller-Id` header (or the
+OpenAI-compatible `user` field in the request body). The proxy maps this to
+a Remnic session key so each user's memory is isolated.
+
+**Capabilities:** observe, recall (store/search happen inside Remnic itself,
+not via the WeClone proxy).
+
+See the [connector package README](https://github.com/joshuaswarren/remnic/tree/main/packages/connector-weclone)
+for the full config reference and architecture diagram.
+
+---
+
 ## Generic MCP Client
 
 Any tool that supports the [Model Context Protocol](https://modelcontextprotocol.io/) can connect to Engram. Point your client at:

--- a/packages/connector-weclone/README.md
+++ b/packages/connector-weclone/README.md
@@ -1,0 +1,146 @@
+# @remnic/connector-weclone
+
+Memory-aware OpenAI-compatible proxy that adds Remnic persistent memory to deployed
+[WeClone](https://github.com/xming521/weclone) avatars.
+
+WeClone fine-tunes a model to sound like you. Remnic gives it memory. Together the
+avatar remembers what happened yesterday and sounds like you while doing it.
+
+## What it does
+
+- Runs as a local OpenAI-compatible HTTP proxy in front of a WeClone API server.
+- On every `POST /v1/chat/completions`, calls Remnic `/engram/v1/recall` and injects
+  retrieved memory into the system prompt before forwarding to WeClone.
+- After WeClone responds, calls `/engram/v1/observe` fire-and-forget so the turn is
+  buffered for extraction.
+- Forwards all other OpenAI-compatible endpoints (`/v1/models`, uploads, etc.)
+  transparently.
+- Supports single-session and per-caller (`X-Caller-Id` header or `user` field)
+  isolation modes.
+- Degrades gracefully: if Remnic is unreachable, the request is still forwarded to
+  WeClone without memory injection.
+
+## Install
+
+The proxy ships as part of the Remnic monorepo and is wired into the `remnic`
+CLI. The recommended install path is:
+
+```bash
+remnic connectors install weclone \
+  --config wecloneApiUrl=http://localhost:8000/v1 \
+  --config proxyPort=8100
+```
+
+This writes two files:
+
+- `~/.config/engram/.engram-connectors/connectors/weclone.json` — connector
+  registry entry (tracked by `remnic connectors list / remove / doctor`).
+- `~/.remnic/connectors/weclone.json` — proxy config read by
+  `remnic-weclone-proxy` at startup.
+
+An auth token for the Remnic daemon is also minted automatically and stored in
+the proxy config so the proxy can authenticate with the daemon.
+
+## Run
+
+Once installed, start the proxy:
+
+```bash
+remnic-weclone-proxy
+```
+
+Or point it at a custom config path:
+
+```bash
+remnic-weclone-proxy --config /path/to/weclone.json
+```
+
+The `REMNIC_HOME` environment variable overrides the default config location
+(`~/.remnic`) — useful for tests and sandboxed deployments.
+
+## Configure
+
+The proxy config file accepts the following fields:
+
+| Field | Default | Description |
+| --- | --- | --- |
+| `wecloneApiUrl` | `http://localhost:8000/v1` | Base URL of the WeClone API. Both path-prefixed (`/v1`, `/weclone/v1`) and bare origins are supported. |
+| `wecloneModelName` | `weclone-avatar` | Optional fine-tuned model name passed through to WeClone. |
+| `proxyPort` | `8100` | Local port the proxy listens on. |
+| `remnicDaemonUrl` | `http://localhost:4318` | URL of the Remnic daemon exposing `/engram/v1/recall` and `/engram/v1/observe`. |
+| `remnicAuthToken` | — | Bearer token for the Remnic daemon. Populated by `remnic connectors install weclone`. |
+| `sessionStrategy` | `single` | `single` uses one shared memory session; `caller-id` maps each caller (via `X-Caller-Id` header or `user` field) to its own namespace. |
+| `memoryInjection.maxTokens` | `1500` | Approximate token budget for injected memory. |
+| `memoryInjection.position` | `system-append` | `system-append` appends memory to an existing system message; `system-prepend` prepends. |
+| `memoryInjection.template` | `[Memory Context]\n{memories}\n[End Memory Context]` | Template used to wrap recalled memories. `{memories}` is the sole placeholder. |
+
+### Example config
+
+```json
+{
+  "wecloneApiUrl": "http://localhost:8000/v1",
+  "proxyPort": 8100,
+  "remnicDaemonUrl": "http://localhost:4318",
+  "remnicAuthToken": "${REMNIC_TOKEN}",
+  "sessionStrategy": "caller-id",
+  "memoryInjection": {
+    "maxTokens": 1500,
+    "position": "system-append",
+    "template": "[Memory Context]\n{memories}\n[End Memory Context]"
+  }
+}
+```
+
+> Config examples use placeholder token strings. Never commit real bearer
+> tokens to version control.
+
+## Architecture
+
+```
+Caller (Discord bot, Telegram bot, AstrBot, LangBot, ...)
+  │
+  ▼
+┌──────────────────────────────┐
+│  remnic-weclone-proxy        │
+│                              │
+│  1. Intercept chat completion│
+│  2. POST /engram/v1/recall   │  ──► Remnic daemon (:4318)
+│  3. Inject memory into       │
+│     system prompt            │
+│  4. Forward to WeClone API   │  ──► WeClone model server (:8000)
+│  5. Capture response         │
+│  6. POST /engram/v1/observe  │  ──► Remnic daemon (:4318)
+│     (fire-and-forget)        │
+│  7. Return response to caller│
+└──────────────────────────────┘
+```
+
+### Session identity
+
+| `sessionStrategy` | Behavior |
+| --- | --- |
+| `single` | All callers share a single `weclone-default` session key. Good for a one-user avatar. |
+| `caller-id` | The proxy extracts the session key from `X-Caller-Id` header, then `body.user`, then falls back to `default`. |
+
+Callers wiring up a Discord bot should pass the Discord user ID as
+`X-Caller-Id` so memory stays partitioned per user.
+
+## Verification
+
+- `GET /health` — returns `{ "status": "ok", "wecloneApi": "..." }` if the proxy
+  is running.
+- `remnic connectors doctor weclone` — verifies both config files exist.
+
+## Security notes
+
+- The proxy config file is written with owner-only permissions (`0o600`) because
+  it embeds a Remnic bearer token.
+- Hop-by-hop headers (`connection`, `keep-alive`, `proxy-authorization`, etc.)
+  are stripped on forward and response paths so proxy credentials never leak
+  upstream or downstream.
+- Multimodal content (image parts, etc.) is preserved verbatim; only the text
+  parts of the last user message are used for recall.
+
+## License
+
+MIT

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -3,7 +3,9 @@
  * CLI entrypoint for @remnic/connector-weclone.
  *
  * Reads config from ~/.remnic/connectors/weclone.json (or --config path)
- * and starts the OpenAI-compatible memory proxy.
+ * and starts the OpenAI-compatible memory proxy. `REMNIC_HOME` (or legacy
+ * `ENGRAM_HOME`) can override the default home directory — this matches the
+ * override honoured by `remnic connectors install weclone` in @remnic/core.
  */
 
 import { createWeCloneProxy } from "./proxy.js";
@@ -12,8 +14,21 @@ import { readFileSync, existsSync } from "node:fs";
 import { resolve } from "node:path";
 import { homedir } from "node:os";
 
+/**
+ * Resolve the default proxy config path. Kept in lockstep with
+ * @remnic/core's resolveWeCloneProxyConfigPath() so install/run pair up
+ * without additional wiring from the caller.
+ */
+function defaultConfigPath(): string {
+  const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
+  if (override && override.length > 0) {
+    return resolve(override, "connectors", "weclone.json");
+  }
+  return resolve(homedir(), ".remnic", "connectors", "weclone.json");
+}
+
 const args = process.argv.slice(2);
-let configPath = resolve(homedir(), ".remnic/connectors/weclone.json");
+let configPath = defaultConfigPath();
 
 for (let i = 0; i < args.length; i++) {
   if (args[i] === "--config") {

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -25,13 +25,21 @@ import { homedir } from "node:os";
  * override could write the config in one location and read it from another,
  * producing spurious "Config not found" errors right after a successful
  * install.
+ *
+ * `HOME=""` edge case: treat an empty-string HOME as absent and fall back
+ * to `os.homedir()`. The core helper does the same; if they diverged here,
+ * install and run would target different directories when `HOME` is
+ * cleared (empty string is not nullish, so `?? os.homedir()` does NOT
+ * substitute it).
  */
 function defaultConfigPath(): string {
   const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
   if (override && override.length > 0) {
     return resolve(override, "connectors", "weclone.json");
   }
-  return resolve(homedir(), ".remnic", "connectors", "weclone.json");
+  const envHome = process.env.HOME;
+  const home = envHome && envHome.length > 0 ? envHome : homedir();
+  return resolve(home, ".remnic", "connectors", "weclone.json");
 }
 
 const args = process.argv.slice(2);

--- a/packages/connector-weclone/src/cli.ts
+++ b/packages/connector-weclone/src/cli.ts
@@ -16,8 +16,15 @@ import { homedir } from "node:os";
 
 /**
  * Resolve the default proxy config path. Kept in lockstep with
- * @remnic/core's resolveWeCloneProxyConfigPath() so install/run pair up
+ * @remnic/core's `resolveWeCloneProxyConfigPath()` so install/run pair up
  * without additional wiring from the caller.
+ *
+ * Both sides use `path.resolve()` (absolute) — NOT `path.join()` — so a
+ * relative override like `REMNIC_HOME=tmp/remnic` is normalized against the
+ * current working directory. If core and CLI disagreed on this, a relative
+ * override could write the config in one location and read it from another,
+ * producing spurious "Config not found" errors right after a successful
+ * install.
  */
 function defaultConfigPath(): string {
   const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -439,6 +439,39 @@ const BUILTIN_CONNECTORS: ConnectorManifest[] = [
     requiresToken: true,
   },
   {
+    id: "weclone",
+    name: "WeClone Avatar",
+    version: "1.0.0",
+    description:
+      "Memory-aware OpenAI-compatible proxy for deployed WeClone avatars — " +
+      "injects Remnic recall into chat completions and buffers turns via observe",
+    capabilities: {
+      observe: true,
+      recall: true,
+      store: false,
+      search: false,
+      entities: false,
+      realtimeSync: false,
+      batch: false,
+      maxBudgetChars: 32000,
+      connectionType: "http",
+    },
+    configSchema: {
+      wecloneApiUrl:
+        "Base URL of the WeClone OpenAI-compatible API (e.g. http://localhost:8000/v1)",
+      proxyPort: "Local port where the memory proxy will listen (default 8100)",
+      remnicDaemonUrl:
+        "URL of the Remnic daemon exposing /engram/v1/recall and /engram/v1/observe",
+      sessionStrategy:
+        "Per-caller session mapping strategy: 'caller-id' | 'single'",
+      wecloneModelName: "Optional fine-tuned model name passed through to WeClone",
+    },
+    homepage: "https://github.com/xming521/weclone",
+    author: "Remnic",
+    tags: ["official", "ai", "weclone", "proxy"],
+    requiresToken: true,
+  },
+  {
     id: "hermes",
     name: "Hermes Agent",
     version: "1.0.0",
@@ -1212,6 +1245,77 @@ export function installConnector(options: InstallOptions): InstallResult {
     }
   }
 
+  // ── WeClone: write proxy config to ~/.remnic/connectors/weclone.json ─────
+  //
+  // The standalone `remnic-weclone-proxy` CLI (see packages/connector-weclone)
+  // reads its config from ~/.remnic/connectors/weclone.json by default so the
+  // proxy can start without depending on Remnic's XDG-scoped registry layout.
+  // Compose and write that file here, BEFORE the registry connector.json is
+  // written, so that a failure in either file's write path rolls back cleanly.
+  //
+  // Precedence for each field: user-supplied via --config → saved prior proxy
+  // config (on --force) → manifest defaults. The generated bearer token (if
+  // any) is persisted into remnicAuthToken so the proxy can authenticate with
+  // the daemon without a second token lookup at runtime.
+  let weCloneProxyHandleRollback: (() => void) | null = null;
+  if (options.connectorId === "weclone") {
+    try {
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const prior = readWeCloneProxyConfigIfExists(proxyConfigPath);
+      const proxyConfig = buildWeCloneProxyConfig({
+        userConfig: safeUserConfig,
+        priorConfig: prior ? safeParseJson(prior) : null,
+        authToken: tokenEntry?.token,
+      });
+      fs.mkdirSync(path.dirname(proxyConfigPath), { recursive: true });
+      writeSecretFileSync(
+        proxyConfigPath,
+        JSON.stringify(proxyConfig, null, 2),
+      );
+      // Prepare rollback: restore prior content on failure, or delete if new.
+      weCloneProxyHandleRollback = () => {
+        try {
+          if (prior === null) {
+            // File was created by this install — delete it.
+            if (fs.existsSync(proxyConfigPath)) {
+              fs.unlinkSync(proxyConfigPath);
+            }
+          } else {
+            writeSecretFileSync(proxyConfigPath, prior);
+          }
+        } catch {
+          // Best-effort rollback.
+        }
+      };
+      // Record the proxy-side config path on the registry JSON so operators
+      // and `remnic connectors doctor weclone` can locate it later. Persist the
+      // effective proxy port so `remnic connectors list` reflects the resolved
+      // value rather than whatever (possibly missing) the user supplied.
+      resolvedConfig.proxyConfigPath = proxyConfigPath;
+      resolvedConfig.proxyPort = proxyConfig.proxyPort;
+      resolvedConfig.wecloneApiUrl = proxyConfig.wecloneApiUrl;
+      resolvedConfig.remnicDaemonUrl = proxyConfig.remnicDaemonUrl;
+      resolvedConfig.sessionStrategy = proxyConfig.sessionStrategy;
+    } catch (weCloneErr) {
+      // Roll back the token store if we wrote one.
+      if (tokenEntry !== null && nonHermesPriorTokenStore !== null) {
+        try {
+          saveTokenStore(nonHermesPriorTokenStore);
+        } catch {
+          // Best-effort rollback.
+        }
+      }
+      return {
+        connectorId: options.connectorId,
+        status: "error",
+        message:
+          `WeClone install aborted: proxy config write failed — ` +
+          `${weCloneErr instanceof Error ? weCloneErr.message : String(weCloneErr)}. ` +
+          `Resolve the write permission issue on ~/.remnic/connectors/, then reinstall.`,
+      };
+    }
+  }
+
   // Finding 5: strip internal/test-only keys that must never be persisted to
   // the config file. These keys are used at install time only (e.g. to inject
   // a synthetic extension source dir in tests) and have no meaning on disk.
@@ -1269,6 +1373,14 @@ export function installConnector(options: InstallOptions): InstallResult {
           "[remnic/connectors] installConnector: config write failed and extension rollback also failed — " +
             "manual cleanup of memories_extensions/remnic may be required.",
         );
+      }
+    }
+    // Roll back the WeClone proxy config if it was written.
+    if (weCloneProxyHandleRollback !== null) {
+      try {
+        weCloneProxyHandleRollback();
+      } catch {
+        // Best-effort rollback.
       }
     }
     // Only include a token-rollback suffix for connectors that actually had a
@@ -1455,6 +1567,23 @@ export function removeConnector(connectorId: string): RemoveResult {
     // The connector config has already been removed at this point.
     const revokeMsg = revokeErr instanceof Error ? revokeErr.message : String(revokeErr);
     notes.push(`Warning: token revocation failed — ${revokeMsg}. The token for ${connectorId} may still be present in tokens.json.`);
+  }
+
+  // WeClone-specific: remove the proxy config file at ~/.remnic/connectors/weclone.json.
+  // Only attempted after successful connector-registry file removal so the two
+  // locations stay consistent. Non-fatal — absence is treated as success.
+  if (connectorId === "weclone") {
+    try {
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      if (fs.existsSync(proxyConfigPath)) {
+        fs.unlinkSync(proxyConfigPath);
+        notes.push(`Removed WeClone proxy config: ${proxyConfigPath}`);
+      }
+    } catch (err) {
+      notes.push(
+        `WeClone proxy config cleanup skipped: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
   }
 
   // Hermes-specific: strip the remnic: block from config.yaml.
@@ -2469,4 +2598,233 @@ function getConnectorsDir(): string {
     ? path.join(process.env.XDG_CONFIG_HOME, "engram")
     : path.join(process.env.HOME ?? "~", ".config", "engram");
   return path.join(configDir, REGISTRY_DIR_NAME, "connectors");
+}
+
+// ── WeClone proxy config helpers ───────────────────────────────────────────
+//
+// The standalone `remnic-weclone-proxy` CLI reads its config from
+// ~/.remnic/connectors/weclone.json by default. `remnic connectors install
+// weclone` composes and persists that file so the proxy can start without
+// additional setup. The file is also tracked by the connector registry (at
+// getConnectorsDir()/weclone.json) so `remnic connectors list/remove/doctor`
+// work uniformly across all connectors.
+
+const WECLONE_PROXY_CONFIG_DIRNAME = ".remnic";
+const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
+
+/**
+ * Resolve the path to ~/.remnic/connectors/weclone.json for the current user.
+ * Honours REMNIC_HOME / ENGRAM_HOME env overrides so tests can point the
+ * install at a temp dir without leaking into the real home directory.
+ */
+export function resolveWeCloneProxyConfigPath(): string {
+  const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
+  if (override && override.length > 0) {
+    return path.join(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
+  }
+  const home = process.env.HOME ?? os.homedir();
+  return path.join(
+    home,
+    WECLONE_PROXY_CONFIG_DIRNAME,
+    "connectors",
+    WECLONE_PROXY_CONFIG_FILENAME,
+  );
+}
+
+/**
+ * Read the existing proxy config file, if any. Returns raw contents so the
+ * caller can both parse it (for value precedence) and restore it verbatim on
+ * rollback without touching byte-level formatting.
+ */
+function readWeCloneProxyConfigIfExists(configPath: string): string | null {
+  try {
+    if (!fs.existsSync(configPath)) return null;
+    return fs.readFileSync(configPath, "utf8");
+  } catch {
+    return null;
+  }
+}
+
+/** Safely parse a JSON string into a record; returns null on error. */
+function safeParseJson(raw: string): Record<string, unknown> | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (typeof parsed === "object" && parsed !== null && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+interface WeCloneProxyConfig {
+  wecloneApiUrl: string;
+  wecloneModelName: string;
+  proxyPort: number;
+  remnicDaemonUrl: string;
+  remnicAuthToken?: string;
+  sessionStrategy: "caller-id" | "single";
+  memoryInjection: {
+    maxTokens: number;
+    position: "system-append" | "system-prepend";
+    template: string;
+  };
+}
+
+const WECLONE_DEFAULTS = {
+  wecloneApiUrl: "http://localhost:8000/v1",
+  wecloneModelName: "weclone-avatar",
+  proxyPort: 8100,
+  remnicDaemonUrl: "http://localhost:4318",
+  sessionStrategy: "single" as const,
+  memoryInjection: {
+    maxTokens: 1500,
+    position: "system-append" as const,
+    template: "[Memory Context]\n{memories}\n[End Memory Context]",
+  },
+};
+
+/**
+ * Resolve a string field with precedence: userConfig → priorConfig → default.
+ * Only non-empty strings are accepted from either source; invalid values fall
+ * through so the user gets a working default rather than a broken install.
+ */
+function resolveStringField(
+  userConfig: Record<string, unknown>,
+  priorConfig: Record<string, unknown> | null,
+  key: string,
+  fallback: string,
+): string {
+  const fromUser = userConfig[key];
+  if (typeof fromUser === "string" && fromUser.length > 0) return fromUser;
+  if (priorConfig) {
+    const fromPrior = priorConfig[key];
+    if (typeof fromPrior === "string" && fromPrior.length > 0) return fromPrior;
+  }
+  return fallback;
+}
+
+/**
+ * Coerce a config value to an integer port in [1, 65535]. Accepts number or
+ * numeric string (parseConnectorConfig produces strings from `--config
+ * proxyPort=8100`). Returns null if the value is missing or invalid so the
+ * caller can fall through to the next precedence level.
+ */
+function coercePort(value: unknown): number | null {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 1 && value <= 65535) {
+    return value;
+  }
+  if (typeof value === "string" && value.length > 0) {
+    const n = Number(value);
+    if (Number.isInteger(n) && n >= 1 && n <= 65535) return n;
+  }
+  return null;
+}
+
+function resolvePort(
+  userConfig: Record<string, unknown>,
+  priorConfig: Record<string, unknown> | null,
+  fallback: number,
+): number {
+  const fromUser = coercePort(userConfig.proxyPort);
+  if (fromUser !== null) return fromUser;
+  if (priorConfig) {
+    const fromPrior = coercePort(priorConfig.proxyPort);
+    if (fromPrior !== null) return fromPrior;
+  }
+  return fallback;
+}
+
+function resolveSessionStrategy(
+  userConfig: Record<string, unknown>,
+  priorConfig: Record<string, unknown> | null,
+): "caller-id" | "single" {
+  const valid = new Set(["caller-id", "single"]);
+  const fromUser = userConfig.sessionStrategy;
+  if (typeof fromUser === "string" && valid.has(fromUser)) {
+    return fromUser as "caller-id" | "single";
+  }
+  if (priorConfig) {
+    const fromPrior = priorConfig.sessionStrategy;
+    if (typeof fromPrior === "string" && valid.has(fromPrior)) {
+      return fromPrior as "caller-id" | "single";
+    }
+  }
+  return WECLONE_DEFAULTS.sessionStrategy;
+}
+
+/**
+ * Compose a WeCloneProxyConfig from user-supplied overrides and any prior
+ * saved config, filling in defaults for every required field. The returned
+ * shape is exactly what the proxy's parseConfig() expects.
+ */
+export function buildWeCloneProxyConfig(args: {
+  userConfig: Record<string, unknown>;
+  priorConfig: Record<string, unknown> | null;
+  authToken?: string;
+}): WeCloneProxyConfig {
+  const { userConfig, priorConfig, authToken } = args;
+
+  const wecloneApiUrl = resolveStringField(
+    userConfig,
+    priorConfig,
+    "wecloneApiUrl",
+    WECLONE_DEFAULTS.wecloneApiUrl,
+  );
+  const wecloneModelName = resolveStringField(
+    userConfig,
+    priorConfig,
+    "wecloneModelName",
+    WECLONE_DEFAULTS.wecloneModelName,
+  );
+  const remnicDaemonUrl = resolveStringField(
+    userConfig,
+    priorConfig,
+    "remnicDaemonUrl",
+    WECLONE_DEFAULTS.remnicDaemonUrl,
+  );
+  const proxyPort = resolvePort(
+    userConfig,
+    priorConfig,
+    WECLONE_DEFAULTS.proxyPort,
+  );
+  const sessionStrategy = resolveSessionStrategy(userConfig, priorConfig);
+
+  // Memory injection: always start from defaults, then shallow-merge any
+  // prior values, then user overrides. Individual field validation happens in
+  // the proxy's parseConfig() at proxy startup — here we only assemble a
+  // best-effort shape. A malformed user override would be rejected later with
+  // a clean error message.
+  const memoryInjection = {
+    ...WECLONE_DEFAULTS.memoryInjection,
+    ...(priorConfig && typeof priorConfig.memoryInjection === "object" && priorConfig.memoryInjection !== null
+      ? (priorConfig.memoryInjection as Record<string, unknown>)
+      : {}),
+    ...(typeof userConfig.memoryInjection === "object" && userConfig.memoryInjection !== null
+      ? (userConfig.memoryInjection as Record<string, unknown>)
+      : {}),
+  } as WeCloneProxyConfig["memoryInjection"];
+
+  const config: WeCloneProxyConfig = {
+    wecloneApiUrl,
+    wecloneModelName,
+    proxyPort,
+    remnicDaemonUrl,
+    sessionStrategy,
+    memoryInjection,
+  };
+
+  // Token precedence: freshly minted token → user-supplied → prior saved.
+  // Never write a token if none is available — the proxy tolerates missing
+  // tokens (it just won't send Authorization headers to the daemon).
+  if (authToken && authToken.length > 0) {
+    config.remnicAuthToken = authToken;
+  } else if (typeof userConfig.remnicAuthToken === "string" && userConfig.remnicAuthToken.length > 0) {
+    config.remnicAuthToken = userConfig.remnicAuthToken;
+  } else if (priorConfig && typeof priorConfig.remnicAuthToken === "string" && priorConfig.remnicAuthToken.length > 0) {
+    config.remnicAuthToken = priorConfig.remnicAuthToken;
+  }
+
+  return config;
 }

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -1260,7 +1260,32 @@ export function installConnector(options: InstallOptions): InstallResult {
   let weCloneProxyHandleRollback: (() => void) | null = null;
   if (options.connectorId === "weclone") {
     try {
-      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      // Force-reinstall (and any reinstall path) must keep using the exact
+      // proxy config path that was persisted on the previous install. If we
+      // re-derive from the current env each time, a user whose REMNIC_HOME /
+      // ENGRAM_HOME changed between installs would end up with two proxy
+      // config files — the old one stays with stale settings + a revoked
+      // token, the new one gets the live token, and any running proxy still
+      // reading the old file starts failing auth. Read the saved
+      // `proxyConfigPath` from the existing registry config first, and only
+      // fall back to env-derivation for genuine first-time installs.
+      let proxyConfigPath: string | null = null;
+      if (existing && fs.existsSync(configPath)) {
+        try {
+          const savedRegistryConfig = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+          if (
+            typeof savedRegistryConfig.proxyConfigPath === "string" &&
+            savedRegistryConfig.proxyConfigPath.length > 0
+          ) {
+            proxyConfigPath = savedRegistryConfig.proxyConfigPath;
+          }
+        } catch {
+          // Saved registry config unreadable — fall through to env resolution.
+        }
+      }
+      if (proxyConfigPath === null) {
+        proxyConfigPath = resolveWeCloneProxyConfigPath();
+      }
       const prior = readWeCloneProxyConfigIfExists(proxyConfigPath);
       const proxyConfig = buildWeCloneProxyConfig({
         userConfig: safeUserConfig,
@@ -2653,14 +2678,20 @@ const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
  * Resolve the path to ~/.remnic/connectors/weclone.json for the current user.
  * Honours REMNIC_HOME / ENGRAM_HOME env overrides so tests can point the
  * install at a temp dir without leaking into the real home directory.
+ *
+ * Always returns an absolute path via `path.resolve` so install-time and
+ * run-time resolution agree even when the override is a relative path like
+ * `tmp/remnic` (which would otherwise be interpreted against the caller's
+ * current working directory). Must stay in lockstep with the proxy CLI's
+ * `defaultConfigPath()` in @remnic/connector-weclone/src/cli.ts.
  */
 export function resolveWeCloneProxyConfigPath(): string {
   const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
   if (override && override.length > 0) {
-    return path.join(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
+    return path.resolve(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
   }
   const home = process.env.HOME ?? os.homedir();
-  return path.join(
+  return path.resolve(
     home,
     WECLONE_PROXY_CONFIG_DIRNAME,
     "connectors",

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -1340,21 +1340,35 @@ export function installConnector(options: InstallOptions): InstallResult {
       resolvedConfig.remnicDaemonUrl = proxyConfig.remnicDaemonUrl;
       resolvedConfig.sessionStrategy = proxyConfig.sessionStrategy;
     } catch (weCloneErr) {
-      // Roll back the token store if we wrote one.
+      // Track token rollback success/failure explicitly so the error message
+      // can truthfully report whether tokens.json was restored or is in a
+      // potentially-inconsistent state. Mirrors the care taken in the
+      // registry-config-write failure handler below.
+      let tokenRolledBack = false;
+      let tokenRollbackMsg = "";
       if (tokenEntry !== null && nonHermesPriorTokenStore !== null) {
         try {
           saveTokenStore(nonHermesPriorTokenStore);
-        } catch {
-          // Best-effort rollback.
+          tokenRolledBack = true;
+        } catch (tokenRestoreErr) {
+          tokenRolledBack = false;
+          tokenRollbackMsg =
+            tokenRestoreErr instanceof Error ? tokenRestoreErr.message : String(tokenRestoreErr);
         }
       }
+      const tokenSuffix = manifest.requiresToken && tokenEntry !== null
+        ? tokenRolledBack
+          ? " Token has been rolled back."
+          : ` Token rollback FAILED (${tokenRollbackMsg}) — tokens.json may contain an orphaned entry. ` +
+            `Manually inspect ~/.remnic/tokens.json and reinstall.`
+        : "";
       return {
         connectorId: options.connectorId,
         status: "error",
         message:
           `WeClone install aborted: proxy config write failed — ` +
-          `${weCloneErr instanceof Error ? weCloneErr.message : String(weCloneErr)}. ` +
-          `Resolve the write permission issue on ~/.remnic/connectors/, then reinstall.`,
+          `${weCloneErr instanceof Error ? weCloneErr.message : String(weCloneErr)}.` +
+          `${tokenSuffix} Resolve the write permission issue on ~/.remnic/connectors/, then reinstall.`,
       };
     }
   }
@@ -1539,9 +1553,18 @@ export function removeConnector(connectorId: string): RemoveResult {
   // config BEFORE deleting it. Using the persisted absolute path (rather than
   // recomputing from current REMNIC_HOME / ENGRAM_HOME / $HOME) guarantees
   // that a remove still targets the original file even if the environment
-  // has changed between install and remove. Falls back to the env-derived
-  // path only if the saved config is missing or malformed.
+  // has changed between install and remove.
+  //
+  // Parse failure handling: if the registry config exists but is malformed,
+  // we MUST abort the whole removal (mirror of the codex-cli provenance
+  // gate). Silently falling back to an env-derived path would delete the
+  // registry entry first and then miss the real proxy config if the
+  // environment had since changed, orphaning the file (which may still hold
+  // a live bearer token). Only install-time WRITES persist the path; if we
+  // lost it on read, the only safe action is to stop and let the operator
+  // fix the config or clean up manually.
   let weCloneProxyConfigPath: string | null = null;
+  let weCloneRegistryParseFailed = false;
   if (connectorId === "weclone") {
     try {
       const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
@@ -1549,16 +1572,35 @@ export function removeConnector(connectorId: string): RemoveResult {
         weCloneProxyConfigPath = stored.proxyConfigPath;
       }
     } catch {
-      // Registry config unreadable — fall back to env-derived path below.
+      weCloneRegistryParseFailed = true;
     }
-    if (weCloneProxyConfigPath === null) {
+    // No persisted path AND parse succeeded means this is a legacy install
+    // pre-dating proxyConfigPath provenance. Fall back to env resolution
+    // only in that specific case so we still make a best-effort cleanup.
+    if (weCloneProxyConfigPath === null && !weCloneRegistryParseFailed) {
       try {
         weCloneProxyConfigPath = resolveWeCloneProxyConfigPath();
       } catch {
-        // Resolution failed (e.g. no HOME) — leave null so the cleanup block
-        // skips gracefully rather than crashing the whole remove.
+        // Resolution failed (e.g. no HOME) — leave null; cleanup block skips.
       }
     }
+  }
+  if (connectorId === "weclone" && weCloneRegistryParseFailed) {
+    console.warn(
+      "[remnic/connectors] removeConnector: weclone.json is malformed — " +
+        "aborting removal to preserve provenance. Fix or delete " +
+        configPath +
+        " manually and retry.",
+    );
+    return {
+      connectorId,
+      configPath,
+      message:
+        "Removal aborted: weclone.json is malformed. Registry config left in place for inspection; " +
+        "proxy config NOT removed.",
+      status: "skipped",
+      reason: "config-parse-failed",
+    };
   }
 
   // Finding 4: if the codex-cli config exists but failed to parse, abort the
@@ -1629,11 +1671,16 @@ export function removeConnector(connectorId: string): RemoveResult {
   // should still succeed. Stale tokens will be rejected by the daemon when the
   // token file is later accessible.
   const notes: string[] = [];
+  // Track revocation success so downstream error branches (e.g. weclone
+  // proxy-delete failure) can accurately report whether the token was
+  // cleaned up rather than hardcoding "Token has been rolled back".
+  let tokenRevoked = true;
   try {
     revokeToken(connectorId);
   } catch (revokeErr) {
     // Surface the failure so callers know the token was not cleaned up.
     // The connector config has already been removed at this point.
+    tokenRevoked = false;
     const revokeMsg = revokeErr instanceof Error ? revokeErr.message : String(revokeErr);
     notes.push(`Warning: token revocation failed — ${revokeMsg}. The token for ${connectorId} may still be present in tokens.json.`);
   }
@@ -1670,12 +1717,20 @@ export function removeConnector(connectorId: string): RemoveResult {
     }
   }
   if (weCloneProxyDeleteFailed !== null && weCloneProxyConfigPath !== null) {
+    // Report the token-revocation status truthfully. If revocation already
+    // failed above, claiming the token was "cleaned up" here would mislead
+    // the operator into thinking the only action left is deleting the
+    // orphan file — when in reality the bearer token is also still live.
+    const tokenStatus = tokenRevoked
+      ? "the registry config was deleted and the token was revoked"
+      : "the registry config was deleted but TOKEN REVOCATION ALSO FAILED — " +
+        "inspect ~/.remnic/tokens.json and revoke manually";
     return {
       connectorId,
       configPath,
       status: "error",
       message:
-        `WeClone remove partially succeeded: registry config and token were cleaned up, ` +
+        `WeClone remove partially succeeded: ${tokenStatus}, ` +
         `but the proxy config at ${weCloneProxyConfigPath} could not be deleted ` +
         `(${weCloneProxyDeleteFailed}). Manually remove that file — it may still contain ` +
         `a Remnic daemon bearer token.`,

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -1492,6 +1492,32 @@ export function removeConnector(connectorId: string): RemoveResult {
     }
   }
 
+  // For weclone, read the persisted proxy config path from the saved registry
+  // config BEFORE deleting it. Using the persisted absolute path (rather than
+  // recomputing from current REMNIC_HOME / ENGRAM_HOME / $HOME) guarantees
+  // that a remove still targets the original file even if the environment
+  // has changed between install and remove. Falls back to the env-derived
+  // path only if the saved config is missing or malformed.
+  let weCloneProxyConfigPath: string | null = null;
+  if (connectorId === "weclone") {
+    try {
+      const stored = JSON.parse(fs.readFileSync(configPath, "utf8")) as Record<string, unknown>;
+      if (typeof stored.proxyConfigPath === "string" && stored.proxyConfigPath.length > 0) {
+        weCloneProxyConfigPath = stored.proxyConfigPath;
+      }
+    } catch {
+      // Registry config unreadable — fall back to env-derived path below.
+    }
+    if (weCloneProxyConfigPath === null) {
+      try {
+        weCloneProxyConfigPath = resolveWeCloneProxyConfigPath();
+      } catch {
+        // Resolution failed (e.g. no HOME) — leave null so the cleanup block
+        // skips gracefully rather than crashing the whole remove.
+      }
+    }
+  }
+
   // Finding 4: if the codex-cli config exists but failed to parse, abort the
   // entire removal. Leave both the config file AND the extension directory
   // untouched so the operator can inspect/fix the config file and retry.
@@ -1569,20 +1595,31 @@ export function removeConnector(connectorId: string): RemoveResult {
     notes.push(`Warning: token revocation failed — ${revokeMsg}. The token for ${connectorId} may still be present in tokens.json.`);
   }
 
-  // WeClone-specific: remove the proxy config file at ~/.remnic/connectors/weclone.json.
-  // Only attempted after successful connector-registry file removal so the two
-  // locations stay consistent. Non-fatal — absence is treated as success.
+  // WeClone-specific: remove the proxy config file at the path persisted in
+  // the registry config (read above before the registry file was deleted).
+  // Using the persisted absolute path — not a re-derivation from the current
+  // environment — is load-bearing: if REMNIC_HOME / ENGRAM_HOME changes (or
+  // is unset) between install and remove, recomputing here would leave the
+  // original proxy config (with a live bearer token) on disk while reporting
+  // success. Non-fatal: if the file is already absent or the path could not
+  // be determined, skip with a note.
   if (connectorId === "weclone") {
-    try {
-      const proxyConfigPath = resolveWeCloneProxyConfigPath();
-      if (fs.existsSync(proxyConfigPath)) {
-        fs.unlinkSync(proxyConfigPath);
-        notes.push(`Removed WeClone proxy config: ${proxyConfigPath}`);
-      }
-    } catch (err) {
+    if (weCloneProxyConfigPath === null) {
       notes.push(
-        `WeClone proxy config cleanup skipped: ${err instanceof Error ? err.message : String(err)}`,
+        "WeClone proxy config cleanup skipped: no persisted path found in saved config " +
+          "(likely a legacy install predating proxyConfigPath provenance).",
       );
+    } else {
+      try {
+        if (fs.existsSync(weCloneProxyConfigPath)) {
+          fs.unlinkSync(weCloneProxyConfigPath);
+          notes.push(`Removed WeClone proxy config: ${weCloneProxyConfigPath}`);
+        }
+      } catch (err) {
+        notes.push(
+          `WeClone proxy config cleanup skipped: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
   }
 

--- a/packages/remnic-core/src/connectors/index.ts
+++ b/packages/remnic-core/src/connectors/index.ts
@@ -1293,15 +1293,16 @@ export function installConnector(options: InstallOptions): InstallResult {
         authToken: tokenEntry?.token,
       });
       fs.mkdirSync(path.dirname(proxyConfigPath), { recursive: true });
-      writeSecretFileSync(
-        proxyConfigPath,
-        JSON.stringify(proxyConfig, null, 2),
-      );
-      // Prepare rollback: restore prior content on failure, or delete if new.
+      // Install the rollback closure BEFORE the write starts. `writeSecretFileSync`
+      // opens the file in truncate mode, so a mid-write failure (ENOSPC, EPERM)
+      // could leave `weclone.json` empty. Creating the rollback now guarantees
+      // we can always restore prior content (or delete a newly-created file)
+      // even if the write itself throws.
       weCloneProxyHandleRollback = () => {
         try {
           if (prior === null) {
-            // File was created by this install — delete it.
+            // File was created (or would have been created) by this install —
+            // delete whatever is left behind, if anything.
             if (fs.existsSync(proxyConfigPath)) {
               fs.unlinkSync(proxyConfigPath);
             }
@@ -1312,6 +1313,23 @@ export function installConnector(options: InstallOptions): InstallResult {
           // Best-effort rollback.
         }
       };
+      try {
+        writeSecretFileSync(
+          proxyConfigPath,
+          JSON.stringify(proxyConfig, null, 2),
+        );
+      } catch (writeErr) {
+        // Truncate-and-write failed partway through — restore the file (or
+        // remove the empty partial) and re-throw so the outer catch drives
+        // the structured error response + token rollback.
+        try {
+          weCloneProxyHandleRollback();
+        } catch {
+          // Best-effort.
+        }
+        weCloneProxyHandleRollback = null;
+        throw writeErr;
+      }
       // Record the proxy-side config path on the registry JSON so operators
       // and `remnic connectors doctor weclone` can locate it later. Persist the
       // effective proxy port so `remnic connectors list` reflects the resolved
@@ -1626,8 +1644,12 @@ export function removeConnector(connectorId: string): RemoveResult {
   // environment — is load-bearing: if REMNIC_HOME / ENGRAM_HOME changes (or
   // is unset) between install and remove, recomputing here would leave the
   // original proxy config (with a live bearer token) on disk while reporting
-  // success. Non-fatal: if the file is already absent or the path could not
-  // be determined, skip with a note.
+  // success. If the file is present but unlink fails (e.g. EPERM), we MUST
+  // surface an error status rather than pretending success — a later retry
+  // via `remnic connectors remove weclone` would go down the `not_found`
+  // path because the registry config was already unlinked, leaving the
+  // proxy config orphaned (potentially with a still-valid token).
+  let weCloneProxyDeleteFailed: string | null = null;
   if (connectorId === "weclone") {
     if (weCloneProxyConfigPath === null) {
       notes.push(
@@ -1641,11 +1663,23 @@ export function removeConnector(connectorId: string): RemoveResult {
           notes.push(`Removed WeClone proxy config: ${weCloneProxyConfigPath}`);
         }
       } catch (err) {
-        notes.push(
-          `WeClone proxy config cleanup skipped: ${err instanceof Error ? err.message : String(err)}`,
-        );
+        // Hard failure: leaving the file behind with a live token is a
+        // security issue. Capture the error so we return status:"error".
+        weCloneProxyDeleteFailed = err instanceof Error ? err.message : String(err);
       }
     }
+  }
+  if (weCloneProxyDeleteFailed !== null && weCloneProxyConfigPath !== null) {
+    return {
+      connectorId,
+      configPath,
+      status: "error",
+      message:
+        `WeClone remove partially succeeded: registry config and token were cleaned up, ` +
+        `but the proxy config at ${weCloneProxyConfigPath} could not be deleted ` +
+        `(${weCloneProxyDeleteFailed}). Manually remove that file — it may still contain ` +
+        `a Remnic daemon bearer token.`,
+    };
   }
 
   // Hermes-specific: strip the remnic: block from config.yaml.
@@ -2684,13 +2718,21 @@ const WECLONE_PROXY_CONFIG_FILENAME = "weclone.json";
  * `tmp/remnic` (which would otherwise be interpreted against the caller's
  * current working directory). Must stay in lockstep with the proxy CLI's
  * `defaultConfigPath()` in @remnic/connector-weclone/src/cli.ts.
+ *
+ * `HOME=""` edge case: `process.env.HOME ?? os.homedir()` would keep the
+ * empty string (empty is not nullish), which `path.resolve("", ...)` then
+ * interprets as CWD. `os.homedir()` by contrast falls back to the OS
+ * password database when HOME is empty, so the two code paths would
+ * disagree. We therefore treat empty HOME as absent and delegate to
+ * `os.homedir()` in both places — the same rule the proxy CLI follows.
  */
 export function resolveWeCloneProxyConfigPath(): string {
   const override = process.env.REMNIC_HOME ?? process.env.ENGRAM_HOME;
   if (override && override.length > 0) {
     return path.resolve(override, "connectors", WECLONE_PROXY_CONFIG_FILENAME);
   }
-  const home = process.env.HOME ?? os.homedir();
+  const envHome = process.env.HOME;
+  const home = envHome && envHome.length > 0 ? envHome : os.homedir();
   return path.resolve(
     home,
     WECLONE_PROXY_CONFIG_DIRNAME,
@@ -2864,12 +2906,21 @@ export function buildWeCloneProxyConfig(args: {
   // the proxy's parseConfig() at proxy startup — here we only assemble a
   // best-effort shape. A malformed user override would be rejected later with
   // a clean error message.
+  //
+  // `typeof [] === "object"` so a bare `typeof ... === "object" && ... !==
+  // null` guard would let an array spread numeric-indexed properties into
+  // the merged object, silently corrupting it. Explicitly reject arrays.
   const memoryInjection = {
     ...WECLONE_DEFAULTS.memoryInjection,
-    ...(priorConfig && typeof priorConfig.memoryInjection === "object" && priorConfig.memoryInjection !== null
+    ...(priorConfig &&
+    typeof priorConfig.memoryInjection === "object" &&
+    priorConfig.memoryInjection !== null &&
+    !Array.isArray(priorConfig.memoryInjection)
       ? (priorConfig.memoryInjection as Record<string, unknown>)
       : {}),
-    ...(typeof userConfig.memoryInjection === "object" && userConfig.memoryInjection !== null
+    ...(typeof userConfig.memoryInjection === "object" &&
+    userConfig.memoryInjection !== null &&
+    !Array.isArray(userConfig.memoryInjection)
       ? (userConfig.memoryInjection as Record<string, unknown>)
       : {}),
   } as WeCloneProxyConfig["memoryInjection"];

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -202,6 +202,109 @@ test("installConnector weclone coerces string port from --config CLI parsing", a
   );
 });
 
+test("installConnector weclone force-reinstall reuses persisted proxyConfigPath even if REMNIC_HOME changed", async (t) => {
+  // Reviewer feedback (codex P2): force-reinstall must target the SAME
+  // on-disk file the previous install wrote, not recompute from the current
+  // REMNIC_HOME. Otherwise the old file is left behind with stale settings
+  // and a revoked token when the env changes between installs.
+  const sandbox = makeSandbox(t);
+  const firstRemnicHome = sandbox.remnicHome;
+  const secondRemnicHome = path.join(sandbox.root, "second-remnic-home");
+  fs.mkdirSync(secondRemnicHome, { recursive: true });
+
+  let firstProxyPath = "";
+
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: firstRemnicHome,
+    },
+    () => {
+      const first = installConnector({
+        connectorId: "weclone",
+        config: { proxyPort: 8700 },
+      });
+      assert.equal(first.status, "installed");
+      firstProxyPath = resolveWeCloneProxyConfigPath();
+      assert.ok(fs.existsSync(firstProxyPath));
+    },
+  );
+
+  // Now force-reinstall with a DIFFERENT REMNIC_HOME. The proxy config
+  // write must target the ORIGINAL firstProxyPath (persisted via
+  // proxyConfigPath in the registry config), not the env-derived path under
+  // secondRemnicHome.
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: secondRemnicHome,
+    },
+    () => {
+      const envDerived = resolveWeCloneProxyConfigPath();
+      assert.notEqual(envDerived, firstProxyPath, "env derivation must differ after REMNIC_HOME change");
+
+      const second = installConnector({
+        connectorId: "weclone",
+        force: true,
+      });
+      assert.equal(second.status, "installed");
+
+      // The ORIGINAL path must still hold the updated config.
+      assert.ok(fs.existsSync(firstProxyPath), "original proxy file must still exist after force-reinstall");
+      // The env-derived path under the new REMNIC_HOME must NOT have been
+      // created — otherwise we'd have two proxy configs with divergent state.
+      assert.equal(
+        fs.existsSync(envDerived),
+        false,
+        "force-reinstall must NOT create a second proxy config at the new env-derived path",
+      );
+
+      // The first proxy file must retain the original custom port (8700) and
+      // have been rewritten with the fresh token.
+      const proxy = JSON.parse(fs.readFileSync(firstProxyPath, "utf8")) as Record<string, unknown>;
+      assert.equal(proxy.proxyPort, 8700, "force-reinstall must preserve prior port");
+    },
+  );
+});
+
+test("resolveWeCloneProxyConfigPath returns an absolute path even for a relative REMNIC_HOME override", async (t) => {
+  // Reviewer feedback (codex P2): install (path.join) and run (path.resolve)
+  // must agree on normalization. With a relative override like
+  // `REMNIC_HOME=tmp/remnic`, `path.join` keeps it relative while
+  // `path.resolve` makes it absolute — if they disagree, run-time fails
+  // to locate the file install-time wrote. Verified by asserting
+  // absoluteness here.
+  const sandbox = makeSandbox(t);
+  const relativeOverride = path.relative(process.cwd(), sandbox.remnicHome);
+  // Guard: the sandbox path might not be relative-expressible (e.g. on a
+  // different drive on Windows). Skip in that case.
+  if (!relativeOverride || path.isAbsolute(relativeOverride)) {
+    t.skip("Cannot construct a relative REMNIC_HOME for this test environment");
+    return;
+  }
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: relativeOverride,
+    },
+    () => {
+      const resolved = resolveWeCloneProxyConfigPath();
+      assert.equal(path.isAbsolute(resolved), true, "resolveWeCloneProxyConfigPath must return an absolute path");
+      // Must normalize to the same absolute path the sandbox represents.
+      assert.equal(
+        resolved,
+        path.resolve(sandbox.remnicHome, "connectors", "weclone.json"),
+      );
+    },
+  );
+});
+
 test("installConnector weclone force-reinstall preserves prior custom fields", async (t) => {
   const sandbox = makeSandbox(t);
   await withEnv(

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -1,0 +1,356 @@
+/**
+ * Integration tests for the WeClone connector install/remove flow.
+ *
+ * Covers gap-fill from Issue #458:
+ *   - `weclone` is registered in BUILTIN_CONNECTORS
+ *   - `remnic connectors install weclone` writes both the registry config
+ *     AND the proxy config at ~/.remnic/connectors/weclone.json
+ *   - Defaults are applied for unspecified fields
+ *   - User-supplied overrides take precedence over defaults
+ *   - Prior saved proxy config is honoured on force-reinstall
+ *   - `remnic connectors remove weclone` removes both files
+ *   - Proxy config precedence: user → prior → default
+ *   - buildWeCloneProxyConfig rejects invalid ports and falls through
+ *   - Synthetic data only — no personal information used
+ */
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  buildWeCloneProxyConfig,
+  installConnector,
+  loadRegistry,
+  removeConnector,
+  resolveWeCloneProxyConfigPath,
+} from "./index.js";
+
+interface Sandbox {
+  root: string;
+  home: string;
+  xdgConfigHome: string;
+  remnicHome: string;
+}
+
+function makeSandbox(t: { after: (fn: () => void | Promise<void>) => void }): Sandbox {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-weclone-test-"));
+  const home = path.join(root, "home");
+  const xdgConfigHome = path.join(home, ".config");
+  const remnicHome = path.join(home, ".remnic");
+  fs.mkdirSync(home, { recursive: true });
+  fs.mkdirSync(xdgConfigHome, { recursive: true });
+  fs.mkdirSync(remnicHome, { recursive: true });
+  t.after(() => {
+    try {
+      fs.rmSync(root, { recursive: true, force: true });
+    } catch {
+      // best effort
+    }
+  });
+  return { root, home, xdgConfigHome, remnicHome };
+}
+
+async function withEnv(
+  overrides: Record<string, string | undefined>,
+  fn: () => void | Promise<void>,
+): Promise<void> {
+  const originals: Record<string, string | undefined> = {};
+  for (const key of Object.keys(overrides)) {
+    originals[key] = process.env[key];
+    const value = overrides[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+  try {
+    await fn();
+  } finally {
+    for (const key of Object.keys(originals)) {
+      const value = originals[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+}
+
+test("weclone manifest is registered in BUILTIN_CONNECTORS", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const registry = loadRegistry();
+      const manifest = registry.connectors.find((c) => c.id === "weclone");
+      assert.ok(manifest, "weclone must be present in the connector registry");
+      assert.equal(manifest!.capabilities.connectionType, "http");
+      assert.equal(manifest!.capabilities.observe, true);
+      assert.equal(manifest!.capabilities.recall, true);
+      assert.equal(manifest!.requiresToken, true, "weclone must require a token");
+    },
+  );
+});
+
+test("installConnector weclone writes registry config AND proxy config with defaults", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const result = installConnector({ connectorId: "weclone" });
+      assert.equal(result.status, "installed", `expected installed, got: ${result.status} — ${result.message}`);
+      assert.ok(result.configPath, "registry configPath must be set");
+      assert.ok(fs.existsSync(result.configPath as string), "registry config must exist on disk");
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      assert.equal(
+        proxyConfigPath,
+        path.join(sandbox.remnicHome, "connectors", "weclone.json"),
+        "proxy config must live under ~/.remnic/connectors/weclone.json (honouring REMNIC_HOME)",
+      );
+      assert.ok(fs.existsSync(proxyConfigPath), "proxy config must exist on disk");
+
+      const proxy = JSON.parse(fs.readFileSync(proxyConfigPath, "utf8")) as Record<string, unknown>;
+      // Defaults
+      assert.equal(proxy.wecloneApiUrl, "http://localhost:8000/v1");
+      assert.equal(proxy.proxyPort, 8100);
+      assert.equal(proxy.remnicDaemonUrl, "http://localhost:4318");
+      assert.equal(proxy.sessionStrategy, "single");
+      assert.ok(proxy.memoryInjection && typeof proxy.memoryInjection === "object");
+
+      // A bearer token should have been minted (requiresToken: true).
+      assert.equal(typeof proxy.remnicAuthToken, "string");
+      assert.ok((proxy.remnicAuthToken as string).length > 0);
+
+      // The registry config must also record the proxy-side config path for doctor.
+      const registryConfig = JSON.parse(
+        fs.readFileSync(result.configPath as string, "utf8"),
+      ) as Record<string, unknown>;
+      assert.equal(registryConfig.proxyConfigPath, proxyConfigPath);
+      assert.equal(registryConfig.proxyPort, 8100);
+    },
+  );
+});
+
+test("installConnector weclone honours user-supplied overrides", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const result = installConnector({
+        connectorId: "weclone",
+        config: {
+          wecloneApiUrl: "http://upstream.example:9000/v1",
+          proxyPort: 8200,
+          remnicDaemonUrl: "http://daemon.example:4318",
+          sessionStrategy: "caller-id",
+        },
+      });
+      assert.equal(result.status, "installed");
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const proxy = JSON.parse(fs.readFileSync(proxyConfigPath, "utf8")) as Record<string, unknown>;
+      assert.equal(proxy.wecloneApiUrl, "http://upstream.example:9000/v1");
+      assert.equal(proxy.proxyPort, 8200);
+      assert.equal(proxy.remnicDaemonUrl, "http://daemon.example:4318");
+      assert.equal(proxy.sessionStrategy, "caller-id");
+    },
+  );
+});
+
+test("installConnector weclone coerces string port from --config CLI parsing", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      // CLI `--config proxyPort=8300` passes the value as a string.
+      const result = installConnector({
+        connectorId: "weclone",
+        config: { proxyPort: "8300" as unknown as number },
+      });
+      assert.equal(result.status, "installed");
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const proxy = JSON.parse(fs.readFileSync(proxyConfigPath, "utf8")) as Record<string, unknown>;
+      assert.equal(proxy.proxyPort, 8300, "string port must be coerced to a number");
+      assert.equal(typeof proxy.proxyPort, "number");
+    },
+  );
+});
+
+test("installConnector weclone force-reinstall preserves prior custom fields", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      // First install with a custom port.
+      const first = installConnector({
+        connectorId: "weclone",
+        config: { proxyPort: 8500, sessionStrategy: "caller-id" },
+      });
+      assert.equal(first.status, "installed");
+
+      // Force-reinstall without supplying any config overrides — the proxy
+      // file must retain the prior custom port and strategy rather than
+      // resetting to the manifest default.
+      const second = installConnector({
+        connectorId: "weclone",
+        force: true,
+      });
+      assert.equal(second.status, "installed");
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const proxy = JSON.parse(fs.readFileSync(proxyConfigPath, "utf8")) as Record<string, unknown>;
+      assert.equal(proxy.proxyPort, 8500, "force-reinstall must preserve prior custom port");
+      assert.equal(proxy.sessionStrategy, "caller-id", "force-reinstall must preserve prior strategy");
+    },
+  );
+});
+
+test("removeConnector weclone cleans up both registry and proxy config files", async (t) => {
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const installResult = installConnector({ connectorId: "weclone" });
+      assert.equal(installResult.status, "installed");
+
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      assert.ok(fs.existsSync(proxyConfigPath), "precondition: proxy config exists");
+      assert.ok(fs.existsSync(installResult.configPath as string), "precondition: registry config exists");
+
+      const removeResult = removeConnector("weclone");
+      assert.equal(removeResult.status, "removed", `expected removed, got: ${removeResult.status}`);
+      assert.equal(fs.existsSync(proxyConfigPath), false, "proxy config must be deleted on remove");
+      assert.equal(
+        fs.existsSync(installResult.configPath as string),
+        false,
+        "registry config must be deleted on remove",
+      );
+    },
+  );
+});
+
+// ── buildWeCloneProxyConfig unit tests (no filesystem) ────────────────────
+
+test("buildWeCloneProxyConfig applies defaults when nothing provided", () => {
+  const config = buildWeCloneProxyConfig({ userConfig: {}, priorConfig: null });
+  assert.equal(config.wecloneApiUrl, "http://localhost:8000/v1");
+  assert.equal(config.proxyPort, 8100);
+  assert.equal(config.remnicDaemonUrl, "http://localhost:4318");
+  assert.equal(config.sessionStrategy, "single");
+  assert.equal(config.memoryInjection.maxTokens, 1500);
+  assert.equal(config.memoryInjection.position, "system-append");
+});
+
+test("buildWeCloneProxyConfig precedence: user > prior > default", () => {
+  const config = buildWeCloneProxyConfig({
+    userConfig: { proxyPort: 9100 },
+    priorConfig: {
+      proxyPort: 9000,
+      wecloneApiUrl: "http://prior.example:8000/v1",
+      sessionStrategy: "caller-id",
+    },
+  });
+  assert.equal(config.proxyPort, 9100, "user wins over prior");
+  assert.equal(config.wecloneApiUrl, "http://prior.example:8000/v1", "prior wins over default");
+  assert.equal(config.sessionStrategy, "caller-id");
+});
+
+test("buildWeCloneProxyConfig falls through invalid port to prior, then default", () => {
+  const config = buildWeCloneProxyConfig({
+    userConfig: { proxyPort: 70000 }, // invalid (>65535)
+    priorConfig: { proxyPort: 9000 },
+  });
+  assert.equal(config.proxyPort, 9000, "invalid user port falls through to prior");
+
+  const config2 = buildWeCloneProxyConfig({
+    userConfig: { proxyPort: -1 }, // invalid
+    priorConfig: { proxyPort: "not-a-number" as unknown as number }, // invalid
+  });
+  assert.equal(config2.proxyPort, 8100, "all invalid falls through to default");
+});
+
+test("buildWeCloneProxyConfig rejects invalid sessionStrategy", () => {
+  const config = buildWeCloneProxyConfig({
+    userConfig: { sessionStrategy: "round-robin" }, // invalid
+    priorConfig: null,
+  });
+  assert.equal(config.sessionStrategy, "single", "invalid strategy falls back to default");
+});
+
+test("buildWeCloneProxyConfig only persists auth token when available", () => {
+  const withToken = buildWeCloneProxyConfig({
+    userConfig: {},
+    priorConfig: null,
+    authToken: "synthetic-test-token",
+  });
+  assert.equal(withToken.remnicAuthToken, "synthetic-test-token");
+
+  const withoutToken = buildWeCloneProxyConfig({
+    userConfig: {},
+    priorConfig: null,
+  });
+  assert.equal(withoutToken.remnicAuthToken, undefined);
+});
+
+test("buildWeCloneProxyConfig fresh token overrides prior", () => {
+  const config = buildWeCloneProxyConfig({
+    userConfig: {},
+    priorConfig: { remnicAuthToken: "stale-token" },
+    authToken: "fresh-token",
+  });
+  assert.equal(config.remnicAuthToken, "fresh-token", "freshly minted token must replace prior");
+});
+
+test("buildWeCloneProxyConfig merges memoryInjection partials", () => {
+  const config = buildWeCloneProxyConfig({
+    userConfig: { memoryInjection: { maxTokens: 2500 } },
+    priorConfig: { memoryInjection: { template: "prior template {memories}" } },
+  });
+  assert.equal(config.memoryInjection.maxTokens, 2500, "user override wins");
+  assert.equal(
+    config.memoryInjection.template,
+    "prior template {memories}",
+    "prior value persists when user did not override",
+  );
+  assert.equal(
+    config.memoryInjection.position,
+    "system-append",
+    "default fills the remaining field",
+  );
+});

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -236,6 +236,65 @@ test("installConnector weclone force-reinstall preserves prior custom fields", a
   );
 });
 
+test("removeConnector weclone uses persisted proxyConfigPath even if REMNIC_HOME changed", async (t) => {
+  // Install into one REMNIC_HOME, then call remove with a DIFFERENT REMNIC_HOME.
+  // The persisted absolute path must win so the original file is deleted even
+  // if the env changed between install and remove (e.g. user rotates their
+  // home dir, or REMNIC_HOME was scoped to a shell that later unset it).
+  const sandbox = makeSandbox(t);
+  const altRemnicHome = path.join(sandbox.root, "alt-remnic-home");
+  fs.mkdirSync(altRemnicHome, { recursive: true });
+
+  let installedProxyPath = "";
+  let installedConfigPath = "";
+
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const installResult = installConnector({ connectorId: "weclone" });
+      assert.equal(installResult.status, "installed");
+      installedProxyPath = resolveWeCloneProxyConfigPath();
+      installedConfigPath = installResult.configPath as string;
+      assert.ok(fs.existsSync(installedProxyPath), "precondition: proxy config exists at install-time path");
+    },
+  );
+
+  // Simulate env change: point REMNIC_HOME at a different directory during
+  // remove. The original proxy file is at installedProxyPath — if removal
+  // were to naively re-resolve from env, it would try to delete a non-existent
+  // path under altRemnicHome and leave the real file behind.
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: altRemnicHome,
+    },
+    () => {
+      // Sanity: the env-derived path now resolves somewhere else.
+      const envDerived = resolveWeCloneProxyConfigPath();
+      assert.notEqual(envDerived, installedProxyPath);
+
+      const removeResult = removeConnector("weclone");
+      assert.equal(removeResult.status, "removed");
+
+      // The ORIGINAL proxy config file must have been deleted via the persisted
+      // proxyConfigPath — not left behind because env has moved on.
+      assert.equal(
+        fs.existsSync(installedProxyPath),
+        false,
+        "original proxy config must be deleted via persisted proxyConfigPath even after REMNIC_HOME changed",
+      );
+      assert.equal(fs.existsSync(installedConfigPath), false, "registry config must also be deleted");
+    },
+  );
+});
+
 test("removeConnector weclone cleans up both registry and proxy config files", async (t) => {
   const sandbox = makeSandbox(t);
   await withEnv(

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -398,6 +398,46 @@ test("removeConnector weclone uses persisted proxyConfigPath even if REMNIC_HOME
   );
 });
 
+test("installConnector weclone install error reports token rollback status truthfully", async (t) => {
+  // Reviewer (cursor MEDIUM): the WeClone outer catch previously swallowed
+  // token-rollback failures. The message must now either say "Token has
+  // been rolled back." (on success) or "Token rollback FAILED (...)" — it
+  // must NEVER silently omit either outcome.
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      // Force proxy write to fail so we hit the WeClone catch branch.
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const originalWrite = fs.writeFileSync.bind(fs);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = t.mock.method(fs, "writeFileSync", (...args: [any, any, any?]) => {
+        if (String(args[0] ?? "") === proxyConfigPath) {
+          throw new Error("ENOSPC: simulated proxy write failure");
+        }
+        return originalWrite(...args);
+      });
+
+      const result = installConnector({ connectorId: "weclone" });
+      mock.mock.restore();
+
+      assert.equal(result.status, "error");
+      // Happy rollback path: token store was restorable, so message must say
+      // so. If the test environment cannot rollback (unlikely), the message
+      // must explicitly say FAILED.
+      assert.ok(
+        /Token has been rolled back\.|Token rollback FAILED/.test(result.message),
+        `install error must report token rollback status; got: ${result.message}`,
+      );
+    },
+  );
+});
+
 test("installConnector weclone restores prior proxy config when write throws mid-truncate", async (t) => {
   // Reviewer (codex P2): writeSecretFileSync opens the file in truncate
   // mode, so a mid-write failure (ENOSPC) can leave weclone.json empty.
@@ -496,6 +536,94 @@ test("removeConnector weclone returns status:error when proxy config delete fail
         removeResult.message.includes(proxyConfigPath),
         `error message must reference the orphan path, got: ${removeResult.message}`,
       );
+    },
+  );
+});
+
+test("removeConnector weclone aborts with status:skipped when weclone.json is malformed", async (t) => {
+  // Reviewer (codex P2): silently falling back to env-derived path when
+  // parsing weclone.json fails can miss the real proxy config if env
+  // changed between install and remove. Must abort the whole removal,
+  // leave the registry config intact for inspection, and NOT delete the
+  // proxy config file (which may still hold a live token).
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      // Real install first so proxy config exists.
+      const installResult = installConnector({ connectorId: "weclone" });
+      assert.equal(installResult.status, "installed");
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const registryConfigPath = installResult.configPath as string;
+      assert.ok(fs.existsSync(proxyConfigPath));
+
+      // Corrupt the registry config.
+      fs.writeFileSync(registryConfigPath, "{ not valid json }}");
+
+      const removeResult = removeConnector("weclone");
+      assert.equal(removeResult.status, "skipped", `expected skipped, got: ${removeResult.status}`);
+      assert.equal(removeResult.reason, "config-parse-failed");
+
+      // Both files must remain untouched so the operator can fix and retry.
+      assert.ok(fs.existsSync(registryConfigPath), "malformed registry config must be preserved");
+      assert.ok(fs.existsSync(proxyConfigPath), "proxy config must not be deleted when we lost provenance");
+    },
+  );
+});
+
+test("removeConnector weclone error message reflects token-revocation status truthfully", async (t) => {
+  // Reviewer (codex P2): when BOTH token revocation AND proxy-config delete
+  // fail, the message must tell the operator the token is still live —
+  // hardcoding "token was cleaned up" would mislead them into thinking they
+  // only need to remove the orphan file.
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const installResult = installConnector({ connectorId: "weclone" });
+      assert.equal(installResult.status, "installed");
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+
+      // Fail both: proxy-config unlink AND the revokeToken path (via
+      // saveTokenStore throwing when it tries to persist the revocation).
+      const originalUnlink = fs.unlinkSync.bind(fs);
+      const originalWrite = fs.writeFileSync.bind(fs);
+      const unlinkMock = t.mock.method(fs, "unlinkSync", (target: fs.PathLike) => {
+        if (String(target) === proxyConfigPath) {
+          throw new Error("EPERM: proxy unlink failed (simulated)");
+        }
+        return originalUnlink(target);
+      });
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const writeMock = t.mock.method(fs, "writeFileSync", (...args: [any, any, any?]) => {
+        if (String(args[0] ?? "").endsWith("tokens.json")) {
+          throw new Error("EPERM: tokens.json write failed (simulated)");
+        }
+        return originalWrite(...args);
+      });
+
+      const removeResult = removeConnector("weclone");
+      unlinkMock.mock.restore();
+      writeMock.mock.restore();
+
+      assert.equal(removeResult.status, "error");
+      // Must mention token revocation failure, not claim success.
+      assert.ok(
+        /TOKEN REVOCATION (ALSO )?FAILED/i.test(removeResult.message),
+        `message must report token revocation failure; got: ${removeResult.message}`,
+      );
+      // Must still mention the orphan proxy path.
+      assert.ok(removeResult.message.includes(proxyConfigPath));
     },
   );
 });

--- a/packages/remnic-core/src/connectors/weclone-installer.test.ts
+++ b/packages/remnic-core/src/connectors/weclone-installer.test.ts
@@ -398,6 +398,108 @@ test("removeConnector weclone uses persisted proxyConfigPath even if REMNIC_HOME
   );
 });
 
+test("installConnector weclone restores prior proxy config when write throws mid-truncate", async (t) => {
+  // Reviewer (codex P2): writeSecretFileSync opens the file in truncate
+  // mode, so a mid-write failure (ENOSPC) can leave weclone.json empty.
+  // The rollback closure must be installed BEFORE the write so prior
+  // contents are restored on failure.
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      // First install succeeds and writes known prior content.
+      const first = installConnector({
+        connectorId: "weclone",
+        config: { proxyPort: 8800 },
+      });
+      assert.equal(first.status, "installed");
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      const priorBytes = fs.readFileSync(proxyConfigPath, "utf8");
+      assert.ok(priorBytes.length > 0);
+
+      // Now mock the internal writeFileSync so that the NEXT call targeting
+      // proxyConfigPath fails. We target writeFileSync because
+      // writeSecretFileSync calls through to it via a wrapper; catching that
+      // exception drives our new rollback path.
+      const originalWrite = fs.writeFileSync.bind(fs);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const mock = t.mock.method(fs, "writeFileSync", (...args: [any, any, any?]) => {
+        const target = String(args[0] ?? "");
+        if (target === proxyConfigPath) {
+          throw new Error("ENOSPC: no space left on device (simulated)");
+        }
+        return originalWrite(...args);
+      });
+
+      const second = installConnector({
+        connectorId: "weclone",
+        force: true,
+        config: { proxyPort: 8900 },
+      });
+      mock.mock.restore();
+
+      // Install must have failed cleanly.
+      assert.equal(second.status, "error", `expected error, got: ${second.status}`);
+
+      // The proxy config file MUST contain the exact prior bytes — not
+      // empty, not corrupted, and not the new (never-committed) config.
+      const afterBytes = fs.readFileSync(proxyConfigPath, "utf8");
+      assert.equal(afterBytes, priorBytes, "prior proxy config content must be restored after failed write");
+    },
+  );
+});
+
+test("removeConnector weclone returns status:error when proxy config delete fails", async (t) => {
+  // Reviewer (codex P2): if proxy config unlink fails, silently swallowing
+  // the error and returning status:"removed" leaves an orphan file that may
+  // still contain a live bearer token. A retry would go down the
+  // `not_found` path (registry config already gone) and never attempt the
+  // cleanup. Must surface status:"error" so automation flags it.
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: sandbox.home,
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: sandbox.remnicHome,
+    },
+    () => {
+      const installResult = installConnector({ connectorId: "weclone" });
+      assert.equal(installResult.status, "installed");
+      const proxyConfigPath = resolveWeCloneProxyConfigPath();
+      assert.ok(fs.existsSync(proxyConfigPath));
+
+      // Mock unlinkSync to fail only when targeting the proxy config file.
+      const originalUnlink = fs.unlinkSync.bind(fs);
+      const mock = t.mock.method(fs, "unlinkSync", (target: fs.PathLike) => {
+        if (String(target) === proxyConfigPath) {
+          throw new Error("EPERM: operation not permitted (simulated)");
+        }
+        return originalUnlink(target);
+      });
+
+      const removeResult = removeConnector("weclone");
+      mock.mock.restore();
+
+      assert.equal(
+        removeResult.status,
+        "error",
+        `proxy-delete failure must surface status:"error", got: ${removeResult.status} — ${removeResult.message}`,
+      );
+      // The message must mention the orphan file path so operators can act.
+      assert.ok(
+        removeResult.message.includes(proxyConfigPath),
+        `error message must reference the orphan path, got: ${removeResult.message}`,
+      );
+    },
+  );
+});
+
 test("removeConnector weclone cleans up both registry and proxy config files", async (t) => {
   const sandbox = makeSandbox(t);
   await withEnv(
@@ -497,6 +599,55 @@ test("buildWeCloneProxyConfig fresh token overrides prior", () => {
     authToken: "fresh-token",
   });
   assert.equal(config.remnicAuthToken, "fresh-token", "freshly minted token must replace prior");
+});
+
+test("buildWeCloneProxyConfig rejects array memoryInjection (typeof [] === 'object' footgun)", () => {
+  // Reviewer (cursor LOW): typeof [] === "object", so a bare object+null
+  // guard would let an array spread numeric-indexed properties into the
+  // merged memoryInjection. The helper must reject arrays explicitly.
+  const config = buildWeCloneProxyConfig({
+    userConfig: { memoryInjection: ["a", "b", "c"] as unknown as Record<string, unknown> },
+    priorConfig: { memoryInjection: [1, 2, 3] as unknown as Record<string, unknown> },
+  });
+  // Defaults survive; array was NOT spread in.
+  assert.equal(config.memoryInjection.maxTokens, 1500);
+  assert.equal(config.memoryInjection.position, "system-append");
+  assert.equal(config.memoryInjection.template, "[Memory Context]\n{memories}\n[End Memory Context]");
+  // Numeric-indexed properties must NOT leak onto the result.
+  assert.equal((config.memoryInjection as unknown as Record<string, unknown>)[0], undefined);
+  assert.equal((config.memoryInjection as unknown as Record<string, unknown>)[1], undefined);
+});
+
+test("resolveWeCloneProxyConfigPath treats empty HOME as absent (aligns with os.homedir())", async (t) => {
+  // Reviewer (cursor MEDIUM): process.env.HOME ?? os.homedir() keeps "" as
+  // the home (empty string is NOT nullish). Without the parity fix, install
+  // and run would disagree whenever HOME is empty. Both must fall back to
+  // os.homedir() so they pick the same directory.
+  //
+  // Strategy: assert the result matches the os.homedir()-based path exactly,
+  // which is what the CLI computes. If HOME="" were used verbatim, the
+  // result would be resolve("", ...) ≡ resolve(".remnic/connectors/...") —
+  // i.e. CWD-relative — which must NOT be the returned path.
+  const sandbox = makeSandbox(t);
+  await withEnv(
+    {
+      HOME: "", // empty, not nullish
+      USERPROFILE: sandbox.home,
+      XDG_CONFIG_HOME: sandbox.xdgConfigHome,
+      REMNIC_HOME: undefined,
+      ENGRAM_HOME: undefined,
+    },
+    () => {
+      const resolved = resolveWeCloneProxyConfigPath();
+      assert.equal(path.isAbsolute(resolved), true, "must be absolute");
+      const expected = path.resolve(os.homedir(), ".remnic", "connectors", "weclone.json");
+      assert.equal(
+        resolved,
+        expected,
+        "empty HOME must fall back to os.homedir() (not collapse to CWD)",
+      );
+    },
+  );
 });
 
 test("buildWeCloneProxyConfig merges memoryInjection partials", () => {


### PR DESCRIPTION
## Summary

Gap-fill for #458. The runtime proxy/config/session/format code was already merged in PR #490. This PR closes the remaining gaps:

- Registers the `weclone` connector in `@remnic/core` `BUILTIN_CONNECTORS` so `remnic connectors install weclone` resolves.
- Adds WeClone-specific install logic in `installConnector()` that composes and writes the proxy config to `~/.remnic/connectors/weclone.json` (the path the standalone `remnic-weclone-proxy` CLI reads by default) alongside the standard registry entry under `~/.config/engram/.engram-connectors/connectors/weclone.json`.
- Atomic rollback: if the registry config write fails, the proxy config file, any issued token, and prior state all roll back together.
- Proxy config field precedence is user `--config` → prior saved → manifest defaults, with port strings from CLI parsing coerced to validated integers.
- `remnic connectors remove weclone` deletes both files.
- Proxy CLI honours `REMNIC_HOME` / legacy `ENGRAM_HOME` for the config path to match the installer.
- Adds `README.md` for the connector-weclone package and a WeClone section in `docs/integration/connector-setup.md`.

## Changes

- `packages/remnic-core/src/connectors/index.ts` — new manifest entry, install/remove hooks, exported helpers.
- `packages/remnic-core/src/connectors/weclone-installer.test.ts` — 13 new tests.
- `packages/connector-weclone/src/cli.ts` — `REMNIC_HOME` override support.
- `packages/connector-weclone/README.md` — new package README.
- `docs/integration/connector-setup.md` — new WeClone section.

## Test plan

- [x] `tsx --test packages/remnic-core/src/connectors/weclone-installer.test.ts` — 13/13 pass
- [x] `tsx --test packages/remnic-core/src/connectors/index.test.ts` — 30/30 pass (no regressions)
- [x] `tsx --test packages/connector-weclone/src/*.test.ts` — 69/69 pass
- [x] `tsx --test tests/cli-connector-id-resolution.test.ts tests/cli-parse-connector-config.test.ts tests/integration/connectors-hermes.test.ts` — 81/81 pass
- [x] Verified no personal data or real tokens committed (per CLAUDE.md public-repo rules).

Pre-existing `tsc --noEmit` errors in `packages/remnic-core/src/cli.ts` and `packages/remnic-core/src/namespaces/search.ts` were confirmed to exist on `main` before this PR and are unrelated.

Closes #458.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new install/remove behavior that writes and deletes a second, token-bearing config file and introduces rollback logic; mistakes could orphan credentials or break connector lifecycle flows.
> 
> **Overview**
> Adds first-class support for the `weclone` connector: it’s registered in `@remnic/core`, and `remnic connectors install weclone` now also generates a dedicated proxy config at `~/.remnic/connectors/weclone.json` (with validated defaults, user/prior-config precedence, and token persistence) plus rollback to keep registry/config/token state consistent on failures.
> 
> Extends `remnic connectors remove weclone` to remove the proxy config using a persisted `proxyConfigPath` provenance record and to surface partial-failure states (e.g., token revocation or proxy-config deletion failures) instead of silently succeeding; the `remnic-weclone-proxy` CLI is updated to honor `REMNIC_HOME`/`ENGRAM_HOME` for matching config-path resolution.
> 
> Adds docs for WeClone setup, a package README for `@remnic/connector-weclone`, and a comprehensive installer/remover test suite covering defaults, overrides, env-path edge cases, and failure/rollback scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abfa6c8283aa3d7b9b124665f7ecfda00768a055. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->