### PR TITLE
feat(extraction-judge): add defer verdict kind to JudgeVerdict union (issue #562 PR 1/4)

### DIFF
--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -34,9 +34,96 @@ export interface JudgeCandidate {
   importanceLevel?: ImportanceLevel;
 }
 
+/**
+ * Verdict kinds (issue #562, PR 1).
+ *
+ * - `"accept"`: fact is durable, persist it.
+ * - `"reject"`: fact is not durable, drop it.
+ * - `"defer"`: fact is ambiguous; push it back into the buffer for another
+ *   pass with fresh context. Inspired by MemReader (arxiv 2604.07877).
+ *
+ * PR 1 only introduces the type. No emit path produces `"defer"` yet — the
+ * defer-capable prompt, buffer re-routing, telemetry, and GRPO data
+ * collection are landing in PRs 2, 3, and 4 respectively.
+ */
+export type JudgeVerdictKind = "accept" | "reject" | "defer";
+
+/**
+ * Judge verdict shape.
+ *
+ * Back-compat note: `kind` is optional. Verdicts serialized before PR 1
+ * (both in-memory cache entries and any persisted caches) only carry
+ * `{ durable, reason }`. Downstream consumers must either read `durable`
+ * directly, or use {@link getVerdictKind} / {@link isDurableVerdict} which
+ * gracefully fall back to the boolean when `kind` is missing, and ignore
+ * unknown future `kind` values rather than crashing.
+ */
 export interface JudgeVerdict {
+  /**
+   * True iff the fact should be persisted. For `"defer"` verdicts this is
+   * `false` — a deferred fact is not (yet) persisted, so callers that only
+   * look at `durable` will treat defer as "skip this turn", which matches
+   * the pre-PR-1 fail-closed behavior for non-accepted verdicts.
+   */
   durable: boolean;
   reason: string;
+  /**
+   * Optional explicit verdict kind. Added in PR 1 of issue #562. Legacy
+   * verdicts (including cache entries produced before this field existed)
+   * do not set `kind`; use {@link getVerdictKind} to read this safely.
+   */
+  kind?: JudgeVerdictKind;
+}
+
+/**
+ * Resolve a verdict's effective kind.
+ *
+ * - If `kind` is explicitly set to one of the known values, return it.
+ * - If `kind` is absent, infer from `durable` (back-compat with pre-PR-1
+ *   cache entries and emit paths that have not been updated yet).
+ * - If `kind` is set to an unrecognised value (forward-compat, e.g. a
+ *   future cache entry loaded by an older build), fall back to `durable`
+ *   so we never crash on unknown strings.
+ */
+export function getVerdictKind(verdict: JudgeVerdict): JudgeVerdictKind {
+  const raw = verdict.kind;
+  if (raw === "accept" || raw === "reject" || raw === "defer") {
+    return raw;
+  }
+  return verdict.durable ? "accept" : "reject";
+}
+
+/**
+ * Type guard: returns `true` only for verdicts that should be persisted.
+ * Treats both `"reject"` and `"defer"` as "not durable" — defer means the
+ * caller should re-evaluate later, not write now.
+ */
+export function isDurableVerdict(verdict: JudgeVerdict): boolean {
+  return getVerdictKind(verdict) === "accept";
+}
+
+/**
+ * Validate a cache entry loaded from persistence / another process.
+ *
+ * Accepts legacy `{ durable, reason }` entries unchanged. Accepts new
+ * `{ durable, reason, kind }` entries when `kind` is one of the known
+ * values. Rejects entries with structurally wrong types or unknown
+ * `kind` values so stale caches cannot poison in-process state.
+ *
+ * Used by the in-memory cache loaders to stay forward- and backward-
+ * compatible without catastrophically failing on an unexpected shape.
+ */
+export function isValidCachedVerdict(value: unknown): value is JudgeVerdict {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.durable !== "boolean") return false;
+  if (typeof v.reason !== "string") return false;
+  if (v.kind !== undefined) {
+    if (v.kind !== "accept" && v.kind !== "reject" && v.kind !== "defer") {
+      return false;
+    }
+  }
+  return true;
 }
 
 export interface JudgeBatchResult {

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -106,23 +106,22 @@ export function isDurableVerdict(verdict: JudgeVerdict): boolean {
  * Validate a cache entry loaded from persistence / another process.
  *
  * Accepts legacy `{ durable, reason }` entries unchanged. Accepts new
- * `{ durable, reason, kind }` entries when `kind` is one of the known
- * values. Rejects entries with structurally wrong types or unknown
- * `kind` values so stale caches cannot poison in-process state.
+ * `{ durable, reason, kind }` entries when `kind` is absent or a string
+ * — including unknown string values, which future builds may introduce.
+ * `getVerdictKind` already collapses unrecognised strings back to the
+ * boolean `durable`, so accepting them here is safe and keeps the loader
+ * forward-compatible.
  *
- * Used by the in-memory cache loaders to stay forward- and backward-
- * compatible without catastrophically failing on an unexpected shape.
+ * Rejects entries with structurally wrong types (missing `durable`,
+ * non-string `reason`, non-string `kind`) so stale or corrupt caches
+ * cannot poison in-process state.
  */
 export function isValidCachedVerdict(value: unknown): value is JudgeVerdict {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   if (typeof v.durable !== "boolean") return false;
   if (typeof v.reason !== "string") return false;
-  if (v.kind !== undefined) {
-    if (v.kind !== "accept" && v.kind !== "reject" && v.kind !== "defer") {
-      return false;
-    }
-  }
+  if (v.kind !== undefined && typeof v.kind !== "string") return false;
   return true;
 }
 

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -105,24 +105,55 @@ export function isDurableVerdict(verdict: JudgeVerdict): boolean {
 /**
  * Validate a cache entry loaded from persistence / another process.
  *
- * Accepts legacy `{ durable, reason }` entries unchanged. Accepts new
- * `{ durable, reason, kind }` entries when `kind` is absent or a string
- * — including unknown string values, which future builds may introduce.
- * `getVerdictKind` already collapses unrecognised strings back to the
- * boolean `durable`, so accepting them here is safe and keeps the loader
- * forward-compatible.
+ * Strict: accepts legacy `{ durable, reason }` entries and new entries
+ * whose `kind` is one of the three known `JudgeVerdictKind` values.
+ * Rejects structurally wrong types and unknown `kind` strings so the
+ * type-guard narrowing is sound — callers that receive
+ * `value is JudgeVerdict` can safely treat `kind` as the declared
+ * union.
  *
- * Rejects entries with structurally wrong types (missing `durable`,
- * non-string `reason`, non-string `kind`) so stale or corrupt caches
- * cannot poison in-process state.
+ * Forward-compat is handled by {@link normalizeCachedVerdict}, which
+ * drops unknown `kind` strings before validation so a newer build's
+ * cache entry still loads instead of being rejected.
  */
 export function isValidCachedVerdict(value: unknown): value is JudgeVerdict {
   if (typeof value !== "object" || value === null) return false;
   const v = value as Record<string, unknown>;
   if (typeof v.durable !== "boolean") return false;
   if (typeof v.reason !== "string") return false;
-  if (v.kind !== undefined && typeof v.kind !== "string") return false;
+  if (v.kind !== undefined) {
+    if (v.kind !== "accept" && v.kind !== "reject" && v.kind !== "defer") {
+      return false;
+    }
+  }
   return true;
+}
+
+/**
+ * Forward-compatible cache-entry loader.
+ *
+ * Drops unknown `kind` strings to `undefined` (so `getVerdictKind` can
+ * fall back to `durable`), then validates structurally. Non-string
+ * `kind` values are still treated as structural violations and rejected.
+ * Returns the sanitised verdict, or `null` when the entry is structurally
+ * unusable.
+ */
+export function normalizeCachedVerdict(value: unknown): JudgeVerdict | null {
+  if (typeof value !== "object" || value === null) return null;
+  const v = value as Record<string, unknown>;
+  if (typeof v.durable !== "boolean") return null;
+  if (typeof v.reason !== "string") return null;
+  let kind: JudgeVerdictKind | undefined;
+  if (v.kind !== undefined) {
+    if (typeof v.kind !== "string") return null;
+    if (v.kind === "accept" || v.kind === "reject" || v.kind === "defer") {
+      kind = v.kind;
+    }
+    // Unknown string `kind`: dropped to undefined for forward-compat.
+  }
+  const out: JudgeVerdict = { durable: v.durable, reason: v.reason };
+  if (kind !== undefined) out.kind = kind;
+  return out;
 }
 
 export interface JudgeBatchResult {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -69,6 +69,7 @@ export {
   getVerdictKind,
   isDurableVerdict,
   isValidCachedVerdict,
+  normalizeCachedVerdict,
   type JudgeCandidate,
   type JudgeVerdict,
   type JudgeVerdictKind,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -66,8 +66,12 @@ export {
   clearVerdictCache,
   verdictCacheSize,
   createVerdictCache,
+  getVerdictKind,
+  isDurableVerdict,
+  isValidCachedVerdict,
   type JudgeCandidate,
   type JudgeVerdict,
+  type JudgeVerdictKind,
   type JudgeBatchResult,
 } from "./extraction-judge.js";
 

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -8,6 +8,7 @@ import {
   getVerdictKind,
   isDurableVerdict,
   isValidCachedVerdict,
+  normalizeCachedVerdict,
   type JudgeCandidate,
   type JudgeVerdict,
   type JudgeVerdictKind,
@@ -559,13 +560,13 @@ test("isValidCachedVerdict accepts new entries with known kind", () => {
   );
 });
 
-test("isValidCachedVerdict accepts unknown string kinds for forward-compat", () => {
-  // Loader should not crash when a future build adds a new kind value.
-  // getVerdictKind collapses unknown strings back to the boolean, so
-  // the cached entry is still safe to consume.
+test("isValidCachedVerdict rejects unknown kind values (strict type-guard)", () => {
+  // Strict: the type-guard predicate narrows to JudgeVerdict, so only
+  // known kinds pass. Forward-compat is the caller's responsibility via
+  // normalizeCachedVerdict.
   assert.equal(
     isValidCachedVerdict({ durable: true, reason: "x", kind: "bogus" }),
-    true,
+    false,
   );
 });
 
@@ -582,6 +583,35 @@ test("isValidCachedVerdict rejects structurally invalid entries", () => {
     isValidCachedVerdict({ durable: true, reason: "x", kind: 42 }),
     false,
   );
+});
+
+test("normalizeCachedVerdict drops unknown kind strings for forward-compat", () => {
+  const result = normalizeCachedVerdict({
+    durable: true,
+    reason: "x",
+    kind: "bogus",
+  });
+  assert.notEqual(result, null);
+  assert.equal(result!.durable, true);
+  assert.equal(result!.reason, "x");
+  assert.equal(result!.kind, undefined);
+  // Re-validating the sanitised result succeeds under the strict guard.
+  assert.equal(isValidCachedVerdict(result), true);
+});
+
+test("normalizeCachedVerdict preserves known kinds", () => {
+  const result = normalizeCachedVerdict({
+    durable: false,
+    reason: "ambiguous",
+    kind: "defer",
+  });
+  assert.deepEqual(result, { durable: false, reason: "ambiguous", kind: "defer" });
+});
+
+test("normalizeCachedVerdict rejects structural violations", () => {
+  assert.equal(normalizeCachedVerdict(null), null);
+  assert.equal(normalizeCachedVerdict({ durable: true }), null);
+  assert.equal(normalizeCachedVerdict({ durable: true, reason: "x", kind: 42 }), null);
 });
 
 test("verdict cache loads legacy entries correctly via judgeFactDurability", async () => {

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -5,7 +5,12 @@ import {
   clearVerdictCache,
   verdictCacheSize,
   validateProcedureExtraction,
+  getVerdictKind,
+  isDurableVerdict,
+  isValidCachedVerdict,
   type JudgeCandidate,
+  type JudgeVerdict,
+  type JudgeVerdictKind,
 } from "../packages/remnic-core/src/extraction-judge.ts";
 import { parseConfig } from "../packages/remnic-core/src/config.ts";
 
@@ -456,4 +461,213 @@ test("validateProcedureExtraction rejects missing trigger phrasing", () => {
     ],
   });
   assert.equal(v.durable, false);
+});
+
+// ---------------------------------------------------------------------------
+// Issue #562 PR 1 — defer verdict kind (type extension only, no behavior yet)
+// ---------------------------------------------------------------------------
+
+test("JudgeVerdictKind union accepts accept/reject/defer", () => {
+  // Compile-time check: all three literals are assignable to JudgeVerdictKind.
+  const accept: JudgeVerdictKind = "accept";
+  const reject: JudgeVerdictKind = "reject";
+  const defer: JudgeVerdictKind = "defer";
+  assert.equal(accept, "accept");
+  assert.equal(reject, "reject");
+  assert.equal(defer, "defer");
+});
+
+test("JudgeVerdict accepts optional kind: 'defer'", () => {
+  // Compile-time check: a verdict with kind="defer" is a valid JudgeVerdict.
+  const v: JudgeVerdict = {
+    durable: false,
+    reason: "Ambiguous referent, revisit next turn",
+    kind: "defer",
+  };
+  assert.equal(v.kind, "defer");
+  assert.equal(v.durable, false);
+});
+
+test("getVerdictKind infers accept from durable=true when kind is absent", () => {
+  const v: JudgeVerdict = { durable: true, reason: "Stable preference" };
+  assert.equal(getVerdictKind(v), "accept");
+});
+
+test("getVerdictKind infers reject from durable=false when kind is absent", () => {
+  const v: JudgeVerdict = { durable: false, reason: "Transient state" };
+  assert.equal(getVerdictKind(v), "reject");
+});
+
+test("getVerdictKind returns explicit kind when set", () => {
+  const accept: JudgeVerdict = { durable: true, reason: "ok", kind: "accept" };
+  const reject: JudgeVerdict = { durable: false, reason: "no", kind: "reject" };
+  const defer: JudgeVerdict = { durable: false, reason: "maybe", kind: "defer" };
+  assert.equal(getVerdictKind(accept), "accept");
+  assert.equal(getVerdictKind(reject), "reject");
+  assert.equal(getVerdictKind(defer), "defer");
+});
+
+test("getVerdictKind ignores unknown kind values and falls back to durable", () => {
+  // Forward-compat: an older build reading a future cache entry whose
+  // `kind` is an unrecognised string must not crash — it should fall
+  // back to the boolean.
+  const unknown = {
+    durable: true,
+    reason: "future-kind",
+    kind: "some-future-kind",
+  } as unknown as JudgeVerdict;
+  assert.equal(getVerdictKind(unknown), "accept");
+});
+
+test("isDurableVerdict is true only for accept", () => {
+  assert.equal(
+    isDurableVerdict({ durable: true, reason: "", kind: "accept" }),
+    true,
+  );
+  assert.equal(
+    isDurableVerdict({ durable: false, reason: "", kind: "reject" }),
+    false,
+  );
+  assert.equal(
+    isDurableVerdict({ durable: false, reason: "", kind: "defer" }),
+    false,
+    "Defer is not durable — caller should re-evaluate, not persist",
+  );
+  // Legacy shape without kind still works via durable fallback.
+  assert.equal(isDurableVerdict({ durable: true, reason: "" }), true);
+  assert.equal(isDurableVerdict({ durable: false, reason: "" }), false);
+});
+
+test("isValidCachedVerdict accepts legacy entries without kind", () => {
+  // Simulates a cache entry produced before PR 1 — only durable + reason.
+  const legacy = { durable: true, reason: "pre-PR1 entry" };
+  assert.equal(isValidCachedVerdict(legacy), true);
+});
+
+test("isValidCachedVerdict accepts new entries with known kind", () => {
+  assert.equal(
+    isValidCachedVerdict({ durable: true, reason: "ok", kind: "accept" }),
+    true,
+  );
+  assert.equal(
+    isValidCachedVerdict({ durable: false, reason: "no", kind: "reject" }),
+    true,
+  );
+  assert.equal(
+    isValidCachedVerdict({ durable: false, reason: "maybe", kind: "defer" }),
+    true,
+  );
+});
+
+test("isValidCachedVerdict rejects entries with unknown kind", () => {
+  assert.equal(
+    isValidCachedVerdict({ durable: true, reason: "x", kind: "bogus" }),
+    false,
+  );
+});
+
+test("isValidCachedVerdict rejects structurally invalid entries", () => {
+  assert.equal(isValidCachedVerdict(null), false);
+  assert.equal(isValidCachedVerdict(undefined), false);
+  assert.equal(isValidCachedVerdict("string"), false);
+  assert.equal(isValidCachedVerdict({}), false);
+  assert.equal(isValidCachedVerdict({ durable: "yes", reason: "x" }), false);
+  assert.equal(isValidCachedVerdict({ durable: true }), false);
+  assert.equal(isValidCachedVerdict({ reason: "x" }), false);
+});
+
+test("verdict cache loads legacy entries correctly via judgeFactDurability", async () => {
+  // Seed a caller-provided cache with a legacy (pre-PR-1) entry — no kind
+  // field. The judge must serve it from cache and the orchestrator-style
+  // consumer (checking `durable`) must keep working.
+  clearVerdictCache();
+  const cache = new Map<string, JudgeVerdict>();
+
+  const candidate: JudgeCandidate = {
+    text: "Legacy-cached fact body",
+    category: "fact",
+    confidence: 0.8,
+    importanceLevel: "normal",
+  };
+  // Mirror the internal cacheKey() helper: sha256 of "text\0category".
+  const { createHash } = await import("node:crypto");
+  const key = createHash("sha256")
+    .update(`${candidate.text}\0${candidate.category}`)
+    .digest("hex");
+  cache.set(key, { durable: true, reason: "legacy entry without kind" });
+
+  // LLM mock that would explode the test if called — serving from cache
+  // should be hit-only.
+  let llmCalled = false;
+  const mockLocalLlm = {
+    chatCompletion: async () => {
+      llmCalled = true;
+      return { content: "[]" };
+    },
+  };
+
+  const config = makeConfig();
+  const result = await judgeFactDurability(
+    [candidate],
+    config,
+    mockLocalLlm as any,
+    null,
+    cache,
+  );
+
+  assert.equal(llmCalled, false, "Legacy cache hit must not call LLM");
+  assert.equal(result.cached, 1);
+  const v = result.verdicts.get(0);
+  assert.ok(v, "verdict should be present");
+  assert.equal(v!.durable, true);
+  assert.equal(v!.reason, "legacy entry without kind");
+  assert.equal(
+    getVerdictKind(v!),
+    "accept",
+    "Legacy verdict should infer accept from durable=true",
+  );
+});
+
+test("no emit path in current judge produces defer (PR 1 is type-only)", async () => {
+  // Sanity: with a mock LLM that returns a well-formed durable/not-durable
+  // response, the returned verdicts only carry accept/reject-equivalent
+  // shapes. Defer is not emitted until PR 2 adds the capable prompt.
+  clearVerdictCache();
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const userMsg = _msgs[1].content;
+      const items = JSON.parse(userMsg) as Array<{ index: number; text: string }>;
+      const verdicts = items.map((item) => ({
+        index: item.index,
+        durable: item.text.includes("durable"),
+        reason: "mock",
+      }));
+      return { content: JSON.stringify(verdicts) };
+    },
+  };
+
+  const candidates: JudgeCandidate[] = [
+    { text: "A durable preference fact", category: "fact", confidence: 0.8, importanceLevel: "normal" },
+    { text: "Transient build state", category: "fact", confidence: 0.5, importanceLevel: "normal" },
+  ];
+  const config = makeConfig();
+  const result = await judgeFactDurability(
+    candidates,
+    config,
+    mockLocalLlm as any,
+    null,
+  );
+
+  for (const v of result.verdicts.values()) {
+    assert.notEqual(
+      v.kind,
+      "defer",
+      "PR 1 must not emit defer — defer-capable prompt lands in PR 2",
+    );
+    assert.notEqual(
+      getVerdictKind(v),
+      "defer",
+      "PR 1 must not emit defer even via inference",
+    );
+  }
 });

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -559,10 +559,13 @@ test("isValidCachedVerdict accepts new entries with known kind", () => {
   );
 });
 
-test("isValidCachedVerdict rejects entries with unknown kind", () => {
+test("isValidCachedVerdict accepts unknown string kinds for forward-compat", () => {
+  // Loader should not crash when a future build adds a new kind value.
+  // getVerdictKind collapses unknown strings back to the boolean, so
+  // the cached entry is still safe to consume.
   assert.equal(
     isValidCachedVerdict({ durable: true, reason: "x", kind: "bogus" }),
-    false,
+    true,
   );
 });
 
@@ -574,6 +577,11 @@ test("isValidCachedVerdict rejects structurally invalid entries", () => {
   assert.equal(isValidCachedVerdict({ durable: "yes", reason: "x" }), false);
   assert.equal(isValidCachedVerdict({ durable: true }), false);
   assert.equal(isValidCachedVerdict({ reason: "x" }), false);
+  // kind present but wrong type — structural violation, reject.
+  assert.equal(
+    isValidCachedVerdict({ durable: true, reason: "x", kind: 42 }),
+    false,
+  );
 });
 
 test("verdict cache loads legacy entries correctly via judgeFactDurability", async () => {


### PR DESCRIPTION
## Summary

Slice 1 of 4 for issue #562 (add a `defer` action to the extraction judge, inspired by MemReader / arxiv 2604.07877). This PR is **type-only** — no behavior change yet.

- Adds `JudgeVerdictKind = "accept" | "reject" | "defer"` union.
- Extends `JudgeVerdict` with an optional `kind` field (legacy entries with only `{ durable, reason }` keep working).
- Adds helpers: `getVerdictKind()`, `isDurableVerdict()`, `isValidCachedVerdict()`.
- Exports the new symbols from `@remnic/core`.
- Unit tests cover: kind union assignability, explicit/inferred kind, unknown-kind forward-compat fallback, cache back-compat (legacy entry load), and a guard that **no current emit path** produces `"defer"`.

## Out of scope (later PRs for #562)

- **PR 2** — defer-capable prompt + buffer re-routing with capped `deferCount`.
- **PR 3** — defer-rate / defer-resolution telemetry.
- **PR 4** — structured (candidate, context, action, outcome) log for future GRPO training.

## Test plan

- [x] `npm run check-types` passes.
- [x] `npx tsx --test tests/extraction-judge.test.ts` — 31/31 pass (18 existing + 13 new).
- [x] All existing `durable`-based consumers continue to work unchanged.
- [x] Legacy cache entry (no `kind`) loaded via `judgeFactDurability` still hits cache and yields `durable: true`.

Refs #562.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type/API surface expansion only: adds an optional `kind` field and cache normalization/validation helpers but does not change judge decision logic. Risk is limited to downstream consumers incorrectly assuming `kind` is always present or strictly validated.
> 
> **Overview**
> Introduces a new `JudgeVerdictKind` union (`"accept" | "reject" | "defer"`) and extends `JudgeVerdict` with an optional `kind` field while keeping legacy `{ durable, reason }` verdicts working.
> 
> Adds helper APIs to safely interpret and ingest verdicts across versions: `getVerdictKind` (durable fallback + ignore unknown future kinds), `isDurableVerdict`, and cache-focused `isValidCachedVerdict` + `normalizeCachedVerdict` (drops unknown string kinds).
> 
> Exports the new types/functions from `@remnic/core` and expands unit tests to cover back/forward compat, strict cache validation, and that no current emit path produces `"defer"` yet.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a26133d6772b8f283d1e35dd6368a2a25eff50c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->