### PR TITLE
feat: add Cursor BugBot configuration

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,95 @@
+# BugBot Review Context — Remnic
+
+## Project Overview
+
+Remnic is a local-first memory plugin (TypeScript monorepo, pnpm workspaces, ESM-only, strict mode). The core package (`packages/remnic-core`) implements a three-phase memory lifecycle: recall, buffer, extract. It integrates with host platforms via hooks and registered tools.
+
+## Critical Rules (block on violation)
+
+### OpenAI API usage
+- **MUST use the Responses API** — never `chat.completions.create`. Use `zodTextFormat()` for structured output. See `packages/remnic-core/src/extraction.ts` for the canonical pattern.
+- **NEVER hard-code model names** — use `src/model-registry.ts`.
+
+### Config schema alignment
+- Every new config property MUST be added to BOTH `src/config.ts` (interface + defaults) AND `openclaw.plugin.json:configSchema`.
+- Zod optional fields: use `.optional().nullable()`, not just `.optional()`.
+- Config schema minimums must honor documented disable values (if docs say "0 to disable", `Math.max(1, value)` is wrong).
+
+### Privacy (PUBLIC REPO)
+- NEVER commit personal data, API keys, tokens, secrets, user memory content, or real conversation data.
+- Paths containing user data (`facts/`, `entities/`, `corrections/`, `questions/`, `state/`, `profile.md`, `IDENTITY.md`) must never be committed.
+- Test data must be synthetic. Config examples use placeholders like `${OPENAI_API_KEY}`.
+
+### Import hygiene
+- Import via package name: `import { X } from "@remnic/core"`, NOT relative cross-package paths like `import { X } from "../../../remnic-core/src/foo.js"`.
+- Core package files must never have host-specific prefixes (e.g., no `openclaw-` prefix in `@remnic/core`).
+
+## High-Priority Review Areas
+
+### JavaScript/TypeScript traps
+- **`slice(-0)` returns the full array** — guard `if (n <= 0)` before `slice(-n)`.
+- **`"false"` is truthy** — coerce boolean-like strings at config-read boundaries.
+- **`JSON.parse('null')` succeeds** — validate `typeof result === 'object' && result !== null`.
+- **`existsSync` returns true for files** — use `statSync().isDirectory()` when a directory is expected.
+- **Sort comparators must return 0 for equals** — use stable secondary keys. Never return 1 for both `compare(a,b)` and `compare(b,a)`.
+- **`Object.entries` key order** — sort keys before hashing/serializing for dedup operations.
+- **Serialized promise chains** — `writeChain.then(fn)` without `.catch()` recovery permanently poisons the chain after first error.
+
+### File I/O safety
+- **Never delete before write** — `rmSync` then `renameSync` loses data if rename fails. Write to temp, then atomic rename.
+- **Write rollback before success markers** — if writing `.migrated-from-engram`, the `.rollback.json` must exist first.
+- **Node.js does NOT expand `~`** — use `expandTilde()` for all user-facing path inputs.
+
+### Dedup & indexing
+- **Don't index content that failed to persist** — phantom index entries suppress legitimate retries.
+- **Hash operations use consistent content form** — if writes hash `rawContent`, reads must too, not `citedContent`.
+- **Cache invalidation must clear ALL layers** — grep all invalidation functions when adding a cache layer.
+
+### Status & enum defaults
+- **Enum defaults must be least-privileged** — default to `"disabled"`, `"pending"`, `"rejected"`, `"none"`, never `"enabled"` or `"approved"`.
+- **Status filters must enumerate ALL non-active states** — define an explicit `ACTIVE_STATUSES` set, not ad-hoc exclusion lists.
+- **Time-range filters use exclusive upper bounds** — `ts < toMs`, not `ts <= toMs` (half-open `[start, end)`).
+
+### Validation
+- **Reject invalid input** — invalid `--format`, `--since`, `--focus`, MCP params must throw errors listing valid options. Never silently default.
+- **Validation allow-lists must match handled values** — if `ALLOWED` includes `"text"` but code only handles `"markdown"`, that's a bug.
+- **CLI values need type coercion** — `--config port=5555` produces `"5555"` (string). Always `Number()` at boundary.
+
+### Concurrency & isolation
+- **Shared mutable objects must not leak across sessions** — per-connection instances or deep-copy for `clientInfo` etc.
+- **Feature gates must be identical across all code paths** — if a gate covers the QMD path but not the fallback path, behavior diverges.
+
+## Medium-Priority Checks
+
+- **Wrap external service calls in try-catch** — token generation, daemon probes, filesystem writes must not crash primary flows.
+- **Expand `~` in all user-facing path inputs** — `expandTilde()`, never ad-hoc regex.
+- **Direct-write paths must trigger reindex** — heartbeat imports etc. must call reindex after writing.
+- **Force-flush must bypass dedupe** — `skipDedupeCheck: true` for session flush and `before_reset`.
+- **New filters/transforms need config gates** — `enabled` check or escape hatch, never unconditional.
+- **Test mock signatures must match production interfaces** — mismatched mocks pass vacuously.
+- **Distinguish empty results from failures** — `{ok: true, results: []}` vs `{ok: false, error: "..."}`.
+- **Deduplicate batch operation inputs** — check for duplicates before processing batch renames.
+
+## What NOT to Flag
+
+- Build output in `dist/` — generated, not reviewed.
+- Lock file changes (`pnpm-lock.yaml`) — dependency updates, not logic.
+- Changelog entries or version bumps — auto-generated by changesets.
+- Test fixture data in `tests/fixtures/` — intentionally static.
+- Eval benchmark code in `evals/` — separate concern from core logic.
+- Docs formatting changes — only flag if they misrepresent behavior.
+
+## Monorepo Structure
+
+```
+packages/
+  remnic-core/src/     — Core engine (161 source files)
+  remnic-cli/           — CLI interface
+  remnic-server/        — HTTP server
+  plugin-claude-code/   — Claude Code plugin adapter
+  plugin-codex/         — Codex plugin adapter
+  plugin-openclaw/      — OpenClaw plugin adapter
+  plugin-hermes/        — Hermes Python plugin
+  bench/                — Benchmark harness
+  shim-openclaw-engram/ — Legacy compatibility shim
+```

