### PR TITLE
refactor: extract shared abort-error helpers

### DIFF
--- a/packages/remnic-core/src/abort-error.test.ts
+++ b/packages/remnic-core/src/abort-error.test.ts
@@ -1,0 +1,49 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { abortError, isAbortError, throwIfAborted } from "./abort-error.js";
+
+test("abortError builds an Error whose name is AbortError", () => {
+  const err = abortError("stop");
+  assert.ok(err instanceof Error);
+  assert.equal(err.name, "AbortError");
+  assert.equal(err.message, "stop");
+});
+
+test("isAbortError returns true for our abort errors and false otherwise", () => {
+  assert.equal(isAbortError(abortError("stop")), true);
+  assert.equal(isAbortError(new Error("regular error")), false);
+  assert.equal(isAbortError(null), false);
+  assert.equal(isAbortError(undefined), false);
+  assert.equal(isAbortError("abort"), false);
+  assert.equal(isAbortError({ name: "AbortError" }), false);
+});
+
+test("throwIfAborted does nothing when signal is absent", () => {
+  throwIfAborted(); // should not throw
+  assert.ok(true);
+});
+
+test("throwIfAborted does nothing when signal is not yet aborted", () => {
+  const controller = new AbortController();
+  throwIfAborted(controller.signal);
+  assert.ok(true);
+});
+
+test("throwIfAborted throws AbortError when signal is aborted", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () => throwIfAborted(controller.signal),
+    (err: Error) => err.name === "AbortError" && err.message === "operation aborted",
+  );
+});
+
+test("throwIfAborted uses the caller-provided message", () => {
+  const controller = new AbortController();
+  controller.abort();
+  assert.throws(
+    () => throwIfAborted(controller.signal, "custom abort message"),
+    (err: Error) => err.message === "custom abort message",
+  );
+});

--- a/packages/remnic-core/src/abort-error.ts
+++ b/packages/remnic-core/src/abort-error.ts
@@ -1,0 +1,46 @@
+/**
+ * Shared abort-error helpers.
+ *
+ * Consolidates the `throwIfAborted` / `abortError` / `isAbortError`
+ * patterns that were independently implemented across
+ * `direct-answer-wiring.ts`, `harmonic-retrieval.ts`, and `qmd.ts`
+ * (plus a private pair in `orchestrator.ts`).  A single helper
+ * means future changes to the abort-error convention are applied
+ * consistently across the codebase.
+ *
+ * The convention (matching Web / Node): throw a standard `Error`
+ * with `name === "AbortError"`.  Callers dispatch on name rather
+ * than a specific class so error propagation across async
+ * boundaries continues to classify correctly.
+ */
+
+/**
+ * Build an Error whose `name` is `"AbortError"`.  Uses
+ * `Object.defineProperty` so the name is non-enumerable and
+ * mirrors the shape of `DOMException("AbortError")` where that
+ * is available.
+ */
+export function abortError(message: string): Error {
+  const err = new Error(message);
+  Object.defineProperty(err, "name", { value: "AbortError" });
+  return err;
+}
+
+/** Return true iff `err` is an Error whose `name` is `"AbortError"`. */
+export function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Throw an AbortError when the given signal has fired.  No-op
+ * when the signal is absent or not yet aborted.  The default
+ * message matches the prior in-module implementations.
+ */
+export function throwIfAborted(
+  signal?: AbortSignal,
+  message = "operation aborted",
+): void {
+  if (signal?.aborted) {
+    throw abortError(message);
+  }
+}

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -29,6 +29,7 @@ import type { TrustZoneName } from "./trust-zones.js";
 import type { Taxonomy } from "./taxonomy/types.js";
 import { resolveCategory } from "./taxonomy/resolver.js";
 import { normalizeRecallTokens } from "./recall-tokenization.js";
+import { throwIfAborted } from "./abort-error.js";
 import {
   isDirectAnswerEligible,
   type DirectAnswerCandidate,
@@ -178,10 +179,3 @@ export async function tryDirectAnswer(
   });
 }
 
