### PR TITLE
feat(core): graph retrieval type contract + no-op queryGraph stub (issue #559 PR 1/5)

### DIFF
--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type EdgeType,
+  type GraphEdge,
+  type GraphNode,
+  type NodeType,
+  type QueryGraphResult,
+  type RemnicGraph,
+  isEdgeType,
+  isNodeType,
+  queryGraph,
+} from "./graph-retrieval.js";
+
+test("RemnicGraph can be constructed with nodes and edges", () => {
+  const nodes = new Map<string, GraphNode>();
+  nodes.set("m1", { id: "m1", type: "memory" });
+  nodes.set("e1", { id: "e1", type: "entity", weight: 0.8 });
+
+  const edges: GraphEdge[] = [
+    { from: "m1", to: "e1", type: "mentions" },
+    { from: "m1", to: "e1", type: "authored-by", weight: 0.5 },
+  ];
+
+  const graph: RemnicGraph = { nodes, edges };
+
+  assert.equal(graph.nodes.size, 2);
+  assert.equal(graph.edges.length, 2);
+  assert.equal(graph.nodes.get("m1")?.type, "memory");
+  assert.equal(graph.nodes.get("e1")?.weight, 0.8);
+  assert.equal(graph.edges[0]?.type, "mentions");
+  assert.equal(graph.edges[1]?.weight, 0.5);
+});
+
+test("GraphNode weight is optional (undefined is valid)", () => {
+  const node: GraphNode = { id: "m1", type: "memory" };
+  assert.equal(node.weight, undefined);
+});
+
+test("GraphEdge weight is optional (undefined is valid)", () => {
+  const edge: GraphEdge = { from: "a", to: "b", type: "related-to" };
+  assert.equal(edge.weight, undefined);
+});
+
+test("nodes can be added and retrieved after construction", () => {
+  const graph: RemnicGraph = { nodes: new Map(), edges: [] };
+  graph.nodes.set("mem-1", { id: "mem-1", type: "memory" });
+  graph.edges.push({ from: "mem-1", to: "mem-2", type: "supersedes" });
+
+  assert.equal(graph.nodes.size, 1);
+  assert.equal(graph.edges.length, 1);
+  assert.equal(graph.edges[0]?.type, "supersedes");
+});
+
+test("queryGraph stub returns an empty ranked list for an empty graph", () => {
+  const graph: RemnicGraph = { nodes: new Map(), edges: [] };
+  const result: QueryGraphResult = queryGraph(graph, []);
+  assert.deepEqual(result, { rankedNodes: [] });
+});
+
+test("queryGraph stub returns an empty ranked list for a populated graph", () => {
+  const nodes = new Map<string, GraphNode>();
+  nodes.set("m1", { id: "m1", type: "memory" });
+  nodes.set("m2", { id: "m2", type: "memory" });
+  const graph: RemnicGraph = {
+    nodes,
+    edges: [{ from: "m1", to: "m2", type: "references" }],
+  };
+
+  const result = queryGraph(graph, ["m1"], { topK: 10, damping: 0.15, iterations: 50 });
+  assert.deepEqual(result.rankedNodes, []);
+});
+
+test("queryGraph stub tolerates arbitrary seed ids and options", () => {
+  const graph: RemnicGraph = { nodes: new Map(), edges: [] };
+  // Should not throw even when seed ids do not exist in the graph.
+  const result = queryGraph(graph, ["does-not-exist", "also-missing"], {});
+  assert.deepEqual(result.rankedNodes, []);
+});
+
+test("isNodeType accepts every documented node type", () => {
+  const expected: NodeType[] = [
+    "memory",
+    "entity",
+    "episode",
+    "concept",
+    "reflection",
+  ];
+  for (const t of expected) {
+    assert.equal(isNodeType(t), true, `expected ${t} to be a NodeType`);
+  }
+});
+
+test("isNodeType rejects unknown values", () => {
+  assert.equal(isNodeType("fact"), false);
+  assert.equal(isNodeType(""), false);
+  assert.equal(isNodeType(null), false);
+  assert.equal(isNodeType(undefined), false);
+  assert.equal(isNodeType(42), false);
+  assert.equal(isNodeType({ type: "memory" }), false);
+});
+
+test("isEdgeType accepts every documented edge type", () => {
+  const expected: EdgeType[] = [
+    "references",
+    "supersedes",
+    "authored-by",
+    "mentions",
+    "derived-from",
+    "temporal-next",
+    "related-to",
+  ];
+  for (const t of expected) {
+    assert.equal(isEdgeType(t), true, `expected ${t} to be an EdgeType`);
+  }
+});
+
+test("isEdgeType rejects unknown values", () => {
+  assert.equal(isEdgeType("points-to"), false);
+  assert.equal(isEdgeType(""), false);
+  assert.equal(isEdgeType(null), false);
+  assert.equal(isEdgeType(undefined), false);
+  assert.equal(isEdgeType(0), false);
+  assert.equal(isEdgeType({ type: "references" }), false);
+});

