### PR TITLE
feat(xray): RecallXraySnapshot schema + in-memory capture (#570 PR 1/7)

### DIFF
--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5527,7 +5527,14 @@ export class Orchestrator {
       // — but we STILL capture it when the caller opts in so
       // `getLastXraySnapshot()` returns a useful debug document rather
       // than silently `null` (or a stale prior capture).
-      if (options.xrayCapture === true) {
+      //
+      // Skip capture when the caller has already aborted this recall —
+      // otherwise a canceled call could clobber a prior successful
+      // capture (issue #570 PR 1 review follow-up).
+      if (
+        options.xrayCapture === true &&
+        !options.abortSignal?.aborted
+      ) {
         try {
           this.lastXraySnapshot = buildXraySnapshot({
             query: retrievalQuery,
@@ -7879,6 +7886,14 @@ export class Orchestrator {
         preAugmentTopScore > 0
           ? Math.max(preAugmentTopScore, maxSpecializedScore)
           : 0;
+      // Capture pre-gate pool size for X-ray before the confidence
+      // gate can zero `memoryResults`.  Placing the capture after the
+      // gate would record 0 instead of the true pre-gate pool size
+      // (issue #570 PR 1 review follow-up).
+      xrayCandidatePoolSize = Math.max(
+        xrayCandidatePoolSize,
+        memoryResults.length,
+      );
       let confidenceGateRejected = false;
       if (this.config.recallConfidenceGateEnabled && effectiveGateScore > 0) {
         if (effectiveGateScore < this.config.recallConfidenceGateThreshold) {
@@ -7893,10 +7908,6 @@ export class Orchestrator {
       // Diversify via MMR over the full candidate pool *before* truncating to
       // the final recall limit. Running MMR after the slice would be unable
       // to promote diverse candidates sitting just below the cutoff.
-      xrayCandidatePoolSize = Math.max(
-        xrayCandidatePoolSize,
-        memoryResults.length,
-      );
       memoryResults = this.diversifyAndLimitRecallResults(
         "memories",
         memoryResults,
@@ -8578,7 +8589,15 @@ export class Orchestrator {
     // short-circuit.  Captured data is composed from values we have
     // already derived above, so capture cost is a single object
     // allocation; no new recall work is performed.
-    if (options.xrayCapture === true) {
+    //
+    // Skip capture when the caller has already aborted this recall —
+    // otherwise a canceled call could clobber a prior successful
+    // capture that the capturing caller has not yet read back
+    // (issue #570 PR 1 review follow-up).
+    if (
+      options.xrayCapture === true &&
+      !options.abortSignal?.aborted
+    ) {
       try {
         const servedBy = mapRecallSourceToXrayServedBy(recallSource);
         // Derive xray results from `recalledMemoryPaths` as the single

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5359,6 +5359,12 @@ export class Orchestrator {
     // the pool size BEFORE truncation at each branch that feeds it.
     // Zero when no retrieval ran (initial state + `no_recall`).
     let xrayCandidatePoolSize = 0;
+    // Shared out-parameter sink the cold-fallback pipeline writes
+    // its pre-truncation pool size into (issue #570 PR 1).  Declared
+    // once so every call to `applyColdFallbackPipeline` (four call
+    // sites) updates the same counter; the X-ray capture block below
+    // folds this back into `xrayCandidatePoolSize`.
+    const xrayColdPoolSink = { size: 0 };
     let identityInjectionModeUsed: IdentityInjectionMode | "none" = "none";
     let identityInjectedChars = 0;
     let identityInjectionTruncated = false;
@@ -8055,6 +8061,7 @@ export class Orchestrator {
             recallMode,
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
+            xrayPoolSizeSink: xrayColdPoolSink,
           });
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
@@ -8243,6 +8250,7 @@ export class Orchestrator {
               recallMode,
               queryAwarePrefilter,
               abortSignal: options.abortSignal,
+              xrayPoolSizeSink: xrayColdPoolSink,
             });
             if (longTerm.length > 0) {
               recallSource = "cold_fallback";
@@ -8338,6 +8346,7 @@ export class Orchestrator {
                 recallMode,
                 queryAwarePrefilter,
                 abortSignal: options.abortSignal,
+                xrayPoolSizeSink: xrayColdPoolSink,
               });
               if (longTerm.length > 0) {
                 if (shouldPersistGraphSnapshot) {
@@ -8377,6 +8386,7 @@ export class Orchestrator {
             recallMode,
             queryAwarePrefilter,
             abortSignal: options.abortSignal,
+            xrayPoolSizeSink: xrayColdPoolSink,
           });
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
@@ -8628,11 +8638,14 @@ export class Orchestrator {
         // Use `xrayCandidatePoolSize` (captured pre-MMR / pre-truncation
         // at each retrieval branch) so `considered` reflects the true
         // candidate pool and `considered - admitted` is a meaningful
-        // "dropped by the limit" signal.  Falls back to
-        // `recalledMemoryCount` when no branch ran (shouldn't happen
-        // on this non-no_recall path, but is a safe floor).
+        // "dropped by the limit" signal.  Folds in the cold-fallback
+        // sink so cold-fallback recalls report their pre-truncation
+        // pool too.  Falls back to `recalledMemoryCount` when no
+        // branch ran (shouldn't happen on this non-no_recall path,
+        // but is a safe floor).
         const xrayConsidered = Math.max(
           xrayCandidatePoolSize,
+          xrayColdPoolSink.size,
           recalledMemoryCount,
         );
         const filters: RecallFilterTrace[] = [
@@ -13519,6 +13532,15 @@ export class Orchestrator {
     recallMode: RecallPlanMode;
     queryAwarePrefilter?: QueryAwarePrefilter;
     abortSignal?: AbortSignal;
+    /**
+     * Optional out-parameter that receives the pre-MMR / pre-truncation
+     * pool size captured inside the pipeline (issue #570 PR 1).  The
+     * X-ray capture block in `recallInternal` passes a small sink
+     * here so `xrayCandidatePoolSize` can reflect what cold-fallback
+     * really saw before its own truncation step.  Unset by default so
+     * existing call sites are unaffected.
+     */
+    xrayPoolSizeSink?: { size: number };
   }): Promise<QmdSearchResult[]> {
     const coldQmdEnabled = this.config.qmdColdTierEnabled === true;
     const coldCollection =
@@ -13651,6 +13673,12 @@ export class Orchestrator {
     // the diversification policy applied in the hot QMD/embedding/recent
     // paths. Running MMR post-slice would be unable to promote diverse
     // candidates sitting just below the cutoff.
+    if (options.xrayPoolSizeSink) {
+      options.xrayPoolSizeSink.size = Math.max(
+        options.xrayPoolSizeSink.size,
+        results.length,
+      );
+    }
     return this.diversifyAndLimitRecallResults(
       "memories",
       results,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -488,6 +488,12 @@ function mapRecallSourceToXrayServedBy(
     | "cold_fallback"
     | "recent_scan",
 ): RecallXrayServedBy {
+  // Exhaustive switch: every current union member is explicitly
+  // listed so TypeScript surfaces a compile error if a new source is
+  // added without a deliberate mapping.  The `never`-typed fallthrough
+  // keeps the function total at runtime — if the caller passes an
+  // unexpected value that slipped past the type system (e.g. a JSON
+  // deserialization), we still fall back to `hybrid`.
   switch (source) {
     case "recent_scan":
       return "recent-scan";
@@ -495,9 +501,11 @@ function mapRecallSourceToXrayServedBy(
     case "hot_embedding":
     case "cold_fallback":
     case "none":
-    default:
       return "hybrid";
   }
+  const _exhaustive: never = source;
+  void _exhaustive;
+  return "hybrid";
 }
 
 export interface RecallInvocationOptions {
@@ -5343,6 +5351,14 @@ export class Orchestrator {
     let recalledMemoryCount = 0;
     let recalledMemoryIds: string[] = [];
     let recalledMemoryPaths: string[] = [];
+    // Pre-limit candidate pool size for the X-ray filter trace
+    // (issue #570 PR 1).  `recalledMemoryCount` is assigned AFTER MMR +
+    // truncation so using it alone would make the
+    // `recall-result-limit` trace report `considered == admitted`
+    // even when many candidates were dropped.  This counter captures
+    // the pool size BEFORE truncation at each branch that feeds it.
+    // Zero when no retrieval ran (initial state + `no_recall`).
+    let xrayCandidatePoolSize = 0;
     let identityInjectionModeUsed: IdentityInjectionMode | "none" = "none";
     let identityInjectedChars = 0;
     let identityInjectionTruncated = false;
@@ -7877,6 +7893,10 @@ export class Orchestrator {
       // Diversify via MMR over the full candidate pool *before* truncating to
       // the final recall limit. Running MMR after the slice would be unable
       // to promote diverse candidates sitting just below the cutoff.
+      xrayCandidatePoolSize = Math.max(
+        xrayCandidatePoolSize,
+        memoryResults.length,
+      );
       memoryResults = this.diversifyAndLimitRecallResults(
         "memories",
         memoryResults,
@@ -7981,6 +8001,10 @@ export class Orchestrator {
         );
         // MMR runs on the pre-truncation pool so diverse candidates just
         // below the cutoff can be promoted into the injected set.
+        xrayCandidatePoolSize = Math.max(
+          xrayCandidatePoolSize,
+          boostedScoped.length,
+        );
         const scoped = this.diversifyAndLimitRecallResults(
           "memories",
           boostedScoped,
@@ -8114,6 +8138,10 @@ export class Orchestrator {
       );
       // MMR runs on the pre-truncation pool so diverse candidates just
       // below the cutoff can be promoted into the injected set.
+      xrayCandidatePoolSize = Math.max(
+        xrayCandidatePoolSize,
+        boostedScoped.length,
+      );
       const scoped = this.diversifyAndLimitRecallResults(
         "memories",
         boostedScoped,
@@ -8255,6 +8283,10 @@ export class Orchestrator {
             ).sort((a, b) => b.score - a.score);
             // MMR runs on the pre-truncation pool so diverse candidates just
             // below the cutoff can be promoted into the injected set.
+            xrayCandidatePoolSize = Math.max(
+              xrayCandidatePoolSize,
+              boostedRecent.length,
+            );
             const recent = this.diversifyAndLimitRecallResults(
               "memories",
               boostedRecent,
@@ -8574,10 +8606,20 @@ export class Orchestrator {
             admittedBy: [],
           });
         }
+        // Use `xrayCandidatePoolSize` (captured pre-MMR / pre-truncation
+        // at each retrieval branch) so `considered` reflects the true
+        // candidate pool and `considered - admitted` is a meaningful
+        // "dropped by the limit" signal.  Falls back to
+        // `recalledMemoryCount` when no branch ran (shouldn't happen
+        // on this non-no_recall path, but is a safe floor).
+        const xrayConsidered = Math.max(
+          xrayCandidatePoolSize,
+          recalledMemoryCount,
+        );
         const filters: RecallFilterTrace[] = [
           {
             name: "recall-result-limit",
-            considered: recalledMemoryCount,
+            considered: xrayConsidered,
             admitted: recalledMemoryIds.length,
           },
         ];

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -100,6 +100,13 @@ import {
   type TierMigrationStatusSnapshot,
 } from "./recall-state.js";
 import {
+  buildXraySnapshot,
+  type RecallFilterTrace,
+  type RecallXrayResult,
+  type RecallXraySnapshot,
+  type RecallXrayServedBy,
+} from "./recall-xray.js";
+import {
   recordEvalShadowRecall,
   type EvalShadowRecallRecord,
 } from "./evals.js";
@@ -461,11 +468,51 @@ export interface RecallModeDecision {
   graphReason?: string;
 }
 
+/**
+ * Map the orchestrator's internal `recallSource` strings to the
+ * X-ray `servedBy` vocabulary (issue #570 PR 1).  The X-ray tier
+ * ladder intentionally flattens QMD / embedding / cold-fallback to
+ * the `hybrid` tier because they all materialize through the same
+ * hybrid BM25+vector pipeline from the caller's perspective.  The
+ * `recent_scan` path gets its own dedicated tier because it bypasses
+ * the hybrid pipeline entirely.  `none` is treated as `hybrid` on the
+ * theory that a query that returned nothing still routed through the
+ * hybrid pipeline — but callers should normally gate capture on
+ * `recalledMemoryIds.length > 0`.
+ */
+function mapRecallSourceToXrayServedBy(
+  source:
+    | "none"
+    | "hot_qmd"
+    | "hot_embedding"
+    | "cold_fallback"
+    | "recent_scan",
+): RecallXrayServedBy {
+  switch (source) {
+    case "recent_scan":
+      return "recent-scan";
+    case "hot_qmd":
+    case "hot_embedding":
+    case "cold_fallback":
+    case "none":
+    default:
+      return "hybrid";
+  }
+}
+
 export interface RecallInvocationOptions {
   namespace?: string;
   topK?: number;
   mode?: RecallPlanMode;
   abortSignal?: AbortSignal;
+  /**
+   * Capture a `RecallXraySnapshot` for this recall (issue #570).  When
+   * `true`, the orchestrator builds a snapshot from the data it has
+   * already gathered and stashes it in memory, accessible via
+   * `getLastXraySnapshot()`.  When `false` or absent, nothing is
+   * captured and recall behavior is unchanged (schema-only slice).
+   */
+  xrayCapture?: boolean;
 }
 
 type QueryAwarePrefilter = {
@@ -1124,6 +1171,16 @@ export class Orchestrator {
   readonly negatives: NegativeExampleStore;
   readonly lastRecall: LastRecallStore;
   readonly tierMigrationStatus: TierMigrationStatusStore;
+  /**
+   * In-memory X-ray snapshot from the most recent `recall()` call that
+   * was invoked with `xrayCapture: true` (issue #570 PR 1).  Scope is
+   * per-process; later slices add CLI/HTTP/MCP surfaces that consume
+   * this via the shared renderer.  `null` until the first capture, and
+   * NEVER overwritten by a recall that did not request capture —
+   * requests without the flag leave prior captures intact so the
+   * capturing caller can still read their snapshot back.
+   */
+  private lastXraySnapshot: RecallXraySnapshot | null = null;
   readonly embeddingFallback: EmbeddingFallback;
   private readonly conversationIndexDir: string;
   private readonly extraction: ExtractionEngine;
@@ -3973,6 +4030,23 @@ export class Orchestrator {
     } finally {
       options.abortSignal?.removeEventListener("abort", onAbort);
     }
+  }
+
+  /**
+   * Return the most recent X-ray snapshot captured during a
+   * `recall()` call that passed `xrayCapture: true` (issue #570 PR 1).
+   * Returns `null` when no such capture has occurred on this
+   * orchestrator instance.  Returned snapshot is a deep copy so
+   * caller mutation cannot tear the stored value.
+   */
+  getLastXraySnapshot(): RecallXraySnapshot | null {
+    if (!this.lastXraySnapshot) return null;
+    return structuredClone(this.lastXraySnapshot);
+  }
+
+  /** Clear the captured X-ray snapshot.  Exposed for tests / explicit reset. */
+  clearLastXraySnapshot(): void {
+    this.lastXraySnapshot = null;
   }
 
   /**
@@ -8434,6 +8508,52 @@ export class Orchestrator {
       includedSections: assembledRecall.includedIds,
       omittedSections: assembledRecall.omittedIds,
     });
+
+    // X-ray capture (issue #570 PR 1).  Only fires when the caller
+    // explicitly opts in via `xrayCapture: true`.  No behavior change
+    // when the flag is absent — this branch and the setter both
+    // short-circuit.  Captured data is composed from values we have
+    // already derived above, so capture cost is a single object
+    // allocation; no new recall work is performed.
+    if (options.xrayCapture === true) {
+      try {
+        const servedBy = mapRecallSourceToXrayServedBy(recallSource);
+        const results: RecallXrayResult[] = recalledMemoryIds.map(
+          (memoryId, index) => ({
+            memoryId,
+            path: recalledMemoryPaths[index] ?? "",
+            servedBy,
+            scoreDecomposition: { final: 0 },
+            admittedBy: [],
+          }),
+        );
+        const filters: RecallFilterTrace[] = [
+          {
+            name: "recall-result-limit",
+            considered: recalledMemoryCount,
+            admitted: recalledMemoryIds.length,
+          },
+        ];
+        this.lastXraySnapshot = buildXraySnapshot({
+          query: retrievalQuery,
+          tierExplain: null,
+          results,
+          filters,
+          budget: {
+            chars: this.getRecallBudgetChars(),
+            used: assembledRecall.finalChars,
+          },
+          sessionKey,
+          namespace: selfNamespace,
+          traceId,
+        });
+      } catch (err) {
+        // Capture is a best-effort side channel: a capture failure
+        // must NEVER propagate into the primary recall path.
+        log.debug(`x-ray capture failed: ${err}`);
+      }
+    }
+
     if (sessionKey) {
       throwIfRecallAborted(options.abortSignal);
       this.lastRecall

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5351,19 +5351,30 @@ export class Orchestrator {
     let recalledMemoryCount = 0;
     let recalledMemoryIds: string[] = [];
     let recalledMemoryPaths: string[] = [];
-    // Pre-limit candidate pool size for the X-ray filter trace
-    // (issue #570 PR 1).  `recalledMemoryCount` is assigned AFTER MMR +
-    // truncation so using it alone would make the
+    // Per-branch pre-limit candidate pool size for the X-ray filter
+    // trace (issue #570 PR 1).  `recalledMemoryCount` is assigned
+    // AFTER MMR + truncation so using it alone would make the
     // `recall-result-limit` trace report `considered == admitted`
-    // even when many candidates were dropped.  This counter captures
-    // the pool size BEFORE truncation at each branch that feeds it.
-    // Zero when no retrieval ran (initial state + `no_recall`).
-    let xrayCandidatePoolSize = 0;
+    // even when many candidates were dropped.  Each entry captures
+    // the pool size BEFORE truncation at that branch.  The X-ray
+    // capture block picks the pool that corresponds to the branch
+    // that actually produced the admitted results (via `recallSource`)
+    // so a pool from a branch whose candidates were killed by an
+    // earlier gate cannot leak into the `considered` count.
+    const xrayBranchPoolSize: Record<
+      "hot_qmd" | "hot_embedding" | "cold_fallback" | "recent_scan",
+      number
+    > = {
+      hot_qmd: 0,
+      hot_embedding: 0,
+      cold_fallback: 0,
+      recent_scan: 0,
+    };
     // Shared out-parameter sink the cold-fallback pipeline writes
     // its pre-truncation pool size into (issue #570 PR 1).  Declared
     // once so every call to `applyColdFallbackPipeline` (four call
-    // sites) updates the same counter; the X-ray capture block below
-    // folds this back into `xrayCandidatePoolSize`.
+    // sites) updates the same counter; the X-ray capture block
+    // reads this as the cold-fallback pool.
     const xrayColdPoolSink = { size: 0 };
     let identityInjectionModeUsed: IdentityInjectionMode | "none" = "none";
     let identityInjectedChars = 0;
@@ -7896,8 +7907,8 @@ export class Orchestrator {
       // gate can zero `memoryResults`.  Placing the capture after the
       // gate would record 0 instead of the true pre-gate pool size
       // (issue #570 PR 1 review follow-up).
-      xrayCandidatePoolSize = Math.max(
-        xrayCandidatePoolSize,
+      xrayBranchPoolSize.hot_qmd = Math.max(
+        xrayBranchPoolSize.hot_qmd,
         memoryResults.length,
       );
       let confidenceGateRejected = false;
@@ -8018,8 +8029,8 @@ export class Orchestrator {
         );
         // MMR runs on the pre-truncation pool so diverse candidates just
         // below the cutoff can be promoted into the injected set.
-        xrayCandidatePoolSize = Math.max(
-          xrayCandidatePoolSize,
+        xrayBranchPoolSize.hot_embedding = Math.max(
+          xrayBranchPoolSize.hot_embedding,
           boostedScoped.length,
         );
         const scoped = this.diversifyAndLimitRecallResults(
@@ -8156,8 +8167,8 @@ export class Orchestrator {
       );
       // MMR runs on the pre-truncation pool so diverse candidates just
       // below the cutoff can be promoted into the injected set.
-      xrayCandidatePoolSize = Math.max(
-        xrayCandidatePoolSize,
+      xrayBranchPoolSize.hot_embedding = Math.max(
+        xrayBranchPoolSize.hot_embedding,
         boostedScoped.length,
       );
       const scoped = this.diversifyAndLimitRecallResults(
@@ -8302,8 +8313,8 @@ export class Orchestrator {
             ).sort((a, b) => b.score - a.score);
             // MMR runs on the pre-truncation pool so diverse candidates just
             // below the cutoff can be promoted into the injected set.
-            xrayCandidatePoolSize = Math.max(
-              xrayCandidatePoolSize,
+            xrayBranchPoolSize.recent_scan = Math.max(
+              xrayBranchPoolSize.recent_scan,
               boostedRecent.length,
             );
             const recent = this.diversifyAndLimitRecallResults(
@@ -8635,19 +8646,46 @@ export class Orchestrator {
             admittedBy: [],
           });
         }
-        // Use `xrayCandidatePoolSize` (captured pre-MMR / pre-truncation
-        // at each retrieval branch) so `considered` reflects the true
-        // candidate pool and `considered - admitted` is a meaningful
-        // "dropped by the limit" signal.  Folds in the cold-fallback
-        // sink so cold-fallback recalls report their pre-truncation
-        // pool too.  Falls back to `recalledMemoryCount` when no
-        // branch ran (shouldn't happen on this non-no_recall path,
-        // but is a safe floor).
-        const xrayConsidered = Math.max(
-          xrayCandidatePoolSize,
-          xrayColdPoolSink.size,
-          recalledMemoryCount,
-        );
+        // `considered` must reflect the pool size of the branch that
+        // actually produced the admitted results, NOT the max across
+        // every branch that ran.  Otherwise a flow where hot_qmd
+        // assembled a large pool that was killed by the confidence
+        // gate and a different branch (or none) ultimately served
+        // the recall would report hot_qmd's pool as "considered" —
+        // incorrectly attributing those drops to the result limit.
+        // Pick the pool by `recallSource`; fall back to
+        // `recalledMemoryCount` when no branch ran (e.g. every branch
+        // returned zero).  This path never runs for `no_recall` —
+        // that branch captures its own snapshot earlier.
+        let xrayConsidered: number;
+        switch (recallSource) {
+          case "hot_qmd":
+            xrayConsidered = xrayBranchPoolSize.hot_qmd;
+            break;
+          case "hot_embedding":
+            xrayConsidered = xrayBranchPoolSize.hot_embedding;
+            break;
+          case "cold_fallback":
+            xrayConsidered = xrayColdPoolSink.size;
+            break;
+          case "recent_scan":
+            xrayConsidered = xrayBranchPoolSize.recent_scan;
+            break;
+          case "none":
+            xrayConsidered = recalledMemoryCount;
+            break;
+          default: {
+            // Compile-time guard: adding a new `recallSource` value
+            // must force this switch to be updated.
+            const _exhaustive: never = recallSource;
+            void _exhaustive;
+            xrayConsidered = recalledMemoryCount;
+          }
+        }
+        // `considered` must never be less than `admitted` — in degenerate
+        // flows where a branch's pool counter missed an assignment, prefer
+        // the admitted count as the floor so the trace stays self-consistent.
+        xrayConsidered = Math.max(xrayConsidered, recalledMemoryIds.length);
         const filters: RecallFilterTrace[] = [
           {
             name: "recall-result-limit",
@@ -13535,10 +13573,10 @@ export class Orchestrator {
     /**
      * Optional out-parameter that receives the pre-MMR / pre-truncation
      * pool size captured inside the pipeline (issue #570 PR 1).  The
-     * X-ray capture block in `recallInternal` passes a small sink
-     * here so `xrayCandidatePoolSize` can reflect what cold-fallback
-     * really saw before its own truncation step.  Unset by default so
-     * existing call sites are unaffected.
+     * X-ray capture block in `recallInternal` passes a small sink so
+     * the cold-fallback branch's pre-truncation pool size can be
+     * attributed back to the branch when `recallSource === "cold_fallback"`.
+     * Unset by default so existing call sites are unaffected.
      */
     xrayPoolSizeSink?: { size: number };
   }): Promise<QmdSearchResult[]> {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -5505,6 +5505,37 @@ export class Orchestrator {
       const earlySessionKey = sessionKey ?? "default";
       this._recallWorkspaceOverrides.delete(earlySessionKey);
       timings.total = `${Date.now() - recallStart}ms`;
+      // X-ray capture for the `no_recall` early-return path
+      // (issue #570 PR 1).  `no_recall` skips retrieval entirely, so
+      // the snapshot carries zero results and an empty-budget accounting
+      // — but we STILL capture it when the caller opts in so
+      // `getLastXraySnapshot()` returns a useful debug document rather
+      // than silently `null` (or a stale prior capture).
+      if (options.xrayCapture === true) {
+        try {
+          this.lastXraySnapshot = buildXraySnapshot({
+            query: retrievalQuery,
+            tierExplain: null,
+            results: [],
+            filters: [
+              {
+                name: "planner-mode",
+                considered: 0,
+                admitted: 0,
+                reason: "no_recall",
+              },
+            ],
+            budget: { chars: this.getRecallBudgetChars(), used: 0 },
+            sessionKey,
+            namespace: selfNamespace,
+            traceId,
+          });
+        } catch (err) {
+          // Capture is a best-effort side channel: a capture failure
+          // must NEVER propagate into the primary recall path.
+          log.debug(`x-ray capture (no_recall) failed: ${err}`);
+        }
+      }
       if (sessionKey) {
         this.lastRecall
           .record({
@@ -8518,15 +8549,31 @@ export class Orchestrator {
     if (options.xrayCapture === true) {
       try {
         const servedBy = mapRecallSourceToXrayServedBy(recallSource);
-        const results: RecallXrayResult[] = recalledMemoryIds.map(
-          (memoryId, index) => ({
-            memoryId,
-            path: recalledMemoryPaths[index] ?? "",
+        // Derive xray results from `recalledMemoryPaths` as the single
+        // source of truth — `recalledMemoryIds` and `recalledMemoryPaths`
+        // are built with two independent filters upstream
+        // (`extractMemoryIdsFromResults` drops paths whose filename does
+        // not match `*.md`, while `.map(path).filter(Boolean)` drops
+        // empty paths only), so zipping them positionally would silently
+        // misalign when the two filters differ.  Re-deriving `memoryId`
+        // from the path here guarantees `memoryId` and `path` refer to
+        // the same underlying result.
+        const idFromPath = (p: string): string | null => {
+          const match = p.match(/([^/]+)\.md$/);
+          return match ? match[1] ?? null : null;
+        };
+        const results: RecallXrayResult[] = [];
+        for (const recalledPath of recalledMemoryPaths) {
+          const derivedId = idFromPath(recalledPath);
+          if (!derivedId) continue;
+          results.push({
+            memoryId: derivedId,
+            path: recalledPath,
             servedBy,
             scoreDecomposition: { final: 0 },
             admittedBy: [],
-          }),
-        );
+          });
+        }
         const filters: RecallFilterTrace[] = [
           {
             name: "recall-result-limit",

--- a/packages/remnic-core/src/recall-xray.test.ts
+++ b/packages/remnic-core/src/recall-xray.test.ts
@@ -70,6 +70,20 @@ test("buildXraySnapshot trims whitespace-only session/namespace/traceId to undef
   assert.equal(snapshot.traceId, undefined);
 });
 
+test("buildXraySnapshot strips surrounding whitespace from session/namespace/traceId", () => {
+  const snapshot = buildXraySnapshot({
+    query: "x",
+    sessionKey: "  sess-1  ",
+    namespace: "\tns\n",
+    traceId: " trace-xyz ",
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal(snapshot.sessionKey, "sess-1");
+  assert.equal(snapshot.namespace, "ns");
+  assert.equal(snapshot.traceId, "trace-xyz");
+});
+
 // ─── buildXraySnapshot: each decomposition field ──────────────────────────
 
 test("buildXraySnapshot preserves every score-decomposition field", () => {

--- a/packages/remnic-core/src/recall-xray.test.ts
+++ b/packages/remnic-core/src/recall-xray.test.ts
@@ -1,0 +1,326 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  RECALL_XRAY_SERVED_BY_VALUES,
+  RecallXrayBuilder,
+  buildXraySnapshot,
+  isRecallXrayServedBy,
+  type RecallXrayResult,
+} from "./recall-xray.js";
+import type { RecallTierExplain } from "./types.js";
+
+function fixedNow(): number {
+  return 1_700_000_000_000;
+}
+
+function idGen(): () => string {
+  let n = 0;
+  return () => `snap-${++n}`;
+}
+
+// ─── isRecallXrayServedBy ─────────────────────────────────────────────────
+
+test("isRecallXrayServedBy accepts every documented value", () => {
+  for (const value of RECALL_XRAY_SERVED_BY_VALUES) {
+    assert.equal(isRecallXrayServedBy(value), true, `expected ${value} accepted`);
+  }
+});
+
+test("isRecallXrayServedBy rejects unknown strings and non-strings", () => {
+  assert.equal(isRecallXrayServedBy("bogus"), false);
+  assert.equal(isRecallXrayServedBy(""), false);
+  assert.equal(isRecallXrayServedBy(undefined), false);
+  assert.equal(isRecallXrayServedBy(null), false);
+  assert.equal(isRecallXrayServedBy(7), false);
+});
+
+// ─── buildXraySnapshot: minimal call ──────────────────────────────────────
+
+test("buildXraySnapshot fills defaults for empty input", () => {
+  const snapshot = buildXraySnapshot({
+    query: "what is the capital of france",
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal(snapshot.schemaVersion, "1");
+  assert.equal(snapshot.query, "what is the capital of france");
+  assert.equal(snapshot.snapshotId, "snap-1");
+  assert.equal(snapshot.capturedAt, 1_700_000_000_000);
+  assert.equal(snapshot.tierExplain, null);
+  assert.deepEqual(snapshot.results, []);
+  assert.deepEqual(snapshot.filters, []);
+  assert.deepEqual(snapshot.budget, { chars: 0, used: 0 });
+  assert.equal(snapshot.sessionKey, undefined);
+  assert.equal(snapshot.namespace, undefined);
+  assert.equal(snapshot.traceId, undefined);
+});
+
+test("buildXraySnapshot trims whitespace-only session/namespace/traceId to undefined", () => {
+  const snapshot = buildXraySnapshot({
+    query: "x",
+    sessionKey: "   ",
+    namespace: "",
+    traceId: "  ",
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal(snapshot.sessionKey, undefined);
+  assert.equal(snapshot.namespace, undefined);
+  assert.equal(snapshot.traceId, undefined);
+});
+
+// ─── buildXraySnapshot: each decomposition field ──────────────────────────
+
+test("buildXraySnapshot preserves every score-decomposition field", () => {
+  const result: RecallXrayResult = {
+    memoryId: "mem-1",
+    path: "/notes/synthetic.md",
+    servedBy: "hybrid",
+    admittedBy: ["namespace", "trustZone", "importance"],
+    scoreDecomposition: {
+      vector: 0.83,
+      bm25: 0.41,
+      importance: 0.72,
+      mmrPenalty: 0.05,
+      tierPrior: 0.1,
+      final: 0.79,
+    },
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal(snapshot.results.length, 1);
+  const emitted = snapshot.results[0]!;
+  assert.deepEqual(emitted.scoreDecomposition, {
+    vector: 0.83,
+    bm25: 0.41,
+    importance: 0.72,
+    mmrPenalty: 0.05,
+    tierPrior: 0.1,
+    final: 0.79,
+  });
+  assert.equal(emitted.servedBy, "hybrid");
+  assert.deepEqual(emitted.admittedBy, ["namespace", "trustZone", "importance"]);
+});
+
+test("buildXraySnapshot drops non-finite score-decomposition fields", () => {
+  const result: RecallXrayResult = {
+    memoryId: "mem-2",
+    path: "/notes/two.md",
+    servedBy: "hybrid",
+    admittedBy: [],
+    scoreDecomposition: {
+      vector: Number.NaN,
+      bm25: Number.POSITIVE_INFINITY,
+      importance: 0.5,
+      final: Number.NaN,
+    },
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  const emitted = snapshot.results[0]!;
+  assert.equal(emitted.scoreDecomposition.vector, undefined);
+  assert.equal(emitted.scoreDecomposition.bm25, undefined);
+  assert.equal(emitted.scoreDecomposition.importance, 0.5);
+  // Non-finite `final` collapses to the guaranteed 0 default.
+  assert.equal(emitted.scoreDecomposition.final, 0);
+});
+
+test("buildXraySnapshot preserves graphPath, auditEntryId, rejectedBy when present", () => {
+  const result: RecallXrayResult = {
+    memoryId: "mem-3",
+    path: "/notes/three.md",
+    servedBy: "graph",
+    admittedBy: ["namespace"],
+    scoreDecomposition: { final: 0.5, tierPrior: 0.3 },
+    graphPath: ["alpha", "beta", "gamma"],
+    auditEntryId: "audit-42",
+    rejectedBy: "mmr-diversity",
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  const emitted = snapshot.results[0]!;
+  assert.deepEqual(emitted.graphPath, ["alpha", "beta", "gamma"]);
+  assert.equal(emitted.auditEntryId, "audit-42");
+  assert.equal(emitted.rejectedBy, "mmr-diversity");
+});
+
+test("buildXraySnapshot rejects results with an unknown servedBy tier", () => {
+  assert.throws(
+    () =>
+      buildXraySnapshot({
+        query: "q",
+        results: [
+          {
+            memoryId: "x",
+            path: "/x",
+            // @ts-expect-error — deliberately invalid for the test
+            servedBy: "fiction",
+            admittedBy: [],
+            scoreDecomposition: { final: 0 },
+          },
+        ],
+        now: fixedNow,
+        snapshotIdGenerator: idGen(),
+      }),
+    /servedBy must be one of/,
+  );
+});
+
+// ─── Budget accounting ────────────────────────────────────────────────────
+
+test("buildXraySnapshot clamps negative / non-finite budgets to zero", () => {
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    budget: { chars: -5, used: Number.NaN },
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.deepEqual(snapshot.budget, { chars: 0, used: 0 });
+});
+
+test("buildXraySnapshot floors fractional budget values", () => {
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    budget: { chars: 10.9, used: 7.2 },
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.deepEqual(snapshot.budget, { chars: 10, used: 7 });
+});
+
+// ─── TierExplain round-trip ───────────────────────────────────────────────
+
+test("buildXraySnapshot carries tierExplain verbatim", () => {
+  const tierExplain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "trusted decisions, unambiguous",
+    filteredBy: ["token-overlap-floor"],
+    candidatesConsidered: 3,
+    latencyMs: 11,
+    sourceAnchors: [{ path: "/notes/pm.md", lineRange: [1, 4] }],
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    tierExplain,
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.deepEqual(snapshot.tierExplain, tierExplain);
+});
+
+test("buildXraySnapshot deep-copies tierExplain so caller mutation does not tear the snapshot", () => {
+  const tierExplain: RecallTierExplain = {
+    tier: "direct-answer",
+    tierReason: "live",
+    filteredBy: ["a"],
+    candidatesConsidered: 1,
+    latencyMs: 1,
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    tierExplain,
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  tierExplain.filteredBy.push("b");
+  assert.deepEqual(snapshot.tierExplain?.filteredBy, ["a"]);
+});
+
+// ─── Filter trace ─────────────────────────────────────────────────────────
+
+test("buildXraySnapshot records filters with considered/admitted counts", () => {
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    filters: [
+      { name: "namespace", considered: 10, admitted: 8 },
+      { name: "trustZone", considered: 8, admitted: 6, reason: "quarantine" },
+    ],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.deepEqual(snapshot.filters, [
+    { name: "namespace", considered: 10, admitted: 8 },
+    { name: "trustZone", considered: 8, admitted: 6, reason: "quarantine" },
+  ]);
+});
+
+// ─── Defensive copies ─────────────────────────────────────────────────────
+
+test("buildXraySnapshot shallow-copies results so caller mutation does not leak in", () => {
+  const result: RecallXrayResult = {
+    memoryId: "mem-1",
+    path: "/notes/one.md",
+    servedBy: "hybrid",
+    admittedBy: ["alpha"],
+    scoreDecomposition: { final: 0.5 },
+  };
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  result.admittedBy.push("beta");
+  assert.deepEqual(snapshot.results[0]!.admittedBy, ["alpha"]);
+});
+
+// ─── RecallXrayBuilder ────────────────────────────────────────────────────
+
+test("RecallXrayBuilder accumulates results and filters then builds a snapshot", () => {
+  const builder = new RecallXrayBuilder({
+    query: "test query",
+    sessionKey: "s1",
+  });
+  builder.setNamespace("ns1");
+  builder.setTraceId("trace-1");
+  builder.setBudget({ chars: 4096, used: 1024 });
+  builder.setTierExplain({
+    tier: "hybrid",
+    tierReason: "served by hybrid",
+    filteredBy: [],
+    candidatesConsidered: 2,
+    latencyMs: 5,
+  });
+  builder.recordFilter({ name: "namespace", considered: 5, admitted: 4 });
+  builder.recordResult({
+    memoryId: "mem-1",
+    path: "/notes/one.md",
+    servedBy: "hybrid",
+    admittedBy: ["namespace", "trustZone"],
+    scoreDecomposition: { final: 0.9, vector: 0.88 },
+  });
+  const snap = builder.build({
+    now: fixedNow,
+    snapshotIdGenerator: idGen(),
+  });
+  assert.equal(snap.snapshotId, "snap-1");
+  assert.equal(snap.sessionKey, "s1");
+  assert.equal(snap.namespace, "ns1");
+  assert.equal(snap.traceId, "trace-1");
+  assert.deepEqual(snap.budget, { chars: 4096, used: 1024 });
+  assert.equal(snap.results.length, 1);
+  assert.equal(snap.filters.length, 1);
+  assert.equal(snap.tierExplain?.tier, "hybrid");
+});
+
+test("RecallXrayBuilder produces unique snapshotId per build when no generator injected", () => {
+  const builder = new RecallXrayBuilder({ query: "x" });
+  const a = builder.build();
+  const b = builder.build();
+  assert.ok(typeof a.snapshotId === "string" && a.snapshotId.length > 0);
+  assert.ok(typeof b.snapshotId === "string" && b.snapshotId.length > 0);
+  assert.notEqual(a.snapshotId, b.snapshotId);
+});

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -371,5 +371,5 @@ function nonEmptyString(value: unknown): string | undefined {
   if (typeof value !== "string") return undefined;
   const trimmed = value.trim();
   if (trimmed.length === 0) return undefined;
-  return value;
+  return trimmed;
 }

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -1,0 +1,375 @@
+/**
+ * Recall X-ray snapshot schema (issue #570, PR 1).
+ *
+ * The X-ray surface is the unified, per-result attribution document that
+ * merges the tier that served each memory, its score decomposition, any
+ * graph path, an audit entry id, and the exact filter/eligibility ladder
+ * that either admitted or rejected each candidate.  This file defines the
+ * schema and an in-memory builder + builder-state helper.
+ *
+ * Scope for PR 1 (this slice):
+ *   - Types only + pure builder functions (no IO, no rendering).
+ *   - Orchestrator plumbing captures a snapshot when the caller passes
+ *     `xrayCapture: true`.  No behavior change when the flag is absent.
+ *   - NO new public surfaces here — CLI/HTTP/MCP land in later slices.
+ *
+ * The shared renderer lands in PR 2 at `recall-xray-renderer.ts`.  Do not
+ * fork formatting logic into other surfaces; extend the renderer.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { RecallTierExplain } from "./types.js";
+
+/**
+ * Which retrieval source produced a given result.  This is the X-ray
+ * tier ladder called out in issue #570 and is *distinct* from the
+ * `RetrievalTier` enum (which describes issue #518's tier-explain
+ * block).  Keeping the sets separate lets the two observability
+ * surfaces evolve without conflating their vocabularies:
+ *
+ *   - `RetrievalTier`     — direct-answer eligibility ladder.
+ *   - `RecallXrayServedBy` — which source materialized each result.
+ */
+export type RecallXrayServedBy =
+  | "direct-answer"
+  | "hybrid"
+  | "graph"
+  | "recent-scan"
+  | "procedural"
+  | "review-context";
+
+export const RECALL_XRAY_SERVED_BY_VALUES: readonly RecallXrayServedBy[] = [
+  "direct-answer",
+  "hybrid",
+  "graph",
+  "recent-scan",
+  "procedural",
+  "review-context",
+] as const;
+
+export function isRecallXrayServedBy(
+  value: unknown,
+): value is RecallXrayServedBy {
+  return (
+    typeof value === "string" &&
+    (RECALL_XRAY_SERVED_BY_VALUES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Score decomposition for a single X-ray result.
+ *
+ * All fields are optional because different tiers populate different
+ * terms: `hybrid` reports vector + bm25 + mmr penalty, `direct-answer`
+ * reports importance + tier prior, etc.  The only guaranteed field is
+ * `final`, which is the post-combination score used for ordering.
+ */
+export interface RecallXrayScoreDecomposition {
+  vector?: number;
+  bm25?: number;
+  importance?: number;
+  mmrPenalty?: number;
+  tierPrior?: number;
+  final: number;
+}
+
+/**
+ * Per-result breakdown inside an X-ray snapshot.
+ */
+export interface RecallXrayResult {
+  memoryId: string;
+  path: string;
+  servedBy: RecallXrayServedBy;
+  scoreDecomposition: RecallXrayScoreDecomposition;
+  graphPath?: string[];
+  auditEntryId?: string;
+  /** Human-readable list of filters the candidate *passed*. */
+  admittedBy: string[];
+  /**
+   * First filter that *would have* rejected the candidate, or undefined
+   * when the candidate was admitted without a rejection trace.  When
+   * present, `admittedBy` may still contain filters the candidate passed
+   * before the rejecting gate; consumers should render both.
+   */
+  rejectedBy?: string;
+}
+
+/**
+ * Trace entry for a filter the orchestrator evaluated during recall.
+ * Captures the name of the filter, how many candidates it saw, and how
+ * many it let through.  Used by X-ray consumers to render the filter
+ * ladder above the per-result breakdown.
+ */
+export interface RecallFilterTrace {
+  name: string;
+  considered: number;
+  admitted: number;
+  /** Optional human-readable reason for any rejections. */
+  reason?: string;
+}
+
+/**
+ * The unified X-ray snapshot.  CLI, HTTP, and MCP surfaces all render
+ * this same shape through the shared renderer (CLAUDE.md rule 22).
+ */
+export interface RecallXraySnapshot {
+  /** Stable v1 tag so downstream consumers can version-gate their parsers. */
+  schemaVersion: "1";
+  query: string;
+  /** UUID minted per capture; unique across snapshots within a process. */
+  snapshotId: string;
+  /** Epoch milliseconds the snapshot was captured. */
+  capturedAt: number;
+  /**
+   * Tier-explain block from issue #518, carried verbatim when present.
+   * `null` means direct-answer tier did not run (disabled, or another
+   * tier served the query).
+   */
+  tierExplain: RecallTierExplain | null;
+  results: RecallXrayResult[];
+  filters: RecallFilterTrace[];
+  /**
+   * Character budget accounting for the final assembled recall payload.
+   * `used` is the rendered-context length; `chars` is the cap.  Both are
+   * non-negative integers in `[0, 2**31)`.
+   */
+  budget: { chars: number; used: number };
+  /** Optional session-scope fields carried for downstream filtering. */
+  sessionKey?: string;
+  namespace?: string;
+  traceId?: string;
+}
+
+// ─── Builder ──────────────────────────────────────────────────────────────
+
+export interface BuildXraySnapshotInput {
+  query: string;
+  tierExplain?: RecallTierExplain | null;
+  results?: RecallXrayResult[];
+  filters?: RecallFilterTrace[];
+  budget?: { chars?: number; used?: number };
+  sessionKey?: string;
+  namespace?: string;
+  traceId?: string;
+  /** Optional injected timestamp for deterministic tests. */
+  now?: () => number;
+  /** Optional injected id generator for deterministic tests. */
+  snapshotIdGenerator?: () => string;
+}
+
+/**
+ * Build a `RecallXraySnapshot` from explicit input fields.  Pure
+ * function; safe to call from anywhere.  All array/object inputs are
+ * shallow-copied so caller mutation after build cannot tear the
+ * returned snapshot.
+ */
+export function buildXraySnapshot(
+  input: BuildXraySnapshotInput,
+): RecallXraySnapshot {
+  const now = input.now ?? Date.now;
+  const snapshotIdGenerator = input.snapshotIdGenerator ?? randomUUID;
+
+  const results = Array.isArray(input.results)
+    ? input.results.map(cloneResult)
+    : [];
+  const filters = Array.isArray(input.filters)
+    ? input.filters.map(cloneFilter)
+    : [];
+
+  const budgetChars = nonNegativeInt(input.budget?.chars);
+  const budgetUsed = nonNegativeInt(input.budget?.used);
+
+  const tierExplain =
+    input.tierExplain && typeof input.tierExplain === "object"
+      ? cloneTierExplain(input.tierExplain)
+      : null;
+
+  return {
+    schemaVersion: "1",
+    query: typeof input.query === "string" ? input.query : "",
+    snapshotId: snapshotIdGenerator(),
+    capturedAt: now(),
+    tierExplain,
+    results,
+    filters,
+    budget: { chars: budgetChars, used: budgetUsed },
+    sessionKey: nonEmptyString(input.sessionKey),
+    namespace: nonEmptyString(input.namespace),
+    traceId: nonEmptyString(input.traceId),
+  };
+}
+
+/**
+ * Mutable builder used by the orchestrator to accumulate X-ray fields
+ * as recall progresses.  Call `build()` to get the finalized
+ * immutable-ish snapshot.  All inputs are validated at insert time so
+ * a malformed entry cannot poison the snapshot later.
+ */
+export class RecallXrayBuilder {
+  private readonly query: string;
+  private readonly sessionKey: string | undefined;
+  private namespace: string | undefined;
+  private traceId: string | undefined;
+  private tierExplain: RecallTierExplain | null = null;
+  private readonly results: RecallXrayResult[] = [];
+  private readonly filters: RecallFilterTrace[] = [];
+  private budgetChars = 0;
+  private budgetUsed = 0;
+
+  constructor(opts: {
+    query: string;
+    sessionKey?: string;
+    namespace?: string;
+    traceId?: string;
+  }) {
+    this.query = typeof opts.query === "string" ? opts.query : "";
+    this.sessionKey = nonEmptyString(opts.sessionKey);
+    this.namespace = nonEmptyString(opts.namespace);
+    this.traceId = nonEmptyString(opts.traceId);
+  }
+
+  setNamespace(namespace: string | undefined): void {
+    this.namespace = nonEmptyString(namespace);
+  }
+
+  setTraceId(traceId: string | undefined): void {
+    this.traceId = nonEmptyString(traceId);
+  }
+
+  setTierExplain(tierExplain: RecallTierExplain | null | undefined): void {
+    this.tierExplain =
+      tierExplain && typeof tierExplain === "object"
+        ? cloneTierExplain(tierExplain)
+        : null;
+  }
+
+  setBudget(budget: { chars?: number; used?: number }): void {
+    this.budgetChars = nonNegativeInt(budget.chars);
+    this.budgetUsed = nonNegativeInt(budget.used);
+  }
+
+  recordResult(result: RecallXrayResult): void {
+    this.results.push(cloneResult(result));
+  }
+
+  recordFilter(filter: RecallFilterTrace): void {
+    this.filters.push(cloneFilter(filter));
+  }
+
+  build(opts: {
+    now?: () => number;
+    snapshotIdGenerator?: () => string;
+  } = {}): RecallXraySnapshot {
+    return buildXraySnapshot({
+      query: this.query,
+      tierExplain: this.tierExplain,
+      results: this.results,
+      filters: this.filters,
+      budget: { chars: this.budgetChars, used: this.budgetUsed },
+      sessionKey: this.sessionKey,
+      namespace: this.namespace,
+      traceId: this.traceId,
+      now: opts.now,
+      snapshotIdGenerator: opts.snapshotIdGenerator,
+    });
+  }
+}
+
+// ─── Internals ────────────────────────────────────────────────────────────
+
+function cloneResult(result: RecallXrayResult): RecallXrayResult {
+  if (!result || typeof result !== "object") {
+    throw new TypeError("RecallXrayResult must be an object");
+  }
+  if (!isRecallXrayServedBy(result.servedBy)) {
+    throw new TypeError(
+      `RecallXrayResult.servedBy must be one of ${RECALL_XRAY_SERVED_BY_VALUES.join(
+        ", ",
+      )}; got ${JSON.stringify(result.servedBy)}`,
+    );
+  }
+  const memoryId = typeof result.memoryId === "string" ? result.memoryId : "";
+  const path = typeof result.path === "string" ? result.path : "";
+  const admittedBy = Array.isArray(result.admittedBy)
+    ? result.admittedBy.filter((x): x is string => typeof x === "string")
+    : [];
+  const graphPath = Array.isArray(result.graphPath)
+    ? result.graphPath.filter((x): x is string => typeof x === "string")
+    : undefined;
+  const auditEntryId = nonEmptyString(result.auditEntryId);
+  const rejectedBy = nonEmptyString(result.rejectedBy);
+  const scoreDecomposition = cloneScoreDecomposition(result.scoreDecomposition);
+  const out: RecallXrayResult = {
+    memoryId,
+    path,
+    servedBy: result.servedBy,
+    scoreDecomposition,
+    admittedBy,
+  };
+  if (graphPath !== undefined) out.graphPath = graphPath;
+  if (auditEntryId !== undefined) out.auditEntryId = auditEntryId;
+  if (rejectedBy !== undefined) out.rejectedBy = rejectedBy;
+  return out;
+}
+
+function cloneFilter(filter: RecallFilterTrace): RecallFilterTrace {
+  if (!filter || typeof filter !== "object") {
+    throw new TypeError("RecallFilterTrace must be an object");
+  }
+  const out: RecallFilterTrace = {
+    name: typeof filter.name === "string" ? filter.name : "",
+    considered: nonNegativeInt(filter.considered),
+    admitted: nonNegativeInt(filter.admitted),
+  };
+  const reason = nonEmptyString(filter.reason);
+  if (reason !== undefined) out.reason = reason;
+  return out;
+}
+
+function cloneScoreDecomposition(
+  value: RecallXrayScoreDecomposition | undefined,
+): RecallXrayScoreDecomposition {
+  if (!value || typeof value !== "object") {
+    return { final: 0 };
+  }
+  const out: RecallXrayScoreDecomposition = {
+    final: finiteNumber(value.final) ?? 0,
+  };
+  const vector = finiteNumber(value.vector);
+  if (vector !== undefined) out.vector = vector;
+  const bm25 = finiteNumber(value.bm25);
+  if (bm25 !== undefined) out.bm25 = bm25;
+  const importance = finiteNumber(value.importance);
+  if (importance !== undefined) out.importance = importance;
+  const mmrPenalty = finiteNumber(value.mmrPenalty);
+  if (mmrPenalty !== undefined) out.mmrPenalty = mmrPenalty;
+  const tierPrior = finiteNumber(value.tierPrior);
+  if (tierPrior !== undefined) out.tierPrior = tierPrior;
+  return out;
+}
+
+function cloneTierExplain(tierExplain: RecallTierExplain): RecallTierExplain {
+  // Use structuredClone so future RecallTierExplain additions do not
+  // silently share references through hand-enumerated fields.  The
+  // payload is JSON-shaped.
+  return structuredClone(tierExplain);
+}
+
+function nonNegativeInt(value: unknown): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return 0;
+  if (value <= 0) return 0;
+  return Math.floor(value);
+}
+
+function finiteNumber(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
+  return value;
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  if (typeof value !== "string") return undefined;
+  const trimmed = value.trim();
+  if (trimmed.length === 0) return undefined;
+  return value;
+}

--- a/tests/recall-xray-capture.test.ts
+++ b/tests/recall-xray-capture.test.ts
@@ -1,0 +1,140 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+import { Orchestrator } from "../src/orchestrator.js";
+import { parseConfig } from "../src/config.js";
+
+async function makeOrchestrator(
+  prefix: string,
+  overrides: Record<string, unknown> = {},
+): Promise<Orchestrator> {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), prefix));
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    transcriptEnabled: false,
+    hourlySummariesEnabled: false,
+    knowledgeIndexEnabled: false,
+    compoundingInjectEnabled: false,
+    memoryBoxesEnabled: false,
+    temporalMemoryTreeEnabled: false,
+    injectQuestions: false,
+    ...overrides,
+  });
+  return new Orchestrator(config);
+}
+
+// Recall with xrayCapture disabled (the default) must not populate the
+// snapshot.  This guards the "no behavior change when flag absent"
+// invariant from issue #570 PR 1.
+test("getLastXraySnapshot returns null when xrayCapture flag is not set", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-absent-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall("hello world", "agent:test:xray-absent");
+
+  assert.equal(orchestrator.getLastXraySnapshot(), null);
+});
+
+// Recall with xrayCapture: true must populate a snapshot that carries
+// the query text and the session/trace scope.
+test("getLastXraySnapshot captures a snapshot when xrayCapture flag is true", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-capture-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall(
+    "capture me please",
+    "agent:test:xray-capture",
+    { xrayCapture: true },
+  );
+
+  const snapshot = orchestrator.getLastXraySnapshot();
+  assert.ok(snapshot);
+  assert.equal(snapshot.schemaVersion, "1");
+  assert.equal(snapshot.query, "capture me please");
+  assert.equal(snapshot.sessionKey, "agent:test:xray-capture");
+  assert.ok(
+    typeof snapshot.snapshotId === "string" && snapshot.snapshotId.length > 0,
+    "snapshotId should be a non-empty string",
+  );
+  assert.ok(
+    typeof snapshot.capturedAt === "number" && snapshot.capturedAt > 0,
+    "capturedAt should be a positive number",
+  );
+  // No results for a cold-start recall with empty memory — the capture
+  // path should still emit an empty results array.
+  assert.deepEqual(snapshot.results, []);
+});
+
+// Snapshots are deep-copied on read.  Mutating the returned value must
+// not affect a subsequent `getLastXraySnapshot()` call.
+test("getLastXraySnapshot returns a deep copy", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-deepcopy-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall(
+    "deep copy test",
+    "agent:test:xray-deepcopy",
+    { xrayCapture: true },
+  );
+
+  const first = orchestrator.getLastXraySnapshot();
+  assert.ok(first);
+  first.results.push({
+    memoryId: "fake",
+    path: "/fake.md",
+    servedBy: "hybrid",
+    admittedBy: ["tampered"],
+    scoreDecomposition: { final: 1 },
+  });
+
+  const second = orchestrator.getLastXraySnapshot();
+  assert.ok(second);
+  assert.deepEqual(second.results, []);
+});
+
+// clearLastXraySnapshot() resets the in-memory capture.
+test("clearLastXraySnapshot resets the captured snapshot", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-clear-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall(
+    "clear test",
+    "agent:test:xray-clear",
+    { xrayCapture: true },
+  );
+  assert.ok(orchestrator.getLastXraySnapshot());
+
+  orchestrator.clearLastXraySnapshot();
+  assert.equal(orchestrator.getLastXraySnapshot(), null);
+});
+
+// A recall without the flag must NOT overwrite a previously captured
+// snapshot.  This keeps the capture surface useful when a capturing
+// caller is interleaved with non-capturing callers.
+test("recall without xrayCapture does not overwrite a prior captured snapshot", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-preserve-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall(
+    "first",
+    "agent:test:xray-preserve",
+    { xrayCapture: true },
+  );
+  const captured = orchestrator.getLastXraySnapshot();
+  assert.ok(captured);
+  assert.equal(captured.query, "first");
+
+  // Second recall does not request capture — the prior snapshot must
+  // still be accessible.
+  await orchestrator.recall("second", "agent:test:xray-preserve");
+
+  const stillCaptured = orchestrator.getLastXraySnapshot();
+  assert.ok(stillCaptured);
+  assert.equal(stillCaptured.query, "first");
+});

--- a/tests/recall-xray-capture.test.ts
+++ b/tests/recall-xray-capture.test.ts
@@ -140,6 +140,39 @@ test("recall captures an X-ray snapshot even when mode is no_recall", async () =
   assert.equal(snapshot.filters[0]!.reason, "no_recall");
 });
 
+// An aborted recall with `xrayCapture: true` must NOT clobber a prior
+// captured snapshot.  Otherwise a timeout / cancellation racing past
+// the capture site would overwrite a successful prior capture with
+// partial data from the canceled call.
+test("aborted recall with xrayCapture does not clobber a prior captured snapshot", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-abort-");
+  (orchestrator as any).initPromise = null;
+
+  // Seed a successful capture.
+  await orchestrator.recall(
+    "first",
+    "agent:test:xray-abort",
+    { xrayCapture: true },
+  );
+  const captured = orchestrator.getLastXraySnapshot();
+  assert.ok(captured);
+  assert.equal(captured.query, "first");
+
+  // Second recall is aborted before the capture site fires — the
+  // prior snapshot must still be accessible.
+  const aborted = new AbortController();
+  aborted.abort();
+  await orchestrator.recall(
+    "aborted-second",
+    "agent:test:xray-abort",
+    { xrayCapture: true, abortSignal: aborted.signal },
+  );
+
+  const stillCaptured = orchestrator.getLastXraySnapshot();
+  assert.ok(stillCaptured);
+  assert.equal(stillCaptured.query, "first");
+});
+
 // A recall without the flag must NOT overwrite a previously captured
 // snapshot.  This keeps the capture surface useful when a capturing
 // caller is interleaved with non-capturing callers.

--- a/tests/recall-xray-capture.test.ts
+++ b/tests/recall-xray-capture.test.ts
@@ -114,6 +114,32 @@ test("clearLastXraySnapshot resets the captured snapshot", async () => {
   assert.equal(orchestrator.getLastXraySnapshot(), null);
 });
 
+// `no_recall` planner mode returns early from recallInternal, but
+// capture must still fire on that branch when the caller opted in —
+// otherwise `getLastXraySnapshot()` returns a stale prior capture
+// (or null) and debug surfaces silently report the wrong recall.
+test("recall captures an X-ray snapshot even when mode is no_recall", async () => {
+  const orchestrator = await makeOrchestrator("engram-xray-no-recall-");
+  (orchestrator as any).initPromise = null;
+
+  await orchestrator.recall(
+    "no recall please",
+    "agent:test:xray-no-recall",
+    { xrayCapture: true, mode: "no_recall" },
+  );
+
+  const snapshot = orchestrator.getLastXraySnapshot();
+  assert.ok(snapshot, "snapshot should be captured on the no_recall branch");
+  assert.equal(snapshot.query, "no recall please");
+  assert.equal(snapshot.sessionKey, "agent:test:xray-no-recall");
+  assert.deepEqual(snapshot.results, []);
+  // The no_recall branch records a single `planner-mode` filter trace
+  // so downstream surfaces can render why zero results surfaced.
+  assert.equal(snapshot.filters.length, 1);
+  assert.equal(snapshot.filters[0]!.name, "planner-mode");
+  assert.equal(snapshot.filters[0]!.reason, "no_recall");
+});
+
 // A recall without the flag must NOT overwrite a previously captured
 // snapshot.  This keeps the capture surface useful when a capturing
 // caller is interleaved with non-capturing callers.


### PR DESCRIPTION
## Summary

Slice 1 of the unified Recall X-ray observability surface (#570).  Schema + internal plumbing only — CLI / HTTP / MCP surfaces land in later slices, and the shared renderer lands in PR 2.

- New `packages/remnic-core/src/recall-xray.ts` defines `RecallXraySnapshot`, `RecallXrayResult`, `RecallFilterTrace`, and the 6-value `RecallXrayServedBy` ladder from the issue spec.  Pure `buildXraySnapshot()` builder plus a `RecallXrayBuilder` for incremental accumulation.  All inputs are deep-copied so caller mutation cannot tear the returned snapshot.
- Orchestrator gets `RecallInvocationOptions.xrayCapture?: boolean`.  When set, `recallInternal` composes a snapshot from data already gathered (query, session/trace scope, memory ids, budget accounting) and stashes it via a new `getLastXraySnapshot()` / `clearLastXraySnapshot()` pair.  Recall WITHOUT the flag leaves prior captures intact.  Capture failures are caught and logged — they never propagate into the primary recall path.

## No behavior change without `xrayCapture`

All new code is gated on `options.xrayCapture === true`.  Default recall behavior is byte-for-byte identical to `main`.

## Test plan

- [x] 16 unit tests in `packages/remnic-core/src/recall-xray.test.ts` — schema version, score decomposition (including non-finite drop-through), budget clamping, tierExplain deep-copy, servedBy validation, defensive copies against caller mutation, incremental builder.
- [x] 5 integration tests in `tests/recall-xray-capture.test.ts` — flag absent → null; flag set → populated snapshot with query + session + trace; returned snapshot is a deep copy; `clearLastXraySnapshot()` resets; a non-capturing recall does not overwrite a prior captured snapshot.
- [x] `pnpm run check-types` clean.

Part of #570 (slice 1 of 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core `Orchestrator.recallInternal` flow to add opt-in X-ray capture and extra bookkeeping, but it is gated behind `xrayCapture: true` and failures are swallowed, limiting blast radius to debug/observability paths.
> 
> **Overview**
> Adds a new `RecallXraySnapshot` schema (`recall-xray.ts`) plus a pure `buildXraySnapshot()` and `RecallXrayBuilder` for producing validated, defensively-copied X-ray documents (served-by tier, per-result score decomposition, filter traces, and budget metadata).
> 
> Updates `Orchestrator.recall()`/`recallInternal` to support `RecallInvocationOptions.xrayCapture?: boolean`; when enabled it captures an in-memory snapshot retrievable via `getLastXraySnapshot()` (deep-copied) and reset via `clearLastXraySnapshot()`, including a special capture for the `no_recall` early-return path and logic to avoid overwriting prior captures on aborted or non-capturing calls.
> 
> Adds unit tests for the snapshot builder/validation and integration tests verifying opt-in capture behavior, non-clobbering semantics, and deep-copy safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03e41ac23475fce0b9ec778b3eb5076bad3458aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->