### PR TITLE
feat(retrieval): complete direct-answer tier wiring + explain surface (#518)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -761,7 +761,7 @@ export class EngramAccessHttpServer {
         storage: this.service.storageRef,
         config: this.service.configRef,
         memoryDir: this.service.memoryDir,
-        embeddingLookup: this.service.embeddingLookupRef,
+        embeddingLookupFactory: this.service.embeddingLookupFactoryRef,
         localLlm: this.service.localLlmRef,
         fallbackLlm: this.service.fallbackLlmRef,
         namespace: typeof body.namespace === "string" ? body.namespace : undefined,

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -352,6 +352,26 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // Tier-explain (issue #518): structured per-result annotation from
+    // the direct-answer retrieval tier.  Orthogonal to /recall/explain
+    // above, which returns a graph-path explanation document.
+    if (req.method === "GET" && pathname === "/engram/v1/recall/tier-explain") {
+      const sessionParam = parsed.searchParams.get("session");
+      const sessionKey = sessionParam && sessionParam.length > 0 ? sessionParam : undefined;
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const namespace = this.resolveNamespace(
+        req,
+        namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+      );
+      const payload = await this.service.recallTierExplain(
+        sessionKey,
+        namespace,
+        this.resolveRequestPrincipal(req),
+      );
+      this.respondJson(res, 200, payload);
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/observe") {
       const body = await this.readValidatedBody(req, "observe");
       this.ensureWriteRateLimitAvailable();

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1473,7 +1473,7 @@ export class EngramMcpServer {
           storage: this.service.storageRef,
           config: this.service.configRef,
           memoryDir: this.service.memoryDir,
-          embeddingLookup: this.service.embeddingLookupRef,
+          embeddingLookupFactory: this.service.embeddingLookupFactoryRef,
           localLlm: this.service.localLlmRef,
           fallbackLlm: this.service.fallbackLlmRef,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -126,6 +126,25 @@ export class EngramMcpServer {
         },
       },
       {
+        name: "engram.recall_tier_explain",
+        description:
+          "Return a structured tier-explain payload for the last direct-answer-eligible recall (issue #518). Orthogonal to engram.recall_explain, which returns a graph-path explanation.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sessionKey: {
+              type: "string",
+              description: "Optional session key. Omit to read the most recent snapshot.",
+            },
+            namespace: {
+              type: "string",
+              description: "Optional namespace to scope the returned snapshot.",
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.day_summary",
         description:
           "Generate a structured end-of-day summary. When memories is omitted or empty, auto-gathers today's facts and hourly summaries from storage.",
@@ -1078,6 +1097,14 @@ export class EngramMcpServer {
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      case "engram.recall_tier_explain":
+        return this.service.recallTierExplain(
+          typeof args.sessionKey === "string" && args.sessionKey.length > 0
+            ? args.sessionKey
+            : undefined,
+          typeof args.namespace === "string" ? args.namespace : undefined,
+          effectivePrincipal,
+        );
       case "engram.day_summary":
         return this.service.daySummary({
           memories: typeof args.memories === "string" ? args.memories : "",

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1102,7 +1102,9 @@ export class EngramMcpServer {
           typeof args.sessionKey === "string" && args.sessionKey.length > 0
             ? args.sessionKey
             : undefined,
-          typeof args.namespace === "string" ? args.namespace : undefined,
+          typeof args.namespace === "string" && args.namespace.length > 0
+            ? args.namespace
+            : undefined,
           effectivePrincipal,
         );
       case "engram.day_summary":

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1445,7 +1445,12 @@ export class EngramMcpServer {
       case "engram.review_list":
       case "remnic.review_list": {
         const { listPairs } = await import("./contradiction/contradiction-review.js");
-        const filter = typeof args.filter === "string" ? args.filter as "all" | "unresolved" | "contradicts" | "independent" | "duplicates" | "needs-user" : "unresolved";
+        const VALID_REVIEW_FILTERS = new Set(["all", "unresolved", "contradicts", "independent", "duplicates", "needs-user"]);
+        const rawFilter = typeof args.filter === "string" ? args.filter : "unresolved";
+        if (!VALID_REVIEW_FILTERS.has(rawFilter)) {
+          throw new Error(`Invalid filter '${rawFilter}'. Valid: ${[...VALID_REVIEW_FILTERS].join(", ")}`);
+        }
+        const filter = rawFilter as "all" | "unresolved" | "contradicts" | "independent" | "duplicates" | "needs-user";
         const ns = typeof args.namespace === "string" ? args.namespace : undefined;
         const limit = typeof args.limit === "number" ? args.limit : 50;
         return listPairs(this.service.memoryDir, { filter, namespace: ns, limit });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2854,10 +2854,17 @@ export class EngramAccessService {
   }
 
   get fallbackLlmRef(): FallbackLlmClient | null {
-    return null;
+    return this.orchestrator.fastGatewayLlm ?? null;
   }
 
   get embeddingLookupRef(): SemanticDedupLookup | undefined {
-    return undefined;
+    if (!this.orchestrator.config.embeddingFallbackEnabled) return undefined;
+    return async (content: string, limit: number) => {
+      try {
+        return await this.orchestrator.semanticDedupLookup(content, limit, this.orchestrator.storage);
+      } catch {
+        return [];
+      }
+    };
   }
 }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2857,17 +2857,6 @@ export class EngramAccessService {
     return this.orchestrator.fastGatewayLlm ?? null;
   }
 
-  get embeddingLookupRef(): SemanticDedupLookup | undefined {
-    if (!this.orchestrator.config.embeddingFallbackEnabled) return undefined;
-    return async (content: string, limit: number) => {
-      try {
-        return await this.orchestrator.semanticDedupLookup(content, limit, this.orchestrator.storage);
-      } catch {
-        return [];
-      }
-    };
-  }
-
   get embeddingLookupFactoryRef(): (storage: import("./storage.js").StorageManager) => SemanticDedupLookup | undefined {
     return (storage) => {
       if (!this.orchestrator.config.embeddingFallbackEnabled) return undefined;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2867,4 +2867,17 @@ export class EngramAccessService {
       }
     };
   }
+
+  get embeddingLookupFactoryRef(): (storage: import("./storage.js").StorageManager) => SemanticDedupLookup | undefined {
+    return (storage) => {
+      if (!this.orchestrator.config.embeddingFallbackEnabled) return undefined;
+      return async (content: string, limit: number) => {
+        try {
+          return await this.orchestrator.semanticDedupLookup(content, limit, storage);
+        } catch {
+          return [];
+        }
+      };
+    };
+  }
 }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -76,6 +76,7 @@ import type {
 import type { LocalLlmClient } from "./local-llm.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import type { SemanticDedupLookup } from "./dedup/semantic.js";
+import { toRecallExplainJson } from "./recall-explain-renderer.js";
 
 export class EngramAccessInputError extends Error {}
 
@@ -1040,6 +1041,46 @@ export class EngramAccessService {
     ]);
     if (!snapshot && !intent && !graph) return { found: false };
     return { found: true, snapshot: snapshot ?? undefined, intent, graph };
+  }
+
+  async recallTierExplain(
+    sessionKey?: string,
+    namespace?: string,
+    authenticatedPrincipal?: string,
+  ) {
+    const namespacesEnabled = this.orchestrator.config.namespacesEnabled;
+    const requestedNamespace = namespace?.trim()
+      ? this.resolveNamespace(namespace)
+      : undefined;
+    const principal = authenticatedPrincipal?.trim()
+      || resolvePrincipal(sessionKey, this.orchestrator.config);
+
+    if (requestedNamespace) {
+      if (!canReadNamespace(principal, requestedNamespace, this.orchestrator.config)) {
+        return toRecallExplainJson(null);
+      }
+    } else if (namespacesEnabled && !authenticatedPrincipal?.trim() && !sessionKey?.trim()) {
+      return toRecallExplainJson(null);
+    }
+
+    const candidate = sessionKey
+      ? this.orchestrator.lastRecall.get(sessionKey)
+      : this.orchestrator.lastRecall.getMostRecent();
+
+    const snapshot = (() => {
+      if (!candidate) return null;
+      if (requestedNamespace) {
+        return candidate.namespace === requestedNamespace ? candidate : null;
+      }
+      if (!namespacesEnabled) return candidate;
+      const snapshotNs = candidate.namespace
+        ?? this.orchestrator.config.defaultNamespace;
+      return canReadNamespace(principal, snapshotNs, this.orchestrator.config)
+        ? candidate
+        : null;
+    })();
+
+    return toRecallExplainJson(snapshot);
   }
 
   async memoryStore(request: EngramAccessMemoryStoreRequest): Promise<EngramAccessWriteResponse> {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -6755,13 +6755,22 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           const options = (args[0] ?? {}) as Record<string, string>;
           const { runContradictionScan } = await import("./contradiction/contradiction-scan.js");
           console.log("Running contradiction scan...");
+          const embeddingLookup = orchestrator.config.embeddingFallbackEnabled
+            ? async (content: string, limit: number) => {
+                try {
+                  return await orchestrator.semanticDedupLookup(content, limit, orchestrator.storage);
+                } catch {
+                  return [];
+                }
+              }
+            : undefined;
           const result = await runContradictionScan({
             storage: orchestrator.storage,
             config: orchestrator.config,
             memoryDir: orchestrator.config.memoryDir,
-            embeddingLookup: undefined,
+            embeddingLookup,
             localLlm: orchestrator.localLlm ?? null,
-            fallbackLlm: null,
+            fallbackLlm: (orchestrator as unknown as { fastGatewayLlm: import("./fallback-llm.js").FallbackLlmClient | null }).fastGatewayLlm ?? null,
             namespace: options.namespace,
           });
           console.log(`Scan complete in ${result.elapsedMs}ms:`);

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -198,6 +198,7 @@ import { resolveHomeDir } from "./runtime/env.js";
 import { convertMemoriesToRecords } from "./training-export/converter.js";
 import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
+import { renderRecallExplain, parseRecallExplainFormat } from "./recall-explain-renderer.js";
 
 interface CliApi {
   registerCli(
@@ -3992,6 +3993,35 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             return;
           }
           if (!reportHasMachineReadableOutput(options)) console.log("OK");
+        });
+
+      cmd
+        .command("recall-explain")
+        .description(
+          "Show tier explain for the most recent recall (or a specific session)",
+        )
+        .option(
+          "--session <key>",
+          "Session key to look up; omit to use the most recent snapshot",
+        )
+        .option("--format <fmt>", "Output format: text (default) or json", "text")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const format = parseRecallExplainFormat(options.format);
+          await orchestrator.lastRecall.load();
+          const sessionKey =
+            typeof options.session === "string" && options.session.length > 0
+              ? options.session
+              : undefined;
+          let snapshot: ReturnType<typeof orchestrator.lastRecall.get> = null;
+          try {
+            snapshot = sessionKey
+              ? orchestrator.lastRecall.get(sessionKey)
+              : orchestrator.lastRecall.getMostRecent();
+          } catch {
+            snapshot = null;
+          }
+          console.log(renderRecallExplain(snapshot, format));
         });
 
       cmd

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -6755,22 +6755,22 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           const options = (args[0] ?? {}) as Record<string, string>;
           const { runContradictionScan } = await import("./contradiction/contradiction-scan.js");
           console.log("Running contradiction scan...");
-          const embeddingLookup = orchestrator.config.embeddingFallbackEnabled
-            ? async (content: string, limit: number) => {
-                try {
-                  return await orchestrator.semanticDedupLookup(content, limit, orchestrator.storage);
-                } catch {
-                  return [];
-                }
-              }
-            : undefined;
           const result = await runContradictionScan({
             storage: orchestrator.storage,
             config: orchestrator.config,
             memoryDir: orchestrator.config.memoryDir,
-            embeddingLookup,
+            embeddingLookupFactory: (storage) => {
+              if (!orchestrator.config.embeddingFallbackEnabled) return undefined;
+              return async (content: string, limit: number) => {
+                try {
+                  return await orchestrator.semanticDedupLookup(content, limit, storage);
+                } catch {
+                  return [];
+                }
+              };
+            },
             localLlm: orchestrator.localLlm ?? null,
-            fallbackLlm: (orchestrator as unknown as { fastGatewayLlm: import("./fallback-llm.js").FallbackLlmClient | null }).fastGatewayLlm ?? null,
+            fallbackLlm: orchestrator.fastGatewayLlm ?? null,
             namespace: options.namespace,
           });
           console.log(`Scan complete in ${result.elapsedMs}ms:`);

--- a/packages/remnic-core/src/contradiction/contradiction-judge.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-judge.ts
@@ -88,7 +88,8 @@ IMPORTANT:
 
 // ── Cache ──────────────────────────────────────────────────────────────────────
 
-let verdictCache: Map<string, ContradictionJudgeResult> = new Map();
+/** Module-level fallback cache — only used when caller does not supply one. */
+let defaultVerdictCache: Map<string, ContradictionJudgeResult> = new Map();
 const CACHE_MAX = 10_000;
 
 function pairKey(idA: string, idB: string): string {
@@ -111,11 +112,11 @@ export function createVerdictCache(): Map<string, ContradictionJudgeResult> {
 }
 
 export function clearVerdictCache(): void {
-  verdictCache.clear();
+  defaultVerdictCache.clear();
 }
 
 export function verdictCacheSize(): number {
-  return verdictCache.size;
+  return defaultVerdictCache.size;
 }
 
 // ── Public API ──────────────────────────────────────────────────────────────────
@@ -135,7 +136,7 @@ export async function judgeContradictionPairs(
 ): Promise<ContradictionJudgeBatchResult> {
   const startTime = Date.now();
   const results = new Map<string, ContradictionJudgeResult>();
-  const activeCache = cache ?? verdictCache;
+  const activeCache = cache ?? defaultVerdictCache;
   let cached = 0;
   let judged = 0;
 

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -132,8 +132,9 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
     categoryB: pair.categoryB,
   }));
 
-  // 6. Send to judge
-  const judgeResult = await judgeContradictionPairs(judgeInputs, config, localLlm, fallbackLlm);
+  // 6. Send to judge (per-scan cache avoids module-level singleton leak)
+  const scanCache = new Map<string, import("./contradiction-judge.js").ContradictionJudgeResult>();
+  const judgeResult = await judgeContradictionPairs(judgeInputs, config, localLlm, fallbackLlm, scanCache);
   log.info("[contradiction-scan] judge completed: %d judged, %d cached in %dms", judgeResult.judged, judgeResult.cached, judgeResult.elapsed);
 
   // 7. Write to review queue

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -102,7 +102,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
   }
 
   // 3. Generate candidate pairs
-  const candidates = generatePairs(memories, existingMap, scanConfig, embeddingLookup);
+  const candidates = await generatePairs(memories, existingMap, scanConfig, embeddingLookup);
   const cooledDown = candidates.skipped;
   log.info("[contradiction-scan] generated %d candidates (%d cooled down)", candidates.pairs.length, cooledDown);
 
@@ -181,12 +181,12 @@ interface PairGenResult {
   skipped: number;
 }
 
-function generatePairs(
+async function generatePairs(
   memories: MemoryFile[],
   existingPairs: Map<string, ContradictionPair>,
   scanConfig: PluginConfig["contradictionScan"],
   embeddingLookup?: SemanticDedupLookup,
-): PairGenResult {
+): Promise<PairGenResult> {
   const pairs: CandidatePair[] = [];
   let skipped = 0;
   const seen = new Set<string>();
@@ -264,6 +264,44 @@ function generatePairs(
         categoryA: a.frontmatter.category as string | undefined,
         categoryB: b.frontmatter.category as string | undefined,
       });
+    }
+  }
+
+  // Strategy 3: Embedding cosine similarity (enforces similarityFloor config)
+  if (embeddingLookup) {
+    const memoryById = new Map(memories.map((m) => [m.frontmatter.id!, m]));
+    for (const mem of memories) {
+      const id = mem.frontmatter.id!;
+      try {
+        const hits = await embeddingLookup(mem.content, 20);
+        for (const hit of hits) {
+          if (hit.score < scanConfig.similarityFloor) continue;
+          if (hit.id === id) continue;
+          const peer = memoryById.get(hit.id);
+          if (!peer) continue;
+
+          const pairId = computePairId(id, hit.id);
+          if (seen.has(pairId)) continue;
+          seen.add(pairId);
+
+          const existing = existingPairs.get(pairId);
+          if (existing && isCoolingDown(existing, scanConfig.cooldownDays)) {
+            skipped++;
+            continue;
+          }
+
+          pairs.push({
+            idA: id,
+            idB: hit.id,
+            textA: mem.content,
+            textB: peer.content,
+            categoryA: mem.frontmatter.category as string | undefined,
+            categoryB: peer.frontmatter.category as string | undefined,
+          });
+        }
+      } catch {
+        // Embedding backend unavailable — skip, entity-ref/tag strategies already covered
+      }
     }
   }
 

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -202,6 +202,7 @@ async function generatePairs(
   embeddingLookup?: SemanticDedupLookup,
 ): Promise<PairGenResult> {
   const pairs: CandidatePair[] = [];
+  const embeddingPairs: CandidatePair[] = [];
   let skipped = 0;
   const seen = new Set<string>();
 
@@ -304,7 +305,7 @@ async function generatePairs(
             continue;
           }
 
-          pairs.push({
+          embeddingPairs.push({
             idA: id,
             idB: hit.id,
             textA: mem.content,
@@ -318,6 +319,10 @@ async function generatePairs(
       }
     }
   }
+
+  // Append embedding pairs after high-precision entity/topic pairs so the
+  // downstream sort+slice(maxPairsPerRun) keeps precision-first ordering.
+  pairs.push(...embeddingPairs);
 
   return { pairs, skipped };
 }

--- a/packages/remnic-core/src/contradiction/contradiction-scan.ts
+++ b/packages/remnic-core/src/contradiction/contradiction-scan.ts
@@ -63,7 +63,14 @@ export interface ScanDependencies {
   storage: StorageManager;
   config: PluginConfig;
   memoryDir: string;
+  /** Pre-built embedding lookup. When provided, used as-is for Strategy 3. */
   embeddingLookup?: SemanticDedupLookup;
+  /**
+   * Factory to build a namespace-scoped embedding lookup.
+   * When provided, takes precedence over `embeddingLookup`.
+   * The scan driver passes its own `storage` so the lookup queries the correct index.
+   */
+  embeddingLookupFactory?: (storage: StorageManager) => SemanticDedupLookup | undefined;
   localLlm: LocalLlmClient | null;
   fallbackLlm: FallbackLlmClient | null;
   namespace?: string;
@@ -78,8 +85,14 @@ export interface ScanDependencies {
  */
 export async function runContradictionScan(deps: ScanDependencies): Promise<ScanResult> {
   const startTime = Date.now();
-  const { storage, config, memoryDir, embeddingLookup, localLlm, fallbackLlm, namespace } = deps;
+  const { storage, config, memoryDir, embeddingLookup, embeddingLookupFactory, localLlm, fallbackLlm, namespace } = deps;
   const scanConfig = config.contradictionScan;
+
+  // Prefer the factory (which uses the scan's own storage for correct namespace scoping)
+  // over a pre-built lookup (which may use default-namespace storage).
+  const scopedEmbeddingLookup = embeddingLookupFactory
+    ? embeddingLookupFactory(storage)
+    : embeddingLookup;
 
   if (!scanConfig.enabled) {
     log.info("[contradiction-scan] disabled by config");
@@ -102,7 +115,7 @@ export async function runContradictionScan(deps: ScanDependencies): Promise<Scan
   }
 
   // 3. Generate candidate pairs
-  const candidates = await generatePairs(memories, existingMap, scanConfig, embeddingLookup);
+  const candidates = await generatePairs(memories, existingMap, scanConfig, scopedEmbeddingLookup);
   const cooledDown = candidates.skipped;
   log.info("[contradiction-scan] generated %d candidates (%d cooled down)", candidates.pairs.length, cooledDown);
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4096,25 +4096,24 @@ export class Orchestrator {
 
       const sources: DirectAnswerSources = {
         taxonomy: DEFAULT_TAXONOMY,
-        listCandidateMemories: async () => {
-          const union: MemoryFile[] = [];
-          for (const ns of namespaces) {
-            const storage =
-              scopedStorages.get(ns) ??
-              (await this.storageRouter.storageFor(ns));
-            const all = await storage.readAllMemories();
-            for (const m of all) {
-              if ((m.frontmatter.status ?? "active") === "active") {
-                union.push(m);
-                memoryNamespaceByPath.set(m.path, ns);
-                if (m.frontmatter.id) {
-                  memoryNamespaceById.set(m.frontmatter.id, ns);
-                }
+        listCandidateMemories: async (options: { namespace: string; abortSignal?: AbortSignal }) => {
+          const targetNs = options.namespace;
+          const storage =
+            scopedStorages.get(targetNs) ??
+            (await this.storageRouter.storageFor(targetNs));
+          const all = await storage.readAllMemories();
+          const active: MemoryFile[] = [];
+          for (const m of all) {
+            if ((m.frontmatter.status ?? "active") === "active") {
+              active.push(m);
+              memoryNamespaceByPath.set(m.path, targetNs);
+              if (m.frontmatter.id) {
+                memoryNamespaceById.set(m.frontmatter.id, targetNs);
               }
             }
           }
-          candidatesConsidered = union.length;
-          return union;
+          candidatesConsidered = active.length;
+          return active;
         },
         trustZoneFor: async (memoryId: string) => {
           const ns = memoryNamespaceById.get(memoryId);

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4116,7 +4116,7 @@ export class Orchestrator {
               }
             }
           }
-          candidatesConsidered = active.length;
+          candidatesConsidered += active.length;
           return active;
         },
         trustZoneFor: async (memoryId: string) => {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4134,14 +4134,21 @@ export class Orchestrator {
             : 0,
       };
 
-      const result = await tryDirectAnswer({
-        query: prompt,
-        namespace: namespaces[0]!,
-        config: this.config,
-        sources,
-      });
+      let result: import("./direct-answer.js").DirectAnswerResult | undefined;
+      for (const ns of namespaces) {
+        const r = await tryDirectAnswer({
+          query: prompt,
+          namespace: ns,
+          config: this.config,
+          sources,
+        });
+        if (r.eligible && r.winner) {
+          result = r;
+          break;
+        }
+      }
 
-      if (!result.eligible || !result.winner) return;
+      if (!result?.eligible || !result?.winner) return;
 
       const explain: RecallTierExplain = {
         tier: "direct-answer",

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -4032,17 +4032,21 @@ export class Orchestrator {
       recordedAt: expectedSnapshot.recordedAt,
     };
     const previous = this.directAnswerObservationChain;
-    this.directAnswerObservationChain = previous.then(() =>
-      this.annotateDirectAnswerTier(
-        observationQuery,
-        sessionKey,
-        observationNamespaces,
-        expectedIdentity,
-        undefined,
-      ).catch((err) => {
-        log.debug(`direct-answer observation chain error: ${err}`);
-      }),
-    );
+    this.directAnswerObservationChain = previous
+      .catch(() => undefined)
+      .then(async () => {
+        try {
+          await this.annotateDirectAnswerTier(
+            observationQuery,
+            sessionKey,
+            observationNamespaces,
+            expectedIdentity,
+            undefined,
+          );
+        } catch (err) {
+          log.debug(`direct-answer observation chain error: ${err}`);
+        }
+      });
   }
 
   private async annotateDirectAnswerTier(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1114,7 +1114,11 @@ export class Orchestrator {
   readonly localLlm: LocalLlmClient;
   readonly fastLlm: LocalLlmClient;
   private readonly judgeVerdictCache: Map<string, JudgeVerdict>;
-  private readonly fastGatewayLlm: FallbackLlmClient | null;
+  private readonly _fastGatewayLlm: FallbackLlmClient | null;
+
+  get fastGatewayLlm(): FallbackLlmClient | null {
+    return this._fastGatewayLlm;
+  }
   readonly modelRegistry: ModelRegistry;
   readonly relevance: RelevanceStore;
   readonly negatives: NegativeExampleStore;
@@ -1457,7 +1461,7 @@ export class Orchestrator {
         })()
       : this.localLlm;
     // Initialize gateway fast LLM for fast-tier ops when modelSource is "gateway"
-    this.fastGatewayLlm = config.modelSource === "gateway"
+    this._fastGatewayLlm = config.modelSource === "gateway"
       ? new FallbackLlmClient(config.gatewayConfig)
       : null;
     if (config.modelSource === "gateway") {
@@ -1741,10 +1745,10 @@ export class Orchestrator {
     messages: Array<{ role: string; content: string }>,
     options: { temperature?: number; maxTokens?: number; timeoutMs?: number; operation?: string; priority?: "background" | "recall-critical" },
   ): Promise<{ content: string } | null> {
-    if (this.fastGatewayLlm && this.config.modelSource === "gateway") {
+    if (this._fastGatewayLlm && this.config.modelSource === "gateway") {
       const agentId =
         this.config.fastGatewayAgentId || this.config.gatewayAgentId || undefined;
-      const result = await this.fastGatewayLlm.chatCompletion(
+      const result = await this._fastGatewayLlm.chatCompletion(
         messages as Array<{ role: "system" | "user" | "assistant"; content: string }>,
         { temperature: options.temperature, maxTokens: options.maxTokens, timeoutMs: options.timeoutMs, agentId },
       );
@@ -1765,7 +1769,7 @@ export class Orchestrator {
       options?: { maxTokens?: number; temperature?: number; timeoutMs?: number; operation?: string; priority?: "recall-critical" | "background" },
     ) => Promise<{ content: string } | null>;
   } {
-    if (this.fastGatewayLlm && this.config.modelSource === "gateway") {
+    if (this._fastGatewayLlm && this.config.modelSource === "gateway") {
       return {
         chatCompletion: (messages, options) =>
           this.fastChatCompletion(messages, options ?? {}),

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13076,7 +13076,7 @@ export class Orchestrator {
    * path prefix (and, for the legacy default-namespace layout at
    * `memoryDir` root, an exclusion list for `namespaces/*`).
    */
-  private async semanticDedupLookup(
+  async semanticDedupLookup(
     content: string,
     limit: number,
     targetStorage: StorageManager,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -176,9 +176,12 @@ import {
   type ObjectiveStateSearchResult,
 } from "./objective-state.js";
 import {
+  listTrustZoneRecords,
   searchTrustZoneRecords,
   type TrustZoneSearchResult,
 } from "./trust-zones.js";
+import { tryDirectAnswer, type DirectAnswerSources } from "./direct-answer-wiring.js";
+import { DEFAULT_TAXONOMY } from "./taxonomy/index.js";
 import {
   searchHarmonicRetrieval,
   type HarmonicRetrievalResult,
@@ -288,6 +291,7 @@ import type {
   QmdSearchResult,
   RecallPlanMode,
   RecallSectionConfig,
+  RecallTierExplain,
   EntityStructuredSection,
   EntityTimelineEntry,
 } from "./types.js";
@@ -1185,6 +1189,11 @@ export class Orchestrator {
   private runtimePolicyValues: RuntimePolicyValues | null = null;
   private utilityRuntimeValues: UtilityRuntimeValues | null = null;
   private evalShadowWriteChain: Promise<void> = Promise.resolve();
+
+  // Pending background observation-mode direct-answer annotations (#518).
+  // Tracks fire-and-forget `annotateDirectAnswerTier` calls so callers (tests,
+  // waitForDirectAnswerObservationIdle) can await settlement.
+  private directAnswerObservationChain: Promise<void> = Promise.resolve();
 
   // Initialization gate: recall() awaits this before proceeding
   private initPromise: Promise<void> | null = null;
@@ -3928,11 +3937,29 @@ export class Orchestrator {
         }, RECALL_TIMEOUT_MS);
       });
 
+      let recallResult: string;
       try {
-        return await Promise.race([recallPromise, timeoutPromise]);
+        recallResult = await Promise.race([recallPromise, timeoutPromise]);
       } finally {
         if (timeoutHandle) clearTimeout(timeoutHandle);
       }
+
+      // Observation-mode direct-answer tier (issue #518 slice 3c).
+      // Runs after the user's recall already succeeded, fire-and-forget,
+      // so annotation latency can never delay the caller's response.
+      if (this.config.recallDirectAnswerEnabled && sessionKey) {
+        try {
+          this.enqueueDirectAnswerObservation(
+            prompt,
+            sessionKey,
+            options.namespace?.trim() || undefined,
+          );
+        } catch (err) {
+          log.debug(`direct-answer observation setup failed: ${err}`);
+        }
+      }
+
+      return recallResult;
     } catch (err) {
       this.logRecallFailure(err);
       // endTrace() is safe here: if no trace is active (disabled or already
@@ -3941,6 +3968,191 @@ export class Orchestrator {
       return ""; // Return empty context on timeout/error
     } finally {
       options.abortSignal?.removeEventListener("abort", onAbort);
+    }
+  }
+
+  /**
+   * Await the in-flight observation-mode direct-answer annotation chain.
+   * Resolves to true when settled, false on timeout.
+   */
+  async waitForDirectAnswerObservationIdle(
+    timeoutMs: number = 60_000,
+  ): Promise<boolean> {
+    let timeoutHandle: NodeJS.Timeout | null = null;
+    try {
+      const timeoutPromise = new Promise<"timeout">((resolve) => {
+        timeoutHandle = setTimeout(() => resolve("timeout"), timeoutMs);
+      });
+      const result = await Promise.race([
+        this.directAnswerObservationChain.then(() => "ok" as const),
+        timeoutPromise,
+      ]);
+      if (result === "timeout") {
+        log.warn(
+          `waitForDirectAnswerObservationIdle timed out after ${timeoutMs}ms`,
+        );
+        return false;
+      }
+      return true;
+    } finally {
+      if (timeoutHandle) clearTimeout(timeoutHandle);
+    }
+  }
+
+  private enqueueDirectAnswerObservation(
+    prompt: string,
+    sessionKey: string,
+    namespaceOverride: string | undefined,
+  ): void {
+    const expectedSnapshot = this.lastRecall.get(sessionKey);
+    if (expectedSnapshot === null) return;
+    if (expectedSnapshot.plannerMode === "no_recall") return;
+
+    const principal = resolvePrincipal(sessionKey, this.config);
+    const observationNamespaces: string[] =
+      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
+        ? [namespaceOverride]
+        : recallNamespacesForPrincipal(principal, this.config);
+    const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
+      cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
+      cronRecallNormalizedQueryMaxChars:
+        this.config.cronRecallNormalizedQueryMaxChars,
+      cronRecallInstructionHeavyTokenCap:
+        this.effectiveCronRecallInstructionHeavyTokenCap(),
+      cronConversationRecallMode: this.config.cronConversationRecallMode,
+    });
+    const observationQuery = observationQueryPolicy.retrievalQuery || prompt;
+    const expectedIdentity = {
+      writeNonce: expectedSnapshot.writeNonce,
+      traceId: expectedSnapshot.traceId,
+      recordedAt: expectedSnapshot.recordedAt,
+    };
+    const previous = this.directAnswerObservationChain;
+    this.directAnswerObservationChain = previous.then(() =>
+      this.annotateDirectAnswerTier(
+        observationQuery,
+        sessionKey,
+        observationNamespaces,
+        expectedIdentity,
+        undefined,
+      ).catch((err) => {
+        log.debug(`direct-answer observation chain error: ${err}`);
+      }),
+    );
+  }
+
+  private async annotateDirectAnswerTier(
+    prompt: string,
+    sessionKey: string,
+    namespaces: string[],
+    expectedIdentity:
+      | { writeNonce?: string; traceId?: string; recordedAt?: string }
+      | undefined,
+    _parentAbortSignal?: AbortSignal,
+  ): Promise<void> {
+    const tierStart = Date.now();
+    try {
+      if (namespaces.length === 0) return;
+
+      const trustZoneByNsAndRecordId = new Map<
+        string,
+        "quarantine" | "working" | "trusted"
+      >();
+      const trustZoneKey = (ns: string, recordId: string) =>
+        `${ns}\u0000${recordId}`;
+      const scopedStorages = new Map<
+        string,
+        Awaited<ReturnType<typeof this.storageRouter.storageFor>>
+      >();
+
+      for (const ns of namespaces) {
+        const storage = await this.storageRouter.storageFor(ns);
+        scopedStorages.set(ns, storage);
+        const trustZones = await listTrustZoneRecords({
+          memoryDir: storage.dir,
+          trustZoneStoreDir: this.config.trustZoneStoreDir,
+          limit: 200,
+        }).catch(() => ({
+          allRecords: [] as Array<{
+            recordId: string;
+            zone: "quarantine" | "working" | "trusted";
+          }>,
+        }));
+        for (const record of trustZones.allRecords ?? []) {
+          trustZoneByNsAndRecordId.set(
+            trustZoneKey(ns, record.recordId),
+            record.zone,
+          );
+        }
+      }
+
+      const memoryNamespaceByPath = new Map<string, string>();
+      const memoryNamespaceById = new Map<string, string>();
+      let candidatesConsidered = 0;
+
+      const sources: DirectAnswerSources = {
+        taxonomy: DEFAULT_TAXONOMY,
+        listCandidateMemories: async () => {
+          const union: MemoryFile[] = [];
+          for (const ns of namespaces) {
+            const storage =
+              scopedStorages.get(ns) ??
+              (await this.storageRouter.storageFor(ns));
+            const all = await storage.readAllMemories();
+            for (const m of all) {
+              if ((m.frontmatter.status ?? "active") === "active") {
+                union.push(m);
+                memoryNamespaceByPath.set(m.path, ns);
+                if (m.frontmatter.id) {
+                  memoryNamespaceById.set(m.frontmatter.id, ns);
+                }
+              }
+            }
+          }
+          candidatesConsidered = union.length;
+          return union;
+        },
+        trustZoneFor: async (memoryId: string) => {
+          const ns = memoryNamespaceById.get(memoryId);
+          if (!ns) return null;
+          return (
+            trustZoneByNsAndRecordId.get(
+              trustZoneKey(ns, memoryId),
+            ) ?? null
+          );
+        },
+        importanceFor: (memory) =>
+          typeof memory.frontmatter.importance?.score === "number"
+            ? memory.frontmatter.importance.score
+            : 0,
+      };
+
+      const result = await tryDirectAnswer({
+        query: prompt,
+        namespace: namespaces[0]!,
+        config: this.config,
+        sources,
+      });
+
+      if (!result.eligible || !result.winner) return;
+
+      const explain: RecallTierExplain = {
+        tier: "direct-answer",
+        tierReason: result.narrative,
+        filteredBy: result.filteredBy,
+        candidatesConsidered,
+        latencyMs: Date.now() - tierStart,
+        sourceAnchors: [{ path: result.winner.memory.path }],
+      };
+
+      await this.lastRecall.annotateTierExplain(
+        sessionKey,
+        explain,
+        expectedIdentity,
+      );
+    } catch (err) {
+      if (err instanceof Error && err.name === "AbortError") return;
+      log.debug(`direct-answer observation failed: ${err}`);
     }
   }
 

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -1,0 +1,199 @@
+/**
+ * Renderers for RecallTierExplain (issue #518).
+ *
+ * Pure functions that format a `LastRecallSnapshot` and its
+ * optional `tierExplain` field for human text and machine JSON
+ * consumption.  CLI / HTTP / MCP surfaces consume these — they do
+ * not format explain output themselves, so rendering is tested in
+ * one place.
+ */
+
+import type { LastRecallSnapshot } from "./recall-state.js";
+import type { RecallTierExplain } from "./types.js";
+import { isRetrievalTier } from "./retrieval-tiers.js";
+
+function sanitizeString(v: unknown): string | null {
+  return typeof v === "string" && v.length > 0 ? v : null;
+}
+
+function sanitizeFiniteNumber(v: unknown): number | null {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+export type RecallExplainFormat = "text" | "json";
+
+export interface RecallExplainJsonPayload {
+  hasExplain: boolean;
+  snapshotFound: boolean;
+  sessionKey: string | null;
+  recordedAt: string | null;
+  namespace: string | null;
+  memoryIds: string[];
+  source: string | null;
+  sourcesUsed: string[] | null;
+  latencyMs: number | null;
+  tierExplain: RecallTierExplain | null;
+}
+
+function normalizeTierExplain(value: unknown): RecallTierExplain | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  const raw = value as Record<string, unknown>;
+  const filteredBy = Array.isArray(raw.filteredBy)
+    ? raw.filteredBy.filter((x): x is string => typeof x === "string")
+    : [];
+  const sourceAnchors = Array.isArray(raw.sourceAnchors)
+    ? raw.sourceAnchors
+        .filter(
+          (a): a is { path: string; lineRange?: unknown } =>
+            !!a && typeof a === "object" && typeof (a as { path?: unknown }).path === "string",
+        )
+        .map((a) => {
+          const lr = (a as { lineRange?: unknown }).lineRange;
+          const lineRange =
+            Array.isArray(lr) &&
+            lr.length === 2 &&
+            Number.isFinite(lr[0]) &&
+            Number.isFinite(lr[1])
+              ? ([lr[0] as number, lr[1] as number] as [number, number])
+              : undefined;
+          return lineRange
+            ? { path: (a as { path: string }).path, lineRange }
+            : { path: (a as { path: string }).path };
+        })
+    : undefined;
+  return {
+    tier: isRetrievalTier(raw.tier) ? raw.tier : "hybrid",
+    tierReason: typeof raw.tierReason === "string" ? raw.tierReason : "",
+    filteredBy,
+    candidatesConsidered: sanitizeFiniteNumber(raw.candidatesConsidered) ?? 0,
+    latencyMs: sanitizeFiniteNumber(raw.latencyMs) ?? 0,
+    ...(sourceAnchors !== undefined ? { sourceAnchors } : {}),
+  };
+}
+
+export function toRecallExplainJson(
+  snapshot: LastRecallSnapshot | null,
+): RecallExplainJsonPayload {
+  if (!snapshot) {
+    return {
+      hasExplain: false,
+      snapshotFound: false,
+      sessionKey: null,
+      recordedAt: null,
+      namespace: null,
+      memoryIds: [],
+      source: null,
+      sourcesUsed: null,
+      latencyMs: null,
+      tierExplain: null,
+    };
+  }
+  const normalizedExplain = normalizeTierExplain(snapshot.tierExplain);
+  return {
+    hasExplain: normalizedExplain !== null,
+    snapshotFound: true,
+    sessionKey: sanitizeString(snapshot.sessionKey),
+    recordedAt: sanitizeString(snapshot.recordedAt),
+    namespace: sanitizeString(snapshot.namespace),
+    memoryIds: Array.isArray(snapshot.memoryIds)
+      ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
+      : [],
+    source: sanitizeString(snapshot.source),
+    sourcesUsed: Array.isArray(snapshot.sourcesUsed)
+      ? snapshot.sourcesUsed.filter((x): x is string => typeof x === "string")
+      : null,
+    latencyMs: sanitizeFiniteNumber(snapshot.latencyMs),
+    tierExplain: normalizedExplain,
+  };
+}
+
+export function toRecallExplainText(
+  snapshot: LastRecallSnapshot | null,
+): string {
+  const lines: string[] = ["=== Recall Explain ==="];
+
+  if (!snapshot) {
+    lines.push("No recall snapshot recorded yet.");
+    return lines.join("\n");
+  }
+
+  const sessionKey = sanitizeString(snapshot.sessionKey);
+  const recordedAt = sanitizeString(snapshot.recordedAt);
+  const namespace = sanitizeString(snapshot.namespace);
+  const source = sanitizeString(snapshot.source);
+  lines.push(`session: ${sessionKey ?? "(unknown)"}`);
+  lines.push(`recorded: ${recordedAt ?? "(unknown)"}`);
+  if (namespace) lines.push(`namespace: ${namespace}`);
+  if (source) lines.push(`source: ${source}`);
+  const sourcesUsed = Array.isArray(snapshot.sourcesUsed)
+    ? snapshot.sourcesUsed.filter((x): x is string => typeof x === "string")
+    : [];
+  if (sourcesUsed.length > 0) {
+    lines.push(`sources-used: ${sourcesUsed.join(", ")}`);
+  }
+  const latencyMs = sanitizeFiniteNumber(snapshot.latencyMs);
+  if (latencyMs !== null) {
+    lines.push(`latency-ms: ${latencyMs}`);
+  }
+  const memoryIds = Array.isArray(snapshot.memoryIds)
+    ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
+    : [];
+  if (memoryIds.length > 0) {
+    lines.push(`memories: ${memoryIds.join(", ")}`);
+  }
+
+  const ex = normalizeTierExplain(snapshot.tierExplain);
+  if (!ex) {
+    lines.push("");
+    lines.push(
+      "tier-explain: (not populated — direct-answer tier disabled or did not fire)",
+    );
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  lines.push("--- tier explain ---");
+  lines.push(`tier: ${ex.tier}`);
+  lines.push(`reason: ${ex.tierReason}`);
+  lines.push(`candidates-considered: ${ex.candidatesConsidered}`);
+  lines.push(`latency-ms: ${ex.latencyMs}`);
+  if (ex.filteredBy.length > 0) {
+    lines.push(`filtered-by: ${ex.filteredBy.join(", ")}`);
+  } else {
+    lines.push("filtered-by: (none)");
+  }
+  if (ex.sourceAnchors && ex.sourceAnchors.length > 0) {
+    lines.push("source-anchors:");
+    for (const anchor of ex.sourceAnchors) {
+      const range = anchor.lineRange
+        ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
+        : "";
+      lines.push(`  - ${anchor.path}${range}`);
+    }
+  }
+  return lines.join("\n");
+}
+
+export function renderRecallExplain(
+  snapshot: LastRecallSnapshot | null,
+  format: RecallExplainFormat,
+): string {
+  if (format === "json") {
+    return JSON.stringify(toRecallExplainJson(snapshot), null, 2);
+  }
+  return toRecallExplainText(snapshot);
+}
+
+export function parseRecallExplainFormat(value: unknown): RecallExplainFormat {
+  if (value === undefined || value === null) return "text";
+  if (typeof value !== "string") {
+    throw new Error(
+      `--format expects "text" or "json", got ${typeof value}`,
+    );
+  }
+  const v = value.trim().toLowerCase();
+  if (v === "text" || v === "json") return v;
+  throw new Error(
+    `--format expects "text" or "json", got ${JSON.stringify(value)}`,
+  );
+}

--- a/packages/remnic-core/src/recall-state.ts
+++ b/packages/remnic-core/src/recall-state.ts
@@ -1,6 +1,6 @@
 import { appendFile, mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
-import { createHash } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { log } from "./logger.js";
 import type {
   IdentityInjectionMode,
@@ -41,6 +41,13 @@ export interface LastRecallSnapshot {
   identityInjectionMode?: IdentityInjectionMode | "none";
   identityInjectedChars?: number;
   identityInjectionTruncated?: boolean;
+  /**
+   * Collision-safe write nonce.  Random UUID set on every `record()`
+   * call so the observation-mode direct-answer hook can detect stale
+   * snapshots and avoid annotating a snapshot that a subsequent recall
+   * already replaced (issue #518).
+   */
+  writeNonce?: string;
   /**
    * Optional tier-level explanation of how recall was served
    * (issue #518).  Populated by orchestrator call sites that can
@@ -248,6 +255,7 @@ export class LastRecallStore {
       sessionKey: opts.sessionKey,
       recordedAt: now,
       queryHash,
+      writeNonce: randomUUID(),
       queryLen: opts.query.length,
       memoryIds: opts.memoryIds,
       namespace: opts.namespace,
@@ -315,9 +323,31 @@ export class LastRecallStore {
   async annotateTierExplain(
     sessionKey: string,
     tierExplain: RecallTierExplain,
+    expected?: { writeNonce?: string; traceId?: string; recordedAt?: string },
   ): Promise<void> {
     const current = this.state[sessionKey];
     if (!current) return;
+    if (expected) {
+      if (
+        typeof expected.writeNonce === "string" &&
+        expected.writeNonce.length > 0
+      ) {
+        if (current.writeNonce !== expected.writeNonce) return;
+      } else {
+        const hasExpectedTraceId =
+          typeof expected.traceId === "string" && expected.traceId.length > 0;
+        const traceIdMatches =
+          hasExpectedTraceId && current.traceId === expected.traceId;
+        const recordedAtMatches =
+          expected.recordedAt !== undefined &&
+          current.recordedAt === expected.recordedAt;
+        if (hasExpectedTraceId) {
+          if (!traceIdMatches) return;
+        } else if (expected.recordedAt !== undefined && !recordedAtMatches) {
+          return;
+        }
+      }
+    }
     this.state[sessionKey] = {
       ...current,
       tierExplain: cloneTierExplain(tierExplain),

--- a/packages/remnic-core/src/retrieval-tiers.ts
+++ b/packages/remnic-core/src/retrieval-tiers.ts
@@ -1,0 +1,34 @@
+/**
+ * Retrieval tier ladder (issue #518).
+ *
+ * Explicit tier ordering so callers can reason about precedence without
+ * inspecting retrieval.ts internals.  The tier names are the same strings
+ * used in `RecallTierExplain.tier` and in profiling spans.
+ *
+ * The ladder is codified here as a read-only array; consumers that need
+ * "is this a valid tier?" use `RETRIEVAL_TIERS.includes(value)`.
+ */
+
+import type { RetrievalTier } from "./types.js";
+
+export const RETRIEVAL_TIERS: readonly RetrievalTier[] = [
+  "exact-cache",
+  "fuzzy-cache",
+  "direct-answer",
+  "hybrid",
+  "rerank-graph",
+  "agentic",
+] as const;
+
+export function isRetrievalTier(value: unknown): value is RetrievalTier {
+  return typeof value === "string" && (RETRIEVAL_TIERS as readonly string[]).includes(value);
+}
+
+/**
+ * Return the tier that should be reported for a recall that was served
+ * from cache (exact or fuzzy).  Used by recallInternal to annotate
+ * `RecallTierExplain` when the cache path fires.
+ */
+export function cacheTier(isExact: boolean): RetrievalTier {
+  return isExact ? "exact-cache" : "fuzzy-cache";
+}

--- a/packages/remnic-core/src/retrieval-tiers.ts
+++ b/packages/remnic-core/src/retrieval-tiers.ts
@@ -23,12 +23,3 @@ export const RETRIEVAL_TIERS: readonly RetrievalTier[] = [
 export function isRetrievalTier(value: unknown): value is RetrievalTier {
   return typeof value === "string" && (RETRIEVAL_TIERS as readonly string[]).includes(value);
 }
-
-/**
- * Return the tier that should be reported for a recall that was served
- * from cache (exact or fuzzy).  Used by recallInternal to annotate
- * `RecallTierExplain` when the cache path fires.
- */
-export function cacheTier(isExact: boolean): RetrievalTier {
-  return isExact ? "exact-cache" : "fuzzy-cache";
-}

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -156,6 +156,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
   const legacyListed = [
     "engram.recall",
     "engram.recall_explain",
+    "engram.recall_tier_explain",
     "engram.day_summary",
     "engram.memory_governance_run",
     "engram.procedure_mining_run",


### PR DESCRIPTION
## Summary
- Lands the remaining #518 deliverables that were stranded in feature branches (slices 3c, 4, 5, 6) and never promoted to main
- Adds `retrieval-tiers.ts` (explicit tier ladder enum), `recall-explain-renderer.ts` (shared CLI/HTTP/MCP renderer), orchestrator observation-mode hook, access-service method, and all three access surfaces
- Completes the #518 deliverables checklist: all 10 items now on main

## Test plan
- [ ] `npm run check-types` passes (verified)
- [ ] `npm run build --workspace=packages/remnic-core` succeeds (verified)
- [ ] Direct-answer eligibility tests pass: `pnpm exec tsx --test src/direct-answer.test.ts` (21/21)
- [ ] Direct-answer wiring tests pass: `pnpm exec tsx --test src/direct-answer-wiring.test.ts` (15/15)
- [ ] MCP tool registration test passes: includes `engram.recall_tier_explain` (5/5)
- [ ] Manual: `remnic recall-explain` CLI command
- [ ] Manual: `GET /engram/v1/recall/tier-explain`
- [ ] Manual: `engram.recall_tier_explain` MCP tool

Closes #518

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall/orchestrator flow and adds asynchronous background annotation with new persistence semantics (`writeNonce`), which could affect correctness/race behavior. Also changes contradiction scan pairing/judging inputs and embedding lookup wiring, which may change scan results and performance.
> 
> **Overview**
> Adds a new *tier-explain* capability for recall: the orchestrator now runs the direct-answer tier in **post-recall observation mode** and annotates the last recall snapshot with a structured `tierExplain`, guarded by a new per-snapshot `writeNonce` to avoid stale writes.
> 
> Exposes this data consistently across surfaces via a shared `recall-explain-renderer` (text/JSON), including a new HTTP endpoint `GET /engram/v1/recall/tier-explain`, a new MCP tool `engram.recall_tier_explain`, and a new CLI command `recall-explain`, plus a new `retrieval-tiers` ladder helper.
> 
> Improves contradiction scanning robustness: switches to an `embeddingLookupFactory` (namespace-scoped), adds an embedding-similarity candidate strategy with `similarityFloor`, uses a per-scan judge cache (avoiding module-level cache bleed), routes fallback LLM to the gateway fast client, and tightens validation for MCP `review_list` filters.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0d14b6b010acef180cb2c008c7f436e749d45cf8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->