### PR TITLE
feat(cli): recall-explain command + shared renderer (#518 slice 4/9)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3436,9 +3436,20 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             typeof options.session === "string" && options.session.length > 0
               ? options.session
               : undefined;
-          const snapshot = sessionKey
-            ? orchestrator.lastRecall.get(sessionKey)
-            : orchestrator.lastRecall.getMostRecent();
+          // `orchestrator.lastRecall.getMostRecent()` sorts via
+          // `recordedAt.localeCompare(...)`, which throws if a stale/corrupt
+          // `last_recall.json` contains a non-string `recordedAt`. Degrade to
+          // the "no snapshot" response so the CLI stays usable even against
+          // malformed on-disk state (and let renderRecallExplain's own
+          // defensive normalization handle any surviving bad fields).
+          let snapshot: ReturnType<typeof orchestrator.lastRecall.get> = null;
+          try {
+            snapshot = sessionKey
+              ? orchestrator.lastRecall.get(sessionKey)
+              : orchestrator.lastRecall.getMostRecent();
+          } catch {
+            snapshot = null;
+          }
           console.log(renderRecallExplain(snapshot, format));
         });
 

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -15,6 +15,10 @@ import type {
 } from "./types.js";
 import { chunkContent } from "./chunking.js";
 import { rescoreMemoryImportance } from "./importance.js";
+import {
+  parseRecallExplainFormat,
+  renderRecallExplain,
+} from "./recall-explain-renderer.js";
 import { exportJsonBundle } from "./transfer/export-json.js";
 import { exportMarkdownBundle } from "./transfer/export-md.js";
 import { backupMemoryDir } from "./transfer/backup.js";
@@ -3412,6 +3416,30 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
               console.log(`  ${cat}: ${count}`);
             }
           }
+        });
+
+      cmd
+        .command("recall-explain")
+        .description(
+          "Show tier explain for the most recent recall (or a specific session)",
+        )
+        .option(
+          "--session <key>",
+          "Session key to look up; omit to use the most recent snapshot across sessions",
+        )
+        .option("--format <fmt>", "Output format: text (default) or json", "text")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const format = parseRecallExplainFormat(options.format);
+          await orchestrator.lastRecall.load();
+          const sessionKey =
+            typeof options.session === "string" && options.session.length > 0
+              ? options.session
+              : undefined;
+          const snapshot = sessionKey
+            ? orchestrator.lastRecall.get(sessionKey)
+            : orchestrator.lastRecall.getMostRecent();
+          console.log(renderRecallExplain(snapshot, format));
         });
 
       cmd

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -140,6 +140,43 @@ test("toRecallExplainJson coerces an unknown tier string to a safe fallback inst
   assert.equal(payload.tierExplain.tier, "hybrid");
 });
 
