### PR TITLE
fix(orchestrator): log extraction-queue aborts at debug, not error (#549)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -83,6 +83,7 @@ Access-layer safety notes:
 | `extractionMaxEntitiesPerRun` | `6` | Cap on entities extracted per LLM call |
 | `extractionMaxQuestionsPerRun` | `3` | Cap on curiosity questions generated per LLM call |
 | `extractionMaxProfileUpdatesPerRun` | `4` | Cap on profile update statements per LLM call |
+| `beforeResetTimeoutMs` | `2000` | Max time (ms, clamped to `[100, 30000]`) to wait for a reset-triggered flush before returning control to the host. Operators running a local LLM for extraction often want this higher — a 7B model on CPU can take 2–5s per extraction, and the default can abort the queued follow-up flush before it completes. See issue #549 for the error-vs-debug log-level behavior around these aborts. |
 
 ## Search Backend (v9.0)
 

--- a/packages/remnic-core/src/orchestrator-extraction-queue.test.ts
+++ b/packages/remnic-core/src/orchestrator-extraction-queue.test.ts
@@ -128,3 +128,70 @@ test("processQueue clears queueProcessing on exit regardless of task outcomes", 
   await orch.processQueue();
   assert.equal(orch.queueProcessing, false);
 });
+
+// ── Outer processQueue().catch() branch (Codex follow-up on #549) ──────────
+
+type QueueProcessorOrchestrator = QueueOrchestrator & {
+  logExtractionQueueFailure: (err: unknown, source: "task" | "processor") => void;
+};
+
+test("logExtractionQueueFailure(processor) classifies AbortError as debug (#549)", async () => {
+  // Covers the outer `processQueue().catch(...)` path in
+  // `queueBufferedExtraction`.  A processor-level AbortError can
+  // bubble from e.g. a processQueue rewrite that awaits an external
+  // signal, so the handler must fail open to debug — otherwise a
+  // session-transition-triggered processor abort would get logged
+  // at error next to the successful extraction it just produced.
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator() as QueueProcessorOrchestrator;
+  orch.logExtractionQueueFailure(
+    abortError("queue processor aborted"),
+    "processor",
+  );
+  const errorEntries = entries.filter((e) => e.level === "error");
+  const debugEntries = entries.filter(
+    (e) =>
+      e.level === "debug" &&
+      e.message.includes("background extraction queue processor aborted"),
+  );
+  assert.equal(errorEntries.length, 0);
+  assert.equal(debugEntries.length, 1);
+});
+
+test("logExtractionQueueFailure(processor) preserves error-level for real failures", async () => {
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator() as QueueProcessorOrchestrator;
+  orch.logExtractionQueueFailure(
+    new Error("unexpected processor crash"),
+    "processor",
+  );
+  const errorEntries = entries.filter((e) => e.level === "error");
+  assert.equal(errorEntries.length, 1);
+  assert.ok(
+    errorEntries[0]?.message.includes(
+      "background extraction queue processor failed",
+    ),
+  );
+});
+
+test("logExtractionQueueFailure names the right layer (task vs processor)", async () => {
+  // Regression guard that keeps the two log messages distinct — a
+  // single shared message would lose the operator context that
+  // tells them whether a specific extraction aborted or the queue
+  // processor itself did.
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator() as QueueProcessorOrchestrator;
+  orch.logExtractionQueueFailure(abortError("a"), "task");
+  orch.logExtractionQueueFailure(abortError("b"), "processor");
+  const debugMessages = entries
+    .filter((e) => e.level === "debug")
+    .map((e) => e.message);
+  assert.ok(
+    debugMessages.some((m) => m.includes("background extraction task aborted")),
+  );
+  assert.ok(
+    debugMessages.some((m) =>
+      m.includes("background extraction queue processor aborted"),
+    ),
+  );
+});

