### PR TITLE
feat(import-weclone): complete issue #460 (README, integration test, CLI type fix)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "dev": "tsup --watch",
     "check-types": "tsc --noEmit",
     "check-config-contract": "tsx scripts/validate-config-contract.ts",
-    "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts'",
+    "test": "tsx --test 'tests/**/*.test.ts' 'packages/remnic-core/src/**/*.test.ts' 'packages/bench/src/**/*.test.ts' 'packages/export-weclone/src/**/*.test.ts' 'packages/import-weclone/src/**/*.test.ts'",
     "test:entity-hardening": "tsx --test tests/intent.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts tests/memory-cache.test.ts tests/entity-retrieval.test.ts tests/entity-synthesis-storage.test.ts tests/entity-synthesis-orchestrator.test.ts tests/config-recall-pipeline.test.ts",
     "bench:list": "node scripts/run-bench-cli.mjs list",
     "bench:run": "node scripts/run-bench-cli.mjs run",

--- a/packages/import-weclone/README.md
+++ b/packages/import-weclone/README.md
@@ -1,0 +1,221 @@
+# @remnic/import-weclone
+
+Import [WeClone](https://github.com/xming521/weclone)-preprocessed chat exports
+(Telegram, WhatsApp, Discord, Slack) into Remnic to bootstrap a memory store
+instantly, rather than waiting for organic memory accumulation through daily AI
+tool usage.
+
+Part of [Remnic](https://github.com/joshuaswarren/remnic), the universal memory
+layer for AI agents.
+
+## Install
+
+```bash
+npm install @remnic/import-weclone
+```
+
+The importer is discovered automatically by `@remnic/core` when the package is
+present in the workspace; no explicit registration is required.
+
+## Why WeClone?
+
+WeClone already handles the hard parts of chat ingestion:
+
+- Platform-specific export parsing (Telegram JSON, WhatsApp, Discord, Slack)
+- PII detection and redaction (Microsoft Presidio)
+- Message deduplication and basic cleanup
+
+Rather than duplicate that pipeline, this package consumes WeClone's
+preprocessed JSON directly and maps it into the bulk-import contract defined by
+`@remnic/core`.
+
+## Pipeline
+
+```
+WeClone preprocessed JSON
+         |
+         v
++---------------------------------+
+|  parseWeCloneExport             |  parser.ts
+|  - platform resolution          |
+|  - role inference (self/bot)    |
+|  - schema validation            |
++---------------+-----------------+
+                | BulkImportSource
+                v
++---------------------------------+
+|  groupIntoThreads               |  threader.ts
+|  - sort by timestamp            |
+|  - split on >30 min time gaps   |
+|  - merge via reply chains       |
++---------------+-----------------+
+                | ThreadGroup[]
+                v
++---------------------------------+
+|  mapParticipants                |  participant.ts
+|  - count messages per sender    |
+|  - classify self/frequent/      |
+|    occasional                   |
++---------------+-----------------+
+                | ParticipantEntity[]
+                v
++---------------------------------+
+|  chunkThreads                   |  chunker.ts
+|  - split long threads with      |
+|    overlap for context          |
++---------------+-----------------+
+                | ImportTurn[][]
+                v
++---------------------------------+
+|  runBulkImportPipeline          |  @remnic/core
+|  - batch extraction             |
+|  - dedup against existing       |
+|  - store with trustLevel=import |
++---------------------------------+
+```
+
+## CLI usage
+
+The importer is exposed via the `engram bulk-import` subcommand in
+`@remnic/core`:
+
+```bash
+# Dry-run: parse, validate, and report counts without persisting
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --dry-run
+
+# Specify a target namespace for the imported memories
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --namespace personal-chat-history \
+  --dry-run
+
+# Strict mode: fail on any invalid message instead of skipping
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --strict \
+  --dry-run
+```
+
+Persistence is currently guarded: invocations without `--dry-run` throw
+`Bulk import persistence is not yet wired` until the orchestrator integration
+lands. Use `--dry-run` to validate your export end-to-end.
+
+## Programmatic usage
+
+```ts
+import { readFileSync } from "node:fs";
+import {
+  parseWeCloneExport,
+  groupIntoThreads,
+  mapParticipants,
+  chunkThreads,
+  wecloneImportAdapter,
+} from "@remnic/import-weclone";
+import {
+  registerBulkImportSource,
+  runBulkImportPipeline,
+} from "@remnic/core";
+
+// 1) Register the adapter (core auto-registers if the package is installed).
+registerBulkImportSource(wecloneImportAdapter);
+
+// 2) Parse a WeClone-preprocessed export.
+const raw = JSON.parse(readFileSync("./export.json", "utf8"));
+const source = parseWeCloneExport(raw, { platform: "telegram" });
+
+// 3) Pre-process into threads, participants, chunks.
+const threads = groupIntoThreads(source.turns);
+const participants = mapParticipants(source.turns);
+const chunks = chunkThreads(threads, { maxTurnsPerChunk: 20 });
+
+// 4) Feed the result into the core bulk-import pipeline.
+const result = await runBulkImportPipeline(
+  source,
+  { batchSize: 20, dryRun: true, dedup: true, trustLevel: "import" },
+  async (batch) => ({
+    memoriesCreated: batch.length,
+    duplicatesSkipped: 0,
+    entitiesCreated: 0,
+  }),
+);
+```
+
+## Supported platforms
+
+| Platform  | `--platform` value |
+|-----------|--------------------|
+| Telegram  | `telegram`         |
+| WhatsApp  | `whatsapp`         |
+| Discord   | `discord`          |
+| Slack     | `slack`            |
+
+The parser defaults to `telegram` when neither `options.platform` nor an
+export-level `platform` field is provided. Unknown platforms are rejected.
+
+## Input schema
+
+The parser accepts either:
+
+1. A wrapper object:
+
+   ```json
+   {
+     "platform": "telegram",
+     "export_date": "2025-01-10T00:00:00.000Z",
+     "messages": [
+       {
+         "sender": "Alice",
+         "text": "hello",
+         "timestamp": "2025-01-10T08:00:00.000Z",
+         "message_id": "m-001",
+         "reply_to_id": "m-000"
+       }
+     ]
+   }
+   ```
+
+2. A raw array of messages (platform defaults to `telegram`).
+
+Required per-message fields: `sender`, `text`, `timestamp` (ISO-8601). Optional:
+`message_id`, `reply_to_id`.
+
+## Role inference
+
+Each `sender` is mapped to one of the `ImportTurn` roles:
+
+- `user` - the "self" sender (first non-bot sender encountered, or override
+  via `selfSender`).
+- `assistant` - any sender matching a bot heuristic (`bot`, `assistant`, `ai`,
+  `chatgpt`, `gpt`, `claude`, `copilot`, `llama`) or listed in
+  `assistantSenders`.
+- `other` - everyone else.
+
+The heuristic uses word-boundary matching so human names that happen to contain
+substrings like `ai` (e.g. `Aidan`, `Caitlin`) are not mis-classified.
+
+## Design notes
+
+- **Imported memories get a lower trust level.** The pipeline tags them with
+  `trustLevel: "import"` so a large historical import does not outweigh
+  organic memories in recall ranking.
+- **Threads are conversation boundaries, not days.** The default 30-minute
+  gap with reply-chain merging produces coherent extraction batches without
+  relying on calendar boundaries.
+- **Entity bootstrapping is best-effort.** `mapParticipants` emits
+  lightweight `ParticipantEntity` records; the core entity graph is populated
+  as the pipeline processes chunks.
+- **Idempotent re-imports.** The pipeline's dedup pass (when wired)
+  fingerprint-matches against existing memories, so re-running the importer
+  after appending new messages is safe.
+
+## License
+
+MIT. See [LICENSE](https://github.com/joshuaswarren/remnic/blob/main/LICENSE).

--- a/packages/import-weclone/src/integration.test.ts
+++ b/packages/import-weclone/src/integration.test.ts
@@ -308,9 +308,10 @@ describe("integration: WeClone → @remnic/core bulk-import", () => {
       { maxTurnsPerChunk: 4, overlapTurns: 1 },
     );
 
-    // Sliding window: step = 4 - 1 = 3, starts at 0, 3, 6, 9 — last chunk
-    // reaches the end of the array and stops.
-    assert.ok(chunks.length >= 3);
+    // Sliding window: step = 4 - 1 = 3. Windows start at 0, 3, 6. The
+    // third window covers msg-6..msg-9 (end === turns.length), so the
+    // loop breaks and we get exactly 3 chunks.
+    assert.equal(chunks.length, 3);
     assert.equal(chunks[0][0].content, "msg-0");
     assert.equal(chunks[0].at(-1)?.content, "msg-3");
     // Overlap of 1 means chunk 1 starts at msg-3 (overlap with chunk 0's tail)

--- a/packages/import-weclone/src/integration.test.ts
+++ b/packages/import-weclone/src/integration.test.ts
@@ -1,0 +1,412 @@
+// ---------------------------------------------------------------------------
+// End-to-end integration test — synthetic WeClone export → bulk-import pipeline
+// ---------------------------------------------------------------------------
+//
+// This test exercises the full WeClone import path against the `@remnic/core`
+// bulk-import pipeline using synthetic fixture data.  No real conversations
+// are used; all senders, timestamps, and content are fabricated.
+//
+// Coverage matrix:
+//
+//   parser      → parses wrapped + raw-array inputs, infers roles
+//   threader    → splits on time gaps, merges reply chains
+//   participant → tags self/frequent/occasional
+//   chunker     → respects maxTurnsPerChunk + overlap
+//   pipeline    → dryRun completes, non-dryRun flows turns through processBatch
+//   adapter     → registers in core and resolves by name
+//
+// Keeping the fixture inline (vs. a JSON file under __fixtures__) makes the
+// causal link between input shape and expected outputs visible without a
+// jump-to-file, and matches the pattern used by other integration tests in
+// this repo (see packages/remnic-core/src/bulk-import/pipeline.test.ts).
+// ---------------------------------------------------------------------------
+
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { writeFileSync, mkdtempSync, unlinkSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { Writable } from "node:stream";
+
+import {
+  registerBulkImportSource,
+  clearBulkImportSources,
+  getBulkImportSource,
+  runBulkImportPipeline,
+} from "@remnic/core";
+import type { BulkImportSource, ImportTurn } from "@remnic/core";
+
+import { wecloneImportAdapter } from "./adapter.js";
+import { parseWeCloneExport } from "./parser.js";
+import { groupIntoThreads } from "./threader.js";
+import { mapParticipants } from "./participant.js";
+import { chunkThreads } from "./chunker.js";
+
+// ---------------------------------------------------------------------------
+// Synthetic fixture — multi-thread export covering all code paths
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a synthetic WeClone-preprocessed export covering:
+ *
+ *   - A morning conversation between Alice (self) and Bob
+ *     (4 messages, all within 30 min)
+ *   - A mid-day conversation with Bob, Carol, and a ChatGPT Bot
+ *     (6 messages, including reply chains)
+ *   - An evening out-of-band reply that threader should merge into
+ *     the morning thread via reply_to_id
+ *   - A lonely late-night message that will be filtered by minThreadSize
+ *
+ * All timestamps are ISO-8601 UTC. Message content is fabricated.
+ */
+function buildSyntheticExport(): unknown {
+  return {
+    platform: "telegram",
+    export_date: "2025-03-15T00:00:00.000Z",
+    messages: [
+      // Thread 1: morning conversation
+      {
+        sender: "Alice",
+        text: "good morning team",
+        timestamp: "2025-03-15T08:00:00.000Z",
+        message_id: "m-001",
+      },
+      {
+        sender: "Bob",
+        text: "morning! ready for the standup?",
+        timestamp: "2025-03-15T08:02:00.000Z",
+        message_id: "m-002",
+        reply_to_id: "m-001",
+      },
+      {
+        sender: "Alice",
+        text: "yep, joining in 5",
+        timestamp: "2025-03-15T08:05:00.000Z",
+        message_id: "m-003",
+      },
+      {
+        sender: "Bob",
+        text: "sounds good",
+        timestamp: "2025-03-15T08:10:00.000Z",
+        message_id: "m-004",
+      },
+
+      // Thread 2: mid-day collaboration with a bot
+      {
+        sender: "Alice",
+        text: "anyone seen the deployment doc?",
+        timestamp: "2025-03-15T13:00:00.000Z",
+        message_id: "m-010",
+      },
+      {
+        sender: "Bob",
+        text: "its in the wiki under infra/releases",
+        timestamp: "2025-03-15T13:02:00.000Z",
+        message_id: "m-011",
+        reply_to_id: "m-010",
+      },
+      {
+        sender: "Carol",
+        text: "I updated it yesterday with the new rollback steps",
+        timestamp: "2025-03-15T13:05:00.000Z",
+        message_id: "m-012",
+      },
+      {
+        sender: "ChatGPT Bot",
+        text: "summary: rollback now uses the snapshot API",
+        timestamp: "2025-03-15T13:06:00.000Z",
+        message_id: "m-013",
+      },
+      {
+        sender: "Alice",
+        text: "thanks!",
+        timestamp: "2025-03-15T13:10:00.000Z",
+        message_id: "m-014",
+        reply_to_id: "m-012",
+      },
+      {
+        sender: "Bob",
+        text: "ill ping you if anything else comes up",
+        timestamp: "2025-03-15T13:15:00.000Z",
+        message_id: "m-015",
+      },
+
+      // Thread 3: evening reply that references thread 1
+      // (time gap > 30 min but reply chain should merge it into thread 1)
+      {
+        sender: "Carol",
+        text: "following up on the standup topic from earlier",
+        timestamp: "2025-03-15T19:00:00.000Z",
+        message_id: "m-020",
+        reply_to_id: "m-002",
+      },
+      {
+        sender: "Alice",
+        text: "good call - lets discuss tomorrow",
+        timestamp: "2025-03-15T19:05:00.000Z",
+        message_id: "m-021",
+        reply_to_id: "m-020",
+      },
+
+      // Thread 4: late-night lonely message (filtered by minThreadSize=2)
+      {
+        sender: "Alice",
+        text: "note to self: push the docs",
+        timestamp: "2025-03-15T23:45:00.000Z",
+        message_id: "m-030",
+      },
+    ],
+  };
+}
+
+function nullStream(): Writable {
+  return new Writable({ write(_chunk, _enc, cb) { cb(); } });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("integration: WeClone → @remnic/core bulk-import", () => {
+  beforeEach(() => {
+    clearBulkImportSources();
+  });
+
+  afterEach(() => {
+    clearBulkImportSources();
+  });
+
+  it("parser produces a valid BulkImportSource with all expected turns", () => {
+    const source = parseWeCloneExport(buildSyntheticExport());
+
+    assert.equal(source.metadata.source, "weclone-telegram");
+    assert.equal(source.metadata.messageCount, 13);
+    assert.equal(
+      source.metadata.dateRange.from,
+      "2025-03-15T08:00:00.000Z",
+    );
+    assert.equal(
+      source.metadata.dateRange.to,
+      "2025-03-15T23:45:00.000Z",
+    );
+
+    // Alice is the first non-bot sender → user role
+    const alice = source.turns.filter((t) => t.participantId === "Alice");
+    assert.ok(alice.length >= 4);
+    for (const turn of alice) {
+      assert.equal(turn.role, "user");
+    }
+
+    // ChatGPT Bot should be classified as assistant
+    const bot = source.turns.find(
+      (t) => t.participantId === "ChatGPT Bot",
+    );
+    assert.equal(bot?.role, "assistant");
+
+    // Bob and Carol are "other"
+    const bob = source.turns.find((t) => t.participantId === "Bob");
+    const carol = source.turns.find((t) => t.participantId === "Carol");
+    assert.equal(bob?.role, "other");
+    assert.equal(carol?.role, "other");
+  });
+
+  it("threader groups messages into threads with reply-chain merging", () => {
+    const source = parseWeCloneExport(buildSyntheticExport());
+    const threads = groupIntoThreads(source.turns);
+
+    // With the default 30-min gap + reply-chain merge, we expect:
+    //   - Thread 1 (morning) MERGED with thread 3 (evening) via m-002 → m-020
+    //   - Thread 2 (mid-day) standalone
+    //   - Thread 4 (late-night lonely) filtered out by minThreadSize=2
+    //
+    // That yields exactly 2 threads.
+    assert.equal(threads.length, 2);
+
+    // The merged thread must contain both morning and evening messages
+    const morningMerged = threads.find((t) =>
+      t.turns.some((turn) => turn.content === "good morning team"),
+    );
+    assert.ok(morningMerged, "morning thread should be present");
+    assert.ok(
+      morningMerged.turns.some(
+        (turn) => turn.content === "following up on the standup topic from earlier",
+      ),
+      "evening reply should be merged into morning thread via reply chain",
+    );
+
+    // Every thread is sorted by timestamp
+    for (const thread of threads) {
+      for (let i = 1; i < thread.turns.length; i += 1) {
+        assert.ok(
+          new Date(thread.turns[i].timestamp).getTime() >=
+            new Date(thread.turns[i - 1].timestamp).getTime(),
+          "thread turns must be sorted by timestamp",
+        );
+      }
+    }
+
+    // The lonely late-night message must NOT appear in any thread
+    for (const thread of threads) {
+      for (const turn of thread.turns) {
+        assert.notEqual(
+          turn.content,
+          "note to self: push the docs",
+          "single-message thread should be filtered out by minThreadSize",
+        );
+      }
+    }
+  });
+
+  it("participant mapper classifies self/frequent/occasional correctly", () => {
+    const source = parseWeCloneExport(buildSyntheticExport());
+    const participants = mapParticipants(source.turns);
+
+    const byId = new Map(participants.map((p) => [p.id, p]));
+    // Alice has the most messages and should be tagged "self"
+    assert.equal(byId.get("Alice")?.relationship, "self");
+    // Bob is a frequent contributor (> 10% of total messages)
+    assert.equal(byId.get("Bob")?.relationship, "frequent");
+    // ChatGPT Bot appears once — occasional in this fixture
+    const bot = byId.get("ChatGPT Bot");
+    assert.ok(
+      bot?.relationship === "occasional" || bot?.relationship === "frequent",
+      `ChatGPT Bot should be occasional or frequent, got ${bot?.relationship}`,
+    );
+
+    // Counts should round-trip with the source turns
+    const totalFromParticipants = participants.reduce(
+      (acc, p) => acc + p.messageCount,
+      0,
+    );
+    assert.equal(totalFromParticipants, source.turns.length);
+  });
+
+  it("chunker splits long threads with the configured overlap", () => {
+    // Build a single long synthetic thread to exercise the chunker
+    // deterministically (isolated from threader behavior).
+    const longThread: ImportTurn[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      longThread.push({
+        role: "user",
+        content: `msg-${i}`,
+        timestamp: new Date(
+          Date.parse("2025-04-01T08:00:00Z") + i * 60_000,
+        ).toISOString(),
+        participantId: "Alice",
+        participantName: "Alice",
+      });
+    }
+    const chunks = chunkThreads(
+      [
+        {
+          turns: longThread,
+          threadId: "thread-0001",
+          startTime: longThread[0].timestamp,
+          endTime: longThread[longThread.length - 1].timestamp,
+        },
+      ],
+      { maxTurnsPerChunk: 4, overlapTurns: 1 },
+    );
+
+    // Sliding window: step = 4 - 1 = 3, starts at 0, 3, 6, 9 — last chunk
+    // reaches the end of the array and stops.
+    assert.ok(chunks.length >= 3);
+    assert.equal(chunks[0][0].content, "msg-0");
+    assert.equal(chunks[0].at(-1)?.content, "msg-3");
+    // Overlap of 1 means chunk 1 starts at msg-3 (overlap with chunk 0's tail)
+    assert.equal(chunks[1][0].content, "msg-3");
+    // Last chunk should end at msg-9
+    assert.equal(chunks.at(-1)?.at(-1)?.content, "msg-9");
+  });
+
+  it("adapter registers in core and resolves by name", () => {
+    registerBulkImportSource(wecloneImportAdapter);
+    const resolved = getBulkImportSource("weclone");
+    assert.ok(resolved, "adapter should be resolvable by name");
+    assert.equal(resolved?.name, "weclone");
+  });
+
+  it("pipeline dryRun completes end-to-end without calling processBatch", async () => {
+    registerBulkImportSource(wecloneImportAdapter);
+    const source = parseWeCloneExport(buildSyntheticExport());
+
+    let batchCalls = 0;
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 5, dryRun: true, dedup: true, trustLevel: "import" },
+      async () => {
+        batchCalls += 1;
+        return {
+          memoriesCreated: 0,
+          duplicatesSkipped: 0,
+          entitiesCreated: 0,
+        };
+      },
+    );
+
+    assert.equal(batchCalls, 0, "processBatch must not be called in dryRun");
+    assert.equal(result.turnsProcessed, source.turns.length);
+    assert.ok(result.batchesProcessed > 0);
+    assert.equal(result.errors.length, 0);
+  });
+
+  it("pipeline flows turns through processBatch in correct batch sizes", async () => {
+    // Simulates what the orchestrator integration will do once persistence is
+    // wired — the callback receives each batch and records how many turns
+    // were seen per batch. Using a mock callback lets us exercise batching
+    // without depending on the orchestrator.
+    const source = parseWeCloneExport(buildSyntheticExport());
+    const seenBatches: number[] = [];
+
+    const result = await runBulkImportPipeline(
+      source,
+      { batchSize: 4, dryRun: false, dedup: true, trustLevel: "import" },
+      async (batch) => {
+        seenBatches.push(batch.length);
+        return {
+          memoriesCreated: batch.length,
+          duplicatesSkipped: 0,
+          entitiesCreated: 0,
+        };
+      },
+    );
+
+    // 13 turns / 4 per batch = 4 batches (sizes 4, 4, 4, 1)
+    assert.deepEqual(seenBatches, [4, 4, 4, 1]);
+    assert.equal(result.turnsProcessed, 13);
+    assert.equal(result.batchesProcessed, 4);
+    assert.equal(result.memoriesCreated, 13);
+    assert.equal(result.errors.length, 0);
+  });
+
+  it("adapter accepts a file-shaped input via parse() like the CLI does", async () => {
+    // Mirrors runBulkImportCliCommand's contract: the CLI reads the file,
+    // JSON.parses it, then calls adapter.parse(inputParsed, {strict, platform}).
+    registerBulkImportSource(wecloneImportAdapter);
+
+    const tmp = mkdtempSync(join(tmpdir(), "weclone-integration-"));
+    const filePath = join(tmp, "export.json");
+    writeFileSync(filePath, JSON.stringify(buildSyntheticExport()));
+
+    try {
+      const adapter = getBulkImportSource("weclone");
+      assert.ok(adapter);
+      const raw = JSON.parse(readFileSync(filePath, "utf-8"));
+      const parsed = (await adapter.parse(raw, {
+        strict: false,
+        platform: "telegram",
+      })) as BulkImportSource;
+      assert.equal(parsed.metadata.source, "weclone-telegram");
+      assert.equal(parsed.metadata.messageCount, 13);
+    } finally {
+      try { unlinkSync(filePath); } catch { /* ignore */ }
+    }
+  });
+
+  it("nullStream helper is usable for CLI-surface tests", () => {
+    // Sanity: the helper is wired correctly so downstream CLI integration
+    // tests can rely on it without redefining.
+    const stream = nullStream();
+    assert.ok(stream instanceof Writable);
+  });
+});

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2978,10 +2978,12 @@ export async function runBulkImportCliCommand(
   }
 
   // Guard: persistence isn't wired yet, so non-dryRun invocations must
-  // fail loudly BEFORE we read/parse the full file. Large exports would
-  // otherwise incur full parse/validate cost just to hit this check.
-  // The orchestrator integration will replace this guard with a real
-  // processBatch callback.
+  // fail loudly BEFORE reading/parsing the file.  Running the full parse
+  // would incur file I/O and memory pressure (imports can be 100k+
+  // messages) only to inevitably throw.  The adapter check above still
+  // fires first so `--source <unknown>` surfaces the more-actionable
+  // "Unknown bulk-import source" error.  The orchestrator integration
+  // will replace this guard with a real processBatch callback.
   if (opts.dryRun !== true) {
     throw new Error(
       "Bulk import persistence is not yet wired. " +

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2977,6 +2977,18 @@ export async function runBulkImportCliCommand(
     );
   }
 
+  // Guard: persistence isn't wired yet, so non-dryRun invocations must
+  // fail loudly BEFORE we read/parse the full file. Large exports would
+  // otherwise incur full parse/validate cost just to hit this check.
+  // The orchestrator integration will replace this guard with a real
+  // processBatch callback.
+  if (opts.dryRun !== true) {
+    throw new Error(
+      "Bulk import persistence is not yet wired. " +
+        "Use --dry-run to validate without persisting.",
+    );
+  }
+
   const inputRaw = await readFile(opts.file, "utf-8");
   let inputParsed: unknown;
   try {
@@ -2996,18 +3008,6 @@ export async function runBulkImportCliCommand(
     strict: opts.strict === true,
     platform: opts.platform,
   });
-
-  // Guard: persistence isn't wired yet, so non-dryRun invocations must
-  // fail loudly before we parse/validate the full file.  Returning a
-  // misleading "success" via silently-swallowed batch errors would hide
-  // the missing integration and produce false telemetry.  The orchestrator
-  // integration will replace this guard with a real processBatch callback.
-  if (opts.dryRun !== true) {
-    throw new Error(
-      "Bulk import persistence is not yet wired. " +
-        "Use --dry-run to validate without persisting.",
-    );
-  }
 
   const processBatch: ProcessBatchFn = async () => {
     // The pipeline never calls processBatch in dryRun mode, so reaching

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2997,14 +2997,25 @@ export async function runBulkImportCliCommand(
     platform: opts.platform,
   });
 
-  const processBatch: ProcessBatchFn = async () => {
-    // The real extraction callback will be wired when the
-    // orchestrator integration lands in a later PR.
-    // The pipeline never calls processBatch in dryRun mode,
-    // so reaching here means a non-dryRun invocation.
+  // Guard: persistence isn't wired yet, so non-dryRun invocations must
+  // fail loudly before we parse/validate the full file.  Returning a
+  // misleading "success" via silently-swallowed batch errors would hide
+  // the missing integration and produce false telemetry.  The orchestrator
+  // integration will replace this guard with a real processBatch callback.
+  if (opts.dryRun !== true) {
     throw new Error(
       "Bulk import persistence is not yet wired. " +
-        "Use --dryRun to validate without persisting.",
+        "Use --dry-run to validate without persisting.",
+    );
+  }
+
+  const processBatch: ProcessBatchFn = async () => {
+    // The pipeline never calls processBatch in dryRun mode, so reaching
+    // here would indicate a bug in the pipeline.  Throwing here provides
+    // a defensive failure mode; the guard above is the primary protection.
+    throw new Error(
+      "Bulk import persistence is not yet wired. " +
+        "Use --dry-run to validate without persisting.",
     );
   };
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -69,11 +69,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,ingestion-entity-recall,ingestion-backlink-f1,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
-  // Schema completeness, setup friction, and citation accuracy remain gated off until their adapter contracts are wired.
+  // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
+  // Setup friction was wired up in PR #498 and is now runner-available.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, false);
-  assert.equal(getBenchmark("ingestion-setup-friction")?.runnerAvailable, false);
+  assert.equal(getBenchmark("ingestion-setup-friction")?.runnerAvailable, true);
   assert.equal(getBenchmark("ingestion-citation-accuracy")?.runnerAvailable, false);
 });
 

--- a/tests/qmd-sync-after-store.test.ts
+++ b/tests/qmd-sync-after-store.test.ts
@@ -24,7 +24,7 @@ test("QmdClient.update() passes collection flag to qmd subprocess", async () => 
   // update() should route through collection-aware update path
   assert.match(
     qmdSource,
-    /async update\(\): Promise<void>\s*\{\s*await this\.runUpdateForCollection\(this\.collection,\s*\{\s*perCollectionThrottle:\s*false\s*\}\);/s,
+    /async update\(signal\?: AbortSignal\): Promise<void>\s*\{\s*await this\.runUpdateForCollection\(this\.collection,\s*\{\s*perCollectionThrottle:\s*false\s*\},\s*signal\);/s,
     "update() should route through runUpdateForCollection(this.collection)",
   );
 


### PR DESCRIPTION
## Summary

Phase-final gap-fill for WeClone chat import (#460). Core pipeline (PR #489) and parser/threader/participant/chunker (PR #491) already landed on main; this PR fills the remaining gaps called out in the issue spec.

- Add `packages/import-weclone/README.md` describing the pipeline, CLI usage, programmatic API, supported platforms, and input schema.
- Add `packages/import-weclone/src/integration.test.ts` — an end-to-end integration test that drives the full parser → threader → participant → chunker → pipeline path against a synthetic multi-thread WeClone export fixture. Nine tests cover role inference, reply-chain merging across the 30-min time-gap boundary, participant classification, chunker overlap, and both dryRun and non-dryRun pipeline behavior.
- Wire `packages/import-weclone/src/**/*.test.ts` into the root `test` script so CI exercises the new tests alongside core.
- Fix CI-blocking type error in `BulkImportCliCommandOptions` that prevented `platform` from being accepted after PR #491 added the `--platform` CLI flag without updating the interface. Also guard the non-dryRun path at the CLI layer so the "persistence not yet wired" message surfaces as an explicit rejection rather than a silent set of swallowed batch errors, and normalise the message to reference `--dry-run` (matching the CLI flag name).
- Fix unrelated pre-existing type error in `NamespaceSearchRouter.updateNamespaces()` that was also blocking `pnpm run check-types` in CI; annotated the mapper's return type as `Promise<number>` so the reduce accumulator type-checks against `(0 | 1)[]`.

All test data is synthetic (fabricated senders, timestamps, content). No real conversations or personal data.

Closes #460.

## Test plan

- [x] `packages/import-weclone` full test suite — 87 tests, 0 fail (unit + new integration)
- [x] `packages/remnic-core/src/bulk-import` full test suite — 81 tests, 0 fail
- [x] `node_modules/.bin/tsc --noEmit` (root tsconfig) — no type errors
- [x] `bash scripts/check-review-patterns.sh` — PASSED, no new review-pattern issues
- [x] `tsx scripts/validate-config-contract.ts` — Config contract OK
- [ ] CI green (awaiting workflow run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly adds documentation and test coverage; the only behavior change is the bulk-import CLI now rejects non-`--dry-run` runs earlier, which could affect users expecting parsing to occur before the guard.
> 
> **Overview**
> **WeClone import is now fully documented and exercised in CI.** Adds a comprehensive `packages/import-weclone/README.md` plus a new end-to-end `integration.test.ts` that drives the WeClone parser→threading→participant mapping→chunking→`runBulkImportPipeline` flow on a synthetic export.
> 
> **CLI behavior is hardened for bulk import.** `runBulkImportCliCommand` now fails fast on non-`--dry-run` invocations (before reading/parsing large files) and standardizes the error message to reference `--dry-run`. The root `test` script now includes `packages/import-weclone` tests, and existing tests are updated for the newly runner-available `ingestion-setup-friction` benchmark and the updated `QmdClient.update(signal?)` signature.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0cccd538272485746249b9999ad7e8e9b460c460. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->