--- a/.cursorignore
+++ b/.cursorignore
@@ -1,5 +1,9 @@
-# Directories that contain user memory data — never index for AI context.
-# These paths exist only at runtime on the user's machine, not in this repo.
+# ============================================================
+# .cursorignore — Files excluded from ALL Cursor features
+# including BugBot code review.
+# ============================================================
+
+# User memory data (runtime only, never in repo)
 facts/
 entities/
 corrections/
@@ -24,3 +28,44 @@ node_modules/
 # OS artefacts
 .DS_Store
 Thumbs.db
+
+# Lock files (dependency updates, not logic)
+pnpm-lock.yaml
+package-lock.json
+
+# Generated docs and changelogs
+CHANGELOG.md
+
+# Eval data (downloaded, not authored)
+evals/datasets/
+evals/results/
+
+# Admin console (separate concern)
+admin-console/
+
+# Dashboard (separate concern)
+dashboard/
+
+# Bench UI (separate concern)
+packages/bench-ui/
+
+# Git worktrees and temp branches
+.claude/worktrees/
+.worktrees/
+
+# Claude session artifacts
+.claude/
+.pr-loop/
+.worktale/
+PR_PREFLIGHT.md
+THEORY.MD
+
+# Logs
+logs/
+
+# Compressed archives
+*.tgz
+*.gz
+
+# Debug/temp files
+irc-debug.ts

--- a/.cursorindexingignore
+++ b/.cursorindexingignore
@@ -1,0 +1,29 @@
+# ============================================================
+# .cursorindexingignore — Files excluded from codebase indexing
+# only. These files remain accessible to AI features but won't
+# appear in @codebase search results. This speeds up indexing
+# and reduces noise for BugBot.
+# ============================================================
+
+# Large generated or data-heavy files that bloat the index
+evals/
+tests/fixtures/
+tests/compat-fixtures/
+
+# Vendor/third-party code
+packages/plugin-hermes/remnic_hermes/
+
+# Template files (not authored logic)
+packages/remnic-cli/templates/
+
+# Build tooling configs (low value for code review)
+.changeset/
+.githooks/
+
+# Scripts that are operational, not core logic
+scripts/faiss/
+scripts/hooks/
+
+# Python scripts (separate tooling)
+scripts/faiss_index.py
+scripts/fetch-model-info.py

