### PR TITLE
feat(core): procedural memory schema + taxonomy (#519 pr 1/6)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -318,6 +318,63 @@
           }
         }
       },
+      "procedural": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519)."
+          },
+          "minOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000,
+            "default": 3,
+            "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
+          },
+          "successFloor": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0.7,
+            "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
+          },
+          "autoPromoteOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000,
+            "default": 8,
+            "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
+          },
+          "autoPromoteEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
+          },
+          "lookbackDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3650,
+            "default": 30,
+            "description": "Trajectory lookback window for procedural mining."
+          },
+          "recallMaxProcedures": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 3,
+            "description": "Maximum procedure memories to inject on task-initiation recall."
+          },
+          "proceduralMiningCronAutoRegister": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, installer may register the nightly procedural mining cron job."
+          }
+        }
+      },
       "slotBehavior": {
         "type": "object",
         "additionalProperties": false,
@@ -1299,7 +1356,8 @@
             "principle",
             "commitment",
             "moment",
-            "skill"
+            "skill",
+            "procedure"
           ]
         },
         "default": [
@@ -2600,7 +2658,8 @@
         },
         "default": [
           "correction",
-          "commitment"
+          "commitment",
+          "procedure"
         ],
         "description": "Memory categories excluded from semantic consolidation."
       },
@@ -3013,7 +3072,8 @@
           "commitment",
           "preference",
           "decision",
-          "principle"
+          "principle",
+          "procedure"
         ],
         "description": "Categories that protect a fact from archival regardless of other criteria."
       },
@@ -3051,7 +3111,8 @@
           "decision",
           "principle",
           "commitment",
-          "preference"
+          "preference",
+          "procedure"
         ],
         "description": "Categories that lifecycle policy will not auto-archive."
       },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -318,6 +318,63 @@
           }
         }
       },
+      "procedural": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Master gate for procedural memory: extraction, recall boost, and mining (issue #519)."
+          },
+          "minOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 1000,
+            "default": 3,
+            "description": "Minimum clustered trajectory occurrences before emitting a candidate procedure (0 disables mining)."
+          },
+          "successFloor": {
+            "type": "number",
+            "minimum": 0,
+            "maximum": 1,
+            "default": 0.7,
+            "description": "Minimum success-rate floor (from trajectory outcomes) for miner promotion."
+          },
+          "autoPromoteOccurrences": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10000,
+            "default": 8,
+            "description": "When auto-promotion is enabled, minimum occurrence count to move pending_review procedures to active (0 disables auto-promotion by count)."
+          },
+          "autoPromoteEnabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, miner may auto-promote trusted procedures to active after autoPromoteOccurrences."
+          },
+          "lookbackDays": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 3650,
+            "default": 30,
+            "description": "Trajectory lookback window for procedural mining."
+          },
+          "recallMaxProcedures": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 10,
+            "default": 3,
+            "description": "Maximum procedure memories to inject on task-initiation recall."
+          },
+          "proceduralMiningCronAutoRegister": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, installer may register the nightly procedural mining cron job."
+          }
+        }
+      },
       "slotBehavior": {
         "type": "object",
         "additionalProperties": false,
@@ -1295,7 +1352,8 @@
             "principle",
             "commitment",
             "moment",
-            "skill"
+            "skill",
+            "procedure"
           ]
         },
         "default": [
@@ -2588,7 +2646,8 @@
         },
         "default": [
           "correction",
-          "commitment"
+          "commitment",
+          "procedure"
         ],
         "description": "Memory categories excluded from semantic consolidation."
       },
@@ -3001,7 +3060,8 @@
           "commitment",
           "preference",
           "decision",
-          "principle"
+          "principle",
+          "procedure"
         ],
         "description": "Categories that protect a fact from archival regardless of other criteria."
       },
@@ -3039,7 +3099,8 @@
           "decision",
           "principle",
           "commitment",
