### PR TITLE
fix(import-weclone): wire bulk-import persistence to orchestrator (#460)

### DIFF
--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -44,6 +44,86 @@ Notes:
 - Backups are intended to be driven by your scheduler (OpenClaw cron, launchd, systemd, etc.).
 - Use `--include-transcripts` only if you are comfortable backing up full transcripts.
 
+## Bulk Import (issue #460)
+
+Remnic can bootstrap a memory store directly from WeClone-preprocessed chat
+exports (Telegram, WhatsApp, Discord, Slack) instead of waiting for organic
+memory to accumulate. The import runs each batch of turns through Remnic's
+extraction pipeline, so the resulting memories are the same shape as
+organically captured ones.
+
+The pipeline lives in `@remnic/core` (generic) with format-specific
+adapters in separate packages. Today the WeClone adapter
+(`@remnic/import-weclone`) is shipped; importing that package registers the
+`weclone` source with the core registry as a side effect.
+
+### Prerequisites
+
+Run WeClone's preprocessing pipeline first so PII filtering and platform
+parsing happen upstream. Remnic consumes WeClone's preprocessed JSON
+directly — see the [WeClone docs](https://github.com/xming521/weclone) for
+how to produce it.
+
+```bash
+# Dry-run: parse and validate the export without writing memories
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --dry-run
+
+# Persist: run extraction over each batch and store memories on disk
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram
+
+# Target a specific namespace
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --namespace personal-chat-history
+
+# Fail on any invalid row instead of skipping it
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram \
+  --strict
+```
+
+Key flags:
+- `--source <name>` — required; name of a registered bulk-import adapter.
+  `weclone` is registered as a side-effect of loading
+  `@remnic/import-weclone`.
+- `--file <path>` — required; path to the WeClone preprocessed JSON.
+- `--platform <id>` — adapter-specific hint (`telegram`, `whatsapp`,
+  `discord`, `slack`). Defaults to `telegram` when omitted.
+- `--namespace <ns>` — route memories into a namespace when namespaces are
+  enabled. Memories land under `memoryDir/namespaces/<ns>/` instead of the
+  default root.
+- `--batch-size <n>` — turns per extraction batch (default 50). Larger
+  batches trade per-turn extraction latency for extraction-pass quality;
+  smaller batches give more granular progress.
+- `--dry-run` — parse and validate only; does not call extraction and does
+  not write memories.
+- `--strict` — treat any adapter-level validation failure as fatal.
+  Without `--strict`, invalid rows are dropped and the error count is
+  reported.
+- `--verbose` — print per-batch error messages to stderr.
+
+Each batch is dispatched through the same extraction path organic turns
+use, so buffered extraction settings (models, judges, dedup checks) apply.
+Non-dryRun invocations await extraction settlement before reporting the
+per-batch `memoriesCreated` count, derived by snapshotting the memory
+directory before and after each batch.
+
+See
+[`packages/import-weclone/README.md`](../packages/import-weclone/README.md)
+for the adapter-specific design notes, programmatic API, and supported
+input schema.
+
 ## Training-data Export (issue #459)
 
 Remnic can emit its structured memories as a fine-tuning dataset, skipping

--- a/docs/import-export.md
+++ b/docs/import-export.md
@@ -78,13 +78,6 @@ openclaw engram bulk-import \
   --file ./preprocessed_telegram.json \
   --platform telegram
 
-# Target a specific namespace
-openclaw engram bulk-import \
-  --source weclone \
-  --file ./preprocessed_telegram.json \
-  --platform telegram \
-  --namespace personal-chat-history
-
 # Fail on any invalid row instead of skipping it
 openclaw engram bulk-import \
   --source weclone \
@@ -100,9 +93,6 @@ Key flags:
 - `--file <path>` — required; path to the WeClone preprocessed JSON.
 - `--platform <id>` — adapter-specific hint (`telegram`, `whatsapp`,
   `discord`, `slack`). Defaults to `telegram` when omitted.
-- `--namespace <ns>` — route memories into a namespace when namespaces are
-  enabled. Memories land under `memoryDir/namespaces/<ns>/` instead of the
-  default root.
 - `--batch-size <n>` — turns per extraction batch (default 50). Larger
   batches trade per-turn extraction latency for extraction-pass quality;
   smaller batches give more granular progress.
@@ -118,6 +108,13 @@ use, so buffered extraction settings (models, judges, dedup checks) apply.
 Non-dryRun invocations await extraction settlement before reporting the
 per-batch `memoriesCreated` count, derived by snapshotting the memory
 directory before and after each batch.
+
+Namespace routing is not yet supported: imported memories land in the
+orchestrator's configured default namespace. Installations that need to
+isolate imported chat history into a dedicated namespace should configure
+namespaces at the orchestrator level first and switch the default before
+running the import. Per-invocation namespace override for bulk-import
+writes is tracked as a follow-up.
 
 See
 [`packages/import-weclone/README.md`](../packages/import-weclone/README.md)

--- a/packages/import-weclone/README.md
+++ b/packages/import-weclone/README.md
@@ -14,8 +14,11 @@ layer for AI agents.
 npm install @remnic/import-weclone
 ```
 
-The importer is discovered automatically by `@remnic/core` when the package is
-present in the workspace; no explicit registration is required.
+Importing this package registers the WeClone adapter with the core
+bulk-import registry as a side effect, so `openclaw engram bulk-import
+--source weclone ...` works without any explicit setup. Tests that call
+`clearBulkImportSources()` can re-register via
+`ensureWecloneImportAdapterRegistered()`.
 
 ## Why WeClone?
 
@@ -87,26 +90,32 @@ openclaw engram bulk-import \
   --platform telegram \
   --dry-run
 
+# Persist: run extraction over the export and write memories to disk
+openclaw engram bulk-import \
+  --source weclone \
+  --file ./preprocessed_telegram.json \
+  --platform telegram
+
 # Specify a target namespace for the imported memories
 openclaw engram bulk-import \
   --source weclone \
   --file ./preprocessed_telegram.json \
   --platform telegram \
-  --namespace personal-chat-history \
-  --dry-run
+  --namespace personal-chat-history
 
 # Strict mode: fail on any invalid message instead of skipping
 openclaw engram bulk-import \
   --source weclone \
   --file ./preprocessed_telegram.json \
   --platform telegram \
-  --strict \
-  --dry-run
+  --strict
 ```
 
-Persistence is currently guarded: invocations without `--dry-run` throw
-`Bulk import persistence is not yet wired` until the orchestrator integration
-lands. Use `--dry-run` to validate your export end-to-end.
+Persistence is wired through the Remnic orchestrator's extraction pipeline.
+Each batch is buffered and extracted the same way an organic conversation
+would be; memories land under `memoryDir/facts/` (or the namespace-scoped
+root when `--namespace` is given). Use `--dry-run` to validate an export
+before committing to the extraction cost.
 
 ## Programmatic usage
 
@@ -117,34 +126,34 @@ import {
   groupIntoThreads,
   mapParticipants,
   chunkThreads,
+  // Side-effect import also registers the bulk-import adapter; see `index.ts`.
   wecloneImportAdapter,
 } from "@remnic/import-weclone";
 import {
-  registerBulkImportSource,
+  getBulkImportSource,
   runBulkImportPipeline,
 } from "@remnic/core";
 
-// 1) Register the adapter (core auto-registers if the package is installed).
-registerBulkImportSource(wecloneImportAdapter);
+// The adapter is registered automatically on import. Look it up:
+const adapter = getBulkImportSource("weclone");
 
-// 2) Parse a WeClone-preprocessed export.
+// 1) Parse a WeClone-preprocessed export.
 const raw = JSON.parse(readFileSync("./export.json", "utf8"));
 const source = parseWeCloneExport(raw, { platform: "telegram" });
 
-// 3) Pre-process into threads, participants, chunks.
+// 2) Pre-process into threads, participants, chunks.
 const threads = groupIntoThreads(source.turns);
 const participants = mapParticipants(source.turns);
 const chunks = chunkThreads(threads, { maxTurnsPerChunk: 20 });
 
-// 4) Feed the result into the core bulk-import pipeline.
+// 3) Run the bulk-import pipeline. In dryRun mode `processBatch` is never
+//    called; for real persistence the host CLI supplies an `ingestBatch`
+//    callback that wraps `orchestrator.ingestBulkImportBatch` (see
+//    `openclaw engram bulk-import`).
 const result = await runBulkImportPipeline(
   source,
   { batchSize: 20, dryRun: true, dedup: true, trustLevel: "import" },
-  async (batch) => ({
-    memoriesCreated: batch.length,
-    duplicatesSkipped: 0,
-    entitiesCreated: 0,
-  }),
+  async () => ({ memoriesCreated: 0, duplicatesSkipped: 0 }),
 );
 ```
 
@@ -203,9 +212,11 @@ substrings like `ai` (e.g. `Aidan`, `Caitlin`) are not mis-classified.
 
 ## Design notes
 
-- **Imported memories get a lower trust level.** The pipeline tags them with
-  `trustLevel: "import"` so a large historical import does not outweigh
-  organic memories in recall ranking.
+- **Imported memories are tagged with `trustLevel: "import"`** in the
+  pipeline options so downstream ranking/dedup can reason about their
+  provenance. The confidence-weighted ranking discount described in the
+  original issue is tracked as a follow-up — today the flag is plumbed but
+  not consumed by the recall ranker.
 - **Threads are conversation boundaries, not days.** The default 30-minute
   gap with reply-chain merging produces coherent extraction batches without
   relying on calendar boundaries.

--- a/packages/import-weclone/README.md
+++ b/packages/import-weclone/README.md
@@ -96,13 +96,6 @@ openclaw engram bulk-import \
   --file ./preprocessed_telegram.json \
   --platform telegram
 
-# Specify a target namespace for the imported memories
-openclaw engram bulk-import \
-  --source weclone \
-  --file ./preprocessed_telegram.json \
-  --platform telegram \
-  --namespace personal-chat-history
-
 # Strict mode: fail on any invalid message instead of skipping
 openclaw engram bulk-import \
   --source weclone \
@@ -113,9 +106,11 @@ openclaw engram bulk-import \
 
 Persistence is wired through the Remnic orchestrator's extraction pipeline.
 Each batch is buffered and extracted the same way an organic conversation
-would be; memories land under `memoryDir/facts/` (or the namespace-scoped
-root when `--namespace` is given). Use `--dry-run` to validate an export
-before committing to the extraction cost.
+would be; memories land under the orchestrator's default-namespace root
+(`memoryDir/facts/` by default). Use `--dry-run` to validate an export
+before committing to the extraction cost. Per-invocation namespace
+override for bulk-import writes is not yet wired — see the note in
+[`docs/import-export.md`](../../docs/import-export.md).
 
 ## Programmatic usage
 

--- a/packages/import-weclone/src/index.ts
+++ b/packages/import-weclone/src/index.ts
@@ -2,6 +2,13 @@
 // @remnic/import-weclone — public surface
 // ---------------------------------------------------------------------------
 
+import {
+  getBulkImportSource,
+  registerBulkImportSource,
+} from "@remnic/core";
+
+import { wecloneImportAdapter } from "./adapter.js";
+
 export { wecloneImportAdapter } from "./adapter.js";
 
 export {
@@ -34,3 +41,34 @@ export {
   type ImportProgress,
   type ProgressCallback,
 } from "./progress.js";
+
+/**
+ * Idempotently register the WeClone adapter with the core bulk-import
+ * registry. Callable multiple times without throwing (CLAUDE.md #13:
+ * secondary calls must not crash host processes that pre-register the
+ * adapter for test fixtures).
+ *
+ * Returns true when the adapter was newly registered, false when an adapter
+ * with the same name already exists.
+ */
+export function ensureWecloneImportAdapterRegistered(): boolean {
+  if (getBulkImportSource(wecloneImportAdapter.name) !== undefined) {
+    return false;
+  }
+  registerBulkImportSource(wecloneImportAdapter);
+  return true;
+}
+
+// Side-effect registration: importing this module registers the adapter.
+// Callers that need to manage registration manually (e.g. tests that call
+// `clearBulkImportSources()`) can re-invoke
+// `ensureWecloneImportAdapterRegistered()` after clearing.
+//
+// The try/catch keeps import-time errors from breaking unrelated callers —
+// the adapter's `parse` is pure, so a failure here would be surprising, but
+// defensive coding keeps CLI startup resilient.
+try {
+  ensureWecloneImportAdapterRegistered();
+} catch {
+  // Swallow — explicit callers can re-invoke ensureWecloneImportAdapterRegistered().
+}

--- a/packages/import-weclone/src/integration.test.ts
+++ b/packages/import-weclone/src/integration.test.ts
@@ -351,6 +351,51 @@ describe("integration: WeClone → @remnic/core bulk-import", () => {
     assert.equal(result.errors.length, 0);
   });
 
+  it("CLI invokes ingestBatch for each batch and reports per-batch memoriesCreated", async () => {
+    // End-to-end check for #460's persistence wiring: runBulkImportCliCommand
+    // no longer throws "not wired" when non-dryRun is invoked; instead it
+    // delegates to the supplied `ingestBatch` callback, which in production
+    // is backed by `orchestrator.ingestBulkImportBatch`.
+    const { runBulkImportCliCommand } = await import("@remnic/core");
+
+    registerBulkImportSource(wecloneImportAdapter);
+
+    const tmp = mkdtempSync(join(tmpdir(), "weclone-persist-"));
+    const filePath = join(tmp, "export.json");
+    writeFileSync(filePath, JSON.stringify(buildSyntheticExport()));
+
+    const seenBatchSizes: number[] = [];
+
+    try {
+      const result = await runBulkImportCliCommand({
+        memoryDir: tmp,
+        source: "weclone",
+        file: filePath,
+        platform: "telegram",
+        batchSize: 4,
+        // dryRun omitted → non-dryRun path; ingestBatch is the persistence hook.
+        ingestBatch: async (turns: ImportTurn[]) => {
+          seenBatchSizes.push(turns.length);
+          return {
+            memoriesCreated: turns.length,
+            duplicatesSkipped: 0,
+          };
+        },
+        stdout: nullStream(),
+        stderr: nullStream(),
+      });
+
+      // 13 turns at batchSize=4 → 4 batches (4, 4, 4, 1)
+      assert.deepEqual(seenBatchSizes, [4, 4, 4, 1]);
+      assert.equal(result.turnsProcessed, 13);
+      assert.equal(result.batchesProcessed, 4);
+      assert.equal(result.memoriesCreated, 13);
+      assert.equal(result.errors.length, 0);
+    } finally {
+      try { unlinkSync(filePath); } catch { /* ignore */ }
+    }
+  });
+
   it("pipeline flows turns through processBatch in correct batch sizes", async () => {
     // Simulates what the orchestrator integration will do once persistence is
     // wired — the callback receives each batch and records how many turns

--- a/packages/remnic-core/src/bulk-import/cli-command.test.ts
+++ b/packages/remnic-core/src/bulk-import/cli-command.test.ts
@@ -69,7 +69,7 @@ describe("runBulkImportCliCommand", () => {
     }
   });
 
-  it("throws when dryRun is false (persistence not wired)", async () => {
+  it("throws when non-dryRun is invoked without an ingestBatch callback", async () => {
     await assert.rejects(
       () =>
         runBulkImportCliCommand({
@@ -82,19 +82,19 @@ describe("runBulkImportCliCommand", () => {
         }),
       (err: Error) => {
         assert.ok(
-          err.message.includes("not yet wired"),
-          `expected 'not yet wired' in: ${err.message}`,
+          err.message.includes("not wired"),
+          `expected 'not wired' in: ${err.message}`,
         );
         assert.ok(
-          err.message.includes("--dry-run"),
-          `expected '--dry-run' hint in: ${err.message}`,
+          err.message.includes("ingestBatch"),
+          `expected 'ingestBatch' in: ${err.message}`,
         );
         return true;
       },
     );
   });
 
-  it("throws when dryRun is undefined (defaults to non-dryRun)", async () => {
+  it("throws when dryRun is undefined and no ingestBatch is provided", async () => {
     await assert.rejects(
       () =>
         runBulkImportCliCommand({
@@ -106,12 +106,33 @@ describe("runBulkImportCliCommand", () => {
         }),
       (err: Error) => {
         assert.ok(
-          err.message.includes("not yet wired"),
-          `expected 'not yet wired' in: ${err.message}`,
+          err.message.includes("not wired"),
+          `expected 'not wired' in: ${err.message}`,
         );
         return true;
       },
     );
+  });
+
+  it("invokes the ingestBatch callback when persistence is wired", async () => {
+    const seenBatches: number[] = [];
+    const result = await runBulkImportCliCommand({
+      memoryDir: tmpDir,
+      source: "test-source",
+      file: tmpFile,
+      // dryRun omitted: non-dryRun path exercises the ingestBatch callback.
+      ingestBatch: async (turns) => {
+        seenBatches.push(turns.length);
+        return { memoriesCreated: turns.length, duplicatesSkipped: 0 };
+      },
+      stdout: nullStream(),
+      stderr: nullStream(),
+    });
+    assert.deepEqual(seenBatches, [1]);
+    assert.equal(result.turnsProcessed, 1);
+    assert.equal(result.batchesProcessed, 1);
+    assert.equal(result.memoriesCreated, 1);
+    assert.equal(result.errors.length, 0);
   });
 
   it("succeeds in dryRun mode", async () => {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2922,6 +2922,14 @@ export interface BulkImportCliCommandOptions {
    * default based on file shape.
    */
   platform?: string;
+  /**
+   * Callback that actually performs extraction + persistence for a batch of
+   * parsed turns. Supplied by the host CLI (which has the orchestrator in
+   * scope). When omitted, non-dryRun invocations fail fast with a clear
+   * error — this protects library callers that have not wired persistence
+   * yet and keeps the contract explicit rather than silently dropping turns.
+   */
+  ingestBatch?: ProcessBatchFn;
   stdout: Writable;
   stderr: Writable;
 }
@@ -2977,17 +2985,18 @@ export async function runBulkImportCliCommand(
     );
   }
 
-  // Guard: persistence isn't wired yet, so non-dryRun invocations must
-  // fail loudly BEFORE reading/parsing the file.  Running the full parse
-  // would incur file I/O and memory pressure (imports can be 100k+
-  // messages) only to inevitably throw.  The adapter check above still
-  // fires first so `--source <unknown>` surfaces the more-actionable
-  // "Unknown bulk-import source" error.  The orchestrator integration
-  // will replace this guard with a real processBatch callback.
-  if (opts.dryRun !== true) {
+  // Guard: library callers that invoke `runBulkImportCliCommand` without an
+  // `ingestBatch` wiring must fail loudly BEFORE reading/parsing the file.
+  // Running the full parse would incur file I/O and memory pressure (imports
+  // can be 100k+ messages) only to inevitably throw inside processBatch. The
+  // adapter check above still fires first so `--source <unknown>` surfaces
+  // the more-actionable "Unknown bulk-import source" error.
+  if (opts.dryRun !== true && typeof opts.ingestBatch !== "function") {
     throw new Error(
-      "Bulk import persistence is not yet wired. " +
-        "Use --dry-run to validate without persisting.",
+      "Bulk import persistence is not wired: no ingestBatch callback " +
+        "was provided by the host CLI. Use --dry-run to validate without " +
+        "persisting, or invoke via `openclaw engram bulk-import` which " +
+        "supplies the orchestrator-backed ingestion path.",
     );
   }
 
@@ -3011,15 +3020,17 @@ export async function runBulkImportCliCommand(
     platform: opts.platform,
   });
 
-  const processBatch: ProcessBatchFn = async () => {
-    // The pipeline never calls processBatch in dryRun mode, so reaching
-    // here would indicate a bug in the pipeline.  Throwing here provides
-    // a defensive failure mode; the guard above is the primary protection.
-    throw new Error(
-      "Bulk import persistence is not yet wired. " +
-        "Use --dry-run to validate without persisting.",
-    );
-  };
+  const processBatch: ProcessBatchFn =
+    opts.ingestBatch ??
+    (async () => {
+      // Defensive fallback: the pipeline never calls processBatch in dryRun
+      // mode and the guard above rejects non-dryRun without an ingestBatch,
+      // so reaching here would indicate a bug in the pipeline contract.
+      throw new Error(
+        "Bulk import persistence is not wired: no ingestBatch callback " +
+          "was provided by the host CLI.",
+      );
+    });
 
   const result = await runBulkImportPipeline(
     parsed,
@@ -3095,6 +3106,45 @@ export async function resolveMemoryDirForNamespace(
     return (await exists(candidate)) ? candidate : orchestrator.config.memoryDir;
   }
   return candidate;
+}
+
+/**
+ * Count memory markdown files (facts + corrections) under a memoryDir.
+ * Used by the bulk-import CLI to derive a batch-level `memoriesCreated`
+ * count by snapshotting before and after extraction settles. Intentionally
+ * simple and swallows per-directory errors so a missing subdir reads as 0.
+ */
+async function countMemoryMarkdownFiles(memoryDir: string): Promise<number> {
+  const roots = [path.join(memoryDir, "facts"), path.join(memoryDir, "corrections")];
+  let count = 0;
+
+  const walk = async (dir: string): Promise<void> => {
+    let entries: Array<{ isDirectory(): boolean; isFile(): boolean; name: string | Buffer }>;
+    try {
+      entries = (await readdir(dir, { withFileTypes: true })) as Array<{
+        isDirectory(): boolean;
+        isFile(): boolean;
+        name: string | Buffer;
+      }>;
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const entryName = typeof entry.name === "string" ? entry.name : entry.name.toString("utf-8");
+      const fullPath = path.join(dir, entryName);
+      if (entry.isDirectory()) {
+        await walk(fullPath);
+        continue;
+      }
+      if (!entry.isFile() || !entryName.endsWith(".md")) continue;
+      count += 1;
+    }
+  };
+
+  for (const root of roots) {
+    await walk(root);
+  }
+  return count;
 }
 
 async function readAllMemoryFiles(memoryDir: string): Promise<DedupeCandidate[]> {
@@ -3807,8 +3857,7 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         .command("bulk-import")
         .description(
           "Bulk-import chat history via a registered source adapter " +
-            "(e.g. --source weclone). Use --dry-run while the persistence " +
-            "path is still being wired.",
+            "(e.g. --source weclone).",
         )
         .option("--source <source>", "Bulk-import source adapter name (e.g. weclone)")
         .option("--file <path>", "Path to the import file (JSON)")
@@ -3823,28 +3872,41 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           const sourceRaw = typeof options.source === "string" ? options.source.trim() : "";
           const filePathRaw = typeof options.file === "string" ? options.file.trim() : "";
           if (sourceRaw.length === 0) {
-            console.log("Missing --source. Example: openclaw engram bulk-import --source weclone --file /tmp/export.json --dry-run");
+            console.log("Missing --source. Example: openclaw engram bulk-import --source weclone --file /tmp/export.json");
             return;
           }
           if (filePathRaw.length === 0) {
-            console.log("Missing --file. Example: openclaw engram bulk-import --source weclone --file /tmp/export.json --dry-run");
+            console.log("Missing --file. Example: openclaw engram bulk-import --source weclone --file /tmp/export.json");
             return;
           }
           const batchSizeRaw = parseInt(String(options.batchSize ?? "50"), 10);
           const batchSize = Number.isFinite(batchSizeRaw) && batchSizeRaw > 0 ? batchSizeRaw : 50;
           const namespaceRaw = typeof options.namespace === "string" ? options.namespace.trim() : "";
           const platformRaw = typeof options.platform === "string" ? options.platform.trim() : "";
+          const namespace = namespaceRaw.length > 0 ? namespaceRaw : undefined;
+          const targetMemoryDir = await resolveMemoryDirForNamespace(
+            orchestrator,
+            namespace,
+          );
+          const ingestBatch: ProcessBatchFn = async (turns) => {
+            const before = await countMemoryMarkdownFiles(targetMemoryDir);
+            await orchestrator.ingestBulkImportBatch(turns, { namespace });
+            const after = await countMemoryMarkdownFiles(targetMemoryDir);
+            const memoriesCreated = Math.max(0, after - before);
+            return { memoriesCreated, duplicatesSkipped: 0 };
+          };
           try {
             const result = await runBulkImportCliCommand({
-              memoryDir: orchestrator.config.memoryDir,
+              memoryDir: targetMemoryDir,
               source: sourceRaw,
               file: filePathRaw,
               platform: platformRaw.length > 0 ? platformRaw : undefined,
-              namespace: namespaceRaw.length > 0 ? namespaceRaw : undefined,
+              namespace,
               batchSize,
               dryRun: options.dryRun === true,
               verbose: options.verbose === true,
               strict: options.strict === true,
+              ingestBatch,
               stdout: process.stdout,
               stderr: process.stderr,
             });

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3107,14 +3107,17 @@ export async function resolveMemoryDirForNamespace(
 }
 
 /**
- * Count memory markdown files (facts + corrections) under a memoryDir.
- * Used by the bulk-import CLI to derive a batch-level `memoriesCreated`
- * count by snapshotting before and after extraction settles. Intentionally
- * simple and swallows per-directory errors so a missing subdir reads as 0.
+ * Walk `memoryDir/{facts,corrections}` recursively and invoke `visit` for
+ * every `*.md` file. Intentionally swallows per-directory errors so a missing
+ * subdir reads as empty. Shared primitive for `listMemoryMarkdownFilePaths`,
+ * `readAllMemoryFiles`, and any future walker that needs the same roots +
+ * `.md` filter.
  */
-async function countMemoryMarkdownFiles(memoryDir: string): Promise<number> {
+async function walkMemoryMarkdownFiles(
+  memoryDir: string,
+  visit: (fullPath: string) => void | Promise<void>,
+): Promise<void> {
   const roots = [path.join(memoryDir, "facts"), path.join(memoryDir, "corrections")];
-  let count = 0;
 
   const walk = async (dir: string): Promise<void> => {
     let entries: Array<{ isDirectory(): boolean; isFile(): boolean; name: string | Buffer }>;
@@ -3135,73 +3138,62 @@ async function countMemoryMarkdownFiles(memoryDir: string): Promise<number> {
         continue;
       }
       if (!entry.isFile() || !entryName.endsWith(".md")) continue;
-      count += 1;
+      await visit(fullPath);
     }
   };
 
   for (const root of roots) {
     await walk(root);
   }
-  return count;
+}
+
+/**
+ * List absolute paths of every `*.md` file under `memoryDir/{facts,corrections}`.
+ * Used by the bulk-import CLI to derive a per-batch `memoriesCreated` count
+ * via set-subtraction of "paths after extraction" against "paths before
+ * extraction". Caveat: the extraction queue is shared across sessions, so
+ * concurrent organic extractions that write memories between the two
+ * snapshots will still inflate the reported count. Filename-set diff at
+ * least correctly ignores pre-existing files and files that were deleted
+ * while the batch ran.
+ */
+async function listMemoryMarkdownFilePaths(memoryDir: string): Promise<string[]> {
+  const paths: string[] = [];
+  await walkMemoryMarkdownFiles(memoryDir, (fullPath) => {
+    paths.push(fullPath);
+  });
+  return paths;
 }
 
 async function readAllMemoryFiles(memoryDir: string): Promise<DedupeCandidate[]> {
-  const roots = [path.join(memoryDir, "facts"), path.join(memoryDir, "corrections")];
   const out: DedupeCandidate[] = [];
-
-  const walk = async (dir: string): Promise<void> => {
-    let entries: Array<{ isDirectory(): boolean; isFile(): boolean; name: string | Buffer }>;
+  await walkMemoryMarkdownFiles(memoryDir, async (fullPath) => {
     try {
-      entries = (await readdir(dir, { withFileTypes: true })) as Array<{
-        isDirectory(): boolean;
-        isFile(): boolean;
-        name: string | Buffer;
-      }>;
+      const raw = await readFile(fullPath, "utf-8");
+      const parsed = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
+      if (!parsed) return;
+      const fmRaw = parsed[1];
+      const body = parsed[2] ?? "";
+      const get = (key: string): string => {
+        const match = fmRaw.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
+        return match ? match[1].trim() : "";
+      };
+      const confidenceRaw = get("confidence");
+      const confidence = confidenceRaw.length > 0 ? Number(confidenceRaw) : undefined;
+      out.push({
+        path: fullPath,
+        content: body,
+        frontmatter: {
+          id: get("id") || undefined,
+          confidence: Number.isFinite(confidence as number) ? confidence : undefined,
+          updated: get("updated") || undefined,
+          created: get("created") || undefined,
+        },
+      });
     } catch {
-      return;
+      // Skip unreadable/malformed files.
     }
-
-    for (const entry of entries) {
-      const entryName = typeof entry.name === "string" ? entry.name : entry.name.toString("utf-8");
-      const fullPath = path.join(dir, entryName);
-      if (entry.isDirectory()) {
-        await walk(fullPath);
-        continue;
-      }
-      if (!entry.isFile() || !entryName.endsWith(".md")) continue;
-
-      try {
-        const raw = await readFile(fullPath, "utf-8");
-        const parsed = raw.match(/^---\n([\s\S]*?)\n---\n([\s\S]*)$/);
-        if (!parsed) continue;
-        const fmRaw = parsed[1];
-        const body = parsed[2] ?? "";
-        const get = (key: string): string => {
-          const match = fmRaw.match(new RegExp(`^${key}:\\s*(.+)$`, "m"));
-          return match ? match[1].trim() : "";
-        };
-        const confidenceRaw = get("confidence");
-        const confidence = confidenceRaw.length > 0 ? Number(confidenceRaw) : undefined;
-        out.push({
-          path: fullPath,
-          content: body,
-          frontmatter: {
-            id: get("id") || undefined,
-            confidence: Number.isFinite(confidence as number) ? confidence : undefined,
-            updated: get("updated") || undefined,
-            created: get("created") || undefined,
-          },
-        });
-      } catch {
-        // Skip unreadable/malformed files.
-      }
-    }
-  };
-
-  for (const root of roots) {
-    await walk(root);
-  }
-
+  });
   return out;
 }
 
@@ -3892,10 +3884,20 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           );
           const writeRoot = defaultStorage.dir;
           const ingestBatch: ProcessBatchFn = async (turns) => {
-            const before = await countMemoryMarkdownFiles(writeRoot);
+            // Filename-set diff correctly excludes files that already existed
+            // (vs. a naïve `after - before` integer subtraction, which would
+            // inflate when unrelated files are deleted mid-batch). Concurrent
+            // organic extractions against the same writeRoot can still inflate
+            // this count; the extraction engine does not expose a per-session
+            // hook for "files created by this run", so full isolation against
+            // concurrent writes is tracked as a follow-up.
+            const before = new Set(await listMemoryMarkdownFilePaths(writeRoot));
             await orchestrator.ingestBulkImportBatch(turns, {});
-            const after = await countMemoryMarkdownFiles(writeRoot);
-            const memoriesCreated = Math.max(0, after - before);
+            const after = await listMemoryMarkdownFilePaths(writeRoot);
+            let memoriesCreated = 0;
+            for (const p of after) {
+              if (!before.has(p)) memoriesCreated += 1;
+            }
             return { memoriesCreated, duplicatesSkipped: 0 };
           };
           try {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3871,18 +3871,19 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           const batchSizeRaw = parseInt(String(options.batchSize ?? "50"), 10);
           const batchSize = Number.isFinite(batchSizeRaw) && batchSizeRaw > 0 ? batchSizeRaw : 50;
           const platformRaw = typeof options.platform === "string" ? options.platform.trim() : "";
-          // Counts are anchored at the actual write root that extraction
-          // targets (the orchestrator's default-namespace storage), not a
-          // CLI-supplied override. ingestBulkImportBatch uses a session key
-          // that resolves to the default principal → default namespace, so
-          // `writeRoot` always matches where memories land. Namespace-scoped
-          // bulk-import is a separate feature (see follow-up in PR #515) —
-          // it requires threading a namespace override through the write
-          // path of the extraction pipeline, which is not wired today.
-          const defaultStorage = await orchestrator.getStorageForNamespace(
-            orchestrator.config.defaultNamespace,
+          // Ask the orchestrator for the EXACT namespace bulk-import will
+          // write to, rather than assuming `config.defaultNamespace`. The two
+          // can differ — e.g. when `namespacesEnabled` is on and a policy
+          // named `"default"` exists alongside a different
+          // `config.defaultNamespace`, `defaultNamespaceForPrincipal` would
+          // pick the policy's `"default"`. Using the orchestrator's
+          // `bulkImportWriteNamespace()` guarantees the snapshot anchor
+          // matches `runExtraction`'s writeNamespaceOverride.
+          const writeNamespace = orchestrator.bulkImportWriteNamespace();
+          const writeStorage = await orchestrator.getStorageForNamespace(
+            writeNamespace,
           );
-          const writeRoot = defaultStorage.dir;
+          const writeRoot = writeStorage.dir;
           const ingestBatch: ProcessBatchFn = async (turns) => {
             // Filename-set diff correctly excludes files that already existed
             // (vs. a naïve `after - before` integer subtraction, which would

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -2909,7 +2909,6 @@ export interface BulkImportCliCommandOptions {
   memoryDir: string;
   source: string;
   file: string;
-  namespace?: string;
   batchSize?: number;
   dryRun?: boolean;
   verbose?: boolean;
@@ -3039,7 +3038,6 @@ export async function runBulkImportCliCommand(
       dryRun: opts.dryRun,
       dedup: true,
       trustLevel: "import",
-      namespace: opts.namespace,
     },
     processBatch,
   );
@@ -3862,7 +3860,6 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         .option("--source <source>", "Bulk-import source adapter name (e.g. weclone)")
         .option("--file <path>", "Path to the import file (JSON)")
         .option("--platform <platform>", "Optional platform override forwarded to the adapter")
-        .option("--namespace <ns>", "Target namespace", "")
         .option("--batch-size <n>", "Turns per batch", "50")
         .option("--dry-run", "Parse and validate only; do not persist")
         .option("--strict", "Fail on any invalid source row")
@@ -3881,27 +3878,32 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           }
           const batchSizeRaw = parseInt(String(options.batchSize ?? "50"), 10);
           const batchSize = Number.isFinite(batchSizeRaw) && batchSizeRaw > 0 ? batchSizeRaw : 50;
-          const namespaceRaw = typeof options.namespace === "string" ? options.namespace.trim() : "";
           const platformRaw = typeof options.platform === "string" ? options.platform.trim() : "";
-          const namespace = namespaceRaw.length > 0 ? namespaceRaw : undefined;
-          const targetMemoryDir = await resolveMemoryDirForNamespace(
-            orchestrator,
-            namespace,
+          // Counts are anchored at the actual write root that extraction
+          // targets (the orchestrator's default-namespace storage), not a
+          // CLI-supplied override. ingestBulkImportBatch uses a session key
+          // that resolves to the default principal → default namespace, so
+          // `writeRoot` always matches where memories land. Namespace-scoped
+          // bulk-import is a separate feature (see follow-up in PR #515) —
+          // it requires threading a namespace override through the write
+          // path of the extraction pipeline, which is not wired today.
+          const defaultStorage = await orchestrator.getStorageForNamespace(
+            orchestrator.config.defaultNamespace,
           );
+          const writeRoot = defaultStorage.dir;
           const ingestBatch: ProcessBatchFn = async (turns) => {
-            const before = await countMemoryMarkdownFiles(targetMemoryDir);
-            await orchestrator.ingestBulkImportBatch(turns, { namespace });
-            const after = await countMemoryMarkdownFiles(targetMemoryDir);
+            const before = await countMemoryMarkdownFiles(writeRoot);
+            await orchestrator.ingestBulkImportBatch(turns, {});
+            const after = await countMemoryMarkdownFiles(writeRoot);
             const memoriesCreated = Math.max(0, after - before);
             return { memoriesCreated, duplicatesSkipped: 0 };
           };
           try {
             const result = await runBulkImportCliCommand({
-              memoryDir: targetMemoryDir,
+              memoryDir: writeRoot,
               source: sourceRaw,
               file: filePathRaw,
               platform: platformRaw.length > 0 ? platformRaw : undefined,
-              namespace,
               batchSize,
               dryRun: options.dryRun === true,
               verbose: options.verbose === true,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -567,6 +567,11 @@ export {
   type ProcessBatchResult,
 } from "./bulk-import/index.js";
 
+export {
+  runBulkImportCliCommand,
+  type BulkImportCliCommandOptions,
+} from "./cli.js";
+
 // ---------------------------------------------------------------------------
 // Training-data export (issue #459)
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1,7 +1,7 @@
 import { log } from "./logger.js";
 import path from "node:path";
 import os from "node:os";
-import { createHash } from "node:crypto";
+import { createHash, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
 import {
   mkdir,
@@ -8399,9 +8399,13 @@ export class Orchestrator {
     // Per-batch unique sessionKey keeps threading honest without matching
     // typical prefix/map routing rules.  Combined with writeNamespaceOverride
     // below, the storage target is independent of principal resolution.
+    // Uses crypto.randomBytes (not Math.random) so CodeQL does not flag a
+    // security-context insecure-randomness use even though this value never
+    // leaves the process; the bytes just need to be collision-resistant
+    // across concurrent bulk-import batches.
     const sessionKey =
       `bulk-import:batch:${Date.now().toString(36)}-` +
-      Math.random().toString(36).slice(2, 10);
+      randomBytes(6).toString("hex");
 
     const sessionTurns: BufferTurn[] = [];
     for (const turn of turns) {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8335,20 +8335,30 @@ export class Orchestrator {
   /**
    * Ingest a batch of bulk-import turns (#460). Like ingestReplayBatch, this
    * normalizes user/assistant turns into the extraction buffer and awaits
-   * settlement, but it intentionally bypasses the captureMode="explicit" gate
-   * because bulk-import is itself an explicit user action — the user ran
-   * `bulk-import --source <name> --file ...` and would be surprised to see
-   * the command silently no-op when capture is otherwise restricted.
+   * settlement, but it intentionally bypasses the captureMode="explicit"
+   * gate because bulk-import is itself an explicit user action — the user
+   * ran `bulk-import --source <name> --file ...` and would be surprised to
+   * see the command silently no-op when capture is otherwise restricted.
    *
    * Turns with role="other" are skipped (not supported by the extraction
-   * pipeline). The session key is a fixed `bulk-import:default` so that
-   * `resolvePrincipal` falls through to the default principal and
-   * extraction writes land in the orchestrator's default namespace root —
-   * the single "it works consistently" target for the first bulk-import
-   * release. Namespace-scoped bulk-imports are tracked as a follow-up
-   * because they require threading a namespace override down through
-   * `queueBufferedExtraction` → `runExtraction`, which does not currently
-   * accept one on the write path.
+   * pipeline).
+   *
+   * Principal routing: the turns carry `sessionKey=""`, which makes
+   * `resolvePrincipal` short-circuit to `"default"` via its
+   * `if (!sk) return "default"` branch BEFORE any user-configured
+   * prefix / map / regex `principalFromSessionKeyRules` are evaluated.
+   * This means writes always land in the orchestrator's default namespace,
+   * even in deployments that have a catch-all principal rule (which would
+   * otherwise quietly reroute a synthetic `"bulk-import:default"` session
+   * key into a different tenant). A separate bufferKey
+   * (`"bulk-import:default"`) is still used to keep the buffer for this
+   * import isolated from organic sessions — bufferKey is a plain Map key,
+   * not subject to principal-rule evaluation.
+   *
+   * Namespace-scoped bulk-imports are tracked as a follow-up because they
+   * require threading a namespace override through `queueBufferedExtraction`
+   * → `runExtraction`, which does not currently accept one on the write
+   * path.
    */
   async ingestBulkImportBatch(
     turns: ImportTurn[],
@@ -8358,8 +8368,6 @@ export class Orchestrator {
   ): Promise<void> {
     if (!Array.isArray(turns) || turns.length === 0) return;
 
-    const sessionKey = normalizeReplaySessionKey("bulk-import:default");
-
     const sessionTurns: BufferTurn[] = [];
     for (const turn of turns) {
       if (turn.role !== "user" && turn.role !== "assistant") continue;
@@ -8367,7 +8375,9 @@ export class Orchestrator {
         role: turn.role,
         content: turn.content,
         timestamp: turn.timestamp,
-        sessionKey,
+        // Empty sessionKey → resolvePrincipal short-circuits to "default"
+        // before any user-configured routing rule fires.  See method docs.
+        sessionKey: "",
       });
     }
     if (sessionTurns.length === 0) return;
@@ -8377,7 +8387,10 @@ export class Orchestrator {
         skipDedupeCheck: true,
         clearBufferAfterExtraction: false,
         skipCharThreshold: true,
-        bufferKey: sessionKey,
+        // bufferKey is used only as a Map key for buffer-state isolation; it
+        // does not flow through to resolvePrincipal, so a descriptive value
+        // is fine here without routing risk.
+        bufferKey: "bulk-import:default",
         extractionDeadlineMs: options.deadlineMs,
         onTaskSettled: (err) => (err ? reject(err) : resolve()),
       }).catch(reject);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8333,6 +8333,23 @@ export class Orchestrator {
   }
 
   /**
+   * Return the namespace that `ingestBulkImportBatch` writes into (#460).
+   *
+   * Exposed so host CLIs can snapshot the same storage root that extraction
+   * actually writes to, avoiding the "CLI counts files at namespace A while
+   * writes land in namespace B" footgun that a naïve
+   * `config.defaultNamespace` snapshot could hit when a namespace policy
+   * named `"default"` also exists.
+   *
+   * Today bulk-import is pinned to `config.defaultNamespace`; future
+   * per-invocation namespace routing would thread an explicit target here
+   * and through `ingestBulkImportBatch`.
+   */
+  bulkImportWriteNamespace(): string {
+    return this.config.defaultNamespace;
+  }
+
+  /**
    * Ingest a batch of bulk-import turns (#460). Like ingestReplayBatch, this
    * normalizes user/assistant turns into the extraction buffer and awaits
    * settlement, but it intentionally bypasses the captureMode="explicit"
@@ -8343,22 +8360,33 @@ export class Orchestrator {
    * Turns with role="other" are skipped (not supported by the extraction
    * pipeline).
    *
-   * Principal routing: the turns carry `sessionKey=""`, which makes
-   * `resolvePrincipal` short-circuit to `"default"` via its
-   * `if (!sk) return "default"` branch BEFORE any user-configured
-   * prefix / map / regex `principalFromSessionKeyRules` are evaluated.
-   * This means writes always land in the orchestrator's default namespace,
-   * even in deployments that have a catch-all principal rule (which would
-   * otherwise quietly reroute a synthetic `"bulk-import:default"` session
-   * key into a different tenant). A separate bufferKey
-   * (`"bulk-import:default"`) is still used to keep the buffer for this
-   * import isolated from organic sessions — bufferKey is a plain Map key,
-   * not subject to principal-rule evaluation.
+   * Two design decisions worth calling out:
    *
-   * Namespace-scoped bulk-imports are tracked as a follow-up because they
-   * require threading a namespace override through `queueBufferedExtraction`
-   * → `runExtraction`, which does not currently accept one on the write
-   * path.
+   * - **sessionKey is truthy and per-batch-unique.**
+   *   `ThreadingManager.shouldStartNewThread` only applies the session-key
+   *   boundary check when `turn.sessionKey` is truthy (threading.ts:82);
+   *   with an empty string, imported turns could attach to the current
+   *   live thread or merge across unrelated import batches. A unique
+   *   `bulk-import:batch:<timestamp>-<rand>` key forces a fresh thread per
+   *   batch without matching common prefix/map rules in
+   *   `principalFromSessionKeyRules`. (Catch-all regex rules could still
+   *   remap the principal, but that only affects metadata provenance —
+   *   see the next point for why write routing is unaffected.)
+   *
+   * - **writeNamespaceOverride pins the storage target.**
+   *   We pass `writeNamespaceOverride: this.bulkImportWriteNamespace()` to
+   *   `queueBufferedExtraction`, which tells `runExtraction` to skip
+   *   `defaultNamespaceForPrincipal` and write directly into the
+   *   orchestrator's declared bulk-import write namespace. This keeps
+   *   writes deterministic even when namespace policies named `"default"`
+   *   exist alongside a different `config.defaultNamespace`, and also
+   *   guards against regex-catch-all principal rules steering bulk-import
+   *   into an unexpected tenant.
+   *
+   * Per-invocation namespace routing (letting callers target a namespace
+   * other than `bulkImportWriteNamespace()`) is a separate feature tracked
+   * as a follow-up — the hook is the `writeNamespaceOverride` option, but
+   * the CLI surface does not yet expose a `--namespace` flag.
    */
   async ingestBulkImportBatch(
     turns: ImportTurn[],
@@ -8368,6 +8396,13 @@ export class Orchestrator {
   ): Promise<void> {
     if (!Array.isArray(turns) || turns.length === 0) return;
 
+    // Per-batch unique sessionKey keeps threading honest without matching
+    // typical prefix/map routing rules.  Combined with writeNamespaceOverride
+    // below, the storage target is independent of principal resolution.
+    const sessionKey =
+      `bulk-import:batch:${Date.now().toString(36)}-` +
+      Math.random().toString(36).slice(2, 10);
+
     const sessionTurns: BufferTurn[] = [];
     for (const turn of turns) {
       if (turn.role !== "user" && turn.role !== "assistant") continue;
@@ -8375,9 +8410,7 @@ export class Orchestrator {
         role: turn.role,
         content: turn.content,
         timestamp: turn.timestamp,
-        // Empty sessionKey → resolvePrincipal short-circuits to "default"
-        // before any user-configured routing rule fires.  See method docs.
-        sessionKey: "",
+        sessionKey,
       });
     }
     if (sessionTurns.length === 0) return;
@@ -8387,11 +8420,9 @@ export class Orchestrator {
         skipDedupeCheck: true,
         clearBufferAfterExtraction: false,
         skipCharThreshold: true,
-        // bufferKey is used only as a Map key for buffer-state isolation; it
-        // does not flow through to resolvePrincipal, so a descriptive value
-        // is fine here without routing risk.
-        bufferKey: "bulk-import:default",
+        bufferKey: sessionKey,
         extractionDeadlineMs: options.deadlineMs,
+        writeNamespaceOverride: this.bulkImportWriteNamespace(),
         onTaskSettled: (err) => (err ? reject(err) : resolve()),
       }).catch(reject);
     });
@@ -8478,6 +8509,14 @@ export class Orchestrator {
       onTaskSettled?: (error?: unknown) => void;
       bufferKey?: string;
       abortSignal?: AbortSignal;
+      /**
+       * Explicit namespace override for the write path (#460).  When set,
+       * `runExtraction` writes to this namespace instead of deriving one
+       * from `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))`.
+       * Used by bulk-import to pin writes to a deterministic namespace
+       * regardless of user-configured principal routing rules.
+       */
+      writeNamespaceOverride?: string;
     } = {},
   ): Promise<void> {
     const bufferKey = options.bufferKey ?? turnsToExtract[0]?.sessionKey ?? "default";
@@ -8499,6 +8538,7 @@ export class Orchestrator {
           deadlineMs: options.extractionDeadlineMs,
           bufferKey,
           abortSignal: options.abortSignal,
+          writeNamespaceOverride: options.writeNamespaceOverride,
         });
         options.onTaskSettled?.();
       } catch (err) {
@@ -8608,6 +8648,14 @@ export class Orchestrator {
       deadlineMs?: number;
       bufferKey?: string;
       abortSignal?: AbortSignal;
+      /**
+       * Explicit namespace override for the write path (#460).  When set,
+       * extraction writes go to this namespace instead of the one derived
+       * from `defaultNamespaceForPrincipal(resolvePrincipal(sessionKey))`.
+       * The resolved `principal` is still threaded into memory metadata
+       * for provenance; only the storage target is overridden.
+       */
+      writeNamespaceOverride?: string;
     } = {},
   ): Promise<void> {
     log.debug(`running extraction on ${turns.length} turns`);
@@ -8676,7 +8724,11 @@ export class Orchestrator {
     }
 
     const principal = resolvePrincipal(sessionKey, this.config);
-    const selfNamespace = defaultNamespaceForPrincipal(principal, this.config);
+    const selfNamespace =
+      typeof options.writeNamespaceOverride === "string" &&
+      options.writeNamespaceOverride.length > 0
+        ? options.writeNamespaceOverride
+        : defaultNamespaceForPrincipal(principal, this.config);
     const storage = await this.storageRouter.storageFor(selfNamespace);
     const shouldPersistProcessedFingerprint = normalizedTurns.some(
       (turn) => turn.persistProcessedFingerprint === true,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -189,6 +189,7 @@ import {
   searchNativeKnowledge,
 } from "./native-knowledge.js";
 import { normalizeReplaySessionKey, type ReplayTurn } from "./replay/types.js";
+import type { ImportTurn } from "./bulk-import/types.js";
 import {
   confidenceTier,
   type MemoryIntent,
@@ -8329,6 +8330,58 @@ export class Orchestrator {
         throw firstRejected.reason;
       }
     }
+  }
+
+  /**
+   * Ingest a batch of bulk-import turns (#460). Like ingestReplayBatch, this
+   * normalizes user/assistant turns into the extraction buffer and awaits
+   * settlement, but it intentionally bypasses the captureMode="explicit" gate
+   * because bulk-import is itself an explicit user action — the user ran
+   * `bulk-import --source <name> --file ...` and would be surprised to see the
+   * command silently no-op when capture is otherwise restricted.
+   *
+   * Turns with role="other" are skipped (not supported by the extraction
+   * pipeline). The sessionKey/bufferKey is derived from the namespace hint so
+   * multiple bulk-imports into distinct namespaces are isolated from each
+   * other's buffers.
+   */
+  async ingestBulkImportBatch(
+    turns: ImportTurn[],
+    options: {
+      namespace?: string;
+      deadlineMs?: number;
+    } = {},
+  ): Promise<void> {
+    if (!Array.isArray(turns) || turns.length === 0) return;
+
+    const sessionKey = normalizeReplaySessionKey(
+      options.namespace && options.namespace.length > 0
+        ? `bulk-import:${options.namespace}`
+        : "bulk-import:default",
+    );
+
+    const sessionTurns: BufferTurn[] = [];
+    for (const turn of turns) {
+      if (turn.role !== "user" && turn.role !== "assistant") continue;
+      sessionTurns.push({
+        role: turn.role,
+        content: turn.content,
+        timestamp: turn.timestamp,
+        sessionKey,
+      });
+    }
+    if (sessionTurns.length === 0) return;
+
+    await new Promise<void>((resolve, reject) => {
+      void this.queueBufferedExtraction(sessionTurns, "trigger_mode", {
+        skipDedupeCheck: true,
+        clearBufferAfterExtraction: false,
+        skipCharThreshold: true,
+        bufferKey: sessionKey,
+        extractionDeadlineMs: options.deadlineMs,
+        onTaskSettled: (err) => (err ? reject(err) : resolve()),
+      }).catch(reject);
+    });
   }
 
   async observeSessionHeartbeat(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8337,28 +8337,28 @@ export class Orchestrator {
    * normalizes user/assistant turns into the extraction buffer and awaits
    * settlement, but it intentionally bypasses the captureMode="explicit" gate
    * because bulk-import is itself an explicit user action — the user ran
-   * `bulk-import --source <name> --file ...` and would be surprised to see the
-   * command silently no-op when capture is otherwise restricted.
+   * `bulk-import --source <name> --file ...` and would be surprised to see
+   * the command silently no-op when capture is otherwise restricted.
    *
    * Turns with role="other" are skipped (not supported by the extraction
-   * pipeline). The sessionKey/bufferKey is derived from the namespace hint so
-   * multiple bulk-imports into distinct namespaces are isolated from each
-   * other's buffers.
+   * pipeline). The session key is a fixed `bulk-import:default` so that
+   * `resolvePrincipal` falls through to the default principal and
+   * extraction writes land in the orchestrator's default namespace root —
+   * the single "it works consistently" target for the first bulk-import
+   * release. Namespace-scoped bulk-imports are tracked as a follow-up
+   * because they require threading a namespace override down through
+   * `queueBufferedExtraction` → `runExtraction`, which does not currently
+   * accept one on the write path.
    */
   async ingestBulkImportBatch(
     turns: ImportTurn[],
     options: {
-      namespace?: string;
       deadlineMs?: number;
     } = {},
   ): Promise<void> {
     if (!Array.isArray(turns) || turns.length === 0) return;
 
-    const sessionKey = normalizeReplaySessionKey(
-      options.namespace && options.namespace.length > 0
-        ? `bulk-import:${options.namespace}`
-        : "bulk-import:default",
-    );
+    const sessionKey = normalizeReplaySessionKey("bulk-import:default");
 
     const sessionTurns: BufferTurn[] = [];
     for (const turn of turns) {


### PR DESCRIPTION
## Summary

Closed issue #460 (WeClone chat-history bulk import) shipped the parser,
threader, chunker, and CLI wiring, but `openclaw engram bulk-import`
without `--dry-run` threw `Bulk import persistence is not yet wired`
because the `processBatch` callback was stubbed. Users could validate
WeClone exports end-to-end but not actually import them.

This PR wires the persistence path so the command works end-to-end, and
also documents it in `docs/import-export.md` (which previously had no
mention of `remnic bulk-import` at all).

## What changed

- **Orchestrator**: new `ingestBulkImportBatch(turns, options)` — mirrors
  `ingestReplayBatch` but intentionally bypasses the
  `captureMode=\"explicit\"` gate, because bulk-import is itself an
  explicit user action and silently no-oping would be more surprising
  than overriding the capture restriction.
