### PR TITLE
feat(coding): project-scoped namespace overlay (#569 PR 2/8)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -318,6 +318,24 @@
           }
         }
       },
+      "codingMode": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Coding-agent project/branch scoping (issue #569).",
+        "properties": {
+          "projectScope": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
+          },
+          "branchScope": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
+          }
+        }
+      },
       "procedural": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -318,6 +318,24 @@
           }
         }
       },
+      "codingMode": {
+        "type": "object",
+        "additionalProperties": false,
+        "default": {},
+        "description": "Coding-agent project/branch scoping (issue #569).",
+        "properties": {
+          "projectScope": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true and the session has a resolved git context, memory routes to a project-scoped namespace (project:<id>). Set to false to restore pre-#569 behaviour exactly."
+          },
+          "branchScope": {
+            "type": "boolean",
+            "default": false,
+            "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
+          }
+        }
+      },
       "procedural": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -61,6 +61,33 @@ test("projectNamespaceName: length-capped to 64 chars, no trailing dash", () => 
   assert.ok(!out.endsWith("-"), "truncation must not leave a trailing dash");
 });
 
+test("branchNamespaceName: capped distinct long branches stay distinct (hash suffix)", () => {
+  // Regression: raw truncation collapsed two branches whose sanitized forms
+  // shared a long prefix but differed near the end, silently mixing recall
+  // and write state. With a deterministic hash suffix applied on truncation,
+  // distinct inputs must map to distinct namespaces.
+  const projectId = "origin:abcd1234";
+  const longA = `feature/${"a".repeat(80)}-variant-one`;
+  const longB = `feature/${"a".repeat(80)}-variant-two`;
+  const nsA = branchNamespaceName(projectId, longA);
+  const nsB = branchNamespaceName(projectId, longB);
+  assert.ok(nsA.length <= 64, `expected length ≤ 64, got ${nsA.length}`);
+  assert.ok(nsB.length <= 64, `expected length ≤ 64, got ${nsB.length}`);
+  assert.notEqual(
+    nsA,
+    nsB,
+    "distinct long branches must not collapse to the same namespace",
+  );
+});
+
+test("branchNamespaceName: capped output is deterministic for the same input", () => {
+  const huge = "x".repeat(200);
+  assert.equal(
+    branchNamespaceName("origin:abcd1234", huge),
+    branchNamespaceName("origin:abcd1234", huge),
+  );
+});
+
 test("projectNamespaceName: output satisfies isSafeRouteNamespace for typical projectIds", () => {
   const cases = [
     "origin:abcd1234",
@@ -95,18 +122,49 @@ test("branchNamespaceName: output satisfies isSafeRouteNamespace for typical bra
   }
 });
 
-test("branchNamespaceName: layers branch on project (uses `-` separators, no `/`)", () => {
+test("branchNamespaceName: simple all-lowercase branch needs no hash disambiguator", () => {
+  // `main` is already safe and lowercase — sanitization is a no-op, so the
+  // output is the plain project-id-branch form without a hash suffix.
   assert.equal(
-    branchNamespaceName("origin:abcd1234", "feat/ui"),
-    "project-origin-abcd1234-branch-feat-ui",
+    branchNamespaceName("origin:abcd1234", "main"),
+    "project-origin-abcd1234-branch-main",
+  );
+});
+
+test("branchNamespaceName: lossy branch names get a deterministic hash suffix", () => {
+  // `feat/ui` sanitizes to `feat-ui` — different from the raw input — so
+  // the namespace must include a disambiguating hash of the raw branch.
+  // The same collision class: `feat-ui` would sanitize to `feat-ui`
+  // unchanged (no hash), so the two inputs produce distinct namespaces
+  // even though their sanitized forms coincide.
+  const slashed = branchNamespaceName("origin:abcd1234", "feat/ui");
+  const dashed = branchNamespaceName("origin:abcd1234", "feat-ui");
+  assert.notEqual(
+    slashed,
+    dashed,
+    "feat/ui and feat-ui must not collapse to the same namespace",
+  );
+  assert.match(slashed, /^project-origin-abcd1234-branch-feat-ui-[0-9a-f]{8}$/);
+  assert.equal(dashed, "project-origin-abcd1234-branch-feat-ui");
+});
+
+test("branchNamespaceName: case-varying branches produce distinct namespaces", () => {
+  // Regression: `Feature` and `feature` both sanitize to `feature` without
+  // disambiguation. Including a hash of the raw input keeps them distinct.
+  const titled = branchNamespaceName("origin:abcd", "Feature");
+  const lowered = branchNamespaceName("origin:abcd", "feature");
+  assert.notEqual(
+    titled,
+    lowered,
+    "case-only variants must not collapse to the same namespace",
   );
 });
 
 test("branchNamespaceName: sanitizes branch name (lowercase + unsafe → dash)", () => {
-  assert.equal(
-    branchNamespaceName("origin:abcd", "FEAT/UI (wip)"),
-    "project-origin-abcd-branch-feat-ui-wip",
-  );
+  // With disambiguation, this also gains a hash suffix since the raw
+  // `FEAT/UI (wip)` is not equal to the sanitized `feat-ui-wip`.
+  const ns = branchNamespaceName("origin:abcd", "FEAT/UI (wip)");
+  assert.match(ns, /^project-origin-abcd-branch-feat-ui-wip-[0-9a-f]{8}$/);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -171,7 +229,13 @@ test("resolveCodingNamespaceOverlay: branchScope=true + branch set → branch ov
   );
   assert.ok(overlay);
   assert.equal(overlay!.scope, "branch");
-  assert.equal(overlay!.namespace, "project-origin-aaaa0000-branch-feat-x");
+  // `feat/x` is lossy under sanitization (`/` → `-`), so the branch
+  // namespace includes a deterministic hash suffix to keep it distinct
+  // from a literal `feat-x` branch on the same project.
+  assert.match(
+    overlay!.namespace,
+    /^project-origin-aaaa0000-branch-feat-x-[0-9a-f]{8}$/,
+  );
   assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000"]);
 });
 

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Tests for `resolveCodingNamespaceOverlay` (issue #569 PR 2).
+ *
+ * All fixtures synthetic. These tests cover the resolver-level contract —
+ * project overlay vs no-overlay, escape hatch, sanitization, read+write
+ * symmetry invariant.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  branchNamespaceName,
+  projectNamespaceName,
+  resolveCodingNamespaceOverlay,
+} from "./coding-namespace.js";
+import type { CodingContext, CodingModeConfig } from "../types.js";
+
+function ctx(overrides: Partial<CodingContext> = {}): CodingContext {
+  return {
+    projectId: "origin:abcd1234",
+    branch: "main",
+    rootPath: "/work/proj",
+    defaultBranch: "main",
+    ...overrides,
+  };
+}
+
+function mode(overrides: Partial<CodingModeConfig> = {}): CodingModeConfig {
+  return {
+    projectScope: true,
+    branchScope: false,
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Name helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+test("projectNamespaceName: stable form for origin-derived id", () => {
+  assert.equal(projectNamespaceName("origin:abcd1234"), "project:origin:abcd1234");
+});
+
+test("projectNamespaceName: lowercases and strips unsafe characters", () => {
+  assert.equal(projectNamespaceName("ORIGIN:ABCD!!"), "project:origin:abcd");
+});
+
+test("projectNamespaceName: empty input falls back to 'unknown'", () => {
+  assert.equal(projectNamespaceName(""), "project:unknown");
+  assert.equal(projectNamespaceName("   "), "project:unknown");
+});
+
+test("branchNamespaceName: layers branch on project (branch slashes collapsed to dashes)", () => {
+  // `/` is not in the safe alphabet — it collapses to `-` so the resulting
+  // name round-trips safely through the collection-name mapper in
+  // namespaces/search.ts. The `project:<id>/branch:<name>` structural
+  // separators remain.
+  assert.equal(
+    branchNamespaceName("origin:abcd1234", "feat/ui"),
+    "project:origin:abcd1234/branch:feat-ui",
+  );
+});
+
+test("branchNamespaceName: sanitizes branch name (lowercase + unsafe → dash)", () => {
+  assert.equal(
+    branchNamespaceName("origin:abcd", "FEAT/UI (wip)"),
+    "project:origin:abcd/branch:feat-ui-wip",
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveCodingNamespaceOverlay — escape hatches
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveCodingNamespaceOverlay: no context → null (connector didn't provide one)", () => {
+  assert.equal(resolveCodingNamespaceOverlay(null, mode()), null);
+  assert.equal(resolveCodingNamespaceOverlay(undefined, mode()), null);
+});
+
+test("resolveCodingNamespaceOverlay: projectScope=false → null (CLAUDE.md #30 escape hatch)", () => {
+  const overlay = resolveCodingNamespaceOverlay(ctx(), mode({ projectScope: false }));
+  assert.equal(overlay, null, "disabling projectScope must restore pre-#569 behaviour exactly");
+});
+
+test("resolveCodingNamespaceOverlay: projectScope=false even with branchScope=true → null", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx(),
+    mode({ projectScope: false, branchScope: true }),
+  );
+  assert.equal(overlay, null, "branchScope without projectScope must not apply");
+});
+
+test("resolveCodingNamespaceOverlay: empty projectId → null (defensive)", () => {
+  const overlay = resolveCodingNamespaceOverlay(ctx({ projectId: "" }), mode());
+  assert.equal(overlay, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveCodingNamespaceOverlay — project scope
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveCodingNamespaceOverlay: projectScope=true → project overlay, no fallbacks", () => {
+  const overlay = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:deadbeef" }), mode());
+  assert.deepEqual(overlay, {
+    namespace: "project:origin:deadbeef",
+    readFallbacks: [],
+    scope: "project",
+  });
+});
+
+test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → still project scope only", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:aaaa0000", branch: null }),
+    mode({ branchScope: true }),
+  );
+  assert.ok(overlay);
+  assert.equal(overlay!.scope, "project");
+  assert.equal(overlay!.namespace, "project:origin:aaaa0000");
+  assert.deepEqual(overlay!.readFallbacks, []);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveCodingNamespaceOverlay — branch scope (PR 3 preview, but logic is here)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveCodingNamespaceOverlay: branchScope=true + branch set → branch overlay with project fallback", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:aaaa0000", branch: "feat/x" }),
+    mode({ branchScope: true }),
+  );
+  assert.ok(overlay);
+  assert.equal(overlay!.scope, "branch");
+  assert.equal(overlay!.namespace, "project:origin:aaaa0000/branch:feat-x");
+  assert.deepEqual(overlay!.readFallbacks, ["project:origin:aaaa0000"]);
+});
+
+test("resolveCodingNamespaceOverlay: branchScope=false → no branch layering even with branch set", () => {
+  const overlay = resolveCodingNamespaceOverlay(ctx({ branch: "feat/x" }), mode({ branchScope: false }));
+  assert.ok(overlay);
+  assert.equal(overlay!.scope, "project");
+  assert.ok(!overlay!.namespace.includes("branch:"));
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cross-project isolation invariant (the core requirement of PR 2)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveCodingNamespaceOverlay: different projects resolve to different namespaces", () => {
+  const a = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:aaaaaaaa" }), mode());
+  const b = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:bbbbbbbb" }), mode());
+  assert.ok(a && b);
+  assert.notEqual(a!.namespace, b!.namespace, "cross-project isolation — different projectIds must map to different namespaces");
+});
+
+test("resolveCodingNamespaceOverlay: read path and write path see identical namespace (rule 42)", () => {
+  // Simulate the read and write paths in orchestrator consulting the same
+  // resolver with the same inputs. They must agree bit-for-bit.
+  const input: [CodingContext, CodingModeConfig] = [
+    ctx({ projectId: "origin:12345678", branch: "feat/y" }),
+    mode({ branchScope: true }),
+  ];
+  const readOverlay = resolveCodingNamespaceOverlay(input[0], input[1]);
+  const writeOverlay = resolveCodingNamespaceOverlay(input[0], input[1]);
+  assert.deepEqual(readOverlay, writeOverlay);
+});

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -14,6 +14,7 @@ import {
   projectNamespaceName,
   resolveCodingNamespaceOverlay,
 } from "./coding-namespace.js";
