### PR TITLE
feat(mcp): engram.recall_tier_explain tool (#518 slice 6/9)

### DIFF
--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -128,14 +128,19 @@ export class EngramMcpServer {
       {
         name: "engram.recall_tier_explain",
         description:
-          "Return a structured tier-explain payload for the last direct-answer-eligible recall (issue #518). Orthogonal to engram.recall_explain, which returns a graph-path explanation. Responses carry snapshotFound and hasExplain booleans so callers can branch without parsing.",
+          "Return a structured tier-explain payload for the last direct-answer-eligible recall (issue #518). Orthogonal to engram.recall_explain, which returns a graph-path explanation. Responses carry snapshotFound and hasExplain booleans so callers can branch without parsing. In multi-principal deployments the caller's authenticated principal is used to scope access; passing `namespace` further constrains results.",
         inputSchema: {
           type: "object",
           properties: {
             sessionKey: {
               type: "string",
               description:
-                "Optional session key. Omit to read the most recent snapshot across sessions.",
+                "Optional session key. Omit to read the most recent snapshot visible to the caller.",
+            },
+            namespace: {
+              type: "string",
+              description:
+                "Optional namespace to scope the returned snapshot to. When omitted, the most recent snapshot readable by the caller is returned.",
             },
           },
           additionalProperties: false,
@@ -1057,10 +1062,19 @@ export class EngramMcpServer {
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
       case "engram.recall_tier_explain":
+        // Forward `namespace` and `effectivePrincipal` so the service
+        // applies the same multi-principal ACL as `recall_explain`.
+        // Without these, the service would resolve the principal from
+        // `sessionKey` alone, which breaks trusted-header deployments
+        // and blocks the namespace-override ACL path in multi-tenant
+        // setups (cross-tenant data leak on the global most-recent
+        // snapshot fallback).
         return this.service.recallTierExplain(
           typeof args.sessionKey === "string" && args.sessionKey.length > 0
             ? args.sessionKey
             : undefined,
+          typeof args.namespace === "string" ? args.namespace : undefined,
+          effectivePrincipal,
         );
       case "engram.day_summary":
         return this.service.daySummary({

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -126,6 +126,22 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.recall_tier_explain",
+        description:
+          "Return a structured tier-explain payload for the last direct-answer-eligible recall (issue #518). Orthogonal to engram.recall_explain, which returns a graph-path explanation. Responses carry snapshotFound and hasExplain booleans so callers can branch without parsing.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sessionKey: {
+              type: "string",
+              description:
+                "Optional session key. Omit to read the most recent snapshot across sessions.",
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.day_summary",
         description:
           "Generate a structured end-of-day summary. When memories is omitted or empty, auto-gathers today's facts and hourly summaries from storage.",
@@ -1040,6 +1056,12 @@ export class EngramMcpServer {
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      case "engram.recall_tier_explain":
+        return this.service.recallTierExplain(
+          typeof args.sessionKey === "string" && args.sessionKey.length > 0
+            ? args.sessionKey
+            : undefined,
+        );
       case "engram.day_summary":
         return this.service.daySummary({
           memories: typeof args.memories === "string" ? args.memories : "",

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -28,12 +28,20 @@ function createFakeService(): EngramAccessService {
       intent: null,
       graph: null,
     }),
-    recallTierExplain: async (sessionKey?: string) => ({
+    // Signature mirrors production (CLAUDE.md rule 33): the service's
+    // recallTierExplain accepts (sessionKey, namespace, authenticatedPrincipal).
+    // The mock echoes them so tests can assert the MCP dispatcher
+    // forwards each one end-to-end.
+    recallTierExplain: async (
+      sessionKey?: string,
+      namespace?: string,
+      _authenticatedPrincipal?: string,
+    ) => ({
       hasExplain: true,
       snapshotFound: true,
       sessionKey: sessionKey ?? "default",
       recordedAt: "2026-04-19T18:00:00.000Z",
-      namespace: "global",
+      namespace: namespace ?? "global",
       memoryIds: ["fact-1"],
       source: "direct-answer",
       sourcesUsed: ["direct-answer"],
@@ -272,6 +280,26 @@ test("MCP server advertises tools and dispatches recall", async () => {
     structuredContent: { sessionKey: string };
   };
   assert.equal(canonicalTierResult.structuredContent.sessionKey, "default");
+
+  // Namespace forwarding (issue #518 — codex review on #539): the MCP
+  // dispatcher must forward the caller-provided `namespace` argument
+  // to the service so multi-tenant ACLs apply.  Regression guard
+  // against the cross-tenant leak where `recallTierExplain` defaulted
+  // to the most recent snapshot across all namespaces.
+  const namespacedTierExplain = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 33,
+    method: "tools/call",
+    params: {
+      name: "engram.recall_tier_explain",
+      arguments: { sessionKey: "sess-ns", namespace: "project-x" },
+    },
+  });
+  const namespacedTierResult = namespacedTierExplain?.result as {
+    structuredContent: { sessionKey: string; namespace: string };
+  };
+  assert.equal(namespacedTierResult.structuredContent.sessionKey, "sess-ns");
+  assert.equal(namespacedTierResult.structuredContent.namespace, "project-x");
 
   const store = await server.handleRequest({
     jsonrpc: "2.0",

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -28,6 +28,24 @@ function createFakeService(): EngramAccessService {
       intent: null,
       graph: null,
     }),
+    recallTierExplain: async (sessionKey?: string) => ({
+      hasExplain: true,
+      snapshotFound: true,
+      sessionKey: sessionKey ?? "default",
+      recordedAt: "2026-04-19T18:00:00.000Z",
+      namespace: "global",
+      memoryIds: ["fact-1"],
+      source: "direct-answer",
+      sourcesUsed: ["direct-answer"],
+      latencyMs: 8,
+      tierExplain: {
+        tier: "direct-answer",
+        tierReason: "trusted decision, unambiguous",
+        filteredBy: [],
+        candidatesConsidered: 1,
+        latencyMs: 8,
+      },
+    }),
     memoryGet: async (memoryId) => ({
       found: true,
       namespace: "global",
@@ -156,6 +174,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
   const legacyListed = [
     "engram.recall",
     "engram.recall_explain",
+    "engram.recall_tier_explain",
     "engram.day_summary",
     "engram.memory_governance_run",
     "engram.procedure_mining_run",
@@ -216,6 +235,43 @@ test("MCP server advertises tools and dispatches recall", async () => {
   const recallResult = recall?.result as { structuredContent: { context: string; memoryIds: string[] } };
   assert.equal(recallResult.structuredContent.context, "ctx");
   assert.deepEqual(recallResult.structuredContent.memoryIds, ["fact-1"]);
+
+  // Tier-explain tool (issue #518) — accepts both legacy and
+  // canonical names; returns the structured payload from the shared
+  // renderer.
+  const legacyTierExplain = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 31,
+    method: "tools/call",
+    params: {
+      name: "engram.recall_tier_explain",
+      arguments: { sessionKey: "sess-42" },
+    },
+  });
+  const legacyTierResult = legacyTierExplain?.result as {
+    structuredContent: {
+      hasExplain: boolean;
+      sessionKey: string;
+      tierExplain: { tier: string } | null;
+    };
+  };
+  assert.equal(legacyTierResult.structuredContent.hasExplain, true);
+  assert.equal(legacyTierResult.structuredContent.sessionKey, "sess-42");
+  assert.equal(legacyTierResult.structuredContent.tierExplain?.tier, "direct-answer");
+
+  const canonicalTierExplain = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 32,
+    method: "tools/call",
+    params: {
+      name: "remnic.recall_tier_explain",
+      arguments: {},
+    },
+  });
+  const canonicalTierResult = canonicalTierExplain?.result as {
+    structuredContent: { sessionKey: string };
+  };
+  assert.equal(canonicalTierResult.structuredContent.sessionKey, "default");
 
   const store = await server.handleRequest({
     jsonrpc: "2.0",


### PR DESCRIPTION
Sixth of nine slices for #518. Stacked on PR #538 (slice 5 — HTTP endpoint). Retargets to \`main\` once upstream slices merge.

## Summary

New MCP tool: \`engram.recall_tier_explain\` (legacy alias) / \`remnic.recall_tier_explain\` (canonical). Both dispatch to the same handler via the repo's existing \`toLegacyToolName()\` normalization.

Input: optional \`sessionKey\`. Omit to read the most recent snapshot across sessions.

Output: the JSON payload produced by the shared renderer (slice 4). Same shape as the HTTP endpoint (slice 5).

## Design notes

- Reuses the dual-naming invariant from the existing MCP surface — defining one tool with the \`engram.\` prefix; \`withToolAliases()\` adds the \`remnic.\` canonical form at list time.
- Empty-string \`sessionKey\` is coerced to "use the most recent snapshot" rather than "look up the session literally named empty-string".
- Tool description explicitly calls out that this is orthogonal to the existing \`engram.recall_explain\` (graph-path explanation) tool, so LLM clients pick the right one.

## Test plan

- [x] \`tests/access-mcp.test.ts\` — 5/5 pass (2 new tool/call assertions, 1 new entry in the tools/list fixture)
- [x] \`tsc --noEmit\` clean

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new MCP surface area for recall introspection and changes dispatcher argument forwarding in a multi-tenant/multi-principal path; mistakes could expose the wrong snapshot across namespaces/principals.
> 
> **Overview**
> Adds a new MCP tool, `engram.recall_tier_explain` (with `remnic.*` alias), returning a structured “tier explain” payload for the last direct-answer-eligible recall.
> 
> Updates tool dispatch to coerce empty `sessionKey` to “most recent” and to forward `namespace` plus the caller’s effective principal into `service.recallTierExplain` to preserve multi-principal ACL behavior and avoid cross-tenant fallback leaks; expands MCP tests to cover tool listing, legacy/canonical names, and namespace forwarding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1fedbd9e9b9ce98bfc6989bd0c928149824c154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->