### PR TITLE
feat(types,config): direct-answer tier schema foundation (#518 slice 1/8)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -682,7 +682,11 @@
       },
       "binaryLifecycleBackendType": {
         "type": "string",
-        "enum": ["none", "filesystem", "s3"],
+        "enum": [
+          "none",
+          "filesystem",
+          "s3"
+        ],
         "default": "none",
         "description": "Storage backend for binary lifecycle mirror stage."
       },
@@ -1869,6 +1873,46 @@
         "type": "boolean",
         "default": false,
         "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
+      },
+      "recallDirectAnswerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+      },
+      "recallDirectAnswerTokenOverlapFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.55,
+        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerImportanceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerAmbiguityMargin": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.15,
+        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+      },
+      "recallDirectAnswerEligibleTaxonomyBuckets": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decisions",
+          "principles",
+          "conventions",
+          "runbooks",
+          "entities"
+        ],
+        "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
       "memoryLinkingEnabled": {
         "type": "boolean",
@@ -3905,6 +3949,30 @@
       "label": "Include Superseded Facts In Recall",
       "advanced": true,
       "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "recallDirectAnswerEnabled": {
+      "label": "Direct-Answer Retrieval Tier",
+      "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDirectAnswerTokenOverlapFloor": {
+      "label": "Direct-Answer Token Overlap Floor",
+      "advanced": true,
+      "placeholder": "0.55"
+    },
+    "recallDirectAnswerImportanceFloor": {
+      "label": "Direct-Answer Importance Floor",
+      "advanced": true,
+      "placeholder": "0.7"
+    },
+    "recallDirectAnswerAmbiguityMargin": {
+      "label": "Direct-Answer Ambiguity Margin",
+      "advanced": true,
+      "placeholder": "0.15"
+    },
+    "recallDirectAnswerEligibleTaxonomyBuckets": {
+      "label": "Direct-Answer Eligible Taxonomy Buckets",
+      "advanced": true,
+      "help": "Taxonomy category IDs eligible for direct-answer routing."
     },
     "memoryLinkingEnabled": {
       "label": "Memory Linking",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1870,6 +1870,38 @@
         "default": false,
         "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
       },
+      "recallDirectAnswerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+      },
+      "recallDirectAnswerTokenOverlapFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.55,
+        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerImportanceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerAmbiguityMargin": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.15,
+        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+      },
+      "recallDirectAnswerEligibleTaxonomyBuckets": {
+        "type": "array",
+        "items": { "type": "string" },
+        "default": ["decisions", "principles", "conventions", "runbooks", "entities"],
+        "description": "Taxonomy category IDs eligible for direct-answer routing."
+      },
       "memoryLinkingEnabled": {
         "type": "boolean",
         "default": false,
@@ -3905,6 +3937,30 @@
       "label": "Include Superseded Facts In Recall",
       "advanced": true,
       "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "recallDirectAnswerEnabled": {
+      "label": "Direct-Answer Retrieval Tier",
+      "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDirectAnswerTokenOverlapFloor": {
+      "label": "Direct-Answer Token Overlap Floor",
+      "advanced": true,
+      "placeholder": "0.55"
+    },
+    "recallDirectAnswerImportanceFloor": {
+      "label": "Direct-Answer Importance Floor",
+      "advanced": true,
+      "placeholder": "0.7"
+    },
+    "recallDirectAnswerAmbiguityMargin": {
+      "label": "Direct-Answer Ambiguity Margin",
+      "advanced": true,
+      "placeholder": "0.15"
+    },
+    "recallDirectAnswerEligibleTaxonomyBuckets": {
+      "label": "Direct-Answer Eligible Taxonomy Buckets",
+      "advanced": true,
+      "help": "Taxonomy category IDs eligible for direct-answer routing."
     },
     "memoryLinkingEnabled": {
       "label": "Memory Linking",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -149,6 +149,31 @@ test("parseConfig recallDirectAnswerTokenOverlapFloor=1.5 falls back to default"
   assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.55);
 });
 