--- a/packages/remnic-core/src/orchestrator-extraction-queue.test.ts
+++ b/packages/remnic-core/src/orchestrator-extraction-queue.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Orchestrator } from "./orchestrator.js";
+import { initLogger, type LoggerBackend } from "./logger.js";
+import { abortError } from "./abort-error.js";
+
+interface LogEntry {
+  level: "info" | "warn" | "error" | "debug";
+  message: string;
+  err?: unknown;
+}
+
+function installCapturingLogger(): { entries: LogEntry[] } {
+  const entries: LogEntry[] = [];
+  const backend: LoggerBackend = {
+    info(message) {
+      entries.push({ level: "info", message });
+    },
+    warn(message) {
+      entries.push({ level: "warn", message });
+    },
+    error(message, err) {
+      entries.push({ level: "error", message, err });
+    },
+    debug(message) {
+      entries.push({ level: "debug", message });
+    },
+  };
+  initLogger(backend, true);
+  return { entries };
+}
+
+type QueueOrchestrator = {
+  extractionQueue: Array<() => Promise<void>>;
+  queueProcessing: boolean;
+  processQueue: () => Promise<void>;
+};
+
+function createQueueOrchestrator(): QueueOrchestrator {
+  const orch = Object.create(Orchestrator.prototype) as QueueOrchestrator;
+  orch.extractionQueue = [];
+  orch.queueProcessing = true;
+  return orch;
+}
+
+// ── Issue #549 ─────────────────────────────────────────────────────────────
+
+test("processQueue logs an AbortError task at debug, not error (#549)", async () => {
+  // Regression for issue #549: session transitions fire the abort
+  // signal, and queued extraction tasks that pick it up throw via
+  // `throwIfRecallAborted` (an Error with `name === "AbortError"`).
+  // That is intentional deduplication, not a failure.  The queue
+  // processor must log it at debug.
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator();
+  orch.extractionQueue.push(async () => {
+    throw abortError("extraction aborted (before_extract)");
+  });
+  await orch.processQueue();
+
+  const errorEntries = entries.filter((e) => e.level === "error");
+  const debugEntries = entries.filter(
+    (e) => e.level === "debug" && e.message.includes("aborted"),
+  );
+  assert.equal(
+    errorEntries.length,
+    0,
+    `expected no error logs for abort; got ${errorEntries.map((e) => e.message).join(", ")}`,
+  );
+  assert.ok(
+    debugEntries.some((e) =>
+      e.message.includes("background extraction task aborted"),
+    ),
+    "expected a debug log describing the session-transition abort",
+  );
+});
+
+test("processQueue still logs real task failures at error", async () => {
+  // Guard the other half: non-abort errors (network, parse, I/O) must
+  // continue to log at error level.
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator();
+  orch.extractionQueue.push(async () => {
+    throw new Error("upstream LLM 500");
+  });
+  await orch.processQueue();
+
+  const errorEntries = entries.filter((e) => e.level === "error");
+  assert.equal(errorEntries.length, 1);
+  assert.ok(
+    errorEntries[0]?.message.includes("background extraction task failed"),
+    `expected failed-task message; got ${errorEntries[0]?.message}`,
+  );
+});
+
+test("processQueue handles a mixed run — abort goes to debug, failure to error", async () => {
+  const { entries } = installCapturingLogger();
+  const orch = createQueueOrchestrator();
+  orch.extractionQueue.push(async () => {
+    throw abortError("extraction aborted (before_clear_buffer)");
+  });
+  orch.extractionQueue.push(async () => {
+    throw new Error("I/O failure");
+  });
+  await orch.processQueue();
+
+  const errorCount = entries.filter((e) => e.level === "error").length;
+  const abortDebugCount = entries.filter(
+    (e) =>
+      e.level === "debug" &&
+      e.message.includes("background extraction task aborted"),
+  ).length;
+  assert.equal(errorCount, 1, "one real failure should log at error");
+  assert.equal(
+    abortDebugCount,
+    1,
+    "one abort should log at debug",
+  );
+});
+
+test("processQueue clears queueProcessing on exit regardless of task outcomes", async () => {
+  installCapturingLogger();
+  const orch = createQueueOrchestrator();
+  orch.extractionQueue.push(async () => {
+    throw abortError("extraction aborted");
+  });
+  await orch.processQueue();
+  assert.equal(orch.queueProcessing, false);
+});

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -103,6 +103,11 @@ import {
   type EvalShadowRecallRecord,
 } from "./evals.js";
 import { SessionObserverState } from "./session-observer-state.js";
+import {
+  abortError as sharedAbortError,
+  isAbortError,
+  throwIfAborted as sharedThrowIfAborted,
+} from "./abort-error.js";
 import { CODEX_THREAD_KEY_PREFIX } from "./codex-thread-key.js";
 import { isDisagreementPrompt } from "./signal.js";
 import { lintWorkspaceFiles, rotateMarkdownFileToArchive } from "./hygiene.js";
@@ -467,19 +472,19 @@ type QueryAwarePrefilter = {
   filteredToFullSearch: boolean;
 };
 
