### PR TITLE
packaging: make optional packages truly à-la-carte (bench/weclone/plugins)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -343,21 +343,29 @@ jobs:
 
       - name: Publish workspace packages to npm
         run: |
-          # Publish the install surfaces that are currently supported from npm.
-          # Uses pnpm (not npm) so that workspace: protocol strings are rewritten to
-          # real version numbers at pack time. npm publish does not perform this
-          # rewriting, which causes "workspace:^" to appear verbatim in the published
-          # package metadata (see issue #403).
+          # Publish the install surfaces supported from npm. Uses pnpm (not
+          # npm) so workspace: protocol strings are rewritten to real
+          # version numbers at pack time; npm publish does not perform this
+          # rewriting, which causes "workspace:^" to appear verbatim in the
+          # published package metadata (see issue #403).
           #
-          # The WeClone helper packages are not part of the npm install path used by
-          # Remnic/OpenClaw today. @remnic/cli bundles its export adapter so the CLI
-          # stays functional without requiring unpublished companion packages.
+          # Ordering is topological: build roots first, then packages that
+          # depend on them. Optional/à-la-carte surfaces (bench, weclone,
+          # plugins) must ship so end users can install only what they need
+          # — see the à-la-carte invariant in CLAUDE.md / AGENTS.md.
           PUBLISH_ORDER=(
             packages/remnic-core
+            packages/bench
+            packages/export-weclone
+            packages/import-weclone
+            packages/connector-weclone
+            packages/connector-replit
+            packages/hermes-provider
             packages/remnic-server
             packages/remnic-cli
-            packages/hermes-provider
             packages/plugin-openclaw
+            packages/plugin-claude-code
+            packages/plugin-codex
             packages/shim-openclaw-engram
           )
           for pkg_dir in "${PUBLISH_ORDER[@]}"; do

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -811,6 +811,46 @@ lost with no recovery path.
 - **Test the failure path** — mock `renameSync` to throw after `rmSync`
   succeeds and verify the error is handled and data is recoverable.
 
+### 44. À-la-carte Packaging — Optional Packages Must Stay Optional at Every Layer
+
+Remnic ships as a family of composable packages. The architectural contract
+is that users install only what they use: `@remnic/core` alone, core plus
+`@remnic/plugin-openclaw`, core plus `@remnic/export-weclone`, or all three.
+A PR that forces an optional package into a base install surface breaks
+this contract even if every test passes, because the breakage only shows
+up at npm-install time for someone who didn't want that optional surface.
+
+- **Load optional packages via computed-specifier dynamic imports.** Never
+  do `import { X } from "@remnic/bench"` in a base install surface (CLI,
+  core, plugin-openclaw). Use `await import("@remnic/" + "bench")` so the
+  bundler cannot statically resolve the module and pull it into the bundle.
+  Wrap in a loader helper (`loadBenchModule()`) that throws a user-facing
+  install hint on miss. Canonical patterns:
+  `packages/remnic-cli/src/optional-bench.ts`,
+  `packages/remnic-cli/src/optional-weclone-export.ts`,
+  `packages/remnic-core/src/cli.ts:ensureBuiltInBulkImportAdapters`.
+- **Declare as optional peer deps, not `dependencies`.** Optional companions
+  go under `peerDependencies` with `peerDependenciesMeta.<name>.optional =
+  true`. If you put them under `dependencies`, npm install of the base
+  package pulls them in and the à-la-carte model is gone.
+- **Never add to `noExternal`.** `packages/remnic-cli/tsup.config.ts` must
+  `external` any optional package (or simply omit it from `noExternal`). A
+  past regression listed `@remnic/bench` and `@remnic/export-weclone` under
+  `noExternal`, which bundled them into every CLI install even for users
+  who never ran `remnic bench *`.
+- **Publish every surface users are told to install.** Any package that
+  docs, error messages, or install hints mention must actually exist on
+  npm. Keeping a package `"private": true` while recommending it in a CLI
+  install hint is a bug — ship it (update
+  `.github/workflows/release-and-publish.yml PUBLISH_ORDER`) or stop
+  recommending it.
+- **Verify both paths end to end.** When you touch tsup configs, optional-
+  loader modules, or the publish workflow, verify that:
+  1. `npm install @remnic/cli` succeeds without the optional packages.
+  2. Running an optional command without the package throws the install
+     hint — not a raw `MODULE_NOT_FOUND`.
+  3. Installing the optional package and rerunning the command works.
+
 ### 43. Documentation-Code Contract — Documented Behavior Must Be Implemented
 
 PRs #397 and #398 had 3 instances where documentation claimed behavior that

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,6 +231,20 @@ grep "\[engram\]" ~/.openclaw/logs/gateway.log
 54. **Never delete before write in file replace operations** — `rmSync(target)` then `renameSync(tmp, target)` loses data permanently if rename fails. Write to temp first, then rename atomically. Verify rename success before cleanup. `renameSync` can fail on cross-device moves. PR #394.
 55. **Documented behavior must have a corresponding implementation and test** — if docs say "timeout is applied to all daemon calls", the provider must forward the timeout parameter AND a test must verify it. CI publish workflows must validate `github.ref == 'refs/heads/main'` on the job, not just the trigger. Config properties defined in schema must be wired end-to-end. PR #397, #398.
 56. **Never merge before AI reviewers post** — `cursor[bot]` and `chatgpt-codex-connector[bot]` take 2-5 minutes to review a PR. Merging immediately after PR creation races past them, leaving comments unaddressed on merged code. Run `scripts/pre-merge-check.sh <PR#>` before every `gh pr merge`. The script verifies: (1) both AI reviewers have posted, (2) zero unresolved threads remain. PRs #429-#439 had 5 comments missed due to this race.
+57. **À-la-carte packages must stay optional at every install layer** — users who only need memory features should not have to install benchmark, weclone, or plugin code. Optional workspace packages (`@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-weclone`, etc.) MUST be loaded via computed-specifier dynamic imports (`await import("@remnic/" + "bench")`) and MUST NOT appear in any base install surface's runtime `dependencies` or `noExternal` bundler list. Declare them as `peerDependenciesMeta.*.optional = true` and surface a user-facing install hint when the dynamic import fails. See `packages/remnic-cli/src/optional-bench.ts` and `optional-weclone-export.ts` for the canonical pattern. See also the "À-la-carte packaging" section below.
+
+## À-la-carte packaging
+
+Remnic ships as a family of packages that compose. Every install surface must respect this contract:
+
+- **Core always works alone.** `@remnic/core` is the only install most users need.
+- **Optional packages never piggyback on the base install.** `@remnic/bench`, `@remnic/export-weclone`, `@remnic/import-weclone`, `@remnic/plugin-openclaw`, etc. must be separately `npm install`-able and must never be bundled, noExternal'd, or declared as a runtime `dependencies` entry on a base package.
+- **Load optional packages lazily.** Use a computed-specifier dynamic import (`await import("@remnic/" + "bench")`) so bundlers cannot statically resolve the module. Wrap in a loader helper that throws a user-facing install hint on miss. Canonical implementations: `packages/remnic-cli/src/optional-bench.ts`, `packages/remnic-cli/src/optional-weclone-export.ts`, `packages/remnic-core/src/cli.ts:ensureBuiltInBulkImportAdapters`.
+- **Declare as optional peer deps.** In the consuming package's `package.json`, list optional companions under `peerDependencies` and mark each as optional via `peerDependenciesMeta.<name>.optional = true`. Do not list them under `dependencies`.
+- **Never add to `noExternal`.** In tsup configs, optional packages must be `external` (or simply omitted from `noExternal`). Adding them to `noExternal` bundles them into the base install and breaks à-la-carte.
+- **Publish everything.** Any package that end users are expected to install (even as an extension) must be published to npm. If it's `"private": true` and you recommend it, that's a bug — ship it or remove the recommendation. The publish order in `.github/workflows/release-and-publish.yml` is the source of truth; keep it topologically sorted.
+
+When you touch any of these files — tsup configs, CLI/plugin package.json `dependencies`, or dynamic-import loaders — re-verify the contract end to end: does `npm install @remnic/cli` still work without the optional packages present? Does the CLI throw a clean install hint instead of a `MODULE_NOT_FOUND`?
 
 ## Cleaner PR Workflow
 