+test('parseConfig recallDirectAnswerTokenOverlapFloor="0.8" (string) coerces to 0.8 (rule 28)', () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: "0.8" });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.8);
+});
+
+test('parseConfig recallDirectAnswerTokenOverlapFloor="0" (string) coerces to 0', () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: "0" });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0);
+});
+
+test('parseConfig recallDirectAnswerTokenOverlapFloor="not-a-number" falls back to default', () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: "not-a-number" });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.55);
+});
+
+test('parseConfig recallDirectAnswerImportanceFloor="0.9" (string) coerces to 0.9', () => {
+  const result = parseConfig({ recallDirectAnswerImportanceFloor: "0.9" });
+  assert.equal(result.recallDirectAnswerImportanceFloor, 0.9);
+});
+
+test('parseConfig recallDirectAnswerAmbiguityMargin="0.25" (string) coerces to 0.25', () => {
+  const result = parseConfig({ recallDirectAnswerAmbiguityMargin: "0.25" });
+  assert.equal(result.recallDirectAnswerAmbiguityMargin, 0.25);
+});
+
 test("parseConfig recallDirectAnswerImportanceFloor defaults to 0.7", () => {
   const result = parseConfig({});
   assert.equal(result.recallDirectAnswerImportanceFloor, 0.7);

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -101,3 +101,121 @@ test("parseConfig preserves custom entity schemas without code changes", () => {
     { key: "working_on", title: "Working On", description: "" },
   ]);
 });
+
+// ── Issue #518: direct-answer retrieval tier config ─────────────────────────
+
+test("parseConfig recallDirectAnswerEnabled defaults to false", () => {
+  const result = parseConfig({});
+  assert.equal(result.recallDirectAnswerEnabled, false);
+});
+
+test('parseConfig recallDirectAnswerEnabled coerces string "true" to boolean true', () => {
+  const result = parseConfig({ recallDirectAnswerEnabled: "true" });
+  assert.equal(result.recallDirectAnswerEnabled, true);
+});
+
+test('parseConfig recallDirectAnswerEnabled coerces string "false" to boolean false (rule 36)', () => {
+  const result = parseConfig({ recallDirectAnswerEnabled: "false" });
+  assert.equal(result.recallDirectAnswerEnabled, false);
+});
+
+test("parseConfig recallDirectAnswerEnabled accepts boolean true", () => {
+  const result = parseConfig({ recallDirectAnswerEnabled: true });
+  assert.equal(result.recallDirectAnswerEnabled, true);
+});
+
+test("parseConfig recallDirectAnswerTokenOverlapFloor defaults to 0.55", () => {
+  const result = parseConfig({});
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.55);
+});
+
+test("parseConfig recallDirectAnswerTokenOverlapFloor=0 is preserved as disable switch (rule 45)", () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: 0 });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0);
+});
+
+test("parseConfig recallDirectAnswerTokenOverlapFloor=0.8 preserves the explicit value", () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: 0.8 });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.8);
+});
+
+test("parseConfig recallDirectAnswerTokenOverlapFloor=-0.1 falls back to default", () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: -0.1 });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.55);
+});
+
+test("parseConfig recallDirectAnswerTokenOverlapFloor=1.5 falls back to default", () => {
+  const result = parseConfig({ recallDirectAnswerTokenOverlapFloor: 1.5 });
+  assert.equal(result.recallDirectAnswerTokenOverlapFloor, 0.55);
+});
+
+test("parseConfig recallDirectAnswerImportanceFloor defaults to 0.7", () => {
+  const result = parseConfig({});
+  assert.equal(result.recallDirectAnswerImportanceFloor, 0.7);
+});
+
+test("parseConfig recallDirectAnswerImportanceFloor=0 is preserved as disable switch", () => {
+  const result = parseConfig({ recallDirectAnswerImportanceFloor: 0 });
+  assert.equal(result.recallDirectAnswerImportanceFloor, 0);
+});
+
+test("parseConfig recallDirectAnswerAmbiguityMargin defaults to 0.15", () => {
+  const result = parseConfig({});
+  assert.equal(result.recallDirectAnswerAmbiguityMargin, 0.15);
+});
+
+test("parseConfig recallDirectAnswerAmbiguityMargin=0.3 preserves explicit value", () => {
+  const result = parseConfig({ recallDirectAnswerAmbiguityMargin: 0.3 });
+  assert.equal(result.recallDirectAnswerAmbiguityMargin, 0.3);
+});
+
+test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets defaults to the documented list", () => {
+  const result = parseConfig({});
+  assert.deepEqual(result.recallDirectAnswerEligibleTaxonomyBuckets, [
+    "decisions",
+    "principles",
+    "conventions",
+    "runbooks",
+    "entities",
+  ]);
+});
+
+test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets preserves a custom array", () => {
+  const result = parseConfig({
+    recallDirectAnswerEligibleTaxonomyBuckets: ["decisions", "runbooks"],
+  });
+  assert.deepEqual(result.recallDirectAnswerEligibleTaxonomyBuckets, [
+    "decisions",
+    "runbooks",
+  ]);
+});
+
+test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets filters non-strings and empty strings", () => {
+  const result = parseConfig({
+    recallDirectAnswerEligibleTaxonomyBuckets: ["decisions", "", 42, null, "runbooks"],
+  });
+  assert.deepEqual(result.recallDirectAnswerEligibleTaxonomyBuckets, [
+    "decisions",
+    "runbooks",
+  ]);
+});
+
+test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets=[] is preserved as a disable-all state", () => {
+  const result = parseConfig({
+    recallDirectAnswerEligibleTaxonomyBuckets: [],
+  });
+  assert.deepEqual(result.recallDirectAnswerEligibleTaxonomyBuckets, []);
+});
+
+test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets non-array value falls back to default", () => {
+  const result = parseConfig({
+    recallDirectAnswerEligibleTaxonomyBuckets: "decisions",
+  });
+  assert.deepEqual(result.recallDirectAnswerEligibleTaxonomyBuckets, [
+    "decisions",
+    "principles",
+    "conventions",
+    "runbooks",
+    "entities",
+  ]);
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -25,7 +25,7 @@ import { normalizeEntitySchemas } from "./entity-schema.js";
 // boolean-coercion logic that connectors/index.ts already exports. The helper
 // lives in connectors/coerce.ts (a tiny, dependency-free module) so neither
 // config.ts → connectors/index.ts nor the reverse circular import arises.