-function abortRecallError(message: string): Error {
-  const err = new Error(message);
-  Object.defineProperty(err, "name", { value: "AbortError" });
-  return err;
-}
+// Recall-specific abort helpers.  Thin wrappers over the shared
+// `abort-error.ts` module so every abort in the codebase shares the
+// same `name === "AbortError"` classification contract (`isAbortError`
+// works uniformly).  We keep the "recall aborted" default message for
+// back-compat with call-site logs; callers that pass an explicit
+// message (e.g. "extraction aborted (before_extract)") are unaffected.
+const abortRecallError = sharedAbortError;
 
 function throwIfRecallAborted(
   signal?: AbortSignal,
   message = "recall aborted",
 ): void {
-  if (signal?.aborted) {
-    throw abortRecallError(message);
-  }
+  sharedThrowIfAborted(signal, message);
 }
 
 async function raceRecallAbort<T>(
@@ -8632,7 +8637,17 @@ export class Orchestrator {
     if (!this.queueProcessing) {
       this.queueProcessing = true;
       this.processQueue().catch((err) => {
-        log.error("background extraction queue processor failed", err);
+        // Issue #549: an AbortError bubbling up here is session-
+        // transition cancellation, not a failure.  Log at debug so
+        // operators don't see spurious "queue processor failed"
+        // errors right next to a successful extraction log.
+        if (isAbortError(err)) {
+          log.debug(
+            "background extraction queue processor aborted (session transition)",
+          );
+        } else {
+          log.error("background extraction queue processor failed", err);
+        }
         this.queueProcessing = false;
       });
     }
@@ -8714,7 +8729,24 @@ export class Orchestrator {
         try {
           await task();
         } catch (err) {
-          log.error("background extraction task failed", err);
+          // Issue #549: `throwIfRecallAborted` (used throughout
+          // runExtraction) raises an Error whose `name` is
+          // `"AbortError"`.  That path fires when `before_reset`
+          // aborts a queued task to avoid duplicate extraction — it
+          // is intentional cancellation, not a failure.  Downgrading
+          // the log to debug prevents spurious `error`-level lines
+          // that routinely appear right next to a successful
+          // `persisted: N facts, M entities` log and that confuse
+          // operators into thinking extraction is broken.  Genuine
+          // extraction failures (network, parse, I/O) still log at
+          // `error`.
+          if (isAbortError(err)) {
+            log.debug(
+              "background extraction task aborted (session transition)",
+            );
+          } else {
+            log.error("background extraction task failed", err);
+          }
         }
       }
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -8637,17 +8637,7 @@ export class Orchestrator {
     if (!this.queueProcessing) {
       this.queueProcessing = true;
       this.processQueue().catch((err) => {
-        // Issue #549: an AbortError bubbling up here is session-
-        // transition cancellation, not a failure.  Log at debug so
-        // operators don't see spurious "queue processor failed"
-        // errors right next to a successful extraction log.
-        if (isAbortError(err)) {
-          log.debug(
-            "background extraction queue processor aborted (session transition)",
-          );
-        } else {
-          log.error("background extraction queue processor failed", err);
-        }
+        this.logExtractionQueueFailure(err, "processor");
         this.queueProcessing = false;
       });
     }
@@ -8729,29 +8719,48 @@ export class Orchestrator {
         try {
           await task();
         } catch (err) {
-          // Issue #549: `throwIfRecallAborted` (used throughout
-          // runExtraction) raises an Error whose `name` is
-          // `"AbortError"`.  That path fires when `before_reset`
-          // aborts a queued task to avoid duplicate extraction — it
-          // is intentional cancellation, not a failure.  Downgrading
-          // the log to debug prevents spurious `error`-level lines
-          // that routinely appear right next to a successful
-          // `persisted: N facts, M entities` log and that confuse
-          // operators into thinking extraction is broken.  Genuine
-          // extraction failures (network, parse, I/O) still log at
-          // `error`.
-          if (isAbortError(err)) {
-            log.debug(
-              "background extraction task aborted (session transition)",
-            );
-          } else {
-            log.error("background extraction task failed", err);
-          }
+          this.logExtractionQueueFailure(err, "task");
         }
       }
     }
 
     this.queueProcessing = false;
+  }
+
+  /**
+   * Classify + log a failure from either the per-task catch inside
+   * `processQueue()` or the outer `processQueue().catch(...)` in
+   * `queueBufferedExtraction()`.  Issue #549: `throwIfRecallAborted`
+   * (used throughout `runExtraction`) raises an Error whose `name` is
+   * `"AbortError"`.  That path fires when `before_reset` aborts a
+   * queued task to avoid duplicate extraction — it is intentional
+   * cancellation, not a failure.  Downgrading the log to debug
+   * prevents spurious `error`-level lines that routinely appear
+   * right next to a successful `persisted: N facts, M entities` log
+   * and that confuse operators into thinking extraction is broken.
+   * Genuine extraction failures (network, parse, I/O) still log at
+   * `error`.
+   *
+   * Source differentiates the two call sites so the log message
+   * names the right layer (`task` vs `processor`).
+   */
+  private logExtractionQueueFailure(
+    err: unknown,
+    source: "task" | "processor",
+  ): void {
+    const aborted =
+      source === "task"
+        ? "background extraction task aborted (session transition)"
+        : "background extraction queue processor aborted (session transition)";
+    const failed =
+      source === "task"
+        ? "background extraction task failed"
+        : "background extraction queue processor failed";
+    if (isAbortError(err)) {
+      log.debug(aborted);
+    } else {
+      log.error(failed, err);
+    }
   }
 
   private async runExtraction(


### PR DESCRIPTION
Closes #549.

## The bug

\`orchestrator.ts:8717\` (pre-fix line number) swallowed every queued-extraction error into \`log.error("background extraction task failed", err)\`. When a session reset fires the abort signal, any queued follow-up extraction throws \`extraction aborted (<stage>)\` via \`throwIfRecallAborted\` — intentional deduplication. The \`error\`-level log next to a successful \`persisted: N facts\` log misleads operators.

The reporter's example:

\`\`\`
17:20:55.502 remnic: persisted: 4 facts, 3 entities, 2 questions, 1 profile updates
17:20:55.506 remnic: background extraction task failed — extraction aborted (before_extract)
\`\`\`

## Fix

Gate the two queue catch sites on \`isAbortError(err)\` from the shared \`abort-error.ts\` module (added in PR #541).

- \`processQueue()\` per-task catch: AbortError → \`log.debug(...aborted (session transition))\`, real failures keep \`log.error\`.
- Outer \`processQueue().catch(...)\` follows the same pattern.

Discriminator is \`err.name === "AbortError"\` — the stable contract set by \`throwIfRecallAborted\` / \`abortError\`. The reporter's proposed \`err.message.includes("extraction aborted")\` string-match would be fragile: the message varies by stage (\`before_extract\`, \`before_clear_buffer\`, \`during_extract\`) and other abort sites use different messages entirely.

## Subsystem-hardening cleanup

The orchestrator still had its own private \`abortRecallError\` and \`throwIfRecallAborted\` helpers — noted but intentionally left by PR #541. Migrated them to thin wrappers over the shared \`abort-error.ts\`, preserving the \`"recall aborted"\` default message so the 9 call sites without an explicit message aren't disturbed. This ensures every abort in the orchestrator produces an error shape that \`isAbortError\` uniformly classifies. CLAUDE.md "Why Review Churn Happens" rule — wider the fix to the whole subsystem, not just the reported symptom.

## \`beforeResetTimeoutMs\` — already configurable

The reporter's second suggestion was to make \`beforeResetTimeoutMs\` configurable or raise the default. Verified it's already exposed in \`openclaw.plugin.json\` (default 2000ms, clamped \`[100, 30000]\`). Raising the default would slightly delay every session transition for every user, so this PR leaves the default alone and adds a doc note so local-LLM operators know to tune it.

## Tests

New: \`packages/remnic-core/src/orchestrator-extraction-queue.test.ts\` (4 cases)

- abort-error task → debug, zero error logs
- regular-error task → error log, unchanged
- mixed run (abort + failure) → one debug + one error
- \`queueProcessing\` flag clears on exit

Existing: \`orchestrator-flush.test.ts\` + \`abort-error.test.ts\` — 26/26 pass unchanged.

## Docs

\`docs/config-reference.md\` — new row for \`beforeResetTimeoutMs\` under Extraction Guardrails with tuning guidance for local-LLM operators and a cross-reference to #549.

Fixes #549.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to log-level classification and shared abort helpers, with added tests to prevent regressions; functional extraction behavior should remain unchanged.
> 
> **Overview**
> Prevents spurious `error` logs during session resets by classifying extraction-queue `AbortError`s as intentional cancellations: both per-task failures in `processQueue()` and the outer `processQueue().catch(...)` path now log aborts at `debug` while keeping real failures at `error`.
> 
> Refactors orchestrator abort helpers to use the shared `abort-error.ts` utilities for consistent `AbortError` detection, adds a focused extraction-queue regression test suite for issue #549, and documents `beforeResetTimeoutMs` tuning guidance in `config-reference.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ab003cd0b4b63e3b990395be90b8681778ec269. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->