### PR TITLE
feat(export-weclone): complete issue #459 (CLI, synthesizer, docs)

### DIFF
--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -44,6 +44,78 @@ Notes:
 - Backups are intended to be driven by your scheduler (OpenClaw cron, launchd, systemd, etc.).
 - Use `--include-transcripts` only if you are comfortable backing up full transcripts.
 
+## Training-data Export (issue #459)
+
+Remnic can emit its structured memories as a fine-tuning dataset, skipping
+the noisy raw-chat-log step that format-specific trainers normally need.
+
+The pipeline lives in `@remnic/core` (generic) with format-specific
+adapters in separate packages. Today the WeClone adapter
+(`@remnic/export-weclone`) is shipped; additional adapters (Axolotl, MLX,
+etc.) can implement the same `TrainingExportAdapter` interface.
+
+```bash
+# Export all memories as a WeClone-compatible Alpaca JSON dataset
+remnic training:export --format weclone --output ./weclone-dataset.json
+
+# Restrict to high-confidence memories in a date window
+remnic training:export \
+  --format weclone \
+  --output ./weclone-dataset.json \
+  --since 2026-01-01 --until 2027-01-01 \
+  --min-confidence 0.7
+
+# Only a few categories
+remnic training:export \
+  --format weclone \
+  --output ./weclone-dataset.json \
+  --categories preference,fact,skill
+
+# Generate conversational Q/A pairs instead of raw fact records
+remnic training:export \
+  --format weclone \
+  --output ./weclone-dataset.json \
+  --synthesize
+
+# Preview only (no file written) — useful for CI
+remnic training:export \
+  --format weclone \
+  --output /tmp/preview.json \
+  --dry-run
+```
+
+Key flags:
+- `--format <name>` — required; must name a registered adapter. `weclone`
+  is registered as a side-effect of loading `@remnic/export-weclone`.
+- `--output <path>` / `--out <path>` — required (unless `--dry-run`).
+- `--memory-dir <path>` — override the resolved memoryDir.
+- `--since` / `--until` — strict ISO 8601 filters on `created`; half-open
+  `[since, until)` semantics (CLAUDE.md #35).
+- `--min-confidence <0..1>` — inclusive lower bound on memory confidence.
+- `--categories <csv>` — only export matching categories.
+- `--include-entities` — also read from `entities/` (off by default).
+- `--synthesize` — emit conversational Q/A pairs via the adapter's
+  synthesizer (WeClone-optimised question templates, category-driven).
+- `--max-pairs-per-record <n>` — when `--synthesize` is on, cap the
+  number of pairs generated per memory.
+- `--no-privacy-sweep` — disable the final PII redaction pass (default:
+  on). Only use when you have a compensating control.
+- `--dry-run` — print statistics (record count, per-category breakdown,
+  redaction count) without writing the output file.
+
+Privacy posture:
+- The output file contains only the Alpaca fields (`instruction`,
+  `input`, `output`). Memory IDs, confidences, and source ranges stay in
+  the memory store.
+- The core converter refuses to follow `.md` symlinks or hard-linked
+  files under `memoryDir`, blocking exfiltration vectors.
+- Date and confidence filters run before any record is materialised in
+  memory.
+
+See
+[`packages/export-weclone/README.md`](../packages/export-weclone/README.md)
+for the adapter-specific docs and programmatic API.
+
 ## Migration Helpers (v8.16 Task 1)
 
 Engram includes bounded migration helpers under `openclaw engram migrate`:

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts'",
+    "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts'",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts",
     "bench:list": "node scripts/run-bench-cli.mjs list",
     "bench:run": "node scripts/run-bench-cli.mjs run",

--- a/packages/export-weclone/README.md
+++ b/packages/export-weclone/README.md
@@ -1,0 +1,171 @@
+# @remnic/export-weclone
+
+Export [Remnic](https://github.com/joshuaswarren/remnic) memories as
+[WeClone](https://github.com/xming521/weclone)-compatible fine-tuning
+datasets. Produces Alpaca-format JSON consumable by
+[LLaMA Factory](https://github.com/hiyouga/LLaMA-Factory), which WeClone
+drives under the hood.
+
+This package solves the noisy-chat-log problem: WeClone normally trains on
+raw Telegram / WeChat exports, which include spam, one-word replies, and
+PII. Remnic has already distilled your conversations into structured
+facts, preferences, entities, and topics — a much higher
+signal-to-noise source for a personal digital avatar.
+
+## Install
+
+```bash
+pnpm add @remnic/export-weclone
+# or: npm i @remnic/export-weclone
+```
+
+`@remnic/export-weclone` depends on `@remnic/core` and is intended to be
+used alongside an existing Remnic memory store.
+
+## Quick start
+
+The primary entry point is the `remnic` CLI (see
+[`@remnic/cli`](../remnic-cli)). Importing this package as a side-effect
+registers the `weclone` adapter with the core training-export registry:
+
+```bash
+remnic training:export --format weclone --output ./weclone-dataset.json
+```
+
+Common options:
+
+```bash
+# Restrict to high-confidence memories created in 2026:
+remnic training:export \
+  --format weclone \
+  --output ./weclone.json \
+  --since 2026-01-01 \
+  --until 2027-01-01 \
+  --min-confidence 0.7
+
+# Restrict to specific categories:
+remnic training:export \
+  --format weclone \
+  --output ./weclone.json \
+  --categories preference,fact,skill
+
+# Generate conversational Q/A pairs instead of raw facts:
+remnic training:export \
+  --format weclone \
+  --output ./weclone.json \
+  --synthesize
+
+# Preview only (no file written):
+remnic training:export --format weclone --output /tmp/preview.json --dry-run
+```
+
+## Output format
+
+WeClone / LLaMA Factory expect [Alpaca
+JSON](https://github.com/tatsu-lab/stanford_alpaca#data-release):
+
+```json
+[
+  {
+    "instruction": "What kind of coffee do you like?",
+    "input": "",
+    "output": "dark roast, ethiopian yirgacheffe. something about that fruity wine-like flavor..."
+  }
+]
+```
+
+The adapter emits only the three Alpaca fields. Remnic metadata
+(`category`, `confidence`, `sourceIds`) is stripped from the output file
+but is preserved on the in-memory records so callers building their own
+pipelines can inspect it before serialization.
+
+## Programmatic API
+
+```ts
+import {
+  ensureWecloneExportAdapterRegistered,
+  wecloneExportAdapter,
+  synthesizeTrainingPairs,
+  extractStyleMarkers,
+  sweepPii,
+} from "@remnic/export-weclone";
+import {
+  convertMemoriesToRecords,
+  getTrainingExportAdapter,
+} from "@remnic/core";
+
+// Side-effect import is usually enough, but explicit registration is safe:
+ensureWecloneExportAdapterRegistered();
+
+const records = await convertMemoriesToRecords({
+  memoryDir: "/path/to/memory",
+  minConfidence: 0.7,
+});
+
+const pairs = synthesizeTrainingPairs(records, { maxPairsPerRecord: 2 });
+const { cleanRecords, redactedCount } = sweepPii(pairs);
+
+const adapter = getTrainingExportAdapter("weclone");
+const json = adapter!.formatRecords(cleanRecords);
+```
+
+### `synthesizeTrainingPairs(records, opts)`
+
+Turns flat memory records into natural conversational Q/A pairs using
+category-driven templates (preferences, opinions, expertise, personal).
+Pure templates — no LLM calls. Optionally applies style markers (e.g.
+lowercase normalization) extracted from the user's own transcripts.
+
+### `extractStyleMarkers(samples)`
+
+Analyses text samples with regex-and-count heuristics and returns a
+`StyleMarkers` profile (`avgSentenceLength`, `usesEmoji`, `formality`,
+`usesLowercase`, `commonPhrases`). Used by `synthesizeTrainingPairs` to
+match the output tone to the user's own writing style.
+
+### `sweepPii(records)`
+
+Belt-and-suspenders PII redaction for email, SSN, credit-card, IP, and
+phone patterns. Runs after Remnic's own privacy controls so that even if
+something slips through the upstream filter, the final dataset cannot leak
+these patterns. Returns `{ cleanRecords, redactedCount, redactionDetails }`.
+
+## How synthesis works
+
+Remnic memories are facts, not conversations. The synthesizer maps each
+memory category to a template group and generates a corresponding
+question, using any parenthesised tags in the instruction as the topic:
+
+```
+Category:  preference
+Memory:    "Dark roast coffee, Ethiopian Yirgacheffe specifically"
+Tags:      food, coffee
+
+Generated pair:
+  instruction: "What kind of food, coffee do you like?"
+  output:      "Dark roast coffee, Ethiopian Yirgacheffe specifically"
+```
+
+Question templates live in `src/synthesizer.ts`. Adding a new category
+mapping is a one-line change.
+
+## Privacy posture
+
+- Output JSON contains only `instruction`, `input`, `output`.
+- Remnic metadata (`sourceIds`, etc.) is **not** written to the dataset
+  file — even the record IDs stay in the memory store.
+- `sweepPii` runs by default in the CLI. Disable only with
+  `--no-privacy-sweep` and only when you have a compensating control.
+- Symlinks and hard-linked `.md` files under `memoryDir` are refused by
+  the core converter to block data-exfiltration vectors out of the memory
+  store (see `packages/remnic-core/src/training-export/converter.ts`).
+
+## Related
+
+- Tracking issue: [remnic#459](https://github.com/joshuaswarren/remnic/issues/459)
+- Upstream: [WeClone](https://github.com/xming521/weclone)
+- Format: [Alpaca JSON via LLaMA Factory](https://github.com/hiyouga/LLaMA-Factory)
+
+## License
+
+MIT. See the root [LICENSE](../../LICENSE) file.

--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -11,7 +11,7 @@
       "types": "./dist/index.d.ts"
     }
   },
-  "files": ["dist"],
+  "files": ["dist", "README.md"],
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "test": "tsx --test 'src/**/*.test.ts'",

--- a/packages/export-weclone/src/index.ts
+++ b/packages/export-weclone/src/index.ts
@@ -6,7 +6,45 @@
  * compatible with WeClone / LLaMA Factory.
  */
 
+import {
+  getTrainingExportAdapter,
+  registerTrainingExportAdapter,
+} from "@remnic/core";
+
+import { wecloneExportAdapter } from "./adapter.js";
+
 export { wecloneExportAdapter } from "./adapter.js";
 export { synthesizeTrainingPairs, type SynthesizerOptions } from "./synthesizer.js";
 export { extractStyleMarkers, type StyleMarkers } from "./style-extractor.js";
 export { sweepPii, type PrivacySweepResult } from "./privacy.js";
+
+/**
+ * Idempotently register the WeClone adapter with the core training-export
+ * registry. Callable multiple times without throwing (CLAUDE.md #13:
+ * secondary calls must not crash host processes that pre-register the
+ * adapter for test fixtures).
+ *
+ * Returns true when the adapter was newly registered, false when an adapter
+ * with the same name already exists.
+ */
+export function ensureWecloneExportAdapterRegistered(): boolean {
+  if (getTrainingExportAdapter(wecloneExportAdapter.name) !== undefined) {
+    return false;
+  }
+  registerTrainingExportAdapter(wecloneExportAdapter);
+  return true;
+}
+
+// Side-effect registration: importing this module registers the adapter.
+// Callers that need to manage registration manually (e.g. tests that call
+// `clearTrainingExportAdapters()`) can re-invoke
+// `ensureWecloneExportAdapterRegistered()` after clearing.
+//
+// The try/catch keeps import-time errors from breaking unrelated callers —
+// the adapter surfaces `formatRecords` purely, so a failure here would be
+// surprising, but defensive coding keeps CLI startup resilient.
+try {
+  ensureWecloneExportAdapterRegistered();
+} catch {
+  // Swallow — explicit callers can re-invoke ensureWecloneExportAdapterRegistered().
+}

--- a/packages/export-weclone/src/integration.test.ts
+++ b/packages/export-weclone/src/integration.test.ts
@@ -1,0 +1,233 @@
+/**
+ * Integration test: full round-trip through a memoryDir fixture.
+ *
+ * Writes synthetic markdown memories, runs the full pipeline
+ * (convertMemoriesToRecords → synthesizeTrainingPairs → sweepPii →
+ * wecloneExportAdapter.formatRecords), and validates that the produced
+ * JSON is Alpaca-shaped and contains the expected content.
+ *
+ * This test validates:
+ *   - The WeClone adapter registers itself on import (side-effect).
+ *   - `getTrainingExportAdapter("weclone")` returns the same adapter.
+ *   - End-to-end CLI-equivalent flow matches issue #459's expected output.
+ *   - Date filtering and confidence filtering are honoured at each step.
+ *   - PII sweep runs and the final JSON never contains the raw PII tokens.
+ *
+ * Kept intentionally dependency-light: uses only Node built-ins and the
+ * public API surface that @remnic/cli also exercises.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  convertMemoriesToRecords,
+  getTrainingExportAdapter,
+} from "@remnic/core";
+
+// Side-effect import registers the adapter with the core registry.
+import {
+  ensureWecloneExportAdapterRegistered,
+  synthesizeTrainingPairs,
+  sweepPii,
+  wecloneExportAdapter,
+} from "./index.js";
+
+interface SyntheticMemory {
+  id: string;
+  category?: string;
+  confidence?: number;
+  created?: string;
+  tags?: string[];
+  content: string;
+}
+
+async function writeSyntheticMemory(
+  dir: string,
+  subdir: string,
+  filename: string,
+  mem: SyntheticMemory,
+): Promise<void> {
+  const fullDir = path.join(dir, subdir);
+  await mkdir(fullDir, { recursive: true });
+  const tags = mem.tags ?? [];
+  const md = [
+    "---",
+    `id: ${mem.id}`,
+    `category: ${mem.category ?? "fact"}`,
+    `created: ${mem.created ?? "2026-01-15T10:00:00.000Z"}`,
+    `updated: ${mem.created ?? "2026-01-15T10:00:00.000Z"}`,
+    `source: test`,
+    `confidence: ${mem.confidence ?? 0.9}`,
+    `confidenceTier: explicit`,
+    `tags: [${tags.map((t) => `"${t}"`).join(", ")}]`,
+    "---",
+    "",
+    mem.content,
+  ].join("\n");
+  await writeFile(path.join(fullDir, filename), md, "utf-8");
+}
+
+describe("@remnic/export-weclone — end-to-end integration", () => {
+  let tmpDir: string;
+
+  before(async () => {
+    tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-weclone-int-"));
+
+    // --- Synthetic fixture covering all template categories ---
+    await writeSyntheticMemory(tmpDir, "facts", "coffee.md", {
+      id: "mem-001",
+      category: "preference",
+      confidence: 0.9,
+      tags: ["food", "coffee"],
+      content: "Prefers dark roast coffee, specifically Ethiopian Yirgacheffe.",
+    });
+    await writeSyntheticMemory(tmpDir, "facts", "typescript.md", {
+      id: "mem-002",
+      category: "skill",
+      confidence: 0.85,
+      tags: ["typescript", "language"],
+      content: "Proficient with TypeScript generics and conditional types.",
+    });
+    await writeSyntheticMemory(tmpDir, "corrections", "postgres.md", {
+      id: "mem-003",
+      category: "decision",
+      confidence: 0.95,
+      tags: ["database"],
+      content: "Chose PostgreSQL over MySQL for its JSONB support.",
+    });
+    // Low-confidence memory that must be filtered out by --min-confidence
+    await writeSyntheticMemory(tmpDir, "facts", "lowconf.md", {
+      id: "mem-004",
+      category: "fact",
+      confidence: 0.4,
+      content: "Unverified claim that should not reach the dataset.",
+    });
+    // PII-bearing memory to exercise the final sweep
+    await writeSyntheticMemory(tmpDir, "facts", "pii.md", {
+      id: "mem-005",
+      category: "fact",
+      confidence: 0.9,
+      content: "Contact placeholder alice@example.test for the shared demo.",
+    });
+  });
+
+  after(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it("registers the weclone adapter via side-effect import", () => {
+    // The side-effect in index.ts has already fired; a second call is a no-op.
+    ensureWecloneExportAdapterRegistered();
+    const looked = getTrainingExportAdapter("weclone");
+    assert.ok(looked, "weclone adapter must be registered");
+    assert.equal(looked, wecloneExportAdapter);
+    assert.equal(looked!.fileExtension, ".json");
+  });
+
+  it("converts memoryDir → Alpaca JSON end-to-end", async () => {
+    const records = await convertMemoriesToRecords({
+      memoryDir: tmpDir,
+      minConfidence: 0.7,
+    });
+
+    // Low-confidence memory must be filtered; three of four high-confidence
+    // memories + the PII memory (all >= 0.7) should survive. The decision
+    // memory lives under corrections/ to prove that subdir is scanned too.
+    const ids = records.map((r) => r.sourceIds?.[0]).sort();
+    assert.deepEqual(ids, ["mem-001", "mem-002", "mem-003", "mem-005"]);
+
+    const { cleanRecords, redactedCount } = sweepPii(records);
+    assert.ok(redactedCount >= 1, "PII sweep should redact the email");
+
+    const json = wecloneExportAdapter.formatRecords(cleanRecords);
+    const parsed = JSON.parse(json) as Array<Record<string, unknown>>;
+
+    assert.ok(Array.isArray(parsed));
+    assert.equal(parsed.length, cleanRecords.length);
+    for (const row of parsed) {
+      assert.deepEqual(
+        Object.keys(row).sort(),
+        ["input", "instruction", "output"],
+        "adapter must emit only Alpaca fields",
+      );
+    }
+
+    // The final JSON must not contain raw PII anywhere.
+    assert.doesNotMatch(
+      json,
+      /alice@example\.test/,
+      "PII must be redacted before adapter serialization",
+    );
+  });
+
+  it("produces conversational Q/A pairs when synthesis is enabled", async () => {
+    const raw = await convertMemoriesToRecords({
+      memoryDir: tmpDir,
+      minConfidence: 0.7,
+    });
+    const pairs = synthesizeTrainingPairs(raw);
+
+    assert.equal(pairs.length, raw.length);
+
+    // The preference record (mem-001) should now surface a preference-style
+    // question pulled from the (food, coffee) tags.
+    const coffeePair = pairs.find((p) => p.sourceIds?.[0] === "mem-001");
+    assert.ok(coffeePair, "expected mem-001 to survive synthesis");
+    assert.match(coffeePair!.instruction.toLowerCase(), /like|preference|favorite/);
+    assert.match(coffeePair!.instruction.toLowerCase(), /food, coffee/);
+
+    // The skill record (mem-002) should surface an expertise-style prompt.
+    const skillPair = pairs.find((p) => p.sourceIds?.[0] === "mem-002");
+    assert.ok(skillPair);
+    assert.match(skillPair!.instruction.toLowerCase(), /tell|know|explain/);
+
+    // Alpaca serialization must succeed after synthesis as well.
+    const json = wecloneExportAdapter.formatRecords(pairs);
+    const parsed = JSON.parse(json) as Array<{ instruction: string }>;
+    assert.equal(parsed.length, pairs.length);
+    for (const row of parsed) {
+      assert.ok(row.instruction.length > 0);
+    }
+  });
+
+  it("honours category filter end-to-end", async () => {
+    const records = await convertMemoriesToRecords({
+      memoryDir: tmpDir,
+      categories: ["preference"],
+      minConfidence: 0.7,
+    });
+
+    assert.equal(records.length, 1);
+    assert.equal(records[0].sourceIds?.[0], "mem-001");
+
+    const json = wecloneExportAdapter.formatRecords(records);
+    const parsed = JSON.parse(json) as Array<{ output: string }>;
+    assert.equal(parsed.length, 1);
+    assert.match(parsed[0].output, /dark roast/i);
+  });
+
+  it("honours since/until date filters end-to-end", async () => {
+    // Write a memory from outside the window into the existing fixture.
+    await writeSyntheticMemory(tmpDir, "facts", "old.md", {
+      id: "mem-old",
+      category: "fact",
+      confidence: 0.9,
+      created: "2025-01-01T00:00:00.000Z",
+      content: "Out-of-window fact.",
+    });
+
+    const records = await convertMemoriesToRecords({
+      memoryDir: tmpDir,
+      since: new Date("2026-01-01T00:00:00.000Z"),
+      until: new Date("2027-01-01T00:00:00.000Z"),
+    });
+
+    const ids = records.map((r) => r.sourceIds?.[0]);
+    assert.ok(!ids.includes("mem-old"), "out-of-window memory must be excluded");
+    assert.ok(ids.includes("mem-001"), "in-window memory must be included");
+  });
+});

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -30,7 +30,8 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:^"
+    "@remnic/core": "workspace:^",
+    "@remnic/export-weclone": "workspace:^"
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -116,6 +116,22 @@ import {
   resolveExtensionsRoot,
   coerceInstallExtension,
 } from "@remnic/core";
+import {
+  convertMemoriesToRecords,
+  getTrainingExportAdapter,
+  listTrainingExportAdapters,
+  parseStrictCliDate,
+  type TrainingExportOptions,
+  type TrainingExportRecord,
+} from "@remnic/core";
+// Side-effect import: registers the weclone adapter with the core registry.
+// `ensureWecloneExportAdapterRegistered` is exported for idempotent explicit
+// calls from tests that reset the registry between cases.
+import {
+  ensureWecloneExportAdapterRegistered,
+  synthesizeTrainingPairs,
+  sweepPii,
+} from "@remnic/export-weclone";
 import type {
   BinaryLifecycleConfig,
 } from "@remnic/core";
@@ -196,7 +212,8 @@ type CommandName =
   | "taxonomy"
   | "enrich"
   | "openclaw"
-  | "extensions";
+  | "extensions"
+  | "training:export";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -3946,6 +3963,253 @@ Usage:
   }
 }
 
+// ── Training export ──────────────────────────────────────────────────────────
+
+/**
+ * Allowed values for `--format`. Derived dynamically from the registry so
+ * any adapter registered via side-effect import (e.g. `@remnic/export-weclone`)
+ * is auto-discovered without a hard-coded switch.
+ *
+ * CLAUDE.md #51: invalid formats must throw an error listing valid options,
+ * not silently default. CLAUDE.md #52: the validator is the registry, so
+ * there is no chance of an allow-list drifting from the handler map.
+ */
+
+interface ParsedTrainingExportArgs {
+  format: string;
+  output: string;
+  memoryDir: string;
+  since?: string;
+  until?: string;
+  minConfidence?: number;
+  categories?: string[];
+  includeEntities: boolean;
+  synthesize: boolean;
+  maxPairsPerRecord?: number;
+  privacySweep: boolean;
+  dryRun: boolean;
+}
+
+/**
+ * Parse training:export CLI flags. Rejects unknown values instead of
+ * silently defaulting, per CLAUDE.md #14/#51.
+ *
+ * Exported for testability.
+ */
+export function parseTrainingExportArgs(
+  rest: string[],
+  defaultMemoryDir: string,
+): ParsedTrainingExportArgs {
+  const format = resolveFlagStrict(rest, "--format");
+  if (!format) {
+    throw new Error(
+      "--format <name> is required. Run `remnic training:export --help` for the list of registered adapters.",
+    );
+  }
+
+  // Accept --out as a short alias for --output (issue #459 spec uses both).
+  const output = resolveFlagStrict(rest, "--output") ?? resolveFlagStrict(rest, "--out");
+  if (!output) {
+    throw new Error(
+      "--output <path> (or --out <path>) is required for training:export. " +
+        "Use --dry-run to print statistics without writing a file.",
+    );
+  }
+
+  const memoryDirFlag = resolveFlagStrict(rest, "--memory-dir");
+  const memoryDir = memoryDirFlag ? expandTilde(memoryDirFlag) : defaultMemoryDir;
+
+  const since = resolveFlagStrict(rest, "--since");
+  const until = resolveFlagStrict(rest, "--until");
+
+  const minConfidenceRaw = resolveFlagStrict(rest, "--min-confidence");
+  let minConfidence: number | undefined;
+  if (minConfidenceRaw !== undefined) {
+    const n = Number(minConfidenceRaw);
+    if (!Number.isFinite(n) || n < 0 || n > 1) {
+      throw new Error(
+        `Invalid --min-confidence value "${minConfidenceRaw}": expected a number in [0, 1].`,
+      );
+    }
+    minConfidence = n;
+  }
+
+  const categoriesRaw = resolveFlagStrict(rest, "--categories");
+  const categories = categoriesRaw
+    ? categoriesRaw
+        .split(",")
+        .map((c) => c.trim())
+        .filter((c) => c.length > 0)
+    : undefined;
+
+  const maxPairsRaw = resolveFlagStrict(rest, "--max-pairs-per-record");
+  let maxPairsPerRecord: number | undefined;
+  if (maxPairsRaw !== undefined) {
+    const n = Number(maxPairsRaw);
+    if (!Number.isInteger(n) || n < 1) {
+      throw new Error(
+        `Invalid --max-pairs-per-record value "${maxPairsRaw}": expected a positive integer.`,
+      );
+    }
+    maxPairsPerRecord = n;
+  }
+
+  const includeEntities = hasFlag(rest, "--include-entities");
+  // `--synthesize` is off by default: it is a WeClone-specific enhancement that
+  // turns Remnic's flat records into conversational Q/A pairs. Users of other
+  // formats (or raw Alpaca) can opt out.
+  const synthesize = hasFlag(rest, "--synthesize");
+  // `--privacy-sweep` is on by default for WeClone and any other adapter that
+  // will be shared as a training dataset. Off switch: --no-privacy-sweep.
+  const privacySweep = !hasFlag(rest, "--no-privacy-sweep");
+  const dryRun = hasFlag(rest, "--dry-run");
+
+  return {
+    format,
+    output: expandTilde(output),
+    memoryDir,
+    since,
+    until,
+    minConfidence,
+    categories,
+    includeEntities,
+    synthesize,
+    maxPairsPerRecord,
+    privacySweep,
+    dryRun,
+  };
+}
+
+/**
+ * Run the full training-export pipeline end-to-end:
+ *   memoryDir → convertMemoriesToRecords → (optional synthesize) →
+ *   (optional PII sweep) → adapter.formatRecords → file
+ *
+ * Exported for integration tests so a harness can drive the full pipeline
+ * without spawning a subprocess.
+ */
+export async function runTrainingExport(
+  args: ParsedTrainingExportArgs,
+  stdout: { write: (s: string) => void } = process.stdout,
+): Promise<{
+  recordsRead: number;
+  recordsWritten: number;
+  redactedCount: number;
+  outputPath: string | null;
+}> {
+  // Ensure the WeClone adapter (and any others registered via side-effect
+  // imports) are available before we ask the registry. `ensureWecloneExportAdapterRegistered`
+  // is idempotent — safe to call even when the adapter is already registered
+  // by a previous CLI invocation in the same process.
+  ensureWecloneExportAdapterRegistered();
+
+  const adapter = getTrainingExportAdapter(args.format);
+  if (!adapter) {
+    const registered = listTrainingExportAdapters();
+    const validList =
+      registered.length > 0
+        ? `Valid formats: [${registered.join(", ")}]`
+        : "No adapters are currently registered.";
+    throw new Error(
+      `Unknown training-export format "${args.format}". ${validList}`,
+    );
+  }
+
+  if (!fs.existsSync(args.memoryDir)) {
+    throw new Error(
+      `--memory-dir "${args.memoryDir}" does not exist. Provide the path to an existing memory directory.`,
+    );
+  }
+  if (!fs.statSync(args.memoryDir).isDirectory()) {
+    throw new Error(
+      `--memory-dir "${args.memoryDir}" is not a directory. Provide the path to a memory directory, not a file.`,
+    );
+  }
+
+  // Parse date filters with the shared strict validator so behavior matches
+  // the core CLI (rejects Feb 31, non-ISO strings, etc.).
+  let since: Date | undefined;
+  if (args.since) since = parseStrictCliDate(args.since, "--since");
+  let until: Date | undefined;
+  if (args.until) until = parseStrictCliDate(args.until, "--until");
+
+  const convertOptions: TrainingExportOptions = {
+    memoryDir: args.memoryDir,
+    since,
+    until,
+    minConfidence: args.minConfidence,
+    categories: args.categories,
+    includeEntities: args.includeEntities,
+  };
+
+  let records: TrainingExportRecord[] = await convertMemoriesToRecords(convertOptions);
+  const recordsRead = records.length;
+
+  if (args.synthesize) {
+    records = synthesizeTrainingPairs(records, {
+      maxPairsPerRecord: args.maxPairsPerRecord,
+    });
+  }
+
+  let redactedCount = 0;
+  if (args.privacySweep) {
+    const swept = sweepPii(records);
+    records = swept.cleanRecords;
+    redactedCount = swept.redactedCount;
+  }
+
+  if (args.dryRun) {
+    stdout.write(`Training export dry run\n`);
+    stdout.write(`Format: ${adapter.name}\n`);
+    stdout.write(`Records read: ${recordsRead}\n`);
+    stdout.write(`Records to write: ${records.length}\n`);
+    if (args.privacySweep) {
+      stdout.write(`Redacted records: ${redactedCount}\n`);
+    }
+    const cats = new Map<string, number>();
+    for (const r of records) {
+      const c = r.category ?? "unknown";
+      cats.set(c, (cats.get(c) ?? 0) + 1);
+    }
+    const sortedCats = [...cats.entries()].sort((a, b) =>
+      a[0].localeCompare(b[0]),
+    );
+    for (const [cat, count] of sortedCats) {
+      stdout.write(`  ${cat}: ${count}\n`);
+    }
+    return {
+      recordsRead,
+      recordsWritten: 0,
+      redactedCount,
+      outputPath: null,
+    };
+  }
+
+  const formatted = adapter.formatRecords(records);
+
+  // Ensure parent directory exists before writing. Use atomic rename to
+  // avoid partial-write corruption (CLAUDE.md #54: never delete before
+  // successful write).
+  const outDir = path.dirname(args.output);
+  fs.mkdirSync(outDir, { recursive: true });
+  const tmpPath = `${args.output}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, formatted, "utf-8");
+  fs.renameSync(tmpPath, args.output);
+
+  stdout.write(
+    `Exported ${records.length} records to ${args.output} (${adapter.name} format)\n`,
+  );
+  if (args.privacySweep && redactedCount > 0) {
+    stdout.write(`Privacy sweep redacted PII in ${redactedCount} record(s).\n`);
+  }
+  return {
+    recordsRead,
+    recordsWritten: records.length,
+    redactedCount,
+    outputPath: args.output,
+  };
+}
+
 // ── CLI entry ────────────────────────────────────────────────────────────────
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
@@ -4238,6 +4502,52 @@ Options:
       break;
     }
 
+    case "training:export": {
+      if (rest.includes("--help") || rest.includes("-h")) {
+        console.log(`
+remnic training:export — Export Remnic memories as fine-tuning datasets (issue #459)
+
+Usage:
+  remnic training:export --format <name> --output <path> [options]
+
+Required:
+  --format <name>              Registered adapter name (e.g. weclone)
+  --output <path> | --out      Path to write the dataset file
+
+Filters:
+  --memory-dir <path>          Memory directory (defaults to resolved memoryDir)
+  --since <YYYY-MM-DD[T...]>   Only include memories created at or after this date
+  --until <YYYY-MM-DD[T...]>   Only include memories created before this date (exclusive)
+  --min-confidence <0..1>      Inclusive lower bound on memory confidence
+  --categories <list>          Comma-separated category filter (fact,preference,...)
+  --include-entities           Also read from entities/ (off by default)
+
+Adapter options:
+  --synthesize                 Generate conversational Q/A pairs (WeClone-optimised)
+  --max-pairs-per-record <n>   When --synthesize, max pairs emitted per memory
+  --no-privacy-sweep           Skip the final PII redaction pass (default: on)
+
+Other:
+  --dry-run                    Print statistics only; do not write the file
+`);
+        break;
+      }
+      let parsed: ParsedTrainingExportArgs;
+      try {
+        parsed = parseTrainingExportArgs(rest, resolveMemoryDir());
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      try {
+        await runTrainingExport(parsed);
+      } catch (err) {
+        console.error(err instanceof Error ? err.message : String(err));
+        process.exit(1);
+      }
+      break;
+    }
+
     case "openclaw": {
       const subAction = rest[0] ?? "help";
       if (subAction === "install") {
@@ -4318,6 +4628,9 @@ Usage:
   remnic enrich --dry-run        Preview what would be enriched
   remnic enrich audit            Show recent enrichment audit log
   remnic enrich providers        List registered providers and their status
+  remnic training:export --format <name> --output <path> [options]
+    Export memories as a fine-tuning dataset (issue #459). See
+    `remnic training:export --help` for the full option list.
 
 Options:
   --json    Output in JSON format

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4007,17 +4007,35 @@ export function parseTrainingExportArgs(
     );
   }
 
+  // Parse --dry-run first so we can relax the --output requirement when the
+  // user only wants statistics (Cursor review on PR #509: the help text and
+  // the earlier error message both documented --dry-run as the
+  // --output-optional escape hatch, but the old ordering unconditionally
+  // required --output and made that combination impossible).
+  const dryRun = hasFlag(rest, "--dry-run");
+
   // Accept --out as a short alias for --output (issue #459 spec uses both).
-  const output = resolveFlagStrict(rest, "--output") ?? resolveFlagStrict(rest, "--out");
-  if (!output) {
+  const outputRaw =
+    resolveFlagStrict(rest, "--output") ?? resolveFlagStrict(rest, "--out");
+  if (!outputRaw && !dryRun) {
     throw new Error(
       "--output <path> (or --out <path>) is required for training:export. " +
         "Use --dry-run to print statistics without writing a file.",
     );
   }
+  // In dry-run mode, `runTrainingExport` never touches the filesystem, so
+  // the output field is unused — we still populate it with a sentinel path
+  // so the parsed-args contract has no optional field and downstream code
+  // doesn't need to re-check dryRun before reading `output`.
+  const output = outputRaw ? expandTilde(outputRaw) : "";
 
+  // Expand ~ in BOTH the --memory-dir flag AND the default resolved dir
+  // (CLAUDE.md #17: Node.js `fs` does not expand ~; apply it to every path
+  // input consistently, not just the explicit flag). `resolveMemoryDir`
+  // can surface a tilde-prefixed path from config or env — validating that
+  // without expansion would reject otherwise-valid memory stores.
   const memoryDirFlag = resolveFlagStrict(rest, "--memory-dir");
-  const memoryDir = memoryDirFlag ? expandTilde(memoryDirFlag) : defaultMemoryDir;
+  const memoryDir = expandTilde(memoryDirFlag ?? defaultMemoryDir);
 
   const since = resolveFlagStrict(rest, "--since");
   const until = resolveFlagStrict(rest, "--until");
@@ -4062,11 +4080,10 @@ export function parseTrainingExportArgs(
   // `--privacy-sweep` is on by default for WeClone and any other adapter that
   // will be shared as a training dataset. Off switch: --no-privacy-sweep.
   const privacySweep = !hasFlag(rest, "--no-privacy-sweep");
-  const dryRun = hasFlag(rest, "--dry-run");
 
   return {
     format,
-    output: expandTilde(output),
+    output,
     memoryDir,
     since,
     until,
@@ -4183,6 +4200,17 @@ export async function runTrainingExport(
       redactedCount,
       outputPath: null,
     };
+  }
+
+  // Defensive: the CLI parser requires --output when --dry-run is absent,
+  // but programmatic callers construct ParsedTrainingExportArgs directly.
+  // Fail loudly rather than write to an empty-string path that the shell
+  // might resolve to cwd in surprising ways.
+  if (!args.output) {
+    throw new Error(
+      "runTrainingExport: `output` is required when dryRun is false. " +
+        "Pass dryRun: true to skip file I/O.",
+    );
   }
 
   const formatted = adapter.formatRecords(records);
@@ -4629,8 +4657,8 @@ Usage:
   remnic enrich audit            Show recent enrichment audit log
   remnic enrich providers        List registered providers and their status
   remnic training:export --format <name> --output <path> [options]
-    Export memories as a fine-tuning dataset (issue #459). See
-    `remnic training:export --help` for the full option list.
+    Export memories as a fine-tuning dataset (issue #459). Run
+    'remnic training:export --help' for the full option list.
 
 Options:
   --json    Output in JSON format

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -196,6 +196,7 @@ import {
 } from "./policy-runtime.js";
 import { resolveHomeDir } from "./runtime/env.js";
 import { convertMemoriesToRecords } from "./training-export/converter.js";
+import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
 
 interface CliApi {
@@ -2138,100 +2139,16 @@ async function readRuntimePolicySnapshot(
 }
 
 /**
- * Days in each month (1-indexed). February is 28; leap-year handling is
- * applied by `isCalendarDateValid` below.
- */
-const DAYS_IN_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
-
-function isLeapYear(year: number): boolean {
-  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-}
-
-/**
- * True iff `year-month-day` is a valid Gregorian calendar date. Input
- * numbers must be integer-valued; month is 1-12, day is 1-31 nominally.
- */
-function isCalendarDateValid(year: number, month: number, day: number): boolean {
-  if (!Number.isInteger(year) || !Number.isInteger(month) || !Number.isInteger(day)) {
-    return false;
-  }
-  if (month < 1 || month > 12) return false;
-  if (day < 1) return false;
-  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month];
-  return day <= maxDay;
-}
-
-/**
- * Parse a date string strictly: rejects overflowed calendar values
- * like "2026-02-31" that JavaScript normalizes silently, and rejects
- * non-ISO formats (e.g. "01/15/2026", "December 25, 2026").
+ * Parse a date string strictly. Thin re-export of the canonical
+ * implementation in `training-export/date-parse.ts` so that the
+ * `@remnic/cli` front-end and the core CLI use identical semantics
+ * (CLAUDE.md #22: shared helpers must not be re-implemented per caller).
  *
- * Accepts:
- *   YYYY-MM-DD
- *   YYYY-MM-DDTHH:mm:ss                (naive / local time)
- *   YYYY-MM-DDTHH:mm:ss.sssZ           (UTC)
- *   YYYY-MM-DDTHH:mm:ss+HH:MM          (with timezone offset)
- *   YYYY-MM-DDTHH:mm:ss.sss-HH:MM      (with timezone offset)
- *
- * Overflow validation is performed structurally on the parsed Y-M-D
- * components, independent of how `Date` interprets the string. This makes
- * the check correct regardless of whether the timestamp is UTC, offset, or
- * naive (local) — i.e. it does not depend on the host timezone.
+ * Existing imports of `parseStrictCliDate` from `./cli.js` continue to
+ * work — this re-export preserves backward compatibility for the
+ * `cli-date-validation.test.ts` suite.
  */
-export function parseStrictCliDate(value: string, flagName: string): Date {
-  // 1. Shape check: must begin YYYY-MM-DD and use ISO 8601 structure.
-  //    This rejects "12/25/2026", "December 25, 2026", RFC 2822, etc.
-  const shape =
-    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:\d{2})?)?$/;
-  const match = value.match(shape);
-  if (!match) {
-    throw new Error(
-      `Invalid ${flagName} value "${value}": expected ISO 8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss[.sss][Z|±HH:MM]).`,
-    );
-  }
-
-  const year = Number(match[1]);
-  const month = Number(match[2]);
-  const day = Number(match[3]);
-
-  // 2. Structural calendar validation. This rejects Feb 31, Feb 29 in
-  //    non-leap years, Apr 31, etc. regardless of the timezone suffix, so
-  //    "2026-02-31T00:00:00+05:30" is rejected the same way as "2026-02-31Z".
-  if (!isCalendarDateValid(year, month, day)) {
-    throw new Error(
-      `Invalid ${flagName} value "${value}": date components overflow (e.g. month has fewer days). Provide a valid calendar date.`,
-    );
-  }
-
-  // 3. Optional time-component validation.
-  //    JavaScript's Date cannot represent a leap second: `:60` is silently
-  //    normalised to `:00` of the following minute, which would make a
-  //    "strict" validator return a different timestamp than the user
-  //    requested. Reject second == 60 outright so a strict parse cannot
-  //    round-trip to a different clock value.
-  if (match[4] !== undefined) {
-    const hour = Number(match[4]);
-    const minute = Number(match[5]);
-    const second = match[6] !== undefined ? Number(match[6]) : 0;
-    if (hour > 23 || minute > 59 || second > 59) {
-      throw new Error(
-        `Invalid ${flagName} value "${value}": time components out of range.`,
-      );
-    }
-  }
-
-  // 4. Finally parse via Date for the actual timestamp value. At this point
-  //    we've already validated structure and calendar correctness, so any
-  //    remaining NaN (extremely unlikely) still fails closed.
-  const d = new Date(value);
-  if (!Number.isFinite(d.getTime())) {
-    throw new Error(
-      `Invalid ${flagName} value "${value}". Provide an ISO 8601 date string (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss).`,
-    );
-  }
-
-  return d;
-}
+export const parseStrictCliDate = parseStrictCliDateShared;
 
 function parseSinceDurationMs(since: string): number {
   const trimmed = since.trim().toLowerCase();

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2914,6 +2914,14 @@ export interface BulkImportCliCommandOptions {
   dryRun?: boolean;
   verbose?: boolean;
   strict?: boolean;
+  /**
+   * Optional adapter-specific platform hint forwarded to `adapter.parse`.
+   * Some bulk-import adapters (e.g. weclone) accept a platform discriminator
+   * so a single adapter can parse Telegram JSON, WeChat JSON, etc. without
+   * shipping a separate source for each. When undefined, adapters pick a
+   * default based on file shape.
+   */
+  platform?: string;
   stdout: Writable;
   stderr: Writable;
 }

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -115,7 +115,7 @@ export class NamespaceSearchRouter {
         return 1;
       }),
     );
-    return results.reduce((sum, v) => sum + v, 0);
+    return results.reduce<number>((sum, v) => sum + v, 0);
   }
 
   async embedNamespaces(namespaces: string[]): Promise<void> {

--- a/packages/remnic-core/src/training-export/date-parse.ts
+++ b/packages/remnic-core/src/training-export/date-parse.ts
@@ -1,0 +1,117 @@
+/**
+ * Strict ISO 8601 date parsing for training-export CLI flags.
+ *
+ * Extracted from `cli.ts` so that both the canonical CLI (in
+ * `@remnic/core`) and the thin front-end CLI (in `@remnic/cli`) can share
+ * the same validator without duplicating the overflow/timezone rules.
+ *
+ * The parser rejects:
+ *   - Non-ISO strings (e.g. "12/25/2026", "Dec 25 2026")
+ *   - Calendar overflows (Feb 30, Feb 29 in non-leap years, Apr 31, etc.)
+ *     regardless of timezone suffix
+ *   - Out-of-range time components (hour >= 24, minute >= 60, second >= 60)
+ *
+ * Calendar overflow is validated structurally on the Y-M-D components, so
+ * results are independent of the host's local timezone.
+ */
+
+/**
+ * Days in each month (1-indexed). February is 28 here; leap-year handling
+ * is applied by `isCalendarDateValid` below.
+ */
+const DAYS_IN_MONTH = [0, 31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * True iff `year-month-day` is a valid Gregorian calendar date. Input
+ * numbers must be integer-valued; month is 1-12, day is 1-31 nominally.
+ */
+export function isCalendarDateValid(
+  year: number,
+  month: number,
+  day: number,
+): boolean {
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day)
+  ) {
+    return false;
+  }
+  if (month < 1 || month > 12) return false;
+  if (day < 1) return false;
+  const maxDay = month === 2 && isLeapYear(year) ? 29 : DAYS_IN_MONTH[month];
+  return day <= maxDay;
+}
+
+/**
+ * Parse a strict ISO 8601 date string, rejecting malformed inputs, calendar
+ * overflows, and out-of-range time components with a descriptive error.
+ *
+ * Accepted forms:
+ *   YYYY-MM-DD
+ *   YYYY-MM-DDTHH:mm:ss                (naive / local time)
+ *   YYYY-MM-DDTHH:mm:ss.sssZ           (UTC)
+ *   YYYY-MM-DDTHH:mm:ss+HH:MM          (with timezone offset)
+ *   YYYY-MM-DDTHH:mm:ss.sss-HH:MM      (with timezone offset)
+ *
+ * `flagName` is included in the error message so users can identify which
+ * input failed (e.g. `--since` vs. `--until`).
+ */
+export function parseStrictCliDate(value: string, flagName: string): Date {
+  // 1. Shape check: must begin YYYY-MM-DD and use ISO 8601 structure.
+  //    This rejects "12/25/2026", "December 25, 2026", RFC 2822, etc.
+  const shape =
+    /^(\d{4})-(\d{2})-(\d{2})(?:T(\d{2}):(\d{2})(?::(\d{2})(?:\.(\d{1,9}))?)?(Z|[+-]\d{2}:\d{2})?)?$/;
+  const match = value.match(shape);
+  if (!match) {
+    throw new Error(
+      `Invalid ${flagName} value "${value}": expected ISO 8601 format (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss[.sss][Z|±HH:MM]).`,
+    );
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  // 2. Structural calendar validation. This rejects Feb 31, Feb 29 in
+  //    non-leap years, Apr 31, etc. regardless of the timezone suffix, so
+  //    "2026-02-31T00:00:00+05:30" is rejected the same way as "2026-02-31Z".
+  if (!isCalendarDateValid(year, month, day)) {
+    throw new Error(
+      `Invalid ${flagName} value "${value}": date components overflow (e.g. month has fewer days). Provide a valid calendar date.`,
+    );
+  }
+
+  // 3. Optional time-component validation.
+  //    JavaScript's Date cannot represent a leap second: `:60` is silently
+  //    normalised to `:00` of the following minute, which would make a
+  //    "strict" validator return a different timestamp than the user
+  //    requested. Reject second == 60 outright so a strict parse cannot
+  //    round-trip to a different clock value.
+  if (match[4] !== undefined) {
+    const hour = Number(match[4]);
+    const minute = Number(match[5]);
+    const second = match[6] !== undefined ? Number(match[6]) : 0;
+    if (hour > 23 || minute > 59 || second > 59) {
+      throw new Error(
+        `Invalid ${flagName} value "${value}": time components out of range.`,
+      );
+    }
+  }
+
+  // 4. Finally parse via Date for the actual timestamp value. At this point
+  //    we've already validated structure and calendar correctness, so any
+  //    remaining NaN (extremely unlikely) still fails closed.
+  const d = new Date(value);
+  if (!Number.isFinite(d.getTime())) {
+    throw new Error(
+      `Invalid ${flagName} value "${value}". Provide an ISO 8601 date string (YYYY-MM-DD or YYYY-MM-DDTHH:mm:ss).`,
+    );
+  }
+
+  return d;
+}

--- a/packages/remnic-core/src/training-export/index.ts
+++ b/packages/remnic-core/src/training-export/index.ts
@@ -18,3 +18,5 @@ export {
 } from "./registry.js";
 
 export { convertMemoriesToRecords } from "./converter.js";
+
+export { parseStrictCliDate, isCalendarDateValid } from "./date-parse.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -190,6 +190,9 @@ importers:
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
+      '@remnic/export-weclone':
+        specifier: workspace:^
+        version: link:../export-weclone
     devDependencies:
       '@remnic/bench':
         specifier: workspace:*


### PR DESCRIPTION
## Summary

Closes the remaining gaps for issue #459 after PRs #488 (core training-export scaffolding) and #492 (`@remnic/export-weclone` adapter package). The end-to-end flow the issue promised — `remnic training:export --format weclone --output ...` — now actually works.

- End-to-end CLI handler in `@remnic/cli` with `--since`, `--until`, `--min-confidence`, `--categories`, `--include-entities`, `--synthesize`, `--max-pairs-per-record`, `--no-privacy-sweep`, `--dry-run`, plus `--out` as an alias for `--output`.
- Adapter self-registration: importing `@remnic/export-weclone` registers the `weclone` adapter with the core training-export registry (idempotent helper `ensureWecloneExportAdapterRegistered` is exported for tests).
- Extracted strict ISO-8601 date parser into `training-export/date-parse.ts` so the core CLI and front-end CLI share identical semantics (CLAUDE.md #22). `cli.ts` re-exports it so existing tests keep passing.
- Integration test against a synthetic `memoryDir` fixture exercises the full pipeline (converter → synthesizer → PII sweep → adapter → parsed JSON). Covers side-effect registration, category/date/confidence filtering, and Alpaca-shape validation.
- README for `@remnic/export-weclone` (CLI usage, programmatic API, synthesis mechanics, privacy posture).
- `docs/import-export.md` now documents the training-export CLI.
- Root `pnpm test` script covers `packages/export-weclone/src` so CI runs the adapter and integration tests.

## Design notes
- **Invalid flags reject** with messages listing valid options (CLAUDE.md #51).
- **Atomic writes**: temp-file + rename to avoid partial-write corruption (CLAUDE.md #54).
- **Privacy sweep on by default**: `--no-privacy-sweep` must be explicit. Output JSON contains only the three Alpaca fields; Remnic metadata never leaves the memory store.
- **Side-effect registration is idempotent**. Tests that call `clearTrainingExportAdapters()` can re-register by calling `ensureWecloneExportAdapterRegistered()`.

## Test plan
- [x] `tsx --test packages/remnic-core/src/training-export/*.test.ts` — 57/57 passing (registry, converter, cli-date-validation).
- [x] `tsx --test packages/export-weclone/src/*.test.ts` — adapter, privacy, style-extractor, synthesizer, **integration** all green (including the new 5-case round-trip test).
- [x] Pre-existing bulk-import test failures confirmed present on `main` (not caused by this PR).
- [ ] CI runs `pnpm test` which now includes `packages/export-weclone/src/**/*.test.ts` (was previously excluded).
- [ ] Manual smoke: `remnic training:export --format weclone --output /tmp/out.json --dry-run` against a real memoryDir.

Refs: #459, #488, #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `remnic training:export` CLI path that reads memory stores, optionally synthesizes/redacts content, and writes datasets to disk, so regressions could affect export correctness and privacy defaults. Changes are additive and covered by new integration tests, but touch CLI argument parsing and file I/O.
> 
> **Overview**
> Implements the promised `remnic training:export` flow (issue #459): parses export flags (date/category/confidence filters, entities, synthesis, privacy sweep, dry-run), resolves a registered adapter dynamically, converts memories to records, optionally synthesizes Q/A pairs and performs PII redaction, then writes output with an atomic temp-file rename.
> 
> Adds WeClone adapter side-effect registration with an idempotent `ensureWecloneExportAdapterRegistered()` helper, plus a new end-to-end integration test fixture validating filtering, synthesis, redaction, and Alpaca JSON shape. Also extracts the strict ISO date parser into `training-export/date-parse.ts` (re-exported for compatibility), updates docs/README, wires `@remnic/export-weclone` into `@remnic/cli`, and expands the root test script to include the adapter tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90fb4de69b4b5f3600fbce69fdaff6b959b84950. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->