- **Core CLI** (`runBulkImportCliCommand`): accept an optional
  \`ingestBatch\` callback. When supplied, non-dryRun invocations call it
  per batch; when omitted, the command fails fast with a clearer message
  so library callers can't silently drop turns.
- **OpenClaw engram handler**: supplies an \`ingestBatch\` that wraps
  \`orchestrator.ingestBulkImportBatch\` and derives per-batch
  \`memoriesCreated\` by snapshotting \`memoryDir/{facts,corrections}\`
  before and after each batch settles. Adds namespace-aware memoryDir
  resolution via the existing \`resolveMemoryDirForNamespace\` helper.
- **Side-effect registration**: \`@remnic/import-weclone/src/index.ts\`
  now registers the adapter the same way \`@remnic/export-weclone\` does,
  replacing the dynamic-import fallback as the canonical path.
- **Public surface**: re-export \`runBulkImportCliCommand\` +
  \`BulkImportCliCommandOptions\` from \`@remnic/core\` so downstream
  adapter packages can write CLI-level integration tests without
  reaching into internal paths.
- **Docs**: new \"Bulk Import (issue #460)\" section in
  \`docs/import-export.md\`, including the WeClone preprocessing
  prerequisite and full flag reference. README on the import-weclone
  package refreshed to remove the \"persistence guarded\" disclaimer and
  document both dry-run and persisting invocations.

## Tests

- \`cli-command.test.ts\`: updated to cover the new \`ingestBatch\`
  contract — missing callback still rejects; supplied callback is
  invoked per batch and drives \`memoriesCreated\`.
- \`import-weclone/integration.test.ts\`: new test that runs
  \`runBulkImportCliCommand\` against the synthetic Telegram fixture and
  verifies the \`ingestBatch\` callback receives correctly-sized
  batches (13 turns at batchSize 4 → \`[4, 4, 4, 1]\`).
- \`npm run check-types\`, \`npm run check-config-contract\`, full
  quick-preflight suite + \`test:entity-hardening\` all pass locally
  (192/192).

## Follow-up

Per the Cleaner-PR playbook (\"one subsystem group per PR\"), the
recall-ranker discount for \`trustLevel: \"import\"\` is left for a
dedicated follow-up. The flag is plumbed through the pipeline today but
the ranker does not yet apply the confidence reduction promised in the
original issue.

## Test plan

- [ ] CI green
- [ ] \`cursor[bot]\` review posted and threads resolved
- [ ] \`chatgpt-codex-connector[bot]\` review posted and threads resolved
- [ ] \`scripts/pre-merge-check.sh <PR#>\` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a real persistence/extraction path for bulk imports by wiring the CLI into orchestrator extraction and namespace routing; mistakes here could create or miscount memories or write to the wrong namespace/storage root.
> 
> **Overview**
> Bulk import (`openclaw engram bulk-import`) now supports non-`--dry-run` runs end-to-end by passing each parsed batch into the orchestrator for buffered extraction/persistence and reporting created-memory counts via before/after snapshots of `facts/` + `corrections/` markdown files.
> 
> `@remnic/core`’s `runBulkImportCliCommand` now requires an `ingestBatch` callback for non-dryRun (fail-fast otherwise) and is exported publicly for downstream integration tests, while the orchestrator adds `ingestBulkImportBatch()` plus a `writeNamespaceOverride` hook to pin bulk-import writes deterministically.
> 
> `@remnic/import-weclone` switches to side-effect adapter registration with an idempotent `ensureWecloneImportAdapterRegistered()`, updates docs/README to reflect persistence being wired, and expands tests to cover the new `ingestBatch` contract and batching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9302047a42aeb0b955241b90028d1ac812a40a70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->