### PR TITLE
feat(bench-ui): integrity badge per result

### DIFF
--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -35,6 +35,25 @@ export interface BenchTaskSummary {
   scoreEntries: BenchTaskScoreEntry[];
 }
 
+export type BenchIntegritySplit = "public" | "holdout" | "unknown";
+
+export interface BenchIntegritySummary {
+  /** Which split produced this result. `unknown` on legacy results. */
+  split: BenchIntegritySplit;
+  /** True when qrels/judge/dataset hashes are all present and well-formed. */
+  sealsPresent: boolean;
+  /** True when the canary score is non-null and sits at or below the floor. */
+  canaryUnderFloor: boolean | null;
+  /** The canary score recorded with the result, when present. */
+  canaryScore: number | null;
+  /** The canary floor applied — defaults to 0.1. */
+  canaryFloor: number;
+  /** Truncated hashes for display (first 12 chars). */
+  qrelsSealedHashShort: string | null;
+  judgePromptHashShort: string | null;
+  datasetHashShort: string | null;
+}
+
 export interface BenchResultSummary {
   id: string;
   benchmark: string;
@@ -58,6 +77,7 @@ export interface BenchResultSummary {
   adapterMode: string;
   aggregateMetrics: BenchAggregateMetric[];
   taskSummaries: BenchTaskSummary[];
+  integrity: BenchIntegritySummary;
   filePath: string;
 }
 

--- a/packages/bench-ui/src/components/IntegrityBadge.tsx
+++ b/packages/bench-ui/src/components/IntegrityBadge.tsx
@@ -1,0 +1,29 @@
+import type { BenchIntegritySummary } from "../bench-data";
+import { describeIntegrity } from "./integrity-model";
+
+export { describeIntegrity } from "./integrity-model";
+export type {
+  IntegrityBadgeLevel,
+  IntegrityBadgeModel,
+} from "./integrity-model";
+
+export function IntegrityBadge({ summary }: { summary: BenchIntegritySummary }) {
+  const model = describeIntegrity(summary);
+  const tooltipParts = [
+    model.splitText,
+    model.canaryText,
+    ...model.sealLines,
+    ...model.reasons,
+  ];
+
+  return (
+    <span
+      className={`integrity-badge integrity-badge--${model.level}`}
+      title={tooltipParts.join("\n")}
+      data-level={model.level}
+    >
+      <span className="integrity-badge__dot" aria-hidden="true" />
+      <span className="integrity-badge__label">{model.label}</span>
+    </span>
+  );
+}

--- a/packages/bench-ui/src/components/RunTable.tsx
+++ b/packages/bench-ui/src/components/RunTable.tsx
@@ -8,6 +8,7 @@ import {
   formatTimestamp,
   humanizeIdentifier,
 } from "../bench-data";
+import { IntegrityBadge } from "./IntegrityBadge";
 
 export function RunTable({
   runs,
@@ -34,6 +35,7 @@ export function RunTable({
             <th>Providers</th>
             <th>Score</th>
             {showDelta ? <th>Delta</th> : null}
+            <th>Integrity</th>
             <th>Latency</th>
             <th>Cost</th>
           </tr>
@@ -63,6 +65,9 @@ export function RunTable({
               </td>
               <td>{formatMetricValue(run.primaryScore)}</td>
               {showDelta ? <td>{formatDelta(run.delta ?? null)}</td> : null}
+              <td>
+                <IntegrityBadge summary={run.integrity} />
+              </td>
               <td>{formatDuration(run.totalLatencyMs)}</td>
               <td>{formatCurrency(run.estimatedCostUsd)}</td>
             </tr>

--- a/packages/bench-ui/src/components/ScoreCard.tsx
+++ b/packages/bench-ui/src/components/ScoreCard.tsx
@@ -5,6 +5,7 @@ import {
   formatTimestamp,
   humanizeIdentifier,
 } from "../bench-data";
+import { IntegrityBadge } from "./IntegrityBadge";
 
 export function ScoreCard({ card }: { card: BenchmarkCard }) {
   return (
@@ -31,6 +32,8 @@ export function ScoreCard({ card }: { card: BenchmarkCard }) {
           {formatDelta(card.delta)}
         </span>
       </div>
+
+      <IntegrityBadge summary={card.latest.integrity} />
 
       <dl className="score-card__meta">
         <div>

--- a/packages/bench-ui/src/components/integrity-model.ts
+++ b/packages/bench-ui/src/components/integrity-model.ts
@@ -1,5 +1,14 @@
 import type { BenchIntegritySummary } from "../bench-data";
 
+/**
+ * Integrity badge levels rendered on the dashboard.
+ *
+ * - `verified`   — sealed hashes present, holdout split, canary under floor.
+ * - `partial`    — most safeguards active, but at least one is missing or
+ *                  the result is a public-split / legacy record.
+ * - `unverified` — seals missing or canary above floor; treat result with
+ *                  suspicion.
+ */
 export type IntegrityBadgeLevel = "verified" | "partial" | "unverified";
 
 export interface IntegrityBadgeModel {

--- a/packages/bench-ui/src/components/integrity-model.ts
+++ b/packages/bench-ui/src/components/integrity-model.ts
@@ -1,0 +1,90 @@
+import type { BenchIntegritySummary } from "../bench-data";
+
+export type IntegrityBadgeLevel = "verified" | "partial" | "unverified";
+
+export interface IntegrityBadgeModel {
+  level: IntegrityBadgeLevel;
+  label: string;
+  reasons: string[];
+  canaryText: string;
+  splitText: string;
+  sealLines: string[];
+}
+
+function describeSplit(split: BenchIntegritySummary["split"]): string {
+  switch (split) {
+    case "holdout":
+      return "Holdout split (leaderboard-eligible)";
+    case "public":
+      return "Public split (self-reported, not publishable)";
+    default:
+      return "Split unknown (legacy result)";
+  }
+}
+
+function describeCanary(summary: BenchIntegritySummary): string {
+  if (summary.canaryScore === null) {
+    return "Canary: not recorded";
+  }
+  const status = summary.canaryUnderFloor ? "under floor" : "ABOVE FLOOR";
+  return `Canary: ${summary.canaryScore.toFixed(3)} (floor ${summary.canaryFloor.toFixed(2)}, ${status})`;
+}
+
+function describeSealLines(summary: BenchIntegritySummary): string[] {
+  const lines: string[] = [];
+  if (summary.qrelsSealedHashShort) {
+    lines.push(`qrels ${summary.qrelsSealedHashShort}`);
+  } else {
+    lines.push("qrels hash missing");
+  }
+  if (summary.judgePromptHashShort) {
+    lines.push(`judge ${summary.judgePromptHashShort}`);
+  } else {
+    lines.push("judge prompt hash missing");
+  }
+  if (summary.datasetHashShort) {
+    lines.push(`dataset ${summary.datasetHashShort}`);
+  } else {
+    lines.push("dataset hash missing");
+  }
+  return lines;
+}
+
+export function describeIntegrity(summary: BenchIntegritySummary): IntegrityBadgeModel {
+  const reasons: string[] = [];
+  const canaryText = describeCanary(summary);
+  const splitText = describeSplit(summary.split);
+  const sealLines = describeSealLines(summary);
+
+  let level: IntegrityBadgeLevel = "verified";
+
+  if (!summary.sealsPresent) {
+    level = "unverified";
+    reasons.push("Sealed-artifact hashes are incomplete.");
+  }
+  if (summary.split === "unknown") {
+    level = level === "verified" ? "partial" : level;
+    reasons.push("Dataset split type was not recorded.");
+  }
+  if (summary.canaryUnderFloor === false) {
+    level = "unverified";
+    reasons.push("Canary adapter scored above the configured floor.");
+  }
+  if (summary.canaryScore === null) {
+    level = level === "verified" ? "partial" : level;
+    reasons.push("Canary score was not attached to this result.");
+  }
+  if (summary.split === "public") {
+    level = level === "verified" ? "partial" : level;
+    reasons.push("Public-split results are not publishable.");
+  }
+
+  const label =
+    level === "verified"
+      ? "Integrity: verified"
+      : level === "partial"
+        ? "Integrity: partial"
+        : "Integrity: unverified";
+
+  return { level, label, reasons, canaryText, splitText, sealLines };
+}

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -3,6 +3,8 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type {
   BenchAggregateMetric,
+  BenchIntegritySplit,
+  BenchIntegritySummary,
   BenchMetricHighlight,
   BenchResultSummary,
   BenchResultSummaryPayload,
@@ -10,6 +12,45 @@ import type {
   BenchTaskSummary,
 } from "./bench-data.js";
 import { compareMetricNames, compareStrings, compareTimestampedRuns } from "./sort-utils.js";
+
+const DEFAULT_CANARY_FLOOR = 0.1;
+const SHA256_HEX_PATTERN = /^[0-9a-f]{64}$/u;
+
+function isSha256Hex(value: unknown): value is string {
+  return typeof value === "string" && SHA256_HEX_PATTERN.test(value);
+}
+
+function shortHash(value: unknown): string | null {
+  return isSha256Hex(value) ? value.slice(0, 12) : null;
+}
+
+function resolveSplit(value: unknown): BenchIntegritySplit {
+  return value === "public" || value === "holdout" ? value : "unknown";
+}
+
+function computeIntegritySummary(meta: JsonRecord): BenchIntegritySummary {
+  const canaryScoreRaw = meta.canaryScore;
+  const canaryScore =
+    typeof canaryScoreRaw === "number" && Number.isFinite(canaryScoreRaw)
+      ? canaryScoreRaw
+      : null;
+
+  const sealsPresent =
+    isSha256Hex(meta.qrelsSealedHash) &&
+    isSha256Hex(meta.judgePromptHash) &&
+    isSha256Hex(meta.datasetHash);
+
+  return {
+    split: resolveSplit(meta.splitType),
+    sealsPresent,
+    canaryScore,
+    canaryFloor: DEFAULT_CANARY_FLOOR,
+    canaryUnderFloor: canaryScore === null ? null : canaryScore <= DEFAULT_CANARY_FLOOR,
+    qrelsSealedHashShort: shortHash(meta.qrelsSealedHash),
+    judgePromptHashShort: shortHash(meta.judgePromptHash),
+    datasetHashShort: shortHash(meta.datasetHash),
+  };
+}
 
 type JsonRecord = Record<string, unknown>;
 
@@ -187,6 +228,7 @@ export function summarizeBenchmarkResult(
       typeof config.adapterMode === "string" ? config.adapterMode : "unknown",
     aggregateMetrics: metrics,
     taskSummaries: tasks,
+    integrity: computeIntegritySummary(meta),
     filePath,
   };
 }

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -28,12 +28,24 @@ function resolveSplit(value: unknown): BenchIntegritySplit {
   return value === "public" || value === "holdout" ? value : "unknown";
 }
 
+function resolveCanaryFloor(value: unknown): number {
+  // Results produced under a custom `REMNIC_BENCH_CANARY_FLOOR` may persist
+  // the floor into `meta.canaryFloor`. If present and finite, honor it so
+  // the badge matches the gate that produced the result.
+  if (typeof value === "number" && Number.isFinite(value) && value >= 0) {
+    return value;
+  }
+  return DEFAULT_CANARY_FLOOR;
+}
+
 function computeIntegritySummary(meta: JsonRecord): BenchIntegritySummary {
   const canaryScoreRaw = meta.canaryScore;
   const canaryScore =
     typeof canaryScoreRaw === "number" && Number.isFinite(canaryScoreRaw)
       ? canaryScoreRaw
       : null;
+
+  const canaryFloor = resolveCanaryFloor(meta.canaryFloor);
 
   const sealsPresent =
     isSha256Hex(meta.qrelsSealedHash) &&
@@ -44,8 +56,8 @@ function computeIntegritySummary(meta: JsonRecord): BenchIntegritySummary {
     split: resolveSplit(meta.splitType),
     sealsPresent,
     canaryScore,
-    canaryFloor: DEFAULT_CANARY_FLOOR,
-    canaryUnderFloor: canaryScore === null ? null : canaryScore <= DEFAULT_CANARY_FLOOR,
+    canaryFloor,
+    canaryUnderFloor: canaryScore === null ? null : canaryScore <= canaryFloor,
     qrelsSealedHashShort: shortHash(meta.qrelsSealedHash),
     judgePromptHashShort: shortHash(meta.judgePromptHash),
     datasetHashShort: shortHash(meta.datasetHash),

--- a/packages/bench-ui/src/styles.css
+++ b/packages/bench-ui/src/styles.css
@@ -238,3 +238,44 @@ select {
     align-items: flex-start;
   }
 }
+
+.integrity-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.78rem;
+  font-weight: 500;
+  letter-spacing: 0.01em;
+  border: 1px solid transparent;
+  cursor: help;
+  white-space: nowrap;
+}
+
+.integrity-badge__dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+}
+
+.integrity-badge--verified {
+  color: #0f5132;
+  background: rgba(25, 135, 84, 0.12);
+  border-color: rgba(25, 135, 84, 0.35);
+}
+
+.integrity-badge--partial {
+  color: #664d03;
+  background: rgba(255, 193, 7, 0.15);
+  border-color: rgba(255, 193, 7, 0.4);
+}
+
+.integrity-badge--unverified {
+  color: #842029;
+  background: rgba(220, 53, 69, 0.12);
+  border-color: rgba(220, 53, 69, 0.4);
+}
+

--- a/tests/bench-ui-integrity-badge.test.ts
+++ b/tests/bench-ui-integrity-badge.test.ts
@@ -1,0 +1,84 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { describeIntegrity } from "../packages/bench-ui/src/components/integrity-model.js";
+import type { BenchIntegritySummary } from "../packages/bench-ui/src/bench-data.js";
+
+function summary(overrides: Partial<BenchIntegritySummary> = {}): BenchIntegritySummary {
+  return {
+    split: "holdout",
+    sealsPresent: true,
+    canaryScore: 0.02,
+    canaryFloor: 0.1,
+    canaryUnderFloor: true,
+    qrelsSealedHashShort: "abcdef012345",
+    judgePromptHashShort: "fedcba987654",
+    datasetHashShort: "0123456789ab",
+    ...overrides,
+  };
+}
+
+test("verified badge when holdout + sealed + canary under floor", () => {
+  const model = describeIntegrity(summary());
+  assert.equal(model.level, "verified");
+  assert.match(model.label, /verified/u);
+  assert.equal(model.reasons.length, 0);
+});
+
+test("partial badge when split is public", () => {
+  const model = describeIntegrity(summary({ split: "public" }));
+  assert.equal(model.level, "partial");
+  assert.ok(model.reasons.some((r) => /Public-split/u.test(r)));
+});
+
+test("partial badge when split is unknown", () => {
+  const model = describeIntegrity(summary({ split: "unknown" }));
+  assert.equal(model.level, "partial");
+  assert.ok(model.reasons.some((r) => /split type/iu.test(r)));
+});
+
+test("unverified badge when seals are missing", () => {
+  const model = describeIntegrity(
+    summary({ sealsPresent: false, qrelsSealedHashShort: null }),
+  );
+  assert.equal(model.level, "unverified");
+  assert.ok(model.reasons.some((r) => /Sealed-artifact/u.test(r)));
+});
+
+test("unverified badge when canary is above floor", () => {
+  const model = describeIntegrity(
+    summary({ canaryScore: 0.4, canaryUnderFloor: false }),
+  );
+  assert.equal(model.level, "unverified");
+  assert.ok(model.reasons.some((r) => /above the configured floor/u.test(r)));
+});
+
+test("partial badge when canary score is missing but everything else is good", () => {
+  const model = describeIntegrity(
+    summary({ canaryScore: null, canaryUnderFloor: null }),
+  );
+  assert.equal(model.level, "partial");
+  assert.ok(model.reasons.some((r) => /Canary score/u.test(r)));
+});
+
+test("model exposes human-readable split and canary text", () => {
+  const model = describeIntegrity(summary());
+  assert.match(model.splitText, /Holdout/iu);
+  assert.match(model.canaryText, /0\.020/u);
+  assert.match(model.canaryText, /floor 0\.10/u);
+});
+
+test("results.ts integrity summary is surfaced for legacy results without hashes", () => {
+  const legacy = summary({
+    split: "unknown",
+    sealsPresent: false,
+    canaryScore: null,
+    canaryUnderFloor: null,
+    qrelsSealedHashShort: null,
+    judgePromptHashShort: null,
+    datasetHashShort: null,
+  });
+  const model = describeIntegrity(legacy);
+  assert.equal(model.level, "unverified");
+  // Legacy result should still render without throwing.
+  assert.ok(model.sealLines.every((line) => typeof line === "string"));
+});

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -130,6 +130,38 @@ test("bench UI loader surfaces integrity metadata from result meta", async () =>
   assert.equal(summary.integrity.qrelsSealedHashShort, "a".repeat(12));
 });
 
+test("bench UI loader honors a per-result canaryFloor when present", async () => {
+  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-floor-"));
+  // With a floor of 0.05 and a score of 0.08 the canary is OVER floor —
+  // the badge must mark the result unverified even though the default
+  // floor (0.1) would accept the same score.
+  await writeFile(
+    path.join(resultsDir, "custom-floor.json"),
+    JSON.stringify({
+      meta: {
+        id: "custom-floor-run",
+        benchmark: "longmemeval",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "full",
+        splitType: "holdout",
+        qrelsSealedHash: "a".repeat(64),
+        judgePromptHash: "b".repeat(64),
+        datasetHash: "c".repeat(64),
+        canaryScore: 0.08,
+        canaryFloor: 0.05,
+      },
+      cost: {},
+      results: { tasks: [], aggregates: {} },
+    }),
+  );
+
+  const payload = await loadBenchResultSummaries(resultsDir);
+  const summary = payload.summaries[0];
+  assert.ok(summary);
+  assert.equal(summary.integrity.canaryFloor, 0.05);
+  assert.equal(summary.integrity.canaryUnderFloor, false);
+});
+
 test("bench UI loader marks legacy results without integrity metadata as unknown split", async () => {
   const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-legacy-"));
   await writeFile(

--- a/tests/bench-ui-results.test.ts
+++ b/tests/bench-ui-results.test.ts
@@ -10,6 +10,7 @@ import {
   filterRuns,
   getBenchmarkCards,
   getTrendPoints,
+  type BenchIntegritySummary,
   type BenchResultSummaryPayload,
 } from "../packages/bench-ui/src/bench-data.js";
 import {
@@ -19,6 +20,17 @@ import {
 } from "../packages/bench-ui/src/pages/BenchmarkDetail.js";
 import { canCompareBenchRuns, filterComparableCandidateRuns } from "../packages/bench-ui/src/pages/Compare.js";
 import { loadBenchResultSummaries } from "../packages/bench-ui/src/results.js";
+
+const FIXTURE_INTEGRITY: BenchIntegritySummary = {
+  split: "unknown",
+  sealsPresent: false,
+  canaryScore: null,
+  canaryFloor: 0.1,
+  canaryUnderFloor: null,
+  qrelsSealedHashShort: null,
+  judgePromptHashShort: null,
+  datasetHashShort: null,
+};
 
 test("bench UI loader summarizes valid benchmark JSON files and ignores invalid entries", async () => {
   const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-"));
@@ -87,6 +99,62 @@ test("bench UI loader summarizes valid benchmark JSON files and ignores invalid 
   ]);
 });
 
+test("bench UI loader surfaces integrity metadata from result meta", async () => {
+  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-integrity-"));
+  await writeFile(
+    path.join(resultsDir, "holdout.json"),
+    JSON.stringify({
+      meta: {
+        id: "holdout-run",
+        benchmark: "longmemeval",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "full",
+        splitType: "holdout",
+        qrelsSealedHash: "a".repeat(64),
+        judgePromptHash: "b".repeat(64),
+        datasetHash: "c".repeat(64),
+        canaryScore: 0.03,
+      },
+      cost: {},
+      results: { tasks: [], aggregates: {} },
+    }),
+  );
+
+  const payload = await loadBenchResultSummaries(resultsDir);
+  const summary = payload.summaries[0];
+  assert.ok(summary);
+  assert.equal(summary.integrity.split, "holdout");
+  assert.equal(summary.integrity.sealsPresent, true);
+  assert.equal(summary.integrity.canaryScore, 0.03);
+  assert.equal(summary.integrity.canaryUnderFloor, true);
+  assert.equal(summary.integrity.qrelsSealedHashShort, "a".repeat(12));
+});
+
+test("bench UI loader marks legacy results without integrity metadata as unknown split", async () => {
+  const resultsDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-ui-legacy-"));
+  await writeFile(
+    path.join(resultsDir, "legacy.json"),
+    JSON.stringify({
+      meta: {
+        id: "legacy-run",
+        benchmark: "longmemeval",
+        timestamp: "2026-04-18T10:00:00.000Z",
+        mode: "quick",
+      },
+      cost: {},
+      results: { tasks: [], aggregates: {} },
+    }),
+  );
+
+  const payload = await loadBenchResultSummaries(resultsDir);
+  const summary = payload.summaries[0];
+  assert.ok(summary);
+  assert.equal(summary.integrity.split, "unknown");
+  assert.equal(summary.integrity.sealsPresent, false);
+  assert.equal(summary.integrity.canaryScore, null);
+  assert.equal(summary.integrity.canaryUnderFloor, null);
+});
+
 test("bench UI loader returns an empty payload when the results directory is missing", async () => {
   const resultsDir = path.join(os.tmpdir(), "remnic-bench-ui-missing");
   const payload = await loadBenchResultSummaries(resultsDir);
@@ -122,6 +190,7 @@ test("getBenchmarkCards keeps delta null when a benchmark has only one run", () 
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/latest-run.json",
       },
     ],
@@ -166,6 +235,7 @@ test("getBenchmarkCards sorts benchmark runs before choosing latest and previous
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/older-run.json",
       },
       {
@@ -191,6 +261,7 @@ test("getBenchmarkCards sorts benchmark runs before choosing latest and previous
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/latest-run.json",
       },
     ],
@@ -230,6 +301,7 @@ test("filterRuns uses wall-clock time for recency windows", async (t) => {
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/stale-run.json",
       },
     ],
@@ -274,6 +346,7 @@ test("getTrendPoints uses wall-clock time for recency windows", async (t) => {
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/stale-run.json",
       },
     ],
@@ -310,6 +383,7 @@ test("recency filters exclude future runs beyond the current wall-clock anchor",
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/future-run.json",
       },
     ],
@@ -359,6 +433,7 @@ test("benchmark detail helpers keep single-run deltas null and sort low scorers 
       { taskId: "task-5", question: "Q5", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.35, scoreEntries: [] },
       { taskId: "task-6", question: "Q6", expected: "", actual: "", latencyMs: 10, totalTokens: 1, primaryScore: 0.05, scoreEntries: [] },
     ],
+    integrity: FIXTURE_INTEGRITY,
     filePath: "/tmp/results/latest-run.json",
   });
 
@@ -394,6 +469,7 @@ test("resolveSelectedRunId falls back to the current benchmark run list", () => 
       adapterMode: "standalone",
       aggregateMetrics: [],
       taskSummaries: [],
+      integrity: FIXTURE_INTEGRITY,
       filePath: "/tmp/results/run-b.json",
     },
     {
@@ -419,6 +495,7 @@ test("resolveSelectedRunId falls back to the current benchmark run list", () => 
       adapterMode: "standalone",
       aggregateMetrics: [],
       taskSummaries: [],
+      integrity: FIXTURE_INTEGRITY,
       filePath: "/tmp/results/run-a.json",
     },
   ];
@@ -459,6 +536,7 @@ test("buildHistogram buckets boundary scores by floor semantics", () => {
       { taskId: "task-5", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 0.8, scoreEntries: [] },
       { taskId: "task-6", question: "", expected: "", actual: "", latencyMs: null, totalTokens: 0, primaryScore: 1, scoreEntries: [] },
     ],
+    integrity: FIXTURE_INTEGRITY,
     filePath: "/tmp/results/latest-run.json",
   };
 
@@ -495,6 +573,7 @@ test("compare helpers constrain candidate options to the selected benchmark", ()
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/baseline-run.json",
       },
       {
@@ -520,6 +599,7 @@ test("compare helpers constrain candidate options to the selected benchmark", ()
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/candidate-run.json",
       },
       {
@@ -545,6 +625,7 @@ test("compare helpers constrain candidate options to the selected benchmark", ()
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/other-run.json",
       },
     ],
@@ -589,6 +670,7 @@ test("buildProviderRows keeps the newest benchmark score for each provider", () 
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/latest-run.json",
       },
       {
@@ -614,6 +696,7 @@ test("buildProviderRows keeps the newest benchmark score for each provider", () 
         adapterMode: "standalone",
         aggregateMetrics: [],
         taskSummaries: [],
+        integrity: FIXTURE_INTEGRITY,
         filePath: "/tmp/results/older-run.json",
       },
     ],


### PR DESCRIPTION
## Summary
- Adds an Integrity badge to the bench dashboard rendered at three levels (verified / partial / unverified) based on split type, sealed-artifact hash presence, and canary-under-floor status.
- `BenchResultSummary` grows an `integrity: BenchIntegritySummary` field computed in `results.ts` from `meta.splitType`, `meta.qrelsSealedHash`, `meta.judgePromptHash`, `meta.datasetHash`, and `meta.canaryScore`.
- Badge renders on the Overview score cards and in the Runs table with a tooltip listing the underlying facts (split, canary score vs. floor, short qrels/judge/dataset hashes, downgrade reasons).
- Legacy results without integrity metadata render as "unverified / split unknown" so the UI never crashes on historical data.
- Pure-TS `describeIntegrity` helper is extracted so tests do not need React.

Follow-up to #507. Closes the final deliverable on #451.

## Test plan
- [x] `tests/bench-ui-integrity-badge.test.ts` — 8 tests cover every level transition.
- [x] `tests/bench-ui-results.test.ts` fixtures updated with `FIXTURE_INTEGRITY`; integrity-summary tests added for holdout + legacy results.
- [ ] Dashboard visual check via `pnpm --filter @remnic/bench-ui dev`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new required `integrity` field on `BenchResultSummary` and threads it through result loading and dashboard rendering, which can break any callers/fixtures not updated. Logic is mostly additive UI/model code with safeguards for legacy results, so impact is contained to the bench UI.
> 
> **Overview**
> Adds per-run *integrity tracking* to the bench UI by extending `BenchResultSummary` with `integrity: BenchIntegritySummary`, derived in `results.ts` from `meta.splitType`, sealed-artifact SHA-256 hashes, and canary score vs a (possibly per-result) floor.
> 
> Renders a new `IntegrityBadge` on overview score cards and in the runs table, with CSS styling and a tooltip that explains split/canary status, short hashes, and downgrade reasons; legacy results without metadata are handled as `unknown`/missing and still render.
> 
> Adds focused unit tests for `describeIntegrity` level transitions and for loader behavior (holdout/public/legacy + custom `canaryFloor`), and updates existing test fixtures to include the new `integrity` field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46b588547e00da54459e45f88ac68b95ee5ead24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->