--- a/README.md
+++ b/README.md
@@ -481,11 +481,17 @@ Engram is organized as a monorepo with a core engine, standalone server/CLI, and
 | `@remnic/server` | [![npm](https://img.shields.io/npm/v/@remnic/server)](https://www.npmjs.com/package/@remnic/server) | Standalone HTTP/MCP server with multi-token auth. Run as daemon via launchd/systemd |
 | `@remnic/cli` | [![npm](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli) | CLI binary — memory management, daemon lifecycle, connectors, tokens, spaces, benchmarks |
 | `@remnic/hermes-provider` | [![npm](https://img.shields.io/npm/v/@remnic/hermes-provider)](https://www.npmjs.com/package/@remnic/hermes-provider) | TypeScript HTTP client for remote Remnic instances |
-| `@remnic/bench` | (private) | Latency ladder benchmarks with CI regression gates |
+| `@remnic/bench` | [![npm](https://img.shields.io/npm/v/@remnic/bench)](https://www.npmjs.com/package/@remnic/bench) | Latency ladder benchmarks with CI regression gates — optional `remnic bench *` surface |
+| `@remnic/export-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/export-weclone)](https://www.npmjs.com/package/@remnic/export-weclone) | WeClone fine-tuning dataset exporter — optional `remnic training:export` surface |
+| `@remnic/import-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/import-weclone)](https://www.npmjs.com/package/@remnic/import-weclone) | WeClone chat-history importer — optional `remnic bulk-import` source |
+| `@remnic/connector-weclone` | [![npm](https://img.shields.io/npm/v/@remnic/connector-weclone)](https://www.npmjs.com/package/@remnic/connector-weclone) | OpenAI-compatible proxy layering Remnic memory onto WeClone avatars |
 | `@remnic/plugin-openclaw` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-openclaw)](https://www.npmjs.com/package/@remnic/plugin-openclaw) | OpenClaw adapter — thin bridge (embedded or delegate mode) |
+| `@remnic/plugin-claude-code` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-claude-code)](https://www.npmjs.com/package/@remnic/plugin-claude-code) | Native Claude Code plugin — hooks, skills, MCP |
+| `@remnic/plugin-codex` | [![npm](https://img.shields.io/npm/v/@remnic/plugin-codex)](https://www.npmjs.com/package/@remnic/plugin-codex) | Native Codex CLI plugin — hooks, skills, MCP |
+| `@remnic/replit` | [![npm](https://img.shields.io/npm/v/@remnic/replit)](https://www.npmjs.com/package/@remnic/replit) | Replit Agent MCP connector — setup snippet + token helper |
 | `remnic-hermes` | [![PyPI](https://img.shields.io/pypi/v/remnic-hermes)](https://pypi.org/project/remnic-hermes/) | Python MemoryProvider for Hermes Agent |
-| `@remnic/plugin-claude-code` | Installed via `remnic connectors install` | Native Claude Code plugin — hooks, skills, MCP |
-| `@remnic/plugin-codex` | (installed via `remnic connectors install`) | Native Codex CLI plugin — hooks, skills, MCP |
+
+Remnic is installed à la carte: `@remnic/core` is the only package most users need, and optional surfaces (bench, weclone, plugins) are installed separately when you need them. Commands like `remnic bench *` and `remnic training:export` lazy-load their companion package and print an install hint if it's missing.
 
 The old `@joshuaswarren/openclaw-engram` package is **deprecated**. Use `@remnic/plugin-openclaw` for OpenClaw installs and `@remnic/*` for standalone or multi-platform use.
 

--- a/docs/development/release-process.md
+++ b/docs/development/release-process.md
@@ -41,6 +41,9 @@ Published automatically by `.github/workflows/release-and-publish.yml`:
 | `packages/plugin-codex` | `@remnic/plugin-codex` | npm |
 | `packages/connector-replit` | `@remnic/replit` | npm |
 | `packages/bench` | `@remnic/bench` | npm |
+| `packages/export-weclone` | `@remnic/export-weclone` | npm |
+| `packages/import-weclone` | `@remnic/import-weclone` | npm |
+| `packages/connector-weclone` | `@remnic/connector-weclone` | npm |
 | `packages/hermes-provider` | `@remnic/hermes-provider` | npm |
 
 All npm publishes include provenance attestations.

--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -1,7 +1,6 @@
 {
   "name": "@remnic/bench",
   "version": "1.0.0",
-  "private": true,
   "description": "Retrieval latency ladder benchmarks + CI regression gates for @remnic/core",
   "type": "module",
   "main": "./dist/index.js",
@@ -12,12 +11,30 @@
       "import": "./dist/index.js"
     }
   },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/bench"
+  },
+  "keywords": [
+    "remnic",
+    "benchmark",
+    "retrieval",
+    "evaluation",
+    "ai-memory"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "scripts": {
     "build": "tsup --config tsup.config.ts",
-    "check-types": "tsc --noEmit"
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
   },
   "dependencies": {
-    "@remnic/core": "workspace:*",
+    "@remnic/core": "workspace:^",
     "yaml": "^2.4.2"
   },
   "devDependencies": {

--- a/packages/connector-replit/package.json
+++ b/packages/connector-replit/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "license": "MIT",

--- a/packages/connector-replit/package.json
+++ b/packages/connector-replit/package.json
@@ -3,7 +3,14 @@
   "version": "1.0.0",
   "description": "Remnic MCP connector for Replit Agent — setup instructions and token generator",
   "type": "module",
-  "private": true,
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -16,5 +23,22 @@
     "replit",
     "mcp",
     "ai-agent"
-  ]
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "files": [
+    "dist",
+    "setup-snippet.json"
+  ],
+  "scripts": {
+    "build": "tsup --config tsup.config.ts",
+    "check-types": "tsc --noEmit",
+    "prepublishOnly": "npm run build"
+  },
+  "devDependencies": {
+    "tsup": "^8.5.1",
+    "typescript": "^5.9.3"
+  }
 }

--- a/packages/connector-replit/src/index.ts
+++ b/packages/connector-replit/src/index.ts
@@ -1,0 +1,7 @@
+// Public entry point for @remnic/replit. Re-exports the installer helpers so
+// consumers can `import { generateReplitInstructions } from "@remnic/replit"`.
+
+export {
+  generateReplitInstructions,
+  type ReplitInstallResult,
+} from "./installer.js";

--- a/packages/connector-replit/tsup.config.ts
+++ b/packages/connector-replit/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "es2022",
+  platform: "node",
+  outDir: "dist",
+  clean: true,
+  dts: true,
+});

--- a/packages/connector-weclone/package.json
+++ b/packages/connector-weclone/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "bin": {

--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": ["dist", "README.md"],

--- a/packages/export-weclone/package.json
+++ b/packages/export-weclone/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "workspace:^"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/import-weclone/package.json
+++ b/packages/import-weclone/package.json
@@ -7,8 +7,8 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "types": "./dist/index.d.ts"
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
     }
   },
   "files": ["dist"],

--- a/packages/import-weclone/package.json
+++ b/packages/import-weclone/package.json
@@ -22,7 +22,7 @@
     "provenance": true
   },
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "workspace:^"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/plugin-claude-code/package.json
+++ b/packages/plugin-claude-code/package.json
@@ -16,7 +16,10 @@
     "plugin",
     "ai-agent"
   ],
-  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "files": [
     ".claude-plugin",
     "hooks",

--- a/packages/plugin-codex/package.json
+++ b/packages/plugin-codex/package.json
@@ -17,7 +17,10 @@
     "plugin",
     "ai-agent"
   ],
-  "private": true,
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
   "files": [
     ".codex-plugin",
     "bin",
@@ -27,6 +30,6 @@
     ".mcp.json"
   ],
   "dependencies": {
-    "@remnic/core": "workspace:*"
+    "@remnic/core": "workspace:^"
   }
 }

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -33,9 +33,20 @@
     "@remnic/core": "workspace:^",
     "yaml": "^2.4.2"
   },
+  "peerDependencies": {
+    "@remnic/bench": "^1.0.0",
+    "@remnic/export-weclone": "^1.0.0",
+    "@remnic/import-weclone": "^1.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@remnic/bench": { "optional": true },
+    "@remnic/export-weclone": { "optional": true },
+    "@remnic/import-weclone": { "optional": true }
+  },
   "devDependencies": {
     "@remnic/bench": "workspace:*",
     "@remnic/export-weclone": "workspace:*",
+    "@remnic/import-weclone": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4856,12 +4856,12 @@ export async function runTrainingExport(
   };
 
   let adapter = getTrainingExportAdapter(args.format);
-  if (!adapter) {
-    // Either the format is weclone but the adapter hasn't been
-    // registered in this process yet, or it's genuinely unknown. Try
-    // registering weclone first; if the format still isn't found, fall
-    // through to the normal "unknown format" error with the real list
-    // of registered adapters.
+  if (!adapter && args.format === "weclone") {
+    // The format is specifically weclone and the adapter hasn't been
+    // registered in this process yet. Only load the optional package
+    // in this case — a typo or genuinely unsupported format should
+    // surface the normal "unknown format" error below, not a weclone
+    // install hint. (Codex feedback on PR #545.)
     const mod = await ensureWeclone();
     mod.ensureWecloneExportAdapterRegistered();
     adapter = getTrainingExportAdapter(args.format);
@@ -4909,39 +4909,38 @@ export async function runTrainingExport(
 
   // synthesize and privacy-sweep currently live in @remnic/export-weclone
   // and produce weclone-shaped output. When the selected adapter isn't
-  // the weclone one (e.g. a plugin-registered format), running these
-  // transforms would be semantically wrong AND would force users to
-  // install an optional package they never asked for, so we skip them
-  // with a clear note instead. privacy-sweep defaults to true, so this
-  // scope check is what actually preserves the à-la-carte contract for
-  // non-weclone formats. (Codex feedback on PR #545.)
+  // the weclone one, we cannot run them — but we must NOT silently
+  // skip privacy-sweep, because it's a security guard that defaults on
+  // and a quiet no-op would let PII leak through plugin/custom formats.
+  // Hard-fail with a clear remediation path instead, so users either
+  // pick --format weclone or explicitly opt out with --no-privacy-sweep.
+  // (Codex P2+P1 feedback on PR #545.)
   const adapterIsWeclone = adapter.name === "weclone";
   if (args.synthesize) {
-    if (adapterIsWeclone) {
-      const mod = await ensureWeclone();
-      records = mod.synthesizeTrainingPairs(records, {
-        maxPairsPerRecord: args.maxPairsPerRecord,
-      });
-    } else {
-      stdout.write(
-        `Note: --synthesize is ignored for --format "${adapter.name}" (weclone-only).\n`,
+    if (!adapterIsWeclone) {
+      throw new Error(
+        `--synthesize is only supported by --format weclone. Got --format ${adapter.name}. ` +
+          `Either rerun with --format weclone or drop --synthesize.`,
       );
     }
+    const mod = await ensureWeclone();
+    records = mod.synthesizeTrainingPairs(records, {
+      maxPairsPerRecord: args.maxPairsPerRecord,
+    });
   }
 
   let redactedCount = 0;
   if (args.privacySweep) {
-    if (adapterIsWeclone) {
-      const mod = await ensureWeclone();
-      const swept = mod.sweepPii(records);
-      records = swept.cleanRecords;
-      redactedCount = swept.redactedCount;
+    if (!adapterIsWeclone) {
+      throw new Error(
+        `--privacy-sweep is only implemented for --format weclone (${adapter.name} would silently skip redaction, which is unsafe). ` +
+          `Rerun with --format weclone to redact PII, or pass --no-privacy-sweep to export ${adapter.name} records as-is after confirming they are safe to emit.`,
+      );
     }
-    // Silent no-op for non-weclone adapters: privacy-sweep defaults to
-    // true, so logging a note for every run would be noisy. Adapters
-    // registered outside weclone are expected to handle their own PII
-    // story; users who specifically need the weclone sweep should pick
-    // --format weclone.
+    const mod = await ensureWeclone();
+    const swept = mod.sweepPii(records);
+    records = swept.cleanRecords;
+    redactedCount = swept.redactedCount;
   }
 
   if (args.dryRun) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -124,41 +124,27 @@ import {
   type TrainingExportOptions,
   type TrainingExportRecord,
 } from "@remnic/core";
-// Side-effect import: registers the weclone adapter with the core registry.
-// `ensureWecloneExportAdapterRegistered` is exported for idempotent explicit
-// calls from tests that reset the registry between cases.
-import {
-  ensureWecloneExportAdapterRegistered,
-  synthesizeTrainingPairs,
-  sweepPii,
-} from "@remnic/export-weclone";
+// @remnic/export-weclone is an optional install surface (training:export
+// only uses it). Load lazily so the CLI works without it — see
+// optional-weclone-export.ts for the install-hint behaviour.
+import { loadWecloneExportModule } from "./optional-weclone-export.js";
 import type {
   BinaryLifecycleConfig,
 } from "@remnic/core";
 import type { MemoryCategory, Taxonomy, TaxonomyCategory } from "@remnic/core";
+// @remnic/bench is an optional install surface. Import types only at the
+// top level (erased at compile time); runtime access goes through
+// loadBenchModule() / tryLoadBenchModule() so the CLI stays functional for
+// users who never run `remnic bench *`.
 import {
-  buildBenchmarkPublishFeed,
-  compareResults,
-  deleteBenchmarkResults,
-  getBenchmarkLowerIsBetter,
-  defaultBenchmarkBaselineDir,
-  discoverAllProviders,
-  defaultBenchmarkPublishPath,
-  listBenchmarkBaselines,
-  listBenchmarkResults,
-  loadBenchmarkBaseline,
-  runBenchSuite,
-  runExplain,
-  loadBaseline,
-  saveBaseline,
-  checkRegression,
-  loadBenchmarkResult,
-  renderBenchmarkResultExport,
-  resolveBenchmarkResultReference,
-  saveBenchmarkBaseline,
-  writeBenchmarkPublishFeed,
-  type BenchConfig,
-  type BenchmarkDefinition,
+  loadBenchModule,
+  tryLoadBenchModule,
+} from "./optional-bench.js";
+import type {
+  BenchConfig,
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ComparisonResult,
 } from "@remnic/bench";
 import { firstSuccessfulCandidate, firstSuccessfulResult } from "./service-candidates.js";
 import {
@@ -280,6 +266,7 @@ const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 type PackageBenchModule = {
   getBenchmark?: (id: string) => {
     runnerAvailable?: boolean;
+    meta?: { category?: string };
   } | undefined;
   runBenchmark?: (id: string, options: {
     mode?: "full" | "quick";
@@ -424,16 +411,12 @@ async function listBenchmarksFromPackage(): Promise<BenchCatalogEntry[] | undefi
 }
 
 async function loadBenchDefinitionsFromPackage(): Promise<BenchmarkDefinition[] | undefined> {
-  try {
-    const benchModule = await import("@remnic/bench") as {
-      listBenchmarks?: () => BenchmarkDefinition[];
-    };
-    if (!benchModule.listBenchmarks) return undefined;
-    const result = benchModule.listBenchmarks();
-    return Array.isArray(result) ? result : undefined;
-  } catch {
+  const benchModule = await tryLoadBenchModule();
+  if (!benchModule || typeof benchModule.listBenchmarks !== "function") {
     return undefined;
   }
+  const result = benchModule.listBenchmarks();
+  return Array.isArray(result) ? result : undefined;
 }
 
 async function resolveAllBenchmarks(): Promise<string[]> {
@@ -588,8 +571,11 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
   });
 }
 
+// Inlined copy of @remnic/bench's defaultBenchmarkBaselineDir so we don't
+// load the optional bench package just to resolve a path. Keep in sync with
+// packages/bench/src/results-store.ts:defaultBenchmarkBaselineDir.
 function resolveBenchBaselineDir(): string {
-  return defaultBenchmarkBaselineDir();
+  return path.join(resolveHomeDir(), ".remnic", "bench", "baselines");
 }
 
 // Resolve the dataset root. In a monorepo checkout we keep using
@@ -747,7 +733,7 @@ function printBenchPackageSummary(
 }
 
 function printStoredBenchResultSummary(
-  result: Awaited<ReturnType<typeof loadBenchmarkResult>>,
+  result: BenchmarkResult,
   summary: { id: string; path: string },
 ): void {
   printBenchPackageSummary(result, summary.path, "Stored result");
@@ -755,7 +741,7 @@ function printStoredBenchResultSummary(
 }
 
 function printStoredBenchResultDetails(
-  result: Awaited<ReturnType<typeof loadBenchmarkResult>>,
+  result: BenchmarkResult,
   summary: { id: string; path: string },
 ): void {
   printStoredBenchResultSummary(result, summary);
@@ -778,7 +764,7 @@ function printStoredBenchResultDetails(
 }
 
 function printBenchComparisonSummary(
-  comparison: ReturnType<typeof compareResults>,
+  comparison: ComparisonResult,
   baseline: { id: string; path: string },
   candidate: { id: string; path: string },
 ): void {
@@ -824,6 +810,12 @@ async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
   }
 
   const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const {
+    resolveBenchmarkResultReference,
+    loadBenchmarkResult,
+    compareResults,
+    getBenchmarkLowerIsBetter,
+  } = await loadBenchModule();
   const [baselineRef, candidateRef] = refs;
   const baselineSummary = await resolveBenchmarkResultReference(resultsDir, baselineRef);
   const candidateSummary = await resolveBenchmarkResultReference(resultsDir, candidateRef);
@@ -872,6 +864,11 @@ async function compareBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
 
 async function showBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
   const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const {
+    listBenchmarkResults,
+    resolveBenchmarkResultReference,
+    loadBenchmarkResult,
+  } = await loadBenchModule();
 
   if (parsed.benchmarks.length === 0) {
     const summaries = await listBenchmarkResults(resultsDir);
@@ -922,6 +919,14 @@ async function showBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
 
 async function manageBenchBaselines(parsed: ParsedBenchArgs): Promise<void> {
   const baselineDir = parsed.baselinesDir ?? resolveBenchBaselineDir();
+  const {
+    listBenchmarkBaselines,
+    resolveBenchmarkResultReference,
+    listBenchmarkResults,
+    loadBenchmarkResult,
+    saveBenchmarkBaseline,
+    loadBenchmarkBaseline,
+  } = await loadBenchModule();
 
   if (parsed.baselineAction === "list") {
     const baselines = await listBenchmarkBaselines(baselineDir);
@@ -1014,6 +1019,11 @@ async function exportBenchPackageResult(parsed: ParsedBenchArgs): Promise<void> 
   }
 
   const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const {
+    resolveBenchmarkResultReference,
+    loadBenchmarkResult,
+    renderBenchmarkResultExport,
+  } = await loadBenchModule();
   const reference = parsed.benchmarks[0]!;
   const summary = await resolveBenchmarkResultReference(resultsDir, reference);
   if (!summary) {
@@ -1137,6 +1147,7 @@ async function manageBenchRuns(parsed: ParsedBenchArgs): Promise<void> {
       );
       process.exit(1);
     }
+    const { deleteBenchmarkResults } = await loadBenchModule();
     const deleted = await deleteBenchmarkResults(resultsDir, parsed.benchmarks);
     if (parsed.json) {
       console.log(JSON.stringify(deleted, null, 2));
@@ -1176,6 +1187,7 @@ async function discoverBenchProviders(parsed: ParsedBenchArgs): Promise<void> {
     process.exit(1);
   }
 
+  const { discoverAllProviders } = await loadBenchModule();
   const discovered = await discoverAllProviders();
 
   if (parsed.json) {
@@ -1220,6 +1232,11 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
   }
 
   const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const {
+    buildBenchmarkPublishFeed,
+    defaultBenchmarkPublishPath,
+    writeBenchmarkPublishFeed,
+  } = await loadBenchModule();
   const feed = await buildBenchmarkPublishFeed(resultsDir, parsed.target);
   if (feed.benchmarks.length === 0) {
     console.error(
@@ -1249,12 +1266,9 @@ async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
 ): Promise<boolean> {
-  let benchModule: PackageBenchModule;
-  try {
-    benchModule = await import("@remnic/bench") as unknown as PackageBenchModule;
-  } catch {
-    return false;
-  }
+  const loaded = await tryLoadBenchModule();
+  if (!loaded) return false;
+  const benchModule = loaded as unknown as PackageBenchModule;
 
   const definition = benchModule.getBenchmark?.(benchmarkId);
   if (!definition?.runnerAvailable || !benchModule.runBenchmark || !benchModule.writeBenchmarkResult) {
@@ -1312,12 +1326,9 @@ async function runBenchViaPackage(
 }
 
 async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolean> {
-  let benchModule: PackageBenchModule;
-  try {
-    benchModule = await import("@remnic/bench") as unknown as PackageBenchModule;
-  } catch {
-    return false;
-  }
+  const loaded = await tryLoadBenchModule();
+  if (!loaded) return false;
+  const benchModule = loaded as unknown as PackageBenchModule;
 
   if (!benchModule.runCustomBenchmarkFile || !benchModule.writeBenchmarkResult) {
     return false;
@@ -1578,6 +1589,7 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const service = new EngramAccessService(orchestrator);
 
   if (explain) {
+    const { runExplain } = await loadBenchModule();
     const result = await runExplain(service, queryText);
     if (json) {
       console.log(JSON.stringify(result, null, 2));
@@ -3066,6 +3078,8 @@ async function cmdLegacyBenchmark(action: string, rest: string[], json: boolean)
   const orchestrator = new Orchestrator(config);
   const service = new EngramAccessService(orchestrator);
 
+  const { runBenchSuite, loadBaseline, checkRegression } = await loadBenchModule();
+
   const benchConfig: BenchConfig = {
     queries: rest.filter((a) => !a.startsWith("--")).length > 0
       ? rest.filter((a) => !a.startsWith("--"))
@@ -4479,8 +4493,11 @@ export async function runTrainingExport(
   // Ensure the WeClone adapter (and any others registered via side-effect
   // imports) are available before we ask the registry. `ensureWecloneExportAdapterRegistered`
   // is idempotent — safe to call even when the adapter is already registered
-  // by a previous CLI invocation in the same process.
-  ensureWecloneExportAdapterRegistered();
+  // by a previous CLI invocation in the same process. The module itself is
+  // an optional install surface; loadWecloneExportModule() throws a
+  // user-facing install hint if @remnic/export-weclone is missing.
+  const wecloneExport = await loadWecloneExportModule();
+  wecloneExport.ensureWecloneExportAdapterRegistered();
 
   const adapter = getTrainingExportAdapter(args.format);
   if (!adapter) {
@@ -4525,14 +4542,14 @@ export async function runTrainingExport(
   const recordsRead = records.length;
 
   if (args.synthesize) {
-    records = synthesizeTrainingPairs(records, {
+    records = wecloneExport.synthesizeTrainingPairs(records, {
       maxPairsPerRecord: args.maxPairsPerRecord,
     });
   }
 
   let redactedCount = 0;
   if (args.privacySweep) {
-    const swept = sweepPii(records);
+    const swept = wecloneExport.sweepPii(records);
     records = swept.cleanRecords;
     redactedCount = swept.redactedCount;
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1928,11 +1928,22 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
     const explainStart = Date.now();
     const recallResult = await service.recall({ query: queryText, mode: "auto" });
     const totalDurationMs = Date.now() - explainStart;
-    const memories = (recallResult as { memories?: Array<{ content: string }> }).memories ?? [];
+    // recall() returns { count, results, memoryIds, ... } (see
+    // EngramAccessRecallResponse). A prior version of this fallback
+    // read .memories, which doesn't exist, so resultsCount was always
+    // 0 and users saw misleading explain output. (Codex feedback on
+    // PR #545.) Prefer the numeric count and fall back to
+    // results.length for robustness across future schema tweaks.
+    const resultsCount =
+      typeof recallResult.count === "number"
+        ? recallResult.count
+        : Array.isArray(recallResult.results)
+          ? recallResult.results.length
+          : 0;
     const minimalExplain = {
       query: queryText,
       totalDurationMs,
-      resultsCount: memories.length,
+      resultsCount,
       note: "Install @remnic/bench for a full tier-level explain breakdown.",
     };
     if (json) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4907,19 +4907,41 @@ export async function runTrainingExport(
   let records: TrainingExportRecord[] = await convertMemoriesToRecords(convertOptions);
   const recordsRead = records.length;
 
+  // synthesize and privacy-sweep currently live in @remnic/export-weclone
+  // and produce weclone-shaped output. When the selected adapter isn't
+  // the weclone one (e.g. a plugin-registered format), running these
+  // transforms would be semantically wrong AND would force users to
+  // install an optional package they never asked for, so we skip them
+  // with a clear note instead. privacy-sweep defaults to true, so this
+  // scope check is what actually preserves the à-la-carte contract for
+  // non-weclone formats. (Codex feedback on PR #545.)
+  const adapterIsWeclone = adapter.name === "weclone";
   if (args.synthesize) {
-    const mod = await ensureWeclone();
-    records = mod.synthesizeTrainingPairs(records, {
-      maxPairsPerRecord: args.maxPairsPerRecord,
-    });
+    if (adapterIsWeclone) {
+      const mod = await ensureWeclone();
+      records = mod.synthesizeTrainingPairs(records, {
+        maxPairsPerRecord: args.maxPairsPerRecord,
+      });
+    } else {
+      stdout.write(
+        `Note: --synthesize is ignored for --format "${adapter.name}" (weclone-only).\n`,
+      );
+    }
   }
 
   let redactedCount = 0;
   if (args.privacySweep) {
-    const mod = await ensureWeclone();
-    const swept = mod.sweepPii(records);
-    records = swept.cleanRecords;
-    redactedCount = swept.redactedCount;
+    if (adapterIsWeclone) {
+      const mod = await ensureWeclone();
+      const swept = mod.sweepPii(records);
+      records = swept.cleanRecords;
+      redactedCount = swept.redactedCount;
+    }
+    // Silent no-op for non-weclone adapters: privacy-sweep defaults to
+    // true, so logging a note for every run would be noisy. Adapters
+    // registered outside weclone are expected to handle their own PII
+    // story; users who specifically need the weclone sweep should pick
+    // --format weclone.
   }
 
   if (args.dryRun) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -32,6 +32,7 @@
  */
 
 import fs from "node:fs";
+import os from "node:os";
 import path from "node:path";
 import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -572,10 +573,16 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
 }
 
 // Inlined copy of @remnic/bench's defaultBenchmarkBaselineDir so we don't
-// load the optional bench package just to resolve a path. Keep in sync with
-// packages/bench/src/results-store.ts:defaultBenchmarkBaselineDir.
+// load the optional bench package just to resolve a path. The home-dir
+// fallback chain must match packages/bench/src/results-store.ts exactly
+// (HOME → USERPROFILE → os.homedir()) — diverging here would make the CLI
+// and the bench package resolve different baseline directories when
+// neither env var is set, so baselines saved by one would be invisible
+// to the other. resolveHomeDir()'s literal `~` fallback is the wrong
+// shape for this use case.
 function resolveBenchBaselineDir(): string {
-  return path.join(resolveHomeDir(), ".remnic", "bench", "baselines");
+  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
+  return path.join(homeDir, ".remnic", "bench", "baselines");
 }
 
 // Resolve the dataset root. In a monorepo checkout we keep using

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -32,7 +32,6 @@
  */
 
 import fs from "node:fs";
-import os from "node:os";
 import path from "node:path";
 import * as childProcess from "node:child_process";
 import { fileURLToPath, pathToFileURL } from "node:url";
@@ -572,19 +571,6 @@ async function launchBenchUi(resultsDir: string): Promise<void> {
   });
 }
 
-// Inlined copy of @remnic/bench's defaultBenchmarkBaselineDir so we don't
-// load the optional bench package just to resolve a path. The home-dir
-// fallback chain must match packages/bench/src/results-store.ts exactly
-// (HOME → USERPROFILE → os.homedir()) — diverging here would make the CLI
-// and the bench package resolve different baseline directories when
-// neither env var is set, so baselines saved by one would be invisible
-// to the other. resolveHomeDir()'s literal `~` fallback is the wrong
-// shape for this use case.
-function resolveBenchBaselineDir(): string {
-  const homeDir = process.env.HOME ?? process.env.USERPROFILE ?? os.homedir();
-  return path.join(homeDir, ".remnic", "bench", "baselines");
-}
-
 // Resolve the dataset root. In a monorepo checkout we keep using
 // evals/datasets so local dev state stays stable; in a published CLI
 // install CLI_REPO_ROOT points under node_modules (not user-writable
@@ -925,8 +911,13 @@ async function showBenchPackageResults(parsed: ParsedBenchArgs): Promise<void> {
 }
 
 async function manageBenchBaselines(parsed: ParsedBenchArgs): Promise<void> {
-  const baselineDir = parsed.baselinesDir ?? resolveBenchBaselineDir();
+  // This handler already needs @remnic/bench for its core work, so we
+  // resolve the default baseline dir from the package too. Inlining the
+  // path helper here created a divergence risk with no payoff, since
+  // the loader runs on the very next line regardless. (cursor feedback
+  // on PR #545)
   const {
+    defaultBenchmarkBaselineDir,
     listBenchmarkBaselines,
     resolveBenchmarkResultReference,
     listBenchmarkResults,
@@ -934,6 +925,7 @@ async function manageBenchBaselines(parsed: ParsedBenchArgs): Promise<void> {
     saveBenchmarkBaseline,
     loadBenchmarkBaseline,
   } = await loadBenchModule();
+  const baselineDir = parsed.baselinesDir ?? defaultBenchmarkBaselineDir();
 
   if (parsed.baselineAction === "list") {
     const baselines = await listBenchmarkBaselines(baselineDir);
@@ -1596,17 +1588,44 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
   const service = new EngramAccessService(orchestrator);
 
   if (explain) {
-    const { runExplain } = await loadBenchModule();
-    const result = await runExplain(service, queryText);
-    if (json) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(`Query: ${result.query}`);
-      console.log(`Tiers used: ${result.tiersUsed.join(" → ")}`);
-      console.log(`Total duration: ${result.totalDurationMs}ms`);
-      for (const t of result.tierResults) {
-        console.log(`  ${t.tier}: ${t.latencyMs}ms (${t.resultsCount} results)`);
+    // `query --explain` is a core-install feature; if @remnic/bench is
+    // installed we use its full tier-breakdown explainer, otherwise we
+    // fall back to a minimal "run the recall and show timing" path so
+    // the flag keeps working without forcing users to install an
+    // optional package. (Codex feedback on PR #545)
+    const bench = await tryLoadBenchModule();
+    if (bench?.runExplain) {
+      const result = await bench.runExplain(service, queryText);
+      if (json) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(`Query: ${result.query}`);
+        console.log(`Tiers used: ${result.tiersUsed.join(" → ")}`);
+        console.log(`Total duration: ${result.totalDurationMs}ms`);
+        for (const t of result.tierResults) {
+          console.log(`  ${t.tier}: ${t.latencyMs}ms (${t.resultsCount} results)`);
+        }
       }
+      return;
+    }
+
+    const explainStart = Date.now();
+    const recallResult = await service.recall({ query: queryText, mode: "auto" });
+    const totalDurationMs = Date.now() - explainStart;
+    const memories = (recallResult as { memories?: Array<{ content: string }> }).memories ?? [];
+    const minimalExplain = {
+      query: queryText,
+      totalDurationMs,
+      resultsCount: memories.length,
+      note: "Install @remnic/bench for a full tier-level explain breakdown.",
+    };
+    if (json) {
+      console.log(JSON.stringify(minimalExplain, null, 2));
+    } else {
+      console.log(`Query: ${minimalExplain.query}`);
+      console.log(`Total duration: ${minimalExplain.totalDurationMs}ms`);
+      console.log(`Results: ${minimalExplain.resultsCount}`);
+      console.log(`Note: ${minimalExplain.note}`);
     }
     return;
   }
@@ -4497,16 +4516,33 @@ export async function runTrainingExport(
   redactedCount: number;
   outputPath: string | null;
 }> {
-  // Ensure the WeClone adapter (and any others registered via side-effect
-  // imports) are available before we ask the registry. `ensureWecloneExportAdapterRegistered`
-  // is idempotent — safe to call even when the adapter is already registered
-  // by a previous CLI invocation in the same process. The module itself is
-  // an optional install surface; loadWecloneExportModule() throws a
-  // user-facing install hint if @remnic/export-weclone is missing.
-  const wecloneExport = await loadWecloneExportModule();
-  wecloneExport.ensureWecloneExportAdapterRegistered();
+  // Resolve the adapter from the registry first. If the user picks a
+  // non-weclone format (registered elsewhere), we never touch the
+  // optional @remnic/export-weclone package. If the format isn't
+  // registered yet, we lazily load weclone to register its adapter and
+  // try again — that keeps weclone a true à-la-carte install while
+  // still supporting `--format weclone` out of the box.
+  // (Codex feedback on PR #545.)
+  type WecloneExportModule = Awaited<ReturnType<typeof loadWecloneExportModule>>;
+  let wecloneExport: WecloneExportModule | undefined;
+  const ensureWeclone = async (): Promise<WecloneExportModule> => {
+    if (!wecloneExport) {
+      wecloneExport = await loadWecloneExportModule();
+    }
+    return wecloneExport;
+  };
 
-  const adapter = getTrainingExportAdapter(args.format);
+  let adapter = getTrainingExportAdapter(args.format);
+  if (!adapter) {
+    // Either the format is weclone but the adapter hasn't been
+    // registered in this process yet, or it's genuinely unknown. Try
+    // registering weclone first; if the format still isn't found, fall
+    // through to the normal "unknown format" error with the real list
+    // of registered adapters.
+    const mod = await ensureWeclone();
+    mod.ensureWecloneExportAdapterRegistered();
+    adapter = getTrainingExportAdapter(args.format);
+  }
   if (!adapter) {
     const registered = listTrainingExportAdapters();
     const validList =
@@ -4549,14 +4585,16 @@ export async function runTrainingExport(
   const recordsRead = records.length;
 
   if (args.synthesize) {
-    records = wecloneExport.synthesizeTrainingPairs(records, {
+    const mod = await ensureWeclone();
+    records = mod.synthesizeTrainingPairs(records, {
       maxPairsPerRecord: args.maxPairsPerRecord,
     });
   }
 
   let redactedCount = 0;
   if (args.privacySweep) {
-    const swept = wecloneExport.sweepPii(records);
+    const mod = await ensureWeclone();
+    const swept = mod.sweepPii(records);
     records = swept.cleanRecords;
     redactedCount = swept.redactedCount;
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4686,6 +4686,15 @@ interface ParsedTrainingExportArgs {
   synthesize: boolean;
   maxPairsPerRecord?: number;
   privacySweep: boolean;
+  /**
+   * Whether the user explicitly chose the privacy-sweep value on the
+   * command line (via `--privacy-sweep` or `--no-privacy-sweep`). When
+   * true, runtime code treats a mismatch with the adapter as a hard
+   * error (don't silently skip something the user asked for). When
+   * false, it means we're using the default, so we can downgrade to a
+   * warning if the adapter doesn't support sweep.
+   */
+  privacySweepExplicit: boolean;
   dryRun: boolean;
 }
 
@@ -4802,9 +4811,15 @@ export function parseTrainingExportArgs(
   // turns Remnic's flat records into conversational Q/A pairs. Users of other
   // formats (or raw Alpaca) can opt out.
   const synthesize = hasFlag(rest, "--synthesize");
-  // `--privacy-sweep` is on by default for WeClone and any other adapter that
-  // will be shared as a training dataset. Off switch: --no-privacy-sweep.
-  const privacySweep = !hasFlag(rest, "--no-privacy-sweep");
+  // `--privacy-sweep` is on by default for WeClone and any other adapter
+  // that will be shared as a training dataset. Off switch:
+  // `--no-privacy-sweep`. We also track whether the choice was explicit
+  // so runtime code can distinguish "user asked for this" (hard error
+  // on mismatch) from "default, we can fall back with a warning".
+  const privacySweepOff = hasFlag(rest, "--no-privacy-sweep");
+  const privacySweepOn = hasFlag(rest, "--privacy-sweep");
+  const privacySweepExplicit = privacySweepOff || privacySweepOn;
+  const privacySweep = !privacySweepOff;
 
   return {
     format,
@@ -4818,6 +4833,7 @@ export function parseTrainingExportArgs(
     synthesize,
     maxPairsPerRecord,
     privacySweep,
+    privacySweepExplicit,
     dryRun,
   };
 }
@@ -4931,16 +4947,29 @@ export async function runTrainingExport(
 
   let redactedCount = 0;
   if (args.privacySweep) {
-    if (!adapterIsWeclone) {
+    if (adapterIsWeclone) {
+      const mod = await ensureWeclone();
+      const swept = mod.sweepPii(records);
+      records = swept.cleanRecords;
+      redactedCount = swept.redactedCount;
+    } else {
+      // privacy-sweep defaults ON because training-export data is
+      // shareable. The sweep itself is weclone-specific today, so on a
+      // non-weclone adapter we refuse to export rather than silently
+      // skip redaction (Codex P1 would have us fail; a warn-and-export
+      // pattern would still leak PII). The error message makes the
+      // opt-out path obvious so the "default breaks my plugin format"
+      // complaint (Cursor Medium) is a one-flag fix, not a mystery.
+      const explicitness = args.privacySweepExplicit
+        ? "was requested"
+        : "defaults on for training exports";
       throw new Error(
-        `--privacy-sweep is only implemented for --format weclone (${adapter.name} would silently skip redaction, which is unsafe). ` +
-          `Rerun with --format weclone to redact PII, or pass --no-privacy-sweep to export ${adapter.name} records as-is after confirming they are safe to emit.`,
+        `--privacy-sweep ${explicitness}, but --format "${adapter.name}" has no PII sweep implementation. ` +
+          `To proceed safely, either:\n` +
+          `  1. Rerun with --format weclone (which supports PII redaction), OR\n` +
+          `  2. Pass --no-privacy-sweep to export ${adapter.name} records as-is (only do this after confirming they are safe to share).`,
       );
     }
-    const mod = await ensureWeclone();
-    const swept = mod.sweepPii(records);
-    records = swept.cleanRecords;
-    redactedCount = swept.redactedCount;
   }
 
   if (args.dryRun) {

--- a/packages/remnic-cli/src/optional-bench.ts
+++ b/packages/remnic-cli/src/optional-bench.ts
@@ -1,0 +1,60 @@
+// Lazy loader for the optional @remnic/bench package.
+//
+// Remnic's CLI is installed à la carte: users who only need memory features
+// should not have to install benchmark tooling, so @remnic/bench is an
+// optional peer dependency, not a bundled dependency. Any command that
+// actually needs benchmark code calls loadBenchModule() lazily; the loader
+// either returns the module or throws a user-facing install hint.
+//
+// The specifier is computed so the bundler leaves the dynamic import as a
+// runtime call (see also core/cli.ts:ensureBuiltInBulkImportAdapters for the
+// same pattern). Mirrors CLAUDE.md invariant: "CLI and plugins MUST load
+// optional workspace packages via computed-specifier dynamic imports."
+
+type BenchModule = typeof import("@remnic/bench");
+
+let cached: BenchModule | null | undefined;
+
+async function tryImportBench(): Promise<BenchModule | null> {
+  try {
+    const specifier = "@remnic/" + "bench";
+    return (await import(specifier)) as BenchModule;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Load @remnic/bench if installed. Throws a user-facing install hint if the
+ * package is not available. Cache the result so repeated calls in the same
+ * CLI invocation do not re-import.
+ */
+export async function loadBenchModule(): Promise<BenchModule> {
+  if (cached === undefined) {
+    cached = await tryImportBench();
+  }
+  if (!cached) {
+    throw new Error(
+      "The `remnic bench` commands require the optional @remnic/bench package.\n" +
+        "\n" +
+        "Install it alongside the CLI:\n" +
+        "  npm install -g @remnic/bench\n" +
+        "\n" +
+        "Or add it to a project:\n" +
+        "  pnpm add @remnic/bench\n",
+    );
+  }
+  return cached;
+}
+
+/**
+ * Return @remnic/bench if present, or undefined if not installed. Use this
+ * for code paths that can degrade gracefully (e.g. `remnic bench list`
+ * falling back to the static catalogue when the package is absent).
+ */
+export async function tryLoadBenchModule(): Promise<BenchModule | undefined> {
+  if (cached === undefined) {
+    cached = await tryImportBench();
+  }
+  return cached ?? undefined;
+}

--- a/packages/remnic-cli/src/optional-bench.ts
+++ b/packages/remnic-cli/src/optional-bench.ts
@@ -11,26 +11,23 @@
 // same pattern). Mirrors CLAUDE.md invariant: "CLI and plugins MUST load
 // optional workspace packages via computed-specifier dynamic imports."
 
+import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+
 type BenchModule = typeof import("@remnic/bench");
+
+const SPECIFIER = "@remnic/" + "bench";
 
 let cached: BenchModule | null | undefined;
 
-function isModuleNotFoundError(err: unknown): boolean {
-  // Node's ESM loader uses ERR_MODULE_NOT_FOUND; CJS and some bundlers
-  // surface the older MODULE_NOT_FOUND code. Either means "the package
-  // isn't installed" — anything else (syntax error, init throw, etc.)
-  // is a real bug inside @remnic/bench that we must surface, not mask
-  // with an install hint.
-  const code = (err as { code?: unknown } | null)?.code;
-  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
-}
-
 async function tryImportBench(): Promise<BenchModule | null> {
   try {
-    const specifier = "@remnic/" + "bench";
-    return (await import(specifier)) as BenchModule;
+    return (await import(SPECIFIER)) as BenchModule;
   } catch (err) {
-    if (isModuleNotFoundError(err)) {
+    // Only swallow "this package isn't installed" errors. Syntax
+    // errors, init throws, or ERR_MODULE_NOT_FOUND from a transitive
+    // miss inside @remnic/bench must all surface so broken releases
+    // are diagnosable instead of producing a misleading install hint.
+    if (isSpecifierNotFoundError(err, SPECIFIER)) {
       return null;
     }
     throw err;

--- a/packages/remnic-cli/src/optional-bench.ts
+++ b/packages/remnic-cli/src/optional-bench.ts
@@ -15,12 +15,25 @@ type BenchModule = typeof import("@remnic/bench");
 
 let cached: BenchModule | null | undefined;
 
+function isModuleNotFoundError(err: unknown): boolean {
+  // Node's ESM loader uses ERR_MODULE_NOT_FOUND; CJS and some bundlers
+  // surface the older MODULE_NOT_FOUND code. Either means "the package
+  // isn't installed" — anything else (syntax error, init throw, etc.)
+  // is a real bug inside @remnic/bench that we must surface, not mask
+  // with an install hint.
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}
+
 async function tryImportBench(): Promise<BenchModule | null> {
   try {
     const specifier = "@remnic/" + "bench";
     return (await import(specifier)) as BenchModule;
-  } catch {
-    return null;
+  } catch (err) {
+    if (isModuleNotFoundError(err)) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/packages/remnic-cli/src/optional-module-loader.ts
+++ b/packages/remnic-cli/src/optional-module-loader.ts
@@ -1,0 +1,53 @@
+// Shared helpers for the CLI's optional-package dynamic-import loaders.
+//
+// Every optional @remnic/* companion package uses the same "swallow only
+// when this specific package is missing, otherwise re-throw" pattern, so
+// extracting the check here removes the duplication between
+// optional-bench.ts and optional-weclone-export.ts (Cursor review
+// feedback on PR #545) and gives us one place to get the specifier-
+// matching logic right.
+
+/**
+ * Return true when `err` is a module-not-found failure for exactly the
+ * `specifier` we were trying to import.
+ *
+ * Node's ESM loader raises `ERR_MODULE_NOT_FOUND` both when the
+ * top-level package is missing and when the package is installed but one
+ * of its transitive dependencies can't be resolved. The latter is a
+ * broken release, not an "optional package not installed" situation,
+ * and emitting the install hint for it sends users chasing the wrong
+ * problem. We therefore require the error message / URL to reference
+ * the specifier we actually requested before treating it as "missing".
+ */
+export function isSpecifierNotFoundError(err: unknown, specifier: string): boolean {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const code = (err as { code?: unknown }).code;
+  if (code !== "ERR_MODULE_NOT_FOUND" && code !== "MODULE_NOT_FOUND") {
+    return false;
+  }
+
+  // Node's "Cannot find package 'x' imported from y" / CJS
+  // "Cannot find module 'x'" messages both embed the failing specifier.
+  // A transitive miss embeds the *inner* specifier, not ours — so we
+  // only treat this as a miss for our package when the message names
+  // our specifier specifically.
+  const message = (err as { message?: unknown }).message;
+  if (typeof message === "string") {
+    if (message.includes(`'${specifier}'`)) return true;
+    if (message.includes(`"${specifier}"`)) return true;
+    // Some runtimes emit the specifier unquoted; guard the boundary so
+    // "@remnic/bench" doesn't match "@remnic/bench-ui".
+    const boundaryRegex = new RegExp(
+      `(?:^|[\\s"'\`\\(])${escapeRegex(specifier)}(?:[\\s"'\`\\)]|$)`,
+    );
+    if (boundaryRegex.test(message)) return true;
+  }
+
+  return false;
+}
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}

--- a/packages/remnic-cli/src/optional-weclone-export.ts
+++ b/packages/remnic-cli/src/optional-weclone-export.ts
@@ -35,12 +35,3 @@ export async function loadWecloneExportModule(): Promise<WecloneExportModule> {
   }
   return cached;
 }
-
-export async function tryLoadWecloneExportModule(): Promise<
-  WecloneExportModule | undefined
-> {
-  if (cached === undefined) {
-    cached = await tryImportWecloneExport();
-  }
-  return cached ?? undefined;
-}

--- a/packages/remnic-cli/src/optional-weclone-export.ts
+++ b/packages/remnic-cli/src/optional-weclone-export.ts
@@ -9,12 +9,24 @@ type WecloneExportModule = typeof import("@remnic/export-weclone");
 
 let cached: WecloneExportModule | null | undefined;
 
+function isModuleNotFoundError(err: unknown): boolean {
+  // Only swallow the "package isn't installed" codes. Any other import
+  // failure (syntax error inside the weclone package, init throw, etc.)
+  // must bubble up so broken releases are diagnosable — masking with
+  // the install hint would send users chasing the wrong problem.
+  const code = (err as { code?: unknown } | null)?.code;
+  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+}
+
 async function tryImportWecloneExport(): Promise<WecloneExportModule | null> {
   try {
     const specifier = "@remnic/" + "export-weclone";
     return (await import(specifier)) as WecloneExportModule;
-  } catch {
-    return null;
+  } catch (err) {
+    if (isModuleNotFoundError(err)) {
+      return null;
+    }
+    throw err;
   }
 }
 

--- a/packages/remnic-cli/src/optional-weclone-export.ts
+++ b/packages/remnic-cli/src/optional-weclone-export.ts
@@ -5,25 +5,22 @@
 // surface. Users who don't use that surface should not need the adapter
 // installed.
 
+import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+
 type WecloneExportModule = typeof import("@remnic/export-weclone");
+
+const SPECIFIER = "@remnic/" + "export-weclone";
 
 let cached: WecloneExportModule | null | undefined;
 
-function isModuleNotFoundError(err: unknown): boolean {
-  // Only swallow the "package isn't installed" codes. Any other import
-  // failure (syntax error inside the weclone package, init throw, etc.)
-  // must bubble up so broken releases are diagnosable — masking with
-  // the install hint would send users chasing the wrong problem.
-  const code = (err as { code?: unknown } | null)?.code;
-  return code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
-}
-
 async function tryImportWecloneExport(): Promise<WecloneExportModule | null> {
   try {
-    const specifier = "@remnic/" + "export-weclone";
-    return (await import(specifier)) as WecloneExportModule;
+    return (await import(SPECIFIER)) as WecloneExportModule;
   } catch (err) {
-    if (isModuleNotFoundError(err)) {
+    // Only swallow the specific "this package isn't installed" case —
+    // see optional-bench.ts for the same guard. A syntax or transitive-
+    // dependency error inside the weclone package should bubble up.
+    if (isSpecifierNotFoundError(err, SPECIFIER)) {
       return null;
     }
     throw err;

--- a/packages/remnic-cli/src/optional-weclone-export.ts
+++ b/packages/remnic-cli/src/optional-weclone-export.ts
@@ -1,0 +1,46 @@
+// Lazy loader for the optional @remnic/export-weclone package.
+//
+// See optional-bench.ts for the full rationale — the CLI is installed à la
+// carte, and weclone export tooling is only used by the `training:export`
+// surface. Users who don't use that surface should not need the adapter
+// installed.
+
+type WecloneExportModule = typeof import("@remnic/export-weclone");
+
+let cached: WecloneExportModule | null | undefined;
+
+async function tryImportWecloneExport(): Promise<WecloneExportModule | null> {
+  try {
+    const specifier = "@remnic/" + "export-weclone";
+    return (await import(specifier)) as WecloneExportModule;
+  } catch {
+    return null;
+  }
+}
+
+export async function loadWecloneExportModule(): Promise<WecloneExportModule> {
+  if (cached === undefined) {
+    cached = await tryImportWecloneExport();
+  }
+  if (!cached) {
+    throw new Error(
+      "The weclone training-export adapter requires the optional @remnic/export-weclone package.\n" +
+        "\n" +
+        "Install it alongside the CLI:\n" +
+        "  npm install -g @remnic/export-weclone\n" +
+        "\n" +
+        "Or add it to a project:\n" +
+        "  pnpm add @remnic/export-weclone\n",
+    );
+  }
+  return cached;
+}
+
+export async function tryLoadWecloneExportModule(): Promise<
+  WecloneExportModule | undefined
+> {
+  if (cached === undefined) {
+    cached = await tryImportWecloneExport();
+  }
+  return cached ?? undefined;
+}

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -1,5 +1,13 @@
 import { defineConfig } from "tsup";
 
+// @remnic/bench, @remnic/export-weclone, and @remnic/import-weclone are
+// optional à-la-carte install surfaces. They MUST stay external here so the
+// CLI does not bundle them into dist/index.js — users who don't need those
+// features should not pay for them at install time. See
+// packages/remnic-cli/src/optional-bench.ts and optional-weclone-export.ts
+// for the computed-specifier dynamic-import loaders the CLI uses to reach
+// them at runtime. Adding any of these to noExternal would violate the
+// à-la-carte invariant documented in AGENTS.md / CLAUDE.md.
 export default defineConfig({
   entry: ["src/index.ts"],
   format: ["esm"],
@@ -7,6 +15,10 @@ export default defineConfig({
   platform: "node",
   outDir: "dist",
   clean: true,
-  external: ["yaml"],
-  noExternal: ["@remnic/bench", "@remnic/export-weclone"],
+  external: [
+    "yaml",
+    "@remnic/bench",
+    "@remnic/export-weclone",
+    "@remnic/import-weclone",
+  ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -68,7 +68,7 @@ importers:
   packages/bench:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../remnic-core
       yaml:
         specifier: ^2.4.2
@@ -109,7 +109,14 @@ importers:
         specifier: ^7.1.12
         version: 7.3.2(@types/node@25.5.2)(tsx@4.21.0)(yaml@2.8.3)
 
-  packages/connector-replit: {}
+  packages/connector-replit:
+    devDependencies:
+      tsup:
+        specifier: ^8.5.1
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
 
   packages/connector-weclone:
     devDependencies:
@@ -126,7 +133,7 @@ importers:
   packages/export-weclone:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../remnic-core
     devDependencies:
       tsup:
@@ -151,7 +158,7 @@ importers:
   packages/import-weclone:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../remnic-core
     devDependencies:
       tsup:
@@ -169,7 +176,7 @@ importers:
   packages/plugin-codex:
     dependencies:
       '@remnic/core':
-        specifier: workspace:*
+        specifier: workspace:^
         version: link:../remnic-core
 
   packages/plugin-openclaw:
@@ -203,6 +210,9 @@ importers:
       '@remnic/export-weclone':
         specifier: workspace:*
         version: link:../export-weclone
+      '@remnic/import-weclone':
+        specifier: workspace:*
+        version: link:../import-weclone
       tsup:
         specifier: ^8.5.1
         version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -2,12 +2,25 @@ import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 import test from "node:test";
 
+// Topological publish order: core first, then the à-la-carte companion
+// packages (bench, weclone family, connector-replit) that install
+// surfaces depend on, then the depend-on-core runtimes (server, CLI) and
+// plugin bundles (openclaw + per-agent plugins), and finally the legacy
+// shim that lives at the tail. Keep in sync with PUBLISH_ORDER in
+// .github/workflows/release-and-publish.yml and AGENTS.md §44.
 const expectedPublishDirs = [
   "packages/remnic-core",
+  "packages/bench",
+  "packages/export-weclone",
+  "packages/import-weclone",
+  "packages/connector-weclone",
+  "packages/connector-replit",
+  "packages/hermes-provider",
   "packages/remnic-server",
   "packages/remnic-cli",
-  "packages/hermes-provider",
   "packages/plugin-openclaw",
+  "packages/plugin-claude-code",
+  "packages/plugin-codex",
   "packages/shim-openclaw-engram",
 ] as const;
 

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -176,7 +176,7 @@ test("bench results, baseline, and export route through the stored package resul
   assert.match(source, /if \(parsed\.action === "export"\) \{\s*await exportBenchPackageResult\(parsed\);/s);
   assert.match(source, /baseline save <name> \[run\]/);
   assert.match(source, /bench export <run> --format <json\|csv\|html>/);
-  assert.match(source, /const baselineDir = parsed\.baselinesDir \?\? resolveBenchBaselineDir\(\)/);
+  assert.match(source, /const baselineDir = parsed\.baselinesDir \?\? defaultBenchmarkBaselineDir\(\)/);
   assert.match(source, /const rendered = renderBenchmarkResultExport\(result, parsed\.format\);/);
   assert.match(source, /ERROR: export requires --format json, csv, or html\./);
   assert.match(source, /printBenchPackageSummary\(result, summary\.path, "Stored result"\);/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -79,8 +79,10 @@ test("CLI uses package-owned adapters for migrated benchmark runs", async () => 
   assert.match(source, /createLightweightAdapter/);
   assert.match(source, /createRemnicAdapter/);
   assert.match(source, /async function runBenchViaPackage/);
-  assert.match(source, /try \{\s*benchModule = await import\("@remnic\/bench"\)/s);
-  assert.match(source, /\} catch \{\s*return false;\s*\}/s);
+  // Per the à-la-carte invariant (AGENTS.md §44), runBenchViaPackage must
+  // reach @remnic/bench through the optional loader so the CLI degrades
+  // gracefully when the package isn't installed.
+  assert.match(source, /const loaded = await tryLoadBenchModule\(\);\s*if \(!loaded\) return false;/s);
   assert.doesNotMatch(source, /evals\/adapter\/engram-adapter\.ts/);
 });
 
@@ -158,12 +160,14 @@ test("bench results, baseline, and export route through the stored package resul
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
   const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
 
-  assert.match(source, /defaultBenchmarkBaselineDir,/);
-  assert.match(source, /listBenchmarkBaselines,/);
-  assert.match(source, /loadBenchmarkBaseline,/);
-  assert.match(source, /listBenchmarkResults,/);
-  assert.match(source, /renderBenchmarkResultExport,/);
-  assert.match(source, /saveBenchmarkBaseline,/);
+  // Symbols are destructured from the optional bench loader inside each
+  // command handler — a bare reference is enough to prove the CLI talks to
+  // the package rather than re-implementing the helper locally.
+  assert.match(source, /\blistBenchmarkBaselines\b/);
+  assert.match(source, /\bloadBenchmarkBaseline\b/);
+  assert.match(source, /\blistBenchmarkResults\b/);
+  assert.match(source, /\brenderBenchmarkResultExport\b/);
+  assert.match(source, /\bsaveBenchmarkBaseline\b/);
   assert.match(source, /async function showBenchPackageResults\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /async function manageBenchBaselines\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /async function exportBenchPackageResult\(parsed: ParsedBenchArgs\): Promise<void>/);
@@ -192,7 +196,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   const parserSource = await readFile("packages/remnic-cli/src/bench-args.ts", "utf8");
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
-  assert.match(source, /discoverAllProviders,/);
+  assert.match(source, /\bdiscoverAllProviders\b/);
   assert.match(source, /Usage: remnic bench <list\|run\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
@@ -532,9 +536,14 @@ test("parseBenchArgs rejects unknown bench publish targets", async () => {
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
 
-  assert.match(source, /type BenchmarkDefinition,\s*\n\s*\} from "@remnic\/bench";/s);
+  // After the à-la-carte refactor, BenchmarkDefinition is a type-only
+  // import (erased at compile time) and loadBenchDefinitionsFromPackage
+  // goes through the optional-bench loader. The key semantic guarantee
+  // is still that the CLI reuses the package's BenchmarkDefinition type
+  // rather than re-defining its own shape.
+  assert.match(source, /BenchmarkDefinition,?\s*\n[\s\S]{0,80}\} from "@remnic\/bench";/s);
   assert.match(source, /async function loadBenchDefinitionsFromPackage\(\): Promise<BenchmarkDefinition\[\] \| undefined>/);
-  assert.match(source, /listBenchmarks\?: \(\) => BenchmarkDefinition\[\];/);
+  assert.match(source, /listBenchmarks\b/);
   assert.doesNotMatch(source, /interface PackageBenchDefinition/);
   assert.doesNotMatch(source, /listBenchmarks\?: \(\) => Promise<.*BenchmarkDefinition\[\].*\|/s);
 });

--- a/tests/remnic-cli-package.test.ts
+++ b/tests/remnic-cli-package.test.ts
@@ -2,29 +2,80 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFile } from "node:fs/promises";
 
-test("remnic CLI bundles private bench helpers instead of publishing them as runtime dependencies", async () => {
-  const [pkgRaw, tsupRaw, buildHelperRaw] = await Promise.all([
-    readFile("packages/remnic-cli/package.json", "utf8"),
-    readFile("packages/remnic-cli/tsup.config.ts", "utf8"),
-    readFile("scripts/ensure-cli-bench-build-deps.mjs", "utf8"),
-  ]);
+test("remnic CLI keeps optional à-la-carte packages external and loads them via dynamic imports", async () => {
+  const [pkgRaw, tsupRaw, optionalBench, optionalWeclone, indexSource] =
+    await Promise.all([
+      readFile("packages/remnic-cli/package.json", "utf8"),
+      readFile("packages/remnic-cli/tsup.config.ts", "utf8"),
+      readFile("packages/remnic-cli/src/optional-bench.ts", "utf8"),
+      readFile("packages/remnic-cli/src/optional-weclone-export.ts", "utf8"),
+      readFile("packages/remnic-cli/src/index.ts", "utf8"),
+    ]);
   const pkg = JSON.parse(pkgRaw) as {
     scripts?: { prebuild?: string; build?: string };
     dependencies?: Record<string, string>;
     devDependencies?: Record<string, string>;
+    peerDependencies?: Record<string, string>;
+    peerDependenciesMeta?: Record<string, { optional?: boolean }>;
   };
 
-  assert.equal(pkg.scripts?.prebuild, "node ../../scripts/ensure-cli-bench-build-deps.mjs");
-  assert.match(pkg.scripts?.build ?? "", /^tsup --config tsup\.config\.ts(\s+&&\s+.+)?$/);
-  assert.match(tsupRaw, /noExternal:\s*\["@remnic\/bench", "@remnic\/export-weclone"\]/);
-  assert.match(buildHelperRaw, /"@remnic\/core"/);
-  assert.match(buildHelperRaw, /"@remnic\/bench"/);
-  assert.match(buildHelperRaw, /"@remnic\/export-weclone"/);
-  assert.match(buildHelperRaw, /packages", "remnic-core", "dist", "index\.js"/);
-  assert.match(buildHelperRaw, /packages", "bench", "dist", "index\.js"/);
-  assert.match(buildHelperRaw, /packages", "export-weclone", "dist", "index\.js"/);
+  // Build wiring stays intact — prebuild still ensures the monorepo sibling
+  // builds exist for local dev runs, and tsup produces dist/index.js.
+  assert.equal(
+    pkg.scripts?.prebuild,
+    "node ../../scripts/ensure-cli-bench-build-deps.mjs",
+  );
+  assert.match(
+    pkg.scripts?.build ?? "",
+    /^tsup --config tsup\.config\.ts(\s+&&\s+.+)?$/,
+  );
+
+  // À-la-carte invariant (see AGENTS.md §44 / CLAUDE.md gotcha #57):
+  // optional companion packages must stay external in the bundler config
+  // and must not appear under runtime dependencies. They belong under
+  // peerDependencies with peerDependenciesMeta marking them optional.
+  assert.match(tsupRaw, /external:[\s\S]*?"@remnic\/bench"/);
+  assert.match(tsupRaw, /external:[\s\S]*?"@remnic\/export-weclone"/);
+  assert.match(tsupRaw, /external:[\s\S]*?"@remnic\/import-weclone"/);
+  assert.doesNotMatch(tsupRaw, /noExternal:[\s\S]*?"@remnic\/bench"/);
+  assert.doesNotMatch(tsupRaw, /noExternal:[\s\S]*?"@remnic\/export-weclone"/);
+
   assert.equal(pkg.dependencies?.["@remnic/bench"], undefined);
   assert.equal(pkg.dependencies?.["@remnic/export-weclone"], undefined);
-  assert.equal(pkg.devDependencies?.["@remnic/bench"], "workspace:*");
-  assert.equal(pkg.devDependencies?.["@remnic/export-weclone"], "workspace:*");
+  assert.equal(pkg.dependencies?.["@remnic/import-weclone"], undefined);
+
+  for (const name of [
+    "@remnic/bench",
+    "@remnic/export-weclone",
+    "@remnic/import-weclone",
+  ]) {
+    const peerSpec = pkg.peerDependencies?.[name];
+    assert.ok(peerSpec, `${name} missing from peerDependencies`);
+    assert.equal(
+      pkg.peerDependenciesMeta?.[name]?.optional,
+      true,
+      `${name} must be marked optional in peerDependenciesMeta`,
+    );
+  }
+
+  // Loaders use computed specifiers so bundlers cannot statically resolve
+  // the module — otherwise esbuild/tsup will happily inline it even with
+  // external set, defeating the à-la-carte contract.
+  assert.match(optionalBench, /"@remnic\/"\s*\+\s*"bench"/);
+  assert.match(optionalWeclone, /"@remnic\/"\s*\+\s*"export-weclone"/);
+
+  // The CLI entry must reach the optional packages via the loaders, not via
+  // direct static imports.
+  assert.match(indexSource, /from "\.\/optional-bench\.js"/);
+  assert.match(indexSource, /from "\.\/optional-weclone-export\.js"/);
+  // A bare `from "@remnic/bench"` (without `import type`) would be a
+  // static runtime import that bundles the package — forbidden.
+  assert.doesNotMatch(
+    indexSource,
+    /^import\s+(?!type\b)[^;]*from "@remnic\/bench";?$/m,
+  );
+  assert.doesNotMatch(
+    indexSource,
+    /^import\s+(?!type\b)[^;]*from "@remnic\/export-weclone";?$/m,
+  );
 });


### PR DESCRIPTION
## Why

`@remnic/core` + `@remnic/cli` were on npm, but every install pulled in benchmark and weclone code whether the user wanted it or not (via tsup `noExternal`), and several companion packages we pointed users at (`@remnic/bench`, `@remnic/plugin-claude-code`, `@remnic/plugin-codex`, `@remnic/replit`, the weclone packages) were `"private": true` or missing from the publish workflow — so `npm install @remnic/bench` 404'd.

The stated model is **à-la-carte**: memory-only users install `@remnic/core`, benchmark users add `@remnic/bench`, weclone users add the weclone packages, plugin users add the plugin they want. This PR makes that model real end to end.

## What changed

### CLI: load optional packages on demand

- New `packages/remnic-cli/src/optional-bench.ts` and `optional-weclone-export.ts` — computed-specifier dynamic-import loaders (`await import("@remnic/" + "bench")`) with a user-facing install hint on miss.
- Every static `@remnic/bench` / `@remnic/export-weclone` usage in `packages/remnic-cli/src/index.ts` now destructures from the loader inside the relevant async handler. Top-level imports become `import type { ... }` so they erase at compile time.
- `tsup.config.ts`: drop `noExternal` for those packages; list them (plus `@remnic/import-weclone`) as `external` so tsup leaves the dynamic imports as runtime calls. **CLI bundle: 393KB → 158KB.**
- `package.json`: move the three optional packages from `devDependencies` into `peerDependencies` with `peerDependenciesMeta.<name>.optional = true`.

### Unprivate + make publishable

- `@remnic/bench`, `@remnic/plugin-claude-code`, `@remnic/plugin-codex`: drop `"private": true`, add `publishConfig` with provenance.
- `@remnic/replit`: add `tsup.config.ts`, public entry `src/index.ts`, `main`/`types`/`files`, `build` + `prepublishOnly` scripts.
- Standardize workspace dep ranges on `workspace:^` across à-la-carte packages for predictable resolution at publish time.

### Publish workflow

- Extend `PUBLISH_ORDER` in `.github/workflows/release-and-publish.yml` to cover `bench`, `export-weclone`, `import-weclone`, `connector-weclone`, `connector-replit`, `plugin-claude-code`, `plugin-codex` in topological order.
- Drop the stale comment claiming the CLI bundles its export adapter.

### Docs

- `CLAUDE.md`: new gotcha **#57** + dedicated **À-la-carte packaging** section covering the computed-specifier dynamic-import pattern, `peerDependenciesMeta` expectations, and the `noExternal` ban.
- `AGENTS.md`: new **§44 À-la-carte Packaging** with the three-step end-to-end verification contract.
- `README.md`: replace `(private)` badges with npm badges for the newly-publishable packages and describe the à-la-carte install model.
- `docs/development/release-process.md`: add the new packages to the publish manifest table.

### Tests

- `tests/remnic-cli-package.test.ts` rewritten to assert the à-la-carte contract (external bundling, no runtime deps, optional `peerDependenciesMeta`, computed-specifier loaders, no direct static runtime imports).
- `tests/remnic-cli-bench-surface.test.ts`: loosen structural assertions that relied on a single static-import block; update `runBenchViaPackage` assertion to the loader pattern.

## Test plan

- [x] CLI typecheck passes (`pnpm --filter @remnic/cli check-types`)
- [x] CLI builds cleanly (`pnpm --filter @remnic/cli build`) — dist drops to 158KB, bundle contains zero definitions of `runBenchSuite` / `synthesizeTrainingPairs` / `sweepPii`
- [x] `node dist/index.js --help` starts without touching any optional package
- [x] Targeted tests green: `remnic-cli-package.test.ts`, `remnic-cli-bench-surface.test.ts`, `workspace-runtime-deps.test.ts`, `monorepo-structure.test.ts`, `bench-registry.test.ts`, `bench-package-surface.test.ts` (38/38 + 29/29)
- [ ] CI full test + publish workflow on merge to `main`

## Post-merge

The release workflow will fire on push to `main` and publish the new packages. First publish for each is version 1.0.0 (connector-replit), 1.0.0 (bench/plugin-claude-code/plugin-codex), and 1.0.1 (export/import/connector-weclone, already public); the workflow's idempotent guard (`npm view ... already published; skipping`) handles re-runs safely.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CLI runtime loading/bundling for optional packages and adjusts training-export privacy-sweep behavior, which can affect installation and CLI command execution paths.
> 
> **Overview**
> Makes Remnic’s npm install surfaces truly **à-la-carte** by keeping optional packages (bench/weclone/import + plugins/connectors) out of the base CLI bundle and install graph, and ensuring those optional surfaces are actually publishable.
> 
> The CLI now lazy-loads `@remnic/bench` and `@remnic/export-weclone` via computed-specifier dynamic import loaders with user-facing install hints, updates `tsup` to keep optional packages `external`, and moves optional companions to optional `peerDependencies` (not runtime `dependencies`). Training export is refactored to only load/register the weclone adapter when `--format weclone` is used, and to **fail closed** when `--privacy-sweep`/`--synthesize` are requested with non-weclone formats.
> 
> Release publishing is updated to publish the newly-supported optional packages in topological order, multiple previously-private packages are made publishable (bench, plugins, replit connector with build entrypoints), docs are updated to codify the invariant, and tests are updated/added to enforce publish order and the à-la-carte packaging contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff2494e89d82e8e01594af24077149d387456c01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->