--- a/packages/plugin-claude-code/.cursor/BUGBOT.md
+++ b/packages/plugin-claude-code/.cursor/BUGBOT.md
@@ -1,0 +1,13 @@
+# Plugin Claude Code Review Context
+
+Adapter between `@remnic/core` and the Claude Code CLI.
+
+## Key Patterns
+- Hooks in `hooks/` are shell scripts that invoke the core package — validate env var handling, never interpolate unsanitized values.
+- Skills in `skills/` define MCP tool surfaces — check parameter validation matches core interfaces.
+- Agents in `agents/` provide agent-facing context — verify no personal data leaks.
+
+## Common Issues
+- Gateway launchd env is isolated — API keys must be in plist EnvironmentVariables, not shell profile.
+- SIGUSR1 doesn't fire `gateway_start` — that's expected, not a bug.
+- Import from `@remnic/core`, not relative paths into `packages/remnic-core/src/`.

--- a/packages/plugin-codex/.cursor/BUGBOT.md
+++ b/packages/plugin-codex/.cursor/BUGBOT.md
@@ -1,0 +1,9 @@
+# Plugin Codex Review Context
+
+Adapter between `@remnic/core` and Codex.
+
+## Key Patterns
+- Memory extensions in `memories_extensions/` define Codex-native tools — verify schema alignment with core types.
+- Skills in `skills/` mirror the Claude Code plugin — keep in sync but respect Codex conventions.
+- Import from `@remnic/core`, not relative paths.
+- Citation blocks (`<oai-mem-citation>`) must be Codex-compatible.

--- a/packages/plugin-openclaw/.cursor/BUGBOT.md
+++ b/packages/plugin-openclaw/.cursor/BUGBOT.md
@@ -1,0 +1,10 @@
+# Plugin OpenClaw Review Context
+
+Adapter between `@remnic/core` and the OpenClaw gateway.
+
+## Key Patterns
+- Hooks register via `api.on("gateway_start")`, `api.on("before_agent_start")`, `api.on("agent_end")`.
+- Tools register via `api.registerTool()`.
+- Commands register via `api.registerCommand()`.
+- Services register via `api.registerService()`.
+- Core package files must never have `openclaw-` prefix — host adapters wrap core, not the other way around.

--- a/packages/remnic-core/.cursor/BUGBOT.md
+++ b/packages/remnic-core/.cursor/BUGBOT.md
@@ -1,0 +1,50 @@
+# Core Package Review Context
+
+This package (`@remnic/core`) is the engine: orchestrator, storage, extraction, retrieval, config, and all shared types.
+
+## Key Files & Their Invariants
+
+### `src/orchestrator.ts` (13.7K lines)
+- Coordinates the three-phase lifecycle (recall → buffer → extract).
+- All runtime globals MUST be scoped by `serviceId` when multiple instances coexist.
+- Clean up ALL test globals in teardown, including unkeyed ones like `__openclawEngramOrchestrator`.
+
+### `src/storage.ts` (5.6K lines)
+- All memory files use markdown + YAML frontmatter.
+- IDs follow `{category}-{timestamp}-{4-char-random}`.
+- Status field: `active`, `superseded`, `expired`, `archived`.
+- **Never delete before write** — write to temp, then atomic rename.
+- Hash operations: if writes hash `rawContent`, reads must hash `rawContent` too.
+
+### `src/extraction.ts` (2.6K lines)
+- **Must use OpenAI Responses API** — never `chat.completions.create`.
+- Uses `zodTextFormat()` for structured output.
+- Extraction judge gate evaluates fact durability before writes.
+- **Don't index content that failed to persist** — rejected content must not go into `contentHashIndex`.
+
+### `src/config.ts` (2.4K lines)
+- Single source of truth for config parsing and defaults.
+- Config resolution must be deduplicated — import from shared utility, never reimplement slot resolution.
+- Legacy env var fallback: try `REMNIC_*` first, then `ENGRAM_*`.
+- Coerce boolean-like strings (`"false"`, `"0"`, `"no"`, `"off"`) at config-read boundaries.
+
+### `src/types.ts` (2K lines)
+- Single source of truth for shared interfaces.
+- When adding types here, verify all consumers in `packages/*/` are updated.
+
+### `src/qmd.ts` (1.9K lines)
+- **QMD `query` command is intentional** — DO NOT change to `search` or `vsearch`. The `query` command provides LLM expansion + reranking.
+
+### `src/cli.ts` (6.7K lines)
+- CLI flag arguments must exist — `--format`, `--focus`, `--since` without a value must throw an error.
+- Coerce CLI values to expected types at input boundaries (`Number()`, boolean coercion).
+
+## Common Review Patterns
+
+- New config properties → must appear in BOTH `config.ts` interface AND `openclaw.plugin.json:configSchema`.
+- New status values → grep ALL status filters across the codebase.
+- New cache layers → update ALL invalidation functions.
+- New feature gates → must be checked in EVERY code path, not just the main one.
+- Sort comparators → must return 0 for equal items, use stable secondary key.
+- `for...of` loops → if you need the key too, use `.entries()`, not `.values()` with outer-scope variable.
+- Line parsers → track position during iteration, don't use `indexOf` (returns first match, not current).


