### PR TITLE
feat(retrieval): direct-answer eligibility module (#518 slice 2/8)

### DIFF
--- a/packages/remnic-core/src/direct-answer.test.ts
+++ b/packages/remnic-core/src/direct-answer.test.ts
@@ -1,0 +1,484 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  FILTER_LABELS,
+  isDirectAnswerEligible,
+  type DirectAnswerCandidate,
+  type DirectAnswerConfig,
+} from "./direct-answer.js";
+import type { MemoryFile } from "./types.js";
+
+const DEFAULT_CONFIG: DirectAnswerConfig = {
+  enabled: true,
+  tokenOverlapFloor: 0.5,
+  importanceFloor: 0.7,
+  ambiguityMargin: 0.15,
+  eligibleTaxonomyBuckets: ["decisions", "principles", "conventions", "runbooks", "entities"],
+};
+
+function makeMemory(overrides: {
+  id?: string;
+  path?: string;
+  content?: string;
+  tags?: string[];
+  status?: MemoryFile["frontmatter"]["status"];
+  verificationState?: MemoryFile["frontmatter"]["verificationState"];
+  entityRef?: string;
+} = {}): MemoryFile {
+  const id = overrides.id ?? "mem-1";
+  return {
+    path: overrides.path ?? `/memory/${id}.md`,
+    frontmatter: {
+      id,
+      category: "decision",
+      created: "2026-04-19T00:00:00.000Z",
+      updated: "2026-04-19T00:00:00.000Z",
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: overrides.tags ?? [],
+      status: overrides.status,
+      verificationState: overrides.verificationState,
+      entityRef: overrides.entityRef,
+    },
+    content: overrides.content ?? "",
+  };
+}
+
+function makeCandidate(overrides: Partial<DirectAnswerCandidate> & { memory?: MemoryFile } = {}): DirectAnswerCandidate {
+  return {
+    memory: overrides.memory ?? makeMemory(),
+    // Use `in` so callers can pass an explicit `null` without it being
+    // clobbered by the default.
+    trustZone: "trustZone" in overrides ? overrides.trustZone ?? null : "trusted",
+    taxonomyBucket:
+      "taxonomyBucket" in overrides ? overrides.taxonomyBucket ?? null : "decisions",
+    importanceScore: overrides.importanceScore ?? 0.9,
+    matchScore: overrides.matchScore,
+  };
+}
+
+// ── Gate: config.enabled ────────────────────────────────────────────────────
+
+test("isDirectAnswerEligible returns reason=disabled when config.enabled is false", () => {
+  const result = isDirectAnswerEligible({
+    query: "anything",
+    candidates: [makeCandidate()],
+    config: { ...DEFAULT_CONFIG, enabled: false },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "disabled");
+  assert.deepEqual(result.filteredBy, []);
+});
+
+// ── Gate: query has no searchable tokens ────────────────────────────────────
+
+test("isDirectAnswerEligible returns empty-query when query tokens normalize to empty", () => {
+  const result = isDirectAnswerEligible({
+    query: "? !!!",
+    candidates: [makeCandidate()],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.reason, "empty-query");
+  assert.equal(result.eligible, false);
+});
+
+// ── Gate: no candidates ──────────────────────────────────────────────────────
+
+test("isDirectAnswerEligible returns no-candidates when candidate list is empty", () => {
+  const result = isDirectAnswerEligible({
+    query: "which package manager do we use for remnic",
+    candidates: [],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.reason, "no-candidates");
+  assert.equal(result.eligible, false);
+});
+
+// ── Filter: status must be active ────────────────────────────────────────────
+
+test("isDirectAnswerEligible filters superseded candidates and records the filter label", () => {
+  const survivor = makeCandidate({
+    memory: makeMemory({
+      id: "live",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm as its package manager",
+    }),
+  });
+  const superseded = makeCandidate({
+    memory: makeMemory({
+      id: "old",
+      status: "superseded",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses npm as its package manager",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [superseded, survivor],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.winner?.memory.frontmatter.id, "live");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.nonActiveStatus));
+});
+
+test("isDirectAnswerEligible treats undefined status as active", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      status: undefined,
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm as its package manager",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, true);
+  assert.ok(!result.filteredBy.includes(FILTER_LABELS.nonActiveStatus));
+});
+
+// ── Filter: trust zone must be trusted ──────────────────────────────────────
+
+test("isDirectAnswerEligible rejects working-zone memories", () => {
+  const working = makeCandidate({
+    trustZone: "working",
+    memory: makeMemory({
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [working],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "no-eligible-candidates");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.notTrustedZone));
+});
+
+test("isDirectAnswerEligible rejects quarantine-zone memories", () => {
+  const quarantined = makeCandidate({
+    trustZone: "quarantine",
+    memory: makeMemory({
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [quarantined],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.notTrustedZone));
+});
+
+// ── Filter: taxonomy bucket must be in allowlist ────────────────────────────
+
+test("isDirectAnswerEligible rejects candidates whose taxonomy bucket is not eligible", () => {
+  const candidate = makeCandidate({
+    taxonomyBucket: "corrections",
+    memory: makeMemory({
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.ineligibleTaxonomyBucket));
+});
+
+test("isDirectAnswerEligible rejects candidates with null taxonomy bucket", () => {
+  const candidate = makeCandidate({
+    taxonomyBucket: null,
+    memory: makeMemory({
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+});
+
+// ── Filter: importance floor OR user_confirmed ──────────────────────────────
+
+test("isDirectAnswerEligible keeps user_confirmed memory below importance floor", () => {
+  const candidate = makeCandidate({
+    importanceScore: 0.1,
+    memory: makeMemory({
+      verificationState: "user_confirmed",
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, true);
+});
+
+test("isDirectAnswerEligible rejects memory below importance floor without user_confirmed", () => {
+  const candidate = makeCandidate({
+    importanceScore: 0.3,
+    memory: makeMemory({
+      verificationState: "unverified",
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowImportanceFloor));
+});
+
+test("isDirectAnswerEligible with importanceFloor=0 keeps low-importance memories (rule 45)", () => {
+  const candidate = makeCandidate({
+    importanceScore: 0,
+    memory: makeMemory({
+      verificationState: "unverified",
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, importanceFloor: 0 },
+  });
+  assert.equal(result.eligible, true);
+});
+
+// ── Filter: entity ref must match when caller supplies hints ────────────────
+
+test("isDirectAnswerEligible filters candidates whose entityRef does not match provided hints", () => {
+  const match = makeCandidate({
+    memory: makeMemory({
+      id: "match",
+      entityRef: "remnic",
+      tags: ["package-manager"],
+      content: "remnic uses pnpm",
+    }),
+  });
+  const mismatch = makeCandidate({
+    memory: makeMemory({
+      id: "mismatch",
+      entityRef: "weclone",
+      tags: ["package-manager"],
+      content: "weclone uses npm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [mismatch, match],
+    config: DEFAULT_CONFIG,
+    queryEntityRefs: ["remnic"],
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.winner?.memory.frontmatter.id, "match");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.entityRefMismatch));
+});
+
+test("isDirectAnswerEligible entity hint match is case-insensitive", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      entityRef: "Remnic",
+      tags: ["package-manager"],
+      content: "Remnic uses pnpm",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+    queryEntityRefs: ["REMNIC"],
+  });
+  assert.equal(result.eligible, true);
+});
+
+test("isDirectAnswerEligible allows memories with no entityRef when hints are supplied", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      entityRef: undefined,
+      tags: ["package-manager"],
+      content: "pnpm is the package manager",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+    queryEntityRefs: ["remnic"],
+  });
+  assert.equal(result.eligible, true);
+});
+
+// ── Gate: token-overlap floor ───────────────────────────────────────────────
+
+test("isDirectAnswerEligible rejects when no candidate meets the token-overlap floor", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "completely unrelated prose about sailing boats",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "below-token-overlap-floor");
+  assert.ok(result.filteredBy.includes(FILTER_LABELS.belowTokenOverlapFloor));
+});
+
+test("isDirectAnswerEligible with tokenOverlapFloor=0 accepts any overlap (rule 45)", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: [],
+      content: "tangential content with remnic mentioned once",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: { ...DEFAULT_CONFIG, tokenOverlapFloor: 0 },
+  });
+  assert.equal(result.eligible, true);
+});
+
+// ── Gate: ambiguity margin ──────────────────────────────────────────────────
+
+test("isDirectAnswerEligible defers to hybrid when top two candidates are within ambiguity margin", () => {
+  const a = makeCandidate({
+    memory: makeMemory({
+      id: "a",
+      path: "/a.md",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm",
+    }),
+    matchScore: 0.9,
+  });
+  const b = makeCandidate({
+    memory: makeMemory({
+      id: "b",
+      path: "/b.md",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm as its package manager",
+    }),
+    matchScore: 0.85,
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [a, b],
+    config: { ...DEFAULT_CONFIG, ambiguityMargin: 0.15 },
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "ambiguous");
+});
+
+test("isDirectAnswerEligible keeps top candidate when second is beyond ambiguity margin", () => {
+  const top = makeCandidate({
+    memory: makeMemory({
+      id: "top",
+      path: "/top.md",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm",
+    }),
+    matchScore: 0.9,
+  });
+  const weak = makeCandidate({
+    memory: makeMemory({
+      id: "weak",
+      path: "/weak.md",
+      tags: ["package-manager"],
+      content: "package manager",
+    }),
+    matchScore: 0.3,
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [top, weak],
+    config: { ...DEFAULT_CONFIG, ambiguityMargin: 0.15 },
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.winner?.memory.frontmatter.id, "top");
+});
+
+// ── Sort stability (CLAUDE.md rule 19) ──────────────────────────────────────
+
+test("isDirectAnswerEligible sort falls back to path comparison when scores tie", () => {
+  const a = makeCandidate({
+    memory: makeMemory({
+      id: "a",
+      path: "/aaa.md",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm",
+    }),
+    matchScore: 0.9,
+  });
+  const b = makeCandidate({
+    memory: makeMemory({
+      id: "b",
+      path: "/zzz.md",
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm",
+    }),
+    matchScore: 0.9,
+  });
+  // Both score identically, which would normally trigger the ambiguity gate.
+  // Set ambiguityMargin to 0 so ties don't auto-defer, and verify the stable
+  // secondary sort returns the same winner regardless of input order.
+  const forward = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [a, b],
+    config: { ...DEFAULT_CONFIG, ambiguityMargin: 0 },
+  });
+  const backward = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [b, a],
+    config: { ...DEFAULT_CONFIG, ambiguityMargin: 0 },
+  });
+  assert.equal(forward.winner?.memory.frontmatter.id, "a");
+  assert.equal(backward.winner?.memory.frontmatter.id, "a");
+});
+
+// ── Happy path narrative ────────────────────────────────────────────────────
+
+test("isDirectAnswerEligible eligible result includes narrative with bucket and overlap", () => {
+  const candidate = makeCandidate({
+    memory: makeMemory({
+      tags: ["package-manager", "remnic"],
+      content: "remnic uses pnpm as its package manager",
+    }),
+  });
+  const result = isDirectAnswerEligible({
+    query: "package manager remnic",
+    candidates: [candidate],
+    config: DEFAULT_CONFIG,
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.reason, "eligible");
+  assert.ok(result.narrative.includes("decisions"));
+  assert.ok(result.narrative.includes("unambiguous"));
+  assert.ok(result.narrative.includes("token-overlap"));
+  assert.ok(result.tokenOverlap !== undefined && result.tokenOverlap > 0);
+});

--- a/packages/remnic-core/src/direct-answer.ts
+++ b/packages/remnic-core/src/direct-answer.ts
@@ -1,0 +1,273 @@
+/**
+ * Direct-answer retrieval tier eligibility (issue #518 slice 2).
+ *
+ * This module is a pure decision layer.  It takes a query, a set of
+ * caller-resolved candidates (each already decorated with trust-zone,
+ * taxonomy-bucket, and importance information), and the direct-answer
+ * config, then returns an eligibility verdict.
+ *
+ * Keeping the module pure means:
+ *
+ * - Tests do not need a trust-zones store, taxonomy resolver, or importance
+ *   scorer on disk.
+ * - Slice 3 (retrieval.ts wiring) is responsible for resolving those signals
+ *   before calling in; the wiring layer decides where candidates come from
+ *   (entity index, token prefilter, etc.).  This module only decides
+ *   whether the surfaced candidates add up to a confident direct answer.
+ *
+ * Not wired into retrieval yet — see slice 3.
+ */
+
+import type { MemoryFile, MemoryStatus } from "./types.js";
+import type { TrustZoneName } from "./trust-zones.js";
+import {
+  countRecallTokenOverlap,
+  normalizeRecallTokens,
+} from "./recall-tokenization.js";
+
+/**
+ * Caller-supplied candidate.
+ *
+ * `trustZone`, `taxonomyBucket`, and `importanceScore` are resolved outside
+ * this module because each comes from a different subsystem.  Passing them
+ * as inputs keeps the function deterministic and easy to unit-test.
+ *
+ * `matchScore` is optional; if omitted, candidates are ranked by
+ * token-overlap ratio.  Callers that already computed a better ranking
+ * score (e.g. BM25, vector similarity) can supply it to drive the
+ * ambiguity check.
+ */
+export interface DirectAnswerCandidate {
+  memory: MemoryFile;
+  trustZone: TrustZoneName | null;
+  taxonomyBucket: string | null;
+  importanceScore: number;
+  matchScore?: number;
+}
+
+export interface DirectAnswerConfig {
+  enabled: boolean;
+  tokenOverlapFloor: number;
+  importanceFloor: number;
+  ambiguityMargin: number;
+  eligibleTaxonomyBuckets: string[];
+}
+
+export interface DirectAnswerInput {
+  query: string;
+  candidates: DirectAnswerCandidate[];
+  config: DirectAnswerConfig;
+  /**
+   * Optional entity-ref hints resolved from the query upstream.  When
+   * supplied, a candidate with a set `entityRef` must match one of these
+   * (case-insensitive) to remain eligible.  Candidates without an
+   * `entityRef` are allowed through regardless.
+   */
+  queryEntityRefs?: string[];
+}
+
+export type DirectAnswerReason =
+  | "disabled"
+  | "empty-query"
+  | "no-candidates"
+  | "no-eligible-candidates"
+  | "below-token-overlap-floor"
+  | "ambiguous"
+  | "eligible";
+
+export interface DirectAnswerResult {
+  eligible: boolean;
+  reason: DirectAnswerReason;
+  /** Winning candidate when eligible. */
+  winner?: DirectAnswerCandidate;
+  /** Computed token-overlap ratio (0..1) of the winner. */
+  tokenOverlap?: number;
+  /**
+   * Human-readable summary suitable for
+   * `RecallTierExplain.tierReason`.
+   */
+  narrative: string;
+  /**
+   * Filter labels that eliminated at least one candidate along the way.
+   * Populated regardless of eligibility so the caller can surface the
+   * narrowing steps in `RecallTierExplain.filteredBy`.
+   */
+  filteredBy: string[];
+}
+
+/** Filter labels — exported so callers and tests can match them structurally. */
+export const FILTER_LABELS = {
+  nonActiveStatus: "non-active-status",
+  notTrustedZone: "not-trusted-zone",
+  ineligibleTaxonomyBucket: "ineligible-taxonomy-bucket",
+  belowImportanceFloor: "below-importance-floor",
+  entityRefMismatch: "entity-ref-mismatch",
+  belowTokenOverlapFloor: "below-token-overlap-floor",
+} as const;
+
+interface ScoredCandidate {
+  candidate: DirectAnswerCandidate;
+  tokenOverlap: number;
+}
+
+/**
+ * Determine whether a query can be served by the direct-answer tier.
+ *
+ * Decision ladder, in order:
+ *
+ *   1. config.enabled === false → "disabled"
+ *   2. empty query tokens → "empty-query"
+ *   3. empty candidates → "no-candidates"
+ *   4. hard filters drop all candidates → "no-eligible-candidates"
+ *   5. token-overlap floor drops all → "below-token-overlap-floor"
+ *   6. top two candidates within ambiguityMargin → "ambiguous"
+ *   7. otherwise → "eligible"
+ */
+export function isDirectAnswerEligible(
+  input: DirectAnswerInput,
+): DirectAnswerResult {
+  const { query, candidates, config, queryEntityRefs } = input;
+
+  if (!config.enabled) {
+    return {
+      eligible: false,
+      reason: "disabled",
+      narrative: "direct-answer tier is disabled",
+      filteredBy: [],
+    };
+  }
+
+  const queryTokens = new Set(normalizeRecallTokens(query));
+  if (queryTokens.size === 0) {
+    return {
+      eligible: false,
+      reason: "empty-query",
+      narrative: "query has no searchable tokens after normalization",
+      filteredBy: [],
+    };
+  }
+
+  if (candidates.length === 0) {
+    return {
+      eligible: false,
+      reason: "no-candidates",
+      narrative: "no candidates supplied",
+      filteredBy: [],
+    };
+  }
+
+  const filteredBy: string[] = [];
+  let working: DirectAnswerCandidate[] = candidates;
+
+  working = applyFilter(working, filteredBy, FILTER_LABELS.nonActiveStatus, (c) => {
+    const status: MemoryStatus = c.memory.frontmatter.status ?? "active";
+    return status === "active";
+  });
+
+  working = applyFilter(working, filteredBy, FILTER_LABELS.notTrustedZone, (c) =>
+    c.trustZone === "trusted",
+  );
+
+  working = applyFilter(
+    working,
+    filteredBy,
+    FILTER_LABELS.ineligibleTaxonomyBucket,
+    (c) =>
+      c.taxonomyBucket !== null &&
+      config.eligibleTaxonomyBuckets.includes(c.taxonomyBucket),
+  );
+
+  working = applyFilter(working, filteredBy, FILTER_LABELS.belowImportanceFloor, (c) => {
+    if (c.memory.frontmatter.verificationState === "user_confirmed") return true;
+    return c.importanceScore >= config.importanceFloor;
+  });
+
+  if (queryEntityRefs && queryEntityRefs.length > 0) {
+    const normRefs = new Set(queryEntityRefs.map((r) => r.toLowerCase()));
+    working = applyFilter(working, filteredBy, FILTER_LABELS.entityRefMismatch, (c) => {
+      const ref = c.memory.frontmatter.entityRef;
+      if (!ref) return true;
+      return normRefs.has(ref.toLowerCase());
+    });
+  }
+
+  if (working.length === 0) {
+    return {
+      eligible: false,
+      reason: "no-eligible-candidates",
+      narrative: "no candidates survived eligibility filters",
+      filteredBy,
+    };
+  }
+
+  const scored: ScoredCandidate[] = working.map((candidate) => {
+    const searchable =
+      `${candidate.memory.frontmatter.tags?.join(" ") ?? ""} ${candidate.memory.content}`.trim();
+    const matches = countRecallTokenOverlap(queryTokens, searchable);
+    return { candidate, tokenOverlap: matches / queryTokens.size };
+  });
+
+  const overlapSurvivors = scored.filter((s) => s.tokenOverlap >= config.tokenOverlapFloor);
+  if (overlapSurvivors.length < scored.length) {
+    filteredBy.push(FILTER_LABELS.belowTokenOverlapFloor);
+  }
+
+  if (overlapSurvivors.length === 0) {
+    return {
+      eligible: false,
+      reason: "below-token-overlap-floor",
+      narrative: `no candidate met token-overlap floor ${config.tokenOverlapFloor}`,
+      filteredBy,
+    };
+  }
+
+  overlapSurvivors.sort(compareScored);
+
+  if (overlapSurvivors.length >= 2) {
+    const topScore = scoreFor(overlapSurvivors[0]);
+    const secondScore = scoreFor(overlapSurvivors[1]);
+    if (topScore - secondScore < config.ambiguityMargin) {
+      return {
+        eligible: false,
+        reason: "ambiguous",
+        narrative: `top two candidates within ambiguityMargin ${config.ambiguityMargin}`,
+        filteredBy,
+      };
+    }
+  }
+
+  const winner = overlapSurvivors[0];
+  const bucket = winner.candidate.taxonomyBucket ?? "unknown";
+  return {
+    eligible: true,
+    reason: "eligible",
+    winner: winner.candidate,
+    tokenOverlap: winner.tokenOverlap,
+    narrative: `trusted ${bucket}, unambiguous, token-overlap ${winner.tokenOverlap.toFixed(2)}`,
+    filteredBy,
+  };
+}
+
+function applyFilter(
+  working: DirectAnswerCandidate[],
+  filteredBy: string[],
+  label: string,
+  keep: (c: DirectAnswerCandidate) => boolean,
+): DirectAnswerCandidate[] {
+  const before = working.length;
+  const next = working.filter(keep);
+  if (next.length < before) filteredBy.push(label);
+  return next;
+}
+
+function scoreFor(s: ScoredCandidate): number {
+  return s.candidate.matchScore ?? s.tokenOverlap;
+}
+
+function compareScored(a: ScoredCandidate, b: ScoredCandidate): number {
+  const diff = scoreFor(b) - scoreFor(a);
+  if (diff !== 0) return diff;
+  // Stable secondary key on path so the comparator returns 0 only for equal
+  // entries (CLAUDE.md rule 19).
+  return a.candidate.memory.path.localeCompare(b.candidate.memory.path);
+}


### PR DESCRIPTION
Second of eight slices for #518. Pure decision-layer module — nothing imports it yet, slice 3 wires it into \`retrieval.ts\`. Safe to merge and release alone.

## Summary

- New \`packages/remnic-core/src/direct-answer.ts\` with \`isDirectAnswerEligible(input)\`.
- New \`direct-answer.test.ts\` with 21 unit tests — all green, \`tsc --noEmit\` clean.
- Depends on slice 1's types and config (PR #522, merged at 93342ccb).

## Design

The module is a deterministic decision layer. Trust-zone, taxonomy-bucket, and importance signals are **resolved upstream** and passed in on each \`DirectAnswerCandidate\`, so tests do not need to stand up a trust-zones store, taxonomy resolver, or importance scorer. Slice 3 is responsible for sourcing candidates and resolving those signals.

Decision ladder, in order:

1. \`config.enabled === false\` → \`"disabled"\`
2. Query normalizes to empty tokens → \`"empty-query"\`
3. Empty candidate list → \`"no-candidates"\`
4. Hard filters (status, trust zone, taxonomy bucket, importance floor OR \`user_confirmed\`, optional caller-supplied entity-ref hints) drop all → \`"no-eligible-candidates"\`
5. Token-overlap floor drops all → \`"below-token-overlap-floor"\`
6. Top two within \`config.ambiguityMargin\` → \`"ambiguous"\`
7. Otherwise → \`"eligible"\`

Ambiguity comparison uses caller-supplied \`matchScore\` when present, else falls back to token-overlap ratio.

## CLAUDE.md rules honored

- **Rule 19** — sort comparator has a stable secondary key on \`memory.path\` so ties are deterministic.
- **Rule 30** — \`enabled: false\` returns immediately; tested.
- **Rule 45** — \`importanceFloor: 0\` and \`tokenOverlapFloor: 0\` both honor the documented disable intent; tested.
- **Rule 53** — status filter defaults undefined → \`"active"\`, consistent with storage.ts; explicitly tested.

## Out of scope for this slice

- Wiring into \`retrieval.ts\` (slice 3)
- Explain plumbing across other tiers (slice 3)
- CLI / HTTP / MCP surfaces (slices 4–6)
- Bench + docs (slices 7–8)

## Test plan

- [x] \`packages/remnic-core/src/direct-answer.test.ts\` — 21/21 pass
- [x] \`packages/remnic-core/src/config.test.ts\` — 39/39 pass (no regressions)
- [x] \`tsc --noEmit\` clean
- [x] Module is genuinely dead code: no other file imports from \`direct-answer.ts\` (verified via grep)

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new, currently-unwired decision function and unit tests; no existing retrieval behavior changes yet, so runtime risk is low aside from potential future integration assumptions.
> 
> **Overview**
> Introduces a new pure eligibility/ranking module for the upcoming **direct-answer** retrieval tier via `isDirectAnswerEligible`, returning a structured verdict (`reason`, optional `winner`, `tokenOverlap`, `filteredBy`, `narrative`).
> 
> The decision ladder applies hard filters (active status, trusted zone, allowed taxonomy bucket, importance-or-`user_confirmed`, optional entity-ref hints), enforces a token-overlap floor using recall tokenization, and blocks direct answers when the top two candidates are within an ambiguity margin (using optional `matchScore` with a deterministic tiebreak on `memory.path`).
> 
> Adds comprehensive unit tests covering each gate/filter, floor disablement via 0 thresholds, ambiguity handling, stable sorting, and narrative/metadata outputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85253bb2c66921ff3926c07210f544dd23512002. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->