--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -3,22 +3,22 @@ import test from "node:test";
 
 import {
   type EdgeType,
-  type GraphEdge,
-  type GraphNode,
   type NodeType,
   type QueryGraphResult,
   type RemnicGraph,
+  type RemnicGraphEdge,
+  type RemnicGraphNode,
   isEdgeType,
   isNodeType,
   queryGraph,
 } from "./graph-retrieval.js";
 
 test("RemnicGraph can be constructed with nodes and edges", () => {
-  const nodes = new Map<string, GraphNode>();
+  const nodes = new Map<string, RemnicGraphNode>();
   nodes.set("m1", { id: "m1", type: "memory" });
   nodes.set("e1", { id: "e1", type: "entity", weight: 0.8 });
 
-  const edges: GraphEdge[] = [
+  const edges: RemnicGraphEdge[] = [
     { from: "m1", to: "e1", type: "mentions" },
     { from: "m1", to: "e1", type: "authored-by", weight: 0.5 },
   ];
@@ -33,13 +33,13 @@ test("RemnicGraph can be constructed with nodes and edges", () => {
   assert.equal(graph.edges[1]?.weight, 0.5);
 });
 
-test("GraphNode weight is optional (undefined is valid)", () => {
-  const node: GraphNode = { id: "m1", type: "memory" };
+test("RemnicGraphNode weight is optional (undefined is valid)", () => {
+  const node: RemnicGraphNode = { id: "m1", type: "memory" };
   assert.equal(node.weight, undefined);
 });
 
-test("GraphEdge weight is optional (undefined is valid)", () => {
-  const edge: GraphEdge = { from: "a", to: "b", type: "related-to" };
+test("RemnicGraphEdge weight is optional (undefined is valid)", () => {
+  const edge: RemnicGraphEdge = { from: "a", to: "b", type: "related-to" };
   assert.equal(edge.weight, undefined);
 });
 
@@ -60,7 +60,7 @@ test("queryGraph stub returns an empty ranked list for an empty graph", () => {
 });
 
 test("queryGraph stub returns an empty ranked list for a populated graph", () => {
-  const nodes = new Map<string, GraphNode>();
+  const nodes = new Map<string, RemnicGraphNode>();
   nodes.set("m1", { id: "m1", type: "memory" });
   nodes.set("m2", { id: "m2", type: "memory" });
   const graph: RemnicGraph = {

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -80,8 +80,12 @@ export type EdgeType =
  * importance score used as a starting bias during Personalized PageRank;
  * it is intentionally optional because most nodes default to uniform
  * priors.
+ *
+ * Named `RemnicGraphNode` (not `GraphNode`) to avoid colliding with the
+ * unrelated `GraphEdge` in `graph.ts`, which models Multi-Graph Memory
+ * (MAGMA/SYNAPSE) edges and is an incompatible shape.
  */
-export interface GraphNode {
+export interface RemnicGraphNode {
   id: string;
   type: NodeType;
   weight?: number;
@@ -93,8 +97,11 @@ export interface GraphNode {
  * `weight` is optional; when absent PPR implementations should treat
  * the edge as weight `1`. We keep weight optional rather than defaulting
  * at construction so producers can serialize a minimal edge shape.
+ *
+ * Named `RemnicGraphEdge` (not `GraphEdge`) to avoid colliding with the
+ * unrelated `GraphEdge` in `graph.ts` (Multi-Graph Memory).
  */
-export interface GraphEdge {
+export interface RemnicGraphEdge {
   from: string;
   to: string;
   type: EdgeType;
@@ -104,14 +111,14 @@ export interface GraphEdge {
 /**
  * The retrieval graph itself.
  *
- * Nodes are held in a `Map<string, GraphNode>` keyed by `id` so PPR
- * lookups are O(1). Edges are kept as a flat array; adjacency indexing
- * is a PR-3 concern (PPR will likely build a transient
+ * Nodes are held in a `Map<string, RemnicGraphNode>` keyed by `id` so
+ * PPR lookups are O(1). Edges are kept as a flat array; adjacency
+ * indexing is a PR-3 concern (PPR will likely build a transient
  * outgoing-adjacency map on demand).
  */
 export interface RemnicGraph {
-  nodes: Map<string, GraphNode>;
-  edges: GraphEdge[];
+  nodes: Map<string, RemnicGraphNode>;
+  edges: RemnicGraphEdge[];
 }
 
 // ---------------------------------------------------------------------------
@@ -137,7 +144,7 @@ export interface QueryGraphOptions {
 /**
  * A scored node returned by `queryGraph()`.
  */
-export interface RankedNode {
+export interface RankedGraphNode {
   id: string;
   score: number;
 }
@@ -146,7 +153,7 @@ export interface RankedNode {
  * The shape returned by `queryGraph()`.
  */
 export interface QueryGraphResult {
-  rankedNodes: RankedNode[];
+  rankedNodes: RankedGraphNode[];
 }
 
 /**

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -1,0 +1,200 @@
+/**
+ * Graph-based retrieval types (issue #559, PR 1 of 5).
+ *
+ * This module defines the forward-looking type contract for Remnic's
+ * first-class retrieval graph (GAAMA / GAM inspired). It ships types
+ * and a no-op `queryGraph()` stub only — no behavior, no I/O, and
+ * no importers inside the codebase yet.
+ *
+ * Subsequent slices will land:
+ *   - PR 2: Edge extraction from existing relationship facts + cross-memory
+ *           entity references during indexing (writes `~/.remnic/graph.json`).
+ *   - PR 3: Pure `personalizedPageRank()` implementation.
+ *   - PR 4: Feature-flagged wiring into `retrieval.ts` behind
+ *           `graphRetrievalEnabled` (default `false`).
+ *   - PR 5: LoCoMo A/B bench harness + default flip decision.
+ *
+ * Keeping the node/edge type enums complete from PR 1 avoids type churn
+ * when later slices add reflection/concept node synthesis or additional
+ * edge semantics.
+ */
+
+// ---------------------------------------------------------------------------
+// Node & edge type enums
+// ---------------------------------------------------------------------------
+
+/**
+ * Kinds of nodes the retrieval graph can hold.
+ *
+ * - `memory`:     a stored memory file (the primary retrieval target).
+ * - `entity`:     a named entity referenced by one or more memories.
+ * - `episode`:    a temporally-bounded interaction or session grouping.
+ * - `concept`:    an abstract topic / idea (forward-looking; synthesis
+ *                 is out of scope for this issue, but the type is
+ *                 defined here to keep later slices additive).
+ * - `reflection`: an LLM-generated summary / meta-memory about other
+ *                 nodes (also forward-looking, same rationale).
+ */
+export type NodeType =
+  | "memory"
+  | "entity"
+  | "episode"
+  | "concept"
+  | "reflection";
+
+/**
+ * Kinds of edges the retrieval graph can hold.
+ *
+ * Edges are directed. `from` → `to` semantics:
+ *
+ * - `references`:    `from` contains an explicit reference to `to`
+ *                    (e.g., a memory referencing another memory).
+ * - `supersedes`:    `from` supersedes `to` (newer memory replaces older).
+ * - `authored-by`:   `from` was authored by the entity in `to`.
+ * - `mentions`:      `from` mentions the entity/concept in `to` without
+ *                    a stronger relationship claim.
+ * - `derived-from`:  `from` was derived from `to` (reflections,
+ *                    consolidations, summaries).
+ * - `temporal-next`: `from` immediately follows `to` in time (episodes).
+ * - `related-to`:    generic weak relationship fallback for edges that
+ *                    do not fit a stronger type.
+ */
+export type EdgeType =
+  | "references"
+  | "supersedes"
+  | "authored-by"
+  | "mentions"
+  | "derived-from"
+  | "temporal-next"
+  | "related-to";
+
+// ---------------------------------------------------------------------------
+// Graph element shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * A single node in the retrieval graph.
+ *
+ * `id` is the caller-controlled stable identifier (typically a memory
+ * file path, entity slug, or episode id). `weight` is an optional prior
+ * importance score used as a starting bias during Personalized PageRank;
+ * it is intentionally optional because most nodes default to uniform
+ * priors.
+ */
+export interface GraphNode {
+  id: string;
+  type: NodeType;
+  weight?: number;
+}
+
+/**
+ * A directed edge between two nodes.
+ *
+ * `weight` is optional; when absent PPR implementations should treat
+ * the edge as weight `1`. We keep weight optional rather than defaulting
+ * at construction so producers can serialize a minimal edge shape.
+ */
+export interface GraphEdge {
+  from: string;
+  to: string;
+  type: EdgeType;
+  weight?: number;
+}
+
+/**
+ * The retrieval graph itself.
+ *
+ * Nodes are held in a `Map<string, GraphNode>` keyed by `id` so PPR
+ * lookups are O(1). Edges are kept as a flat array; adjacency indexing
+ * is a PR-3 concern (PPR will likely build a transient
+ * outgoing-adjacency map on demand).
+ */
+export interface RemnicGraph {
+  nodes: Map<string, GraphNode>;
+  edges: GraphEdge[];
+}
+
+// ---------------------------------------------------------------------------
+// Query surface (stub)
+// ---------------------------------------------------------------------------
+
+/**
+ * Options for `queryGraph()`.
+ *
+ * All fields are optional in PR 1. They are declared here so later
+ * slices can add the real PPR parameters (`damping`, `iterations`,
+ * `topK`, `seedWeights`, etc.) without breaking the public signature.
+ */
+export interface QueryGraphOptions {
+  /** Number of top-ranked nodes to return. */
+  topK?: number;
+  /** PPR damping factor (typical range 0.1 – 0.3). */
+  damping?: number;
+  /** Maximum PPR iterations before convergence fallback. */
+  iterations?: number;
+}
+
+/**
+ * A scored node returned by `queryGraph()`.
+ */
+export interface RankedNode {
+  id: string;
+  score: number;
+}
+
+/**
+ * The shape returned by `queryGraph()`.
+ */
+export interface QueryGraphResult {
+  rankedNodes: RankedNode[];
+}
+
+/**
+ * No-op stub. Returns an empty `rankedNodes` list for every input.
+ *
+ * The real implementation lands in PR 3 (Personalized PageRank). This
+ * stub exists so downstream type-checked code can reference the final
+ * signature starting in PR 1 without any behavior change.
+ *
+ * Parameters are intentionally unused; arguments are accepted only to
+ * lock the public signature.
+ */
+export function queryGraph(
+  _graph: RemnicGraph,
+  _seedIds: readonly string[],
+  _options?: QueryGraphOptions,
+): QueryGraphResult {
+  return { rankedNodes: [] };
+}
+
+// ---------------------------------------------------------------------------
+// Type guards (useful for defensive construction from untyped JSON)
+// ---------------------------------------------------------------------------
+
+const NODE_TYPES: ReadonlySet<NodeType> = new Set<NodeType>([
+  "memory",
+  "entity",
+  "episode",
+  "concept",
+  "reflection",
+]);
+
+const EDGE_TYPES: ReadonlySet<EdgeType> = new Set<EdgeType>([
+  "references",
+  "supersedes",
+  "authored-by",
+  "mentions",
+  "derived-from",
+  "temporal-next",
+  "related-to",
+]);
+
+/** Returns true iff `value` is a valid `NodeType`. */
+export function isNodeType(value: unknown): value is NodeType {
+  return typeof value === "string" && NODE_TYPES.has(value as NodeType);
+}
+
+/** Returns true iff `value` is a valid `EdgeType`. */
+export function isEdgeType(value: unknown): value is EdgeType {
+  return typeof value === "string" && EDGE_TYPES.has(value as EdgeType);
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -618,6 +618,24 @@ export {
 export * from "./training-export/index.js";
 
 // ---------------------------------------------------------------------------
+// Graph retrieval types (issue #559, PR 1 of 5)
+// ---------------------------------------------------------------------------
+
+export {
+  queryGraph,
+  isNodeType,
+  isEdgeType,
+  type NodeType,
+  type EdgeType,
+  type GraphNode,
+  type GraphEdge,
+  type RemnicGraph,
+  type QueryGraphOptions,
+  type QueryGraphResult,
+  type RankedNode,
+} from "./graph-retrieval.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -627,12 +627,12 @@ export {
   isEdgeType,
   type NodeType,
   type EdgeType,
-  type GraphNode,
-  type GraphEdge,
+  type RemnicGraphNode,
+  type RemnicGraphEdge,
   type RemnicGraph,
   type QueryGraphOptions,
   type QueryGraphResult,
-  type RankedNode,
+  type RankedGraphNode,
 } from "./graph-retrieval.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

First slice of issue #559 (graph-based retrieval with PPR).

Adds `packages/remnic-core/src/graph-retrieval.ts` — a pure type-contract
module for Remnic's forward-looking retrieval graph (GAAMA / GAM inspired).

- `NodeType` = `"memory" | "entity" | "episode" | "concept" | "reflection"`
- `EdgeType` = `"references" | "supersedes" | "authored-by" | "mentions" | "derived-from" | "temporal-next" | "related-to"`
- `RemnicGraph = { nodes: Map<string, GraphNode>, edges: GraphEdge[] }`
- `queryGraph(graph, seedIds, options?)` — no-op stub returning `{ rankedNodes: [] }`
- `isNodeType()` / `isEdgeType()` — type guards for defensive JSON parsing

Types are re-exported from `@remnic/core`. Node/edge enums are defined
once, fully populated (including `concept` / `reflection` / `related-to`)
so PR 2–4 can add edge producers and PPR without churning the public
signature.

**Behavior change: none.** No module in the codebase imports
`graph-retrieval.ts` yet.

## Out of scope (future PRs on #559)

Per the slice boundaries in issue #559:

- **PR 2 — Edge extraction.** Derive edges from relationship facts and
  cross-memory entity references during indexing; persist to
  `~/.remnic/graph.json` alongside the QMD index.
- **PR 3 — PPR implementation.** Pure `personalizedPageRank(graph, seedWeights, opts)`
  with unit tests on hand-built graphs.
- **PR 4 — Retrieval integration (feature-flagged).** Wire PPR as a
  post-QMD expansion pass in `retrieval.ts` behind `graphRetrievalEnabled`
  (default `false`).
- **PR 5 — LoCoMo A/B bench + default flip.** Measure lift; flip default
  if the threshold is met.

This PR deliberately stays in the "schema/surface contract" split from
the Cleaner PR Workflow in AGENTS.md. Reviewers: please push
retrieval-behavior or integration feedback to PR 4 rather than this
slice.

## Test plan

- `npx tsx --test packages/remnic-core/src/graph-retrieval.test.ts`
  (11 tests, all pass) — covers construction, optional weights, stub
  contract, and both type guards' accept/reject paths.
- `cd packages/remnic-core && npx tsc --noEmit` — clean.
- `npm run preflight:quick` — `check-types`, `check-config-contract`,
  and `check-review-patterns` all pass.

Refs #559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds new types/exports and a deliberately no-op function with tests; no existing retrieval behavior is modified.
> 
> **Overview**
> Introduces a new `graph-retrieval.ts` module that defines the public type contract for a future retrieval graph (`NodeType`/`EdgeType`, `RemnicGraph*` shapes, `QueryGraphOptions`/`QueryGraphResult`) plus `isNodeType`/`isEdgeType` guards.
> 
> Adds a no-op `queryGraph()` stub (always returns empty rankings), re-exports the new API from `@remnic/core`, and includes unit tests covering graph shape construction, optional weights, the stub contract, and type-guard accept/reject cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ea49fdcf6394855ef8e4a746e6ebb77b9ab42d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->