### PR TITLE
feat(core): intent-gated procedure recall (#519 pr 4/6)

### DIFF
--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2195,6 +2195,15 @@ function buildDefaultRecallPipeline(cfg: Record<string, unknown>): RecallSection
           : 40,
     },
     { id: "verbatim-artifacts", enabled: cfg.verbatimArtifactsEnabled === true },
+    {
+      id: "procedure-recall",
+      enabled:
+        typeof cfg.procedural === "object" &&
+        cfg.procedural !== null &&
+        !Array.isArray(cfg.procedural) &&
+        (cfg.procedural as { enabled?: unknown }).enabled === true,
+      maxChars: 2400,
+    },
     { id: "memory-boxes", enabled: cfg.memoryBoxesEnabled === true },
     { id: "temporal-memory-tree", enabled: cfg.temporalMemoryTreeEnabled === true },
     { id: "lcm-compressed-history", enabled: cfg.lcmEnabled === true },

--- a/packages/remnic-core/src/intent.ts
+++ b/packages/remnic-core/src/intent.ts
@@ -24,6 +24,10 @@ const ENTITY_PATTERNS: Array<{ re: RegExp; entityType: string }> = [
   { re: /\b(doc|readme|docs|changelog)\b/i, entityType: "docs" },
 ];
 
+/** User/agent is starting a hands-on task (issue #519 procedure recall gate). */
+const TASK_INITIATION_RE =
+  /\b(ship(?:ping|ped)?|deploy(?:ing|ed)?|release|publish|open(?:ing)?\s+(?:a\s+)?(?:pr|pull\s+request)|merge(?:ing)?\s+(?:the\s+)?(?:pr|pull\s+request)|run\s+(?:the\s+)?tests?|start(?:ing)?\s+(?:work|on|the)|kick\s+off|implement(?:ing|ed)?|let's\s+|going\s+to\s+(?:ship|deploy|release|open|run|merge)|need\s+to\s+(?:ship|deploy|run|open|merge|test)|fix(?:ing|ed)?\s+(?:the\s+)?(?:bug|build)|patch(?:ing|ed)?|build(?:ing)?\s+(?:and\s+)?(?:ship|deploy))\b/i;
+
 function normalizeTextInput(input: unknown): string {
   return typeof input === "string" ? input : "";
 }
@@ -35,12 +39,18 @@ export function inferIntentFromText(text: string): MemoryIntent {
   const entityTypes = Array.from(
     new Set(ENTITY_PATTERNS.filter((p) => p.re.test(safeText)).map((p) => p.entityType)),
   );
+  const taskInitiation = TASK_INITIATION_RE.test(safeText);
 
   return {
     goal,
     actionType,
     entityTypes,
+    taskInitiation,
   };
+}
+
+export function isTaskInitiationIntent(intent: MemoryIntent): boolean {
+  return intent.taskInitiation === true;
 }
 
 export function intentCompatibilityScore(queryIntent: MemoryIntent, memoryIntent: MemoryIntent): number {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -28,6 +28,7 @@ import {
   type JudgeVerdict,
 } from "./extraction-judge.js";
 import { buildProcedurePersistBody } from "./procedural/procedure-types.js";
+import { buildProcedureRecallSection } from "./procedural/procedure-recall.js";
 import {
   attachCitation,
   type CitationContext,
@@ -918,6 +919,7 @@ function parseMemoryIntentSnapshot(value: unknown): MemoryIntent {
           (item): item is string => typeof item === "string",
         )
       : [],
+    taskInitiation: candidate.taskInitiation === true,
   };
 }
 
@@ -931,6 +933,9 @@ function buildQmdIntentHint(intent: MemoryIntent): string | undefined {
   }
   if (intent.entityTypes.length > 0) {
     parts.push(`entities:${intent.entityTypes.join(",")}`);
+  }
+  if (intent.taskInitiation === true) {
+    parts.push("task_initiation");
   }
   return parts.length > 0 ? parts.join(" ") : undefined;
 }
@@ -6759,6 +6764,22 @@ export class Orchestrator {
       return section;
     })();
 
