### PR TITLE
feat(coding): add pure GitContextResolver module (#569 PR 1/8)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -195,6 +195,7 @@ import {
   type RuntimePolicyValues,
 } from "./policy-runtime.js";
 import { resolveHomeDir } from "./runtime/env.js";
+import { expandTildePath } from "./utils/path.js";
 import { convertMemoriesToRecords } from "./training-export/converter.js";
 import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
@@ -830,21 +831,6 @@ function isWorkTaskPriority(value: string | undefined): value is "low" | "medium
 
 function isWorkProjectStatus(value: string | undefined): value is "active" | "on_hold" | "completed" | "archived" {
   return value === "active" || value === "on_hold" || value === "completed" || value === "archived";
-}
-
-/**
- * Expand a leading `~` or `~/` in a user-supplied path to the real home
- * directory. Node.js `fs` does NOT expand `~` (per CLAUDE.md #17), and this
- * applies to every user-facing path input, not just `memoryDir`.
- * Uses `resolveHomeDir()` so that the `HOME` env-var override path is respected
- * consistently with the rest of the codebase.
- */
-function expandTildePath(p: string): string {
-  if (p === "~") return resolveHomeDir();
-  if (p.startsWith("~/") || p.startsWith("~\\")) {
-    return path.join(resolveHomeDir(), p.slice(2));
-  }
-  return p;
 }
 
 export async function runTrainingExportCliCommand(

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -139,6 +139,24 @@ test("normalizeOriginUrl: git:// protocol form", () => {
   );
 });
 
