### PR TITLE
feat(taxonomy): add reasoning_trace memory category (#564 PR 1/4)

### DIFF
--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -78,6 +78,7 @@ const categorySchema = z
   .enum([
     "fact", "preference", "correction", "entity", "decision",
     "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure",
+    "reasoning_trace",
   ])
   .optional();
 const confidenceSchema = z.number().min(0).max(1).optional();

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -173,6 +173,7 @@ export const VALID_MEMORY_CATEGORIES = new Set([
   "skill",
   "rule",
   "procedure",
+  "reasoning_trace",
 ]);
 
 const DEFAULT_BEHAVIOR_LOOP_PROTECTED_PARAMS = [

--- a/packages/remnic-core/src/explicit-capture.ts
+++ b/packages/remnic-core/src/explicit-capture.ts
@@ -45,6 +45,7 @@ const INLINE_ALLOWED_CATEGORIES = new Set<MemoryCategory>([
   "skill",
   "rule",
   "procedure",
+  "reasoning_trace",
 ]);
 
 const SECRET_PATTERNS: RegExp[] = [

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -1247,6 +1247,7 @@ ${truncatedConversation}`;
       "skill",
       "rule",
       "procedure",
+      "reasoning_trace",
     ]);
     const allowedEntityTypes = new Set([
       "person",

--- a/packages/remnic-core/src/importance.ts
+++ b/packages/remnic-core/src/importance.ts
@@ -91,18 +91,19 @@ const TRIVIAL_PATTERNS = [
 // ---------------------------------------------------------------------------
 
 const CATEGORY_BOOSTS: Record<MemoryCategory, number> = {
-  correction: 0.15,    // Corrections are always important
-  principle: 0.12,     // Durable rules/values
-  rule: 0.11,          // Causal IF→THEN rules
-  procedure: 0.10,     // Repeatable workflows (issue #519)
-  preference: 0.10,    // User preferences matter
-  commitment: 0.10,    // Promises/obligations
-  decision: 0.08,      // Decisions with rationale
-  relationship: 0.05,  // Entity relationships
-  skill: 0.05,         // Capabilities
-  moment: 0.03,        // Emotional milestones
-  entity: 0.02,        // Entity facts
-  fact: 0.00,          // Base facts, no boost
+  correction: 0.15,        // Corrections are always important
+  principle: 0.12,         // Durable rules/values
+  rule: 0.11,              // Causal IF→THEN rules
+  procedure: 0.10,         // Repeatable workflows (issue #519)
+  preference: 0.10,        // User preferences matter
+  commitment: 0.10,        // Promises/obligations
+  reasoning_trace: 0.09,   // Stored reasoning chains (issue #564)
+  decision: 0.08,          // Decisions with rationale
+  relationship: 0.05,      // Entity relationships
+  skill: 0.05,             // Capabilities
+  moment: 0.03,            // Emotional milestones
+  entity: 0.02,            // Entity facts
+  fact: 0.00,              // Base facts, no boost
 };
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/routing/engine.ts
+++ b/packages/remnic-core/src/routing/engine.ts
@@ -39,6 +39,7 @@ const DEFAULT_CATEGORIES: readonly MemoryCategory[] = [
   "skill",
   "rule",
   "procedure",
+  "reasoning_trace",
 ] as const;
 
 function normalizeNamespace(namespace: string): string {

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -65,6 +65,7 @@ export const ExtractedFactSchema = z.object({
     "skill",
     "rule",
     "procedure",
+    "reasoning_trace",
   ]),
   content: z
     .string()

--- a/packages/remnic-core/src/taxonomy/default-taxonomy.ts
+++ b/packages/remnic-core/src/taxonomy/default-taxonomy.ts
@@ -72,5 +72,16 @@ export const DEFAULT_TAXONOMY: Taxonomy = {
       priority: 60,
       memoryCategories: ["moment"],
     },
+    {
+      id: "reasoning-traces",
+      name: "Reasoning Traces",
+      description:
+        "Stored intermediate reasoning / solution chains for a problem the agent previously solved",
+      filingRules: [
+        "A multi-step reasoning chain or solution walkthrough the agent can replay for a similar problem",
+      ],
+      priority: 55,
+      memoryCategories: ["reasoning_trace"],
+    },
   ],
 };

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1,7 +1,7 @@
 export type ReasoningEffort = "none" | "low" | "medium" | "high";
 export type TriggerMode = "smart" | "every_n" | "time_based";
 export type SignalLevel = "none" | "low" | "medium" | "high";
-export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule" | "procedure";
+export type MemoryCategory = "fact" | "preference" | "correction" | "entity" | "decision" | "relationship" | "principle" | "commitment" | "moment" | "skill" | "rule" | "procedure" | "reasoning_trace";
 export type ConsolidationAction = "ADD" | "MERGE" | "UPDATE" | "INVALIDATE" | "SKIP";
 export type ConfidenceTier = "explicit" | "implied" | "inferred" | "speculative";
 export type PrincipalFromSessionKeyMode = "map" | "prefix" | "regex";

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -1964,8 +1964,8 @@ Best for:
         category: Type.Optional(
           Type.String({
             description:
-              'Category: "fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure" (default: "fact")',
-            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure"],
+              'Category: "fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure", "reasoning_trace" (default: "fact")',
+            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure", "reasoning_trace"],
           }),
         ),
         tags: Type.Optional(
@@ -2036,7 +2036,7 @@ Best for:
         category: Type.Optional(
           Type.String({
             description: "Memory category.",
-            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure"],
+            enum: ["fact", "preference", "correction", "entity", "decision", "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure", "reasoning_trace"],
           }),
         ),
         tags: Type.Optional(

--- a/tests/causal-rule-extraction.test.ts
+++ b/tests/causal-rule-extraction.test.ts
@@ -12,6 +12,7 @@ describe("causal rule category", () => {
     const categories: MemoryCategory[] = [
       "fact", "preference", "correction", "entity", "decision",
       "relationship", "principle", "commitment", "moment", "skill", "rule", "procedure",
+      "reasoning_trace",
     ];
     assert.equal(new Set(categories).size, categories.length);
   });

--- a/tests/mece-taxonomy.test.ts
+++ b/tests/mece-taxonomy.test.ts
@@ -56,6 +56,7 @@ const ALL_MEMORY_CATEGORIES: MemoryCategory[] = [
   "skill",
   "rule",
   "procedure",
+  "reasoning_trace",
 ];
 
 // ── Default taxonomy structure ──────────────────────────────────────────────

--- a/tests/reasoning-trace-category.test.ts
+++ b/tests/reasoning-trace-category.test.ts
@@ -1,0 +1,111 @@
+/**
+ * Tests for the "reasoning_trace" MemoryCategory (#564 PR 1).
+ *
+ * Covers:
+ * - Storage round-trip: a memory file written with category: reasoning_trace
+ *   reads back with that category intact.
+ * - Validator: VALID_MEMORY_CATEGORIES accepts the new value.
+ * - Taxonomy resolver: `reasoning_trace` maps to the `reasoning-traces`
+ *   taxonomy category.
+ * - Zod / request schemas (memory store + extracted fact) accept the new
+ *   value end-to-end.
+ * - Routing engine validateRouteTarget accepts the new value.
+ *
+ * Out of scope (follow-up PRs): extraction prompt recognition, retrieval
+ * path, benchmark coverage.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { StorageManager } from "../src/storage.ts";
+import { VALID_MEMORY_CATEGORIES } from "../packages/remnic-core/src/config.js";
+import {
+  DEFAULT_TAXONOMY,
+  resolveCategory,
+} from "../packages/remnic-core/src/taxonomy/index.js";
+import { validateRouteTarget } from "../packages/remnic-core/src/routing/engine.js";
+import { ExtractedFactSchema } from "../packages/remnic-core/src/schemas.js";
+import { memoryStoreRequestSchema } from "../packages/remnic-core/src/access-schema.js";
+import type { MemoryCategory } from "../src/types.js";
+
+describe("reasoning_trace category", () => {
+  it("is assignable as a MemoryCategory value", () => {
+    const category: MemoryCategory = "reasoning_trace";
+    assert.equal(category, "reasoning_trace");
+  });
+
+  it("is present in VALID_MEMORY_CATEGORIES", () => {
+    assert.ok(VALID_MEMORY_CATEGORIES.has("reasoning_trace"));
+  });
+
+  it("round-trips through StorageManager write/read", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-reasoning-trace-"));
+    try {
+      const storage = new StorageManager(dir);
+      const body = [
+        "Problem: find the lowest-latency path between two services.",
+        "Step 1: enumerate candidate routes.",
+        "Step 2: measure round-trip time for each candidate.",
+        "Step 3: pick the lowest observed p95 that also stayed below the SLO.",
+        "Outcome: route-b won and we pinned it.",
+      ].join("\n");
+
+      const id = await storage.writeMemory("reasoning_trace", body, {
+        source: "test",
+        tags: ["reasoning", "routing-decision"],
+        confidence: 0.9,
+      });
+
+      const memories = await storage.readAllMemories();
+      const found = memories.find((m) => m.frontmatter.id === id);
+      assert.ok(found, "written memory should be discoverable via readAllMemories");
+      assert.equal(found.frontmatter.category, "reasoning_trace");
+      assert.equal(found.frontmatter.source, "test");
+      assert.deepEqual(found.frontmatter.tags, ["reasoning", "routing-decision"]);
+      assert.ok(
+        found.content.includes("route-b won"),
+        "stored body should contain the full reasoning chain",
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("resolves through the default taxonomy to the reasoning-traces category", () => {
+    const decision = resolveCategory(
+      "Walk-through of how we chose route-b over route-a.",
+      "reasoning_trace",
+      DEFAULT_TAXONOMY,
+    );
+    assert.equal(decision.categoryId, "reasoning-traces");
+    assert.equal(decision.confidence, 1.0);
+  });
+
+  it("is accepted by validateRouteTarget", () => {
+    const result = validateRouteTarget({ category: "reasoning_trace" });
+    assert.equal(result.ok, true);
+    assert.equal(result.target?.category, "reasoning_trace");
+  });
+
+  it("is accepted by ExtractedFactSchema (zod)", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "Tried A, fell back to B when A timed out; documented why.",
+      confidence: 0.85,
+      tags: ["reasoning"],
+    });
+    assert.equal(parsed.success, true);
+  });
+
+  it("is accepted by memoryStoreRequestSchema (zod)", () => {
+    const parsed = memoryStoreRequestSchema.safeParse({
+      content: "Reasoning chain for the latency investigation.",
+      category: "reasoning_trace",
+    });
+    assert.equal(parsed.success, true);
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of 4 for the Thought-Retriever issue (#564). Introduces the new
`reasoning_trace` memory category end-to-end at the schema / category
registration layer:

- Adds `"reasoning_trace"` to the central `MemoryCategory` union in
  `packages/remnic-core/src/types.ts`.
- Registers it in `VALID_MEMORY_CATEGORIES` (config), the default MECE
  taxonomy (new `reasoning-traces` taxonomy entry, priority 55),
  `DEFAULT_CATEGORIES` in the routing engine, `ExtractedFactSchema`,
  `memoryStoreRequestSchema`, `extractPartialFacts` allow-list,
  `INLINE_ALLOWED_CATEGORIES`, `CATEGORY_BOOSTS`, and the OpenClaw
  tool category enums in `src/tools.ts`.
- Keeps existing exhaustive test lists (`tests/mece-taxonomy.test.ts`,
  `tests/causal-rule-extraction.test.ts`) in sync with the new value
  so MECE invariants stay verified.

## Out of scope (follow-up PRs)

- PR 2: Extraction recognition — prompt-level identification of
  multi-step reasoning arcs.
- PR 3: Retrieval path — intent classifier + reasoning-trace-biased
  recall, gated behind a config flag.
- PR 4: Benchmark — AcademicEval (or a synthetic internal benchmark)
  + A/B measurement.

## Test plan

- [x] `npx tsx --test tests/reasoning-trace-category.test.ts` — new
  round-trip + validator suite (7 tests).
- [x] `npx tsx --test tests/mece-taxonomy.test.ts tests/causal-rule-extraction.test.ts`
  — existing exhaustiveness checks still pass with the new entry.
- [x] `npx tsx --test tests/storage-procedure-write.test.ts tests/storage-frontmatter-escape-roundtrip.test.ts`
  — adjacent storage round-trip tests still pass.
- [x] `cd packages/remnic-core && npx tsc --noEmit` clean.
- [x] Root `npx tsc --noEmit` clean.

Refs #564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Broad but mostly additive changes across validation, routing, and taxonomy; main risk is missed call sites or downstream consumers relying on exhaustive category enums.
> 
> **Overview**
> Adds a new `reasoning_trace` memory category and wires it through core validation/registration points so it can be stored, routed, and schema-validated end-to-end (API zod schemas, `VALID_MEMORY_CATEGORIES`, extraction allowlists, routing engine categories, and tool parameter enums).
> 
> Extends the default taxonomy with a new **Reasoning Traces** bucket and updates importance scoring boosts for the new category, plus adds/updates tests (including a new storage round-trip + validator suite) to keep category exhaustiveness/MECE invariants passing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3fbc383abe920608d8761e229edebd5b98eeb2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->