### PR TITLE
feat(config): flip recallDirectAnswerEnabled default to true (#518 slice 8a/9)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1934,8 +1934,8 @@
       },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+        "default": true,
+        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1930,8 +1930,8 @@
       },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+        "default": true,
+        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -104,9 +104,9 @@ test("parseConfig preserves custom entity schemas without code changes", () => {
 
 // ── Issue #518: direct-answer retrieval tier config ─────────────────────────
 
-test("parseConfig recallDirectAnswerEnabled defaults to false", () => {
+test("parseConfig recallDirectAnswerEnabled defaults to true (slice 8a flip)", () => {
   const result = parseConfig({});
-  assert.equal(result.recallDirectAnswerEnabled, false);
+  assert.equal(result.recallDirectAnswerEnabled, true);
 });
 
 test('parseConfig recallDirectAnswerEnabled coerces string "true" to boolean true', () => {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -885,9 +885,13 @@ export function parseConfig(raw: unknown): PluginConfig {
     temporalSupersessionEnabled: cfg.temporalSupersessionEnabled !== false, // On by default
     temporalSupersessionIncludeInRecall:
       cfg.temporalSupersessionIncludeInRecall === true, // Off by default
-    // Direct-answer retrieval tier (issue #518)
+    // Direct-answer retrieval tier (issue #518).  Default on — the
+    // tier runs in observation mode: it annotates
+    // LastRecallSnapshot.tierExplain but never short-circuits the
+    // QMD path.  Operators can opt out with
+    // recallDirectAnswerEnabled=false.
     recallDirectAnswerEnabled:
-      coerceBool(cfg.recallDirectAnswerEnabled) ?? false,
+      coerceBool(cfg.recallDirectAnswerEnabled) ?? true,
     recallDirectAnswerTokenOverlapFloor: (() => {
       const n = coerceNumber(cfg.recallDirectAnswerTokenOverlapFloor);
       return n !== undefined && n >= 0 && n <= 1 ? n : 0.55;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1876,8 +1876,8 @@
       },
       "recallDirectAnswerEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "When true, recall checks whether a single validated high-trust memory can answer the query before QMD runs (issue #518). Default off until bench validation."
+        "default": true,
+        "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",


### PR DESCRIPTION
**Draft**. Opened so the work is ready to land once upstream slices are in; see the recommended merge ordering below.

## Summary

Flips the master switch for the direct-answer retrieval tier from \`false\` to \`true\`. The tier runs in **observation mode** only — it annotates \`LastRecallSnapshot.tierExplain\` with which tier would have served the query but never short-circuits the QMD path, so the caller's answer is unchanged.

## Changes

- \`packages/remnic-core/src/config.ts\` — \`coerceBool(cfg.recallDirectAnswerEnabled) ?? true\`
- \`packages/plugin-openclaw/openclaw.plugin.json\` (source + synced mirror) — \`default: true\`; description rewritten to describe observation behavior
- \`packages/remnic-core/src/config.test.ts\` — default test expects \`true\`. 40/40 config tests pass.

## Recommended merge order (this PR last)

1. PR #535 slice 3b — schema
2. PR #537 / #538 / #539 slices 4 / 5 / 6 — surfaces (any order)
3. PR #540 slice 3c — orchestrator wiring
4. PR #542 slice 7 — bench
5. PR #541 — abort-error refactor (independent)
6. PR #543 slice 8b — docs
7. **This PR (#544 slice 8a)** — default flip

Swap to ready-for-review once the above stack is on main and an operator \`bench run retrieval-direct-answer\` produces an observation latency number they're comfortable shipping.

## Escape hatch

Operators who want to opt out:

\`\`\`json
{ "recallDirectAnswerEnabled": false }
\`\`\`

Or via CLI: \`--config recallDirectAnswerEnabled=false\` (coerced correctly — CLAUDE.md rule 36).

Closes the last piece of #518.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Flips a retrieval-tier feature flag default, which could change runtime behavior/latency for deployments that rely on implicit defaults. Although described as observation-only (no QMD short-circuit), it still enables additional logic and should be monitored in production.
> 
> **Overview**
> **Enables the direct-answer recall tier by default** by changing `recallDirectAnswerEnabled`’s default from `false` to `true` in `parseConfig`.
> 
> Updates the plugin config schemas (root `openclaw.plugin.json`, `packages/plugin-openclaw/openclaw.plugin.json`, and the shim mirror) to reflect the new default and clarifies in the setting description that it runs in *observation mode* (annotates `LastRecallSnapshot.tierExplain` without short-circuiting QMD). Tests are updated to expect the new default.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c84ccc4959b7b1cd3a566b768ee1053872c83e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->