### PR TITLE
fix: harden local benchmark teardown and LM Studio diagnostics

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -5,7 +5,7 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Orchestrator, parseConfig } from "@remnic/core";
+import { Orchestrator, parseConfig, shutdownQmdResources } from "@remnic/core";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -81,6 +81,15 @@ export const BENCH_ADAPTER_MODE_CONFIG: Record<BenchAdapterMode, Record<string, 
     extractionMinUserTurns: 1000000,
     recallPlannerEnabled: false,
   },
+};
+
+type OrchestratorTeardownView = {
+  abortDeferredInit(): void;
+  deferredReady: Promise<void>;
+  lcmEngine: { close(): void } | null;
+  qmdMaintenanceTimer?: NodeJS.Timeout | null;
+  qmdMaintenancePending?: boolean;
+  qmdMaintenanceInFlight?: boolean;
 };
 
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
@@ -205,7 +214,22 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
     };
 
     const cleanup = async (): Promise<void> => {
-      state.orchestrator.lcmEngine?.close();
+      const orchestrator = state.orchestrator as unknown as OrchestratorTeardownView;
+
+      orchestrator.abortDeferredInit();
+      if (orchestrator.qmdMaintenanceTimer) {
+        clearTimeout(orchestrator.qmdMaintenanceTimer);
+      }
+      orchestrator.qmdMaintenanceTimer = null;
+      orchestrator.qmdMaintenancePending = false;
+      orchestrator.qmdMaintenanceInFlight = false;
+      shutdownQmdResources();
+      try {
+        await orchestrator.deferredReady;
+      } catch {
+        // deferredReady is expected to resolve, but adapter teardown should not fail closed.
+      }
+      orchestrator.lcmEngine?.close();
       await rm(state.tempDir, { recursive: true, force: true });
     };
 
