### PR TITLE
Version Packages

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -350,6 +350,9 @@ jobs:
           # package metadata (see issue #403).
           PUBLISH_ORDER=(
             packages/remnic-core
+            packages/connector-weclone
+            packages/export-weclone
+            packages/import-weclone
             packages/remnic-server
             packages/remnic-cli
             packages/hermes-provider

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3690,6 +3690,7 @@
       },
       "briefing": {
         "type": "object",
+        "additionalProperties": false,
         "default": {
           "enabled": true,
           "defaultWindow": "yesterday",
@@ -3699,6 +3700,52 @@
           "saveByDefault": false,
           "saveDir": null,
           "llmFollowups": true
+        },
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "defaultWindow": {
+            "type": "string",
+            "default": "yesterday"
+          },
+          "defaultFormat": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "json"
+            ],
+            "default": "markdown"
+          },
+          "maxFollowups": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          },
+          "calendarSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "saveByDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "saveDir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "llmFollowups": {
+            "type": "boolean",
+            "default": true
+          }
         },
         "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
       },

--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/connector-weclone",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "OpenAI-compatible proxy adding Remnic persistent memory to WeClone avatars",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/connector-weclone/src/proxy.ts
+++ b/packages/connector-weclone/src/proxy.ts
@@ -327,9 +327,12 @@ async function transparentProxy(
     headers: forwardHeaders,
   };
   if (body && method !== "GET" && method !== "HEAD") {
-    // Use Uint8Array (a valid BodyInit) instead of Buffer to satisfy
-    // RequestInit typing and forward raw bytes verbatim.
-    fetchInit.body = new Uint8Array(body.buffer, body.byteOffset, body.byteLength);
+    // Copy into a plain ArrayBuffer so the forwarded request keeps the exact
+    // byte payload while remaining compatible with this package's BodyInit
+    // typing during declaration builds.
+    const rawBody = new ArrayBuffer(body.byteLength);
+    new Uint8Array(rawBody).set(body);
+    fetchInit.body = rawBody;
   }
 
   try {

--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/export-weclone",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Export Remnic memories as WeClone-compatible Alpaca-format fine-tuning datasets",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/export-weclone/src/privacy.ts
+++ b/packages/export-weclone/src/privacy.ts
@@ -74,7 +74,7 @@ export function sweepPii(records: TrainingExportRecord[]): PrivacySweepResult {
   const recordHasRedaction = new Set<number>();
 
   const cleanRecords = records.map((record, idx) => {
-    const cleaned: Record<string, unknown> = { ...record };
+    const cleaned: TrainingExportRecord = { ...record };
 
     for (const field of SCANNED_FIELDS) {
       let value = record[field];
@@ -98,7 +98,7 @@ export function sweepPii(records: TrainingExportRecord[]): PrivacySweepResult {
       cleaned[field] = value;
     }
 
-    return cleaned as TrainingExportRecord;
+    return cleaned;
   });
 
   return {

--- a/packages/hermes-provider/package.json
+++ b/packages/hermes-provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/hermes-provider",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Typed HTTP client for the Remnic memory API",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/import-weclone/package.json
+++ b/packages/import-weclone/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/import-weclone",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Import WeClone-preprocessed chat exports to bootstrap Remnic memory",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3678,6 +3678,7 @@
       },
       "briefing": {
         "type": "object",
+        "additionalProperties": false,
         "default": {
           "enabled": true,
           "defaultWindow": "yesterday",
@@ -3687,6 +3688,52 @@
           "saveByDefault": false,
           "saveDir": null,
           "llmFollowups": true
+        },
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "defaultWindow": {
+            "type": "string",
+            "default": "yesterday"
+          },
+          "defaultFormat": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "json"
+            ],
+            "default": "markdown"
+          },
+          "maxFollowups": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          },
+          "calendarSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "saveByDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "saveDir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "llmFollowups": {
+            "type": "boolean",
+            "default": true
+          }
         },
         "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
       },

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",
@@ -29,6 +29,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@remnic/core": "workspace:^",
     "openai": "^6.0.0"
   },
   "peerDependencies": {

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/cli",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "CLI for Remnic memory — init, query, doctor, daemon management",
   "type": "module",
   "main": "dist/index.js",
@@ -31,7 +31,8 @@
   },
   "dependencies": {
     "@remnic/core": "workspace:^",
-    "@remnic/export-weclone": "workspace:^"
+    "@remnic/export-weclone": "workspace:^",
+    "yaml": "^2.4.2"
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -7,5 +7,6 @@ export default defineConfig({
   platform: "node",
   outDir: "dist",
   clean: true,
+  external: ["yaml"],
   noExternal: ["@remnic/bench"],
 });

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-server/package.json
+++ b/packages/remnic-server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/server",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Standalone Remnic memory server — HTTP + MCP without OpenClaw",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3629,6 +3629,7 @@
       },
       "briefing": {
         "type": "object",
+        "additionalProperties": false,
         "default": {
           "enabled": true,
           "defaultWindow": "yesterday",
@@ -3638,6 +3639,52 @@
           "saveByDefault": false,
           "saveDir": null,
           "llmFollowups": true
+        },
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": true
+          },
+          "defaultWindow": {
+            "type": "string",
+            "default": "yesterday"
+          },
+          "defaultFormat": {
+            "type": "string",
+            "enum": [
+              "markdown",
+              "json"
+            ],
+            "default": "markdown"
+          },
+          "maxFollowups": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 10,
+            "default": 5
+          },
+          "calendarSource": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "saveByDefault": {
+            "type": "boolean",
+            "default": false
+          },
+          "saveDir": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null
+          },
+          "llmFollowups": {
+            "type": "boolean",
+            "default": true
+          }
         },
         "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
       },

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1,7 +1,15 @@
 {
   "id": "openclaw-engram",
   "kind": "memory",
-  "description": "Legacy compatibility shim for the openclaw-engram plugin id. This id has been renamed to openclaw-remnic — install @remnic/plugin-openclaw for the current release. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "description": "Local semantic memory for OpenClaw. Requires plugins.slots.memory set to this plugin id for hooks to fire.",
+  "supports": {
+    "memorySlot": true,
+    "dreamingSlot": true,
+    "activeMemory": true,
+    "heartbeat": true,
+    "commandsList": true,
+    "beforeReset": true
+  },
   "configSchema": {
     "type": "object",
     "additionalProperties": false,
@@ -165,6 +173,555 @@
       "memoryDir": {
         "type": "string",
         "description": "Override memory storage directory"
+      },
+      "entitySchemas": {
+        "type": "object",
+        "description": "Optional per-entity-type structured section schema overrides.",
+        "additionalProperties": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "sections": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "key": {
+                    "type": "string"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "aliases": {
+                    "type": "array",
+                    "items": {
+                      "type": "string"
+                    }
+                  }
+                },
+                "anyOf": [
+                  {
+                    "required": [
+                      "key"
+                    ]
+                  },
+                  {
+                    "required": [
+                      "title"
+                    ]
+                  }
+                ]
+              }
+            }
+          },
+          "required": [
+            "sections"
+          ]
+        }
+      },
+      "dreaming": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "journalPath": {
+            "type": "string",
+            "default": "DREAMS.md"
+          },
+          "maxEntries": {
+            "anyOf": [
+              {
+                "type": "integer",
+                "const": 0
+              },
+              {
+                "type": "integer",
+                "minimum": 10,
+                "maximum": 10000
+              }
+            ],
+            "default": 500
+          },
+          "injectRecentCount": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 20,
+            "default": 3
+          },
+          "minIntervalMinutes": {
+            "type": "integer",
+            "minimum": 1,
+            "default": 120
+          },
+          "narrativeModel": {
+            "type": "string",
+            "default": ""
+          },
+          "narrativePromptStyle": {
+            "type": "string",
+            "enum": [
+              "reflective",
+              "diary",
+              "analytical"
+            ],
+            "default": "reflective"
+          },
+          "watchFile": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "heartbeat": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "journalPath": {
+            "type": "string",
+            "default": "HEARTBEAT.md"
+          },
+          "maxPreviousRuns": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 20,
+            "default": 5
+          },
+          "watchFile": {
+            "type": "boolean",
+            "default": true
+          },
+          "detectionMode": {
+            "type": "string",
+            "enum": [
+              "runtime-signal",
+              "heuristic",
+              "auto"
+            ],
+            "default": "auto"
+          },
+          "gateExtractionDuringHeartbeat": {
+            "type": "boolean",
+            "default": true
+          }
+        }
+      },
+      "slotBehavior": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "requireExclusiveMemorySlot": {
+            "type": "boolean",
+            "default": true
+          },
+          "onSlotMismatch": {
+            "type": "string",
+            "enum": [
+              "error",
+              "warn",
+              "silent"
+            ],
+            "default": "error"
+          }
+        }
+      },
+      "beforeResetTimeoutMs": {
+        "type": "integer",
+        "minimum": 100,
+        "maximum": 30000,
+        "default": 2000,
+        "description": "Maximum time to wait for a reset-triggered flush before returning control to OpenClaw."
+      },
+      "flushOnResetEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Flush buffered turns through extraction when OpenClaw resets a session."
+      },
+      "commandsListEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Advertise Remnic slash-command descriptors through the commands.list runtime surface."
+      },
+      "openclawToolsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Register the OpenClaw memory.search and memory.get tool adapters."
+      },
+      "openclawToolSnippetMaxChars": {
+        "type": "integer",
+        "minimum": 80,
+        "maximum": 4000,
+        "default": 600,
+        "description": "Maximum snippet size returned by the OpenClaw memory tool adapters."
+      },
+      "sessionTogglesEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable per-session recall toggle state for OpenClaw runtime surfaces."
+      },
+      "verboseRecallVisibility": {
+        "type": "boolean",
+        "default": true,
+        "description": "Allow verbose recall headers to surface runtime recall diagnostics in prompts."
+      },
+      "recallTranscriptsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Write JSONL recall audit transcripts for runtime-surface injections."
+      },
+      "recallTranscriptRetentionDays": {
+        "type": "integer",
+        "minimum": 1,
+        "maximum": 365,
+        "default": 30,
+        "description": "Days of runtime recall audit transcripts to retain before pruning."
+      },
+      "respectBundledActiveMemoryToggle": {
+        "type": "boolean",
+        "default": true,
+        "description": "Honor the bundled active-memory session toggle file when resolving Remnic recall toggles."
+      },
+      "activeRecallEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the OpenClaw active-recall prompt surface."
+      },
+      "activeRecallAgents": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "description": "Optional allowlist of OpenClaw agent ids that may use active recall."
+      },
+      "activeRecallAllowedChatTypes": {
+        "type": "array",
+        "items": {
+          "type": "string",
+          "enum": [
+            "direct",
+            "group",
+            "channel"
+          ]
+        },
+        "default": [
+          "direct",
+          "group",
+          "channel"
+        ],
+        "description": "OpenClaw chat types eligible for active recall."
+      },
+      "activeRecallQueryMode": {
+        "type": "string",
+        "enum": [
+          "recent",
+          "message",
+          "full"
+        ],
+        "default": "recent",
+        "description": "How much recent OpenClaw conversation context is fed into the active-recall query builder."
+      },
+      "activeRecallPromptStyle": {
+        "type": "string",
+        "enum": [
+          "balanced",
+          "strict",
+          "contextual",
+          "recall-heavy",
+          "precision-heavy",
+          "preference-only"
+        ],
+        "default": "balanced",
+        "description": "Prompt assembly style for the active-recall surface."
+      },
+      "activeRecallPromptOverride": {
+        "type": "string",
+        "description": "Optional full prompt override for the active-recall surface."
+      },
+      "activeRecallPromptAppend": {
+        "type": "string",
+        "description": "Optional prompt suffix appended to the active-recall system prompt."
+      },
+      "activeRecallMaxSummaryChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 220,
+        "description": "Maximum summary size produced by the active-recall surface."
+      },
+      "activeRecallRecentUserTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 4,
+        "default": 2,
+        "description": "How many recent user turns to include in the active-recall query context."
+      },
+      "activeRecallRecentAssistantTurns": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "How many recent assistant turns to include in the active-recall query context."
+      },
+      "activeRecallRecentUserChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 600,
+        "description": "Per-user-turn character cap for active-recall context assembly."
+      },
+      "activeRecallRecentAssistantChars": {
+        "type": "integer",
+        "minimum": 40,
+        "maximum": 1000,
+        "default": 400,
+        "description": "Per-assistant-turn character cap for active-recall context assembly."
+      },
+      "activeRecallThinking": {
+        "type": "string",
+        "enum": [
+          "off",
+          "minimal",
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "adaptive"
+        ],
+        "default": "low",
+        "description": "Reasoning effort used by the active-recall engine."
+      },
+      "activeRecallTimeoutMs": {
+        "type": "integer",
+        "minimum": 250,
+        "default": 15000,
+        "description": "Timeout for an active-recall run."
+      },
+      "activeRecallCacheTtlMs": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 120000,
+        "default": 15000,
+        "description": "Cache TTL for active-recall summaries; 0 disables the cache."
+      },
+      "activeRecallModel": {
+        "type": "string",
+        "description": "Optional model override for active recall."
+      },
+      "activeRecallModelFallbackPolicy": {
+        "type": "string",
+        "enum": [
+          "default-remote",
+          "resolved-only"
+        ],
+        "default": "default-remote",
+        "description": "How active recall falls back when an explicit model cannot be resolved."
+      },
+      "activeRecallPersistTranscripts": {
+        "type": "boolean",
+        "default": false,
+        "description": "Persist full active-recall request and response transcripts."
+      },
+      "activeRecallTranscriptDir": {
+        "type": "string",
+        "default": "active-recall",
+        "description": "Memory-relative directory for active-recall transcripts."
+      },
+      "activeRecallEntityGraphDepth": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 3,
+        "default": 1,
+        "description": "Entity-graph traversal depth used by active recall."
+      },
+      "activeRecallIncludeCausalTrajectories": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include causal trajectory recall evidence in active-recall summaries."
+      },
+      "activeRecallIncludeDaySummary": {
+        "type": "boolean",
+        "default": false,
+        "description": "Include the latest day summary in active-recall context."
+      },
+      "activeRecallAttachRecallExplain": {
+        "type": "boolean",
+        "default": false,
+        "description": "Attach recall explain output to active-recall diagnostics."
+      },
+      "activeRecallAllowChainedActiveMemory": {
+        "type": "boolean",
+        "default": false,
+        "description": "Allow active recall to chain into the bundled active-memory surface."
+      },
+      "codex": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "installExtension": {
+            "type": "boolean",
+            "default": true,
+            "description": "Install the Remnic Codex memory extension during Codex connector setup."
+          },
+          "codexHome": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "default": null,
+            "description": "Optional Codex home directory override used for connector install and materialization."
+          }
+        }
+      },
+      "codexMaterializeMemories": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex native memory materialization into the Codex memories directory."
+      },
+      "codexMaterializeNamespace": {
+        "type": "string",
+        "default": "auto",
+        "description": "Namespace to materialize for Codex. \"auto\" derives the namespace from the active connector context."
+      },
+      "codexMaterializeMaxSummaryTokens": {
+        "type": "number",
+        "minimum": 0,
+        "default": 4500,
+        "description": "Whitespace-token cap for Codex memory summary materialization."
+      },
+      "codexMaterializeRolloutRetentionDays": {
+        "type": "number",
+        "minimum": 0,
+        "default": 30,
+        "description": "Retention window in days for Codex rollout materialization artifacts."
+      },
+      "codexMaterializeOnConsolidation": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization after semantic or causal consolidation completes."
+      },
+      "codexMaterializeOnSessionEnd": {
+        "type": "boolean",
+        "default": true,
+        "description": "Run Codex memory materialization from the Codex session-end hook."
+      },
+      "codexMarketplaceEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Enable Codex marketplace integration for plugin discovery and installation."
+      },
+      "versioningEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable page-level versioning with sidecar snapshots."
+      },
+      "versioningMaxPerPage": {
+        "type": "integer",
+        "default": 50,
+        "minimum": 0,
+        "description": "Maximum number of version snapshots per page. Set to 0 to disable pruning."
+      },
+      "versioningSidecarDir": {
+        "type": "string",
+        "default": ".versions",
+        "description": "Name of the sidecar directory inside memoryDir for version snapshots."
+      },
+      "taxonomyEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the MECE taxonomy knowledge directory for categorizing memories."
+      },
+      "taxonomyAutoGenResolver": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-regenerate RESOLVER.md when the taxonomy changes."
+      },
+      "citationsEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable oai-mem-citation blocks in recall responses for Codex citation parity."
+      },
+      "citationsAutoDetect": {
+        "type": "boolean",
+        "default": true,
+        "description": "Auto-enable citations when the Codex adapter is detected."
+      },
+      "memoryExtensionsEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Whether third-party memory extensions are discovered and injected into consolidation prompts."
+      },
+      "memoryExtensionsRoot": {
+        "type": "string",
+        "default": "",
+        "description": "Root directory for memory extensions. Empty string derives from memoryDir (go up to Remnic home and append memory_extensions)."
+      },
+      "binaryLifecycleEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable binary file lifecycle management. When true, binary files in the memory directory are mirrored, redirected, and cleaned."
+      },
+      "binaryLifecycleGracePeriodDays": {
+        "type": "number",
+        "default": 7,
+        "minimum": 0,
+        "description": "Days to wait before cleaning local copies of mirrored binary files."
+      },
+      "binaryLifecycleBackendType": {
+        "type": "string",
+        "enum": [
+          "none",
+          "filesystem",
+          "s3"
+        ],
+        "default": "none",
+        "description": "Storage backend for binary lifecycle mirror stage."
+      },
+      "binaryLifecycleBackendPath": {
+        "type": "string",
+        "default": "",
+        "description": "Base path for the filesystem storage backend."
+      },
+      "codexCompat": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "properties": {
+          "enabled": {
+            "type": "boolean",
+            "default": false
+          },
+          "threadIdBufferKeying": {
+            "type": "boolean",
+            "default": true
+          },
+          "compactionFlushMode": {
+            "type": "string",
+            "enum": [
+              "signal",
+              "heuristic",
+              "auto"
+            ],
+            "default": "auto"
+          },
+          "fingerprintDedup": {
+            "type": "boolean",
+            "default": true
+          }
+        }
       },
       "debug": {
         "type": "boolean",
@@ -1240,6 +1797,53 @@
         "default": 2,
         "description": "Number of sentences to overlap between chunks"
       },