+    const procedureRecallPromise = (async (): Promise<string | null> => {
+      if (this.config.procedural?.enabled !== true) return null;
+      if (!this.isRecallSectionEnabled("procedure-recall", true)) return null;
+      try {
+        return await buildProcedureRecallSection(
+          this.storage,
+          retrievalQuery,
+          this.config,
+        );
+      } catch (err) {
+        log.debug(
+          `procedure-recall: failed open: ${err instanceof Error ? err.message : String(err)}`,
+        );
+        return null;
+      }
+    })();
 
     const compoundingPromise = observeEnrichmentPromise(
       (async (): Promise<string | null> => {
@@ -6844,6 +6865,7 @@ export class Orchestrator {
       causalTrajectorySection,
       cmcCausalChainsSection,
       calibrationSection,
+      procedureRecallSection,
       trustZoneSection,
       verifiedRecallSection,
       verifiedRulesSection,
@@ -6866,6 +6888,7 @@ export class Orchestrator {
             ["causalTraj", causalTrajectoryPromise],
             ["cmc", cmcRetrievalPromise],
             ["calibration", calibrationPromise],
+            ["procedureRecall", procedureRecallPromise],
             ["trustZone", trustZonePromise],
             ["verifiedRecall", verifiedRecallPromise],
             ["verifiedRules", verifiedRulesPromise],
@@ -6895,6 +6918,7 @@ export class Orchestrator {
           typeof causalTrajectoryPromise extends Promise<infer T> ? T : never,
           typeof cmcRetrievalPromise extends Promise<infer T> ? T : never,
           typeof calibrationPromise extends Promise<infer T> ? T : never,
+          typeof procedureRecallPromise extends Promise<infer T> ? T : never,
           typeof trustZonePromise extends Promise<infer T> ? T : never,
           typeof verifiedRecallPromise extends Promise<infer T> ? T : never,
           typeof verifiedRulesPromise extends Promise<infer T> ? T : never,
@@ -7027,6 +7051,13 @@ export class Orchestrator {
       );
     }
 
+    if (procedureRecallSection) {
+      this.appendRecallSection(
+        sectionBuckets,
+        "procedure-recall",
+        procedureRecallSection,
+      );
+    }
 
     // 1a. Identity continuity
     if (identityContinuity) {

--- a/packages/remnic-core/src/procedural/procedure-recall.ts
+++ b/packages/remnic-core/src/procedural/procedure-recall.ts
@@ -1,0 +1,92 @@
+/**
+ * Intent-gated recall for active procedure memories (issue #519).
+ */
+
+import type { MemoryFile, PluginConfig } from "../types.js";
+import type { StorageManager } from "../storage.js";
+import { inferIntentFromText, intentCompatibilityScore, isTaskInitiationIntent } from "../intent.js";
+
+function tokenOverlapScore(prompt: string, memoryText: string): number {
+  const norm = (s: string) =>
+    s
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter((t) => t.length > 2);
+  const promptTokens = new Set(norm(prompt));
+  const memTokens = new Set(norm(memoryText));
+  if (promptTokens.size === 0 || memTokens.size === 0) return 0;
+  let inter = 0;
+  for (const t of promptTokens) {
+    if (memTokens.has(t)) inter++;
+  }
+  const union = new Set([...promptTokens, ...memTokens]);
+  return inter / Math.max(1, union.size);
+}
+
+function scoreProcedureForPrompt(
+  m: MemoryFile,
+  prompt: string,
+  queryIntent: ReturnType<typeof inferIntentFromText>,
+): number {
+  const memText = `${m.content}\n${(m.frontmatter.tags ?? []).join(" ")}`;
+  const jaccard = tokenOverlapScore(prompt, memText);
+  const memIntent = inferIntentFromText(m.content.slice(0, 2000));
+  const intentScore = intentCompatibilityScore(queryIntent, memIntent);
+  return jaccard * 0.55 + intentScore * 0.45;
+}
+
+/**
+ * Build markdown for the recall pipeline when procedural memory is enabled and
+ * the prompt looks like task initiation.
+ */
+export async function buildProcedureRecallSection(
+  storage: StorageManager,
+  prompt: string,
+  config: PluginConfig,
+): Promise<string | null> {
+  if (config.procedural?.enabled !== true) return null;
+  const trimmed = typeof prompt === "string" ? prompt.trim() : "";
+  if (!trimmed) return null;
+
+  const queryIntent = inferIntentFromText(trimmed);
+  if (!isTaskInitiationIntent(queryIntent)) return null;
+
+  const maxN = Math.min(
+    10,
+    Math.max(
+      1,
+      typeof config.procedural.recallMaxProcedures === "number" &&
+        Number.isFinite(config.procedural.recallMaxProcedures)
+        ? Math.floor(config.procedural.recallMaxProcedures)
+        : 3,
+    ),
+  );
+
+  const all = await storage.readAllMemories();
+  const scored = all
+    .filter(
+      (m) =>
+        m.frontmatter.category === "procedure" &&
+        m.frontmatter.status !== "pending_review" &&
+        m.frontmatter.status !== "rejected" &&
+        m.frontmatter.status !== "quarantined" &&
+        m.frontmatter.status !== "superseded" &&
+        m.frontmatter.status !== "archived",
+    )
+    .map((m) => ({ m, score: scoreProcedureForPrompt(m, trimmed, queryIntent) }))
+    .filter((x) => x.score > 0.04)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, maxN);
+
+  if (scored.length === 0) return null;
+
+  const blocks = scored.map(({ m, score }) => {
+    const id = m.frontmatter.id;
+    const flat = m.content.replace(/\s+/g, " ").trim();
+    const preview = flat.slice(0, 320);
+    const suffix = flat.length > 320 ? "…" : "";
+    return `### ${id} (match ${score.toFixed(2)})\n\n${preview}${suffix}`;
+  });
+
+  return `## Relevant procedures\n\n${blocks.join("\n\n")}`;
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1460,6 +1460,8 @@ export interface MemoryIntent {
   goal: string;
   actionType: string;
   entityTypes: string[];
+  /** True when the prompt reads like starting a concrete task (ship/deploy/tests/PR, etc.). */
+  taskInitiation?: boolean;
 }
 
 export interface ExtractedQuestion {

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -1,6 +1,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { hasBroadGraphIntent, inferIntentFromText, planRecallMode } from "../src/intent.ts";
+import {
+  hasBroadGraphIntent,
+  inferIntentFromText,
+  isTaskInitiationIntent,
+  planRecallMode,
+} from "../src/intent.ts";
 
 test("planRecallMode keeps acknowledgements in no_recall", () => {
   assert.equal(planRecallMode("ok"), "no_recall");
@@ -64,6 +69,16 @@ test("inferIntentFromText recognizes summarize/recap conjugations", () => {
 
   const recapped = inferIntentFromText("We recapped the timeline at standup");
   assert.equal(recapped.actionType, "summarize");
+});
+
+test("inferIntentFromText sets taskInitiation for ship/deploy/run tests phrasing", () => {
+  const deploy = inferIntentFromText("Let's deploy the gateway to production");
+  assert.equal(deploy.taskInitiation, true);
+  assert.equal(isTaskInitiationIntent(deploy), true);
+
+  const vague = inferIntentFromText("What is deployment?");
+  assert.ok(vague.taskInitiation !== true);
+  assert.equal(isTaskInitiationIntent(vague), false);
 });
 
 test("runtime guards tolerate nullish/non-string inputs", () => {

--- a/tests/procedure-recall.test.ts
+++ b/tests/procedure-recall.test.ts
@@ -1,0 +1,61 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+import { parseConfig } from "../packages/remnic-core/src/config.ts";
+import { buildProcedureRecallSection } from "../packages/remnic-core/src/procedural/procedure-recall.ts";
+import { buildProcedureMarkdownBody } from "../packages/remnic-core/src/procedural/procedure-types.ts";
+
+test("buildProcedureRecallSection returns ranked procedures on task-initiation prompts", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-recall-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const body = buildProcedureMarkdownBody([
+      { order: 1, intent: "Run deploy checks for production gateway" },
+      { order: 2, intent: "Push the release tag" },
+    ]);
+    const id = await storage.writeMemory(
+      "procedure",
+      `When you deploy the gateway\n\n${body}`,
+      { source: "test", tags: ["deploy", "gateway"] },
+    );
+
+    const config = parseConfig({
+      memoryDir: dir,
+      workspaceDir: path.join(dir, "ws"),
+      openaiApiKey: "test-key",
+      procedural: { enabled: true, recallMaxProcedures: 2 },
+    });
+
+    const section = await buildProcedureRecallSection(
+      storage,
+      "Let's deploy the gateway to production today",
+      config,
+    );
+    assert.ok(section);
+    assert.match(section, /## Relevant procedures/);
+    assert.match(section, new RegExp(id));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildProcedureRecallSection returns null when procedural.enabled is false", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-recall-off-"));
+  try {
+    const storage = new StorageManager(dir);
+    const config = parseConfig({
+      memoryDir: dir,
+      workspaceDir: path.join(dir, "ws"),
+      openaiApiKey: "test-key",
+      procedural: { enabled: false },
+    });
+    const section = await buildProcedureRecallSection(storage, "Let's deploy", config);
+    assert.equal(section, null);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- `MemoryIntent.taskInitiation` + `inferIntentFromText` / `isTaskInitiationIntent`.
- `procedural/procedure-recall.ts` and recall pipeline `procedure-recall` slice in `config.ts`.
- Orchestrator phase-1 hook + `appendRecallSection` ordering.

Depends on #526. Part of #519.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new recall slice and intent signal that can change what memory is injected into prompts, impacting recall relevance and token/latency behavior. Risk is moderated by being gated behind `procedural.enabled` and additional task-initiation heuristics with fail-open error handling and tests.
> 
> **Overview**
> **Intent-gated procedure recall**: introduces `MemoryIntent.taskInitiation` detection in `inferIntentFromText` (plus `isTaskInitiationIntent`) and threads the new signal through QMD intent hints.
> 
> When `procedural.enabled` is on, the recall pipeline gains a new `procedure-recall` section that pulls active procedure memories, scores/ranks them against the current prompt, and injects a short preview early in recall assembly; includes new unit tests covering the intent flag and procedure recall behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e53cba6373558aa5447fe94ae82c188440ef2036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->