@@ -231,7 +255,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
       async recall(sessionId: string, query: string, budgetChars?: number): Promise<string> {
         const engine = getEngine();
-        const budget = budgetChars ?? 32000;
+        const budget = budgetChars ?? 32_000;
         const sections: string[] = [];
 
         if (query) {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -93,6 +93,8 @@ type OrchestratorTeardownView = {
   qmdMaintenanceInFlight?: boolean;
 };
 
+const BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS = 500;
+
 function cloneBenchConfig(config: Record<string, unknown>): Record<string, unknown> {
   return cloneBenchConfigValue(config) as Record<string, unknown>;
 }
@@ -224,11 +226,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       orchestrator.qmdMaintenanceTimer = null;
       orchestrator.qmdMaintenancePending = false;
       orchestrator.qmdMaintenanceInFlight = false;
-      try {
-        await orchestrator.deferredReady;
-      } catch {
-        // deferredReady is expected to resolve, but adapter teardown should not fail closed.
-      }
+      await Promise.race([
+        orchestrator.deferredReady.catch(() => undefined),
+        new Promise((resolve) =>
+          setTimeout(resolve, BENCH_TEARDOWN_DEFERRED_READY_WAIT_MS),
+        ),
+      ]);
       await orchestrator.qmd.dispose?.();
       orchestrator.lcmEngine?.close();
       await rm(state.tempDir, { recursive: true, force: true });

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -5,7 +5,7 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Orchestrator, parseConfig, shutdownQmdResources } from "@remnic/core";
+import { Orchestrator, parseConfig } from "@remnic/core";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -87,6 +87,7 @@ type OrchestratorTeardownView = {
   abortDeferredInit(): void;
   deferredReady: Promise<void>;
   lcmEngine: { close(): void } | null;
+  qmd: { dispose?(): void | Promise<void> };
   qmdMaintenanceTimer?: NodeJS.Timeout | null;
   qmdMaintenancePending?: boolean;
   qmdMaintenanceInFlight?: boolean;
@@ -223,12 +224,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       orchestrator.qmdMaintenanceTimer = null;
       orchestrator.qmdMaintenancePending = false;
       orchestrator.qmdMaintenanceInFlight = false;
-      shutdownQmdResources();
       try {
         await orchestrator.deferredReady;
       } catch {
         // deferredReady is expected to resolve, but adapter teardown should not fail closed.
       }
+      await orchestrator.qmd.dispose?.();
       orchestrator.lcmEngine?.close();
       await rm(state.tempDir, { recursive: true, force: true });
     };

--- a/packages/bench/src/providers/openai-compatible.test.ts
+++ b/packages/bench/src/providers/openai-compatible.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createOpenAiCompatibleProvider } from "./openai-compatible.ts";
+
+test("OpenAI-compatible provider adds an LM Studio context hint for context window errors", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response(
+      JSON.stringify({
+        error:
+          "The number of tokens to keep from the initial prompt is greater than the context length (n_keep: 4249>= n_ctx: 4096).",
+      }),
+      {
+        status: 400,
+        statusText: "Bad Request",
+        headers: { "content-type": "application/json" },
+      },
+    );
+
+  try {
+    const provider = createOpenAiCompatibleProvider({
+      provider: "openai",
+      model: "google/gemma-4-26b-a4b",
+      baseUrl: "http://127.0.0.1:1234/v1",
+    });
+
+    await assert.rejects(
+      provider.complete("hello"),
+      /LM Studio is running this model with a context window that is too small for this benchmark/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenAI-compatible provider leaves unrelated errors unchanged", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("unauthorized", {
+      status: 401,
+      statusText: "Unauthorized",
+      headers: { "content-type": "text/plain" },
+    });
+
+  try {
+    const provider = createOpenAiCompatibleProvider({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      baseUrl: "http://127.0.0.1:1234/v1",
+    });
+
+    await assert.rejects(
+      provider.complete("hello"),
+      /OpenAI-compatible completion failed: 401 Unauthorized — unauthorized$/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -78,8 +78,9 @@ class OpenAiCompatibleProvider implements LlmProvider {
 
     if (!response.ok) {
       const errorBody = await readErrorBody(response);
+      const contextHint = buildContextHint(errorBody, this.config.baseUrl);
       throw new Error(
-        `OpenAI-compatible completion failed: ${response.status} ${response.statusText}${errorBody ? ` — ${errorBody}` : ""}`,
+        `OpenAI-compatible completion failed: ${response.status} ${response.statusText}${errorBody ? ` — ${errorBody}` : ""}${contextHint}`,
       );
     }
 
@@ -182,6 +183,43 @@ async function readErrorBody(response: Response): Promise<string> {
     return text.replace(/\s+/g, " ").slice(0, 400);
   } catch {
     return "";
+  }
+}
+
+function buildContextHint(errorBody: string, baseUrl?: string): string {
+  if (!isContextWindowError(errorBody)) {
+    return "";
+  }
+
+  if (isLmStudioBaseUrl(baseUrl)) {
+    return " — LM Studio is running this model with a context window that is too small for this benchmark. Increase the model context length in LM Studio and rerun.";
+  }
+
+  return " — The OpenAI-compatible model server is running this model with a context window that is too small for this benchmark. Increase the loaded model context length and rerun.";
+}
+
+function isContextWindowError(errorBody: string): boolean {
+  const normalized = errorBody.toLowerCase();
+  return (
+    normalized.includes("context length") ||
+    normalized.includes("n_keep") ||
+    normalized.includes("n_ctx")
+  );
+}
+
+function isLmStudioBaseUrl(baseUrl?: string): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    return (
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost") &&
+      url.port === "1234"
+    );
+  } catch {
+    return false;
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -225,6 +225,8 @@ const CLI_MODULE_DIR = path.dirname(fileURLToPath(import.meta.url));
 const CLI_REPO_ROOT = path.resolve(CLI_MODULE_DIR, "../../..");
 const EVAL_RUNNER_PATH = path.join(CLI_REPO_ROOT, "evals", "run.ts");
 const OPENCLAW_GATEWAY_LABEL = "ai.openclaw.gateway";
+const CLI_SUCCESS_EXIT_GRACE_MS = 2_000;
+const CLI_OUTPUT_FLUSH_GRACE_MS = 250;
 
 export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
   {
@@ -6148,6 +6150,39 @@ Options:
   }
 }
 
+function waitForStreamDrain(stream: NodeJS.WriteStream): Promise<void> {
+  if (!stream.writableNeedDrain) {
+    return Promise.resolve();
+  }
+  return new Promise((resolve) => {
+    stream.once("drain", resolve);
+  });
+}
+
+async function armCliSuccessExitWatchdog(): Promise<void> {
+  process.exitCode = 0;
+
+  await Promise.race([
+    Promise.allSettled([
+      waitForStreamDrain(process.stdout),
+      waitForStreamDrain(process.stderr),
+    ]),
+    new Promise((resolve) => setTimeout(resolve, CLI_OUTPUT_FLUSH_GRACE_MS)),
+  ]);
+
+  const watchdog = setTimeout(() => {
+    try {
+      process.stderr.write(
+        `Warning: remnic CLI forced a clean exit after ${CLI_SUCCESS_EXIT_GRACE_MS}ms because a handle remained open.\n`,
+      );
+    } catch {
+      // Ignore write failures during forced shutdown.
+    }
+    process.exit(0);
+  }, CLI_SUCCESS_EXIT_GRACE_MS);
+  watchdog.unref?.();
+}
+
 // Auto-run when executed directly (covers: remnic and legacy engram entrypoints,
 // or invoked via wrappers that set REMNIC_CLI_BIN / ENGRAM_CLI_BIN)
 const argv1 = process.argv[1] ?? "";
@@ -6164,6 +6199,7 @@ if (
   process.env.ENGRAM_CLI_BIN === "1"
 ) {
   main()
+    .then(() => armCliSuccessExitWatchdog())
     .catch((err) => {
       process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6164,9 +6164,6 @@ if (
   process.env.ENGRAM_CLI_BIN === "1"
 ) {
   main()
-    .then(() => {
-      process.exit(process.exitCode ?? 0);
-    })
     .catch((err) => {
       process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
       process.exit(1);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3443,7 +3443,7 @@ function cmdReview(action: string, rest: string[]): void {
   }
 }
 
-function cmdSync(action: string, rest: string[], json: boolean): void {
+async function cmdSync(action: string, rest: string[], json: boolean): Promise<void> {
   // Extract --source before positional args so that rest args can override it
   const sourceIdx = rest.indexOf("--source");
   const sourceDir = sourceIdx >= 0 && rest[sourceIdx + 1] ? rest[sourceIdx + 1] : ".";
@@ -3476,6 +3476,7 @@ function cmdSync(action: string, rest: string[], json: boolean): void {
       stop();
       console.log("Stopped watching.");
     });
+    await new Promise(() => {});
   } else {
     console.log("Usage: remnic sync <run|watch> [--source <dir>]");
     process.exit(1);
@@ -5921,7 +5922,7 @@ Options:
     case "sync": {
       const action = rest[0] ?? "run";
       const json = rest.includes("--json");
-      cmdSync(action, rest.slice(1), json);
+      await cmdSync(action, rest.slice(1), json);
       break;
     }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6163,8 +6163,12 @@ if (
   process.env.REMNIC_CLI_BIN === "1" ||
   process.env.ENGRAM_CLI_BIN === "1"
 ) {
-  main().catch((err) => {
-    process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
-    process.exit(1);
-  });
+  main()
+    .then(() => {
+      process.exit(process.exitCode ?? 0);
+    })
+    .catch((err) => {
+      process.stderr.write(`Fatal: ${err instanceof Error ? err.message : String(err)}\n`);
+      process.exit(1);
+    });
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6160,7 +6160,8 @@ function waitForStreamDrain(stream: NodeJS.WriteStream): Promise<void> {
 }
 
 async function armCliSuccessExitWatchdog(): Promise<void> {
-  process.exitCode = 0;
+  const exitCode = process.exitCode ?? 0;
+  process.exitCode = exitCode;
 
   await Promise.race([
     Promise.allSettled([
@@ -6178,7 +6179,7 @@ async function armCliSuccessExitWatchdog(): Promise<void> {
     } catch {
       // Ignore write failures during forced shutdown.
     }
-    process.exit(0);
+    process.exit(exitCode);
   }, CLI_SUCCESS_EXIT_GRACE_MS);
   watchdog.unref?.();
 }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -125,7 +125,7 @@ export {
 // Search backends
 // ---------------------------------------------------------------------------
 
-export { QmdClient, shutdownQmdResources } from "./qmd.js";
+export { QmdClient } from "./qmd.js";
 export { LanceDbBackend } from "./search/lancedb-backend.js";
 export { OramaBackend } from "./search/orama-backend.js";
 export { MeilisearchBackend } from "./search/meilisearch-backend.js";

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -125,7 +125,7 @@ export {
 // Search backends
 // ---------------------------------------------------------------------------
 
-export { QmdClient } from "./qmd.js";
+export { QmdClient, shutdownQmdResources } from "./qmd.js";
 export { LanceDbBackend } from "./search/lancedb-backend.js";
 export { OramaBackend } from "./search/orama-backend.js";
 export { MeilisearchBackend } from "./search/meilisearch-backend.js";

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1228,6 +1228,10 @@ export class Orchestrator {
     }
   }
 
+  private async disposeSearchBackendIfNeeded(): Promise<void> {
+    await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
+  }
+
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
   setRecallWorkspaceOverride(sessionKey: string, dir: string): void {
     this._recallWorkspaceOverrides.set(sessionKey, dir);
@@ -1880,6 +1884,7 @@ export class Orchestrator {
               (entry) => entry.namespace === this.config.defaultNamespace,
             )?.state ?? "unknown";
           if (defaultState === "missing") {
+            await this.disposeSearchBackendIfNeeded();
             this.qmd = new NoopSearchBackend();
             log.warn(
               "Search collection missing for Remnic memory store; disabling search retrieval for this runtime (fallback retrieval remains enabled)",
@@ -2181,6 +2186,7 @@ export class Orchestrator {
       if ("available" in this.qmd) {
         (this.qmd as any).available = false;
       }
+      await this.disposeSearchBackendIfNeeded();
       this.qmd = new NoopSearchBackend();
       log.warn("startupSearchSync: search collection missing; disabling search (fallback retrieval remains enabled)");
       return false;

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -772,20 +772,6 @@ type SharedDaemonSessionEntry = {
 
 const SHARED_DAEMON_SESSIONS = new Map<string, SharedDaemonSessionEntry>();
 
-export function shutdownQmdResources(): void {
-  for (const entry of SHARED_DAEMON_SESSIONS.values()) {
-    entry.session.invalidate();
-  }
-  SHARED_DAEMON_SESSIONS.clear();
-
-  for (const child of [...ACTIVE_QMD_CHILDREN]) {
-    ACTIVE_QMD_CHILDREN.delete(child);
-    if (!child.killed) {
-      child.kill("SIGKILL");
-    }
-  }
-}
-
 function retainSharedDaemonSession(qmdPath: string): QmdDaemonSession {
   const normalizedPath = qmdPath.trim() || "qmd";
   const existing = SHARED_DAEMON_SESSIONS.get(normalizedPath);

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -765,13 +765,18 @@ function parseQmdSearchStdout(
   );
 }
 
-let _sharedDaemonSession: QmdDaemonSession | null = null;
-let _sharedDaemonSessionPath: string | null = null;
+type SharedDaemonSessionEntry = {
+  refs: number;
+  session: QmdDaemonSession;
+};
+
+const SHARED_DAEMON_SESSIONS = new Map<string, SharedDaemonSessionEntry>();
 
 export function shutdownQmdResources(): void {
-  _sharedDaemonSession?.invalidate();
-  _sharedDaemonSession = null;
-  _sharedDaemonSessionPath = null;
+  for (const entry of SHARED_DAEMON_SESSIONS.values()) {
+    entry.session.invalidate();
+  }
+  SHARED_DAEMON_SESSIONS.clear();
 
   for (const child of [...ACTIVE_QMD_CHILDREN]) {
     ACTIVE_QMD_CHILDREN.delete(child);
@@ -781,18 +786,34 @@ export function shutdownQmdResources(): void {
   }
 }
 
-function getSharedDaemonSession(qmdPath: string): QmdDaemonSession {
+function retainSharedDaemonSession(qmdPath: string): QmdDaemonSession {
   const normalizedPath = qmdPath.trim() || "qmd";
-  if (_sharedDaemonSession && _sharedDaemonSessionPath !== normalizedPath) {
-    _sharedDaemonSession.invalidate();
-    _sharedDaemonSession = null;
-    _sharedDaemonSessionPath = null;
+  const existing = SHARED_DAEMON_SESSIONS.get(normalizedPath);
+  if (existing) {
+    existing.refs += 1;
+    return existing.session;
   }
-  if (!_sharedDaemonSession) {
-    _sharedDaemonSession = new QmdDaemonSession(normalizedPath);
-    _sharedDaemonSessionPath = normalizedPath;
+
+  const session = new QmdDaemonSession(normalizedPath);
+  SHARED_DAEMON_SESSIONS.set(normalizedPath, {
+    refs: 1,
+    session,
+  });
+  return session;
+}
+
+function releaseSharedDaemonSession(session: QmdDaemonSession | null): void {
+  if (!session) return;
+
+  for (const [qmdPath, entry] of SHARED_DAEMON_SESSIONS.entries()) {
+    if (entry.session !== session) continue;
+    entry.refs = Math.max(0, entry.refs - 1);
+    if (entry.refs === 0) {
+      entry.session.invalidate();
+      SHARED_DAEMON_SESSIONS.delete(qmdPath);
+    }
+    return;
   }
-  return _sharedDaemonSession;
 }
 
 // ---------------------------------------------------------------------------
@@ -832,6 +853,7 @@ export class QmdClient implements SearchBackend {
   // Daemon mode fields
   private daemonSession: QmdDaemonSession | null = null;
   private daemonAvailable = false;
+  private daemonSessionPath: string | null = null;
   private lastDaemonCheckAtMs = 0;
   private readonly daemonEnabled: boolean;
   private readonly daemonRecheckIntervalMs: number;
@@ -868,7 +890,12 @@ export class QmdClient implements SearchBackend {
 
   private async probeDaemon(): Promise<boolean> {
     this.lastDaemonCheckAtMs = Date.now();
-    this.daemonSession = getSharedDaemonSession(this.qmdPath);
+    const normalizedPath = this.qmdPath.trim() || "qmd";
+    if (!this.daemonSession || this.daemonSessionPath !== normalizedPath) {
+      releaseSharedDaemonSession(this.daemonSession);
+      this.daemonSession = retainSharedDaemonSession(normalizedPath);
+      this.daemonSessionPath = normalizedPath;
+    }
     try {
       // Race start() against a short window: if the session is already initialized
       // this returns instantly; if the process is still loading its index we fail
@@ -1010,6 +1037,14 @@ export class QmdClient implements SearchBackend {
 
   isDaemonMode(): boolean {
     return this.daemonAvailable;
+  }
+
+  dispose(): void {
+    releaseSharedDaemonSession(this.daemonSession);
+    this.daemonSession = null;
+    this.daemonSessionPath = null;
+    this.daemonAvailable = false;
+    this.daemonTransientFailures = 0;
   }
 
   /**

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -40,6 +40,7 @@ const QMD_FALLBACK_PATHS = [
   "/opt/homebrew/bin/qmd",
 ];
 const QMD_GLOBAL_STATE_KEY = "__openclawEngramQmdGlobalState";
+const ACTIVE_QMD_CHILDREN = new Set<CommandChildProcess>();
 
 type QmdGlobalState = {
   warnedGlobalUpdateBehavior: boolean;
@@ -316,7 +317,9 @@ function runQmdOnce(
       env: mergeEnv({ NO_COLOR: "1" }),
       stdio: ["ignore", "pipe", "pipe"],
     });
+    ACTIVE_QMD_CHILDREN.add(child);
     if (!child.stdout || !child.stderr) {
+      ACTIVE_QMD_CHILDREN.delete(child);
       reject(new Error(`qmd ${args.join(" ")} failed to open stdio pipes`));
       return;
     }
@@ -341,6 +344,7 @@ function runQmdOnce(
     };
     const cleanup = () => {
       signal?.removeEventListener("abort", onAbort);
+      ACTIVE_QMD_CHILDREN.delete(child);
     };
     signal?.addEventListener("abort", onAbort, { once: true });
 
@@ -426,6 +430,7 @@ class QmdDaemonSession {
             env: mergeEnv({ NO_COLOR: "1" }),
             stdio: ["pipe", "pipe", "pipe"],
           });
+          ACTIVE_QMD_CHILDREN.add(child);
           this.child = child;
           this.buffer = "";
 
@@ -633,6 +638,7 @@ class QmdDaemonSession {
     if (opts?.killChild && !target.killed) {
       target.kill("SIGTERM");
     }
+    ACTIVE_QMD_CHILDREN.delete(target);
     this.initialized = false;
     for (const [, pending] of this.pendingRequests) {
       clearTimeout(pending.timer);
@@ -761,6 +767,19 @@ function parseQmdSearchStdout(
 
 let _sharedDaemonSession: QmdDaemonSession | null = null;
 let _sharedDaemonSessionPath: string | null = null;
+
+export function shutdownQmdResources(): void {
+  _sharedDaemonSession?.invalidate();
+  _sharedDaemonSession = null;
+  _sharedDaemonSessionPath = null;
+
+  for (const child of [...ACTIVE_QMD_CHILDREN]) {
+    ACTIVE_QMD_CHILDREN.delete(child);
+    if (!child.killed) {
+      child.kill("SIGKILL");
+    }
+  }
+}
 
 function getSharedDaemonSession(qmdPath: string): QmdDaemonSession {
   const normalizedPath = qmdPath.trim() || "qmd";

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -40,7 +40,6 @@ const QMD_FALLBACK_PATHS = [
   "/opt/homebrew/bin/qmd",
 ];
 const QMD_GLOBAL_STATE_KEY = "__openclawEngramQmdGlobalState";
-const ACTIVE_QMD_CHILDREN = new Set<CommandChildProcess>();
 
 type QmdGlobalState = {
   warnedGlobalUpdateBehavior: boolean;
@@ -317,9 +316,7 @@ function runQmdOnce(
       env: mergeEnv({ NO_COLOR: "1" }),
       stdio: ["ignore", "pipe", "pipe"],
     });
-    ACTIVE_QMD_CHILDREN.add(child);
     if (!child.stdout || !child.stderr) {
-      ACTIVE_QMD_CHILDREN.delete(child);
       reject(new Error(`qmd ${args.join(" ")} failed to open stdio pipes`));
       return;
     }
@@ -344,7 +341,6 @@ function runQmdOnce(
     };
     const cleanup = () => {
       signal?.removeEventListener("abort", onAbort);
-      ACTIVE_QMD_CHILDREN.delete(child);
     };
     signal?.addEventListener("abort", onAbort, { once: true });
 
@@ -430,7 +426,6 @@ class QmdDaemonSession {
             env: mergeEnv({ NO_COLOR: "1" }),
             stdio: ["pipe", "pipe", "pipe"],
           });
-          ACTIVE_QMD_CHILDREN.add(child);
           this.child = child;
           this.buffer = "";
 
@@ -638,7 +633,6 @@ class QmdDaemonSession {
     if (opts?.killChild && !target.killed) {
       target.kill("SIGTERM");
     }
-    ACTIVE_QMD_CHILDREN.delete(target);
     this.initialized = false;
     for (const [, pending] of this.pendingRequests) {
       clearTimeout(pending.timer);


### PR DESCRIPTION
## Summary
- prevent local benchmark runs from hanging after successful completion by hardening bench adapter teardown and forcing the direct CLI entrypoint to exit cleanly
- preserve normal benchmark recall behavior for existing users instead of globally shrinking recall payloads
- add an explicit LM Studio context-window hint when a local OpenAI-compatible endpoint fails because the loaded model context is too small

## Why
The original local Gemma investigation surfaced two separate issues:
1. benchmark runs could finish but leave local resources open, which made the CLI appear hung
2. full `ama-bench` against LM Studio Gemma can fail with `n_keep >= n_ctx`, which is an LM Studio model context configuration issue rather than a Remnic benchmark logic bug

This PR fixes the first issue in code and makes the second issue diagnosable without changing benchmark semantics for everyone else.

## Verification
- `pnpm exec tsx --test packages/bench/src/adapters/remnic-adapter.test.ts packages/bench/src/providers/openai-compatible.test.ts`
- `pnpm --filter @remnic/core build && pnpm --filter @remnic/bench build && pnpm --filter @remnic/cli build`
- `pnpm exec tsx packages/remnic-cli/src/index.ts bench run --quick ama-bench --runtime-profile real --remnic-config ~/.config/remnic/config.json --system-provider openai --system-base-url http://127.0.0.1:1234/v1 --system-model google/gemma-4-26b-a4b --judge-provider openai --judge-base-url http://127.0.0.1:1234/v1 --judge-model google/gemma-4-26b-a4b`
- confirmed full-mode failure now reports the LM Studio context-window configuration problem explicitly:
  - `OpenAI-compatible completion failed: 400 ... n_keep ... n_ctx ... LM Studio is running this model with a context window that is too small for this benchmark. Increase the model context length in LM Studio and rerun.`

## Notes
- I intentionally did **not** keep the temporary `3000`-char recall cap discovered during local debugging, because that would silently change normal benchmark behavior for users with correctly configured model servers.
- Full non-quick Gemma runs remain throughput-heavy and depend on the local LM Studio model being loaded with a sufficiently large context window.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches process/daemon lifecycle and teardown paths (bench adapter, CLI exit, QMD daemon session pooling), which can cause hangs or premature shutdown if incorrect. No auth or data-model changes, but behavior changes are runtime-sensitive.
> 
> **Overview**
> Hardens local benchmark shutdown to avoid post-run hangs by aborting orchestrator deferred init, clearing QMD maintenance timers/flags, waiting briefly for `deferredReady`, disposing QMD, then closing the LCM engine before removing the temp dir.
> 
> Improves OpenAI-compatible error diagnostics by appending a context-window hint (special-cased for LM Studio `127.0.0.1:1234`) when responses indicate `n_ctx`/context-length issues, with new tests covering both hinted and unchanged error cases.
> 
> Makes CLI completion more reliable by keeping `sync watch` alive via an awaited never-resolving promise and arming a success-exit watchdog that flushes stdout/stderr then forces a clean exit after a short grace period if handles remain open.
> 
> Prevents leaked QMD resources by adding `dispose()` support to `QmdClient` (ref-counted shared daemon sessions) and having `Orchestrator` dispose the current search backend before swapping to `NoopSearchBackend` when collections are missing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce902807788bbf844eadd7fa5b9f1b8c772e6d2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->