### PR TITLE
feat(bench-ui): Assistant dashboard section (issue #450 part 2/2)

### DIFF
--- a/packages/bench-ui/src/App.tsx
+++ b/packages/bench-ui/src/App.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import { HashRouter, NavLink, Navigate, Route, Routes } from "react-router-dom";
 import type { BenchResultSummaryPayload } from "./bench-data";
 import { listBenchmarks } from "./bench-data";
+import { Assistant } from "./pages/Assistant";
 import { BenchmarkDetail } from "./pages/BenchmarkDetail";
 import { Compare } from "./pages/Compare";
 import { Ingestion } from "./pages/Ingestion";
@@ -12,6 +13,7 @@ import { Runs } from "./pages/Runs";
 
 const navigationItems = [
   { label: "Overview", path: "/" },
+  { label: "Assistant", path: "/assistant" },
   { label: "Ingestion", path: "/ingestion" },
   { label: "Runs", path: "/runs" },
   { label: "Compare", path: "/compare" },
@@ -155,6 +157,7 @@ export function App() {
       >
         <Routes>
           <Route path="/" element={<Overview payload={payload} />} />
+          <Route path="/assistant" element={<Assistant payload={payload} />} />
           <Route path="/ingestion" element={<Ingestion payload={payload} />} />
           <Route path="/runs" element={<Runs payload={payload} />} />
           <Route path="/compare" element={<Compare payload={payload} />} />

--- a/packages/bench-ui/src/bench-data.ts
+++ b/packages/bench-ui/src/bench-data.ts
@@ -24,6 +24,25 @@ export interface BenchTaskScoreEntry {
   value: number;
 }
 
+export interface BenchPerSeedScore {
+  seed: number;
+  identityAccuracy: number | null;
+  stanceCoherence: number | null;
+  novelty: number | null;
+  calibration: number | null;
+  parseOk: boolean;
+  notes: string;
+  latencyMs: number | null;
+}
+
+export interface BenchAssistantTaskDetails {
+  focus: string | null;
+  rubricId: string | null;
+  rubricSha256: string | null;
+  perSeedScores: BenchPerSeedScore[];
+  judgeParseFailures: number | null;
+}
+
 export interface BenchTaskSummary {
   taskId: string;
   question: string;
@@ -33,6 +52,7 @@ export interface BenchTaskSummary {
   totalTokens: number;
   primaryScore: number | null;
   scoreEntries: BenchTaskScoreEntry[];
+  assistantDetails?: BenchAssistantTaskDetails | null;
 }
 
 export type BenchIntegritySplit = "public" | "holdout" | "unknown";
@@ -78,6 +98,9 @@ export interface BenchResultSummary {
   aggregateMetrics: BenchAggregateMetric[];
   taskSummaries: BenchTaskSummary[];
   integrity: BenchIntegritySummary;
+  assistantRubricId?: string | null;
+  assistantRubricSha256?: string | null;
+  assistantRunId?: string | null;
   filePath: string;
 }
 
@@ -530,4 +553,149 @@ export function benchmarkRuns(
     .filter((summary) => summary.benchmark === benchmark)
     .slice()
     .sort(compareTimestampedRuns);
+}
+
+export const ASSISTANT_BENCHMARK_IDS = [
+  "assistant-morning-brief",
+  "assistant-meeting-prep",
+  "assistant-next-best-action",
+  "assistant-synthesis",
+] as const;
+
+export type AssistantBenchmarkId = (typeof ASSISTANT_BENCHMARK_IDS)[number];
+
+export const ASSISTANT_RUBRIC_DIMENSION_KEYS = [
+  "identity_accuracy",
+  "stance_coherence",
+  "novelty",
+  "calibration",
+  "overall",
+] as const;
+
+export type AssistantRubricDimensionKey =
+  (typeof ASSISTANT_RUBRIC_DIMENSION_KEYS)[number];
+
+export interface AssistantDimensionBar {
+  dimension: AssistantRubricDimensionKey;
+  label: string;
+  mean: number | null;
+  ciLower: number | null;
+  ciUpper: number | null;
+}
+
+export function isAssistantBenchmark(benchmark: string): boolean {
+  return (ASSISTANT_BENCHMARK_IDS as readonly string[]).includes(benchmark);
+}
+
+export function getAssistantRuns(
+  payload: BenchResultSummaryPayload,
+): BenchResultSummary[] {
+  return payload.summaries
+    .filter((summary) => isAssistantBenchmark(summary.benchmark))
+    .slice()
+    .sort(compareTimestampedRuns);
+}
+
+export function getLatestAssistantRunByBenchmark(
+  payload: BenchResultSummaryPayload,
+): Record<string, BenchResultSummary | null> {
+  const latest: Record<string, BenchResultSummary | null> = {};
+  for (const id of ASSISTANT_BENCHMARK_IDS) {
+    latest[id] = null;
+  }
+  for (const run of getAssistantRuns(payload)) {
+    if (!latest[run.benchmark]) {
+      latest[run.benchmark] = run;
+    }
+  }
+  return latest;
+}
+
+export function dimensionLabel(
+  dimension: AssistantRubricDimensionKey,
+): string {
+  switch (dimension) {
+    case "identity_accuracy":
+      return "Identity accuracy";
+    case "stance_coherence":
+      return "Stance coherence";
+    case "novelty":
+      return "Novelty";
+    case "calibration":
+      return "Calibration";
+    case "overall":
+      return "Overall";
+  }
+}
+
+export function getAssistantDimensionBars(
+  summary: BenchResultSummary | null,
+): AssistantDimensionBar[] {
+  if (!summary) {
+    return ASSISTANT_RUBRIC_DIMENSION_KEYS.map((dimension) => ({
+      dimension,
+      label: dimensionLabel(dimension),
+      mean: null,
+      ciLower: null,
+      ciUpper: null,
+    }));
+  }
+  const lookup = new Map(
+    summary.aggregateMetrics.map((metric) => [metric.name, metric]),
+  );
+  return ASSISTANT_RUBRIC_DIMENSION_KEYS.map((dimension) => {
+    const metric = lookup.get(dimension);
+    return {
+      dimension,
+      label: dimensionLabel(dimension),
+      mean: metric?.mean ?? null,
+      ciLower: metric?.ciLower ?? null,
+      ciUpper: metric?.ciUpper ?? null,
+    };
+  });
+}
+
+export function flattenAssistantSpotChecks(
+  summary: BenchResultSummary | null,
+): Array<{
+  taskId: string;
+  seed: number;
+  identityAccuracy: number | null;
+  stanceCoherence: number | null;
+  novelty: number | null;
+  calibration: number | null;
+  parseOk: boolean;
+  notes: string;
+  focus: string | null;
+}> {
+  if (!summary) return [];
+  const rows: Array<{
+    taskId: string;
+    seed: number;
+    identityAccuracy: number | null;
+    stanceCoherence: number | null;
+    novelty: number | null;
+    calibration: number | null;
+    parseOk: boolean;
+    notes: string;
+    focus: string | null;
+  }> = [];
+  for (const task of summary.taskSummaries) {
+    const details = task.assistantDetails;
+    if (!details) continue;
+    for (const seed of details.perSeedScores) {
+      rows.push({
+        taskId: task.taskId,
+        seed: seed.seed,
+        identityAccuracy: seed.identityAccuracy,
+        stanceCoherence: seed.stanceCoherence,
+        novelty: seed.novelty,
+        calibration: seed.calibration,
+        parseOk: seed.parseOk,
+        notes: seed.notes,
+        focus: details.focus,
+      });
+    }
+  }
+  return rows;
 }

--- a/packages/bench-ui/src/components/AssistantDimensionChart.tsx
+++ b/packages/bench-ui/src/components/AssistantDimensionChart.tsx
@@ -1,0 +1,69 @@
+import type { AssistantDimensionBar } from "../bench-data";
+
+const MAX_SCORE = 5;
+
+export function AssistantDimensionChart({
+  bars,
+}: {
+  bars: AssistantDimensionBar[];
+}) {
+  return (
+    <div className="assistant-chart" role="img" aria-label="Per-dimension rubric scores with 95% CI error bars">
+      {bars.map((bar) => {
+        const meanPercent =
+          bar.mean !== null
+            ? Math.max(0, Math.min(100, (bar.mean / MAX_SCORE) * 100))
+            : 0;
+        const ciLowerPercent =
+          bar.ciLower !== null
+            ? Math.max(0, Math.min(100, (bar.ciLower / MAX_SCORE) * 100))
+            : meanPercent;
+        const ciUpperPercent =
+          bar.ciUpper !== null
+            ? Math.max(0, Math.min(100, (bar.ciUpper / MAX_SCORE) * 100))
+            : meanPercent;
+        const hasCi =
+          bar.ciLower !== null &&
+          bar.ciUpper !== null &&
+          bar.ciUpper > bar.ciLower;
+
+        return (
+          <div key={bar.dimension} className="assistant-chart__row">
+            <div className="assistant-chart__label">{bar.label}</div>
+            <div className="assistant-chart__track" aria-hidden="true">
+              {bar.mean === null ? (
+                <span className="assistant-chart__na">no data</span>
+              ) : (
+                <>
+                  <div
+                    className="assistant-chart__fill"
+                    style={{ width: `${meanPercent}%` }}
+                  />
+                  {hasCi ? (
+                    <div
+                      className="assistant-chart__error-bar"
+                      style={{
+                        left: `${ciLowerPercent}%`,
+                        width: `${Math.max(0.5, ciUpperPercent - ciLowerPercent)}%`,
+                      }}
+                      title={`95% CI: ${bar.ciLower?.toFixed(2)} - ${bar.ciUpper?.toFixed(2)}`}
+                    />
+                  ) : null}
+                </>
+              )}
+            </div>
+            <div className="assistant-chart__value">
+              {bar.mean === null ? "—" : bar.mean.toFixed(2)}
+              {hasCi ? (
+                <span className="assistant-chart__ci">
+                  {" "}
+                  (95% CI {bar.ciLower?.toFixed(2)}–{bar.ciUpper?.toFixed(2)})
+                </span>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/packages/bench-ui/src/components/AssistantSpotCheckViewer.tsx
+++ b/packages/bench-ui/src/components/AssistantSpotCheckViewer.tsx
@@ -1,0 +1,81 @@
+import type { BenchResultSummary } from "../bench-data";
+import { flattenAssistantSpotChecks } from "../bench-data";
+
+export function AssistantSpotCheckViewer({
+  summary,
+}: {
+  summary: BenchResultSummary | null;
+}) {
+  const rows = flattenAssistantSpotChecks(summary);
+
+  if (!summary) {
+    return (
+      <p className="assistant-spot-check__empty">
+        Select an Assistant benchmark run to inspect per-seed judge decisions.
+      </p>
+    );
+  }
+
+  if (rows.length === 0) {
+    return (
+      <p className="assistant-spot-check__empty">
+        This run has no per-seed judge decisions available. Spot-check JSONL
+        logs live under
+        {" "}
+        <code>benchmarks/results/spot-checks/{summary.assistantRunId ?? "<run-id>"}.jsonl</code>.
+      </p>
+    );
+  }
+
+  return (
+    <div className="assistant-spot-check">
+      <table className="assistant-spot-check__table">
+        <thead>
+          <tr>
+            <th scope="col">Task</th>
+            <th scope="col">Seed</th>
+            <th scope="col">Identity</th>
+            <th scope="col">Stance</th>
+            <th scope="col">Novelty</th>
+            <th scope="col">Calibration</th>
+            <th scope="col">Parsed</th>
+            <th scope="col">Notes</th>
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row) => (
+            <tr key={`${row.taskId}#${row.seed}`}>
+              <td>
+                <span className="assistant-spot-check__task">{row.taskId}</span>
+                {row.focus ? (
+                  <span className="assistant-spot-check__focus">({row.focus})</span>
+                ) : null}
+              </td>
+              <td>{row.seed}</td>
+              <td>{formatSeedScore(row.identityAccuracy)}</td>
+              <td>{formatSeedScore(row.stanceCoherence)}</td>
+              <td>{formatSeedScore(row.novelty)}</td>
+              <td>{formatSeedScore(row.calibration)}</td>
+              <td>{row.parseOk ? "yes" : "no"}</td>
+              <td>
+                <span className="assistant-spot-check__notes">
+                  {row.notes || "—"}
+                </span>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+      <p className="assistant-spot-check__footnote">
+        The randomly-sampled JSONL log of judge decisions is written to
+        {" "}
+        <code>benchmarks/results/spot-checks/{summary.assistantRunId ?? "<run-id>"}.jsonl</code>
+        {" "}for offline review.
+      </p>
+    </div>
+  );
+}
+
+function formatSeedScore(value: number | null): string {
+  return value === null ? "—" : value.toFixed(2);
+}

--- a/packages/bench-ui/src/pages/Assistant.tsx
+++ b/packages/bench-ui/src/pages/Assistant.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from "react";
+import type { BenchResultSummaryPayload } from "../bench-data";
+import {
+  ASSISTANT_BENCHMARK_IDS,
+  benchmarkRuns,
+  formatTimestamp,
+  getAssistantDimensionBars,
+  getLatestAssistantRunByBenchmark,
+  humanizeIdentifier,
+} from "../bench-data";
+import { AssistantDimensionChart } from "../components/AssistantDimensionChart";
+import { AssistantSpotCheckViewer } from "../components/AssistantSpotCheckViewer";
+
+export function Assistant({
+  payload,
+}: {
+  payload: BenchResultSummaryPayload;
+}) {
+  const latestByBenchmark = getLatestAssistantRunByBenchmark(payload);
+  const firstId = ASSISTANT_BENCHMARK_IDS[0];
+  const [activeBenchmark, setActiveBenchmark] = useState<string>(firstId);
+  const runsForActive = useMemo(
+    () => benchmarkRuns(payload, activeBenchmark),
+    [payload, activeBenchmark],
+  );
+  const [selectedRunId, setSelectedRunId] = useState<string | null>(null);
+  const selectedRun =
+    runsForActive.find((run) => run.id === selectedRunId) ??
+    runsForActive[0] ??
+    null;
+  const bars = getAssistantDimensionBars(selectedRun);
+
+  return (
+    <section className="page">
+      <header className="page-header">
+        <div>
+          <span className="section-kicker">Assistant</span>
+          <h3>Assistant / Personalization tier</h3>
+        </div>
+        <p>
+          Sealed-rubric evaluations scored along four dimensions
+          (identity_accuracy, stance_coherence, novelty, calibration) with
+          bootstrap 95% confidence intervals. Error bars widen when the judge
+          disagrees across seeded runs — treat wide intervals as a signal to
+          look at the spot-check log.
+        </p>
+      </header>
+
+      <section className="score-grid">
+        {ASSISTANT_BENCHMARK_IDS.map((id) => {
+          const latest = latestByBenchmark[id];
+          const isActive = id === activeBenchmark;
+          return (
+            <button
+              key={id}
+              type="button"
+              className={`score-card assistant-card${
+                isActive ? " assistant-card--active" : ""
+              }`}
+              onClick={() => {
+                setActiveBenchmark(id);
+                setSelectedRunId(null);
+              }}
+            >
+              <div className="score-card__header">
+                <div>
+                  <span className="section-kicker">remnic</span>
+                  <h4>{humanizeIdentifier(id)}</h4>
+                </div>
+                {latest ? (
+                  <span className="score-card__timestamp">
+                    {formatTimestamp(latest.timestamp)}
+                  </span>
+                ) : (
+                  <span className="score-card__timestamp">no runs</span>
+                )}
+              </div>
+              <div className="score-card__score-row">
+                <strong>
+                  {latest?.primaryScore !== null && latest?.primaryScore !== undefined
+                    ? latest.primaryScore.toFixed(2)
+                    : "—"}
+                </strong>
+                <span className="delta-pill">{latest?.runCount ?? 0} runs</span>
+              </div>
+              <dl className="score-card__meta">
+                <div>
+                  <dt>Rubric</dt>
+                  <dd>{latest?.assistantRubricId ?? "—"}</dd>
+                </div>
+                <div>
+                  <dt>System</dt>
+                  <dd>{latest?.systemProvider ?? "—"}</dd>
+                </div>
+                <div>
+                  <dt>Judge</dt>
+                  <dd>{latest?.judgeProvider ?? "—"}</dd>
+                </div>
+              </dl>
+            </button>
+          );
+        })}
+      </section>
+
+      <section className="panel controls-panel">
+        <div className="control-group">
+          <label htmlFor="assistant-run-select">Run</label>
+          <select
+            id="assistant-run-select"
+            value={selectedRun?.id ?? ""}
+            onChange={(event) => setSelectedRunId(event.target.value)}
+            disabled={runsForActive.length === 0}
+          >
+            {runsForActive.length === 0 ? (
+              <option value="">No runs available</option>
+            ) : (
+              runsForActive.map((run) => (
+                <option key={run.id} value={run.id}>
+                  {formatTimestamp(run.timestamp)} · {run.mode} ·{" "}
+                  {run.systemProvider}
+                </option>
+              ))
+            )}
+          </select>
+        </div>
+        {selectedRun?.assistantRubricSha256 ? (
+          <div className="assistant-rubric-pill" title="Sealed rubric digest">
+            <span className="section-kicker">rubric sha256</span>
+            <code>{selectedRun.assistantRubricSha256.slice(0, 12)}…</code>
+          </div>
+        ) : null}
+      </section>
+
+      <section className="page-block">
+        <div className="section-title">
+          <span className="section-kicker">Per-dimension scores</span>
+          <h4>{humanizeIdentifier(activeBenchmark)} — 95% CI error bars</h4>
+        </div>
+        <AssistantDimensionChart bars={bars} />
+      </section>
+
+      <section className="page-block">
+        <div className="section-title">
+          <span className="section-kicker">Spot-check viewer</span>
+          <h4>Per-seed judge decisions</h4>
+        </div>
+        <AssistantSpotCheckViewer summary={selectedRun} />
+      </section>
+    </section>
+  );
+}

--- a/packages/bench-ui/src/results.ts
+++ b/packages/bench-ui/src/results.ts
@@ -3,9 +3,11 @@ import { readdir, readFile } from "node:fs/promises";
 import path from "node:path";
 import type {
   BenchAggregateMetric,
+  BenchAssistantTaskDetails,
   BenchIntegritySplit,
   BenchIntegritySummary,
   BenchMetricHighlight,
+  BenchPerSeedScore,
   BenchResultSummary,
   BenchResultSummaryPayload,
   BenchTaskScoreEntry,
@@ -155,6 +157,40 @@ function metricHighlights(metrics: BenchAggregateMetric[]): BenchMetricHighlight
     .map((metric) => ({ name: metric.name, mean: metric.mean }));
 }
 
+function assistantPerSeedScore(value: unknown): BenchPerSeedScore | null {
+  if (!isRecord(value)) return null;
+  const scores = isRecord(value.scores) ? value.scores : {};
+  const seed = toFiniteNumber(value.seed);
+  if (seed === null) return null;
+  return {
+    seed,
+    identityAccuracy: toFiniteNumber(scores.identity_accuracy),
+    stanceCoherence: toFiniteNumber(scores.stance_coherence),
+    novelty: toFiniteNumber(scores.novelty),
+    calibration: toFiniteNumber(scores.calibration),
+    parseOk: value.parseOk === true,
+    notes: typeof value.notes === "string" ? value.notes : "",
+    latencyMs: toFiniteNumber(value.latencyMs),
+  };
+}
+
+function assistantDetails(value: unknown): BenchAssistantTaskDetails | null {
+  if (!isRecord(value)) return null;
+  const perSeedRaw = Array.isArray(value.perSeedScores) ? value.perSeedScores : null;
+  if (!perSeedRaw) return null;
+  const perSeedScores = perSeedRaw
+    .map(assistantPerSeedScore)
+    .filter((entry): entry is BenchPerSeedScore => entry !== null);
+  return {
+    focus: typeof value.focus === "string" ? value.focus : null,
+    rubricId: typeof value.rubricId === "string" ? value.rubricId : null,
+    rubricSha256:
+      typeof value.rubricSha256 === "string" ? value.rubricSha256 : null,
+    perSeedScores,
+    judgeParseFailures: toFiniteNumber(value.judgeParseFailures),
+  };
+}
+
 function taskSummaries(result: JsonRecord): BenchTaskSummary[] {
   const results = isRecord(result.results) ? result.results : {};
   const tasks = Array.isArray(results.tasks) ? results.tasks : [];
@@ -182,6 +218,7 @@ function taskSummaries(result: JsonRecord): BenchTaskSummary[] {
           (toFiniteNumber(tokens.input) ?? 0) + (toFiniteNumber(tokens.output) ?? 0),
         primaryScore: primaryEntry?.value ?? null,
         scoreEntries: entries,
+        assistantDetails: assistantDetails(task.details),
       };
     })
     .filter((task): task is BenchTaskSummary => task !== null)
@@ -214,6 +251,19 @@ export function summarizeBenchmarkResult(
 
   const systemProvider = providerLabel(config.systemProvider);
   const judgeProvider = providerLabel(config.judgeProvider);
+  const remnicConfig = isRecord(config.remnicConfig) ? config.remnicConfig : {};
+  const assistantRubricId =
+    typeof remnicConfig.assistantRubricId === "string"
+      ? remnicConfig.assistantRubricId
+      : null;
+  const assistantRubricSha256 =
+    typeof remnicConfig.assistantRubricSha256 === "string"
+      ? remnicConfig.assistantRubricSha256
+      : null;
+  const assistantRunId =
+    typeof remnicConfig.assistantRunId === "string"
+      ? remnicConfig.assistantRunId
+      : null;
 
   return {
     id: meta.id,
@@ -241,6 +291,9 @@ export function summarizeBenchmarkResult(
     aggregateMetrics: metrics,
     taskSummaries: tasks,
     integrity: computeIntegritySummary(meta),
+    assistantRubricId,
+    assistantRubricSha256,
+    assistantRunId,
     filePath,
   };
 }

--- a/packages/bench-ui/src/styles.css
+++ b/packages/bench-ui/src/styles.css
@@ -279,3 +279,140 @@ select {
   border-color: rgba(220, 53, 69, 0.4);
 }
 
+/* Assistant tier -------------------------------------------------------- */
+
+.assistant-card {
+  cursor: pointer;
+  background: inherit;
+  text-align: left;
+  border: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+.assistant-card--active {
+  border-color: rgba(103, 156, 255, 0.85);
+  box-shadow: 0 0 0 1px rgba(103, 156, 255, 0.45);
+}
+
+.assistant-chart {
+  display: grid;
+  gap: 10px;
+}
+
+.assistant-chart__row {
+  display: grid;
+  grid-template-columns: 180px 1fr 220px;
+  align-items: center;
+  gap: 12px;
+}
+
+.assistant-chart__label {
+  font-weight: 600;
+  color: #cbd5ec;
+}
+
+.assistant-chart__track {
+  position: relative;
+  height: 22px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.06);
+  overflow: hidden;
+}
+
+.assistant-chart__fill {
+  height: 100%;
+  background: linear-gradient(90deg, #679cff 0%, #a5c5ff 100%);
+  transition: width 220ms ease;
+}
+
+.assistant-chart__error-bar {
+  position: absolute;
+  top: 4px;
+  bottom: 4px;
+  background: rgba(255, 255, 255, 0.45);
+  border-left: 2px solid rgba(255, 255, 255, 0.9);
+  border-right: 2px solid rgba(255, 255, 255, 0.9);
+  pointer-events: none;
+}
+
+.assistant-chart__value {
+  font-variant-numeric: tabular-nums;
+  color: #d5def0;
+}
+
+.assistant-chart__ci {
+  color: #8ea0bf;
+  font-size: 0.85em;
+}
+
+.assistant-chart__na {
+  padding-left: 10px;
+  color: #8ea0bf;
+  font-style: italic;
+  line-height: 22px;
+}
+
+.assistant-rubric-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 12px;
+  border-radius: 999px;
+  background: rgba(103, 156, 255, 0.08);
+  border: 1px solid rgba(103, 156, 255, 0.25);
+}
+
+.assistant-rubric-pill code {
+  font-family: "JetBrains Mono", "Menlo", monospace;
+  font-size: 0.85em;
+}
+
+.assistant-spot-check {
+  overflow-x: auto;
+}
+
+.assistant-spot-check__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.assistant-spot-check__table th,
+.assistant-spot-check__table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+  text-align: left;
+  font-variant-numeric: tabular-nums;
+}
+
+.assistant-spot-check__task {
+  font-weight: 600;
+}
+
+.assistant-spot-check__focus {
+  display: block;
+  font-size: 0.8em;
+  color: #8ea0bf;
+}
+
+.assistant-spot-check__notes {
+  color: #cbd5ec;
+  font-size: 0.9em;
+}
+
+.assistant-spot-check__empty,
+.assistant-spot-check__footnote {
+  color: #8ea0bf;
+  font-size: 0.9em;
+}
+
+.assistant-spot-check__footnote code {
+  color: #cbd5ec;
+  background: rgba(255, 255, 255, 0.06);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+@media (max-width: 900px) {
+  .assistant-chart__row {
+    grid-template-columns: 1fr;
+  }
+}

--- a/tests/bench-ui-assistant.test.ts
+++ b/tests/bench-ui-assistant.test.ts
@@ -1,0 +1,341 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import {
+  ASSISTANT_BENCHMARK_IDS,
+  ASSISTANT_RUBRIC_DIMENSION_KEYS,
+  flattenAssistantSpotChecks,
+  getAssistantDimensionBars,
+  getAssistantRuns,
+  getLatestAssistantRunByBenchmark,
+  isAssistantBenchmark,
+  type BenchResultSummary,
+  type BenchResultSummaryPayload,
+} from "../packages/bench-ui/src/bench-data.js";
+import { loadBenchResultSummaries } from "../packages/bench-ui/src/results.js";
+
+function buildAssistantSummary(overrides: Partial<BenchResultSummary> = {}): BenchResultSummary {
+  const base: BenchResultSummary = {
+    id: "assistant-morning-brief-run-1",
+    benchmark: "assistant-morning-brief",
+    benchmarkTier: "remnic",
+    timestamp: "2026-04-18T10:00:00.000Z",
+    mode: "full",
+    totalLatencyMs: 1000,
+    meanQueryLatencyMs: 200,
+    taskCount: 3,
+    metricHighlights: [
+      { name: "identity_accuracy", mean: 4.1 },
+      { name: "stance_coherence", mean: 3.2 },
+      { name: "novelty", mean: 3.9 },
+    ],
+    primaryMetric: "identity_accuracy",
+    primaryScore: 4.1,
+    runCount: 5,
+    estimatedCostUsd: 0,
+    totalTokens: 0,
+    inputTokens: 0,
+    outputTokens: 0,
+    systemProvider: "openai/gpt-5.4",
+    judgeProvider: "openai/gpt-5.4-mini",
+    providerKey: "openai/gpt-5.4__openai/gpt-5.4-mini",
+    adapterMode: "direct",
+    aggregateMetrics: [
+      {
+        name: "identity_accuracy",
+        mean: 4.1,
+        median: 4,
+        stdDev: 0.3,
+        min: 3.6,
+        max: 4.5,
+        ciLower: 3.9,
+        ciUpper: 4.3,
+        ciLevel: 0.95,
+        effectSize: null,
+        effectInterpretation: null,
+      },
+      {
+        name: "stance_coherence",
+        mean: 3.2,
+        median: 3,
+        stdDev: 0.5,
+        min: 2.5,
+        max: 4,
+        ciLower: 2.9,
+        ciUpper: 3.5,
+        ciLevel: 0.95,
+        effectSize: null,
+        effectInterpretation: null,
+      },
+      {
+        name: "novelty",
+        mean: 3.9,
+        median: 4,
+        stdDev: 0.4,
+        min: 3.2,
+        max: 4.3,
+        ciLower: 3.6,
+        ciUpper: 4.2,
+        ciLevel: 0.95,
+        effectSize: null,
+        effectInterpretation: null,
+      },
+      {
+        name: "calibration",
+        mean: 4.5,
+        median: 5,
+        stdDev: 0.4,
+        min: 3.8,
+        max: 5,
+        ciLower: 4.2,
+        ciUpper: 4.8,
+        ciLevel: 0.95,
+        effectSize: null,
+        effectInterpretation: null,
+      },
+      {
+        name: "overall",
+        mean: 3.925,
+        median: 4,
+        stdDev: 0.35,
+        min: 3.4,
+        max: 4.3,
+        ciLower: 3.7,
+        ciUpper: 4.15,
+        ciLevel: 0.95,
+        effectSize: null,
+        effectInterpretation: null,
+      },
+    ],
+    taskSummaries: [
+      {
+        taskId: "morning-brief.monday-priorities",
+        question: "Morning brief",
+        expected: "<rubric-judged>",
+        actual: "synthesized",
+        latencyMs: 120,
+        totalTokens: 0,
+        primaryScore: 4.1,
+        scoreEntries: [],
+        assistantDetails: {
+          focus: "priority_surfacing",
+          rubricId: "assistant-rubric-v1",
+          rubricSha256: "abc123",
+          perSeedScores: [
+            {
+              seed: 1,
+              identityAccuracy: 4,
+              stanceCoherence: 3,
+              novelty: 4,
+              calibration: 5,
+              parseOk: true,
+              notes: "scripted:morning-brief.monday-priorities#seed-1",
+              latencyMs: 120,
+            },
+            {
+              seed: 2,
+              identityAccuracy: 4,
+              stanceCoherence: 3,
+              novelty: 4,
+              calibration: 4,
+              parseOk: true,
+              notes: "scripted:morning-brief.monday-priorities#seed-2",
+              latencyMs: 110,
+            },
+          ],
+          judgeParseFailures: 0,
+        },
+      },
+    ],
+    assistantRubricId: "assistant-rubric-v1",
+    assistantRubricSha256: "abc123",
+    assistantRunId: "assistant-morning-brief-2026-04-18T10-00-00-000Z",
+    filePath: "/tmp/assistant-run-1.json",
+  };
+  return { ...base, ...overrides };
+}
+
+test("isAssistantBenchmark recognises the registered assistant ids", () => {
+  for (const id of ASSISTANT_BENCHMARK_IDS) {
+    assert.equal(isAssistantBenchmark(id), true);
+  }
+  assert.equal(isAssistantBenchmark("longmemeval"), false);
+  assert.equal(isAssistantBenchmark(""), false);
+});
+
+test("getAssistantDimensionBars surfaces all five rubric dimension keys with CI bounds", () => {
+  const summary = buildAssistantSummary();
+  const bars = getAssistantDimensionBars(summary);
+  assert.equal(bars.length, ASSISTANT_RUBRIC_DIMENSION_KEYS.length);
+  assert.deepEqual(
+    bars.map((bar) => bar.dimension),
+    [...ASSISTANT_RUBRIC_DIMENSION_KEYS],
+  );
+  const identity = bars.find((bar) => bar.dimension === "identity_accuracy")!;
+  assert.equal(identity.mean, 4.1);
+  assert.equal(identity.ciLower, 3.9);
+  assert.equal(identity.ciUpper, 4.3);
+});
+
+test("getAssistantDimensionBars returns null means when summary is missing", () => {
+  const bars = getAssistantDimensionBars(null);
+  assert.equal(bars.length, ASSISTANT_RUBRIC_DIMENSION_KEYS.length);
+  for (const bar of bars) {
+    assert.equal(bar.mean, null);
+    assert.equal(bar.ciLower, null);
+    assert.equal(bar.ciUpper, null);
+  }
+});
+
+test("getAssistantRuns filters to Assistant-tier benchmarks only", () => {
+  const summary = buildAssistantSummary();
+  const nonAssistant = buildAssistantSummary({
+    id: "longmemeval-1",
+    benchmark: "longmemeval",
+    benchmarkTier: "published",
+  });
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [summary, nonAssistant],
+  };
+  assert.deepEqual(
+    getAssistantRuns(payload).map((run) => run.benchmark),
+    ["assistant-morning-brief"],
+  );
+});
+
+test("getLatestAssistantRunByBenchmark picks the newest run per benchmark", () => {
+  const older = buildAssistantSummary({
+    id: "mb-old",
+    timestamp: "2026-04-17T10:00:00.000Z",
+  });
+  const newer = buildAssistantSummary({
+    id: "mb-new",
+    timestamp: "2026-04-18T11:00:00.000Z",
+  });
+  const payload: BenchResultSummaryPayload = {
+    resultsDir: "/tmp/results",
+    summaries: [older, newer],
+  };
+  const latest = getLatestAssistantRunByBenchmark(payload);
+  assert.equal(latest["assistant-morning-brief"]?.id, "mb-new");
+  assert.equal(latest["assistant-meeting-prep"], null);
+});
+
+test("flattenAssistantSpotChecks expands per-seed decisions with task context", () => {
+  const summary = buildAssistantSummary();
+  const rows = flattenAssistantSpotChecks(summary);
+  assert.equal(rows.length, 2);
+  assert.equal(rows[0]?.taskId, "morning-brief.monday-priorities");
+  assert.equal(rows[0]?.seed, 1);
+  assert.equal(rows[0]?.focus, "priority_surfacing");
+  assert.equal(rows[0]?.parseOk, true);
+});
+
+test("bench UI loader surfaces assistant rubric metadata and per-seed details", async () => {
+  const resultsDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-ui-assistant-"),
+  );
+  await writeFile(
+    path.join(resultsDir, "assistant.json"),
+    JSON.stringify(
+      {
+        meta: {
+          id: "assistant-run-1",
+          benchmark: "assistant-morning-brief",
+          benchmarkTier: "remnic",
+          timestamp: "2026-04-18T10:00:00.000Z",
+          mode: "full",
+        },
+        config: {
+          remnicConfig: {
+            assistantRubricId: "assistant-rubric-v1",
+            assistantRubricSha256:
+              "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+            assistantRunId: "assistant-morning-brief-2026-04-18T10-00-00-000Z",
+          },
+        },
+        cost: { totalLatencyMs: 100, meanQueryLatencyMs: 50 },
+        results: {
+          aggregates: {
+            identity_accuracy: { mean: 4 },
+            calibration: { mean: 4.5 },
+            overall: { mean: 4.2 },
+          },
+          statistics: {
+            confidenceIntervals: {
+              identity_accuracy: { lower: 3.8, upper: 4.2, level: 0.95 },
+              calibration: { lower: 4.3, upper: 4.7, level: 0.95 },
+              overall: { lower: 4.0, upper: 4.4, level: 0.95 },
+            },
+            bootstrapSamples: 1000,
+          },
+          tasks: [
+            {
+              taskId: "morning-brief.monday-priorities",
+              question: "Morning brief",
+              expected: "<rubric-judged>",
+              actual: "synthesized",
+              scores: {
+                identity_accuracy: 4,
+                calibration: 4.5,
+                overall: 4.2,
+              },
+              latencyMs: 120,
+              tokens: { input: 0, output: 0 },
+              details: {
+                focus: "priority_surfacing",
+                rubricId: "assistant-rubric-v1",
+                rubricSha256:
+                  "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
+                perSeedScores: [
+                  {
+                    seed: 1,
+                    scores: {
+                      identity_accuracy: 4,
+                      stance_coherence: 3,
+                      novelty: 4,
+                      calibration: 5,
+                    },
+                    parseOk: true,
+                    notes: "seed 1",
+                    latencyMs: 120,
+                  },
+                ],
+                judgeParseFailures: 0,
+              },
+            },
+          ],
+        },
+      },
+      null,
+      2,
+    ),
+  );
+
+  const payload = await loadBenchResultSummaries(resultsDir);
+  assert.equal(payload.summaries.length, 1);
+  const summary = payload.summaries[0]!;
+  assert.equal(summary.assistantRubricId, "assistant-rubric-v1");
+  assert.equal(summary.assistantRubricSha256?.length, 64);
+  assert.equal(summary.assistantRunId, "assistant-morning-brief-2026-04-18T10-00-00-000Z");
+
+  const task = summary.taskSummaries[0]!;
+  assert.ok(task.assistantDetails, "assistantDetails should be populated");
+  assert.equal(task.assistantDetails?.focus, "priority_surfacing");
+  assert.equal(task.assistantDetails?.perSeedScores.length, 1);
+  assert.equal(task.assistantDetails?.perSeedScores[0]?.seed, 1);
+  assert.equal(task.assistantDetails?.perSeedScores[0]?.identityAccuracy, 4);
+  assert.equal(task.assistantDetails?.perSeedScores[0]?.parseOk, true);
+
+  const aggregate = summary.aggregateMetrics.find(
+    (metric) => metric.name === "identity_accuracy",
+  );
+  assert.ok(aggregate);
+  assert.equal(aggregate?.ciLower, 3.8);
+  assert.equal(aggregate?.ciUpper, 4.2);
+  assert.equal(aggregate?.ciLevel, 0.95);
+});


### PR DESCRIPTION
## Summary

Follow-on to #508. Adds an "Assistant" page to `@remnic/bench-ui` that
surfaces the sealed-rubric Assistant-tier benchmarks introduced in PR A.

- Per-benchmark cards (morning brief, meeting prep, next-best-action,
  synthesis) with primary-score and rubric-provenance summary.
- Per-dimension horizontal bar chart with bootstrap 95% CI error bars.
- Spot-check viewer showing per-seed judge decisions, linking to the
  JSONL log path written by the core runner.
- Loader changes in `packages/bench-ui/src/results.ts` extend
  `BenchResultSummary` with optional `assistantRubricId`,
  `assistantRubricSha256`, and `assistantRunId` fields, plus per-task
  `assistantDetails`. All new fields are optional so existing UI tests
  keep passing.

## Test plan

- [x] `tests/bench-ui-assistant.test.ts` exercises the new helpers
  (`getAssistantDimensionBars`, `getAssistantRuns`,
  `getLatestAssistantRunByBenchmark`, `flattenAssistantSpotChecks`)
  and verifies the loader surfaces rubric metadata + per-seed details
  from a synthetic benchmark result fixture.
- [ ] Local smoke test: load a real Assistant run in `bench-ui` and
  confirm the "Assistant" nav item renders the four benchmark cards,
  the dimension chart, and the per-seed spot-check table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new UI surface and extends result parsing/types to ingest new Assistant-tier JSON fields; risk is mainly around compatibility with existing result files and assumptions about metric naming/CI bounds.
> 
> **Overview**
> Introduces a new **Assistant** section in `@remnic/bench-ui` with a dedicated route and navigation entry that summarizes the four Assistant-tier benchmarks and lets users select runs.
> 
> Adds Assistant-specific data modeling and helpers in `bench-data.ts` (registered benchmark IDs, per-dimension bar inputs, and spot-check flattening), plus new UI components for a per-dimension score chart with 95% CI error bars and a per-seed judge decision table that links to the expected JSONL spot-check log.
> 
> Extends the results loader (`results.ts`) and shared summary types to optionally surface Assistant rubric provenance (`assistantRubricId`, `assistantRubricSha256`, `assistantRunId`) and per-task `assistantDetails` parsed from `task.details`, with CSS and new tests covering the helpers and loader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24b1fcfd85484a4ba2d9c17a6131d37273719c8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->