### PR TITLE
fix(local-llm): gate thinking-mode suppression on main client via config (#548)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -560,6 +560,7 @@ Set `modelSource` to `plugin` (or remove it) to restore the original behavior wh
 | `localLlmFastModel` | `""` | Optional model id for the fast local tier |
 | `localLlmFastUrl` | `http://localhost:1234/v1` | Optional dedicated base URL for the fast local tier |
 | `localLlmFastTimeoutMs` | `15000` | Timeout for the fast local tier |
+| `localLlmDisableThinking` | `true` | Suppress chain-of-thought / thinking mode on the main local LLM by sending `chat_template_kwargs: { enable_thinking: false }` (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens; thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) commonly blow the 60s timeout before emitting content. Set to `false` to restore thinking for narrative tasks. The fast-tier client always disables thinking regardless of this flag. |
 | `localLlmHomeDir` | `(unset)` | Optional home-dir override used when resolving local helper binaries |
 | `localLmsCliPath` | `(auto)` | Path to `lms` CLI (LM Studio) |
 | `localLmsBinDir` | `(auto)` | LM Studio binary directory |
@@ -1270,6 +1271,7 @@ This appendix is flattened from the runtime config schema and the live `parseCon
 | `localLlmFastModel` | `""` | `""` |
 | `localLlmFastUrl` | `http://localhost:1234/v1` | `http://localhost:1234/v1` |
 | `localLlmFastTimeoutMs` | `15000` | `15000` |
+| `localLlmDisableThinking` | `true` | `true` (skip reasoning tokens on structured extraction); set `false` if you want thinking on narrative tasks |
 | `hourlySummaryCronAutoRegister` | `false` | `false` |
 | `hourlySummariesExtendedEnabled` | `false` | `false` unless structured hourly summaries are useful |
 | `hourlySummariesIncludeToolStats` | `false` | `false` |

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2390,7 +2390,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -4291,7 +4291,7 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2387,6 +2387,11 @@
         "default": 15000,
         "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
       },
+      "localLlmDisableThinking": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+      },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
         "default": false,
@@ -4282,6 +4287,11 @@
       "label": "Fast LLM Timeout (ms)",
       "advanced": true,
       "help": "Timeout for fast-tier requests. Lower than primary since fast ops should complete quickly."
+    },
+    "localLlmDisableThinking": {
+      "label": "Disable Local LLM Thinking Mode",
+      "advanced": true,
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2378,7 +2378,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -4279,7 +4279,7 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2375,6 +2375,11 @@
         "default": 15000,
         "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
       },
+      "localLlmDisableThinking": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+      },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
         "default": false,
@@ -4270,6 +4275,11 @@
       "label": "Fast LLM Timeout (ms)",
       "advanced": true,
       "help": "Timeout for fast-tier requests. Lower than primary since fast ops should complete quickly."
+    },
+    "localLlmDisableThinking": {
+      "label": "Disable Local LLM Thinking Mode",
+      "advanced": true,
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -245,6 +245,36 @@ test("parseConfig recallDirectAnswerEligibleTaxonomyBuckets non-array value fall
   ]);
 });
 
