### PR TITLE
Add real-runtime benchmark profiles and CLI orchestration

### DIFF
--- a/docs/plans/2026-04-19-real-runtime-benchmarks.md
+++ b/docs/plans/2026-04-19-real-runtime-benchmarks.md
@@ -1,0 +1,270 @@
+# Real Runtime Benchmarks Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add real-runtime benchmark execution so `remnic bench run` can measure config-driven Remnic retrieval, direct provider-backed answering/judging, and OpenClaw-chain-backed answering from the CLI.
+
+**Architecture:** Keep the benchmark CLI thin and push the runtime logic into `@remnic/bench`. Introduce a shared runtime-profile/responder layer so published retrieval benchmarks can score both recalled context and final answers without copying provider or OpenClaw wiring into each runner.
+
+**Tech Stack:** TypeScript, Node.js, `@remnic/bench`, `@remnic/cli`, `@remnic/core`, OpenClaw config loading, OpenAI-compatible/Anthropic/Ollama/LiteLLM provider adapters, Node test runner.
+
+---
+
+### Task 1: Extend bench CLI arguments for runtime profiles and matrix mode
+
+**Files:**
+- Modify: `packages/remnic-cli/src/bench-args.ts`
+- Modify: `packages/remnic-cli/src/index.ts`
+- Test: `tests/remnic-cli-bench-surface.test.ts`
+- Test: `tests/remnic-cli-bench-ui-surface.test.ts`
+
+**Step 1: Write the failing parser and help-surface tests**
+
+Add tests covering:
+- `remnic bench run longmemeval --runtime-profile real`
+- `remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config ~/.openclaw/openclaw.json --gateway-agent-id my-agent`
+- `remnic bench run longmemeval --system-provider openai --system-model gpt-5.4-mini --judge-provider anthropic --judge-model claude-sonnet-4.5`
+- `remnic bench run longmemeval --matrix baseline,real,openclaw-chain`
+
+**Step 2: Run the targeted CLI surface tests to verify RED**
+
+Run: `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts`
+
+Expected: FAIL due to missing parser fields, missing usage text, and missing CLI routing.
+
+**Step 3: Add the minimal parser surface**
+
+Add parsed fields for:
+- `runtimeProfile`
+- `matrixProfiles`
+- `remnicConfigPath`
+- `openclawConfigPath`
+- `modelSource`
+- `gatewayAgentId`
+- `fastGatewayAgentId`
+- `systemProvider`
+- `systemModel`
+- `systemBaseUrl`
+- `judgeProvider`
+- `judgeModel`
+- `judgeBaseUrl`
+
+Update the bench help text with explicit examples for direct-provider and OpenClaw-chain runs.
+
+**Step 4: Re-run the targeted CLI surface tests to verify GREEN**
+
+Run: `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts`
+
+Expected: PASS for the new parser and help-text assertions, with unrelated tests still green.
+
+**Step 5: Commit the parser surface**
+
+```bash
+git add packages/remnic-cli/src/bench-args.ts packages/remnic-cli/src/index.ts tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts
+git commit -m "feat(cli): add real-runtime benchmark flags"
+```
+
+### Task 2: Add shared runtime-profile, provider, and OpenClaw config resolution in @remnic/bench
+
+**Files:**
+- Create: `packages/bench/src/runtime-profiles.ts`
+- Create: `packages/bench/src/responders.ts`
+- Modify: `packages/bench/src/index.ts`
+- Modify: `packages/bench/src/types.ts`
+- Modify: `packages/bench/src/adapters/types.ts`
+- Modify: `packages/bench/src/adapters/remnic-adapter.ts`
+- Test: `packages/bench/src/runtime-profiles.test.ts`
+- Test: `packages/bench/src/responders.test.ts`
+
+**Step 1: Write failing tests for config-driven adapter creation and provider/OpenClaw profile resolution**
+
+Cover:
+- baseline runtime profile still disables QMD/rerank/query expansion
+- real runtime profile preserves parsed Remnic config and allows QMD-enabled paths
+- OpenClaw runtime profile loads `openclaw.json`, extracts `gatewayConfig`, and sets `modelSource: "gateway"`
+- provider-backed responder and judge factories reject incomplete configs and return typed wrappers for valid configs
+
+**Step 2: Run the focused bench tests to verify RED**
+
+Run: `pnpm exec tsx --test packages/bench/src/runtime-profiles.test.ts packages/bench/src/responders.test.ts`
+
+Expected: FAIL because the files and factories do not exist yet.
+
+**Step 3: Implement runtime profile resolution**
+
+Create a shared module that:
+- normalizes `baseline`, `real`, and `openclaw-chain`
+- merges Remnic config overrides into `createRemnicAdapter`
+- loads OpenClaw config when requested and passes `gatewayConfig`, `modelSource`, `gatewayAgentId`, and `fastGatewayAgentId`
+- returns a bench runtime bundle with adapter config plus optional responder/judge factories
+
+**Step 4: Implement responder/judge wrappers**
+
+Create shared wrappers that adapt existing provider adapters (`openai`, `anthropic`, `ollama`, `litellm`) into:
+- answer-generation responders
+- benchmark judge adapters
+
+Add a fallback OpenClaw-chain responder that uses core’s `gatewayConfig` model-routing contract instead of direct provider calls.
+
+**Step 5: Update the Remnic adapter factory**
+
+Make `createRemnicAdapter()` accept resolved config overrides instead of always hardcoding the stripped-down profile. Keep `createLightweightAdapter()` for smoke mode, but make the direct adapter able to run against “real” Remnic features.
+
+**Step 6: Re-run the focused bench tests to verify GREEN**
+
+Run: `pnpm exec tsx --test packages/bench/src/runtime-profiles.test.ts packages/bench/src/responders.test.ts`
+
+Expected: PASS with runtime profiles and responder/judge wrappers working in isolation.
+
+**Step 7: Commit the runtime layer**
+
+```bash
+git add packages/bench/src/runtime-profiles.ts packages/bench/src/responders.ts packages/bench/src/index.ts packages/bench/src/types.ts packages/bench/src/adapters/types.ts packages/bench/src/adapters/remnic-adapter.ts packages/bench/src/runtime-profiles.test.ts packages/bench/src/responders.test.ts
+git commit -m "feat(bench): add runtime profiles and responder wiring"
+```
+
+### Task 3: Add a shared answer-generation layer for published retrieval benchmarks
+
+**Files:**
+- Create: `packages/bench/src/answering.ts`
+- Modify: `packages/bench/src/benchmarks/published/ama-bench/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/amemgym/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/beam/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/locomo/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/longmemeval/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/membench/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/memory-agentbench/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/memory-arena/runner.ts`
+- Modify: `packages/bench/src/benchmarks/published/personamem/runner.ts`
+- Test: `packages/bench/src/answering.test.ts`
+
+**Step 1: Write the failing shared-answering tests**
+
+Cover:
+- no responder configured → benchmark uses recalled text as the answer
+- responder configured → benchmark scores the generated final answer instead of raw recall text
+- details payload retains both `recalledText` and `answeredText`
+- usage/tokens from provider-backed responders are preserved in benchmark result cost summaries
+
+**Step 2: Run the focused tests to verify RED**
+
+Run: `pnpm exec tsx --test packages/bench/src/answering.test.ts`
+
+Expected: FAIL because the shared answering helper does not exist yet.
+
+**Step 3: Implement the shared helper**
+
+Create a helper that accepts:
+- benchmark question
+- recalled text
+- optional responder
+
+Return:
+- `finalAnswer`
+- `recalledText`
+- responder token/latency usage
+
+**Step 4: Update published retrieval runners**
+
+Replace ad hoc scoring against raw recall text with the shared helper so each runner:
+- still records retrieval/search details
+- can score a real model-generated answer when configured
+- still works in deterministic/no-provider mode
+
+**Step 5: Re-run the focused tests to verify GREEN**
+
+Run: `pnpm exec tsx --test packages/bench/src/answering.test.ts`
+
+Expected: PASS with both deterministic and provider-backed paths covered.
+
+**Step 6: Commit the answer-generation layer**
+
+```bash
+git add packages/bench/src/answering.ts packages/bench/src/answering.test.ts packages/bench/src/benchmarks/published
+git commit -m "feat(bench): score published benchmarks with generated answers"
+```
+
+### Task 4: Wire the CLI run path to runtime profiles, providers, and matrix execution
+
+**Files:**
+- Modify: `packages/remnic-cli/src/index.ts`
+- Modify: `packages/bench/src/benchmark.ts`
+- Modify: `packages/bench/src/types.ts`
+- Test: `tests/remnic-cli-bench-surface.test.ts`
+- Test: `tests/bench-results-store.test.ts`
+
+**Step 1: Write failing tests for run orchestration**
+
+Cover:
+- `runtimeProfile=real` resolves and runs once
+- `runtimeProfile=openclaw-chain` uses OpenClaw config
+- `systemProvider` and `judgeProvider` metadata are written into stored results
+- `--matrix baseline,real,openclaw-chain` produces multiple stored runs with distinct profile metadata
+
+**Step 2: Run the focused orchestration tests to verify RED**
+
+Run: `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/bench-results-store.test.ts`
+
+Expected: FAIL because the CLI still runs a single adapter path without matrix/profile support.
+
+**Step 3: Implement CLI runtime resolution**
+
+Route `bench run` through the new runtime-profile layer so the CLI can:
+- load Remnic config files
+- load OpenClaw config files
+- build direct provider responders/judges
+- build OpenClaw-chain responders
+- emit profile-aware stored results
+
+**Step 4: Implement matrix mode**
+
+Allow `--matrix` to run the selected benchmark repeatedly across requested profiles and write each result separately. Keep single-profile execution unchanged when `--matrix` is absent.
+
+**Step 5: Re-run the focused orchestration tests to verify GREEN**
+
+Run: `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/bench-results-store.test.ts`
+
+Expected: PASS with stored-result metadata and matrix-mode orchestration covered.
+
+**Step 6: Commit the orchestration layer**
+
+```bash
+git add packages/remnic-cli/src/index.ts packages/bench/src/benchmark.ts packages/bench/src/types.ts tests/remnic-cli-bench-surface.test.ts tests/bench-results-store.test.ts
+git commit -m "feat(cli): run benchmark profiles and matrices"
+```
+
+### Task 5: Update docs and run end-to-end verification
+
+**Files:**
+- Modify: `packages/remnic-cli/README.md`
+- Modify: `packages/plugin-openclaw/README.md`
+- Modify: `docs/plans/2026-04-19-real-runtime-benchmarks.md` (status notes if needed)
+
+**Step 1: Document the new runtime modes**
+
+Add examples for:
+- baseline retrieval-only runs
+- real runtime runs with Remnic config
+- direct provider-backed runs
+- OpenClaw-chain runs
+- matrix runs
+
+**Step 2: Run the verification commands**
+
+Run:
+- `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-results-store.test.ts packages/bench/src/runtime-profiles.test.ts packages/bench/src/responders.test.ts packages/bench/src/answering.test.ts`
+- `pnpm --filter @remnic/bench build && pnpm --filter @remnic/cli build`
+
+If the runtime smoke path is available, also run:
+- `node packages/remnic-cli/dist/index.js bench run --quick longmemeval --runtime-profile baseline`
+- `node packages/remnic-cli/dist/index.js bench run --quick longmemeval --runtime-profile real`
+
+**Step 3: Review scope and open the PR**
+
+```bash
+git status -sb
+git push -u origin codex/bench-real-runtime-profiles
+gh pr create --draft --base main --head codex/bench-real-runtime-profiles
+```
+
+Include validation evidence and note whether OpenClaw-chain smoke runs required local gateway config to be present.

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -19,6 +19,24 @@ test("direct adapter keeps its recall-friendly defaults without overrides", () =
   assert.equal(config.queryExpansionEnabled, false);
 });
 