-function throwIfAborted(signal?: AbortSignal): void {
-  if (signal?.aborted) {
-    const err = new Error("direct-answer wiring aborted");
-    Object.defineProperty(err, "name", { value: "AbortError" });
-    throw err;
-  }
-}

--- a/packages/remnic-core/src/direct-answer-wiring.ts
+++ b/packages/remnic-core/src/direct-answer-wiring.ts
@@ -127,9 +127,9 @@ export async function tryDirectAnswer(
     });
   }
 
-  throwIfAborted(abortSignal);
+  throwIfAborted(abortSignal, "direct-answer wiring aborted");
   const memories = await sources.listCandidateMemories({ namespace, abortSignal });
-  throwIfAborted(abortSignal);
+  throwIfAborted(abortSignal, "direct-answer wiring aborted");
   const candidates: DirectAnswerCandidate[] = [];
 
   for (const memory of memories) {
@@ -139,10 +139,10 @@ export async function tryDirectAnswer(
     // chance to reject.  The check repeats after every await so an
     // abort that lands during the in-flight I/O on the final memory
     // (after which no further iteration would exist) still stops us.
-    throwIfAborted(abortSignal);
+    throwIfAborted(abortSignal, "direct-answer wiring aborted");
 
     const trustZone = await sources.trustZoneFor(memory.frontmatter.id);
-    throwIfAborted(abortSignal);
+    throwIfAborted(abortSignal, "direct-answer wiring aborted");
 
     // Cheap pre-filter: non-trusted memories can't qualify, so skip
     // taxonomy and importance resolution for them.
@@ -169,7 +169,7 @@ export async function tryDirectAnswer(
   // Final check — if abort landed during the trust-zone await for the
   // last memory, the loop condition no longer fires.  Guard before we
   // hand candidates to the eligibility gate.
-  throwIfAborted(abortSignal);
+  throwIfAborted(abortSignal, "direct-answer wiring aborted");
 
   return isDirectAnswerEligible({
     query,

--- a/packages/remnic-core/src/harmonic-retrieval.ts
+++ b/packages/remnic-core/src/harmonic-retrieval.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { listJsonFiles, readJsonFile } from "./json-store.js";
+import { throwIfAborted } from "./abort-error.js";
 import {
   resolveAbstractionNodeStoreDir,
   validateAbstractionNode,
@@ -221,9 +222,3 @@ export async function searchHarmonicRetrieval(options: {
     .slice(0, options.maxResults);
 }
 
-function throwIfAborted(signal?: AbortSignal): void {
-  if (!signal?.aborted) return;
-  const err = new Error("harmonic retrieval aborted");
-  Object.defineProperty(err, "name", { value: "AbortError" });
-  throw err;
-}

--- a/packages/remnic-core/src/harmonic-retrieval.ts
+++ b/packages/remnic-core/src/harmonic-retrieval.ts
@@ -146,7 +146,7 @@ export async function searchHarmonicRetrieval(options: {
   anchorsEnabled: boolean;
   abortSignal?: AbortSignal;
 }): Promise<HarmonicRetrievalResult[]> {
-  throwIfAborted(options.abortSignal);
+  throwIfAborted(options.abortSignal, "harmonic retrieval aborted");
   const queryTokens = new Set(normalizeRecallTokens(options.query, ["what", "which"]));
   if (queryTokens.size === 0 || options.maxResults <= 0) return [];
 
@@ -154,7 +154,7 @@ export async function searchHarmonicRetrieval(options: {
   const candidates = new Map<string, HarmonicCandidate>();
 
   for (const node of nodes) {
-    throwIfAborted(options.abortSignal);
+    throwIfAborted(options.abortSignal, "harmonic retrieval aborted");
     const { score, matchedFields } = scoreNode(node, queryTokens);
     if (score <= 0) continue;
     candidates.set(node.nodeId, {
@@ -167,11 +167,11 @@ export async function searchHarmonicRetrieval(options: {
   }
 
   if (options.anchorsEnabled) {
-    throwIfAborted(options.abortSignal);
+    throwIfAborted(options.abortSignal, "harmonic retrieval aborted");
     const anchors = await readCueAnchors(options);
     const nodeIndex = new Map(nodes.map((node) => [node.nodeId, node]));
     for (const anchor of anchors) {
-      throwIfAborted(options.abortSignal);
+      throwIfAborted(options.abortSignal, "harmonic retrieval aborted");
       const { score, matchedFields } = scoreAnchor(anchor, queryTokens);
       if (score <= 0) continue;
       for (const nodeRef of anchor.nodeRefs) {

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -3,6 +3,11 @@ import os from "node:os";
 import path from "node:path";
 import { log } from "./logger.js";
 import { getCachedQmdSearch, setCachedQmdSearch } from "./memory-cache.js";
+import {
+  abortError,
+  isAbortError,
+  throwIfAborted,
+} from "./abort-error.js";
 import type { QmdSearchExplain, QmdSearchResult } from "./types.js";
 import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "./search/port.js";
 import { launchProcess, type CommandChildProcess } from "./runtime/child-process.js";
@@ -72,16 +77,6 @@ function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-function abortError(message: string): Error {
-  const err = new Error(message);
-  Object.defineProperty(err, "name", { value: "AbortError" });
-  return err;
-}
-
-function isAbortError(err: unknown): boolean {
-  return err instanceof Error && err.name === "AbortError";
-}
-
 function errorMessage(err: unknown): string {
   if (typeof err === "string") return err;
   if (err instanceof Error) return err.message;
@@ -103,12 +98,6 @@ function isCallerCancellation(err: unknown, signal?: AbortSignal): boolean {
 
 function isDaemonTimeoutError(err: unknown): boolean {
   return /timed out/i.test(errorMessage(err));
-}
-
-function throwIfAborted(signal?: AbortSignal, message = "operation aborted"): void {
-  if (signal?.aborted) {
-    throw abortError(message);
-  }
 }
 
 function sleepWithSignal(ms: number, signal?: AbortSignal): Promise<void> {


### PR DESCRIPTION
Resolves the Cursor low-severity finding from PR #533 that was deferred in favor of keeping slice 3's surface tight.

## Summary

The \`abortError\` / \`isAbortError\` / \`throwIfAborted\` pattern was independently implemented in three places:

- \`direct-answer-wiring.ts\` (simple throwIfAborted)
- \`harmonic-retrieval.ts\` (simple throwIfAborted)
- \`qmd.ts\` (full kit with message support)

Any future change to the abort-error convention had to hand-verify each call site. This PR introduces \`abort-error.ts\` consolidating all three helpers behind the qmd.ts-shaped contract.

- \`abortError(message): Error\` — Error with \`name === "AbortError"\`
- \`isAbortError(err): boolean\` — type-narrowing check
- \`throwIfAborted(signal, message?): void\` — default message \`"operation aborted"\`

## Changes

- New \`packages/remnic-core/src/abort-error.ts\` + 6 unit tests
- \`direct-answer-wiring.ts\`, \`harmonic-retrieval.ts\`, \`qmd.ts\` import from it and delete their local copies

## Compatibility

- Existing error shapes unchanged — still standard \`Error\` with \`name === "AbortError"\`.
- Local error messages differ slightly from before (e.g. \`"harmonic retrieval aborted"\` → \`"operation aborted"\`), but no caller parses the message; classification uses \`err.name\`.

## Test plan

- [x] \`abort-error.test.ts\` — 6/6 pass
- [x] \`direct-answer-wiring.test.ts\` — 15/15 pass (no regressions)
- [x] \`tsc --noEmit\` clean

Not a blocker for any #518 slice but makes future abort-related work easier.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor that centralizes abort/cancellation error construction and checks; primary risk is subtle behavior/message differences affecting abort handling paths.
> 
> **Overview**
> Introduces a shared `abort-error.ts` module exporting `abortError`, `isAbortError`, and `throwIfAborted`, plus a new unit test suite covering their behavior.
> 
> Updates `direct-answer-wiring.ts`, `harmonic-retrieval.ts`, and `qmd.ts` to import these helpers and deletes their in-file implementations, standardizing abort error shape (`Error` with `name === "AbortError"`) and making abort checks use the shared `throwIfAborted` (with explicit per-module messages where needed).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1966a16509be0525cf21d58cbd725f71ef30422. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->