### PR TITLE
docs: surface procedural.enabled for operators and agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,7 @@ public export surface.
 Reviewers caught features that unconditionally transformed behavior without any
 escape hatch or configuration gate.
 
+- **Procedural memory (issue #519)** — All runtime behavior is behind **`procedural.enabled`** (default **`false`**). Docs: `docs/procedural-memory.md`. When changing extraction, recall injection, or mining paths, keep gates aligned with that flag and the nested `procedural.*` knobs in `parseConfig`.
 - **Add an `enabled` check or escape hatch for every new filter/transform** —
   if a new recall filter unconditionally removes `dream`/`procedural` memories,
   users can never search for them even when the feature is disabled. Mirror the

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,10 @@
 - `.gitignore`
 - This `CLAUDE.md` file
 
+### Procedural memory (issue #519)
+
+Ships **disabled** until plugin config sets **`procedural.enabled`: `true`** (nested `procedural` object). Operators and agents should read `docs/procedural-memory.md` and the README **Configuration** table before enabling.
+
 ### Before every commit, verify:
 - `git diff --cached` contains NO personal information
 - No hardcoded API keys, URLs with tokens, or credentials

--- a/README.md
+++ b/README.md
@@ -560,6 +560,7 @@ Run Engram as a standalone HTTP server that multiple agent harnesses share. Isol
 - **Extraction Judge** — LLM-as-judge post-extraction filter that evaluates fact durability before write. Has shadow mode for calibration. Opt-in via `extractionJudgeEnabled`. (issue #376)
 - **Semantic Chunking** — Smoothing-based topic boundary detection using sentence embeddings and cosine similarity, as an alternative to recursive chunking. Opt-in via `semanticChunkingEnabled`. (issue #368)
 - **OAI-mem-citation Blocks** — Recall responses emit `<oai-mem-citation>` blocks matching the Codex citation format for memory attribution and usage tracking. Opt-in via `citationsEnabled`. (issue #379)
+- **Procedural memory** — Stores repeatable **how-to** memories as `category: procedure` markdown under `procedures/`, mines candidates from causal trajectories, and can inject a **Relevant procedures** section on task-initiation prompts. **Off by default**; set `procedural.enabled` to `true` in plugin config. See [Procedural memory](docs/procedural-memory.md). (issue #519)
 
 ### Organization & Taxonomy (opt-in)
 
@@ -880,6 +881,7 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | `taxonomyEnabled` | `false` | MECE knowledge directory with resolver decision tree |
 | `enrichmentEnabled` | `false` | External entity enrichment pipeline |
 | `binaryLifecycleEnabled` | `false` | Binary file lifecycle management (mirror/redirect/clean) |
+| `procedural.enabled` | `false` | **Procedural memory (issue #519):** master gate for procedure extraction, task-init recall injection, and trajectory mining. Set nested `procedural: { "enabled": true }` in plugin config (see [Procedural memory](docs/procedural-memory.md)). |
 
 **[See the full config reference for all 60+ settings](docs/config-reference.md)** including search backend configuration, namespace policies, Memory OS features, governance, evaluation harness, trust zones, causal trajectories, and more.
 
@@ -919,6 +921,7 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Binary Lifecycle](docs/architecture/binary-lifecycle.md) — Binary file management
 - [Memory Extensions](docs/architecture/memory-extensions.md) — Third-party extension discovery
 - [Codex Marketplace](docs/plugins/codex-marketplace.md) — Marketplace installation
+- [Procedural memory](docs/procedural-memory.md) — Procedure files, recall injection, mining; enable with `procedural.enabled` (issue #519)
 
 ## Contributing
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -956,7 +956,7 @@ Stored as `category: procedure` markdown under `memoryDir/procedures/`. Narrativ
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `procedural.enabled` | `false` | Master gate: when `false`, skip procedure extraction writes, task-initiation procedure recall injection, and trajectory mining side effects. Set `true` to enable the full feature set. |
-| `procedural.minOccurrences` | `3` | Minimum cluster recurrence before the miner can emit a candidate (`0` disables the recurrence threshold). |
+| `procedural.minOccurrences` | `3` | Minimum cluster size for a candidate; clusters smaller than this are skipped. **`0` disables procedural mining** (`runProcedureMining` returns immediately with `skippedReason: "minOccurrences_zero"`). |
 | `procedural.successFloor` | `0.7` | Minimum trajectory success rate in `[0, 1]` for miner eligibility. |
 | `procedural.autoPromoteOccurrences` | `8` | When auto-promotion is on, occurrences before `pending_review` → `active`. |
 | `procedural.autoPromoteEnabled` | `false` | Allow automatic promotion of miner candidates that meet thresholds. |
@@ -1389,7 +1389,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `lifecycleProtectedCategories` | `["decision","principle","commitment","preference","procedure"]` | `["decision","principle","commitment","preference","procedure"]` |
 | `lifecycleMetricsEnabled` | `false` | `true` when `lifecyclePolicyEnabled=true` |
 | `procedural.enabled` | `false` | `true` only after reading [procedural-memory.md](procedural-memory.md) and validating extraction + recall impact |
-| `procedural.minOccurrences` | `3` | `3` |
+| `procedural.minOccurrences` | `3` | `3` (use `0` only to intentionally disable mining; see narrative section) |
 | `procedural.successFloor` | `0.7` | `0.7` |
 | `procedural.autoPromoteOccurrences` | `8` | `8` |
 | `procedural.autoPromoteEnabled` | `false` | `false` until promotion rules are validated on your corpus |

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -333,7 +333,7 @@ Direct `includeFiles` sync plus the OpenClaw workspace adapter both persist incr
 | `lifecyclePromoteHeatThreshold` | `0.55` | Heat threshold for promotion toward `validated`/`active`. |
 | `lifecycleStaleDecayThreshold` | `0.65` | Decay threshold to move a memory to `stale`. |
 | `lifecycleArchiveDecayThreshold` | `0.85` | Decay threshold to move a memory to `archived` (non-protected categories). |
-| `lifecycleProtectedCategories` | `["decision","principle","commitment","preference"]` | Categories protected from automatic archive transition. |
+| `lifecycleProtectedCategories` | `["decision","principle","commitment","preference","procedure"]` | Categories protected from automatic archive transition (includes `procedure` when procedural memories exist). |
 | `lifecycleMetricsEnabled` | `false` (auto-`true` when policy enabled unless explicitly set) | Emit lifecycle metrics snapshot at `state/lifecycle-metrics.json`. |
 
 ## v8.3 Proactive + Policy Learning Foundation
@@ -802,7 +802,7 @@ See [compounding.md](compounding.md).
 | `factArchivalAgeDays` | `90` | Minimum age to archive |
 | `factArchivalMaxImportance` | `0.3` | Maximum importance to archive |
 | `factArchivalMaxAccessCount` | `2` | Maximum access count to archive |
-| `factArchivalProtectedCategories` | `["commitment","preference","decision","principle"]` | Never archived |
+| `factArchivalProtectedCategories` | `["commitment","preference","decision","principle","procedure"]` | Never archived |
 
 ### Write-time semantic dedup (issue #373)
 
@@ -948,6 +948,21 @@ of truth for similarity logic across read-time and write-time code paths.
 | `binaryLifecycleGracePeriodDays` | `7` | Days before local cleanup of mirrored files |
 | `binaryLifecycleBackendType` | `"none"` | Storage backend: `"none"`, `"filesystem"`, `"s3"` |
 | `binaryLifecycleBackendPath` | `""` | Base path for filesystem backend |
+
+## Procedural memory (issue #519)
+
+Stored as `category: procedure` markdown under `memoryDir/procedures/`. Narrative overview: [procedural-memory.md](procedural-memory.md).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `procedural.enabled` | `false` | Master gate: when `false`, skip procedure extraction writes, task-initiation procedure recall injection, and trajectory mining side effects. Set `true` to enable the full feature set. |
+| `procedural.minOccurrences` | `3` | Minimum cluster recurrence before the miner can emit a candidate (`0` disables the recurrence threshold). |
+| `procedural.successFloor` | `0.7` | Minimum trajectory success rate in `[0, 1]` for miner eligibility. |
+| `procedural.autoPromoteOccurrences` | `8` | When auto-promotion is on, occurrences before `pending_review` → `active`. |
+| `procedural.autoPromoteEnabled` | `false` | Allow automatic promotion of miner candidates that meet thresholds. |
+| `procedural.lookbackDays` | `30` | Trajectory lookback window for mining (days). |
+| `procedural.proceduralMiningCronAutoRegister` | `false` | When `true`, installer may register the nightly procedural mining cron entry. |
+| `procedural.recallMaxProcedures` | `3` | Max procedure previews injected on task-initiation recall (`1`–`10`). |
 
 ## Codex Marketplace (issue #418)
 
@@ -1365,14 +1380,22 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `factArchivalAgeDays` | `90` | `90` |
 | `factArchivalMaxImportance` | `0.3` | `0.3` |
 | `factArchivalMaxAccessCount` | `2` | `2` |
-| `factArchivalProtectedCategories` | `["commitment","preference","decision","principle"]` | `["commitment","preference","decision","principle"]` |
+| `factArchivalProtectedCategories` | `["commitment","preference","decision","principle","procedure"]` | `["commitment","preference","decision","principle","procedure"]` |
 | `lifecyclePolicyEnabled` | `false` | `false` until you are ready to measure lifecycle outcomes |
 | `lifecycleFilterStaleEnabled` | `false` | `false` for the initial lifecycle rollout |
 | `lifecyclePromoteHeatThreshold` | `0.55` | `0.55` |
 | `lifecycleStaleDecayThreshold` | `0.65` | `0.65` |
 | `lifecycleArchiveDecayThreshold` | `0.85` | `0.85` |
-| `lifecycleProtectedCategories` | `["decision","principle","commitment","preference"]` | `["decision","principle","commitment","preference"]` |
+| `lifecycleProtectedCategories` | `["decision","principle","commitment","preference","procedure"]` | `["decision","principle","commitment","preference","procedure"]` |
 | `lifecycleMetricsEnabled` | `false` | `true` when `lifecyclePolicyEnabled=true` |
+| `procedural.enabled` | `false` | `true` only after reading [procedural-memory.md](procedural-memory.md) and validating extraction + recall impact |
+| `procedural.minOccurrences` | `3` | `3` |
+| `procedural.successFloor` | `0.7` | `0.7` |
+| `procedural.autoPromoteOccurrences` | `8` | `8` |
+| `procedural.autoPromoteEnabled` | `false` | `false` until promotion rules are validated on your corpus |
+| `procedural.lookbackDays` | `30` | `30` |
+| `procedural.proceduralMiningCronAutoRegister` | `false` | `false` unless you intentionally want installer cron registration |
+| `procedural.recallMaxProcedures` | `3` | `3` |
 | `proactiveExtractionEnabled` | `false` | `false` until you validate the second pass in your environment |
 | `contextCompressionActionsEnabled` | `false` | `false` unless you are validating action-policy flows |
 | `compressionGuidelineLearningEnabled` | `false` | `false` unless action-policy telemetry is already stable |

--- a/docs/enable-all-v8.md
+++ b/docs/enable-all-v8.md
@@ -36,6 +36,11 @@ Apply under:
   "lifecycleFilterStaleEnabled": true,
   "lifecycleMetricsEnabled": true,
 
+  "procedural": {
+    "enabled": true,
+    "proceduralMiningCronAutoRegister": false
+  },
+
   "proactiveExtractionEnabled": true,
   "contextCompressionActionsEnabled": true,
   "compressionGuidelineLearningEnabled": true,
@@ -72,6 +77,7 @@ Apply under:
 - `debug: true` is recommended while validating; disable later for quieter logs.
 - If you use `conversationIndexBackend: "faiss"`, install `scripts/faiss_requirements.txt` first and optionally set `ENGRAM_FAISS_ENABLE_ST=1` for sentence-transformers embeddings.
 - If you prefer QMD for transcript recall, swap the FAISS fields for `conversationIndexBackend: "qmd"` plus `conversationIndexQmdCollection`.
+- **`procedural.enabled`** turns on issue #519 procedural memory (writes under `procedures/`, recall injection, mining). The sample block above enables it; remove the `procedural` object or set `"enabled": false` if you want this profile without procedural behavior. See [procedural-memory.md](procedural-memory.md).
 
 ## Required Restart
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -219,6 +219,7 @@ See [Search Backends](search-backends.md) for a full comparison and configuratio
 ## Next Steps
 
 - [Search Backends](search-backends.md) — choose and configure your search engine
+- [Procedural memory](procedural-memory.md) — optional how-to / runbook memories (issue #519); **defaults off** — set `procedural.enabled` to `true` under the Remnic plugin config when you want extraction, mining, and recall-time procedure injection
 - [Enable All Features](enable-all-v8.md) — explicit full-profile config for all feature families
 - [Config Reference](config-reference.md) — full settings list with defaults and recommended values
 - [Operations](operations.md) — backups, exports, hourly summaries

--- a/docs/procedural-memory.md
+++ b/docs/procedural-memory.md
@@ -4,6 +4,8 @@ Procedural memories are first-class **`category: procedure`** items stored under
 
 This feature tracks [issue #519](https://github.com/joshuaswarren/remnic/issues/519).
 
+Also indexed from the repo [README](../README.md) (Features + Configuration), [Getting started](getting-started.md) (Next steps), and [Config reference](config-reference.md) (Procedural memory section) so operators and agents see the **`procedural.enabled`** gate without opening this page first.
+
 ## Enablement
 
 Everything behavioral is gated by plugin config **`procedural.enabled`** (default **`false`**). When disabled:

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -434,7 +434,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       : 3;
   const procedural: ProceduralConfig = {
     enabled: coerceBool(rawProcedural.enabled) === true,
-    /** 0 disables miner emission threshold (no clusters qualify). */
+    /** `0` skips all mining (`minOccurrences_zero`); otherwise clusters need at least this many members. */
     minOccurrences: Math.min(1000, Math.max(0, proceduralMinRaw)),
     successFloor,
     autoPromoteOccurrences,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -186,7 +186,7 @@ export interface DreamingConfig {
 /** Procedural memory (issue #519): mining + recall gates. All sub-features default off. */
 export interface ProceduralConfig {
   enabled: boolean;
-  /** Minimum recurrence count before emitting a candidate procedure (0 disables mining threshold). */
+  /** Minimum cluster size before emitting a candidate; `0` disables mining (`minOccurrences_zero`). */
   minOccurrences: number;
   /** Minimum success rate from trajectory outcomes in [0, 1]. */
   successFloor: number;

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -23,6 +23,7 @@ See `AGENTS.md` (root) for the full list. Key reminders:
 3. **`no_recall` gates everything** — when planner returns `no_recall`, skip all retrieval paths.
 4. **Config `0` means `0`** — never coerce zero limits to non-zero values.
 5. **OpenAI Responses API only** — never use Chat Completions anywhere in this directory.
+6. **Procedural memory (issue #519)** — Shipped **off** until `procedural.enabled` is `true` in plugin config. See `docs/procedural-memory.md` before changing procedure extraction, recall injection, or mining.
 
 ## File Ownership
 


### PR DESCRIPTION
## Summary

Issue #519 procedural memory shipped **off** until `procedural.enabled` is set. The deep reference was already in `docs/procedural-memory.md`, but README, getting started, config reference, and agent guides did not point people (or agents) at that gate.

## Changes

- **README** — Features bullet, Configuration table row (`procedural.enabled`), Documentation list link.
- **docs/config-reference.md** — New **Procedural memory** section with nested keys; appendix rows; lifecycle + fact-archival protected-category defaults aligned with `parseConfig` (includes `procedure`).
- **docs/getting-started.md** — Next step + explicit opt-in sentence.
- **docs/enable-all-v8.md** — Sample `procedural` block + safety note (and how to disable).
- **docs/procedural-memory.md** — Cross-links back to README / getting started / config reference.
- **AGENTS.md**, **src/AGENTS.md**, **CLAUDE.md** — Short invariant-style pointers for agents.

## Testing

Documentation-only; no code paths changed.

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily documentation and guide updates; the only code changes are comment/docstring clarifications, so there’s minimal behavioral risk.
> 
> **Overview**
> Makes the *procedural memory* feature gate (`procedural.enabled`, default `false`) visible across operator/agent-facing docs (README, getting started, enable-all profile, AGENTS/CLAUDE guides) and adds a dedicated section to `docs/config-reference.md` documenting the nested `procedural.*` knobs.
> 
> Aligns documentation defaults to treat `procedure` as a protected category in lifecycle and fact-archival settings, and clarifies in code comments that `procedural.minOccurrences=0` fully skips mining (rather than acting as a threshold).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b97c13e5b31b5ed4fdbeb8c794c66282234e660. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->