### PR TITLE
feat(core): procedural mining MCP + cron (#519 pr 5/6)

### DIFF
--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -156,6 +156,18 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.procedure_mining_run",
+        description:
+          "Run procedural memory mining from causal trajectories (issue #519). Respects procedural.enabled; writes under procedures/ when clusters qualify.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.memory_get",
         description: "Fetch one Remnic memory by id.",
         inputSchema: {
@@ -1043,6 +1055,14 @@ export class EngramMcpServer {
           batchSize: typeof args.batchSize === "number" && Number.isFinite(args.batchSize) ? args.batchSize : undefined,
           authenticatedPrincipal: effectivePrincipal,
         }, effectivePrincipal);
+      case "engram.procedure_mining_run":
+        return this.service.procedureMiningRun(
+          {
+            namespace: typeof args.namespace === "string" ? args.namespace : undefined,
+            authenticatedPrincipal: effectivePrincipal,
+          },
+          effectivePrincipal,
+        );
       case "engram.memory_get":
         return this.service.memoryGet(
           typeof args.memoryId === "string" ? args.memoryId : "",

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -77,7 +77,7 @@ const writeContentSchema = z.string().min(1, "content is required").max(50000);
 const categorySchema = z
   .enum([
     "fact", "preference", "correction", "entity", "decision",
-    "relationship", "principle", "commitment", "moment", "skill", "rule",
+    "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure",
   ])
   .optional();
 const confidenceSchema = z.number().min(0).max(1).optional();

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -23,6 +23,7 @@ import {
   readMemoryGovernanceRunArtifact,
   runMemoryGovernance,
 } from "./maintenance/memory-governance.js";
+import { runProcedureMining } from "./procedural/procedure-miner.js";
 import {
   normalizeProjectionPreview,
   normalizeProjectionTags,
@@ -1616,6 +1617,37 @@ export class EngramAccessService {
       appliedActionCount: result.appliedActions.length,
       summaryPath: result.summaryPath,
       reportPath: result.reportPath,
+    };
+  }
+
+  async procedureMiningRun(
+    request: {
+      namespace?: string;
+      authenticatedPrincipal?: string;
+    },
+    principal?: string,
+  ): Promise<{
+    namespace: string;
+    clustersProcessed: number;
+    proceduresWritten: number;
+    skippedReason?: string;
+  }> {
+    const resolvedNamespace = this.resolveWritableNamespace(
+      request.namespace,
+      undefined,
+      request.authenticatedPrincipal ?? principal,
+    );
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const result = await runProcedureMining({
+      memoryDir: storage.dir,
+      storage,
+      config: this.orchestrator.config,
+    });
+    return {
+      namespace: resolvedNamespace,
+      clustersProcessed: result.clustersProcessed,
+      proceduresWritten: result.proceduresWritten,
+      skippedReason: result.skippedReason,
     };
   }
 

--- a/packages/remnic-core/src/causal-trajectory.ts
+++ b/packages/remnic-core/src/causal-trajectory.ts
@@ -149,7 +149,7 @@ export async function recordCausalTrajectory(options: {
   return filePath;
 }
 
-async function readCausalTrajectoryRecords(options: {
+export async function readCausalTrajectoryRecords(options: {
   memoryDir: string;
   causalTrajectoryStoreDir?: string;
 }): Promise<{
@@ -172,6 +172,20 @@ async function readCausalTrajectoryRecords(options: {
     }
   }
   return { files, trajectories, invalidTrajectories };
+}
+
+/** Keep trajectories whose recordedAt is within the last `lookbackDays` (issue #519 miner). */
+export function filterTrajectoriesByLookbackDays(
+  trajectories: CausalTrajectoryRecord[],
+  lookbackDays: number,
+  nowMs: number = Date.now(),
+): CausalTrajectoryRecord[] {
+  const days = Math.max(1, Math.floor(lookbackDays));
+  const cutoff = nowMs - days * 86_400_000;
+  return trajectories.filter((t) => {
+    const ms = Date.parse(t.recordedAt);
+    return Number.isFinite(ms) && ms >= cutoff;
+  });
 }
 
 export async function getCausalTrajectoryStoreStatus(options: {

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -3,6 +3,7 @@ import path from "node:path";
 
 const DAY_SUMMARY_CRON_ID = "engram-day-summary";
 const GOVERNANCE_CRON_ID = "engram-nightly-governance";
+const PROCEDURAL_MINING_CRON_ID = "engram-procedural-mining";
 
 type CronJobsShape =
   | Array<Record<string, unknown>>
@@ -177,4 +178,45 @@ export async function ensureNightlyGovernanceCron(
       },
       delivery: { mode: "none" },
     }));
+}
+
+export async function ensureProceduralMiningCron(
+  jobsPath: string,
+  options: {
+    timezone: string;
+    agentId?: string;
+    scheduleExpr?: string;
+  },
+): Promise<{ created: boolean; jobId: string }> {
+  const scheduleExpr =
+    typeof options.scheduleExpr === "string" && options.scheduleExpr.trim().length > 0
+      ? options.scheduleExpr.trim()
+      : "17 3 * * *";
+  const agentId =
+    typeof options.agentId === "string" && options.agentId.trim().length > 0
+      ? options.agentId.trim()
+      : "main";
+
+  return ensureCronJob(jobsPath, PROCEDURAL_MINING_CRON_ID, () => ({
+    id: PROCEDURAL_MINING_CRON_ID,
+    agentId,
+    name: "Remnic Procedural Mining (nightly)",
+    enabled: true,
+    schedule: {
+      kind: "cron",
+      expr: scheduleExpr,
+      tz: options.timezone,
+    },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      timeoutSeconds: 900,
+      thinking: "off",
+      message:
+        "You are OpenClaw automation. Call tool `engram.procedure_mining_run` with empty params. " +
+        "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+    },
+    delivery: { mode: "none" },
+  }));
 }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -65,7 +65,11 @@ import { TranscriptManager } from "./transcript.js";
 import { HourlySummarizer } from "./summarizer.js";
 import { LocalLlmClient } from "./local-llm.js";
 import { FallbackLlmClient } from "./fallback-llm.js";
-import { ensureDaySummaryCron, ensureNightlyGovernanceCron } from "./maintenance/memory-governance-cron.js";
+import {
+  ensureDaySummaryCron,
+  ensureNightlyGovernanceCron,
+  ensureProceduralMiningCron,
+} from "./maintenance/memory-governance-cron.js";
 import { ModelRegistry } from "./model-registry.js";
 import { applyRuntimeRetrievalPolicy, expandQuery } from "./retrieval.js";
 import {
@@ -2080,6 +2084,13 @@ export class Orchestrator {
         log.debug(`nightly governance cron auto-register failed (non-fatal): ${err}`);
       }
     }
+    if (this.config.procedural?.proceduralMiningCronAutoRegister) {
+      try {
+        await this.autoRegisterProceduralMiningCron();
+      } catch (err) {
+        log.debug(`procedural mining cron auto-register failed (non-fatal): ${err}`);
+      }
+    }
 
     log.info("orchestrator initialized (full — deferred steps complete)");
   }
@@ -2271,6 +2282,26 @@ export class Orchestrator {
     }
   }
 
+  private async autoRegisterProceduralMiningCron(): Promise<void> {
+    const home = resolveHomeDir();
+    const jobsPath = path.join(home, ".openclaw", "cron", "jobs.json");
+    try {
+      if (!existsSync(jobsPath)) {
+        log.debug("procedural mining cron: jobs.json not found, skipping auto-register");
+        return;
+      }
+      const created = await ensureProceduralMiningCron(jobsPath, {
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+      });
+      if (created.created) {
+        log.info(`procedural mining cron auto-registered (${created.jobId})`);
+      } else {
+        log.debug("procedural mining cron already exists, skipping auto-register");
+      }
+    } catch (err) {
+      log.debug(`procedural mining cron auto-register error: ${err}`);
+    }
+  }
 
   async applyBehaviorRuntimePolicy(
     state: BehaviorLoopPolicyState,

--- a/packages/remnic-core/src/procedural/procedure-miner.ts
+++ b/packages/remnic-core/src/procedural/procedure-miner.ts
@@ -1,0 +1,145 @@
+/**
+ * Cluster causal trajectories into candidate procedure memories (issue #519).
+ */
+
+import type { PluginConfig } from "../types.js";
+import type { StorageManager } from "../storage.js";
+import type { CausalTrajectoryRecord } from "../causal-trajectory.js";
+import {
+  readCausalTrajectoryRecords,
+  filterTrajectoriesByLookbackDays,
+} from "../causal-trajectory.js";
+import { buildProcedurePersistBody, normalizeProcedureSteps, type ProcedureStep } from "./procedure-types.js";
+import { log } from "../logger.js";
+
+export interface ProcedureMiningResult {
+  clustersProcessed: number;
+  proceduresWritten: number;
+  skippedReason?: string;
+}
+
+function clusterKey(record: CausalTrajectoryRecord): string {
+  const goal = record.goal.trim().toLowerCase().replace(/\s+/g, " ").slice(0, 120);
+  const refs = [...(record.entityRefs ?? [])].map((r) => r.trim().toLowerCase()).sort();
+  return `${goal}|${refs.join(",")}`;
+}
+
+function successRate(group: CausalTrajectoryRecord[]): number {
+  if (group.length === 0) return 0;
+  const ok = group.filter((g) => g.outcomeKind === "success" || g.outcomeKind === "partial").length;
+  return ok / group.length;
+}
+
+/** Derive ordered pseudo-steps from trajectory text (v1 heuristic; no tool-call array on records). */
+function pseudoStepsFromCluster(group: CausalTrajectoryRecord[]): ProcedureStep[] {
+  const sentences: string[] = [];
+  const pushUnique = (raw: string) => {
+    const t = raw.trim();
+    if (t.length < 8) return;
+    if (!sentences.includes(t)) sentences.push(t);
+  };
+  for (const g of group) {
+    const parts = [g.actionSummary, g.observationSummary, g.outcomeSummary]
+      .join(" ")
+      .split(/[.!?]\s+|;|\n+/)
+      .map((s) => s.trim())
+      .filter((s) => s.length > 12);
+    for (const p of parts) pushUnique(p);
+    if (sentences.length >= 5) break;
+  }
+  if (sentences.length < 2 && group[0]) {
+    pushUnique(`${group[0].goal.trim()} — confirm prerequisites and context.`);
+    pushUnique("Execute the planned actions, then record the outcome.");
+  }
+  return sentences.slice(0, 6).map((intent, i) => ({
+    order: i + 1,
+    intent,
+  }));
+}
+
+async function hasExistingClusterWrite(
+  storage: StorageManager,
+  cluster: string,
+): Promise<boolean> {
+  const memories = await storage.readAllMemories();
+  for (const m of memories) {
+    if (m.frontmatter.category !== "procedure") continue;
+    const c = m.frontmatter.structuredAttributes?.procedure_cluster;
+    if (c === cluster) return true;
+  }
+  return false;
+}
+
+/**
+ * Mine recurring successful trajectories into `procedure` memories (pending_review
+ * by default; active when auto-promotion thresholds are met).
+ */
+export async function runProcedureMining(options: {
+  memoryDir: string;
+  storage: StorageManager;
+  config: PluginConfig;
+}): Promise<ProcedureMiningResult> {
+  const cfg = options.config.procedural;
+  if (!cfg?.enabled) {
+    return { clustersProcessed: 0, proceduresWritten: 0, skippedReason: "procedural_disabled" };
+  }
+  if (cfg.minOccurrences <= 0) {
+    return { clustersProcessed: 0, proceduresWritten: 0, skippedReason: "minOccurrences_zero" };
+  }
+
+  const { trajectories } = await readCausalTrajectoryRecords({
+    memoryDir: options.memoryDir,
+  });
+  const recent = filterTrajectoriesByLookbackDays(trajectories, cfg.lookbackDays);
+
+  const clusters = new Map<string, CausalTrajectoryRecord[]>();
+  for (const t of recent) {
+    const key = clusterKey(t);
+    const arr = clusters.get(key) ?? [];
+    arr.push(t);
+    clusters.set(key, arr);
+  }
+
+  let clustersProcessed = 0;
+  let proceduresWritten = 0;
+
+  for (const [key, group] of clusters) {
+    if (group.length < cfg.minOccurrences) continue;
+    const rate = successRate(group);
+    if (rate < cfg.successFloor) continue;
+
+    clustersProcessed += 1;
+
+    if (await hasExistingClusterWrite(options.storage, key)) {
+      log.debug(`procedure-miner: skip duplicate cluster key=${key.slice(0, 40)}…`);
+      continue;
+    }
+
+    const steps = normalizeProcedureSteps(pseudoStepsFromCluster(group));
+    if (steps.length < 2) continue;
+
+    const title = `When you work on goals like: ${group[0].goal.trim().slice(0, 140)}`;
+    const body = buildProcedurePersistBody(title, steps);
+
+    const promote =
+      cfg.autoPromoteEnabled === true && group.length >= cfg.autoPromoteOccurrences && rate >= cfg.successFloor;
+
+    await options.storage.writeMemory("procedure", body, {
+      source: "procedure-miner",
+      status: promote ? "active" : "pending_review",
+      tags: ["procedure-miner", "causal-trajectory"],
+      structuredAttributes: {
+        procedure_cluster: key.slice(0, 500),
+        trajectory_ids: group
+          .map((g) => g.trajectoryId)
+          .join(",")
+          .slice(0, 1900),
+        trajectory_count: String(group.length),
+        success_rate: rate.toFixed(4),
+      },
+    });
+    proceduresWritten += 1;
+  }
+
+  return { clustersProcessed, proceduresWritten };
+}

--- a/tests/memory-governance-cron.test.ts
+++ b/tests/memory-governance-cron.test.ts
@@ -3,7 +3,11 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
-import { ensureDaySummaryCron, ensureNightlyGovernanceCron } from "../src/maintenance/memory-governance-cron.ts";
+import {
+  ensureDaySummaryCron,
+  ensureNightlyGovernanceCron,
+  ensureProceduralMiningCron,
+} from "../src/maintenance/memory-governance-cron.ts";
 
 test("nightly governance cron auto-registers a bounded job once", async () => {
   const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-governance-cron-"));
@@ -69,6 +73,26 @@ test("day-summary and nightly governance cron registration share the same write 
       parsed.jobs.map((job) => job.id).sort(),
       ["engram-day-summary", "engram-nightly-governance"],
     );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("procedural mining cron registers once and references engram.procedure_mining_run", async () => {
+  const tempDir = await mkdtemp(path.join(os.tmpdir(), "engram-procedural-mining-cron-"));
+  const jobsPath = path.join(tempDir, "jobs.json");
+  try {
+    await writeFile(jobsPath, JSON.stringify({ version: 1, jobs: [] }, null, 2) + "\n", "utf-8");
+    const first = await ensureProceduralMiningCron(jobsPath, { timezone: "UTC" });
+    assert.equal(first.created, true);
+    const second = await ensureProceduralMiningCron(jobsPath, { timezone: "UTC" });
+    assert.equal(second.created, false);
+    const parsed = JSON.parse(await readFile(jobsPath, "utf-8")) as {
+      jobs: Array<{ id: string; payload: { message: string } }>;
+    };
+    const job = parsed.jobs.find((j) => j.id === "engram-procedural-mining");
+    assert.ok(job);
+    assert.match(job.payload.message, /engram\.procedure_mining_run/);
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/tests/procedure-miner.test.ts
+++ b/tests/procedure-miner.test.ts
@@ -1,0 +1,92 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+import { parseConfig } from "../packages/remnic-core/src/config.ts";
+import { runProcedureMining } from "../packages/remnic-core/src/procedural/procedure-miner.ts";
+
+async function writeTrajectory(
+  root: string,
+  id: string,
+  goal: string,
+  outcome: "success" | "failure",
+  recordedAt: string,
+) {
+  const day = recordedAt.slice(0, 10);
+  const dir = path.join(root, "state", "causal-trajectories", "trajectories", day);
+  await mkdir(dir, { recursive: true });
+  const record = {
+    schemaVersion: 1,
+    trajectoryId: id,
+    recordedAt,
+    sessionKey: "test-session",
+    goal,
+    actionSummary: "Ran validation and deployed the service.",
+    observationSummary: "Health checks passed.",
+    outcomeKind: outcome,
+    outcomeSummary: outcome === "success" ? "Completed without errors." : "Rolled back.",
+    entityRefs: ["project-demo"],
+  };
+  await writeFile(path.join(dir, `${id}.json`), JSON.stringify(record, null, 2), "utf-8");
+}
+
+test("runProcedureMining writes a pending_review procedure for recurring successful trajectories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-miner-"));
+  try {
+    const now = new Date();
+    const iso = (d: Date) => d.toISOString();
+    const g = "Ship the demo gateway to staging";
+    await writeTrajectory(dir, "t-a", g, "success", iso(new Date(now.getTime() - 86_400_000)));
+    await writeTrajectory(dir, "t-b", g, "success", iso(new Date(now.getTime() - 2 * 86_400_000)));
+    await writeTrajectory(dir, "t-c", g, "success", iso(new Date(now.getTime() - 3 * 86_400_000)));
+
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const config = parseConfig({
+      memoryDir: dir,
+      workspaceDir: path.join(dir, "ws"),
+      openaiApiKey: "test-key",
+      procedural: {
+        enabled: true,
+        minOccurrences: 3,
+        successFloor: 0.6,
+        lookbackDays: 30,
+        autoPromoteEnabled: false,
+        autoPromoteOccurrences: 8,
+      },
+    });
+
+    const result = await runProcedureMining({ memoryDir: dir, storage, config });
+    assert.equal(result.proceduresWritten, 1);
+    assert.ok((result.clustersProcessed ?? 0) >= 1);
+
+    const memories = await storage.readAllMemories();
+    const proc = memories.find((m) => m.frontmatter.category === "procedure");
+    assert.ok(proc);
+    assert.equal(proc.frontmatter.status, "pending_review");
+    assert.equal(proc.frontmatter.structuredAttributes?.trajectory_count, "3");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runProcedureMining no-ops when procedural.enabled is false", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "openclaw-engram-procedure-miner-off-"));
+  try {
+    const storage = new StorageManager(dir);
+    const config = parseConfig({
+      memoryDir: dir,
+      workspaceDir: path.join(dir, "ws"),
+      openaiApiKey: "test-key",
+      procedural: { enabled: false },
+    });
+    const result = await runProcedureMining({ memoryDir: dir, storage, config });
+    assert.equal(result.proceduresWritten, 0);
+    assert.equal(result.skippedReason, "procedural_disabled");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- `procedure-miner.ts` + causal trajectory filtering.
- MCP tool + `AccessService` wiring; `ensureProceduralMiningCron` + tests.
- Orchestrator registers mining cron when `proceduralMiningCronAutoRegister` is set.

Depends on #527. Part of #519.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new background job and write path that can create `procedure` memories from stored causal trajectories; behavior is gated by `procedural.enabled`/threshold config but impacts persisted data when enabled.
> 
> **Overview**
> **Adds procedural memory mining (issue #519).** Introduces `runProcedureMining` to cluster recent causal trajectories by goal/entity refs, apply success/occurrence thresholds, and write new `procedure` memories (pending review by default, with optional auto-promotion).
> 
> Wires the feature through a new MCP tool `engram.procedure_mining_run` and `EngramAccessService.procedureMiningRun`, exports trajectory reading utilities plus a lookback filter helper, and adds `ensureProceduralMiningCron` + orchestrator auto-registration behind `procedural.proceduralMiningCronAutoRegister`.
> 
> Extends request validation to accept `category: "procedure"` and adds tests covering the new cron job registration and procedure miner output/skipping behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82f400d5d3d66af16c76d6367e711e860c459d9c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->