+test("adapter sandbox paths cannot be overridden by runtime config", () => {
+  const overrides = {
+    memoryDir: "/tmp/real-user-memory",
+    workspaceDir: "/tmp/real-user-workspace",
+    lcmEnabled: false,
+  };
+
+  const direct = buildBenchAdapterConfig("direct", BASE_CONFIG, overrides);
+  const lightweight = buildBenchAdapterConfig("lightweight", BASE_CONFIG, overrides);
+
+  assert.equal(direct.memoryDir, BASE_CONFIG.memoryDir);
+  assert.equal(direct.workspaceDir, BASE_CONFIG.workspaceDir);
+  assert.equal(direct.lcmEnabled, true);
+  assert.equal(lightweight.memoryDir, BASE_CONFIG.memoryDir);
+  assert.equal(lightweight.workspaceDir, BASE_CONFIG.workspaceDir);
+  assert.equal(lightweight.lcmEnabled, true);
+});
+
 test("lightweight adapter keeps smoke-run guardrails even when overrides conflict", () => {
   const assistantHook = { enabled: true };
   const config = buildBenchAdapterConfig("lightweight", BASE_CONFIG, {

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildBenchAdapterConfig } from "./remnic-adapter.ts";
+
+const BASE_CONFIG = {
+  memoryDir: "/tmp/remnic-bench-memory",
+  workspaceDir: "/tmp/remnic-bench-workspace",
+  lcmEnabled: true as const,
+};
+
+test("direct adapter keeps its recall-friendly defaults without overrides", () => {
+  const config = buildBenchAdapterConfig("direct", BASE_CONFIG);
+
+  assert.equal(config.extractionDedupeEnabled, true);
+  assert.equal(config.extractionMinChars, 10);
+  assert.equal(config.extractionMinUserTurns, 0);
+  assert.equal(config.recallPlannerEnabled, true);
+  assert.equal(config.queryExpansionEnabled, false);
+});
+
+test("lightweight adapter keeps smoke-run guardrails even when overrides conflict", () => {
+  const assistantHook = { enabled: true };
+  const config = buildBenchAdapterConfig("lightweight", BASE_CONFIG, {
+    extractionDedupeEnabled: true,
+    extractionMinChars: 10,
+    extractionMinUserTurns: 0,
+    recallPlannerEnabled: true,
+    assistantHook,
+  });
+
+  assert.equal(config.extractionDedupeEnabled, false);
+  assert.equal(config.extractionMinChars, 1000000);
+  assert.equal(config.extractionMinUserTurns, 1000000);
+  assert.equal(config.recallPlannerEnabled, false);
+  assert.equal(config.assistantHook, assistantHook);
+});

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -61,5 +61,22 @@ test("lightweight adapter keeps smoke-run guardrails even when overrides conflic
   assert.equal(config.extractionMinChars, 1000000);
   assert.equal(config.extractionMinUserTurns, 1000000);
   assert.equal(config.recallPlannerEnabled, false);
-  assert.equal(config.assistantHook, assistantHook);
+  assert.deepEqual(config.assistantHook, assistantHook);
+});
+
+test("benchmark config builders do not share nested nativeKnowledge state", () => {
+  const first = buildBenchAdapterConfig("direct", BASE_CONFIG) as {
+    nativeKnowledge: { enabled: boolean };
+  };
+  const second = buildBenchAdapterConfig("direct", BASE_CONFIG) as {
+    nativeKnowledge: { enabled: boolean };
+  };
+  const baseline = buildBenchBaselineRemnicConfig() as {
+    nativeKnowledge: { enabled: boolean };
+  };
+
+  first.nativeKnowledge.enabled = true;
+
+  assert.equal(second.nativeKnowledge.enabled, false);
+  assert.equal(baseline.nativeKnowledge.enabled, false);
 });

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,5 +1,6 @@
 import assert from "node:assert/strict";
 import test from "node:test";
+import { parseConfig } from "@remnic/core";
 
 import {
   buildBenchAdapterConfig,
@@ -105,4 +106,19 @@ test("benchmark config builders preserve function-valued assistant hooks", async
   assert.deepEqual(await config.assistantJudge.evaluate(), { score: 0.8 });
   assert.notEqual(config.assistantAgent, assistantAgent);
   assert.notEqual(config.assistantJudge, assistantJudge);
+});
+
+test("runtime-backed direct configs preserve core defaults for omitted keys", () => {
+  const parsed = parseConfig(
+    buildBenchAdapterConfig(
+      "direct",
+      BASE_CONFIG,
+      { assistantAgent: { enabled: true } },
+      { preserveRuntimeDefaults: true },
+    ),
+  );
+
+  assert.equal(parsed.qmdEnabled, true);
+  assert.equal(parsed.identityEnabled, true);
+  assert.equal(parsed.workspaceDir, BASE_CONFIG.workspaceDir);
 });

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -1,7 +1,10 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildBenchAdapterConfig } from "./remnic-adapter.ts";
+import {
+  buildBenchAdapterConfig,
+  buildBenchBaselineRemnicConfig,
+} from "./remnic-adapter.ts";
 
 const BASE_CONFIG = {
   memoryDir: "/tmp/remnic-bench-memory",
@@ -17,6 +20,13 @@ test("direct adapter keeps its recall-friendly defaults without overrides", () =
   assert.equal(config.extractionMinUserTurns, 0);
   assert.equal(config.recallPlannerEnabled, true);
   assert.equal(config.queryExpansionEnabled, false);
+});
+
+test("persisted baseline config stays aligned with direct adapter defaults", () => {
+  const { memoryDir: _memoryDir, workspaceDir: _workspaceDir, ...directConfig } =
+    buildBenchAdapterConfig("direct", BASE_CONFIG);
+
+  assert.deepEqual(buildBenchBaselineRemnicConfig(), directConfig);
 });
 
 test("adapter sandbox paths cannot be overridden by runtime config", () => {

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -80,3 +80,29 @@ test("benchmark config builders do not share nested nativeKnowledge state", () =
   assert.equal(second.nativeKnowledge.enabled, false);
   assert.equal(baseline.nativeKnowledge.enabled, false);
 });
+
+test("benchmark config builders preserve function-valued assistant hooks", async () => {
+  const assistantAgent = {
+    async respond(): Promise<string> {
+      return "ok";
+    },
+  };
+  const assistantJudge = {
+    async evaluate(): Promise<{ score: number }> {
+      return { score: 0.8 };
+    },
+  };
+
+  const config = buildBenchAdapterConfig("direct", BASE_CONFIG, {
+    assistantAgent,
+    assistantJudge,
+  }) as {
+    assistantAgent: typeof assistantAgent;
+    assistantJudge: typeof assistantJudge;
+  };
+
+  assert.equal(await config.assistantAgent.respond(), "ok");
+  assert.deepEqual(await config.assistantJudge.evaluate(), { score: 0.8 });
+  assert.notEqual(config.assistantAgent, assistantAgent);
+  assert.notEqual(config.assistantJudge, assistantJudge);
+});

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -83,7 +83,27 @@ export const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, 
 };
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
-  return structuredClone(config);
+  return cloneBenchConfigValue(config);
+}
+
+function cloneBenchConfigValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => cloneBenchConfigValue(entry));
+  }
+
+  if (typeof value === "function") {
+    return value;
+  }
+
+  if (value && typeof value === "object") {
+    const next: Record<string, unknown> = {};
+    for (const [key, entry] of Object.entries(value)) {
+      next[key] = cloneBenchConfigValue(entry);
+    }
+    return next;
+  }
+
+  return value;
 }
 
 export function buildBenchBaselineRemnicConfig(): Record<string, unknown> {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -21,69 +21,107 @@ export interface RemnicAdapterOptions {
   judge?: BenchJudge;
 }
 
+type BenchAdapterMode = "lightweight" | "direct";
+
+interface BenchAdapterBaseConfig {
+  memoryDir: string;
+  workspaceDir: string;
+  lcmEnabled: true;
+}
+
+const BENCH_ADAPTER_SHARED_CONFIG: Record<string, unknown> = {
+  qmdEnabled: false,
+  qmdColdTierEnabled: false,
+  transcriptEnabled: false,
+  hourlySummariesEnabled: false,
+  daySummaryEnabled: false,
+  identityEnabled: false,
+  identityContinuityEnabled: false,
+  namespacesEnabled: false,
+  sharedContextEnabled: false,
+  workTasksEnabled: false,
+  workProjectsEnabled: false,
+  commitmentLedgerEnabled: false,
+  resumeBundlesEnabled: false,
+  nativeKnowledge: { enabled: false },
+  lcmLeafBatchSize: 4,
+  lcmRollupFanIn: 3,
+  lcmFreshTailTurns: 8,
+  lcmMaxDepth: 4,
+  lcmDeterministicMaxTokens: 512,
+  lcmRecallBudgetShare: 1.0,
+  queryExpansionEnabled: false,
+  rerankEnabled: false,
+  memoryBoxesEnabled: false,
+  traceWeaverEnabled: false,
+  threadingEnabled: false,
+  factDeduplicationEnabled: false,
+  knowledgeIndexEnabled: false,
+  entityRetrievalEnabled: false,
+  verifiedRecallEnabled: false,
+  queryAwareIndexingEnabled: false,
+  contradictionDetectionEnabled: false,
+  memoryLinkingEnabled: false,
+  topicExtractionEnabled: false,
+  chunkingEnabled: true,
+  episodeNoteModeEnabled: false,
+};
+
+const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, unknown>> = {
+  direct: {
+    extractionDedupeEnabled: true,
+    extractionMinChars: 10,
+    extractionMinUserTurns: 0,
+    recallPlannerEnabled: true,
+  },
+  lightweight: {
+    extractionDedupeEnabled: false,
+    extractionMinChars: 1000000,
+    extractionMinUserTurns: 1000000,
+    recallPlannerEnabled: false,
+  },
+};
+
+export function buildBenchAdapterConfig(
+  mode: BenchAdapterMode,
+  baseConfig: BenchAdapterBaseConfig,
+  overrides: Record<string, unknown> = {},
+): Record<string, unknown> {
+  const modeConfig = {
+    ...BENCH_ADAPTER_SHARED_CONFIG,
+    ...BENCH_ADAPTER_MODE_CONFIG[mode],
+  };
+
+  if (mode === "lightweight") {
+    return {
+      ...baseConfig,
+      ...overrides,
+      ...modeConfig,
+    };
+  }
+
+  return {
+    ...baseConfig,
+    ...modeConfig,
+    ...overrides,
+  };
+}
+
 async function createBenchOrchestrator(
-  mode: "lightweight" | "direct",
+  mode: BenchAdapterMode,
   overrides?: Record<string, unknown>,
 ): Promise<{ tempDir: string; orchestrator: Orchestrator }> {
   const tempDir = await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   await mkdir(path.join(tempDir, "state"), { recursive: true });
 
-  const commonConfig = {
+  const commonConfig: BenchAdapterBaseConfig = {
     memoryDir: tempDir,
     workspaceDir: tempDir,
     lcmEnabled: true,
   };
-  const lightweightConfig =
-    mode === "lightweight"
-      ? {
-          qmdEnabled: false,
-          qmdColdTierEnabled: false,
-          transcriptEnabled: false,
-          hourlySummariesEnabled: false,
-          daySummaryEnabled: false,
-          identityEnabled: false,
-          identityContinuityEnabled: false,
-          namespacesEnabled: false,
-          sharedContextEnabled: false,
-          workTasksEnabled: false,
-          workProjectsEnabled: false,
-          commitmentLedgerEnabled: false,
-          resumeBundlesEnabled: false,
-          nativeKnowledge: { enabled: false },
-          lcmLeafBatchSize: 4,
-          lcmRollupFanIn: 3,
-          lcmFreshTailTurns: 8,
-          lcmMaxDepth: 4,
-          lcmDeterministicMaxTokens: 512,
-          lcmRecallBudgetShare: 1.0,
-          extractionDedupeEnabled: false,
-          extractionMinChars: 1000000,
-          extractionMinUserTurns: 1000000,
-          recallPlannerEnabled: false,
-          queryExpansionEnabled: false,
-          rerankEnabled: false,
-          memoryBoxesEnabled: false,
-          traceWeaverEnabled: false,
-          threadingEnabled: false,
-          factDeduplicationEnabled: false,
-          knowledgeIndexEnabled: false,
-          entityRetrievalEnabled: false,
-          verifiedRecallEnabled: false,
-          queryAwareIndexingEnabled: false,
-          contradictionDetectionEnabled: false,
-          memoryLinkingEnabled: false,
-          topicExtractionEnabled: false,
-          chunkingEnabled: true,
-          episodeNoteModeEnabled: false,
-        }
-      : {};
 
   const orchestrator = new Orchestrator(
-    parseConfig({
-      ...commonConfig,
-      ...lightweightConfig,
-      ...overrides,
-    }),
+    parseConfig(buildBenchAdapterConfig(mode, commonConfig, overrides)),
   );
 
   await orchestrator.initialize();

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -84,7 +84,7 @@ export const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, 
 };
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
-  return cloneBenchConfigValue(config);
+  return cloneBenchConfigValue(config) as Record<string, unknown>;
 }
 
 function cloneBenchConfigValue(value: unknown): unknown {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -29,7 +29,7 @@ interface BenchAdapterBaseConfig {
   lcmEnabled: true;
 }
 
-const BENCH_ADAPTER_SHARED_CONFIG: Record<string, unknown> = {
+export const BENCH_ADAPTER_SHARED_CONFIG: Record<string, unknown> = {
   qmdEnabled: false,
   qmdColdTierEnabled: false,
   transcriptEnabled: false,
@@ -67,7 +67,7 @@ const BENCH_ADAPTER_SHARED_CONFIG: Record<string, unknown> = {
   episodeNoteModeEnabled: false,
 };
 
-const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, unknown>> = {
+export const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, unknown>> = {
   direct: {
     extractionDedupeEnabled: true,
     extractionMinChars: 10,
@@ -81,6 +81,14 @@ const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, unknown
     recallPlannerEnabled: false,
   },
 };
+
+export function buildBenchBaselineRemnicConfig(): Record<string, unknown> {
+  return {
+    ...BENCH_ADAPTER_SHARED_CONFIG,
+    ...BENCH_ADAPTER_MODE_CONFIG.direct,
+    lcmEnabled: true,
+  };
+}
 
 export function buildBenchAdapterConfig(
   mode: BenchAdapterMode,

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -17,6 +17,7 @@ import type {
 
 export interface RemnicAdapterOptions {
   configOverrides?: Record<string, unknown>;
+  preserveRuntimeDefaults?: boolean;
   responder?: BenchResponder;
   judge?: BenchJudge;
 }
@@ -118,6 +119,7 @@ export function buildBenchAdapterConfig(
   mode: BenchAdapterMode,
   baseConfig: BenchAdapterBaseConfig,
   overrides: Record<string, unknown> = {},
+  options: { preserveRuntimeDefaults?: boolean } = {},
 ): Record<string, unknown> {
   const sandboxConfig = {
     memoryDir: baseConfig.memoryDir,
@@ -138,6 +140,14 @@ export function buildBenchAdapterConfig(
     });
   }
 
+  if (options.preserveRuntimeDefaults === true) {
+    return cloneBenchConfig({
+      ...baseConfig,
+      ...overrides,
+      ...sandboxConfig,
+    });
+  }
+
   return cloneBenchConfig({
     ...baseConfig,
     ...modeConfig,
@@ -149,6 +159,7 @@ export function buildBenchAdapterConfig(
 async function createBenchOrchestrator(
   mode: BenchAdapterMode,
   overrides?: Record<string, unknown>,
+  preserveRuntimeDefaults = false,
 ): Promise<{ tempDir: string; orchestrator: Orchestrator }> {
   const tempDir = await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   await mkdir(path.join(tempDir, "state"), { recursive: true });
@@ -160,7 +171,11 @@ async function createBenchOrchestrator(
   };
 
   const orchestrator = new Orchestrator(
-    parseConfig(buildBenchAdapterConfig(mode, commonConfig, overrides)),
+    parseConfig(
+      buildBenchAdapterConfig(mode, commonConfig, overrides, {
+        preserveRuntimeDefaults,
+      }),
+    ),
   );
 
   await orchestrator.initialize();
@@ -175,7 +190,11 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
   return async function createAdapter(
     options: RemnicAdapterOptions = {},
   ): Promise<BenchMemoryAdapter> {
-    let state = await createBenchOrchestrator(mode, options.configOverrides);
+    let state = await createBenchOrchestrator(
+      mode,
+      options.configOverrides,
+      options.preserveRuntimeDefaults === true,
+    );
 
     const getEngine = () => {
       const engine = state.orchestrator.lcmEngine;
@@ -192,7 +211,11 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
     const rebuild = async (): Promise<void> => {
       await cleanup();
-      state = await createBenchOrchestrator(mode, options.configOverrides);
+      state = await createBenchOrchestrator(
+        mode,
+        options.configOverrides,
+        options.preserveRuntimeDefaults === true,
+      );
     };
 
     return {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -87,6 +87,11 @@ export function buildBenchAdapterConfig(
   baseConfig: BenchAdapterBaseConfig,
   overrides: Record<string, unknown> = {},
 ): Record<string, unknown> {
+  const sandboxConfig = {
+    memoryDir: baseConfig.memoryDir,
+    workspaceDir: baseConfig.workspaceDir,
+    lcmEnabled: baseConfig.lcmEnabled,
+  };
   const modeConfig = {
     ...BENCH_ADAPTER_SHARED_CONFIG,
     ...BENCH_ADAPTER_MODE_CONFIG[mode],
@@ -97,6 +102,7 @@ export function buildBenchAdapterConfig(
       ...baseConfig,
       ...overrides,
       ...modeConfig,
+      ...sandboxConfig,
     };
   }
 
@@ -104,6 +110,7 @@ export function buildBenchAdapterConfig(
     ...baseConfig,
     ...modeConfig,
     ...overrides,
+    ...sandboxConfig,
   };
 }
 

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -6,10 +6,19 @@ import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { Orchestrator, parseConfig } from "@remnic/core";
-import type { BenchMemoryAdapter, MemoryStats, Message, SearchResult } from "./types.js";
+import type {
+  BenchJudge,
+  BenchMemoryAdapter,
+  BenchResponder,
+  MemoryStats,
+  Message,
+  SearchResult,
+} from "./types.js";
 
 export interface RemnicAdapterOptions {
   configOverrides?: Record<string, unknown>;
+  responder?: BenchResponder;
+  judge?: BenchJudge;
 }
 
 async function createBenchOrchestrator(
@@ -19,50 +28,60 @@ async function createBenchOrchestrator(
   const tempDir = await mkdtemp(path.join(tmpdir(), `remnic-bench-${mode}-`));
   await mkdir(path.join(tempDir, "state"), { recursive: true });
 
+  const commonConfig = {
+    memoryDir: tempDir,
+    workspaceDir: tempDir,
+    lcmEnabled: true,
+  };
+  const lightweightConfig =
+    mode === "lightweight"
+      ? {
+          qmdEnabled: false,
+          qmdColdTierEnabled: false,
+          transcriptEnabled: false,
+          hourlySummariesEnabled: false,
+          daySummaryEnabled: false,
+          identityEnabled: false,
+          identityContinuityEnabled: false,
+          namespacesEnabled: false,
+          sharedContextEnabled: false,
+          workTasksEnabled: false,
+          workProjectsEnabled: false,
+          commitmentLedgerEnabled: false,
+          resumeBundlesEnabled: false,
+          nativeKnowledge: { enabled: false },
+          lcmLeafBatchSize: 4,
+          lcmRollupFanIn: 3,
+          lcmFreshTailTurns: 8,
+          lcmMaxDepth: 4,
+          lcmDeterministicMaxTokens: 512,
+          lcmRecallBudgetShare: 1.0,
+          extractionDedupeEnabled: false,
+          extractionMinChars: 1000000,
+          extractionMinUserTurns: 1000000,
+          recallPlannerEnabled: false,
+          queryExpansionEnabled: false,
+          rerankEnabled: false,
+          memoryBoxesEnabled: false,
+          traceWeaverEnabled: false,
+          threadingEnabled: false,
+          factDeduplicationEnabled: false,
+          knowledgeIndexEnabled: false,
+          entityRetrievalEnabled: false,
+          verifiedRecallEnabled: false,
+          queryAwareIndexingEnabled: false,
+          contradictionDetectionEnabled: false,
+          memoryLinkingEnabled: false,
+          topicExtractionEnabled: false,
+          chunkingEnabled: true,
+          episodeNoteModeEnabled: false,
+        }
+      : {};
+
   const orchestrator = new Orchestrator(
     parseConfig({
-      memoryDir: tempDir,
-      workspaceDir: tempDir,
-      qmdEnabled: false,
-      qmdColdTierEnabled: false,
-      transcriptEnabled: false,
-      hourlySummariesEnabled: false,
-      daySummaryEnabled: false,
-      identityEnabled: false,
-      identityContinuityEnabled: false,
-      namespacesEnabled: false,
-      sharedContextEnabled: false,
-      workTasksEnabled: false,
-      workProjectsEnabled: false,
-      commitmentLedgerEnabled: false,
-      resumeBundlesEnabled: false,
-      nativeKnowledge: { enabled: false },
-      lcmEnabled: true,
-      lcmLeafBatchSize: 4,
-      lcmRollupFanIn: 3,
-      lcmFreshTailTurns: 8,
-      lcmMaxDepth: 4,
-      lcmDeterministicMaxTokens: 512,
-      lcmRecallBudgetShare: 1.0,
-      extractionDedupeEnabled: mode === "direct",
-      extractionMinChars: mode === "direct" ? 10 : 1000000,
-      extractionMinUserTurns: mode === "direct" ? 0 : 1000000,
-      recallPlannerEnabled: mode === "direct",
-      queryExpansionEnabled: false,
-      rerankEnabled: false,
-      memoryBoxesEnabled: false,
-      traceWeaverEnabled: false,
-      threadingEnabled: false,
-      factDeduplicationEnabled: false,
-      knowledgeIndexEnabled: false,
-      entityRetrievalEnabled: false,
-      verifiedRecallEnabled: false,
-      queryAwareIndexingEnabled: false,
-      contradictionDetectionEnabled: false,
-      memoryLinkingEnabled: false,
-      topicExtractionEnabled: false,
-      chunkingEnabled: true,
-      episodeNoteModeEnabled: false,
+      ...commonConfig,
+      ...lightweightConfig,
       ...overrides,
     }),
   );
@@ -175,6 +194,9 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       async destroy(): Promise<void> {
         await cleanup();
       },
+
+      responder: options.responder,
+      judge: options.judge,
     };
   };
 }

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -82,12 +82,16 @@ export const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, 
   },
 };
 
+function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
+  return structuredClone(config);
+}
+
 export function buildBenchBaselineRemnicConfig(): Record<string, unknown> {
-  return {
+  return cloneBenchConfig({
     ...BENCH_ADAPTER_SHARED_CONFIG,
     ...BENCH_ADAPTER_MODE_CONFIG.direct,
     lcmEnabled: true,
-  };
+  });
 }
 
 export function buildBenchAdapterConfig(
@@ -106,20 +110,20 @@ export function buildBenchAdapterConfig(
   };
 
   if (mode === "lightweight") {
-    return {
+    return cloneBenchConfig({
       ...baseConfig,
       ...overrides,
       ...modeConfig,
       ...sandboxConfig,
-    };
+    });
   }
 
-  return {
+  return cloneBenchConfig({
     ...baseConfig,
     ...modeConfig,
     ...overrides,
     ...sandboxConfig,
-  };
+  });
 }
 
 async function createBenchOrchestrator(

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -35,8 +35,23 @@ export interface BenchResponder {
   respond(question: string, recalledText: string): Promise<BenchResponse>;
 }
 
+export interface BenchJudgeResult {
+  score: number;
+  tokens: {
+    input: number;
+    output: number;
+  };
+  latencyMs: number;
+  model?: string;
+}
+
 export interface BenchJudge {
   score(question: string, predicted: string, expected: string): Promise<number>;
+  scoreWithMetrics?(
+    question: string,
+    predicted: string,
+    expected: string,
+  ): Promise<BenchJudgeResult>;
 }
 
 export interface BenchMemoryAdapter {

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -21,6 +21,20 @@ export interface MemoryStats {
   maxDepth: number;
 }
 
+export interface BenchResponse {
+  text: string;
+  tokens: {
+    input: number;
+    output: number;
+  };
+  latencyMs: number;
+  model: string;
+}
+
+export interface BenchResponder {
+  respond(question: string, recalledText: string): Promise<BenchResponse>;
+}
+
 export interface BenchJudge {
   score(question: string, predicted: string, expected: string): Promise<number>;
 }
@@ -32,6 +46,7 @@ export interface BenchMemoryAdapter {
   reset(sessionId?: string): Promise<void>;
   getStats(sessionId?: string): Promise<MemoryStats>;
   destroy(): Promise<void>;
+  responder?: BenchResponder;
   judge?: BenchJudge;
 }
 

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -1,0 +1,52 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { answerBenchmarkQuestion } from "./answering.ts";
+
+test("without a responder the benchmark answer falls back to recalled text", async () => {
+  const result = await answerBenchmarkQuestion({
+    question: "What happened?",
+    recalledText: "The recalled memory.",
+  });
+
+  assert.equal(result.finalAnswer, "The recalled memory.");
+  assert.equal(result.recalledText, "The recalled memory.");
+  assert.equal(result.answeredText, "The recalled memory.");
+  assert.deepEqual(result.tokens, {
+    input: 0,
+    output: 0,
+  });
+  assert.equal(result.latencyMs, 0);
+});
+
+test("with a responder the benchmark answer uses the generated final answer and preserves usage", async () => {
+  const result = await answerBenchmarkQuestion({
+    question: "What happened?",
+    recalledText: "The recalled memory.",
+    responder: {
+      async respond(question, recalledText) {
+        assert.equal(question, "What happened?");
+        assert.equal(recalledText, "The recalled memory.");
+        return {
+          text: "The generated answer.",
+          tokens: {
+            input: 32,
+            output: 9,
+          },
+          latencyMs: 44,
+          model: "gpt-5.4-mini",
+        };
+      },
+    },
+  });
+
+  assert.equal(result.finalAnswer, "The generated answer.");
+  assert.equal(result.recalledText, "The recalled memory.");
+  assert.equal(result.answeredText, "The generated answer.");
+  assert.deepEqual(result.tokens, {
+    input: 32,
+    output: 9,
+  });
+  assert.equal(result.latencyMs, 44);
+  assert.equal(result.model, "gpt-5.4-mini");
+});

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -1,0 +1,46 @@
+import type { BenchResponder } from "./adapters/types.js";
+
+export interface BenchmarkAnswerResult {
+  finalAnswer: string;
+  recalledText: string;
+  answeredText: string;
+  latencyMs: number;
+  tokens: {
+    input: number;
+    output: number;
+  };
+  model?: string;
+}
+
+export async function answerBenchmarkQuestion(options: {
+  question: string;
+  recalledText: string;
+  responder?: BenchResponder;
+}): Promise<BenchmarkAnswerResult> {
+  if (!options.responder) {
+    return {
+      finalAnswer: options.recalledText,
+      recalledText: options.recalledText,
+      answeredText: options.recalledText,
+      latencyMs: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+      },
+    };
+  }
+
+  const response = await options.responder.respond(
+    options.question,
+    options.recalledText,
+  );
+
+  return {
+    finalAnswer: response.text,
+    recalledText: options.recalledText,
+    answeredText: response.text,
+    latencyMs: response.latencyMs,
+    tokens: response.tokens,
+    model: response.model,
+  };
+}

--- a/packages/bench/src/benchmark.ts
+++ b/packages/bench/src/benchmark.ts
@@ -6,6 +6,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { EngramAccessService } from "@remnic/core";
 import { getRegisteredBenchmark, listBenchmarks, getBenchmark } from "./registry.js";
+import { finalizeBenchmarkResultConfig } from "./result-config.js";
 import { buildBenchmarkRunSeeds } from "./run-seeds.js";
 import type {
   BenchConfig,
@@ -131,11 +132,13 @@ export async function runBenchmark(
     );
   }
 
-  return registeredBenchmark.run({
+  const result = await registeredBenchmark.run({
     ...options,
     mode: options.mode ?? "quick",
     benchmark: definition,
   });
+
+  return finalizeBenchmarkResultConfig(result, options);
 }
 
 function benchmarkDefinition(id: string): BenchmarkDefinition {

--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { runCustomBenchmarkFile } from "./runner.ts";
+
+test("custom benchmark latency includes reported judge latency outside the search timer", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-custom-bench-"));
+  const benchmarkPath = path.join(tempDir, "latency.yaml");
+
+  try {
+    await writeFile(
+      benchmarkPath,
+      [
+        "name: Custom Latency",
+        "scoring: llm_judge",
+        "tasks:",
+        "  - question: What happened?",
+        "    expected: It happened.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runCustomBenchmarkFile(benchmarkPath, {
+      mode: "quick",
+      system: {
+        async store() {},
+        async recall() {
+          return "";
+        },
+        async search(query) {
+          assert.equal(query, "What happened?");
+          return [
+            {
+              turnIndex: 0,
+              role: "assistant",
+              snippet: "It happened.",
+              sessionId: "session-1",
+            },
+          ];
+        },
+        async reset() {},
+        async getStats() {
+          return {
+            totalMessages: 0,
+            totalSummaryNodes: 0,
+            maxDepth: 0,
+          };
+        },
+        async destroy() {},
+        judge: {
+          async score() {
+            return 0.75;
+          },
+          async scoreWithMetrics(question, predicted, expected) {
+            assert.equal(question, "What happened?");
+            assert.equal(predicted, "It happened.");
+            assert.equal(expected, "It happened.");
+            return {
+              score: 0.75,
+              tokens: { input: 12, output: 4 },
+              latencyMs: 50,
+              model: "judge-model",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    assert.equal(result.results.tasks[0]?.scores.llm_judge, 0.75);
+    assert.equal(result.results.tasks[0]?.tokens.input, 12);
+    assert.equal(result.results.tasks[0]?.tokens.output, 4);
+    assert.equal(result.results.tasks[0]?.details?.judgeModel, "judge-model");
+    assert.ok(
+      (result.results.tasks[0]?.latencyMs ?? 0) >= 50,
+      `expected task latency to include the reported judge latency, received ${result.results.tasks[0]?.latencyMs}`,
+    );
+    assert.equal(
+      result.cost.totalLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+    assert.equal(
+      result.cost.meanQueryLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -189,6 +189,7 @@ test("custom benchmarks score responder output and include responder usage", asy
 
     const result = await runCustomBenchmarkFile(benchmarkPath, {
       mode: "quick",
+      runtimeProfile: "openclaw-chain",
       system: {
         async store() {},
         async recall() {
@@ -232,6 +233,7 @@ test("custom benchmarks score responder output and include responder usage", asy
     assert.equal(result.results.tasks.length, 1);
     assert.equal(result.results.tasks[0]?.actual, "The generated answer.");
     assert.equal(result.results.tasks[0]?.scores.exact_match, 1);
+    assert.equal(result.config.runtimeProfile, "openclaw-chain");
     assert.equal(result.results.tasks[0]?.tokens.input, 9);
     assert.equal(result.results.tasks[0]?.tokens.output, 3);
     assert.equal(result.results.tasks[0]?.details?.recalledText, "The recalled memory.");

--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -143,7 +143,7 @@ test("custom benchmark latency includes fallback judge wall time", async () => {
             assert.equal(question, "What happened?");
             assert.equal(predicted, "It happened.");
             assert.equal(expected, "It happened.");
-            await delay(20);
+            await delay(40);
             return 0.75;
           },
         },
@@ -153,7 +153,7 @@ test("custom benchmark latency includes fallback judge wall time", async () => {
     assert.equal(result.results.tasks.length, 1);
     assert.equal(result.results.tasks[0]?.scores.llm_judge, 0.75);
     assert.ok(
-      (result.results.tasks[0]?.latencyMs ?? 0) >= 20,
+      (result.results.tasks[0]?.latencyMs ?? 0) >= 10,
       `expected task latency to include fallback judge wall time, received ${result.results.tasks[0]?.latencyMs}`,
     );
     assert.equal(

--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -168,3 +168,88 @@ test("custom benchmark latency includes fallback judge wall time", async () => {
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("custom benchmarks score responder output and include responder usage", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-custom-bench-"));
+  const benchmarkPath = path.join(tempDir, "responder.yaml");
+
+  try {
+    await writeFile(
+      benchmarkPath,
+      [
+        "name: Custom Responder",
+        "scoring: exact_match",
+        "tasks:",
+        "  - question: What happened?",
+        "    expected: The generated answer.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runCustomBenchmarkFile(benchmarkPath, {
+      mode: "quick",
+      system: {
+        async store() {},
+        async recall() {
+          return "";
+        },
+        async search(query) {
+          assert.equal(query, "What happened?");
+          return [
+            {
+              turnIndex: 0,
+              role: "assistant",
+              snippet: "The recalled memory.",
+              sessionId: "session-1",
+            },
+          ];
+        },
+        async reset() {},
+        async getStats() {
+          return {
+            totalMessages: 0,
+            totalSummaryNodes: 0,
+            maxDepth: 0,
+          };
+        },
+        async destroy() {},
+        responder: {
+          async respond(question, recalledText) {
+            assert.equal(question, "What happened?");
+            assert.equal(recalledText, "The recalled memory.");
+            return {
+              text: "The generated answer.",
+              tokens: { input: 9, output: 3 },
+              latencyMs: 25,
+              model: "responder-model",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    assert.equal(result.results.tasks[0]?.actual, "The generated answer.");
+    assert.equal(result.results.tasks[0]?.scores.exact_match, 1);
+    assert.equal(result.results.tasks[0]?.tokens.input, 9);
+    assert.equal(result.results.tasks[0]?.tokens.output, 3);
+    assert.equal(result.results.tasks[0]?.details?.recalledText, "The recalled memory.");
+    assert.equal(result.results.tasks[0]?.details?.answeredText, "The generated answer.");
+    assert.equal(result.results.tasks[0]?.details?.responderModel, "responder-model");
+    assert.ok(
+      (result.results.tasks[0]?.latencyMs ?? 0) >= 25,
+      `expected task latency to include responder latency, received ${result.results.tasks[0]?.latencyMs}`,
+    );
+    assert.equal(
+      result.cost.totalLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+    assert.equal(
+      result.cost.meanQueryLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/custom/runner.test.ts
+++ b/packages/bench/src/benchmarks/custom/runner.test.ts
@@ -3,6 +3,7 @@ import { mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
+import { setTimeout as delay } from "node:timers/promises";
 
 import { runCustomBenchmarkFile } from "./runner.ts";
 
@@ -78,6 +79,82 @@ test("custom benchmark latency includes reported judge latency outside the searc
     assert.ok(
       (result.results.tasks[0]?.latencyMs ?? 0) >= 50,
       `expected task latency to include the reported judge latency, received ${result.results.tasks[0]?.latencyMs}`,
+    );
+    assert.equal(
+      result.cost.totalLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+    assert.equal(
+      result.cost.meanQueryLatencyMs,
+      result.results.tasks[0]?.latencyMs,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("custom benchmark latency includes fallback judge wall time", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-custom-bench-"));
+  const benchmarkPath = path.join(tempDir, "latency-fallback.yaml");
+
+  try {
+    await writeFile(
+      benchmarkPath,
+      [
+        "name: Custom Latency Fallback",
+        "scoring: llm_judge",
+        "tasks:",
+        "  - question: What happened?",
+        "    expected: It happened.",
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    const result = await runCustomBenchmarkFile(benchmarkPath, {
+      mode: "quick",
+      system: {
+        async store() {},
+        async recall() {
+          return "";
+        },
+        async search(query) {
+          assert.equal(query, "What happened?");
+          return [
+            {
+              turnIndex: 0,
+              role: "assistant",
+              snippet: "It happened.",
+              sessionId: "session-1",
+            },
+          ];
+        },
+        async reset() {},
+        async getStats() {
+          return {
+            totalMessages: 0,
+            totalSummaryNodes: 0,
+            maxDepth: 0,
+          };
+        },
+        async destroy() {},
+        judge: {
+          async score(question, predicted, expected) {
+            assert.equal(question, "What happened?");
+            assert.equal(predicted, "It happened.");
+            assert.equal(expected, "It happened.");
+            await delay(20);
+            return 0.75;
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    assert.equal(result.results.tasks[0]?.scores.llm_judge, 0.75);
+    assert.ok(
+      (result.results.tasks[0]?.latencyMs ?? 0) >= 20,
+      `expected task latency to include fallback judge wall time, received ${result.results.tasks[0]?.latencyMs}`,
     );
     assert.equal(
       result.cost.totalLatencyMs,

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -8,6 +8,7 @@ import type { RunBenchmarkOptions, BenchmarkDefinition, BenchmarkResult, Resolve
 import { answerBenchmarkQuestion } from "../../answering.js";
 import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScoreDetailed, rougeL, timed } from "../../scorer.js";
 import { orchestrateBenchmarkRuns } from "../../benchmark.js";
+import { finalizeBenchmarkResultConfig } from "../../result-config.js";
 import { getGitSha, getRemnicVersion } from "../../reporter.js";
 import { loadCustomBenchmarkFile } from "./loader.js";
 import type { CustomBenchmarkScoring, CustomBenchmarkSpec } from "./types.js";
@@ -47,7 +48,7 @@ async function runCustomBenchmark(
   const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
   const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
-  return {
+  return finalizeBenchmarkResultConfig({
     meta: {
       id: randomUUID(),
       benchmark: options.benchmark.id,
@@ -83,7 +84,7 @@ async function runCustomBenchmark(
       nodeVersion: process.version,
       hardware: process.arch,
     },
-  };
+  }, options);
 }
 
 async function runCustomBenchmarkRun(

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -5,7 +5,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { RunBenchmarkOptions, BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../types.js";
-import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScore, rougeL, timed } from "../../scorer.js";
+import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScoreDetailed, rougeL, timed } from "../../scorer.js";
 import { orchestrateBenchmarkRuns } from "../../benchmark.js";
 import { getGitSha, getRemnicVersion } from "../../reporter.js";
 import { loadCustomBenchmarkFile } from "./loader.js";
@@ -43,6 +43,8 @@ async function runCustomBenchmark(
   );
   const tasks = runs.flat();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -64,9 +66,9 @@ async function runCustomBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
@@ -101,7 +103,7 @@ async function runCustomBenchmarkRun(
     const { result, durationMs } = await timed(async () => {
       const searchResults = await options.system.search(task.question, 10);
       const actual = searchResults.map((entry) => entry.snippet).join("\n\n");
-      const score = await scoreTask(
+      const scored = await scoreTask(
         benchmark.scoring,
         options,
         task.question,
@@ -110,7 +112,8 @@ async function runCustomBenchmarkRun(
       );
       return {
         actual,
-        score,
+        score: scored.score,
+        judgeMetrics: scored.judgeMetrics,
         searchHits: searchResults.length,
       };
     });
@@ -122,13 +125,14 @@ async function runCustomBenchmarkRun(
       actual: result.actual,
       scores: { [benchmark.scoring]: result.score },
       latencyMs: durationMs,
-      tokens: { input: 0, output: 0 },
+      tokens: result.judgeMetrics.tokens,
       details: {
         tags: task.tags ?? [],
         searchHits: result.searchHits,
         scoring: benchmark.scoring,
         runIndex,
         seed,
+        judgeModel: result.judgeMetrics.model,
       },
     });
   }
@@ -142,16 +146,42 @@ async function scoreTask(
   question: string,
   actual: string,
   expected: string,
-): Promise<number> {
+): Promise<{
+  score: number;
+  judgeMetrics: {
+    score: number;
+    tokens: { input: number; output: number };
+    latencyMs: number;
+    model?: string;
+  };
+}> {
   switch (scoring) {
     case "exact_match":
-      return exactMatch(actual, expected);
+      return {
+        score: exactMatch(actual, expected),
+        judgeMetrics: { score: -1, tokens: { input: 0, output: 0 }, latencyMs: 0 },
+      };
     case "f1":
-      return f1Score(actual, expected);
+      return {
+        score: f1Score(actual, expected),
+        judgeMetrics: { score: -1, tokens: { input: 0, output: 0 }, latencyMs: 0 },
+      };
     case "rouge_l":
-      return rougeL(actual, expected);
+      return {
+        score: rougeL(actual, expected),
+        judgeMetrics: { score: -1, tokens: { input: 0, output: 0 }, latencyMs: 0 },
+      };
     case "llm_judge":
-      return llmJudgeScore(options.system.judge, question, actual, expected);
+      const judgeMetrics = await llmJudgeScoreDetailed(
+        options.system.judge,
+        question,
+        actual,
+        expected,
+      );
+      return {
+        score: judgeMetrics.score,
+        judgeMetrics,
+      };
     default:
       throw new Error(`Unsupported custom benchmark scoring: ${scoring as string}`);
   }

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -100,39 +100,33 @@ async function runCustomBenchmarkRun(
 
   const results: TaskResult[] = [];
   for (const [taskIndex, task] of tasks.entries()) {
-    const { result, durationMs } = await timed(async () => {
-      const searchResults = await options.system.search(task.question, 10);
-      const actual = searchResults.map((entry) => entry.snippet).join("\n\n");
-      const scored = await scoreTask(
-        benchmark.scoring,
-        options,
-        task.question,
-        actual,
-        task.expected,
-      );
-      return {
-        actual,
-        score: scored.score,
-        judgeMetrics: scored.judgeMetrics,
-        searchHits: searchResults.length,
-      };
-    });
+    const { result: searchResults, durationMs } = await timed(async () =>
+      options.system.search(task.question, 10),
+    );
+    const actual = searchResults.map((entry) => entry.snippet).join("\n\n");
+    const scored = await scoreTask(
+      benchmark.scoring,
+      options,
+      task.question,
+      actual,
+      task.expected,
+    );
 
     results.push({
       taskId: `${slugify(benchmark.name)}-${runIndex + 1}-${taskIndex + 1}`,
       question: task.question,
       expected: task.expected,
-      actual: result.actual,
-      scores: { [benchmark.scoring]: result.score },
-      latencyMs: durationMs,
-      tokens: result.judgeMetrics.tokens,
+      actual,
+      scores: { [benchmark.scoring]: scored.score },
+      latencyMs: durationMs + scored.judgeMetrics.latencyMs,
+      tokens: scored.judgeMetrics.tokens,
       details: {
         tags: task.tags ?? [],
-        searchHits: result.searchHits,
+        searchHits: searchResults.length,
         scoring: benchmark.scoring,
         runIndex,
         seed,
-        judgeModel: result.judgeMetrics.model,
+        judgeModel: scored.judgeMetrics.model,
       },
     });
   }

--- a/packages/bench/src/benchmarks/custom/runner.ts
+++ b/packages/bench/src/benchmarks/custom/runner.ts
@@ -5,6 +5,7 @@
 import { randomUUID } from "node:crypto";
 import path from "node:path";
 import type { RunBenchmarkOptions, BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../types.js";
+import { answerBenchmarkQuestion } from "../../answering.js";
 import { aggregateTaskScores, exactMatch, f1Score, llmJudgeScoreDetailed, rougeL, timed } from "../../scorer.js";
 import { orchestrateBenchmarkRuns } from "../../benchmark.js";
 import { getGitSha, getRemnicVersion } from "../../reporter.js";
@@ -103,12 +104,17 @@ async function runCustomBenchmarkRun(
     const { result: searchResults, durationMs } = await timed(async () =>
       options.system.search(task.question, 10),
     );
-    const actual = searchResults.map((entry) => entry.snippet).join("\n\n");
+    const recalledText = searchResults.map((entry) => entry.snippet).join("\n\n");
+    const answered = await answerBenchmarkQuestion({
+      question: task.question,
+      recalledText,
+      responder: options.system.responder,
+    });
     const scored = await scoreTask(
       benchmark.scoring,
       options,
       task.question,
-      actual,
+      answered.finalAnswer,
       task.expected,
     );
 
@@ -116,16 +122,24 @@ async function runCustomBenchmarkRun(
       taskId: `${slugify(benchmark.name)}-${runIndex + 1}-${taskIndex + 1}`,
       question: task.question,
       expected: task.expected,
-      actual,
+      actual: answered.finalAnswer,
       scores: { [benchmark.scoring]: scored.score },
-      latencyMs: durationMs + scored.judgeMetrics.latencyMs,
-      tokens: scored.judgeMetrics.tokens,
+      latencyMs: durationMs + answered.latencyMs + scored.judgeMetrics.latencyMs,
+      tokens: {
+        input: answered.tokens.input + scored.judgeMetrics.tokens.input,
+        output: answered.tokens.output + scored.judgeMetrics.tokens.output,
+      },
       details: {
         tags: task.tags ?? [],
         searchHits: searchResults.length,
         scoring: benchmark.scoring,
         runIndex,
         seed,
+        recalledLength: recalledText.length,
+        answeredLength: answered.finalAnswer.length,
+        recalledText,
+        answeredText: answered.finalAnswer,
+        responderModel: answered.model,
         judgeModel: scored.judgeMetrics.model,
       },
     });

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -20,7 +20,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -73,7 +73,7 @@ export async function runAmaBenchBenchmark(
         recalledText,
         responder: options.system.responder,
       });
-      const judgeScore = await llmJudgeScore(
+      const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,
         qa.question,
         answered.finalAnswer,
@@ -84,8 +84,8 @@ export async function runAmaBenchBenchmark(
         f1: f1Score(answered.finalAnswer, qa.answer),
         contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
       };
-      if (judgeScore >= 0) {
-        scores.llm_judge = judgeScore;
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
       }
 
       tasks.push({
@@ -94,8 +94,11 @@ export async function runAmaBenchBenchmark(
         expected: qa.answer,
         actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs + answered.latencyMs,
-        tokens: answered.tokens,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
         details: {
           qaType: qa.type,
           domain: episode.domain,
@@ -109,6 +112,7 @@ export async function runAmaBenchBenchmark(
           recalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
+          judgeModel: judgeResult.model,
         },
       });
     }

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -9,6 +9,7 @@ import {
   AMA_BENCH_SMOKE_FIXTURE,
   type AMABenchEpisode,
 } from "./fixture.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -67,16 +68,21 @@ export async function runAmaBenchBenchmark(
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, qa.question),
       );
+      const answered = await answerBenchmarkQuestion({
+        question: qa.question,
+        recalledText,
+        responder: options.system.responder,
+      });
       const judgeScore = await llmJudgeScore(
         options.system.judge,
         qa.question,
-        recalledText,
+        answered.finalAnswer,
         qa.answer,
       );
 
       const scores: Record<string, number> = {
-        f1: f1Score(recalledText, qa.answer),
-        contains_answer: containsAnswer(recalledText, qa.answer),
+        f1: f1Score(answered.finalAnswer, qa.answer),
+        contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
       };
       if (judgeScore >= 0) {
         scores.llm_judge = judgeScore;
@@ -86,10 +92,10 @@ export async function runAmaBenchBenchmark(
         taskId: qa.question_uuid,
         question: qa.question,
         expected: qa.answer,
-        actual: recalledText,
+        actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs,
-        tokens: { input: 0, output: 0 },
+        latencyMs: durationMs + answered.latencyMs,
+        tokens: answered.tokens,
         details: {
           qaType: qa.type,
           domain: episode.domain,
@@ -99,6 +105,10 @@ export async function runAmaBenchBenchmark(
           numTurns: episode.num_turns,
           totalTokens: episode.total_tokens,
           recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
         },
       });
     }
@@ -106,6 +116,8 @@ export async function runAmaBenchBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -127,9 +139,9 @@ export async function runAmaBenchBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import {
   AMEMGYM_SMOKE_FIXTURE,
   type AMemGymProfile,
@@ -102,15 +103,20 @@ export async function runAMemGymBenchmark(
       const { result: recallText, durationMs } = await timed(async () => {
         return options.system.recall(sessionId, qa.query);
       });
+      const answered = await answerBenchmarkQuestion({
+        question: qa.query,
+        recalledText: recallText,
+        responder: options.system.responder,
+      });
 
       const scores: Record<string, number> = {
-        f1: f1Score(recallText, expectedAnswer),
-        contains_answer: containsAnswer(recallText, expectedAnswer),
+        f1: f1Score(answered.finalAnswer, expectedAnswer),
+        contains_answer: containsAnswer(answered.finalAnswer, expectedAnswer),
       };
       const judgeScore = await llmJudgeScore(
         options.system.judge,
         qa.query,
-        recallText,
+        answered.finalAnswer,
         expectedAnswer,
       );
       if (judgeScore >= 0) {
@@ -121,10 +127,10 @@ export async function runAMemGymBenchmark(
         taskId: `${profile.id}-q${questionIndex}`,
         question: qa.query,
         expected: expectedAnswer,
-        actual: recallText,
+        actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs,
-        tokens: { input: 0, output: 0 },
+        latencyMs: durationMs + answered.latencyMs,
+        tokens: answered.tokens,
         details: {
           profileId: profile.id,
           profileName: profile.user_profile.name,
@@ -132,6 +138,10 @@ export async function runAMemGymBenchmark(
           periodCount: profile.periods.length,
           requiredInfo: qa.required_info,
           recalledLength: recallText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText: recallText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
         },
       });
     }

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -23,7 +23,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -113,14 +113,14 @@ export async function runAMemGymBenchmark(
         f1: f1Score(answered.finalAnswer, expectedAnswer),
         contains_answer: containsAnswer(answered.finalAnswer, expectedAnswer),
       };
-      const judgeScore = await llmJudgeScore(
+      const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,
         qa.query,
         answered.finalAnswer,
         expectedAnswer,
       );
-      if (judgeScore >= 0) {
-        scores.llm_judge = judgeScore;
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
       }
 
       tasks.push({
@@ -129,8 +129,11 @@ export async function runAMemGymBenchmark(
         expected: expectedAnswer,
         actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs + answered.latencyMs,
-        tokens: answered.tokens,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
         details: {
           profileId: profile.id,
           profileName: profile.user_profile.name,
@@ -142,6 +145,7 @@ export async function runAMemGymBenchmark(
           recalledText: recallText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
+          judgeModel: judgeResult.model,
         },
       });
     }

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -17,7 +17,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   rougeL,
   timed,
 } from "../../../scorer.js";
@@ -105,7 +105,7 @@ export async function runBeamBenchmark(
           responder: options.system.responder,
         });
         const searchResults = await options.system.search(probe.question, 10);
-        const judgeScore = await llmJudgeScore(
+        const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,
           probe.question,
           answered.finalAnswer,
@@ -124,8 +124,8 @@ export async function runBeamBenchmark(
             rubricTargets,
           );
         }
-        if (judgeScore >= 0) {
-          scores.llm_judge = judgeScore;
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
         }
 
         tasks.push({
@@ -134,8 +134,11 @@ export async function runBeamBenchmark(
           expected,
           actual: answered.finalAnswer,
           scores,
-          latencyMs: durationMs + answered.latencyMs,
-          tokens: answered.tokens,
+          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          tokens: {
+            input: answered.tokens.input + judgeResult.tokens.input,
+            output: answered.tokens.output + judgeResult.tokens.output,
+          },
           details: {
             ability,
             scale: entry.scale,
@@ -150,6 +153,7 @@ export async function runBeamBenchmark(
             recalledText,
             answeredText: answered.finalAnswer,
             responderModel: answered.model,
+            judgeModel: judgeResult.model,
           },
         });
         taskIndex += 1;

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { readFile, readdir } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -98,23 +99,28 @@ export async function runBeamBenchmark(
           );
           return recalledSessions.filter(Boolean).join("\n\n");
         });
+        const answered = await answerBenchmarkQuestion({
+          question: probe.question,
+          recalledText,
+          responder: options.system.responder,
+        });
         const searchResults = await options.system.search(probe.question, 10);
         const judgeScore = await llmJudgeScore(
           options.system.judge,
           probe.question,
-          recalledText,
+          answered.finalAnswer,
           expected,
         );
 
         const scores: Record<string, number> = {
-          f1: f1Score(recalledText, expected),
-          contains_answer: containsAnswer(recalledText, expected),
-          rouge_l: rougeL(recalledText, expected),
+          f1: f1Score(answered.finalAnswer, expected),
+          contains_answer: containsAnswer(answered.finalAnswer, expected),
+          rouge_l: rougeL(answered.finalAnswer, expected),
           search_hits: searchResults.length,
         };
         if (rubricTargets.length > 0) {
           scores.rubric_coverage = computeRubricCoverage(
-            recalledText,
+            answered.finalAnswer,
             rubricTargets,
           );
         }
@@ -126,10 +132,10 @@ export async function runBeamBenchmark(
           taskId: `${entry.scale}-${entry.conversation.conversation_id}-${ability}-${taskIndex}`,
           question: probe.question,
           expected,
-          actual: recalledText,
+          actual: answered.finalAnswer,
           scores,
-          latencyMs: durationMs,
-          tokens: { input: 0, output: 0 },
+          latencyMs: durationMs + answered.latencyMs,
+          tokens: answered.tokens,
           details: {
             ability,
             scale: entry.scale,
@@ -140,6 +146,10 @@ export async function runBeamBenchmark(
             sourceChatIds: probe.source_chat_ids,
             rubric: probe.rubric,
             recalledLength: recalledText.length,
+            answeredLength: answered.finalAnswer.length,
+            recalledText,
+            answeredText: answered.finalAnswer,
+            responderModel: answered.model,
           },
         });
         taskIndex += 1;
@@ -149,6 +159,8 @@ export async function runBeamBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -170,9 +182,9 @@ export async function runBeamBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -23,7 +23,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   rougeL,
   timed,
 } from "../../../scorer.js";
@@ -139,7 +139,7 @@ export async function runLoCoMoBenchmark(
         recalledText,
         responder: options.system.responder,
       });
-      const judgeScore = await llmJudgeScore(
+      const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,
         qa.question,
         answered.finalAnswer,
@@ -151,8 +151,8 @@ export async function runLoCoMoBenchmark(
         contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
         rouge_l: rougeL(answered.finalAnswer, qa.answer),
       };
-      if (judgeScore >= 0) {
-        scores.llm_judge = judgeScore;
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
       }
 
       tasks.push({
@@ -161,8 +161,11 @@ export async function runLoCoMoBenchmark(
         expected: qa.answer,
         actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs + answered.latencyMs,
-        tokens: answered.tokens,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
         details: {
           category: qa.category,
           categoryName,
@@ -174,6 +177,7 @@ export async function runLoCoMoBenchmark(
           recalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
+          judgeModel: judgeResult.model,
         },
       });
     }

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import {
   LOCOMO_SMOKE_FIXTURE,
   type LoCoMoConversation,
@@ -133,17 +134,22 @@ export async function runLoCoMoBenchmark(
         );
         return recalledSessions.filter(Boolean).join("\n\n");
       });
+      const answered = await answerBenchmarkQuestion({
+        question: qa.question,
+        recalledText,
+        responder: options.system.responder,
+      });
       const judgeScore = await llmJudgeScore(
         options.system.judge,
         qa.question,
-        recalledText,
+        answered.finalAnswer,
         qa.answer,
       );
 
       const scores: Record<string, number> = {
-        f1: f1Score(recalledText, qa.answer),
-        contains_answer: containsAnswer(recalledText, qa.answer),
-        rouge_l: rougeL(recalledText, qa.answer),
+        f1: f1Score(answered.finalAnswer, qa.answer),
+        contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
+        rouge_l: rougeL(answered.finalAnswer, qa.answer),
       };
       if (judgeScore >= 0) {
         scores.llm_judge = judgeScore;
@@ -153,10 +159,10 @@ export async function runLoCoMoBenchmark(
         taskId: `${conversation.sample_id}-q${questionIndex}-${categoryName}`,
         question: qa.question,
         expected: qa.answer,
-        actual: recalledText,
+        actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs,
-        tokens: { input: 0, output: 0 },
+        latencyMs: durationMs + answered.latencyMs,
+        tokens: answered.tokens,
         details: {
           category: qa.category,
           categoryName,
@@ -164,6 +170,10 @@ export async function runLoCoMoBenchmark(
           conversationId: conversation.sample_id,
           sessionIds,
           recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
         },
       });
     }
@@ -171,6 +181,8 @@ export async function runLoCoMoBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -192,9 +204,9 @@ export async function runLoCoMoBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -9,6 +9,7 @@ import {
   LONG_MEM_EVAL_SMOKE_FIXTURE,
   type LongMemEvalItem,
 } from "./fixture.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type { Message } from "../../../adapters/types.js";
 import type {
   BenchmarkDefinition,
@@ -80,18 +81,23 @@ export async function runLongMemEvalBenchmark(
       );
       return recalledSessions.filter(Boolean).join("\n\n");
     });
+    const answered = await answerBenchmarkQuestion({
+      question: item.question,
+      recalledText,
+      responder: options.system.responder,
+    });
 
     const searchResults = await options.system.search(item.question, 10);
     const judgeScore = await llmJudgeScore(
       options.system.judge,
       item.question,
-      recalledText,
+      answered.finalAnswer,
       item.answer,
     );
 
     const scores: Record<string, number> = {
-      f1: f1Score(recalledText, item.answer),
-      contains_answer: containsAnswer(recalledText, item.answer),
+      f1: f1Score(answered.finalAnswer, item.answer),
+      contains_answer: containsAnswer(answered.finalAnswer, item.answer),
       search_hits: searchResults.length,
     };
     if (judgeScore >= 0) {
@@ -102,16 +108,21 @@ export async function runLongMemEvalBenchmark(
       taskId: `q${item.question_id}`,
       question: item.question,
       expected: item.answer,
-      actual: recalledText,
+      actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs,
-      tokens: { input: 0, output: 0 },
+      latencyMs: durationMs + answered.latencyMs,
+      tokens: answered.tokens,
       details: {
         questionType: item.question_type,
         questionDate: item.question_date,
         haystackDates: item.haystack_dates,
         haystackSessionIds: item.haystack_session_ids,
         answerSessionIds: item.answer_session_ids,
+        recalledLength: recalledText.length,
+        answeredLength: answered.finalAnswer.length,
+        recalledText,
+        answeredText: answered.finalAnswer,
+        responderModel: answered.model,
       },
     });
   }

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -21,7 +21,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -88,7 +88,7 @@ export async function runLongMemEvalBenchmark(
     });
 
     const searchResults = await options.system.search(item.question, 10);
-    const judgeScore = await llmJudgeScore(
+    const judgeResult = await llmJudgeScoreDetailed(
       options.system.judge,
       item.question,
       answered.finalAnswer,
@@ -100,8 +100,8 @@ export async function runLongMemEvalBenchmark(
       contains_answer: containsAnswer(answered.finalAnswer, item.answer),
       search_hits: searchResults.length,
     };
-    if (judgeScore >= 0) {
-      scores.llm_judge = judgeScore;
+    if (judgeResult.score >= 0) {
+      scores.llm_judge = judgeResult.score;
     }
 
     tasks.push({
@@ -110,8 +110,11 @@ export async function runLongMemEvalBenchmark(
       expected: item.answer,
       actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs + answered.latencyMs,
-      tokens: answered.tokens,
+      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+      tokens: {
+        input: answered.tokens.input + judgeResult.tokens.input,
+        output: answered.tokens.output + judgeResult.tokens.output,
+      },
       details: {
         questionType: item.question_type,
         questionDate: item.question_date,
@@ -123,6 +126,7 @@ export async function runLongMemEvalBenchmark(
         recalledText,
         answeredText: answered.finalAnswer,
         responderModel: answered.model,
+        judgeModel: judgeResult.model,
       },
     });
   }

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -9,6 +9,7 @@ import {
   MEMBENCH_SMOKE_FIXTURE,
   type MemBenchCase,
 } from "./fixture.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type { Message } from "../../../adapters/types.js";
 import type {
   BenchmarkDefinition,
@@ -76,16 +77,21 @@ export async function runMemBenchBenchmark(
     const { result: recalledText, durationMs } = await timed(async () =>
       options.system.recall(sessionId, testCase.question),
     );
+    const answered = await answerBenchmarkQuestion({
+      question: testCase.question,
+      recalledText,
+      responder: options.system.responder,
+    });
     const judgeScore = await llmJudgeScore(
       options.system.judge,
       testCase.question,
-      recalledText,
+      answered.finalAnswer,
       testCase.answer,
     );
 
     const scores: Record<string, number> = {
-      f1: f1Score(recalledText, testCase.answer),
-      contains_answer: containsAnswer(recalledText, testCase.answer),
+      f1: f1Score(answered.finalAnswer, testCase.answer),
+      contains_answer: containsAnswer(answered.finalAnswer, testCase.answer),
     };
     if (judgeScore >= 0) {
       scores.llm_judge = judgeScore;
@@ -95,22 +101,28 @@ export async function runMemBenchBenchmark(
       taskId: testCase.id,
       question: testCase.question,
       expected: testCase.answer,
-      actual: recalledText,
+      actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs,
-      tokens: { input: 0, output: 0 },
+      latencyMs: durationMs + answered.latencyMs,
+      tokens: answered.tokens,
       details: {
         memoryType: testCase.memoryType,
         scenario: testCase.scenario,
         level: testCase.level,
         turnCount: testCase.turns.length,
         recalledLength: recalledText.length,
+        answeredLength: answered.finalAnswer.length,
+        recalledText,
+        answeredText: answered.finalAnswer,
+        responderModel: answered.model,
       },
     });
   }
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -132,9 +144,9 @@ export async function runMemBenchBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -21,7 +21,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -82,7 +82,7 @@ export async function runMemBenchBenchmark(
       recalledText,
       responder: options.system.responder,
     });
-    const judgeScore = await llmJudgeScore(
+    const judgeResult = await llmJudgeScoreDetailed(
       options.system.judge,
       testCase.question,
       answered.finalAnswer,
@@ -93,8 +93,8 @@ export async function runMemBenchBenchmark(
       f1: f1Score(answered.finalAnswer, testCase.answer),
       contains_answer: containsAnswer(answered.finalAnswer, testCase.answer),
     };
-    if (judgeScore >= 0) {
-      scores.llm_judge = judgeScore;
+    if (judgeResult.score >= 0) {
+      scores.llm_judge = judgeResult.score;
     }
 
     tasks.push({
@@ -103,8 +103,11 @@ export async function runMemBenchBenchmark(
       expected: testCase.answer,
       actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs + answered.latencyMs,
-      tokens: answered.tokens,
+      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+      tokens: {
+        input: answered.tokens.input + judgeResult.tokens.input,
+        output: answered.tokens.output + judgeResult.tokens.output,
+      },
       details: {
         memoryType: testCase.memoryType,
         scenario: testCase.scenario,
@@ -115,6 +118,7 @@ export async function runMemBenchBenchmark(
         recalledText,
         answeredText: answered.finalAnswer,
         responderModel: answered.model,
+        judgeModel: judgeResult.model,
       },
     });
   }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -23,7 +23,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -86,7 +86,7 @@ export async function runMemoryArenaBenchmark(
           recalledText,
           responder: options.system.responder,
         });
-        const judgeScore = await llmJudgeScore(
+        const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,
           question,
           answered.finalAnswer,
@@ -97,8 +97,8 @@ export async function runMemoryArenaBenchmark(
           f1: f1Score(answered.finalAnswer, expected),
           contains_answer: containsAnswer(answered.finalAnswer, expected),
         };
-        if (judgeScore >= 0) {
-          scores.llm_judge = judgeScore;
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
         }
 
         tasks.push({
@@ -107,8 +107,11 @@ export async function runMemoryArenaBenchmark(
           expected,
           actual: answered.finalAnswer,
           scores,
-          latencyMs: durationMs + answered.latencyMs,
-          tokens: answered.tokens,
+          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          tokens: {
+            input: answered.tokens.input + judgeResult.tokens.input,
+            output: answered.tokens.output + judgeResult.tokens.output,
+          },
           details: {
             domain,
             taskId: task.id,
@@ -119,6 +122,7 @@ export async function runMemoryArenaBenchmark(
             recalledText,
             answeredText: answered.finalAnswer,
             responderModel: answered.model,
+            judgeModel: judgeResult.model,
           },
         });
 

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -12,6 +12,7 @@ import {
   type ArenaTask,
   type DomainData,
 } from "./fixture.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -80,16 +81,21 @@ export async function runMemoryArenaBenchmark(
         const { result: recalledText, durationMs } = await timed(async () =>
           options.system.recall(sessionId, question),
         );
+        const answered = await answerBenchmarkQuestion({
+          question,
+          recalledText,
+          responder: options.system.responder,
+        });
         const judgeScore = await llmJudgeScore(
           options.system.judge,
           question,
-          recalledText,
+          answered.finalAnswer,
           expected,
         );
 
         const scores: Record<string, number> = {
-          f1: f1Score(recalledText, expected),
-          contains_answer: containsAnswer(recalledText, expected),
+          f1: f1Score(answered.finalAnswer, expected),
+          contains_answer: containsAnswer(answered.finalAnswer, expected),
         };
         if (judgeScore >= 0) {
           scores.llm_judge = judgeScore;
@@ -99,16 +105,20 @@ export async function runMemoryArenaBenchmark(
           taskId: `${domain}-t${task.id}-q${questionIndex}`,
           question,
           expected,
-          actual: recalledText,
+          actual: answered.finalAnswer,
           scores,
-          latencyMs: durationMs,
-          tokens: { input: 0, output: 0 },
+          latencyMs: durationMs + answered.latencyMs,
+          tokens: answered.tokens,
           details: {
             domain,
             taskId: task.id,
             subtaskIndex: questionIndex,
             category: task.category,
             recalledLength: recalledText.length,
+            answeredLength: answered.finalAnswer.length,
+            recalledText,
+            answeredText: answered.finalAnswer,
+            responderModel: answered.model,
           },
         });
 
@@ -124,6 +134,8 @@ export async function runMemoryArenaBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -145,9 +157,9 @@ export async function runMemoryArenaBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import {
   MEMORY_AGENT_BENCH_SMOKE_FIXTURE,
   type MemoryAgentBenchCompetency,
@@ -125,22 +126,27 @@ export async function runMemoryAgentBenchBenchmark(
         );
         return recalledSessions.filter(Boolean).join("\n\n");
       });
-      const bestExpectedAnswer = selectBestMatchingAnswer(recalledText, answerVariants);
+      const answered = await answerBenchmarkQuestion({
+        question,
+        recalledText,
+        responder: options.system.responder,
+      });
+      const bestExpectedAnswer = selectBestMatchingAnswer(answered.finalAnswer, answerVariants);
       const judgeScore = await llmJudgeScore(
         options.system.judge,
         question,
-        recalledText,
+        answered.finalAnswer,
         bestExpectedAnswer,
       );
 
       const scores: Record<string, number> = {
-        f1: scoreAgainstVariants(recalledText, answerVariants, f1Score),
+        f1: scoreAgainstVariants(answered.finalAnswer, answerVariants, f1Score),
         contains_answer: answerVariants.some((variant) =>
-          containsAnswer(recalledText, variant),
+          containsAnswer(answered.finalAnswer, variant),
         )
           ? 1
           : 0,
-        rouge_l: scoreAgainstVariants(recalledText, answerVariants, rougeL),
+        rouge_l: scoreAgainstVariants(answered.finalAnswer, answerVariants, rougeL),
       };
       if (judgeScore >= 0) {
         scores.llm_judge = judgeScore;
@@ -152,10 +158,10 @@ export async function runMemoryAgentBenchBenchmark(
           `${item.metadata.source}-q${questionIndex}`,
         question,
         expected: answerVariants[0]!,
-        actual: recalledText,
+        actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs,
-        tokens: { input: 0, output: 0 },
+        latencyMs: durationMs + answered.latencyMs,
+        tokens: answered.tokens,
         details: {
           competency: item.metadata.competency,
           source: item.metadata.source,
@@ -169,6 +175,10 @@ export async function runMemoryAgentBenchBenchmark(
           sessionIds,
           storedSessionCount: sessionIds.length,
           recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
         },
       });
     }
@@ -176,6 +186,8 @@ export async function runMemoryAgentBenchBenchmark(
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -197,9 +209,9 @@ export async function runMemoryAgentBenchBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -24,7 +24,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   rougeL,
   timed,
 } from "../../../scorer.js";
@@ -132,7 +132,7 @@ export async function runMemoryAgentBenchBenchmark(
         responder: options.system.responder,
       });
       const bestExpectedAnswer = selectBestMatchingAnswer(answered.finalAnswer, answerVariants);
-      const judgeScore = await llmJudgeScore(
+      const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,
         question,
         answered.finalAnswer,
@@ -148,8 +148,8 @@ export async function runMemoryAgentBenchBenchmark(
           : 0,
         rouge_l: scoreAgainstVariants(answered.finalAnswer, answerVariants, rougeL),
       };
-      if (judgeScore >= 0) {
-        scores.llm_judge = judgeScore;
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
       }
 
       tasks.push({
@@ -160,8 +160,11 @@ export async function runMemoryAgentBenchBenchmark(
         expected: answerVariants[0]!,
         actual: answered.finalAnswer,
         scores,
-        latencyMs: durationMs + answered.latencyMs,
-        tokens: answered.tokens,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
         details: {
           competency: item.metadata.competency,
           source: item.metadata.source,
@@ -179,6 +182,7 @@ export async function runMemoryAgentBenchBenchmark(
           recalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
+          judgeModel: judgeResult.model,
         },
       });
     }

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -6,6 +6,7 @@ import { randomUUID } from "node:crypto";
 import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../../answering.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -94,16 +95,21 @@ export async function runPersonaMemBenchmark(
       10,
       sessionId,
     );
+    const answered = await answerBenchmarkQuestion({
+      question: sample.userQuery,
+      recalledText,
+      responder: options.system.responder,
+    });
     const judgeScore = await llmJudgeScore(
       options.system.judge,
       sample.userQuery,
-      recalledText,
+      answered.finalAnswer,
       sample.correctAnswer,
     );
 
     const scores: Record<string, number> = {
-      f1: f1Score(recalledText, sample.correctAnswer),
-      contains_answer: containsAnswer(recalledText, sample.correctAnswer),
+      f1: f1Score(answered.finalAnswer, sample.correctAnswer),
+      contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
       search_hits: searchResults.length,
     };
     if (judgeScore >= 0) {
@@ -114,10 +120,10 @@ export async function runPersonaMemBenchmark(
       taskId: `${sample.personaId}-q${sampleIndex}`,
       question: sample.userQuery,
       expected: sample.correctAnswer,
-      actual: recalledText,
+      actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs,
-      tokens: { input: 0, output: 0 },
+      latencyMs: durationMs + answered.latencyMs,
+      tokens: answered.tokens,
       details: {
         personaId: sample.personaId,
         topicQuery: sample.topicQuery,
@@ -131,12 +137,19 @@ export async function runPersonaMemBenchmark(
         chatHistoryMessageCount: sample.chatHistory.chat_history.length,
         chatHistory32kLink: sample.chatHistory32kLink,
         chatHistory128kLink: sample.chatHistory128kLink,
+        recalledLength: recalledText.length,
+        answeredLength: answered.finalAnswer.length,
+        recalledText,
+        answeredText: answered.finalAnswer,
+        responderModel: answered.model,
       },
     });
   }
 
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
+  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
 
   return {
     meta: {
@@ -158,9 +171,9 @@ export async function runPersonaMemBenchmark(
       remnicConfig: options.remnicConfig ?? {},
     },
     cost: {
-      totalTokens: 0,
-      inputTokens: 0,
-      outputTokens: 0,
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
       estimatedCostUsd: 0,
       totalLatencyMs,
       meanQueryLatencyMs:

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -17,7 +17,7 @@ import {
   aggregateTaskScores,
   containsAnswer,
   f1Score,
-  llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
@@ -100,7 +100,7 @@ export async function runPersonaMemBenchmark(
       recalledText,
       responder: options.system.responder,
     });
-    const judgeScore = await llmJudgeScore(
+    const judgeResult = await llmJudgeScoreDetailed(
       options.system.judge,
       sample.userQuery,
       answered.finalAnswer,
@@ -112,8 +112,8 @@ export async function runPersonaMemBenchmark(
       contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
       search_hits: searchResults.length,
     };
-    if (judgeScore >= 0) {
-      scores.llm_judge = judgeScore;
+    if (judgeResult.score >= 0) {
+      scores.llm_judge = judgeResult.score;
     }
 
     tasks.push({
@@ -122,8 +122,11 @@ export async function runPersonaMemBenchmark(
       expected: sample.correctAnswer,
       actual: answered.finalAnswer,
       scores,
-      latencyMs: durationMs + answered.latencyMs,
-      tokens: answered.tokens,
+      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+      tokens: {
+        input: answered.tokens.input + judgeResult.tokens.input,
+        output: answered.tokens.output + judgeResult.tokens.output,
+      },
       details: {
         personaId: sample.personaId,
         topicQuery: sample.topicQuery,
@@ -142,6 +145,7 @@ export async function runPersonaMemBenchmark(
         recalledText,
         answeredText: answered.finalAnswer,
         responderModel: answered.model,
+        judgeModel: judgeResult.model,
       },
     });
   }

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -17,6 +17,7 @@ export type {
   BenchmarkTier,
   BenchmarkStatus,
   BenchmarkCategory,
+  BenchRuntimeProfile,
   BuiltInProvider,
   ProviderConfig,
   TaskTokenUsage,
@@ -45,6 +46,8 @@ export type {
   Message,
   SearchResult,
   MemoryStats,
+  BenchResponse,
+  BenchResponder,
   BenchJudge,
   BenchMemoryAdapter,
   LlmJudge,
@@ -77,6 +80,7 @@ export {
   createLightweightAdapter,
   createRemnicAdapter,
 } from "./adapters/remnic-adapter.js";
+export type { RemnicAdapterOptions } from "./adapters/remnic-adapter.js";
 export type {
   AnthropicProviderConfig,
   CompletionOpts,
@@ -97,9 +101,27 @@ export {
   createProvider,
   discoverAllProviders,
 } from "./providers/factory.js";
+export {
+  answerBenchmarkQuestion,
+} from "./answering.js";
+export {
+  createGatewayResponder,
+  createJudgeFromProvider,
+  createProviderBackedJudge,
+  createProviderBackedResponder,
+  createProviderBackedStructuredJudge,
+  createResponderFromProvider,
+  createStructuredJudgeFromProvider,
+} from "./responders.js";
 export { createLiteLlmProvider } from "./providers/litellm.js";
 export { createOllamaProvider } from "./providers/ollama.js";
 export { createOpenAiCompatibleProvider } from "./providers/openai-compatible.js";
+export type {
+  BenchModelSource,
+  ResolveBenchRuntimeProfileOptions,
+  ResolvedBenchRuntimeProfile,
+} from "./runtime-profiles.js";
+export { resolveBenchRuntimeProfile } from "./runtime-profiles.js";
 export {
   buildBenchmarkRunSeeds,
   orchestrateBenchmarkRuns,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -106,7 +106,6 @@ export {
 } from "./answering.js";
 export {
   createGatewayResponder,
-  createJudgeFromProvider,
   createProviderBackedJudge,
   createProviderBackedResponder,
   createProviderBackedStructuredJudge,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -48,6 +48,7 @@ export type {
   MemoryStats,
   BenchResponse,
   BenchResponder,
+  BenchJudgeResult,
   BenchJudge,
   BenchMemoryAdapter,
   LlmJudge,
@@ -144,6 +145,7 @@ export {
   precisionAtK,
   containsAnswer,
   llmJudgeScore,
+  llmJudgeScoreDetailed,
   timed,
   aggregateTaskScores,
 } from "./scorer.js";

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -109,6 +109,12 @@ test("provider-backed judge parses fraction and percent score formats", async ()
   );
   assert.equal(await fractionJudge.score("q", "predicted", "expected"), 0.8);
 
+  const extendedFractionJudge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Score: 7/20"),
+  );
+  assert.equal(await extendedFractionJudge.score("q", "predicted", "expected"), 0.35);
+
   const percentJudge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
     createFakeProvider("75%"),
@@ -126,6 +132,15 @@ test("provider-backed judge ignores date-like fractions and uses the trailing sc
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },
     createFakeProvider("Reviewed on 2026/04/19. Final score: 0.4"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
+});
+
+test("provider-backed judge does not treat month/day text as a slash score", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Reviewed on 4/20. Final score: 0.4"),
   );
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -59,6 +59,12 @@ test("responder wrappers adapt a provider instance into answer-generation and ju
   const judge = createProviderBackedJudge({ provider: "openai", model: "gpt-5.4-mini" }, judgeProvider);
   const score = await judge.score("q", "predicted", "expected");
   assert.equal(score, 0.82);
+  const judgeResult = await judge.scoreWithMetrics?.("q", "predicted", "expected");
+  assert.equal(judgeResult?.score, 0.82);
+  assert.equal(judgeResult?.tokens.input > 0, true);
+  assert.equal(judgeResult?.tokens.output > 0, true);
+  assert.equal(judgeResult?.latencyMs, 12);
+  assert.equal(judgeResult?.model, "test-model");
 
   const structuredProvider = createFakeProvider("{\"identity_accuracy\":0.9,\"stance_coherence\":0.8,\"novelty\":0.7,\"calibration\":0.6,\"notes\":\"ok\"}");
   const structuredJudge = createStructuredJudgeFromProvider(structuredProvider);
@@ -108,4 +114,13 @@ test("provider-backed judge parses fraction and percent score formats", async ()
     createFakeProvider("75%"),
   );
   assert.equal(await percentJudge.score("q", "predicted", "expected"), 0.75);
+});
+
+test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Reviewed on 2026/04/19. Final score: 0.4"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
 });

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -95,3 +95,17 @@ test("gateway responder requires gateway config", () => {
     /gateway responder requires gatewayConfig/i,
   );
 });
+
+test("provider-backed judge parses fraction and percent score formats", async () => {
+  const fractionJudge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("8/10"),
+  );
+  assert.equal(await fractionJudge.score("q", "predicted", "expected"), 0.8);
+
+  const percentJudge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("75%"),
+  );
+  assert.equal(await percentJudge.score("q", "predicted", "expected"), 0.75);
+});

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createGatewayResponder,
+  createProviderBackedJudge,
+  createProviderBackedResponder,
+  createResponderFromProvider,
+  createStructuredJudgeFromProvider,
+} from "./responders.ts";
+import type { LlmProvider } from "./providers/types.ts";
+
+function createFakeProvider(resultText: string): LlmProvider {
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  return {
+    id: "fake:test-model",
+    name: "test-model",
+    provider: "openai",
+    async complete(prompt) {
+      inputTokens += prompt.length;
+      outputTokens += resultText.length;
+      return {
+        text: resultText,
+        tokens: {
+          input: prompt.length,
+          output: resultText.length,
+        },
+        latencyMs: 12,
+        model: "test-model",
+      };
+    },
+    getUsage() {
+      return {
+        inputTokens,
+        outputTokens,
+        totalTokens: inputTokens + outputTokens,
+      };
+    },
+    resetUsage() {
+      inputTokens = 0;
+      outputTokens = 0;
+    },
+  };
+}
+
+test("responder wrappers adapt a provider instance into answer-generation and judge surfaces", async () => {
+  const responderProvider = createFakeProvider("final answer");
+  const responder = createResponderFromProvider(responderProvider);
+  const response = await responder.respond("What is the plan?", "Stored memory context");
+
+  assert.equal(response.text, "final answer");
+  assert.equal(response.tokens.input > 0, true);
+  assert.equal(response.tokens.output > 0, true);
+  assert.equal(response.latencyMs, 12);
+
+  const judgeProvider = createFakeProvider("0.82");
+  const judge = createProviderBackedJudge({ provider: "openai", model: "gpt-5.4-mini" }, judgeProvider);
+  const score = await judge.score("q", "predicted", "expected");
+  assert.equal(score, 0.82);
+
+  const structuredProvider = createFakeProvider("{\"identity_accuracy\":0.9,\"stance_coherence\":0.8,\"novelty\":0.7,\"calibration\":0.6,\"notes\":\"ok\"}");
+  const structuredJudge = createStructuredJudgeFromProvider(structuredProvider);
+  const raw = await structuredJudge.evaluate({
+    system: "judge-system",
+    user: "judge-user",
+    rubricId: "assistant-rubric-v1",
+    taskId: "task-1",
+  });
+  assert.match(raw, /identity_accuracy/);
+});
+
+test("provider-backed responder factories reject invalid configs and produce typed wrappers", () => {
+  assert.throws(
+    () => createProviderBackedResponder({ provider: "openai", model: "" } as never),
+    /provider-backed responder requires a non-empty model/i,
+  );
+
+  assert.throws(
+    () => createProviderBackedJudge({ provider: "openai", model: "" } as never),
+    /provider-backed judge requires a non-empty model/i,
+  );
+
+  const responder = createProviderBackedResponder({
+    provider: "openai",
+    model: "gpt-5.4-mini",
+  });
+  assert.equal(typeof responder.respond, "function");
+});
+
+test("gateway responder requires gateway config", () => {
+  assert.throws(
+    () => createGatewayResponder({}),
+    /gateway responder requires gatewayConfig/i,
+  );
+});

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -145,3 +145,12 @@ test("provider-backed judge does not treat month/day text as a slash score", asy
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
 });
+
+test("provider-backed judge rejects date-like slash triplets before trailing scores", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Reviewed on 4/5/2026. Final score: 0.4"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
+});

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -154,3 +154,21 @@ test("provider-backed judge rejects date-like slash triplets before trailing sco
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
 });
+
+test("provider-backed judge does not treat month/day pairs as slash scores", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Reviewed on 4/5. Final score: 0.4"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.4);
+});
+
+test("provider-backed judge ignores trailing large scalar metadata after a normalized score", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Score is 0.5. Reviewed 2026"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.5);
+});

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -172,3 +172,13 @@ test("provider-backed judge ignores trailing large scalar metadata after a norma
 
   assert.equal(await judge.score("q", "predicted", "expected"), 0.5);
 });
+
+test("provider-backed judge keeps out-of parsing stable across repeated calls", async () => {
+  const judge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Score: 8 out of 10"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.8);
+  assert.equal(await judge.score("q", "predicted", "expected"), 0.8);
+});

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -114,6 +114,12 @@ test("provider-backed judge parses fraction and percent score formats", async ()
     createFakeProvider("75%"),
   );
   assert.equal(await percentJudge.score("q", "predicted", "expected"), 0.75);
+
+  const outOfJudge = createProviderBackedJudge(
+    { provider: "openai", model: "gpt-5.4-mini" },
+    createFakeProvider("Score: 8 out of 10"),
+  );
+  assert.equal(await outOfJudge.score("q", "predicted", "expected"), 0.8);
 });
 
 test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -1,0 +1,197 @@
+import {
+  FallbackLlmClient,
+  type GatewayConfig,
+} from "@remnic/core";
+import type {
+  BenchJudge,
+  BenchResponder,
+  BenchResponse,
+} from "./adapters/types.js";
+import { createProvider } from "./providers/factory.js";
+import type {
+  LlmProvider,
+  ProviderFactoryConfig,
+} from "./providers/types.js";
+import type { StructuredJudge } from "./judges/sealed-rubric.js";
+
+const DEFAULT_RESPONDER_SYSTEM_PROMPT = [
+  "You answer benchmark questions using only the supplied Remnic memory context.",
+  "If the context does not contain enough information, say that the answer is unknown.",
+  "Do not invent facts that are not grounded in the provided context.",
+].join(" ");
+
+const DEFAULT_JUDGE_SYSTEM_PROMPT = [
+  "You are grading a benchmark answer against an expected answer.",
+  "Return only a numeric score from 0.00 to 1.00 inclusive.",
+  "Use 1.00 for a fully correct answer, 0.00 for a fully incorrect answer, and fractional values for partial matches.",
+].join(" ");
+
+export interface GatewayResponderOptions {
+  gatewayConfig?: GatewayConfig;
+  agentId?: string;
+}
+
+export function createResponderFromProvider(provider: LlmProvider): BenchResponder {
+  return {
+    async respond(question: string, recalledText: string): Promise<BenchResponse> {
+      const completion = await provider.complete(
+        [
+          `QUESTION: ${question}`,
+          "",
+          "REMNIC_MEMORY_CONTEXT:",
+          recalledText.trim().length > 0 ? recalledText : "(no memory context available)",
+          "",
+          "Answer the question using only the supplied memory context.",
+        ].join("\n"),
+        {
+          systemPrompt: DEFAULT_RESPONDER_SYSTEM_PROMPT,
+          temperature: 0,
+        },
+      );
+
+      return {
+        text: completion.text,
+        tokens: completion.tokens,
+        latencyMs: completion.latencyMs,
+        model: completion.model,
+      };
+    },
+  };
+}
+
+export function createProviderBackedResponder(
+  config: ProviderFactoryConfig,
+  providerInstance?: LlmProvider,
+): BenchResponder {
+  validateProviderConfig(config, "responder");
+  return createResponderFromProvider(providerInstance ?? createProvider(config));
+}
+
+export function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
+  return {
+    async score(question: string, predicted: string, expected: string): Promise<number> {
+      const completion = await provider.complete(
+        [
+          `QUESTION: ${question}`,
+          "",
+          `EXPECTED_ANSWER: ${expected}`,
+          "",
+          `PREDICTED_ANSWER: ${predicted}`,
+          "",
+          "Score the predicted answer against the expected answer.",
+        ].join("\n"),
+        {
+          systemPrompt: DEFAULT_JUDGE_SYSTEM_PROMPT,
+          temperature: 0,
+        },
+      );
+
+      return parseScalarJudgeScore(completion.text);
+    },
+  };
+}
+
+export function createProviderBackedJudge(
+  config: ProviderFactoryConfig,
+  providerInstance?: LlmProvider,
+): BenchJudge {
+  validateProviderConfig(config, "judge");
+  return createJudgeFromProvider(providerInstance ?? createProvider(config));
+}
+
+export function createStructuredJudgeFromProvider(
+  provider: LlmProvider,
+): StructuredJudge {
+  return {
+    async evaluate(request) {
+      const completion = await provider.complete(request.user, {
+        systemPrompt: request.system,
+        temperature: 0,
+      });
+      return completion.text;
+    },
+  };
+}
+
+export function createProviderBackedStructuredJudge(
+  config: ProviderFactoryConfig,
+  providerInstance?: LlmProvider,
+): StructuredJudge {
+  validateProviderConfig(config, "judge");
+  return createStructuredJudgeFromProvider(providerInstance ?? createProvider(config));
+}
+
+export function createGatewayResponder(
+  options: GatewayResponderOptions,
+): BenchResponder {
+  if (!options.gatewayConfig) {
+    throw new Error("gateway responder requires gatewayConfig");
+  }
+
+  const llm = new FallbackLlmClient(options.gatewayConfig);
+
+  return {
+    async respond(question: string, recalledText: string): Promise<BenchResponse> {
+      const startedAt = performance.now();
+      const response = await llm.chatCompletion(
+        [
+          { role: "system", content: DEFAULT_RESPONDER_SYSTEM_PROMPT },
+          {
+            role: "user",
+            content: [
+              `QUESTION: ${question}`,
+              "",
+              "REMNIC_MEMORY_CONTEXT:",
+              recalledText.trim().length > 0
+                ? recalledText
+                : "(no memory context available)",
+              "",
+              "Answer the question using only the supplied memory context.",
+            ].join("\n"),
+          },
+        ],
+        {
+          temperature: 0,
+          agentId: options.agentId,
+        },
+      );
+
+      if (!response?.content) {
+        throw new Error("gateway responder returned no content");
+      }
+
+      return {
+        text: response.content,
+        tokens: {
+          input: response.usage?.inputTokens ?? 0,
+          output: response.usage?.outputTokens ?? 0,
+        },
+        latencyMs: Math.round(performance.now() - startedAt),
+        model: response.modelUsed,
+      };
+    },
+  };
+}
+
+function validateProviderConfig(
+  config: ProviderFactoryConfig,
+  kind: "responder" | "judge",
+): void {
+  if (typeof config.model !== "string" || config.model.trim().length === 0) {
+    throw new Error(`provider-backed ${kind} requires a non-empty model`);
+  }
+}
+
+function parseScalarJudgeScore(raw: string): number {
+  const match = raw.match(/-?\d+(?:\.\d+)?/);
+  if (!match) {
+    return -1;
+  }
+
+  const value = Number.parseFloat(match[0]);
+  if (!Number.isFinite(value)) {
+    return -1;
+  }
+
+  return Math.max(0, Math.min(1, Number(value.toFixed(4))));
+}

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -183,15 +183,42 @@ function validateProviderConfig(
 }
 
 function parseScalarJudgeScore(raw: string): number {
-  const match = raw.match(/-?\d+(?:\.\d+)?/);
-  if (!match) {
+  const trimmed = raw.trim();
+
+  const fractionMatch = trimmed.match(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/);
+  if (fractionMatch) {
+    const numerator = Number.parseFloat(fractionMatch[1]);
+    const denominator = Number.parseFloat(fractionMatch[2]);
+    if (
+      Number.isFinite(numerator) &&
+      Number.isFinite(denominator) &&
+      denominator > 0
+    ) {
+      return clampNormalizedScore(numerator / denominator);
+    }
+  }
+
+  const percentMatch = trimmed.match(/(-?\d+(?:\.\d+)?)\s*%/);
+  if (percentMatch) {
+    const percent = Number.parseFloat(percentMatch[1]);
+    if (Number.isFinite(percent)) {
+      return clampNormalizedScore(percent / 100);
+    }
+  }
+
+  const scalarMatch = trimmed.match(/-?\d+(?:\.\d+)?/);
+  if (!scalarMatch) {
     return -1;
   }
 
-  const value = Number.parseFloat(match[0]);
+  const value = Number.parseFloat(scalarMatch[0]);
   if (!Number.isFinite(value)) {
     return -1;
   }
 
+  return clampNormalizedScore(value);
+}
+
+function clampNormalizedScore(value: number): number {
   return Math.max(0, Math.min(1, Number(value.toFixed(4))));
 }

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -28,6 +28,7 @@ const DEFAULT_JUDGE_SYSTEM_PROMPT = [
 ].join(" ");
 
 const SCORE_OUT_OF_REGEX = /(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi;
+const SCORE_CUE_REGEX = /\b(score|rated|rating|grade|graded|result|overall|final)\b/;
 
 export interface GatewayResponderOptions {
   gatewayConfig?: GatewayConfig;
@@ -231,17 +232,14 @@ function parseScalarJudgeScore(raw: string): number {
   }
 
   const scalarMatches = [...trimmed.matchAll(/-?\d+(?:\.\d+)?/g)];
-  const scalarMatch = scalarMatches.at(-1);
-  if (!scalarMatch) {
-    return -1;
+  for (const match of scalarMatches.reverse()) {
+    const value = Number.parseFloat(match[0]);
+    if (isPlausibleScalarScore(value)) {
+      return clampNormalizedScore(value);
+    }
   }
 
-  const value = Number.parseFloat(scalarMatch[0]);
-  if (!Number.isFinite(value)) {
-    return -1;
-  }
-
-  return clampNormalizedScore(value);
+  return -1;
 }
 
 function isPlausibleScoreFraction(
@@ -280,19 +278,36 @@ function isPlausibleSlashScoreFraction(
     if (/^\s*\/\s*\d/.test(afterContext)) {
       return false;
     }
+    return isStandaloneSlashScore(raw, start, end) || hasScoreCueBefore(raw, start);
+  }
+
+  const end = start + match[0].length;
+  if (isStandaloneSlashScore(raw, start, end)) {
     return true;
   }
 
-  const candidate = match[0].trim();
-  if (raw.trim() === candidate) {
-    return true;
-  }
+  return hasScoreCueBefore(raw, start);
+}
 
+function isStandaloneSlashScore(
+  raw: string,
+  start: number,
+  end: number,
+): boolean {
+  return raw.slice(0, start).trim().length === 0 &&
+    /^[\s.!?]*$/.test(raw.slice(end));
+}
+
+function hasScoreCueBefore(raw: string, start: number): boolean {
   const beforeContext = raw
     .slice(Math.max(0, start - 20), start)
     .toLowerCase();
 
-  return /\b(score|rated|rating|grade|graded|result|overall|final)\b/.test(beforeContext);
+  return SCORE_CUE_REGEX.test(beforeContext);
+}
+
+function isPlausibleScalarScore(value: number): boolean {
+  return Number.isFinite(value) && value >= 0 && value <= 1;
 }
 
 function clampNormalizedScore(value: number): number {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -208,7 +208,7 @@ function parseScalarJudgeScore(raw: string): number {
   for (const match of fractionMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);
-    if (isPlausibleScoreFraction(numerator, denominator)) {
+    if (isPlausibleSlashScoreFraction(trimmed, match, numerator, denominator)) {
       return clampNormalizedScore(numerator / denominator);
     }
   }
@@ -256,7 +256,38 @@ function isPlausibleScoreFraction(
     return false;
   }
 
-  return denominator <= 10 || denominator === 100;
+  return denominator <= 10 || denominator === 100 || denominator % 5 === 0;
+}
+
+function isPlausibleSlashScoreFraction(
+  raw: string,
+  match: RegExpMatchArray,
+  numerator: number,
+  denominator: number,
+): boolean {
+  if (!isPlausibleScoreFraction(numerator, denominator)) {
+    return false;
+  }
+
+  if (denominator <= 10 || denominator === 100) {
+    return true;
+  }
+
+  const start = match.index ?? -1;
+  if (start < 0) {
+    return false;
+  }
+
+  const candidate = match[0].trim();
+  if (raw.trim() === candidate) {
+    return true;
+  }
+
+  const beforeContext = raw
+    .slice(Math.max(0, start - 20), start)
+    .toLowerCase();
+
+  return /\b(score|rated|rating|grade|graded|result|overall|final)\b/.test(beforeContext);
 }
 
 function clampNormalizedScore(value: number): number {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -67,7 +67,7 @@ export function createProviderBackedResponder(
   return createResponderFromProvider(providerInstance ?? createProvider(config));
 }
 
-export function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
+function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
   return {
     async score(question: string, predicted: string, expected: string): Promise<number> {
       const completion = await provider.complete(

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -205,7 +205,7 @@ function parseScalarJudgeScore(raw: string): number {
   const fractionMatches = [
     ...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/g),
   ];
-  for (const match of [...fractionMatches].reverse()) {
+  for (const match of fractionMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);
     if (isPlausibleScoreFraction(numerator, denominator)) {
@@ -214,7 +214,7 @@ function parseScalarJudgeScore(raw: string): number {
   }
 
   const percentMatches = [...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*%/g)];
-  for (const match of [...percentMatches].reverse()) {
+  for (const match of percentMatches.reverse()) {
     const percent = Number.parseFloat(match[1]);
     if (Number.isFinite(percent)) {
       return clampNormalizedScore(percent / 100);
@@ -222,7 +222,7 @@ function parseScalarJudgeScore(raw: string): number {
   }
 
   const outOfMatches = [...trimmed.matchAll(SCORE_OUT_OF_REGEX)];
-  for (const match of [...outOfMatches].reverse()) {
+  for (const match of outOfMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);
     if (isPlausibleScoreFraction(numerator, denominator)) {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -27,7 +27,6 @@ const DEFAULT_JUDGE_SYSTEM_PROMPT = [
   "Use 1.00 for a fully correct answer, 0.00 for a fully incorrect answer, and fractional values for partial matches.",
 ].join(" ");
 
-const SCORE_OUT_OF_REGEX = /(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi;
 const SCORE_CUE_REGEX = /\b(score|rated|rating|grade|graded|result|overall|final)\b/;
 
 export interface GatewayResponderOptions {
@@ -222,7 +221,9 @@ function parseScalarJudgeScore(raw: string): number {
     }
   }
 
-  const outOfMatches = [...trimmed.matchAll(SCORE_OUT_OF_REGEX)];
+  const outOfMatches = [
+    ...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi),
+  ];
   for (const match of outOfMatches.reverse()) {
     const numerator = Number.parseFloat(match[1]);
     const denominator = Number.parseFloat(match[2]);

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -269,13 +269,18 @@ function isPlausibleSlashScoreFraction(
     return false;
   }
 
-  if (denominator <= 10 || denominator === 100) {
-    return true;
-  }
-
   const start = match.index ?? -1;
   if (start < 0) {
     return false;
+  }
+
+  if (denominator <= 10 || denominator === 100) {
+    const end = start + match[0].length;
+    const afterContext = raw.slice(end);
+    if (/^\s*\/\s*\d/.test(afterContext)) {
+      return false;
+    }
+    return true;
   }
 
   const candidate = match[0].trim();

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -4,6 +4,7 @@ import {
 } from "@remnic/core";
 import type {
   BenchJudge,
+  BenchJudgeResult,
   BenchResponder,
   BenchResponse,
 } from "./adapters/types.js";
@@ -68,26 +69,40 @@ export function createProviderBackedResponder(
 }
 
 function createJudgeFromProvider(provider: LlmProvider): BenchJudge {
+  async function scoreWithMetrics(
+    question: string,
+    predicted: string,
+    expected: string,
+  ): Promise<BenchJudgeResult> {
+    const completion = await provider.complete(
+      [
+        `QUESTION: ${question}`,
+        "",
+        `EXPECTED_ANSWER: ${expected}`,
+        "",
+        `PREDICTED_ANSWER: ${predicted}`,
+        "",
+        "Score the predicted answer against the expected answer.",
+      ].join("\n"),
+      {
+        systemPrompt: DEFAULT_JUDGE_SYSTEM_PROMPT,
+        temperature: 0,
+      },
+    );
+
+    return {
+      score: parseScalarJudgeScore(completion.text),
+      tokens: completion.tokens,
+      latencyMs: completion.latencyMs,
+      model: completion.model,
+    };
+  }
+
   return {
     async score(question: string, predicted: string, expected: string): Promise<number> {
-      const completion = await provider.complete(
-        [
-          `QUESTION: ${question}`,
-          "",
-          `EXPECTED_ANSWER: ${expected}`,
-          "",
-          `PREDICTED_ANSWER: ${predicted}`,
-          "",
-          "Score the predicted answer against the expected answer.",
-        ].join("\n"),
-        {
-          systemPrompt: DEFAULT_JUDGE_SYSTEM_PROMPT,
-          temperature: 0,
-        },
-      );
-
-      return parseScalarJudgeScore(completion.text);
+      return (await scoreWithMetrics(question, predicted, expected)).score;
     },
+    scoreWithMetrics,
   };
 }
 
@@ -185,28 +200,27 @@ function validateProviderConfig(
 function parseScalarJudgeScore(raw: string): number {
   const trimmed = raw.trim();
 
-  const fractionMatch = trimmed.match(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/);
-  if (fractionMatch) {
-    const numerator = Number.parseFloat(fractionMatch[1]);
-    const denominator = Number.parseFloat(fractionMatch[2]);
-    if (
-      Number.isFinite(numerator) &&
-      Number.isFinite(denominator) &&
-      denominator > 0
-    ) {
+  const fractionMatches = [
+    ...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*\/\s*(-?\d+(?:\.\d+)?)/g),
+  ];
+  for (const match of [...fractionMatches].reverse()) {
+    const numerator = Number.parseFloat(match[1]);
+    const denominator = Number.parseFloat(match[2]);
+    if (isPlausibleScoreFraction(numerator, denominator)) {
       return clampNormalizedScore(numerator / denominator);
     }
   }
 
-  const percentMatch = trimmed.match(/(-?\d+(?:\.\d+)?)\s*%/);
-  if (percentMatch) {
-    const percent = Number.parseFloat(percentMatch[1]);
+  const percentMatches = [...trimmed.matchAll(/(-?\d+(?:\.\d+)?)\s*%/g)];
+  for (const match of [...percentMatches].reverse()) {
+    const percent = Number.parseFloat(match[1]);
     if (Number.isFinite(percent)) {
       return clampNormalizedScore(percent / 100);
     }
   }
 
-  const scalarMatch = trimmed.match(/-?\d+(?:\.\d+)?/);
+  const scalarMatches = [...trimmed.matchAll(/-?\d+(?:\.\d+)?/g)];
+  const scalarMatch = scalarMatches.at(-1);
   if (!scalarMatch) {
     return -1;
   }
@@ -217,6 +231,21 @@ function parseScalarJudgeScore(raw: string): number {
   }
 
   return clampNormalizedScore(value);
+}
+
+function isPlausibleScoreFraction(
+  numerator: number,
+  denominator: number,
+): boolean {
+  if (!Number.isFinite(numerator) || !Number.isFinite(denominator)) {
+    return false;
+  }
+
+  if (denominator <= 0 || numerator < 0 || numerator > denominator) {
+    return false;
+  }
+
+  return denominator <= 10 || denominator === 100;
 }
 
 function clampNormalizedScore(value: number): number {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -27,6 +27,8 @@ const DEFAULT_JUDGE_SYSTEM_PROMPT = [
   "Use 1.00 for a fully correct answer, 0.00 for a fully incorrect answer, and fractional values for partial matches.",
 ].join(" ");
 
+const SCORE_OUT_OF_REGEX = /(-?\d+(?:\.\d+)?)\s+out\s+of\s+(-?\d+(?:\.\d+)?)/gi;
+
 export interface GatewayResponderOptions {
   gatewayConfig?: GatewayConfig;
   agentId?: string;
@@ -216,6 +218,15 @@ function parseScalarJudgeScore(raw: string): number {
     const percent = Number.parseFloat(match[1]);
     if (Number.isFinite(percent)) {
       return clampNormalizedScore(percent / 100);
+    }
+  }
+
+  const outOfMatches = [...trimmed.matchAll(SCORE_OUT_OF_REGEX)];
+  for (const match of [...outOfMatches].reverse()) {
+    const numerator = Number.parseFloat(match[1]);
+    const denominator = Number.parseFloat(match[2]);
+    if (isPlausibleScoreFraction(numerator, denominator)) {
+      return clampNormalizedScore(numerator / denominator);
     }
   }
 

--- a/packages/bench/src/result-config.test.ts
+++ b/packages/bench/src/result-config.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { finalizeBenchmarkResultConfig } from "./result-config.ts";
+import type { BenchmarkResult } from "./types.js";
+
+function buildResult(): BenchmarkResult {
+  return {
+    meta: {
+      id: "result-1",
+      benchmark: "assistant-morning-brief",
+      benchmarkTier: "remnic",
+      version: "1.0.0",
+      remnicVersion: "0.0.0-test",
+      gitSha: "deadbeef",
+      timestamp: "2026-04-19T20:00:00.000Z",
+      mode: "quick",
+      runCount: 1,
+      seeds: [1234],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "direct",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [],
+      aggregates: {},
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+    },
+  };
+}
+
+test("finalizeBenchmarkResultConfig applies runtime profile when missing", () => {
+  const result = buildResult();
+
+  const finalized = finalizeBenchmarkResultConfig(result, {
+    runtimeProfile: "openclaw-chain",
+  });
+
+  assert.equal(finalized.config.runtimeProfile, "openclaw-chain");
+});
+
+test("finalizeBenchmarkResultConfig preserves an explicit runtime profile", () => {
+  const result = buildResult();
+  result.config.runtimeProfile = "real";
+
+  const finalized = finalizeBenchmarkResultConfig(result, {
+    runtimeProfile: "baseline",
+  });
+
+  assert.equal(finalized.config.runtimeProfile, "real");
+});
+
+test("finalizeBenchmarkResultConfig normalizes omitted runtime profile to null", () => {
+  const result = buildResult();
+
+  const finalized = finalizeBenchmarkResultConfig(result, {});
+
+  assert.equal(finalized.config.runtimeProfile, null);
+});

--- a/packages/bench/src/result-config.ts
+++ b/packages/bench/src/result-config.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared benchmark result config finalization.
+ */
+
+import type { BenchmarkResult, RunBenchmarkOptions } from "./types.js";
+
+export function finalizeBenchmarkResultConfig(
+  result: BenchmarkResult,
+  options: Pick<RunBenchmarkOptions, "runtimeProfile">,
+): BenchmarkResult {
+  result.config.runtimeProfile ??= options.runtimeProfile ?? null;
+  return result;
+}

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -36,6 +36,9 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
       verifiedRecallEnabled: true,
       openaiApiKey: "super-secret",
       secretKey: "secondary-secret",
+      apikey: "compact-secret",
+      authtoken: "compact-token",
+      clientsecret: "compact-client-secret",
       sessionToken: "metadata-not-a-secret",
     },
   }),
@@ -53,9 +56,15 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
   assert.equal(resolved.remnicConfig.openaiApiKey, "[redacted]");
   assert.equal(resolved.remnicConfig.secretKey, "[redacted]");
+  assert.equal(resolved.remnicConfig.apikey, "[redacted]");
+  assert.equal(resolved.remnicConfig.authtoken, "[redacted]");
+  assert.equal(resolved.remnicConfig.clientsecret, "[redacted]");
   assert.equal(resolved.remnicConfig.sessionToken, "metadata-not-a-secret");
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
+  assert.equal(resolved.effectiveRemnicConfig.apikey, "compact-secret");
+  assert.equal(resolved.effectiveRemnicConfig.authtoken, "compact-token");
+  assert.equal(resolved.effectiveRemnicConfig.clientsecret, "compact-client-secret");
   assert.equal(resolved.effectiveRemnicConfig.sessionToken, "metadata-not-a-secret");
   assert.equal(
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -14,6 +14,7 @@ test("baseline runtime profile keeps the stripped retrieval-only config", async 
 
   assert.equal(resolved.profile, "baseline");
   assert.deepEqual(resolved.remnicConfig, buildBenchBaselineRemnicConfig());
+  assert.deepEqual(resolved.effectiveRemnicConfig, buildBenchBaselineRemnicConfig());
   assert.equal(resolved.remnicConfig.qmdEnabled, false);
   assert.equal(resolved.remnicConfig.queryExpansionEnabled, false);
   assert.equal(resolved.remnicConfig.rerankEnabled, false);
@@ -49,6 +50,7 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.rerankEnabled, true);
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
   assert.equal(resolved.remnicConfig.openaiApiKey, undefined);
+  assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
     "super-secret",
@@ -119,6 +121,12 @@ test("openclaw-chain runtime profile loads OpenClaw config and forces gateway ro
       models?: { providers?: { openai?: { apiKey?: string } } };
     }).models?.providers?.openai?.apiKey,
     undefined,
+  );
+  assert.equal(
+    (resolved.effectiveRemnicConfig.gatewayConfig as {
+      models?: { providers?: { openai?: { apiKey?: string } } };
+    }).models?.providers?.openai?.apiKey,
+    "test-key",
   );
 });
 

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -114,6 +114,47 @@ test("openclaw-chain runtime profile loads OpenClaw config and forces gateway ro
   );
 });
 
+test("openclaw-chain ignores direct system-provider overrides and keeps gateway routing", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-openclaw-override-"));
+  const configPath = path.join(root, "openclaw.json");
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4-mini",
+          },
+        },
+      },
+      plugins: {
+        slots: {
+          memory: "openclaw-remnic",
+        },
+        entries: {
+          "openclaw-remnic": {
+            config: {
+              qmdEnabled: true,
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "openclaw-chain",
+    openclawConfigPath: configPath,
+    systemProvider: "openai",
+    systemModel: "gpt-5.4",
+  });
+
+  assert.equal(resolved.profile, "openclaw-chain");
+  assert.equal(resolved.remnicConfig.modelSource, "gateway");
+  assert.equal(resolved.systemProvider, null);
+});
+
 test("provider-backed runtime resolution rejects incomplete provider configuration", async () => {
   await assert.rejects(
     () =>

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -31,6 +31,7 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
         queryExpansionEnabled: true,
         rerankEnabled: true,
         verifiedRecallEnabled: true,
+        openaiApiKey: "super-secret",
       },
     }),
   );
@@ -45,6 +46,11 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.queryExpansionEnabled, true);
   assert.equal(resolved.remnicConfig.rerankEnabled, true);
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
+  assert.equal(resolved.remnicConfig.openaiApiKey, undefined);
+  assert.equal(
+    (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
+    "super-secret",
+  );
   assert.equal(resolved.systemProvider, null);
   assert.equal(resolved.judgeProvider, null);
 });

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { mkdtemp, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { resolveBenchRuntimeProfile } from "./runtime-profiles.ts";
+
+test("baseline runtime profile keeps the stripped retrieval-only config", async () => {
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "baseline",
+  });
+
+  assert.equal(resolved.profile, "baseline");
+  assert.equal(resolved.remnicConfig.qmdEnabled, false);
+  assert.equal(resolved.remnicConfig.queryExpansionEnabled, false);
+  assert.equal(resolved.remnicConfig.rerankEnabled, false);
+  assert.equal(resolved.remnicConfig.verifiedRecallEnabled, false);
+  assert.equal(resolved.remnicConfig.knowledgeIndexEnabled, false);
+});
+
+test("real runtime profile preserves the configured Remnic retrieval settings", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-runtime-"));
+  const configPath = path.join(root, "remnic.config.json");
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      remnic: {
+        qmdEnabled: true,
+        queryExpansionEnabled: true,
+        rerankEnabled: true,
+        verifiedRecallEnabled: true,
+      },
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "real",
+    remnicConfigPath: configPath,
+  });
+
+  assert.equal(resolved.profile, "real");
+  assert.equal(resolved.remnicConfig.qmdEnabled, true);
+  assert.equal(resolved.remnicConfig.queryExpansionEnabled, true);
+  assert.equal(resolved.remnicConfig.rerankEnabled, true);
+  assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
+  assert.equal(resolved.systemProvider, null);
+  assert.equal(resolved.judgeProvider, null);
+});
+
+test("openclaw-chain runtime profile loads OpenClaw config and forces gateway routing", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-openclaw-"));
+  const configPath = path.join(root, "openclaw.json");
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4-mini",
+          },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            baseUrl: "https://api.openai.com/v1",
+            apiKey: "test-key",
+          },
+        },
+      },
+      plugins: {
+        slots: {
+          memory: "openclaw-remnic",
+        },
+        entries: {
+          "openclaw-remnic": {
+            config: {
+              qmdEnabled: true,
+              queryExpansionEnabled: true,
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "openclaw-chain",
+    openclawConfigPath: configPath,
+    gatewayAgentId: "memory-primary",
+    fastGatewayAgentId: "memory-fast",
+  });
+
+  assert.equal(resolved.profile, "openclaw-chain");
+  assert.equal(resolved.remnicConfig.qmdEnabled, true);
+  assert.equal(resolved.remnicConfig.queryExpansionEnabled, true);
+  assert.equal(resolved.remnicConfig.modelSource, "gateway");
+  assert.equal(resolved.remnicConfig.gatewayAgentId, "memory-primary");
+  assert.equal(resolved.remnicConfig.fastGatewayAgentId, "memory-fast");
+  assert.deepEqual(
+    (resolved.remnicConfig.gatewayConfig as { agents?: { defaults?: { model?: { primary?: string } } } }).agents?.defaults?.model,
+    {
+      primary: "openai/gpt-5.4-mini",
+    },
+  );
+});
+
+test("provider-backed runtime resolution rejects incomplete provider configuration", async () => {
+  await assert.rejects(
+    () =>
+      resolveBenchRuntimeProfile({
+        runtimeProfile: "real",
+        systemProvider: "openai",
+      }),
+    /system provider requires both provider and model/i,
+  );
+
+  await assert.rejects(
+    () =>
+      resolveBenchRuntimeProfile({
+        runtimeProfile: "real",
+        judgeModel: "gpt-5.4-mini",
+      }),
+    /judge provider requires both provider and model/i,
+  );
+});

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -33,11 +33,12 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
         qmdEnabled: true,
         queryExpansionEnabled: true,
         rerankEnabled: true,
-        verifiedRecallEnabled: true,
-        openaiApiKey: "super-secret",
-        secretKey: "secondary-secret",
-      },
-    }),
+      verifiedRecallEnabled: true,
+      openaiApiKey: "super-secret",
+      secretKey: "secondary-secret",
+      sessionToken: "metadata-not-a-secret",
+    },
+  }),
   );
 
   const resolved = await resolveBenchRuntimeProfile({
@@ -50,10 +51,12 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.queryExpansionEnabled, true);
   assert.equal(resolved.remnicConfig.rerankEnabled, true);
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
-  assert.equal(resolved.remnicConfig.openaiApiKey, undefined);
-  assert.equal(resolved.remnicConfig.secretKey, undefined);
+  assert.equal(resolved.remnicConfig.openaiApiKey, "[redacted]");
+  assert.equal(resolved.remnicConfig.secretKey, "[redacted]");
+  assert.equal(resolved.remnicConfig.sessionToken, "metadata-not-a-secret");
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
+  assert.equal(resolved.effectiveRemnicConfig.sessionToken, "metadata-not-a-secret");
   assert.equal(
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
     "super-secret",
@@ -124,7 +127,7 @@ test("openclaw-chain runtime profile loads OpenClaw config and forces gateway ro
     (resolved.remnicConfig.gatewayConfig as {
       models?: { providers?: { openai?: { apiKey?: string } } };
     }).models?.providers?.openai?.apiKey,
-    undefined,
+    "[redacted]",
   );
   assert.equal(
     (resolved.effectiveRemnicConfig.gatewayConfig as {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -36,6 +36,7 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
       verifiedRecallEnabled: true,
       openaiApiKey: "super-secret",
       secretKey: "secondary-secret",
+      refreshToken: "oauth-refresh-token",
       apikey: "compact-secret",
       authtoken: "compact-token",
       clientsecret: "compact-client-secret",
@@ -56,12 +57,14 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
   assert.equal(resolved.remnicConfig.openaiApiKey, "[redacted]");
   assert.equal(resolved.remnicConfig.secretKey, "[redacted]");
+  assert.equal(resolved.remnicConfig.refreshToken, "[redacted]");
   assert.equal(resolved.remnicConfig.apikey, "[redacted]");
   assert.equal(resolved.remnicConfig.authtoken, "[redacted]");
   assert.equal(resolved.remnicConfig.clientsecret, "[redacted]");
   assert.equal(resolved.remnicConfig.sessionToken, "metadata-not-a-secret");
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
+  assert.equal(resolved.effectiveRemnicConfig.refreshToken, "oauth-refresh-token");
   assert.equal(resolved.effectiveRemnicConfig.apikey, "compact-secret");
   assert.equal(resolved.effectiveRemnicConfig.authtoken, "compact-token");
   assert.equal(resolved.effectiveRemnicConfig.clientsecret, "compact-client-secret");
@@ -222,6 +225,46 @@ test("openclaw-chain does not instantiate a direct provider-backed responder", a
     openclawConfigPath: configPath,
     systemProvider: "unsupported-provider" as never,
     systemModel: "ignored-model",
+  });
+
+  assert.equal(resolved.profile, "openclaw-chain");
+  assert.equal(resolved.systemProvider, null);
+  assert.equal(resolved.remnicConfig.modelSource, "gateway");
+});
+
+test("openclaw-chain ignores incomplete direct system-provider config", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-openclaw-ignore-system-"));
+  const configPath = path.join(root, "openclaw.json");
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4-mini",
+          },
+        },
+      },
+      plugins: {
+        slots: {
+          memory: "openclaw-remnic",
+        },
+        entries: {
+          "openclaw-remnic": {
+            config: {
+              qmdEnabled: true,
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "openclaw-chain",
+    openclawConfigPath: configPath,
+    systemProvider: "openai",
   });
 
   assert.equal(resolved.profile, "openclaw-chain");

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -35,6 +35,7 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
         rerankEnabled: true,
         verifiedRecallEnabled: true,
         openaiApiKey: "super-secret",
+        secretKey: "secondary-secret",
       },
     }),
   );
@@ -50,7 +51,9 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.rerankEnabled, true);
   assert.equal(resolved.remnicConfig.verifiedRecallEnabled, true);
   assert.equal(resolved.remnicConfig.openaiApiKey, undefined);
+  assert.equal(resolved.remnicConfig.secretKey, undefined);
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
+  assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
   assert.equal(
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
     "super-secret",

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { buildBenchBaselineRemnicConfig } from "./adapters/remnic-adapter.ts";
 import { resolveBenchRuntimeProfile } from "./runtime-profiles.ts";
 
 test("baseline runtime profile keeps the stripped retrieval-only config", async () => {
@@ -12,6 +13,7 @@ test("baseline runtime profile keeps the stripped retrieval-only config", async 
   });
 
   assert.equal(resolved.profile, "baseline");
+  assert.deepEqual(resolved.remnicConfig, buildBenchBaselineRemnicConfig());
   assert.equal(resolved.remnicConfig.qmdEnabled, false);
   assert.equal(resolved.remnicConfig.queryExpansionEnabled, false);
   assert.equal(resolved.remnicConfig.rerankEnabled, false);

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -40,7 +40,8 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
       apikey: "compact-secret",
       authtoken: "compact-token",
       clientsecret: "compact-client-secret",
-      sessionToken: "metadata-not-a-secret",
+      oauthToken: "oauth-token",
+      sessionTokenCount: 3,
     },
   }),
   );
@@ -61,14 +62,16 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
   assert.equal(resolved.remnicConfig.apikey, "[redacted]");
   assert.equal(resolved.remnicConfig.authtoken, "[redacted]");
   assert.equal(resolved.remnicConfig.clientsecret, "[redacted]");
-  assert.equal(resolved.remnicConfig.sessionToken, "metadata-not-a-secret");
+  assert.equal(resolved.remnicConfig.oauthToken, "[redacted]");
+  assert.equal(resolved.remnicConfig.sessionTokenCount, 3);
   assert.equal(resolved.effectiveRemnicConfig.openaiApiKey, "super-secret");
   assert.equal(resolved.effectiveRemnicConfig.secretKey, "secondary-secret");
   assert.equal(resolved.effectiveRemnicConfig.refreshToken, "oauth-refresh-token");
   assert.equal(resolved.effectiveRemnicConfig.apikey, "compact-secret");
   assert.equal(resolved.effectiveRemnicConfig.authtoken, "compact-token");
   assert.equal(resolved.effectiveRemnicConfig.clientsecret, "compact-client-secret");
-  assert.equal(resolved.effectiveRemnicConfig.sessionToken, "metadata-not-a-secret");
+  assert.equal(resolved.effectiveRemnicConfig.oauthToken, "oauth-token");
+  assert.equal(resolved.effectiveRemnicConfig.sessionTokenCount, 3);
   assert.equal(
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
     "super-secret",

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -106,6 +106,12 @@ test("openclaw-chain runtime profile loads OpenClaw config and forces gateway ro
       primary: "openai/gpt-5.4-mini",
     },
   );
+  assert.equal(
+    (resolved.remnicConfig.gatewayConfig as {
+      models?: { providers?: { openai?: { apiKey?: string } } };
+    }).models?.providers?.openai?.apiKey,
+    undefined,
+  );
 });
 
 test("provider-backed runtime resolution rejects incomplete provider configuration", async () => {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -58,6 +58,7 @@ test("real runtime profile preserves the configured Remnic retrieval settings", 
     (resolved.adapterOptions.configOverrides as { openaiApiKey?: string }).openaiApiKey,
     "super-secret",
   );
+  assert.equal(resolved.adapterOptions.preserveRuntimeDefaults, true);
   assert.equal(resolved.systemProvider, null);
   assert.equal(resolved.judgeProvider, null);
 });
@@ -131,6 +132,7 @@ test("openclaw-chain runtime profile loads OpenClaw config and forces gateway ro
     }).models?.providers?.openai?.apiKey,
     "test-key",
   );
+  assert.equal(resolved.adapterOptions.preserveRuntimeDefaults, true);
 });
 
 test("openclaw-chain ignores direct system-provider overrides and keeps gateway routing", async () => {

--- a/packages/bench/src/runtime-profiles.test.ts
+++ b/packages/bench/src/runtime-profiles.test.ts
@@ -171,6 +171,47 @@ test("openclaw-chain ignores direct system-provider overrides and keeps gateway 
   assert.equal(resolved.systemProvider, null);
 });
 
+test("openclaw-chain does not instantiate a direct provider-backed responder", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-openclaw-lazy-"));
+  const configPath = path.join(root, "openclaw.json");
+
+  await writeFile(
+    configPath,
+    JSON.stringify({
+      agents: {
+        defaults: {
+          model: {
+            primary: "openai/gpt-5.4-mini",
+          },
+        },
+      },
+      plugins: {
+        slots: {
+          memory: "openclaw-remnic",
+        },
+        entries: {
+          "openclaw-remnic": {
+            config: {
+              qmdEnabled: true,
+            },
+          },
+        },
+      },
+    }),
+  );
+
+  const resolved = await resolveBenchRuntimeProfile({
+    runtimeProfile: "openclaw-chain",
+    openclawConfigPath: configPath,
+    systemProvider: "unsupported-provider" as never,
+    systemModel: "ignored-model",
+  });
+
+  assert.equal(resolved.profile, "openclaw-chain");
+  assert.equal(resolved.systemProvider, null);
+  assert.equal(resolved.remnicConfig.modelSource, "gateway");
+});
+
 test("provider-backed runtime resolution rejects incomplete provider configuration", async () => {
   await assert.rejects(
     () =>

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -132,16 +132,19 @@ export async function resolveBenchRuntimeProfile(
     : undefined;
 
   if (profile === "baseline") {
-    const remnicConfig = withAssistantHooks(
+    const persistedRemnicConfig = sanitizePersistedConfig({
+      ...BASELINE_REMNIC_CONFIG,
+    });
+    const effectiveRemnicConfig = withAssistantHooks(
       { ...BASELINE_REMNIC_CONFIG },
       responder,
       structuredJudge,
     );
     return {
       profile,
-      remnicConfig,
+      remnicConfig: persistedRemnicConfig,
       adapterOptions: {
-        configOverrides: remnicConfig,
+        configOverrides: effectiveRemnicConfig,
         responder,
         judge,
       },
@@ -154,7 +157,16 @@ export async function resolveBenchRuntimeProfile(
     const fileConfig = options.remnicConfigPath
       ? await loadRemnicConfigFile(options.remnicConfigPath)
       : {};
-    const remnicConfig = withAssistantHooks(
+    const persistedRemnicConfig = sanitizePersistedConfig({
+      ...fileConfig,
+      lcmEnabled: true,
+      ...(options.modelSource ? { modelSource: options.modelSource } : {}),
+      ...(options.gatewayAgentId ? { gatewayAgentId: options.gatewayAgentId } : {}),
+      ...(options.fastGatewayAgentId
+        ? { fastGatewayAgentId: options.fastGatewayAgentId }
+        : {}),
+    });
+    const effectiveRemnicConfig = withAssistantHooks(
       {
         ...fileConfig,
         lcmEnabled: true,
@@ -169,9 +181,9 @@ export async function resolveBenchRuntimeProfile(
     );
     return {
       profile,
-      remnicConfig,
+      remnicConfig: persistedRemnicConfig,
       adapterOptions: {
-        configOverrides: remnicConfig,
+        configOverrides: effectiveRemnicConfig,
         responder,
         judge,
       },
@@ -192,11 +204,21 @@ export async function resolveBenchRuntimeProfile(
     gatewayConfig,
     agentId: gatewayAgentId,
   });
-  const remnicConfig = withAssistantHooks(
+  const persistedRemnicConfig = sanitizePersistedConfig(
     {
       ...openclawRuntime.remnicConfig,
       lcmEnabled: true,
       gatewayConfig: openclawRuntime.persistedGatewayConfig,
+      modelSource: "gateway",
+      ...(gatewayAgentId ? { gatewayAgentId } : {}),
+      ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
+    },
+  );
+  const effectiveRemnicConfig = withAssistantHooks(
+    {
+      ...openclawRuntime.remnicConfig,
+      lcmEnabled: true,
+      gatewayConfig,
       modelSource: "gateway",
       ...(gatewayAgentId ? { gatewayAgentId } : {}),
       ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
@@ -207,9 +229,9 @@ export async function resolveBenchRuntimeProfile(
 
   return {
     profile,
-    remnicConfig,
+    remnicConfig: persistedRemnicConfig,
     adapterOptions: {
-      configOverrides: remnicConfig,
+      configOverrides: effectiveRemnicConfig,
       responder: gatewayResponder,
       judge,
     },
@@ -352,13 +374,18 @@ function asNonEmptyString(value: unknown): string | undefined {
 }
 
 function sanitizeGatewayConfig(config: GatewayConfig): GatewayConfig {
-  const sanitized = sanitizeGatewayValue(config);
+  const sanitized = sanitizePersistedConfig(config);
   return isPlainObject(sanitized) ? sanitized as GatewayConfig : {};
 }
 
-function sanitizeGatewayValue(value: unknown): unknown {
+function sanitizePersistedConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = sanitizePersistedValue(config);
+  return isPlainObject(sanitized) ? sanitized : {};
+}
+
+function sanitizePersistedValue(value: unknown): unknown {
   if (Array.isArray(value)) {
-    return value.map((entry) => sanitizeGatewayValue(entry));
+    return value.map((entry) => sanitizePersistedValue(entry));
   }
 
   if (!isPlainObject(value)) {
@@ -367,15 +394,15 @@ function sanitizeGatewayValue(value: unknown): unknown {
 
   const next: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
-    if (isGatewaySecretKey(key)) {
+    if (isSecretKey(key)) {
       continue;
     }
-    next[key] = sanitizeGatewayValue(entry);
+    next[key] = sanitizePersistedValue(entry);
   }
   return next;
 }
 
-function isGatewaySecretKey(key: string): boolean {
+function isSecretKey(key: string): boolean {
   const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
   return GATEWAY_SECRET_SUFFIXES.some((suffix) => normalized === suffix || normalized.endsWith(suffix));
 }

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -46,6 +46,7 @@ export interface ResolvedBenchRuntimeProfile {
   effectiveRemnicConfig: Record<string, unknown>;
   adapterOptions: {
     configOverrides: Record<string, unknown>;
+    preserveRuntimeDefaults?: boolean;
     responder?: BenchResponder;
     judge?: BenchJudge;
   };
@@ -157,6 +158,7 @@ export async function resolveBenchRuntimeProfile(
       effectiveRemnicConfig,
       adapterOptions: {
         configOverrides: effectiveRemnicConfig,
+        preserveRuntimeDefaults: true,
         responder,
         judge,
       },
@@ -206,6 +208,7 @@ export async function resolveBenchRuntimeProfile(
     effectiveRemnicConfig,
     adapterOptions: {
       configOverrides: effectiveRemnicConfig,
+      preserveRuntimeDefaults: true,
       responder: gatewayResponder,
       judge,
     },

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -54,17 +54,24 @@ export interface ResolvedBenchRuntimeProfile {
   judgeProvider: ProviderConfig | null;
 }
 
-const GATEWAY_SECRET_SUFFIXES = [
-  "apikey",
-  "authtoken",
-  "accesstoken",
-  "clientsecret",
-  "secretkey",
+const EXACT_SECRET_KEYS = new Set([
   "authorization",
   "password",
   "secret",
   "token",
-] as const;
+] as const);
+
+const SECRET_KEY_SEGMENT_SUFFIXES = new Set([
+  "apikey",
+  "authtoken",
+  "accesstoken",
+  "bearertoken",
+  "clientsecret",
+  "secretkey",
+  "privatekey",
+] as const);
+
+const REDACTED_CONFIG_VALUE = "[redacted]";
 
 export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
@@ -372,6 +379,7 @@ function sanitizePersistedValue(value: unknown): unknown {
   const next: Record<string, unknown> = {};
   for (const [key, entry] of Object.entries(value)) {
     if (isSecretKey(key)) {
+      next[key] = REDACTED_CONFIG_VALUE;
       continue;
     }
     next[key] = sanitizePersistedValue(entry);
@@ -380,8 +388,29 @@ function sanitizePersistedValue(value: unknown): unknown {
 }
 
 function isSecretKey(key: string): boolean {
-  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
-  return GATEWAY_SECRET_SUFFIXES.some((suffix) => normalized === suffix || normalized.endsWith(suffix));
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^a-z0-9]+/i)
+    .map((segment) => segment.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return false;
+  }
+
+  const normalized = segments.join("");
+  if (EXACT_SECRET_KEYS.has(normalized as (typeof EXACT_SECRET_KEYS extends Set<infer T> ? T : never))) {
+    return true;
+  }
+
+  for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
+    const candidate = segments.slice(-width).join("");
+    if (SECRET_KEY_SEGMENT_SUFFIXES.has(candidate as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never))) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -414,6 +414,14 @@ function isSecretKey(key: string): boolean {
     return true;
   }
 
+  const lastSegment = segments.at(-1);
+  if (
+    lastSegment &&
+    EXACT_SECRET_KEYS.has(lastSegment as (typeof EXACT_SECRET_KEYS extends Set<infer T> ? T : never))
+  ) {
+    return true;
+  }
+
   for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
     const candidate = segments.slice(-width).join("");
     if (SECRET_KEY_SEGMENT_SUFFIXES.has(candidate as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never))) {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -21,6 +21,7 @@ import {
   createProviderBackedStructuredJudge,
 } from "./responders.js";
 import type { ProviderFactoryConfig } from "./providers/types.js";
+import { createProvider } from "./providers/factory.js";
 import type { BenchRuntimeProfile, BuiltInProvider, ProviderConfig } from "./types.js";
 export type BenchModelSource = "plugin" | "gateway";
 
@@ -83,11 +84,17 @@ export async function resolveBenchRuntimeProfile(
   const responder = systemProvider
     ? createProviderBackedResponder(asProviderFactoryConfig(systemProvider))
     : undefined;
-  const judge = judgeProvider
-    ? createProviderBackedJudge(asProviderFactoryConfig(judgeProvider))
+  const judgeFactoryConfig = judgeProvider
+    ? asProviderFactoryConfig(judgeProvider)
     : undefined;
-  const structuredJudge = judgeProvider
-    ? createProviderBackedStructuredJudge(asProviderFactoryConfig(judgeProvider))
+  const judgeProviderInstance = judgeFactoryConfig
+    ? createProvider(judgeFactoryConfig)
+    : undefined;
+  const judge = judgeFactoryConfig
+    ? createProviderBackedJudge(judgeFactoryConfig, judgeProviderInstance)
+    : undefined;
+  const structuredJudge = judgeFactoryConfig
+    ? createProviderBackedStructuredJudge(judgeFactoryConfig, judgeProviderInstance)
     : undefined;
 
   if (profile === "baseline") {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -50,6 +50,17 @@ export interface ResolvedBenchRuntimeProfile {
   judgeProvider: ProviderConfig | null;
 }
 
+const GATEWAY_SECRET_SUFFIXES = [
+  "apikey",
+  "authtoken",
+  "accesstoken",
+  "clientsecret",
+  "authorization",
+  "password",
+  "secret",
+  "token",
+] as const;
+
 const BASELINE_REMNIC_CONFIG: Record<string, unknown> = {
   qmdEnabled: false,
   qmdColdTierEnabled: false,
@@ -186,7 +197,7 @@ export async function resolveBenchRuntimeProfile(
     {
       ...openclawRuntime.remnicConfig,
       lcmEnabled: true,
-      gatewayConfig,
+      gatewayConfig: openclawRuntime.persistedGatewayConfig,
       modelSource: "gateway",
       ...(gatewayAgentId ? { gatewayAgentId } : {}),
       ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
@@ -225,7 +236,11 @@ async function loadRemnicConfigFile(
 
 async function loadOpenclawRuntimeConfig(
   filePath: string | undefined,
-): Promise<{ remnicConfig: Record<string, unknown>; gatewayConfig: GatewayConfig }> {
+): Promise<{
+  remnicConfig: Record<string, unknown>;
+  gatewayConfig: GatewayConfig;
+  persistedGatewayConfig: GatewayConfig;
+}> {
   if (!filePath) {
     throw new Error("openclaw-chain runtime profile requires an OpenClaw config path");
   }
@@ -235,12 +250,15 @@ async function loadOpenclawRuntimeConfig(
   const remnicConfig =
     isPlainObject(entry?.config) ? { ...entry.config } : {};
 
+  const gatewayConfig: GatewayConfig = {
+    ...(isPlainObject(parsed.agents) ? { agents: parsed.agents as GatewayConfig["agents"] } : {}),
+    ...(isPlainObject(parsed.models) ? { models: parsed.models as GatewayConfig["models"] } : {}),
+  };
+
   return {
     remnicConfig,
-    gatewayConfig: {
-      ...(isPlainObject(parsed.agents) ? { agents: parsed.agents as GatewayConfig["agents"] } : {}),
-      ...(isPlainObject(parsed.models) ? { models: parsed.models as GatewayConfig["models"] } : {}),
-    },
+    gatewayConfig,
+    persistedGatewayConfig: sanitizeGatewayConfig(gatewayConfig),
   };
 }
 
@@ -332,6 +350,35 @@ function asNonEmptyString(value: unknown): string | undefined {
   return typeof value === "string" && value.trim().length > 0
     ? value.trim()
     : undefined;
+}
+
+function sanitizeGatewayConfig(config: GatewayConfig): GatewayConfig {
+  const sanitized = sanitizeGatewayValue(config);
+  return isPlainObject(sanitized) ? sanitized as GatewayConfig : {};
+}
+
+function sanitizeGatewayValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeGatewayValue(entry));
+  }
+
+  if (!isPlainObject(value)) {
+    return value;
+  }
+
+  const next: Record<string, unknown> = {};
+  for (const [key, entry] of Object.entries(value)) {
+    if (isGatewaySecretKey(key)) {
+      continue;
+    }
+    next[key] = sanitizeGatewayValue(entry);
+  }
+  return next;
+}
+
+function isGatewaySecretKey(key: string): boolean {
+  const normalized = key.replace(/[^a-z0-9]/gi, "").toLowerCase();
+  return GATEWAY_SECRET_SUFFIXES.some((suffix) => normalized === suffix || normalized.endsWith(suffix));
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -80,9 +80,8 @@ export async function resolveBenchRuntimeProfile(
     options.judgeModel,
     options.judgeBaseUrl,
   );
-
-  const responder = systemProvider
-    ? createProviderBackedResponder(asProviderFactoryConfig(systemProvider))
+  const responderFactoryConfig = systemProvider
+    ? asProviderFactoryConfig(systemProvider)
     : undefined;
   const judgeFactoryConfig = judgeProvider
     ? asProviderFactoryConfig(judgeProvider)
@@ -98,6 +97,9 @@ export async function resolveBenchRuntimeProfile(
     : undefined;
 
   if (profile === "baseline") {
+    const responder = responderFactoryConfig
+      ? createProviderBackedResponder(responderFactoryConfig)
+      : undefined;
     const baselineConfig = buildBenchBaselineRemnicConfig();
     const persistedRemnicConfig = sanitizePersistedConfig(baselineConfig);
     const effectiveRemnicConfig = withAssistantHooks(
@@ -120,6 +122,9 @@ export async function resolveBenchRuntimeProfile(
   }
 
   if (profile === "real") {
+    const responder = responderFactoryConfig
+      ? createProviderBackedResponder(responderFactoryConfig)
+      : undefined;
     const fileConfig = options.remnicConfigPath
       ? await loadRemnicConfigFile(options.remnicConfigPath)
       : {};

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -8,6 +8,7 @@ import type {
   BenchJudge,
   BenchResponder,
 } from "./adapters/types.js";
+import { buildBenchBaselineRemnicConfig } from "./adapters/remnic-adapter.ts";
 import {
   ASSISTANT_AGENT_CONFIG_KEY,
   ASSISTANT_JUDGE_CONFIG_KEY,
@@ -61,49 +62,6 @@ const GATEWAY_SECRET_SUFFIXES = [
   "token",
 ] as const;
 
-const BASELINE_REMNIC_CONFIG: Record<string, unknown> = {
-  qmdEnabled: false,
-  qmdColdTierEnabled: false,
-  transcriptEnabled: false,
-  hourlySummariesEnabled: false,
-  daySummaryEnabled: false,
-  identityEnabled: false,
-  identityContinuityEnabled: false,
-  namespacesEnabled: false,
-  sharedContextEnabled: false,
-  workTasksEnabled: false,
-  workProjectsEnabled: false,
-  commitmentLedgerEnabled: false,
-  resumeBundlesEnabled: false,
-  nativeKnowledge: { enabled: false },
-  lcmEnabled: true,
-  lcmLeafBatchSize: 4,
-  lcmRollupFanIn: 3,
-  lcmFreshTailTurns: 8,
-  lcmMaxDepth: 4,
-  lcmDeterministicMaxTokens: 512,
-  lcmRecallBudgetShare: 1.0,
-  extractionDedupeEnabled: true,
-  extractionMinChars: 10,
-  extractionMinUserTurns: 0,
-  recallPlannerEnabled: true,
-  queryExpansionEnabled: false,
-  rerankEnabled: false,
-  memoryBoxesEnabled: false,
-  traceWeaverEnabled: false,
-  threadingEnabled: false,
-  factDeduplicationEnabled: false,
-  knowledgeIndexEnabled: false,
-  entityRetrievalEnabled: false,
-  verifiedRecallEnabled: false,
-  queryAwareIndexingEnabled: false,
-  contradictionDetectionEnabled: false,
-  memoryLinkingEnabled: false,
-  topicExtractionEnabled: false,
-  chunkingEnabled: true,
-  episodeNoteModeEnabled: false,
-};
-
 export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
 ): Promise<ResolvedBenchRuntimeProfile> {
@@ -132,11 +90,10 @@ export async function resolveBenchRuntimeProfile(
     : undefined;
 
   if (profile === "baseline") {
-    const persistedRemnicConfig = sanitizePersistedConfig({
-      ...BASELINE_REMNIC_CONFIG,
-    });
+    const baselineConfig = buildBenchBaselineRemnicConfig();
+    const persistedRemnicConfig = sanitizePersistedConfig(baselineConfig);
     const effectiveRemnicConfig = withAssistantHooks(
-      { ...BASELINE_REMNIC_CONFIG },
+      { ...baselineConfig },
       responder,
       structuredJudge,
     );

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -1,0 +1,339 @@
+import { readFile } from "node:fs/promises";
+
+import {
+  resolveRemnicPluginEntry,
+  type GatewayConfig,
+} from "@remnic/core";
+import type {
+  BenchJudge,
+  BenchResponder,
+} from "./adapters/types.js";
+import {
+  ASSISTANT_AGENT_CONFIG_KEY,
+  ASSISTANT_JUDGE_CONFIG_KEY,
+} from "./benchmarks/remnic/_assistant-common/default-agent.js";
+import type { AssistantAgent } from "./benchmarks/remnic/_assistant-common/types.js";
+import {
+  createGatewayResponder,
+  createProviderBackedJudge,
+  createProviderBackedResponder,
+  createProviderBackedStructuredJudge,
+} from "./responders.js";
+import type { ProviderFactoryConfig } from "./providers/types.js";
+import type { BenchRuntimeProfile, BuiltInProvider, ProviderConfig } from "./types.js";
+export type BenchModelSource = "plugin" | "gateway";
+
+export interface ResolveBenchRuntimeProfileOptions {
+  runtimeProfile?: BenchRuntimeProfile;
+  remnicConfigPath?: string;
+  openclawConfigPath?: string;
+  modelSource?: BenchModelSource;
+  gatewayAgentId?: string;
+  fastGatewayAgentId?: string;
+  systemProvider?: BuiltInProvider;
+  systemModel?: string;
+  systemBaseUrl?: string;
+  judgeProvider?: BuiltInProvider;
+  judgeModel?: string;
+  judgeBaseUrl?: string;
+}
+
+export interface ResolvedBenchRuntimeProfile {
+  profile: BenchRuntimeProfile;
+  remnicConfig: Record<string, unknown>;
+  adapterOptions: {
+    configOverrides: Record<string, unknown>;
+    responder?: BenchResponder;
+    judge?: BenchJudge;
+  };
+  systemProvider: ProviderConfig | null;
+  judgeProvider: ProviderConfig | null;
+}
+
+const BASELINE_REMNIC_CONFIG: Record<string, unknown> = {
+  qmdEnabled: false,
+  qmdColdTierEnabled: false,
+  transcriptEnabled: false,
+  hourlySummariesEnabled: false,
+  daySummaryEnabled: false,
+  identityEnabled: false,
+  identityContinuityEnabled: false,
+  namespacesEnabled: false,
+  sharedContextEnabled: false,
+  workTasksEnabled: false,
+  workProjectsEnabled: false,
+  commitmentLedgerEnabled: false,
+  resumeBundlesEnabled: false,
+  nativeKnowledge: { enabled: false },
+  lcmEnabled: true,
+  lcmLeafBatchSize: 4,
+  lcmRollupFanIn: 3,
+  lcmFreshTailTurns: 8,
+  lcmMaxDepth: 4,
+  lcmDeterministicMaxTokens: 512,
+  lcmRecallBudgetShare: 1.0,
+  extractionDedupeEnabled: true,
+  extractionMinChars: 10,
+  extractionMinUserTurns: 0,
+  recallPlannerEnabled: true,
+  queryExpansionEnabled: false,
+  rerankEnabled: false,
+  memoryBoxesEnabled: false,
+  traceWeaverEnabled: false,
+  threadingEnabled: false,
+  factDeduplicationEnabled: false,
+  knowledgeIndexEnabled: false,
+  entityRetrievalEnabled: false,
+  verifiedRecallEnabled: false,
+  queryAwareIndexingEnabled: false,
+  contradictionDetectionEnabled: false,
+  memoryLinkingEnabled: false,
+  topicExtractionEnabled: false,
+  chunkingEnabled: true,
+  episodeNoteModeEnabled: false,
+};
+
+export async function resolveBenchRuntimeProfile(
+  options: ResolveBenchRuntimeProfileOptions,
+): Promise<ResolvedBenchRuntimeProfile> {
+  const profile = options.runtimeProfile ?? "baseline";
+  const systemProvider = resolveProviderConfig(
+    "system",
+    options.systemProvider,
+    options.systemModel,
+    options.systemBaseUrl,
+  );
+  const judgeProvider = resolveProviderConfig(
+    "judge",
+    options.judgeProvider,
+    options.judgeModel,
+    options.judgeBaseUrl,
+  );
+
+  const responder = systemProvider
+    ? createProviderBackedResponder(asProviderFactoryConfig(systemProvider))
+    : undefined;
+  const judge = judgeProvider
+    ? createProviderBackedJudge(asProviderFactoryConfig(judgeProvider))
+    : undefined;
+  const structuredJudge = judgeProvider
+    ? createProviderBackedStructuredJudge(asProviderFactoryConfig(judgeProvider))
+    : undefined;
+
+  if (profile === "baseline") {
+    const remnicConfig = withAssistantHooks(
+      { ...BASELINE_REMNIC_CONFIG },
+      responder,
+      structuredJudge,
+    );
+    return {
+      profile,
+      remnicConfig,
+      adapterOptions: {
+        configOverrides: remnicConfig,
+        responder,
+        judge,
+      },
+      systemProvider,
+      judgeProvider,
+    };
+  }
+
+  if (profile === "real") {
+    const fileConfig = options.remnicConfigPath
+      ? await loadRemnicConfigFile(options.remnicConfigPath)
+      : {};
+    const remnicConfig = withAssistantHooks(
+      {
+        ...fileConfig,
+        lcmEnabled: true,
+        ...(options.modelSource ? { modelSource: options.modelSource } : {}),
+        ...(options.gatewayAgentId ? { gatewayAgentId: options.gatewayAgentId } : {}),
+        ...(options.fastGatewayAgentId
+          ? { fastGatewayAgentId: options.fastGatewayAgentId }
+          : {}),
+      },
+      responder,
+      structuredJudge,
+    );
+    return {
+      profile,
+      remnicConfig,
+      adapterOptions: {
+        configOverrides: remnicConfig,
+        responder,
+        judge,
+      },
+      systemProvider,
+      judgeProvider,
+    };
+  }
+
+  const openclawRuntime = await loadOpenclawRuntimeConfig(options.openclawConfigPath);
+  const gatewayConfig = openclawRuntime.gatewayConfig;
+  const gatewayAgentId =
+    options.gatewayAgentId ??
+    asNonEmptyString(openclawRuntime.remnicConfig.gatewayAgentId);
+  const fastGatewayAgentId =
+    options.fastGatewayAgentId ??
+    asNonEmptyString(openclawRuntime.remnicConfig.fastGatewayAgentId);
+  const gatewayResponder = responder ??
+    createGatewayResponder({
+      gatewayConfig,
+      agentId: gatewayAgentId,
+    });
+  const remnicConfig = withAssistantHooks(
+    {
+      ...openclawRuntime.remnicConfig,
+      lcmEnabled: true,
+      gatewayConfig,
+      modelSource: "gateway",
+      ...(gatewayAgentId ? { gatewayAgentId } : {}),
+      ...(fastGatewayAgentId ? { fastGatewayAgentId } : {}),
+    },
+    gatewayResponder,
+    structuredJudge,
+  );
+
+  return {
+    profile,
+    remnicConfig,
+    adapterOptions: {
+      configOverrides: remnicConfig,
+      responder: gatewayResponder,
+      judge,
+    },
+    systemProvider,
+    judgeProvider,
+  };
+}
+
+async function loadRemnicConfigFile(
+  filePath: string,
+): Promise<Record<string, unknown>> {
+  const parsed = await loadJsonObject(filePath, "Remnic config");
+  const remnic = parsed.remnic;
+  if (isPlainObject(remnic)) {
+    return { ...remnic };
+  }
+  const engram = parsed.engram;
+  if (isPlainObject(engram)) {
+    return { ...engram };
+  }
+  return parsed;
+}
+
+async function loadOpenclawRuntimeConfig(
+  filePath: string | undefined,
+): Promise<{ remnicConfig: Record<string, unknown>; gatewayConfig: GatewayConfig }> {
+  if (!filePath) {
+    throw new Error("openclaw-chain runtime profile requires an OpenClaw config path");
+  }
+
+  const parsed = await loadJsonObject(filePath, "OpenClaw config");
+  const entry = resolveRemnicPluginEntry(parsed);
+  const remnicConfig =
+    isPlainObject(entry?.config) ? { ...entry.config } : {};
+
+  return {
+    remnicConfig,
+    gatewayConfig: {
+      ...(isPlainObject(parsed.agents) ? { agents: parsed.agents as GatewayConfig["agents"] } : {}),
+      ...(isPlainObject(parsed.models) ? { models: parsed.models as GatewayConfig["models"] } : {}),
+    },
+  };
+}
+
+async function loadJsonObject(
+  filePath: string,
+  label: string,
+): Promise<Record<string, unknown>> {
+  const raw = await readFile(filePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (error) {
+    throw new Error(
+      `${label} at ${filePath} contains invalid JSON: ${
+        error instanceof Error ? error.message : String(error)
+      }`,
+    );
+  }
+
+  if (!isPlainObject(parsed)) {
+    throw new Error(`${label} at ${filePath} must be a JSON object`);
+  }
+
+  return parsed;
+}
+
+function resolveProviderConfig(
+  kind: "system" | "judge",
+  provider: BuiltInProvider | undefined,
+  model: string | undefined,
+  baseUrl: string | undefined,
+): ProviderConfig | null {
+  const hasProvider = typeof provider === "string";
+  const hasModel = typeof model === "string" && model.trim().length > 0;
+  const hasBaseUrl = typeof baseUrl === "string" && baseUrl.trim().length > 0;
+
+  if (!hasProvider && !hasModel && !hasBaseUrl) {
+    return null;
+  }
+
+  if (!hasProvider || !hasModel) {
+    throw new Error(`${kind} provider requires both provider and model`);
+  }
+
+  return {
+    provider,
+    model: model.trim(),
+    ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
+  };
+}
+
+function withAssistantHooks(
+  config: Record<string, unknown>,
+  responder: BenchResponder | undefined,
+  structuredJudge: ReturnType<typeof createProviderBackedStructuredJudge> | undefined,
+): Record<string, unknown> {
+  const next = { ...config };
+
+  if (responder) {
+    next[ASSISTANT_AGENT_CONFIG_KEY] = createAssistantAgentFromResponder(responder);
+  }
+  if (structuredJudge) {
+    next[ASSISTANT_JUDGE_CONFIG_KEY] = structuredJudge;
+  }
+
+  return next;
+}
+
+function createAssistantAgentFromResponder(
+  responder: BenchResponder,
+): AssistantAgent {
+  return {
+    async respond(request) {
+      const response = await responder.respond(request.prompt, request.memoryView);
+      return response.text;
+    },
+  };
+}
+
+function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig {
+  return {
+    provider: config.provider,
+    model: config.model,
+    ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+  } as ProviderFactoryConfig;
+}
+
+function asNonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0
+    ? value.trim()
+    : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -58,6 +58,7 @@ const GATEWAY_SECRET_SUFFIXES = [
   "authtoken",
   "accesstoken",
   "clientsecret",
+  "secretkey",
   "authorization",
   "password",
   "secret",

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -8,7 +8,7 @@ import type {
   BenchJudge,
   BenchResponder,
 } from "./adapters/types.js";
-import { buildBenchBaselineRemnicConfig } from "./adapters/remnic-adapter.ts";
+import { buildBenchBaselineRemnicConfig } from "./adapters/remnic-adapter.js";
 import {
   ASSISTANT_AGENT_CONFIG_KEY,
   ASSISTANT_JUDGE_CONFIG_KEY,

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -403,6 +403,14 @@ function isSecretKey(key: string): boolean {
     return true;
   }
 
+  if (
+    SECRET_KEY_SEGMENT_SUFFIXES.has(
+      normalized as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never),
+    )
+  ) {
+    return true;
+  }
+
   for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
     const candidate = segments.slice(-width).join("");
     if (SECRET_KEY_SEGMENT_SUFFIXES.has(candidate as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never))) {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -42,6 +42,7 @@ export interface ResolveBenchRuntimeProfileOptions {
 export interface ResolvedBenchRuntimeProfile {
   profile: BenchRuntimeProfile;
   remnicConfig: Record<string, unknown>;
+  effectiveRemnicConfig: Record<string, unknown>;
   adapterOptions: {
     configOverrides: Record<string, unknown>;
     responder?: BenchResponder;
@@ -100,6 +101,7 @@ export async function resolveBenchRuntimeProfile(
     return {
       profile,
       remnicConfig: persistedRemnicConfig,
+      effectiveRemnicConfig,
       adapterOptions: {
         configOverrides: effectiveRemnicConfig,
         responder,
@@ -139,6 +141,7 @@ export async function resolveBenchRuntimeProfile(
     return {
       profile,
       remnicConfig: persistedRemnicConfig,
+      effectiveRemnicConfig,
       adapterOptions: {
         configOverrides: effectiveRemnicConfig,
         responder,
@@ -187,6 +190,7 @@ export async function resolveBenchRuntimeProfile(
   return {
     profile,
     remnicConfig: persistedRemnicConfig,
+    effectiveRemnicConfig,
     adapterOptions: {
       configOverrides: effectiveRemnicConfig,
       responder: gatewayResponder,

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -188,11 +188,10 @@ export async function resolveBenchRuntimeProfile(
   const fastGatewayAgentId =
     options.fastGatewayAgentId ??
     asNonEmptyString(openclawRuntime.remnicConfig.fastGatewayAgentId);
-  const gatewayResponder = responder ??
-    createGatewayResponder({
-      gatewayConfig,
-      agentId: gatewayAgentId,
-    });
+  const gatewayResponder = createGatewayResponder({
+    gatewayConfig,
+    agentId: gatewayAgentId,
+  });
   const remnicConfig = withAssistantHooks(
     {
       ...openclawRuntime.remnicConfig,
@@ -214,7 +213,7 @@ export async function resolveBenchRuntimeProfile(
       responder: gatewayResponder,
       judge,
     },
-    systemProvider,
+    systemProvider: null,
     judgeProvider,
   };
 }

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -65,6 +65,7 @@ const SECRET_KEY_SEGMENT_SUFFIXES = new Set([
   "apikey",
   "authtoken",
   "accesstoken",
+  "refreshtoken",
   "bearertoken",
   "clientsecret",
   "secretkey",
@@ -77,12 +78,14 @@ export async function resolveBenchRuntimeProfile(
   options: ResolveBenchRuntimeProfileOptions,
 ): Promise<ResolvedBenchRuntimeProfile> {
   const profile = options.runtimeProfile ?? "baseline";
-  const systemProvider = resolveProviderConfig(
-    "system",
-    options.systemProvider,
-    options.systemModel,
-    options.systemBaseUrl,
-  );
+  const systemProvider = profile === "openclaw-chain"
+    ? null
+    : resolveProviderConfig(
+      "system",
+      options.systemProvider,
+      options.systemModel,
+      options.systemBaseUrl,
+    );
   const judgeProvider = resolveProviderConfig(
     "judge",
     options.judgeProvider,

--- a/packages/bench/src/schema.ts
+++ b/packages/bench/src/schema.ts
@@ -58,6 +58,15 @@ export const BENCHMARK_RESULT_SCHEMA = {
         "remnicConfig",
       ],
       properties: {
+        runtimeProfile: {
+          anyOf: [
+            { type: "null" },
+            {
+              type: "string",
+              enum: ["baseline", "real", "openclaw-chain"],
+            },
+          ],
+        },
         systemProvider: {
           anyOf: [
             { type: "null" },

--- a/packages/bench/src/scorer.test.ts
+++ b/packages/bench/src/scorer.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { llmJudgeScoreDetailed } from "./scorer.ts";
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+test("llmJudgeScoreDetailed includes failed score wall time in latency metrics", async () => {
+  const result = await llmJudgeScoreDetailed(
+    {
+      async score() {
+        await delay(40);
+        throw new Error("judge timeout");
+      },
+    },
+    "question",
+    "predicted",
+    "expected",
+  );
+
+  assert.equal(result.score, -1);
+  assert.equal(result.tokens.input, 0);
+  assert.equal(result.tokens.output, 0);
+  assert.equal(result.latencyMs >= 10, true);
+});
+
+test("llmJudgeScoreDetailed includes failed scoreWithMetrics wall time in latency metrics", async () => {
+  const result = await llmJudgeScoreDetailed(
+    {
+      async score() {
+        throw new Error("unreachable fallback");
+      },
+      async scoreWithMetrics() {
+        await delay(40);
+        throw new Error("structured judge timeout");
+      },
+    },
+    "question",
+    "predicted",
+    "expected",
+  );
+
+  assert.equal(result.score, -1);
+  assert.equal(result.tokens.input, 0);
+  assert.equal(result.tokens.output, 0);
+  assert.equal(result.latencyMs >= 10, true);
+});

--- a/packages/bench/src/scorer.ts
+++ b/packages/bench/src/scorer.ts
@@ -141,6 +141,7 @@ export async function llmJudgeScoreDetailed(
     };
   }
 
+  const startedAt = performance.now();
   try {
     if (judge.scoreWithMetrics) {
       return await judge.scoreWithMetrics(question, predicted, expected);
@@ -159,7 +160,7 @@ export async function llmJudgeScoreDetailed(
     return {
       score: -1,
       tokens: { input: 0, output: 0 },
-      latencyMs: 0,
+      latencyMs: Math.round(performance.now() - startedAt),
     };
   }
 }

--- a/packages/bench/src/scorer.ts
+++ b/packages/bench/src/scorer.ts
@@ -3,6 +3,7 @@
  */
 
 import type { AggregateMetrics } from "./types.js";
+import type { BenchJudgeResult } from "./adapters/types.js";
 
 export function exactMatch(
   predicted: string,
@@ -101,18 +102,61 @@ export function containsAnswer(
 
 export async function llmJudgeScore(
   judge:
-    | { score(question: string, predicted: string, expected: string): Promise<number> }
+    | {
+      score(question: string, predicted: string, expected: string): Promise<number>;
+      scoreWithMetrics?(
+        question: string,
+        predicted: string,
+        expected: string,
+      ): Promise<BenchJudgeResult>;
+    }
     | undefined,
   question: string,
   predicted: string,
   expected: string,
 ): Promise<number> {
-  if (!judge) return -1;
+  return (await llmJudgeScoreDetailed(judge, question, predicted, expected)).score;
+}
+
+export async function llmJudgeScoreDetailed(
+  judge:
+    | {
+      score(question: string, predicted: string, expected: string): Promise<number>;
+      scoreWithMetrics?(
+        question: string,
+        predicted: string,
+        expected: string,
+      ): Promise<BenchJudgeResult>;
+    }
+    | undefined,
+  question: string,
+  predicted: string,
+  expected: string,
+): Promise<BenchJudgeResult> {
+  if (!judge) {
+    return {
+      score: -1,
+      tokens: { input: 0, output: 0 },
+      latencyMs: 0,
+    };
+  }
 
   try {
-    return await judge.score(question, predicted, expected);
+    if (judge.scoreWithMetrics) {
+      return await judge.scoreWithMetrics(question, predicted, expected);
+    }
+
+    return {
+      score: await judge.score(question, predicted, expected),
+      tokens: { input: 0, output: 0 },
+      latencyMs: 0,
+    };
   } catch {
-    return -1;
+    return {
+      score: -1,
+      tokens: { input: 0, output: 0 },
+      latencyMs: 0,
+    };
   }
 }
 

--- a/packages/bench/src/scorer.ts
+++ b/packages/bench/src/scorer.ts
@@ -146,10 +146,14 @@ export async function llmJudgeScoreDetailed(
       return await judge.scoreWithMetrics(question, predicted, expected);
     }
 
+    const { result: score, durationMs } = await timed(() =>
+      judge.score(question, predicted, expected),
+    );
+
     return {
-      score: await judge.score(question, predicted, expected),
+      score,
       tokens: { input: 0, output: 0 },
-      latencyMs: 0,
+      latencyMs: durationMs,
     };
   } catch {
     return {

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -11,6 +11,7 @@ export type BenchmarkMode = "full" | "quick";
 export type BenchmarkTier = "published" | "remnic" | "custom";
 export type BenchmarkStatus = "ready" | "planned";
 export type BenchmarkCategory = "agentic" | "retrieval" | "conversational" | "ingestion";
+export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
 export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm";
 
 export interface ProviderConfig {
@@ -124,6 +125,7 @@ export interface BenchmarkResult {
     canaryScore?: number;
   };
   config: {
+    runtimeProfile?: BenchRuntimeProfile | null;
     systemProvider: ProviderConfig | null;
     judgeProvider: ProviderConfig | null;
     adapterMode: string;
@@ -181,6 +183,7 @@ export interface RunBenchmarkOptions {
   limit?: number;
   seed?: number;
   adapterMode?: string;
+  runtimeProfile?: BenchRuntimeProfile | null;
   system: import("./adapters/types.js").BenchMemoryAdapter;
   ingestionAdapter?: import("./ingestion-types.js").IngestionBenchAdapter;
   systemProvider?: ProviderConfig | null;

--- a/packages/export-weclone/src/privacy.ts
+++ b/packages/export-weclone/src/privacy.ts
@@ -74,7 +74,7 @@ export function sweepPii(records: TrainingExportRecord[]): PrivacySweepResult {
   const recordHasRedaction = new Set<number>();
 
   const cleanRecords = records.map((record, idx) => {
-    const cleaned: Record<string, unknown> = { ...record };
+    const cleaned: TrainingExportRecord = { ...record };
 
     for (const field of SCANNED_FIELDS) {
       let value = record[field];
@@ -98,7 +98,7 @@ export function sweepPii(records: TrainingExportRecord[]): PrivacySweepResult {
       cleaned[field] = value;
     }
 
-    return cleaned as TrainingExportRecord;
+    return cleaned;
   });
 
   return {

--- a/packages/plugin-openclaw/README.md
+++ b/packages/plugin-openclaw/README.md
@@ -38,6 +38,42 @@ Then restart the gateway:
 launchctl kickstart -k gui/501/ai.openclaw.gateway
 ```
 
+## Benchmarking The OpenClaw Chain
+
+The benchmark CLI can now exercise the real OpenClaw-backed answer path instead
+of only the stripped retrieval harness. Use the `openclaw-chain` runtime
+profile to load the Remnic plugin config from `openclaw.json`, route answer
+generation through the configured gateway chain, and optionally attach a
+provider-backed judge:
+
+```bash
+remnic bench run longmemeval \
+  --runtime-profile openclaw-chain \
+  --openclaw-config ~/.openclaw/openclaw.json \
+  --gateway-agent-id memory-primary
+
+remnic bench run longmemeval \
+  --runtime-profile openclaw-chain \
+  --openclaw-config ~/.openclaw/openclaw.json \
+  --gateway-agent-id memory-primary \
+  --judge-provider openai \
+  --judge-model gpt-5.4-mini
+```
+
+To compare the stripped harness, direct Remnic runtime, and OpenClaw chain in a
+single pass, run a profile matrix:
+
+```bash
+remnic bench run longmemeval \
+  --matrix baseline,real,openclaw-chain \
+  --openclaw-config ~/.openclaw/openclaw.json \
+  --remnic-config ~/.config/remnic/config.json
+```
+
+Each stored result records its `runtimeProfile`, provider metadata, and the
+resolved Remnic config so benchmark comparisons can distinguish retrieval-only
+runs from real runtime and OpenClaw chain runs.
+
 ## What it does
 
 This plugin hooks into the OpenClaw gateway lifecycle:

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -53,8 +53,12 @@ kept as a compatibility alias.
 
 ```bash
 remnic bench list
-remnic bench run --quick longmemeval
+remnic bench run --quick longmemeval --runtime-profile baseline
 remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
+remnic bench run longmemeval --runtime-profile real --remnic-config ~/.config/remnic/config.json
+remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model gpt-5.4-mini
+remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config ~/.openclaw/openclaw.json --gateway-agent-id memory-primary
+remnic bench run longmemeval --matrix baseline,real,openclaw-chain
 remnic bench compare base-run candidate-run
 remnic bench baseline save main candidate-run
 remnic bench baseline list

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { parseBenchArgs } from "./bench-args.js";
+
+test("parseBenchArgs keeps validated matrix profiles typed and ordered", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "assistant-morning-brief",
+    "--matrix",
+    "baseline,real,openclaw-chain",
+  ]);
+
+  assert.deepEqual(parsed.matrixProfiles, [
+    "baseline",
+    "real",
+    "openclaw-chain",
+  ]);
+});

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -1,4 +1,5 @@
 import path from "node:path";
+import type { BuiltInProvider } from "@remnic/bench";
 import { expandTilde } from "./path-utils.js";
 
 export type BenchAction =
@@ -19,6 +20,8 @@ export type BenchBaselineAction = "save" | "list";
 export type BenchExportFormat = "json" | "csv" | "html";
 export type BenchProviderAction = "discover";
 export type BenchPublishTarget = "remnic-ai";
+export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
+export type BenchModelSource = "plugin" | "gateway";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -30,6 +33,19 @@ export interface ParsedBenchArgs {
   datasetDir?: string;
   resultsDir?: string;
   baselinesDir?: string;
+  runtimeProfile?: BenchRuntimeProfile;
+  matrixProfiles?: BenchRuntimeProfile[];
+  remnicConfigPath?: string;
+  openclawConfigPath?: string;
+  modelSource?: BenchModelSource;
+  gatewayAgentId?: string;
+  fastGatewayAgentId?: string;
+  systemProvider?: BuiltInProvider;
+  systemModel?: string;
+  systemBaseUrl?: string;
+  judgeProvider?: BuiltInProvider;
+  judgeModel?: string;
+  judgeBaseUrl?: string;
   threshold?: number;
   baselineAction?: BenchBaselineAction;
   providerAction?: BenchProviderAction;
@@ -61,6 +77,19 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--dataset-dir" ||
       arg === "--results-dir" ||
       arg === "--baselines-dir" ||
+      arg === "--runtime-profile" ||
+      arg === "--matrix" ||
+      arg === "--remnic-config" ||
+      arg === "--openclaw-config" ||
+      arg === "--model-source" ||
+      arg === "--gateway-agent-id" ||
+      arg === "--fast-gateway-agent-id" ||
+      arg === "--system-provider" ||
+      arg === "--system-model" ||
+      arg === "--system-base-url" ||
+      arg === "--judge-provider" ||
+      arg === "--judge-model" ||
+      arg === "--judge-base-url" ||
       arg === "--threshold" ||
       arg === "--custom" ||
       arg === "--format" ||
@@ -131,11 +160,101 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const datasetDir = readBenchOptionValue(args, "--dataset-dir");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
   const baselinesDir = readBenchOptionValue(args, "--baselines-dir");
+  const runtimeProfileRaw = readBenchOptionValue(args, "--runtime-profile");
+  const matrixRaw = readBenchOptionValue(args, "--matrix");
+  const remnicConfigRaw = readBenchOptionValue(args, "--remnic-config");
+  const openclawConfigRaw = readBenchOptionValue(args, "--openclaw-config");
+  const modelSourceRaw = readBenchOptionValue(args, "--model-source");
+  const gatewayAgentId = readBenchOptionValue(args, "--gateway-agent-id");
+  const fastGatewayAgentId = readBenchOptionValue(args, "--fast-gateway-agent-id");
+  const systemProviderRaw = readBenchOptionValue(args, "--system-provider");
+  const systemModel = readBenchOptionValue(args, "--system-model");
+  const systemBaseUrl = readBenchOptionValue(args, "--system-base-url");
+  const judgeProviderRaw = readBenchOptionValue(args, "--judge-provider");
+  const judgeModel = readBenchOptionValue(args, "--judge-model");
+  const judgeBaseUrl = readBenchOptionValue(args, "--judge-base-url");
   const thresholdRaw = readBenchOptionValue(args, "--threshold");
   const customRaw = readBenchOptionValue(args, "--custom");
   const formatRaw = readBenchOptionValue(args, "--format");
   const output = readBenchOptionValue(args, "--output");
   const targetRaw = readBenchOptionValue(args, "--target");
+  let runtimeProfile: BenchRuntimeProfile | undefined;
+  if (runtimeProfileRaw !== undefined) {
+    if (
+      runtimeProfileRaw !== "baseline" &&
+      runtimeProfileRaw !== "real" &&
+      runtimeProfileRaw !== "openclaw-chain"
+    ) {
+      throw new Error(
+        'ERROR: --runtime-profile must be "baseline", "real", or "openclaw-chain".',
+      );
+    }
+    runtimeProfile = runtimeProfileRaw;
+  }
+
+  let matrixProfiles: BenchRuntimeProfile[] | undefined;
+  if (matrixRaw !== undefined) {
+    const candidates = matrixRaw
+      .split(",")
+      .map((value) => value.trim())
+      .filter((value) => value.length > 0);
+    if (candidates.length === 0) {
+      throw new Error(
+        'ERROR: --matrix must contain one or more of "baseline", "real", or "openclaw-chain".',
+      );
+    }
+    for (const candidate of candidates) {
+      if (
+        candidate !== "baseline" &&
+        candidate !== "real" &&
+        candidate !== "openclaw-chain"
+      ) {
+        throw new Error(
+          'ERROR: --matrix must contain only "baseline", "real", or "openclaw-chain".',
+        );
+      }
+    }
+    matrixProfiles = candidates;
+  }
+
+  let modelSource: BenchModelSource | undefined;
+  if (modelSourceRaw !== undefined) {
+    if (modelSourceRaw !== "plugin" && modelSourceRaw !== "gateway") {
+      throw new Error('ERROR: --model-source must be "plugin" or "gateway".');
+    }
+    modelSource = modelSourceRaw;
+  }
+
+  let systemProvider: BuiltInProvider | undefined;
+  if (systemProviderRaw !== undefined) {
+    if (
+      systemProviderRaw !== "openai" &&
+      systemProviderRaw !== "anthropic" &&
+      systemProviderRaw !== "ollama" &&
+      systemProviderRaw !== "litellm"
+    ) {
+      throw new Error(
+        'ERROR: --system-provider must be "openai", "anthropic", "ollama", or "litellm".',
+      );
+    }
+    systemProvider = systemProviderRaw;
+  }
+
+  let judgeProvider: BuiltInProvider | undefined;
+  if (judgeProviderRaw !== undefined) {
+    if (
+      judgeProviderRaw !== "openai" &&
+      judgeProviderRaw !== "anthropic" &&
+      judgeProviderRaw !== "ollama" &&
+      judgeProviderRaw !== "litellm"
+    ) {
+      throw new Error(
+        'ERROR: --judge-provider must be "openai", "anthropic", "ollama", or "litellm".',
+      );
+    }
+    judgeProvider = judgeProviderRaw;
+  }
+
   let threshold: number | undefined;
   if (thresholdRaw !== undefined) {
     threshold = Number(thresholdRaw);
@@ -170,6 +289,19 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     datasetDir: datasetDir ? path.resolve(expandTilde(datasetDir)) : undefined,
     resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
     baselinesDir: baselinesDir ? path.resolve(expandTilde(baselinesDir)) : undefined,
+    runtimeProfile,
+    matrixProfiles,
+    remnicConfigPath: remnicConfigRaw ? path.resolve(expandTilde(remnicConfigRaw)) : undefined,
+    openclawConfigPath: openclawConfigRaw ? path.resolve(expandTilde(openclawConfigRaw)) : undefined,
+    modelSource,
+    gatewayAgentId,
+    fastGatewayAgentId,
+    systemProvider,
+    systemModel,
+    systemBaseUrl,
+    judgeProvider,
+    judgeModel,
+    judgeBaseUrl,
     threshold,
     custom: customRaw ? path.resolve(expandTilde(customRaw)) : undefined,
     baselineAction,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -61,6 +61,33 @@ export interface ParsedBenchArgs {
   target?: BenchPublishTarget;
 }
 
+function isBenchRuntimeProfile(value: string): value is BenchRuntimeProfile {
+  return (
+    value === "baseline" ||
+    value === "real" ||
+    value === "openclaw-chain"
+  );
+}
+
+function parseBenchRuntimeProfile(
+  value: string,
+  flagName: "--runtime-profile" | "--matrix",
+): BenchRuntimeProfile {
+  if (isBenchRuntimeProfile(value)) {
+    return value;
+  }
+
+  if (flagName === "--runtime-profile") {
+    throw new Error(
+      'ERROR: --runtime-profile must be "baseline", "real", or "openclaw-chain".',
+    );
+  }
+
+  throw new Error(
+    'ERROR: --matrix must contain only "baseline", "real", or "openclaw-chain".',
+  );
+}
+
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
   const index = argv.indexOf(flag);
   if (index === -1) {
@@ -212,16 +239,10 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const targetRaw = readBenchOptionValue(args, "--target");
   let runtimeProfile: BenchRuntimeProfile | undefined;
   if (runtimeProfileRaw !== undefined) {
-    if (
-      runtimeProfileRaw !== "baseline" &&
-      runtimeProfileRaw !== "real" &&
-      runtimeProfileRaw !== "openclaw-chain"
-    ) {
-      throw new Error(
-        'ERROR: --runtime-profile must be "baseline", "real", or "openclaw-chain".',
-      );
-    }
-    runtimeProfile = runtimeProfileRaw;
+    runtimeProfile = parseBenchRuntimeProfile(
+      runtimeProfileRaw,
+      "--runtime-profile",
+    );
   }
 
   let matrixProfiles: BenchRuntimeProfile[] | undefined;
@@ -235,18 +256,9 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         'ERROR: --matrix must contain one or more of "baseline", "real", or "openclaw-chain".',
       );
     }
-    for (const candidate of candidates) {
-      if (
-        candidate !== "baseline" &&
-        candidate !== "real" &&
-        candidate !== "openclaw-chain"
-      ) {
-        throw new Error(
-          'ERROR: --matrix must contain only "baseline", "real", or "openclaw-chain".',
-        );
-      }
-    }
-    matrixProfiles = candidates;
+    matrixProfiles = candidates.map((candidate) =>
+      parseBenchRuntimeProfile(candidate, "--matrix"),
+    );
   }
 
   let modelSource: BenchModelSource | undefined;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -405,6 +405,18 @@ type PackageBenchModule = {
   }) => Promise<{ destroy(): Promise<void> }>;
 };
 
+type PackageBenchAdapterFactory = NonNullable<
+  PackageBenchModule["createLightweightAdapter"] | PackageBenchModule["createRemnicAdapter"]
+>;
+
+type PackageBenchAdapterMode = "lightweight" | "direct";
+
+export interface PackageBenchExecutionPlan {
+  runtime: ResolvedBenchRuntimeProfile;
+  createAdapter: PackageBenchAdapterFactory;
+  adapterMode: PackageBenchAdapterMode;
+}
+
 export function getBenchUsageText(): string {
   return `Usage: remnic bench <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
        remnic benchmark <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
@@ -1457,17 +1469,16 @@ async function runBenchViaPackage(
     );
   }
 
-  const runtime = await resolvePackageBenchRuntime(
+  const plans = await buildPackageBenchExecutionPlans(
     benchModule,
     parsed,
-    runtimeProfile,
+    [runtimeProfile],
   );
-  const createAdapter =
-    parsed.quick && runtime.profile === "baseline"
-      ? benchModule.createLightweightAdapter
-      : benchModule.createRemnicAdapter;
-
-  if (!createAdapter) {
+  if (!plans) {
+    return false;
+  }
+  const [plan] = plans;
+  if (!plan) {
     return false;
   }
 
@@ -1483,11 +1494,7 @@ async function runBenchViaPackage(
     );
   }
 
-  const system = await createAdapter(runtime.adapterOptions);
-  const adapterMode =
-    parsed.quick && runtime.profile === "baseline"
-      ? "lightweight"
-      : "direct";
+  const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
   try {
     const result = await benchModule.runBenchmark(benchmarkId, {
@@ -1495,15 +1502,15 @@ async function runBenchViaPackage(
       datasetDir,
       outputDir,
       limit: parsed.quick ? 1 : undefined,
-      adapterMode,
-      runtimeProfile: runtime.profile,
-      systemProvider: runtime.systemProvider,
-      judgeProvider: runtime.judgeProvider,
-      remnicConfig: runtime.effectiveRemnicConfig,
+      adapterMode: plan.adapterMode,
+      runtimeProfile: plan.runtime.profile,
+      systemProvider: plan.runtime.systemProvider,
+      judgeProvider: plan.runtime.judgeProvider,
+      remnicConfig: plan.runtime.effectiveRemnicConfig,
       system,
     });
-    result.config.runtimeProfile = runtime.profile;
-    result.config.remnicConfig = runtime.remnicConfig;
+    result.config.runtimeProfile = plan.runtime.profile;
+    result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -1529,42 +1536,33 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
     return false;
   }
 
+  const plans = await buildPackageBenchExecutionPlans(
+    benchModule,
+    parsed,
+    runtimeProfiles,
+  );
+  if (!plans) {
+    return false;
+  }
+
   const outputDir = resolveBenchOutputDir();
-  for (const runtimeProfile of runtimeProfiles) {
-    const runtime = await resolvePackageBenchRuntime(
-      benchModule,
-      parsed,
-      runtimeProfile,
-    );
-    const createAdapter =
-      parsed.quick && runtime.profile === "baseline"
-        ? benchModule.createLightweightAdapter
-        : benchModule.createRemnicAdapter;
-
-    if (!createAdapter) {
-      return false;
-    }
-
-    const system = await createAdapter(runtime.adapterOptions);
-    const adapterMode =
-      parsed.quick && runtime.profile === "baseline"
-        ? "lightweight"
-        : "direct";
+  for (const plan of plans) {
+    const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
     try {
       const result = await benchModule.runCustomBenchmarkFile(parsed.custom!, {
         mode: parsed.quick ? "quick" : "full",
         outputDir,
         limit: parsed.quick ? 1 : undefined,
-        adapterMode,
-        runtimeProfile: runtime.profile,
-        systemProvider: runtime.systemProvider,
-        judgeProvider: runtime.judgeProvider,
-        remnicConfig: runtime.effectiveRemnicConfig,
+        adapterMode: plan.adapterMode,
+        runtimeProfile: plan.runtime.profile,
+        systemProvider: plan.runtime.systemProvider,
+        judgeProvider: plan.runtime.judgeProvider,
+        remnicConfig: plan.runtime.effectiveRemnicConfig,
         system,
       });
-      result.config.runtimeProfile = runtime.profile;
-      result.config.remnicConfig = runtime.remnicConfig;
+      result.config.runtimeProfile = plan.runtime.profile;
+      result.config.remnicConfig = plan.runtime.remnicConfig;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));
@@ -1626,6 +1624,56 @@ function resolveBenchRunProfiles(
   parsed: ParsedBenchArgs,
 ): BenchRuntimeProfile[] {
   return parsed.matrixProfiles ?? [parsed.runtimeProfile ?? "baseline"];
+}
+
+function resolvePackageBenchAdapterMode(
+  quick: boolean,
+  runtimeProfile: BenchRuntimeProfile,
+): PackageBenchAdapterMode {
+  return quick && runtimeProfile === "baseline" ? "lightweight" : "direct";
+}
+
+function resolvePackageBenchAdapterFactory(
+  benchModule: PackageBenchModule,
+  quick: boolean,
+  runtimeProfile: BenchRuntimeProfile,
+): PackageBenchAdapterFactory | undefined {
+  return resolvePackageBenchAdapterMode(quick, runtimeProfile) === "lightweight"
+    ? benchModule.createLightweightAdapter
+    : benchModule.createRemnicAdapter;
+}
+
+export async function buildPackageBenchExecutionPlans(
+  benchModule: PackageBenchModule,
+  parsed: ParsedBenchArgs,
+  runtimeProfiles: BenchRuntimeProfile[],
+): Promise<PackageBenchExecutionPlan[] | false> {
+  const plans: PackageBenchExecutionPlan[] = [];
+
+  for (const runtimeProfile of runtimeProfiles) {
+    const runtime = await resolvePackageBenchRuntime(
+      benchModule,
+      parsed,
+      runtimeProfile,
+    );
+    const createAdapter = resolvePackageBenchAdapterFactory(
+      benchModule,
+      parsed.quick,
+      runtime.profile,
+    );
+
+    if (!createAdapter) {
+      return false;
+    }
+
+    plans.push({
+      runtime,
+      createAdapter,
+      adapterMode: resolvePackageBenchAdapterMode(parsed.quick, runtime.profile),
+    });
+  }
+
+  return plans;
 }
 
 async function resolvePackageBenchRuntime(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -138,6 +138,7 @@ import type {
 import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
 import {
   buildBenchmarkPublishFeed,
+  type BenchRuntimeProfile,
   compareResults,
   getBenchmarkLowerIsBetter,
   defaultBenchmarkBaselineDir,
@@ -158,6 +159,8 @@ import {
   writeBenchmarkPublishFeed,
   type BenchConfig,
   type BenchmarkDefinition,
+  type ResolveBenchRuntimeProfileOptions,
+  type ResolvedBenchRuntimeProfile,
 } from "@remnic/bench";
 import { firstSuccessfulCandidate, firstSuccessfulResult } from "./service-candidates.js";
 import {
@@ -279,18 +282,51 @@ const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 type PackageBenchModule = {
   getBenchmark?: (id: string) => {
     runnerAvailable?: boolean;
+    meta?: {
+      category?: string;
+    };
   } | undefined;
+  resolveBenchRuntimeProfile?: (
+    options: ResolveBenchRuntimeProfileOptions,
+  ) => Promise<ResolvedBenchRuntimeProfile>;
   runBenchmark?: (id: string, options: {
     mode?: "full" | "quick";
     datasetDir?: string;
     outputDir?: string;
     limit?: number;
     adapterMode?: string;
+    runtimeProfile?: BenchRuntimeProfile | null;
+    systemProvider?: {
+      provider: string;
+      model: string;
+      baseUrl?: string;
+    } | null;
+    judgeProvider?: {
+      provider: string;
+      model: string;
+      baseUrl?: string;
+    } | null;
+    remnicConfig?: Record<string, unknown>;
     system: {
       destroy(): Promise<void>;
     };
   }) => Promise<{
     meta: { benchmark: string; mode: string };
+    config: {
+      runtimeProfile?: BenchRuntimeProfile | null;
+      systemProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      judgeProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      adapterMode: string;
+      remnicConfig: Record<string, unknown>;
+    };
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   }>;
@@ -299,17 +335,71 @@ type PackageBenchModule = {
     outputDir?: string;
     limit?: number;
     adapterMode?: string;
+    runtimeProfile?: BenchRuntimeProfile | null;
+    systemProvider?: {
+      provider: string;
+      model: string;
+      baseUrl?: string;
+    } | null;
+    judgeProvider?: {
+      provider: string;
+      model: string;
+      baseUrl?: string;
+    } | null;
+    remnicConfig?: Record<string, unknown>;
     system: {
       destroy(): Promise<void>;
     };
   }) => Promise<{
     meta: { benchmark: string; mode: string };
+    config: {
+      runtimeProfile?: BenchRuntimeProfile | null;
+      systemProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      judgeProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      adapterMode: string;
+      remnicConfig: Record<string, unknown>;
+    };
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   }>;
-  writeBenchmarkResult?: (result: unknown, outputDir: string) => Promise<string>;
-  createLightweightAdapter?: () => Promise<{ destroy(): Promise<void> }>;
-  createRemnicAdapter?: () => Promise<{ destroy(): Promise<void> }>;
+  writeBenchmarkResult?: (result: {
+    meta: { benchmark: string; mode: string };
+    config: {
+      runtimeProfile?: BenchRuntimeProfile | null;
+      systemProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      judgeProvider?: {
+        provider: string;
+        model: string;
+        baseUrl?: string;
+      } | null;
+      adapterMode: string;
+      remnicConfig: Record<string, unknown>;
+    };
+    results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
+    cost: { meanQueryLatencyMs: number };
+  }, outputDir: string) => Promise<string>;
+  createLightweightAdapter?: (options?: {
+    configOverrides?: Record<string, unknown>;
+    responder?: unknown;
+    judge?: unknown;
+  }) => Promise<{ destroy(): Promise<void> }>;
+  createRemnicAdapter?: (options?: {
+    configOverrides?: Record<string, unknown>;
+    responder?: unknown;
+    judge?: unknown;
+  }) => Promise<{ destroy(): Promise<void> }>;
 };
 
 export function getBenchUsageText(): string {
@@ -336,7 +426,25 @@ Commands:
 Options:
   --quick                  Run a lightweight quick pass (maps to --lightweight --limit 1)
   --all                    Run every published benchmark
+  --runtime-profile <baseline|real|openclaw-chain>
+                           Choose the benchmark runtime profile
+  --matrix <profiles>      Run a benchmark across a comma-separated profile matrix
   --dataset-dir <path>     Override the benchmark dataset directory for full runs
+  --remnic-config <path>   Load runtime settings from a Remnic config file
+  --openclaw-config <path> Load runtime settings from an OpenClaw config file
+  --model-source <plugin|gateway>
+                           Override whether Remnic uses plugin or gateway model routing
+  --gateway-agent-id <id>  OpenClaw agent persona id for gateway model routing
+  --fast-gateway-agent-id <id>
+                           OpenClaw fast-tier agent persona id for gateway model routing
+  --system-provider <openai|anthropic|ollama|litellm>
+                           Use a direct provider-backed answering path
+  --system-model <model>   Model name for the direct answering provider
+  --system-base-url <url>  Base URL for the direct answering provider
+  --judge-provider <openai|anthropic|ollama|litellm>
+                           Use a direct provider-backed judge
+  --judge-model <model>    Model name for the judge provider
+  --judge-base-url <url>   Base URL for the judge provider
   --custom <path>          Run a YAML-defined custom benchmark file
   --results-dir <path>     Override the stored benchmark results directory
   --baselines-dir <path>   Override the named baseline directory
@@ -349,8 +457,12 @@ Options:
 
 Examples:
   remnic bench list
-  remnic bench run --quick longmemeval
+  remnic bench run --quick longmemeval --runtime-profile baseline
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
+  remnic bench run longmemeval --runtime-profile real --remnic-config ~/.config/remnic/config.json
+  remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model gpt-5.4-mini
+  remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config ~/.openclaw/openclaw.json --gateway-agent-id memory-primary
+  remnic bench run longmemeval --matrix baseline,real,openclaw-chain
   remnic bench compare base-run candidate-run
   remnic bench results
   remnic bench results candidate-run --detail
@@ -538,6 +650,9 @@ function resolveBenchDatasetDir(
 function printBenchPackageSummary(
   result: {
     meta: { benchmark: string; mode: string };
+    config: {
+      runtimeProfile?: BenchRuntimeProfile | null;
+    };
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   },
@@ -546,6 +661,9 @@ function printBenchPackageSummary(
 ): void {
   console.log(`Benchmark: ${result.meta.benchmark}`);
   console.log(`Mode: ${result.meta.mode}`);
+  if (result.config.runtimeProfile) {
+    console.log(`Runtime profile: ${result.config.runtimeProfile}`);
+  }
   console.log(`Tasks: ${result.results.tasks.length}`);
   console.log(`Mean query latency: ${result.cost.meanQueryLatencyMs.toFixed(1)}ms`);
   for (const [metric, aggregate] of Object.entries(result.results.aggregates).sort()) {
@@ -922,6 +1040,7 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
 async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
+  runtimeProfile: BenchRuntimeProfile,
 ): Promise<boolean> {
   let benchModule: PackageBenchModule;
   try {
@@ -942,9 +1061,15 @@ async function runBenchViaPackage(
     );
   }
 
-  const createAdapter = parsed.quick
-    ? benchModule.createLightweightAdapter
-    : benchModule.createRemnicAdapter;
+  const runtime = await resolvePackageBenchRuntime(
+    benchModule,
+    parsed,
+    runtimeProfile,
+  );
+  const createAdapter =
+    parsed.quick && runtime.profile === "baseline"
+      ? benchModule.createLightweightAdapter
+      : benchModule.createRemnicAdapter;
 
   if (!createAdapter) {
     return false;
@@ -962,7 +1087,11 @@ async function runBenchViaPackage(
     );
   }
 
-  const system = await createAdapter();
+  const system = await createAdapter(runtime.adapterOptions);
+  const adapterMode =
+    parsed.quick && runtime.profile === "baseline"
+      ? "lightweight"
+      : "direct";
 
   try {
     const result = await benchModule.runBenchmark(benchmarkId, {
@@ -970,9 +1099,14 @@ async function runBenchViaPackage(
       datasetDir,
       outputDir,
       limit: parsed.quick ? 1 : undefined,
-      adapterMode: parsed.quick ? "lightweight" : "direct",
+      adapterMode,
+      runtimeProfile: runtime.profile,
+      systemProvider: runtime.systemProvider,
+      judgeProvider: runtime.judgeProvider,
+      remnicConfig: runtime.remnicConfig,
       system,
     });
+    result.config.runtimeProfile = runtime.profile;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -986,6 +1120,7 @@ async function runBenchViaPackage(
 }
 
 async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolean> {
+  const runtimeProfiles = resolveBenchRunProfiles(parsed);
   let benchModule: PackageBenchModule;
   try {
     benchModule = await import("@remnic/bench") as unknown as PackageBenchModule;
@@ -997,35 +1132,53 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
     return false;
   }
 
-  const createAdapter = parsed.quick
-    ? benchModule.createLightweightAdapter
-    : benchModule.createRemnicAdapter;
-
-  if (!createAdapter) {
-    return false;
-  }
-
   const outputDir = resolveBenchOutputDir();
-  const system = await createAdapter();
+  for (const runtimeProfile of runtimeProfiles) {
+    const runtime = await resolvePackageBenchRuntime(
+      benchModule,
+      parsed,
+      runtimeProfile,
+    );
+    const createAdapter =
+      parsed.quick && runtime.profile === "baseline"
+        ? benchModule.createLightweightAdapter
+        : benchModule.createRemnicAdapter;
 
-  try {
-    const result = await benchModule.runCustomBenchmarkFile(parsed.custom!, {
-      mode: parsed.quick ? "quick" : "full",
-      outputDir,
-      limit: parsed.quick ? 1 : undefined,
-      adapterMode: parsed.quick ? "lightweight" : "direct",
-      system,
-    });
-    const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
-    if (parsed.json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      printBenchPackageSummary(result, writtenPath);
+    if (!createAdapter) {
+      return false;
     }
-    return true;
-  } finally {
-    await system.destroy();
+
+    const system = await createAdapter(runtime.adapterOptions);
+    const adapterMode =
+      parsed.quick && runtime.profile === "baseline"
+        ? "lightweight"
+        : "direct";
+
+    try {
+      const result = await benchModule.runCustomBenchmarkFile(parsed.custom!, {
+        mode: parsed.quick ? "quick" : "full",
+        outputDir,
+        limit: parsed.quick ? 1 : undefined,
+        adapterMode,
+        runtimeProfile: runtime.profile,
+        systemProvider: runtime.systemProvider,
+        judgeProvider: runtime.judgeProvider,
+        remnicConfig: runtime.remnicConfig,
+        system,
+      });
+      result.config.runtimeProfile = runtime.profile;
+      const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
+      if (parsed.json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        printBenchPackageSummary(result, writtenPath);
+      }
+    } finally {
+      await system.destroy();
+    }
   }
+
+  return true;
 }
 
 // ── Config helpers ───────────────────────────────────────────────────────────
@@ -1045,6 +1198,54 @@ function resolveConfigPath(cliPath?: string): string {
     if (fs.existsSync(candidate)) return candidate;
   }
   return path.join(resolveHomeDir(), ".config", "remnic", "config.json");
+}
+
+function resolveExistingBenchRemnicConfigPath(cliPath?: string): string | undefined {
+  const configPath = resolveConfigPath(cliPath);
+  return fs.existsSync(configPath) ? configPath : undefined;
+}
+
+function resolveExistingBenchOpenclawConfigPath(cliPath?: string): string {
+  return resolveOpenclawConfigPath(cliPath);
+}
+
+function resolveBenchRunProfiles(
+  parsed: ParsedBenchArgs,
+): BenchRuntimeProfile[] {
+  return parsed.matrixProfiles ?? [parsed.runtimeProfile ?? "baseline"];
+}
+
+async function resolvePackageBenchRuntime(
+  benchModule: PackageBenchModule,
+  parsed: ParsedBenchArgs,
+  runtimeProfile: BenchRuntimeProfile,
+): Promise<ResolvedBenchRuntimeProfile> {
+  if (!benchModule.resolveBenchRuntimeProfile) {
+    throw new Error(
+      "Installed @remnic/bench runtime does not expose resolveBenchRuntimeProfile().",
+    );
+  }
+
+  return benchModule.resolveBenchRuntimeProfile({
+    runtimeProfile,
+    remnicConfigPath:
+      runtimeProfile === "real"
+        ? resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath)
+        : undefined,
+    openclawConfigPath:
+      runtimeProfile === "openclaw-chain"
+        ? resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath)
+        : undefined,
+    modelSource: parsed.modelSource,
+    gatewayAgentId: parsed.gatewayAgentId,
+    fastGatewayAgentId: parsed.fastGatewayAgentId,
+    systemProvider: parsed.systemProvider,
+    systemModel: parsed.systemModel,
+    systemBaseUrl: parsed.systemBaseUrl,
+    judgeProvider: parsed.judgeProvider,
+    judgeModel: parsed.judgeModel,
+    judgeBaseUrl: parsed.judgeBaseUrl,
+  });
 }
 
 function resolveMemoryDir(): string {
@@ -2915,10 +3116,17 @@ async function cmdBench(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const runtimeProfiles = resolveBenchRunProfiles(parsed);
   for (const benchmarkId of selectedBenchmarks) {
-    const handledByPackage = await runBenchViaPackage(parsed, benchmarkId);
-    if (!handledByPackage) {
-      await runBenchViaFallback(parsed, benchmarkId);
+    for (const runtimeProfile of runtimeProfiles) {
+      const handledByPackage = await runBenchViaPackage(
+        parsed,
+        benchmarkId,
+        runtimeProfile,
+      );
+      if (!handledByPackage) {
+        await runBenchViaFallback(parsed, benchmarkId);
+      }
     }
   }
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -490,6 +490,41 @@ export function buildBenchRunnerArgs(
   return args;
 }
 
+export function buildBenchRuntimeProfileRequest(
+  parsed: ParsedBenchArgs,
+  runtimeProfile: BenchRuntimeProfile,
+): ResolveBenchRuntimeProfileOptions {
+  return {
+    runtimeProfile,
+    remnicConfigPath:
+      runtimeProfile === "real"
+        ? resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath)
+        : undefined,
+    openclawConfigPath:
+      runtimeProfile === "openclaw-chain"
+        ? resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath)
+        : undefined,
+    modelSource: runtimeProfile === "real" ? parsed.modelSource : undefined,
+    gatewayAgentId: parsed.gatewayAgentId,
+    fastGatewayAgentId: parsed.fastGatewayAgentId,
+    systemProvider:
+      runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemProvider,
+    systemModel:
+      runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemModel,
+    systemBaseUrl:
+      runtimeProfile === "openclaw-chain"
+        ? undefined
+        : parsed.systemBaseUrl,
+    judgeProvider: parsed.judgeProvider,
+    judgeModel: parsed.judgeModel,
+    judgeBaseUrl: parsed.judgeBaseUrl,
+  };
+}
+
 function coerceBenchCategory(
   benchmarkId: string,
   category: string | undefined,
@@ -564,7 +599,35 @@ async function resolveKnownBenchmarkIds(): Promise<Set<string>> {
 async function runBenchViaFallback(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
+  runtimeProfile: BenchRuntimeProfile,
 ): Promise<void> {
+  if (runtimeProfile === "real") {
+    resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath);
+    throw new Error(
+      'Fallback benchmark runner does not support --runtime-profile "real". Build/install @remnic/bench to use package-backed runtime profiles.',
+    );
+  }
+  if (runtimeProfile === "openclaw-chain") {
+    resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath);
+    throw new Error(
+      'Fallback benchmark runner does not support --runtime-profile "openclaw-chain". Build/install @remnic/bench to use package-backed runtime profiles.',
+    );
+  }
+  if (
+    parsed.modelSource !== undefined ||
+    parsed.gatewayAgentId !== undefined ||
+    parsed.fastGatewayAgentId !== undefined ||
+    parsed.systemProvider !== undefined ||
+    parsed.systemModel !== undefined ||
+    parsed.systemBaseUrl !== undefined ||
+    parsed.judgeProvider !== undefined ||
+    parsed.judgeModel !== undefined ||
+    parsed.judgeBaseUrl !== undefined
+  ) {
+    throw new Error(
+      "Fallback benchmark runner does not support provider-backed or gateway runtime flags. Build/install @remnic/bench to use those options.",
+    );
+  }
   if (!fs.existsSync(EVAL_RUNNER_PATH)) {
     console.error(
       "Benchmark runner not found. Expected eval runner at evals/run.ts or a phase-1 @remnic/bench runtime export.",
@@ -1241,26 +1304,9 @@ async function resolvePackageBenchRuntime(
     );
   }
 
-  return benchModule.resolveBenchRuntimeProfile({
-    runtimeProfile,
-    remnicConfigPath:
-      runtimeProfile === "real"
-        ? resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath)
-        : undefined,
-    openclawConfigPath:
-      runtimeProfile === "openclaw-chain"
-        ? resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath)
-        : undefined,
-    modelSource: parsed.modelSource,
-    gatewayAgentId: parsed.gatewayAgentId,
-    fastGatewayAgentId: parsed.fastGatewayAgentId,
-    systemProvider: parsed.systemProvider,
-    systemModel: parsed.systemModel,
-    systemBaseUrl: parsed.systemBaseUrl,
-    judgeProvider: parsed.judgeProvider,
-    judgeModel: parsed.judgeModel,
-    judgeBaseUrl: parsed.judgeBaseUrl,
-  });
+  return benchModule.resolveBenchRuntimeProfile(
+    buildBenchRuntimeProfileRequest(parsed, runtimeProfile),
+  );
 }
 
 function resolveMemoryDir(): string {
@@ -3140,7 +3186,7 @@ async function cmdBench(rest: string[]): Promise<void> {
         runtimeProfile,
       );
       if (!handledByPackage) {
-        await runBenchViaFallback(parsed, benchmarkId);
+        await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
       }
     }
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -393,11 +393,13 @@ type PackageBenchModule = {
   }, outputDir: string) => Promise<string>;
   createLightweightAdapter?: (options?: {
     configOverrides?: Record<string, unknown>;
+    preserveRuntimeDefaults?: boolean;
     responder?: unknown;
     judge?: unknown;
   }) => Promise<{ destroy(): Promise<void> }>;
   createRemnicAdapter?: (options?: {
     configOverrides?: Record<string, unknown>;
+    preserveRuntimeDefaults?: boolean;
     responder?: unknown;
     judge?: unknown;
   }) => Promise<{ destroy(): Promise<void> }>;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1506,9 +1506,10 @@ async function runBenchViaPackage(
       runtimeProfile: plan.runtime.profile,
       systemProvider: plan.runtime.systemProvider,
       judgeProvider: plan.runtime.judgeProvider,
-      remnicConfig: plan.runtime.remnicConfig,
+      remnicConfig: plan.runtime.effectiveRemnicConfig,
       system,
     });
+    result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -1556,9 +1557,10 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         runtimeProfile: plan.runtime.profile,
         systemProvider: plan.runtime.systemProvider,
         judgeProvider: plan.runtime.judgeProvider,
-        remnicConfig: plan.runtime.remnicConfig,
+        remnicConfig: plan.runtime.effectiveRemnicConfig,
         system,
       });
+      result.config.remnicConfig = plan.runtime.remnicConfig;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1202,11 +1202,26 @@ function resolveConfigPath(cliPath?: string): string {
 
 function resolveExistingBenchRemnicConfigPath(cliPath?: string): string | undefined {
   const configPath = resolveConfigPath(cliPath);
-  return fs.existsSync(configPath) ? configPath : undefined;
+  if (fs.existsSync(configPath)) {
+    return configPath;
+  }
+  if (cliPath) {
+    throw new Error(`Remnic config file not found: ${configPath}`);
+  }
+  return undefined;
 }
 
 function resolveExistingBenchOpenclawConfigPath(cliPath?: string): string {
-  return resolveOpenclawConfigPath(cliPath);
+  const configPath = resolveOpenclawConfigPath(cliPath);
+  if (fs.existsSync(configPath)) {
+    return configPath;
+  }
+  if (cliPath) {
+    throw new Error(`OpenClaw config file not found: ${configPath}`);
+  }
+  throw new Error(
+    `openclaw-chain runtime profile requires an OpenClaw config file. Not found at ${configPath}`,
+  );
 }
 
 function resolveBenchRunProfiles(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1493,10 +1493,11 @@ async function runBenchViaPackage(
       runtimeProfile: runtime.profile,
       systemProvider: runtime.systemProvider,
       judgeProvider: runtime.judgeProvider,
-      remnicConfig: runtime.remnicConfig,
+      remnicConfig: runtime.effectiveRemnicConfig,
       system,
     });
     result.config.runtimeProfile = runtime.profile;
+    result.config.remnicConfig = runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -1553,10 +1554,11 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         runtimeProfile: runtime.profile,
         systemProvider: runtime.systemProvider,
         judgeProvider: runtime.judgeProvider,
-        remnicConfig: runtime.remnicConfig,
+        remnicConfig: runtime.effectiveRemnicConfig,
         system,
       });
       result.config.runtimeProfile = runtime.profile;
+      result.config.remnicConfig = runtime.remnicConfig;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -615,6 +615,12 @@ async function runBenchViaFallback(
   benchmarkId: string,
   runtimeProfile: BenchRuntimeProfile,
 ): Promise<void> {
+  if (runtimeProfile === "real" && parsed.remnicConfigPath) {
+    resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath);
+  }
+  if (runtimeProfile === "openclaw-chain" && parsed.openclawConfigPath) {
+    resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath);
+  }
   if (runtimeProfile === "real") {
     throw new Error(
       'Fallback benchmark runner does not support --runtime-profile "real". Build/install @remnic/bench to use package-backed runtime profiles.',

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1506,11 +1506,10 @@ async function runBenchViaPackage(
       runtimeProfile: plan.runtime.profile,
       systemProvider: plan.runtime.systemProvider,
       judgeProvider: plan.runtime.judgeProvider,
-      remnicConfig: plan.runtime.effectiveRemnicConfig,
+      remnicConfig: plan.runtime.remnicConfig,
       system,
     });
     result.config.runtimeProfile = plan.runtime.profile;
-    result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -1558,11 +1557,10 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         runtimeProfile: plan.runtime.profile,
         systemProvider: plan.runtime.systemProvider,
         judgeProvider: plan.runtime.judgeProvider,
-        remnicConfig: plan.runtime.effectiveRemnicConfig,
+        remnicConfig: plan.runtime.remnicConfig,
         system,
       });
       result.config.runtimeProfile = plan.runtime.profile;
-      result.config.remnicConfig = plan.runtime.remnicConfig;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -616,13 +616,11 @@ async function runBenchViaFallback(
   runtimeProfile: BenchRuntimeProfile,
 ): Promise<void> {
   if (runtimeProfile === "real") {
-    resolveExistingBenchRemnicConfigPath(parsed.remnicConfigPath);
     throw new Error(
       'Fallback benchmark runner does not support --runtime-profile "real". Build/install @remnic/bench to use package-backed runtime profiles.',
     );
   }
   if (runtimeProfile === "openclaw-chain") {
-    resolveExistingBenchOpenclawConfigPath(parsed.openclawConfigPath);
     throw new Error(
       'Fallback benchmark runner does not support --runtime-profile "openclaw-chain". Build/install @remnic/bench to use package-backed runtime profiles.',
     );

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1509,7 +1509,6 @@ async function runBenchViaPackage(
       remnicConfig: plan.runtime.remnicConfig,
       system,
     });
-    result.config.runtimeProfile = plan.runtime.profile;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
       console.log(JSON.stringify(result, null, 2));
@@ -1560,7 +1559,6 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         remnicConfig: plan.runtime.remnicConfig,
         system,
       });
-      result.config.runtimeProfile = plan.runtime.profile;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -572,6 +572,8 @@ export {
   type BulkImportCliCommandOptions,
 } from "./cli.js";
 
+export { FallbackLlmClient, type FallbackLlmOptions, type FallbackLlmResponse } from "./fallback-llm.js";
+
 // ---------------------------------------------------------------------------
 // Training-data export (issue #459)
 // ---------------------------------------------------------------------------
@@ -584,6 +586,7 @@ export * from "./training-export/index.js";
 
 export type {
   PluginConfig,
+  GatewayConfig,
   MemoryFile,
   MemoryCategory,
   MemoryActionType,

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -158,6 +158,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall_explain",
     "engram.day_summary",
     "engram.memory_governance_run",
+    "engram.procedure_mining_run",
     "engram.memory_get",
     "engram.memory_timeline",
     "engram.memory_store",

--- a/tests/bench-custom-benchmark.test.ts
+++ b/tests/bench-custom-benchmark.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchJudge,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -15,6 +16,7 @@ import { runCustomBenchmarkFile } from "../packages/bench/src/benchmarks/custom/
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  judge?: BenchJudge;
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -186,4 +188,54 @@ tasks:
   assert.equal(result.results.tasks[0]?.actual, "The sky is blue.");
   assert.equal(result.results.tasks[0]?.scores.exact_match, 1);
   assert.equal(result.results.aggregates.exact_match?.mean, 1);
+});
+
+test("runCustomBenchmarkFile includes judge token and latency usage for llm_judge scoring", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-custom-bench-judge-"));
+  const filePath = path.join(tmpDir, "judge-check.yaml");
+  await writeFile(
+    filePath,
+    `
+name: Judge Check
+description: Custom benchmark with llm_judge scoring
+scoring: llm_judge
+tasks:
+  - question: What color is the sky?
+    expected: The sky is blue.
+`,
+  );
+
+  const adapter = new FakeMemoryAdapter();
+  adapter.judge = {
+    async score() {
+      return 0.9;
+    },
+    async scoreWithMetrics() {
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      return {
+        score: 0.9,
+        tokens: { input: 11, output: 7 },
+        latencyMs: 25,
+        model: "gpt-5.4-mini",
+      };
+    },
+  };
+  await adapter.store("memory", [
+    { role: "assistant", content: "The sky is blue." },
+  ]);
+
+  const result = await runCustomBenchmarkFile(filePath, {
+    mode: "quick",
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.scores.llm_judge, 0.9);
+  assert.deepEqual(result.results.tasks[0]?.tokens, { input: 11, output: 7 });
+  assert.equal((result.results.tasks[0]?.latencyMs ?? 0) >= 20, true);
+  assert.equal(result.results.tasks[0]?.details.judgeModel, "gpt-5.4-mini");
+  assert.equal(result.cost.inputTokens, 11);
+  assert.equal(result.cost.outputTokens, 7);
+  assert.equal(result.cost.totalTokens, 18);
+  assert.equal(result.cost.totalLatencyMs >= 20, true);
+  assert.equal(result.cost.meanQueryLatencyMs >= 20, true);
 });

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -28,6 +28,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "page-versioning",
       "retrieval-personalization",
       "retrieval-temporal",
+      "procedural-recall",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
@@ -67,11 +68,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.

--- a/tests/bench-results-store.test.ts
+++ b/tests/bench-results-store.test.ts
@@ -42,6 +42,7 @@ function buildResult(
       datasetHash: hashString(`${benchmark}:dataset`),
     },
     config: {
+      runtimeProfile: null,
       systemProvider: null,
       judgeProvider: null,
       adapterMode: "lightweight",
@@ -119,6 +120,18 @@ test("loadBenchmarkResult rejects incomplete benchmark result payloads", async (
     () => loadBenchmarkResult(invalidPath),
     /Invalid benchmark result file/,
   );
+});
+
+test("loadBenchmarkResult preserves runtime profile metadata on stored results", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-runtime-profile-"));
+  const filePath = path.join(root, "runtime-profile.json");
+  const result = buildResult("runtime-profile-run", "2026-04-18T00:30:00.000Z");
+  result.config.runtimeProfile = "real";
+
+  await writeFile(filePath, `${JSON.stringify(result)}\n`);
+
+  const loaded = await loadBenchmarkResult(filePath);
+  assert.equal(loaded.config.runtimeProfile, "real");
 });
 
 test("resolveBenchmarkResultReference matches by id, basename, or direct path", async () => {

--- a/tests/config-lifecycle-policy.test.ts
+++ b/tests/config-lifecycle-policy.test.ts
@@ -9,7 +9,7 @@ test("parseConfig sets lifecycle policy defaults with policy disabled", () => {
   assert.equal(cfg.lifecyclePromoteHeatThreshold, 0.55);
   assert.equal(cfg.lifecycleStaleDecayThreshold, 0.65);
   assert.equal(cfg.lifecycleArchiveDecayThreshold, 0.85);
-  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference"]);
+  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference", "procedure"]);
   assert.equal(cfg.lifecycleMetricsEnabled, false);
 });
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -546,6 +546,52 @@ export function ensureWecloneImportAdapterRegistered() {}
   }
 });
 
+test("buildBenchRuntimeProfileRequest keeps openclaw-chain on gateway routing in matrix mode", async () => {
+  const { mkdtemp, writeFile } = await import("node:fs/promises");
+  const os = await import("node:os");
+  const path = await import("node:path");
+  const { buildBenchRuntimeProfileRequest } = await import("../packages/remnic-cli/src/index.ts");
+
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-openclaw-matrix-"));
+  const openclawConfigPath = path.join(root, "openclaw.json");
+  await writeFile(openclawConfigPath, JSON.stringify({ plugins: { entries: {} } }));
+
+  const parsed = {
+    action: "run",
+    benchmarks: ["longmemeval"],
+    quick: true,
+    all: false,
+    json: false,
+    detail: false,
+    matrixProfiles: ["baseline", "openclaw-chain"],
+    openclawConfigPath,
+    modelSource: "gateway",
+    gatewayAgentId: "memory-primary",
+    fastGatewayAgentId: "memory-fast",
+    systemProvider: "openai",
+    systemModel: "gpt-5.4-mini",
+    systemBaseUrl: "http://localhost:4000/v1",
+    judgeProvider: "anthropic",
+    judgeModel: "claude-sonnet-4-5",
+    judgeBaseUrl: "http://localhost:4100",
+  } as const;
+
+  const baseline = buildBenchRuntimeProfileRequest(parsed, "baseline");
+  const openclaw = buildBenchRuntimeProfileRequest(parsed, "openclaw-chain");
+
+  assert.equal(baseline.systemProvider, "openai");
+  assert.equal(baseline.systemModel, "gpt-5.4-mini");
+  assert.equal(baseline.openclawConfigPath, undefined);
+  assert.equal(openclaw.openclawConfigPath, openclawConfigPath);
+  assert.equal(openclaw.systemProvider, undefined);
+  assert.equal(openclaw.systemModel, undefined);
+  assert.equal(openclaw.systemBaseUrl, undefined);
+  assert.equal(openclaw.judgeProvider, "anthropic");
+  assert.equal(openclaw.judgeModel, "claude-sonnet-4-5");
+  assert.equal(openclaw.gatewayAgentId, "memory-primary");
+  assert.equal(openclaw.fastGatewayAgentId, "memory-fast");
+});
+
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {
   const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -110,9 +110,10 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /if \(!parsed\.quick && !datasetDir\) \{\s*throw new Error\(/s);
   assert.match(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const runtime = await resolvePackageBenchRuntime\(/);
-  assert.match(source, /const system = await createAdapter\(runtime\.adapterOptions\);/);
-  assert.match(source, /remnicConfig: runtime\.effectiveRemnicConfig,/);
-  assert.match(source, /result\.config\.remnicConfig = runtime\.remnicConfig;/);
+  assert.match(source, /const plans = await buildPackageBenchExecutionPlans\(/);
+  assert.match(source, /const system = await plan\.createAdapter\(plan\.runtime\.adapterOptions\);/);
+  assert.match(source, /remnicConfig: plan\.runtime\.effectiveRemnicConfig,/);
+  assert.match(source, /result\.config\.remnicConfig = plan\.runtime\.remnicConfig;/);
 });
 
 test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {
@@ -737,6 +738,135 @@ export function ensureWecloneImportAdapterRegistered() {}
     assert.equal(openclaw.judgeModel, "claude-sonnet-4-5");
     assert.equal(openclaw.gatewayAgentId, "memory-primary");
     assert.equal(openclaw.fastGatewayAgentId, "memory-fast");
+  } finally {
+    for (const stub of stubs) stub.cleanup();
+  }
+});
+
+test("buildPackageBenchExecutionPlans preflights the full custom matrix before any adapter runs", async () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(__dirname, "..");
+
+  interface StubHandle {
+    cleanup: () => void;
+  }
+
+  const stubWorkspacePackage = (
+    packageName: string,
+    moduleBody: string,
+  ): StubHandle => {
+    const linkRoot = join(repoRoot, "packages/remnic-cli/node_modules", packageName);
+    const moduleRoot = existsSync(linkRoot) ? realpathSync(linkRoot) : linkRoot;
+    const distDir = join(moduleRoot, "dist");
+    const entry = join(distDir, "index.js");
+    const packageJson = join(moduleRoot, "package.json");
+    const needsEntry = !existsSync(entry);
+    const createdLinkRoot = !existsSync(linkRoot);
+    const createdPackageJson = needsEntry && !existsSync(packageJson);
+    const createdDistDir = needsEntry && !existsSync(distDir);
+
+    if (needsEntry) {
+      mkdirSync(distDir, { recursive: true });
+      if (createdPackageJson) {
+        writeFileSync(
+          packageJson,
+          JSON.stringify({
+            name: packageName,
+            type: "module",
+            exports: { ".": "./dist/index.js" },
+          }),
+        );
+      }
+      writeFileSync(entry, moduleBody);
+    }
+
+    return {
+      cleanup: () => {
+        if (!needsEntry) return;
+        rmSync(entry, { force: true });
+        if (createdDistDir) rmSync(distDir, { recursive: true, force: true });
+        if (createdPackageJson) rmSync(packageJson, { force: true });
+        if (createdLinkRoot) rmSync(moduleRoot, { recursive: true, force: true });
+      },
+    };
+  };
+
+  const stubs: StubHandle[] = [
+    stubWorkspacePackage(
+      "@remnic/bench",
+      `
+export function compareResults() {}
+export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai", generatedAt: new Date(0).toISOString(), benchmarks: [] }; }
+export function checkRegression() { return null; }
+export function defaultBenchmarkBaselineDir() { return ""; }
+export function defaultBenchmarkPublishPath() { return ""; }
+export async function discoverAllProviders() { return []; }
+export function getBenchmarkLowerIsBetter() { return new Set(); }
+export async function listBenchmarkBaselines() { return []; }
+export async function listBenchmarkResults() { return []; }
+export async function loadBenchmarkBaseline() { return null; }
+export async function runBenchSuite() { return null; }
+export async function runExplain() { return null; }
+export async function loadBaseline() { return null; }
+export async function saveBaseline() { return null; }
+export async function loadBenchmarkResult() { return null; }
+export function renderBenchmarkResultExport() { return ""; }
+export async function resolveBenchmarkResultReference() { return null; }
+export async function saveBenchmarkBaseline() { return null; }
+export async function writeBenchmarkPublishFeed() { return ""; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/export-weclone",
+      `
+export const wecloneExportAdapter = { name: "weclone", fileExtension: "json", formatRecords: () => "" };
+export function ensureWecloneExportAdapterRegistered() {}
+export function synthesizeTrainingPairs() { return []; }
+export function sweepPii(input) { return input; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/import-weclone",
+      `
+export const wecloneImportAdapter = { name: "weclone", parse: async () => ({ turns: [], metadata: {} }) };
+export function ensureWecloneImportAdapterRegistered() {}
+`,
+    ),
+  ];
+
+  try {
+    const { buildPackageBenchExecutionPlans } = await import(
+      `../packages/remnic-cli/src/index.ts?matrix-preflight=${Date.now()}`
+    );
+
+    const parsed = {
+      action: "run",
+      benchmarks: [],
+      quick: true,
+      all: false,
+      json: false,
+      detail: false,
+    } as const;
+
+    const plans = await buildPackageBenchExecutionPlans(
+      {
+        resolveBenchRuntimeProfile: async (options) => ({
+          profile: options.runtimeProfile ?? "baseline",
+          remnicConfig: {},
+          effectiveRemnicConfig: {},
+          adapterOptions: {},
+          systemProvider: null,
+          judgeProvider: null,
+        }),
+        createLightweightAdapter: async () => {
+          throw new Error("adapter construction should not happen during plan building");
+        },
+      },
+      parsed,
+      ["baseline", "real"],
+    );
+
+    assert.equal(plans, false);
   } finally {
     for (const stub of stubs) stub.cleanup();
   }

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -103,7 +103,8 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /const datasetDir = resolveBenchDatasetDir\(/);
   assert.match(source, /if \(!parsed\.quick && !datasetDir\) \{\s*throw new Error\(/s);
   assert.match(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
-  assert.match(source, /const system = await createAdapter\(\);/);
+  assert.match(source, /const runtime = await resolvePackageBenchRuntime\(/);
+  assert.match(source, /const system = await createAdapter\(runtime\.adapterOptions\);/);
 });
 
 test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {
@@ -113,6 +114,92 @@ test("parseBenchArgs supports custom benchmark files without counting them as be
 
   assert.match(parsed.custom ?? "", /benchmarks[\/\\]custom\.yaml$/);
   assert.deepEqual(parsed.benchmarks, []);
+});
+
+test("bench CLI exposes runtime profile and provider-backed run surfaces", async () => {
+  const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
+  const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
+  const readme = await readFile("packages/remnic-cli/README.md", "utf8");
+
+  assert.match(source, /--runtime-profile <baseline\|real\|openclaw-chain>/);
+  assert.match(source, /--matrix <profiles>/);
+  assert.match(source, /--remnic-config <path>/);
+  assert.match(source, /--openclaw-config <path>/);
+  assert.match(source, /--model-source <plugin\|gateway>/);
+  assert.match(source, /--gateway-agent-id <id>/);
+  assert.match(source, /--fast-gateway-agent-id <id>/);
+  assert.match(source, /--system-provider <openai\|anthropic\|ollama\|litellm>/);
+  assert.match(source, /--system-model <model>/);
+  assert.match(source, /--judge-provider <openai\|anthropic\|ollama\|litellm>/);
+  assert.match(source, /--judge-model <model>/);
+  assert.match(source, /remnic bench run --quick longmemeval --runtime-profile baseline/);
+  assert.match(source, /remnic bench run longmemeval --runtime-profile real --remnic-config/);
+  assert.match(source, /remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config/);
+  assert.match(source, /remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model/);
+  assert.match(source, /remnic bench run longmemeval --matrix baseline,real,openclaw-chain/);
+
+  assert.match(parserSource, /export type BenchRuntimeProfile = "baseline" \| "real" \| "openclaw-chain";/);
+  assert.match(parserSource, /runtimeProfile\?: BenchRuntimeProfile;/);
+  assert.match(parserSource, /matrixProfiles\?: BenchRuntimeProfile\[];/);
+  assert.match(parserSource, /systemProvider\?: BuiltInProvider;/);
+  assert.match(parserSource, /judgeProvider\?: BuiltInProvider;/);
+  assert.match(parserSource, /const runtimeProfileRaw = readBenchOptionValue\(args, "--runtime-profile"\);/);
+  assert.match(parserSource, /const matrixRaw = readBenchOptionValue\(args, "--matrix"\);/);
+  assert.match(parserSource, /const remnicConfigRaw = readBenchOptionValue\(args, "--remnic-config"\);/);
+  assert.match(parserSource, /const openclawConfigRaw = readBenchOptionValue\(args, "--openclaw-config"\);/);
+  assert.match(parserSource, /const systemProviderRaw = readBenchOptionValue\(args, "--system-provider"\);/);
+  assert.match(parserSource, /const judgeProviderRaw = readBenchOptionValue\(args, "--judge-provider"\);/);
+  assert.match(readme, /remnic bench run --quick longmemeval --runtime-profile baseline/);
+  assert.match(readme, /remnic bench run longmemeval --runtime-profile real --remnic-config/);
+  assert.match(readme, /remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config/);
+});
+
+test("parseBenchArgs supports runtime profiles, provider-backed runs, and matrix mode", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs([
+    "run",
+    "longmemeval",
+    "--runtime-profile",
+    "openclaw-chain",
+    "--openclaw-config",
+    "~/.openclaw/openclaw.json",
+    "--model-source",
+    "gateway",
+    "--gateway-agent-id",
+    "memory-primary",
+    "--fast-gateway-agent-id",
+    "memory-fast",
+    "--system-provider",
+    "openai",
+    "--system-model",
+    "gpt-5.4-mini",
+    "--system-base-url",
+    "http://localhost:4000/v1",
+    "--judge-provider",
+    "anthropic",
+    "--judge-model",
+    "claude-sonnet-4-5",
+    "--judge-base-url",
+    "http://localhost:4100",
+    "--matrix",
+    "baseline,real,openclaw-chain",
+  ]);
+
+  assert.equal(parsed.action, "run");
+  assert.deepEqual(parsed.benchmarks, ["longmemeval"]);
+  assert.equal(parsed.runtimeProfile, "openclaw-chain");
+  assert.deepEqual(parsed.matrixProfiles, ["baseline", "real", "openclaw-chain"]);
+  assert.equal(parsed.modelSource, "gateway");
+  assert.equal(parsed.gatewayAgentId, "memory-primary");
+  assert.equal(parsed.fastGatewayAgentId, "memory-fast");
+  assert.equal(parsed.systemProvider, "openai");
+  assert.equal(parsed.systemModel, "gpt-5.4-mini");
+  assert.equal(parsed.judgeProvider, "anthropic");
+  assert.equal(parsed.judgeModel, "claude-sonnet-4-5");
+  assert.match(parsed.openclawConfigPath ?? "", /openclaw\.json$/);
+  assert.match(parsed.systemBaseUrl ?? "", /4000\/v1$/);
+  assert.match(parsed.judgeBaseUrl ?? "", /4100$/);
 });
 
 test("bench compare routes through stored package results with threshold and results-dir options", async () => {
@@ -468,7 +555,7 @@ test("parseBenchArgs rejects unknown bench publish targets", async () => {
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
 
-  assert.match(source, /type BenchmarkDefinition,\s*\n\s*\} from "@remnic\/bench";/s);
+  assert.match(source, /type BenchmarkDefinition,/);
   assert.match(source, /async function loadBenchDefinitionsFromPackage\(\): Promise<BenchmarkDefinition\[\] \| undefined>/);
   assert.match(source, /listBenchmarks\?: \(\) => BenchmarkDefinition\[\];/);
   assert.doesNotMatch(source, /interface PackageBenchDefinition/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -428,6 +428,124 @@ export function ensureWecloneImportAdapterRegistered() {}
   }
 });
 
+test("bench run fails loudly when an explicit --remnic-config path is missing", async () => {
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(__dirname, "..");
+  const cliEntry = pathToFileURL(join(repoRoot, "packages/remnic-cli/src/index.ts")).href;
+
+  interface StubHandle {
+    cleanup: () => void;
+  }
+
+  const stubWorkspacePackage = (
+    packageName: string,
+    moduleBody: string,
+  ): StubHandle => {
+    const linkRoot = join(repoRoot, "packages/remnic-cli/node_modules", packageName);
+    const moduleRoot = existsSync(linkRoot) ? realpathSync(linkRoot) : linkRoot;
+    const distDir = join(moduleRoot, "dist");
+    const entry = join(distDir, "index.js");
+    const packageJson = join(moduleRoot, "package.json");
+    const needsEntry = !existsSync(entry);
+    const createdLinkRoot = !existsSync(linkRoot);
+    const createdPackageJson = needsEntry && !existsSync(packageJson);
+    const createdDistDir = needsEntry && !existsSync(distDir);
+
+    if (needsEntry) {
+      mkdirSync(distDir, { recursive: true });
+      if (createdPackageJson) {
+        writeFileSync(
+          packageJson,
+          JSON.stringify({
+            name: packageName,
+            type: "module",
+            exports: { ".": "./dist/index.js" },
+          }),
+        );
+      }
+      writeFileSync(entry, moduleBody);
+    }
+
+    return {
+      cleanup: () => {
+        if (!needsEntry) return;
+        rmSync(entry, { force: true });
+        if (createdDistDir) rmSync(distDir, { recursive: true, force: true });
+        if (createdPackageJson) rmSync(packageJson, { force: true });
+        if (createdLinkRoot) rmSync(moduleRoot, { recursive: true, force: true });
+      },
+    };
+  };
+
+  const stubs: StubHandle[] = [
+    stubWorkspacePackage(
+      "@remnic/bench",
+      `
+export function getBenchmark() { return { runnerAvailable: true, meta: { category: "retrieval" } }; }
+export function compareResults() {}
+export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai", generatedAt: new Date(0).toISOString(), benchmarks: [] }; }
+export function checkRegression() { return null; }
+export function defaultBenchmarkBaselineDir() { return ""; }
+export function defaultBenchmarkPublishPath() { return ""; }
+export async function discoverAllProviders() { return []; }
+export function getBenchmarkLowerIsBetter() { return new Set(); }
+export async function listBenchmarkBaselines() { return []; }
+export async function listBenchmarkResults() { return []; }
+export async function loadBenchmarkBaseline() { return null; }
+export async function runBenchSuite() { return null; }
+export async function runExplain() { return null; }
+export async function loadBaseline() { return null; }
+export async function saveBaseline() { return null; }
+export async function loadBenchmarkResult() { return null; }
+export function renderBenchmarkResultExport() { return ""; }
+export async function resolveBenchmarkResultReference() { return null; }
+export async function saveBenchmarkBaseline() { return null; }
+export async function runBenchmark() { throw new Error("runBenchmark should not be called"); }
+export async function writeBenchmarkResult() { return ""; }
+export async function writeBenchmarkPublishFeed() { return ""; }
+export async function resolveBenchRuntimeProfile() { throw new Error("resolveBenchRuntimeProfile should not be called"); }
+export async function createLightweightAdapter() { return { async destroy() {} }; }
+export async function createRemnicAdapter() { return { async destroy() {} }; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/export-weclone",
+      `
+export const wecloneExportAdapter = { name: "weclone", fileExtension: "json", formatRecords: () => "" };
+export function ensureWecloneExportAdapterRegistered() {}
+export function synthesizeTrainingPairs() { return []; }
+export function sweepPii(input) { return input; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/import-weclone",
+      `
+export const wecloneImportAdapter = { name: "weclone", parse: async () => ({ turns: [], metadata: {} }) };
+export function ensureWecloneImportAdapterRegistered() {}
+`,
+    ),
+  ];
+
+  try {
+    const { main } = await import(`${cliEntry}?missing-remnic-config=${Date.now()}`);
+    await assert.rejects(
+      () =>
+        main([
+          "bench",
+          "run",
+          "longmemeval",
+          "--runtime-profile",
+          "real",
+          "--remnic-config",
+          "./definitely-missing-remnic-config.json",
+        ]),
+      /Remnic config file not found:/,
+    );
+  } finally {
+    for (const stub of stubs) stub.cleanup();
+  }
+});
+
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {
   const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -111,6 +111,8 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const runtime = await resolvePackageBenchRuntime\(/);
   assert.match(source, /const system = await createAdapter\(runtime\.adapterOptions\);/);
+  assert.match(source, /remnicConfig: runtime\.effectiveRemnicConfig,/);
+  assert.match(source, /result\.config\.remnicConfig = runtime\.remnicConfig;/);
 });
 
 test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -550,46 +550,142 @@ test("buildBenchRuntimeProfileRequest keeps openclaw-chain on gateway routing in
   const { mkdtemp, writeFile } = await import("node:fs/promises");
   const os = await import("node:os");
   const path = await import("node:path");
-  const { buildBenchRuntimeProfileRequest } = await import("../packages/remnic-cli/src/index.ts");
+  const __dirname = dirname(fileURLToPath(import.meta.url));
+  const repoRoot = join(__dirname, "..");
+
+  interface StubHandle {
+    cleanup: () => void;
+  }
+
+  const stubWorkspacePackage = (
+    packageName: string,
+    moduleBody: string,
+  ): StubHandle => {
+    const linkRoot = join(repoRoot, "packages/remnic-cli/node_modules", packageName);
+    const moduleRoot = existsSync(linkRoot) ? realpathSync(linkRoot) : linkRoot;
+    const distDir = join(moduleRoot, "dist");
+    const entry = join(distDir, "index.js");
+    const packageJson = join(moduleRoot, "package.json");
+    const needsEntry = !existsSync(entry);
+    const createdLinkRoot = !existsSync(linkRoot);
+    const createdPackageJson = needsEntry && !existsSync(packageJson);
+    const createdDistDir = needsEntry && !existsSync(distDir);
+
+    if (needsEntry) {
+      mkdirSync(distDir, { recursive: true });
+      if (createdPackageJson) {
+        writeFileSync(
+          packageJson,
+          JSON.stringify({
+            name: packageName,
+            type: "module",
+            exports: { ".": "./dist/index.js" },
+          }),
+        );
+      }
+      writeFileSync(entry, moduleBody);
+    }
+
+    return {
+      cleanup: () => {
+        if (!needsEntry) return;
+        rmSync(entry, { force: true });
+        if (createdDistDir) rmSync(distDir, { recursive: true, force: true });
+        if (createdPackageJson) rmSync(packageJson, { force: true });
+        if (createdLinkRoot) rmSync(moduleRoot, { recursive: true, force: true });
+      },
+    };
+  };
+
+  const stubs: StubHandle[] = [
+    stubWorkspacePackage(
+      "@remnic/bench",
+      `
+export function compareResults() {}
+export async function buildBenchmarkPublishFeed() { return { target: "remnic-ai", generatedAt: new Date(0).toISOString(), benchmarks: [] }; }
+export function checkRegression() { return null; }
+export function defaultBenchmarkBaselineDir() { return ""; }
+export function defaultBenchmarkPublishPath() { return ""; }
+export async function discoverAllProviders() { return []; }
+export function getBenchmarkLowerIsBetter() { return new Set(); }
+export async function listBenchmarkBaselines() { return []; }
+export async function listBenchmarkResults() { return []; }
+export async function loadBenchmarkBaseline() { return null; }
+export async function runBenchSuite() { return null; }
+export async function runExplain() { return null; }
+export async function loadBaseline() { return null; }
+export async function saveBaseline() { return null; }
+export async function loadBenchmarkResult() { return null; }
+export function renderBenchmarkResultExport() { return ""; }
+export async function resolveBenchmarkResultReference() { return null; }
+export async function saveBenchmarkBaseline() { return null; }
+export async function writeBenchmarkPublishFeed() { return ""; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/export-weclone",
+      `
+export const wecloneExportAdapter = { name: "weclone", fileExtension: "json", formatRecords: () => "" };
+export function ensureWecloneExportAdapterRegistered() {}
+export function synthesizeTrainingPairs() { return []; }
+export function sweepPii(input) { return input; }
+`,
+    ),
+    stubWorkspacePackage(
+      "@remnic/import-weclone",
+      `
+export const wecloneImportAdapter = { name: "weclone", parse: async () => ({ turns: [], metadata: {} }) };
+export function ensureWecloneImportAdapterRegistered() {}
+`,
+    ),
+  ];
 
   const root = await mkdtemp(path.join(os.tmpdir(), "remnic-cli-openclaw-matrix-"));
   const openclawConfigPath = path.join(root, "openclaw.json");
   await writeFile(openclawConfigPath, JSON.stringify({ plugins: { entries: {} } }));
 
-  const parsed = {
-    action: "run",
-    benchmarks: ["longmemeval"],
-    quick: true,
-    all: false,
-    json: false,
-    detail: false,
-    matrixProfiles: ["baseline", "openclaw-chain"],
-    openclawConfigPath,
-    modelSource: "gateway",
-    gatewayAgentId: "memory-primary",
-    fastGatewayAgentId: "memory-fast",
-    systemProvider: "openai",
-    systemModel: "gpt-5.4-mini",
-    systemBaseUrl: "http://localhost:4000/v1",
-    judgeProvider: "anthropic",
-    judgeModel: "claude-sonnet-4-5",
-    judgeBaseUrl: "http://localhost:4100",
-  } as const;
+  try {
+    const { buildBenchRuntimeProfileRequest } = await import(
+      `../packages/remnic-cli/src/index.ts?matrix-runtime-request=${Date.now()}`
+    );
 
-  const baseline = buildBenchRuntimeProfileRequest(parsed, "baseline");
-  const openclaw = buildBenchRuntimeProfileRequest(parsed, "openclaw-chain");
+    const parsed = {
+      action: "run",
+      benchmarks: ["longmemeval"],
+      quick: true,
+      all: false,
+      json: false,
+      detail: false,
+      matrixProfiles: ["baseline", "openclaw-chain"],
+      openclawConfigPath,
+      modelSource: "gateway",
+      gatewayAgentId: "memory-primary",
+      fastGatewayAgentId: "memory-fast",
+      systemProvider: "openai",
+      systemModel: "gpt-5.4-mini",
+      systemBaseUrl: "http://localhost:4000/v1",
+      judgeProvider: "anthropic",
+      judgeModel: "claude-sonnet-4-5",
+      judgeBaseUrl: "http://localhost:4100",
+    } as const;
 
-  assert.equal(baseline.systemProvider, "openai");
-  assert.equal(baseline.systemModel, "gpt-5.4-mini");
-  assert.equal(baseline.openclawConfigPath, undefined);
-  assert.equal(openclaw.openclawConfigPath, openclawConfigPath);
-  assert.equal(openclaw.systemProvider, undefined);
-  assert.equal(openclaw.systemModel, undefined);
-  assert.equal(openclaw.systemBaseUrl, undefined);
-  assert.equal(openclaw.judgeProvider, "anthropic");
-  assert.equal(openclaw.judgeModel, "claude-sonnet-4-5");
-  assert.equal(openclaw.gatewayAgentId, "memory-primary");
-  assert.equal(openclaw.fastGatewayAgentId, "memory-fast");
+    const baseline = buildBenchRuntimeProfileRequest(parsed, "baseline");
+    const openclaw = buildBenchRuntimeProfileRequest(parsed, "openclaw-chain");
+
+    assert.equal(baseline.systemProvider, "openai");
+    assert.equal(baseline.systemModel, "gpt-5.4-mini");
+    assert.equal(baseline.openclawConfigPath, undefined);
+    assert.equal(openclaw.openclawConfigPath, openclawConfigPath);
+    assert.equal(openclaw.systemProvider, undefined);
+    assert.equal(openclaw.systemModel, undefined);
+    assert.equal(openclaw.systemBaseUrl, undefined);
+    assert.equal(openclaw.judgeProvider, "anthropic");
+    assert.equal(openclaw.judgeModel, "claude-sonnet-4-5");
+    assert.equal(openclaw.gatewayAgentId, "memory-primary");
+    assert.equal(openclaw.fastGatewayAgentId, "memory-fast");
+  } finally {
+    for (const stub of stubs) stub.cleanup();
+  }
 });
 
 test("parseBenchArgs excludes --dataset-dir values from benchmark ids", async () => {


### PR DESCRIPTION
## Summary
- add real-runtime benchmark profile resolution in `@remnic/bench` for `baseline`, `real`, and `openclaw-chain`
- add provider-backed responders/judges plus shared answer-generation so published benchmark runners can score final answers, not only recalled text
- wire `remnic bench run` to profile-aware single runs and matrix runs, persist `runtimeProfile` metadata, and document the OpenClaw-chain benchmark path
- fix an `@remnic/export-weclone` DTS failure found during verification so workspace builds stay green

## Implementation
- added `packages/bench/src/runtime-profiles.ts` and `packages/bench/src/responders.ts`
- added `packages/bench/src/answering.ts` and updated published benchmark runners to use the shared answer path
- updated the Remnic adapter contract to carry optional responder/judge hooks and to accept runtime config overrides
- extended bench CLI parsing and orchestration for runtime profiles, direct provider runs, OpenClaw-chain runs, and profile matrices
- documented the new benchmark surfaces in the CLI README and OpenClaw plugin README

## Verification
- `pnpm exec tsx --test tests/remnic-cli-bench-surface.test.ts tests/remnic-cli-bench-ui-surface.test.ts tests/bench-results-store.test.ts packages/bench/src/runtime-profiles.test.ts packages/bench/src/responders.test.ts packages/bench/src/answering.test.ts`
- `pnpm --filter @remnic/export-weclone build`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/bench build`
- `pnpm --filter @remnic/cli build`
- `pnpm rebuild better-sqlite3`
- `pnpm exec tsx packages/remnic-cli/src/index.ts bench run --quick longmemeval --runtime-profile baseline`
- `pnpm exec tsx packages/remnic-cli/src/index.ts bench run --quick longmemeval --runtime-profile real`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new benchmark execution modes that load external configs, call real LLM providers/gateway chains, and change how scores/latency/tokens are computed and persisted, which can affect result validity and CLI behavior.
> 
> **Overview**
> Adds **runtime-profile driven benchmark execution** to `@remnic/bench` (`baseline`, `real`, `openclaw-chain`), including Remnic/OpenClaw config loading, secret redaction for persisted configs, and optional provider-backed responders/judges plus a gateway responder.
> 
> Updates benchmark runners (published + custom) to optionally **generate final answers** via a shared `answerBenchmarkQuestion` helper and to record **tokens/latency/model metadata** for responder/judge paths; scoring now uses `llmJudgeScoreDetailed` to capture metrics and wall-time failures.
> 
> Extends `remnic bench run` with new flags (`--runtime-profile`, `--matrix`, provider/judge params, config paths) and wires execution to run single or matrix profiles via package-backed runtime resolution, storing `runtimeProfile` in result schema/output; also updates docs and fixes a `@remnic/export-weclone` typing issue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93220bd3686174fe3f9053b42ed83412285643a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->