+      "semanticChunkingEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable semantic chunking with embedding-based topic boundary detection (requires embedding provider)"
+      },
+      "semanticChunkingConfig": {
+        "type": "object",
+        "default": {},
+        "description": "Optional overrides for the semantic chunking algorithm",
+        "properties": {
+          "targetTokens": {
+            "type": "number",
+            "default": 200,
+            "description": "Target tokens per chunk"
+          },
+          "minTokens": {
+            "type": "number",
+            "default": 100,
+            "description": "Minimum tokens for a segment before merging with neighbor"
+          },
+          "maxTokens": {
+            "type": "number",
+            "default": 400,
+            "description": "Maximum tokens for a segment before recursive splitting"
+          },
+          "smoothingWindowSize": {
+            "type": "number",
+            "default": 3,
+            "description": "Window size for the moving-average smoothing filter (auto-rounded to odd)"
+          },
+          "boundaryThresholdStdDevs": {
+            "type": "number",
+            "default": 1,
+            "description": "Standard deviations below mean for boundary detection"
+          },
+          "embeddingBatchSize": {
+            "type": "number",
+            "default": 32,
+            "description": "Batch size for embedding requests"
+          },
+          "fallbackToRecursive": {
+            "type": "boolean",
+            "default": true,
+            "description": "Fall back to recursive chunking when embeddings are unavailable"
+          }
+        }
+      },
       "contradictionDetectionEnabled": {
         "type": "boolean",
         "default": false,
@@ -1259,6 +1863,56 @@
         "type": "boolean",
         "default": true,
         "description": "Automatically supersede contradicted memories"
+      },
+      "temporalSupersessionEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Mark older facts superseded when a new fact writes a conflicting value for the same entityRef + structuredAttribute key (issue #375)"
+      },
+      "temporalSupersessionIncludeInRecall": {
+        "type": "boolean",
+        "default": false,
+        "description": "If true, include temporally-superseded facts in recall results (for audit/history). Default: exclude."
+      },
+      "recallDirectAnswerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+      },
+      "recallDirectAnswerTokenOverlapFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.55,
+        "description": "Minimum query↔memory token-overlap ratio for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerImportanceFloor": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.7,
+        "description": "Minimum calibrated importance score for direct-answer eligibility. Set to 0 to disable the gate."
+      },
+      "recallDirectAnswerAmbiguityMargin": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.15,
+        "description": "If the second-best candidate scores within this ratio of the top, direct-answer defers to hybrid."
+      },
+      "recallDirectAnswerEligibleTaxonomyBuckets": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decisions",
+          "principles",
+          "conventions",
+          "runbooks",
+          "entities"
+        ],
+        "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
       "memoryLinkingEnabled": {
         "type": "boolean",
@@ -1530,6 +2184,37 @@
         ],
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
+      },
+      "extractionJudgeEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the LLM-as-judge fact-worthiness gate. When enabled, extracted facts are evaluated for durability before being persisted. Off by default (opt-in)."
+      },
+      "extractionJudgeModel": {
+        "type": "string",
+        "default": "",
+        "description": "Model override for the extraction judge LLM. Empty string uses the configured local model."
+      },
+      "extractionJudgeBatchSize": {
+        "type": "number",
+        "default": 20,
+        "minimum": 1,
+        "description": "Maximum number of candidate facts sent to the judge LLM in a single batch call."
+      },
+      "extractionJudgeShadow": {
+        "type": "boolean",
+        "default": false,
+        "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
+      },
+      "inlineSourceAttributionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable inline source attribution markers on persisted facts for downstream provenance tracking."
+      },
+      "inlineSourceAttributionFormat": {
+        "type": "string",
+        "default": "[Source: agent={agent}, session={sessionId}, ts={ts}]",
+        "description": "Template used when inline source attribution is enabled."
       },
       "extractionMinUserTurns": {
         "type": "number",
@@ -2281,6 +2966,24 @@
         "default": true,
         "description": "Enable content-hash deduplication to prevent storing semantically identical facts."
       },
