### PR TITLE
feat(retrieval): direct-answer wiring layer (#518 slice 3/8)

### DIFF
--- a/packages/remnic-core/src/direct-answer-wiring.test.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.test.ts
@@ -1,0 +1,363 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  tryDirectAnswer,
+  type DirectAnswerSources,
+  type DirectAnswerWiringInput,
+} from "./direct-answer-wiring.js";
+import { DEFAULT_TAXONOMY } from "./taxonomy/default-taxonomy.js";
+import type { MemoryFile, PluginConfig } from "./types.js";
+import type { TrustZoneName } from "./trust-zones.js";
+
+type WiringConfig = DirectAnswerWiringInput["config"];
+
+const BASE_CONFIG: WiringConfig = {
+  recallDirectAnswerEnabled: true,
+  recallDirectAnswerTokenOverlapFloor: 0.5,
+  recallDirectAnswerImportanceFloor: 0.7,
+  recallDirectAnswerAmbiguityMargin: 0.15,
+  recallDirectAnswerEligibleTaxonomyBuckets: [
+    "decisions",
+    "principles",
+    "conventions",
+    "runbooks",
+    "entities",
+  ],
+};
+
+function makeMemory(overrides: {
+  id?: string;
+  category?: MemoryFile["frontmatter"]["category"];
+  tags?: string[];
+  content?: string;
+  status?: MemoryFile["frontmatter"]["status"];
+  verificationState?: MemoryFile["frontmatter"]["verificationState"];
+  entityRef?: string;
+} = {}): MemoryFile {
+  const id = overrides.id ?? "m1";
+  return {
+    path: `/memory/${id}.md`,
+    frontmatter: {
+      id,
+      category: overrides.category ?? "decision",
+      created: "2026-04-19T00:00:00.000Z",
+      updated: "2026-04-19T00:00:00.000Z",
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: overrides.tags ?? [],
+      status: overrides.status,
+      verificationState: overrides.verificationState,
+      entityRef: overrides.entityRef,
+    },
+    content: overrides.content ?? "",
+  };
+}
+
+interface MockSources extends DirectAnswerSources {
+  calls: {
+    listCandidates: number;
+    trustZone: string[];
+    importance: string[];
+  };
+}
+
+function makeMockSources(init: {
+  memories?: MemoryFile[];
+  trustZones?: Record<string, TrustZoneName | null>;
+  importance?: Record<string, number>;
+} = {}): MockSources {
+  const calls = { listCandidates: 0, trustZone: [] as string[], importance: [] as string[] };
+  return {
+    calls,
+    taxonomy: DEFAULT_TAXONOMY,
+    listCandidateMemories: async () => {
+      calls.listCandidates += 1;
+      return init.memories ?? [];
+    },
+    trustZoneFor: async (id: string) => {
+      calls.trustZone.push(id);
+      return init.trustZones?.[id] ?? null;
+    },
+    importanceFor: (memory: MemoryFile) => {
+      calls.importance.push(memory.frontmatter.id);
+      return init.importance?.[memory.frontmatter.id] ?? 0;
+    },
+  };
+}
+
+// ── Disabled path: short-circuits without touching any source ───────────────
+
+test("tryDirectAnswer disabled-path does not call any source accessor", async () => {
+  const sources = makeMockSources({ memories: [makeMemory()] });
+  const result = await tryDirectAnswer({
+    query: "does not matter",
+    namespace: "default",
+    config: { ...BASE_CONFIG, recallDirectAnswerEnabled: false },
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "disabled");
+  assert.equal(sources.calls.listCandidates, 0);
+  assert.deepEqual(sources.calls.trustZone, []);
+  assert.deepEqual(sources.calls.importance, []);
+});
+
+// ── Empty memory list ───────────────────────────────────────────────────────
+
+test("tryDirectAnswer with empty memory list returns no-candidates", async () => {
+  const sources = makeMockSources({ memories: [] });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.reason, "no-candidates");
+  assert.equal(sources.calls.listCandidates, 1);
+});
+
+// ── Pre-filter: non-trusted memories don't trigger importance resolution ────
+
+test("tryDirectAnswer skips importance resolution for non-trusted memories", async () => {
+  const memory = makeMemory({
+    id: "working-zone",
+    tags: ["pnpm"],
+    content: "remnic uses pnpm",
+  });
+  const sources = makeMockSources({
+    memories: [memory],
+    trustZones: { "working-zone": "working" },
+    importance: { "working-zone": 0.99 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "no-candidates");
+  // Importance was never read because the memory was dropped at the
+  // trust-zone pre-filter.
+  assert.deepEqual(sources.calls.importance, []);
+});
+
+test("tryDirectAnswer skips importance for quarantine-zone memories", async () => {
+  const memory = makeMemory({
+    id: "quarantined",
+    tags: ["pnpm"],
+    content: "remnic uses pnpm",
+  });
+  const sources = makeMockSources({
+    memories: [memory],
+    trustZones: { quarantined: "quarantine" },
+    importance: { quarantined: 0.99 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.deepEqual(sources.calls.importance, []);
+});
+
+test("tryDirectAnswer skips importance when trust zone is missing (null)", async () => {
+  const memory = makeMemory({
+    id: "no-zone",
+    tags: ["pnpm"],
+    content: "remnic uses pnpm",
+  });
+  const sources = makeMockSources({
+    memories: [memory],
+    trustZones: { "no-zone": null },
+    importance: { "no-zone": 0.99 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.deepEqual(sources.calls.importance, []);
+});
+
+// ── Pre-filter: ineligible taxonomy bucket ──────────────────────────────────
+
+test("tryDirectAnswer skips importance when taxonomy bucket is not eligible", async () => {
+  // "correction" maps to the "corrections" taxonomy bucket, not in the
+  // default eligible list.
+  const memory = makeMemory({
+    id: "correction-memory",
+    category: "correction",
+    tags: ["pnpm"],
+    content: "remnic uses pnpm",
+  });
+  const sources = makeMockSources({
+    memories: [memory],
+    trustZones: { "correction-memory": "trusted" },
+    importance: { "correction-memory": 0.99 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.deepEqual(sources.calls.importance, []);
+});
+
+// ── Happy path ──────────────────────────────────────────────────────────────
+
+test("tryDirectAnswer returns eligible for a single trusted user-confirmed decision", async () => {
+  const memory = makeMemory({
+    id: "pm",
+    category: "decision",
+    verificationState: "user_confirmed",
+    tags: ["package-manager", "remnic"],
+    content: "remnic uses pnpm as its package manager",
+  });
+  const sources = makeMockSources({
+    memories: [memory],
+    trustZones: { pm: "trusted" },
+    importance: { pm: 0.8 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.winner?.memory.frontmatter.id, "pm");
+  assert.ok(result.narrative.includes("decisions"));
+  assert.deepEqual(sources.calls.importance, ["pm"]);
+});
+
+// ── Multi-candidate: eligibility module applies the ambiguity gate ──────────
+
+test("tryDirectAnswer defers to hybrid when two trusted candidates are within ambiguity margin", async () => {
+  const a = makeMemory({
+    id: "a",
+    tags: ["package-manager", "remnic"],
+    content: "remnic uses pnpm",
+  });
+  const b = makeMemory({
+    id: "b",
+    tags: ["package-manager", "remnic"],
+    content: "remnic uses pnpm as its package manager",
+  });
+  const sources = makeMockSources({
+    memories: [a, b],
+    trustZones: { a: "trusted", b: "trusted" },
+    importance: { a: 0.9, b: 0.9 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.eligible, false);
+  assert.equal(result.reason, "ambiguous");
+});
+
+// ── Abort signal interrupts the resolution loop ─────────────────────────────
+
+test("tryDirectAnswer honors an aborted signal mid-loop", async () => {
+  const first = makeMemory({
+    id: "first",
+    tags: ["package-manager"],
+    content: "remnic uses pnpm",
+  });
+  const second = makeMemory({
+    id: "second",
+    tags: ["package-manager"],
+    content: "remnic uses pnpm",
+  });
+
+  const controller = new AbortController();
+  const sources: DirectAnswerSources = {
+    taxonomy: DEFAULT_TAXONOMY,
+    listCandidateMemories: async () => [first, second],
+    trustZoneFor: async (id: string) => {
+      if (id === "first") {
+        // Simulate user aborting recall while resolving the first candidate.
+        controller.abort();
+      }
+      return "trusted";
+    },
+    importanceFor: () => 0.9,
+  };
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+    abortSignal: controller.signal,
+  });
+  // Abort happens after first candidate is resolved; second is never
+  // processed.  Result depends on whether "first" passes all gates,
+  // but the test's point is we did not keep walking after abort.
+  assert.ok(result.reason === "eligible" || result.reason === "ambiguous" || result.reason === "below-token-overlap-floor" || result.reason === "no-eligible-candidates");
+});
+
+// ── Namespace flows through to the source accessor ──────────────────────────
+
+test("tryDirectAnswer passes the requested namespace to listCandidateMemories", async () => {
+  let observedNamespace: string | null = null;
+  const sources: DirectAnswerSources = {
+    taxonomy: DEFAULT_TAXONOMY,
+    listCandidateMemories: async ({ namespace }) => {
+      observedNamespace = namespace;
+      return [];
+    },
+    trustZoneFor: async () => null,
+    importanceFor: () => 0,
+  };
+  await tryDirectAnswer({
+    query: "anything",
+    namespace: "project-x",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(observedNamespace, "project-x");
+});
+
+// ── Query entity refs are propagated to the eligibility module ──────────────
+
+test("tryDirectAnswer forwards queryEntityRefs to the eligibility gate", async () => {
+  const match = makeMemory({
+    id: "match",
+    verificationState: "user_confirmed",
+    entityRef: "remnic",
+    tags: ["package-manager"],
+    content: "remnic uses pnpm",
+  });
+  const mismatch = makeMemory({
+    id: "mismatch",
+    verificationState: "user_confirmed",
+    entityRef: "weclone",
+    tags: ["package-manager"],
+    content: "weclone uses npm",
+  });
+  const sources = makeMockSources({
+    memories: [match, mismatch],
+    trustZones: { match: "trusted", mismatch: "trusted" },
+    importance: { match: 0.9, mismatch: 0.9 },
+  });
+  const result = await tryDirectAnswer({
+    query: "package manager remnic",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+    queryEntityRefs: ["remnic"],
+  });
+  assert.equal(result.eligible, true);
+  assert.equal(result.winner?.memory.frontmatter.id, "match");
+});

--- a/packages/remnic-core/src/direct-answer-wiring.test.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.test.ts
@@ -269,7 +269,7 @@ test("tryDirectAnswer defers to hybrid when two trusted candidates are within am
 
 // ── Abort signal interrupts the resolution loop ─────────────────────────────
 
-test("tryDirectAnswer honors an aborted signal mid-loop", async () => {
+test("tryDirectAnswer throws AbortError when signal aborts mid-loop", async () => {
   const first = makeMemory({
     id: "first",
     tags: ["package-manager"],
@@ -282,29 +282,55 @@ test("tryDirectAnswer honors an aborted signal mid-loop", async () => {
   });
 
   const controller = new AbortController();
+  let secondTrustZoneConsulted = false;
   const sources: DirectAnswerSources = {
     taxonomy: DEFAULT_TAXONOMY,
     listCandidateMemories: async () => [first, second],
     trustZoneFor: async (id: string) => {
       if (id === "first") {
-        // Simulate user aborting recall while resolving the first candidate.
+        // Simulate the caller aborting recall while resolving the first
+        // candidate.  Abort between the accessor call and the loop guard.
         controller.abort();
+        return "trusted";
       }
+      secondTrustZoneConsulted = true;
       return "trusted";
     },
     importanceFor: () => 0.9,
   };
-  const result = await tryDirectAnswer({
-    query: "package manager remnic",
-    namespace: "default",
-    config: BASE_CONFIG,
-    sources,
-    abortSignal: controller.signal,
-  });
-  // Abort happens after first candidate is resolved; second is never
-  // processed.  Result depends on whether "first" passes all gates,
-  // but the test's point is we did not keep walking after abort.
-  assert.ok(result.reason === "eligible" || result.reason === "ambiguous" || result.reason === "below-token-overlap-floor" || result.reason === "no-eligible-candidates");
+  await assert.rejects(
+    () =>
+      tryDirectAnswer({
+        query: "package manager remnic",
+        namespace: "default",
+        config: BASE_CONFIG,
+        sources,
+        abortSignal: controller.signal,
+      }),
+    (err: Error) => err.name === "AbortError",
+  );
+  // Second candidate must never have been consulted — abort should
+  // short-circuit before the next iteration.
+  assert.equal(secondTrustZoneConsulted, false);
+});
+
+test("tryDirectAnswer throws when signal is already aborted before I/O", async () => {
+  const sources = makeMockSources({ memories: [makeMemory()] });
+  const controller = new AbortController();
+  controller.abort();
+  await assert.rejects(
+    () =>
+      tryDirectAnswer({
+        query: "anything",
+        namespace: "default",
+        config: BASE_CONFIG,
+        sources,
+        abortSignal: controller.signal,
+      }),
+    (err: Error) => err.name === "AbortError",
+  );
+  // listCandidateMemories must never have been called.
+  assert.equal(sources.calls.listCandidates, 0);
 });
 
 // ── Namespace flows through to the source accessor ──────────────────────────

--- a/packages/remnic-core/src/direct-answer-wiring.test.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.test.ts
@@ -104,6 +104,29 @@ test("tryDirectAnswer disabled-path does not call any source accessor", async ()
   assert.deepEqual(sources.calls.importance, []);
 });
 
+// ── Empty-query short-circuit: no I/O ───────────────────────────────────────
+
+test("tryDirectAnswer skips all I/O when query normalizes to zero searchable tokens", async () => {
+  // Regression for PR #533 second-round P2 review: isDirectAnswerEligible
+  // deterministically returns "empty-query" in that case, so the wiring
+  // must not materialize candidates or call trust-zone/importance first.
+  const sources = makeMockSources({
+    memories: [makeMemory({ tags: ["pnpm"], content: "remnic uses pnpm" })],
+    trustZones: { m1: "trusted" },
+    importance: { m1: 0.9 },
+  });
+  const result = await tryDirectAnswer({
+    query: "? !!!  ",
+    namespace: "default",
+    config: BASE_CONFIG,
+    sources,
+  });
+  assert.equal(result.reason, "empty-query");
+  assert.equal(sources.calls.listCandidates, 0);
+  assert.deepEqual(sources.calls.trustZone, []);
+  assert.deepEqual(sources.calls.importance, []);
+});
+
 // ── Empty memory list ───────────────────────────────────────────────────────
 
 test("tryDirectAnswer with empty memory list returns no-candidates", async () => {

--- a/packages/remnic-core/src/direct-answer-wiring.test.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.test.ts
@@ -314,6 +314,67 @@ test("tryDirectAnswer throws AbortError when signal aborts mid-loop", async () =
   assert.equal(secondTrustZoneConsulted, false);
 });
 
+test("tryDirectAnswer throws when abort lands during trustZoneFor on the only memory", async () => {
+  // Regression for PR #533 P1 review: if abortSignal flips while the
+  // trust-zone await is in-flight on the last (or only) memory, the
+  // function must still throw — not fall through to eligibility with
+  // whatever was scored.
+  const memory = makeMemory({
+    id: "only",
+    tags: ["package-manager", "remnic"],
+    content: "remnic uses pnpm",
+  });
+  const controller = new AbortController();
+  const sources: DirectAnswerSources = {
+    taxonomy: DEFAULT_TAXONOMY,
+    listCandidateMemories: async () => [memory],
+    trustZoneFor: async () => {
+      controller.abort();
+      return "trusted";
+    },
+    importanceFor: () => 0.9,
+  };
+  await assert.rejects(
+    () =>
+      tryDirectAnswer({
+        query: "package manager remnic",
+        namespace: "default",
+        config: BASE_CONFIG,
+        sources,
+        abortSignal: controller.signal,
+      }),
+    (err: Error) => err.name === "AbortError",
+  );
+});
+
+test("tryDirectAnswer throws when abort lands during trustZoneFor on the last of several memories", async () => {
+  const memories = [
+    makeMemory({ id: "first", tags: ["package-manager"], content: "remnic uses pnpm" }),
+    makeMemory({ id: "last", tags: ["package-manager"], content: "remnic uses pnpm" }),
+  ];
+  const controller = new AbortController();
+  const sources: DirectAnswerSources = {
+    taxonomy: DEFAULT_TAXONOMY,
+    listCandidateMemories: async () => memories,
+    trustZoneFor: async (id: string) => {
+      if (id === "last") controller.abort();
+      return "trusted";
+    },
+    importanceFor: () => 0.9,
+  };
+  await assert.rejects(
+    () =>
+      tryDirectAnswer({
+        query: "package manager remnic",
+        namespace: "default",
+        config: BASE_CONFIG,
+        sources,
+        abortSignal: controller.signal,
+      }),
+    (err: Error) => err.name === "AbortError",
+  );
+});
+
 test("tryDirectAnswer throws when signal is already aborted before I/O", async () => {
   const sources = makeMockSources({ memories: [makeMemory()] });
   const controller = new AbortController();

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -1,0 +1,148 @@
+/**
+ * Direct-answer wiring (issue #518 slice 3).
+ *
+ * Binds the pure eligibility decision (`direct-answer.ts`) to the data
+ * sources needed to build candidates: storage, trust-zones, taxonomy,
+ * and importance scoring.  Kept as a separate module so that:
+ *
+ * - The eligibility layer stays pure and unit-testable without stores.
+ * - Each caller injects its own source accessors.  The orchestrator
+ *   binding is a follow-on slice; tests here use mock sources.
+ * - The wiring is safe to ship alone — nothing calls `tryDirectAnswer`
+ *   yet, so enabling this module's presence does not change recall
+ *   behavior.  The next slice adds exactly one call site before QMD.
+ *
+ * Short-circuit contract:
+ *
+ * - When `config.recallDirectAnswerEnabled === false`, the function
+ *   returns the eligibility verdict with reason `"disabled"` without
+ *   touching any source accessor.  This is the documented default.
+ * - When enabled, the wiring cheaply drops non-trusted-zone memories
+ *   and ineligible taxonomy buckets before computing importance, so
+ *   the eligibility module sees a pre-filtered candidate set.  The
+ *   eligibility module still performs the same checks itself — this
+ *   module is purely an I/O and prefiltering layer.
+ */
+
+import type { MemoryFile, PluginConfig } from "./types.js";
+import type { TrustZoneName } from "./trust-zones.js";
+import type { Taxonomy } from "./taxonomy/types.js";
+import { resolveCategory } from "./taxonomy/resolver.js";
+import {
+  isDirectAnswerEligible,
+  type DirectAnswerCandidate,
+  type DirectAnswerConfig,
+  type DirectAnswerResult,
+} from "./direct-answer.js";
+
+/**
+ * Caller-provided accessors for candidate sourcing.  Decouples the
+ * wiring from any specific storage / trust-zone / importance backend.
+ */
+export interface DirectAnswerSources {
+  /**
+   * List memories eligible to be considered for direct-answer.
+   * Callers are expected to return only active, non-superseded memories
+   * in the requested namespace; the wiring will cheaply re-filter on
+   * trust zone and taxonomy bucket and hand the rest to the eligibility
+   * module, which applies the full gate ladder.
+   */
+  listCandidateMemories(options: {
+    namespace: string;
+    abortSignal?: AbortSignal;
+  }): Promise<MemoryFile[]>;
+  /**
+   * Resolve the trust-zone record for a memory.  Returns `null` when
+   * the memory has no trust-zone record (treated as not trusted).
+   */
+  trustZoneFor(memoryId: string): Promise<TrustZoneName | null>;
+  /**
+   * Resolve a calibrated importance score in [0, 1] for a memory.
+   */
+  importanceFor(memory: MemoryFile): number;
+  /**
+   * Taxonomy used to classify memories into direct-answer buckets.
+   */
+  taxonomy: Taxonomy;
+}
+
+export interface DirectAnswerWiringInput {
+  query: string;
+  namespace: string;
+  config: Pick<
+    PluginConfig,
+    | "recallDirectAnswerEnabled"
+    | "recallDirectAnswerTokenOverlapFloor"
+    | "recallDirectAnswerImportanceFloor"
+    | "recallDirectAnswerAmbiguityMargin"
+    | "recallDirectAnswerEligibleTaxonomyBuckets"
+  >;
+  sources: DirectAnswerSources;
+  queryEntityRefs?: string[];
+  abortSignal?: AbortSignal;
+}
+
+/**
+ * Attempt direct-answer resolution.  Returns the eligibility verdict
+ * produced by `isDirectAnswerEligible` with candidates materialized
+ * from the caller-supplied sources.
+ */
+export async function tryDirectAnswer(
+  input: DirectAnswerWiringInput,
+): Promise<DirectAnswerResult> {
+  const { query, namespace, config, sources, queryEntityRefs, abortSignal } = input;
+
+  const eligibilityConfig: DirectAnswerConfig = {
+    enabled: config.recallDirectAnswerEnabled,
+    tokenOverlapFloor: config.recallDirectAnswerTokenOverlapFloor,
+    importanceFloor: config.recallDirectAnswerImportanceFloor,
+    ambiguityMargin: config.recallDirectAnswerAmbiguityMargin,
+    eligibleTaxonomyBuckets: config.recallDirectAnswerEligibleTaxonomyBuckets,
+  };
+
+  // Short-circuit disabled case before touching any I/O.
+  if (!eligibilityConfig.enabled) {
+    return isDirectAnswerEligible({
+      query,
+      candidates: [],
+      config: eligibilityConfig,
+      queryEntityRefs,
+    });
+  }
+
+  const memories = await sources.listCandidateMemories({ namespace, abortSignal });
+  const candidates: DirectAnswerCandidate[] = [];
+
+  for (const memory of memories) {
+    if (abortSignal?.aborted) break;
+
+    const trustZone = await sources.trustZoneFor(memory.frontmatter.id);
+    // Cheap pre-filter: non-trusted memories can't qualify, so skip
+    // taxonomy and importance resolution for them.
+    if (trustZone !== "trusted") continue;
+
+    const decision = resolveCategory(
+      memory.content,
+      memory.frontmatter.category,
+      sources.taxonomy,
+    );
+    const taxonomyBucket = decision.categoryId;
+    if (!eligibilityConfig.eligibleTaxonomyBuckets.includes(taxonomyBucket)) continue;
+
+    const importanceScore = sources.importanceFor(memory);
+
+    candidates.push({
+      memory,
+      trustZone,
+      taxonomyBucket,
+      importanceScore,
+    });
+  }
+
+  return isDirectAnswerEligible({
+    query,
+    candidates,
+    config: eligibilityConfig,
+    queryEntityRefs,
+  });
+}

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -110,11 +110,17 @@ export async function tryDirectAnswer(
     });
   }
 
+  throwIfAborted(abortSignal);
   const memories = await sources.listCandidateMemories({ namespace, abortSignal });
+  throwIfAborted(abortSignal);
   const candidates: DirectAnswerCandidate[] = [];
 
   for (const memory of memories) {
-    if (abortSignal?.aborted) break;
+    // Throw rather than returning a partial verdict — a mid-loop abort
+    // that left competing candidates unprocessed could otherwise surface
+    // a spurious "eligible" result that the ambiguity gate never got a
+    // chance to reject.
+    throwIfAborted(abortSignal);
 
     const trustZone = await sources.trustZoneFor(memory.frontmatter.id);
     // Cheap pre-filter: non-trusted memories can't qualify, so skip
@@ -145,4 +151,12 @@ export async function tryDirectAnswer(
     config: eligibilityConfig,
     queryEntityRefs,
   });
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    const err = new Error("direct-answer wiring aborted");
+    Object.defineProperty(err, "name", { value: "AbortError" });
+    throw err;
+  }
 }

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -119,10 +119,14 @@ export async function tryDirectAnswer(
     // Throw rather than returning a partial verdict — a mid-loop abort
     // that left competing candidates unprocessed could otherwise surface
     // a spurious "eligible" result that the ambiguity gate never got a
-    // chance to reject.
+    // chance to reject.  The check repeats after every await so an
+    // abort that lands during the in-flight I/O on the final memory
+    // (after which no further iteration would exist) still stops us.
     throwIfAborted(abortSignal);
 
     const trustZone = await sources.trustZoneFor(memory.frontmatter.id);
+    throwIfAborted(abortSignal);
+
     // Cheap pre-filter: non-trusted memories can't qualify, so skip
     // taxonomy and importance resolution for them.
     if (trustZone !== "trusted") continue;
@@ -144,6 +148,11 @@ export async function tryDirectAnswer(
       importanceScore,
     });
   }
+
+  // Final check — if abort landed during the trust-zone await for the
+  // last memory, the loop condition no longer fires.  Guard before we
+  // hand candidates to the eligibility gate.
+  throwIfAborted(abortSignal);
 
   return isDirectAnswerEligible({
     query,

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -28,6 +28,7 @@ import type { MemoryFile, PluginConfig } from "./types.js";
 import type { TrustZoneName } from "./trust-zones.js";
 import type { Taxonomy } from "./taxonomy/types.js";
 import { resolveCategory } from "./taxonomy/resolver.js";
+import { normalizeRecallTokens } from "./recall-tokenization.js";
 import {
   isDirectAnswerEligible,
   type DirectAnswerCandidate,
@@ -102,6 +103,21 @@ export async function tryDirectAnswer(
 
   // Short-circuit disabled case before touching any I/O.
   if (!eligibilityConfig.enabled) {
+    return isDirectAnswerEligible({
+      query,
+      candidates: [],
+      config: eligibilityConfig,
+      queryEntityRefs,
+    });
+  }
+
+  // Short-circuit empty-query case before any I/O.  isDirectAnswerEligible
+  // deterministically returns reason "empty-query" when the query
+  // normalizes to zero searchable tokens; there's no point materializing
+  // candidates just to reach the same verdict, and doing so would
+  // surface avoidable upstream errors for requests that should exit
+  // immediately.
+  if (normalizeRecallTokens(query).length === 0) {
     return isDirectAnswerEligible({
       query,
       candidates: [],


### PR DESCRIPTION
Third of eight slices for #518. Binds the pure direct-answer eligibility decision (slice 2, merged at \`04c23cbb\`) to the data sources needed to build candidates. Dead code — no call site yet, safe to merge and release alone. The next slice adds exactly one call site in \`recallInternal()\` before QMD, plus the \`LastRecallSnapshot\` field that carries \`RecallTierExplain\` out.

## Summary

- New \`packages/remnic-core/src/direct-answer-wiring.ts\` with \`tryDirectAnswer(input)\`.
- New \`direct-answer-wiring.test.ts\` — 11 tests, all green. \`tsc --noEmit\` clean.
- Combined slice-1/2/3 core tests: 71/71 pass.

## Design

- **Source decoupling.** Orchestrator internals stay out of this layer — callers inject a \`DirectAnswerSources\` interface (\`listCandidateMemories\`, \`trustZoneFor\`, \`importanceFor\`, \`taxonomy\`). Tests use mock sources, production binding is slice 3b's job.
- **Zero-I/O disabled path.** When \`config.recallDirectAnswerEnabled === false\`, the function returns immediately with reason \`"disabled"\` without calling any accessor. This is the documented default and the contract test enforces it.
- **Pre-filter then delegate.** When enabled, cheaply drops non-trusted-zone memories before taxonomy resolution, and skips importance resolution for ineligible taxonomy buckets. The full gate ladder still runs inside \`isDirectAnswerEligible\` — the pre-filter is purely an I/O optimization, not a correctness boundary.
- **Abort-aware.** \`abortSignal\` is checked before each candidate resolution so recall cancellation halts the walk.

## CLAUDE.md rules honored

- **Rule 30** — \`enabled: false\` gate tested explicitly, not-touching-sources contract asserted.
- **Rule 42** — namespace flows through all access; the wiring does not cross namespaces on its own.
- **Rule 51** — all inputs validated upstream by slice 1 (\`parseConfig\`) and slice 2 (eligibility gates).

## Out of scope for this slice

- Call site in \`recallInternal\` (slice 3b — a tiny diff)
- \`LastRecallSnapshot.tierExplain\` extension (slice 3b)
- CLI / HTTP / MCP surfaces (slices 4–6)
- Bench + docs (slices 7–8)

## Test plan

- [x] \`packages/remnic-core/src/direct-answer-wiring.test.ts\` — 11/11 pass
- [x] \`packages/remnic-core/src/direct-answer.test.ts\` — 21/21 pass (no regressions)
- [x] \`packages/remnic-core/src/config.test.ts\` — 39/39 pass (no regressions)
- [x] \`tsc --noEmit\` clean
- [x] Module is genuinely dead code: \`grep -rn 'direct-answer-wiring\\|tryDirectAnswer' src packages\` returns only the module and its test

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new, currently unreferenced wiring module plus unit tests; it doesn’t change runtime behavior until a call site is introduced. Risk is mainly around future integration correctness (abort handling and prefiltering) rather than regressions today.
> 
> **Overview**
> Introduces a new `tryDirectAnswer` wiring layer that materializes direct-answer candidates from injected sources (candidate listing, trust zone lookup, taxonomy resolution, and importance scoring) and then delegates the final verdict to `isDirectAnswerEligible`.
> 
> The wiring adds **zero-I/O short-circuits** for `recallDirectAnswerEnabled=false` and for queries that normalize to no searchable tokens, performs cheap prefiltering (drop non-`trusted` and ineligible taxonomy buckets before computing importance), propagates `namespace`/`queryEntityRefs`, and is **abort-signal aware** (throws `AbortError` on cancellation).
> 
> Adds a comprehensive test suite covering the short-circuit contracts, prefiltering behavior, ambiguity deferral, namespace/queryEntityRefs plumbing, and abort edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1053733b43ba001cc00162bdfea6c188491f7c27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->