### PR TITLE
fix(export-weclone): harden training:export flag parsing (follow-up to #509)

### DIFF
--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3991,8 +3991,33 @@ interface ParsedTrainingExportArgs {
 }
 
 /**
- * Parse training:export CLI flags. Rejects unknown values instead of
- * silently defaulting, per CLAUDE.md #14/#51.
+ * Resolve a value-taking flag, rejecting the "flag present but missing
+ * value" case (e.g. `--memory-dir --since 2026-01-01`). CLAUDE.md #14
+ * requires that `--foo` without an argument throws rather than silently
+ * defaulting — critical here because `training:export` emits shareable
+ * data and a wrongly-broadened filter would leak memories the user
+ * intended to exclude (Codex review follow-up to PR #509).
+ *
+ * Returns `undefined` only when the flag is absent; throws when the flag
+ * is present but its value is missing or shaped like another flag.
+ */
+function resolveRequiredValueFlag(
+  args: string[],
+  flag: string,
+): string | undefined {
+  if (!hasFlag(args, flag)) return undefined;
+  const value = resolveFlagStrict(args, flag);
+  if (value === undefined) {
+    throw new Error(
+      `${flag} requires a value. Provide it as \`${flag} <value>\`, not as a bare flag.`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Parse training:export CLI flags. Rejects unknown values and missing
+ * flag values instead of silently defaulting, per CLAUDE.md #14/#51.
  *
  * Exported for testability.
  */
@@ -4000,7 +4025,7 @@ export function parseTrainingExportArgs(
   rest: string[],
   defaultMemoryDir: string,
 ): ParsedTrainingExportArgs {
-  const format = resolveFlagStrict(rest, "--format");
+  const format = resolveRequiredValueFlag(rest, "--format");
   if (!format) {
     throw new Error(
       "--format <name> is required. Run `remnic training:export --help` for the list of registered adapters.",
@@ -4016,7 +4041,8 @@ export function parseTrainingExportArgs(
 
   // Accept --out as a short alias for --output (issue #459 spec uses both).
   const outputRaw =
-    resolveFlagStrict(rest, "--output") ?? resolveFlagStrict(rest, "--out");
+    resolveRequiredValueFlag(rest, "--output") ??
+    resolveRequiredValueFlag(rest, "--out");
   if (!outputRaw && !dryRun) {
     throw new Error(
       "--output <path> (or --out <path>) is required for training:export. " +
@@ -4034,13 +4060,13 @@ export function parseTrainingExportArgs(
   // input consistently, not just the explicit flag). `resolveMemoryDir`
   // can surface a tilde-prefixed path from config or env — validating that
   // without expansion would reject otherwise-valid memory stores.
-  const memoryDirFlag = resolveFlagStrict(rest, "--memory-dir");
+  const memoryDirFlag = resolveRequiredValueFlag(rest, "--memory-dir");
   const memoryDir = expandTilde(memoryDirFlag ?? defaultMemoryDir);
 
-  const since = resolveFlagStrict(rest, "--since");
-  const until = resolveFlagStrict(rest, "--until");
+  const since = resolveRequiredValueFlag(rest, "--since");
+  const until = resolveRequiredValueFlag(rest, "--until");
 
-  const minConfidenceRaw = resolveFlagStrict(rest, "--min-confidence");
+  const minConfidenceRaw = resolveRequiredValueFlag(rest, "--min-confidence");
   let minConfidence: number | undefined;
   if (minConfidenceRaw !== undefined) {
     const n = Number(minConfidenceRaw);
@@ -4052,7 +4078,7 @@ export function parseTrainingExportArgs(
     minConfidence = n;
   }
 
-  const categoriesRaw = resolveFlagStrict(rest, "--categories");
+  const categoriesRaw = resolveRequiredValueFlag(rest, "--categories");
   const categories = categoriesRaw
     ? categoriesRaw
         .split(",")
@@ -4060,7 +4086,7 @@ export function parseTrainingExportArgs(
         .filter((c) => c.length > 0)
     : undefined;
 
-  const maxPairsRaw = resolveFlagStrict(rest, "--max-pairs-per-record");
+  const maxPairsRaw = resolveRequiredValueFlag(rest, "--max-pairs-per-record");
   let maxPairsPerRecord: number | undefined;
   if (maxPairsRaw !== undefined) {
     const n = Number(maxPairsRaw);

--- a/packages/remnic-core/src/training-export/index.ts
+++ b/packages/remnic-core/src/training-export/index.ts
@@ -19,4 +19,8 @@ export {
 
 export { convertMemoriesToRecords } from "./converter.js";
 
-export { parseStrictCliDate, isCalendarDateValid } from "./date-parse.js";
+// `parseStrictCliDate` is the only public surface; `isCalendarDateValid`
+// is an internal helper (not re-exported). Exposing it as a public API
+// would commit to maintaining it indefinitely for no external caller
+// (Cursor review follow-up to PR #509).
+export { parseStrictCliDate } from "./date-parse.js";


### PR DESCRIPTION
## Summary

Follow-up to #509 addressing two AI review comments that were posted after the fix-forward push but before the squash-merge landed.

- **Codex P2**: `--memory-dir --since 2026-01-01` silently dropped the memoryDir flag (the next token looked like a flag, so `resolveFlagStrict` returned undefined) and fell back to the resolver default. That is risky for a command that emits shareable datasets where a broadened filter can leak memories the user intended to exclude. Added `resolveRequiredValueFlag` that throws when a value-taking flag is present without a value, and routed every value-taking option through it: `--format`, `--output`, `--out`, `--memory-dir`, `--since`, `--until`, `--min-confidence`, `--categories`, `--max-pairs-per-record`.
- **Cursor (low severity)**: `isCalendarDateValid` was accidentally re-exported from `@remnic/core`'s training-export barrel. It was never a public API and has no external callers — un-exported to avoid committing to long-term support for an internal helper.

No behaviour change for well-formed invocations — only malformed flag sequences now fail fast instead of silently broadening the export.

## Test plan
- [x] `pnpm run check-types` clean
- [x] `tsx --test packages/export-weclone/src/*.test.ts` — 61/61 passing (adapter, privacy, style-extractor, synthesizer, integration).

Refs: #459, #509.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens CLI parsing for `training:export` to throw on previously-accepted malformed flag sequences, which could break automation but reduces risk of unintentionally exporting broader datasets. Also changes the public `@remnic/core` barrel exports, which may affect any downstream code importing the removed symbol.
> 
> **Overview**
> **Hardens `remnic training:export` argument parsing** by introducing `resolveRequiredValueFlag` and routing all value-taking flags (`--format`, `--output/--out`, `--memory-dir`, date filters, and numeric/category options) through it so a present-but-missing value now throws instead of silently defaulting.
> 
> **Narrows the `@remnic/core` training-export public API** by no longer re-exporting the internal `isCalendarDateValid` helper; only `parseStrictCliDate` remains exported from the barrel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 423182e643f877540623a6d2beec7fc3703bfe62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->