+test("normalizeOriginUrl: uppercase .GIT suffix stripped (case-insensitive)", () => {
+  // Regression: earlier `.endsWith('.git')` was case-sensitive, so `.GIT`
+  // leaked through and appeared as `.git` in the lowercased output.
+  assert.equal(
+    normalizeOriginUrl("https://github.com/foo/bar.GIT"),
+    "github.com/foo/bar",
+  );
+  assert.equal(
+    normalizeOriginUrl("https://github.com/foo/bar.Git"),
+    "github.com/foo/bar",
+  );
+  assert.equal(
+    normalizeOriginUrl("https://github.com/foo/bar.git"),
+    normalizeOriginUrl("https://github.com/foo/bar.GIT"),
+    "case of .git suffix must not affect normalization",
+  );
+});
+
 test("normalizeOriginUrl: case-insensitive", () => {
   assert.equal(
     normalizeOriginUrl("https://GitHub.com/Foo/Bar.git"),
@@ -211,6 +229,29 @@ test("resolveGitContext: outside a git repo returns null", async () => {
 test("resolveGitContext: git not on PATH (exit 127) returns null", async () => {
   const invoker: GitInvoker = () => ({ stdout: "", exitCode: 127 });
   const ctx = await resolveGitContext("/tmp/anything", { invoker });
+  assert.equal(ctx, null);
+});
+
+test("resolveGitContext: custom invoker throwing synchronously → returns null (never throws contract)", async () => {
+  // Regression: the documented "Never throws" contract had no top-level
+  // try/catch. A misbehaving custom invoker used to propagate its error.
+  const invoker: GitInvoker = () => {
+    throw new Error("synthetic invoker failure");
+  };
+  const ctx = await resolveGitContext("/tmp/anything", { invoker });
+  assert.equal(ctx, null);
+});
+
+test("resolveGitContext: custom invoker throwing on a later call → returns null", async () => {
+  // First call succeeds (pretend we're in a repo), subsequent call throws.
+  // Must still resolve to null rather than leaking the error.
+  let callCount = 0;
+  const invoker: GitInvoker = (cwd) => {
+    callCount += 1;
+    if (callCount === 1) return { stdout: `${cwd}\n`, exitCode: 0 };
+    throw new Error(`synthetic failure on call ${callCount}`);
+  };
+  const ctx = await resolveGitContext("/work/repo", { invoker });
   assert.equal(ctx, null);
 });
 

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -82,18 +82,18 @@ test("normalizeOriginUrl: ssh:// protocol form normalizes", () => {
   assert.equal(sshProto, "github.com/foo/bar");
 });
 
-test("normalizeOriginUrl: ssh:// with non-standard port — port stripped, host preserved", () => {
-  // Regression: earlier scp-style regex greedily matched the whole URL
-  // because the proto branch ran second. Ordering fix routes ssh:// through
-  // the protocol branch first.
+test("normalizeOriginUrl: ssh:// with non-standard port — port preserved on host", () => {
+  // Port is preserved so `host:2222/foo/bar` and `host/foo/bar` route to
+  // different project namespaces. Losing the port would false-coalesce
+  // separate repos on custom SSH mesh setups.
   assert.equal(
     normalizeOriginUrl("ssh://git@github.com:2222/foo/bar.git"),
-    "github.com/foo/bar",
+    "github.com:2222/foo/bar",
   );
 });
 
-test("normalizeOriginUrl: ssh:// and ssh://...:port normalize to the same string (port ignored)", () => {
-  assert.equal(
+test("normalizeOriginUrl: ssh://host:port and ssh://host normalize to distinct strings", () => {
+  assert.notEqual(
     normalizeOriginUrl("ssh://git@github.com/foo/bar.git"),
     normalizeOriginUrl("ssh://git@github.com:2222/foo/bar.git"),
   );
@@ -136,10 +136,10 @@ test("normalizeOriginUrl: IPv6 host in protocol URL", () => {
     normalizeOriginUrl("https://[2001:db8::1]/org/repo.git"),
     "2001:db8::1/org/repo",
   );
-  // Port is discarded, same host + path as the non-port form.
+  // Port is preserved on the host part of the output.
   assert.equal(
     normalizeOriginUrl("ssh://[2001:db8::1]:2222/org/repo.git"),
-    normalizeOriginUrl("ssh://[2001:db8::1]/org/repo.git"),
+    "2001:db8::1:2222/org/repo",
   );
 });
 
@@ -155,10 +155,10 @@ test("normalizeOriginUrl: single-character scp host alias is accepted", () => {
   );
 });
 
-test("normalizeOriginUrl: https:// with non-standard port — port stripped", () => {
+test("normalizeOriginUrl: https:// with non-standard port — port preserved on host", () => {
   assert.equal(
     normalizeOriginUrl("https://github.com:8443/foo/bar.git"),
-    "github.com/foo/bar",
+    "github.com:8443/foo/bar",
   );
 });
 

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -107,6 +107,14 @@ test("normalizeOriginUrl: userless scp form (`host:path`) normalizes identically
   assert.equal(normalizeOriginUrl("github.com:foo/bar.git"), "github.com/foo/bar");
 });
 
+test("normalizeOriginUrl: scp paths may start with digits", () => {
+  // Valid scp remote where the first path segment is purely numeric.
+  assert.equal(
+    normalizeOriginUrl("git@host:123/repo.git"),
+    "host/123/repo",
+  );
+});
+
 test("normalizeOriginUrl: https:// with non-standard port — port stripped", () => {
   assert.equal(
     normalizeOriginUrl("https://github.com:8443/foo/bar.git"),

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -115,6 +115,16 @@ test("normalizeOriginUrl: scp paths may start with digits", () => {
   );
 });
 
+test("normalizeOriginUrl: Windows drive-letter path is not parsed as scp", () => {
+  // `git remote get-url origin` can return `C:/repos/app.git` for local
+  // Windows paths.  A single-letter host should not trigger scp parsing.
+  // Expected: raw-lowercase fallback (without `.git`).
+  assert.equal(
+    normalizeOriginUrl("C:/repos/app.git"),
+    "c:/repos/app",
+  );
+});
+
 test("normalizeOriginUrl: https:// with non-standard port — port stripped", () => {
   assert.equal(
     normalizeOriginUrl("https://github.com:8443/foo/bar.git"),

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -136,10 +136,17 @@ test("normalizeOriginUrl: IPv6 host in protocol URL", () => {
     normalizeOriginUrl("https://[2001:db8::1]/org/repo.git"),
     "2001:db8::1/org/repo",
   );
-  // Port is preserved on the host part of the output.
+  // Port is preserved. IPv6 brackets stay when a port is attached so the
+  // `host:port` boundary can't collide with a longer bare IPv6 literal.
   assert.equal(
     normalizeOriginUrl("ssh://[2001:db8::1]:2222/org/repo.git"),
-    "2001:db8::1:2222/org/repo",
+    "[2001:db8::1]:2222/org/repo",
+  );
+  // Regression: `[2001:db8::1]:2222` (IPv6 + port) must not normalize
+  // to the same string as the longer bare address `2001:db8::1:2222`.
+  assert.notEqual(
+    normalizeOriginUrl("ssh://[2001:db8::1]:2222/org/repo.git"),
+    normalizeOriginUrl("ssh://[2001:db8::1:2222]/org/repo.git"),
   );
 });
 

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -1,0 +1,309 @@
+/**
+ * Tests for `resolveGitContext` (issue #569 PR 1).
+ *
+ * All fixtures synthetic — no real repositories, no real user data. The git
+ * invocation layer is mocked via the `GitInvoker` seam so the tests never
+ * spawn a real `git` process.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  expandTildePath,
+  normalizeOriginUrl,
+  resolveGitContext,
+  stableHash,
+  type GitInvoker,
+} from "./git-context.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Mock invoker helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+type InvokeKey = string;
+
+function keyFor(cwd: string, args: string[]): InvokeKey {
+  return `${cwd}::${args.join(" ")}`;
+}
+
+/**
+ * Build a deterministic mock invoker keyed on `${cwd}::${args.join(' ')}`.
+ * Any unregistered call returns exitCode 1 with empty stdout so tests fail
+ * loudly when they exercise an unexpected code path.
+ */
+function mockInvoker(responses: Record<InvokeKey, { stdout: string; exitCode: number }>): GitInvoker {
+  return (cwd, args) => {
+    const key = keyFor(cwd, args);
+    if (key in responses) {
+      const resp = responses[key];
+      if (resp) return resp;
+    }
+    return { stdout: "", exitCode: 1 };
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// expandTildePath
+// ──────────────────────────────────────────────────────────────────────────
+
+test("expandTildePath: returns input unchanged when no leading `~`", () => {
+  assert.equal(expandTildePath("/abs/path"), "/abs/path");
+  assert.equal(expandTildePath("relative/path"), "relative/path");
+});
+
+test("expandTildePath: expands bare `~` to home dir", () => {
+  const out = expandTildePath("~");
+  assert.notEqual(out, "~");
+  assert.ok(out.length > 1, "home dir should be non-empty");
+});
+
+test("expandTildePath: expands `~/sub` to <home>/sub", () => {
+  const out = expandTildePath("~/projects/remnic");
+  assert.ok(out.endsWith("/projects/remnic"), `expected suffix /projects/remnic, got: ${out}`);
+  assert.ok(!out.startsWith("~"), "tilde must be expanded");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// normalizeOriginUrl
+// ──────────────────────────────────────────────────────────────────────────
+
+test("normalizeOriginUrl: scp-style ssh and https form of same repo normalize equally", () => {
+  const scp = normalizeOriginUrl("git@github.com:foo/bar.git");
+  const https = normalizeOriginUrl("https://github.com/foo/bar.git");
+  const httpsNoDotGit = normalizeOriginUrl("https://github.com/foo/bar");
+  assert.equal(scp, "github.com/foo/bar");
+  assert.equal(https, "github.com/foo/bar");
+  assert.equal(httpsNoDotGit, "github.com/foo/bar");
+});
+
+test("normalizeOriginUrl: ssh:// protocol form normalizes", () => {
+  const sshProto = normalizeOriginUrl("ssh://git@github.com/foo/bar.git");
+  assert.equal(sshProto, "github.com/foo/bar");
+});
+
+test("normalizeOriginUrl: case-insensitive", () => {
+  assert.equal(
+    normalizeOriginUrl("https://GitHub.com/Foo/Bar.git"),
+    "github.com/foo/bar",
+  );
+});
+
+test("normalizeOriginUrl: empty input yields empty string", () => {
+  assert.equal(normalizeOriginUrl(""), "");
+  assert.equal(normalizeOriginUrl("   "), "");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// stableHash
+// ──────────────────────────────────────────────────────────────────────────
+
+test("stableHash: deterministic — same input always yields same output", () => {
+  const a = stableHash("github.com/foo/bar");
+  const b = stableHash("github.com/foo/bar");
+  assert.equal(a, b);
+});
+
+test("stableHash: different inputs produce different outputs", () => {
+  const a = stableHash("github.com/foo/bar");
+  const b = stableHash("github.com/foo/baz");
+  assert.notEqual(a, b);
+});
+
+test("stableHash: output is 8-char lowercase hex", () => {
+  const out = stableHash("anything");
+  assert.match(out, /^[0-9a-f]{8}$/);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveGitContext — invalid inputs
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveGitContext: empty cwd returns null", async () => {
+  const ctx = await resolveGitContext("", { invoker: mockInvoker({}) });
+  assert.equal(ctx, null);
+});
+
+test("resolveGitContext: non-absolute cwd returns null (CLAUDE.md #51)", async () => {
+  const ctx = await resolveGitContext("relative/path", { invoker: mockInvoker({}) });
+  assert.equal(ctx, null);
+});
+
+test("resolveGitContext: non-string cwd returns null", async () => {
+  // @ts-expect-error — intentionally exercising defensive branch
+  const ctx = await resolveGitContext(undefined, { invoker: mockInvoker({}) });
+  assert.equal(ctx, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveGitContext — outside a repo
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveGitContext: outside a git repo returns null", async () => {
+  // rev-parse --show-toplevel exits non-zero.
+  const invoker = mockInvoker({
+    [keyFor("/tmp/not-a-repo", ["rev-parse", "--show-toplevel"])]: {
+      stdout: "",
+      exitCode: 128,
+    },
+  });
+  const ctx = await resolveGitContext("/tmp/not-a-repo", { invoker });
+  assert.equal(ctx, null);
+});
+
+test("resolveGitContext: git not on PATH (exit 127) returns null", async () => {
+  const invoker: GitInvoker = () => ({ stdout: "", exitCode: 127 });
+  const ctx = await resolveGitContext("/tmp/anything", { invoker });
+  assert.equal(ctx, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveGitContext — happy path (origin, branch, default branch)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveGitContext: full happy path with origin + branch + default branch", async () => {
+  const cwd = "/work/proj-a";
+  const root = "/work/proj-a";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "feat/ui\n", exitCode: 0 },
+    [keyFor(root, ["remote", "get-url", "origin"])]: {
+      stdout: "git@github.com:acme/proj-a.git\n",
+      exitCode: 0,
+    },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "refs/remotes/origin/main\n",
+      exitCode: 0,
+    },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx, "context should resolve");
+  assert.equal(ctx?.rootPath, root);
+  assert.equal(ctx?.branch, "feat/ui");
+  assert.equal(ctx?.defaultBranch, "main");
+  assert.ok(ctx?.projectId.startsWith("origin:"), `expected origin: prefix, got ${ctx?.projectId}`);
+  assert.match(ctx?.projectId ?? "", /^origin:[0-9a-f]{8}$/);
+});
+
+test("resolveGitContext: projectId is equal for scp and https forms of same repo", async () => {
+  const scpRoot = "/work/scp";
+  const httpsRoot = "/work/https";
+
+  const scpInvoker = mockInvoker({
+    [keyFor(scpRoot, ["rev-parse", "--show-toplevel"])]: { stdout: `${scpRoot}\n`, exitCode: 0 },
+    [keyFor(scpRoot, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "main\n", exitCode: 0 },
+    [keyFor(scpRoot, ["remote", "get-url", "origin"])]: {
+      stdout: "git@github.com:acme/same.git\n",
+      exitCode: 0,
+    },
+    [keyFor(scpRoot, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "",
+      exitCode: 1,
+    },
+  });
+
+  const httpsInvoker = mockInvoker({
+    [keyFor(httpsRoot, ["rev-parse", "--show-toplevel"])]: { stdout: `${httpsRoot}\n`, exitCode: 0 },
+    [keyFor(httpsRoot, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "main\n", exitCode: 0 },
+    [keyFor(httpsRoot, ["remote", "get-url", "origin"])]: {
+      stdout: "https://github.com/acme/same\n",
+      exitCode: 0,
+    },
+    [keyFor(httpsRoot, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "",
+      exitCode: 1,
+    },
+  });
+
+  const scpCtx = await resolveGitContext(scpRoot, { invoker: scpInvoker });
+  const httpsCtx = await resolveGitContext(httpsRoot, { invoker: httpsInvoker });
+  assert.ok(scpCtx && httpsCtx);
+  assert.equal(scpCtx!.projectId, httpsCtx!.projectId, "same repo via different remote URL forms must share projectId");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveGitContext — partial / degraded inputs
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveGitContext: detached HEAD — branch is null", async () => {
+  const cwd = "/work/detached";
+  const root = "/work/detached";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "HEAD\n", exitCode: 0 },
+    [keyFor(root, ["remote", "get-url", "origin"])]: { stdout: "git@github.com:acme/x.git\n", exitCode: 0 },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "refs/remotes/origin/main\n",
+      exitCode: 0,
+    },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx);
+  assert.equal(ctx!.branch, null);
+  assert.equal(ctx!.defaultBranch, "main");
+});
+
+test("resolveGitContext: no origin remote — falls back to root: projectId", async () => {
+  const cwd = "/work/no-origin";
+  const root = "/work/no-origin";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "main\n", exitCode: 0 },
+    // origin lookup fails
+    [keyFor(root, ["remote", "get-url", "origin"])]: { stdout: "", exitCode: 128 },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: { stdout: "", exitCode: 1 },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx);
+  assert.match(ctx!.projectId, /^root:[0-9a-f]{8}$/);
+  assert.equal(ctx!.defaultBranch, null);
+});
+
+test("resolveGitContext: no origin HEAD symref — defaultBranch is null", async () => {
+  const cwd = "/work/no-head";
+  const root = "/work/no-head";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "main\n", exitCode: 0 },
+    [keyFor(root, ["remote", "get-url", "origin"])]: {
+      stdout: "git@github.com:acme/x.git\n",
+      exitCode: 0,
+    },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "",
+      exitCode: 1,
+    },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx);
+  assert.equal(ctx!.defaultBranch, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveGitContext — rootPath vs cwd
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveGitContext: cwd inside repo returns repo root, not cwd", async () => {
+  const cwd = "/work/proj/src/deep/dir";
+  const root = "/work/proj";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "main\n", exitCode: 0 },
+    [keyFor(root, ["remote", "get-url", "origin"])]: {
+      stdout: "git@github.com:acme/proj.git\n",
+      exitCode: 0,
+    },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "refs/remotes/origin/main\n",
+      exitCode: 0,
+    },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx);
+  assert.equal(ctx!.rootPath, root);
+});

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -199,6 +199,22 @@ test("normalizeOriginUrl: empty input yields empty string", () => {
   assert.equal(normalizeOriginUrl("   "), "");
 });
 
+test("normalizeOriginUrl: scp-style IPv6 host matches ssh:// IPv6 host", () => {
+  // Regression: git accepts `git@[2001:db8::1]:org/repo.git` as an scp
+  // remote. Without bracket-aware parsing the regex split on the first
+  // internal `:` of the IPv6 literal, producing a malformed host and a
+  // different projectId from the equivalent ssh://[...]/ form.
+  assert.equal(
+    normalizeOriginUrl("git@[2001:db8::1]:org/repo.git"),
+    "2001:db8::1/org/repo",
+  );
+  assert.equal(
+    normalizeOriginUrl("git@[2001:db8::1]:org/repo.git"),
+    normalizeOriginUrl("ssh://git@[2001:db8::1]/org/repo.git"),
+    "scp and ssh:// IPv6 forms must normalize identically",
+  );
+});
+
 test("normalizeOriginUrl: file:/// URLs do not fall through to scp parser", () => {
   // Regression: `file:///path/to/repo` has an empty host component. Before the
   // fix, the protocol regex required a non-empty host and so fell through to

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -82,6 +82,37 @@ test("normalizeOriginUrl: ssh:// protocol form normalizes", () => {
   assert.equal(sshProto, "github.com/foo/bar");
 });
 
+test("normalizeOriginUrl: ssh:// with non-standard port — port stripped, host preserved", () => {
+  // Regression: earlier scp-style regex greedily matched the whole URL
+  // because the proto branch ran second. Ordering fix routes ssh:// through
+  // the protocol branch first.
+  assert.equal(
+    normalizeOriginUrl("ssh://git@github.com:2222/foo/bar.git"),
+    "github.com/foo/bar",
+  );
+});
+
+test("normalizeOriginUrl: ssh:// and ssh://...:port normalize to the same string (port ignored)", () => {
+  assert.equal(
+    normalizeOriginUrl("ssh://git@github.com/foo/bar.git"),
+    normalizeOriginUrl("ssh://git@github.com:2222/foo/bar.git"),
+  );
+});
+
+test("normalizeOriginUrl: https:// with non-standard port — port stripped", () => {
+  assert.equal(
+    normalizeOriginUrl("https://github.com:8443/foo/bar.git"),
+    "github.com/foo/bar",
+  );
+});
+
+test("normalizeOriginUrl: git:// protocol form", () => {
+  assert.equal(
+    normalizeOriginUrl("git://github.com/foo/bar.git"),
+    "github.com/foo/bar",
+  );
+});
+
 test("normalizeOriginUrl: case-insensitive", () => {
   assert.equal(
     normalizeOriginUrl("https://GitHub.com/Foo/Bar.git"),

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -199,6 +199,29 @@ test("normalizeOriginUrl: empty input yields empty string", () => {
   assert.equal(normalizeOriginUrl("   "), "");
 });
 
+test("normalizeOriginUrl: file:/// URLs do not fall through to scp parser", () => {
+  // Regression: `file:///path/to/repo` has an empty host component. Before the
+  // fix, the protocol regex required a non-empty host and so fell through to
+  // the scp regex, which mis-parsed `file` as the host and `///path/to/repo`
+  // as the path, producing `file/path/to/repo`. Now the protocol regex
+  // accepts an empty host and `file://` URLs normalize under a stable
+  // `localhost/<path>` prefix.
+  assert.equal(
+    normalizeOriginUrl("file:///path/to/repo"),
+    "localhost/path/to/repo",
+  );
+  // Two distinct local file paths must NOT collapse to the same namespace.
+  assert.notEqual(
+    normalizeOriginUrl("file:///home/alice/repo"),
+    normalizeOriginUrl("file:///home/bob/repo"),
+  );
+  // file:// with an explicit host still normalizes under that host.
+  assert.equal(
+    normalizeOriginUrl("file://host.example/path/to/repo"),
+    "host.example/path/to/repo",
+  );
+});
+
 // ──────────────────────────────────────────────────────────────────────────
 // stableHash
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -124,6 +124,25 @@ test("normalizeOriginUrl: Windows drive-letter path is not parsed as scp", () =>
   );
 });
 
+test("normalizeOriginUrl: IPv6 host in protocol URL", () => {
+  // Valid git remotes may use bracketed IPv6 addresses. The brackets are
+  // stripped in the normalised form since they were only for
+  // URL-level port disambiguation.
+  assert.equal(
+    normalizeOriginUrl("ssh://git@[2001:db8::1]/org/repo.git"),
+    "2001:db8::1/org/repo",
+  );
+  assert.equal(
+    normalizeOriginUrl("https://[2001:db8::1]/org/repo.git"),
+    "2001:db8::1/org/repo",
+  );
+  // Port is discarded, same host + path as the non-port form.
+  assert.equal(
+    normalizeOriginUrl("ssh://[2001:db8::1]:2222/org/repo.git"),
+    normalizeOriginUrl("ssh://[2001:db8::1]/org/repo.git"),
+  );
+});
+
 test("normalizeOriginUrl: single-character scp host alias is accepted", () => {
   // `.ssh/config` host aliases may be a single character (`h:foo/bar`),
   // and git treats those as scp remotes. The Windows drive-letter check

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -99,6 +99,14 @@ test("normalizeOriginUrl: ssh:// and ssh://...:port normalize to the same string
   );
 });
 
+test("normalizeOriginUrl: userless scp form (`host:path`) normalizes identically to user@ form", () => {
+  assert.equal(
+    normalizeOriginUrl("github.com:foo/bar.git"),
+    normalizeOriginUrl("git@github.com:foo/bar.git"),
+  );
+  assert.equal(normalizeOriginUrl("github.com:foo/bar.git"), "github.com/foo/bar");
+});
+
 test("normalizeOriginUrl: https:// with non-standard port — port stripped", () => {
   assert.equal(
     normalizeOriginUrl("https://github.com:8443/foo/bar.git"),

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -117,11 +117,22 @@ test("normalizeOriginUrl: scp paths may start with digits", () => {
 
 test("normalizeOriginUrl: Windows drive-letter path is not parsed as scp", () => {
   // `git remote get-url origin` can return `C:/repos/app.git` for local
-  // Windows paths.  A single-letter host should not trigger scp parsing.
-  // Expected: raw-lowercase fallback (without `.git`).
+  // Windows paths. The drive-letter branch short-circuits scp parsing.
   assert.equal(
     normalizeOriginUrl("C:/repos/app.git"),
     "c:/repos/app",
+  );
+});
+
+test("normalizeOriginUrl: single-character scp host alias is accepted", () => {
+  // `.ssh/config` host aliases may be a single character (`h:foo/bar`),
+  // and git treats those as scp remotes. The Windows drive-letter check
+  // only matches `[A-Za-z]:[\\/]`, so a single-char alias followed by
+  // `:<path>` (no slash immediately after the colon) still falls through
+  // to scp.
+  assert.equal(
+    normalizeOriginUrl("h:foo/bar.git"),
+    "h/foo/bar",
   );
 });
 
@@ -379,6 +390,30 @@ test("resolveGitContext: no origin HEAD symref — defaultBranch is null", async
   const ctx = await resolveGitContext(cwd, { invoker });
   assert.ok(ctx);
   assert.equal(ctx!.defaultBranch, null);
+});
+
+test("resolveGitContext: unborn HEAD repo — branch recovered from symbolic-ref HEAD", async () => {
+  // Fresh `git init` leaves HEAD unborn: `rev-parse --abbrev-ref HEAD`
+  // fails, but `symbolic-ref HEAD` still returns `refs/heads/main`.
+  const cwd = "/work/fresh";
+  const root = "/work/fresh";
+  const invoker = mockInvoker({
+    [keyFor(cwd, ["rev-parse", "--show-toplevel"])]: { stdout: `${root}\n`, exitCode: 0 },
+    [keyFor(root, ["rev-parse", "--abbrev-ref", "HEAD"])]: { stdout: "", exitCode: 128 },
+    [keyFor(root, ["symbolic-ref", "--quiet", "HEAD"])]: {
+      stdout: "refs/heads/main\n",
+      exitCode: 0,
+    },
+    [keyFor(root, ["remote", "get-url", "origin"])]: { stdout: "", exitCode: 1 },
+    [keyFor(root, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"])]: {
+      stdout: "",
+      exitCode: 1,
+    },
+  });
+
+  const ctx = await resolveGitContext(cwd, { invoker });
+  assert.ok(ctx);
+  assert.equal(ctx!.branch, "main");
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -146,8 +146,11 @@ export function normalizeOriginUrl(rawUrl: string): string {
   let url = rawUrl.trim();
   if (!url) return "";
 
-  // Strip trailing `.git`
-  if (url.endsWith(".git")) url = url.slice(0, -4);
+  // Strip trailing `.git` case-insensitively — the whole result is
+  // lowercased at the end, so `.GIT` / `.Git` must be treated the same as
+  // `.git`. Previously the `.endsWith(".git")` check let `.GIT` leak
+  // through and appear in the output.
+  if (/\.git$/i.test(url)) url = url.slice(0, -4);
 
   // Protocol-prefixed: ssh://, https://, http://, git://, file://
   // Must be tried FIRST so that scp-style detection below doesn't
@@ -209,60 +212,69 @@ export async function resolveGitContext(
   cwd: string,
   options: ResolveGitContextOptions = {},
 ): Promise<GitContext | null> {
-  // Validate input: must be a non-empty string.
-  if (typeof cwd !== "string" || cwd.length === 0) return null;
+  // Wrap the whole body so the documented "Never throws" contract is
+  // enforced. Possible throw sites include:
+  //   - `expandTildePath` → `resolveHomeDir()` → `os.homedir()` when HOME
+  //     is unset (e.g. minimal containers)
+  //   - a custom `options.invoker` that raises instead of returning a
+  //     non-zero exitCode
+  //   - any future helper added to this chain
+  // All of those map to "not in a repo" / `null`.
+  try {
+    // Validate input: must be a non-empty string.
+    if (typeof cwd !== "string" || cwd.length === 0) return null;
 
-  // Expand `~` per CLAUDE.md #17, then require absolute path.
-  const expanded = expandTildePath(cwd);
-  if (!path.isAbsolute(expanded)) return null;
+    // Expand `~` per CLAUDE.md #17, then require absolute path.
+    const expanded = expandTildePath(cwd);
+    if (!path.isAbsolute(expanded)) return null;
 
-  const invoker = options.invoker ?? defaultGitInvoker();
+    const invoker = options.invoker ?? defaultGitInvoker();
 
-  // 1. Locate the repo root. `rev-parse --show-toplevel` returns the absolute
-  //    path to the top of the working tree, or exits non-zero when outside a
-  //    repo.
-  const topLevel = invoker(expanded, ["rev-parse", "--show-toplevel"]);
-  if (topLevel.exitCode !== 0) return null;
-  const rootPath = topLevel.stdout.trim();
-  if (!rootPath) return null;
+    // 1. Locate the repo root.
+    const topLevel = invoker(expanded, ["rev-parse", "--show-toplevel"]);
+    if (topLevel.exitCode !== 0) return null;
+    const rootPath = topLevel.stdout.trim();
+    if (!rootPath) return null;
 
-  // 2. Current branch. `--abbrev-ref HEAD` returns `HEAD` in detached state,
-  //    which we normalize to `null`.
-  const branchResult = invoker(rootPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
-  let branch: string | null = null;
-  if (branchResult.exitCode === 0) {
-    const raw = branchResult.stdout.trim();
-    branch = raw && raw !== "HEAD" ? raw : null;
-  }
-
-  // 3. Origin URL — optional. Used to derive a stable `projectId`.
-  const originResult = invoker(rootPath, ["remote", "get-url", "origin"]);
-  let projectId: string;
-  if (originResult.exitCode === 0) {
-    const normalized = normalizeOriginUrl(originResult.stdout);
-    projectId = normalized ? `origin:${stableHash(normalized)}` : `root:${stableHash(rootPath)}`;
-  } else {
-    // No origin remote — fall back to hashing the root path.
-    projectId = `root:${stableHash(rootPath)}`;
-  }
-
-  // 4. Default branch — best effort. `symbolic-ref refs/remotes/origin/HEAD`
-  //    returns e.g. `refs/remotes/origin/main`.
-  const headRef = invoker(rootPath, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"]);
-  let defaultBranch: string | null = null;
-  if (headRef.exitCode === 0) {
-    const raw = headRef.stdout.trim();
-    const prefix = "refs/remotes/origin/";
-    if (raw.startsWith(prefix)) {
-      const candidate = raw.slice(prefix.length);
-      if (candidate) defaultBranch = candidate;
+    // 2. Current branch. `--abbrev-ref HEAD` returns `HEAD` in detached
+    //    state, which we normalize to `null`.
+    const branchResult = invoker(rootPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    let branch: string | null = null;
+    if (branchResult.exitCode === 0) {
+      const raw = branchResult.stdout.trim();
+      branch = raw && raw !== "HEAD" ? raw : null;
     }
-  }
 
-  return {
-    projectId,
-    branch,
-    rootPath,
-    defaultBranch,
-  };
+    // 3. Origin URL — optional. Used to derive a stable `projectId`.
+    const originResult = invoker(rootPath, ["remote", "get-url", "origin"]);
+    let projectId: string;
+    if (originResult.exitCode === 0) {
+      const normalized = normalizeOriginUrl(originResult.stdout);
+      projectId = normalized ? `origin:${stableHash(normalized)}` : `root:${stableHash(rootPath)}`;
+    } else {
+      projectId = `root:${stableHash(rootPath)}`;
+    }
+
+    // 4. Default branch — best effort.
+    const headRef = invoker(rootPath, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"]);
+    let defaultBranch: string | null = null;
+    if (headRef.exitCode === 0) {
+      const raw = headRef.stdout.trim();
+      const prefix = "refs/remotes/origin/";
+      if (raw.startsWith(prefix)) {
+        const candidate = raw.slice(prefix.length);
+        if (candidate) defaultBranch = candidate;
+      }
+    }
+
+    return {
+      projectId,
+      branch,
+      rootPath,
+      defaultBranch,
+    };
+  } catch {
+    // Never throws — any unexpected error falls back to "not in a repo".
+    return null;
+  }
 }

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -1,0 +1,260 @@
+/**
+ * GitContextResolver — pure module for detecting the git project + branch
+ * a session is operating in.
+ *
+ * Introduced by issue #569 (coding-agent project/branch-scoped namespaces).
+ *
+ * This module is deliberately pure:
+ *   - no orchestrator references
+ *   - no config side-effects
+ *   - no namespace wiring
+ *
+ * Downstream slices (PR 2+ of #569) wire `resolveGitContext` into the
+ * `NamespaceResolver` / `Orchestrator` so that memories are scoped to a
+ * detected project / branch without leaking across repos.
+ *
+ * CLAUDE.md rule 17 (expand `~`): the `rootPath` returned here is always an
+ * absolute, tilde-expanded path. Callers must not re-expand.
+ *
+ * CLAUDE.md rule 51 (reject invalid input): `cwd` must be an absolute path
+ * and must exist. `resolveGitContext` returns `null` — rather than throwing —
+ * when the directory is not inside a git worktree, because being outside a
+ * repo is a normal runtime state (e.g. agent opened in a scratch dir).
+ */
+import path from "node:path";
+
+import { resolveHomeDir } from "../runtime/env.js";
+import { launchProcessSync } from "../runtime/child-process.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Public types
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface GitContext {
+  /**
+   * Stable identifier for the project. Derived from `git remote get-url origin`
+   * when an origin remote is configured, otherwise from the repo root path.
+   *
+   * Formatted as `origin:<hex>` or `root:<hex>` so that the source is visible
+   * to operators (see `remnic doctor`, issue #569 acceptance criteria).
+   */
+  projectId: string;
+  /**
+   * Current branch, e.g. `main`, `feat/foo`. `null` only in detached-HEAD
+   * state (e.g. rebase in progress). Callers should treat `null` as "no
+   * branch-scope overlay applies" without erroring.
+   */
+  branch: string | null;
+  /**
+   * Absolute path to the repository root (the directory containing `.git`).
+   * Tilde-expanded per CLAUDE.md #17.
+   */
+  rootPath: string;
+  /**
+   * Best-effort default branch (usually `main` or `master`). Derived from the
+   * `refs/remotes/origin/HEAD` symbolic ref. `null` when not available (e.g.
+   * fresh clone without a default branch symref, or no origin remote).
+   */
+  defaultBranch: string | null;
+}
+
+/**
+ * Injectable git-invocation surface. Only the commands `resolveGitContext`
+ * actually needs are exposed. Tests inject a mock implementation to avoid
+ * spawning a real git process.
+ */
+export interface GitInvoker {
+  /**
+   * Run `git <args>` with `cwd` as the working directory. Must return
+   * `{ stdout, exitCode }` with `stdout` trimmed by the caller as needed.
+   * Implementations should NOT throw for non-zero exit codes — they should
+   * return the exit code so the resolver can decide how to recover.
+   */
+  (cwd: string, args: string[]): { stdout: string; exitCode: number };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tilde expansion (CLAUDE.md #17)
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Expand a leading `~` to the home directory. Matches the CLI helper pattern
+ * so behavior is consistent across user-facing path inputs.
+ */
+export function expandTildePath(p: string): string {
+  if (p === "~") return resolveHomeDir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(resolveHomeDir(), p.slice(2));
+  }
+  return p;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Default git invoker — spawns real `git` via the shared child-process helper
+// ──────────────────────────────────────────────────────────────────────────
+
+const DEFAULT_GIT_TIMEOUT_MS = 2_000;
+
+export function defaultGitInvoker(): GitInvoker {
+  return (cwd: string, args: string[]) => {
+    const result = launchProcessSync("git", args, {
+      cwd,
+      encoding: "utf-8",
+      timeout: DEFAULT_GIT_TIMEOUT_MS,
+      shell: false,
+    });
+    if (result.error) {
+      // Spawn failure (git not on PATH, timeout, etc.). Surface as non-zero.
+      return { stdout: "", exitCode: 127 };
+    }
+    return {
+      stdout: typeof result.stdout === "string" ? result.stdout : "",
+      exitCode: typeof result.status === "number" ? result.status : 1,
+    };
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Stable hashing
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Non-cryptographic stable hash. Used only to derive a deterministic
+ * `projectId` from either the origin URL or the root path. The hash does not
+ * need to be collision-resistant against adversarial input — it is purely a
+ * namespace discriminator.
+ *
+ * Uses FNV-1a 32-bit so we don't pull in `node:crypto` for a simple bucket
+ * key. Output is lowercase hex, zero-padded to 8 characters.
+ */
+export function stableHash(input: string): string {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Origin URL normalization
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a git remote URL so that equivalent SSH / HTTPS forms of the
+ * same repo produce the same `projectId`. Handles:
+ *   - `git@github.com:foo/bar.git`  → `github.com/foo/bar`
+ *   - `https://github.com/foo/bar`  → `github.com/foo/bar`
+ *   - `https://github.com/foo/bar.git` → `github.com/foo/bar`
+ *   - `ssh://git@github.com/foo/bar` → `github.com/foo/bar`
+ *
+ * Case-insensitive (remote hostnames and most repo paths on major forges are
+ * case-insensitive in practice).
+ */
+export function normalizeOriginUrl(rawUrl: string): string {
+  let url = rawUrl.trim();
+  if (!url) return "";
+
+  // Strip trailing `.git`
+  if (url.endsWith(".git")) url = url.slice(0, -4);
+
+  // scp-like syntax: user@host:path
+  const scpMatch = /^([^@\s]+)@([^:\s]+):(.+)$/.exec(url);
+  if (scpMatch) {
+    const host = scpMatch[2] ?? "";
+    const repoPath = scpMatch[3] ?? "";
+    return `${host}/${repoPath.replace(/^\/+/, "")}`.toLowerCase();
+  }
+
+  // Protocol-prefixed: ssh://, https://, http://, git://, file://
+  const protoMatch = /^[a-z]+:\/\/(?:[^@/]+@)?([^/]+)(\/.+)?$/i.exec(url);
+  if (protoMatch) {
+    const host = protoMatch[1] ?? "";
+    const repoPath = (protoMatch[2] ?? "").replace(/^\/+/, "");
+    return `${host}/${repoPath}`.toLowerCase();
+  }
+
+  // Fallback: use raw lowercased
+  return url.toLowerCase();
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Resolver
+// ──────────────────────────────────────────────────────────────────────────
+
+export interface ResolveGitContextOptions {
+  /** Inject a git invoker (tests). Defaults to spawning real `git`. */
+  invoker?: GitInvoker;
+}
+
+/**
+ * Detect the git project + branch for `cwd`.
+ *
+ * Returns `null` when:
+ *   - `cwd` is not an absolute path (invalid input, CLAUDE.md #51)
+ *   - `cwd` is not inside a git worktree
+ *   - `git` is not available on PATH
+ *
+ * Never throws.
+ */
+export async function resolveGitContext(
+  cwd: string,
+  options: ResolveGitContextOptions = {},
+): Promise<GitContext | null> {
+  // Validate input: must be a non-empty string.
+  if (typeof cwd !== "string" || cwd.length === 0) return null;
+
+  // Expand `~` per CLAUDE.md #17, then require absolute path.
+  const expanded = expandTildePath(cwd);
+  if (!path.isAbsolute(expanded)) return null;
+
+  const invoker = options.invoker ?? defaultGitInvoker();
+
+  // 1. Locate the repo root. `rev-parse --show-toplevel` returns the absolute
+  //    path to the top of the working tree, or exits non-zero when outside a
+  //    repo.
+  const topLevel = invoker(expanded, ["rev-parse", "--show-toplevel"]);
+  if (topLevel.exitCode !== 0) return null;
+  const rootPath = topLevel.stdout.trim();
+  if (!rootPath) return null;
+
+  // 2. Current branch. `--abbrev-ref HEAD` returns `HEAD` in detached state,
+  //    which we normalize to `null`.
+  const branchResult = invoker(rootPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  let branch: string | null = null;
+  if (branchResult.exitCode === 0) {
+    const raw = branchResult.stdout.trim();
+    branch = raw && raw !== "HEAD" ? raw : null;
+  }
+
+  // 3. Origin URL — optional. Used to derive a stable `projectId`.
+  const originResult = invoker(rootPath, ["remote", "get-url", "origin"]);
+  let projectId: string;
+  if (originResult.exitCode === 0) {
+    const normalized = normalizeOriginUrl(originResult.stdout);
+    projectId = normalized ? `origin:${stableHash(normalized)}` : `root:${stableHash(rootPath)}`;
+  } else {
+    // No origin remote — fall back to hashing the root path.
+    projectId = `root:${stableHash(rootPath)}`;
+  }
+
+  // 4. Default branch — best effort. `symbolic-ref refs/remotes/origin/HEAD`
+  //    returns e.g. `refs/remotes/origin/main`.
+  const headRef = invoker(rootPath, ["symbolic-ref", "--quiet", "refs/remotes/origin/HEAD"]);
+  let defaultBranch: string | null = null;
+  if (headRef.exitCode === 0) {
+    const raw = headRef.stdout.trim();
+    const prefix = "refs/remotes/origin/";
+    if (raw.startsWith(prefix)) {
+      const candidate = raw.slice(prefix.length);
+      if (candidate) defaultBranch = candidate;
+    }
+  }
+
+  return {
+    projectId,
+    branch,
+    rootPath,
+    defaultBranch,
+  };
+}

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -165,20 +165,22 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // Must be tried FIRST so that scp-style detection below doesn't
   // incorrectly swallow an ssh:// URL that happens to contain `:port/`.
   //
-  // Matches either:
-  //   - bracketed IPv6 host: `[2001:db8::1]` (captures `2001:db8::1`)
-  //   - plain host without `:` or `/` chars
-  // Followed by optional port and optional path.
+  // Matches:
+  //   1: host — bracketed IPv6 `[2001:db8::1]` or plain host with no `:` / `/`
+  //   2: port (optional) — preserved in the output so two repos on the same
+  //      host under different ports get distinct project namespaces.
+  //      Losing the port risked false-coalescing separate repos on custom
+  //      SSH mesh setups.
+  //   3: path (optional)
   const protoMatch =
-    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]+)(?::\d+)?(\/.*)?$/i.exec(url);
+    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]+)(?::(\d+))?(\/.*)?$/i.exec(url);
   if (protoMatch) {
     let host = protoMatch[1] ?? "";
-    // Strip surrounding `[]` on IPv6 hosts so the normalised form doesn't
-    // bring the brackets along (they were only for URL-level disambiguation
-    // of the port).
     if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
-    const repoPath = (protoMatch[2] ?? "").replace(/^\/+/, "");
-    return `${host}/${repoPath}`.toLowerCase();
+    const port = protoMatch[2];
+    const repoPath = (protoMatch[3] ?? "").replace(/^\/+/, "");
+    const hostPort = port ? `${host}:${port}` : host;
+    return `${hostPort}/${repoPath}`.toLowerCase();
   }
 
   // scp-like syntax: [user@]host:path. Deliberately rejects anything that

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -171,7 +171,11 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // digits (e.g. `git@host:123/repo.git`), so no numeric guard is needed:
   // port-bearing URLs have the `://` prefix and match the protocol branch
   // above before reaching here.
-  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(.+)$/.exec(url);
+  //
+  // Requires the host to be at least two characters to avoid misreading
+  // Windows local paths like `C:/repos/app.git` (which `git remote get-url
+  // origin` can return verbatim) as an scp remote with host `C`.
+  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]{2,}):(.+)$/.exec(url);
   if (scpMatch) {
     const host = scpMatch[2] ?? "";
     const repoPath = scpMatch[3] ?? "";

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -23,8 +23,14 @@
  */
 import path from "node:path";
 
-import { resolveHomeDir } from "../runtime/env.js";
+import { expandTildePath } from "../utils/path.js";
 import { launchProcessSync } from "../runtime/child-process.js";
+
+// Re-export so existing callers / tests that imported `expandTildePath` from
+// this module keep working. CLAUDE.md #17 requires consistent `~` expansion
+// across every user-facing path input; the canonical implementation now
+// lives in `utils/path.ts`.
+export { expandTildePath };
 
 // ──────────────────────────────────────────────────────────────────────────
 // Public types
@@ -71,22 +77,6 @@ export interface GitInvoker {
    * return the exit code so the resolver can decide how to recover.
    */
   (cwd: string, args: string[]): { stdout: string; exitCode: number };
-}
-
-// ──────────────────────────────────────────────────────────────────────────
-// Tilde expansion (CLAUDE.md #17)
-// ──────────────────────────────────────────────────────────────────────────
-
-/**
- * Expand a leading `~` to the home directory. Matches the CLI helper pattern
- * so behavior is consistent across user-facing path inputs.
- */
-export function expandTildePath(p: string): string {
-  if (p === "~") return resolveHomeDir();
-  if (p.startsWith("~/") || p.startsWith("~\\")) {
-    return path.join(resolveHomeDir(), p.slice(2));
-  }
-  return p;
 }
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -147,6 +137,7 @@ export function stableHash(input: string): string {
  *   - `https://github.com/foo/bar`  → `github.com/foo/bar`
  *   - `https://github.com/foo/bar.git` → `github.com/foo/bar`
  *   - `ssh://git@github.com/foo/bar` → `github.com/foo/bar`
+ *   - `ssh://git@github.com:2222/foo/bar` → `github.com/foo/bar` (port stripped)
  *
  * Case-insensitive (remote hostnames and most repo paths on major forges are
  * case-insensitive in practice).
@@ -158,20 +149,31 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // Strip trailing `.git`
   if (url.endsWith(".git")) url = url.slice(0, -4);
 
-  // scp-like syntax: user@host:path
-  const scpMatch = /^([^@\s]+)@([^:\s]+):(.+)$/.exec(url);
-  if (scpMatch) {
-    const host = scpMatch[2] ?? "";
-    const repoPath = scpMatch[3] ?? "";
-    return `${host}/${repoPath.replace(/^\/+/, "")}`.toLowerCase();
-  }
-
   // Protocol-prefixed: ssh://, https://, http://, git://, file://
-  const protoMatch = /^[a-z]+:\/\/(?:[^@/]+@)?([^/]+)(\/.+)?$/i.exec(url);
+  // Must be tried FIRST so that scp-style detection below doesn't
+  // incorrectly swallow an ssh:// URL that happens to contain `:port/`.
+  //
+  // Matching groups:
+  //   1: host (userinfo stripped)
+  //   2: port (optional, discarded — same repo on :22 vs :2222 is the
+  //      same repo for memory-routing purposes)
+  //   3: path (optional)
+  const protoMatch = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?(\/.*)?$/i.exec(url);
   if (protoMatch) {
     const host = protoMatch[1] ?? "";
     const repoPath = (protoMatch[2] ?? "").replace(/^\/+/, "");
     return `${host}/${repoPath}`.toLowerCase();
+  }
+
+  // scp-like syntax: user@host:path. Deliberately rejects anything that
+  // contains `://` (handled above), and uses `[^:@/\s]+` for the host so that
+  // `git@host:port/repo` is only treated as scp when the part after `:` is
+  // non-numeric — scp paths start with a path component, not a port number.
+  const scpMatch = /^([^@\s/]+)@([^:@\s/]+):(.+)$/.exec(url);
+  if (scpMatch) {
+    const host = scpMatch[2] ?? "";
+    const repoPath = scpMatch[3] ?? "";
+    return `${host}/${repoPath.replace(/^\/+/, "")}`.toLowerCase();
   }
 
   // Fallback: use raw lowercased

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -167,11 +167,11 @@ export function normalizeOriginUrl(rawUrl: string): string {
 
   // scp-like syntax: [user@]host:path. Deliberately rejects anything that
   // contains `://` (handled above). `user@` is optional — git also accepts
-  // userless scp forms like `host:org/repo`. Uses `[^:@/\s]+` for the host
-  // so that `host:port/repo` is only treated as scp when the part after `:`
-  // is non-numeric — scp paths start with a path component, not a port
-  // number.
-  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(?!\d+(?:\/|$))(.+)$/.exec(url);
+  // userless scp forms like `host:org/repo`. Valid scp paths may start with
+  // digits (e.g. `git@host:123/repo.git`), so no numeric guard is needed:
+  // port-bearing URLs have the `://` prefix and match the protocol branch
+  // above before reaching here.
+  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(.+)$/.exec(url);
   if (scpMatch) {
     const host = scpMatch[2] ?? "";
     const repoPath = scpMatch[3] ?? "";

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -199,9 +199,16 @@ export function normalizeOriginUrl(rawUrl: string): string {
   //
   // Windows drive letters were filtered above, so single-character SSH
   // host aliases (`h:foo/bar`) are accepted here.
-  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(.+)$/.exec(url);
+  //
+  // Bracketed IPv6 (`[2001:db8::1]`) is supported: the host alternative
+  // matches the bracketed literal up to `]` without splitting on internal
+  // `:`. Brackets are stripped in the normalised form so the scp and
+  // `ssh://` forms of the same IPv6 remote produce identical projectIds.
+  const scpMatch =
+    /^(?:([^@\s/]+)@)?(\[[^\]]+\]|[^:@\s/]+):(.+)$/.exec(url);
   if (scpMatch) {
-    const host = scpMatch[2] ?? "";
+    let host = scpMatch[2] ?? "";
+    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
     const repoPath = scpMatch[3] ?? "";
     // Reject protocol-like leftovers (e.g. `file:///path` where the scp
     // regex greedily matched `file` as host and `///path` as path).

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -165,11 +165,13 @@ export function normalizeOriginUrl(rawUrl: string): string {
     return `${host}/${repoPath}`.toLowerCase();
   }
 
-  // scp-like syntax: user@host:path. Deliberately rejects anything that
-  // contains `://` (handled above), and uses `[^:@/\s]+` for the host so that
-  // `git@host:port/repo` is only treated as scp when the part after `:` is
-  // non-numeric — scp paths start with a path component, not a port number.
-  const scpMatch = /^([^@\s/]+)@([^:@\s/]+):(.+)$/.exec(url);
+  // scp-like syntax: [user@]host:path. Deliberately rejects anything that
+  // contains `://` (handled above). `user@` is optional — git also accepts
+  // userless scp forms like `host:org/repo`. Uses `[^:@/\s]+` for the host
+  // so that `host:port/repo` is only treated as scp when the part after `:`
+  // is non-numeric — scp paths start with a path component, not a port
+  // number.
+  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(?!\d+(?:\/|$))(.+)$/.exec(url);
   if (scpMatch) {
     const host = scpMatch[2] ?? "";
     const repoPath = scpMatch[3] ?? "";

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -152,6 +152,15 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // through and appear in the output.
   if (/\.git$/i.test(url)) url = url.slice(0, -4);
 
+  // Windows drive-letter local path (e.g. `C:/repos/app`): detect here
+  // so the scp matcher below can accept single-character SSH host aliases
+  // (`h:foo/bar` from `.ssh/config`). A drive letter is exactly one ASCII
+  // letter followed by `:/` or `:\`; SSH aliases never have a slash
+  // immediately after the colon.
+  if (/^[A-Za-z]:[\\/]/.test(url)) {
+    return url.toLowerCase();
+  }
+
   // Protocol-prefixed: ssh://, https://, http://, git://, file://
   // Must be tried FIRST so that scp-style detection below doesn't
   // incorrectly swallow an ssh:// URL that happens to contain `:port/`.
@@ -175,10 +184,9 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // port-bearing URLs have the `://` prefix and match the protocol branch
   // above before reaching here.
   //
-  // Requires the host to be at least two characters to avoid misreading
-  // Windows local paths like `C:/repos/app.git` (which `git remote get-url
-  // origin` can return verbatim) as an scp remote with host `C`.
-  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]{2,}):(.+)$/.exec(url);
+  // Windows drive letters were filtered above, so single-character SSH
+  // host aliases (`h:foo/bar`) are accepted here.
+  const scpMatch = /^(?:([^@\s/]+)@)?([^:@\s/]+):(.+)$/.exec(url);
   if (scpMatch) {
     const host = scpMatch[2] ?? "";
     const repoPath = scpMatch[3] ?? "";
@@ -237,12 +245,25 @@ export async function resolveGitContext(
     if (!rootPath) return null;
 
     // 2. Current branch. `--abbrev-ref HEAD` returns `HEAD` in detached
-    //    state, which we normalize to `null`.
+    //    state, which we normalize to `null`. On a fresh `git init` the
+    //    HEAD ref is unborn and `--abbrev-ref HEAD` fails, but
+    //    `symbolic-ref HEAD` still returns the target branch. Fall back
+    //    so newly-initialized repos get a sensible branch name.
     const branchResult = invoker(rootPath, ["rev-parse", "--abbrev-ref", "HEAD"]);
     let branch: string | null = null;
     if (branchResult.exitCode === 0) {
       const raw = branchResult.stdout.trim();
       branch = raw && raw !== "HEAD" ? raw : null;
+    } else {
+      const unbornRef = invoker(rootPath, ["symbolic-ref", "--quiet", "HEAD"]);
+      if (unbornRef.exitCode === 0) {
+        const raw = unbornRef.stdout.trim();
+        const prefix = "refs/heads/";
+        if (raw.startsWith(prefix)) {
+          const candidate = raw.slice(prefix.length);
+          if (candidate) branch = candidate;
+        }
+      }
     }
 
     // 3. Origin URL — optional. Used to derive a stable `projectId`.

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -165,14 +165,18 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // Must be tried FIRST so that scp-style detection below doesn't
   // incorrectly swallow an ssh:// URL that happens to contain `:port/`.
   //
-  // Matching groups:
-  //   1: host (userinfo stripped)
-  //   2: port (optional, discarded — same repo on :22 vs :2222 is the
-  //      same repo for memory-routing purposes)
-  //   3: path (optional)
-  const protoMatch = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\d+)?(\/.*)?$/i.exec(url);
+  // Matches either:
+  //   - bracketed IPv6 host: `[2001:db8::1]` (captures `2001:db8::1`)
+  //   - plain host without `:` or `/` chars
+  // Followed by optional port and optional path.
+  const protoMatch =
+    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]+)(?::\d+)?(\/.*)?$/i.exec(url);
   if (protoMatch) {
-    const host = protoMatch[1] ?? "";
+    let host = protoMatch[1] ?? "";
+    // Strip surrounding `[]` on IPv6 hosts so the normalised form doesn't
+    // bring the brackets along (they were only for URL-level disambiguation
+    // of the port).
+    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
     const repoPath = (protoMatch[2] ?? "").replace(/^\/+/, "");
     return `${host}/${repoPath}`.toLowerCase();
   }

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -166,29 +166,36 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // incorrectly swallow an ssh:// URL that happens to contain `:port/`.
   //
   // Matches:
-  //   1: host — bracketed IPv6 `[2001:db8::1]` or plain host with no `:` / `/`
+  //   1: host — bracketed IPv6 `[2001:db8::1]`, plain host with no `:` / `/`,
+  //      OR empty (for `file:///path` which has no host component).
   //   2: port (optional) — preserved in the output so two repos on the same
   //      host under different ports get distinct project namespaces.
   //      Losing the port risked false-coalescing separate repos on custom
   //      SSH mesh setups.
   //   3: path (optional)
   const protoMatch =
-    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]+)(?::(\d+))?(\/.*)?$/i.exec(url);
+    /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]*)(?::(\d+))?(\/.*)?$/i.exec(url);
   if (protoMatch) {
     let host = protoMatch[1] ?? "";
     if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
     const port = protoMatch[2];
     const repoPath = (protoMatch[3] ?? "").replace(/^\/+/, "");
     const hostPort = port ? `${host}:${port}` : host;
-    return `${hostPort}/${repoPath}`.toLowerCase();
+    // For protocols without a host component (file:///path), fall back to
+    // a stable prefix so distinct local paths don't collapse to "/path".
+    const prefix = hostPort.length > 0 ? hostPort : "localhost";
+    return `${prefix}/${repoPath}`.toLowerCase();
   }
 
-  // scp-like syntax: [user@]host:path. Deliberately rejects anything that
-  // contains `://` (handled above). `user@` is optional — git also accepts
-  // userless scp forms like `host:org/repo`. Valid scp paths may start with
-  // digits (e.g. `git@host:123/repo.git`), so no numeric guard is needed:
-  // port-bearing URLs have the `://` prefix and match the protocol branch
-  // above before reaching here.
+  // scp-like syntax: [user@]host:path. Protocol-prefixed URLs (`scheme://`)
+  // are handled above, so the scp branch below guards against them: a
+  // matched `host` of `scheme` followed by a path starting with `//` is
+  // a protocol URL that fell through and must NOT be parsed here.
+  // `user@` is optional — git also accepts userless scp forms like
+  // `host:org/repo`. Valid scp paths may start with digits (e.g.
+  // `git@host:123/repo.git`), so no numeric guard is needed: port-bearing
+  // URLs have the `://` prefix and match the protocol branch above before
+  // reaching here.
   //
   // Windows drive letters were filtered above, so single-character SSH
   // host aliases (`h:foo/bar`) are accepted here.
@@ -196,6 +203,11 @@ export function normalizeOriginUrl(rawUrl: string): string {
   if (scpMatch) {
     const host = scpMatch[2] ?? "";
     const repoPath = scpMatch[3] ?? "";
+    // Reject protocol-like leftovers (e.g. `file:///path` where the scp
+    // regex greedily matched `file` as host and `///path` as path).
+    if (repoPath.startsWith("//")) {
+      return url.toLowerCase();
+    }
     return `${host}/${repoPath.replace(/^\/+/, "")}`.toLowerCase();
   }
 

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -177,10 +177,20 @@ export function normalizeOriginUrl(rawUrl: string): string {
     /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?(\[[^\]]+\]|[^/:]*)(?::(\d+))?(\/.*)?$/i.exec(url);
   if (protoMatch) {
     let host = protoMatch[1] ?? "";
-    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+    // Detect IPv6 via the bracketed input form BEFORE stripping brackets,
+    // so that when we later re-attach a port we can preserve the
+    // `[host]:port` boundary. Without the brackets, `host:2222` is
+    // ambiguous with a longer bare IPv6 address like `2001:db8::1:2222`.
+    const wasBracketed =
+      host.startsWith("[") && host.endsWith("]");
+    if (wasBracketed) host = host.slice(1, -1);
     const port = protoMatch[2];
     const repoPath = (protoMatch[3] ?? "").replace(/^\/+/, "");
-    const hostPort = port ? `${host}:${port}` : host;
+    const hostPort = port
+      ? wasBracketed
+        ? `[${host}]:${port}`
+        : `${host}:${port}`
+      : host;
     // For protocols without a host component (file:///path), fall back to
     // a stable prefix so distinct local paths don't collapse to "/path".
     const prefix = hostPort.length > 0 ? hostPort : "localhost";

--- a/packages/remnic-core/src/utils/path.ts
+++ b/packages/remnic-core/src/utils/path.ts
@@ -1,0 +1,26 @@
+/**
+ * Shared path helpers. CLAUDE.md #17 requires consistent `~` expansion across
+ * every user-facing path input, but Node's `fs` does not expand `~`, so every
+ * call site must go through this helper.
+ */
+
+import path from "node:path";
+
+import { resolveHomeDir } from "../runtime/env.js";
+
+/**
+ * Expand a leading `~` or `~/…` to the resolved home directory.
+ *
+ * Leaves paths without a leading `~` unchanged — including absolute paths,
+ * relative paths, and paths that contain `~` in the middle.
+ *
+ * Accepts both `~/` (POSIX) and `~\` (Windows) as separators so call sites
+ * don't have to branch on platform.
+ */
+export function expandTildePath(p: string): string {
+  if (p === "~") return resolveHomeDir();
+  if (p.startsWith("~/") || p.startsWith("~\\")) {
+    return path.join(resolveHomeDir(), p.slice(2));
+  }
+  return p;
+}


### PR DESCRIPTION
## Summary

Introduces `packages/remnic-core/src/coding/git-context.ts`, a pure detection module that returns `{ projectId, branch, rootPath, defaultBranch }` for a cwd inside a git worktree, or `null` when outside a repo / git is unavailable.

Slice 1 of issue #569. **No wiring** to orchestrator, namespace resolver, or config — downstream slices add those.

## Design

- **Pure function** — injectable `GitInvoker` seam so tests never spawn a real `git` process.
- **`projectId`** = stable FNV-1a hash of the normalized origin URL, with `origin:` prefix. Falls back to `root:<hash>` when origin is absent. scp-style and https:// forms of the same remote normalize to the same id.
- **`rootPath`** tilde-expanded per CLAUDE.md #17.
- **Invalid input** (non-absolute / non-string / empty cwd) returns `null` — this is an internal detector, and being outside a repo is a normal runtime state.
- **Detached HEAD** yields `branch: null`.
- **`defaultBranch`** is best-effort from `refs/remotes/origin/HEAD`; `null` when unavailable.

## Test plan

- [x] 21 unit cases, all green:
  - `expandTildePath` (bare `~`, `~/sub`, no-op)
  - `normalizeOriginUrl` (scp ↔ https ↔ `.git` suffix, case-insensitive, empty)
  - `stableHash` (determinism, distinctness, format)
  - `resolveGitContext` invalid input (empty, non-absolute, non-string)
  - `resolveGitContext` outside-repo / git-not-found paths
  - `resolveGitContext` happy path + scp/https projectId equivalence
  - `resolveGitContext` detached HEAD, missing origin, missing origin HEAD, deep-cwd-in-repo
- [x] `pnpm run check-types` clean

Part of #569 (slice 1 of 8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive, with a small refactor to centralize `~` expansion; no existing orchestration/namespace logic is modified, and the new git-detection module is not yet wired into runtime flows.
> 
> **Overview**
> Adds a new pure `GitContextResolver` module (`coding/git-context.ts`) that detects repo root, branch/default branch, and derives a stable `projectId` (from normalized `origin` URL or repo root) via a pluggable `GitInvoker`.
> 
> Centralizes `~` expansion into a shared `utils/path.ts` helper and updates the training-export CLI to import it, alongside a comprehensive new unit test suite covering URL normalization edge cases, hashing, and resolver fallbacks/error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 051f5226d4d4b8279ef40f88e44461048eaf4534. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->