### PR DESCRIPTION
## Summary

- Add hierarchical `.cursor/BUGBOT.md` review context files (root + 4 subsystem-specific) covering critical gotchas, JS/TS traps, privacy rules, and architecture patterns
- Update `.cursorignore` to exclude non-review files (lock files, eval data, admin console, changelogs, worktrees, session artifacts)
- Add `.cursorindexingignore` to keep the codebase index lean (excludes evals, fixtures, templates, Python scripts)

## What this does for BugBot

**Faster reviews:**
- `.cursorindexingignore` removes ~7MB of eval datasets, fixtures, and templates from the index
- `.cursorignore` excludes lock files, changelogs, admin UI, and session artifacts from context window entirely

**Fewer missed issues:**
- Root `BUGBOT.md` documents 30+ project-specific traps (slice(-0), string "false" truthy, JSON.parse('null'), sort comparator contract, etc.) extracted from the CLAUDE.md gotchas list
- Subsystem BUGBOT.md files in `remnic-core`, `plugin-claude-code`, `plugin-codex`, and `plugin-openclaw` provide targeted context per review path
- Hierarchical loading means BugBot gets the right context for each changed file

**Better signal-to-noise:**
- Explicit "What NOT to Flag" section prevents false positives on generated files
- Critical rules (privacy, API usage, config alignment) are separated from medium-priority checks

## Files changed

| File | Purpose |
|------|---------|
| `.cursor/BUGBOT.md` | Project-wide review rules and architecture context |
| `.cursorignore` | Expanded exclusion list for all Cursor features |
| `.cursorindexingignore` | Index-only exclusions to keep search lean |
| `packages/remnic-core/.cursor/BUGBOT.md` | Core engine invariants (orchestrator, storage, extraction, config) |
| `packages/plugin-claude-code/.cursor/BUGBOT.md` | Claude Code adapter patterns |
| `packages/plugin-codex/.cursor/BUGBOT.md` | Codex adapter patterns |
| `packages/plugin-openclaw/.cursor/BUGBOT.md` | OpenClaw gateway adapter patterns |

## Next steps (dashboard-side, not in this PR)

1. Enable BugBot autofix → "Create New Branch" mode in Cursor dashboard
2. Add scoped manual rules for high-frequency patterns (e.g., `**/extraction.ts` → "must use Responses API")
3. Let learned rules accumulate for a few PR cycles before adding more manual rules

## Test plan

- [x] No code changes — config-only PR
- [x] Verified `.cursorignore` patterns match gitignore syntax
- [x] Verified BUGBOT.md content contains no personal data
- [ ] Confirm BugBot runs on this PR and picks up the new context

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds Cursor/BugBot configuration and ignore lists only, with no runtime code or dependency changes. Main risk is accidentally hiding relevant files from AI review/indexing if the ignore patterns are too broad.
> 
> **Overview**
> Adds hierarchical Cursor BugBot review-context docs (`.cursor/BUGBOT.md` plus per-package `packages/*/.cursor/BUGBOT.md`) to encode project-specific review rules (privacy, OpenAI API usage, config-schema alignment, and common TS/Node pitfalls).
> 
> Expands `.cursorignore` to exclude additional non-review and potentially sensitive/irrelevant paths (lockfiles, changelogs, eval data, dashboards/admin UIs, worktrees/session artifacts, logs, archives), and introduces `.cursorindexingignore` to keep Cursor codebase search/indexing focused by omitting large datasets, fixtures, templates, vendor code, and operational scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c4ca9074c962f1cc4fdf8bbec8758c6f6db38f10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->