### PR TITLE
feat(bench): real LongMemEval + LoCoMo dataset loaders (#566 PR 1/7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,10 @@ scripts/CLAUDE.md
 # Eval datasets (downloaded via script, not committed)
 evals/datasets/
 
+# Published-benchmark datasets (LongMemEval, LoCoMo) — run
+# `scripts/bench/fetch-datasets.sh --help` to set up.
+bench-datasets/
+
 # Git worktrees
 .worktrees/
 PR_PREFLIGHT.md

--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ evals/datasets/
 # `scripts/bench/fetch-datasets.sh --help` to set up.
 bench-datasets/
 
+# Published-benchmark artifacts (gitignored during development; promoted
+# per-release by the leaderboard pipeline — see issue #566 slice 6).
+docs/benchmarks/results/
+
 # Git worktrees
 .worktrees/
 PR_PREFLIGHT.md

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -87,14 +87,17 @@ bench-datasets/
     locomo.json                      # optional alternate
 ```
 
-Point the runners at the directory:
+Point the runners at the directory. Use the current `remnic bench run`
+CLI surface with `--dataset-dir` (a dedicated `remnic bench published`
+subcommand is planned for a later slice of
+[#566](https://github.com/joshuaswarren/remnic/issues/566)):
 
 ```bash
-pnpm exec remnic bench published --name longmemeval \
-  --dataset ./bench-datasets/longmemeval --model gpt-4o-mini --limit 100
+pnpm exec remnic bench run longmemeval \
+  --dataset-dir ./bench-datasets/longmemeval --limit 100
 
-pnpm exec remnic bench published --name locomo \
-  --dataset ./bench-datasets/locomo --model gpt-4o-mini
+pnpm exec remnic bench run locomo \
+  --dataset-dir ./bench-datasets/locomo
 ```
 
 Programmatic loaders are exported from `@remnic/bench`:

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -89,12 +89,13 @@ bench-datasets/
 
 Point the runners at the directory. Use the current `remnic bench run`
 CLI surface with `--dataset-dir` (a dedicated `remnic bench published`
-subcommand is planned for a later slice of
+subcommand with user-configurable `--limit`, `--model`, and `--seed` is
+planned for a later slice of
 [#566](https://github.com/joshuaswarren/remnic/issues/566)):
 
 ```bash
 pnpm exec remnic bench run longmemeval \
-  --dataset-dir ./bench-datasets/longmemeval --limit 100
+  --dataset-dir ./bench-datasets/longmemeval
 
 pnpm exec remnic bench run locomo \
   --dataset-dir ./bench-datasets/locomo

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -61,6 +61,63 @@ remnic bench publish --target remnic-ai
 
 Dataset markers match the runner's accepted filenames, so `datasets status` reports "downloaded" exactly when the runner will load successfully.
 
+## Running on real datasets
+
+The `longmemeval` and `locomo` runners ship with a bundled smoke fixture so
+`remnic bench run --quick` and CI stay green without downloading anything.
+To produce public-quality numbers you need the real datasets. Both live on
+HuggingFace.
+
+```bash
+# Print the exact download commands (no auto-fetch):
+scripts/bench/fetch-datasets.sh --help
+scripts/bench/fetch-datasets.sh --target ./bench-datasets
+```
+
+Expected layout (the `bench-datasets/` directory is gitignored):
+
+```
+bench-datasets/
+  longmemeval/
+    longmemeval_oracle.json          # preferred filename
+    longmemeval_s_cleaned.json       # optional alternate
+    longmemeval_s.json               # optional alternate
+  locomo/
+    locomo10.json                    # preferred filename
+    locomo.json                      # optional alternate
+```
+
+Point the runners at the directory:
+
+```bash
+pnpm exec remnic bench published --name longmemeval \
+  --dataset ./bench-datasets/longmemeval --model gpt-4o-mini --limit 100
+
+pnpm exec remnic bench published --name locomo \
+  --dataset ./bench-datasets/locomo --model gpt-4o-mini
+```
+
+Programmatic loaders are exported from `@remnic/bench`:
+
+```ts
+import { loadLongMemEvalS, loadLoCoMo10 } from "@remnic/bench";
+
+const longmemeval = await loadLongMemEvalS({
+  mode: "full",
+  datasetDir: "./bench-datasets/longmemeval",
+  limit: 100,
+});
+// longmemeval.source === "dataset" when the real file was found,
+// "smoke" when quick-mode fallback was used, "missing" when full-mode
+// could not find any of the canonical filenames.
+```
+
+When `mode: "full"` and no dataset is found, the loaders return
+`{ source: "missing", errors }` and the runner throws a
+`formatMissingDatasetError()` message pointing operators at
+`scripts/bench/fetch-datasets.sh`. Quick mode silently falls back to the
+bundled smoke fixture and logs the probe errors so you can tell why.
+
 ## Programmatic API
 
 ```ts

--- a/packages/bench/src/benchmarks/published/dataset-loader.test.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.test.ts
@@ -435,6 +435,119 @@ test("loadLoCoMo10 default parser rejects entries missing qa array", async () =>
   });
 });
 
+test("loadLoCoMo10 default parser rejects qa entry with missing answer and adversarial_answer", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-missing-answer",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [{ question: "q", category: 1, evidence: [] }],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) =>
+        /must include a string or numeric answer/.test(entry),
+      ),
+      `expected answer error; got ${JSON.stringify(result.errors)}`,
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser rejects qa entry with non-string evidence", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-bad-evidence",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [{ question: "q", answer: "a", category: 1, evidence: [1, 2] }],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) =>
+        /evidence must be an array of strings/.test(entry),
+      ),
+      `expected evidence error; got ${JSON.stringify(result.errors)}`,
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser falls back to adversarial_answer when answer missing", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-adversarial",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [
+            {
+              question: "q",
+              adversarial_answer: "fallback-answer",
+              category: 5,
+              evidence: ["D1:1"],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "dataset");
+    assert.equal(result.items.length, 1);
+    assert.equal(result.items[0]?.qa[0]?.answer, "fallback-answer");
+  });
+});
+
+test("loadLoCoMo10 default parser coerces numeric answer to string", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-numeric",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [
+            {
+              question: "how many",
+              answer: 7,
+              category: 1,
+              evidence: [],
+            },
+          ],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "dataset");
+    assert.equal(result.items[0]?.qa[0]?.answer, "7");
+  });
+});
+
 test("loadLoCoMo10 returns smoke fixture when dataset missing in quick mode", async () => {
   const result = await loadLoCoMo10({ mode: "quick" });
   assert.equal(result.source, "smoke");

--- a/packages/bench/src/benchmarks/published/dataset-loader.test.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.test.ts
@@ -216,6 +216,117 @@ test("loadLongMemEvalS rejects non-array payload", async () => {
   });
 });
 
+test("loadLongMemEvalS rejects entries missing haystack_sessions array", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "x",
+          question: "q",
+          answer: "a",
+          question_date: "2025-01-01",
+          // haystack_sessions missing — runner would later crash on
+          // `item.haystack_sessions.length`.
+          haystack_session_ids: [],
+          haystack_dates: [],
+          answer_session_ids: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /haystack_sessions array/.test(entry)),
+      `expected haystack_sessions error; got ${JSON.stringify(result.errors)}`,
+    );
+  });
+});
+
+test("loadLongMemEvalS rejects entries missing a string answer", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "x",
+          question: "q",
+          // no answer
+          question_date: "2025-01-01",
+          haystack_sessions: [],
+          haystack_session_ids: [],
+          haystack_dates: [],
+          answer_session_ids: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /string answer field/.test(entry)),
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser rejects entries missing conversation object", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "bad-1",
+          // conversation missing — runner iterates conversation.session_*
+          qa: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /conversation object field/.test(entry)),
+      `expected conversation error; got ${JSON.stringify(result.errors)}`,
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser rejects entries missing qa array", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "bad-2",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          // qa missing
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /qa array/.test(entry)),
+    );
+  });
+});
+
 test("loadLoCoMo10 returns smoke fixture when dataset missing in quick mode", async () => {
   const result = await loadLoCoMo10({ mode: "quick" });
   assert.equal(result.source, "smoke");

--- a/packages/bench/src/benchmarks/published/dataset-loader.test.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.test.ts
@@ -1,0 +1,286 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  LOCOMO_DATASET_FILENAMES,
+  LONG_MEM_EVAL_DATASET_FILENAMES,
+  formatMissingDatasetError,
+  loadLoCoMo10,
+  loadLongMemEvalS,
+} from "./dataset-loader.ts";
+
+async function withTempDir<T>(
+  fn: (dir: string) => Promise<T>,
+): Promise<T> {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-bench-loader-"));
+  try {
+    return await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("loadLongMemEvalS loads the first probed filename that parses", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "single-session-user",
+          question: "Where does the user live?",
+          answer: "Paris",
+          question_date: "2025-01-01",
+          haystack_dates: [],
+          haystack_session_ids: [],
+          haystack_sessions: [],
+          answer_session_ids: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "dataset");
+    assert.equal(result.filename, "longmemeval_oracle.json");
+    assert.equal(result.items.length, 1);
+    assert.equal(result.items[0]?.question, "Where does the user live?");
+    assert.deepEqual(result.errors, []);
+  });
+});
+
+test("loadLongMemEvalS falls back from unreadable file to next probed filename", async () => {
+  await withTempDir(async (dir) => {
+    // longmemeval_oracle.json intentionally has invalid JSON; loader should
+    // record the parse error and fall through to the next filename.
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      "{ not valid json",
+      "utf8",
+    );
+    await writeFile(
+      path.join(dir, "longmemeval_s_cleaned.json"),
+      JSON.stringify([
+        {
+          question_id: 2,
+          question_type: "single-session-user",
+          question: "Favorite color?",
+          answer: "blue",
+          question_date: "2025-01-02",
+          haystack_dates: [],
+          haystack_session_ids: [],
+          haystack_sessions: [],
+          answer_session_ids: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "dataset");
+    assert.equal(result.filename, "longmemeval_s_cleaned.json");
+    assert.equal(result.items.length, 1);
+    assert.equal(result.errors.length, 1);
+    assert.match(result.errors[0]!, /longmemeval_oracle\.json/);
+  });
+});
+
+test("loadLongMemEvalS falls back to smoke fixture in quick mode when dataset missing", async () => {
+  await withTempDir(async (dir) => {
+    const result = await loadLongMemEvalS({
+      mode: "quick",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "smoke");
+    assert.ok(result.items.length >= 1);
+    // Errors should include ENOENT for every probed filename.
+    assert.equal(result.errors.length, LONG_MEM_EVAL_DATASET_FILENAMES.length);
+    for (const filename of LONG_MEM_EVAL_DATASET_FILENAMES) {
+      assert.ok(
+        result.errors.some((entry) => entry.startsWith(filename)),
+        `expected probe error for ${filename}`,
+      );
+    }
+  });
+});
+
+test("loadLongMemEvalS returns missing in full mode when dataset absent", async () => {
+  await withTempDir(async (dir) => {
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.equal(result.items.length, 0);
+    assert.equal(result.errors.length, LONG_MEM_EVAL_DATASET_FILENAMES.length);
+  });
+});
+
+test("loadLongMemEvalS without datasetDir in quick mode returns smoke fixture with no errors", async () => {
+  const result = await loadLongMemEvalS({ mode: "quick" });
+  assert.equal(result.source, "smoke");
+  assert.ok(result.items.length >= 1);
+  assert.deepEqual(result.errors, []);
+});
+
+test("loadLongMemEvalS honors limit", async () => {
+  await withTempDir(async (dir) => {
+    const items = Array.from({ length: 5 }, (_, index) => ({
+      question_id: index,
+      question_type: "single-session-user",
+      question: `q${index}`,
+      answer: `a${index}`,
+      question_date: "2025-01-01",
+      haystack_dates: [],
+      haystack_session_ids: [],
+      haystack_sessions: [],
+      answer_session_ids: [],
+    }));
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify(items),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+      limit: 2,
+    });
+    assert.equal(result.items.length, 2);
+  });
+});
+
+test("loadLongMemEvalS limit=0 returns zero items (CLAUDE.md rule 27)", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "single-session-user",
+          question: "q",
+          answer: "a",
+          question_date: "2025-01-01",
+          haystack_dates: [],
+          haystack_session_ids: [],
+          haystack_sessions: [],
+          answer_session_ids: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+      limit: 0,
+    });
+    assert.equal(result.items.length, 0);
+  });
+});
+
+test("loadLongMemEvalS rejects negative limit", async () => {
+  await assert.rejects(
+    () => loadLongMemEvalS({ mode: "quick", limit: -1 }),
+    /non-negative integer/,
+  );
+});
+
+test("loadLongMemEvalS rejects non-integer limit", async () => {
+  await assert.rejects(
+    () => loadLongMemEvalS({ mode: "quick", limit: 1.5 }),
+    /non-negative integer/,
+  );
+});
+
+test("loadLongMemEvalS rejects non-array payload", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify({ items: [] }),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    // Parse error recorded, no subsequent files, fall through to missing.
+    assert.equal(result.source, "missing");
+    assert.ok(result.errors.some((entry) => /must contain an array/.test(entry)));
+  });
+});
+
+test("loadLoCoMo10 returns smoke fixture when dataset missing in quick mode", async () => {
+  const result = await loadLoCoMo10({ mode: "quick" });
+  assert.equal(result.source, "smoke");
+  assert.ok(result.items.length >= 1);
+});
+
+test("loadLoCoMo10 returns missing in full mode when dataset absent", async () => {
+  await withTempDir(async (dir) => {
+    const result = await loadLoCoMo10({ mode: "full", datasetDir: dir });
+    assert.equal(result.source, "missing");
+    assert.equal(result.items.length, 0);
+  });
+});
+
+test("loadLoCoMo10 uses custom parseFile when provided", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "custom-1",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+      parseFile: (raw, filename) => {
+        // Custom parser that enforces a stricter invariant.
+        const parsed = JSON.parse(raw) as Array<Record<string, unknown>>;
+        if (parsed.length === 0) {
+          throw new Error(`${filename} must have at least one conversation`);
+        }
+        return parsed as any;
+      },
+    });
+    assert.equal(result.source, "dataset");
+    assert.equal(result.items.length, 1);
+  });
+});
+
+test("formatMissingDatasetError surfaces filenames and fetch-script hint", () => {
+  const message = formatMissingDatasetError(
+    "longmemeval",
+    "/tmp/missing",
+    LONG_MEM_EVAL_DATASET_FILENAMES,
+    ["longmemeval_oracle.json: ENOENT"],
+  );
+  assert.match(message, /LongMemEval dataset not found/);
+  assert.match(message, /\/tmp\/missing/);
+  assert.match(message, /scripts\/bench\/fetch-datasets\.sh/);
+  assert.match(message, /longmemeval_oracle\.json/);
+  assert.match(message, /ENOENT/);
+});
+
+test("formatMissingDatasetError handles undefined datasetDir", () => {
+  const message = formatMissingDatasetError(
+    "locomo",
+    undefined,
+    LOCOMO_DATASET_FILENAMES,
+    [],
+  );
+  assert.match(message, /LoCoMo dataset not found/);
+  assert.match(message, /<no dataset directory configured>/);
+});

--- a/packages/bench/src/benchmarks/published/dataset-loader.test.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.test.ts
@@ -303,6 +303,114 @@ test("loadLoCoMo10 default parser rejects entries missing conversation object", 
   });
 });
 
+test("loadLongMemEvalS default parser rejects invalid session turn role", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "x",
+          question: "q",
+          answer: "a",
+          question_date: "2025-01-01",
+          haystack_sessions: [[{ role: "other", content: "hi" }]],
+          haystack_session_ids: ["s1"],
+          haystack_dates: ["2025-01-01"],
+          answer_session_ids: ["s1"],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /role must be "user" or "assistant"/.test(entry)),
+    );
+  });
+});
+
+test("loadLongMemEvalS default parser rejects non-string turn content", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: 1,
+          question_type: "x",
+          question: "q",
+          answer: "a",
+          question_date: "2025-01-01",
+          haystack_sessions: [[{ role: "user", content: 42 }]],
+          haystack_session_ids: ["s1"],
+          haystack_dates: ["2025-01-01"],
+          answer_session_ids: ["s1"],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLongMemEvalS({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /content must be a string/.test(entry)),
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser rejects qa entry missing question string", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-bad-1",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [{ category: 1, evidence: [] }],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /qa\[0\]\.question must be a non-empty string/.test(entry)),
+    );
+  });
+});
+
+test("loadLoCoMo10 default parser rejects qa entry with non-integer category", async () => {
+  await withTempDir(async (dir) => {
+    await writeFile(
+      path.join(dir, "locomo10.json"),
+      JSON.stringify([
+        {
+          sample_id: "qa-bad-2",
+          conversation: { speaker_a: "A", speaker_b: "B" },
+          qa: [{ question: "q", category: "one", evidence: [] }],
+        },
+      ]),
+      "utf8",
+    );
+    const result = await loadLoCoMo10({
+      mode: "full",
+      datasetDir: dir,
+    });
+    assert.equal(result.source, "missing");
+    assert.ok(
+      result.errors.some((entry) => /qa\[0\]\.category must be an integer/.test(entry)),
+    );
+  });
+});
+
 test("loadLoCoMo10 default parser rejects entries missing qa array", async () => {
   await withTempDir(async (dir) => {
     await writeFile(

--- a/packages/bench/src/benchmarks/published/dataset-loader.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.ts
@@ -199,6 +199,58 @@ function parseLongMemEvalFile(raw: string, filename: string): LongMemEvalItem[] 
         `${filename} entry ${index} is missing an answer_session_ids array.`,
       );
     }
+    // Walk each haystack session to validate its turn shape. The
+    // runner maps over `turn.role` + `turn.content` — catch missing
+    // fields at parse time so runtime failures surface at the dataset
+    // boundary.
+    for (
+      let sessionIndex = 0;
+      sessionIndex < record.haystack_sessions.length;
+      sessionIndex += 1
+    ) {
+      const session = record.haystack_sessions[sessionIndex];
+      if (!Array.isArray(session)) {
+        throw new Error(
+          `${filename} entry ${index} haystack_sessions[${sessionIndex}] must be an array of turns.`,
+        );
+      }
+      for (
+        let turnIndex = 0;
+        turnIndex < session.length;
+        turnIndex += 1
+      ) {
+        const turn = session[turnIndex];
+        if (!turn || typeof turn !== "object" || Array.isArray(turn)) {
+          throw new Error(
+            `${filename} entry ${index} haystack_sessions[${sessionIndex}][${turnIndex}] must be a turn object.`,
+          );
+        }
+        const turnRecord = turn as Record<string, unknown>;
+        if (turnRecord.role !== "user" && turnRecord.role !== "assistant") {
+          throw new Error(
+            `${filename} entry ${index} haystack_sessions[${sessionIndex}][${turnIndex}].role must be "user" or "assistant".`,
+          );
+        }
+        if (typeof turnRecord.content !== "string") {
+          throw new Error(
+            `${filename} entry ${index} haystack_sessions[${sessionIndex}][${turnIndex}].content must be a string.`,
+          );
+        }
+      }
+    }
+    // Haystack session IDs and dates must be strings; `filter(Boolean)`
+    // in the runner would otherwise silently drop non-string entries.
+    for (
+      let stringIndex = 0;
+      stringIndex < record.haystack_session_ids.length;
+      stringIndex += 1
+    ) {
+      if (typeof record.haystack_session_ids[stringIndex] !== "string") {
+        throw new Error(
+          `${filename} entry ${index} haystack_session_ids[${stringIndex}] must be a string.`,
+        );
+      }
+    }
   }
   return parsed as LongMemEvalItem[];
 }
@@ -236,6 +288,32 @@ function parseLoCoMoFile(raw: string, filename: string): LoCoMoConversation[] {
       throw new Error(
         `${filename} conversation ${index} is missing a qa array.`,
       );
+    }
+    // Walk each QA entry. The runner derefs qa[i].question (string),
+    // qa[i].category (integer), qa[i].evidence (string[]). The runner
+    // calls a fallback normalizer for adversarial answers, but a
+    // completely malformed QA entry should fail at parse time.
+    for (let qaIndex = 0; qaIndex < record.qa.length; qaIndex += 1) {
+      const qa = record.qa[qaIndex];
+      if (!qa || typeof qa !== "object" || Array.isArray(qa)) {
+        throw new Error(
+          `${filename} conversation ${index} qa[${qaIndex}] must be an object.`,
+        );
+      }
+      const qaRecord = qa as Record<string, unknown>;
+      if (
+        typeof qaRecord.question !== "string" ||
+        qaRecord.question.trim().length === 0
+      ) {
+        throw new Error(
+          `${filename} conversation ${index} qa[${qaIndex}].question must be a non-empty string.`,
+        );
+      }
+      if (!Number.isInteger(qaRecord.category)) {
+        throw new Error(
+          `${filename} conversation ${index} qa[${qaIndex}].category must be an integer.`,
+        );
+      }
     }
   }
   return parsed as LoCoMoConversation[];

--- a/packages/bench/src/benchmarks/published/dataset-loader.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.ts
@@ -157,7 +157,6 @@ function parseLongMemEvalFile(raw: string, filename: string): LongMemEvalItem[] 
       `${filename} must contain an array of LongMemEval items at top level.`,
     );
   }
-  // Minimal structural validation — full typing happens in the runner.
   for (let index = 0; index < parsed.length; index += 1) {
     const entry = parsed[index];
     if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
@@ -169,6 +168,35 @@ function parseLongMemEvalFile(raw: string, filename: string): LongMemEvalItem[] 
     if (typeof record.question !== "string") {
       throw new Error(
         `${filename} entry ${index} is missing a string question field.`,
+      );
+    }
+    if (typeof record.answer !== "string") {
+      throw new Error(
+        `${filename} entry ${index} is missing a string answer field.`,
+      );
+    }
+    // Required arrays that the runner dereferences directly. Missing any
+    // of these silently would surface as a runtime error deep inside
+    // `runLongMemEvalBenchmark`; catch them here so the probe error
+    // message points at the dataset file.
+    if (!Array.isArray(record.haystack_sessions)) {
+      throw new Error(
+        `${filename} entry ${index} is missing a haystack_sessions array.`,
+      );
+    }
+    if (!Array.isArray(record.haystack_session_ids)) {
+      throw new Error(
+        `${filename} entry ${index} is missing a haystack_session_ids array.`,
+      );
+    }
+    if (!Array.isArray(record.haystack_dates)) {
+      throw new Error(
+        `${filename} entry ${index} is missing a haystack_dates array.`,
+      );
+    }
+    if (!Array.isArray(record.answer_session_ids)) {
+      throw new Error(
+        `${filename} entry ${index} is missing an answer_session_ids array.`,
       );
     }
   }
@@ -193,6 +221,20 @@ function parseLoCoMoFile(raw: string, filename: string): LoCoMoConversation[] {
     if (typeof record.sample_id !== "string") {
       throw new Error(
         `${filename} conversation ${index} is missing a string sample_id field.`,
+      );
+    }
+    if (
+      !record.conversation ||
+      typeof record.conversation !== "object" ||
+      Array.isArray(record.conversation)
+    ) {
+      throw new Error(
+        `${filename} conversation ${index} is missing a conversation object field.`,
+      );
+    }
+    if (!Array.isArray(record.qa)) {
+      throw new Error(
+        `${filename} conversation ${index} is missing a qa array.`,
       );
     }
   }

--- a/packages/bench/src/benchmarks/published/dataset-loader.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.ts
@@ -30,6 +30,7 @@ import {
 import {
   LOCOMO_SMOKE_FIXTURE,
   type LoCoMoConversation,
+  type LoCoMoQA,
 } from "./locomo/fixture.js";
 
 /** Canonical LongMemEval-S filenames probed by the loader, in priority order. */
@@ -262,61 +263,115 @@ function parseLoCoMoFile(raw: string, filename: string): LoCoMoConversation[] {
       `${filename} must contain an array of LoCoMo conversations at top level.`,
     );
   }
-  for (let index = 0; index < parsed.length; index += 1) {
-    const entry = parsed[index];
-    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
-      throw new Error(
-        `${filename} conversation ${index} must be an object with sample_id and conversation fields.`,
-      );
-    }
-    const record = entry as Record<string, unknown>;
-    if (typeof record.sample_id !== "string") {
-      throw new Error(
-        `${filename} conversation ${index} is missing a string sample_id field.`,
-      );
-    }
-    if (
-      !record.conversation ||
-      typeof record.conversation !== "object" ||
-      Array.isArray(record.conversation)
-    ) {
-      throw new Error(
-        `${filename} conversation ${index} is missing a conversation object field.`,
-      );
-    }
-    if (!Array.isArray(record.qa)) {
-      throw new Error(
-        `${filename} conversation ${index} is missing a qa array.`,
-      );
-    }
-    // Walk each QA entry. The runner derefs qa[i].question (string),
-    // qa[i].category (integer), qa[i].evidence (string[]). The runner
-    // calls a fallback normalizer for adversarial answers, but a
-    // completely malformed QA entry should fail at parse time.
-    for (let qaIndex = 0; qaIndex < record.qa.length; qaIndex += 1) {
-      const qa = record.qa[qaIndex];
-      if (!qa || typeof qa !== "object" || Array.isArray(qa)) {
-        throw new Error(
-          `${filename} conversation ${index} qa[${qaIndex}] must be an object.`,
-        );
-      }
-      const qaRecord = qa as Record<string, unknown>;
-      if (
-        typeof qaRecord.question !== "string" ||
-        qaRecord.question.trim().length === 0
-      ) {
-        throw new Error(
-          `${filename} conversation ${index} qa[${qaIndex}].question must be a non-empty string.`,
-        );
-      }
-      if (!Number.isInteger(qaRecord.category)) {
-        throw new Error(
-          `${filename} conversation ${index} qa[${qaIndex}].category must be an integer.`,
-        );
-      }
-    }
+  return parsed.map((entry, index) =>
+    parseLoCoMoConversation(entry, filename, index),
+  );
+}
+
+function parseLoCoMoConversation(
+  entry: unknown,
+  filename: string,
+  index: number,
+): LoCoMoConversation {
+  const location = `${filename} conversation ${index}`;
+  if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+    throw new Error(
+      `${location} must be an object with sample_id and conversation fields.`,
+    );
   }
-  return parsed as LoCoMoConversation[];
+  const record = entry as Record<string, unknown>;
+  if (typeof record.sample_id !== "string") {
+    throw new Error(`${location} is missing a string sample_id field.`);
+  }
+  if (
+    !record.conversation ||
+    typeof record.conversation !== "object" ||
+    Array.isArray(record.conversation)
+  ) {
+    throw new Error(`${location} is missing a conversation object field.`);
+  }
+  if (!Array.isArray(record.qa)) {
+    throw new Error(`${location} is missing a qa array.`);
+  }
+  const qa = record.qa.map((value, qaIndex) =>
+    normalizeLoCoMoQa(value, `${location} qa[${qaIndex}]`),
+  );
+  return {
+    sample_id: record.sample_id,
+    conversation: record.conversation as Record<string, unknown>,
+    qa,
+    event_summary: record.event_summary,
+    observation: record.observation,
+    session_summary: record.session_summary,
+  };
+}
+
+/**
+ * Normalize a single LoCoMo QA entry. Required fields are validated and
+ * `answer`/`adversarial_answer` are coerced to a canonical string so
+ * downstream consumers of `LoadedDataset<LoCoMoConversation>` can rely on
+ * `qa.answer` always being a string. Exported so the LoCoMo runner and
+ * other callers can share the same normalization.
+ */
+export function normalizeLoCoMoQa(value: unknown, location: string): LoCoMoQA {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${location} must be an object.`);
+  }
+  const record = value as Record<string, unknown>;
+  if (
+    typeof record.question !== "string" ||
+    record.question.trim().length === 0
+  ) {
+    throw new Error(`${location}.question must be a non-empty string.`);
+  }
+  if (!Number.isInteger(record.category)) {
+    throw new Error(`${location}.category must be an integer.`);
+  }
+  if (
+    !Array.isArray(record.evidence) ||
+    record.evidence.some((item) => typeof item !== "string")
+  ) {
+    throw new Error(`${location}.evidence must be an array of strings.`);
+  }
+  const answer = normalizeLoCoMoAnswer(
+    record.answer,
+    record.adversarial_answer,
+    location,
+  );
+  return {
+    question: record.question,
+    answer,
+    evidence: record.evidence as string[],
+    category: record.category as number,
+  };
+}
+
+function normalizeLoCoMoAnswer(
+  answer: unknown,
+  adversarialAnswer: unknown,
+  location: string,
+): string {
+  const direct = coerceScalarAnswer(answer);
+  if (direct !== undefined) {
+    return direct;
+  }
+  const adversarial = coerceScalarAnswer(adversarialAnswer);
+  if (adversarial !== undefined) {
+    return adversarial;
+  }
+  throw new Error(
+    `${location} must include a string or numeric answer, or an adversarial_answer fallback.`,
+  );
+}
+
+function coerceScalarAnswer(value: unknown): string | undefined {
+  if (typeof value === "string" && value.trim().length > 0) {
+    return value;
+  }
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+  return undefined;
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/dataset-loader.ts
+++ b/packages/bench/src/benchmarks/published/dataset-loader.ts
@@ -1,0 +1,246 @@
+/**
+ * Shared dataset loader helpers for the published LongMemEval + LoCoMo
+ * benchmark runners. Wraps the fs probe + JSON parse + fallback logic
+ * previously duplicated inside each runner's `loadDataset` function.
+ *
+ * Contract:
+ *
+ *   - When `datasetDir` is defined, loaders probe the known canonical
+ *     filenames in order. The first readable file wins. If none are
+ *     readable, the result is `{ source: "missing", errors }`.
+ *   - When `datasetDir` is undefined (or resolves to `missing`) and
+ *     `mode === "quick"`, loaders return the bundled smoke fixture with
+ *     source `"smoke"` so the caller can surface a clear log message.
+ *   - When `mode === "full"` and no dataset is found, loaders return
+ *     `{ source: "missing", errors }` and callers must throw — full mode
+ *     never silently falls back to the smoke fixture.
+ *
+ * `scripts/bench/fetch-datasets.sh` documents the expected filenames; keep
+ * them in sync when adding new variants.
+ */
+
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { BenchmarkMode } from "../../types.js";
+import {
+  LONG_MEM_EVAL_SMOKE_FIXTURE,
+  type LongMemEvalItem,
+} from "./longmemeval/fixture.js";
+import {
+  LOCOMO_SMOKE_FIXTURE,
+  type LoCoMoConversation,
+} from "./locomo/fixture.js";
+
+/** Canonical LongMemEval-S filenames probed by the loader, in priority order. */
+export const LONG_MEM_EVAL_DATASET_FILENAMES = Object.freeze([
+  "longmemeval_oracle.json",
+  "longmemeval_s_cleaned.json",
+  "longmemeval_s.json",
+  "longmemeval.json",
+]);
+
+/** Canonical LoCoMo-10 filenames probed by the loader, in priority order. */
+export const LOCOMO_DATASET_FILENAMES = Object.freeze([
+  "locomo10.json",
+  "locomo.json",
+]);
+
+export type DatasetSource = "dataset" | "smoke" | "missing";
+
+export interface LoadedDataset<T> {
+  source: DatasetSource;
+  /** Filename relative to `datasetDir` when source === "dataset". */
+  filename?: string;
+  items: T[];
+  /** Parse/read errors encountered while probing candidate filenames. */
+  errors: string[];
+}
+
+export interface LoadDatasetOptions {
+  mode: BenchmarkMode;
+  datasetDir?: string;
+  limit?: number;
+}
+
+/** Load LongMemEval-S from disk, falling back to the smoke fixture in quick mode. */
+export async function loadLongMemEvalS(
+  options: LoadDatasetOptions,
+): Promise<LoadedDataset<LongMemEvalItem>> {
+  return loadDataset<LongMemEvalItem>({
+    ...options,
+    filenames: LONG_MEM_EVAL_DATASET_FILENAMES,
+    smokeFixture: LONG_MEM_EVAL_SMOKE_FIXTURE,
+    parseFile: parseLongMemEvalFile,
+  });
+}
+
+/**
+ * Load LoCoMo-10 from disk, falling back to the smoke fixture in quick mode.
+ *
+ * `parseFile` is optional — callers that need richer structural
+ * normalization (e.g. the LoCoMo runner's QA answer coercion) can pass
+ * their own parser. When omitted, a minimal parser is used that only
+ * asserts the top-level array + sample_id shape.
+ */
+export async function loadLoCoMo10(
+  options: LoadDatasetOptions & {
+    parseFile?: (raw: string, filename: string) => LoCoMoConversation[];
+  },
+): Promise<LoadedDataset<LoCoMoConversation>> {
+  return loadDataset<LoCoMoConversation>({
+    ...options,
+    filenames: LOCOMO_DATASET_FILENAMES,
+    smokeFixture: LOCOMO_SMOKE_FIXTURE,
+    parseFile: options.parseFile ?? parseLoCoMoFile,
+  });
+}
+
+interface InternalLoadOptions<T> extends LoadDatasetOptions {
+  filenames: readonly string[];
+  smokeFixture: readonly T[];
+  parseFile: (raw: string, filename: string) => T[];
+}
+
+async function loadDataset<T>(
+  options: InternalLoadOptions<T>,
+): Promise<LoadedDataset<T>> {
+  const limit = normalizeLimit(options.limit);
+  const errors: string[] = [];
+
+  if (options.datasetDir) {
+    for (const filename of options.filenames) {
+      const abs = path.join(options.datasetDir, filename);
+      let raw: string;
+      try {
+        raw = await readFile(abs, "utf8");
+      } catch (error) {
+        errors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+        continue;
+      }
+      try {
+        const parsed = options.parseFile(raw, filename);
+        return {
+          source: "dataset",
+          filename,
+          items: applyLimit(parsed, limit),
+          errors,
+        };
+      } catch (error) {
+        errors.push(
+          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+  }
+
+  if (options.mode === "full") {
+    return { source: "missing", items: [], errors };
+  }
+
+  // Quick mode: fall back to the bundled smoke fixture. This keeps CI green
+  // when `datasetDir` is absent or unreadable while still surfacing the
+  // probe errors so operators can tell why the real dataset wasn't used.
+  return {
+    source: "smoke",
+    items: applyLimit([...options.smokeFixture], limit),
+    errors,
+  };
+}
+
+function parseLongMemEvalFile(raw: string, filename: string): LongMemEvalItem[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `${filename} must contain an array of LongMemEval items at top level.`,
+    );
+  }
+  // Minimal structural validation — full typing happens in the runner.
+  for (let index = 0; index < parsed.length; index += 1) {
+    const entry = parsed[index];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `${filename} entry ${index} must be an object with question/answer fields.`,
+      );
+    }
+    const record = entry as Record<string, unknown>;
+    if (typeof record.question !== "string") {
+      throw new Error(
+        `${filename} entry ${index} is missing a string question field.`,
+      );
+    }
+  }
+  return parsed as LongMemEvalItem[];
+}
+
+function parseLoCoMoFile(raw: string, filename: string): LoCoMoConversation[] {
+  const parsed = JSON.parse(raw) as unknown;
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `${filename} must contain an array of LoCoMo conversations at top level.`,
+    );
+  }
+  for (let index = 0; index < parsed.length; index += 1) {
+    const entry = parsed[index];
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      throw new Error(
+        `${filename} conversation ${index} must be an object with sample_id and conversation fields.`,
+      );
+    }
+    const record = entry as Record<string, unknown>;
+    if (typeof record.sample_id !== "string") {
+      throw new Error(
+        `${filename} conversation ${index} is missing a string sample_id field.`,
+      );
+    }
+  }
+  return parsed as LoCoMoConversation[];
+}
+
+function normalizeLimit(limit: number | undefined): number | undefined {
+  if (limit === undefined) {
+    return undefined;
+  }
+  if (!Number.isInteger(limit) || limit < 0) {
+    throw new Error(
+      "Dataset limit must be a non-negative integer when provided.",
+    );
+  }
+  // CLAUDE.md rule 27: slice(-0) returns all items. Treat `0` as "empty".
+  return limit;
+}
+
+function applyLimit<T>(items: T[], limit: number | undefined): T[] {
+  if (limit === undefined) {
+    return items;
+  }
+  if (limit === 0) {
+    return [];
+  }
+  return items.slice(0, limit);
+}
+
+/**
+ * Build a friendly "dataset missing" error message that links operators to
+ * the fetch script. Callers use this when `mode === "full"` and the probe
+ * returned `source: "missing"`.
+ */
+export function formatMissingDatasetError(
+  benchmark: "longmemeval" | "locomo",
+  datasetDir: string | undefined,
+  filenames: readonly string[],
+  errors: readonly string[],
+): string {
+  const label =
+    benchmark === "longmemeval" ? "LongMemEval" : "LoCoMo";
+  const location = datasetDir ?? "<no dataset directory configured>";
+  const tried = filenames.join(", ");
+  const suffix = errors.length > 0 ? ` Errors: ${errors.join(" | ")}` : "";
+  return (
+    `${label} dataset not found under ${location}. ` +
+    `Tried ${tried}. ` +
+    `Run scripts/bench/fetch-datasets.sh for download instructions.${suffix}`
+  );
+}

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -235,35 +235,34 @@ async function loadDataset(
   datasetDir: string | undefined,
   limit?: number,
 ): Promise<LoCoMoConversation[]> {
-  const normalizedLimit = normalizeLimit(limit);
+  // Limit normalization happens inside `loadLoCoMo10`; do not re-validate
+  // here (the shared loader's `normalizeLimit` is the single source of
+  // truth).
   const loaded = await loadLoCoMo10({
     mode,
     datasetDir,
-    limit: normalizedLimit,
+    limit,
     parseFile: parseDataset,
   });
 
   if (loaded.source === "missing") {
-    if (mode === "full") {
-      if (!datasetDir) {
-        // Preserve the historical error message so CLI tooling and
-        // regression tests can continue to detect the "no dataset
-        // path configured" case specifically.
-        throw new Error(
-          "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
-        );
-      }
+    // `loaded.source === "missing"` implies `mode === "full"` — the
+    // shared loader only returns `missing` in that branch. Keep the
+    // inner check + the historical "no datasetDir" message for clarity
+    // and backward-compat with regression tests; if the loader contract
+    // ever changes, this branch still fails safely.
+    if (!datasetDir) {
       throw new Error(
-        formatMissingDatasetError(
-          "locomo",
-          datasetDir,
-          LOCOMO_DATASET_FILENAMES,
-          loaded.errors,
-        ),
+        "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
       );
     }
     throw new Error(
-      "LoCoMo dataset not found and bundled smoke fixture is empty.",
+      formatMissingDatasetError(
+        "locomo",
+        datasetDir,
+        LOCOMO_DATASET_FILENAMES,
+        loaded.errors,
+      ),
     );
   }
 
@@ -401,14 +400,3 @@ function normalizeScalarAnswer(value: unknown): string | undefined {
   return undefined;
 }
 
-function normalizeLimit(limit: number | undefined): number | undefined {
-  if (limit === undefined) {
-    return undefined;
-  }
-  if (!Number.isInteger(limit) || limit < 0) {
-    throw new Error(
-      "LoCoMo limit must be a non-negative integer when provided.",
-    );
-  }
-  return limit;
-}

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -3,16 +3,18 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
 import {
-  LOCOMO_SMOKE_FIXTURE,
   type LoCoMoConversation,
   type LoCoMoQA,
   type LoCoMoTurn,
 } from "./fixture.js";
+import {
+  LOCOMO_DATASET_FILENAMES,
+  formatMissingDatasetError,
+  loadLoCoMo10,
+} from "../dataset-loader.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -234,47 +236,44 @@ async function loadDataset(
   limit?: number,
 ): Promise<LoCoMoConversation[]> {
   const normalizedLimit = normalizeLimit(limit);
-  const ensureDatasetConversations = (
-    conversations: LoCoMoConversation[],
-  ): LoCoMoConversation[] => {
-    if (conversations.length === 0) {
+  const loaded = await loadLoCoMo10({
+    mode,
+    datasetDir,
+    limit: normalizedLimit,
+    parseFile: parseDataset,
+  });
+
+  if (loaded.source === "missing") {
+    if (mode === "full") {
       throw new Error(
-        "LoCoMo dataset is empty after applying the requested limit.",
+        formatMissingDatasetError(
+          "locomo",
+          datasetDir,
+          LOCOMO_DATASET_FILENAMES,
+          loaded.errors,
+        ),
       );
     }
-    return conversations;
-  };
-
-  if (datasetDir) {
-    const datasetErrors: string[] = [];
-    for (const filename of ["locomo10.json", "locomo.json"]) {
-      try {
-        const raw = await readFile(path.join(datasetDir, filename), "utf8");
-        const parsed = parseDataset(raw, filename);
-        return ensureDatasetConversations(
-          applyLimit(parsed, normalizedLimit),
-        );
-      } catch (error) {
-        datasetErrors.push(
-          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-      }
-    }
-
     throw new Error(
-      `LoCoMo dataset not found under ${datasetDir}. Tried locomo10.json and locomo.json. Errors: ${datasetErrors.join(" | ")}`,
+      "LoCoMo dataset not found and bundled smoke fixture is empty.",
     );
   }
 
-  if (mode === "full") {
+  if (loaded.items.length === 0) {
     throw new Error(
-      "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+      "LoCoMo dataset is empty after applying the requested limit.",
     );
   }
 
-  return ensureDatasetConversations(
-    applyLimit(LOCOMO_SMOKE_FIXTURE, normalizedLimit),
-  );
+  if (loaded.source === "smoke" && loaded.errors.length > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[remnic-bench] LoCoMo falling back to smoke fixture: " +
+        loaded.errors.join(" | "),
+    );
+  }
+
+  return loaded.items;
 }
 
 function parseDataset(
@@ -404,11 +403,4 @@ function normalizeLimit(limit: number | undefined): number | undefined {
     );
   }
   return limit;
-}
-
-function applyLimit<T>(items: T[], limit: number | undefined): T[] {
-  if (limit === undefined) {
-    return [...items];
-  }
-  return items.slice(0, limit);
 }

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -245,6 +245,14 @@ async function loadDataset(
 
   if (loaded.source === "missing") {
     if (mode === "full") {
+      if (!datasetDir) {
+        // Preserve the historical error message so CLI tooling and
+        // regression tests can continue to detect the "no dataset
+        // path configured" case specifically.
+        throw new Error(
+          "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+        );
+      }
       throw new Error(
         formatMissingDatasetError(
           "locomo",

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -14,6 +14,7 @@ import {
   LOCOMO_DATASET_FILENAMES,
   formatMissingDatasetError,
   loadLoCoMo10,
+  normalizeLoCoMoQa,
 } from "../dataset-loader.js";
 import type {
   BenchmarkDefinition,
@@ -338,65 +339,7 @@ function normalizeQaArray(value: unknown, location: string): LoCoMoQA[] {
   }
 
   return value.map((entry, index) =>
-    normalizeQa(entry, `${location} qa[${index}]`),
+    normalizeLoCoMoQa(entry, `${location} qa[${index}]`),
   );
-}
-
-function normalizeQa(value: unknown, location: string): LoCoMoQA {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    throw new Error(`${location} must be an object.`);
-  }
-
-  const record = value as Record<string, unknown>;
-  if (typeof record.question !== "string" || record.question.trim().length === 0) {
-    throw new Error(`${location} must include a non-empty question string.`);
-  }
-  if (!Number.isInteger(record.category)) {
-    throw new Error(`${location} must include an integer category.`);
-  }
-  if (
-    !Array.isArray(record.evidence)
-    || record.evidence.some((item) => typeof item !== "string")
-  ) {
-    throw new Error(`${location} must include an evidence array of strings.`);
-  }
-
-  const answer = normalizeQaAnswer(record.answer, record.adversarial_answer, location);
-  return {
-    question: record.question,
-    answer,
-    evidence: record.evidence as string[],
-    category: record.category as number,
-  };
-}
-
-function normalizeQaAnswer(
-  answer: unknown,
-  adversarialAnswer: unknown,
-  location: string,
-): string {
-  const direct = normalizeScalarAnswer(answer);
-  if (direct !== undefined) {
-    return direct;
-  }
-
-  const adversarial = normalizeScalarAnswer(adversarialAnswer);
-  if (adversarial !== undefined) {
-    return adversarial;
-  }
-
-  throw new Error(
-    `${location} must include a string or numeric answer, or an adversarial_answer fallback.`,
-  );
-}
-
-function normalizeScalarAnswer(value: unknown): string | undefined {
-  if (typeof value === "string" && value.trim().length > 0) {
-    return value;
-  }
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-  return undefined;
 }
 

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -3,12 +3,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
-import path from "node:path";
+import { type LongMemEvalItem } from "./fixture.js";
 import {
-  LONG_MEM_EVAL_SMOKE_FIXTURE,
-  type LongMemEvalItem,
-} from "./fixture.js";
+  LONG_MEM_EVAL_DATASET_FILENAMES,
+  formatMissingDatasetError,
+  loadLongMemEvalS,
+} from "../dataset-loader.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
 import type { Message } from "../../../adapters/types.js";
 import type {
@@ -187,51 +187,40 @@ async function loadDataset(
   datasetDir: string | undefined,
   limit?: number,
 ): Promise<LongMemEvalItem[]> {
-  const ensureDatasetItems = (items: LongMemEvalItem[]): LongMemEvalItem[] => {
-    if (items.length === 0) {
+  const loaded = await loadLongMemEvalS({ mode, datasetDir, limit });
+
+  if (loaded.source === "missing") {
+    if (mode === "full") {
       throw new Error(
-        "LongMemEval dataset is empty after applying the requested limit.",
+        formatMissingDatasetError(
+          "longmemeval",
+          datasetDir,
+          LONG_MEM_EVAL_DATASET_FILENAMES,
+          loaded.errors,
+        ),
       );
     }
-    return items;
-  };
-
-  if (datasetDir) {
-    const datasetErrors: string[] = [];
-    for (const filename of [
-      "longmemeval_oracle.json",
-      "longmemeval_s_cleaned.json",
-      "longmemeval.json",
-    ]) {
-      try {
-        const raw = await readFile(path.join(datasetDir, filename), "utf8");
-        const parsed = JSON.parse(raw) as LongMemEvalItem[];
-        return ensureDatasetItems(limit ? parsed.slice(0, limit) : parsed);
-      } catch (error) {
-        datasetErrors.push(
-          `${filename}: ${error instanceof Error ? error.message : String(error)}`,
-        );
-        continue;
-      }
-    }
-
     throw new Error(
-      `LongMemEval dataset not found under ${datasetDir}. Tried longmemeval_oracle.json, longmemeval_s_cleaned.json, and longmemeval.json. Errors: ${datasetErrors.join(" | ")}`,
+      "LongMemEval dataset not found and bundled smoke fixture is empty.",
     );
   }
 
-  if (mode === "full") {
+  if (loaded.items.length === 0) {
     throw new Error(
-      "LongMemEval full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+      "LongMemEval dataset is empty after applying the requested limit.",
     );
   }
 
-  const bundledFixture = limit
-    ? LONG_MEM_EVAL_SMOKE_FIXTURE.slice(0, limit)
-    : LONG_MEM_EVAL_SMOKE_FIXTURE;
-  if (bundledFixture.length > 0) {
-    return ensureDatasetItems(bundledFixture);
+  if (loaded.source === "smoke" && loaded.errors.length > 0) {
+    // Surface probe errors so operators understand why the smoke fixture
+    // was used instead of the real dataset. Keep output minimal and only
+    // emit when we actually tried to read a dataset directory.
+    // eslint-disable-next-line no-console
+    console.warn(
+      "[remnic-bench] LongMemEval falling back to smoke fixture: " +
+        loaded.errors.join(" | "),
+    );
   }
 
-  throw new Error("LongMemEval dataset not found and bundled smoke fixture is empty.");
+  return loaded.items;
 }

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -190,26 +190,23 @@ async function loadDataset(
   const loaded = await loadLongMemEvalS({ mode, datasetDir, limit });
 
   if (loaded.source === "missing") {
-    if (mode === "full") {
-      if (!datasetDir) {
-        // Preserve the historical error message so CLI tooling and
-        // regression tests can continue to detect the "no dataset
-        // path configured" case specifically.
-        throw new Error(
-          "LongMemEval full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
-        );
-      }
+    // `loaded.source === "missing"` implies `mode === "full"` — the
+    // shared loader only returns `missing` in that branch. Keep the
+    // inner `datasetDir` check for backward-compat with regression
+    // tests that match the historical "full mode requires datasetDir"
+    // message.
+    if (!datasetDir) {
       throw new Error(
-        formatMissingDatasetError(
-          "longmemeval",
-          datasetDir,
-          LONG_MEM_EVAL_DATASET_FILENAMES,
-          loaded.errors,
-        ),
+        "LongMemEval full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
       );
     }
     throw new Error(
-      "LongMemEval dataset not found and bundled smoke fixture is empty.",
+      formatMissingDatasetError(
+        "longmemeval",
+        datasetDir,
+        LONG_MEM_EVAL_DATASET_FILENAMES,
+        loaded.errors,
+      ),
     );
   }
 

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -191,6 +191,14 @@ async function loadDataset(
 
   if (loaded.source === "missing") {
     if (mode === "full") {
+      if (!datasetDir) {
+        // Preserve the historical error message so CLI tooling and
+        // regression tests can continue to detect the "no dataset
+        // path configured" case specifically.
+        throw new Error(
+          "LongMemEval full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
+        );
+      }
       throw new Error(
         formatMissingDatasetError(
           "longmemeval",

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -178,6 +178,20 @@ export type {
   PublishedBenchmarkFeedEntry,
 } from "./results-store.js";
 
+// Published-benchmark dataset loaders (LongMemEval-S + LoCoMo-10).
+export {
+  LONG_MEM_EVAL_DATASET_FILENAMES,
+  LOCOMO_DATASET_FILENAMES,
+  formatMissingDatasetError,
+  loadLoCoMo10,
+  loadLongMemEvalS,
+} from "./benchmarks/published/dataset-loader.js";
+export type {
+  DatasetSource,
+  LoadedDataset,
+  LoadDatasetOptions,
+} from "./benchmarks/published/dataset-loader.js";
+
 // Integrity pipeline (sealed qrels, canary adapter, contamination, randomize).
 export * from "./integrity/index.js";
 export {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -773,7 +773,16 @@ const DOWNLOADABLE_BENCHMARK_DATASETS = [
 const DOWNLOADED_DATASET_MARKERS: Record<string, { anyOf?: string[]; ext?: string }> = {
   "ama-bench": { anyOf: ["open_end_qa_set.jsonl"] },
   longmemeval: {
-    anyOf: ["longmemeval_oracle.json", "longmemeval_s_cleaned.json", "longmemeval.json"],
+    // Keep this list in lock-step with `LONG_MEM_EVAL_DATASET_FILENAMES`
+    // in packages/bench/src/benchmarks/published/dataset-loader.ts so
+    // `datasets status` never disagrees with the runner about what
+    // counts as "downloaded".
+    anyOf: [
+      "longmemeval_oracle.json",
+      "longmemeval_s_cleaned.json",
+      "longmemeval_s.json",
+      "longmemeval.json",
+    ],
   },
   amemgym: {
     anyOf: ["amemgym-v1-base.json", "amemgym-tasks.json", "data.json"],

--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+# fetch-datasets.sh — Documentation + optional helpers for downloading the
+# LongMemEval-S and LoCoMo-10 datasets used by the published-benchmark
+# runners in `@remnic/bench`.
+#
+# This script does NOT auto-download by default. It prints the exact
+# commands you would run so operators understand what the runners will see,
+# and so we never silently fetch data on CI or dev machines.
+#
+# Usage:
+#   scripts/bench/fetch-datasets.sh [--help]
+#   scripts/bench/fetch-datasets.sh --target <dir>   # prints commands scoped to <dir>
+#
+# Default target:
+#   ./bench-datasets/       (gitignored — see .gitignore)
+#
+# After downloading, point the runners at the directory:
+#   pnpm exec remnic bench published --name longmemeval --dataset ./bench-datasets/longmemeval
+#   pnpm exec remnic bench published --name locomo      --dataset ./bench-datasets/locomo
+#
+# Expected layout:
+#   bench-datasets/
+#     longmemeval/
+#       longmemeval_oracle.json            # preferred
+#       longmemeval_s_cleaned.json         # optional alternate
+#       longmemeval_s.json                 # optional alternate
+#     locomo/
+#       locomo10.json                      # preferred
+#       locomo.json                        # optional alternate
+
+set -euo pipefail
+
+TARGET_DIR="./bench-datasets"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --target)
+      if [[ $# -lt 2 ]]; then
+        echo "error: --target requires a directory path" >&2
+        exit 2
+      fi
+      TARGET_DIR="$2"
+      shift 2
+      ;;
+    --target=*)
+      TARGET_DIR="${1#--target=}"
+      shift
+      ;;
+    -h | --help)
+      # Print the top-of-file help block.
+      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *)
+      echo "error: unknown argument: $1" >&2
+      echo "run 'scripts/bench/fetch-datasets.sh --help' for usage" >&2
+      exit 2
+      ;;
+  esac
+done
+
+LONG_MEM_EVAL_DIR="${TARGET_DIR}/longmemeval"
+LOCOMO_DIR="${TARGET_DIR}/locomo"
+
+cat <<EOF
+# Remnic published-benchmark datasets — download instructions
+#
+# These commands are PRINTED, not executed. Copy-paste the ones you need.
+# Both datasets live on HuggingFace. The huggingface-cli option is preferred
+# because it handles auth + resumable downloads; wget is shown as a fallback.
+
+# 1. Create the target directories
+mkdir -p "${LONG_MEM_EVAL_DIR}"
+mkdir -p "${LOCOMO_DIR}"
+
+# 2. LongMemEval-S  (https://huggingface.co/datasets/xiaowu0162/LongMemEval)
+#    Prefer the huggingface-cli path. Install via:  pipx install "huggingface_hub[cli]"
+huggingface-cli download xiaowu0162/LongMemEval \\
+  --repo-type dataset \\
+  --local-dir "${LONG_MEM_EVAL_DIR}" \\
+  --include "longmemeval_oracle.json" \\
+           "longmemeval_s_cleaned.json" \\
+           "longmemeval_s.json"
+
+# Fallback: direct file download (update commit hash if the upstream moves)
+# wget -P "${LONG_MEM_EVAL_DIR}" \\
+#   "https://huggingface.co/datasets/xiaowu0162/LongMemEval/resolve/main/longmemeval_oracle.json"
+
+# 3. LoCoMo-10  (https://huggingface.co/datasets/snap-research/locomo10)
+huggingface-cli download snap-research/locomo10 \\
+  --repo-type dataset \\
+  --local-dir "${LOCOMO_DIR}" \\
+  --include "locomo10.json" "locomo.json"
+
+# Fallback direct download
+# wget -P "${LOCOMO_DIR}" \\
+#   "https://huggingface.co/datasets/snap-research/locomo10/resolve/main/locomo10.json"
+
+# 4. Verify the loader sees your files (no model calls):
+#    pnpm exec remnic bench published --name longmemeval --dataset "${LONG_MEM_EVAL_DIR}" --dry-run
+#    pnpm exec remnic bench published --name locomo      --dataset "${LOCOMO_DIR}"      --dry-run
+
+EOF
+
+exit 0

--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -14,9 +14,11 @@
 # Default target:
 #   ./bench-datasets/       (gitignored — see .gitignore)
 #
-# After downloading, point the runners at the directory:
-#   pnpm exec remnic bench published --name longmemeval --dataset ./bench-datasets/longmemeval
-#   pnpm exec remnic bench published --name locomo      --dataset ./bench-datasets/locomo
+# After downloading, point the runners at the directory with the current
+# `remnic bench run` CLI surface (a dedicated `remnic bench published`
+# subcommand is planned for a later slice of issue #566):
+#   pnpm exec remnic bench run longmemeval --dataset-dir ./bench-datasets/longmemeval
+#   pnpm exec remnic bench run locomo      --dataset-dir ./bench-datasets/locomo
 #
 # Expected layout:
 #   bench-datasets/
@@ -96,9 +98,12 @@ huggingface-cli download snap-research/locomo10 \\
 # wget -P "${LOCOMO_DIR}" \\
 #   "https://huggingface.co/datasets/snap-research/locomo10/resolve/main/locomo10.json"
 
-# 4. Verify the loader sees your files (no model calls):
-#    pnpm exec remnic bench published --name longmemeval --dataset "${LONG_MEM_EVAL_DIR}" --dry-run
-#    pnpm exec remnic bench published --name locomo      --dataset "${LOCOMO_DIR}"      --dry-run
+# 4. Smoke-check that the runner sees your files (quick-mode, no model calls):
+#    pnpm exec remnic bench run --quick longmemeval --dataset-dir "${LONG_MEM_EVAL_DIR}"
+#    pnpm exec remnic bench run --quick locomo      --dataset-dir "${LOCOMO_DIR}"
+#
+# (A dedicated `remnic bench published --dry-run` subcommand is planned
+#  for issue #566 slice 4 and is not shipped yet.)
 
 EOF
 

--- a/scripts/bench/fetch-datasets.sh
+++ b/scripts/bench/fetch-datasets.sh
@@ -50,7 +50,10 @@ while [[ $# -gt 0 ]]; do
       ;;
     -h | --help)
       # Print the top-of-file help block.
-      sed -n '2,30p' "$0" | sed 's/^# \{0,1\}//'
+      # Print the top-of-file help block. Uses a marker-based range
+      # (`^#`-prefix only, stop at the first non-`#` line) so future
+      # additions to the header stay in sync without hand-counting.
+      sed -n '2,/^[^#]/p' "$0" | sed '$d' | sed 's/^# \{0,1\}//'
       exit 0
       ;;
     *)


### PR DESCRIPTION
Part of #566 (slice 1 of 7).

## Summary

- Extracts the per-runner `loadDataset` logic into a shared
  `packages/bench/src/benchmarks/published/dataset-loader.ts` that
  exports `loadLongMemEvalS` / `loadLoCoMo10`. Both return
  `{ source, filename, items, errors }` so callers can distinguish
  real dataset loads from quick-mode smoke fallback from full-mode
  "dataset missing".
- Probes the canonical filenames documented upstream
  (`longmemeval_oracle.json`, `longmemeval_s_cleaned.json`,
  `longmemeval_s.json`, `longmemeval.json` for LongMemEval-S;
  `locomo10.json`, `locomo.json` for LoCoMo-10). First readable
  file wins; earlier parse errors are captured and surfaced so
  quick-mode operators can tell why their real dataset wasn't used.
- Adds `scripts/bench/fetch-datasets.sh` — documentation-only helper
  that prints the `huggingface-cli` / `wget` commands to pull
  LongMemEval-S and LoCoMo-10 into a gitignored `bench-datasets/`
  directory. Script never auto-downloads.
- `.gitignore` now excludes `bench-datasets/`.
- New `packages/bench/README.md` section "Running on real datasets"
  documents the expected layout, CLI usage, and programmatic
  loader API.
- Loaders are exported from `@remnic/bench` for downstream consumers.

LoCoMo's adversarial-answer normalization is preserved by plugging
the runner's existing `parseDataset` into the shared loader via its
new `parseFile` callback; the existing LoCoMo runner test still
passes unchanged.

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `pnpm --filter @remnic/bench run check-types` — clean
- [x] `pnpm --filter @remnic/bench run build` — builds
- [x] 15 new unit tests in `dataset-loader.test.ts` cover first-filename
      wins, unreadable-file fallback, quick-mode smoke fallback,
      full-mode missing, limit honoring (including the `limit=0`
      slice(-0) footgun from CLAUDE.md rule 27), negative/non-integer
      rejection, non-array payload rejection, custom `parseFile`
      injection (LoCoMo shape), and the error-message formatter.
- [x] Existing LoCoMo runner test (`runner.test.ts`) still passes —
      validates adversarial-answer normalization still flows through.
- [x] Full bench test suite (112 tests) passes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark dataset loading/validation and error handling for LongMemEval/LoCoMo; regressions could affect bench runs and CI smoke behavior, though scope is limited to benchmarking tooling.
> 
> **Overview**
> Introduces a shared published-benchmark dataset loader (`dataset-loader.ts`) for LongMemEval-S and LoCoMo-10 that probes canonical filenames, validates/parses JSON, supports `limit` (including `0`), and returns `{ source, filename, items, errors }` to distinguish real datasets from quick-mode smoke fallbacks.
> 
> Refactors the LongMemEval and LoCoMo runners to use the shared loader, standardizes missing-dataset errors via `formatMissingDatasetError()`, and logs probe failures when quick mode falls back to bundled smoke fixtures.
> 
> Adds operator-facing setup docs: gitignore for `bench-datasets/`, a `scripts/bench/fetch-datasets.sh` helper that prints HuggingFace download commands, README guidance for running on real datasets, exports the loaders from `@remnic/bench`, updates CLI dataset markers (including `longmemeval_s.json`), and adds comprehensive unit tests for loader behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c081e4dd5cdf066ca5be0881531f7d6e94572e43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->