### PR TITLE
feat(core): procedure extraction + judge gate (#519 pr 3/6)

### DIFF
--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -19,6 +19,7 @@ import type { PluginConfig, ImportanceLevel } from "./types.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import { extractJsonCandidates } from "./json-extract.js";
+import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 
 // ---------------------------------------------------------------------------
 // Public interfaces
@@ -121,6 +122,29 @@ function enforceMaxCacheSize(cache: Map<string, JudgeVerdict>): void {
 // ---------------------------------------------------------------------------
 
 const AUTO_APPROVE_CATEGORIES = new Set(["correction", "principle"]);
+
+/** Explicit trigger phrasing — procedures must match to persist (issue #519). */
+const PROCEDURE_TRIGGER_RE =
+  /(when you|whenever|before you|before running|always\s|first\b.*\bthen|to deploy|to ship|run these steps|follow these steps|how (i|we)\s|recipe for|workflow|each time you)/i;
+
+/**
+ * Deterministic gate for extracted `procedure` memories: ≥2 steps with non-empty
+ * intents and explicit trigger wording in title and/or steps.
+ */
+export function validateProcedureExtraction(input: {
+  content: string;
+  procedureSteps?: unknown;
+}): JudgeVerdict {
+  const steps = normalizeProcedureSteps(input.procedureSteps);
+  if (steps.length < 2) {
+    return { durable: false, reason: "Procedure requires at least two steps with intents" };
+  }
+  const combined = [input.content, ...steps.map((s) => s.intent)].join(" ").toLowerCase();
+  if (!PROCEDURE_TRIGGER_RE.test(combined)) {
+    return { durable: false, reason: "Procedure missing explicit trigger phrasing" };
+  }
+  return { durable: true, reason: "Procedure structure validated" };
+}
 
 // ---------------------------------------------------------------------------
 // Core judge function

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -34,6 +34,7 @@ import { applyWorkExtractionBoundary } from "./work/boundary.js";
 import { buildChatCompletionTokenLimit, shouldAssumeOpenAiChatCompletions } from "./openai-chat-compat.js";
 import { formatDaySummaryMemories, loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-summary.js";
 import { ProfilingCollector } from "./profiling.js";
+import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
@@ -152,19 +153,22 @@ export class ExtractionEngine {
   }
 
   private sanitizeExtractionResult(result: ExtractionResult, messageTimestamp?: Date): ExtractionResult {
+    const proceduralOn = this.config.procedural?.enabled === true;
     const ts = messageTimestamp ?? new Date();
-    const facts = result.facts.map((fact) => {
-      const sanitized = sanitizeMemoryContent(fact.content);
-      if (!sanitized.clean) {
-        log.warn(`extraction fact sanitized; violations=${sanitized.violations.join(", ")}`);
-      }
-      let content = sanitized.text;
-      // De-linearize: resolve coreferences + anchor temporal expressions
-      if (this.config.delinearizeEnabled) {
-        content = delinearize(content, result.entities, ts);
-      }
-      return { ...fact, content };
-    });
+    const facts = result.facts
+      .filter((fact) => proceduralOn || fact.category !== "procedure")
+      .map((fact) => {
+        const sanitized = sanitizeMemoryContent(fact.content);
+        if (!sanitized.clean) {
+          log.warn(`extraction fact sanitized; violations=${sanitized.violations.join(", ")}`);
+        }
+        let content = sanitized.text;
+        // De-linearize: resolve coreferences + anchor temporal expressions
+        if (this.config.delinearizeEnabled) {
+          content = delinearize(content, result.entities, ts);
+        }
+        return { ...fact, content };
+      });
     return { ...result, facts };
   }
 
@@ -200,6 +204,9 @@ export class ExtractionEngine {
                       .filter(([k, v]) => typeof k === "string" && typeof v === "string")
                   ) as Record<string, string>
                 : undefined,
+            procedureSteps: Array.isArray(f?.procedureSteps)
+              ? normalizeProcedureSteps(f.procedureSteps)
+              : undefined,
           }))
           .filter((f: any) => f.content.length > 0)
       : [];