+// ── Issue #548: local LLM thinking-mode suppression ─────────────────────────
+
+test("parseConfig localLlmDisableThinking defaults to true (issue #548)", () => {
+  const result = parseConfig({});
+  assert.equal(result.localLlmDisableThinking, true);
+});
+
+test("parseConfig localLlmDisableThinking=false preserves operator opt-out", () => {
+  const result = parseConfig({ localLlmDisableThinking: false });
+  assert.equal(result.localLlmDisableThinking, false);
+});
+
+test('parseConfig localLlmDisableThinking="false" (CLI string) coerces to boolean false (rule 36)', () => {
+  // `--config localLlmDisableThinking=false` arrives as string; must
+  // coerce or the opt-out silently fails.
+  const result = parseConfig({ localLlmDisableThinking: "false" });
+  assert.equal(result.localLlmDisableThinking, false);
+});
+
+test('parseConfig localLlmDisableThinking="true" (CLI string) coerces to boolean true', () => {
+  const result = parseConfig({ localLlmDisableThinking: "true" });
+  assert.equal(result.localLlmDisableThinking, true);
+});
+
+test('parseConfig localLlmDisableThinking "0"/"no"/"off" all coerce to false', () => {
+  assert.equal(parseConfig({ localLlmDisableThinking: "0" }).localLlmDisableThinking, false);
+  assert.equal(parseConfig({ localLlmDisableThinking: "no" }).localLlmDisableThinking, false);
+  assert.equal(parseConfig({ localLlmDisableThinking: "off" }).localLlmDisableThinking, false);
+});
+
 test("parseConfig procedural numeric fields coerce from CLI-style strings (issue #519)", () => {
   const result = parseConfig({
     openaiApiKey: "sk-test",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1419,6 +1419,13 @@ export function parseConfig(raw: unknown): PluginConfig {
     // client (e.g. for narrative tasks) can set this to false via
     // config or --config CLI flag.  The fast-tier `fastLlm` always
     // disables thinking and is unaffected by this flag.
+    //
+    // Injection is backend-gated inside LocalLlmClient: the
+    // `chat_template_kwargs` field is only sent when the detected
+    // backend is in `THINKING_COMPATIBLE_BACKENDS` (LM Studio, vLLM).
+    // Strict OpenAI-compatible backends reject unknown request
+    // fields with 400, so the client fails open on unknown backends
+    // rather than tripping the 400 cooldown (Codex P1 on PR #550).
     localLlmDisableThinking:
       coerceBool(cfg.localLlmDisableThinking) ?? true,
     // Gateway config (passed from index.ts for fallback AI)

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1411,6 +1411,16 @@ export function parseConfig(raw: unknown): PluginConfig {
           : "http://localhost:1234/v1",
     localLlmFastTimeoutMs:
       typeof cfg.localLlmFastTimeoutMs === "number" ? cfg.localLlmFastTimeoutMs : 15_000,
+    // Thinking-mode suppression on the main local LLM (issue #548).
+    // Default true — extraction / consolidation produce structured
+    // JSON and gain nothing from chain-of-thought; thinking-capable
+    // models burn their token budget on reasoning and blow the
+    // default 60s timeout.  Operators who need thinking on the main
+    // client (e.g. for narrative tasks) can set this to false via
+    // config or --config CLI flag.  The fast-tier `fastLlm` always
+    // disables thinking and is unaffected by this flag.
+    localLlmDisableThinking:
+      coerceBool(cfg.localLlmDisableThinking) ?? true,
     // Gateway config (passed from index.ts for fallback AI)
     gatewayConfig: cfg.gatewayConfig as PluginConfig["gatewayConfig"],
     // Gateway model source (v9.2) — route LLM calls through gateway agent model chain

--- a/packages/remnic-core/src/local-llm-thinking.test.ts
+++ b/packages/remnic-core/src/local-llm-thinking.test.ts
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { LocalLlmClient, type LocalLlmType } from "./local-llm.js";
+import type { PluginConfig } from "./types.js";
+
+function createConfig(): PluginConfig {
+  return {
+    localLlmEnabled: true,
+    localLlmModel: "test-local-model",
+    localLlmUrl: "http://127.0.0.1:1234",
+    localLlmTimeoutMs: 1_000,
+    localLlmRetry5xxCount: 0,
+    localLlmRetryBackoffMs: 1,
+    localLlmHeaders: {},
+    localLlmApiKey: undefined,
+    localLlmAuthHeader: false,
+    localLlm400TripThreshold: 3,
+    localLlm400CooldownMs: 60_000,
+    debug: false,
+    slowLogEnabled: false,
+    slowLogThresholdMs: 1_000,
+  } as unknown as PluginConfig;
+}
+
+function okResponse(content: string): Response {
+  return new Response(
+    JSON.stringify({
+      choices: [{ message: { content } }],
+      usage: { prompt_tokens: 1, completion_tokens: 1, total_tokens: 2 },
+    }),
+    { status: 200, headers: { "content-type": "application/json" } },
+  );
+}
+
+/**
+ * Make `checkAvailability()` short-circuit on its cached hit instead
+ * of probing the mock server (which could re-detect the backend type
+ * as something other than what the test wants to exercise), and pin
+ * both `_disableThinking` and `detectedType` to the requested values.
+ */
+function primeClient(
+  client: LocalLlmClient,
+  opts: { thinking: boolean; detected: LocalLlmType | null },
+): void {
+  const internals = client as unknown as {
+    _disableThinking: boolean;
+    detectedType: LocalLlmType | null;
+    isAvailable: boolean;
+    lastHealthCheck: number;
+  };
+  internals._disableThinking = opts.thinking;
+  internals.detectedType = opts.detected;
+  internals.isAvailable = true;
+  internals.lastHealthCheck = Date.now();
+}
+
+function captureFetchBodies(): {
+  restore: () => void;
+  bodies: Array<Record<string, unknown>>;
+} {
+  const original = globalThis.fetch;
+  const bodies: Array<Record<string, unknown>> = [];
+  globalThis.fetch = (async (_url: string, init?: { body?: string }) => {
+    if (init?.body) {
+      try {
+        bodies.push(JSON.parse(init.body) as Record<string, unknown>);
+      } catch {
+        // ignore non-JSON bodies
+      }
+    }
+    return okResponse("ok");
+  }) as typeof fetch;
+  return {
+    restore: () => {
+      globalThis.fetch = original;
+    },
+    bodies,
+  };
+}
+
+async function runOneChatCompletion(client: LocalLlmClient): Promise<void> {
+  await client.chatCompletion(
+    [{ role: "user", content: "hello" }],
+    { maxTokens: 16 },
+  );
+}
+
+test("disableThinking injects chat_template_kwargs for lmstudio backend (#548)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal(bodies.length, 1);
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking injects chat_template_kwargs for vllm backend (#548)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "vllm" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.deepEqual(bodies[0]?.chat_template_kwargs, { enable_thinking: false });
+});
+
+test("disableThinking fails open for generic backend — no kwarg sent (#548 Codex P1)", async () => {
+  // Regression for Codex P1 on PR #550: `chat_template_kwargs` is a
+  // llama.cpp / LM-Studio / vLLM extension.  Strict OpenAI-compat
+  // backends reject unknown fields with 400, which trips the
+  // localLlm400Trip cooldown.  `generic` means "backend didn't
+  // positively identify as thinking-capable" — do not send.
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "generic" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal(bodies.length, 1);
+  assert.equal(
+    "chat_template_kwargs" in (bodies[0] ?? {}),
+    false,
+    "generic backend must not receive chat_template_kwargs",
+  );
+});
+
+test("disableThinking fails open for ollama backend — no kwarg sent", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: "ollama" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});
+
+test("disableThinking fails open when backend is undetected (null)", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: true, detected: null });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});
+
+test("disableThinking=false never injects chat_template_kwargs, regardless of backend", async () => {
+  const client = new LocalLlmClient(createConfig());
+  primeClient(client, { thinking: false, detected: "lmstudio" });
+  const { restore, bodies } = captureFetchBodies();
+  try {
+    await runOneChatCompletion(client);
+  } finally {
+    restore();
+  }
+  assert.equal("chat_template_kwargs" in (bodies[0] ?? {}), false);
+});

--- a/packages/remnic-core/src/local-llm.ts
+++ b/packages/remnic-core/src/local-llm.ts
@@ -22,6 +22,23 @@ function trimTrailingSlashes(s: string): string {
  */
 export type LocalLlmType = "lmstudio" | "ollama" | "mlx" | "vllm" | "generic";
 
+/**
+ * Backends known to honor `chat_template_kwargs: { enable_thinking: false }`
+ * on OpenAI-compatible `/v1/chat/completions`.  LM Studio and vLLM both
+ * forward this field to the jinja chat template, where thinking-capable
+ * models (Qwen 3.5, Gemma 4, DeepSeek) suppress reasoning tokens.
+ *
+ * Strict OpenAI-compatible backends (standard OpenAI, Azure OpenAI, some
+ * proxies) reject unknown request fields with 400 — which trips the
+ * `localLlm400*` cooldown path.  `LocalLlmClient` therefore only injects
+ * the kwarg when the detected backend is in this set; unknown / `generic`
+ * / `ollama` / `mlx` fail open (no injection, no 400 risk).  Issue #548.
+ */
+const THINKING_COMPATIBLE_BACKENDS: ReadonlySet<LocalLlmType> = new Set([
+  "lmstudio",
+  "vllm",
+]);
+
 interface LocalServerConfig {
   type: LocalLlmType;
   defaultPort: number;
@@ -132,9 +149,16 @@ export class LocalLlmClient {
   }
 
   /**
-   * Disable thinking/reasoning mode for models that support it (e.g. Qwen 3.5).
-   * When enabled, adds chat_template_kwargs to suppress chain-of-thought,
-   * reducing latency for fast-tier operations.
+   * Request thinking/reasoning suppression on the next chat completion.
+   *
+   * When `true`, the client will inject
+   * `chat_template_kwargs: { enable_thinking: false }` into the request
+   * body — **but only when the detected backend is known to support it**
+   * (LM Studio, vLLM; see `THINKING_COMPATIBLE_BACKENDS`).  Strict
+   * OpenAI-compat backends reject unknown fields with 400; on those the
+   * client fails open (thinking runs normally).  This is the safe
+   * default for Remnic extraction / consolidation: measurable latency
+   * win on thinking-capable backends, zero risk on others.  Issue #548.
    */
   set disableThinking(value: boolean) {
     this._disableThinking = value;
@@ -767,10 +791,24 @@ export class LocalLlmClient {
         requestBody.response_format = options.responseFormat;
       }
 
-      // Suppress thinking/reasoning for fast-tier models (e.g. Qwen 3.5 small).
-      // These models default to non-thinking but LM Studio may force thinking via
-      // chat template. Sending this kwarg explicitly disables it.
-      if (this._disableThinking) {
+      // Suppress thinking/reasoning for thinking-capable models
+      // (Qwen 3.5, Gemma 4, DeepSeek).  These models default to
+      // thinking-on via their chat template; sending
+      // `chat_template_kwargs: { enable_thinking: false }` tells the
+      // template to skip reasoning tokens.
+      //
+      // Gate the injection on detected backend support (issue #548,
+      // Codex P1 on PR #550): `chat_template_kwargs` is an LM Studio /
+      // vLLM / llama.cpp extension, not part of standard OpenAI chat
+      // completions.  Strict OpenAI-compatible backends reject
+      // unknown fields with 400, which trips the 400-cooldown path and
+      // can effectively disable local extraction.  Fail open when the
+      // backend hasn't been positively identified as thinking-capable.
+      if (
+        this._disableThinking &&
+        this.detectedType !== null &&
+        THINKING_COMPATIBLE_BACKENDS.has(this.detectedType)
+      ) {
         requestBody.chat_template_kwargs = { enable_thinking: false };
       }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1415,6 +1415,14 @@ export class Orchestrator {
     );
     this.judgeVerdictCache = createVerdictCache();
     this.localLlm = new LocalLlmClient(config, this.modelRegistry);
+    // Issue #548: the main local-LLM client is used by extraction,
+    // consolidation, and other structured-output tasks that gain
+    // nothing from chain-of-thought reasoning.  Apply the operator's
+    // configured preference (default true) so thinking-capable models
+    // skip reasoning tokens and avoid the common 60s extraction
+    // timeout.  Operators can set `localLlmDisableThinking: false`
+    // when they want thinking enabled for narrative paths.
+    this.localLlm.disableThinking = config.localLlmDisableThinking;
     this.fastLlm = config.localLlmFastEnabled
       ? (() => {
           const client = new LocalLlmClient(
@@ -1426,6 +1434,9 @@ export class Orchestrator {
             },
             this.modelRegistry,
           );
+          // Fast-tier always suppresses thinking — the contract of
+          // `fastLlm` is "low latency at all costs" and that is
+          // independent of the main-client config.
           client.disableThinking = true;
           return client;
         })()

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -641,6 +641,21 @@ export interface PluginConfig {
   localLlmFastModel: string;
   localLlmFastUrl: string;
   localLlmFastTimeoutMs: number;
+  /**
+   * Suppress chain-of-thought / thinking mode on the main local LLM
+   * (issue #548).  When true, Remnic injects
+   * `chat_template_kwargs: { enable_thinking: false }` on every
+   * request so thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek,
+   * etc.) skip reasoning tokens that structured-output tasks like
+   * extraction and consolidation cannot benefit from.  Default: true
+   * — the dominant localLlm use case is JSON-shaped extraction where
+   * thinking is pure latency tax and a common cause of 60s timeouts.
+   * Set to false to restore thinking for narrative tasks.
+   *
+   * The fast-tier client (`fastLlm`) always disables thinking; that
+   * contract is baked into "fast tier" and is unaffected by this flag.
+   */
+  localLlmDisableThinking: boolean;
   // Gateway config for fallback AI
   gatewayConfig?: GatewayConfig;
   // Gateway model source (v9.2) — route LLM calls through gateway agent model chain

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2329,6 +2329,11 @@
         "default": 15000,
         "description": "Timeout for fast-tier local LLM requests (ms). Lower than primary since fast ops should complete quickly."
       },
+      "localLlmDisableThinking": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+      },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
         "default": false,
@@ -4221,6 +4226,11 @@
       "label": "Fast LLM Timeout (ms)",
       "advanced": true,
       "help": "Timeout for fast-tier requests. Lower than primary since fast ops should complete quickly."
+    },
+    "localLlmDisableThinking": {
+      "label": "Disable Local LLM Thinking Mode",
+      "advanced": true,
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2332,7 +2332,7 @@
       "localLlmDisableThinking": {
         "type": "boolean",
         "default": true,
-        "description": "When true (default), suppress chain-of-thought / thinking mode on the main local LLM by sending chat_template_kwargs: { enable_thinking: false } (issue #548). Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
+        "description": "When true (default), request chain-of-thought / thinking-mode suppression on the main local LLM (issue #548). The `chat_template_kwargs: { enable_thinking: false }` field is only injected when the detected backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open to avoid the 400-cooldown path. Structured-output tasks like extraction and consolidation gain nothing from reasoning tokens and thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) often blow the 60s timeout before emitting content. Set to false to restore thinking for narrative tasks. The fast-tier client always disables thinking and is not affected by this flag."
       },
       "hourlySummaryCronAutoRegister": {
         "type": "boolean",
@@ -4230,7 +4230,7 @@
     "localLlmDisableThinking": {
       "label": "Disable Local LLM Thinking Mode",
       "advanced": true,
-      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
+      "help": "Suppress chain-of-thought reasoning on the main local LLM. Default on — extraction / consolidation are structured-output tasks where thinking is pure latency tax and a common cause of 60s timeouts on Qwen 3.5 / Gemma 4 / DeepSeek. The suppression field (chat_template_kwargs) is only sent when the backend is known to support it (LM Studio, vLLM); strict OpenAI-compat backends fail open. Turn off if you want thinking on narrative tasks. Fast-tier client always disables thinking regardless."
     },
     "evalHarnessEnabled": {
       "label": "Evaluation Harness",


### PR DESCRIPTION
Closes #548.

## The bug

\`LocalLlmClient\` has a \`disableThinking\` property that, when true, injects \`chat_template_kwargs: { enable_thinking: false }\` into the request body (\`packages/remnic-core/src/local-llm.ts:773\`). Only the fast-tier client flipped it — the main \`this.localLlm\` used by extraction, consolidation, and every background structured-output task left it at \`false\`.

Thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek) then burn most of their token budget on chain-of-thought reasoning before emitting JSON, blowing the default 60s extraction timeout. The reporter measured 10× latency on Gemma 4 E4B (7–10s with thinking, 0.5–1.5s without) and 9s+ consolidation calls that hit the 60s wall. Thinking provides no quality benefit for Remnic's structured JSON extraction — it is pure latency tax on that path.

## Why option B (the config path)

The reporter proposed two options. The PR implements **option B** (new config key) because:

- **Operator escape hatch.** Option A hardcoded \`this.localLlm.disableThinking = true\` and gave narrative-task operators (day summaries, briefings) no way to opt back in — they'd have to patch \`dist/index.js\` just like today's workaround.
- **CLAUDE.md rule 30.** "Every new recall filter, config transformation, or behavioral override needs an \`enabled\` check or escape hatch." A hardcoded flip violates that.
- **Same bug-fix outcome.** Default \`true\` gives users the fix out of the box; they never have to touch config.
- **Repo pattern match.** Sits next to other \`localLlm*\` keys with matching schema + UI metadata; uses the shared \`coerceBool\` helper so CLI strings work (rule 36).

## Changes

### Core (1 line of wiring + one required config field)

- \`packages/remnic-core/src/orchestrator.ts\` — \`this.localLlm.disableThinking = config.localLlmDisableThinking;\` right after constructing the main client. Fast-tier client keeps its unconditional \`true\` because "fast tier = no thinking" is its contract.
- \`packages/remnic-core/src/types.ts\` — new required \`localLlmDisableThinking: boolean\` on \`PluginConfig\` with a full doc comment.
- \`packages/remnic-core/src/config.ts\` — \`coerceBool(cfg.localLlmDisableThinking) ?? true\`.

### Manifests (both shipped)

- \`packages/plugin-openclaw/openclaw.plugin.json\` + synced root mirror: schema entry (\`default: true\`) + UI metadata.
- \`packages/shim-openclaw-engram/openclaw.plugin.json\`: same entry. PR #544 caught this shim-gap on another issue; covering it proactively here.

### Tests (5 new cases in \`config.test.ts\`)

- default = \`true\`
- explicit \`false\` honored
- CLI strings \`"false"\` / \`"0"\` / \`"no"\` / \`"off"\` all coerce to \`false\` (rule 36)
- CLI string \`"true"\` coerces to \`true\`

45/45 config tests pass. \`tsc --noEmit\` clean.

### Docs

- \`docs/config-reference.md\` — row in the Local LLM / OpenAI-Compatible section with the full rationale, plus a matching entry in the "Recommended defaults by profile" table.

## Escape hatch

Operators who want thinking mode on narrative tasks:

\`\`\`json
{ "localLlmDisableThinking": false }
\`\`\`

Or via CLI: \`--config localLlmDisableThinking=false\` (coerced correctly per rule 36).

## Out of scope

- Per-call thinking control from specific extraction / summarization sites. Future work if operators want thinking on narrative tasks while structured calls stay fast — they can add per-site flags then.
- \`fastLlm\`'s unconditional \`true\`. Fast-tier is defined as lowest latency; operators wanting thinking there should use the main client instead.

Fixes #548.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the local LLM request payload and orchestrator wiring; mis-detection or config coercion bugs could change extraction/consolidation behavior or trigger unexpected 4xx responses on some backends.
> 
> **Overview**
> **Adds a new `localLlmDisableThinking` config (default `true`) to suppress local LLM chain-of-thought for structured tasks.** The orchestrator now applies this flag to the main `LocalLlmClient`, while the fast-tier client continues to always disable thinking.
> 
> `LocalLlmClient` now only injects `chat_template_kwargs: { enable_thinking: false }` when the detected backend is known to support it (LM Studio, vLLM), failing open for generic/unknown backends to avoid 400-triggered cooldowns. This is backed by new config-coercion tests (including CLI string values) and new request-body injection tests, plus schema/UI/docs updates in the plugin manifests and config reference.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74173bc3827ff4cbba99c90e792fcf9fc3443e82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->