-import { coerceBool, coerceInstallExtension } from "./connectors/coerce.js";
+import { coerceBool, coerceInstallExtension, coerceNumber } from "./connectors/coerce.js";
 
 const DEFAULT_MEMORY_DIR = path.join(
   resolveHomeDir(),
@@ -841,24 +841,18 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Direct-answer retrieval tier (issue #518)
     recallDirectAnswerEnabled:
       coerceBool(cfg.recallDirectAnswerEnabled) ?? false,
-    recallDirectAnswerTokenOverlapFloor:
-      typeof cfg.recallDirectAnswerTokenOverlapFloor === "number" &&
-      cfg.recallDirectAnswerTokenOverlapFloor >= 0 &&
-      cfg.recallDirectAnswerTokenOverlapFloor <= 1
-        ? cfg.recallDirectAnswerTokenOverlapFloor
-        : 0.55,
-    recallDirectAnswerImportanceFloor:
-      typeof cfg.recallDirectAnswerImportanceFloor === "number" &&
-      cfg.recallDirectAnswerImportanceFloor >= 0 &&
-      cfg.recallDirectAnswerImportanceFloor <= 1
-        ? cfg.recallDirectAnswerImportanceFloor
-        : 0.7,
-    recallDirectAnswerAmbiguityMargin:
-      typeof cfg.recallDirectAnswerAmbiguityMargin === "number" &&
-      cfg.recallDirectAnswerAmbiguityMargin >= 0 &&
-      cfg.recallDirectAnswerAmbiguityMargin <= 1
-        ? cfg.recallDirectAnswerAmbiguityMargin
-        : 0.15,
+    recallDirectAnswerTokenOverlapFloor: (() => {
+      const n = coerceNumber(cfg.recallDirectAnswerTokenOverlapFloor);
+      return n !== undefined && n >= 0 && n <= 1 ? n : 0.55;
+    })(),
+    recallDirectAnswerImportanceFloor: (() => {
+      const n = coerceNumber(cfg.recallDirectAnswerImportanceFloor);
+      return n !== undefined && n >= 0 && n <= 1 ? n : 0.7;
+    })(),
+    recallDirectAnswerAmbiguityMargin: (() => {
+      const n = coerceNumber(cfg.recallDirectAnswerAmbiguityMargin);
+      return n !== undefined && n >= 0 && n <= 1 ? n : 0.15;
+    })(),
     recallDirectAnswerEligibleTaxonomyBuckets: Array.isArray(
       cfg.recallDirectAnswerEligibleTaxonomyBuckets,
     )

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -838,6 +838,34 @@ export function parseConfig(raw: unknown): PluginConfig {
     temporalSupersessionEnabled: cfg.temporalSupersessionEnabled !== false, // On by default
     temporalSupersessionIncludeInRecall:
       cfg.temporalSupersessionIncludeInRecall === true, // Off by default
+    // Direct-answer retrieval tier (issue #518)
+    recallDirectAnswerEnabled:
+      coerceBool(cfg.recallDirectAnswerEnabled) ?? false,
+    recallDirectAnswerTokenOverlapFloor:
+      typeof cfg.recallDirectAnswerTokenOverlapFloor === "number" &&
+      cfg.recallDirectAnswerTokenOverlapFloor >= 0 &&
+      cfg.recallDirectAnswerTokenOverlapFloor <= 1
+        ? cfg.recallDirectAnswerTokenOverlapFloor
+        : 0.55,
+    recallDirectAnswerImportanceFloor:
+      typeof cfg.recallDirectAnswerImportanceFloor === "number" &&
+      cfg.recallDirectAnswerImportanceFloor >= 0 &&
+      cfg.recallDirectAnswerImportanceFloor <= 1
+        ? cfg.recallDirectAnswerImportanceFloor
+        : 0.7,
+    recallDirectAnswerAmbiguityMargin:
+      typeof cfg.recallDirectAnswerAmbiguityMargin === "number" &&
+      cfg.recallDirectAnswerAmbiguityMargin >= 0 &&
+      cfg.recallDirectAnswerAmbiguityMargin <= 1
+        ? cfg.recallDirectAnswerAmbiguityMargin
+        : 0.15,
+    recallDirectAnswerEligibleTaxonomyBuckets: Array.isArray(
+      cfg.recallDirectAnswerEligibleTaxonomyBuckets,
+    )
+      ? (cfg.recallDirectAnswerEligibleTaxonomyBuckets as unknown[]).filter(
+          (v): v is string => typeof v === "string" && v.length > 0,
+        )
+      : ["decisions", "principles", "conventions", "runbooks", "entities"],
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially
     // Conversation Threading (Phase 3B)

--- a/packages/remnic-core/src/connectors/coerce.ts
+++ b/packages/remnic-core/src/connectors/coerce.ts
@@ -35,3 +35,28 @@ export function coerceBool(value: unknown): boolean | undefined {
 export function coerceInstallExtension(value: unknown): boolean | undefined {
   return coerceBool(value);
 }
+
+/**
+ * Generic numeric coercion: accepts a finite number or a string that
+ * parses cleanly to one. Returns `undefined` otherwise so callers can
+ * fall back to a default.
+ *
+ * Rules:
+ * - number: returned as-is only if finite (NaN / ±Infinity → undefined).
+ * - string: trimmed, parsed with `Number()`. Returns `undefined` on
+ *   empty, NaN, or Infinity.
+ *
+ * CLAUDE.md gotcha #28: Coerce CLI values to expected types at input boundaries.
+ */
+export function coerceNumber(value: unknown): number | undefined {
+  if (typeof value === "number") {
+    return Number.isFinite(value) ? value : undefined;
+  }
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    if (trimmed.length === 0) return undefined;
+    const n = Number(trimmed);
+    return Number.isFinite(n) ? n : undefined;
+  }
+  return undefined;
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -35,6 +35,38 @@ export type ActiveRecallThinking =
 export type ActiveRecallChatType = "direct" | "group" | "channel";
 export type ActiveRecallModelFallbackPolicy = "default-remote" | "resolved-only";
 
+/**
+ * Retrieval tier ladder (issue #518).  Identifies which tier served a recall
+ * result.  Ordered top-to-bottom by cost, but routing is not strictly
+ * sequential — callers may jump straight to a lower tier when eligibility
+ * does not hold.
+ */
+export type RetrievalTier =
+  | "exact-cache"
+  | "fuzzy-cache"
+  | "direct-answer"
+  | "hybrid"
+  | "rerank-graph"
+  | "agentic";
+
+/**
+ * Per-recall annotation describing which retrieval tier served a result,
+ * why that tier was chosen, and what was filtered along the way.  Added as
+ * part of issue #518 (direct-answer tier + `query --explain`).
+ *
+ * Not to be confused with the existing `recallExplain` operation
+ * (graph-path explanation) — that is a user-invoked RPC; this is a
+ * per-result annotation that can be attached to any recall response.
+ */
+export interface RecallTierExplain {
+  tier: RetrievalTier;
+  tierReason: string;
+  filteredBy: string[];
+  candidatesConsidered: number;
+  latencyMs: number;
+  sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
+}
+
 export interface RecallSectionConfig {
   id: string;
   enabled?: boolean;
@@ -300,6 +332,33 @@ export interface PluginConfig {
    * filtered out.
    */
   temporalSupersessionIncludeInRecall: boolean;
+  // Direct-answer retrieval tier (issue #518)
+  /**
+   * When true, recall checks whether a single validated memory in a
+   * high-trust taxonomy bucket can answer the query before invoking QMD.
+   * Default false — enable explicitly after bench validation.
+   */
+  recallDirectAnswerEnabled: boolean;
+  /**
+   * Minimum token-overlap ratio (query tokens ∩ memory tokens / query tokens)
+   * required for direct-answer eligibility.  Set to 0 to disable the gate.
+   */
+  recallDirectAnswerTokenOverlapFloor: number;
+  /**
+   * Minimum calibrated importance score required for direct-answer
+   * eligibility.  Set to 0 to disable the gate.
+   */
+  recallDirectAnswerImportanceFloor: number;
+  /**
+   * Ambiguity margin: if the second-best candidate scores within this
+   * ratio of the top candidate, direct-answer defers to the hybrid tier.
+   */
+  recallDirectAnswerAmbiguityMargin: number;
+  /**
+   * Taxonomy category IDs eligible for direct-answer routing.  Memories
+   * whose resolved taxonomy category is not in this list never qualify.
+   */
+  recallDirectAnswerEligibleTaxonomyBuckets: string[];
   // Memory Linking (Phase 3A)
   memoryLinkingEnabled: boolean;
   // Conversation Threading (Phase 3B)


### PR DESCRIPTION
First of eight slices for #518 (direct-answer retrieval tier + \`query --explain\`).

Pure types + config surface. No runtime behavior change. Safe to merge and release alone — subsequent slices wire the tier into recall.

## Summary

- Adds \`RetrievalTier\` union and \`RecallTierExplain\` interface in \`types.ts\`.
- Adds 5 new \`PluginConfig\` fields under the \`recallDirectAnswer*\` prefix, with defaults chosen to keep behavior identical until a later slice flips the \`enabled\` flag.
- Adds schema + UI metadata entries in the OpenClaw plugin manifest (source + synced mirror).
- Adds 16 \`parseConfig\` tests covering defaults, string-boolean coercion (CLAUDE.md rule 36), out-of-range fallback, \`0\` as documented disable (rule 45), array filtering, and empty-array preservation.

## Design notes

- \`RecallTierExplain\` is distinct from the existing \`recallExplain\` operation (graph-path explanation). The latter is a user-invoked RPC; this is a per-result annotation.
- \`recallDirectAnswerEnabled\` defaults to \`false\` so enabling the feature is a deliberate, reviewable change after bench validation lands.
- Float thresholds accept \`0\` as a documented disable and reject values outside \`[0, 1]\`, falling back to default (rules 45, 51).
- Empty taxonomy-bucket array is preserved (explicit disable-all), non-array values fall back to default.
- Boolean flag uses the shared \`coerceBool\` helper so CLI string values (\`--config recallDirectAnswerEnabled=false\`) coerce properly.

## Out of scope for this slice

- \`direct-answer.ts\` eligibility module (slice 2)
- \`retrieval.ts\` wiring + explain plumbing across tiers (slice 3)
- CLI / HTTP / MCP surfaces (slices 4–6)
- Bench scenario (slice 7)
- Docs + flipping \`enabled\` to \`true\` (slice 8)

## Test plan

- [x] \`packages/remnic-core/src/config.test.ts\` passes (34 tests, 16 new)
- [x] \`tsc --noEmit\` clean
- [x] \`pnpm run check:openclaw-plugin-sync\` passes (manifest mirror in sync)
- [x] Sample of unrelated core tests still pass (\`briefing.test.ts\`, \`buffer-session.test.ts\`)

Closes part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds new config fields, coercion helper, and type definitions with defaults that keep the feature disabled, plus tests and manifest metadata updates.
> 
> **Overview**
> Introduces the schema foundation for issue #518 by adding `RetrievalTier` and `RecallTierExplain` types and extending `PluginConfig` with `recallDirectAnswer*` settings (enable flag, threshold floors/margins, and eligible taxonomy buckets).
> 
> Updates `parseConfig` to coerce/validate these new values (including new shared `coerceNumber` and range checks with safe defaults), adds comprehensive config parsing tests, and wires the new settings into the OpenClaw plugin manifest (both source and synced copy) including UI hints.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d1459fd14d5afe82b706af0e15700676c2004f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->