### PR TITLE
chore(changeset): bump core/plugin-openclaw/shim to publish #548 + #549 fixes

### DIFF
--- a/.changeset/publish-548-549-batch.md
+++ b/.changeset/publish-548-549-batch.md
@@ -1,0 +1,21 @@
+---
+"@remnic/core": minor
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Publish pending fixes that have been on `main` since the last npm release (`@remnic/core@1.0.3`, `@remnic/plugin-openclaw@1.0.6`, `@joshuaswarren/openclaw-engram@9.3.5`). Users installing from npm currently hit issues #548 and #549 because the code that fixes them is on `main` but not in a published release.
+
+`@remnic/core` — **minor** (one user-visible behavior change plus several fixes):
+
+- Flip `recallDirectAnswerEnabled` default to `true` so the observation-mode direct-answer tier runs out of the box — annotates `LastRecallSnapshot.tierExplain` for the CLI/HTTP/MCP explain surfaces (#544, #518 slice 8a).
+- Gate local-LLM thinking-mode suppression behind the new `localLlmDisableThinking` config (default `true`); backend-detected so the `chat_template_kwargs` field is only sent to LM Studio / vLLM and never trips strict OpenAI-compat backends with 400s (#550, issue #548).
+- Log extraction-queue aborts at `debug`, not `error`. Session-transition cancellations are intentional deduplication and were being misreported as failures next to the successful extraction log (#552, issue #549). The orchestrator's private abort helpers now route through the shared `abort-error.ts` module for uniform `isAbortError` classification.
+- Add the contradiction-scan maintenance cron on top of temporal supersession (#553).
+- Several smaller fixes: openclaw-chain benchmark gateway path (#547), Cursor Bugbot configuration integration (#546).
+
+`@remnic/plugin-openclaw` — **patch**: schema + UI metadata updates in `openclaw.plugin.json` for the new/changed config keys (`recallDirectAnswerEnabled` default flip, new `localLlmDisableThinking`, contradiction-scan cron toggles).
+
+`@joshuaswarren/openclaw-engram` (legacy shim) — **patch**: mirror of the plugin-openclaw manifest updates so operators on the legacy plugin id get the same fixes and defaults.
+
+No API breaks. Users installing after this release pick up all of the above automatically; operators who need to restore prior behavior can set `recallDirectAnswerEnabled: false` or `localLlmDisableThinking: false` via config.


### PR DESCRIPTION
Publishing-only PR. No code changes — just a changeset markdown that tells the release pipeline to bump per-package versions on merge.

## Why

Users installing \`@remnic/core\` from npm today hit exactly the bugs that issues #548 and #549 filed. The fixes merged days ago (#550 for #548, #552 for #549) but the merging PRs didn't include \`.changeset/\` files, so the automated Version Packages PR hasn't re-opened with per-package bumps. The release workflow auto-bumps the workspace root (9.3.83) but the publish step skips packages whose own \`package.json\` version is already on npm — which is every single package, because nobody bumped them.

**Current npm state:** \`@remnic/core@1.0.3\`, \`@remnic/plugin-openclaw@1.0.6\`, \`@joshuaswarren/openclaw-engram@9.3.5\` — all from ~Apr 19 17:xx UTC, before the recent fix stack.

## What this PR does

Adds \`.changeset/publish-548-549-batch.md\` that flags:

- \`@remnic/core\`: **minor** bump (1.0.3 → 1.1.0) — the \`recallDirectAnswerEnabled: true\` default flip from PR #544 is a user-visible behavior change, so minor is the right classification. Rolls in #546, #547, #550, #552, #553 at the same time.
- \`@remnic/plugin-openclaw\`: **patch** (1.0.6 → 1.0.7) — schema + UI metadata updates.
- \`@joshuaswarren/openclaw-engram\` (shim): **patch** (9.3.5 → 9.3.6) — mirror of the plugin-openclaw manifest updates.

## What happens after merge

1. \`@changesets/cli\` workflow consumes this changeset on its next run.
2. It opens (or updates) the automated \"Version Packages\" PR with the three per-package bumps and the rendered CHANGELOG entries.
3. When that PR merges, the \"Release and Publish\" workflow picks up the new versions and publishes to npm.

After the chain completes, \`npm install @remnic/core\` will pull the code containing all six fixes listed in the changeset body.

## Escape hatches (documented in the changeset body)

- \`recallDirectAnswerEnabled: false\` — disable the new default direct-answer observation
- \`localLlmDisableThinking: false\` — restore thinking mode on the main local LLM

No API breaks. Doc-only + metadata-only files touched.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Publishing-only change that adds a Changesets entry to bump package versions; no runtime code is modified. Risk is limited to release/versioning accuracy (wrong bump levels or changelog text).
> 
> **Overview**
> Adds a single Changesets file (`.changeset/publish-548-549-batch.md`) to trigger npm releases for `@remnic/core` (**minor**) and `@remnic/plugin-openclaw` / `@joshuaswarren/openclaw-engram` (**patch**).
> 
> The changeset documents that the release is intended to publish already-merged fixes (including default/config behavior tweaks and logging/cron adjustments) so npm users receive the #548/#549-related fixes; **no implementation code changes are included in this PR**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7989bd32fcab02c5e20e41719adbfdbecf4cd8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->