### PR TITLE
feat(http): /recall/tier-explain endpoint (#518 slice 5/9)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -358,7 +358,16 @@ export class EngramAccessHttpServer {
     if (req.method === "GET" && pathname === "/engram/v1/recall/tier-explain") {
       const sessionParam = parsed.searchParams.get("session");
       const sessionKey = sessionParam && sessionParam.length > 0 ? sessionParam : undefined;
-      const payload = await this.service.recallTierExplain(sessionKey);
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const namespace = this.resolveNamespace(
+        req,
+        namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+      );
+      const payload = await this.service.recallTierExplain(
+        sessionKey,
+        namespace,
+        this.resolveRequestPrincipal(req),
+      );
       this.respondJson(res, 200, payload);
       return;
     }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -352,6 +352,17 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // Tier-explain (issue #518): structured per-result annotation from
+    // the direct-answer retrieval tier.  Orthogonal to /recall/explain
+    // above, which returns a graph-path explanation document.
+    if (req.method === "GET" && pathname === "/engram/v1/recall/tier-explain") {
+      const sessionParam = parsed.searchParams.get("session");
+      const sessionKey = sessionParam && sessionParam.length > 0 ? sessionParam : undefined;
+      const payload = await this.service.recallTierExplain(sessionKey);
+      this.respondJson(res, 200, payload);
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/observe") {
       const body = await this.readValidatedBody(req, "observe");
       this.ensureWriteRateLimitAvailable();

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2645,15 +2645,70 @@ export class EngramAccessService {
    * Orthogonal to `recallExplain()` above, which returns a graph-path
    * explanation document.  This is the per-result annotation introduced
    * by the direct-answer retrieval tier.
+   *
+   * ACL model mirrors `recallExplain()`: when namespaces are enabled,
+   * an explicit `namespace` override is checked with `canReadNamespace`
+   * and snapshots are filtered to that namespace.  When namespaces are
+   * enabled and no namespace is provided, we require an authenticated
+   * principal (via `sessionKey` or a trusted header) and silently
+   * filter the global most-recent snapshot to those the principal can
+   * read — preventing cross-tenant metadata leaks.
+   *
+   * We intentionally do NOT call `lastRecall.load()` here: the
+   * orchestrator loads the snapshot store once at init, and an
+   * unconditional `load()` on every request races with in-flight
+   * `record()` writes (the write reads `this.state` after an `await`,
+   * which `load()` can replace with stale disk state between calls).
    */
-  async recallTierExplain(sessionKey?: string) {
-    // Ensure the on-disk snapshot store is loaded — HTTP/MCP callers
-    // may hit this endpoint after a gateway restart before any recall
-    // has primed the store in memory.
-    await this.orchestrator.lastRecall.load();
-    const snapshot = sessionKey
+  async recallTierExplain(
+    sessionKey?: string,
+    namespace?: string,
+    authenticatedPrincipal?: string,
+  ) {
+    const namespacesEnabled = this.orchestrator.config.namespacesEnabled;
+    const requestedNamespace = namespace?.trim()
+      ? this.resolveNamespace(namespace)
+      : undefined;
+
+    // Resolve principal: prefer a trusted authenticated principal (e.g.,
+    // from a verified bearer subject), then the session-derived principal.
+    const principal = authenticatedPrincipal?.trim()
+      || resolvePrincipal(sessionKey, this.orchestrator.config);
+
+    // Enforce explicit namespace override ACL.  Match `recallExplain`'s
+    // return-empty-on-denied semantics (no throw) so callers can't
+    // distinguish "no recall" from "forbidden" via a 4xx oracle.
+    if (requestedNamespace) {
+      if (!canReadNamespace(principal, requestedNamespace, this.orchestrator.config)) {
+        return toRecallExplainJson(null);
+      }
+    } else if (namespacesEnabled && !authenticatedPrincipal?.trim() && !sessionKey?.trim()) {
+      // Namespaces enabled but caller is unauthenticated and did not
+      // pass a session — unsafe to return the global most-recent.
+      return toRecallExplainJson(null);
+    }
+
+    const candidate = sessionKey
       ? this.orchestrator.lastRecall.get(sessionKey)
       : this.orchestrator.lastRecall.getMostRecent();
+
+    // Apply namespace / ACL filter to the candidate snapshot.  A
+    // requested namespace must match exactly; otherwise (global
+    // most-recent with namespaces enabled) the snapshot's namespace
+    // must be readable by the resolved principal.
+    const snapshot = (() => {
+      if (!candidate) return null;
+      if (requestedNamespace) {
+        return candidate.namespace === requestedNamespace ? candidate : null;
+      }
+      if (!namespacesEnabled) return candidate;
+      const snapshotNs = candidate.namespace
+        ?? this.orchestrator.config.defaultNamespace;
+      return canReadNamespace(principal, snapshotNs, this.orchestrator.config)
+        ? candidate
+        : null;
+    })();
+
     return toRecallExplainJson(snapshot);
   }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -24,6 +24,7 @@ import {
   runMemoryGovernance,
 } from "./maintenance/memory-governance.js";
 import { runProcedureMining } from "./procedural/procedure-miner.js";
+import { toRecallExplainJson } from "./recall-explain-renderer.js";
 import {
   normalizeProjectionPreview,
   normalizeProjectionTags,
@@ -2635,6 +2636,25 @@ export class EngramAccessService {
       ? this.orchestrator.lastRecall.get(sessionKey)
       : this.orchestrator.lastRecall.getMostRecent();
     return snapshot ?? { message: "No recall snapshot available" };
+  }
+
+  /**
+   * Return a structured tier-explain payload for the most recent recall
+   * (or a specific session when `sessionKey` is supplied).  Issue #518.
+   *
+   * Orthogonal to `recallExplain()` above, which returns a graph-path
+   * explanation document.  This is the per-result annotation introduced
+   * by the direct-answer retrieval tier.
+   */
+  async recallTierExplain(sessionKey?: string) {
+    // Ensure the on-disk snapshot store is loaded — HTTP/MCP callers
+    // may hit this endpoint after a gateway restart before any recall
+    // has primed the store in memory.
+    await this.orchestrator.lastRecall.load();
+    const snapshot = sessionKey
+      ? this.orchestrator.lastRecall.get(sessionKey)
+      : this.orchestrator.lastRecall.getMostRecent();
+    return toRecallExplainJson(snapshot);
   }
 
   async intentDebug(namespace?: string): Promise<unknown> {

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -60,6 +60,24 @@ function createFakeService(): EngramAccessService {
       intent: null,
       graph: null,
     }),
+    recallTierExplain: async (sessionKey?: string) => ({
+      hasExplain: true,
+      snapshotFound: true,
+      sessionKey: sessionKey ?? "default",
+      recordedAt: "2026-04-19T17:30:00.000Z",
+      namespace: "global",
+      memoryIds: ["fact-1"],
+      source: "direct-answer",
+      sourcesUsed: ["direct-answer"],
+      latencyMs: 8,
+      tierExplain: {
+        tier: "direct-answer",
+        tierReason: "trusted decision, unambiguous",
+        filteredBy: [],
+        candidatesConsidered: 1,
+        latencyMs: 8,
+      },
+    }),
     memoryGet: async (memoryId) => ({
       found: true,
       namespace: "global",
@@ -386,6 +404,37 @@ test("access HTTP server enforces bearer auth and serves phase 1 routes", async 
     const explain = await explainRes.json() as { found: boolean; snapshot: { sessionKey: string } };
     assert.equal(explain.found, true);
     assert.equal(explain.snapshot.sessionKey, "sess-1");
+
+    // Tier-explain endpoint (issue #518): returns the structured
+    // per-result annotation.  Uses GET + ?session= so it is trivially
+    // cacheable and doesn't require a body.
+    const tierExplainRes = await fetch(
+      `${base}/engram/v1/recall/tier-explain?session=sess-42`,
+      { headers },
+    );
+    assert.equal(tierExplainRes.status, 200);
+    const tierExplain = await tierExplainRes.json() as {
+      hasExplain: boolean;
+      snapshotFound: boolean;
+      sessionKey: string;
+      tierExplain: { tier: string; candidatesConsidered: number } | null;
+    };
+    assert.equal(tierExplain.hasExplain, true);
+    assert.equal(tierExplain.snapshotFound, true);
+    assert.equal(tierExplain.sessionKey, "sess-42");
+    assert.equal(tierExplain.tierExplain?.tier, "direct-answer");
+    assert.equal(tierExplain.tierExplain?.candidatesConsidered, 1);
+
+    // Tier-explain without a session parameter falls back to the most
+    // recent snapshot — the fake service returns the same payload, but
+    // with a default sessionKey.
+    const latestRes = await fetch(
+      `${base}/engram/v1/recall/tier-explain`,
+      { headers },
+    );
+    assert.equal(latestRes.status, 200);
+    const latest = await latestRes.json() as { sessionKey: string };
+    assert.equal(latest.sessionKey, "default");
 
     const memoryRes = await fetch(`${base}/engram/v1/memories/fact-1`, { headers });
     assert.equal(memoryRes.status, 200);

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -60,12 +60,16 @@ function createFakeService(): EngramAccessService {
       intent: null,
       graph: null,
     }),
-    recallTierExplain: async (sessionKey?: string) => ({
+    recallTierExplain: async (
+      sessionKey?: string,
+      namespace?: string,
+      _authenticatedPrincipal?: string,
+    ) => ({
       hasExplain: true,
       snapshotFound: true,
       sessionKey: sessionKey ?? "default",
       recordedAt: "2026-04-19T17:30:00.000Z",
-      namespace: "global",
+      namespace: namespace ?? "global",
       memoryIds: ["fact-1"],
       source: "direct-answer",
       sourcesUsed: ["direct-answer"],

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -901,11 +901,13 @@ test("recallTierExplain denies cross-tenant namespace override via ACL", async (
   assert.deepEqual(response.memoryIds, []);
 });
 
-test("recallTierExplain with no namespace filters global most-recent by principal ACL", async () => {
+test("recallTierExplain with no sessionKey filters global most-recent by principal ACL", async () => {
   const service = new EngramAccessService(
     makeTierExplainOrchestrator({
       namespacesEnabled: true,
-      // Most-recent snapshot belongs to secret-team.
+      // Most-recent snapshot belongs to secret-team.  No session-keyed
+      // snapshot — this forces the service down the getMostRecent()
+      // branch where the ACL filter must execute.
       snapshot: {
         sessionKey: "secret-team:session",
         recordedAt: "2026-04-19T00:00:00.000Z",
@@ -917,17 +919,49 @@ test("recallTierExplain with no namespace filters global most-recent by principa
     }) as any,
   );
 
-  // project-x caller must NOT see secret-team metadata when asking for
-  // global most-recent.  Previous implementation leaked cross-tenant data.
+  // project-x caller (via authenticatedPrincipal, no sessionKey) must
+  // NOT see secret-team metadata when asking for global most-recent.
+  // This exercises the getMostRecent() + canReadNamespace() filter
+  // path (not the sessionKey lookup path).
   const response = await service.recallTierExplain(
-    "project-x:session",
     undefined,
     undefined,
+    "project-x",
   ) as { snapshotFound: boolean; memoryIds: unknown[]; namespace: unknown };
 
   assert.equal(response.snapshotFound, false);
   assert.deepEqual(response.memoryIds, []);
   assert.equal(response.namespace, null);
+});
+
+test("recallTierExplain with authorized principal sees global most-recent in their namespace", async () => {
+  // Complement to the previous test: verify the ACL filter allows the
+  // snapshot through when the principal CAN read the snapshot's
+  // namespace, so we know the test above is failing for the right
+  // reason (denial) rather than because the snapshot is unreachable.
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: true,
+      snapshot: {
+        sessionKey: "secret-team:session",
+        recordedAt: "2026-04-19T00:00:00.000Z",
+        queryHash: "h",
+        queryLen: 1,
+        memoryIds: ["fact-secret"],
+        namespace: "secret-team",
+      },
+    }) as any,
+  );
+
+  const response = await service.recallTierExplain(
+    undefined,
+    undefined,
+    "secret-team",
+  ) as { snapshotFound: boolean; memoryIds: string[]; namespace: string | null };
+
+  assert.equal(response.snapshotFound, true);
+  assert.deepEqual(response.memoryIds, ["fact-secret"]);
+  assert.equal(response.namespace, "secret-team");
 });
 
 test("recallTierExplain rejects unauthenticated caller when namespaces are enabled and no session supplied", async () => {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -790,6 +790,232 @@ test("access service recallExplain filters session snapshots by the requested na
   assert.equal(response.snapshot, undefined);
 });
 
+// ---------------------------------------------------------------------------
+// recallTierExplain — issue #518, slice 5.  These tests exercise the ACL +
+// no-race-load invariants added in response to AI review feedback (cursor +
+// chatgpt-codex-connector) on the slice 5 PR.
+// ---------------------------------------------------------------------------
+
+function makeTierExplainOrchestrator(opts: {
+  namespacesEnabled: boolean;
+  snapshot: unknown;
+  sessionSnapshotByKey?: Record<string, unknown>;
+  loadCalls?: { count: number };
+}) {
+  return {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: opts.namespacesEnabled,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [
+        { match: "project-x:", principal: "project-x" },
+        { match: "secret-team:", principal: "secret-team" },
+      ],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x"],
+          writePrincipals: ["project-x"],
+        },
+        {
+          name: "secret-team",
+          readPrincipals: ["secret-team"],
+          writePrincipals: ["secret-team"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+    },
+    recall: async () => "ctx",
+    lastRecall: {
+      load: async () => {
+        if (opts.loadCalls) opts.loadCalls.count += 1;
+      },
+      get: (key: string) => opts.sessionSnapshotByKey?.[key] ?? null,
+      getMostRecent: () => opts.snapshot,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+}
+
+test("recallTierExplain does not call lastRecall.load() on every request (race fix)", async () => {
+  const loadCalls = { count: 0 };
+  const snapshot = {
+    sessionKey: "default",
+    recordedAt: "2026-04-19T00:00:00.000Z",
+    queryHash: "h",
+    queryLen: 1,
+    memoryIds: ["fact-1"],
+    namespace: "global",
+  };
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: false,
+      snapshot,
+      loadCalls,
+    }) as any,
+  );
+
+  await service.recallTierExplain();
+  await service.recallTierExplain();
+  await service.recallTierExplain("some-session");
+
+  assert.equal(
+    loadCalls.count,
+    0,
+    "recallTierExplain must not call lastRecall.load(); orchestrator loads it at init. Calling load() on every request races with in-flight record() writes.",
+  );
+});
+
+test("recallTierExplain denies cross-tenant namespace override via ACL", async () => {
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: true,
+      snapshot: {
+        sessionKey: "secret-team:session",
+        recordedAt: "2026-04-19T00:00:00.000Z",
+        queryHash: "h",
+        queryLen: 1,
+        memoryIds: ["fact-secret"],
+        namespace: "secret-team",
+      },
+    }) as any,
+  );
+
+  // Caller with project-x principal asks for secret-team namespace.
+  const response = await service.recallTierExplain(
+    "project-x:session",
+    "secret-team",
+    undefined,
+  ) as { hasExplain: boolean; snapshotFound: boolean; memoryIds: unknown[] };
+
+  assert.equal(response.hasExplain, false);
+  assert.equal(response.snapshotFound, false);
+  assert.deepEqual(response.memoryIds, []);
+});
+
+test("recallTierExplain with no namespace filters global most-recent by principal ACL", async () => {
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: true,
+      // Most-recent snapshot belongs to secret-team.
+      snapshot: {
+        sessionKey: "secret-team:session",
+        recordedAt: "2026-04-19T00:00:00.000Z",
+        queryHash: "h",
+        queryLen: 1,
+        memoryIds: ["fact-secret"],
+        namespace: "secret-team",
+      },
+    }) as any,
+  );
+
+  // project-x caller must NOT see secret-team metadata when asking for
+  // global most-recent.  Previous implementation leaked cross-tenant data.
+  const response = await service.recallTierExplain(
+    "project-x:session",
+    undefined,
+    undefined,
+  ) as { snapshotFound: boolean; memoryIds: unknown[]; namespace: unknown };
+
+  assert.equal(response.snapshotFound, false);
+  assert.deepEqual(response.memoryIds, []);
+  assert.equal(response.namespace, null);
+});
+
+test("recallTierExplain rejects unauthenticated caller when namespaces are enabled and no session supplied", async () => {
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: true,
+      snapshot: {
+        sessionKey: "project-x:session",
+        recordedAt: "2026-04-19T00:00:00.000Z",
+        queryHash: "h",
+        queryLen: 1,
+        memoryIds: ["fact-1"],
+        namespace: "project-x",
+      },
+    }) as any,
+  );
+
+  // No sessionKey, no namespace, no authenticatedPrincipal — must return empty.
+  const response = await service.recallTierExplain() as {
+    snapshotFound: boolean;
+    memoryIds: unknown[];
+  };
+  assert.equal(response.snapshotFound, false);
+  assert.deepEqual(response.memoryIds, []);
+});
+
+test("recallTierExplain returns snapshot for authorized principal on matching namespace", async () => {
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: true,
+      snapshot: null,
+      sessionSnapshotByKey: {
+        "project-x:session": {
+          sessionKey: "project-x:session",
+          recordedAt: "2026-04-19T00:00:00.000Z",
+          queryHash: "h",
+          queryLen: 1,
+          memoryIds: ["fact-1"],
+          namespace: "project-x",
+          tierExplain: {
+            tier: "direct-answer",
+            tierReason: "unambiguous",
+            filteredBy: [],
+            candidatesConsidered: 3,
+          },
+        },
+      },
+    }) as any,
+  );
+
+  const response = await service.recallTierExplain(
+    "project-x:session",
+    "project-x",
+    undefined,
+  ) as {
+    hasExplain: boolean;
+    snapshotFound: boolean;
+    tierExplain: { tier: string } | null;
+  };
+  assert.equal(response.snapshotFound, true);
+  assert.equal(response.hasExplain, true);
+  assert.equal(response.tierExplain?.tier, "direct-answer");
+});
+
+test("recallTierExplain with namespaces disabled returns the snapshot without ACL filtering", async () => {
+  const snapshot = {
+    sessionKey: "any-session",
+    recordedAt: "2026-04-19T00:00:00.000Z",
+    queryHash: "h",
+    queryLen: 1,
+    memoryIds: ["fact-1"],
+    namespace: "global",
+  };
+  const service = new EngramAccessService(
+    makeTierExplainOrchestrator({
+      namespacesEnabled: false,
+      snapshot,
+    }) as any,
+  );
+
+  const response = await service.recallTierExplain() as {
+    snapshotFound: boolean;
+    memoryIds: string[];
+  };
+  assert.equal(response.snapshotFound, true);
+  assert.deepEqual(response.memoryIds, ["fact-1"]);
+});
+
 test("access service memoryStore persists and enforces idempotency conflicts", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-access-service-store-"));
   try {


### PR DESCRIPTION
Fifth of nine slices for #518. Stacked on PR #537 (slice 4 — CLI \`recall-explain\` + renderer). Retargets to \`main\` once upstream slices merge.

## Summary

New endpoint:

    GET /engram/v1/recall/tier-explain[?session=<key>]

Returns the structured \`RecallTierExplain\` payload for the caller's most recent recall (or a specific session). Uses the same \`toRecallExplainJson()\` renderer the CLI slice added.

## Rationale

The existing \`POST /recall/explain\` returns a graph-path explanation document — a separate subsystem. The direct-answer tier (#518) introduces a per-result annotation that describes which retrieval tier served a query. Giving it its own endpoint keeps both semantics clean and lets clients opt into whichever they need.

\`snapshotFound\` and \`hasExplain\` boolean flags in the payload let clients handle the "no recall yet" and "recall happened but direct-answer didn't fire" cases without string parsing.

## Design notes

- GET, not POST, so it's trivially cacheable at the HTTP layer and doesn't need a body.
- Service layer calls \`lastRecall.load()\` first — covers the case where the gateway restarted and no recall has primed the in-memory store yet.
- Orchestrator wiring (slice 3c) populates \`tierExplain\` on the snapshot; until that lands, real traffic returns \`hasExplain: false\` while the endpoint still functions for testing.

## Test plan

- [x] \`tests/access-http.test.ts\` — 21/21 pass (2 new assertions)
- [x] \`tsc --noEmit\` clean
- [x] Fake service in test mirrors the production service shape via \`as unknown as EngramAccessService\`

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new read endpoint that exposes recall snapshot metadata and implements namespace ACL filtering; mistakes could leak cross-tenant information. Also changes snapshot access behavior to avoid a load/write race, so correctness depends on the new filtering and snapshot selection logic.
> 
> **Overview**
> **New recall introspection endpoint:** Adds `GET /engram/v1/recall/tier-explain` (with optional `?session` and `?namespace`) to return the structured *tier-explain* payload for the most recent recall or a specific session.
> 
> **Service-layer behavior & safety:** Implements `EngramAccessService.recallTierExplain()` using the shared `toRecallExplainJson()` renderer, enforces namespace read ACLs (including returning empty payloads on denied access), blocks unauthenticated access to the global most-recent snapshot when namespaces are enabled, and avoids calling `lastRecall.load()` to prevent a load/record race.
> 
> **Tests:** Extends HTTP tests to cover the new route and adds focused service tests for ACL denial/allow cases, unauthenticated behavior, and the no-`load()` invariant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b1171901d701c3fbbe4359d6511553ccc1af27b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->