+      "semanticDedupEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Issue #373 — enable write-time semantic similarity guard that skips near-duplicate facts by comparing embeddings to existing memories. Fails open when the embedding backend is unavailable."
+      },
+      "semanticDedupThreshold": {
+        "type": "number",
+        "default": 0.92,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Cosine similarity threshold in [0, 1]. Candidate facts whose nearest neighbor scores at or above this value are treated as duplicates and skipped."
+      },
+      "semanticDedupCandidates": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Number of nearest-neighbor candidates to inspect during the write-time semantic dedup check. Set to 0 to disable the embedding lookup entirely (equivalent to semanticDedupEnabled=false)."
+      },
       "factArchivalEnabled": {
         "type": "boolean",
         "default": false,
@@ -2636,6 +3339,20 @@
         "default": true,
         "description": "Generate LLM summaries for entities during consolidation"
       },
+      "entitySynthesisMaxTokens": {
+        "anyOf": [
+          {
+            "type": "integer",
+            "const": 0
+          },
+          {
+            "type": "integer",
+            "minimum": 10
+          }
+        ],
+        "default": 500,
+        "description": "Max tokens used when refreshing an entity synthesis from its timeline."
+      },
       "recallBudgetChars": {
         "type": "number",
         "description": "Hard character cap for total recall injection. Defaults to maxMemoryTokens * 4."
@@ -2909,6 +3626,36 @@
         "type": "number",
         "default": 20,
         "description": "Maximum results fetched per agent before merge."
+      },
+      "briefing": {
+        "type": "object",
+        "default": {
+          "enabled": true,
+          "defaultWindow": "yesterday",
+          "defaultFormat": "markdown",
+          "maxFollowups": 5,
+          "calendarSource": null,
+          "saveByDefault": false,
+          "saveDir": null,
+          "llmFollowups": true
+        },
+        "description": "Daily Context Briefing (#370). Knobs: enabled, defaultWindow ('yesterday', '3d', '1w', '24h', ...), defaultFormat (markdown|json), maxFollowups (0-10), calendarSource (path to ICS/JSON file, null = off), saveByDefault, saveDir (null = $REMNIC_HOME/briefings/), llmFollowups (disable to skip Responses API calls)."
+      },
+      "enrichmentEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the external enrichment pipeline (#365). When true, entities can be enriched via registered providers."
+      },
+      "enrichmentAutoOnCreate": {
+        "type": "boolean",
+        "default": false,
+        "description": "Automatically enrich newly created entities when the enrichment pipeline is enabled."
+      },
+      "enrichmentMaxCandidatesPerEntity": {
+        "type": "integer",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum enrichment candidates accepted per entity per run. Set to 0 to accept none."
       }
     }
   },