+// Regression for codex-connector P2 on PR #537: top-level snapshot fields
+// (sessionKey, recordedAt, namespace, source) come from an unvalidated
+// JSON.parse and can be objects/numbers at runtime. The advertised
+// `string | null` schema must hold; malformed values coerce to null.
+test("toRecallExplainJson sanitizes non-string top-level fields to null", () => {
+  const malformed = {
+    sessionKey: 123,
+    recordedAt: { nested: true },
+    namespace: 7,
+    source: [],
+    memoryIds: ["ok", 42, null, "also-ok"],
+    sourcesUsed: [1, "qmd", false, "rerank"],
+    latencyMs: "not-a-number",
+  } as unknown as LastRecallSnapshot;
+  const payload = toRecallExplainJson(malformed);
+  assert.equal(payload.snapshotFound, true);
+  assert.equal(payload.sessionKey, null);
+  assert.equal(payload.recordedAt, null);
+  assert.equal(payload.namespace, null);
+  assert.equal(payload.source, null);
+  assert.equal(payload.latencyMs, null);
+  assert.deepEqual(payload.memoryIds, ["ok", "also-ok"]);
+  assert.deepEqual(payload.sourcesUsed, ["qmd", "rerank"]);
+});
+
+test("toRecallExplainText prints (unknown) for malformed sessionKey / recordedAt instead of [object Object]", () => {
+  const malformed = {
+    sessionKey: { weird: true },
+    recordedAt: 42,
+    memoryIds: [],
+  } as unknown as LastRecallSnapshot;
+  const out = toRecallExplainText(malformed);
+  assert.ok(out.includes("session: (unknown)"));
+  assert.ok(out.includes("recorded: (unknown)"));
+  assert.ok(!out.includes("[object Object]"));
+});
+
 test("toRecallExplainText renders a malformed tierExplain with empty filtered-by instead of throwing", () => {
   const malformed = {
     tier: "direct-answer",

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -52,6 +52,22 @@ test("toRecallExplainJson reports missing tierExplain when snapshot exists witho
   assert.equal(payload.tierExplain, null);
 });
 
+// Regression for cursor Bugbot finding on PR #537: LastRecallStore.load() does
+// an unvalidated JSON.parse with a type assertion, so tierExplain can be null
+// at runtime even though the TS type says undefined-or-present. hasExplain and
+// the tierExplain field must stay in sync: both null → hasExplain=false.
+test("toRecallExplainJson treats a null tierExplain the same as missing (hasExplain=false)", () => {
+  const snapshot = makeSnapshot({
+    // Force null past the type system to simulate a value that survived an
+    // unvalidated JSON.parse.
+    tierExplain: null as unknown as RecallTierExplain | undefined,
+  });
+  const payload = toRecallExplainJson(snapshot);
+  assert.equal(payload.snapshotFound, true);
+  assert.equal(payload.hasExplain, false);
+  assert.equal(payload.tierExplain, null);
+});
+
 test("toRecallExplainJson serializes tierExplain with all fields", () => {
   const tierExplain = makeTierExplain();
   const payload = toRecallExplainJson(makeSnapshot({ tierExplain }));

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -68,6 +68,91 @@ test("toRecallExplainJson treats a null tierExplain the same as missing (hasExpl
   assert.equal(payload.tierExplain, null);
 });
 
+// Regression for codex-connector findings on PR #537: LastRecallStore.load()
+// is unvalidated, so malformed runtime values must never crash the renderer
+// or produce an internally inconsistent payload (hasExplain true while
+// tierExplain null).
+test("toRecallExplainJson treats falsy-but-defined tierExplain as absent (hasExplain false)", () => {
+  for (const bad of ["", 0, false]) {
+    const snapshot = makeSnapshot({
+      tierExplain: bad as unknown as RecallTierExplain | undefined,
+    });
+    const payload = toRecallExplainJson(snapshot);
+    assert.equal(payload.snapshotFound, true, `input=${JSON.stringify(bad)}`);
+    assert.equal(payload.hasExplain, false, `input=${JSON.stringify(bad)}`);
+    assert.equal(payload.tierExplain, null, `input=${JSON.stringify(bad)}`);
+  }
+});
+
+test("toRecallExplainJson defaults malformed array fields instead of throwing", () => {
+  const malformed = {
+    tier: "direct-answer",
+    tierReason: "stale-snapshot",
+    // Bad shape: should be string[]
+    filteredBy: null as unknown as string[],
+    candidatesConsidered: 3,
+    latencyMs: 5,
+  } as unknown as RecallTierExplain;
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain: malformed }));
+  assert.equal(payload.hasExplain, true);
+  assert.ok(payload.tierExplain);
+  // Normalized to empty array, not a crash
+  assert.deepEqual(payload.tierExplain.filteredBy, []);
+});
+
+test("toRecallExplainJson drops malformed sourceAnchors entries and lineRange", () => {
+  const malformed = {
+    tier: "direct-answer",
+    tierReason: "",
+    filteredBy: [],
+    candidatesConsidered: 0,
+    latencyMs: 0,
+    sourceAnchors: [
+      { path: "/ok.md", lineRange: [1, 2] },
+      { path: "/bad-range.md", lineRange: ["nope", 2] },
+      { noPath: true },
+      "not-an-object",
+    ],
+  } as unknown as RecallTierExplain;
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain: malformed }));
+  assert.ok(payload.tierExplain?.sourceAnchors);
+  assert.equal(payload.tierExplain.sourceAnchors.length, 2);
+  assert.deepEqual(payload.tierExplain.sourceAnchors[0], {
+    path: "/ok.md",
+    lineRange: [1, 2],
+  });
+  // Bad range dropped, path preserved
+  assert.deepEqual(payload.tierExplain.sourceAnchors[1], {
+    path: "/bad-range.md",
+  });
+});
+
+test("toRecallExplainJson coerces an unknown tier string to a safe fallback instead of crashing", () => {
+  const malformed = {
+    tier: "telepathic-hybrid",
+    tierReason: "",
+    filteredBy: [],
+    candidatesConsidered: 0,
+    latencyMs: 0,
+  } as unknown as RecallTierExplain;
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain: malformed }));
+  assert.ok(payload.tierExplain);
+  assert.equal(payload.tierExplain.tier, "hybrid");
+});
+
+test("toRecallExplainText renders a malformed tierExplain with empty filtered-by instead of throwing", () => {
+  const malformed = {
+    tier: "direct-answer",
+    tierReason: "stale",
+    filteredBy: null as unknown as string[],
+    candidatesConsidered: 1,
+    latencyMs: 2,
+  } as unknown as RecallTierExplain;
+  const out = toRecallExplainText(makeSnapshot({ tierExplain: malformed }));
+  assert.ok(out.includes("tier: direct-answer"));
+  assert.ok(out.includes("filtered-by: (none)"));
+});
+
 test("toRecallExplainJson serializes tierExplain with all fields", () => {
   const tierExplain = makeTierExplain();
   const payload = toRecallExplainJson(makeSnapshot({ tierExplain }));

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -1,0 +1,157 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  parseRecallExplainFormat,
+  renderRecallExplain,
+  toRecallExplainJson,
+  toRecallExplainText,
+} from "./recall-explain-renderer.js";
+import type { LastRecallSnapshot } from "./recall-state.js";
+import type { RecallTierExplain } from "./types.js";
+
+function makeSnapshot(overrides: Partial<LastRecallSnapshot> = {}): LastRecallSnapshot {
+  return {
+    sessionKey: "session-a",
+    recordedAt: "2026-04-19T17:30:00.000Z",
+    queryHash: "a".repeat(64),
+    queryLen: 42,
+    memoryIds: ["mem-1", "mem-2"],
+    namespace: "default",
+    ...overrides,
+  };
+}
+
+function makeTierExplain(overrides: Partial<RecallTierExplain> = {}): RecallTierExplain {
+  return {
+    tier: "direct-answer",
+    tierReason: "trusted decisions, unambiguous, token-overlap 0.86",
+    filteredBy: ["below-token-overlap-floor"],
+    candidatesConsidered: 4,
+    latencyMs: 12,
+    sourceAnchors: [{ path: "/memory/pm.md", lineRange: [10, 14] }],
+    ...overrides,
+  };
+}
+
+// ── JSON renderer ───────────────────────────────────────────────────────────
+
+test("toRecallExplainJson with null snapshot reports absence", () => {
+  const payload = toRecallExplainJson(null);
+  assert.equal(payload.snapshotFound, false);
+  assert.equal(payload.hasExplain, false);
+  assert.equal(payload.sessionKey, null);
+  assert.equal(payload.tierExplain, null);
+  assert.deepEqual(payload.memoryIds, []);
+});
+
+test("toRecallExplainJson reports missing tierExplain when snapshot exists without it", () => {
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain: undefined }));
+  assert.equal(payload.snapshotFound, true);
+  assert.equal(payload.hasExplain, false);
+  assert.equal(payload.tierExplain, null);
+});
+
+test("toRecallExplainJson serializes tierExplain with all fields", () => {
+  const tierExplain = makeTierExplain();
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain }));
+  assert.equal(payload.hasExplain, true);
+  assert.deepEqual(payload.tierExplain, tierExplain);
+});
+
+test("toRecallExplainJson deep-copies tierExplain so caller mutation does not tear payload", () => {
+  const tierExplain = makeTierExplain();
+  const payload = toRecallExplainJson(makeSnapshot({ tierExplain }));
+  // Mutate source
+  tierExplain.filteredBy.push("not-trusted-zone");
+  if (tierExplain.sourceAnchors?.[0]?.lineRange) {
+    tierExplain.sourceAnchors[0].lineRange[0] = 999;
+  }
+  assert.deepEqual(payload.tierExplain?.filteredBy, ["below-token-overlap-floor"]);
+  assert.deepEqual(payload.tierExplain?.sourceAnchors?.[0]?.lineRange, [10, 14]);
+});
+
+// ── Text renderer ───────────────────────────────────────────────────────────
+
+test("toRecallExplainText(null) explains that no snapshot exists", () => {
+  const out = toRecallExplainText(null);
+  assert.ok(out.includes("No recall snapshot recorded yet."));
+});
+
+test("toRecallExplainText without tierExplain surfaces the snapshot metadata and a not-populated notice", () => {
+  const out = toRecallExplainText(
+    makeSnapshot({
+      tierExplain: undefined,
+      source: "qmd-hybrid",
+      sourcesUsed: ["qmd", "rerank"],
+      latencyMs: 231,
+    }),
+  );
+  assert.ok(out.includes("session: session-a"));
+  assert.ok(out.includes("source: qmd-hybrid"));
+  assert.ok(out.includes("sources-used: qmd, rerank"));
+  assert.ok(out.includes("latency-ms: 231"));
+  assert.ok(out.includes("memories: mem-1, mem-2"));
+  assert.ok(out.includes("(not populated"));
+});
+
+test("toRecallExplainText with tierExplain renders tier, reason, candidates, latency, filters, and anchors", () => {
+  const out = toRecallExplainText(makeSnapshot({ tierExplain: makeTierExplain() }));
+  assert.ok(out.includes("tier: direct-answer"));
+  assert.ok(out.includes("reason: trusted decisions, unambiguous, token-overlap 0.86"));
+  assert.ok(out.includes("candidates-considered: 4"));
+  assert.ok(out.includes("filtered-by: below-token-overlap-floor"));
+  assert.ok(out.includes("/memory/pm.md:10-14"));
+});
+
+test("toRecallExplainText with empty filteredBy prints (none)", () => {
+  const out = toRecallExplainText(
+    makeSnapshot({ tierExplain: makeTierExplain({ filteredBy: [] }) }),
+  );
+  assert.ok(out.includes("filtered-by: (none)"));
+});
+
+test("toRecallExplainText with anchor lacking lineRange omits the range suffix", () => {
+  const out = toRecallExplainText(
+    makeSnapshot({
+      tierExplain: makeTierExplain({
+        sourceAnchors: [{ path: "/memory/pm.md" }],
+      }),
+    }),
+  );
+  assert.ok(out.includes("/memory/pm.md"));
+  assert.ok(!out.includes("/memory/pm.md:"));
+});
+
+// ── Dispatcher ──────────────────────────────────────────────────────────────
+
+test("renderRecallExplain dispatches to text by default", () => {
+  const out = renderRecallExplain(makeSnapshot({ tierExplain: makeTierExplain() }), "text");
+  assert.ok(out.startsWith("=== Recall Explain ==="));
+});
+
+test("renderRecallExplain produces valid JSON when format=json", () => {
+  const out = renderRecallExplain(makeSnapshot({ tierExplain: makeTierExplain() }), "json");
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.hasExplain, true);
+  assert.equal(parsed.tierExplain.tier, "direct-answer");
+});
+
+// ── Format flag parsing (rule 51) ───────────────────────────────────────────
+
+test("parseRecallExplainFormat accepts undefined and defaults to text", () => {
+  assert.equal(parseRecallExplainFormat(undefined), "text");
+  assert.equal(parseRecallExplainFormat(null), "text");
+});
+
+test("parseRecallExplainFormat accepts text and json (case-insensitive, trimmed)", () => {
+  assert.equal(parseRecallExplainFormat("text"), "text");
+  assert.equal(parseRecallExplainFormat("TEXT"), "text");
+  assert.equal(parseRecallExplainFormat("  json  "), "json");
+});
+
+test("parseRecallExplainFormat rejects unknown values (rule 51)", () => {
+  assert.throws(() => parseRecallExplainFormat("yaml"), /--format expects/);
+  assert.throws(() => parseRecallExplainFormat(""), /--format expects/);
+  assert.throws(() => parseRecallExplainFormat(42), /--format expects/);
+});

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -144,6 +144,56 @@ test("toRecallExplainJson coerces an unknown tier string to a safe fallback inst
 // (sessionKey, recordedAt, namespace, source) come from an unvalidated
 // JSON.parse and can be objects/numbers at runtime. The advertised
 // `string | null` schema must hold; malformed values coerce to null.
+// Regression for codex-connector (P2) + cursor Bugbot on PR #537: arrays
+// pass both `typeof === "object"` and `!value === false`, so an array
+// tierExplain from a corrupt snapshot used to be coerced into a synthetic
+// hybrid explain with zeroed fields, falsely setting hasExplain=true.
+test("toRecallExplainJson rejects an array tierExplain (hasExplain=false)", () => {
+  const snapshot = makeSnapshot({
+    tierExplain: [] as unknown as RecallTierExplain,
+  });
+  const payload = toRecallExplainJson(snapshot);
+  assert.equal(payload.hasExplain, false);
+  assert.equal(payload.tierExplain, null);
+  // Same invariant for a non-empty array
+  const snapshot2 = makeSnapshot({
+    tierExplain: [1, 2, 3] as unknown as RecallTierExplain,
+  });
+  const payload2 = toRecallExplainJson(snapshot2);
+  assert.equal(payload2.hasExplain, false);
+  assert.equal(payload2.tierExplain, null);
+});
+
+// Regression for cursor Bugbot on PR #537: sanitizeString is documented as
+// producing a non-empty string or null, but `""` leaked through and broke
+// the `?? "(unknown)"` fallback in toRecallExplainText.
+test("toRecallExplainJson coerces empty-string top-level fields to null", () => {
+  const payload = toRecallExplainJson({
+    sessionKey: "",
+    recordedAt: "",
+    namespace: "",
+    source: "",
+    memoryIds: [],
+  } as unknown as LastRecallSnapshot);
+  assert.equal(payload.sessionKey, null);
+  assert.equal(payload.recordedAt, null);
+  assert.equal(payload.namespace, null);
+  assert.equal(payload.source, null);
+});
+
+test("toRecallExplainText falls back to (unknown) when sessionKey / recordedAt are empty strings", () => {
+  const out = toRecallExplainText({
+    sessionKey: "",
+    recordedAt: "",
+    memoryIds: [],
+  } as unknown as LastRecallSnapshot);
+  assert.ok(out.includes("session: (unknown)"));
+  assert.ok(out.includes("recorded: (unknown)"));
+  // No bare `session: ` (trailing space with no value)
+  assert.ok(!/session: $/m.test(out));
+  assert.ok(!/recorded: $/m.test(out));
+});
+
 test("toRecallExplainJson sanitizes non-string top-level fields to null", () => {
   const malformed = {
     sessionKey: 123,

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -227,6 +227,57 @@ test("toRecallExplainText prints (unknown) for malformed sessionKey / recordedAt
   assert.ok(!out.includes("[object Object]"));
 });
 
+// Regression for cursor Bugbot on PR #537: typeof NaN === "number", so a
+// plain typeof guard let NaN/Infinity through from a corrupt last_recall.json.
+// JSON.stringify(NaN) emits `null`, breaking the advertised `number` schema,
+// and the text renderer would have printed `latency-ms: NaN`.
+test("toRecallExplainJson rejects NaN and Infinity in numeric fields", () => {
+  const snapshot = {
+    sessionKey: "s",
+    recordedAt: "t",
+    memoryIds: [],
+    latencyMs: Number.NaN,
+    tierExplain: {
+      tier: "direct-answer",
+      tierReason: "",
+      filteredBy: [],
+      candidatesConsidered: Number.NaN,
+      latencyMs: Number.POSITIVE_INFINITY,
+      sourceAnchors: [
+        { path: "/a.md", lineRange: [Number.NaN, 2] },
+        { path: "/b.md", lineRange: [3, Number.POSITIVE_INFINITY] },
+        { path: "/c.md", lineRange: [5, 9] },
+      ],
+    },
+  } as unknown as LastRecallSnapshot;
+  const payload = toRecallExplainJson(snapshot);
+  assert.equal(payload.latencyMs, null);
+  assert.ok(payload.tierExplain);
+  // NaN/Infinity fall back to 0 inside the normalized explain
+  assert.equal(payload.tierExplain.candidatesConsidered, 0);
+  assert.equal(payload.tierExplain.latencyMs, 0);
+  // Only the well-formed anchor survives; malformed ranges are dropped (the
+  // path is still preserved).
+  const good = payload.tierExplain.sourceAnchors?.find((a) => a.path === "/c.md");
+  assert.deepEqual(good?.lineRange, [5, 9]);
+  const badA = payload.tierExplain.sourceAnchors?.find((a) => a.path === "/a.md");
+  assert.equal(badA?.lineRange, undefined);
+  const badB = payload.tierExplain.sourceAnchors?.find((a) => a.path === "/b.md");
+  assert.equal(badB?.lineRange, undefined);
+});
+
+test("toRecallExplainText skips the latency-ms line when latencyMs is NaN", () => {
+  const snapshot = {
+    sessionKey: "s",
+    recordedAt: "t",
+    memoryIds: [],
+    latencyMs: Number.NaN,
+  } as unknown as LastRecallSnapshot;
+  const out = toRecallExplainText(snapshot);
+  assert.ok(!out.includes("latency-ms"));
+  assert.ok(!out.includes("NaN"));
+});
+
 test("toRecallExplainText renders a malformed tierExplain with empty filtered-by instead of throwing", () => {
   const malformed = {
     tier: "direct-answer",

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -38,6 +38,18 @@ function sanitizeString(v: unknown): string | null {
   return typeof v === "string" && v.length > 0 ? v : null;
 }
 
+/**
+ * Narrow an arbitrary persisted numeric field to a finite number or null.
+ * `typeof NaN === "number"`, so a plain `typeof` check lets corrupt state
+ * through.  `JSON.stringify(NaN)` silently emits `null`, so the JSON payload
+ * ends up contradicting its own `number` schema; the text renderer would
+ * print literal `NaN`.  Use `Number.isFinite` to match other defensive
+ * parsers in the codebase (recall-state.ts, access-mcp.ts).
+ */
+function sanitizeFiniteNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
 export type RecallExplainFormat = "text" | "json";
 
 export interface RecallExplainJsonPayload {
@@ -83,12 +95,14 @@ function normalizeTierExplain(value: unknown): RecallTierExplain | null {
         )
         .map((a) => {
           const lr = (a as { lineRange?: unknown }).lineRange;
+          // Require both entries to be finite numbers — NaN/Infinity from a
+          // corrupt snapshot would otherwise pass a plain typeof check.
           const lineRange =
             Array.isArray(lr) &&
             lr.length === 2 &&
-            typeof lr[0] === "number" &&
-            typeof lr[1] === "number"
-              ? ([lr[0], lr[1]] as [number, number])
+            Number.isFinite(lr[0]) &&
+            Number.isFinite(lr[1])
+              ? ([lr[0] as number, lr[1] as number] as [number, number])
               : undefined;
           return lineRange
             ? { path: (a as { path: string }).path, lineRange }
@@ -104,9 +118,8 @@ function normalizeTierExplain(value: unknown): RecallTierExplain | null {
     tier: isRetrievalTier(raw.tier) ? raw.tier : "hybrid",
     tierReason: typeof raw.tierReason === "string" ? raw.tierReason : "",
     filteredBy,
-    candidatesConsidered:
-      typeof raw.candidatesConsidered === "number" ? raw.candidatesConsidered : 0,
-    latencyMs: typeof raw.latencyMs === "number" ? raw.latencyMs : 0,
+    candidatesConsidered: sanitizeFiniteNumber(raw.candidatesConsidered) ?? 0,
+    latencyMs: sanitizeFiniteNumber(raw.latencyMs) ?? 0,
     ...(sourceAnchors !== undefined ? { sourceAnchors } : {}),
   };
 }
@@ -149,7 +162,7 @@ export function toRecallExplainJson(
     sourcesUsed: Array.isArray(snapshot.sourcesUsed)
       ? snapshot.sourcesUsed.filter((x): x is string => typeof x === "string")
       : null,
-    latencyMs: typeof snapshot.latencyMs === "number" ? snapshot.latencyMs : null,
+    latencyMs: sanitizeFiniteNumber(snapshot.latencyMs),
     tierExplain: normalizedExplain,
   };
 }
@@ -184,8 +197,9 @@ export function toRecallExplainText(
   if (sourcesUsed.length > 0) {
     lines.push(`sources-used: ${sourcesUsed.join(", ")}`);
   }
-  if (typeof snapshot.latencyMs === "number") {
-    lines.push(`latency-ms: ${snapshot.latencyMs}`);
+  const latencyMs = sanitizeFiniteNumber(snapshot.latencyMs);
+  if (latencyMs !== null) {
+    lines.push(`latency-ms: ${latencyMs}`);
   }
   const memoryIds = Array.isArray(snapshot.memoryIds)
     ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -29,12 +29,13 @@ function isRetrievalTier(v: unknown): v is RetrievalTier {
  * for the top-level snapshot fields the renderer advertises as
  * `string | null` in its JSON schema: `sessionKey`, `recordedAt`,
  * `namespace`, `source`.  `LastRecallStore.load()` ingests `last_recall.json`
- * via unvalidated `JSON.parse`, so stale/corrupt state could return numbers
- * or objects for these fields.  Coerce anything else to null so HTTP/MCP
- * consumers can rely on the advertised schema.
+ * via unvalidated `JSON.parse`, so stale/corrupt state could return numbers,
+ * objects, or empty strings for these fields.  Empty strings are coerced to
+ * null so downstream `?? "(unknown)"` fallbacks work as intended; `"" ??
+ * "(unknown)"` would otherwise still be `""`.
  */
 function sanitizeString(v: unknown): string | null {
-  return typeof v === "string" ? v : null;
+  return typeof v === "string" && v.length > 0 ? v : null;
 }
 
 export type RecallExplainFormat = "text" | "json";
@@ -65,7 +66,11 @@ export interface RecallExplainJsonPayload {
  * `hasExplain` derive from this single predicate so the payload is coherent.
  */
 function normalizeTierExplain(value: unknown): RecallTierExplain | null {
-  if (!value || typeof value !== "object") return null;
+  // Plain-object check: reject null/undefined/primitive, and also arrays
+  // (typeof [] === "object").  An array tierExplain from a corrupt snapshot
+  // would otherwise be coerced into a synthetic explain with all-zero
+  // defaults, which falsely sets hasExplain=true and misleads consumers.
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
   const raw = value as Record<string, unknown>;
   const filteredBy = Array.isArray(raw.filteredBy)
     ? raw.filteredBy.filter((x): x is string => typeof x === "string")

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -44,7 +44,11 @@ export function toRecallExplainJson(
     };
   }
   return {
-    hasExplain: snapshot.tierExplain !== undefined,
+    // Consistent null/undefined guard with the tierExplain field below
+    // (truthiness): hasExplain must never be true while tierExplain is null.
+    // Cursor Bugbot flagged the prior `!== undefined` check as inconsistent
+    // because `LastRecallStore.load()` can produce a null tierExplain.
+    hasExplain: snapshot.tierExplain != null,
     snapshotFound: true,
     sessionKey: snapshot.sessionKey,
     recordedAt: snapshot.recordedAt,

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -1,0 +1,159 @@
+/**
+ * Renderers for RecallTierExplain (issue #518).
+ *
+ * Pure functions that format a `LastRecallSnapshot` and its
+ * optional `tierExplain` field for human text and machine JSON
+ * consumption.  CLI / HTTP / MCP surfaces consume these — they do
+ * not format explain output themselves, so rendering is tested in
+ * one place.
+ */
+
+import type { LastRecallSnapshot } from "./recall-state.js";
+import type { RecallTierExplain } from "./types.js";
+
+export type RecallExplainFormat = "text" | "json";
+
+export interface RecallExplainJsonPayload {
+  hasExplain: boolean;
+  snapshotFound: boolean;
+  sessionKey: string | null;
+  recordedAt: string | null;
+  namespace: string | null;
+  memoryIds: string[];
+  source: string | null;
+  sourcesUsed: string[] | null;
+  latencyMs: number | null;
+  tierExplain: RecallTierExplain | null;
+}
+
+export function toRecallExplainJson(
+  snapshot: LastRecallSnapshot | null,
+): RecallExplainJsonPayload {
+  if (!snapshot) {
+    return {
+      hasExplain: false,
+      snapshotFound: false,
+      sessionKey: null,
+      recordedAt: null,
+      namespace: null,
+      memoryIds: [],
+      source: null,
+      sourcesUsed: null,
+      latencyMs: null,
+      tierExplain: null,
+    };
+  }
+  return {
+    hasExplain: snapshot.tierExplain !== undefined,
+    snapshotFound: true,
+    sessionKey: snapshot.sessionKey,
+    recordedAt: snapshot.recordedAt,
+    namespace: snapshot.namespace ?? null,
+    memoryIds: [...snapshot.memoryIds],
+    source: snapshot.source ?? null,
+    sourcesUsed: snapshot.sourcesUsed ? [...snapshot.sourcesUsed] : null,
+    latencyMs: snapshot.latencyMs ?? null,
+    tierExplain: snapshot.tierExplain
+      ? {
+          ...snapshot.tierExplain,
+          filteredBy: [...snapshot.tierExplain.filteredBy],
+          sourceAnchors: snapshot.tierExplain.sourceAnchors
+            ? snapshot.tierExplain.sourceAnchors.map((a) => ({
+                path: a.path,
+                lineRange: a.lineRange
+                  ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
+                  : undefined,
+              }))
+            : undefined,
+        }
+      : null,
+  };
+}
+
+/**
+ * Human-readable text rendering.  Fixed layout so the output is easy
+ * to grep and diff; do not introduce locale-specific formatting.
+ */
+export function toRecallExplainText(
+  snapshot: LastRecallSnapshot | null,
+): string {
+  const lines: string[] = ["=== Recall Explain ==="];
+
+  if (!snapshot) {
+    lines.push("No recall snapshot recorded yet.");
+    return lines.join("\n");
+  }
+
+  lines.push(`session: ${snapshot.sessionKey}`);
+  lines.push(`recorded: ${snapshot.recordedAt}`);
+  if (snapshot.namespace) lines.push(`namespace: ${snapshot.namespace}`);
+  if (snapshot.source) lines.push(`source: ${snapshot.source}`);
+  if (snapshot.sourcesUsed && snapshot.sourcesUsed.length > 0) {
+    lines.push(`sources-used: ${snapshot.sourcesUsed.join(", ")}`);
+  }
+  if (typeof snapshot.latencyMs === "number") {
+    lines.push(`latency-ms: ${snapshot.latencyMs}`);
+  }
+  if (snapshot.memoryIds.length > 0) {
+    lines.push(`memories: ${snapshot.memoryIds.join(", ")}`);
+  }
+
+  if (!snapshot.tierExplain) {
+    lines.push("");
+    lines.push(
+      "tier-explain: (not populated — direct-answer tier disabled or did not fire)",
+    );
+    return lines.join("\n");
+  }
+
+  const ex = snapshot.tierExplain;
+  lines.push("");
+  lines.push("--- tier explain ---");
+  lines.push(`tier: ${ex.tier}`);
+  lines.push(`reason: ${ex.tierReason}`);
+  lines.push(`candidates-considered: ${ex.candidatesConsidered}`);
+  lines.push(`latency-ms: ${ex.latencyMs}`);
+  if (ex.filteredBy.length > 0) {
+    lines.push(`filtered-by: ${ex.filteredBy.join(", ")}`);
+  } else {
+    lines.push("filtered-by: (none)");
+  }
+  if (ex.sourceAnchors && ex.sourceAnchors.length > 0) {
+    lines.push("source-anchors:");
+    for (const anchor of ex.sourceAnchors) {
+      const range = anchor.lineRange
+        ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
+        : "";
+      lines.push(`  - ${anchor.path}${range}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function renderRecallExplain(
+  snapshot: LastRecallSnapshot | null,
+  format: RecallExplainFormat,
+): string {
+  if (format === "json") {
+    return JSON.stringify(toRecallExplainJson(snapshot), null, 2);
+  }
+  return toRecallExplainText(snapshot);
+}
+
+/**
+ * Validate a user-supplied format flag.  Throws with a clear message
+ * on invalid input rather than silently defaulting (CLAUDE.md rule 51).
+ */
+export function parseRecallExplainFormat(value: unknown): RecallExplainFormat {
+  if (value === undefined || value === null) return "text";
+  if (typeof value !== "string") {
+    throw new Error(
+      `--format expects "text" or "json", got ${typeof value}`,
+    );
+  }
+  const v = value.trim().toLowerCase();
+  if (v === "text" || v === "json") return v;
+  throw new Error(
+    `--format expects "text" or "json", got ${JSON.stringify(value)}`,
+  );
+}

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -24,6 +24,19 @@ function isRetrievalTier(v: unknown): v is RetrievalTier {
   return typeof v === "string" && (KNOWN_RETRIEVAL_TIERS as readonly string[]).includes(v);
 }
 
+/**
+ * Narrow an arbitrary persisted field to a non-empty string, or null.  Used
+ * for the top-level snapshot fields the renderer advertises as
+ * `string | null` in its JSON schema: `sessionKey`, `recordedAt`,
+ * `namespace`, `source`.  `LastRecallStore.load()` ingests `last_recall.json`
+ * via unvalidated `JSON.parse`, so stale/corrupt state could return numbers
+ * or objects for these fields.  Coerce anything else to null so HTTP/MCP
+ * consumers can rely on the advertised schema.
+ */
+function sanitizeString(v: unknown): string | null {
+  return typeof v === "string" ? v : null;
+}
+
 export type RecallExplainFormat = "text" | "json";
 
 export interface RecallExplainJsonPayload {
@@ -114,15 +127,23 @@ export function toRecallExplainJson(
   // from the same normalized value so the payload is never internally
   // inconsistent, even against malformed persisted state.
   const normalizedExplain = normalizeTierExplain(snapshot.tierExplain);
+  // Top-level fields are forwarded from LastRecallStore.load(), which casts a
+  // raw JSON.parse result.  Sanitize each field to the schema the payload
+  // advertises so downstream HTTP/MCP consumers can rely on `string | null`
+  // and `string[]` invariants even against a stale/corrupt file.
   return {
     hasExplain: normalizedExplain !== null,
     snapshotFound: true,
-    sessionKey: snapshot.sessionKey,
-    recordedAt: snapshot.recordedAt,
-    namespace: snapshot.namespace ?? null,
-    memoryIds: Array.isArray(snapshot.memoryIds) ? [...snapshot.memoryIds] : [],
-    source: snapshot.source ?? null,
-    sourcesUsed: Array.isArray(snapshot.sourcesUsed) ? [...snapshot.sourcesUsed] : null,
+    sessionKey: sanitizeString(snapshot.sessionKey),
+    recordedAt: sanitizeString(snapshot.recordedAt),
+    namespace: sanitizeString(snapshot.namespace),
+    memoryIds: Array.isArray(snapshot.memoryIds)
+      ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
+      : [],
+    source: sanitizeString(snapshot.source),
+    sourcesUsed: Array.isArray(snapshot.sourcesUsed)
+      ? snapshot.sourcesUsed.filter((x): x is string => typeof x === "string")
+      : null,
     latencyMs: typeof snapshot.latencyMs === "number" ? snapshot.latencyMs : null,
     tierExplain: normalizedExplain,
   };
@@ -142,18 +163,30 @@ export function toRecallExplainText(
     return lines.join("\n");
   }
 
-  lines.push(`session: ${snapshot.sessionKey}`);
-  lines.push(`recorded: ${snapshot.recordedAt}`);
-  if (snapshot.namespace) lines.push(`namespace: ${snapshot.namespace}`);
-  if (snapshot.source) lines.push(`source: ${snapshot.source}`);
-  if (Array.isArray(snapshot.sourcesUsed) && snapshot.sourcesUsed.length > 0) {
-    lines.push(`sources-used: ${snapshot.sourcesUsed.join(", ")}`);
+  // Sanitize the same top-level fields the JSON payload sanitizes so text
+  // output is equally robust to a stale/corrupt last_recall.json.
+  const sessionKey = sanitizeString(snapshot.sessionKey);
+  const recordedAt = sanitizeString(snapshot.recordedAt);
+  const namespace = sanitizeString(snapshot.namespace);
+  const source = sanitizeString(snapshot.source);
+  lines.push(`session: ${sessionKey ?? "(unknown)"}`);
+  lines.push(`recorded: ${recordedAt ?? "(unknown)"}`);
+  if (namespace) lines.push(`namespace: ${namespace}`);
+  if (source) lines.push(`source: ${source}`);
+  const sourcesUsed = Array.isArray(snapshot.sourcesUsed)
+    ? snapshot.sourcesUsed.filter((x): x is string => typeof x === "string")
+    : [];
+  if (sourcesUsed.length > 0) {
+    lines.push(`sources-used: ${sourcesUsed.join(", ")}`);
   }
   if (typeof snapshot.latencyMs === "number") {
     lines.push(`latency-ms: ${snapshot.latencyMs}`);
   }
-  if (Array.isArray(snapshot.memoryIds) && snapshot.memoryIds.length > 0) {
-    lines.push(`memories: ${snapshot.memoryIds.join(", ")}`);
+  const memoryIds = Array.isArray(snapshot.memoryIds)
+    ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
+    : [];
+  if (memoryIds.length > 0) {
+    lines.push(`memories: ${memoryIds.join(", ")}`);
   }
 
   // Use the same validated/normalized explain as toRecallExplainJson so the

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -9,7 +9,20 @@
  */
 
 import type { LastRecallSnapshot } from "./recall-state.js";
-import type { RecallTierExplain } from "./types.js";
+import type { RecallTierExplain, RetrievalTier } from "./types.js";
+
+const KNOWN_RETRIEVAL_TIERS: readonly RetrievalTier[] = [
+  "exact-cache",
+  "fuzzy-cache",
+  "direct-answer",
+  "hybrid",
+  "rerank-graph",
+  "agentic",
+];
+
+function isRetrievalTier(v: unknown): v is RetrievalTier {
+  return typeof v === "string" && (KNOWN_RETRIEVAL_TIERS as readonly string[]).includes(v);
+}
 
 export type RecallExplainFormat = "text" | "json";
 
@@ -24,6 +37,60 @@ export interface RecallExplainJsonPayload {
   sourcesUsed: string[] | null;
   latencyMs: number | null;
   tierExplain: RecallTierExplain | null;
+}
+
+/**
+ * Defensively validate and normalize a tierExplain value.  Returns a fresh,
+ * well-shaped `RecallTierExplain` if the input is usable, otherwise null.
+ *
+ * `LastRecallStore.load()` ingests `last_recall.json` via unvalidated
+ * `JSON.parse`, so the runtime value may be null, undefined, a non-object, or
+ * an object with malformed fields (e.g., `filteredBy: null`, `tier: 0`).
+ * Without this guard the renderer can crash (`TypeError` from spreading a
+ * non-iterable) and produce an internally inconsistent payload (hasExplain
+ * true while the serialized tierExplain is null).  All rendering paths and
+ * `hasExplain` derive from this single predicate so the payload is coherent.
+ */
+function normalizeTierExplain(value: unknown): RecallTierExplain | null {
+  if (!value || typeof value !== "object") return null;
+  const raw = value as Record<string, unknown>;
+  const filteredBy = Array.isArray(raw.filteredBy)
+    ? raw.filteredBy.filter((x): x is string => typeof x === "string")
+    : [];
+  const sourceAnchors = Array.isArray(raw.sourceAnchors)
+    ? raw.sourceAnchors
+        .filter(
+          (a): a is { path: string; lineRange?: unknown } =>
+            !!a && typeof a === "object" && typeof (a as { path?: unknown }).path === "string",
+        )
+        .map((a) => {
+          const lr = (a as { lineRange?: unknown }).lineRange;
+          const lineRange =
+            Array.isArray(lr) &&
+            lr.length === 2 &&
+            typeof lr[0] === "number" &&
+            typeof lr[1] === "number"
+              ? ([lr[0], lr[1]] as [number, number])
+              : undefined;
+          return lineRange
+            ? { path: (a as { path: string }).path, lineRange }
+            : { path: (a as { path: string }).path };
+        })
+    : undefined;
+  // A malformed/unknown tier is preserved as a string so operators can still
+  // see what was written, but we coerce to `hybrid` (the generic fallback)
+  // when it does not match the closed union so downstream consumers stay
+  // well-typed.  Reject the whole explain only when structural invariants
+  // fail (non-object); string/number mismatches degrade gracefully.
+  return {
+    tier: isRetrievalTier(raw.tier) ? raw.tier : "hybrid",
+    tierReason: typeof raw.tierReason === "string" ? raw.tierReason : "",
+    filteredBy,
+    candidatesConsidered:
+      typeof raw.candidatesConsidered === "number" ? raw.candidatesConsidered : 0,
+    latencyMs: typeof raw.latencyMs === "number" ? raw.latencyMs : 0,
+    ...(sourceAnchors !== undefined ? { sourceAnchors } : {}),
+  };
 }
 
 export function toRecallExplainJson(
@@ -43,34 +110,21 @@ export function toRecallExplainJson(
       tierExplain: null,
     };
   }
+  // Single predicate: derive both `hasExplain` and the serialized `tierExplain`
+  // from the same normalized value so the payload is never internally
+  // inconsistent, even against malformed persisted state.
+  const normalizedExplain = normalizeTierExplain(snapshot.tierExplain);
   return {
-    // Consistent null/undefined guard with the tierExplain field below
-    // (truthiness): hasExplain must never be true while tierExplain is null.
-    // Cursor Bugbot flagged the prior `!== undefined` check as inconsistent
-    // because `LastRecallStore.load()` can produce a null tierExplain.
-    hasExplain: snapshot.tierExplain != null,
+    hasExplain: normalizedExplain !== null,
     snapshotFound: true,
     sessionKey: snapshot.sessionKey,
     recordedAt: snapshot.recordedAt,
     namespace: snapshot.namespace ?? null,
-    memoryIds: [...snapshot.memoryIds],
+    memoryIds: Array.isArray(snapshot.memoryIds) ? [...snapshot.memoryIds] : [],
     source: snapshot.source ?? null,
-    sourcesUsed: snapshot.sourcesUsed ? [...snapshot.sourcesUsed] : null,
-    latencyMs: snapshot.latencyMs ?? null,
-    tierExplain: snapshot.tierExplain
-      ? {
-          ...snapshot.tierExplain,
-          filteredBy: [...snapshot.tierExplain.filteredBy],
-          sourceAnchors: snapshot.tierExplain.sourceAnchors
-            ? snapshot.tierExplain.sourceAnchors.map((a) => ({
-                path: a.path,
-                lineRange: a.lineRange
-                  ? ([a.lineRange[0], a.lineRange[1]] as [number, number])
-                  : undefined,
-              }))
-            : undefined,
-        }
-      : null,
+    sourcesUsed: Array.isArray(snapshot.sourcesUsed) ? [...snapshot.sourcesUsed] : null,
+    latencyMs: typeof snapshot.latencyMs === "number" ? snapshot.latencyMs : null,
+    tierExplain: normalizedExplain,
   };
 }
 
@@ -92,17 +146,20 @@ export function toRecallExplainText(
   lines.push(`recorded: ${snapshot.recordedAt}`);
   if (snapshot.namespace) lines.push(`namespace: ${snapshot.namespace}`);
   if (snapshot.source) lines.push(`source: ${snapshot.source}`);
-  if (snapshot.sourcesUsed && snapshot.sourcesUsed.length > 0) {
+  if (Array.isArray(snapshot.sourcesUsed) && snapshot.sourcesUsed.length > 0) {
     lines.push(`sources-used: ${snapshot.sourcesUsed.join(", ")}`);
   }
   if (typeof snapshot.latencyMs === "number") {
     lines.push(`latency-ms: ${snapshot.latencyMs}`);
   }
-  if (snapshot.memoryIds.length > 0) {
+  if (Array.isArray(snapshot.memoryIds) && snapshot.memoryIds.length > 0) {
     lines.push(`memories: ${snapshot.memoryIds.join(", ")}`);
   }
 
-  if (!snapshot.tierExplain) {
+  // Use the same validated/normalized explain as toRecallExplainJson so the
+  // text and JSON renderers agree on when data is "present enough to show".
+  const ex = normalizeTierExplain(snapshot.tierExplain);
+  if (!ex) {
     lines.push("");
     lines.push(
       "tier-explain: (not populated — direct-answer tier disabled or did not fire)",
@@ -110,7 +167,6 @@ export function toRecallExplainText(
     return lines.join("\n");
   }
 
-  const ex = snapshot.tierExplain;
   lines.push("");
   lines.push("--- tier explain ---");
   lines.push(`tier: ${ex.tier}`);


### PR DESCRIPTION
Fourth of nine slices for #518. Stacked on PR #535 (slice 3b — \`LastRecallSnapshot.tierExplain\` schema). Retargets to \`main\` once #535 merges.

## Summary

- New \`engram recall-explain [--session <key>] [--format text|json]\` CLI command.
- New renderer module \`recall-explain-renderer.ts\` consumed by this CLI now and by HTTP / MCP slices next.
- Reads the last-recall snapshot for the requested session (most recent across sessions by default) and renders the tier explain block if present, with a clear "(not populated)" notice when direct-answer has not fired.

## Behavior

- \`--format\` validates to \`text\` or \`json\` (case-insensitive, trimmed). Unknown values are rejected with a clear message — no silent default (CLAUDE.md rule 51).
- JSON payload is a stable shape \`{ hasExplain, snapshotFound, sessionKey, recordedAt, namespace, memoryIds, source, sourcesUsed, latencyMs, tierExplain }\`. Deep-copies \`tierExplain\` through so caller-side mutation of the snapshot cannot tear the rendered payload.
- Text format is fixed layout (no locale-specific formatting) so the output is easy to grep and diff.

## Slice plan

- 3b (PR #535): \`LastRecallSnapshot.tierExplain\` schema
- **4 (this PR): CLI renderer + recall-explain command**
- 5: HTTP \`?explain=1\`
- 6: MCP \`remnic_recall_explain\` tool
- 3c: orchestrator wiring (actual populate of tierExplain from recall path)
- 7: bench \`direct-answer-latency\`
- 8a: flip default
- Refactor: abort-error.ts extraction
- 8b: docs

## Test plan

- [x] \`recall-explain-renderer.test.ts\` — 14/14 pass
- [x] \`recall-state.test.ts\` — 4/4 pass (no regressions)
- [x] \`tsc --noEmit\` clean
- [x] Manual CLI integration sanity check not required — renderer is the only non-trivial logic and is fully covered by unit tests

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new CLI command and a standalone renderer module with defensive handling of malformed on-disk `last_recall.json` data, without changing recall behavior or storage formats.
> 
> **Overview**
> Adds a new `engram recall-explain` CLI command that loads the most recent (or specified) last-recall snapshot and prints a tier-explain report in either `text` or `json`.
> 
> Introduces a shared `recall-explain-renderer` module that normalizes/sanitizes snapshot fields and `tierExplain` to avoid crashes and keep `hasExplain`/payload output consistent even with corrupt persisted state, plus comprehensive unit tests covering these edge cases and `--format` validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5ab75c84a19ee1cbbbca4f8a9f539484a4c842f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->