### PR TITLE
fix(core): procedural memory follow-up for PR #524–#529 review threads

### DIFF
--- a/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
@@ -24,6 +24,14 @@ import {
   PROCEDURAL_RECALL_INTENT_SMOKE_FIXTURE,
 } from "./fixture.js";
 
+function sliceWithBudget<T>(cases: T[], budget: number): { picked: T[]; remaining: number } {
+  if (!Number.isFinite(budget) || budget <= 0) {
+    return { picked: cases, remaining: 0 };
+  }
+  const n = Math.min(cases.length, Math.floor(budget));
+  return { picked: cases.slice(0, n), remaining: budget - n };
+}
+
 export const proceduralRecallDefinition: BenchmarkDefinition = {
   id: "procedural-recall",
   title: "Procedural Recall",
@@ -45,8 +53,19 @@ export async function runProceduralRecallBenchmark(
 ): Promise<BenchmarkResult> {
   const tasks: TaskResult[] = [];
 
-  const intentCases =
+  const intentSource =
     options.mode === "quick" ? PROCEDURAL_RECALL_INTENT_SMOKE_FIXTURE : PROCEDURAL_RECALL_INTENT_FIXTURE;
+  const e2eSource =
+    options.mode === "quick" ? PROCEDURAL_RECALL_E2E_SMOKE_FIXTURE : PROCEDURAL_RECALL_E2E_FIXTURE;
+
+  const taskBudget =
+    typeof options.limit === "number" && options.limit > 0 && Number.isFinite(options.limit)
+      ? Math.floor(options.limit)
+      : Number.POSITIVE_INFINITY;
+  let remainingBudget = taskBudget;
+  const intentPick = sliceWithBudget(intentSource, remainingBudget);
+  const intentCases = intentPick.picked;
+  remainingBudget = intentPick.remaining;
 
   for (const sample of intentCases) {
     const startedAt = performance.now();
@@ -68,8 +87,7 @@ export async function runProceduralRecallBenchmark(
     });
   }
 
-  const e2eCases =
-    options.mode === "quick" ? PROCEDURAL_RECALL_E2E_SMOKE_FIXTURE : PROCEDURAL_RECALL_E2E_FIXTURE;
+  const e2eCases = sliceWithBudget(e2eSource, remainingBudget).picked;
 
   for (const sample of e2eCases) {
     const startedAt = performance.now();

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
@@ -26,7 +26,7 @@ import {
 
 function sliceWithBudget<T>(cases: T[], budget: number): { picked: T[]; remaining: number } {
   if (!Number.isFinite(budget)) {
-    return { picked: cases, remaining: 0 };
+    return { picked: cases, remaining: Number.POSITIVE_INFINITY };
   }
   if (budget <= 0) {
     return { picked: [], remaining: 0 };

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/runner.ts
@@ -25,8 +25,11 @@ import {
 } from "./fixture.js";
 
 function sliceWithBudget<T>(cases: T[], budget: number): { picked: T[]; remaining: number } {
-  if (!Number.isFinite(budget) || budget <= 0) {
+  if (!Number.isFinite(budget)) {
     return { picked: cases, remaining: 0 };
+  }
+  if (budget <= 0) {
+    return { picked: [], remaining: 0 };
   }
   const n = Math.min(cases.length, Math.floor(budget));
   return { picked: cases.slice(0, n), remaining: budget - n };

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -244,3 +244,22 @@ test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets non-array value fall
     "entities",
   ]);
 });
+
+test("parseConfig procedural numeric fields coerce from CLI-style strings (issue #519)", () => {
+  const result = parseConfig({
+    openaiApiKey: "sk-test",
+    procedural: {
+      enabled: true,
+      minOccurrences: "5",
+      successFloor: "0.82",
+      autoPromoteOccurrences: "12",
+      lookbackDays: "14",
+      recallMaxProcedures: "2",
+    },
+  });
+  assert.equal(result.procedural.minOccurrences, 5);
+  assert.equal(result.procedural.successFloor, 0.82);
+  assert.equal(result.procedural.autoPromoteOccurrences, 12);
+  assert.equal(result.procedural.lookbackDays, 14);
+  assert.equal(result.procedural.recallMaxProcedures, 2);
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -403,39 +403,45 @@ export function parseConfig(raw: unknown): PluginConfig {
     cfg.procedural && typeof cfg.procedural === "object" && !Array.isArray(cfg.procedural)
       ? (cfg.procedural as Record<string, unknown>)
       : {};
+  const proceduralMinCoerced = coerceNumber(rawProcedural.minOccurrences);
   const proceduralMinRaw =
-    typeof rawProcedural.minOccurrences === "number" && Number.isFinite(rawProcedural.minOccurrences)
-      ? Math.floor(rawProcedural.minOccurrences)
+    proceduralMinCoerced !== undefined
+      ? Math.floor(proceduralMinCoerced)
+      : 3;
+  const successFloorRaw = coerceNumber(rawProcedural.successFloor);
+  const successFloor =
+    successFloorRaw !== undefined &&
+    successFloorRaw >= 0 &&
+    successFloorRaw <= 1
+      ? successFloorRaw
+      : 0.7;
+  const autoPromoteOccRaw = coerceNumber(rawProcedural.autoPromoteOccurrences);
+  const autoPromoteOccurrences =
+    autoPromoteOccRaw !== undefined && Number.isFinite(autoPromoteOccRaw)
+      ? autoPromoteOccRaw <= 0
+        ? 0
+        : Math.min(10_000, Math.max(1, Math.floor(autoPromoteOccRaw)))
+      : 8;
+  const lookbackCoerced = coerceNumber(rawProcedural.lookbackDays);
+  const lookbackDays =
+    lookbackCoerced !== undefined && Number.isFinite(lookbackCoerced)
+      ? Math.min(3650, Math.max(1, Math.floor(lookbackCoerced)))
+      : 30;
+  const recallMaxCoerced = coerceNumber(rawProcedural.recallMaxProcedures);
+  const recallMaxProcedures =
+    recallMaxCoerced !== undefined && Number.isFinite(recallMaxCoerced)
+      ? Math.min(10, Math.max(1, Math.floor(recallMaxCoerced)))
       : 3;
   const procedural: ProceduralConfig = {
     enabled: coerceBool(rawProcedural.enabled) === true,
     /** 0 disables miner emission threshold (no clusters qualify). */
     minOccurrences: Math.min(1000, Math.max(0, proceduralMinRaw)),
-    successFloor:
-      typeof rawProcedural.successFloor === "number" &&
-      Number.isFinite(rawProcedural.successFloor) &&
-      rawProcedural.successFloor >= 0 &&
-      rawProcedural.successFloor <= 1
-        ? rawProcedural.successFloor
-        : 0.7,
-    autoPromoteOccurrences:
-      typeof rawProcedural.autoPromoteOccurrences === "number" &&
-      Number.isFinite(rawProcedural.autoPromoteOccurrences)
-        ? rawProcedural.autoPromoteOccurrences <= 0
-          ? 0
-          : Math.min(10_000, Math.max(1, Math.floor(rawProcedural.autoPromoteOccurrences)))
-        : 8,
+    successFloor,
+    autoPromoteOccurrences,
     autoPromoteEnabled: coerceBool(rawProcedural.autoPromoteEnabled) === true,
-    lookbackDays:
-      typeof rawProcedural.lookbackDays === "number" && Number.isFinite(rawProcedural.lookbackDays)
-        ? Math.min(3650, Math.max(1, Math.floor(rawProcedural.lookbackDays)))
-        : 30,
+    lookbackDays,
     proceduralMiningCronAutoRegister: coerceBool(rawProcedural.proceduralMiningCronAutoRegister) === true,
-    recallMaxProcedures:
-      typeof rawProcedural.recallMaxProcedures === "number" &&
-      Number.isFinite(rawProcedural.recallMaxProcedures)
-        ? Math.min(10, Math.max(1, Math.floor(rawProcedural.recallMaxProcedures)))
-        : 3,
+    recallMaxProcedures,
   };
 
   const memoryDir =

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1036,6 +1036,8 @@ Memory categories — use the MOST SPECIFIC category that fits:
 - commitment: Promises, obligations, deadlines
 - moment: Emotionally significant events
 - skill: Demonstrated capabilities
+- rule: Explicit operational rules or constraints
+- procedure: Repeatable workflows — use when the user describes a multi-step play (≥2 ordered steps). Put the human-readable trigger/context in "content" (e.g. "When you deploy…") and list steps in "procedureSteps" as [{"order":1,"intent":"…"}, …] mirroring the gateway extraction schema.
 
 IMPORTANT: Do NOT label everything as "fact". Use "decision" for architectural choices, "commitment" for deadlines/promises, "principle" for reusable rules, "correction" for when the user rejects a suggestion, etc.
 
@@ -1097,7 +1099,7 @@ Also generate:
 
 Output JSON:
 {
-  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9}],
+  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "procedure", "content": "When you cut a hotfix release, follow the checklist", "importance": 8, "confidence": 0.9, "procedureSteps": [{"order": 1, "intent": "Branch from main and cherry-pick the fix"}, {"order": 2, "intent": "Run CI and tag the release"}]}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9}],
   "entities": [{"name": "person-jane-doe", "type": "person", "facts": ["Works at Acme Corp", "Prefers Python over JavaScript"], "structuredSections": [{"key": "beliefs", "title": "Beliefs", "facts": ["Python is a better fit than JavaScript for backend work."]}]}, {"name": "project-acme-store", "type": "project", "facts": ["Built with Next.js", "Deployed on Vercel"]}],
   "profileUpdates": ["User prefers dark mode in all editors"],
   "questions": [{"question": "Which cloud provider hosts the staging environment?", "context": "Came up during deployment discussion", "priority": 0.5}],

--- a/packages/remnic-core/src/intent.ts
+++ b/packages/remnic-core/src/intent.ts
@@ -26,7 +26,7 @@ const ENTITY_PATTERNS: Array<{ re: RegExp; entityType: string }> = [
 
 /** User/agent is starting a hands-on task (issue #519 procedure recall gate). */
 const TASK_INITIATION_RE =
-  /\b(ship(?:ping|ped)?|deploy(?:ing|ed)?|release|publish|open(?:ing)?\s+(?:a\s+)?(?:pr|pull\s+request)|merge(?:ing)?\s+(?:the\s+)?(?:pr|pull\s+request)|run\s+(?:the\s+)?tests?|start(?:ing)?\s+(?:work|on|the)|kick\s+off|implement(?:ing|ed)?|let's\s+|going\s+to\s+(?:ship|deploy|release|open|run|merge)|need\s+to\s+(?:ship|deploy|run|open|merge|test)|fix(?:ing|ed)?\s+(?:the\s+)?(?:bug|build)|patch(?:ing|ed)?|build(?:ing)?\s+(?:and\s+)?(?:ship|deploy))\b/i;
+  /\b(ship(?:ping|ped)?|deploy(?:ing|ed)?|release|publish|open(?:ing)?\s+(?:a\s+)?(?:pr|pull\s+request)|merge(?:ing)?\s+(?:the\s+)?(?:pr|pull\s+request)|run\s+(?:the\s+)?tests?|start(?:ing)?\s+(?:work|on|the)|kick\s+off|implement(?:ing|ed)?|let's\s+(?:ship|deploy|release|publish|open|run|merge|implement|fix|patch|build|start|do|get|put|wire|hook|land|roll)\b|going\s+to\s+(?:ship|deploy|release|open|run|merge)|need\s+to\s+(?:ship|deploy|run|open|merge|test)|fix(?:ing|ed)?\s+(?:(?:the|a)\s+)?(?:\w+\s+){0,4}(?:bug|build)\b|patch(?:ing|ed)?|build(?:ing)?\s+(?:and\s+)?(?:ship|deploy))\b/i;
 
 function normalizeTextInput(input: unknown): string {
   return typeof input === "string" ? input : "";

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -6800,7 +6800,7 @@ export class Orchestrator {
       if (!this.isRecallSectionEnabled("procedure-recall", true)) return null;
       try {
         return await buildProcedureRecallSection(
-          this.storage,
+          profileStorage,
           retrievalQuery,
           this.config,
         );
@@ -9977,24 +9977,9 @@ export class Orchestrator {
       // formats. For all-placeholder templates it cannot detect citations and
       // returns the text unchanged — dedup may miss in that edge case, which
       // is acceptable (no false-positive suppression).
-      if (this.contentHashIndex) {
-        const canonicalContent =
-          citationEnabled &&
-          hasCitationForTemplate(fact.content, citationTemplate)
-            ? stripCitationForTemplate(fact.content, citationTemplate)
-            : fact.content;
-        if (this.contentHashIndex.has(canonicalContent)) {
-          log.debug(
-            `dedup: skipping duplicate fact "${fact.content.slice(0, 60)}…"`,
-          );
-          dedupedCount++;
-          continue;
-        }
-      }
-
-      // Score importance using local heuristics (Phase 1B).
-      // Routing runs first so that category overrides (which affect scoring)
-      // are applied before the importance gate.
+      //
+      // Routing runs before content-hash dedup and scoring so category overrides
+      // affect both the dedup fingerprint and importance (issue #519 procedure routing).
       let writeCategory = fact.category;
       let targetStorage = storage;
       let routedRuleId: string | undefined;
@@ -10019,6 +10004,28 @@ export class Orchestrator {
           );
         }
       }
+
+      // Procedures: fingerprint the full serialized body (title + steps), not
+      // the title alone, so distinct step lists are not collapsed (issue #519).
+      const canonicalContentForHash =
+        citationEnabled &&
+        hasCitationForTemplate(fact.content, citationTemplate)
+          ? stripCitationForTemplate(fact.content, citationTemplate)
+          : fact.content;
+      const contentHashDedupKey =
+        writeCategory === "procedure"
+          ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
+          : canonicalContentForHash;
+      if (this.contentHashIndex && this.contentHashIndex.has(contentHashDedupKey)) {
+        log.debug(
+          `dedup: skipping duplicate fact "${fact.content.slice(0, 60)}…"`,
+        );
+        dedupedCount++;
+        continue;
+      }
+
+      // Score importance using local heuristics (Phase 1B).
+      // writeCategory / targetStorage already reflect routing.
       const importance = scoreImportance(
         fact.content,
         writeCategory,
@@ -10079,22 +10086,17 @@ export class Orchestrator {
 
       // Procedure extraction gate (issue #519): ≥2 steps + trigger phrasing.
       // Runs even when extractionJudgeEnabled is false (durability judge is unrelated).
+      // Never tied to extractionJudgeShadow — that flag is only for the LLM durability judge.
       if (writeCategory === "procedure") {
         const procGate = validateProcedureExtraction({
           content: fact.content,
           procedureSteps: fact.procedureSteps,
         });
         if (!procGate.durable) {
-          if (this.config.extractionJudgeShadow) {
-            log.info(
-              `extraction-procedure-gate[shadow]: would reject "${fact.content.slice(0, 60)}…" reason="${procGate.reason}"`,
-            );
-          } else {
-            log.debug(
-              `extraction-procedure-gate: rejected "${fact.content.slice(0, 60)}…" reason="${procGate.reason}"`,
-            );
-            continue;
-          }
+          log.debug(
+            `extraction-procedure-gate: rejected "${fact.content.slice(0, 60)}…" reason="${procGate.reason}"`,
+          );
+          continue;
         }
       }
 
@@ -10726,7 +10728,11 @@ export class Orchestrator {
           hasCitationForTemplate(fact.content, citationTemplate)
             ? stripCitationForTemplate(fact.content, citationTemplate)
             : fact.content;
-        this.contentHashIndex.add(canonicalFactContent);
+        const hashRegisterKey =
+          writeCategory === "procedure"
+            ? buildProcedurePersistBody(fact.content, fact.procedureSteps)
+            : canonicalFactContent;
+        this.contentHashIndex.add(hashRegisterKey);
       }
     }
 

--- a/packages/remnic-core/src/procedural/procedure-miner.ts
+++ b/packages/remnic-core/src/procedural/procedure-miner.ts
@@ -12,6 +12,9 @@ import {
 import { buildProcedurePersistBody, normalizeProcedureSteps, type ProcedureStep } from "./procedure-types.js";
 import { log } from "../logger.js";
 
+/** Must match truncation on `procedure_cluster` structured attribute (dedupe + storage). */
+const PROCEDURE_CLUSTER_ATTR_MAX = 500;
+
 export interface ProcedureMiningResult {
   clustersProcessed: number;
   proceduresWritten: number;
@@ -61,11 +64,12 @@ async function hasExistingClusterWrite(
   storage: StorageManager,
   cluster: string,
 ): Promise<boolean> {
+  const clusterKey = cluster.slice(0, PROCEDURE_CLUSTER_ATTR_MAX);
   const memories = await storage.readAllMemories();
   for (const m of memories) {
     if (m.frontmatter.category !== "procedure") continue;
     const c = m.frontmatter.structuredAttributes?.procedure_cluster;
-    if (c === cluster) return true;
+    if (c === clusterKey) return true;
   }
   return false;
 }
@@ -87,8 +91,14 @@ export async function runProcedureMining(options: {
     return { clustersProcessed: 0, proceduresWritten: 0, skippedReason: "minOccurrences_zero" };
   }
 
+  const trajectoryDir =
+    typeof options.config.causalTrajectoryStoreDir === "string" &&
+    options.config.causalTrajectoryStoreDir.trim().length > 0
+      ? options.config.causalTrajectoryStoreDir.trim()
+      : undefined;
   const { trajectories } = await readCausalTrajectoryRecords({
     memoryDir: options.memoryDir,
+    causalTrajectoryStoreDir: trajectoryDir,
   });
   const recent = filterTrajectoriesByLookbackDays(trajectories, cfg.lookbackDays);
 
@@ -129,7 +139,7 @@ export async function runProcedureMining(options: {
       status: promote ? "active" : "pending_review",
       tags: ["procedure-miner", "causal-trajectory"],
       structuredAttributes: {
-        procedure_cluster: key.slice(0, 500),
+        procedure_cluster: key.slice(0, PROCEDURE_CLUSTER_ATTR_MAX),
         trajectory_ids: group
           .map((g) => g.trajectoryId)
           .join(",")

--- a/packages/remnic-core/src/search/document-scanner.ts
+++ b/packages/remnic-core/src/search/document-scanner.ts
@@ -73,11 +73,16 @@ async function scanDir(dir: string): Promise<IndexableDocument[]> {
 }
 
 /**
- * Scan `facts/` and `corrections/` subdirs of memoryDir for indexable markdown documents.
+ * Scan `facts/`, `corrections/`, and `procedures/` subdirs of memoryDir for indexable markdown documents.
  */
 export async function scanMemoryDir(memoryDir: string): Promise<IndexableDocument[]> {
   const factsDir = path.join(memoryDir, "facts");
   const correctionsDir = path.join(memoryDir, "corrections");
-  const [facts, corrections] = await Promise.all([scanDir(factsDir), scanDir(correctionsDir)]);
-  return [...facts, ...corrections];
+  const proceduresDir = path.join(memoryDir, "procedures");
+  const [facts, corrections, procedures] = await Promise.all([
+    scanDir(factsDir),
+    scanDir(correctionsDir),
+    scanDir(proceduresDir),
+  ]);
+  return [...facts, ...corrections, ...procedures];
 }

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -158,6 +158,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall_explain",
     "engram.day_summary",
     "engram.memory_governance_run",
+    "engram.procedure_mining_run",
     "engram.memory_get",
     "engram.memory_timeline",
     "engram.memory_store",

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -28,6 +28,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "page-versioning",
       "retrieval-personalization",
       "retrieval-temporal",
+      "procedural-recall",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
       "ingestion-backlink-f1",
@@ -67,11 +68,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.

--- a/tests/config-lifecycle-policy.test.ts
+++ b/tests/config-lifecycle-policy.test.ts
@@ -9,7 +9,7 @@ test("parseConfig sets lifecycle policy defaults with policy disabled", () => {
   assert.equal(cfg.lifecyclePromoteHeatThreshold, 0.55);
   assert.equal(cfg.lifecycleStaleDecayThreshold, 0.65);
   assert.equal(cfg.lifecycleArchiveDecayThreshold, 0.85);
-  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference"]);
+  assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference", "procedure"]);
   assert.equal(cfg.lifecycleMetricsEnabled, false);
 });
 

--- a/tests/intent.test.ts
+++ b/tests/intent.test.ts
@@ -81,6 +81,16 @@ test("inferIntentFromText sets taskInitiation for ship/deploy/run tests phrasing
   assert.equal(isTaskInitiationIntent(vague), false);
 });
 
+test("inferIntentFromText taskInitiation matches broken-build phrasing (issue #519 bench)", () => {
+  const fixBuild = inferIntentFromText("Fixing the broken build on main");
+  assert.equal(fixBuild.taskInitiation, true);
+});
+
+test("inferIntentFromText does not treat conversational let's as task initiation", () => {
+  const discuss = inferIntentFromText("Let's discuss the roadmap tomorrow");
+  assert.equal(discuss.taskInitiation, false);
+});
+
 test("runtime guards tolerate nullish/non-string inputs", () => {
   assert.doesNotThrow(() => planRecallMode(undefined as unknown as string));
   assert.doesNotThrow(() => planRecallMode(null as unknown as string));


### PR DESCRIPTION
## Summary

Addresses outstanding **Codex** and **Cursor Bugbot** review comments on the merged procedural-memory stack (**#524–#529**, parent **#519**). This is a follow-up only; it does not revert the original merges.

## Changes

| Area | What |
|------|------|
| **Config** | `procedural.*` numeric fields accept CLI-style **strings** via `coerceNumber` (e.g. `minOccurrences: "5"`). |
| **Search** | `scanMemoryDir` also indexes `procedures/` so vector/keyword backends see procedure files. |
| **Recall** | `buildProcedureRecallSection` uses **`profileStorage`** (active namespace) instead of `this.storage`. |
| **Extraction** | Procedure structural gate **always enforces** rejections; no longer tied to `extractionJudgeShadow`. Content-hash dedup for procedures uses **`buildProcedurePersistBody`** (title + steps); routing runs **before** dedup so the fingerprint matches `writeCategory`. |
| **Local LLM** | `extractWithLocalLlm` prompt documents **`procedure`** / **`rule`** and includes a JSON example with `procedureSteps`. |
| **Intent** | `TASK_INITIATION_RE`: narrow `let's …` to action verbs; allow words between “the” and **bug/build** (bench phrase “Fixing the broken build on main”). |
| **Miner** | Cluster dedupe compares the **same truncated key** stored on `procedure_cluster`; `readCausalTrajectoryRecords` receives **`causalTrajectoryStoreDir`** when set. |
| **Bench** | `procedural-recall` runner applies **`options.limit`** as a shared budget across intent + e2e tasks. |

## Verification

- `npm run check-types`
- `npm run test:entity-hardening`
- `npx tsx --test packages/remnic-core/src/config.test.ts tests/intent.test.ts`

## Process

Opened as a normal PR from `main` for review and CI (no admin merge).

Refs #519

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core extraction persistence/dedup and recall assembly paths for the new `procedure` category, which could affect what gets stored/recalled and how duplicates are suppressed. Changes are bounded and covered by targeted tests, but regressions could impact memory quality and recall behavior.
> 
> **Overview**
> Improves procedural-memory reliability across the stack: `procedural.*` numeric config fields now coerce from CLI-style strings (with new tests), and search scanning includes `procedures/` so procedure files are indexed.
> 
> Fixes procedural recall/persistence correctness by using the active `profileStorage` for `buildProcedureRecallSection`, running routing *before* content-hash dedup/scoring, and deduping `procedure` memories on the full serialized body (title + steps) rather than title alone; the procedure structural gate now always enforces rejection (no shadow bypass).
> 
> Follow-up hardening includes refining task-initiation intent matching (avoid conversational “let’s…”, handle “broken build” phrasing), aligning procedure-miner cluster dedupe with the same truncated `procedure_cluster` key (and honoring `causalTrajectoryStoreDir`), adding the `procedural-recall` benchmark to the registry, and applying `options.limit` as a shared budget across its intent + e2e tasks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e8359b0c22e7e3d3aef0538b00935ee5e60450ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->