@@ -1236,6 +1243,8 @@ ${truncatedConversation}`;
       "commitment",
       "moment",
       "skill",
+      "rule",
+      "procedure",
     ]);
     const allowedEntityTypes = new Set([
       "person",
@@ -1300,6 +1309,7 @@ Memory categories:
 - moment: Emotionally significant events or milestones (e.g., "first successful deployment of engram")
 - skill: Capabilities the user or agent has demonstrated (e.g., "user is proficient with Kubernetes")${this.config.causalRuleExtractionEnabled ? `
 - rule: Causal rules discovered through experience (format: "IF <condition> THEN <action/outcome>", e.g., "IF Shopify API returns 401 THEN the admin token is missing read_products scope")` : ""}
+- procedure: A reusable workflow the user wants remembered the same way across sessions. Set category to "procedure". Use "content" for a short title that includes explicit trigger phrasing (e.g. "When you deploy to production…", "Whenever you ship a release…"). Add "procedureSteps": an array of at least two objects {"order": number, "intent": "concrete step description"} in execution order. Optional per-step "toolCall": {"kind": "…", "signature": "…"}, "expectedOutcome", "optional": true.
 
 Rules:
 - Only extract genuinely NEW information worth remembering across sessions

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -22,10 +22,12 @@ import { isAboveImportanceThreshold, scoreImportance } from "./importance.js";
 import {
   judgeFactDurability,
   createVerdictCache,
+  validateProcedureExtraction,
   type JudgeBatchResult,
   type JudgeCandidate,
   type JudgeVerdict,
 } from "./extraction-judge.js";
+import { buildProcedurePersistBody } from "./procedural/procedure-types.js";
 import {
   attachCitation,
   type CitationContext,
@@ -2263,6 +2265,7 @@ export class Orchestrator {
       log.debug(`nightly governance cron auto-register error: ${err}`);
     }
   }
+
 
   async applyBehaviorRuntimePolicy(
     state: BehaviorLoopPolicyState,
@@ -6756,6 +6759,7 @@ export class Orchestrator {
       return section;
     })();
 
+
     const compoundingPromise = observeEnrichmentPromise(
       (async (): Promise<string | null> => {
         const t0 = Date.now();
@@ -7022,6 +7026,7 @@ export class Orchestrator {
         calibrationSection,
       );
     }
+
 
     // 1a. Identity continuity
     if (identityContinuity) {
@@ -9817,6 +9822,9 @@ export class Orchestrator {
           // category slugs defined in the taxonomy; the fallback is the
           // original ExtractedFact.category which is already typed.
           const judgeCategory = (preRoutedCategories[fi] ?? f.category) as import("./types.js").MemoryCategory;
+          if (judgeCategory === "procedure") {
+            continue;
+          }
           const tags = Array.isArray(f.tags) ? f.tags : [];
           const imp = scoreImportance(
             f.content,
@@ -9955,6 +9963,11 @@ export class Orchestrator {
         fact.tags,
       );
 
+      if (writeCategory === "procedure" && this.config.procedural?.enabled !== true) {
+        log.debug("persistExtraction: skip procedure memory (procedural.enabled is false)");
+        continue;
+      }
+
       // Importance write-gate (issue #372). Drop facts whose locally-scored
       // level falls below the configured minimum BEFORE the semantic dedup
       // lookup so that low-importance facts never incur an embedding search.
@@ -9996,6 +10009,27 @@ export class Orchestrator {
             judgeGatedCount++;
             log.debug(
               `extraction-judge: rejected "${fact.content.slice(0, 60)}…" reason="${verdict.reason}"`,
+            );
+            continue;
+          }
+        }
+      }
+
+      // Procedure extraction gate (issue #519): ≥2 steps + trigger phrasing.
+      // Runs even when extractionJudgeEnabled is false (durability judge is unrelated).
+      if (writeCategory === "procedure") {
+        const procGate = validateProcedureExtraction({
+          content: fact.content,
+          procedureSteps: fact.procedureSteps,
+        });
+        if (!procGate.durable) {
+          if (this.config.extractionJudgeShadow) {
+            log.info(
+              `extraction-procedure-gate[shadow]: would reject "${fact.content.slice(0, 60)}…" reason="${procGate.reason}"`,
+            );
+          } else {
+            log.debug(
+              `extraction-procedure-gate: rejected "${fact.content.slice(0, 60)}…" reason="${procGate.reason}"`,
             );
             continue;
           }
@@ -10177,7 +10211,7 @@ export class Orchestrator {
       // When semanticChunkingEnabled is true, prefer the embedding-based
       // semantic chunker which produces more coherent topic-aligned segments.
       // Falls back to the recursive sentence-boundary chunker on failure.
-      if (this.config.chunkingEnabled) {
+      if (this.config.chunkingEnabled && writeCategory !== "procedure") {
         let chunkResult: { chunked: boolean; chunks: { content: string; index: number; tokenCount: number }[] };
 
         if (this.config.semanticChunkingEnabled) {
@@ -10451,9 +10485,12 @@ export class Orchestrator {
       }
 
       // Classify memory kind (v8.0 Phase 2B: HiMem episode/note dual store)
-      const memoryKind = this.config.episodeNoteModeEnabled
-        ? classifyMemoryKind(fact.content, fact.tags ?? [], writeCategory)
-        : undefined;
+      const memoryKind =
+        writeCategory === "procedure"
+          ? undefined
+          : this.config.episodeNoteModeEnabled
+            ? classifyMemoryKind(fact.content, fact.tags ?? [], writeCategory)
+            : undefined;
 
       // Normal write (no chunking)
       //
@@ -10471,7 +10508,11 @@ export class Orchestrator {
       // write and defeat cross-session dedup (see `findDuplicateExplicitCapture`
       // in explicit-capture.ts which calls `hasFactContentHash(candidate.content)`
       // on raw content).
-      const citedFactContent = applyInlineCitation(fact.content);
+      const rawPersistBody =
+        writeCategory === "procedure"
+          ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
+          : fact.content;
+      const citedFactContent = applyInlineCitation(rawPersistBody);
       const memoryId = await targetStorage.writeMemory(
         writeCategory,
         citedFactContent,
@@ -10491,7 +10532,7 @@ export class Orchestrator {
           intentEntityTypes: inferredIntent?.entityTypes,
           memoryKind,
           structuredAttributes: fact.structuredAttributes,
-          contentHashSource: fact.content,
+          contentHashSource: writeCategory === "fact" ? fact.content : undefined,
         },
       );
       if (routedRuleId) {

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -37,8 +37,35 @@ export function parseMemoryActionEligibilityContext(
   };
 }
 
+export const ProcedureStepExtractSchema = z.object({
+  order: z.number(),
+  intent: z.string(),
+  toolCall: z
+    .object({
+      kind: z.string(),
+      signature: z.string(),
+    })
+    .optional()
+    .nullable(),
+  expectedOutcome: z.string().optional().nullable(),
+  optional: z.boolean().optional().nullable(),
+});
+
 export const ExtractedFactSchema = z.object({
-  category: z.enum(["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule"]),
+  category: z.enum([
+    "fact",
+    "preference",
+    "correction",
+    "entity",
+    "decision",
+    "relationship",
+    "principle",
+    "commitment",
+    "moment",
+    "skill",
+    "rule",
+    "procedure",
+  ]),
   content: z
     .string()
     .describe("The memory content — a clear, standalone statement"),
@@ -63,6 +90,13 @@ export const ExtractedFactSchema = z.object({
     .optional()
     .nullable()
     .describe("Structured key-value attributes when the fact contains measurable or categorical data (e.g., {\"price\": \"29.99\", \"color\": \"blue\", \"date\": \"2024-03-15\"})."),
+  procedureSteps: z
+    .array(ProcedureStepExtractSchema)
+    .optional()
+    .nullable()
+    .describe(
+      'For category "procedure" only: ordered steps (intent per step). At least two steps; include explicit trigger phrasing in content (e.g. "When you deploy…").',
+    ),
 });
 
 export const EntityMentionSchema = z.object({

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1433,6 +1433,14 @@ export interface MemoryFile {
   content: string;
 }
 
+/** Ordered step for extracted procedure memories (issue #519). */
+export interface ExtractedProcedureStep {
+  order: number;
+  intent: string;
+  toolCall?: { kind: string; signature: string };
+  expectedOutcome?: string;
+  optional?: boolean;
+}
 
 export interface ExtractedFact {
   category: MemoryCategory;
@@ -1444,6 +1452,8 @@ export interface ExtractedFact {
   promptedByQuestion?: string;
   /** Structured key-value attributes extracted from the content (e.g., product attributes, dates, quantities). */
   structuredAttributes?: Record<string, string>;
+  /** When category is `procedure`, ordered steps with intents (persisted under procedures/). */
+  procedureSteps?: ExtractedProcedureStep[];
 }
 
 export interface MemoryIntent {

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -4,6 +4,7 @@ import {
   judgeFactDurability,
   clearVerdictCache,
   verdictCacheSize,
+  validateProcedureExtraction,
   type JudgeCandidate,
 } from "../packages/remnic-core/src/extraction-judge.ts";
 import { parseConfig } from "../packages/remnic-core/src/config.ts";
@@ -425,4 +426,34 @@ test("judge elapsed time is reported", async () => {
   const result = await judgeFactDurability(candidates, config, mockLocalLlm as any, null);
   assert.ok(typeof result.elapsed === "number");
   assert.ok(result.elapsed >= 0);
+});
+
+test("validateProcedureExtraction approves two steps with trigger phrasing", () => {
+  const v = validateProcedureExtraction({
+    content: "When you deploy to production, follow this checklist.",
+    procedureSteps: [
+      { order: 1, intent: "Run the test suite" },
+      { order: 2, intent: "Push the release tag" },
+    ],
+  });
+  assert.equal(v.durable, true);
+});
+
+test("validateProcedureExtraction rejects fewer than two steps", () => {
+  const v = validateProcedureExtraction({
+    content: "When you deploy, do the thing.",
+    procedureSteps: [{ order: 1, intent: "Only one step" }],
+  });
+  assert.equal(v.durable, false);
+});
+
+test("validateProcedureExtraction rejects missing trigger phrasing", () => {
+  const v = validateProcedureExtraction({
+    content: "Release checklist for the service.",
+    procedureSteps: [
+      { order: 1, intent: "Run tests" },
+      { order: 2, intent: "Tag release" },
+    ],
+  });
+  assert.equal(v.durable, false);
 });


### PR DESCRIPTION
## Summary
- Extraction + Zod schema support for `procedure` with ordered steps.
- `validateProcedureExtraction` gate in `extraction-judge.ts`; orchestrator persists procedures via `buildProcedurePersistBody` when `procedural.enabled` is true.
- No intent-gated recall, miner, bench, or docs yet (PRs 4–6).

Depends on #525. Part of #519.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new persisted memory category (`procedure`) and changes the extraction/persistence pipeline (sanitization, judging, chunking, content hashing), which could affect what gets stored and deduped. Risk is moderated by explicit gating + tests, but mis-gating could drop or mis-format procedure memories.
> 
> **Overview**
> Adds first-class support for extracted `procedure` memories, including `procedureSteps` normalization/types and Zod validation, and extends extraction prompts/partial JSON recovery to allow the new category.
> 
> Updates persistence so procedures are **feature-flagged** (`procedural.enabled`), bypass the LLM durability judge queue, must pass a new deterministic `validateProcedureExtraction` gate (≥2 steps + trigger phrasing), skip chunking/memory-kind classification, and are persisted via `buildProcedurePersistBody` (markdown step serialization). Also adds targeted tests for the new procedure validation gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73d1b02db89758afb595d73a80bc3f0f3c43051b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->