### PR TITLE
feat(consolidation): add ConsolidationOperator vocab and derived_from/derived_via frontmatter (issue #561 PR 1/5)

### DIFF
--- a/packages/remnic-core/src/consolidation-operator.ts
+++ b/packages/remnic-core/src/consolidation-operator.ts
@@ -1,0 +1,71 @@
+/**
+ * consolidation-operator.ts — Standalone operator vocabulary + validators
+ * for the consolidation subsystem (issue #561, All-Mem paper
+ * arxiv:2603.19595).
+ *
+ * This module is intentionally dependency-free so storage, the `remnic
+ * doctor` check (PR 4), and the undo CLI (PR 5) can import the validators
+ * without dragging in the full consolidation engine — which in turn pulls
+ * in the Codex materialize runner and creates a `storage → consolidation
+ * → codex-materialize-runner → storage` import cycle.
+ *
+ * The `semantic-consolidation.ts` module re-exports these symbols so
+ * existing import paths continue to work.
+ */
+
+/**
+ * Operator algebra for non-destructive consolidation.
+ *
+ * - `split`  — one source memory is rewritten as multiple smaller memories.
+ * - `merge`  — multiple source memories are collapsed into one canonical
+ *   memory.
+ * - `update` — a newer value supersedes an older value within the same
+ *   logical fact.
+ */
+export type ConsolidationOperator = "split" | "merge" | "update";
+
+/**
+ * Allowed values for the `derived_via` frontmatter field.  Used by storage
+ * validation to reject unknown operator values on write.
+ */
+export const CONSOLIDATION_OPERATORS: readonly ConsolidationOperator[] = [
+  "split",
+  "merge",
+  "update",
+] as const;
+
+/**
+ * Regular expression for validating a single `derived_from` entry.
+ *
+ * Format: `<non-empty memory path>:<integer version >= 0>`.  Matches the
+ * `path:versionNumber` convention used by `page-versioning.ts` snapshots
+ * (e.g. `"facts/preferences.md:3"`).  The path portion is greedy-last so
+ * paths that themselves contain a colon remain parseable — only the final
+ * `:<digits>` is consumed as the version.
+ */
+const DERIVED_FROM_ENTRY_RE = /^(.+):(\d+)$/;
+
+/**
+ * Validate a `derived_from` entry string.  Returns `true` if the entry
+ * parses as `<non-empty path>:<integer >= 0>`.  Kept pure so storage and
+ * future CLI/doctor paths can share the same validator.
+ */
+export function isValidDerivedFromEntry(entry: unknown): entry is string {
+  if (typeof entry !== "string") return false;
+  const match = entry.match(DERIVED_FROM_ENTRY_RE);
+  if (!match) return false;
+  const pathPart = match[1];
+  if (pathPart.length === 0 || pathPart.trim().length === 0) return false;
+  const versionNum = Number(match[2]);
+  return Number.isInteger(versionNum) && versionNum >= 0;
+}
+
+/**
+ * Type guard for `ConsolidationOperator`.
+ */
+export function isConsolidationOperator(value: unknown): value is ConsolidationOperator {
+  return (
+    typeof value === "string" &&
+    (CONSOLIDATION_OPERATORS as readonly string[]).includes(value)
+  );
+}

--- a/packages/remnic-core/src/semantic-consolidation.test.ts
+++ b/packages/remnic-core/src/semantic-consolidation.test.ts
@@ -1,0 +1,71 @@
+/**
+ * Unit tests for the ConsolidationOperator vocabulary and derived_from
+ * validator introduced in issue #561 PR 1.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  CONSOLIDATION_OPERATORS,
+  isConsolidationOperator,
+  isValidDerivedFromEntry,
+  type ConsolidationOperator,
+} from "./semantic-consolidation.js";
+
+test("CONSOLIDATION_OPERATORS enumerates exactly split/merge/update", () => {
+  assert.deepEqual([...CONSOLIDATION_OPERATORS], ["split", "merge", "update"]);
+});
+
+test("isConsolidationOperator accepts every defined operator", () => {
+  for (const op of CONSOLIDATION_OPERATORS) {
+    assert.equal(isConsolidationOperator(op), true, `${op} should be accepted`);
+  }
+});
+
+test("isConsolidationOperator rejects unknown and non-string values", () => {
+  assert.equal(isConsolidationOperator("MERGE"), false); // case-sensitive
+  assert.equal(isConsolidationOperator("annihilate"), false);
+  assert.equal(isConsolidationOperator(""), false);
+  assert.equal(isConsolidationOperator(undefined), false);
+  assert.equal(isConsolidationOperator(null), false);
+  assert.equal(isConsolidationOperator(42), false);
+  assert.equal(isConsolidationOperator({ op: "merge" }), false);
+});
+
+test("isValidDerivedFromEntry accepts well-formed path:version strings", () => {
+  assert.equal(isValidDerivedFromEntry("facts/a.md:0"), true);
+  assert.equal(isValidDerivedFromEntry("facts/a.md:2"), true);
+  assert.equal(isValidDerivedFromEntry("facts/2026-01-15/pref-001.md:17"), true);
+  assert.equal(isValidDerivedFromEntry("entities/person-alice.md:1"), true);
+  // Paths containing colons are still parseable because only the final
+  // `:<digits>` is consumed as the version.
+  assert.equal(isValidDerivedFromEntry("facts/weird:name.md:3"), true);
+});
+
+test("isValidDerivedFromEntry rejects malformed entries", () => {
+  assert.equal(isValidDerivedFromEntry(""), false, "empty string");
+  assert.equal(isValidDerivedFromEntry("facts/a.md"), false, "no version");
+  assert.equal(isValidDerivedFromEntry("facts/a.md:"), false, "missing digits");
+  assert.equal(isValidDerivedFromEntry("facts/a.md:abc"), false, "non-numeric version");
+  assert.equal(isValidDerivedFromEntry("facts/a.md:-1"), false, "negative version");
+  assert.equal(isValidDerivedFromEntry("facts/a.md:1.5"), false, "fractional version");
+  assert.equal(isValidDerivedFromEntry(":3"), false, "empty path");
+  assert.equal(isValidDerivedFromEntry("   :3"), false, "whitespace-only path");
+});
+
+test("isValidDerivedFromEntry rejects non-string values", () => {
+  assert.equal(isValidDerivedFromEntry(undefined), false);
+  assert.equal(isValidDerivedFromEntry(null), false);
+  assert.equal(isValidDerivedFromEntry(42), false);
+  assert.equal(isValidDerivedFromEntry(["facts/a.md:2"]), false);
+  assert.equal(isValidDerivedFromEntry({ path: "facts/a.md", version: 2 }), false);
+});
+
+test("ConsolidationOperator type includes split/merge/update", () => {
+  // Compile-time-only: ensure every literal is assignable to the type.
+  const split: ConsolidationOperator = "split";
+  const merge: ConsolidationOperator = "merge";
+  const update: ConsolidationOperator = "update";
+  assert.equal([split, merge, update].length, 3);
+});

--- a/packages/remnic-core/src/semantic-consolidation.test.ts
+++ b/packages/remnic-core/src/semantic-consolidation.test.ts
@@ -12,6 +12,19 @@ import {
   isValidDerivedFromEntry,
   type ConsolidationOperator,
 } from "./semantic-consolidation.js";
+// The standalone module is the source of truth; semantic-consolidation.ts
+// re-exports it.  This test import proves both surfaces work.
+import {
+  CONSOLIDATION_OPERATORS as CONSOLIDATION_OPERATORS_DIRECT,
+  isConsolidationOperator as isConsolidationOperatorDirect,
+  isValidDerivedFromEntry as isValidDerivedFromEntryDirect,
+} from "./consolidation-operator.js";
+
+test("semantic-consolidation.ts re-exports match consolidation-operator.ts", () => {
+  assert.deepEqual([...CONSOLIDATION_OPERATORS], [...CONSOLIDATION_OPERATORS_DIRECT]);
+  assert.equal(isConsolidationOperator, isConsolidationOperatorDirect);
+  assert.equal(isValidDerivedFromEntry, isValidDerivedFromEntryDirect);
+});
 
 test("CONSOLIDATION_OPERATORS enumerates exactly split/merge/update", () => {
   assert.deepEqual([...CONSOLIDATION_OPERATORS], ["split", "merge", "update"]);

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -17,6 +17,70 @@ import { log } from "./logger.js";
 // consumers that import from semantic-consolidation.ts continue to work.
 export { resolveExtensionsRoot } from "./memory-extension-host/index.js";
 
+/**
+ * Operator algebra for non-destructive consolidation (issue #561, All-Mem
+ * paper arxiv:2603.19595).  Every consolidated memory records which
+ * operator produced it and which source versions it was derived from, so
+ * consolidation becomes auditable and reversible.
+ *
+ * - `split`  — one source memory is rewritten as multiple smaller memories.
+ * - `merge`  — multiple source memories are collapsed into one canonical
+ *   memory.
+ * - `update` — a newer value supersedes an older value within the same
+ *   logical fact.
+ *
+ * This PR introduces the type and the frontmatter round-trip only.
+ * Emission, explicit prompt selection, doctor integrity checks, and undo
+ * tooling are follow-up PRs.
+ */
+export type ConsolidationOperator = "split" | "merge" | "update";
+
+/**
+ * Allowed values for the `derived_via` frontmatter field.  Used by storage
+ * validation to reject unknown operator values on write.
+ */
+export const CONSOLIDATION_OPERATORS: readonly ConsolidationOperator[] = [
+  "split",
+  "merge",
+  "update",
+] as const;
+
+/**
+ * Regular expression for validating a single `derived_from` entry.
+ *
+ * Format: `<non-empty memory path>:<integer version >= 0>`.  Matches the
+ * `path:versionNumber` convention used by `page-versioning.ts` snapshots
+ * (e.g. `"facts/preferences.md:3"`).  The path portion is greedy-last so
+ * paths that themselves contain a colon remain parseable — only the final
+ * `:<digits>` is consumed as the version.
+ */
+const DERIVED_FROM_ENTRY_RE = /^(.+):(\d+)$/;
+
+/**
+ * Validate a `derived_from` entry string.  Returns `true` if the entry
+ * parses as `<non-empty path>:<integer >= 0>`.  Kept pure so storage and
+ * future CLI/doctor paths can share the same validator.
+ */
+export function isValidDerivedFromEntry(entry: unknown): entry is string {
+  if (typeof entry !== "string") return false;
+  const match = entry.match(DERIVED_FROM_ENTRY_RE);
+  if (!match) return false;
+  const pathPart = match[1];
+  if (pathPart.length === 0 || pathPart.trim().length === 0) return false;
+  const versionNum = Number(match[2]);
+  return Number.isInteger(versionNum) && versionNum >= 0;
+}
+
+/**
+ * Type guard for `ConsolidationOperator`.
+ */
+export function isConsolidationOperator(value: unknown): value is ConsolidationOperator {
+  return (
+    typeof value === "string" &&
+    (CONSOLIDATION_OPERATORS as readonly string[]).includes(value)
+  );
+}
+
 export interface ConsolidationCluster {
   category: string;
   memories: MemoryFile[];

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -17,69 +17,17 @@ import { log } from "./logger.js";
 // consumers that import from semantic-consolidation.ts continue to work.
 export { resolveExtensionsRoot } from "./memory-extension-host/index.js";
 
-/**
- * Operator algebra for non-destructive consolidation (issue #561, All-Mem
- * paper arxiv:2603.19595).  Every consolidated memory records which
- * operator produced it and which source versions it was derived from, so
- * consolidation becomes auditable and reversible.
- *
- * - `split`  — one source memory is rewritten as multiple smaller memories.
- * - `merge`  — multiple source memories are collapsed into one canonical
- *   memory.
- * - `update` — a newer value supersedes an older value within the same
- *   logical fact.
- *
- * This PR introduces the type and the frontmatter round-trip only.
- * Emission, explicit prompt selection, doctor integrity checks, and undo
- * tooling are follow-up PRs.
- */
-export type ConsolidationOperator = "split" | "merge" | "update";
-
-/**
- * Allowed values for the `derived_via` frontmatter field.  Used by storage
- * validation to reject unknown operator values on write.
- */
-export const CONSOLIDATION_OPERATORS: readonly ConsolidationOperator[] = [
-  "split",
-  "merge",
-  "update",
-] as const;
-
-/**
- * Regular expression for validating a single `derived_from` entry.
- *
- * Format: `<non-empty memory path>:<integer version >= 0>`.  Matches the
- * `path:versionNumber` convention used by `page-versioning.ts` snapshots
- * (e.g. `"facts/preferences.md:3"`).  The path portion is greedy-last so
- * paths that themselves contain a colon remain parseable — only the final
- * `:<digits>` is consumed as the version.
- */
-const DERIVED_FROM_ENTRY_RE = /^(.+):(\d+)$/;
-
-/**
- * Validate a `derived_from` entry string.  Returns `true` if the entry
- * parses as `<non-empty path>:<integer >= 0>`.  Kept pure so storage and
- * future CLI/doctor paths can share the same validator.
- */
-export function isValidDerivedFromEntry(entry: unknown): entry is string {
-  if (typeof entry !== "string") return false;
-  const match = entry.match(DERIVED_FROM_ENTRY_RE);
-  if (!match) return false;
-  const pathPart = match[1];
-  if (pathPart.length === 0 || pathPart.trim().length === 0) return false;
-  const versionNum = Number(match[2]);
-  return Number.isInteger(versionNum) && versionNum >= 0;
-}
-
-/**
- * Type guard for `ConsolidationOperator`.
- */
-export function isConsolidationOperator(value: unknown): value is ConsolidationOperator {
-  return (
-    typeof value === "string" &&
-    (CONSOLIDATION_OPERATORS as readonly string[]).includes(value)
-  );
-}
+// Operator vocabulary (issue #561).  The types and validators live in a
+// standalone `consolidation-operator.ts` module so `storage.ts` can import
+// them without creating a `storage → semantic-consolidation →
+// codex-materialize-runner → storage` cycle.  Re-exported here so existing
+// consumers that reach for `./semantic-consolidation.js` keep working.
+export {
+  CONSOLIDATION_OPERATORS,
+  isConsolidationOperator,
+  isValidDerivedFromEntry,
+  type ConsolidationOperator,
+} from "./consolidation-operator.js";
 
 export interface ConsolidationCluster {
   category: string;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -356,16 +356,20 @@ function parseFrontmatter(
   // / malformed entries survive a read, but serialization validates on
   // write (see serializeFrontmatter).  `derived_via` is a single operator
   // string; unknown values become `undefined` on read rather than raising.
+  //
+  // Use a quote-aware tokenizer (mirrors the importanceReasons path) so
+  // entries whose path contains a comma — a legal filesystem path — round
+  // trip correctly instead of being chopped at the first `,`.
   let derived_from: string[] | undefined;
   const derivedFromStr = fm.derived_from ?? "";
-  const derivedFromMatch = derivedFromStr.match(/\[(.*)]/);
-  if (derivedFromMatch) {
-    derived_from = derivedFromMatch[1]
-      .split(",")
-      .map((e) => e.trim().replace(/^"|"$/g, ""))
-      .map((e) => e.replace(/\\"/g, '"').replace(/\\\\/g, "\\"))
-      .filter(Boolean);
-    if (derived_from.length === 0) derived_from = undefined;
+  if (derivedFromStr.trim().startsWith("[") && derivedFromStr.trim().endsWith("]")) {
+    const entries: string[] = [];
+    for (const match of derivedFromStr.matchAll(/"((?:\\.|[^"\\])*)"/g)) {
+      // Unescape the same way we escaped on write.
+      const unescaped = match[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+      if (unescaped.length > 0) entries.push(unescaped);
+    }
+    if (entries.length > 0) derived_from = entries;
   }
   const derivedViaRaw = fm.derived_via;
   const derived_via = isConsolidationOperator(derivedViaRaw) ? derivedViaRaw : undefined;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -335,13 +335,18 @@ function parseFrontmatter(
         const next = rawLines[j];
         const m = next.match(/^(\s+)- (.*)$/);
         if (!m || m[1].length <= baseIndent) break;
-        // Strip optional matching surrounding quotes; preserve inner chars.
+        // Strip matching surrounding quotes and apply YAML unescape rules
+        // so block-style entries round-trip identically to flow-style ones.
+        //   double-quoted: `\"` → `"`, `\\` → `\`
+        //   single-quoted: `''` → `'` (YAML's native escape)
         let item = m[2].trim();
-        if (
-          (item.startsWith('"') && item.endsWith('"')) ||
-          (item.startsWith("'") && item.endsWith("'"))
-        ) {
-          item = item.slice(1, -1);
+        if (item.startsWith('"') && item.endsWith('"') && item.length >= 2) {
+          item = item
+            .slice(1, -1)
+            .replace(/\\"/g, '"')
+            .replace(/\\\\/g, "\\");
+        } else if (item.startsWith("'") && item.endsWith("'") && item.length >= 2) {
+          item = item.slice(1, -1).replace(/''/g, "'");
         }
         items.push(item);
         j++;
@@ -418,16 +423,17 @@ function parseFrontmatter(
   if (derivedFromStr.startsWith("[") && derivedFromStr.endsWith("]")) {
     const inner = derivedFromStr.slice(1, -1);
     const entries: string[] = [];
-    let sawQuoted = false;
     // Hand-rolled tokenizer: walk the inner characters, honoring
     // double-quote escapes (`\"`, `\\`) and YAML single-quote doubling
     // (`''` in a `'...'` string means a literal `'`).  This avoids the
     // `'...'` regex footgun where `''` is parsed as two empty strings.
+    // Bare tokens (not quoted) are read until the next comma/whitespace
+    // so flow sequences that mix quoted and bare scalars preserve every
+    // entry.
     let i = 0;
     while (i < inner.length) {
       const ch = inner[i];
       if (ch === '"') {
-        sawQuoted = true;
         let buf = "";
         i++;
         while (i < inner.length) {
@@ -457,7 +463,6 @@ function parseFrontmatter(
         }
         if (buf.length > 0) entries.push(buf);
       } else if (ch === "'") {
-        sawQuoted = true;
         let buf = "";
         i++;
         while (i < inner.length) {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -369,15 +369,67 @@ function parseFrontmatter(
   if (derivedFromStr.startsWith("[") && derivedFromStr.endsWith("]")) {
     const inner = derivedFromStr.slice(1, -1);
     const entries: string[] = [];
-    // First try quoted tokens (double or single).  Each quoted form has
-    // its own escape convention; `\\` and `\"` mirror the serializer.
-    const quoted = inner.matchAll(/"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'/g);
     let sawQuoted = false;
-    for (const match of quoted) {
-      sawQuoted = true;
-      const raw = match[1] ?? match[2] ?? "";
-      const unescaped = raw.replace(/\\"/g, '"').replace(/\\'/g, "'").replace(/\\\\/g, "\\");
-      if (unescaped.length > 0) entries.push(unescaped);
+    // Hand-rolled tokenizer: walk the inner characters, honoring
+    // double-quote escapes (`\"`, `\\`) and YAML single-quote doubling
+    // (`''` in a `'...'` string means a literal `'`).  This avoids the
+    // `'...'` regex footgun where `''` is parsed as two empty strings.
+    let i = 0;
+    while (i < inner.length) {
+      const ch = inner[i];
+      if (ch === '"') {
+        sawQuoted = true;
+        let buf = "";
+        i++;
+        while (i < inner.length) {
+          const c = inner[i];
+          if (c === "\\" && i + 1 < inner.length) {
+            const next = inner[i + 1];
+            if (next === '"') {
+              buf += '"';
+              i += 2;
+              continue;
+            }
+            if (next === "\\") {
+              buf += "\\";
+              i += 2;
+              continue;
+            }
+            buf += c;
+            i++;
+            continue;
+          }
+          if (c === '"') {
+            i++;
+            break;
+          }
+          buf += c;
+          i++;
+        }
+        if (buf.length > 0) entries.push(buf);
+      } else if (ch === "'") {
+        sawQuoted = true;
+        let buf = "";
+        i++;
+        while (i < inner.length) {
+          const c = inner[i];
+          if (c === "'") {
+            // YAML single-quote escape: `''` means a literal `'`.
+            if (i + 1 < inner.length && inner[i + 1] === "'") {
+              buf += "'";
+              i += 2;
+              continue;
+            }
+            i++;
+            break;
+          }
+          buf += c;
+          i++;
+        }
+        if (buf.length > 0) entries.push(buf);
+      } else {
+        i++;
+      }
     }
     if (!sawQuoted && inner.trim().length > 0) {
       // Bare YAML — split on commas.  Entries with commas in the path

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -8,6 +8,10 @@ import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import {
+  isConsolidationOperator,
+  isValidDerivedFromEntry,
+} from "./semantic-consolidation.js";
+import {
   matchEntitySchemaSection,
   normalizeEntityStructuredSection,
   sortStructuredSectionsBySchema,
@@ -223,6 +227,38 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
   }
   // Raw-content dedup hash — format-agnostic archive/consolidation cleanup
   if (fm.contentHash) lines.push(`contentHash: ${fm.contentHash}`);
+  // Consolidation provenance (issue #561).  Validate on write so malformed
+  // entries cannot leak into the on-disk format.  Read-through parsing is
+  // permissive; only writes go through the validator.
+  if (fm.derived_from !== undefined) {
+    if (!Array.isArray(fm.derived_from)) {
+      throw new Error(
+        `serializeFrontmatter: derived_from must be an array of "<path>:<version>" strings`,
+      );
+    }
+    for (const entry of fm.derived_from) {
+      if (!isValidDerivedFromEntry(entry)) {
+        throw new Error(
+          `serializeFrontmatter: invalid derived_from entry ${JSON.stringify(entry)} — expected "<path>:<version>" with version >= 0`,
+        );
+      }
+    }
+    if (fm.derived_from.length > 0) {
+      lines.push(
+        `derived_from: [${fm.derived_from
+          .map((e) => `"${e.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
+          .join(", ")}]`,
+      );
+    }
+  }
+  if (fm.derived_via !== undefined) {
+    if (!isConsolidationOperator(fm.derived_via)) {
+      throw new Error(
+        `serializeFrontmatter: invalid derived_via ${JSON.stringify(fm.derived_via)} — expected one of "split" | "merge" | "update"`,
+      );
+    }
+    lines.push(`derived_via: ${fm.derived_via}`);
+  }
   lines.push("---");
   return lines.join("\n");
 }
@@ -315,6 +351,25 @@ function parseFrontmatter(
       .filter(Boolean);
   }
 
+  // Parse consolidation provenance (issue #561).  `derived_from` is an
+  // array of `"<path>:<version>"` strings; parsing is permissive so legacy
+  // / malformed entries survive a read, but serialization validates on
+  // write (see serializeFrontmatter).  `derived_via` is a single operator
+  // string; unknown values become `undefined` on read rather than raising.
+  let derived_from: string[] | undefined;
+  const derivedFromStr = fm.derived_from ?? "";
+  const derivedFromMatch = derivedFromStr.match(/\[(.*)]/);
+  if (derivedFromMatch) {
+    derived_from = derivedFromMatch[1]
+      .split(",")
+      .map((e) => e.trim().replace(/^"|"$/g, ""))
+      .map((e) => e.replace(/\\"/g, '"').replace(/\\\\/g, "\\"))
+      .filter(Boolean);
+    if (derived_from.length === 0) derived_from = undefined;
+  }
+  const derivedViaRaw = fm.derived_via;
+  const derived_via = isConsolidationOperator(derivedViaRaw) ? derivedViaRaw : undefined;
+
   // Parse accessCount
   const accessCount = fm.accessCount ? parseInt(fm.accessCount, 10) : undefined;
   const decayScore = fm.decayScore !== undefined ? parseFloat(fm.decayScore) : undefined;
@@ -400,6 +455,10 @@ function parseFrontmatter(
       structuredAttributes: parseStructuredAttributes(fm.structuredAttributes),
       // Raw-content dedup hash (format-agnostic archive/consolidation cleanup)
       contentHash: fm.contentHash || undefined,
+      // Consolidation provenance (issue #561) — read-through only in this
+      // PR; no code produces these fields yet.
+      derived_from,
+      derived_via,
     },
     content,
   };

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -310,7 +310,56 @@ function parseFrontmatter(
   const content = match[2].trim();
   const fm: Record<string, string> = {};
 
-  for (const line of fmBlock.split("\n")) {
+  // Collapse YAML block-sequence style into inline flow style so the
+  // downstream per-key parsers (derived_from, tags, lineage, etc.) keep
+  // working.  A key like
+  //     derived_from:
+  //       - facts/a.md:2
+  //       - facts/b.md:5
+  // becomes
+  //     derived_from: ["facts/a.md:2", "facts/b.md:5"]
+  // before the line-split.  Only applies when the key's own line has an
+  // empty scalar — any inline value or explicit flow sequence short-circuits
+  // this and is parsed as-is.
+  const rawLines = fmBlock.split("\n");
+  const lines: string[] = [];
+  let i = 0;
+  while (i < rawLines.length) {
+    const line = rawLines[i];
+    const colonIdx = line.indexOf(":");
+    if (colonIdx !== -1 && line.slice(colonIdx + 1).trim() === "") {
+      const baseIndent = line.match(/^\s*/)![0].length;
+      const items: string[] = [];
+      let j = i + 1;
+      while (j < rawLines.length) {
+        const next = rawLines[j];
+        const m = next.match(/^(\s+)- (.*)$/);
+        if (!m || m[1].length <= baseIndent) break;
+        // Strip optional matching surrounding quotes; preserve inner chars.
+        let item = m[2].trim();
+        if (
+          (item.startsWith('"') && item.endsWith('"')) ||
+          (item.startsWith("'") && item.endsWith("'"))
+        ) {
+          item = item.slice(1, -1);
+        }
+        items.push(item);
+        j++;
+      }
+      if (items.length > 0) {
+        const inline = items
+          .map((v) => `"${v.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`)
+          .join(", ");
+        lines.push(`${line.slice(0, colonIdx + 1)} [${inline}]`);
+        i = j;
+        continue;
+      }
+    }
+    lines.push(line);
+    i++;
+  }
+
+  for (const line of lines) {
     const colonIdx = line.indexOf(":");
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -10,7 +10,7 @@ import { createVersion as createPageVersion, type VersioningConfig, type Version
 import {
   isConsolidationOperator,
   isValidDerivedFromEntry,
-} from "./semantic-consolidation.js";
+} from "./consolidation-operator.js";
 import {
   matchEntitySchemaSection,
   normalizeEntityStructuredSection,
@@ -357,22 +357,50 @@ function parseFrontmatter(
   // write (see serializeFrontmatter).  `derived_via` is a single operator
   // string; unknown values become `undefined` on read rather than raising.
   //
-  // Use a quote-aware tokenizer (mirrors the importanceReasons path) so
-  // entries whose path contains a comma — a legal filesystem path — round
-  // trip correctly instead of being chopped at the first `,`.
+  // Tokenization handles every inline-YAML flavor we may encounter from
+  // external editors and older builds:
+  //   - our canonical escape:   ["facts/a.md:2", "facts/b.md:5"]
+  //   - single-quoted:          ['facts/a.md:2', 'facts/b.md:5']
+  //   - bare (no quotes):       [facts/a.md:2, facts/b.md:5]
+  // Quoted entries preserve embedded commas in the path; bare entries
+  // fall back to comma splitting but are still validated on write.
   let derived_from: string[] | undefined;
-  const derivedFromStr = fm.derived_from ?? "";
-  if (derivedFromStr.trim().startsWith("[") && derivedFromStr.trim().endsWith("]")) {
+  const derivedFromStr = (fm.derived_from ?? "").trim();
+  if (derivedFromStr.startsWith("[") && derivedFromStr.endsWith("]")) {
+    const inner = derivedFromStr.slice(1, -1);
     const entries: string[] = [];
-    for (const match of derivedFromStr.matchAll(/"((?:\\.|[^"\\])*)"/g)) {
-      // Unescape the same way we escaped on write.
-      const unescaped = match[1].replace(/\\"/g, '"').replace(/\\\\/g, "\\");
+    // First try quoted tokens (double or single).  Each quoted form has
+    // its own escape convention; `\\` and `\"` mirror the serializer.
+    const quoted = inner.matchAll(/"((?:\\.|[^"\\])*)"|'((?:\\.|[^'\\])*)'/g);
+    let sawQuoted = false;
+    for (const match of quoted) {
+      sawQuoted = true;
+      const raw = match[1] ?? match[2] ?? "";
+      const unescaped = raw.replace(/\\"/g, '"').replace(/\\'/g, "'").replace(/\\\\/g, "\\");
       if (unescaped.length > 0) entries.push(unescaped);
+    }
+    if (!sawQuoted && inner.trim().length > 0) {
+      // Bare YAML — split on commas.  Entries with commas in the path
+      // cannot be round-tripped bare; our serializer always quotes so
+      // this path only matters for externally authored frontmatter.
+      for (const chunk of inner.split(",")) {
+        const trimmed = chunk.trim();
+        if (trimmed.length > 0) entries.push(trimmed);
+      }
     }
     if (entries.length > 0) derived_from = entries;
   }
-  const derivedViaRaw = fm.derived_via;
-  const derived_via = isConsolidationOperator(derivedViaRaw) ? derivedViaRaw : undefined;
+  // `derived_via` may arrive quoted from external YAML emitters
+  // (`derived_via: "merge"` or `'merge'`).  Strip a single surrounding
+  // quote pair before operator validation so semantically valid entries
+  // aren't silently downgraded to `undefined`.
+  const derivedViaRaw = (fm.derived_via ?? "").trim();
+  const derivedViaUnquoted =
+    (derivedViaRaw.startsWith('"') && derivedViaRaw.endsWith('"')) ||
+    (derivedViaRaw.startsWith("'") && derivedViaRaw.endsWith("'"))
+      ? derivedViaRaw.slice(1, -1)
+      : derivedViaRaw;
+  const derived_via = isConsolidationOperator(derivedViaUnquoted) ? derivedViaUnquoted : undefined;
 
   // Parse accessCount
   const accessCount = fm.accessCount ? parseInt(fm.accessCount, 10) : undefined;

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -427,17 +427,21 @@ function parseFrontmatter(
           i++;
         }
         if (buf.length > 0) entries.push(buf);
-      } else {
+      } else if (ch === "," || /\s/.test(ch)) {
+        // Separator between entries — skip.
         i++;
-      }
-    }
-    if (!sawQuoted && inner.trim().length > 0) {
-      // Bare YAML — split on commas.  Entries with commas in the path
-      // cannot be round-tripped bare; our serializer always quotes so
-      // this path only matters for externally authored frontmatter.
-      for (const chunk of inner.split(",")) {
-        const trimmed = chunk.trim();
-        if (trimmed.length > 0) entries.push(trimmed);
+      } else {
+        // Bare token — read until next comma or whitespace.  Supports
+        // mixed-style YAML sequences like `["facts/a.md:1", facts/b.md:2]`
+        // where some entries are quoted and others are bare.
+        let buf = "";
+        while (i < inner.length) {
+          const c = inner[i];
+          if (c === "," || /\s/.test(c)) break;
+          buf += c;
+          i++;
+        }
+        if (buf.length > 0) entries.push(buf);
       }
     }
     if (entries.length > 0) derived_from = entries;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1410,6 +1410,26 @@ export interface MemoryFrontmatter {
    * [Source: ...] format and silently fails for custom citation templates.
    */
   contentHash?: string;
+  /**
+   * Consolidation provenance — pointers to the page-versioning snapshots
+   * that this memory was derived from (issue #561).  Each entry is a
+   * `"<memory-path>:<version-number>"` string (e.g.
+   * `"facts/preferences.md:3"`) referencing a snapshot recorded by
+   * `page-versioning.ts`.
+   *
+   * PR 1 introduces this field as read-through only — storage preserves
+   * it verbatim but no code produces it yet.  PR 2 populates it on
+   * consolidation writes; PR 4 adds a `remnic doctor` integrity check
+   * that validates each referent actually exists.
+   */
+  derived_from?: string[];
+  /**
+   * Which consolidation operator produced this memory (issue #561).  See
+   * `ConsolidationOperator` in `semantic-consolidation.ts` for the
+   * operator algebra.  Absent on memories that were not produced by a
+   * consolidation pass.
+   */
+  derived_via?: "split" | "merge" | "update";
 }
 
 /** Memory link relationship types */

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -141,6 +141,14 @@ test("StorageManager accepts single-quoted and bare YAML derived_from entries fr
         line: 'derived_from: ["facts/a.md:2", "facts/b.md:5"]',
         expected: ["facts/a.md:2", "facts/b.md:5"],
       },
+      {
+        // YAML single-quote escape: `''` is a literal `'` inside a
+        // single-quoted scalar.  External YAML emitters do this for
+        // paths containing apostrophes.
+        id: "fact-derived-single-doubled-apos",
+        line: "derived_from: ['facts/it''s.md:2', 'facts/b.md:5']",
+        expected: ["facts/it's.md:2", "facts/b.md:5"],
+      },
     ];
 
     for (const flavor of flavors) {

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Storage round-trip tests for the consolidation provenance frontmatter
+ * fields introduced in issue #561 PR 1:
+ *
+ *   - `derived_from?: string[]`  — `"<path>:<version>"` references into the
+ *     page-versioning snapshots.
+ *   - `derived_via?: "split" | "merge" | "update"` — which consolidation
+ *     operator produced this memory.
+ *
+ * PR 1 only wires the frontmatter round-trip (preservation on read/write)
+ * and the write-path validator.  No code emits these fields yet — that
+ * lands in PR 2.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+
+test("StorageManager round-trips derived_from and derived_via frontmatter", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-roundtrip-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const day = "2026-04-19";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-derived-roundtrip";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-19T01:00:00.000Z",
+      "updated: 2026-04-19T01:00:00.000Z",
+      "source: test",
+      "confidence: 0.9",
+      "confidenceTier: implied",
+      'tags: ["consolidation"]',
+      'derived_from: ["facts/a.md:2", "facts/b.md:5"]',
+      "derived_via: merge",
+      "---",
+      "",
+      "merged payload",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory, "memory should be readable");
+    assert.deepEqual(memory.frontmatter.derived_from, [
+      "facts/a.md:2",
+      "facts/b.md:5",
+    ]);
+    assert.equal(memory.frontmatter.derived_via, "merge");
+
+    // Rewrite via archive — the serializer must emit the same fields.
+    const archivedPath = await storage.archiveMemory(memory);
+    assert.ok(archivedPath, "memory should archive");
+
+    const archivedRaw = await readFile(archivedPath, "utf-8");
+    assert.ok(
+      archivedRaw.includes('derived_from: ["facts/a.md:2", "facts/b.md:5"]'),
+      `archived file should contain derived_from line; got:\n${archivedRaw}`,
+    );
+    assert.ok(
+      archivedRaw.includes("derived_via: merge"),
+      `archived file should contain derived_via line; got:\n${archivedRaw}`,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager reads legacy memories without derived_from or derived_via", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-legacy-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "legacy payload", {
+      source: "test",
+    });
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory, "legacy memory should load");
+    assert.equal(memory.frontmatter.derived_from, undefined);
+    assert.equal(memory.frontmatter.derived_via, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager supports all three ConsolidationOperator values on derived_via", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-ops-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const day = "2026-04-19";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const operators: Array<"split" | "merge" | "update"> = ["split", "merge", "update"];
+    for (const op of operators) {
+      const id = `fact-derived-${op}`;
+      const filePath = path.join(factDir, `${id}.md`);
+      const raw = [
+        "---",
+        `id: ${id}`,
+        "category: fact",
+        "created: 2026-04-19T01:00:00.000Z",
+        "updated: 2026-04-19T01:00:00.000Z",
+        "source: test",
+        "confidence: 0.8",
+        "confidenceTier: implied",
+        'tags: ["consolidation"]',
+        'derived_from: ["facts/source.md:1"]',
+        `derived_via: ${op}`,
+        "---",
+        "",
+        `${op} payload`,
+        "",
+      ].join("\n");
+      await writeFile(filePath, raw, "utf-8");
+    }
+
+    const all = await storage.readAllMemories();
+    for (const op of operators) {
+      const memory = all.find((m) => m.frontmatter.id === `fact-derived-${op}`);
+      assert.ok(memory, `memory for operator ${op} should load`);
+      assert.equal(memory.frontmatter.derived_via, op);
+      assert.deepEqual(memory.frontmatter.derived_from, ["facts/source.md:1"]);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager rejects malformed derived_from on write", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-malformed-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "seed payload", { source: "test" });
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+
+    const targetPath = path.join(dir, "facts", "2026-04-19", `${id}.md`);
+
+    // Each case is a distinct malformed `derived_from` value that the
+    // serializer must reject.  Tests cover: missing version, non-numeric
+    // version, empty string, and non-array shape.
+    const badEntries: Array<unknown[]> = [
+      ["facts/a.md"], // missing version
+      ["facts/a.md:abc"], // non-numeric version
+      [""], // empty entry
+      ["facts/a.md:-1"], // negative version
+    ];
+    for (const bad of badEntries) {
+      const mutated = {
+        ...memory,
+        frontmatter: { ...memory.frontmatter, derived_from: bad as string[] },
+      };
+      await assert.rejects(
+        () => storage.moveMemoryToPath(mutated, targetPath),
+        /invalid derived_from entry/,
+        `should reject malformed derived_from ${JSON.stringify(bad)}`,
+      );
+    }
+
+    // Non-array shape is rejected with a different error message.
+    const nonArray = {
+      ...memory,
+      frontmatter: {
+        ...memory.frontmatter,
+        derived_from: "facts/a.md:2" as unknown as string[],
+      },
+    };
+    await assert.rejects(
+      () => storage.moveMemoryToPath(nonArray, targetPath),
+      /derived_from must be an array/,
+      "should reject non-array derived_from",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager rejects unknown derived_via on write", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-via-unknown-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "seed payload", { source: "test" });
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+
+    const targetPath = path.join(dir, "facts", "2026-04-19", `${id}.md`);
+    const mutated = {
+      ...memory,
+      frontmatter: {
+        ...memory.frontmatter,
+        derived_via: "annihilate" as unknown as "split" | "merge" | "update",
+      },
+    };
+
+    await assert.rejects(
+      () => storage.moveMemoryToPath(mutated, targetPath),
+      /invalid derived_via/,
+      "should reject unknown derived_via",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager tolerates unknown derived_via on read (drops to undefined)", async () => {
+  // Read-path is intentionally permissive so future operator additions
+  // don't brick a rollback to an older build.  Write-path rejects unknown
+  // operators (covered in semantic-consolidation.test below).
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-unknown-op-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const day = "2026-04-19";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-derived-unknown";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-19T01:00:00.000Z",
+      "updated: 2026-04-19T01:00:00.000Z",
+      "source: test",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      'tags: ["consolidation"]',
+      "derived_via: annihilate",
+      "---",
+      "",
+      "payload",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+    assert.equal(memory.frontmatter.derived_via, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -77,6 +77,41 @@ test("StorageManager round-trips derived_from and derived_via frontmatter", asyn
   }
 });
 
+test("StorageManager round-trips derived_from entries whose paths contain commas and quotes", async () => {
+  // Quote-aware parser must not split on a comma embedded inside a path
+  // component.  The escape policy for embedded double-quotes mirrors the
+  // importanceReasons pipeline: `"` -> `\"` and `\` -> `\\`.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-commapath-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "payload", { source: "test" });
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+
+    const pathyEntries = [
+      "facts/a,b.md:2", // comma inside path
+      'facts/weird "name".md:5', // quote inside path
+      "facts/normal.md:0",
+    ];
+    const targetPath = path.join(dir, "facts", "2026-04-19", `${id}.md`);
+    const mutated = {
+      ...memory,
+      frontmatter: { ...memory.frontmatter, derived_from: pathyEntries },
+    };
+    await storage.moveMemoryToPath(mutated, targetPath);
+
+    const reread = await storage.readAllMemories();
+    const back = reread.find((m) => m.frontmatter.id === id);
+    assert.ok(back);
+    assert.deepEqual(back.frontmatter.derived_from, pathyEntries);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("StorageManager reads legacy memories without derived_from or derived_via", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-legacy-"));
   try {

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -149,6 +149,13 @@ test("StorageManager accepts single-quoted and bare YAML derived_from entries fr
         line: "derived_from: ['facts/it''s.md:2', 'facts/b.md:5']",
         expected: ["facts/it's.md:2", "facts/b.md:5"],
       },
+      {
+        // YAML flow sequences may mix quoted + bare scalars.  Every entry
+        // must survive, regardless of whether its neighbor was quoted.
+        id: "fact-derived-mixed-quoted-bare",
+        line: 'derived_from: ["facts/a.md:1", facts/b.md:2, \'facts/c.md:3\']',
+        expected: ["facts/a.md:1", "facts/b.md:2", "facts/c.md:3"],
+      },
     ];
 
     for (const flavor of flavors) {

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -156,6 +156,15 @@ test("StorageManager accepts single-quoted and bare YAML derived_from entries fr
         line: 'derived_from: ["facts/a.md:1", facts/b.md:2, \'facts/c.md:3\']',
         expected: ["facts/a.md:1", "facts/b.md:2", "facts/c.md:3"],
       },
+      {
+        // YAML block sequence: `key:` with an empty scalar followed by
+        // indented `- item` lines.  Many external YAML emitters prefer
+        // this style; the reader collapses it back to flow form before
+        // tokenization.
+        id: "fact-derived-block-sequence",
+        line: "derived_from:\n  - facts/a.md:2\n  - facts/b.md:5",
+        expected: ["facts/a.md:2", "facts/b.md:5"],
+      },
     ];
 
     for (const flavor of flavors) {

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -165,6 +165,14 @@ test("StorageManager accepts single-quoted and bare YAML derived_from entries fr
         line: "derived_from:\n  - facts/a.md:2\n  - facts/b.md:5",
         expected: ["facts/a.md:2", "facts/b.md:5"],
       },
+      {
+        // Block-sequence items may be quoted with YAML escape rules.
+        // Single-quoted `'it''s'` decodes to `it's`; double-quoted
+        // `"he said \"hi\""` decodes to `he said "hi"`.
+        id: "fact-derived-block-escaped",
+        line: "derived_from:\n  - 'facts/it''s.md:2'\n  - \"facts/b.md:5\"",
+        expected: ["facts/it's.md:2", "facts/b.md:5"],
+      },
     ];
 
     for (const flavor of flavors) {

--- a/tests/storage-derived-frontmatter.test.ts
+++ b/tests/storage-derived-frontmatter.test.ts
@@ -112,6 +112,123 @@ test("StorageManager round-trips derived_from entries whose paths contain commas
   }
 });
 
+test("StorageManager accepts single-quoted and bare YAML derived_from entries from external editors", async () => {
+  // External YAML emitters may produce any of: double-quoted (our
+  // canonical form), single-quoted, or bare inline lists.  The parser
+  // must preserve provenance regardless of which flavor arrives.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-yaml-flavors-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const day = "2026-04-19";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const flavors: Array<{ id: string; line: string; expected: string[] }> = [
+      {
+        id: "fact-derived-bare",
+        line: "derived_from: [facts/a.md:2, facts/b.md:5]",
+        expected: ["facts/a.md:2", "facts/b.md:5"],
+      },
+      {
+        id: "fact-derived-single-quoted",
+        line: "derived_from: ['facts/a.md:2', 'facts/b.md:5']",
+        expected: ["facts/a.md:2", "facts/b.md:5"],
+      },
+      {
+        id: "fact-derived-double-quoted",
+        line: 'derived_from: ["facts/a.md:2", "facts/b.md:5"]',
+        expected: ["facts/a.md:2", "facts/b.md:5"],
+      },
+    ];
+
+    for (const flavor of flavors) {
+      const raw = [
+        "---",
+        `id: ${flavor.id}`,
+        "category: fact",
+        "created: 2026-04-19T01:00:00.000Z",
+        "updated: 2026-04-19T01:00:00.000Z",
+        "source: test",
+        "confidence: 0.8",
+        "confidenceTier: implied",
+        'tags: ["consolidation"]',
+        flavor.line,
+        "---",
+        "",
+        "yaml flavor payload",
+        "",
+      ].join("\n");
+      await writeFile(path.join(factDir, `${flavor.id}.md`), raw, "utf-8");
+    }
+
+    const all = await storage.readAllMemories();
+    for (const flavor of flavors) {
+      const memory = all.find((m) => m.frontmatter.id === flavor.id);
+      assert.ok(memory, `${flavor.id} should load`);
+      assert.deepEqual(
+        memory.frontmatter.derived_from,
+        flavor.expected,
+        `${flavor.id} should parse to ${JSON.stringify(flavor.expected)}`,
+      );
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("StorageManager accepts quoted derived_via from external YAML emitters", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-via-quoted-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const day = "2026-04-19";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const flavors: Array<{ id: string; line: string }> = [
+      { id: "fact-via-bare", line: "derived_via: merge" },
+      { id: "fact-via-double", line: 'derived_via: "merge"' },
+      { id: "fact-via-single", line: "derived_via: 'merge'" },
+    ];
+
+    for (const flavor of flavors) {
+      const raw = [
+        "---",
+        `id: ${flavor.id}`,
+        "category: fact",
+        "created: 2026-04-19T01:00:00.000Z",
+        "updated: 2026-04-19T01:00:00.000Z",
+        "source: test",
+        "confidence: 0.8",
+        "confidenceTier: implied",
+        'tags: ["consolidation"]',
+        flavor.line,
+        "---",
+        "",
+        "payload",
+        "",
+      ].join("\n");
+      await writeFile(path.join(factDir, `${flavor.id}.md`), raw, "utf-8");
+    }
+
+    const all = await storage.readAllMemories();
+    for (const flavor of flavors) {
+      const memory = all.find((m) => m.frontmatter.id === flavor.id);
+      assert.ok(memory, `${flavor.id} should load`);
+      assert.equal(
+        memory.frontmatter.derived_via,
+        "merge",
+        `${flavor.id} should parse to "merge"`,
+      );
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("StorageManager reads legacy memories without derived_from or derived_via", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-legacy-"));
   try {


### PR DESCRIPTION
## Summary

PR 1 of 5 for issue #561 (SPLIT/MERGE/UPDATE operators + `derived_from` provenance).

This slice is schema-only — no behavior change. It adds the operator
vocabulary and the consolidation-provenance frontmatter fields, and wires
the storage round-trip + write-path validation. Later PRs produce the
fields, emit operators from the consolidation prompt, add a doctor
integrity check, and add an undo CLI path.

## Changes

- **`packages/remnic-core/src/semantic-consolidation.ts`**: exports
  `ConsolidationOperator = "split" | "merge" | "update"`, the
  `CONSOLIDATION_OPERATORS` array, an `isConsolidationOperator` guard, and
  an `isValidDerivedFromEntry` validator for the `"<path>:<version>"`
  string format.
- **`packages/remnic-core/src/types.ts`**: adds optional `derived_from?: string[]`
  and `derived_via?: "split" | "merge" | "update"` fields to
  `MemoryFrontmatter` (purely additive; no existing field reordered).
- **`packages/remnic-core/src/storage.ts`**: `serializeFrontmatter`
  validates both fields on write (malformed entries throw with a clear
  error); `parseFrontmatter` is permissive on read so legacy memories and
  future operator values survive rollbacks.

## Out of scope (follow-up PRs)

- **PR 2** — write paths in `materializeAfterSemanticConsolidation` emit
  `derived_from` + `derived_via` on every consolidation output.
- **PR 3** — `buildConsolidationPrompt` / `parseConsolidationResponse`
  refactor to return structured `{ operator, sources, output }` triples
  per cluster, so the LLM picks SPLIT vs MERGE vs UPDATE.
- **PR 4** — `remnic doctor` check that validates every `derived_from`
  referent actually exists in the page-version store.
- **PR 5** — `remnic consolidation undo <memory-id>` CLI path.

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/semantic-consolidation.test.ts` —
  7 unit tests cover validator accept/reject and the operator type guard.
- [x] `npx tsx --test tests/storage-derived-frontmatter.test.ts` — 6
  integration tests cover: round-trip of both fields, all three operator
  values, legacy memories without the fields, unknown-operator tolerance
  on read, malformed `derived_from` rejection on write, and unknown
  `derived_via` rejection on write.
- [x] `cd packages/remnic-core && npx tsc --noEmit` — clean.
- [x] Existing `storage-lifecycle-frontmatter`,
  `storage-frontmatter-escape-roundtrip`, `storage-links-frontmatter`,
  and `storage-status-version` suites still pass (no regressions in
  sibling frontmatter paths).

Refs #561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches `storage.ts` frontmatter parsing/serialization and adds strict write-time validation, which could reject or reformat existing on-disk memories if edge cases were missed. Read-path is intentionally permissive, but the new block-sequence collapsing/tokenizer logic increases parsing complexity.
> 
> **Overview**
> Introduces consolidation provenance metadata by adding `derived_from` (snapshot references) and `derived_via` (operator: `split`/`merge`/`update`) to `MemoryFrontmatter`, plus a standalone `consolidation-operator.ts` with the operator vocabulary and validators (re-exported from `semantic-consolidation.ts` to avoid import cycles).
> 
> Updates `StorageManager` frontmatter handling to **preserve these fields on read**, accept multiple YAML list styles (flow, single-quoted, bare, and block sequences), and **validate on write** so malformed `derived_from` entries or unknown `derived_via` operators throw. Adds unit + integration tests covering the new validators and round-trip/validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b69969a5401cb8e17c2c6b58f889e6bb6cc5d70a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->