-          "preference"
+          "preference",
+          "procedure"
         ],
         "description": "Categories that lifecycle policy will not auto-archive."
       },

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -3,6 +3,7 @@ import type {
   CodexCompactionFlushMode,
   CodexCompatConfig,
   DreamingConfig,
+  ProceduralConfig,
   HeartbeatConfig,
   IdentityInjectionMode,
   MemoryOsPresetName,
@@ -144,6 +145,7 @@ export const VALID_MEMORY_CATEGORIES = new Set([
   "moment",
   "skill",
   "rule",
+  "procedure",
 ]);
 
 const DEFAULT_BEHAVIOR_LOOP_PROTECTED_PARAMS = [
@@ -395,6 +397,45 @@ export function parseConfig(raw: unknown): PluginConfig {
         ? (rawCodexCompat.compactionFlushMode as CodexCompactionFlushMode)
         : "auto",
     fingerprintDedup: rawCodexCompat.fingerprintDedup !== false,
+  };
+
+  const rawProcedural =
+    cfg.procedural && typeof cfg.procedural === "object" && !Array.isArray(cfg.procedural)
+      ? (cfg.procedural as Record<string, unknown>)
+      : {};
+  const proceduralMinRaw =
+    typeof rawProcedural.minOccurrences === "number" && Number.isFinite(rawProcedural.minOccurrences)
+      ? Math.floor(rawProcedural.minOccurrences)
+      : 3;
+  const procedural: ProceduralConfig = {
+    enabled: coerceBool(rawProcedural.enabled) === true,
+    /** 0 disables miner emission threshold (no clusters qualify). */
+    minOccurrences: Math.min(1000, Math.max(0, proceduralMinRaw)),
+    successFloor:
+      typeof rawProcedural.successFloor === "number" &&
+      Number.isFinite(rawProcedural.successFloor) &&
+      rawProcedural.successFloor >= 0 &&
+      rawProcedural.successFloor <= 1
+        ? rawProcedural.successFloor
+        : 0.7,
+    autoPromoteOccurrences:
+      typeof rawProcedural.autoPromoteOccurrences === "number" &&
+      Number.isFinite(rawProcedural.autoPromoteOccurrences)
+        ? rawProcedural.autoPromoteOccurrences <= 0
+          ? 0
+          : Math.min(10_000, Math.max(1, Math.floor(rawProcedural.autoPromoteOccurrences)))
+        : 8,
+    autoPromoteEnabled: coerceBool(rawProcedural.autoPromoteEnabled) === true,
+    lookbackDays:
+      typeof rawProcedural.lookbackDays === "number" && Number.isFinite(rawProcedural.lookbackDays)
+        ? Math.min(3650, Math.max(1, Math.floor(rawProcedural.lookbackDays)))
+        : 30,
+    proceduralMiningCronAutoRegister: coerceBool(rawProcedural.proceduralMiningCronAutoRegister) === true,
+    recallMaxProcedures:
+      typeof rawProcedural.recallMaxProcedures === "number" &&
+      Number.isFinite(rawProcedural.recallMaxProcedures)
+        ? Math.min(10, Math.max(1, Math.floor(rawProcedural.recallMaxProcedures)))
+        : 3,
   };
 
   const memoryDir =
@@ -1030,6 +1071,7 @@ export function parseConfig(raw: unknown): PluginConfig {
     activeRecallAllowChainedActiveMemory:
       cfg.activeRecallAllowChainedActiveMemory === true,
     dreaming,
+    procedural,
     heartbeat,
     slotBehavior,
     codexCompat,
@@ -1161,7 +1203,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       ? (cfg.semanticConsolidationExcludeCategories as unknown[]).filter(
           (c): c is string => typeof c === "string" && c.length > 0,
         )
-      : ["correction", "commitment"],
+      : ["correction", "commitment", "procedure"],
     semanticConsolidationIntervalHours:
       typeof cfg.semanticConsolidationIntervalHours === "number"
         ? Math.max(1, Math.floor(cfg.semanticConsolidationIntervalHours))
@@ -1619,7 +1661,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.factArchivalMaxAccessCount === "number" ? cfg.factArchivalMaxAccessCount : 2,
     factArchivalProtectedCategories: Array.isArray(cfg.factArchivalProtectedCategories)
       ? (cfg.factArchivalProtectedCategories as any[]).filter((c) => typeof c === "string")
-      : ["commitment", "preference", "decision", "principle"],
+      : ["commitment", "preference", "decision", "principle", "procedure"],
     // v8.3 lifecycle policy engine (default off)
     lifecyclePolicyEnabled: cfg.lifecyclePolicyEnabled === true,
     lifecycleFilterStaleEnabled: cfg.lifecycleFilterStaleEnabled === true,
@@ -1640,7 +1682,7 @@ export function parseConfig(raw: unknown): PluginConfig {
           (c): c is PluginConfig["lifecycleProtectedCategories"][number] =>
             typeof c === "string" && VALID_MEMORY_CATEGORIES.has(c),
         )
-      : ["decision", "principle", "commitment", "preference"],
+      : ["decision", "principle", "commitment", "preference", "procedure"],
     lifecycleMetricsEnabled:
       typeof cfg.lifecycleMetricsEnabled === "boolean"
         ? cfg.lifecycleMetricsEnabled

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -44,6 +44,7 @@ const INLINE_ALLOWED_CATEGORIES = new Set<MemoryCategory>([
   "moment",
   "skill",
   "rule",
+  "procedure",
 ]);
 
 const SECRET_PATTERNS: RegExp[] = [

--- a/packages/remnic-core/src/importance.ts
+++ b/packages/remnic-core/src/importance.ts
@@ -94,6 +94,7 @@ const CATEGORY_BOOSTS: Record<MemoryCategory, number> = {
   correction: 0.15,    // Corrections are always important
   principle: 0.12,     // Durable rules/values
   rule: 0.11,          // Causal IF→THEN rules
+  procedure: 0.10,     // Repeatable workflows (issue #519)
   preference: 0.10,    // User preferences matter
   commitment: 0.10,    // Promises/obligations
   decision: 0.08,      // Decisions with rationale

--- a/packages/remnic-core/src/lifecycle.ts
+++ b/packages/remnic-core/src/lifecycle.ts
@@ -54,7 +54,7 @@ const DEFAULT_POLICY: LifecyclePolicy = {
   promoteHeatThreshold: 0.55,
   staleDecayThreshold: 0.65,
   archiveDecayThreshold: 0.85,
-  protectedCategories: ["decision", "principle", "commitment", "preference"],
+  protectedCategories: ["decision", "principle", "commitment", "preference", "procedure"],
 };
 
 export function clamp01(value: number): number {

--- a/packages/remnic-core/src/routing/engine.ts
+++ b/packages/remnic-core/src/routing/engine.ts
@@ -38,6 +38,7 @@ const DEFAULT_CATEGORIES: readonly MemoryCategory[] = [
   "moment",
   "skill",
   "rule",
+  "procedure",
 ] as const;
 
 function normalizeNamespace(namespace: string): string {

--- a/packages/remnic-core/src/taxonomy/default-taxonomy.ts
+++ b/packages/remnic-core/src/taxonomy/default-taxonomy.ts
@@ -25,6 +25,14 @@ export const DEFAULT_TAXONOMY: Taxonomy = {
       memoryCategories: ["principle", "rule", "skill"],
     },
     {
+      id: "procedures",
+      name: "Procedures",
+      description: "Ordered multi-step workflows the user repeats",
+      filingRules: ["A repeatable sequence of steps or commands for a task"],
+      priority: 25,
+      memoryCategories: ["procedure"],
+    },
+    {
       id: "entities",
       name: "Entities",
       description: "People, organizations, places, projects",

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1,7 +1,7 @@
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 export type TriggerMode = "smart" | "every_n" | "time_based";
 export type SignalLevel = "none" | "low" | "medium" | "high";
-export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule";
+export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule" | "procedure";
 export type ConsolidationAction = "ADD" | "MERGE" | "UPDATE" | "INVALIDATE" | "SKIP";
 export type ConfidenceTier = "explicit" | "implied" | "inferred" | "speculative";
 export type PrincipalFromSessionKeyMode = "map" | "prefix" | "regex";
@@ -181,6 +181,23 @@ export interface DreamingConfig {
   narrativeModel: string | null;
   narrativePromptStyle: DreamingNarrativePromptStyle;
   watchFile: boolean;
+}
+
+/** Procedural memory (issue #519): mining + recall gates. All sub-features default off. */
+export interface ProceduralConfig {
+  enabled: boolean;
+  /** Minimum recurrence count before emitting a candidate procedure (0 disables mining threshold). */
+  minOccurrences: number;
+  /** Minimum success rate from trajectory outcomes in [0, 1]. */
+  successFloor: number;
+  /** When auto-promotion is enabled, promote pending_review → active after this many occurrences. */
+  autoPromoteOccurrences: number;
+  autoPromoteEnabled: boolean;
+  lookbackDays: number;
+  /** When true, installer may register the nightly procedural mining cron (default off). */
+  proceduralMiningCronAutoRegister: boolean;
+  /** Max procedure memories to inject on task-initiation recall (1–10). */
+  recallMaxProcedures: number;
 }
 
 export interface HeartbeatConfig {
@@ -424,6 +441,7 @@ export interface PluginConfig {
   activeRecallAttachRecallExplain: boolean;
   activeRecallAllowChainedActiveMemory: boolean;
   dreaming: DreamingConfig;
+  procedural: ProceduralConfig;
   heartbeat: HeartbeatConfig;
   slotBehavior: SlotBehaviorConfig;
   codexCompat: CodexCompatConfig;
@@ -1414,6 +1432,7 @@ export interface MemoryFile {
   frontmatter: MemoryFrontmatter;
   content: string;
 }
+
 
 export interface ExtractedFact {
   category: MemoryCategory;

--- a/packages/remnic-core/src/utils/category-dir.ts
+++ b/packages/remnic-core/src/utils/category-dir.ts
@@ -18,6 +18,7 @@ export const CATEGORY_DIR_MAP: Record<string, string> = {
   rule: "rules",
   skill: "skills",
   relationship: "relationships",
+  procedure: "procedures",
 };
 
 /** All directory names derived from CATEGORY_DIR_MAP, plus "facts" (the default). */

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1964,8 +1964,8 @@ Best for:
         category: Type.Optional(
           Type.String({
             description:
-              'Category: "fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule" (default: "fact")',
-            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule"],
+              'Category: "fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure" (default: "fact")',
+            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure"],
           }),
         ),
         tags: Type.Optional(
@@ -2036,7 +2036,7 @@ Best for:
         category: Type.Optional(
           Type.String({
             description: "Memory category.",
-            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule"],
+            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure"],
           }),
         ),
         tags: Type.Optional(

--- a/tests/causal-rule-extraction.test.ts
+++ b/tests/causal-rule-extraction.test.ts
@@ -11,7 +11,7 @@ describe("causal rule category", () => {
   it("rule is distinct from existing categories", () => {
     const categories: MemoryCategory[] = [
       "fact", "preference", "correction", "entity", "decision",
-      "relationship", "principle", "commitment", "moment", "skill", "rule",
+      "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure",
     ];
     assert.equal(new Set(categories).size, categories.length);
   });

--- a/tests/mece-taxonomy.test.ts
+++ b/tests/mece-taxonomy.test.ts
@@ -55,6 +55,7 @@ const ALL_MEMORY_CATEGORIES: MemoryCategory[] = [
   "moment",
   "skill",
   "rule",
+  "procedure",
 ];
 
 // ── Default taxonomy structure ──────────────────────────────────────────────
@@ -154,6 +155,16 @@ describe("resolveCategory", () => {
       DEFAULT_TAXONOMY,
     );
     assert.equal(decision.categoryId, "moments");
+    assert.equal(decision.confidence, 1.0);
+  });
+
+  it("procedure -> procedures category", () => {
+    const decision = resolveCategory(
+      "When shipping: run tests, open PR, wait for CI",
+      "procedure",
+      DEFAULT_TAXONOMY,
+    );
+    assert.equal(decision.categoryId, "procedures");
     assert.equal(decision.confidence, 1.0);
   });
 


### PR DESCRIPTION
## Summary
- Adds `procedure` to `MemoryCategory`, default taxonomy bucket, `procedures/` dir mapping, and `CATEGORY_BOOSTS`.
- Introduces `ProceduralConfig` + `parseConfig` wiring (defaults **off**), plugin JSON schema, and allowlist / lifecycle / consolidation defaults that include `procedure`.
- No storage, extraction, recall, miner, bench, or docs yet (follow-up PRs 2–6).

Part of #519 (stacked delivery).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily adds a new `procedure` category and config/schema plumbing with defaults off; behavior changes are limited to updated default category allow/deny lists and importance/lifecycle protections.
> 
> **Overview**
> Adds a new memory category, `procedure`, and wires it through core typing and routing surfaces (category dir mapping, explicit capture allowlist, OpenClaw tool enums, tests).
> 
> Introduces `ProceduralConfig` (defaulted and parsed from `cfg.procedural`) and exposes corresponding settings in the OpenClaw plugin JSON schema, while updating consolidation/lifecycle/archival defaults to treat `procedure` as protected or excluded where appropriate and giving it an importance boost.
> 
> Updates the default taxonomy to include a new **Procedures** bucket mapped to the `procedure` category.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ff39b8ed0c3d1fac69c6d5c32ea8a4300dd41b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->