### PR TITLE
feat(core): procedure storage under procedures/ (#519 pr 2/6)

### DIFF
--- a/packages/remnic-core/src/procedural/procedure-types.ts
+++ b/packages/remnic-core/src/procedural/procedure-types.ts
@@ -1,0 +1,132 @@
+/**
+ * Procedural memory types (issue #519).
+ * Bodies use ordered "## Step N" sections; machine fields live in frontmatter / structuredAttributes.
+ */
+
+export interface ProcedureStep {
+  order: number;
+  intent: string;
+  toolCall?: {
+    kind: string;
+    signature: string;
+  };
+  expectedOutcome?: string;
+  optional?: boolean;
+}
+
+/** Normalize loose extraction JSON into ProcedureStep records. */
+export function normalizeProcedureSteps(raw: unknown): ProcedureStep[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ProcedureStep[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const s = raw[i];
+    if (!s || typeof s !== "object") continue;
+    const o = s as Record<string, unknown>;
+    const intent = typeof o.intent === "string" ? o.intent.trim() : "";
+    if (!intent) continue;
+    const orderRaw = o.order;
+    const order =
+      typeof orderRaw === "number" && Number.isFinite(orderRaw)
+        ? Math.max(1, Math.floor(orderRaw))
+        : i + 1;
+    let toolCall: ProcedureStep["toolCall"];
+    const tc = o.toolCall;
+    if (tc && typeof tc === "object" && !Array.isArray(tc)) {
+      const t = tc as Record<string, unknown>;
+      const kind = typeof t.kind === "string" ? t.kind.trim() : "";
+      const signature = typeof t.signature === "string" ? t.signature.trim() : "";
+      if (kind && signature) {
+        toolCall = { kind, signature };
+      }
+    }
+    const expectedOutcome =
+      typeof o.expectedOutcome === "string" && o.expectedOutcome.trim()
+        ? o.expectedOutcome.trim()
+        : undefined;
+    const optional = o.optional === true ? true : undefined;
+    out.push({ order, intent, toolCall, expectedOutcome, optional });
+  }
+  return out;
+}
+
+/** Title line plus serialized steps for storage.writeMemory body. */
+export function buildProcedurePersistBody(title: string, procedureSteps: unknown): string {
+  const head = typeof title === "string" ? title.trim() : "";
+  const steps = normalizeProcedureSteps(procedureSteps);
+  if (steps.length === 0) return head;
+  return `${head}\n\n${buildProcedureMarkdownBody(steps)}`.trimEnd() + "\n";
+}
+
+/** Serialize steps into markdown body (human-editable). */
+export function buildProcedureMarkdownBody(steps: ProcedureStep[]): string {
+  const sorted = [...steps].sort((a, b) => a.order - b.order);
+  const lines: string[] = [];
+  for (const step of sorted) {
+    const n = Number.isFinite(step.order) ? Math.max(1, Math.floor(step.order)) : 1;
+    lines.push(`## Step ${n}`);
+    lines.push("");
+    lines.push(step.intent.trim());
+    if (step.toolCall?.kind && step.toolCall.signature) {
+      lines.push("");
+      lines.push(`- Tool: \`${step.toolCall.kind}\` — ${step.toolCall.signature}`);
+    }
+    if (step.expectedOutcome?.trim()) {
+      lines.push("");
+      lines.push(`- Expected: ${step.expectedOutcome.trim()}`);
+    }
+    if (step.optional === true) {
+      lines.push("");
+      lines.push("- Optional: true");
+    }
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+const STEP_HEADER_RE = /^##\s+Step\s+(\d+)\s*$/im;
+
+/**
+ * Best-effort parse of "## Step N" blocks into ProcedureStep records.
+ * Returns null when no step headers are found.
+ */
+export function parseProcedureStepsFromBody(content: string): ProcedureStep[] | null {
+  const text = content.replace(/\r\n/g, "\n").trim();
+  if (!text) return null;
+  const matches = [...text.matchAll(new RegExp(STEP_HEADER_RE.source, "gim"))];
+  if (matches.length === 0) return null;
+
+  const steps: ProcedureStep[] = [];
+  for (let i = 0; i < matches.length; i++) {
+    const m = matches[i];
+    const order = Number.parseInt(m[1] ?? "1", 10);
+    const start = (m.index ?? 0) + m[0].length;
+    const end = i + 1 < matches.length ? (matches[i + 1].index ?? text.length) : text.length;
+    const block = text.slice(start, end).trim();
+    const lines = block.split("\n").map((l) => l.trim());
+    const intentLines = lines.filter(
+      (l) => l.length > 0 && !l.startsWith("- Tool:") && !l.startsWith("- Expected:") && !l.startsWith("- Optional:"),
+    );
+    const intent = intentLines.join(" ").trim() || "(unspecified)";
+    let toolCall: ProcedureStep["toolCall"];
+    const toolLine = lines.find((l) => l.startsWith("- Tool:"));
+    if (toolLine) {
+      const inner = toolLine.replace(/^- Tool:\s*/i, "").trim();
+      const tick = inner.match(/^`([^`]+)`\s*[—-]\s*(.+)$/);
+      if (tick) {
+        toolCall = { kind: tick[1].trim(), signature: tick[2].trim() };
+      }
+    }
+    const expectedLine = lines.find((l) => l.startsWith("- Expected:"));
+    const expectedOutcome = expectedLine?.replace(/^- Expected:\s*/i, "").trim();
+    const optional = /^- Optional:\s*true$/i.test(lines.find((l) => l.startsWith("- Optional:")) ?? "");
+
+    steps.push({
+      order: Number.isFinite(order) ? order : i + 1,
+      intent,
+      toolCall,
+      expectedOutcome: expectedOutcome?.length ? expectedOutcome : undefined,
+      optional: optional || undefined,
+    });
+  }
+  return steps.length > 0 ? steps : null;
+}

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1835,6 +1835,9 @@ export class StorageManager {
   private get correctionsDir(): string {
     return path.join(this.baseDir, "corrections");
   }
+  private get proceduresDir(): string {
+    return path.join(this.baseDir, "procedures");
+  }
   private get entitiesDir(): string {
     return path.join(this.baseDir, "entities");
   }
@@ -2042,6 +2045,7 @@ export class StorageManager {
   async ensureDirectories(): Promise<void> {
     const today = new Date().toISOString().slice(0, 10);
     await mkdir(path.join(this.factsDir, today), { recursive: true });
+    await mkdir(path.join(this.proceduresDir, today), { recursive: true });
     await mkdir(this.correctionsDir, { recursive: true });
     await mkdir(this.entitiesDir, { recursive: true });
     await mkdir(this.stateDir, { recursive: true });
@@ -2088,6 +2092,7 @@ export class StorageManager {
        * even when their citation timestamp differs.
        */
       contentHashSource?: string;
+      status?: MemoryStatus;
     } = {},
   ): Promise<string> {
     await this.ensureDirectories();
@@ -2130,6 +2135,9 @@ export class StorageManager {
       memoryKind: options.memoryKind,
       structuredAttributes: options.structuredAttributes,
     };
+    if (options.status !== undefined) {
+      fm.status = options.status;
+    }
 
     // Append structured attributes as searchable suffix so QMD indexes them.
     // normalizeAttributePairs sorts and lowercases keys so the enriched content
@@ -2163,6 +2171,9 @@ export class StorageManager {
     let filePath: string;
     if (category === "correction") {
       filePath = path.join(this.correctionsDir, `${id}.md`);
+    } else if (category === "procedure") {
+      await mkdir(path.join(this.proceduresDir, today), { recursive: true });
+      filePath = path.join(this.proceduresDir, today, `${id}.md`);
     } else {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }
@@ -2687,6 +2698,7 @@ export class StorageManager {
     };
 
     await collectPaths(this.factsDir);
+    await collectPaths(this.proceduresDir);
     await collectPaths(this.correctionsDir);
     return filePaths;
   }
@@ -3086,6 +3098,9 @@ export class StorageManager {
     }
     if (memory.frontmatter.category === "correction") {
       return path.join(root, "corrections", `${memory.frontmatter.id}.md`);
+    }
+    if (memory.frontmatter.category === "procedure") {
+      return path.join(root, "procedures", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
     }
     return path.join(root, "facts", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
   }
@@ -5325,6 +5340,9 @@ export class StorageManager {
     let filePath: string;
     if (category === "correction") {
       filePath = path.join(this.correctionsDir, `${id}.md`);
+    } else if (category === "procedure") {
+      await mkdir(path.join(this.proceduresDir, today), { recursive: true });
+      filePath = path.join(this.proceduresDir, today, `${id}.md`);
     } else {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }

--- a/tests/storage-procedure-write.test.ts
+++ b/tests/storage-procedure-write.test.ts
@@ -1,0 +1,53 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { access, mkdtemp, rm } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+import {
+  buildProcedureMarkdownBody,
+  parseProcedureStepsFromBody,
+} from "../packages/remnic-core/src/procedural/procedure-types.ts";
+
+test("procedure markdown helpers round-trip ordered steps", () => {
+  const body = buildProcedureMarkdownBody([
+    { order: 1, intent: "Open the repo", toolCall: { kind: "shell", signature: "cd project && ls" } },
+    { order: 2, intent: "Run tests", expectedOutcome: "All green" },
+  ]);
+  const parsed = parseProcedureStepsFromBody(body);
+  assert.ok(parsed);
+  assert.equal(parsed.length, 2);
+  assert.equal(parsed[0].intent, "Open the repo");
+  assert.equal(parsed[0].toolCall?.kind, "shell");
+  assert.equal(parsed[1].intent, "Run tests");
+  assert.equal(parsed[1].expectedOutcome, "All green");
+});
+
+test("StorageManager.writeMemory writes procedure memories under procedures/<date>/", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-write-"));
+  try {
+    const storage = new StorageManager(dir);
+    const body = buildProcedureMarkdownBody([{ order: 1, intent: "Ship the fix" }]);
+    const id = await storage.writeMemory("procedure", body, {
+      source: "test",
+      status: "pending_review",
+    });
+
+    const today = new Date().toISOString().slice(0, 10);
+    const expected = path.join(dir, "procedures", today, `${id}.md`);
+    await access(expected);
+
+    const memories = await storage.readAllMemories();
+    const found = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(found);
+    assert.equal(found.frontmatter.category, "procedure");
+    assert.equal(found.frontmatter.status, "pending_review");
+    assert.ok(found.path.replace(/\\/g, "/").includes("/procedures/"));
+
+    const again = parseProcedureStepsFromBody(found.content);
+    assert.ok(again);
+    assert.equal(again[0].intent, "Ship the fix");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- Adds `procedural/procedure-types.ts` (step body helpers / parsing).
- Extends `StorageManager` so `category: procedure` writes under `procedures/YYYY-MM-DD/` and participates in active-memory collection.
- Adds `tests/storage-procedure-write.test.ts`.

Depends on #524 (schema). Part of #519 (stacked delivery).

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes on-disk write locations and active-memory scanning for a new `procedure` category, which could affect recall/indexing behavior if any downstream code assumes procedures live under `facts/`.
> 
> **Overview**
> Adds a new procedural memory helper module (`procedural/procedure-types.ts`) to normalize extracted step JSON, serialize steps into a human-editable `## Step N` markdown format, and parse those step blocks back into structured data.
> 
> Extends `StorageManager` to treat `category: "procedure"` as a first-class memory type: it now creates `procedures/YYYY-MM-DD/`, writes both full memories and chunks into that tree, includes procedures in active-memory path collection, and routes tier moves via `buildTierMemoryPath` accordingly. New tests verify the markdown round-trip and that `writeMemory("procedure", ...)` persists under `procedures/<date>/` while preserving frontmatter `status`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 821cc229a97095b000a8bcaa2d7e8ede318a7b9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->