### PR TITLE
[codex] Add benchmark dataset and run management commands

### DIFF
--- a/evals/scripts/download-datasets.sh
+++ b/evals/scripts/download-datasets.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-DATASETS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)/datasets"
+# Honor an explicit DATASETS_DIR from the environment so packaged CLI
+# installs can route downloads to a user-writable location (e.g.
+# ~/.remnic/bench/datasets) instead of a sibling of the script dir.
+DATASETS_DIR="${DATASETS_DIR:-$(cd "$SCRIPT_DIR/.." && pwd)/datasets}"
 
 usage() {
   echo "Usage: $0 [--benchmark <name>]"

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -135,6 +135,7 @@ export { compareResults, getBenchmarkLowerIsBetter } from "./stats/comparison.js
 export {
   assertPublishableIntegrity,
   buildBenchmarkPublishFeed,
+  deleteBenchmarkResults,
   defaultBenchmarkBaselineDir,
   defaultBenchmarkPublishPath,
   loadBenchmarkResult,

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -384,12 +384,23 @@ export async function deleteBenchmarkResults(
       missing.push(reference);
       continue;
     }
-    if (seenPaths.has(summary.path)) {
+    // Canonicalize before dedupe so a relative path and an absolute
+    // path that point at the same file collapse to a single key.
+    const canonicalPath = path.resolve(summary.path);
+    if (seenPaths.has(canonicalPath)) {
       continue;
     }
+    seenPaths.add(canonicalPath);
 
-    await unlink(summary.path);
-    seenPaths.add(summary.path);
+    try {
+      await unlink(summary.path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+        // Already removed (e.g. by a concurrent delete) — treat as success.
+      } else {
+        throw error;
+      }
+    }
     deleted.push(summary);
   }
 

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -332,15 +332,11 @@ export async function resolveBenchmarkResultReference(
   outputDir: string,
   reference: string,
 ): Promise<StoredBenchmarkResultSummary | undefined> {
-  if (fs.existsSync(reference)) {
-    try {
-      const result = await loadBenchmarkResult(reference);
-      return toSummary(result, reference);
-    } catch {
-      // Fall through to id/basename matching under the results directory.
-    }
-  }
-
+  // Store-first resolution keeps `runs show <id>` deterministic: a
+  // bare identifier always maps to the stored run rather than an
+  // unrelated file in the current working directory that happens to
+  // share the same name. Only fall back to the filesystem when the
+  // reference is unambiguously path-shaped.
   const summaries = await listBenchmarkResults(outputDir);
   const exactIdMatch = summaries.find((summary) => summary.id === reference);
   if (exactIdMatch) {
@@ -350,7 +346,20 @@ export async function resolveBenchmarkResultReference(
   const basenameMatch = summaries.find(
     (summary) => path.basename(summary.path) === reference,
   );
-  return basenameMatch;
+  if (basenameMatch) {
+    return basenameMatch;
+  }
+
+  if (looksLikeFilesystemPath(reference) && fs.existsSync(reference)) {
+    try {
+      const result = await loadBenchmarkResult(reference);
+      return toSummary(result, reference);
+    } catch {
+      return undefined;
+    }
+  }
+
+  return undefined;
 }
 
 // A reference is treated as a filesystem path only when it looks like

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -1,4 +1,4 @@
-import { mkdir, readdir, readFile, writeFile } from "node:fs/promises";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -351,6 +351,49 @@ export async function resolveBenchmarkResultReference(
     (summary) => path.basename(summary.path) === reference,
   );
   return basenameMatch;
+}
+
+export async function deleteBenchmarkResults(
+  outputDir: string,
+  references: string[],
+): Promise<{
+  deleted: StoredBenchmarkResultSummary[];
+  missing: string[];
+}> {
+  const summaries = await listBenchmarkResults(outputDir);
+  const deleted: StoredBenchmarkResultSummary[] = [];
+  const missing: string[] = [];
+  const seenPaths = new Set<string>();
+
+  for (const reference of references) {
+    let summary: StoredBenchmarkResultSummary | undefined;
+    if (fs.existsSync(reference)) {
+      try {
+        const result = await loadBenchmarkResult(reference);
+        summary = toSummary(result, reference);
+      } catch {
+        summary = undefined;
+      }
+    }
+    if (!summary) {
+      summary =
+        summaries.find((entry) => entry.id === reference) ??
+        summaries.find((entry) => path.basename(entry.path) === reference);
+    }
+    if (!summary) {
+      missing.push(reference);
+      continue;
+    }
+    if (seenPaths.has(summary.path)) {
+      continue;
+    }
+
+    await unlink(summary.path);
+    seenPaths.add(summary.path);
+    deleted.push(summary);
+  }
+
+  return { deleted, missing };
 }
 
 function comparePublishedBenchmarkEntries(

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -353,6 +353,18 @@ export async function resolveBenchmarkResultReference(
   return basenameMatch;
 }
 
+// A reference is treated as a filesystem path only when it looks like
+// one — absolute, contains a path separator, or points to a .json file.
+// Bare identifiers (e.g. run IDs) stay scoped to the store.
+function looksLikeFilesystemPath(reference: string): boolean {
+  return (
+    path.isAbsolute(reference) ||
+    reference.includes("/") ||
+    reference.includes(path.sep) ||
+    reference.endsWith(".json")
+  );
+}
+
 export async function deleteBenchmarkResults(
   outputDir: string,
   references: string[],
@@ -366,19 +378,23 @@ export async function deleteBenchmarkResults(
   const seenPaths = new Set<string>();
 
   for (const reference of references) {
-    let summary: StoredBenchmarkResultSummary | undefined;
-    if (fs.existsSync(reference)) {
+    // Resolve stored-run references first (by id or basename) so
+    // `remnic bench runs delete <id>` never unlinks an unrelated file
+    // that happens to share the same name in the current working
+    // directory. Only fall back to treating the reference as a direct
+    // filesystem path when it is unambiguously path-shaped or no
+    // stored run matches.
+    let summary: StoredBenchmarkResultSummary | undefined =
+      summaries.find((entry) => entry.id === reference) ??
+      summaries.find((entry) => path.basename(entry.path) === reference);
+
+    if (!summary && looksLikeFilesystemPath(reference) && fs.existsSync(reference)) {
       try {
         const result = await loadBenchmarkResult(reference);
         summary = toSummary(result, reference);
       } catch {
         summary = undefined;
       }
-    }
-    if (!summary) {
-      summary =
-        summaries.find((entry) => entry.id === reference) ??
-        summaries.find((entry) => path.basename(entry.path) === reference);
     }
     if (!summary) {
       missing.push(reference);

--- a/packages/bench/src/results-store.ts
+++ b/packages/bench/src/results-store.ts
@@ -397,12 +397,22 @@ export async function deleteBenchmarkResults(
       summaries.find((entry) => entry.id === reference) ??
       summaries.find((entry) => path.basename(entry.path) === reference);
 
-    if (!summary && looksLikeFilesystemPath(reference) && fs.existsSync(reference)) {
-      try {
-        const result = await loadBenchmarkResult(reference);
-        summary = toSummary(result, reference);
-      } catch {
-        summary = undefined;
+    if (!summary && looksLikeFilesystemPath(reference)) {
+      // If we've already deleted the file this path points at earlier
+      // in the same batch, treat a repeat reference as a duplicate —
+      // not a missing run — so multi-ref automation that mixes id and
+      // path aliases for the same run still exits cleanly.
+      const canonicalRef = path.resolve(reference);
+      if (seenPaths.has(canonicalRef)) {
+        continue;
+      }
+      if (fs.existsSync(reference)) {
+        try {
+          const result = await loadBenchmarkResult(reference);
+          summary = toSummary(result, reference);
+        } catch {
+          summary = undefined;
+        }
       }
     }
     if (!summary) {

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -37,6 +37,8 @@ remnic query "hello" --explain  # Test query with tier breakdown
 | `remnic sync` | Diff-aware sync with external sources |
 | `remnic spaces` | Manage memory namespaces |
 | `remnic bench list` | List published benchmark packs |
+| `remnic bench datasets status/download` | Check or download local benchmark datasets |
+| `remnic bench runs list/show/delete` | Manage stored benchmark result files |
 | `remnic bench run` | Run one or more published benchmark packs |
 | `remnic bench compare` | Compare two stored benchmark results |
 | `remnic bench baseline` | Save or list named benchmark baselines |
@@ -53,6 +55,12 @@ kept as a compatibility alias.
 
 ```bash
 remnic bench list
+remnic bench datasets status
+remnic bench datasets download longmemeval
+remnic bench datasets download --all
+remnic bench runs list
+remnic bench runs show candidate-run --detail
+remnic bench runs delete candidate-run
 remnic bench run --quick longmemeval
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
 remnic bench compare base-run candidate-run
@@ -71,6 +79,10 @@ ships a bundled smoke fixture, `--quick` uses that tracked fixture by default;
 full runs need a real benchmark dataset. In a repo checkout the CLI will use
 `evals/datasets/<benchmark>` automatically; in packaged installs pass
 `--dataset-dir <path>` explicitly.
+
+`remnic bench datasets download` currently manages the script-backed published
+datasets for `ama-bench`, `memory-arena`, `amemgym`, `longmemeval`, and `locomo`.
+Other benchmark fixtures remain repo-managed or need manual dataset wiring.
 
 ## Connecting agents
 

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -25,7 +25,7 @@
   },
   "scripts": {
     "prebuild": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
-    "build": "tsup --config tsup.config.ts",
+    "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"
   },

--- a/packages/remnic-cli/scripts/copy-bench-assets.mjs
+++ b/packages/remnic-cli/scripts/copy-bench-assets.mjs
@@ -1,0 +1,25 @@
+import fs from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const pkgRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = path.resolve(pkgRoot, "../..");
+
+const assets = [
+  {
+    from: path.join(repoRoot, "evals", "scripts", "download-datasets.sh"),
+    to: path.join(pkgRoot, "dist", "assets", "download-datasets.sh"),
+    mode: 0o755,
+  },
+];
+
+for (const asset of assets) {
+  if (!fs.existsSync(asset.from)) {
+    console.error(`[copy-bench-assets] source not found: ${asset.from}`);
+    process.exit(1);
+  }
+  fs.mkdirSync(path.dirname(asset.to), { recursive: true });
+  fs.copyFileSync(asset.from, asset.to);
+  fs.chmodSync(asset.to, asset.mode);
+  console.log(`[copy-bench-assets] ${path.relative(repoRoot, asset.from)} → ${path.relative(repoRoot, asset.to)}`);
+}

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -5,6 +5,8 @@ export type BenchAction =
   | "help"
   | "list"
   | "run"
+  | "datasets"
+  | "runs"
   | "compare"
   | "ui"
   | "results"
@@ -16,9 +18,11 @@ export type BenchAction =
   | "report";
 
 export type BenchBaselineAction = "save" | "list";
+export type BenchDatasetAction = "download" | "status";
 export type BenchExportFormat = "json" | "csv" | "html";
 export type BenchProviderAction = "discover";
 export type BenchPublishTarget = "remnic-ai";
+export type BenchRunAction = "list" | "show" | "delete";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -32,7 +36,9 @@ export interface ParsedBenchArgs {
   baselinesDir?: string;
   threshold?: number;
   baselineAction?: BenchBaselineAction;
+  datasetAction?: BenchDatasetAction;
   providerAction?: BenchProviderAction;
+  runAction?: BenchRunAction;
   format?: BenchExportFormat;
   output?: string;
   custom?: string;
@@ -85,6 +91,8 @@ export function parseBenchActionArgs(argv: string[]): {
   const action: BenchAction =
     first === "list" ||
     first === "run" ||
+    first === "datasets" ||
+    first === "runs" ||
     first === "compare" ||
     first === "ui" ||
     first === "results" ||
@@ -113,20 +121,44 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         ? args[0]
         : undefined
       : undefined;
+  const datasetAction =
+    action === "datasets"
+      ? args[0] === "download" || args[0] === "status"
+        ? args[0]
+        : undefined
+      : undefined;
   const providerAction =
     action === "providers"
       ? args[0] === "discover"
         ? args[0]
         : undefined
       : undefined;
+  const runAction =
+    action === "runs"
+      ? args[0] === "list" || args[0] === "show" || args[0] === "delete"
+        ? args[0]
+        : undefined
+      : undefined;
   if (action === "baseline" && baselineAction === undefined) {
     throw new Error("ERROR: baseline requires a subcommand: save or list.");
+  }
+  if (action === "datasets" && datasetAction === undefined) {
+    throw new Error("ERROR: datasets requires a subcommand: download or status.");
   }
   if (action === "providers" && providerAction === undefined) {
     throw new Error("ERROR: providers requires a subcommand: discover.");
   }
+  if (action === "runs" && runAction === undefined) {
+    throw new Error("ERROR: runs requires a subcommand: list, show, or delete.");
+  }
 
-  const benchmarkArgs = action === "baseline" || action === "providers" ? args.slice(1) : args;
+  const benchmarkArgs =
+    action === "baseline" ||
+    action === "datasets" ||
+    action === "providers" ||
+    action === "runs"
+      ? args.slice(1)
+      : args;
   const benchmarks = collectBenchmarks(benchmarkArgs);
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
@@ -173,7 +205,9 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,
+    datasetAction,
     providerAction,
+    runAction,
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,
     target,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -706,29 +706,24 @@ function resolveBenchDatasetDir(
   // Match the dataset root that `datasets download` and `datasets
   // status` use so full benchmark runs can consume a dataset that
   // was just downloaded through the packaged CLI without requiring
-  // an explicit `--dataset-dir` override.
+  // an explicit `--dataset-dir` override. Gate auto-selection on the
+  // same per-benchmark content markers as `datasets status` so a
+  // partial/interrupted download doesn't silently feed an empty
+  // directory into the benchmark loader.
   const managedRoot = resolveRepoDatasetRoot();
   const managedDatasetDir = path.join(managedRoot, benchmarkId);
-  if (isExistingDirectory(managedDatasetDir)) {
+  if (isDatasetDownloaded(managedDatasetDir, benchmarkId)) {
     return managedDatasetDir;
   }
 
   // Fall back to the in-repo evals/datasets/<benchmark> location so
   // monorepo checkouts that keep datasets committed continue to work.
   const repoDatasetDir = path.join(CLI_REPO_ROOT, "evals", "datasets", benchmarkId);
-  if (isExistingDirectory(repoDatasetDir)) {
+  if (isDatasetDownloaded(repoDatasetDir, benchmarkId)) {
     return repoDatasetDir;
   }
 
   return undefined;
-}
-
-function isExistingDirectory(candidate: string): boolean {
-  try {
-    return fs.statSync(candidate).isDirectory();
-  } catch {
-    return false;
-  }
 }
 
 function printBenchPackageSummary(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -703,11 +703,31 @@ function resolveBenchDatasetDir(
     return undefined;
   }
 
+  // Match the dataset root that `datasets download` and `datasets
+  // status` use so full benchmark runs can consume a dataset that
+  // was just downloaded through the packaged CLI without requiring
+  // an explicit `--dataset-dir` override.
+  const managedRoot = resolveRepoDatasetRoot();
+  const managedDatasetDir = path.join(managedRoot, benchmarkId);
+  if (isExistingDirectory(managedDatasetDir)) {
+    return managedDatasetDir;
+  }
+
+  // Fall back to the in-repo evals/datasets/<benchmark> location so
+  // monorepo checkouts that keep datasets committed continue to work.
   const repoDatasetDir = path.join(CLI_REPO_ROOT, "evals", "datasets", benchmarkId);
+  if (isExistingDirectory(repoDatasetDir)) {
+    return repoDatasetDir;
+  }
+
+  return undefined;
+}
+
+function isExistingDirectory(candidate: string): boolean {
   try {
-    return fs.statSync(repoDatasetDir).isDirectory() ? repoDatasetDir : undefined;
+    return fs.statSync(candidate).isDirectory();
   } catch {
-    return undefined;
+    return false;
   }
 }
 
@@ -1268,7 +1288,7 @@ async function runBenchViaPackage(
   );
   if (!parsed.quick && !datasetDir) {
     throw new Error(
-      `full benchmark runs for "${benchmarkId}" require dataset files. Pass --dataset-dir <path> or run from a Remnic repo checkout with evals/datasets/${benchmarkId}.`,
+      `full benchmark runs for "${benchmarkId}" require dataset files. Run "remnic bench datasets download ${benchmarkId}" or pass --dataset-dir <path>.`,
     );
   }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -547,6 +547,41 @@ function resolveDatasetDownloadScriptPath(): string {
   return path.join(CLI_REPO_ROOT, "evals", "scripts", "download-datasets.sh");
 }
 
+function runDatasetDownloadScript(
+  scriptPath: string,
+  benchmarkId: string,
+  jsonMode: boolean,
+): void {
+  // In --json mode, redirect the script's stdout to parent stderr so
+  // progress logs don't corrupt the JSON payload we emit on stdout.
+  const stdio: childProcess.StdioOptions = jsonMode
+    ? ["inherit", process.stderr, "inherit"]
+    : "inherit";
+  const options: childProcess.SpawnSyncOptions = {
+    cwd: CLI_REPO_ROOT,
+    stdio,
+    env: process.env,
+  };
+  const args = ["--benchmark", benchmarkId];
+
+  // On Unix we rely on the script's shebang and executable bit — this
+  // avoids forcing bash in PATH. On Windows (which doesn't honor POSIX
+  // shebangs) we fall back to bash and surface a clear error when it's
+  // absent, since the script itself is bash-only.
+  if (process.platform !== "win32") {
+    childProcess.execFileSync(scriptPath, args, options);
+    return;
+  }
+
+  const bashProbe = childProcess.spawnSync("bash", ["--version"], { stdio: "ignore" });
+  if (bashProbe.error || bashProbe.status !== 0) {
+    throw new Error(
+      "bench datasets download requires bash on Windows (Git Bash or WSL). Install bash or run this command from a Unix shell.",
+    );
+  }
+  childProcess.execFileSync("bash", [scriptPath, ...args], options);
+}
+
 function resolveSelectedDatasetDownloads(parsed: ParsedBenchArgs): string[] {
   const supported = listDownloadableBenchmarks();
   if (parsed.all) {
@@ -957,11 +992,7 @@ async function manageBenchDatasets(parsed: ParsedBenchArgs): Promise<void> {
   const selected = resolveSelectedDatasetDownloads(parsed);
   const downloaded: Array<{ benchmark: string; path: string }> = [];
   for (const benchmarkId of selected) {
-    childProcess.execFileSync("bash", [scriptPath, "--benchmark", benchmarkId], {
-      cwd: CLI_REPO_ROOT,
-      stdio: "inherit",
-      env: process.env,
-    });
+    runDatasetDownloadScript(scriptPath, benchmarkId, parsed.json === true);
     downloaded.push({
       benchmark: benchmarkId,
       path: path.join(datasetRoot, benchmarkId),

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -139,6 +139,7 @@ import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   buildBenchmarkPublishFeed,
   compareResults,
+  deleteBenchmarkResults,
   getBenchmarkLowerIsBetter,
   defaultBenchmarkBaselineDir,
   discoverAllProviders,
@@ -313,12 +314,18 @@ type PackageBenchModule = {
 };
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
-       remnic benchmark <list|run|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
+       remnic benchmark <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
   run [benchmark...]       Run one or more benchmark packs
+  datasets download [benchmark...]
+                           Download local datasets for supported published benchmarks
+  datasets status          Show local dataset availability for supported benchmarks
+  runs list                List stored benchmark runs
+  runs show <run>          Show one stored benchmark run
+  runs delete <run...>     Delete one or more stored benchmark runs
   compare <base> <cand>    Compare two stored benchmark runs by id or file path
   results [run]            List stored runs or inspect a stored run
   baseline save <name> [run]
@@ -349,6 +356,12 @@ Options:
 
 Examples:
   remnic bench list
+  remnic bench datasets status
+  remnic bench datasets download longmemeval
+  remnic bench datasets download --all
+  remnic bench runs list
+  remnic bench runs show candidate-run --detail
+  remnic bench runs delete candidate-run
   remnic bench run --quick longmemeval
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
   remnic bench compare base-run candidate-run
@@ -475,6 +488,14 @@ function resolveBenchOutputDir(): string {
   return path.join(resolveHomeDir(), ".remnic", "bench", "results");
 }
 
+const DOWNLOADABLE_BENCHMARK_DATASETS = [
+  "ama-bench",
+  "memory-arena",
+  "amemgym",
+  "longmemeval",
+  "locomo",
+] as const;
+
 async function launchBenchUi(resultsDir: string): Promise<void> {
   const benchUiDir = path.join(CLI_REPO_ROOT, "packages", "bench-ui");
   const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
@@ -512,6 +533,41 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
 
 function resolveBenchBaselineDir(): string {
   return defaultBenchmarkBaselineDir();
+}
+
+function resolveRepoDatasetRoot(): string {
+  return path.join(CLI_REPO_ROOT, "evals", "datasets");
+}
+
+function listDownloadableBenchmarks(): string[] {
+  return [...DOWNLOADABLE_BENCHMARK_DATASETS];
+}
+
+function resolveDatasetDownloadScriptPath(): string {
+  return path.join(CLI_REPO_ROOT, "evals", "scripts", "download-datasets.sh");
+}
+
+function resolveSelectedDatasetDownloads(parsed: ParsedBenchArgs): string[] {
+  const supported = listDownloadableBenchmarks();
+  if (parsed.all) {
+    return supported;
+  }
+  if (parsed.benchmarks.length === 0) {
+    console.error(
+      "ERROR: datasets download requires at least one benchmark id or --all. Usage: remnic bench datasets download <benchmark...> [--all] [--json]",
+    );
+    process.exit(1);
+  }
+
+  const selected = [...new Set(parsed.benchmarks)];
+  const unsupported = selected.filter((benchmarkId) => !supported.includes(benchmarkId));
+  if (unsupported.length > 0) {
+    console.error(
+      `ERROR: unsupported downloadable benchmark dataset(s): ${unsupported.join(", ")}. Supported datasets: ${supported.join(", ")}.`,
+    );
+    process.exit(1);
+  }
+  return selected;
 }
 
 function resolveBenchDatasetDir(
@@ -840,6 +896,150 @@ async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> 
   }
 
   process.stdout.write(rendered);
+}
+
+async function manageBenchDatasets(parsed: ParsedBenchArgs): Promise<void> {
+  const datasetRoot = resolveRepoDatasetRoot();
+  const supported = listDownloadableBenchmarks();
+
+  if (parsed.datasetAction === "status") {
+    if (parsed.benchmarks.length > 0 || parsed.all) {
+      console.error(
+        "ERROR: datasets status does not accept benchmark names or --all. Usage: remnic bench datasets status [--json]",
+      );
+      process.exit(1);
+    }
+
+    const status = supported.map((benchmarkId) => {
+      const datasetPath = path.join(datasetRoot, benchmarkId);
+      let downloaded = false;
+      try {
+        downloaded = fs.statSync(datasetPath).isDirectory();
+      } catch {
+        downloaded = false;
+      }
+      return {
+        benchmark: benchmarkId,
+        downloaded,
+        path: datasetPath,
+      };
+    });
+
+    if (parsed.json) {
+      console.log(JSON.stringify(status, null, 2));
+      return;
+    }
+
+    console.log("Downloadable benchmark datasets:");
+    for (const entry of status) {
+      console.log(
+        `  ${entry.benchmark.padEnd(16)} ${entry.downloaded ? "downloaded" : "missing"}  ${entry.path}`,
+      );
+    }
+    console.log("");
+    console.log(
+      "Only the script-backed published datasets are managed here. Other benchmark fixtures remain repo-managed or manual.",
+    );
+    return;
+  }
+
+  if (parsed.datasetAction !== "download") {
+    console.error("ERROR: datasets requires a subcommand: download or status.");
+    process.exit(1);
+  }
+
+  const scriptPath = resolveDatasetDownloadScriptPath();
+  if (!fs.existsSync(scriptPath)) {
+    console.error(`ERROR: dataset download script not found: ${scriptPath}`);
+    process.exit(1);
+  }
+
+  const selected = resolveSelectedDatasetDownloads(parsed);
+  const downloaded: Array<{ benchmark: string; path: string }> = [];
+  for (const benchmarkId of selected) {
+    childProcess.execFileSync("bash", [scriptPath, "--benchmark", benchmarkId], {
+      cwd: CLI_REPO_ROOT,
+      stdio: "inherit",
+      env: process.env,
+    });
+    downloaded.push({
+      benchmark: benchmarkId,
+      path: path.join(datasetRoot, benchmarkId),
+    });
+  }
+
+  if (parsed.json) {
+    console.log(JSON.stringify(downloaded, null, 2));
+    return;
+  }
+
+  console.log("Downloaded benchmark datasets:");
+  for (const entry of downloaded) {
+    console.log(`  ${entry.benchmark}  ${entry.path}`);
+  }
+}
+
+async function manageBenchRuns(parsed: ParsedBenchArgs): Promise<void> {
+  const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+
+  if (parsed.runAction === "list") {
+    if (parsed.benchmarks.length > 0 || parsed.all) {
+      console.error(
+        "ERROR: runs list does not accept benchmark names or --all. Usage: remnic bench runs list [--results-dir <path>] [--json]",
+      );
+      process.exit(1);
+    }
+    await showBenchPackageResults({ ...parsed, action: "results", benchmarks: [] });
+    return;
+  }
+
+  if (parsed.runAction === "show") {
+    if (parsed.benchmarks.length !== 1 || parsed.all) {
+      console.error(
+        "ERROR: runs show requires exactly one stored result reference. Usage: remnic bench runs show <run> [--detail] [--results-dir <path>] [--json]",
+      );
+      process.exit(1);
+    }
+    await showBenchPackageResults(parsed);
+    return;
+  }
+
+  if (parsed.runAction === "delete") {
+    if (parsed.benchmarks.length === 0 || parsed.all) {
+      console.error(
+        "ERROR: runs delete requires at least one stored result reference. Usage: remnic bench runs delete <run...> [--results-dir <path>] [--json]",
+      );
+      process.exit(1);
+    }
+    const deleted = await deleteBenchmarkResults(resultsDir, parsed.benchmarks);
+    if (parsed.json) {
+      console.log(JSON.stringify(deleted, null, 2));
+    } else {
+      if (deleted.deleted.length === 0) {
+        console.log("No benchmark runs were deleted.");
+      } else {
+        console.log("Deleted benchmark runs:");
+        for (const summary of deleted.deleted) {
+          console.log(`  ${summary.id}  ${summary.path}`);
+        }
+      }
+
+      if (deleted.missing.length > 0) {
+        console.log("Missing benchmark runs:");
+        for (const reference of deleted.missing) {
+          console.log(`  ${reference}`);
+        }
+      }
+    }
+
+    if (deleted.missing.length > 0) {
+      process.exit(1);
+    }
+    return;
+  }
+
+  console.error("ERROR: runs requires a subcommand: list, show, or delete.");
+  process.exit(1);
 }
 
 async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
@@ -2851,6 +3051,16 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
+  if (parsed.action === "datasets") {
+    await manageBenchDatasets(parsed);
+    return;
+  }
+
+  if (parsed.action === "runs") {
+    await manageBenchRuns(parsed);
+    return;
+  }
+
   if (parsed.action === "publish") {
     await publishBenchPackageResults(parsed);
     return;
@@ -4659,9 +4869,9 @@ Usage:
   remnic extensions <list|show|validate|reload>  Manage memory extensions
   remnic space <list|switch|create|delete|push|pull|share|promote|audit>  Manage spaces
     create accepts --parent <id> to set parent-child relationship
-  remnic bench <list|run|compare|results|baseline|export|publish|ui|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv|html>] [--output <path>] [--target remnic-ai] [--json]
+  remnic bench <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers> [benchmark...] [--quick] [--all] [--dataset-dir <path>] [--results-dir <path>] [--baselines-dir <path>] [--threshold <value>] [--detail] [--format <json|csv|html>] [--output <path>] [--target remnic-ai] [--json]
     benchmark is kept as a compatibility alias. check/report remain under that alias.
-  remnic benchmark <list|run|compare|results|baseline|export|publish|ui|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
+  remnic benchmark <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers|check|report> [queries...] [--explain] [--baseline=<path>] [--report=<path>]
   remnic briefing [--since <window>] [--focus <filter>] [--save] [--format markdown|json]
     Daily context briefing. Windows: yesterday, today, NNh, NNd, NNw.
     Focus: person:<name>, project:<name>, topic:<name>.

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -715,18 +715,13 @@ function resolveBenchDatasetDir(
   // an explicit `--dataset-dir` override. Gate auto-selection on the
   // same per-benchmark content markers as `datasets status` so a
   // partial/interrupted download doesn't silently feed an empty
-  // directory into the benchmark loader.
-  const managedRoot = resolveRepoDatasetRoot();
-  const managedDatasetDir = path.join(managedRoot, benchmarkId);
-  if (isDatasetDownloaded(managedDatasetDir, benchmarkId)) {
-    return managedDatasetDir;
-  }
-
-  // Fall back to the in-repo evals/datasets/<benchmark> location so
-  // monorepo checkouts that keep datasets committed continue to work.
-  const repoDatasetDir = path.join(CLI_REPO_ROOT, "evals", "datasets", benchmarkId);
-  if (isDatasetDownloaded(repoDatasetDir, benchmarkId)) {
-    return repoDatasetDir;
+  // directory into the benchmark loader. `resolveRepoDatasetRoot`
+  // already picks the correct layout (evals/datasets in monorepo
+  // checkouts, ~/.remnic/bench/datasets in packaged installs), so one
+  // lookup covers both install modes.
+  const datasetDir = path.join(resolveRepoDatasetRoot(), benchmarkId);
+  if (isDatasetDownloaded(datasetDir, benchmarkId)) {
+    return datasetDir;
   }
 
   return undefined;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -586,21 +586,50 @@ function resolveBenchBaselineDir(): string {
   return defaultBenchmarkBaselineDir();
 }
 
+// Resolve the dataset root. In a monorepo checkout we keep using
+// evals/datasets so local dev state stays stable; in a published CLI
+// install CLI_REPO_ROOT points under node_modules (not user-writable
+// and missing the repo-only evals/ tree) so we fall back to
+// ~/.remnic/bench/datasets.
 function resolveRepoDatasetRoot(): string {
-  return path.join(CLI_REPO_ROOT, "evals", "datasets");
+  const repoCandidate = path.join(CLI_REPO_ROOT, "evals", "datasets");
+  if (isRepoCheckout()) {
+    return repoCandidate;
+  }
+  return path.join(resolveHomeDir(), ".remnic", "bench", "datasets");
 }
 
 function listDownloadableBenchmarks(): string[] {
   return [...DOWNLOADABLE_BENCHMARK_DATASETS];
 }
 
+// The download script is shipped with the CLI package at
+// dist/assets/download-datasets.sh. When running from a monorepo
+// checkout the built copy may be absent, so we also accept the
+// in-repo source path as a fallback.
 function resolveDatasetDownloadScriptPath(): string {
+  const bundled = path.join(CLI_MODULE_DIR, "assets", "download-datasets.sh");
+  if (fs.existsSync(bundled)) {
+    return bundled;
+  }
   return path.join(CLI_REPO_ROOT, "evals", "scripts", "download-datasets.sh");
+}
+
+function isRepoCheckout(): boolean {
+  // Treat the install as a repo checkout only when the monorepo
+  // marker files are present next to CLI_REPO_ROOT. In published
+  // @remnic/cli installs, CLI_REPO_ROOT points inside node_modules
+  // where these files do not exist.
+  return (
+    fs.existsSync(path.join(CLI_REPO_ROOT, "pnpm-workspace.yaml")) &&
+    fs.existsSync(path.join(CLI_REPO_ROOT, "evals", "scripts", "download-datasets.sh"))
+  );
 }
 
 function runDatasetDownloadScript(
   scriptPath: string,
   benchmarkId: string,
+  datasetRoot: string,
   jsonMode: boolean,
 ): void {
   // In --json mode, redirect the script's stdout to parent stderr so
@@ -608,10 +637,15 @@ function runDatasetDownloadScript(
   const stdio: childProcess.StdioOptions = jsonMode
     ? ["inherit", process.stderr, "inherit"]
     : "inherit";
+  // Thread the resolved dataset root through DATASETS_DIR so the
+  // script writes to the same location `datasets status` reads from,
+  // regardless of where the script file itself lives (repo vs
+  // packaged node_modules install).
+  const env = { ...process.env, DATASETS_DIR: datasetRoot };
   const options: childProcess.SpawnSyncOptions = {
     cwd: CLI_REPO_ROOT,
     stdio,
-    env: process.env,
+    env,
   };
   const args = ["--benchmark", benchmarkId];
 
@@ -1037,7 +1071,7 @@ async function manageBenchDatasets(parsed: ParsedBenchArgs): Promise<void> {
   const selected = resolveSelectedDatasetDownloads(parsed);
   const downloaded: Array<{ benchmark: string; path: string }> = [];
   for (const benchmarkId of selected) {
-    runDatasetDownloadScript(scriptPath, benchmarkId, parsed.json === true);
+    runDatasetDownloadScript(scriptPath, benchmarkId, datasetRoot, parsed.json === true);
     downloaded.push({
       benchmark: benchmarkId,
       path: path.join(datasetRoot, benchmarkId),

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -496,16 +496,22 @@ const DOWNLOADABLE_BENCHMARK_DATASETS = [
   "locomo",
 ] as const;
 
-// Required content markers per benchmark. A `files` entry is matched literally;
-// a `glob` entry matches any file in the directory with the given extension.
-// Mirrors the expectations in evals/scripts/download-datasets.sh so `datasets
-// status` reports a partial/interrupted download as "missing" instead of
-// "downloaded" based on directory existence alone.
-const DOWNLOADED_DATASET_MARKERS: Record<string, { files?: string[]; ext?: string }> = {
-  "ama-bench": { files: ["open_end_qa_set.jsonl"] },
-  longmemeval: { files: ["longmemeval_oracle.json"] },
-  amemgym: { files: ["amemgym-v1-base.json"] },
-  locomo: { files: ["locomo10.json"] },
+// Required content markers per benchmark. `anyOf` lists the filenames
+// a benchmark runner will accept — a dataset directory is considered
+// "downloaded" as soon as any one of them is present. `ext` matches
+// any file in the directory with the given extension. The filename
+// sets mirror the dataset loaders under packages/bench/src/benchmarks
+// so `datasets status`/`resolveBenchDatasetDir` never disagree with
+// the runner about whether a dataset is ready.
+const DOWNLOADED_DATASET_MARKERS: Record<string, { anyOf?: string[]; ext?: string }> = {
+  "ama-bench": { anyOf: ["open_end_qa_set.jsonl"] },
+  longmemeval: {
+    anyOf: ["longmemeval_oracle.json", "longmemeval_s_cleaned.json", "longmemeval.json"],
+  },
+  amemgym: {
+    anyOf: ["amemgym-v1-base.json", "amemgym-tasks.json", "data.json"],
+  },
+  locomo: { anyOf: ["locomo10.json", "locomo.json"] },
   "memory-arena": { ext: ".jsonl" },
 };
 
@@ -528,8 +534,8 @@ function isDatasetDownloaded(datasetPath: string, benchmarkId: string): boolean 
       return false;
     }
   }
-  if (marker.files) {
-    return marker.files.every((name) => {
+  if (marker.anyOf) {
+    return marker.anyOf.some((name) => {
       try {
         return fs.statSync(path.join(datasetPath, name)).isFile();
       } catch {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -496,6 +496,57 @@ const DOWNLOADABLE_BENCHMARK_DATASETS = [
   "locomo",
 ] as const;
 
+// Required content markers per benchmark. A `files` entry is matched literally;
+// a `glob` entry matches any file in the directory with the given extension.
+// Mirrors the expectations in evals/scripts/download-datasets.sh so `datasets
+// status` reports a partial/interrupted download as "missing" instead of
+// "downloaded" based on directory existence alone.
+const DOWNLOADED_DATASET_MARKERS: Record<string, { files?: string[]; ext?: string }> = {
+  "ama-bench": { files: ["open_end_qa_set.jsonl"] },
+  longmemeval: { files: ["longmemeval_oracle.json"] },
+  amemgym: { files: ["amemgym-v1-base.json"] },
+  locomo: { files: ["locomo10.json"] },
+  "memory-arena": { ext: ".jsonl" },
+};
+
+function isDatasetDownloaded(datasetPath: string, benchmarkId: string): boolean {
+  let stats: fs.Stats;
+  try {
+    stats = fs.statSync(datasetPath);
+  } catch {
+    return false;
+  }
+  if (!stats.isDirectory()) {
+    return false;
+  }
+  const marker = DOWNLOADED_DATASET_MARKERS[benchmarkId];
+  if (!marker) {
+    // Unknown benchmark: fall back to "directory has at least one file".
+    try {
+      return fs.readdirSync(datasetPath).length > 0;
+    } catch {
+      return false;
+    }
+  }
+  if (marker.files) {
+    return marker.files.every((name) => {
+      try {
+        return fs.statSync(path.join(datasetPath, name)).isFile();
+      } catch {
+        return false;
+      }
+    });
+  }
+  if (marker.ext) {
+    try {
+      return fs.readdirSync(datasetPath).some((name) => name.endsWith(marker.ext!));
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
 async function launchBenchUi(resultsDir: string): Promise<void> {
   const benchUiDir = path.join(CLI_REPO_ROOT, "packages", "bench-ui");
   const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
@@ -947,15 +998,9 @@ async function manageBenchDatasets(parsed: ParsedBenchArgs): Promise<void> {
 
     const status = supported.map((benchmarkId) => {
       const datasetPath = path.join(datasetRoot, benchmarkId);
-      let downloaded = false;
-      try {
-        downloaded = fs.statSync(datasetPath).isDirectory();
-      } catch {
-        downloaded = false;
-      }
       return {
         benchmark: benchmarkId,
-        downloaded,
+        downloaded: isDatasetDownloaded(datasetPath, benchmarkId),
         path: datasetPath,
       };
     });

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, readFile, writeFile } from "node:fs/promises";
 import {
   buildBenchmarkPublishFeed,
+  deleteBenchmarkResults,
   defaultBenchmarkBaselineDir,
   defaultBenchmarkPublishPath,
   listBenchmarkBaselines,
@@ -158,6 +159,27 @@ test("resolveBenchmarkResultReference falls back to id matching when a same-name
   } finally {
     process.chdir(cwd);
   }
+});
+
+test("deleteBenchmarkResults removes matched stored results and reports unmatched references", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-delete-"));
+  const firstPath = path.join(root, "first.json");
+  const secondPath = path.join(root, "second.json");
+  await writeFile(
+    firstPath,
+    `${JSON.stringify(buildResult("run-first", "2026-04-18T03:00:00.000Z"))}\n`,
+  );
+  await writeFile(
+    secondPath,
+    `${JSON.stringify(buildResult("run-second", "2026-04-18T04:00:00.000Z"))}\n`,
+  );
+
+  const result = await deleteBenchmarkResults(root, ["run-first", "missing-run"]);
+  const listed = await listBenchmarkResults(root);
+
+  assert.deepEqual(result.deleted.map((entry) => entry.id), ["run-first"]);
+  assert.deepEqual(result.missing, ["missing-run"]);
+  assert.deepEqual(listed.map((entry) => entry.id), ["run-second"]);
 });
 
 test("saveBenchmarkBaseline persists a named baseline and listBenchmarkBaselines returns newest first", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -12,7 +12,7 @@ test("remnic CLI source wires the new bench command and keeps benchmark as an al
   assert.match(source, /case "bench": \{/);
   assert.match(source, /case "benchmark": \{/);
   assert.match(source, /await cmdBench\(rest\);/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
+  assert.match(source, /remnic bench <list\|run\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /benchmark is kept as a compatibility alias/i);
 });
 
@@ -49,6 +49,9 @@ test("CLI README documents bench list and quick-run examples", async () => {
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
   assert.match(readme, /remnic bench list/);
+  assert.match(readme, /remnic bench datasets download longmemeval/);
+  assert.match(readme, /remnic bench runs list/);
+  assert.match(readme, /remnic bench runs show candidate-run --detail/);
   assert.match(readme, /remnic bench run --quick longmemeval/);
   assert.match(readme, /--dataset-dir ~\/datasets\/longmemeval/);
   assert.match(readme, /remnic bench compare base-run candidate-run/);
@@ -91,7 +94,10 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /async function runCustomBenchViaPackage\(parsed: ParsedBenchArgs\): Promise<boolean>/);
   assert.match(parserSource, /function readBenchOptionValue\(argv: string\[\], flag: string\)/);
   assert.match(parserSource, /function collectBenchmarks\(argv: string\[\]\): string\[\]/);
-  assert.match(parserSource, /const benchmarkArgs = action === "baseline" \|\| action === "providers" \? args\.slice\(1\) : args;/);
+  assert.match(
+    parserSource,
+    /const benchmarkArgs =[\s\S]*action === "baseline"[\s\S]*action === "datasets"[\s\S]*action === "providers"[\s\S]*action === "runs"[\s\S]*args\.slice\(1\)[\s\S]*:\s*args;/,
+  );
   assert.match(parserSource, /const benchmarks = collectBenchmarks\(benchmarkArgs\);/);
   assert.match(parserSource, /requires a value\./);
   assert.match(parserSource, /arg === "--dataset-dir"[\s\S]*arg === "--results-dir"[\s\S]*arg === "--baselines-dir"[\s\S]*arg === "--threshold"[\s\S]*arg === "--custom"[\s\S]*arg === "--format"[\s\S]*arg === "--output"/);
@@ -128,7 +134,7 @@ test("bench compare routes through stored package results with threshold and res
   assert.match(source, /parsed\.resultsDir \?\? resolveBenchOutputDir\(\)/);
   assert.match(source, /compareResults\(\s*baseline,\s*candidate,\s*parsed\.threshold \?\? 0\.05/s);
   assert.match(source, /benchmark mismatch: \$\{baseline\.meta\.benchmark\} vs \$\{candidate\.meta\.benchmark\}/);
-  assert.match(parserSource, /export type BenchAction =[\s\S]*"results"[\s\S]*"baseline"[\s\S]*"export"[\s\S]*"publish"[\s\S]*"check"[\s\S]*"report";/);
+  assert.match(parserSource, /export type BenchAction =[\s\S]*"datasets"[\s\S]*"runs"[\s\S]*"results"[\s\S]*"baseline"[\s\S]*"export"[\s\S]*"publish"[\s\S]*"check"[\s\S]*"report";/);
   assert.match(parserSource, /const resultsDir = readBenchOptionValue\(args, "--results-dir"\);/);
   assert.match(parserSource, /const thresholdRaw = readBenchOptionValue\(args, "--threshold"\);/);
   assert.match(parserSource, /ERROR: --threshold must be a non-negative number\./);
@@ -175,7 +181,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
   assert.match(source, /discoverAllProviders,/);
-  assert.match(source, /Usage: remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
+  assert.match(source, /Usage: remnic bench <list\|run\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /providers discover does not accept positional arguments/);
@@ -196,6 +202,51 @@ test("bench surface retains local UI compatibility alongside providers discovery
   assert.match(parserSource, /first === "ui"/);
   assert.match(source, /ui\s+Launch the local benchmark overview UI/);
   assert.match(source, /if \(parsed\.action === "ui"\) \{\s*await launchBenchUi\(parsed\.resultsDir \?\? resolveBenchOutputDir\(\)\);\s*return;\s*\}/s);
+});
+
+test("bench datasets and runs surfaces are exposed through parser, help text, and README", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+  const readme = await readFile("packages/remnic-cli/README.md", "utf8");
+
+  assert.match(parserSource, /\| "datasets"/);
+  assert.match(parserSource, /\| "runs"/);
+  assert.match(parserSource, /export type BenchDatasetAction = "download" \| "status";/);
+  assert.match(parserSource, /export type BenchRunAction = "list" \| "show" \| "delete";/);
+  assert.match(parserSource, /datasetAction\?: BenchDatasetAction;/);
+  assert.match(parserSource, /runAction\?: BenchRunAction;/);
+  assert.match(parserSource, /first === "datasets"/);
+  assert.match(parserSource, /first === "runs"/);
+  assert.match(source, /datasets download \[benchmark\.\.\.\]/);
+  assert.match(source, /datasets status/);
+  assert.match(source, /runs list/);
+  assert.match(source, /runs show <run>/);
+  assert.match(source, /runs delete <run\.\.\.>/);
+  assert.match(source, /async function manageBenchDatasets\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /async function manageBenchRuns\(parsed: ParsedBenchArgs\): Promise<void>/);
+  assert.match(source, /if \(parsed\.action === "datasets"\) \{\s*await manageBenchDatasets\(parsed\);/s);
+  assert.match(source, /if \(parsed\.action === "runs"\) \{\s*await manageBenchRuns\(parsed\);/s);
+  assert.match(readme, /remnic bench datasets status/);
+  assert.match(readme, /remnic bench datasets download longmemeval/);
+  assert.match(readme, /remnic bench runs list/);
+  assert.match(readme, /remnic bench runs show candidate-run --detail/);
+  assert.match(readme, /remnic bench runs delete candidate-run/);
+});
+
+test("parseBenchArgs supports datasets download and runs show aliases", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const datasets = parseBenchArgs(["datasets", "download", "longmemeval", "--json"]);
+  assert.equal(datasets.action, "datasets");
+  assert.equal(datasets.datasetAction, "download");
+  assert.deepEqual(datasets.benchmarks, ["longmemeval"]);
+  assert.equal(datasets.json, true);
+
+  const runs = parseBenchArgs(["runs", "show", "candidate-run", "--detail"]);
+  assert.equal(runs.action, "runs");
+  assert.equal(runs.runAction, "show");
+  assert.deepEqual(runs.benchmarks, ["candidate-run"]);
+  assert.equal(runs.detail, true);
 });
 
 test("parseBenchArgs supports the providers discovery surface", async () => {
@@ -237,32 +288,36 @@ test("bench providers discover rejects unexpected trailing positional args", asy
   const exportModuleEntry = join(exportModuleDist, "index.js");
   const exportPackageJson = join(exportModuleRoot, "package.json");
   const cliEntry = pathToFileURL(join(repoRoot, "packages/remnic-cli/src/index.ts")).href;
-  const stubbedBenchModule = !existsSync(benchModuleEntry);
   const stubbedExportModule = !existsSync(exportModuleEntry);
+  const existingEntry = existsSync(benchModuleEntry)
+    ? await readFile(benchModuleEntry, "utf8")
+    : undefined;
+  const existingPackageJson = existsSync(benchPackageJson)
+    ? await readFile(benchPackageJson, "utf8")
+    : undefined;
   const createdModuleRoot = !existsSync(benchModuleLinkRoot);
-  const createdPackageJson = stubbedBenchModule && !existsSync(benchPackageJson);
-  const createdDistDir = stubbedBenchModule && !existsSync(benchModuleDist);
+  const createdPackageJson = !existsSync(benchPackageJson);
+  const createdDistDir = !existsSync(benchModuleDist);
   const createdExportModuleRoot = !existsSync(exportModuleLinkRoot);
   const createdExportPackageJson = stubbedExportModule && !existsSync(exportPackageJson);
   const createdExportDistDir = stubbedExportModule && !existsSync(exportModuleDist);
 
-  if (stubbedBenchModule) {
-    mkdirSync(benchModuleDist, { recursive: true });
-    if (createdPackageJson) {
-      writeFileSync(
-        benchPackageJson,
-        JSON.stringify({
-          name: "@remnic/bench",
-          type: "module",
-          exports: {
-            ".": "./dist/index.js",
-          },
-        }),
-      );
-    }
+  mkdirSync(benchModuleDist, { recursive: true });
+  if (createdPackageJson) {
     writeFileSync(
-      benchModuleEntry,
-      `
+      benchPackageJson,
+      JSON.stringify({
+        name: "@remnic/bench",
+        type: "module",
+        exports: {
+          ".": "./dist/index.js",
+        },
+      }),
+    );
+  }
+  writeFileSync(
+    benchModuleEntry,
+    `
 export function compareResults() {}
 export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai", generatedAt: new Date(0).toISOString(), benchmarks: [] }; }
 export function checkRegression() { return null; }
@@ -281,10 +336,10 @@ export async function loadBenchmarkResult() { return null; }
 export function renderBenchmarkResultExport() { return ""; }
 export async function resolveBenchmarkResultReference() { return null; }
 export async function saveBenchmarkBaseline() { return null; }
+export async function deleteBenchmarkResults() { return { deleted: [], missing: [] }; }
 export async function writeBenchmarkPublishFeed() { return ""; }
 `,
-    );
-  }
+  );
 
   if (stubbedExportModule) {
     mkdirSync(exportModuleDist, { recursive: true });
@@ -339,17 +394,21 @@ export function sweepPii(records) { return { records, redactions: [] }; }
         rmSync(exportModuleRoot, { recursive: true, force: true });
       }
     }
-    if (stubbedBenchModule) {
+    if (existingEntry !== undefined) {
+      writeFileSync(benchModuleEntry, existingEntry);
+    } else {
       rmSync(benchModuleEntry, { force: true });
-      if (createdDistDir) {
-        rmSync(benchModuleDist, { recursive: true, force: true });
-      }
-      if (createdPackageJson) {
-        rmSync(benchPackageJson, { force: true });
-      }
-      if (createdModuleRoot) {
-        rmSync(benchModuleRoot, { recursive: true, force: true });
-      }
+    }
+    if (existingPackageJson !== undefined) {
+      writeFileSync(benchPackageJson, existingPackageJson);
+    } else if (createdPackageJson) {
+      rmSync(benchPackageJson, { force: true });
+    }
+    if (createdDistDir) {
+      rmSync(benchModuleDist, { recursive: true, force: true });
+    }
+    if (createdModuleRoot) {
+      rmSync(benchModuleRoot, { recursive: true, force: true });
     }
   }
 });

--- a/tests/remnic-cli-bench-ui-surface.test.ts
+++ b/tests/remnic-cli-bench-ui-surface.test.ts
@@ -21,7 +21,7 @@ test("CLI source wires remnic bench ui to the local bench-ui package", async () 
 
   assert.match(parserSource, /\| "ui"/);
   assert.match(parserSource, /first === "ui"/);
-  assert.match(source, /remnic bench <list\|run\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
+  assert.match(source, /remnic bench <list\|run\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /ui\s+Launch the local benchmark overview UI/);
   assert.match(source, /if \(parsed\.action === "ui"\) \{\s*await launchBenchUi\(parsed\.resultsDir \?\? resolveBenchOutputDir\(\)\);\s*return;\s*\}/s);
   assert.match(source, /async function launchBenchUi\(resultsDir: string\): Promise<void>/);

--- a/tests/remnic-cli-package.test.ts
+++ b/tests/remnic-cli-package.test.ts
@@ -15,7 +15,7 @@ test("remnic CLI bundles the private bench package instead of publishing it as a
   };
 
   assert.equal(pkg.scripts?.prebuild, "node ../../scripts/ensure-cli-bench-build-deps.mjs");
-  assert.equal(pkg.scripts?.build, "tsup --config tsup.config.ts");
+  assert.match(pkg.scripts?.build ?? "", /^tsup --config tsup\.config\.ts(\s+&&\s+.+)?$/);
   assert.match(tsupRaw, /noExternal:\s*\["@remnic\/bench"\]/);
   assert.match(buildHelperRaw, /"@remnic\/core"/);
   assert.match(buildHelperRaw, /"@remnic\/bench"/);


### PR DESCRIPTION
## What changed
- add `remnic bench datasets status|download` for script-backed benchmark dataset management
- add `remnic bench runs list|show|delete` for stored benchmark run management
- export stored-result deletion from `@remnic/bench` and cover the new CLI surfaces in focused tests

## Why
The benchmark tooling existed, but the CLI did not expose a clean way to inspect/download supported datasets or manage saved runs directly from `remnic`.

## Validation
- `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-results-store.test.ts`
- `pnpm --filter @remnic/bench build && pnpm --filter @remnic/cli build`

## Notes
- I attempted a direct CLI runtime smoke in this clean worktree, but the CLI source/runtime path currently depends on `@remnic/export-weclone/dist` being built in the workspace. I did not keep hammering that path after confirming the package builds and focused CLI tests were green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new CLI subcommands that execute a bundled bash download script and delete stored benchmark result files, which can impact user filesystem state if paths are mis-resolved. Guardrails were added (store-first resolution, path-shape checks, dedupe) but the surface area is still operationally sensitive.
> 
> **Overview**
> Adds first-class benchmark management to the `remnic bench` CLI with new `datasets status|download` and `runs list|show|delete` subcommands, including updated help text and README examples.
> 
> Dataset handling now works in both monorepo checkouts and packaged installs by resolving a user-writable dataset root (`~/.remnic/bench/datasets`), bundling `evals/scripts/download-datasets.sh` into the CLI build, and auto-detecting dataset readiness via per-benchmark marker files.
> 
> Stored-run management is expanded by exporting `deleteBenchmarkResults` from `@remnic/bench`, making result reference resolution deterministic (prefer stored run ids/basenames; only treat inputs as filesystem paths when they look path-shaped), and adding tests covering deletion and the new CLI surfaces.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec514f0ec6186635930313e74e68eed90155ca44. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->