@@ -3167,6 +3914,15 @@
       "advanced": true,
       "placeholder": "2"
     },
+    "semanticChunkingEnabled": {
+      "label": "Semantic Chunking",
+      "help": "Use embedding-based topic detection for more coherent chunks (requires chunking enabled)"
+    },
+    "semanticChunkingConfig": {
+      "label": "Semantic Chunking Config",
+      "advanced": true,
+      "help": "Override defaults for semantic chunking algorithm parameters"
+    },
     "contradictionDetectionEnabled": {
       "label": "Contradiction Detection",
       "help": "Detect and resolve conflicting memories using LLM verification"
@@ -3184,6 +3940,39 @@
     "contradictionAutoResolve": {
       "label": "Auto-Resolve Contradictions",
       "help": "Automatically supersede old memories when contradiction is confirmed"
+    },
+    "temporalSupersessionEnabled": {
+      "label": "Temporal Supersession",
+      "help": "Mark older facts superseded when a newer fact writes a conflicting value for the same entityRef + structured attribute (issue #375)"
+    },
+    "temporalSupersessionIncludeInRecall": {
+      "label": "Include Superseded Facts In Recall",
+      "advanced": true,
+      "help": "If enabled, superseded facts still surface in recall (audit/history mode)."
+    },
+    "recallDirectAnswerEnabled": {
+      "label": "Direct-Answer Retrieval Tier",
+      "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDirectAnswerTokenOverlapFloor": {
+      "label": "Direct-Answer Token Overlap Floor",
+      "advanced": true,
+      "placeholder": "0.55"
+    },
+    "recallDirectAnswerImportanceFloor": {
+      "label": "Direct-Answer Importance Floor",
+      "advanced": true,
+      "placeholder": "0.7"
+    },
+    "recallDirectAnswerAmbiguityMargin": {
+      "label": "Direct-Answer Ambiguity Margin",
+      "advanced": true,
+      "placeholder": "0.15"
+    },
+    "recallDirectAnswerEligibleTaxonomyBuckets": {
+      "label": "Direct-Answer Eligible Taxonomy Buckets",
+      "advanced": true,
+      "help": "Taxonomy category IDs eligible for direct-answer routing."
     },
     "memoryLinkingEnabled": {
       "label": "Memory Linking",
@@ -3606,6 +4395,20 @@
       "label": "Fact Deduplication",
       "help": "Prevent storing semantically identical facts using content hashing"
     },
+    "semanticDedupEnabled": {
+      "label": "Semantic Dedup (write-time)",
+      "help": "Skip near-duplicate facts at write time by comparing embeddings to existing memories (issue #373)."
+    },
+    "semanticDedupThreshold": {
+      "label": "Semantic Dedup Threshold",
+      "advanced": true,
+      "placeholder": "0.92"
+    },
+    "semanticDedupCandidates": {
+      "label": "Semantic Dedup Candidates",
+      "advanced": true,
+      "placeholder": "5"
+    },
     "factArchivalEnabled": {
       "label": "Fact Archival",
       "help": "Automatically archive old, low-importance, rarely-accessed facts during consolidation"
@@ -3803,6 +4606,12 @@
     "entitySummaryEnabled": {
       "label": "Entity Summaries",
       "help": "Generate LLM summaries for entities during consolidation"
+    },
+    "entitySynthesisMaxTokens": {
+      "label": "Entity Synthesis Max Tokens",
+      "advanced": true,
+      "placeholder": "500",
+      "help": "Max tokens used when refreshing an entity synthesis from its timeline."
     },
     "recallBudgetChars": {
       "label": "Recall Budget (Chars)",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.4",
+  "version": "9.3.5",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -174,6 +174,9 @@ importers:
 
   packages/plugin-openclaw:
     dependencies:
+      '@remnic/core':
+        specifier: workspace:^
+        version: link:../remnic-core
       openai:
         specifier: ^6.0.0
         version: 6.33.0(zod@4.0.0)
@@ -193,6 +196,9 @@ importers:
       '@remnic/export-weclone':
         specifier: workspace:^
         version: link:../export-weclone
+      yaml:
+        specifier: ^2.4.2
+        version: 2.8.3
     devDependencies:
       '@remnic/bench':
         specifier: workspace:*

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -158,6 +158,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall_explain",
     "engram.day_summary",
     "engram.memory_governance_run",
+    "engram.procedure_mining_run",
     "engram.memory_get",
     "engram.memory_timeline",
     "engram.memory_store",

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -28,6 +28,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "page-versioning",
       "retrieval-personalization",
       "retrieval-temporal",
+      "procedural-recall",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
@@ -67,11 +68,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.
@@ -240,6 +242,17 @@ test("getBenchmark returns retrieval-temporal metadata with a runnable benchmark
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "retrieval-temporal");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns procedural-recall metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("procedural-recall");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "procedural-recall");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");

--- a/tests/config-lifecycle-policy.test.ts
+++ b/tests/config-lifecycle-policy.test.ts
@@ -9,7 +9,7 @@ test("parseConfig sets lifecycle policy defaults with policy disabled", () => {
   assert.equal(cfg.lifecyclePromoteHeatThreshold, 0.55);
   assert.equal(cfg.lifecycleStaleDecayThreshold, 0.65);
   assert.equal(cfg.lifecycleArchiveDecayThreshold, 0.85);
-  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference"]);
+  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference", "procedure"]);
   assert.equal(cfg.lifecycleMetricsEnabled, false);
 });
 

--- a/tests/openclaw-plugin-runtime-surfaces.test.ts
+++ b/tests/openclaw-plugin-runtime-surfaces.test.ts
@@ -189,6 +189,32 @@ for (const manifestPath of [
       "entitySynthesisMaxTokens must keep 0 as a disable switch without advertising unusable 1..9 values",
     );
     assert.equal(entitySynthesisMaxTokens?.default, 500);
+
+    const briefing = properties.briefing;
+    assert.ok(briefing, "briefing config block should exist");
+    assert.equal(
+      briefing.additionalProperties,
+      false,
+      "briefing config block must reject unknown keys to prevent silent typo acceptance",
+    );
+    assert.deepEqual(
+      Object.keys(briefing.properties ?? {}).sort(),
+      [
+        "calendarSource",
+        "defaultFormat",
+        "defaultWindow",
+        "enabled",
+        "llmFollowups",
+        "maxFollowups",
+        "saveByDefault",
+        "saveDir",
+      ],
+    );
+    assert.deepEqual(briefing.properties?.defaultFormat?.enum, ["markdown", "json"]);
+    assert.equal(briefing.properties?.maxFollowups?.minimum, 0);
+    assert.equal(briefing.properties?.maxFollowups?.maximum, 10);
+    assert.deepEqual(briefing.properties?.calendarSource?.type, ["string", "null"]);
+    assert.deepEqual(briefing.properties?.saveDir?.type, ["string", "null"]);
   });
 }
 

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -1,0 +1,40 @@
+import assert from "node:assert/strict";
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import test from "node:test";
+
+async function publicPackageDirs(): Promise<string[]> {
+  const packagesDir = path.resolve("packages");
+  const dirs = await readdir(packagesDir, { withFileTypes: true });
+  const publicDirs: string[] = [];
+  for (const entry of dirs) {
+    if (!entry.isDirectory()) continue;
+    const pkgPath = path.join(packagesDir, entry.name, "package.json");
+    try {
+      const raw = await readFile(pkgPath, "utf8");
+      const pkg = JSON.parse(raw) as {
+        private?: boolean;
+        publishConfig?: { access?: string };
+      };
+      if (pkg.private) continue;
+      if (pkg.publishConfig?.access !== "public") continue;
+      publicDirs.push(`packages/${entry.name}`);
+    } catch {
+      continue;
+    }
+  }
+  return publicDirs.sort();
+}
+
+test("release workflow publish order includes every public workspace package", async () => {
+  const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
+  const publicDirs = await publicPackageDirs();
+
+  for (const pkgDir of publicDirs) {
+    assert.match(
+      workflow,
+      new RegExp(`\\b${pkgDir.replace("/", "\\/")}\\b`),
+      `release-and-publish.yml must publish ${pkgDir}`,
+    );
+  }
+});

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.4");
+  assert.equal(pkg.version, "9.3.5");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -19,10 +19,13 @@ const packageExpectations = [
       "@remnic/core": "workspace:^",
     },
   },
