### PR TITLE
docs(bench): procedural memory bench + docs (#519 pr 6/6)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -32,4 +32,5 @@ See **[docs/architecture/overview.md](architecture/overview.md)** for the full s
 
 - [Architecture Overview](architecture/overview.md) — full internals
 - [Retrieval Pipeline](architecture/retrieval-pipeline.md) — how recall works
+- [Procedural memory](procedural-memory.md) — optional `procedure` category, recall gate, miner
 - [Memory Lifecycle](architecture/memory-lifecycle.md) — write, consolidation, expiry

--- a/docs/advanced-retrieval.md
+++ b/docs/advanced-retrieval.md
@@ -68,6 +68,12 @@ Behavior:
 - Negative examples apply a **small, bounded penalty** during ranking (soft bias only).
 - Safe default: the batch tool requires explicit IDs (or a `usefulMemoryIds` allowlist + `autoMarkOthersNotUseful=true`) to avoid accidental mass-negative marking.
 
+### Procedural memory (optional)
+
+When **`procedural.enabled`** is true, Remnic can inject a short **“Relevant procedures”** section at recall time for prompts that look like **task initiation** (for example deploy, ship, or open a PR), using active `category: procedure` files under `procedures/`. This path is separate from QMD hybrid search and from `memoryKind: procedural` dream-surface filtering.
+
+See [Procedural memory](./procedural-memory.md) for configuration, mining, and the `procedural-recall` benchmark.
+
 ## Example: Enable Local-only Re-ranking
 
 In `openclaw.json`:

--- a/docs/architecture/retrieval-pipeline.md
+++ b/docs/architecture/retrieval-pipeline.md
@@ -27,6 +27,7 @@ before_agent_start
 │  b. QMD hybrid search           │  BM25 + vector subprocess calls in parallel
 │  c. Embedding fallback          │  when QMD unavailable or returns empty results
 │  d. Namespace filter (v3.0)     │  filter to allowed namespaces
+│  e. Procedural recall (opt.)    │  intent-gated `procedure` files; see docs/procedural-memory.md
 └──────────────┬──────────────────┘
                ▼
 ┌─────────────────────────────────┐

--- a/docs/procedural-memory.md
+++ b/docs/procedural-memory.md
@@ -1,0 +1,54 @@
+# Procedural memory
+
+Procedural memories are first-class **`category: procedure`** items stored under `memoryDir/procedures/YYYY-MM-DD/` as markdown (same persistence path as other memories via `StorageManager.writeMemory`). They capture ordered **steps** (human-editable in the body) plus YAML frontmatter for lifecycle, provenance, and review state.
+
+This feature tracks [issue #519](https://github.com/joshuaswarren/remnic/issues/519).
+
+## Enablement
+
+Everything behavioral is gated by plugin config **`procedural.enabled`** (default **`false`**). When disabled:
+
+- Direct extraction does not emit new procedure memories.
+- Intent-gated recall does not inject a procedure section.
+- The nightly miner MCP entry returns without writing files.
+
+Mirror the same keys under `openclaw.plugin.json` / host config as for other Engram-style toggles.
+
+## Taxonomy and filing
+
+- `MemoryCategory` includes `"procedure"`.
+- Default taxonomy exposes a **`procedures`** bucket (priority between principles and entities).
+- `category-dir` maps `procedure` → `procedures/`.
+
+## Extraction (user-taught workflows)
+
+When the extractor proposes `category: "procedure"`, the **extraction judge** requires at least **two steps** and **explicit trigger-style** phrasing before the memory is accepted. Failed checks drop the candidate rather than downgrading silently.
+
+## Recall (task initiation)
+
+On prompts that look like **starting hands-on work** (deploy, ship, open a PR, run tests, etc.), the orchestrator may inject a **`## Relevant procedures`** block built from **active** procedure files only. **`pending_review`** miner suggestions are not injected by default.
+
+Relevant config keys include:
+
+- `procedural.recallMaxProcedures` — cap on injected procedure previews.
+
+See also: [Advanced retrieval](./advanced-retrieval.md) and [Retrieval pipeline](./architecture/retrieval-pipeline.md).
+
+## Mining (trajectories)
+
+A dedicated miner clusters **causal trajectory** records (bounded lookback by `recordedAt` / `lookbackDays`) and can write **`status: pending_review`** procedure candidates. Promotion to **`active`** respects optional auto-promote rules and avoids clobbering user-edited bodies.
+
+Automation is **not** part of `runMemoryGovernance`. Use the MCP tool **`engram.procedure_mining_run`** (and optional cron registration mirroring other nightly jobs) so procedural mining stays isolated from shadow/apply governance.
+
+## Benchmark
+
+The **`procedural-recall`** benchmark in `@remnic/bench` scores:
+
+1. **Task initiation gate** — deterministic intent classification vs. labeled prompts.
+2. **Procedure section gate** — temp `memoryDir` round-trip: whether a non-null recall section is produced when expected (feature on/off and non-task prompts).
+
+Run a quick pass:
+
+```bash
+npm run bench:run -- --quick procedural-recall
+```

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/fixture.ts
@@ -1,0 +1,80 @@
+/**
+ * Synthetic cases for procedural recall: task-initiation gating + optional
+ * storage-backed recall (issue #519).
+ */
+
+export interface ProceduralRecallIntentCase {
+  id: string;
+  prompt: string;
+  /** Whether `isTaskInitiationIntent(inferIntentFromText(prompt))` should be true. */
+  expectTaskInit: boolean;
+}
+
+export interface ProceduralRecallE2eCase {
+  id: string;
+  prompt: string;
+  procedurePreamble: string;
+  procedureSteps: Array<{ order: number; intent: string }>;
+  procedureTags: string[];
+  /** When true, `buildProcedureRecallSection` should return non-null markdown. */
+  expectNonNullSection: boolean;
+  proceduralEnabled?: boolean;
+}
+
+export const PROCEDURAL_RECALL_INTENT_FIXTURE: ProceduralRecallIntentCase[] = [
+  { id: "deploy-gateway", prompt: "Let's deploy the gateway to production today", expectTaskInit: true },
+  { id: "open-pr", prompt: "Open a PR for the regression fix", expectTaskInit: true },
+  { id: "run-tests", prompt: "Run the tests before we merge the release branch", expectTaskInit: true },
+  { id: "ship-release", prompt: "We need to ship this release tonight", expectTaskInit: true },
+  { id: "merge-pr", prompt: "Merge the pull request after CI is green", expectTaskInit: true },
+  { id: "start-work", prompt: "Starting work on the production hotfix", expectTaskInit: true },
+  { id: "fix-build", prompt: "Fixing the broken build on main", expectTaskInit: true },
+  { id: "memory-question", prompt: "What did we decide about the gateway deploy last week?", expectTaskInit: false },
+  { id: "summarize", prompt: "Summarize the timeline of the outage", expectTaskInit: false },
+  { id: "thanks", prompt: "Thanks, that helps", expectTaskInit: false },
+  { id: "how-retrieval", prompt: "How does hybrid retrieval work in this stack?", expectTaskInit: false },
+  { id: "explain", prompt: "Explain the difference between a fact and a principle memory", expectTaskInit: false },
+];
+
+export const PROCEDURAL_RECALL_INTENT_SMOKE_FIXTURE = PROCEDURAL_RECALL_INTENT_FIXTURE.slice(0, 6);
+
+export const PROCEDURAL_RECALL_E2E_FIXTURE: ProceduralRecallE2eCase[] = [
+  {
+    id: "ranked-deploy",
+    prompt: "Let's deploy the gateway to production today",
+    procedurePreamble: "When you deploy the gateway",
+    procedureSteps: [
+      { order: 1, intent: "Run deploy checks for production gateway" },
+      { order: 2, intent: "Push the release tag" },
+    ],
+    procedureTags: ["deploy", "gateway"],
+    expectNonNullSection: true,
+    proceduralEnabled: true,
+  },
+  {
+    id: "disabled-gate",
+    prompt: "Let's deploy everything now",
+    procedurePreamble: "Ship checklist",
+    procedureSteps: [
+      { order: 1, intent: "Verify CI" },
+      { order: 2, intent: "Tag release" },
+    ],
+    procedureTags: ["ship"],
+    expectNonNullSection: false,
+    proceduralEnabled: false,
+  },
+  {
+    id: "no-task-init",
+    prompt: "What is our usual process for production deploys?",
+    procedurePreamble: "Production deploy runbook",
+    procedureSteps: [
+      { order: 1, intent: "Notify on-call" },
+      { order: 2, intent: "Apply change window" },
+    ],
+    procedureTags: ["deploy", "runbook"],
+    expectNonNullSection: false,
+    proceduralEnabled: true,
+  },
+];
+
+export const PROCEDURAL_RECALL_E2E_SMOKE_FIXTURE = PROCEDURAL_RECALL_E2E_FIXTURE.slice(0, 1);

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
@@ -1,0 +1,159 @@
+/**
+ * Deterministic benchmark for procedural recall gating (issue #519).
+ */
+
+import { randomUUID } from "node:crypto";
+import { mkdtemp, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  StorageManager,
+  parseConfig,
+  inferIntentFromText,
+  isTaskInitiationIntent,
+  buildProcedureRecallSection,
+  buildProcedureMarkdownBody,
+} from "@remnic/core";
+import type { BenchmarkDefinition, BenchmarkResult, ResolvedRunBenchmarkOptions, TaskResult } from "../../../types.js";
+import { aggregateTaskScores, exactMatch } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  PROCEDURAL_RECALL_E2E_FIXTURE,
+  PROCEDURAL_RECALL_E2E_SMOKE_FIXTURE,
+  PROCEDURAL_RECALL_INTENT_FIXTURE,
+  PROCEDURAL_RECALL_INTENT_SMOKE_FIXTURE,
+} from "./fixture.js";
+
+export const proceduralRecallDefinition: BenchmarkDefinition = {
+  id: "procedural-recall",
+  title: "Procedural Recall",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "procedural-recall",
+    version: "1.0.0",
+    description:
+      "Task-initiation intent accuracy plus optional storage-backed procedure section assembly (issue #519).",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #519",
+  },
+};
+
+export async function runProceduralRecallBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const tasks: TaskResult[] = [];
+
+  const intentCases =
+    options.mode === "quick" ? PROCEDURAL_RECALL_INTENT_SMOKE_FIXTURE : PROCEDURAL_RECALL_INTENT_FIXTURE;
+
+  for (const sample of intentCases) {
+    const startedAt = performance.now();
+    const intent = inferIntentFromText(sample.prompt);
+    const actual = isTaskInitiationIntent(intent);
+    const latencyMs = Math.round(performance.now() - startedAt);
+
+    tasks.push({
+      taskId: `intent:${sample.id}`,
+      question: sample.prompt,
+      expected: String(sample.expectTaskInit),
+      actual: String(actual),
+      scores: {
+        task_initiation_gate: exactMatch(String(actual), String(sample.expectTaskInit)),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: { intent },
+    });
+  }
+
+  const e2eCases =
+    options.mode === "quick" ? PROCEDURAL_RECALL_E2E_SMOKE_FIXTURE : PROCEDURAL_RECALL_E2E_FIXTURE;
+
+  for (const sample of e2eCases) {
+    const startedAt = performance.now();
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-procedural-recall-"));
+    let section: string | null = null;
+    try {
+      const storage = new StorageManager(dir);
+      await storage.ensureDirectories();
+      const body = buildProcedureMarkdownBody(sample.procedureSteps);
+      await storage.writeMemory(
+        "procedure",
+        `${sample.procedurePreamble}\n\n${body}`,
+        { source: "bench", tags: sample.procedureTags },
+      );
+
+      const config = parseConfig({
+        memoryDir: dir,
+        workspaceDir: path.join(dir, "ws"),
+        openaiApiKey: "bench-key",
+        procedural: {
+          enabled: sample.proceduralEnabled !== false,
+          recallMaxProcedures: 3,
+        },
+      });
+
+      section = await buildProcedureRecallSection(storage, sample.prompt, config);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const nonNull = section !== null && section.length > 0;
+    tasks.push({
+      taskId: `e2e:${sample.id}`,
+      question: sample.prompt,
+      expected: String(sample.expectNonNullSection),
+      actual: String(nonNull),
+      scores: {
+        procedure_section_gate: exactMatch(String(nonNull), String(sample.expectNonNullSection)),
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: { sectionPreview: section?.slice(0, 200) ?? null },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -68,6 +68,10 @@ import {
   runRetrievalTemporalBenchmark,
 } from "./benchmarks/remnic/retrieval-temporal/runner.js";
 import {
+  proceduralRecallDefinition,
+  runProceduralRecallBenchmark,
+} from "./benchmarks/remnic/procedural-recall/runner.js";
+import {
   ingestionEntityRecallDefinition,
   runIngestionEntityRecallBenchmark,
 } from "./benchmarks/remnic/ingestion-entity-recall/runner.js";
@@ -172,6 +176,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalTemporalDefinition,
     run: runRetrievalTemporalBenchmark,
+  },
+  {
+    ...proceduralRecallDefinition,
+    run: runProceduralRecallBenchmark,
   },
   {
     ...ingestionEntityRecallDefinition,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -72,6 +72,24 @@ export {
 } from "./extraction-judge.js";
 
 // ---------------------------------------------------------------------------
+// Intent + procedural recall (issue #519)
+// ---------------------------------------------------------------------------
+
+export {
+  inferIntentFromText,
+  isTaskInitiationIntent,
+  intentCompatibilityScore,
+  planRecallMode,
+  hasBroadGraphIntent,
+} from "./intent.js";
+
+export { buildProcedureRecallSection } from "./procedural/procedure-recall.js";
+export {
+  buildProcedureMarkdownBody,
+  parseProcedureStepsFromBody,
+} from "./procedural/procedure-types.js";
+
+// ---------------------------------------------------------------------------
 // Inline source attribution (issue #369)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- `procedural-recall` benchmark + registry entry.
- `docs/procedural-memory.md` and cross-links from retrieval docs / architecture overview.
- Public exports from `@remnic/core` for bench and downstream callers.

Depends on #528. Closes #519.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly documentation and benchmarking additions; the main code change is expanding the public `@remnic/core` export surface, which is low risk but could affect downstream consumers if names collide or bundling changes.
> 
> **Overview**
> Adds first-class documentation for *optional* procedural memory, including how `procedural.enabled` gates extraction/recall/mining, and links it into the architecture and retrieval docs.
> 
> Introduces a new `procedural-recall` benchmark in `@remnic/bench` (fixtures + runner) and registers it in the benchmark registry to score task-initiation intent gating and whether a procedure recall section is produced.
> 
> Exports intent and procedural recall helpers (e.g. `inferIntentFromText`, `isTaskInitiationIntent`, `buildProcedureRecallSection`, procedure markdown helpers) from `@remnic/core` for bench and downstream callers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 748f357fedc16b14ab49e5de1f00de1af99cf320. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->