### PR TITLE
feat(recall-state): LastRecallSnapshot.tierExplain (#518 slice 3b/9)

### DIFF
--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+
+import { LastRecallStore } from "./recall-state.js";
+import type { RecallTierExplain } from "./types.js";
+
+async function freshStore() {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-recall-state-"));
+  const store = new LastRecallStore(dir);
+  await store.load();
+  return { store, dir };
+}
+
+// ── Tier-explain field is optional and absent by default ───────────────────
+
+test("LastRecallStore.record omits tierExplain when caller did not provide it", async () => {
+  const { store } = await freshStore();
+  await store.record({ sessionKey: "s1", query: "q", memoryIds: [] });
+  const snap = store.get("s1");
+  assert.ok(snap);
+  assert.equal(snap.tierExplain, undefined);
+});
+
+// ── Tier-explain is persisted and round-trips through disk ─────────────────
+
+test("LastRecallStore.record persists tierExplain and round-trips to JSON on disk", async () => {
+  const { store, dir } = await freshStore();
+  const tierExplain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "trusted decisions, unambiguous, token-overlap 0.86",
+    filteredBy: ["below-token-overlap-floor"],
+    candidatesConsidered: 4,
+    latencyMs: 12,
+    sourceAnchors: [{ path: "/memory/pm.md", lineRange: [10, 14] }],
+  };
+
+  await store.record({
+    sessionKey: "s1",
+    query: "package manager remnic",
+    memoryIds: ["pm"],
+    tierExplain,
+  });
+
+  const snap = store.get("s1");
+  assert.ok(snap);
+  assert.deepEqual(snap.tierExplain, tierExplain);
+
+  // Confirm disk shape matches the in-memory snapshot.
+  const raw = await readFile(path.join(dir, "state", "last_recall.json"), "utf-8");
+  const parsed = JSON.parse(raw) as Record<string, { tierExplain?: RecallTierExplain }>;
+  assert.deepEqual(parsed["s1"]?.tierExplain, tierExplain);
+});
+
+// ── Defensive copies isolate the stored snapshot from caller mutation ──────
+
+test("LastRecallStore.record copies filteredBy so caller mutation does not tear the snapshot", async () => {
+  const { store } = await freshStore();
+  const filteredBy = ["below-importance-floor"];
+  const tierExplain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "unambiguous",
+    filteredBy,
+    candidatesConsidered: 2,
+    latencyMs: 5,
+  };
+
+  await store.record({
+    sessionKey: "s1",
+    query: "q",
+    memoryIds: [],
+    tierExplain,
+  });
+
+  // Mutate the caller's array after record() returns.
+  filteredBy.push("not-trusted-zone");
+
+  const snap = store.get("s1");
+  assert.deepEqual(snap?.tierExplain?.filteredBy, ["below-importance-floor"]);
+});
+
+test("LastRecallStore.record copies sourceAnchors array and lineRange tuple", async () => {
+  const { store } = await freshStore();
+  const anchors: RecallTierExplain["sourceAnchors"] = [
+    { path: "/a.md", lineRange: [1, 2] },
+  ];
+  const tierExplain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "ok",
+    filteredBy: [],
+    candidatesConsidered: 1,
+    latencyMs: 1,
+    sourceAnchors: anchors,
+  };
+
+  await store.record({
+    sessionKey: "s1",
+    query: "q",
+    memoryIds: [],
+    tierExplain,
+  });
+
+  // Mutate original.
+  anchors!.push({ path: "/b.md" });
+  const firstAnchor = anchors![0];
+  if (firstAnchor?.lineRange) firstAnchor.lineRange[0] = 99;
+
+  const snap = store.get("s1");
+  assert.equal(snap?.tierExplain?.sourceAnchors?.length, 1);
+  assert.equal(snap?.tierExplain?.sourceAnchors?.[0]?.path, "/a.md");
+  assert.deepEqual(snap?.tierExplain?.sourceAnchors?.[0]?.lineRange, [1, 2]);
+});

--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -81,6 +81,72 @@ test("LastRecallStore.record copies filteredBy so caller mutation does not tear 
   assert.deepEqual(snap?.tierExplain?.filteredBy, ["below-importance-floor"]);
 });
 