-  // Note: @remnic/plugin-openclaw intentionally has no @remnic/core dependency —
-  // it does not import @remnic/core at runtime. Keeping it would cause the
-  // workspace:^ protocol string to appear verbatim in the published package
-  // metadata when released via npm publish (see issue #403).
+  {
+    label: "OpenClaw plugin",
+    path: new URL("../packages/plugin-openclaw/package.json", testDir),
+    deps: {
+      "@remnic/core": "workspace:^",
+    },
+  },
 ] as const;
 
 test("runtime workspace packages preserve local linking in source manifests", async () => {


### PR DESCRIPTION
## Summary
- bump every public package version for the next npm release
- fix the npm release surface so packed installs match source reality
- add regression coverage for publish-order and runtime workspace dependency drift

## Why
The currently published npm set drifted out of parity with `main`:
- `@remnic/cli@1.0.4` installed but failed at runtime because the published core package was too old for its imports
- `@remnic/plugin-openclaw@1.0.5` published without `@remnic/core`, which broke normal npm/OpenClaw installs
- the release workflow was not publishing every public package
- two latent DTS issues and one CLI tarball runtime issue would have broken the next publish as well

## What changed
- versioned all public packages:
  - `@remnic/core` `1.0.2 -> 1.0.3`
  - `@remnic/server` `1.0.4 -> 1.0.5`
  - `@remnic/cli` `1.0.4 -> 1.0.5`
  - `@remnic/plugin-openclaw` `1.0.5 -> 1.0.6`
  - `@remnic/connector-weclone` `1.0.0 -> 1.0.1`
  - `@remnic/export-weclone` `1.0.0 -> 1.0.1`
  - `@remnic/import-weclone` `1.0.0 -> 1.0.1`
  - `@remnic/hermes-provider` `1.0.0 -> 1.0.1`
  - `@joshuaswarren/openclaw-engram` `9.3.4 -> 9.3.5`
- added the missing `@remnic/core` runtime dependency to `@remnic/plugin-openclaw`
- expanded `release-and-publish.yml` to include every public workspace package
- fixed `@remnic/connector-weclone` DTS body typing for transparent proxy requests
- fixed `@remnic/export-weclone` DTS typing in the privacy sweep
- fixed `@remnic/cli` tarball runtime by externalizing `yaml` from the bundled bench path and declaring it as a runtime dependency
- refreshed the shim manifest and lockfile to match the new release surface

## Verification
- `pnpm exec tsx --test tests/workspace-runtime-deps.test.ts tests/release-workflow-public-packages.test.ts`
- `pnpm --filter @remnic/export-weclone test`
- `pnpm -r run build`
- packed tarballs and inspected published manifests for:
  - `@remnic/core@1.0.3`
  - `@remnic/cli@1.0.5`
  - `@remnic/plugin-openclaw@1.0.6`
- npm temp-install smoke tests:
  - `@remnic/cli` tarball install now runs `remnic --help`
  - `@remnic/plugin-openclaw` tarball install now imports successfully alongside packed `@remnic/core`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the npm publish workflow and multiple package manifests/runtime deps, which can break releases or downstream installs if the publish order or dependency wiring is wrong.
> 
> **Overview**
> Bumps versions across all public workspace packages and updates the release workflow publish order to include the WeClone connector/import/export packages so npm releases don’t miss public artifacts.
> 
> Fixes release/install parity issues by adding a missing runtime dependency (`@remnic/core`) to `@remnic/plugin-openclaw`, declaring/externalizing `yaml` for `@remnic/cli`, and updating the lockfile accordingly. Also includes small DTS/typing fixes in the WeClone proxy request body forwarding and the export PII sweep helper.
> 
> Tightens OpenClaw plugin config validation by expanding the `briefing` schema (explicit properties + `additionalProperties: false`), and refreshes the legacy `openclaw-engram` shim manifest/support flags; tests are updated and expanded (including a new regression test) to prevent publish-order and runtime dependency drift and to register a new `procedural-recall` benchmark/tool surface expectation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a9613b6b19ed5cc268cb5f3ee9d3616c53378c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->