### PR TITLE
fix(release): unblock npm publish for versioned packages

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -343,16 +343,17 @@ jobs:
 
       - name: Publish workspace packages to npm
         run: |
-          # Publish in dependency order: core first, then packages that depend on it.
+          # Publish the install surfaces that are currently supported from npm.
           # Uses pnpm (not npm) so that workspace: protocol strings are rewritten to
           # real version numbers at pack time. npm publish does not perform this
           # rewriting, which causes "workspace:^" to appear verbatim in the published
           # package metadata (see issue #403).
+          #
+          # The WeClone helper packages are not part of the npm install path used by
+          # Remnic/OpenClaw today. @remnic/cli bundles its export adapter so the CLI
+          # stays functional without requiring unpublished companion packages.
           PUBLISH_ORDER=(
             packages/remnic-core
-            packages/connector-weclone
-            packages/export-weclone
-            packages/import-weclone
             packages/remnic-server
             packages/remnic-cli
             packages/hermes-provider

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -31,11 +31,11 @@
   },
   "dependencies": {
     "@remnic/core": "workspace:^",
-    "@remnic/export-weclone": "workspace:^",
     "yaml": "^2.4.2"
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",
+    "@remnic/export-weclone": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -8,5 +8,5 @@ export default defineConfig({
   outDir: "dist",
   clean: true,
   external: ["yaml"],
-  noExternal: ["@remnic/bench"],
+  noExternal: ["@remnic/bench", "@remnic/export-weclone"],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -193,9 +193,6 @@ importers:
       '@remnic/core':
         specifier: workspace:^
         version: link:../remnic-core
-      '@remnic/export-weclone':
-        specifier: workspace:^
-        version: link:../export-weclone
       yaml:
         specifier: ^2.4.2
         version: 2.8.3
@@ -203,6 +200,9 @@ importers:
       '@remnic/bench':
         specifier: workspace:*
         version: link:../bench
+      '@remnic/export-weclone':
+        specifier: workspace:*
+        version: link:../export-weclone
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/scripts/ensure-cli-bench-build-deps.mjs
+++ b/scripts/ensure-cli-bench-build-deps.mjs
@@ -38,3 +38,7 @@ ensurePackageBuild(
   "@remnic/bench",
   path.join(repoRoot, "packages", "bench", "dist", "index.js"),
 );
+ensurePackageBuild(
+  "@remnic/export-weclone",
+  path.join(repoRoot, "packages", "export-weclone", "dist", "index.js"),
+);

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -1,36 +1,25 @@
 import assert from "node:assert/strict";
-import { readdir, readFile } from "node:fs/promises";
-import path from "node:path";
+import { readFile } from "node:fs/promises";
 import test from "node:test";
 
-async function publicPackageDirs(): Promise<string[]> {
-  const packagesDir = path.resolve("packages");
-  const dirs = await readdir(packagesDir, { withFileTypes: true });
-  const publicDirs: string[] = [];
-  for (const entry of dirs) {
-    if (!entry.isDirectory()) continue;
-    const pkgPath = path.join(packagesDir, entry.name, "package.json");
-    try {
-      const raw = await readFile(pkgPath, "utf8");
-      const pkg = JSON.parse(raw) as {
-        private?: boolean;
-        publishConfig?: { access?: string };
-      };
-      if (pkg.private) continue;
-      if (pkg.publishConfig?.access !== "public") continue;
-      publicDirs.push(`packages/${entry.name}`);
-    } catch {
-      continue;
-    }
-  }
-  return publicDirs.sort();
-}
+const expectedPublishDirs = [
+  "packages/remnic-core",
+  "packages/remnic-server",
+  "packages/remnic-cli",
+  "packages/hermes-provider",
+  "packages/plugin-openclaw",
+  "packages/shim-openclaw-engram",
+] as const;
 
-test("release workflow publish order includes every public workspace package", async () => {
+test("release workflow publish order matches the supported npm install surfaces", async () => {
   const workflow = await readFile(".github/workflows/release-and-publish.yml", "utf8");
-  const publicDirs = await publicPackageDirs();
+  const publishOrderMatch = workflow.match(/PUBLISH_ORDER=\(\s*([\s\S]*?)\s*\)/);
+  assert.ok(publishOrderMatch, "release workflow must define PUBLISH_ORDER");
+  const publishDirs = [...publishOrderMatch[1].matchAll(/packages\/[A-Za-z0-9_-]+/g)].map((match) => match[0]);
 
-  for (const pkgDir of publicDirs) {
+  assert.deepEqual(publishDirs, [...expectedPublishDirs]);
+
+  for (const pkgDir of expectedPublishDirs) {
     assert.match(
       workflow,
       new RegExp(`\\b${pkgDir.replace("/", "\\/")}\\b`),

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -45,6 +45,18 @@ test("workspace scripts expose bench list, bench run, and a quick smoke path", a
   assert.match(helper, /\["exec", "tsx", "packages\/remnic-cli\/src\/index\.ts", "bench"/);
 });
 
+test("CLI prebuild helper hydrates the bundled export adapter before building", async () => {
+  const helper = await readFile("scripts/ensure-cli-bench-build-deps.mjs", "utf8");
+
+  assert.match(helper, /packages", "remnic-core", "dist", "index\.js"/);
+  assert.match(helper, /packages", "bench", "dist", "index\.js"/);
+  assert.match(helper, /packages", "export-weclone", "dist", "index\.js"/);
+  assert.match(helper, /run\(\["--filter", pkgName, "build"\]\);/);
+  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/core"/);
+  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/bench"/);
+  assert.match(helper, /ensurePackageBuild\(\s*"@remnic\/export-weclone"/);
+});
+
 test("CLI README documents bench list and quick-run examples", async () => {
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 

--- a/tests/remnic-cli-package.test.ts
+++ b/tests/remnic-cli-package.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-test("remnic CLI bundles the private bench package instead of publishing it as a runtime dependency", async () => {
+test("remnic CLI bundles private bench helpers instead of publishing them as runtime dependencies", async () => {
   const [pkgRaw, tsupRaw, buildHelperRaw] = await Promise.all([
     readFile("packages/remnic-cli/package.json", "utf8"),
     readFile("packages/remnic-cli/tsup.config.ts", "utf8"),
@@ -16,11 +16,15 @@ test("remnic CLI bundles the private bench package instead of publishing it as a
 
   assert.equal(pkg.scripts?.prebuild, "node ../../scripts/ensure-cli-bench-build-deps.mjs");
   assert.match(pkg.scripts?.build ?? "", /^tsup --config tsup\.config\.ts(\s+&&\s+.+)?$/);
-  assert.match(tsupRaw, /noExternal:\s*\["@remnic\/bench"\]/);
+  assert.match(tsupRaw, /noExternal:\s*\["@remnic\/bench", "@remnic\/export-weclone"\]/);
   assert.match(buildHelperRaw, /"@remnic\/core"/);
   assert.match(buildHelperRaw, /"@remnic\/bench"/);
+  assert.match(buildHelperRaw, /"@remnic\/export-weclone"/);
   assert.match(buildHelperRaw, /packages", "remnic-core", "dist", "index\.js"/);
   assert.match(buildHelperRaw, /packages", "bench", "dist", "index\.js"/);
+  assert.match(buildHelperRaw, /packages", "export-weclone", "dist", "index\.js"/);
   assert.equal(pkg.dependencies?.["@remnic/bench"], undefined);
+  assert.equal(pkg.dependencies?.["@remnic/export-weclone"], undefined);
   assert.equal(pkg.devDependencies?.["@remnic/bench"], "workspace:*");
+  assert.equal(pkg.devDependencies?.["@remnic/export-weclone"], "workspace:*");
 });

--- a/tests/workspace-runtime-deps.test.ts
+++ b/tests/workspace-runtime-deps.test.ts
@@ -31,13 +31,29 @@ const packageExpectations = [
 test("runtime workspace packages preserve local linking in source manifests", async () => {
   for (const pkgSpec of packageExpectations) {
     const raw = await readFile(pkgSpec.path, "utf8");
-    const pkg = JSON.parse(raw) as { dependencies?: Record<string, string> };
+    const pkg = JSON.parse(raw) as {
+      dependencies?: Record<string, string>;
+      devDependencies?: Record<string, string>;
+    };
 
     for (const [depName, expectedRange] of Object.entries(pkgSpec.deps)) {
       assert.equal(
         pkg.dependencies?.[depName],
         expectedRange,
         `${pkgSpec.label} should use ${expectedRange} for ${depName}`,
+      );
+    }
+
+    if (pkgSpec.label === "CLI") {
+      assert.equal(
+        pkg.dependencies?.["@remnic/export-weclone"],
+        undefined,
+        "CLI should not publish a runtime dependency on @remnic/export-weclone",
+      );
+      assert.equal(
+        pkg.devDependencies?.["@remnic/export-weclone"],
+        "workspace:*",
+        "CLI should keep @remnic/export-weclone as a build-time workspace dependency",
       );
     }
   }


### PR DESCRIPTION
## Summary
- stop the release workflow from trying to publish the unpublished WeClone helper packages
- bundle the CLI export adapter so @remnic/cli no longer needs @remnic/export-weclone at runtime
- add release/workspace tests covering the supported npm install surfaces

## Verification
- pnpm --filter @remnic/cli build
- pnpm exec tsx --test tests/release-workflow-public-packages.test.ts tests/workspace-runtime-deps.test.ts tests/remnic-cli-bench-surface.test.ts
- pnpm exec tsx --test tests/register-multi-registry.test.ts
- pnpm exec tsx --test tests/intent.test.ts
- pnpm exec tsx --test tests/runtime-input-guards.test.ts
- pnpm exec tsx --test tests/artifact-recall-limit.test.ts
- pnpm exec tsx --test tests/artifact-status-snapshot.test.ts
- pnpm exec tsx --test tests/recall-no-recall-short-circuit.test.ts
- pnpm exec tsx --test tests/orchestrator-path-filter.test.ts
- pnpm exec tsx --test tests/artifact-cache.test.ts

## Why
PR #530 tagged the release successfully, but the publish job failed when npm rejected @remnic/connector-weclone with E404. This narrows the publish set to the actual supported npm install surfaces and keeps the CLI functional in published installs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the release/publish workflow and alters CLI bundling/dependency boundaries, which could affect published artifacts if misconfigured. No direct runtime business-logic or security-sensitive code paths are modified.
> 
> **Overview**
> **Release publishing is restricted to supported npm install surfaces.** The release workflow `PUBLISH_ORDER` no longer includes the WeClone helper packages, and tests now assert the publish list matches an explicit allowlist.
> 
> **`@remnic/cli` no longer ships a runtime dependency on `@remnic/export-weclone`.** The adapter is moved to a build-time dependency, bundled via `tsup` (`noExternal`), and the CLI prebuild helper now ensures `@remnic/export-weclone` is built; dependency-lock and workspace dependency tests are updated accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5aa7c652c305dfd5c8baafa0f9eefdb2fbb55b31. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->