+import { isSafeRouteNamespace } from "../routing/engine.js";
 import type { CodingContext, CodingModeConfig } from "../types.js";
 
 function ctx(overrides: Partial<CodingContext> = {}): CodingContext {
@@ -38,34 +39,73 @@ function mode(overrides: Partial<CodingModeConfig> = {}): CodingModeConfig {
 // Name helpers
 // ──────────────────────────────────────────────────────────────────────────
 
-test("projectNamespaceName: stable form for origin-derived id", () => {
-  assert.equal(projectNamespaceName("origin:abcd1234"), "project:origin:abcd1234");
+test("projectNamespaceName: stable form for origin-derived id (safe-route compatible)", () => {
+  // `:` is not in the router's safe-namespace alphabet, so it collapses to
+  // `-`. Resulting name must pass `isSafeRouteNamespace`.
+  assert.equal(projectNamespaceName("origin:abcd1234"), "project-origin-abcd1234");
 });
 
 test("projectNamespaceName: lowercases and strips unsafe characters", () => {
-  assert.equal(projectNamespaceName("ORIGIN:ABCD!!"), "project:origin:abcd");
+  assert.equal(projectNamespaceName("ORIGIN:ABCD!!"), "project-origin-abcd");
 });
 
 test("projectNamespaceName: empty input falls back to 'unknown'", () => {
-  assert.equal(projectNamespaceName(""), "project:unknown");
-  assert.equal(projectNamespaceName("   "), "project:unknown");
+  assert.equal(projectNamespaceName(""), "project-unknown");
+  assert.equal(projectNamespaceName("   "), "project-unknown");
 });
 
-test("branchNamespaceName: layers branch on project (branch slashes collapsed to dashes)", () => {
-  // `/` is not in the safe alphabet — it collapses to `-` so the resulting
-  // name round-trips safely through the collection-name mapper in
-  // namespaces/search.ts. The `project:<id>/branch:<name>` structural
-  // separators remain.
+test("projectNamespaceName: length-capped to 64 chars, no trailing dash", () => {
+  const huge = "a".repeat(200);
+  const out = projectNamespaceName(huge);
+  assert.ok(out.length <= 64, `expected length ≤ 64, got ${out.length}`);
+  assert.ok(!out.endsWith("-"), "truncation must not leave a trailing dash");
+});
+
+test("projectNamespaceName: output satisfies isSafeRouteNamespace for typical projectIds", () => {
+  const cases = [
+    "origin:abcd1234",
+    "origin:deadbeef",
+    "root:12345678",
+    "ORIGIN:ABCD!!",
+    "",
+  ];
+  for (const input of cases) {
+    const ns = projectNamespaceName(input);
+    assert.ok(
+      isSafeRouteNamespace(ns),
+      `projectNamespaceName(${JSON.stringify(input)}) = ${JSON.stringify(ns)} must be a safe route namespace`,
+    );
+  }
+});
+
+test("branchNamespaceName: output satisfies isSafeRouteNamespace for typical branches", () => {
+  const cases: Array<[string, string]> = [
+    ["origin:abcd", "main"],
+    ["origin:abcd", "feat/x"],
+    ["origin:abcd", "hotfix/JIRA-1234"],
+    ["origin:abcd", "release-v2.0"],
+    ["origin:abcd", "user_branch.test"],
+  ];
+  for (const [projectId, branch] of cases) {
+    const ns = branchNamespaceName(projectId, branch);
+    assert.ok(
+      isSafeRouteNamespace(ns),
+      `branchNamespaceName(${JSON.stringify(projectId)}, ${JSON.stringify(branch)}) = ${JSON.stringify(ns)} must be a safe route namespace`,
+    );
+  }
+});
+
+test("branchNamespaceName: layers branch on project (uses `-` separators, no `/`)", () => {
   assert.equal(
     branchNamespaceName("origin:abcd1234", "feat/ui"),
-    "project:origin:abcd1234/branch:feat-ui",
+    "project-origin-abcd1234-branch-feat-ui",
   );
 });
 
 test("branchNamespaceName: sanitizes branch name (lowercase + unsafe → dash)", () => {
   assert.equal(
     branchNamespaceName("origin:abcd", "FEAT/UI (wip)"),
-    "project:origin:abcd/branch:feat-ui-wip",
+    "project-origin-abcd-branch-feat-ui-wip",
   );
 });
 
@@ -103,7 +143,7 @@ test("resolveCodingNamespaceOverlay: empty projectId → null (defensive)", () =
 test("resolveCodingNamespaceOverlay: projectScope=true → project overlay, no fallbacks", () => {
   const overlay = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:deadbeef" }), mode());
   assert.deepEqual(overlay, {
-    namespace: "project:origin:deadbeef",
+    namespace: "project-origin-deadbeef",
     readFallbacks: [],
     scope: "project",
   });
@@ -116,7 +156,7 @@ test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → still
   );
   assert.ok(overlay);
   assert.equal(overlay!.scope, "project");
-  assert.equal(overlay!.namespace, "project:origin:aaaa0000");
+  assert.equal(overlay!.namespace, "project-origin-aaaa0000");
   assert.deepEqual(overlay!.readFallbacks, []);
 });
 
@@ -131,8 +171,8 @@ test("resolveCodingNamespaceOverlay: branchScope=true + branch set → branch ov
   );
   assert.ok(overlay);
   assert.equal(overlay!.scope, "branch");
-  assert.equal(overlay!.namespace, "project:origin:aaaa0000/branch:feat-x");
-  assert.deepEqual(overlay!.readFallbacks, ["project:origin:aaaa0000"]);
+  assert.equal(overlay!.namespace, "project-origin-aaaa0000-branch-feat-x");
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000"]);
 });
 
 test("resolveCodingNamespaceOverlay: branchScope=false → no branch layering even with branch set", () => {

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -1,0 +1,137 @@
+/**
+ * Coding-agent namespace overlay (issue #569 PR 2 + PR 3).
+ *
+ * Given a `CodingContext` (from `resolveGitContext`) and a `CodingModeConfig`,
+ * returns the namespace that recall + write paths should use — or `null` when
+ * no overlay should apply (coding mode disabled, no context supplied, or
+ * feature flags off).
+ *
+ * PR 2 ships the project overlay. PR 3 will add the branch overlay; the
+ * function here already handles both flags so the schema / types / plumbing
+ * don't have to change a second time when branch-scope lands.
+ *
+ * Pure function — no orchestrator, no config side-effects. Callers keep rule
+ * 42 (read + write through same namespace layer) by consulting the same
+ * function on both paths.
+ */
+
+import type { CodingContext, CodingModeConfig } from "../types.js";
+
+export interface CodingNamespaceOverlay {
+  /**
+   * Effective namespace to use for this session's memory operations. When
+   * `branchScope` is on, takes the form `project:<id>/branch:<b>`; otherwise
+   * `project:<id>`.
+   */
+  namespace: string;
+  /**
+   * Read fallbacks — additional namespaces a caller should include in recall
+   * so that, for example, a branch-scoped session still sees project-level
+   * memories that were written before the branch scope was enabled.
+   *
+   * Writes MUST go to `namespace` only; these are read-side only.
+   *
+   * Introduced to carry PR 3's branch→project fallback; PR 2 returns an empty
+   * array here.
+   */
+  readFallbacks: string[];
+  /**
+   * `"project"` when only project scope applies, `"branch"` when branch scope
+   * is also layered on. Used for diagnostics (`remnic doctor`) and logging.
+   */
+  scope: "project" | "branch";
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Sanitization
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Normalize a projectId / branch fragment so the resulting namespace is safe
+ * to use as a collection-name token. The collection-name mapper in
+ * `namespaces/search.ts` performs its own lowercase + `[^a-z0-9._-]→-`
+ * normalization; we pre-sanitize here so the human-readable `<project:…>`
+ * form stored in configs / logs / audits is stable.
+ *
+ * NOT a security boundary — projectIds produced by `resolveGitContext` are
+ * already controlled hex (`origin:<8hex>` or `root:<8hex>`), and branch names
+ * come from local git. This defends against corrupt input only.
+ */
+function sanitizeFragment(input: string): string {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._:-]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Produce the project-scope namespace name. Exported for tests and for
+ * `remnic doctor` to render.
+ */
+export function projectNamespaceName(projectId: string): string {
+  const frag = sanitizeFragment(projectId);
+  return `project:${frag || "unknown"}`;
+}
+
+/**
+ * Produce the branch-scope namespace name. Exported for tests and doctor.
+ */
+export function branchNamespaceName(projectId: string, branch: string): string {
+  const projectFrag = sanitizeFragment(projectId);
+  const branchFrag = sanitizeFragment(branch);
+  return `project:${projectFrag || "unknown"}/branch:${branchFrag || "unknown"}`;
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Overlay resolver
+// ──────────────────────────────────────────────────────────────────────────
+
+/**
+ * Compute the namespace overlay for a session.
+ *
+ * Returns `null` when no overlay applies — callers should then use their
+ * existing `defaultNamespaceForPrincipal(...)` result unchanged. This keeps
+ * CLAUDE.md #30 (escape hatch): setting `codingMode.projectScope: false`
+ * exactly restores pre-#569 behaviour at every call site.
+ */
+export function resolveCodingNamespaceOverlay(
+  codingContext: CodingContext | null | undefined,
+  config: Pick<CodingModeConfig, "projectScope" | "branchScope">,
+): CodingNamespaceOverlay | null {
+  // No context supplied (session isn't in a git repo, or connector didn't
+  // attach one) → no overlay.
+  if (!codingContext) return null;
+
+  // Project scope disabled → no overlay at all. Branch scope depends on
+  // project scope being on; there is no branch-only mode.
+  if (!config.projectScope) return null;
+
+  // Require a non-empty projectId — defensive.
+  const projectId = typeof codingContext.projectId === "string" ? codingContext.projectId.trim() : "";
+  if (!projectId) return null;
+
+  const projectNs = projectNamespaceName(projectId);
+
+  // Branch-scope layering (PR 3):
+  //   - only when config.branchScope is explicitly true
+  //   - only when we actually have a branch (null in detached HEAD)
+  //   - project namespace becomes a read fallback so project-level memories
+  //     remain visible from any branch (deliberate asymmetry — branch writes
+  //     don't leak up, but project reads leak down).
+  if (config.branchScope && typeof codingContext.branch === "string" && codingContext.branch.length > 0) {
+    const branchNs = branchNamespaceName(projectId, codingContext.branch);
+    return {
+      namespace: branchNs,
+      readFallbacks: [projectNs],
+      scope: "branch",
+    };
+  }
+
+  return {
+    namespace: projectNs,
+    readFallbacks: [],
+    scope: "project",
+  };
+}

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -47,41 +47,59 @@ export interface CodingNamespaceOverlay {
 // ──────────────────────────────────────────────────────────────────────────
 
 /**
- * Normalize a projectId / branch fragment so the resulting namespace is safe
- * to use as a collection-name token. The collection-name mapper in
- * `namespaces/search.ts` performs its own lowercase + `[^a-z0-9._-]→-`
- * normalization; we pre-sanitize here so the human-readable `<project:…>`
- * form stored in configs / logs / audits is stable.
+ * Normalize a projectId / branch fragment so the resulting namespace passes
+ * the router's `isSafeRouteNamespace` check (`[A-Za-z0-9._-]{1,64}`).
  *
- * NOT a security boundary — projectIds produced by `resolveGitContext` are
- * already controlled hex (`origin:<8hex>` or `root:<8hex>`), and branch names
- * come from local git. This defends against corrupt input only.
+ * Namespaces are used as filesystem directory names and must not contain
+ * path separators (`/`, `\`) or colons — so both `:` and `/` collapse to `-`.
+ * The project-id format `origin:<8hex>` and branch names like `feat/x` both
+ * flow through this helper before hitting the storage layer.
+ *
+ * NOT a security boundary — projectIds come from `resolveGitContext` (known
+ * hex), and branch names come from local git. This defends against corrupt
+ * input only.
  */
 function sanitizeFragment(input: string): string {
   return input
     .trim()
     .toLowerCase()
-    .replace(/[^a-z0-9._:-]+/g, "-")
+    .replace(/[^a-z0-9._-]+/g, "-")
     .replace(/-+/g, "-")
     .replace(/^-+|-+$/g, "");
 }
 
 /**
- * Produce the project-scope namespace name. Exported for tests and for
- * `remnic doctor` to render.
+ * Cap to the router's per-namespace upper bound. Trim trailing `-` introduced
+ * by truncation so the final character is always alphanumeric or `.`, `_`.
  */
-export function projectNamespaceName(projectId: string): string {
-  const frag = sanitizeFragment(projectId);
-  return `project:${frag || "unknown"}`;
+const MAX_NAMESPACE_LEN = 64;
+function capLength(value: string): string {
+  if (value.length <= MAX_NAMESPACE_LEN) return value;
+  return value.slice(0, MAX_NAMESPACE_LEN).replace(/-+$/g, "");
 }
 
 /**
- * Produce the branch-scope namespace name. Exported for tests and doctor.
+ * Produce the project-scope namespace name. Exported for tests and for
+ * `remnic doctor` to render. Guaranteed to satisfy `isSafeRouteNamespace`:
+ * no `/`, no `:`, lowercase only, length-capped to 64 chars.
+ */
+export function projectNamespaceName(projectId: string): string {
+  const frag = sanitizeFragment(projectId);
+  return capLength(`project-${frag || "unknown"}`);
+}
+
+/**
+ * Produce the branch-scope namespace name. Format:
+ * `project-<id>-branch-<name>`. Uses `-` as the structural separator rather
+ * than `/` or `:` so the result is a single safe route-namespace token that
+ * can be used directly as a filesystem directory.
  */
 export function branchNamespaceName(projectId: string, branch: string): string {
   const projectFrag = sanitizeFragment(projectId);
   const branchFrag = sanitizeFragment(branch);
-  return `project:${projectFrag || "unknown"}/branch:${branchFrag || "unknown"}`;
+  return capLength(
+    `project-${projectFrag || "unknown"}-branch-${branchFrag || "unknown"}`,
+  );
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -16,6 +16,7 @@
  */
 
 import type { CodingContext, CodingModeConfig } from "../types.js";
+import { stableHash } from "./git-context.js";
 
 export interface CodingNamespaceOverlay {
   /**
@@ -59,13 +60,36 @@ export interface CodingNamespaceOverlay {
  * hex), and branch names come from local git. This defends against corrupt
  * input only.
  */
+/**
+ * Single-pass sanitization — each input character is visited exactly once.
+ * Rewriting as an explicit loop (instead of chained `replace()` calls with
+ * greedy quantifiers) closes the polynomial-backtracking surface that
+ * CodeQL flagged on patterns like `-+` and `^-+|-+$`.
+ */
 function sanitizeFragment(input: string): string {
-  return input
-    .trim()
-    .toLowerCase()
-    .replace(/[^a-z0-9._-]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
+  if (typeof input !== "string") return "";
+  const trimmed = input.trim().toLowerCase();
+  let out = "";
+  let prevIsDash = true; // suppress leading dashes
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const c = trimmed[i]!;
+    const cc = trimmed.charCodeAt(i);
+    const isSafe =
+      (cc >= 48 && cc <= 57) /* 0-9 */ ||
+      (cc >= 97 && cc <= 122) /* a-z */ ||
+      cc === 46 /* . */ ||
+      cc === 95 /* _ */;
+    if (isSafe) {
+      out += c;
+      prevIsDash = false;
+    } else if (!prevIsDash) {
+      out += "-";
+      prevIsDash = true;
+    }
+  }
+  // Strip a single trailing dash introduced by the final run of unsafe chars.
+  if (out.endsWith("-")) out = out.slice(0, -1);
+  return out;
 }
 
 /**
@@ -86,24 +110,20 @@ function sanitizeFragment(input: string): string {
 const MAX_NAMESPACE_LEN = 64;
 const HASH_SUFFIX_LEN = 9; // "-" + 8 hex chars
 
-function fnv1a32Hex(value: string): string {
-  // FNV-1a 32-bit hash — pure, deterministic, no crypto dependency needed
-  // for non-security-boundary namespace disambiguation.
-  let hash = 0x811c9dc5;
-  for (let i = 0; i < value.length; i += 1) {
-    hash ^= value.charCodeAt(i);
-    hash = (hash * 0x01000193) >>> 0;
-  }
-  return hash.toString(16).padStart(8, "0");
-}
-
 function capLength(value: string): string {
   if (value.length <= MAX_NAMESPACE_LEN) return value;
-  const hash = fnv1a32Hex(value);
-  const head = value
-    .slice(0, MAX_NAMESPACE_LEN - HASH_SUFFIX_LEN)
-    .replace(/-+$/g, "");
-  return `${head}-${hash}`;
+  // Reuse the FNV-1a 32-bit hash from git-context — one canonical
+  // implementation, one set of edge-case fixes. Uses Math.imul for
+  // correct 32-bit wrap-around, which plain `*` would not guarantee
+  // for the largest intermediate products.
+  const hash = stableHash(value);
+  // Trim trailing '-' with a linear, non-backtracking loop. A regex
+  // like `-+$` is linear too, but an explicit loop keeps CodeQL happy
+  // about polynomial backtracking warnings when several `\-+` patterns
+  // appear in the same module.
+  let end = MAX_NAMESPACE_LEN - HASH_SUFFIX_LEN;
+  while (end > 0 && value.charCodeAt(end - 1) === 45 /* '-' */) end -= 1;
+  return `${value.slice(0, end)}-${hash}`;
 }
 
 /**
@@ -114,6 +134,43 @@ function capLength(value: string): string {
 export function projectNamespaceName(projectId: string): string {
   const frag = sanitizeFragment(projectId);
   return capLength(`project-${frag || "unknown"}`);
+}
+
+/**
+ * Preserve case when sanitizing a principal-derived base namespace. The
+ * router's `isSafeRouteNamespace` check accepts `[A-Za-z0-9._-]{1,64}`, so
+ * upper-case characters in the principal name are safe and MUST be kept to
+ * avoid colliding two otherwise-distinct principals (e.g. `Alice` vs
+ * `alice`) into the same combined namespace.
+ *
+ * Otherwise identical to `sanitizeFragment`: single-pass, linear, no
+ * polynomial-backtracking quantifiers, unsafe chars collapse to `-` with
+ * leading/trailing dashes suppressed.
+ */
+function sanitizeBaseFragment(input: string): string {
+  if (typeof input !== "string") return "";
+  const trimmed = input.trim();
+  let out = "";
+  let prevIsDash = true;
+  for (let i = 0; i < trimmed.length; i += 1) {
+    const c = trimmed[i]!;
+    const cc = trimmed.charCodeAt(i);
+    const isSafe =
+      (cc >= 48 && cc <= 57) /* 0-9 */ ||
+      (cc >= 65 && cc <= 90) /* A-Z */ ||
+      (cc >= 97 && cc <= 122) /* a-z */ ||
+      cc === 46 /* . */ ||
+      cc === 95 /* _ */;
+    if (isSafe) {
+      out += c;
+      prevIsDash = false;
+    } else if (!prevIsDash) {
+      out += "-";
+      prevIsDash = true;
+    }
+  }
+  if (out.endsWith("-")) out = out.slice(0, -1);
+  return out;
 }
 
 /**
@@ -128,13 +185,18 @@ export function projectNamespaceName(projectId: string): string {
  *
  *   alice + project-origin-ab12  →  alice-project-origin-ab12
  *   bob   + project-origin-ab12  →  bob-project-origin-ab12
+ *   Alice + project-origin-ab12  →  Alice-project-origin-ab12 (distinct)
+ *
+ * The base fragment preserves case so `Alice` and `alice` remain distinct;
+ * the overlay fragment is still lowercase-sanitized because it derives from
+ * deterministic, pre-lowercased git hashes.
  *
  * Output is re-capped through `capLength` so a very long base + overlay
  * combination still fits inside `isSafeRouteNamespace` (≤ 64 chars). The
  * deterministic hash suffix on truncation keeps distinct inputs distinct.
  */
 export function combineNamespaces(base: string, overlay: string): string {
-  const baseFrag = sanitizeFragment(base);
+  const baseFrag = sanitizeBaseFragment(base);
   const overlayFrag = sanitizeFragment(overlay);
   if (!baseFrag) return capLength(overlayFrag || "unknown");
   if (!overlayFrag) return capLength(baseFrag);
@@ -175,7 +237,7 @@ export function branchNamespaceName(projectId: string, branch: string): string {
   // stays readable.
   const disambig = trimmedBranch.length > 0 && branchFrag !== trimmedBranch;
   const base = `project-${projectFrag || "unknown"}-branch-${branchFrag || "unknown"}`;
-  const suffixed = disambig ? `${base}-${fnv1a32Hex(trimmedBranch)}` : base;
+  const suffixed = disambig ? `${base}-${stableHash(trimmedBranch)}` : base;
   return capLength(suffixed);
 }
 

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -137,43 +137,6 @@ export function projectNamespaceName(projectId: string): string {
 }
 
 /**
- * Preserve case when sanitizing a principal-derived base namespace. The
- * router's `isSafeRouteNamespace` check accepts `[A-Za-z0-9._-]{1,64}`, so
- * upper-case characters in the principal name are safe and MUST be kept to
- * avoid colliding two otherwise-distinct principals (e.g. `Alice` vs
- * `alice`) into the same combined namespace.
- *
- * Otherwise identical to `sanitizeFragment`: single-pass, linear, no
- * polynomial-backtracking quantifiers, unsafe chars collapse to `-` with
- * leading/trailing dashes suppressed.
- */
-function sanitizeBaseFragment(input: string): string {
-  if (typeof input !== "string") return "";
-  const trimmed = input.trim();
-  let out = "";
-  let prevIsDash = true;
-  for (let i = 0; i < trimmed.length; i += 1) {
-    const c = trimmed[i]!;
-    const cc = trimmed.charCodeAt(i);
-    const isSafe =
-      (cc >= 48 && cc <= 57) /* 0-9 */ ||
-      (cc >= 65 && cc <= 90) /* A-Z */ ||
-      (cc >= 97 && cc <= 122) /* a-z */ ||
-      cc === 46 /* . */ ||
-      cc === 95 /* _ */;
-    if (isSafe) {
-      out += c;
-      prevIsDash = false;
-    } else if (!prevIsDash) {
-      out += "-";
-      prevIsDash = true;
-    }
-  }
-  if (out.endsWith("-")) out = out.slice(0, -1);
-  return out;
-}
-
-/**
  * Combine a principal-derived base namespace (e.g. `default`, `alice`) with a
  * coding-agent overlay namespace (e.g. `project-origin-abcd1234`). The result
  * is a single safe-route token that preserves principal isolation (CLAUDE.md
@@ -185,18 +148,22 @@ function sanitizeBaseFragment(input: string): string {
  *
  *   alice + project-origin-ab12  →  alice-project-origin-ab12
  *   bob   + project-origin-ab12  →  bob-project-origin-ab12
- *   Alice + project-origin-ab12  →  Alice-project-origin-ab12 (distinct)
  *
- * The base fragment preserves case so `Alice` and `alice` remain distinct;
- * the overlay fragment is still lowercase-sanitized because it derives from
- * deterministic, pre-lowercased git hashes.
+ * BOTH fragments are lowercase-sanitized even though `isSafeRouteNamespace`
+ * accepts upper-case: the namespace is ultimately used as a filesystem
+ * directory name, and case-insensitive filesystems (common on Windows and
+ * default macOS) would collapse `Alice-project-...` and `alice-project-...`
+ * to the same directory — producing cross-principal leakage specifically in
+ * the case where the in-memory router thinks they are distinct. Principal
+ * resolution upstream should normalize case itself; this is a defensive
+ * second layer so the storage boundary matches the routing boundary.
  *
  * Output is re-capped through `capLength` so a very long base + overlay
  * combination still fits inside `isSafeRouteNamespace` (≤ 64 chars). The
  * deterministic hash suffix on truncation keeps distinct inputs distinct.
  */
 export function combineNamespaces(base: string, overlay: string): string {
-  const baseFrag = sanitizeBaseFragment(base);
+  const baseFrag = sanitizeFragment(base);
   const overlayFrag = sanitizeFragment(overlay);
   if (!baseFrag) return capLength(overlayFrag || "unknown");
   if (!overlayFrag) return capLength(baseFrag);

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -69,13 +69,41 @@ function sanitizeFragment(input: string): string {
 }
 
 /**
- * Cap to the router's per-namespace upper bound. Trim trailing `-` introduced
- * by truncation so the final character is always alphanumeric or `.`, `_`.
+ * Cap to the router's per-namespace upper bound.
+ *
+ * Raw truncation alone would collapse distinct long inputs that differ near
+ * the end (e.g. two `feat/...` branches with different suffixes) into the
+ * same namespace — silently mixing recall/write state across branches or
+ * projects. When truncation is needed, we append a short deterministic
+ * hash suffix (`-<8hex>`) derived from the FULL pre-truncated value so
+ * collisions only happen under true hash collisions, not simple prefix
+ * overlap.
+ *
+ * The tail is trimmed to leave room for the separator and 8-char hash and
+ * any trailing `-` introduced by the slice is stripped so the final
+ * character before `-<hash>` is always alphanumeric or `.`/`_`.
  */
 const MAX_NAMESPACE_LEN = 64;
+const HASH_SUFFIX_LEN = 9; // "-" + 8 hex chars
+
+function fnv1a32Hex(value: string): string {
+  // FNV-1a 32-bit hash — pure, deterministic, no crypto dependency needed
+  // for non-security-boundary namespace disambiguation.
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash.toString(16).padStart(8, "0");
+}
+
 function capLength(value: string): string {
   if (value.length <= MAX_NAMESPACE_LEN) return value;
-  return value.slice(0, MAX_NAMESPACE_LEN).replace(/-+$/g, "");
+  const hash = fnv1a32Hex(value);
+  const head = value
+    .slice(0, MAX_NAMESPACE_LEN - HASH_SUFFIX_LEN)
+    .replace(/-+$/g, "");
+  return `${head}-${hash}`;
 }
 
 /**
@@ -89,17 +117,66 @@ export function projectNamespaceName(projectId: string): string {
 }
 
 /**
+ * Combine a principal-derived base namespace (e.g. `default`, `alice`) with a
+ * coding-agent overlay namespace (e.g. `project-origin-abcd1234`). The result
+ * is a single safe-route token that preserves principal isolation (CLAUDE.md
+ * rule 42: read + write must resolve through the same namespace layer — and
+ * here, through the same principal-scoped prefix) while layering project or
+ * project/branch scope on top.
+ *
+ * Multiple principals working in the same repo thus get distinct namespaces:
+ *
+ *   alice + project-origin-ab12  →  alice-project-origin-ab12
+ *   bob   + project-origin-ab12  →  bob-project-origin-ab12
+ *
+ * Output is re-capped through `capLength` so a very long base + overlay
+ * combination still fits inside `isSafeRouteNamespace` (≤ 64 chars). The
+ * deterministic hash suffix on truncation keeps distinct inputs distinct.
+ */
+export function combineNamespaces(base: string, overlay: string): string {
+  const baseFrag = sanitizeFragment(base);
+  const overlayFrag = sanitizeFragment(overlay);
+  if (!baseFrag) return capLength(overlayFrag || "unknown");
+  if (!overlayFrag) return capLength(baseFrag);
+  return capLength(`${baseFrag}-${overlayFrag}`);
+}
+
+/**
  * Produce the branch-scope namespace name. Format:
- * `project-<id>-branch-<name>`. Uses `-` as the structural separator rather
- * than `/` or `:` so the result is a single safe route-namespace token that
- * can be used directly as a filesystem directory.
+ * `project-<id>-branch-<name>[-<hash>]`. Uses `-` as the structural separator
+ * rather than `/` or `:` so the result is a single safe route-namespace
+ * token that can be used directly as a filesystem directory.
+ *
+ * Two failure modes must not collapse distinct branches to one namespace:
+ *
+ *   1. Sanitization is lossy (`feat/x` and `feat-x` both sanitize to
+ *      `feat-x`; `Feature` and `feature` both sanitize to `feature`). When
+ *      sanitization rewrote any character, we append a short hash of the
+ *      RAW branch so distinct inputs stay distinct.
+ *   2. Truncation is applied when the total exceeds 64 chars. In that
+ *      mode `capLength` appends its own hash of the full pre-truncated
+ *      value.
+ *
+ * Long branches that also sanitize may receive both kinds of hashes — that
+ * is acceptable: the router only requires the result be unique and
+ * deterministic, and the two hashes derive from different domains so they
+ * don't conflict.
  */
 export function branchNamespaceName(projectId: string, branch: string): string {
   const projectFrag = sanitizeFragment(projectId);
-  const branchFrag = sanitizeFragment(branch);
-  return capLength(
-    `project-${projectFrag || "unknown"}-branch-${branchFrag || "unknown"}`,
-  );
+  const trimmedBranch = branch.trim();
+  const branchFrag = sanitizeFragment(trimmedBranch);
+  // Lossy-sanitization disambiguator: append hash of the raw (trimmed)
+  // branch when sanitization actually changed the string. Preserves
+  // distinctness across `feat/x` vs `feat-x` and `Feature` vs `feature`.
+  // The comparison uses the raw trimmed value (NOT `.toLowerCase()`) so
+  // case-only variants are treated as lossy and receive their own hash.
+  // Empty / already-safe-lowercase inputs get no hash so the common case
+  // stays readable.
+  const disambig = trimmedBranch.length > 0 && branchFrag !== trimmedBranch;
+  const base = `project-${projectFrag || "unknown"}-branch-${branchFrag || "unknown"}`;
+  const suffixed = disambig ? `${base}-${fnv1a32Hex(trimmedBranch)}` : base;
+  return capLength(suffixed);
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/coding-orchestrator.test.ts
+++ b/packages/remnic-core/src/coding/coding-orchestrator.test.ts
@@ -8,7 +8,7 @@
  *
  *   1. A session without a coding context gets the default namespace.
  *   2. A session with a coding context + `codingMode.projectScope: true`
- *      gets a `project:<id>` overlay on both read and write paths.
+ *      gets a `project-<id>` overlay on both read and write paths.
  *   3. Disabling `codingMode.projectScope: false` exactly restores the
  *      default namespace (CLAUDE.md #30 escape hatch).
  *   4. Rule 42 invariant: read-path overlay and write-path overlay return
@@ -113,7 +113,7 @@ test("applyCodingNamespaceOverlay: returns project overlay when context is set a
   orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));
   assert.equal(
     orch.applyCodingNamespaceOverlay("session-A", "default"),
-    "project:origin:abcdef12",
+    "project-origin-abcdef12",
   );
 });
 
@@ -140,7 +140,7 @@ test("applyCodingRecallOverlay: project context → overlay with empty fallbacks
   const orch = makeOrchestrator();
   orch.setCodingContextForSession("session-A", contextFor("origin:aaaaaaaa"));
   const overlay = orch.applyCodingRecallOverlay("session-A");
-  assert.deepEqual(overlay, { namespace: "project:origin:aaaaaaaa", readFallbacks: [] });
+  assert.deepEqual(overlay, { namespace: "project-origin-aaaaaaaa", readFallbacks: [] });
 });
 
 test("applyCodingRecallOverlay: projectScope=false → null (escape hatch)", () => {
@@ -175,6 +175,6 @@ test("two sessions on different projects resolve to different namespaces (no cro
   const nsA = orch.applyCodingNamespaceOverlay("session-A", "default");
   const nsB = orch.applyCodingNamespaceOverlay("session-B", "default");
   assert.notEqual(nsA, nsB);
-  assert.equal(nsA, "project:origin:11111111");
-  assert.equal(nsB, "project:origin:22222222");
+  assert.equal(nsA, "project-origin-11111111");
+  assert.equal(nsB, "project-origin-22222222");
 });

--- a/packages/remnic-core/src/coding/coding-orchestrator.test.ts
+++ b/packages/remnic-core/src/coding/coding-orchestrator.test.ts
@@ -137,6 +137,26 @@ test("applyCodingNamespaceOverlay: different principals on same repo get isolate
   );
 });
 
+test("applyCodingNamespaceOverlay: principal base namespace preserves case", () => {
+  // Regression: sanitizeFragment() was lowercasing the base, so two valid
+  // but case-differing principal identifiers (`Alice` vs `alice`) would
+  // collapse to the same combined namespace. The router accepts
+  // [A-Za-z0-9._-]{1,64}, so case is a legal discriminator and must not
+  // be dropped on the write / read paths.
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("A-sess", contextFor("origin:deadbeef"));
+  orch.setCodingContextForSession("a-sess", contextFor("origin:deadbeef"));
+  const upperNs = orch.applyCodingNamespaceOverlay("A-sess", "Alice");
+  const lowerNs = orch.applyCodingNamespaceOverlay("a-sess", "alice");
+  assert.notEqual(
+    upperNs,
+    lowerNs,
+    "case-only principal variants must not collapse to the same namespace",
+  );
+  assert.equal(upperNs, "Alice-project-origin-deadbeef");
+  assert.equal(lowerNs, "alice-project-origin-deadbeef");
+});
+
 test("applyCodingNamespaceOverlay: projectScope=false returns base unchanged (escape hatch)", () => {
   const orch = makeOrchestrator({ projectScope: false });
   orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));

--- a/packages/remnic-core/src/coding/coding-orchestrator.test.ts
+++ b/packages/remnic-core/src/coding/coding-orchestrator.test.ts
@@ -137,24 +137,27 @@ test("applyCodingNamespaceOverlay: different principals on same repo get isolate
   );
 });
 
-test("applyCodingNamespaceOverlay: principal base namespace preserves case", () => {
-  // Regression: sanitizeFragment() was lowercasing the base, so two valid
-  // but case-differing principal identifiers (`Alice` vs `alice`) would
-  // collapse to the same combined namespace. The router accepts
-  // [A-Za-z0-9._-]{1,64}, so case is a legal discriminator and must not
-  // be dropped on the write / read paths.
+test("applyCodingNamespaceOverlay: principal base namespace is canonicalized to lowercase", () => {
+  // Design note: the combined namespace is ultimately used as a
+  // filesystem directory. On case-insensitive filesystems (common on
+  // Windows and default macOS), `Alice-project-…` and `alice-project-…`
+  // would resolve to the same directory — producing silent
+  // cross-principal leakage specifically in the case where the in-memory
+  // router thinks two sessions are isolated. We therefore lowercase the
+  // base fragment at the boundary; upstream principal resolution is
+  // expected to canonicalize case itself, and this is a defensive
+  // second layer so the storage boundary matches the routing boundary.
   const orch = makeOrchestrator();
   orch.setCodingContextForSession("A-sess", contextFor("origin:deadbeef"));
   orch.setCodingContextForSession("a-sess", contextFor("origin:deadbeef"));
   const upperNs = orch.applyCodingNamespaceOverlay("A-sess", "Alice");
   const lowerNs = orch.applyCodingNamespaceOverlay("a-sess", "alice");
-  assert.notEqual(
+  assert.equal(
     upperNs,
     lowerNs,
-    "case-only principal variants must not collapse to the same namespace",
+    "case-only principal variants must resolve to the same namespace (filesystem safety)",
   );
-  assert.equal(upperNs, "Alice-project-origin-deadbeef");
-  assert.equal(lowerNs, "alice-project-origin-deadbeef");
+  assert.equal(upperNs, "alice-project-origin-deadbeef");
 });
 
 test("applyCodingNamespaceOverlay: projectScope=false returns base unchanged (escape hatch)", () => {

--- a/packages/remnic-core/src/coding/coding-orchestrator.test.ts
+++ b/packages/remnic-core/src/coding/coding-orchestrator.test.ts
@@ -108,12 +108,32 @@ test("applyCodingNamespaceOverlay: returns base unchanged when no context attach
   assert.equal(orch.applyCodingNamespaceOverlay("session-A", "default"), "default");
 });
 
-test("applyCodingNamespaceOverlay: returns project overlay when context is set and projectScope on", () => {
+test("applyCodingNamespaceOverlay: combines base + project overlay when context is set and projectScope on", () => {
   const orch = makeOrchestrator();
   orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));
+  // Rule 42 / principal isolation: overlay is COMBINED with the principal
+  // base, not a replacement. Two principals in the same repo thus get
+  // distinct namespaces (`alice-project-…` vs `bob-project-…`).
   assert.equal(
     orch.applyCodingNamespaceOverlay("session-A", "default"),
-    "project-origin-abcdef12",
+    "default-project-origin-abcdef12",
+  );
+  assert.equal(
+    orch.applyCodingNamespaceOverlay("session-A", "alice"),
+    "alice-project-origin-abcdef12",
+  );
+});
+
+test("applyCodingNamespaceOverlay: different principals on same repo get isolated namespaces", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("alice-sess", contextFor("origin:deadbeef"));
+  orch.setCodingContextForSession("bob-sess", contextFor("origin:deadbeef"));
+  const aliceNs = orch.applyCodingNamespaceOverlay("alice-sess", "alice");
+  const bobNs = orch.applyCodingNamespaceOverlay("bob-sess", "bob");
+  assert.notEqual(
+    aliceNs,
+    bobNs,
+    "distinct principals on the same repo must route to distinct namespaces",
   );
 });
 
@@ -124,6 +144,20 @@ test("applyCodingNamespaceOverlay: projectScope=false returns base unchanged (es
     orch.applyCodingNamespaceOverlay("session-A", "default"),
     "default",
     "codingMode.projectScope=false must exactly restore pre-#569 behaviour",
+  );
+});
+
+test("applyCodingNamespaceOverlay: namespacesEnabled=false returns base unchanged", () => {
+  // When namespacesEnabled is off the storage router maps every namespace
+  // to the same directory — a `project-*` overlay would create apparent
+  // route separation with no actual isolation. In that mode, coding mode
+  // degrades to unscoped behavior.
+  const orch = makeOrchestrator();
+  (orch.config as unknown as { namespacesEnabled: boolean }).namespacesEnabled = false;
+  orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));
+  assert.equal(
+    orch.applyCodingNamespaceOverlay("session-A", "default"),
+    "default",
   );
 });
 
@@ -149,18 +183,33 @@ test("applyCodingRecallOverlay: projectScope=false → null (escape hatch)", () 
   assert.equal(orch.applyCodingRecallOverlay("session-A"), null);
 });
 
+test("applyCodingRecallOverlay: namespacesEnabled=false → null", () => {
+  const orch = makeOrchestrator();
+  (orch.config as unknown as { namespacesEnabled: boolean }).namespacesEnabled = false;
+  orch.setCodingContextForSession("session-A", contextFor("origin:aaaaaaaa"));
+  assert.equal(orch.applyCodingRecallOverlay("session-A"), null);
+});
+
 // ──────────────────────────────────────────────────────────────────────────
-// Rule 42 — read path and write path agree (bit-for-bit)
+// Rule 42 — read path and write path resolve consistently
 // ──────────────────────────────────────────────────────────────────────────
 
-test("CLAUDE.md #42: read and write paths resolve the same namespace for the same session", () => {
+test("CLAUDE.md #42: read and write paths resolve the same namespace for the same principal + session", () => {
+  // With the principal-scoped combine, the write-path namespace is
+  // `<principal>-project-<id>` and the read-path self namespace is the
+  // combine of the same principal base with the overlay. Both must be
+  // identical for the same (sessionKey, baseNamespace) pair.
   const orch = makeOrchestrator();
   orch.setCodingContextForSession("session-A", contextFor("origin:deadbeef"));
 
-  const writeNs = orch.applyCodingNamespaceOverlay("session-A", "default");
+  const base = "default";
+  const writeNs = orch.applyCodingNamespaceOverlay("session-A", base);
   const recallOverlay = orch.applyCodingRecallOverlay("session-A");
   assert.ok(recallOverlay);
-  assert.equal(writeNs, recallOverlay!.namespace);
+  // The read path callers also perform the combine; here we verify the
+  // equivalence contract: a raw overlay + base combined on the read path
+  // must match the write-path namespace.
+  assert.equal(writeNs, `${base}-${recallOverlay!.namespace}`);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -175,6 +224,6 @@ test("two sessions on different projects resolve to different namespaces (no cro
   const nsA = orch.applyCodingNamespaceOverlay("session-A", "default");
   const nsB = orch.applyCodingNamespaceOverlay("session-B", "default");
   assert.notEqual(nsA, nsB);
-  assert.equal(nsA, "project-origin-11111111");
-  assert.equal(nsB, "project-origin-22222222");
+  assert.equal(nsA, "default-project-origin-11111111");
+  assert.equal(nsB, "default-project-origin-22222222");
 });

--- a/packages/remnic-core/src/coding/coding-orchestrator.test.ts
+++ b/packages/remnic-core/src/coding/coding-orchestrator.test.ts
@@ -1,0 +1,180 @@
+/**
+ * Integration tests for the orchestrator's coding-namespace overlay surface
+ * (issue #569 PR 2).
+ *
+ * These tests use `Object.create(Orchestrator.prototype)` to exercise the
+ * overlay helpers in isolation — no storage, no extraction. The end-to-end
+ * contract being verified:
+ *
+ *   1. A session without a coding context gets the default namespace.
+ *   2. A session with a coding context + `codingMode.projectScope: true`
+ *      gets a `project:<id>` overlay on both read and write paths.
+ *   3. Disabling `codingMode.projectScope: false` exactly restores the
+ *      default namespace (CLAUDE.md #30 escape hatch).
+ *   4. Rule 42 invariant: read-path overlay and write-path overlay return
+ *      the same namespace for the same session + context.
+ *   5. Isolation: two sessions on different projects resolve to different
+ *      namespaces — cross-project leakage cannot occur at the routing layer.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { Orchestrator } from "../orchestrator.js";
+import type { CodingContext, CodingModeConfig, PluginConfig } from "../types.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Minimal orchestrator stub
+// ──────────────────────────────────────────────────────────────────────────
+
+type OrchestratorLike = {
+  config: PluginConfig;
+  // The private map on the real orchestrator — we mirror its name so the
+  // methods under test read from the same slot.
+  _codingContextBySession: Map<string, CodingContext>;
+  setCodingContextForSession: Orchestrator["setCodingContextForSession"];
+  getCodingContextForSession: Orchestrator["getCodingContextForSession"];
+  applyCodingNamespaceOverlay: Orchestrator["applyCodingNamespaceOverlay"];
+  applyCodingRecallOverlay: Orchestrator["applyCodingRecallOverlay"];
+  resolveSelfNamespace: Orchestrator["resolveSelfNamespace"];
+  resolvePrincipal: Orchestrator["resolvePrincipal"];
+};
+
+function makeOrchestrator(codingMode: Partial<CodingModeConfig> = {}): OrchestratorLike {
+  const orch = Object.create(Orchestrator.prototype) as OrchestratorLike;
+  orch._codingContextBySession = new Map<string, CodingContext>();
+  // Minimal PluginConfig — only the fields the overlay path reads.
+  orch.config = {
+    namespacesEnabled: true,
+    defaultNamespace: "default",
+    sharedNamespace: "shared",
+    namespacePolicies: [],
+    defaultRecallNamespaces: ["self", "shared"],
+    principalFromSessionKeyMode: "prefix",
+    principalFromSessionKeyRules: [],
+    codingMode: {
+      projectScope: true,
+      branchScope: false,
+      ...codingMode,
+    },
+  } as unknown as PluginConfig;
+  return orch;
+}
+
+function contextFor(projectId: string, branch: string | null = "main"): CodingContext {
+  return {
+    projectId,
+    branch,
+    rootPath: `/work/${projectId}`,
+    defaultBranch: "main",
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Basic setters / getters
+// ──────────────────────────────────────────────────────────────────────────
+
+test("setCodingContextForSession: stores context; getCodingContextForSession returns it", () => {
+  const orch = makeOrchestrator();
+  const ctx = contextFor("origin:a1");
+  orch.setCodingContextForSession("session-A", ctx);
+  assert.deepEqual(orch.getCodingContextForSession("session-A"), ctx);
+});
+
+test("setCodingContextForSession: null clears the context", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("session-A", contextFor("origin:a1"));
+  orch.setCodingContextForSession("session-A", null);
+  assert.equal(orch.getCodingContextForSession("session-A"), null);
+});
+
+test("getCodingContextForSession: missing session returns null", () => {
+  const orch = makeOrchestrator();
+  assert.equal(orch.getCodingContextForSession("unknown"), null);
+});
+
+test("setCodingContextForSession: empty sessionKey is a no-op (defensive)", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("", contextFor("origin:a1"));
+  assert.equal(orch._codingContextBySession.size, 0);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Overlay on write path
+// ──────────────────────────────────────────────────────────────────────────
+
+test("applyCodingNamespaceOverlay: returns base unchanged when no context attached", () => {
+  const orch = makeOrchestrator();
+  assert.equal(orch.applyCodingNamespaceOverlay("session-A", "default"), "default");
+});
+
+test("applyCodingNamespaceOverlay: returns project overlay when context is set and projectScope on", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));
+  assert.equal(
+    orch.applyCodingNamespaceOverlay("session-A", "default"),
+    "project:origin:abcdef12",
+  );
+});
+
+test("applyCodingNamespaceOverlay: projectScope=false returns base unchanged (escape hatch)", () => {
+  const orch = makeOrchestrator({ projectScope: false });
+  orch.setCodingContextForSession("session-A", contextFor("origin:abcdef12"));
+  assert.equal(
+    orch.applyCodingNamespaceOverlay("session-A", "default"),
+    "default",
+    "codingMode.projectScope=false must exactly restore pre-#569 behaviour",
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Overlay on read path
+// ──────────────────────────────────────────────────────────────────────────
+
+test("applyCodingRecallOverlay: no context → null (caller uses its existing namespaces)", () => {
+  const orch = makeOrchestrator();
+  assert.equal(orch.applyCodingRecallOverlay("session-A"), null);
+});
+
+test("applyCodingRecallOverlay: project context → overlay with empty fallbacks", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("session-A", contextFor("origin:aaaaaaaa"));
+  const overlay = orch.applyCodingRecallOverlay("session-A");
+  assert.deepEqual(overlay, { namespace: "project:origin:aaaaaaaa", readFallbacks: [] });
+});
+
+test("applyCodingRecallOverlay: projectScope=false → null (escape hatch)", () => {
+  const orch = makeOrchestrator({ projectScope: false });
+  orch.setCodingContextForSession("session-A", contextFor("origin:aaaaaaaa"));
+  assert.equal(orch.applyCodingRecallOverlay("session-A"), null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Rule 42 — read path and write path agree (bit-for-bit)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("CLAUDE.md #42: read and write paths resolve the same namespace for the same session", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("session-A", contextFor("origin:deadbeef"));
+
+  const writeNs = orch.applyCodingNamespaceOverlay("session-A", "default");
+  const recallOverlay = orch.applyCodingRecallOverlay("session-A");
+  assert.ok(recallOverlay);
+  assert.equal(writeNs, recallOverlay!.namespace);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Isolation invariant — two projects, two namespaces
+// ──────────────────────────────────────────────────────────────────────────
+
+test("two sessions on different projects resolve to different namespaces (no cross-project leakage)", () => {
+  const orch = makeOrchestrator();
+  orch.setCodingContextForSession("session-A", contextFor("origin:11111111"));
+  orch.setCodingContextForSession("session-B", contextFor("origin:22222222"));
+
+  const nsA = orch.applyCodingNamespaceOverlay("session-A", "default");
+  const nsB = orch.applyCodingNamespaceOverlay("session-B", "default");
+  assert.notEqual(nsA, nsB);
+  assert.equal(nsA, "project:origin:11111111");
+  assert.equal(nsB, "project:origin:22222222");
+});

--- a/packages/remnic-core/src/coding/git-context.test.ts
+++ b/packages/remnic-core/src/coding/git-context.test.ts
@@ -118,9 +118,18 @@ test("normalizeOriginUrl: scp paths may start with digits", () => {
 test("normalizeOriginUrl: Windows drive-letter path is not parsed as scp", () => {
   // `git remote get-url origin` can return `C:/repos/app.git` for local
   // Windows paths. The drive-letter branch short-circuits scp parsing.
+  //
+  // Only the drive letter is case-folded (NTFS is case-insensitive for
+  // the drive letter). The rest of the path is preserved verbatim because
+  // on case-sensitive filesystems reachable via network shares, paths can
+  // still be case-sensitive.
   assert.equal(
     normalizeOriginUrl("C:/repos/app.git"),
     "c:/repos/app",
+  );
+  assert.equal(
+    normalizeOriginUrl("C:/Repos/App.git"),
+    "c:/Repos/App",
   );
 });
 
@@ -194,10 +203,34 @@ test("normalizeOriginUrl: uppercase .GIT suffix stripped (case-insensitive)", ()
   );
 });
 
-test("normalizeOriginUrl: case-insensitive", () => {
+test("normalizeOriginUrl: hostname is case-folded, repo path case is preserved", () => {
+  // Hostnames are case-insensitive per DNS, so `GitHub.com` and `github.com`
+  // must normalize to the same host. Repository paths, however, can be
+  // case-sensitive on Git backends (notably self-hosted servers on
+  // case-sensitive filesystems) — preserving case is required for
+  // cross-tenant isolation there.
   assert.equal(
     normalizeOriginUrl("https://GitHub.com/Foo/Bar.git"),
-    "github.com/foo/bar",
+    "github.com/Foo/Bar",
+  );
+});
+
+test("normalizeOriginUrl: repo paths differing only in case stay distinct (case-sensitive backends)", () => {
+  // Regression for the P1 review finding: case-sensitive backends treat
+  // `Team/Repo` and `team/repo` as different repositories. Normalization
+  // must NOT collapse them — doing so would give both the same projectId
+  // and merge recall/write data across unrelated projects.
+  assert.notEqual(
+    normalizeOriginUrl("git@host.example:Team/Repo.git"),
+    normalizeOriginUrl("git@host.example:team/repo.git"),
+  );
+  assert.notEqual(
+    normalizeOriginUrl("https://host.example/Team/Repo.git"),
+    normalizeOriginUrl("https://host.example/team/repo.git"),
+  );
+  assert.notEqual(
+    normalizeOriginUrl("ssh://git@host.example/Team/Repo.git"),
+    normalizeOriginUrl("ssh://git@host.example/team/repo.git"),
   );
 });
 

--- a/packages/remnic-core/src/coding/git-context.ts
+++ b/packages/remnic-core/src/coding/git-context.ts
@@ -139,8 +139,13 @@ export function stableHash(input: string): string {
  *   - `ssh://git@github.com/foo/bar` → `github.com/foo/bar`
  *   - `ssh://git@github.com:2222/foo/bar` → `github.com/foo/bar` (port stripped)
  *
- * Case-insensitive (remote hostnames and most repo paths on major forges are
- * case-insensitive in practice).
+ * Case handling: the HOST segment (and port) is folded to lowercase (DNS
+ * hostnames are case-insensitive by spec). The REPO PATH segment is
+ * preserved verbatim — Git backends on case-sensitive filesystems (most
+ * self-hosted servers, Gitea, GitLab EE on Linux, etc.) treat `Team/Repo`
+ * and `team/repo` as distinct repositories, so folding the path would
+ * collapse them onto the same `projectId` and merge recall/write data
+ * across unrelated projects.
  */
 export function normalizeOriginUrl(rawUrl: string): string {
   let url = rawUrl.trim();
@@ -157,8 +162,14 @@ export function normalizeOriginUrl(rawUrl: string): string {
   // (`h:foo/bar` from `.ssh/config`). A drive letter is exactly one ASCII
   // letter followed by `:/` or `:\`; SSH aliases never have a slash
   // immediately after the colon.
+  //
+  // Case handling: lowercase ONLY the drive letter (NTFS is case-insensitive
+  // for the drive letter itself), but preserve the REST of the path. Git
+  // backends on case-sensitive filesystems treat `C:/Repos/App` and
+  // `C:/repos/app` as distinct repositories; folding the whole string
+  // would collapse them onto the same projectId.
   if (/^[A-Za-z]:[\\/]/.test(url)) {
-    return url.toLowerCase();
+    return `${url[0]!.toLowerCase()}${url.slice(1)}`;
   }
 
   // Protocol-prefixed: ssh://, https://, http://, git://, file://
@@ -194,7 +205,14 @@ export function normalizeOriginUrl(rawUrl: string): string {
     // For protocols without a host component (file:///path), fall back to
     // a stable prefix so distinct local paths don't collapse to "/path".
     const prefix = hostPort.length > 0 ? hostPort : "localhost";
-    return `${prefix}/${repoPath}`.toLowerCase();
+    // Case handling: fold ONLY the host:port prefix (DNS hostnames and
+    // numeric ports are case-insensitive). Preserve the repository path
+    // verbatim — Git backends on case-sensitive filesystems (most
+    // self-hosted servers, Gitea, GitLab EE on Linux, etc.) treat
+    // `Team/Repo` and `team/repo` as distinct repositories. Folding the
+    // path would collapse them onto the same projectId and merge
+    // recall/write data across unrelated projects.
+    return `${prefix.toLowerCase()}/${repoPath}`;
   }
 
   // scp-like syntax: [user@]host:path. Protocol-prefixed URLs (`scheme://`)
@@ -223,13 +241,20 @@ export function normalizeOriginUrl(rawUrl: string): string {
     // Reject protocol-like leftovers (e.g. `file:///path` where the scp
     // regex greedily matched `file` as host and `///path` as path).
     if (repoPath.startsWith("//")) {
-      return url.toLowerCase();
+      // Preserve case on the fallback path (see below for rationale).
+      return url;
     }
-    return `${host}/${repoPath.replace(/^\/+/, "")}`.toLowerCase();
+    // Fold ONLY the host; preserve the repo path verbatim for
+    // case-sensitive Git backends. See the protocol branch above for
+    // rationale.
+    return `${host.toLowerCase()}/${repoPath.replace(/^\/+/, "")}`;
   }
 
-  // Fallback: use raw lowercased
-  return url.toLowerCase();
+  // Fallback: preserve the raw input. Opaque strings could include
+  // case-sensitive repo paths; preserving case means distinct inputs stay
+  // distinct. `projectId` hashing still differentiates case-different
+  // strings into distinct namespaces.
+  return url;
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -293,3 +293,25 @@ test("parseConfig procedural numeric fields coerce from CLI-style strings (issue
   assert.equal(result.procedural.lookbackDays, 14);
   assert.equal(result.procedural.recallMaxProcedures, 2);
 });
+
+test("parseConfig codingMode: defaults projectScope=true, branchScope=false (issue #569)", () => {
+  const result = parseConfig({ openaiApiKey: "sk-test" });
+  assert.equal(result.codingMode.projectScope, true, "projectScope defaults to true");
+  assert.equal(result.codingMode.branchScope, false, "branchScope defaults to false (opt-in)");
+});
+
+test("parseConfig codingMode: accepts explicit booleans and CLI-style strings (issue #569)", () => {
+  // CLAUDE.md #36: string "false" must coerce to boolean false.
+  const result = parseConfig({
+    openaiApiKey: "sk-test",
+    codingMode: { projectScope: "false", branchScope: "true" },
+  });
+  assert.equal(result.codingMode.projectScope, false);
+  assert.equal(result.codingMode.branchScope, true);
+});
+
+test("parseConfig codingMode: unknown object shape falls back to defaults", () => {
+  const result = parseConfig({ openaiApiKey: "sk-test", codingMode: null });
+  assert.equal(result.codingMode.projectScope, true);
+  assert.equal(result.codingMode.branchScope, false);
+});

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import type {
   CodexCompactionFlushMode,
+  CodingModeConfig,
   ContradictionScanConfig,
   CodexCompatConfig,
   DreamingConfig,
@@ -470,6 +471,20 @@ export function parseConfig(raw: unknown): PluginConfig {
     lookbackDays,
     proceduralMiningCronAutoRegister: coerceBool(rawProcedural.proceduralMiningCronAutoRegister) === true,
     recallMaxProcedures,
+  };
+
+  // Coding-agent project/branch scoping (issue #569)
+  const rawCodingMode =
+    cfg.codingMode && typeof cfg.codingMode === "object" && !Array.isArray(cfg.codingMode)
+      ? (cfg.codingMode as Record<string, unknown>)
+      : {};
+  // Default: projectScope=true (enabled), branchScope=false (opt-in).
+  // `coerceBool` treats "false"/"0"/"no"/"off" as false (CLAUDE.md #36).
+  const codingProjectScopeRaw = coerceBool(rawCodingMode.projectScope);
+  const codingBranchScopeRaw = coerceBool(rawCodingMode.branchScope);
+  const codingMode: CodingModeConfig = {
+    projectScope: codingProjectScopeRaw === undefined ? true : codingProjectScopeRaw,
+    branchScope: codingBranchScopeRaw === true,
   };
 
   const memoryDir =
@@ -1112,6 +1127,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       cfg.activeRecallAllowChainedActiveMemory === true,
     dreaming,
     procedural,
+    codingMode,
     heartbeat,
     slotBehavior,
     codexCompat,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -243,7 +243,10 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
-import { resolveCodingNamespaceOverlay } from "./coding/coding-namespace.js";
+import {
+  combineNamespaces,
+  resolveCodingNamespaceOverlay,
+} from "./coding/coding-namespace.js";
 import type { CodingContext } from "./types.js";
 import { NamespaceSearchRouter } from "./namespaces/search.js";
 import { SharedContextManager } from "./shared-context/manager.js";
@@ -1385,15 +1388,29 @@ export class Orchestrator {
    *
    * Given a base namespace computed from the principal, returns the overlaid
    * coding namespace when the session has a coding context AND
-   * `codingMode.projectScope` is true. Otherwise returns `baseNamespace`
-   * unchanged — CLAUDE.md #30 escape hatch.
+   * `codingMode.projectScope` is true AND `namespacesEnabled` is true.
+   * Otherwise returns `baseNamespace` unchanged — CLAUDE.md #30 escape hatch.
+   *
+   * Principal isolation (CLAUDE.md rule 42): the overlay is COMBINED with
+   * the principal-derived `baseNamespace` rather than replacing it, so two
+   * principals working in the same repository do not share memories through
+   * a common `project-*` namespace.
+   *
+   * Namespaces-disabled gate: when `namespacesEnabled` is false, the
+   * storage router maps every namespace to the same `memoryDir`. Returning
+   * `project-*` in that mode would create apparent route separation with
+   * no actual storage isolation — a false-isolation trap. In that mode we
+   * return `baseNamespace` unchanged so coding mode degrades to the existing
+   * unscoped behavior.
    *
    * @internal
    */
   applyCodingNamespaceOverlay(sessionKey: string | undefined, baseNamespace: string): string {
+    if (!this.config.namespacesEnabled) return baseNamespace;
     const codingContext = this.getCodingContextForSession(sessionKey);
     const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
-    return overlay ? overlay.namespace : baseNamespace;
+    if (!overlay) return baseNamespace;
+    return combineNamespaces(baseNamespace, overlay.namespace);
   }
 
   /**
@@ -1401,12 +1418,20 @@ export class Orchestrator {
    * from, including any read fallbacks (branch → project asymmetry lands in
    * PR 3; PR 2 returns an empty fallbacks list).
    *
-   * When no overlay applies, returns `null` so callers fall back to their
-   * existing recall-namespace computation.
+   * Returns `null` when:
+   *   - `namespacesEnabled` is false (overlay would create false isolation)
+   *   - no context attached to the session
+   *   - `codingMode.projectScope` is false (CLAUDE.md #30 escape hatch)
+   *
+   * The returned `namespace` / `readFallbacks` are RAW overlay fragments
+   * (e.g. `project-origin-ab12`). Callers MUST combine them with the
+   * principal-derived base through `combineNamespaces()` before passing to
+   * storage, so principal isolation is preserved (rule 42).
    *
    * @internal
    */
   applyCodingRecallOverlay(sessionKey: string | undefined): { namespace: string; readFallbacks: string[] } | null {
+    if (!this.config.namespacesEnabled) return null;
     const codingContext = this.getCodingContextForSession(sessionKey);
     const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
     if (!overlay) return null;
@@ -4194,17 +4219,29 @@ export class Orchestrator {
       namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
         ? null
         : this.applyCodingRecallOverlay(sessionKey);
-    const observationNamespaces: string[] =
-      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
-        ? [namespaceOverride]
-        : observationCodingOverlay
-          ? Array.from(
-              new Set<string>([
-                observationCodingOverlay.namespace,
-                ...observationCodingOverlay.readFallbacks,
-              ]),
-            )
-          : recallNamespacesForPrincipal(principal, this.config);
+    const observationPrincipalSelf = defaultNamespaceForPrincipal(principal, this.config);
+    const observationCodingSelf = observationCodingOverlay
+      ? combineNamespaces(observationPrincipalSelf, observationCodingOverlay.namespace)
+      : null;
+    let observationNamespaces: string[];
+    if (namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)) {
+      observationNamespaces = [namespaceOverride];
+    } else if (observationCodingOverlay && observationCodingSelf) {
+      // Rule 42 / parity with the main recall path: substitute the self
+      // namespace within the principal's recall list rather than
+      // replacing the full list. Preserves shared and policy-include
+      // namespaces for direct-answer observation queries.
+      const base = recallNamespacesForPrincipal(principal, this.config);
+      const mapped = base.map((ns) =>
+        ns === observationPrincipalSelf ? observationCodingSelf : ns,
+      );
+      const fallbackNs = observationCodingOverlay.readFallbacks.map((fallback) =>
+        combineNamespaces(observationPrincipalSelf, fallback),
+      );
+      observationNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
+    } else {
+      observationNamespaces = recallNamespacesForPrincipal(principal, this.config);
+    }
     const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
       cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
       cronRecallNormalizedQueryMaxChars:
@@ -5581,21 +5618,40 @@ export class Orchestrator {
     // Recall path — overlay the coding-agent namespace (issue #569) when
     // the session has a codingContext and `codingMode.projectScope` is true.
     // Explicit `namespace` option still wins, preserving pre-#569 semantics.
+    //
+    // Rule 42: the overlay substitutes the SELF namespace within the
+    // principal's recall list — it does NOT replace the full list. Shared
+    // and `includeInRecallByDefault` policy namespaces stay in the recall
+    // set so coding sessions continue to see team/shared memories. The
+    // overlay is combined with the principal base through `combineNamespaces`
+    // to preserve principal isolation (cross-tenant leakage guard).
     const codingOverlay = namespaceOverride ? null : this.applyCodingRecallOverlay(sessionKey);
+    const principalSelfNamespace = defaultNamespaceForPrincipal(principal, this.config);
+    const codingSelfNamespace = codingOverlay
+      ? combineNamespaces(principalSelfNamespace, codingOverlay.namespace)
+      : null;
     const selfNamespace =
       namespaceOverride ??
-      codingOverlay?.namespace ??
-      defaultNamespaceForPrincipal(principal, this.config);
-    const recallNamespaces = namespaceOverride
-      ? [namespaceOverride]
-      : codingOverlay
-        ? // Branch overlay (PR 3) adds project-level read fallbacks. PR 2
-          // ships this with empty fallbacks; only the branch slice exercises
-          // the array.
-          Array.from(
-            new Set<string>([codingOverlay.namespace, ...codingOverlay.readFallbacks]),
-          )
-        : readableRecallNamespaces;
+      codingSelfNamespace ??
+      principalSelfNamespace;
+    let recallNamespaces: string[];
+    if (namespaceOverride) {
+      recallNamespaces = [namespaceOverride];
+    } else if (codingOverlay && codingSelfNamespace) {
+      // Substitute the principal's self namespace with the coding-scoped
+      // one, and append any read fallbacks (branch→project, PR 3) combined
+      // with the principal base so principal isolation is preserved on
+      // fallback entries as well.
+      const mapped = readableRecallNamespaces.map((ns) =>
+        ns === principalSelfNamespace ? codingSelfNamespace : ns,
+      );
+      const fallbackNs = codingOverlay.readFallbacks.map((fallback) =>
+        combineNamespaces(principalSelfNamespace, fallback),
+      );
+      recallNamespaces = Array.from(new Set<string>([...mapped, ...fallbackNs]));
+    } else {
+      recallNamespaces = readableRecallNamespaces;
+    }
     const qmdAvailable = this.qmd.isAvailable();
     let graphDecisionStatus: IntentDebugSnapshot["graphDecision"]["status"] =
       recallDecision.plannedMode === "graph_mode" ? "skipped" : "not_requested";

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1353,6 +1353,13 @@ export class Orchestrator {
    */
   setCodingContextForSession(sessionKey: string, codingContext: CodingContext | null): void {
     if (typeof sessionKey !== "string" || sessionKey.length === 0) return;
+    // Defensive init — `Object.create(Orchestrator.prototype)` stubs in
+    // legacy tests skip class-field initializers (rule 16 applies to test
+    // teardown; we apply the same defensiveness on construction here so
+    // PR 2 doesn't break those tests).
+    if (!this._codingContextBySession) {
+      (this as unknown as { _codingContextBySession: Map<string, CodingContext> })._codingContextBySession = new Map();
+    }
     if (codingContext === null) {
       this._codingContextBySession.delete(sessionKey);
       return;
@@ -1363,10 +1370,14 @@ export class Orchestrator {
   /**
    * Read-only accessor for the coding context attached to a session. Returns
    * `null` when none is set. Used by `remnic doctor` and by tests.
+   *
+   * Defensive `_codingContextBySession` lookup — legacy orchestrator-flush
+   * tests use `Object.create(Orchestrator.prototype)` which does not run
+   * class-field initializers, so the Map may be undefined on stubs.
    */
   getCodingContextForSession(sessionKey: string | undefined): CodingContext | null {
     if (typeof sessionKey !== "string" || sessionKey.length === 0) return null;
-    return this._codingContextBySession.get(sessionKey) ?? null;
+    return this._codingContextBySession?.get(sessionKey) ?? null;
   }
 
   /**

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -243,6 +243,8 @@ import {
   recallNamespacesForPrincipal,
   resolvePrincipal,
 } from "./namespaces/principal.js";
+import { resolveCodingNamespaceOverlay } from "./coding/coding-namespace.js";
+import type { CodingContext } from "./types.js";
 import { NamespaceSearchRouter } from "./namespaces/search.js";
 import { SharedContextManager } from "./shared-context/manager.js";
 import {
@@ -1211,6 +1213,14 @@ export class Orchestrator {
    * Using a Map prevents concurrent sessions from overwriting each other.
    */
   private _recallWorkspaceOverrides = new Map<string, string>();
+  /**
+   * Per-session coding-agent context (issue #569). Populated by connectors at
+   * session-start (PRs 5/6/7) via `setCodingContextForSession`. Used by both
+   * the recall path and the write path so that memory routing respects the
+   * project/branch scope a session is operating in (rule 42 — read + write
+   * through the same namespace layer).
+   */
+  private readonly _codingContextBySession = new Map<string, CodingContext>();
   private routingRulesStore: RoutingRulesStore | null = null;
   private contentHashIndex: ContentHashIndex | null = null;
   private readonly artifactSourceStatusCache = new WeakMap<
@@ -1325,10 +1335,71 @@ export class Orchestrator {
   }
 
   resolveSelfNamespace(sessionKey?: string): string {
-    return defaultNamespaceForPrincipal(
+    const base = defaultNamespaceForPrincipal(
       this.resolvePrincipal(sessionKey),
       this.config,
     );
+    return this.applyCodingNamespaceOverlay(sessionKey, base);
+  }
+
+  /**
+   * Attach a coding-agent context to a session (issue #569). Called by the
+   * Claude Code / Codex / Cursor connectors at session start after
+   * `resolveGitContext(cwd)`. The context is consulted by the recall path
+   * and the write path so that memories route to a project- (and optionally
+   * branch-) scoped namespace.
+   *
+   * Pass `null` to clear.
+   */
+  setCodingContextForSession(sessionKey: string, codingContext: CodingContext | null): void {
+    if (typeof sessionKey !== "string" || sessionKey.length === 0) return;
+    if (codingContext === null) {
+      this._codingContextBySession.delete(sessionKey);
+      return;
+    }
+    this._codingContextBySession.set(sessionKey, codingContext);
+  }
+
+  /**
+   * Read-only accessor for the coding context attached to a session. Returns
+   * `null` when none is set. Used by `remnic doctor` and by tests.
+   */
+  getCodingContextForSession(sessionKey: string | undefined): CodingContext | null {
+    if (typeof sessionKey !== "string" || sessionKey.length === 0) return null;
+    return this._codingContextBySession.get(sessionKey) ?? null;
+  }
+
+  /**
+   * Shared helper used by both the recall path and the write path (rule 42).
+   *
+   * Given a base namespace computed from the principal, returns the overlaid
+   * coding namespace when the session has a coding context AND
+   * `codingMode.projectScope` is true. Otherwise returns `baseNamespace`
+   * unchanged — CLAUDE.md #30 escape hatch.
+   *
+   * @internal
+   */
+  applyCodingNamespaceOverlay(sessionKey: string | undefined, baseNamespace: string): string {
+    const codingContext = this.getCodingContextForSession(sessionKey);
+    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
+    return overlay ? overlay.namespace : baseNamespace;
+  }
+
+  /**
+   * Read-side overlay: returns the list of namespaces a session should read
+   * from, including any read fallbacks (branch → project asymmetry lands in
+   * PR 3; PR 2 returns an empty fallbacks list).
+   *
+   * When no overlay applies, returns `null` so callers fall back to their
+   * existing recall-namespace computation.
+   *
+   * @internal
+   */
+  applyCodingRecallOverlay(sessionKey: string | undefined): { namespace: string; readFallbacks: string[] } | null {
+    const codingContext = this.getCodingContextForSession(sessionKey);
+    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
+    if (!overlay) return null;
+    return { namespace: overlay.namespace, readFallbacks: overlay.readFallbacks };
   }
 
   async getStorageForNamespace(namespace?: string): Promise<StorageManager> {
@@ -4105,10 +4176,24 @@ export class Orchestrator {
     if (expectedSnapshot.plannerMode === "no_recall") return;
 
     const principal = resolvePrincipal(sessionKey, this.config);
+    // Coding-agent overlay (issue #569) is applied when the session has a
+    // coding context and there is no explicit namespaceOverride — mirrors
+    // the main recall path above.
+    const observationCodingOverlay =
+      namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
+        ? null
+        : this.applyCodingRecallOverlay(sessionKey);
     const observationNamespaces: string[] =
       namespaceOverride && canReadNamespace(principal, namespaceOverride, this.config)
         ? [namespaceOverride]
-        : recallNamespacesForPrincipal(principal, this.config);
+        : observationCodingOverlay
+          ? Array.from(
+              new Set<string>([
+                observationCodingOverlay.namespace,
+                ...observationCodingOverlay.readFallbacks,
+              ]),
+            )
+          : recallNamespacesForPrincipal(principal, this.config);
     const observationQueryPolicy = buildRecallQueryPolicy(prompt, sessionKey, {
       cronRecallPolicyEnabled: this.config.cronRecallPolicyEnabled,
       cronRecallNormalizedQueryMaxChars:
@@ -5482,11 +5567,24 @@ export class Orchestrator {
         `namespace override is not readable: ${namespaceOverride}`,
       );
     }
+    // Recall path — overlay the coding-agent namespace (issue #569) when
+    // the session has a codingContext and `codingMode.projectScope` is true.
+    // Explicit `namespace` option still wins, preserving pre-#569 semantics.
+    const codingOverlay = namespaceOverride ? null : this.applyCodingRecallOverlay(sessionKey);
     const selfNamespace =
-      namespaceOverride ?? defaultNamespaceForPrincipal(principal, this.config);
+      namespaceOverride ??
+      codingOverlay?.namespace ??
+      defaultNamespaceForPrincipal(principal, this.config);
     const recallNamespaces = namespaceOverride
       ? [namespaceOverride]
-      : readableRecallNamespaces;
+      : codingOverlay
+        ? // Branch overlay (PR 3) adds project-level read fallbacks. PR 2
+          // ships this with empty fallbacks; only the branch slice exercises
+          // the array.
+          Array.from(
+            new Set<string>([codingOverlay.namespace, ...codingOverlay.readFallbacks]),
+          )
+        : readableRecallNamespaces;
     const qmdAvailable = this.qmd.isAvailable();
     let graphDecisionStatus: IntentDebugSnapshot["graphDecision"]["status"] =
       recallDecision.plannedMode === "graph_mode" ? "skipped" : "not_requested";
@@ -9393,11 +9491,18 @@ export class Orchestrator {
     }
 
     const principal = resolvePrincipal(sessionKey, this.config);
+    // Write path — overlay the coding-agent namespace (issue #569) when the
+    // session has a codingContext and `codingMode.projectScope` is true.
+    // Explicit `writeNamespaceOverride` from callers still wins, matching
+    // pre-#569 semantics.
     const selfNamespace =
       typeof options.writeNamespaceOverride === "string" &&
       options.writeNamespaceOverride.length > 0
         ? options.writeNamespaceOverride
-        : defaultNamespaceForPrincipal(principal, this.config);
+        : this.applyCodingNamespaceOverlay(
+            sessionKey,
+            defaultNamespaceForPrincipal(principal, this.config),
+          );
     const storage = await this.storageRouter.storageFor(selfNamespace);
     const shouldPersistProcessedFingerprint = normalizedTurns.some(
       (turn) => turn.persistProcessedFingerprint === true,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -200,6 +200,50 @@ export interface ProceduralConfig {
   recallMaxProcedures: number;
 }
 
+/**
+ * Coding-agent mode config (issue #569).
+ *
+ * When the connector provides a `CodingContext` (see below), Remnic overlays
+ * a project- and/or branch-scoped namespace on top of the principal's default
+ * namespace so that memories written while working on project A do not surface
+ * while working on project B.
+ *
+ * Both flags default off-for-branch / on-for-project. Per CLAUDE.md #30 every
+ * filter or transform needs an escape hatch: set `projectScope: false` to
+ * exactly restore pre-#569 behaviour.
+ */
+export interface CodingModeConfig {
+  /**
+   * When true (default), a session with a resolved `CodingContext` uses a
+   * project-scoped namespace. When false, the principal's default namespace
+   * is used unchanged (pre-#569 behaviour).
+   */
+  projectScope: boolean;
+  /**
+   * When true, recall/write also overlay the current branch on top of the
+   * project namespace. Default false — branch-scope is opt-in because active
+   * development typically wants recall across branches. (Wired by PR 3 of
+   * issue #569; declared here so the schema ships in one slice.)
+   */
+  branchScope: boolean;
+}
+
+/**
+ * Session-scoped coding context. Produced by `resolveGitContext()` in the
+ * connector layer and attached to a session so that recall + write paths can
+ * compute an overlay namespace.
+ *
+ * All fields mirror `GitContext` from `./coding/git-context.ts`; kept as a
+ * separate interface because `types.ts` must stay dependency-free (it is
+ * imported by every other module).
+ */
+export interface CodingContext {
+  projectId: string;
+  branch: string | null;
+  rootPath: string;
+  defaultBranch: string | null;
+}
+
 /** Configuration for the nightly contradiction-scan cron (issue #520). */
 export interface ContradictionScanConfig {
   /** Master switch for the contradiction scan cron. Default true. */
@@ -460,6 +504,8 @@ export interface PluginConfig {
   activeRecallAllowChainedActiveMemory: boolean;
   dreaming: DreamingConfig;
   procedural: ProceduralConfig;
+  // Coding-agent project/branch scoping (issue #569)
+  codingMode: CodingModeConfig;
   heartbeat: HeartbeatConfig;
   slotBehavior: SlotBehaviorConfig;
   codexCompat: CodexCompatConfig;


### PR DESCRIPTION
## Summary

Wires coding-agent sessions to project-scoped memory namespaces so that facts written while working on project A do not leak into recall while working on project B.

**Stacked on #577 (PR 1)** — merge #577 first; this branch will rebase cleanly onto main once PR 1 lands.

## What this slice ships

- **Pure resolver** `coding/coding-namespace.ts` — turns `CodingContext + CodingModeConfig` → `{ namespace, readFallbacks, scope } | null`. `branchNamespaceName` / `branchScope` plumbing is included ahead of time so PR 3 only flips a config flag.
- **Config** `codingMode: { projectScope: true, branchScope: false }` in both the top-level and plugin-openclaw schemas. `projectScope: false` exactly restores pre-#569 behaviour (CLAUDE.md #30).
- **Orchestrator wiring**:
  - Private `_codingContextBySession: Map<string, CodingContext>` per session.
  - `setCodingContextForSession(sessionKey, ctx | null)` — called by connectors in PRs 5/6/7.
  - `getCodingContextForSession(sessionKey)` — for `remnic doctor` (PR 8) + tests.
  - `applyCodingNamespaceOverlay` (write path) and `applyCodingRecallOverlay` (read path) — both consult the **same** resolver → CLAUDE.md #42 compliance.
  - Recall path (`orchestrator.recall`) and write path (`runExtraction`) both now route through the overlay. Explicit `namespace` / `writeNamespaceOverride` options still win.

Zero schema changes to stored memories — this is namespace routing only, per the issue's acceptance criteria.

## CLAUDE.md compliance

- **#17** — rootPath from GitContextResolver is tilde-expanded (PR 1).
- **#30** — `codingMode.projectScope: false` exactly restores pre-#569 behaviour (tested).
- **#36** — string `"false"/"0"/"no"/"off"` coerced to boolean `false` in config parsing (tested).
- **#42** — read + write paths consult the same resolver with identical inputs (tested: bit-for-bit agreement).
- **#51** — empty sessionKey is a no-op on `setCodingContextForSession`.

## Test plan

- [x] `coding/coding-namespace.test.ts` — 15 cases (name helpers, escape hatches, project overlay, branch-scope preview, cross-project isolation invariant, rule-42 read/write symmetry).
- [x] `coding/coding-orchestrator.test.ts` — 12 cases (per-session context set/get/clear, overlay on write + read, escape hatch, rule-42 invariant, multi-session isolation).
- [x] `config.test.ts` — 3 new cases covering `codingMode` defaults + coercion.
- [x] `pnpm run check-types` clean.
- [x] 109/109 relevant unit tests green.

Part of #569 (slice 2 of 8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how recall and extraction writes choose namespaces for coding sessions, which could affect memory visibility/routing if misconfigured or if context resolution is wrong. Scope is contained behind `codingMode` flags with explicit escape hatches and tests.
> 
> **Overview**
> Adds a new `codingMode` config (schema + parser) to **optionally scope memory by git project (and future branch)**, defaulting to `projectScope: true` / `branchScope: false`.
> 
> Introduces a pure `coding-namespace` resolver with safe, length-capped namespace generation and integrates it into the orchestrator so both **recall (including direct-answer observation)** and **extraction writes** apply the same overlay per session, while preserving principal isolation and honoring explicit namespace overrides.
> 
> Tightens git remote normalization to lowercase only hosts (and drive letters) while preserving repo-path case to avoid collapsing distinct repos, and adds focused unit/integration tests covering config coercion, namespace generation, overlay behavior, and isolation invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680de56209550271c28cbf42ad5f48ae42926f9b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->