### PR TITLE
feat(bench): retrieval-direct-answer benchmark (#518 slice 7/9)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/fixture.ts
@@ -1,0 +1,247 @@
+/**
+ * Synthetic fixture for the direct-answer latency benchmark
+ * (issue #518).
+ *
+ * Each case feeds a hand-crafted candidate set + a query into the
+ * eligibility gate.  Cases are split by expected verdict so the
+ * scorer can measure precision (positive cases fire Tier 2), recall
+ * (negative cases defer to the hybrid path), and gate latency.
+ */
+
+import type { MemoryFile } from "@remnic/core";
+
+export interface DirectAnswerCaseCandidate {
+  id: string;
+  content: string;
+  tags: string[];
+  category: "decision" | "principle" | "skill" | "rule" | "fact" | "entity";
+  trustZone: "trusted" | "working" | "quarantine" | null;
+  importanceScore: number;
+  verificationState?: "unverified" | "user_confirmed" | "system_inferred" | "disputed";
+  status?: "active" | "superseded" | "archived" | "pending_review" | "rejected" | "quarantined";
+  entityRef?: string;
+  taxonomyBucket?: string;
+}
+
+export interface DirectAnswerBenchCase {
+  id: string;
+  query: string;
+  candidates: DirectAnswerCaseCandidate[];
+  queryEntityRefs?: string[];
+  expected: "eligible" | "defer";
+  /** Memory id we expect to win when expected==="eligible". */
+  expectedWinnerId?: string;
+}
+
+function trustedDecision(overrides: Partial<DirectAnswerCaseCandidate> & Pick<DirectAnswerCaseCandidate, "id" | "content" | "tags">): DirectAnswerCaseCandidate {
+  return {
+    category: "decision",
+    trustZone: "trusted",
+    importanceScore: 0.85,
+    verificationState: "user_confirmed",
+    taxonomyBucket: "decisions",
+    ...overrides,
+  };
+}
+
+function untrustedNote(overrides: Partial<DirectAnswerCaseCandidate> & Pick<DirectAnswerCaseCandidate, "id" | "content" | "tags">): DirectAnswerCaseCandidate {
+  return {
+    category: "fact",
+    trustZone: "working",
+    importanceScore: 0.4,
+    taxonomyBucket: "facts",
+    ...overrides,
+  };
+}
+
+export const DIRECT_ANSWER_BENCH_FIXTURE: DirectAnswerBenchCase[] = [
+  // Positive: a single trusted decision memory answers the query cleanly.
+  {
+    id: "pos-pkg-manager",
+    query: "package manager remnic",
+    candidates: [
+      trustedDecision({
+        id: "pm",
+        content: "remnic uses pnpm as its package manager",
+        tags: ["package-manager", "remnic"],
+        entityRef: "remnic",
+      }),
+    ],
+    expected: "eligible",
+    expectedWinnerId: "pm",
+  },
+  // Positive: winner beats a noisy working-zone distractor.
+  {
+    id: "pos-beats-distractor",
+    query: "package manager remnic",
+    candidates: [
+      trustedDecision({
+        id: "pm",
+        content: "remnic uses pnpm as its package manager",
+        tags: ["package-manager", "remnic"],
+      }),
+      untrustedNote({
+        id: "noise",
+        content: "package manager remnic npm",
+        tags: ["package-manager"],
+      }),
+    ],
+    expected: "eligible",
+    expectedWinnerId: "pm",
+  },
+  // Negative: two trusted candidates within ambiguity margin → defer.
+  {
+    id: "neg-ambiguous",
+    query: "package manager remnic",
+    candidates: [
+      trustedDecision({
+        id: "a",
+        content: "remnic uses pnpm as its package manager",
+        tags: ["package-manager", "remnic"],
+      }),
+      trustedDecision({
+        id: "b",
+        content: "remnic switched to pnpm for package manager",
+        tags: ["package-manager", "remnic"],
+      }),
+    ],
+    expected: "defer",
+  },
+  // Negative: the memory is in working zone, must defer.
+  {
+    id: "neg-not-trusted",
+    query: "package manager remnic",
+    candidates: [
+      untrustedNote({
+        id: "working",
+        content: "remnic uses pnpm",
+        tags: ["package-manager", "remnic"],
+      }),
+    ],
+    expected: "defer",
+  },
+  // Negative: low-importance unverified memory in eligible bucket, must defer.
+  {
+    id: "neg-below-importance",
+    query: "package manager remnic",
+    candidates: [
+      {
+        id: "weak",
+        content: "remnic uses pnpm",
+        tags: ["package-manager", "remnic"],
+        category: "decision",
+        trustZone: "trusted",
+        importanceScore: 0.2,
+        taxonomyBucket: "decisions",
+      },
+    ],
+    expected: "defer",
+  },
+  // Negative: eligible memory but token overlap too low to trust.
+  {
+    id: "neg-low-overlap",
+    query: "package manager remnic",
+    candidates: [
+      trustedDecision({
+        id: "off-topic",
+        content: "remnic is an agentic memory substrate",
+        tags: ["overview"],
+      }),
+    ],
+    expected: "defer",
+  },
+  // Positive: entity hint routes correctly.
+  {
+    id: "pos-entity-hint",
+    query: "package manager",
+    candidates: [
+      trustedDecision({
+        id: "remnic-pm",
+        content: "remnic uses pnpm for package management",
+        tags: ["package-manager"],
+        entityRef: "remnic",
+      }),
+      trustedDecision({
+        id: "weclone-pm",
+        content: "weclone uses npm for package management",
+        tags: ["package-manager"],
+        entityRef: "weclone",
+      }),
+    ],
+    queryEntityRefs: ["remnic"],
+    expected: "eligible",
+    expectedWinnerId: "remnic-pm",
+  },
+  // Negative: superseded memory cannot answer.
+  {
+    id: "neg-superseded",
+    query: "package manager remnic",
+    candidates: [
+      {
+        ...trustedDecision({
+          id: "old",
+          content: "remnic uses npm",
+          tags: ["package-manager", "remnic"],
+        }),
+        status: "superseded",
+      },
+    ],
+    expected: "defer",
+  },
+  // Negative: taxonomy bucket not eligible (correction).
+  {
+    id: "neg-bucket",
+    query: "package manager remnic",
+    candidates: [
+      {
+        id: "correction",
+        content: "remnic uses pnpm",
+        tags: ["package-manager", "remnic"],
+        category: "fact",
+        trustZone: "trusted",
+        importanceScore: 0.9,
+        taxonomyBucket: "corrections",
+      },
+    ],
+    expected: "defer",
+  },
+  // Positive: runbook bucket is eligible.
+  {
+    id: "pos-runbook",
+    query: "ship the branch",
+    candidates: [
+      {
+        id: "ship",
+        content: "run tests, rebase, then gh pr merge --squash",
+        tags: ["ship", "runbook"],
+        category: "skill",
+        trustZone: "trusted",
+        importanceScore: 0.85,
+        verificationState: "user_confirmed",
+        taxonomyBucket: "runbooks",
+      },
+    ],
+    expected: "eligible",
+    expectedWinnerId: "ship",
+  },
+];
+
+export function memoryFileFromCase(candidate: DirectAnswerCaseCandidate): MemoryFile {
+  return {
+    path: `/memory/${candidate.id}.md`,
+    frontmatter: {
+      id: candidate.id,
+      category: candidate.category,
+      created: "2026-04-19T00:00:00.000Z",
+      updated: "2026-04-19T00:00:00.000Z",
+      source: "bench",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: candidate.tags,
+      entityRef: candidate.entityRef,
+      status: candidate.status,
+      verificationState: candidate.verificationState,
+    },
+    content: candidate.content,
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
@@ -1,0 +1,154 @@
+/**
+ * Direct-answer latency benchmark (issue #518).
+ *
+ * Exercises the eligibility gate on a hand-crafted synthetic fixture
+ * and reports precision (positive cases fire Tier 2), deferral recall
+ * (negative cases defer to the hybrid path), and per-case latency.
+ * Does not require an orchestrator or a search backend — candidates
+ * are synthesized in-memory, so the bench stays deterministic and
+ * fast.
+ */
+
+import { isDirectAnswerEligible, type DirectAnswerCandidate } from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  DIRECT_ANSWER_BENCH_FIXTURE,
+  memoryFileFromCase,
+  type DirectAnswerBenchCase,
+} from "./fixture.js";
+
+export const retrievalDirectAnswerDefinition: BenchmarkDefinition = {
+  id: "retrieval-direct-answer",
+  title: "Retrieval: Direct-Answer Gate",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retrieval-direct-answer",
+    version: "1.0.0",
+    description:
+      "Measures the direct-answer tier eligibility gate: precision on positive cases, deferral recall on negative cases, and per-case decision latency (issue #518).",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #518",
+  },
+};
+
+const DEFAULT_CONFIG = {
+  enabled: true,
+  tokenOverlapFloor: 0.5,
+  importanceFloor: 0.7,
+  ambiguityMargin: 0.15,
+  eligibleTaxonomyBuckets: [
+    "decisions",
+    "principles",
+    "conventions",
+    "runbooks",
+    "entities",
+  ],
+};
+
+function buildCandidates(benchCase: DirectAnswerBenchCase): DirectAnswerCandidate[] {
+  return benchCase.candidates.map((c) => ({
+    memory: memoryFileFromCase(c),
+    trustZone: c.trustZone,
+    taxonomyBucket: c.taxonomyBucket ?? null,
+    importanceScore: c.importanceScore,
+  }));
+}
+
+function scoreCase(benchCase: DirectAnswerBenchCase): { scores: Record<string, number>; actualVerdict: string; winnerId: string | null; latencyMs: number } {
+  const candidates = buildCandidates(benchCase);
+  const start = performance.now();
+  const result = isDirectAnswerEligible({
+    query: benchCase.query,
+    candidates,
+    config: DEFAULT_CONFIG,
+    queryEntityRefs: benchCase.queryEntityRefs,
+  });
+  const latencyMs = performance.now() - start;
+  const actualVerdict = result.eligible ? "eligible" : "defer";
+  const winnerId = result.winner?.memory.frontmatter.id ?? null;
+
+  const verdictCorrect = actualVerdict === benchCase.expected ? 1 : 0;
+  const winnerCorrect =
+    benchCase.expected === "eligible"
+      ? winnerId === (benchCase.expectedWinnerId ?? null)
+        ? 1
+        : 0
+      : 1; // non-eligible cases have no winner to check
+
+  return {
+    scores: {
+      verdict_correct: verdictCorrect,
+      winner_correct: winnerCorrect,
+      latency_under_5ms: latencyMs < 5 ? 1 : 0,
+    },
+    actualVerdict,
+    winnerId,
+    latencyMs,
+  };
+}
+
+export async function runRetrievalDirectAnswerBenchmark(
+  _options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const tasks: TaskResult[] = [];
+  const latencies: number[] = [];
+
+  for (const benchCase of DIRECT_ANSWER_BENCH_FIXTURE) {
+    const { scores, actualVerdict, winnerId, latencyMs } = scoreCase(benchCase);
+    latencies.push(latencyMs);
+    tasks.push({
+      taskId: benchCase.id,
+      question: benchCase.query,
+      expected:
+        benchCase.expected === "eligible"
+          ? `eligible:${benchCase.expectedWinnerId ?? ""}`
+          : "defer",
+      actual: actualVerdict === "eligible" ? `eligible:${winnerId ?? ""}` : "defer",
+      scores,
+      latencyMs: Math.round(latencyMs * 100) / 100,
+      tokens: { input: 0, output: 0 },
+      details: {
+        caseId: benchCase.id,
+        candidateCount: benchCase.candidates.length,
+      },
+    });
+  }
+
+  latencies.sort((a, b) => a - b);
+  const p50 = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
+  const p95 = latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] ?? 0;
+
+  const aggregated = aggregateTaskScores(tasks);
+
+  return {
+    runId: `retrieval-direct-answer-${Date.now()}`,
+    benchmarkId: retrievalDirectAnswerDefinition.id,
+    startedAt: new Date().toISOString(),
+    completedAt: new Date().toISOString(),
+    gitSha: await getGitSha(),
+    remnicVersion: await getRemnicVersion(),
+    mode: _options.mode,
+    tasks,
+    results: {
+      summary: {
+        taskCount: tasks.length,
+        correctVerdicts: tasks.filter((t) => t.scores.verdict_correct === 1).length,
+        correctWinners: tasks.filter((t) => t.scores.winner_correct === 1).length,
+      },
+      aggregates: {
+        ...aggregated,
+        latency_p50_ms: Math.round(p50 * 100) / 100,
+        latency_p95_ms: Math.round(p95 * 100) / 100,
+      },
+    },
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
@@ -78,23 +78,50 @@ function scoreCase(benchCase: DirectAnswerBenchCase): { scores: Record<string, n
   const winnerId = result.winner?.memory.frontmatter.id ?? null;
 
   const verdictCorrect = actualVerdict === benchCase.expected ? 1 : 0;
-  const winnerCorrect =
-    benchCase.expected === "eligible"
-      ? winnerId === (benchCase.expectedWinnerId ?? null)
-        ? 1
-        : 0
-      : 1; // non-eligible cases have no winner to check
+  const scores: Record<string, number> = {
+    verdict_correct: verdictCorrect,
+    latency_under_5ms: latencyMs < 5 ? 1 : 0,
+  };
+  // Only record winner_correct on cases that expect an eligible verdict.
+  // Hard-coding 1 for defer cases would inflate the aggregate mean and mask
+  // real winner-selection regressions on eligible cases. Omitting the metric
+  // causes aggregateTaskScores to average only over eligible cases (see
+  // collectMetricValues, which filters non-numeric entries).
+  if (benchCase.expected === "eligible") {
+    scores.winner_correct =
+      winnerId === (benchCase.expectedWinnerId ?? null) ? 1 : 0;
+  }
 
   return {
-    scores: {
-      verdict_correct: verdictCorrect,
-      winner_correct: winnerCorrect,
-      latency_under_5ms: latencyMs < 5 ? 1 : 0,
-    },
+    scores,
     actualVerdict,
     winnerId,
     latencyMs,
   };
+}
+
+function selectCases(
+  mode: "quick" | "full",
+  limit?: number,
+): DirectAnswerBenchCase[] {
+  // Quick mode defaults to the first case; explicit --limit always wins.
+  const effectiveLimit =
+    limit !== undefined ? limit : mode === "quick" ? 1 : undefined;
+  if (effectiveLimit === undefined) {
+    return DIRECT_ANSWER_BENCH_FIXTURE;
+  }
+  if (!Number.isInteger(effectiveLimit) || effectiveLimit <= 0) {
+    throw new Error(
+      "retrieval-direct-answer limit must be a positive integer",
+    );
+  }
+  const limited = DIRECT_ANSWER_BENCH_FIXTURE.slice(0, effectiveLimit);
+  if (limited.length === 0) {
+    throw new Error(
+      "retrieval-direct-answer fixture is empty after applying the requested limit.",
+    );
+  }
+  return limited;
 }
 
 export async function runRetrievalDirectAnswerBenchmark(
@@ -102,8 +129,9 @@ export async function runRetrievalDirectAnswerBenchmark(
 ): Promise<BenchmarkResult> {
   const tasks: TaskResult[] = [];
   const latencies: number[] = [];
+  const cases = selectCases(options.mode, options.limit);
 
-  for (const benchCase of DIRECT_ANSWER_BENCH_FIXTURE) {
+  for (const benchCase of cases) {
     const { scores, actualVerdict, winnerId, latencyMs } = scoreCase(benchCase);
     latencies.push(latencyMs);
     tasks.push({

--- a/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-direct-answer/runner.ts
@@ -9,6 +9,7 @@
  * fast.
  */
 
+import { randomUUID } from "node:crypto";
 import { isDirectAnswerEligible, type DirectAnswerCandidate } from "@remnic/core";
 import type {
   BenchmarkDefinition,
@@ -97,7 +98,7 @@ function scoreCase(benchCase: DirectAnswerBenchCase): { scores: Record<string, n
 }
 
 export async function runRetrievalDirectAnswerBenchmark(
-  _options: ResolvedRunBenchmarkOptions,
+  options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
   const tasks: TaskResult[] = [];
   const latencies: number[] = [];
@@ -124,31 +125,55 @@ export async function runRetrievalDirectAnswerBenchmark(
   }
 
   latencies.sort((a, b) => a - b);
-  const p50 = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
-  const p95 = latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] ?? 0;
+  const p50Raw = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
+  const p95Raw =
+    latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] ?? 0;
+  const p50 = Math.round(p50Raw * 100) / 100;
+  const p95 = Math.round(p95Raw * 100) / 100;
 
-  const aggregated = aggregateTaskScores(tasks);
+  const aggregated = aggregateTaskScores(tasks.map((task) => task.scores));
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
 
   return {
-    runId: `retrieval-direct-answer-${Date.now()}`,
-    benchmarkId: retrievalDirectAnswerDefinition.id,
-    startedAt: new Date().toISOString(),
-    completedAt: new Date().toISOString(),
-    gitSha: await getGitSha(),
-    remnicVersion: await getRemnicVersion(),
-    mode: _options.mode,
-    tasks,
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
     results: {
-      summary: {
-        taskCount: tasks.length,
-        correctVerdicts: tasks.filter((t) => t.scores.verdict_correct === 1).length,
-        correctWinners: tasks.filter((t) => t.scores.winner_correct === 1).length,
-      },
+      tasks,
       aggregates: {
         ...aggregated,
-        latency_p50_ms: Math.round(p50 * 100) / 100,
-        latency_p95_ms: Math.round(p95 * 100) / 100,
+        latency_p50_ms: { mean: p50, median: p50, stdDev: 0, min: p50, max: p50 },
+        latency_p95_ms: { mean: p95, median: p95, stdDev: 0, min: p95, max: p95 },
       },
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
     },
   };
 }

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -68,6 +68,10 @@ import {
   runRetrievalTemporalBenchmark,
 } from "./benchmarks/remnic/retrieval-temporal/runner.js";
 import {
+  retrievalDirectAnswerDefinition,
+  runRetrievalDirectAnswerBenchmark,
+} from "./benchmarks/remnic/retrieval-direct-answer/runner.js";
+import {
   proceduralRecallDefinition,
   runProceduralRecallBenchmark,
 } from "./benchmarks/remnic/procedural-recall/runner.js";
@@ -176,6 +180,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalTemporalDefinition,
     run: runRetrievalTemporalBenchmark,
+  },
+  {
+    ...retrievalDirectAnswerDefinition,
+    run: runRetrievalDirectAnswerBenchmark,
   },
   {
     ...proceduralRecallDefinition,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -90,6 +90,20 @@ export {
 } from "./procedural/procedure-types.js";
 
 // ---------------------------------------------------------------------------
+// Direct-answer retrieval tier (issue #518)
+// ---------------------------------------------------------------------------
+
+export {
+  isDirectAnswerEligible,
+  FILTER_LABELS as DIRECT_ANSWER_FILTER_LABELS,
+  type DirectAnswerCandidate,
+  type DirectAnswerConfig,
+  type DirectAnswerInput,
+  type DirectAnswerReason,
+  type DirectAnswerResult,
+} from "./direct-answer.js";
+
+// ---------------------------------------------------------------------------
 // Inline source attribution (issue #369)
 // ---------------------------------------------------------------------------
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -28,6 +28,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "page-versioning",
       "retrieval-personalization",
       "retrieval-temporal",
+      "retrieval-direct-answer",
       "procedural-recall",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
@@ -69,11 +70,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.
@@ -242,6 +244,17 @@ test("getBenchmark returns retrieval-temporal metadata with a runnable benchmark
 
   assert.ok(benchmark);
   assert.equal(benchmark?.id, "retrieval-temporal");
+  assert.equal(benchmark?.status, "ready");
+  assert.equal(benchmark?.runnerAvailable, true);
+  assert.equal(benchmark?.tier, "remnic");
+  assert.equal(benchmark?.meta.category, "retrieval");
+});
+
+test("getBenchmark returns retrieval-direct-answer metadata with a runnable benchmark entry", () => {
+  const benchmark = getBenchmark("retrieval-direct-answer");
+
+  assert.ok(benchmark);
+  assert.equal(benchmark?.id, "retrieval-direct-answer");
   assert.equal(benchmark?.status, "ready");
   assert.equal(benchmark?.runnerAvailable, true);
   assert.equal(benchmark?.tier, "remnic");


### PR DESCRIPTION
Adds a synthetic bench scenario for the direct-answer eligibility gate (#518). Covers 10 hand-crafted cases spanning every gate behavior.

## Summary

- 10 synthetic cases: trusted-single-hit, noisy distractors, ambiguity (two trusted within margin), non-trusted zones, below-importance-floor, low token overlap, entity-hint routing, superseded memories, ineligible taxonomy buckets, runbook bucket acceptance.
- Per-case metrics: \`verdict_correct\` (Tier 2 fires on positives, defers on negatives), \`winner_correct\` (right memory when eligible), \`latency_under_5ms\`.
- Aggregates: \`latency_p50_ms\`, \`latency_p95_ms\`, plus the task-score aggregates from \`aggregateTaskScores\`.
- No orchestrator / backend dependency — candidates are built in-memory, so the bench is deterministic.

## Operator usage

    npx remnic bench run retrieval-direct-answer

## Out of scope

- CI threshold (defer until operator runs produce a stable range)
- Full end-to-end bench via the orchestrator (depends on #540 slice 3c landing; follow-up slice can add)
- Clean/dirty schema-tier split (pattern from #448 — follow-up)

## Test plan

- [x] \`tsc --noEmit\` clean
- [x] Registered in \`packages/bench/src/registry.ts\`
- [x] Core re-exports \`isDirectAnswerEligible\` + related types so bench can invoke the gate

Part of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new synthetic benchmark and exposes existing direct-answer eligibility APIs via `@remnic/core` exports; no production retrieval behavior changes.
> 
> **Overview**
> Adds a new deterministic `retrieval-direct-answer` benchmark that runs the `isDirectAnswerEligible` gate against a small synthetic fixture, recording per-case correctness (`verdict_correct`, conditional `winner_correct`) and a simple latency SLA plus p50/p95 latency aggregates.
> 
> Registers the new benchmark in the bench registry and updates registry tests, and re-exports `isDirectAnswerEligible` plus related direct-answer types/labels from `@remnic/core` so the bench can call the gate.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0930fff0f16fffce2c1ccc56f4b7a2b22e07b7ed. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->