### PR TITLE
feat(core): add Memory Worth counters to memory frontmatter (issue #560 PR 1/5)

### DIFF
--- a/packages/remnic-core/src/memory-worth-frontmatter.test.ts
+++ b/packages/remnic-core/src/memory-worth-frontmatter.test.ts
@@ -1,0 +1,239 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+
+import { StorageManager } from "./storage.js";
+import { summarizeMemoryWorthLegacyCounters } from "./operator-toolkit.js";
+
+/**
+ * Issue #560 PR 1 — Memory Worth counters: frontmatter schema + storage round-trip.
+ *
+ * These tests pin the on-disk contract for the `mw_success` and `mw_fail`
+ * frontmatter fields. They live in the core package (not the root tests/
+ * directory) so they co-locate with storage.ts, where the parser/serializer
+ * they cover resides.
+ *
+ * Scope per PR 1:
+ *   - Round-trip: explicit counters survive write → read intact.
+ *   - Legacy memories without the fields read cleanly (no crash) and return
+ *     `undefined` from the parser (matching the accessCount pattern).
+ *   - `remnic doctor` legacy-count correctly partitions instrumented from
+ *     uninstrumented memories.
+ *   - Negative values are rejected on write (silent clamping would mask
+ *     miscounts in the feedback pipeline added by PR 3).
+ *
+ * Out of scope (later PRs in issue #560):
+ *   - computeMemoryWorth() scoring helper (PR 2)
+ *   - Outcome-signal pipeline that increments the counters (PR 3)
+ *   - Recall filter gated on the computed score (PR 4)
+ *   - Benchmark + default flip (PR 5)
+ */
+
+/**
+ * Build a fact file on disk with a bare-bones frontmatter plus arbitrary
+ * extra lines. Used to synthesize legacy and instrumented memories without
+ * going through `writeMemory`, which doesn't expose mw_* options (by design —
+ * those are set by the outcome pipeline in PR 3, not at creation time).
+ */
+async function writeFactFile(
+  storage: StorageManager,
+  body: string,
+  extraFrontmatterLines: string[] = [],
+): Promise<string> {
+  const today = new Date().toISOString().slice(0, 10);
+  const id = `fact-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const lines = [
+    "---",
+    `id: ${id}`,
+    "category: fact",
+    `created: ${new Date().toISOString()}`,
+    `updated: ${new Date().toISOString()}`,
+    "source: extraction",
+    "confidence: 0.8",
+    "confidenceTier: high",
+    "tags: []",
+    ...extraFrontmatterLines,
+    "---",
+  ];
+  const factsDir = path.join((storage as unknown as { baseDir: string }).baseDir, "facts", today);
+  await mkdir(factsDir, { recursive: true });
+  await writeFile(path.join(factsDir, `${id}.md`), `${lines.join("\n")}\n\n${body}\n`, "utf-8");
+  return id;
+}
+
+test("round-trip: mw_success / mw_fail survive write → readAllMemories", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-roundtrip-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await writeFactFile(storage, "Production DB uses pgBouncer.", [
+      "mw_success: 3",
+      "mw_fail: 1",
+    ]);
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written, "fact must be discoverable after write");
+    assert.equal(written!.frontmatter.mw_success, 3);
+    assert.equal(written!.frontmatter.mw_fail, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("round-trip: explicit zero counters are preserved (distinguishable from absent)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-zero-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await writeFactFile(storage, "Observed zero successes.", [
+      "mw_success: 0",
+      "mw_fail: 0",
+    ]);
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written);
+    assert.equal(written!.frontmatter.mw_success, 0, "explicit 0 must round-trip as 0, not undefined");
+    assert.equal(written!.frontmatter.mw_fail, 0, "explicit 0 must round-trip as 0, not undefined");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("legacy memory without mw fields reads cleanly — fields are undefined", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-legacy-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await writeFactFile(storage, "Legacy fact pre-dating Memory Worth counters.");
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written, "legacy fact must still be readable");
+    assert.equal(written!.frontmatter.mw_success, undefined);
+    assert.equal(written!.frontmatter.mw_fail, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("corrupt counter values (negative / non-integer) parse back as undefined, not corrupt numbers", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-corrupt-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await writeFactFile(storage, "Fact with hand-edited corrupt counters.", [
+      "mw_success: -2",
+      "mw_fail: 1.5",
+    ]);
+
+    const memories = await storage.readAllMemories();
+    const written = memories.find((m) => m.frontmatter.id === id);
+    assert.ok(written);
+    // Corrupt values must NOT round-trip — they fail safely to undefined so
+    // downstream scoring isn't poisoned. See parseMemoryWorthCounterField.
+    assert.equal(written!.frontmatter.mw_success, undefined);
+    assert.equal(written!.frontmatter.mw_fail, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("doctor legacy-count: mixed corpus partitions correctly", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-doctor-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    // Two legacy, one instrumented. Write three distinct facts.
+    await writeFactFile(storage, "Legacy fact A.");
+    await writeFactFile(storage, "Legacy fact B.");
+    await writeFactFile(storage, "Instrumented fact.", ["mw_success: 2", "mw_fail: 0"]);
+
+    const check = await summarizeMemoryWorthLegacyCounters(storage);
+    assert.equal(check.key, "memory_worth_legacy");
+    assert.equal(check.status, "ok", "legacy memories must never fail the doctor check");
+    const details = check.details as { legacy: number; instrumented: number; total: number };
+    assert.equal(details.legacy, 2);
+    assert.equal(details.instrumented, 1);
+    assert.equal(details.total, 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("doctor legacy-count: empty memory dir reports zero without warning", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-doctor-empty-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const check = await summarizeMemoryWorthLegacyCounters(storage);
+    assert.equal(check.status, "ok");
+    const details = check.details as { legacy: number; instrumented: number; total: number };
+    assert.equal(details.total, 0);
+    assert.equal(details.legacy, 0);
+    assert.equal(details.instrumented, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Negative-value rejection on serialize.
+//
+// The serializer throws on invalid counter values, but `writeMemory` never
+// supplies mw fields (they're set by the PR 3 pipeline through spread-based
+// updates on an existing frontmatter). Exercise the validator via an update
+// path: write a fact, then attempt to update its frontmatter with a negative
+// counter. The failure must surface rather than silently clamp.
+// ---------------------------------------------------------------------------
+
+test("negative mw_success on update throws rather than silently clamping", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-negative-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const id = await writeFactFile(storage, "Fact to be poisoned with a bad counter.");
+
+    // updateMemoryFrontmatter routes through serializeFrontmatter, so the
+    // validator will reject the write.
+    await assert.rejects(
+      async () =>
+        storage.updateMemoryFrontmatter(id, {
+          mw_success: -1,
+        }),
+      /mw_success/,
+      "writing a negative Memory Worth counter must throw",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("non-integer mw_fail on update throws rather than silently truncating", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-float-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const id = await writeFactFile(storage, "Fact to be poisoned with a float counter.");
+
+    await assert.rejects(
+      async () =>
+        storage.updateMemoryFrontmatter(id, {
+          mw_fail: 2.5,
+        }),
+      /mw_fail/,
+      "writing a non-integer Memory Worth counter must throw",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/memory-worth-frontmatter.test.ts
+++ b/packages/remnic-core/src/memory-worth-frontmatter.test.ts
@@ -63,6 +63,34 @@ async function writeFactFile(
   return id;
 }
 
+/**
+ * Write a bare-bones correction file. Corrections are NOT eligible for Memory
+ * Worth instrumentation, so the doctor audit must exclude them from both the
+ * legacy and instrumented tallies.
+ */
+async function writeCorrectionFile(storage: StorageManager, body: string): Promise<string> {
+  const id = `correction-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+  const lines = [
+    "---",
+    `id: ${id}`,
+    "category: correction",
+    `created: ${new Date().toISOString()}`,
+    `updated: ${new Date().toISOString()}`,
+    "source: extraction",
+    "confidence: 0.8",
+    "confidenceTier: high",
+    "tags: []",
+    "---",
+  ];
+  const correctionsDir = path.join(
+    (storage as unknown as { baseDir: string }).baseDir,
+    "corrections",
+  );
+  await mkdir(correctionsDir, { recursive: true });
+  await writeFile(path.join(correctionsDir, `${id}.md`), `${lines.join("\n")}\n\n${body}\n`, "utf-8");
+  return id;
+}
+
 test("round-trip: mw_success / mw_fail survive write → readAllMemories", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-roundtrip-"));
   try {
@@ -152,18 +180,56 @@ test("doctor legacy-count: mixed corpus partitions correctly", async () => {
     const storage = new StorageManager(dir);
     await storage.ensureDirectories();
 
-    // Two legacy, one instrumented. Write three distinct facts.
+    // Two legacy facts, one instrumented fact, one correction. The correction
+    // must be excluded from both legacy and instrumented tallies because
+    // Memory Worth is a per-fact signal (see MEMORY_WORTH_ELIGIBLE_CATEGORIES).
     await writeFactFile(storage, "Legacy fact A.");
     await writeFactFile(storage, "Legacy fact B.");
     await writeFactFile(storage, "Instrumented fact.", ["mw_success: 2", "mw_fail: 0"]);
+    await writeCorrectionFile(storage, "Out-of-scope correction — must not count.");
 
     const check = await summarizeMemoryWorthLegacyCounters(storage);
     assert.equal(check.key, "memory_worth_legacy");
     assert.equal(check.status, "ok", "legacy memories must never fail the doctor check");
-    const details = check.details as { legacy: number; instrumented: number; total: number };
+    const details = check.details as {
+      legacy: number;
+      instrumented: number;
+      total: number;
+      ineligible: number;
+    };
     assert.equal(details.legacy, 2);
     assert.equal(details.instrumented, 1);
-    assert.equal(details.total, 3);
+    assert.equal(details.total, 3, "total reflects only eligible (fact) memories");
+    assert.equal(details.ineligible, 1, "correction is counted as ineligible, not legacy");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("doctor legacy-count: non-fact memories never count as legacy", async () => {
+  // Regression guard: a pure-correction corpus must report zero legacy and
+  // zero instrumented, not N legacy. Without the category filter, operators
+  // would see the legacy bucket permanently inflated even when every fact is
+  // fully instrumented.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-mw-doctor-corrections-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    await writeCorrectionFile(storage, "Correction 1.");
+    await writeCorrectionFile(storage, "Correction 2.");
+
+    const check = await summarizeMemoryWorthLegacyCounters(storage);
+    const details = check.details as {
+      legacy: number;
+      instrumented: number;
+      total: number;
+      ineligible: number;
+    };
+    assert.equal(details.legacy, 0, "corrections must not inflate the legacy bucket");
+    assert.equal(details.instrumented, 0);
+    assert.equal(details.total, 0);
+    assert.equal(details.ineligible, 2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -177,10 +243,16 @@ test("doctor legacy-count: empty memory dir reports zero without warning", async
 
     const check = await summarizeMemoryWorthLegacyCounters(storage);
     assert.equal(check.status, "ok");
-    const details = check.details as { legacy: number; instrumented: number; total: number };
+    const details = check.details as {
+      legacy: number;
+      instrumented: number;
+      total: number;
+      ineligible: number;
+    };
     assert.equal(details.total, 0);
     assert.equal(details.legacy, 0);
     assert.equal(details.instrumented, 0);
+    assert.equal(details.ineligible, 0);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1167,6 +1167,14 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     : [];
   checks.push(summarizeHygieneWarnings(warnings, config.fileHygiene));
 
+  // Memory Worth legacy counter audit (issue #560 PR 1).
+  // Memories written before #560 have no `mw_success` / `mw_fail` frontmatter
+  // fields. That is fully supported — readers treat the absence as a uniform
+  // Beta(1,1) prior — but surfacing the count helps operators understand how
+  // much history will bootstrap the scoring pipeline landed in later PRs.
+  // This is an informational check, never an error.
+  checks.push(await summarizeMemoryWorthLegacyCounters(new StorageManager(config.memoryDir)));
+
   const summary = checks.reduce(
     (acc, check) => {
       acc[check.status] += 1;
@@ -1182,6 +1190,54 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
     summary,
     config: configStatus,
     checks,
+  };
+}
+
+/**
+ * Count memories that pre-date the Memory Worth counters introduced in issue
+ * #560 — i.e., neither `mw_success` nor `mw_fail` is set on the frontmatter.
+ *
+ * Returned as an `ok` check regardless of count, since legacy memories are
+ * fully functional (readers treat missing counters as zero observations). The
+ * numbers are informational for operators following the #560 rollout.
+ *
+ * Exported so unit tests can exercise the classification logic without
+ * booting a full orchestrator.
+ */
+export async function summarizeMemoryWorthLegacyCounters(
+  storage: StorageManager,
+): Promise<OperatorDoctorCheck> {
+  let legacy = 0;
+  let instrumented = 0;
+  try {
+    const memories = await storage.readAllMemories();
+    for (const memory of memories) {
+      const { mw_success, mw_fail } = memory.frontmatter;
+      if (mw_success === undefined && mw_fail === undefined) {
+        legacy += 1;
+      } else {
+        instrumented += 1;
+      }
+    }
+  } catch (err) {
+    return {
+      key: "memory_worth_legacy",
+      status: "warn",
+      summary: "Could not enumerate memories to count Memory Worth instrumentation.",
+      remediation: "Retry `remnic doctor` after ensuring the memory directory is readable.",
+      details: { error: String(err) },
+    };
+  }
+
+  const total = legacy + instrumented;
+  return {
+    key: "memory_worth_legacy",
+    status: "ok",
+    summary:
+      total === 0
+        ? "No memories on disk yet — Memory Worth counters will populate as extractions run."
+        : `${legacy} of ${total} memories have no Memory Worth counters yet (${instrumented} instrumented).`,
+    details: { legacy, instrumented, total },
   };
 }
 

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1194,8 +1194,31 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
 }
 
 /**
+ * Categories whose memories are eligible for Memory Worth instrumentation.
+ *
+ * Memory Worth is a per-fact utility signal: the counters ride on extracted
+ * facts whose retrieval outcome can be judged (success/fail) by the feedback
+ * pipeline landing in issue #560 PR 3. Procedures, corrections, and other
+ * non-fact memory kinds are out of scope — they are not expected to be
+ * instrumented, and counting them as "legacy" would permanently inflate the
+ * legacy bucket and make rollout progress misleading even when every fact
+ * memory is instrumented.
+ *
+ * If a later PR widens Memory Worth to additional categories, extend this set
+ * alongside the scoring/increment logic so the doctor audit stays in sync.
+ */
+const MEMORY_WORTH_ELIGIBLE_CATEGORIES: ReadonlySet<MemoryFile["frontmatter"]["category"]> =
+  new Set(["fact"]);
+
+/**
  * Count memories that pre-date the Memory Worth counters introduced in issue
  * #560 — i.e., neither `mw_success` nor `mw_fail` is set on the frontmatter.
+ *
+ * Only memories whose category is eligible for Memory Worth (see
+ * `MEMORY_WORTH_ELIGIBLE_CATEGORIES`) are considered. Procedures, corrections,
+ * and other kinds that are not instrumented are excluded entirely — they're
+ * neither "legacy" nor "instrumented" for the purposes of this audit. The
+ * total in the returned details reflects only eligible memories.
  *
  * Returned as an `ok` check regardless of count, since legacy memories are
  * fully functional (readers treat missing counters as zero observations). The
@@ -1209,9 +1232,14 @@ export async function summarizeMemoryWorthLegacyCounters(
 ): Promise<OperatorDoctorCheck> {
   let legacy = 0;
   let instrumented = 0;
+  let ineligible = 0;
   try {
     const memories = await storage.readAllMemories();
     for (const memory of memories) {
+      if (!MEMORY_WORTH_ELIGIBLE_CATEGORIES.has(memory.frontmatter.category)) {
+        ineligible += 1;
+        continue;
+      }
       const { mw_success, mw_fail } = memory.frontmatter;
       if (mw_success === undefined && mw_fail === undefined) {
         legacy += 1;
@@ -1235,9 +1263,9 @@ export async function summarizeMemoryWorthLegacyCounters(
     status: "ok",
     summary:
       total === 0
-        ? "No memories on disk yet — Memory Worth counters will populate as extractions run."
-        : `${legacy} of ${total} memories have no Memory Worth counters yet (${instrumented} instrumented).`,
-    details: { legacy, instrumented, total },
+        ? "No Memory Worth–eligible memories on disk yet — counters will populate as facts are extracted."
+        : `${legacy} of ${total} eligible memories have no Memory Worth counters yet (${instrumented} instrumented).`,
+    details: { legacy, instrumented, total, ineligible },
   };
 }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -143,6 +143,25 @@ function tokenizeArtifactSearchText(input: string): string[] {
     .filter((t) => !ARTIFACT_SEARCH_STOPWORDS.has(t));
 }
 
+/**
+ * Validate a Memory Worth counter (`mw_success` / `mw_fail`) before we persist
+ * it. Rejects non-finite, non-integer, and negative values rather than silently
+ * clamping — a silent clamp would mask miscounts in the feedback pipeline
+ * (issue #560 PR 3). Callers should pass only explicit user/pipeline values;
+ * `undefined` is checked at the callsite and skipped entirely.
+ */
+function assertMemoryWorthCounter(field: "mw_success" | "mw_fail", value: number): void {
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(`${field} must be a finite number, got ${String(value)}`);
+  }
+  if (!Number.isInteger(value)) {
+    throw new Error(`${field} must be an integer, got ${value}`);
+  }
+  if (value < 0) {
+    throw new Error(`${field} must be >= 0, got ${value}`);
+  }
+}
+
 function serializeFrontmatter(fm: MemoryFrontmatter): string {
   const lines = [
     "---",
@@ -178,6 +197,18 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
     lines.push(`accessCount: ${fm.accessCount}`);
   }
   if (fm.lastAccessed) lines.push(`lastAccessed: ${fm.lastAccessed}`);
+  // Memory Worth counters (issue #560). Emit verbatim when present — including
+  // explicit zeros — so consumers can distinguish "never observed" (absent)
+  // from "observed with zero successes" (present, value 0). Validation below
+  // rejects negatives and non-integers so we never persist a corrupt counter.
+  if (fm.mw_success !== undefined) {
+    assertMemoryWorthCounter("mw_success", fm.mw_success);
+    lines.push(`mw_success: ${fm.mw_success}`);
+  }
+  if (fm.mw_fail !== undefined) {
+    assertMemoryWorthCounter("mw_fail", fm.mw_fail);
+    lines.push(`mw_fail: ${fm.mw_fail}`);
+  }
   // Importance scoring
   if (fm.importance) {
     lines.push(`importanceScore: ${fm.importance.score}`);
@@ -264,6 +295,21 @@ function parseLinkReasonValue(rawValue: string): string {
   }
 }
 
+/**
+ * Parse a Memory Worth counter from its raw YAML string form. Returns
+ * `undefined` for missing, blank, negative, or non-integer values so a
+ * corrupt stored counter fails safely rather than poisoning downstream
+ * scoring. Pair with `assertMemoryWorthCounter` on the write path.
+ */
+function parseMemoryWorthCounterField(raw: string | undefined): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed.length === 0) return undefined;
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n) || n < 0) return undefined;
+  return n;
+}
+
 function parseFrontmatter(
   raw: string,
 ): { frontmatter: MemoryFrontmatter; content: string } | null {
@@ -319,6 +365,13 @@ function parseFrontmatter(
   const accessCount = fm.accessCount ? parseInt(fm.accessCount, 10) : undefined;
   const decayScore = fm.decayScore !== undefined ? parseFloat(fm.decayScore) : undefined;
   const heatScore = fm.heatScore !== undefined ? parseFloat(fm.heatScore) : undefined;
+
+  // Parse Memory Worth counters (issue #560). We preserve explicit zeros so
+  // callers can distinguish "observed with zero successes" from "never
+  // observed". Invalid (non-integer / negative) stored values round-trip to
+  // `undefined` — better to drop corrupt counters than to poison scoring.
+  const mw_success = parseMemoryWorthCounterField(fm.mw_success);
+  const mw_fail = parseMemoryWorthCounterField(fm.mw_fail);
 
   // Parse importance
   let importance: ImportanceScore | undefined;
@@ -381,6 +434,9 @@ function parseFrontmatter(
       // Access tracking
       accessCount: accessCount && accessCount > 0 ? accessCount : undefined,
       lastAccessed: fm.lastAccessed || undefined,
+      // Memory Worth counters (issue #560)
+      mw_success,
+      mw_fail,
       // Importance scoring
       importance,
       // Chunking

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1373,6 +1373,19 @@ export interface MemoryFrontmatter {
   accessCount?: number;
   /** Last time this memory was accessed (ISO 8601) */
   lastAccessed?: string;
+  // Memory Worth counters (issue #560)
+  //
+  // Per-fact outcome counters used to derive a dynamic utility score —
+  // `p(success | retrieved)` — as a complement to the static `importance`
+  // field. Absent on legacy memories written before #560; readers must treat
+  // `undefined` as zero observations (uniform Beta(1,1) prior).
+  //
+  // Both values must be non-negative integers on write. PR 1 wires only the
+  // schema + storage round-trip — no increments, scoring, or filtering yet.
+  /** Number of sessions where this memory was retrieved and the outcome was judged a success. */
+  mw_success?: number;
+  /** Number of sessions where this memory was retrieved and the outcome was judged a failure. */
+  mw_fail?: number;
   // Importance scoring (Phase 1B)
   /** Importance score with level, reasons, and keywords */
   importance?: ImportanceScore;


### PR DESCRIPTION
## Summary

PR 1 of 5 for issue #560 (Memory Worth). Adds two optional integer counters —
`mw_success` and `mw_fail` — to the `MemoryFrontmatter` YAML schema so later
PRs can derive a dynamic per-fact utility score (`p(success | retrieved)`)
from outcome signals already collected in the recall-audit trail.

This slice is deliberately additive: schema + storage round-trip only, zero
behavioral changes to retrieval, scoring, or filtering.

## What this PR does

- **`packages/remnic-core/src/types.ts`** — Adds `mw_success?: number` and
  `mw_fail?: number` to `MemoryFrontmatter` with doc comments explaining the
  Beta(1,1) zero-observation prior for absent fields.
- **`packages/remnic-core/src/storage.ts`**
  - `serializeFrontmatter` emits `mw_success` / `mw_fail` verbatim when
    present, **including explicit zeros**, so `never observed` (absent) is
    distinguishable from `observed with zero successes` (present, value 0).
  - New `assertMemoryWorthCounter` throws on negative / non-integer /
    non-finite writes rather than silently clamping.
  - New `parseMemoryWorthCounterField` rejects corrupt stored values back to
    `undefined` instead of returning `NaN` / negatives.
- **`packages/remnic-core/src/operator-toolkit.ts`** — `runOperatorDoctor`
  emits a new informational `memory_worth_legacy` check that partitions
  memories into legacy (no counters) vs instrumented. Always `status: ok` —
  legacy memories are fully supported.
- **`packages/remnic-core/src/memory-worth-frontmatter.test.ts`** — 8 tests
  covering round-trip, explicit-zero preservation, legacy read, corrupt-value
  safety, doctor legacy-count on mixed + empty corpora, and negative / float
  rejection on the update path.

## Out of scope (later PRs in #560)

- PR 2: `computeMemoryWorth()` pure helper (scoring math only)
- PR 3: recall-audit → counter-increment pipeline (the actual feedback loop)
- PR 4: recall reranker filter gated on computed score (feature-flagged)
- PR 5: LongMemEval + LoCoMo benchmark and default-flip decision

## Migration

Fully backward compatible. Memories written before this PR have neither
field and are treated as zero-observation by the parser (matches
`accessCount` semantics). `remnic doctor` now surfaces the legacy count for
operators following the #560 rollout, but it never fails.

## Test plan

- [x] `cd packages/remnic-core && npx tsc --noEmit` — clean
- [x] `npx tsx --test src/memory-worth-frontmatter.test.ts` — 8/8 pass
- [x] `npx tsx --test src/source-attribution-roundtrip.test.ts
      src/temporal-supersession.test.ts src/dedup/semantic.test.ts
      src/orchestrator-source-attribution.test.ts` — all existing
      storage-adjacent tests still pass (107/107)
- [ ] CI green (quality, ai-reviewers, cursor, codeql, etc.)

## Conflict note

Issues #561 and #564 also touch `packages/remnic-core/src/types.ts` this
round. Fields here are appended between `lastAccessed` and the
`Importance scoring` block — a merge conflict should resolve by interleaving
field additions rather than reordering.

Refs #560.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core on-disk frontmatter serialization/parsing and adds new validation that can fail writes if callers attempt to persist invalid counters. Behavior is otherwise additive/backward-compatible and covered by focused tests.
> 
> **Overview**
> Introduces **Memory Worth** frontmatter counters by adding optional `mw_success` / `mw_fail` fields to `MemoryFrontmatter`, and wiring them through storage parsing/serialization so values (including explicit zeros) round-trip cleanly while legacy memories simply yield `undefined`.
> 
> Tightens persistence rules in `storage.ts`: writes now validate these counters (finite, integer, non-negative) and stored corrupt values are ignored on read (parsed as `undefined`) rather than propagating bad numbers.
> 
> Extends `runOperatorDoctor` with a new informational `memory_worth_legacy` check (`summarizeMemoryWorthLegacyCounters`) that counts eligible memories (currently `fact` only) partitioned into legacy vs instrumented and tracks ineligible categories separately; adds a dedicated test suite covering round-trips, legacy/corrupt handling, doctor partitioning, and rejection of invalid updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69961771612e7447364bbb9749bc60a8a8dde5b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->