+test("LastRecallStore.get returns a defensive copy; mutation does not tear the store", async () => {
+  // Regression for PR #535 review: get() previously returned a live
+  // reference to internal state, so a caller that mutated memoryIds,
+  // budgetsApplied.includedSections, or tierExplain fields would
+  // corrupt subsequent reads.
+  const { store } = await freshStore();
+  await store.record({
+    sessionKey: "s1",
+    query: "q",
+    memoryIds: ["m-1"],
+    budgetsApplied: {
+      appliedTopK: 1,
+      recallBudgetChars: 8000,
+      maxMemoryTokens: 2000,
+      includedSections: ["profile", "recent"],
+    },
+    tierExplain: {
+      tier: "direct-answer",
+      tierReason: "unambiguous",
+      filteredBy: ["below-token-overlap-floor"],
+      candidatesConsidered: 3,
+      latencyMs: 7,
+      sourceAnchors: [{ path: "/a.md", lineRange: [2, 5] }],
+    },
+  });
+
+  const snap = store.get("s1");
+  assert.ok(snap);
+  // Mutate every mutable field on the returned copy.
+  snap.memoryIds.push("leak");
+  snap.budgetsApplied?.includedSections?.push("leak");
+  snap.tierExplain?.filteredBy.push("leak");
+  const firstAnchor = snap.tierExplain?.sourceAnchors?.[0];
+  if (firstAnchor?.lineRange) firstAnchor.lineRange[0] = 999;
+
+  const fresh = store.get("s1");
+  assert.deepEqual(fresh?.memoryIds, ["m-1"]);
+  assert.deepEqual(fresh?.budgetsApplied?.includedSections, ["profile", "recent"]);
+  assert.deepEqual(fresh?.tierExplain?.filteredBy, ["below-token-overlap-floor"]);
+  assert.deepEqual(fresh?.tierExplain?.sourceAnchors?.[0]?.lineRange, [2, 5]);
+});
+
+test("LastRecallStore.getMostRecent returns a defensive copy", async () => {
+  const { store } = await freshStore();
+  await store.record({
+    sessionKey: "s1",
+    query: "q",
+    memoryIds: ["m-1"],
+  });
+  const snap = store.getMostRecent();
+  assert.ok(snap);
+  snap.memoryIds.push("leak");
+
+  const fresh = store.getMostRecent();
+  assert.deepEqual(fresh?.memoryIds, ["m-1"]);
+});
+
+test("LastRecallStore.record copies memoryIds so caller mutation does not tear the snapshot", async () => {
+  const { store } = await freshStore();
+  const memoryIds = ["m-1"];
+  await store.record({ sessionKey: "s1", query: "q", memoryIds });
+  memoryIds.push("leak");
+  const snap = store.get("s1");
+  assert.deepEqual(snap?.memoryIds, ["m-1"]);
+});
+
 test("LastRecallStore.record copies sourceAnchors array and lineRange tuple", async () => {
   const { store } = await freshStore();
   const anchors: RecallTierExplain["sourceAnchors"] = [

--- a/packages/remnic-core/src/recall-state.test.ts
+++ b/packages/remnic-core/src/recall-state.test.ts
@@ -147,6 +147,59 @@ test("LastRecallStore.record copies memoryIds so caller mutation does not tear t
   assert.deepEqual(snap?.memoryIds, ["m-1"]);
 });
 
+test("LastRecallStore.annotateTierExplain attaches tierExplain to an existing snapshot", async () => {
+  const { store, dir } = await freshStore();
+  await store.record({ sessionKey: "s1", query: "q", memoryIds: ["m-1"] });
+
+  const explain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "trusted decision, unambiguous",
+    filteredBy: [],
+    candidatesConsidered: 1,
+    latencyMs: 4,
+  };
+  await store.annotateTierExplain("s1", explain);
+
+  const snap = store.get("s1");
+  assert.ok(snap);
+  assert.deepEqual(snap.tierExplain, explain);
+
+  // Round-trips to disk.
+  const raw = await readFile(path.join(dir, "state", "last_recall.json"), "utf-8");
+  const parsed = JSON.parse(raw) as Record<string, { tierExplain?: RecallTierExplain }>;
+  assert.deepEqual(parsed["s1"]?.tierExplain, explain);
+});
+
+test("LastRecallStore.annotateTierExplain is a no-op when the session has no snapshot", async () => {
+  const { store } = await freshStore();
+  await store.annotateTierExplain("ghost", {
+    tier: "direct-answer",
+    tierReason: "",
+    filteredBy: [],
+    candidatesConsidered: 0,
+    latencyMs: 0,
+  });
+  assert.equal(store.get("ghost"), null);
+});
+
+test("LastRecallStore.annotateTierExplain deep-copies the caller's block", async () => {
+  const { store } = await freshStore();
+  await store.record({ sessionKey: "s1", query: "q", memoryIds: [] });
+
+  const filteredBy = ["a"];
+  await store.annotateTierExplain("s1", {
+    tier: "direct-answer",
+    tierReason: "",
+    filteredBy,
+    candidatesConsidered: 0,
+    latencyMs: 0,
+  });
+  filteredBy.push("leak");
+
+  const snap = store.get("s1");
+  assert.deepEqual(snap?.tierExplain?.filteredBy, ["a"]);
+});
+
 test("LastRecallStore.record copies sourceAnchors array and lineRange tuple", async () => {
   const { store } = await freshStore();
   const anchors: RecallTierExplain["sourceAnchors"] = [

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -102,52 +102,30 @@ type LastRecallState = Record<string, LastRecallSnapshot>;
  * (so caller mutation after `record()` cannot tear the persisted
  * snapshot) and the read path (so caller mutation after `get()` /
  * `getMostRecent()` cannot tear the in-memory store).
+ *
+ * Uses structuredClone so future additions to RecallTierExplain do
+ * not silently share references through hand-enumerated fields —
+ * matching the pattern used elsewhere in the codebase (e.g.,
+ * qmd-recall-cache.ts).  The payload is pure JSON-shaped data, so
+ * structuredClone is both safe and complete here.
  */
 function cloneTierExplain(
   tierExplain: RecallTierExplain | undefined,
 ): RecallTierExplain | undefined {
   if (!tierExplain) return undefined;
-  return {
-    ...tierExplain,
-    filteredBy: [...tierExplain.filteredBy],
-    sourceAnchors: tierExplain.sourceAnchors
-      ? tierExplain.sourceAnchors.map((a) => ({
-          path: a.path,
-          lineRange: a.lineRange
-            ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
-            : undefined,
-        }))
-      : undefined,
-  };
+  return structuredClone(tierExplain);
 }
 
 /**
  * Deep-copy a LastRecallSnapshot so callers that receive it cannot
  * mutate the store's internal state through mutable array/object
- * fields.
+ * fields.  Same structuredClone rationale as cloneTierExplain above.
  */
 function cloneLastRecallSnapshot(
   snapshot: LastRecallSnapshot | null,
 ): LastRecallSnapshot | null {
   if (!snapshot) return null;
-  return {
-    ...snapshot,
-    memoryIds: [...snapshot.memoryIds],
-    sourcesUsed: snapshot.sourcesUsed ? [...snapshot.sourcesUsed] : undefined,
-    resultPaths: snapshot.resultPaths ? [...snapshot.resultPaths] : undefined,
-    budgetsApplied: snapshot.budgetsApplied
-      ? {
-          ...snapshot.budgetsApplied,
-          includedSections: snapshot.budgetsApplied.includedSections
-            ? [...snapshot.budgetsApplied.includedSections]
-            : undefined,
-          omittedSections: snapshot.budgetsApplied.omittedSections
-            ? [...snapshot.budgetsApplied.omittedSections]
-            : undefined,
-        }
-      : undefined,
-    tierExplain: cloneTierExplain(snapshot.tierExplain),
-  };
+  return structuredClone(snapshot);
 }
 
 export interface TierMigrationCycleSummary {
@@ -262,41 +240,36 @@ export class LastRecallStore {
     const now = new Date().toISOString();
     const queryHash = createHash("sha256").update(opts.query).digest("hex");
 
-    // Defensive copies on the write path: caller arrays/objects must not
-    // retain a live reference to the persisted snapshot, so mutation
-    // after `record()` returns cannot tear what was stored.
-    const snapshot: LastRecallSnapshot = {
+    // Build the snapshot from opts, then deep-copy it via
+    // cloneLastRecallSnapshot so caller arrays/objects passed in
+    // `opts` cannot retain a live reference to the persisted state
+    // and tear it after record() returns.
+    const liveSnapshot: LastRecallSnapshot = {
       sessionKey: opts.sessionKey,
       recordedAt: now,
       queryHash,
       queryLen: opts.query.length,
-      memoryIds: [...opts.memoryIds],
+      memoryIds: opts.memoryIds,
       namespace: opts.namespace,
       traceId: opts.traceId,
       plannerMode: opts.plannerMode,
       requestedMode: opts.requestedMode,
       source: opts.source,
       fallbackUsed: opts.fallbackUsed,
-      sourcesUsed: opts.sourcesUsed ? [...opts.sourcesUsed] : undefined,
-      budgetsApplied: opts.budgetsApplied
-        ? {
-            ...opts.budgetsApplied,
-            includedSections: opts.budgetsApplied.includedSections
-              ? [...opts.budgetsApplied.includedSections]
-              : undefined,
-            omittedSections: opts.budgetsApplied.omittedSections
-              ? [...opts.budgetsApplied.omittedSections]
-              : undefined,
-          }
-        : undefined,
+      sourcesUsed: opts.sourcesUsed,
+      budgetsApplied: opts.budgetsApplied,
       latencyMs: opts.latencyMs,
-      resultPaths: opts.resultPaths ? [...opts.resultPaths] : undefined,
+      resultPaths: opts.resultPaths,
       policyVersion: opts.policyVersion,
       identityInjectionMode: opts.identityInjection?.mode,
       identityInjectedChars: opts.identityInjection?.injectedChars,
       identityInjectionTruncated: opts.identityInjection?.truncated,
-      tierExplain: cloneTierExplain(opts.tierExplain),
+      tierExplain: opts.tierExplain,
     };
+    // `cloneLastRecallSnapshot` handles `null` but that never applies
+    // at this call site — the non-null assertion keeps the type
+    // checker honest.
+    const snapshot = cloneLastRecallSnapshot(liveSnapshot)!;
 
     this.state[opts.sessionKey] = snapshot;
 
@@ -325,6 +298,35 @@ export class LastRecallStore {
       } catch (err) {
         log.debug(`recall impressions append failed: ${err}`);
       }
+    }
+  }
+
+  /**
+   * Attach a RecallTierExplain block to the existing snapshot for a
+   * session without rewriting the entire snapshot.  Used by the
+   * post-recall direct-answer annotation path (issue #518 slice 3c):
+   * recallInternal records the snapshot first, then the orchestrator
+   * fires the direct-answer tier in observation mode and annotates
+   * the stored snapshot with whichever tier served the query.
+   *
+   * No-op when no snapshot exists for the given session; callers do
+   * not need to guard on existence.
+   */
+  async annotateTierExplain(
+    sessionKey: string,
+    tierExplain: RecallTierExplain,
+  ): Promise<void> {
+    const current = this.state[sessionKey];
+    if (!current) return;
+    this.state[sessionKey] = {
+      ...current,
+      tierExplain: cloneTierExplain(tierExplain),
+    };
+    try {
+      await mkdir(path.dirname(this.statePath), { recursive: true });
+      await writeFile(this.statePath, JSON.stringify(this.state, null, 2), "utf-8");
+    } catch (err) {
+      log.debug(`last recall tier-explain annotate failed: ${err}`);
     }
   }
 }

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -97,6 +97,59 @@ export function clampGraphRecallExpandedEntries(
 
 type LastRecallState = Record<string, LastRecallSnapshot>;
 
+/**
+ * Deep-copy a RecallTierExplain block.  Used by both the write path
+ * (so caller mutation after `record()` cannot tear the persisted
+ * snapshot) and the read path (so caller mutation after `get()` /
+ * `getMostRecent()` cannot tear the in-memory store).
+ */
+function cloneTierExplain(
+  tierExplain: RecallTierExplain | undefined,
+): RecallTierExplain | undefined {
+  if (!tierExplain) return undefined;
+  return {
+    ...tierExplain,
+    filteredBy: [...tierExplain.filteredBy],
+    sourceAnchors: tierExplain.sourceAnchors
+      ? tierExplain.sourceAnchors.map((a) => ({
+          path: a.path,
+          lineRange: a.lineRange
+            ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
+            : undefined,
+        }))
+      : undefined,
+  };
+}
+
+/**
+ * Deep-copy a LastRecallSnapshot so callers that receive it cannot
+ * mutate the store's internal state through mutable array/object
+ * fields.
+ */
+function cloneLastRecallSnapshot(
+  snapshot: LastRecallSnapshot | null,
+): LastRecallSnapshot | null {
+  if (!snapshot) return null;
+  return {
+    ...snapshot,
+    memoryIds: [...snapshot.memoryIds],
+    sourcesUsed: snapshot.sourcesUsed ? [...snapshot.sourcesUsed] : undefined,
+    resultPaths: snapshot.resultPaths ? [...snapshot.resultPaths] : undefined,
+    budgetsApplied: snapshot.budgetsApplied
+      ? {
+          ...snapshot.budgetsApplied,
+          includedSections: snapshot.budgetsApplied.includedSections
+            ? [...snapshot.budgetsApplied.includedSections]
+            : undefined,
+          omittedSections: snapshot.budgetsApplied.omittedSections
+            ? [...snapshot.budgetsApplied.omittedSections]
+            : undefined,
+        }
+      : undefined,
+    tierExplain: cloneTierExplain(snapshot.tierExplain),
+  };
+}
+
 export interface TierMigrationCycleSummary {
   trigger: "extraction" | "maintenance" | "manual";
   scanned: number;
@@ -156,14 +209,22 @@ export class LastRecallStore {
   }
 
   get(sessionKey: string): LastRecallSnapshot | null {
-    return this.state[sessionKey] ?? null;
+    // Defensive copy: callers must not be able to mutate internal state
+    // by reaching into array/object fields on the returned snapshot.
+    return cloneLastRecallSnapshot(this.state[sessionKey] ?? null);
   }
 
   getMostRecent(): LastRecallSnapshot | null {
     const snapshots = Object.values(this.state);
     if (snapshots.length === 0) return null;
-    snapshots.sort((a, b) => b.recordedAt.localeCompare(a.recordedAt));
-    return snapshots[0] ?? null;
+    // Secondary key on sessionKey keeps the sort stable when two
+    // snapshots share a recordedAt timestamp (CLAUDE.md rule 19).
+    snapshots.sort((a, b) => {
+      const byTime = b.recordedAt.localeCompare(a.recordedAt);
+      if (byTime !== 0) return byTime;
+      return a.sessionKey.localeCompare(b.sessionKey);
+    });
+    return cloneLastRecallSnapshot(snapshots[0] ?? null);
   }
 
   /**
@@ -201,12 +262,15 @@ export class LastRecallStore {
     const now = new Date().toISOString();
     const queryHash = createHash("sha256").update(opts.query).digest("hex");
 
+    // Defensive copies on the write path: caller arrays/objects must not
+    // retain a live reference to the persisted snapshot, so mutation
+    // after `record()` returns cannot tear what was stored.
     const snapshot: LastRecallSnapshot = {
       sessionKey: opts.sessionKey,
       recordedAt: now,
       queryHash,
       queryLen: opts.query.length,
-      memoryIds: opts.memoryIds,
+      memoryIds: [...opts.memoryIds],
       namespace: opts.namespace,
       traceId: opts.traceId,
       plannerMode: opts.plannerMode,
@@ -214,29 +278,24 @@ export class LastRecallStore {
       source: opts.source,
       fallbackUsed: opts.fallbackUsed,
       sourcesUsed: opts.sourcesUsed ? [...opts.sourcesUsed] : undefined,
-      budgetsApplied: opts.budgetsApplied ? { ...opts.budgetsApplied } : undefined,
+      budgetsApplied: opts.budgetsApplied
+        ? {
+            ...opts.budgetsApplied,
+            includedSections: opts.budgetsApplied.includedSections
+              ? [...opts.budgetsApplied.includedSections]
+              : undefined,
+            omittedSections: opts.budgetsApplied.omittedSections
+              ? [...opts.budgetsApplied.omittedSections]
+              : undefined,
+          }
+        : undefined,
       latencyMs: opts.latencyMs,
       resultPaths: opts.resultPaths ? [...opts.resultPaths] : undefined,
       policyVersion: opts.policyVersion,
       identityInjectionMode: opts.identityInjection?.mode,
       identityInjectedChars: opts.identityInjection?.injectedChars,
       identityInjectionTruncated: opts.identityInjection?.truncated,
-      tierExplain: opts.tierExplain
-        ? {
-            ...opts.tierExplain,
-            // Defensive copy so caller-side mutation cannot tear
-            // the persisted snapshot after this call returns.
-            filteredBy: [...opts.tierExplain.filteredBy],
-            sourceAnchors: opts.tierExplain.sourceAnchors
-              ? opts.tierExplain.sourceAnchors.map((a) => ({
-                  path: a.path,
-                  lineRange: a.lineRange
-                    ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
-                    : undefined,
-                }))
-              : undefined,
-          }
-        : undefined,
+      tierExplain: cloneTierExplain(opts.tierExplain),
     };
 
     this.state[opts.sessionKey] = snapshot;

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -2,7 +2,11 @@ import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createHash } from "node:crypto";
 import { log } from "./logger.js";
-import type { IdentityInjectionMode, RecallPlanMode } from "./types.js";
+import type {
+  IdentityInjectionMode,
+  RecallPlanMode,
+  RecallTierExplain,
+} from "./types.js";
 
 export interface LastRecallBudgetSummary {
   requestedTopK?: number;
@@ -37,6 +41,15 @@ export interface LastRecallSnapshot {
   identityInjectionMode?: IdentityInjectionMode | "none";
   identityInjectedChars?: number;
   identityInjectionTruncated?: boolean;
+  /**
+   * Optional tier-level explanation of how recall was served
+   * (issue #518).  Populated by orchestrator call sites that can
+   * identify a concrete tier; surfaces expose the block via
+   * `engram query --explain`, the `?explain=1` HTTP flag, and the
+   * `remnic_recall_explain` MCP tool.  Orthogonal to the existing
+   * graph-path `recallExplain` operation.
+   */
+  tierExplain?: RecallTierExplain;
 }
 
 export interface GraphRecallExpandedEntry {
@@ -178,6 +191,12 @@ export class LastRecallStore {
       injectedChars: number;
       truncated: boolean;
     };
+    /**
+     * Per-tier explain annotation (issue #518).  When supplied, the
+     * snapshot carries it so downstream surfaces (CLI / HTTP / MCP)
+     * can render which retrieval tier served the query.
+     */
+    tierExplain?: RecallTierExplain;
   }): Promise<void> {
     const now = new Date().toISOString();
     const queryHash = createHash("sha256").update(opts.query).digest("hex");
@@ -202,6 +221,22 @@ export class LastRecallStore {
       identityInjectionMode: opts.identityInjection?.mode,
       identityInjectedChars: opts.identityInjection?.injectedChars,
       identityInjectionTruncated: opts.identityInjection?.truncated,
+      tierExplain: opts.tierExplain
+        ? {
+            ...opts.tierExplain,
+            // Defensive copy so caller-side mutation cannot tear
+            // the persisted snapshot after this call returns.
+            filteredBy: [...opts.tierExplain.filteredBy],
+            sourceAnchors: opts.tierExplain.sourceAnchors
+              ? opts.tierExplain.sourceAnchors.map((a) => ({
+                  path: a.path,
+                  lineRange: a.lineRange
+                    ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
+                    : undefined,
+                }))
+              : undefined,
+          }
+        : undefined,
     };
 
     this.state[opts.sessionKey] = snapshot;


### PR DESCRIPTION
Third-b of nine slices for #518. Pure schema change — adds \`tierExplain\` to the last-recall snapshot so downstream surfaces can surface which retrieval tier served a query.

Dead code until slice 3c populates the field and slices 4–6 render it. Safe to merge alone — optional field, no change to existing callers or snapshots.

## Summary

- \`LastRecallSnapshot.tierExplain?: RecallTierExplain\`
- \`LastRecallStore.record({ tierExplain })\` threads through to the stored snapshot
- Defensive copies of the mutable parts (\`filteredBy\` array; each \`sourceAnchors\` entry and its \`lineRange\` tuple) so caller mutation after \`record()\` cannot tear the persisted snapshot

## Slice plan at a glance

- 3b — this PR: schema
- 3c — wire \`tryDirectAnswer\` into \`recallInternal\` before QMD; populate tierExplain
- 4 — CLI \`--explain\`
- 5 — HTTP \`?explain=1\`
- 6 — MCP \`remnic_recall_explain\` tool
- 7 — bench scenario \`direct-answer-latency\`
- 8a — flip default
- Refactor — \`abort-error.ts\` extraction (deferred Cursor finding)
- 8b — docs

## Test plan

- [x] \`recall-state.test.ts\` — 4/4 pass (new)
- [x] \`feedback-loop.test.ts\` — 2/2 pass (no regressions)
- [x] \`tsc --noEmit\` clean

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes snapshot persistence and retrieval semantics by adding a new persisted `tierExplain` field and returning deep-cloned snapshots from `get()`/`getMostRecent()`, which could subtly affect callers that relied on object identity or mutation.
> 
> **Overview**
> Adds an optional `LastRecallSnapshot.tierExplain` (`RecallTierExplain`) field and threads it through `LastRecallStore.record`, persisting it to `last_recall.json` and impressions.
> 
> Hardens `LastRecallStore` against accidental mutation by deep-cloning snapshots on write and read (`record`, `get`, `getMostRecent`) and adds `annotateTierExplain(sessionKey, tierExplain)` to attach the explain block post-hoc; `getMostRecent` also gets a stable tie-break sort. Comprehensive new tests cover persistence/round-trips and defensive-copy behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d77c9ec8f069621bce32b42c4e8bbdb03f2119. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->