### PR TITLE
feat(importers): shared importer base + `remnic import` CLI entry (#568 PR 1/7)

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -27,6 +27,7 @@
     "prebuild": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "check-types": "tsc --noEmit",
+    "test": "tsx --test src/import-dispatch.test.ts src/optional-importer.test.ts src/bench-args.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -1,0 +1,252 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  defaultWriteMemoriesToOrchestrator,
+  runImporter,
+  type ImportedMemory,
+  type ImporterAdapter,
+  type ImporterWriteTarget,
+  type ImportTurn,
+} from "@remnic/core";
+
+import {
+  parseImportArgs,
+  runImportCommand,
+  type ImportDispatchArgs,
+  type ImportDispatchIO,
+} from "./import-dispatch.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeTarget(): { target: ImporterWriteTarget; received: ImportTurn[][] } {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+function makeIo(opts: {
+  fileContents?: string;
+  adapter: ImporterAdapter<unknown>;
+  target: ImporterWriteTarget;
+}): {
+  io: ImportDispatchIO;
+  stdoutLines: string[];
+  stderrLines: string[];
+} {
+  const stdoutLines: string[] = [];
+  const stderrLines: string[] = [];
+  return {
+    io: {
+      readFile: async () => opts.fileContents ?? "{}",
+      loadAdapter: async () => opts.adapter,
+      runImporter,
+      target: opts.target,
+      stdout: (line) => stdoutLines.push(line),
+      stderr: (line) => stderrLines.push(line),
+    },
+    stdoutLines,
+    stderrLines,
+  };
+}
+
+function makeFakeAdapter(memories: ImportedMemory[]): ImporterAdapter<ImportedMemory[]> {
+  return {
+    name: "chatgpt",
+    sourceLabel: "chatgpt",
+    parse: () => memories,
+    transform: (parsed) => parsed,
+    async writeTo(target, batch) {
+      return defaultWriteMemoriesToOrchestrator(target, batch);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// parseImportArgs — flag validation (CLAUDE.md rules 14, 51)
+// ---------------------------------------------------------------------------
+
+describe("parseImportArgs", () => {
+  it("requires --adapter", () => {
+    assert.throws(() => parseImportArgs([]), /--adapter/);
+  });
+
+  it("rejects an unknown adapter with the valid list", () => {
+    assert.throws(
+      () => parseImportArgs(["--adapter", "bogus"]),
+      /chatgpt, claude, gemini, mem0/,
+    );
+  });
+
+  it("accepts the four canonical adapters", () => {
+    for (const name of ["chatgpt", "claude", "gemini", "mem0"] as const) {
+      const parsed = parseImportArgs(["--adapter", name]);
+      assert.equal(parsed.adapter, name);
+    }
+  });
+
+  it("rejects --adapter with no following value", () => {
+    assert.throws(() => parseImportArgs(["--adapter"]), /requires a value/);
+  });
+
+  it("rejects --file with no following value", () => {
+    assert.throws(
+      () => parseImportArgs(["--adapter", "chatgpt", "--file"]),
+      /requires a value/,
+    );
+  });
+
+  it("rejects --batch-size with non-numeric value", () => {
+    assert.throws(
+      () =>
+        parseImportArgs([
+          "--adapter",
+          "chatgpt",
+          "--batch-size",
+          "not-a-number",
+        ]),
+      /--batch-size/,
+    );
+  });
+
+  it("rejects --rate-limit of zero", () => {
+    assert.throws(
+      () =>
+        parseImportArgs([
+          "--adapter",
+          "mem0",
+          "--rate-limit",
+          "0",
+        ]),
+      /rateLimit/,
+    );
+  });
+
+  it("accepts --dry-run as a boolean flag", () => {
+    const parsed = parseImportArgs([
+      "--adapter",
+      "chatgpt",
+      "--file",
+      "/tmp/x.json",
+      "--dry-run",
+    ]);
+    assert.equal(parsed.dryRun, true);
+    assert.equal(parsed.file, "/tmp/x.json");
+  });
+
+  it("accepts --include-conversations", () => {
+    const parsed = parseImportArgs([
+      "--adapter",
+      "chatgpt",
+      "--include-conversations",
+    ]);
+    assert.equal(parsed.includeConversations, true);
+  });
+
+  it("rejects unknown flags rather than silently ignoring", () => {
+    assert.throws(
+      () => parseImportArgs(["--adapter", "chatgpt", "--unknown-opt", "x"]),
+      /Unknown flag/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runImportCommand — dry-run + full integration (slice 1 contract)
+// ---------------------------------------------------------------------------
+
+describe("runImportCommand — slice 1 integration", () => {
+  it("dry-run with 3 fake memories reports a plan and never writes", async () => {
+    const memories: ImportedMemory[] = [1, 2, 3].map((i) => ({
+      content: `memory-${i}`,
+      sourceLabel: "chatgpt",
+    }));
+    const adapter = makeFakeAdapter(memories);
+    const { target, received } = makeTarget();
+    const { io, stdoutLines } = makeIo({ adapter, target });
+
+    const args: ImportDispatchArgs = {
+      adapter: "chatgpt",
+      file: "/tmp/fake.json",
+      dryRun: true,
+      includeConversations: false,
+    };
+    const result = await runImportCommand(args, io);
+    assert.ok(result);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(received.length, 0);
+    assert.ok(
+      stdoutLines.some((l) => l.includes("Dry-run") && l.includes("3")),
+      `expected dry-run stdout, got: ${stdoutLines.join("\n")}`,
+    );
+  });
+
+  it("non-dry-run hands memories to the orchestrator target", async () => {
+    const memories: ImportedMemory[] = [1, 2, 3].map((i) => ({
+      content: `memory-${i}`,
+      sourceLabel: "chatgpt",
+    }));
+    const adapter = makeFakeAdapter(memories);
+    const { target, received } = makeTarget();
+    const { io, stdoutLines } = makeIo({ adapter, target });
+
+    const args: ImportDispatchArgs = {
+      adapter: "chatgpt",
+      file: "/tmp/fake.json",
+      dryRun: false,
+      batchSize: 2,
+      includeConversations: false,
+    };
+    const result = await runImportCommand(args, io);
+    assert.ok(result);
+    assert.equal(result.dryRun, false);
+    assert.equal(result.memoriesWritten, 3);
+    assert.equal(received.length, 2);
+    assert.ok(
+      stdoutLines.some((l) => l.includes("Imported 3 memories")),
+      `expected success stdout, got: ${stdoutLines.join("\n")}`,
+    );
+  });
+
+  it("surfaces the loader's install-hint error when the adapter is missing", async () => {
+    const { target } = makeTarget();
+    const io: ImportDispatchIO = {
+      readFile: async () => "{}",
+      loadAdapter: async () => {
+        throw new Error(
+          "The 'chatgpt' importer requires the optional @remnic/import-chatgpt package.",
+        );
+      },
+      runImporter,
+      target,
+      stdout: () => {},
+      stderr: () => {},
+    };
+    await assert.rejects(
+      () =>
+        runImportCommand(
+          {
+            adapter: "chatgpt",
+            file: "/tmp/fake.json",
+            dryRun: true,
+            includeConversations: false,
+          },
+          io,
+        ),
+      /optional @remnic\/import-chatgpt/,
+    );
+  });
+});

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -167,6 +167,50 @@ describe("parseImportArgs", () => {
       /Unknown flag/,
     );
   });
+
+  // Cursor bugbot on PR #583: boolean flags must not be consumed before
+  // value flags, otherwise `--batch-size --dry-run 10` silently collapses
+  // into `--batch-size 10` + `--dry-run`, violating rule 14.
+  it("rejects --batch-size when the following token is another --flag", () => {
+    assert.throws(
+      () =>
+        parseImportArgs([
+          "--adapter",
+          "chatgpt",
+          "--batch-size",
+          "--dry-run",
+          "10",
+        ]),
+      /--batch-size/,
+    );
+  });
+
+  it("rejects --rate-limit when the following token is another --flag", () => {
+    assert.throws(
+      () =>
+        parseImportArgs([
+          "--adapter",
+          "chatgpt",
+          "--rate-limit",
+          "--include-conversations",
+          "5",
+        ]),
+      /--rate-limit/,
+    );
+  });
+
+  it("rejects --file when the following token is another --flag", () => {
+    assert.throws(
+      () =>
+        parseImportArgs([
+          "--adapter",
+          "chatgpt",
+          "--file",
+          "--dry-run",
+        ]),
+      /--file/,
+    );
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -44,20 +44,26 @@ function makeIo(opts: {
   io: ImportDispatchIO;
   stdoutLines: string[];
   stderrLines: string[];
+  getWriteTargetCalls: { count: number };
 } {
   const stdoutLines: string[] = [];
   const stderrLines: string[] = [];
+  const getWriteTargetCalls = { count: 0 };
   return {
     io: {
       readFile: async () => opts.fileContents ?? "{}",
       loadAdapter: async () => opts.adapter,
       runImporter,
-      target: opts.target,
+      getWriteTarget: async () => {
+        getWriteTargetCalls.count += 1;
+        return opts.target;
+      },
       stdout: (line) => stdoutLines.push(line),
       stderr: (line) => stderrLines.push(line),
     },
     stdoutLines,
     stderrLines,
+    getWriteTargetCalls,
   };
 }
 
@@ -174,7 +180,7 @@ describe("runImportCommand — slice 1 integration", () => {
     }));
     const adapter = makeFakeAdapter(memories);
     const { target, received } = makeTarget();
-    const { io, stdoutLines } = makeIo({ adapter, target });
+    const { io, stdoutLines, getWriteTargetCalls } = makeIo({ adapter, target });
 
     const args: ImportDispatchArgs = {
       adapter: "chatgpt",
@@ -188,6 +194,12 @@ describe("runImportCommand — slice 1 integration", () => {
     assert.equal(result.memoriesPlanned, 3);
     assert.equal(result.memoriesWritten, 0);
     assert.equal(received.length, 0);
+    // Dry-run must NOT instantiate the real write target (Cursor review).
+    assert.equal(
+      getWriteTargetCalls.count,
+      0,
+      "dry-run must not call getWriteTarget (lazy orchestrator invariant)",
+    );
     assert.ok(
       stdoutLines.some((l) => l.includes("Dry-run") && l.includes("3")),
       `expected dry-run stdout, got: ${stdoutLines.join("\n")}`,
@@ -201,7 +213,7 @@ describe("runImportCommand — slice 1 integration", () => {
     }));
     const adapter = makeFakeAdapter(memories);
     const { target, received } = makeTarget();
-    const { io, stdoutLines } = makeIo({ adapter, target });
+    const { io, stdoutLines, getWriteTargetCalls } = makeIo({ adapter, target });
 
     const args: ImportDispatchArgs = {
       adapter: "chatgpt",
@@ -215,6 +227,7 @@ describe("runImportCommand — slice 1 integration", () => {
     assert.equal(result.dryRun, false);
     assert.equal(result.memoriesWritten, 3);
     assert.equal(received.length, 2);
+    assert.equal(getWriteTargetCalls.count, 1);
     assert.ok(
       stdoutLines.some((l) => l.includes("Imported 3 memories")),
       `expected success stdout, got: ${stdoutLines.join("\n")}`,
@@ -223,6 +236,7 @@ describe("runImportCommand — slice 1 integration", () => {
 
   it("surfaces the loader's install-hint error when the adapter is missing", async () => {
     const { target } = makeTarget();
+    let writeTargetCalls = 0;
     const io: ImportDispatchIO = {
       readFile: async () => "{}",
       loadAdapter: async () => {
@@ -231,7 +245,10 @@ describe("runImportCommand — slice 1 integration", () => {
         );
       },
       runImporter,
-      target,
+      getWriteTarget: async () => {
+        writeTargetCalls += 1;
+        return target;
+      },
       stdout: () => {},
       stderr: () => {},
     };
@@ -248,5 +265,40 @@ describe("runImportCommand — slice 1 integration", () => {
         ),
       /optional @remnic\/import-chatgpt/,
     );
+    // Install-hint miss must happen before any write target is requested.
+    assert.equal(writeTargetCalls, 0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseImportArgs tilde-expansion (Cursor review fix on PR #583)
+// ---------------------------------------------------------------------------
+
+describe("parseImportArgs tilde expansion", () => {
+  it("expands a leading ~ in --file", () => {
+    const parsed = parseImportArgs([
+      "--adapter",
+      "chatgpt",
+      "--file",
+      "~/exports/chatgpt.json",
+    ]);
+    assert.ok(parsed.file);
+    // Expanded path must no longer begin with the tilde.
+    assert.ok(
+      !parsed.file!.startsWith("~/"),
+      `expected ~ expansion, got: ${parsed.file}`,
+    );
+    // Resolved to an absolute path somewhere under the user's home.
+    assert.ok(parsed.file!.includes("/exports/chatgpt.json"));
+  });
+
+  it("leaves non-tilde paths unchanged", () => {
+    const parsed = parseImportArgs([
+      "--adapter",
+      "chatgpt",
+      "--file",
+      "/tmp/export.json",
+    ]);
+    assert.equal(parsed.file, "/tmp/export.json");
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -11,6 +11,7 @@ import {
 } from "@remnic/core";
 
 import {
+  cmdImport,
   parseImportArgs,
   runImportCommand,
   type ImportDispatchArgs,
@@ -300,5 +301,51 @@ describe("parseImportArgs tilde expansion", () => {
       "/tmp/export.json",
     ]);
     assert.equal(parsed.file, "/tmp/export.json");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cmdImport dispose contract (Cursor review fix on PR #583)
+// ---------------------------------------------------------------------------
+
+describe("cmdImport dispose contract", () => {
+  it("install-hint miss does NOT invoke dispose (no target was materialized)", async () => {
+    // `cmdImport` sets process.exitCode when the adapter load fails (install
+    // hint path). Snapshot and restore around the test so tsx's
+    // exit-code reporting is not polluted.
+    const savedExitCode = process.exitCode;
+    process.exitCode = 0;
+    try {
+      let factoryCalls = 0;
+      let disposeCalls = 0;
+      const factory = async () => {
+        factoryCalls += 1;
+        return {
+          async ingestBulkImportBatch() {},
+          bulkImportWriteNamespace() {
+            return "default";
+          },
+        } as ImporterWriteTarget;
+      };
+      const dispose = async () => {
+        disposeCalls += 1;
+      };
+      // Use `claude` because its package is known NOT to be installed in
+      // this test environment — the loader will throw an install hint and
+      // `cmdImport` must short-circuit before materializing the target.
+      await cmdImport(
+        ["--adapter", "claude", "--file", "/dev/null", "--dry-run"],
+        factory,
+        dispose,
+      );
+      assert.equal(factoryCalls, 0, "factory must not run when adapter is missing");
+      assert.equal(
+        disposeCalls,
+        0,
+        "dispose must not run when write target was never materialized",
+      );
+    } finally {
+      process.exitCode = savedExitCode;
+    }
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -126,12 +126,17 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
     );
   }
 
+  // CRITICAL: Extract value-bearing flags FIRST, before consuming boolean
+  // flags. If we consumed boolean flags first via splice, then an argv like
+  // `--batch-size --dry-run 10` would first collapse to `--batch-size 10`,
+  // silently accepting `10` as the batch-size value — violating rule 14's
+  // "bare value flag must be rejected" contract. By taking value flags
+  // first, `takeValue` sees the adjacent `--dry-run` token and correctly
+  // rejects it as a missing value. Cursor bugbot flagged this on PR #583.
   const fileRaw = takeOptionalValue(args, "--file");
   // Expand leading `~` so paths like `~/export.json` resolve. Node's fs
   // does not expand the tilde — CLAUDE.md rule 17.
   const file = fileRaw !== undefined ? expandTilde(fileRaw) : undefined;
-  const dryRun = consumeFlag(args, "--dry-run");
-  const includeConversations = consumeFlag(args, "--include-conversations");
 
   const batchSizeRaw = takeOptionalValue(args, "--batch-size");
   let batchSize: number | undefined;
@@ -156,6 +161,12 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
     }
     rateLimit = validateImportRateLimit(parsed);
   }
+
+  // Boolean flags last: after all value-bearing flags have claimed their
+  // adjacent value tokens, any remaining standalone flags are genuine
+  // booleans.
+  const dryRun = consumeFlag(args, "--dry-run");
+  const includeConversations = consumeFlag(args, "--include-conversations");
 
   // Any remaining unknown --flag tokens should be rejected rather than
   // silently ignored (CLAUDE.md rule 51). We allow positional leftovers to

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -1,0 +1,314 @@
+// ---------------------------------------------------------------------------
+// `remnic import` command dispatcher (issue #568, slice 1)
+// ---------------------------------------------------------------------------
+//
+// This module is the top-level CLI entry for the four memory importers
+// (ChatGPT, Claude, Gemini, Mem0). Slice 1 wires ONLY the infrastructure —
+// actual source adapters land in slices 2-5 and are discovered via the
+// computed-specifier loader in `optional-importer.ts`. Running
+// `remnic import --adapter chatgpt ...` today will therefore surface a clean
+// "optional package not installed" hint rather than a bare MODULE_NOT_FOUND.
+//
+// Flag contract (CLAUDE.md rule 14 — every value flag must reject
+//   `--flag` without a following value; rule 51 — reject invalid input with
+//   a list of valid options instead of silently defaulting):
+//
+//   --adapter <name>       Required. One of chatgpt|claude|gemini|mem0.
+//   --file <path>          Required unless the adapter accepts an API-only
+//                          input (mem0). Expanded via ~.
+//   --dry-run              Parse + transform only; no writes, no API calls.
+//   --batch-size <n>       Memories per orchestrator batch. Rejects non-
+//                          integers and values outside [1, 500].
+//   --rate-limit <rps>     API-backed importers only. Rejects <= 0.
+//   --include-conversations Adapter hint forwarded into transform().
+//   --help, -h             Print usage.
+
+import fs from "node:fs";
+
+import {
+  runImporter,
+  validateImportBatchSize,
+  validateImportRateLimit,
+  type ImporterAdapter,
+  type ImporterWriteTarget,
+  type RunImporterResult,
+  type RunImportOptions,
+  type ImporterParseOptions,
+  type ImporterTransformOptions,
+} from "@remnic/core";
+
+import {
+  isSupportedImporterName,
+  loadImporterModule,
+  SUPPORTED_IMPORTERS,
+  type SupportedImporterName,
+} from "./optional-importer.js";
+
+export interface ImportDispatchArgs {
+  adapter: SupportedImporterName;
+  file?: string;
+  dryRun: boolean;
+  batchSize?: number;
+  rateLimit?: number;
+  includeConversations: boolean;
+}
+
+export interface ImportDispatchIO {
+  readFile: (path: string) => Promise<string>;
+  loadAdapter: (name: SupportedImporterName) => Promise<ImporterAdapter<unknown>>;
+  runImporter: typeof runImporter;
+  target: ImporterWriteTarget;
+  stdout: (line: string) => void;
+  stderr: (line: string) => void;
+}
+
+export const IMPORT_USAGE = `remnic import — Bring memory from ChatGPT, Claude, Gemini, or Mem0 (issue #568)
+
+Usage:
+  remnic import --adapter <name> --file <path> [options]
+
+Required:
+  --adapter <name>            One of: ${SUPPORTED_IMPORTERS.join(" | ")}
+  --file <path>               Path to the source export (JSON or ZIP). May be
+                              omitted for API-only adapters (mem0).
+
+Options:
+  --dry-run                   Parse and transform only; do not write memories.
+  --batch-size <n>            Memories per orchestrator batch (default 25).
+  --rate-limit <rps>          Requests per second for API importers.
+  --include-conversations     Adapter hint: opt into conversation imports
+                              (e.g. ChatGPT bulk conversation summaries).
+  --help, -h                  Show this help.
+
+Slice 1 ships infrastructure only. The four adapter packages
+(@remnic/import-chatgpt, @remnic/import-claude, @remnic/import-gemini,
+@remnic/import-mem0) land in slices 2-5. Install whichever you need:
+
+  npm install -g @remnic/import-chatgpt
+  npm install -g @remnic/import-claude
+  npm install -g @remnic/import-gemini
+  npm install -g @remnic/import-mem0
+`;
+
+/**
+ * Parse `remnic import ...` flags into a structured args object. Throws with
+ * a user-facing message on missing values, unknown adapters, or invalid
+ * numeric inputs — callers should catch and print `err.message`.
+ *
+ * Exported for testability so slice-1 tests can validate the flag contract
+ * without booting the full CLI.
+ */
+export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
+  const args = [...rest];
+
+  const adapter = takeValue(args, "--adapter");
+  if (!adapter) {
+    throw new Error(
+      `--adapter <name> is required. Valid values: ${SUPPORTED_IMPORTERS.join(", ")}`,
+    );
+  }
+  if (!isSupportedImporterName(adapter)) {
+    throw new Error(
+      `Unknown importer '${adapter}'. Valid values: ${SUPPORTED_IMPORTERS.join(", ")}`,
+    );
+  }
+
+  const file = takeOptionalValue(args, "--file");
+  const dryRun = consumeFlag(args, "--dry-run");
+  const includeConversations = consumeFlag(args, "--include-conversations");
+
+  const batchSizeRaw = takeOptionalValue(args, "--batch-size");
+  let batchSize: number | undefined;
+  if (batchSizeRaw !== undefined) {
+    const parsed = Number(batchSizeRaw);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(
+        `--batch-size must be an integer. Received '${batchSizeRaw}'.`,
+      );
+    }
+    batchSize = validateImportBatchSize(parsed);
+  }
+
+  const rateLimitRaw = takeOptionalValue(args, "--rate-limit");
+  let rateLimit: number | undefined;
+  if (rateLimitRaw !== undefined) {
+    const parsed = Number(rateLimitRaw);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(
+        `--rate-limit must be a positive number (requests per second). Received '${rateLimitRaw}'.`,
+      );
+    }
+    rateLimit = validateImportRateLimit(parsed);
+  }
+
+  // Any remaining unknown --flag tokens should be rejected rather than
+  // silently ignored (CLAUDE.md rule 51). We allow positional leftovers to
+  // pass through untouched because adapters may define their own hints in
+  // future slices.
+  const unknownFlags = args.filter((a) => a.startsWith("--"));
+  if (unknownFlags.length > 0) {
+    throw new Error(
+      `Unknown flag(s) for 'remnic import': ${unknownFlags.join(", ")}. ` +
+        `Run 'remnic import --help' for the full option list.`,
+    );
+  }
+
+  return {
+    adapter,
+    file,
+    dryRun,
+    batchSize,
+    rateLimit,
+    includeConversations,
+  };
+}
+
+/**
+ * Execute `remnic import` given already-parsed args. The IO parameter is
+ * injected so tests can assert on the CLI's behaviour without touching the
+ * filesystem or loading real importer packages.
+ */
+export async function runImportCommand(
+  args: ImportDispatchArgs,
+  io: ImportDispatchIO,
+): Promise<RunImporterResult> {
+  const adapter = await io.loadAdapter(args.adapter);
+
+  // Shape inputs the adapter understands. Adapters that accept raw file
+  // bytes (e.g. a ZIP buffer) are free to re-read the path themselves via
+  // `parseOptions.filePath`; this slice-1 wiring passes the file contents as
+  // a string for text/JSON exports and the path as a fallback so adapters
+  // can choose.
+  let input: unknown;
+  if (args.file) {
+    try {
+      input = await io.readFile(args.file);
+    } catch (err) {
+      throw new Error(
+        `Failed to read --file '${args.file}': ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  } else {
+    // No file → API-only adapter (mem0). Pass `undefined` through; adapters
+    // that require a file will surface their own error.
+    input = undefined;
+  }
+
+  const parseOptions: ImporterParseOptions = {
+    filePath: args.file,
+  };
+  const transformOptions: ImporterTransformOptions = {
+    includeConversations: args.includeConversations,
+  };
+  const runOptions: RunImportOptions & {
+    parseOptions?: ImporterParseOptions;
+    transformOptions?: ImporterTransformOptions;
+  } = {
+    dryRun: args.dryRun,
+    ...(args.batchSize !== undefined ? { batchSize: args.batchSize } : {}),
+    ...(args.rateLimit !== undefined ? { rateLimit: args.rateLimit } : {}),
+    parseOptions,
+    transformOptions,
+    onProgress: (progress) => {
+      if (progress.phase === "write") {
+        io.stdout(
+          `  progress: ${progress.processed}/${progress.total} memories written`,
+        );
+      }
+    },
+  };
+
+  const result = await io.runImporter(adapter, input, io.target, runOptions);
+
+  if (result.dryRun) {
+    io.stdout(
+      `Dry-run: would import ${result.memoriesPlanned} memories from '${result.sourceLabel}'.`,
+    );
+    io.stdout("(no memories were written; re-run without --dry-run to commit)");
+  } else {
+    io.stdout(
+      `Imported ${result.memoriesWritten} memories from '${result.sourceLabel}' ` +
+        `(${result.batchesProcessed} batch${result.batchesProcessed === 1 ? "" : "es"}).`,
+    );
+  }
+  return result;
+}
+
+/**
+ * Top-level CLI entry: `remnic import ...`. Reads `rest` from the CLI switch
+ * statement. Uses `process.stdout` / `process.stderr` via the supplied io.
+ */
+export async function cmdImport(
+  rest: string[],
+  target: ImporterWriteTarget,
+): Promise<RunImporterResult | undefined> {
+  if (rest.includes("--help") || rest.includes("-h")) {
+    process.stdout.write(IMPORT_USAGE);
+    return undefined;
+  }
+  let parsed: ImportDispatchArgs;
+  try {
+    parsed = parseImportArgs(rest);
+  } catch (err) {
+    process.stderr.write(
+      (err instanceof Error ? err.message : String(err)) + "\n",
+    );
+    process.exitCode = 1;
+    return undefined;
+  }
+
+  const io: ImportDispatchIO = {
+    readFile: async (p) => fs.promises.readFile(p, "utf-8"),
+    loadAdapter: async (name) => (await loadImporterModule(name)).adapter,
+    runImporter,
+    target,
+    stdout: (line) => process.stdout.write(line + "\n"),
+    stderr: (line) => process.stderr.write(line + "\n"),
+  };
+
+  try {
+    return await runImportCommand(parsed, io);
+  } catch (err) {
+    process.stderr.write(
+      (err instanceof Error ? err.message : String(err)) + "\n",
+    );
+    process.exitCode = 1;
+    return undefined;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Argv helpers (local to this file — rule 14: reject bare flags)
+// ---------------------------------------------------------------------------
+
+function consumeFlag(args: string[], flag: string): boolean {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return false;
+  args.splice(idx, 1);
+  return true;
+}
+
+function takeValue(args: string[], flag: string): string | undefined {
+  const idx = args.indexOf(flag);
+  if (idx === -1) return undefined;
+  if (idx + 1 >= args.length) {
+    throw new Error(
+      `${flag} requires a value. Example: ${flag} <value>`,
+    );
+  }
+  const value = args[idx + 1];
+  if (typeof value !== "string" || value.startsWith("--")) {
+    throw new Error(
+      `${flag} requires a value. Example: ${flag} <value>`,
+    );
+  }
+  args.splice(idx, 2);
+  return value;
+}
+
+function takeOptionalValue(args: string[], flag: string): string | undefined {
+  if (!args.includes(flag)) return undefined;
+  return takeValue(args, flag);
+}

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -62,16 +62,15 @@ export interface ImportDispatchIO {
    * Lazy factory for the write target. Called only when the run requires
    * writes (dryRun === false). Keeping it lazy means `--dry-run` and
    * `--help` invocations can complete without booting a full orchestrator
-   * — critical for CLI responsiveness and for Cursor-flagged I/O minimisation.
+   * — critical for CLI responsiveness and for I/O minimisation.
+   *
+   * Disposal is the caller's responsibility (see `cmdImport`'s `dispose`
+   * parameter). We deliberately do NOT expose `disposeWriteTarget` on the
+   * IO interface because `runImportCommand` has no hook to call it — all
+   * IO cleanup is owned by `cmdImport`, which tracks whether the target
+   * was actually constructed before invoking dispose.
    */
   getWriteTarget: () => Promise<ImporterWriteTarget>;
-  /**
-   * Optional cleanup hook paired with `getWriteTarget`. Called after
-   * `runImporter` completes so hosts can shut down an orchestrator they
-   * constructed on demand. Skipping this on dry-run avoids the shutdown
-   * overhead entirely.
-   */
-  disposeWriteTarget?: () => Promise<void>;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }
@@ -311,12 +310,19 @@ export async function cmdImport(
     return undefined;
   }
 
+  // Track whether `getWriteTarget` was actually called so dispose only runs
+  // when a target was materialized. An install-hint miss (loadAdapter throws)
+  // must NOT trigger dispose — there's nothing to dispose and disposing may
+  // itself throw, masking the original error.
+  let targetMaterialized = false;
   const io: ImportDispatchIO = {
     readFile: async (p) => fs.promises.readFile(p, "utf-8"),
     loadAdapter: async (name) => (await loadImporterModule(name)).adapter,
     runImporter,
-    getWriteTarget: targetFactory,
-    ...(disposeTarget !== undefined ? { disposeWriteTarget: disposeTarget } : {}),
+    getWriteTarget: async () => {
+      targetMaterialized = true;
+      return targetFactory();
+    },
     stdout: (line) => process.stdout.write(line + "\n"),
     stderr: (line) => process.stderr.write(line + "\n"),
   };
@@ -330,12 +336,10 @@ export async function cmdImport(
     process.exitCode = 1;
     return undefined;
   } finally {
-    // Only run the disposer when writes actually happened — dry-run and
-    // install-hint misses never instantiate the target, so there is nothing
-    // to dispose. `runImportCommand` uses `dryRunWriteTarget()` on dry-run
-    // and does not call `getWriteTarget`, so the flag mirrors whether
-    // writes were intended.
-    if (!parsed.dryRun && disposeTarget !== undefined) {
+    // Only dispose when the write target was actually constructed. Checking
+    // `parsed.dryRun` alone would incorrectly dispose after install-hint
+    // misses or parse errors that happen BEFORE `getWriteTarget` is called.
+    if (targetMaterialized && disposeTarget !== undefined) {
       try {
         await disposeTarget();
       } catch {

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -43,6 +43,7 @@ import {
   SUPPORTED_IMPORTERS,
   type SupportedImporterName,
 } from "./optional-importer.js";
+import { expandTilde } from "./path-utils.js";
 
 export interface ImportDispatchArgs {
   adapter: SupportedImporterName;
@@ -57,7 +58,20 @@ export interface ImportDispatchIO {
   readFile: (path: string) => Promise<string>;
   loadAdapter: (name: SupportedImporterName) => Promise<ImporterAdapter<unknown>>;
   runImporter: typeof runImporter;
-  target: ImporterWriteTarget;
+  /**
+   * Lazy factory for the write target. Called only when the run requires
+   * writes (dryRun === false). Keeping it lazy means `--dry-run` and
+   * `--help` invocations can complete without booting a full orchestrator
+   * — critical for CLI responsiveness and for Cursor-flagged I/O minimisation.
+   */
+  getWriteTarget: () => Promise<ImporterWriteTarget>;
+  /**
+   * Optional cleanup hook paired with `getWriteTarget`. Called after
+   * `runImporter` completes so hosts can shut down an orchestrator they
+   * constructed on demand. Skipping this on dry-run avoids the shutdown
+   * overhead entirely.
+   */
+  disposeWriteTarget?: () => Promise<void>;
   stdout: (line: string) => void;
   stderr: (line: string) => void;
 }
@@ -113,7 +127,10 @@ export function parseImportArgs(rest: readonly string[]): ImportDispatchArgs {
     );
   }
 
-  const file = takeOptionalValue(args, "--file");
+  const fileRaw = takeOptionalValue(args, "--file");
+  // Expand leading `~` so paths like `~/export.json` resolve. Node's fs
+  // does not expand the tilde — CLAUDE.md rule 17.
+  const file = fileRaw !== undefined ? expandTilde(fileRaw) : undefined;
   const dryRun = consumeFlag(args, "--dry-run");
   const includeConversations = consumeFlag(args, "--include-conversations");
 
@@ -220,7 +237,17 @@ export async function runImportCommand(
     },
   };
 
-  const result = await io.runImporter(adapter, input, io.target, runOptions);
+  // Dry-run must never boot the orchestrator — callers of
+  // getWriteTarget() may construct an Orchestrator instance, which opens
+  // cache / watcher handles that are wasted work when writes are skipped.
+  // Cursor review on PR #583 flagged the non-lazy version.
+  let target: ImporterWriteTarget;
+  if (args.dryRun) {
+    target = dryRunWriteTarget();
+  } else {
+    target = await io.getWriteTarget();
+  }
+  const result = await io.runImporter(adapter, input, target, runOptions);
 
   if (result.dryRun) {
     io.stdout(
@@ -237,12 +264,37 @@ export async function runImportCommand(
 }
 
 /**
+ * Write target used during `--dry-run`. `runImporter` short-circuits before
+ * invoking `writeTo`, but adapters may still pass this target around; every
+ * method throws to make accidental writes from a dry-run path loud rather
+ * than silent.
+ */
+function dryRunWriteTarget(): ImporterWriteTarget {
+  return {
+    async ingestBulkImportBatch() {
+      throw new Error(
+        "dry-run import: ingestBulkImportBatch was called despite dryRun being set. " +
+          "Adapters MUST NOT write in dry-run mode.",
+      );
+    },
+    bulkImportWriteNamespace() {
+      return "dry-run";
+    },
+  };
+}
+
+/**
  * Top-level CLI entry: `remnic import ...`. Reads `rest` from the CLI switch
  * statement. Uses `process.stdout` / `process.stderr` via the supplied io.
+ *
+ * `targetFactory` is invoked lazily only for non-dry-run invocations — this
+ * keeps `--dry-run` and missing-adapter install-hint paths from spinning up
+ * the orchestrator (Cursor review on PR #583).
  */
 export async function cmdImport(
   rest: string[],
-  target: ImporterWriteTarget,
+  targetFactory: () => Promise<ImporterWriteTarget>,
+  disposeTarget?: () => Promise<void>,
 ): Promise<RunImporterResult | undefined> {
   if (rest.includes("--help") || rest.includes("-h")) {
     process.stdout.write(IMPORT_USAGE);
@@ -263,7 +315,8 @@ export async function cmdImport(
     readFile: async (p) => fs.promises.readFile(p, "utf-8"),
     loadAdapter: async (name) => (await loadImporterModule(name)).adapter,
     runImporter,
-    target,
+    getWriteTarget: targetFactory,
+    ...(disposeTarget !== undefined ? { disposeWriteTarget: disposeTarget } : {}),
     stdout: (line) => process.stdout.write(line + "\n"),
     stderr: (line) => process.stderr.write(line + "\n"),
   };
@@ -276,6 +329,19 @@ export async function cmdImport(
     );
     process.exitCode = 1;
     return undefined;
+  } finally {
+    // Only run the disposer when writes actually happened — dry-run and
+    // install-hint misses never instantiate the target, so there is nothing
+    // to dispose. `runImportCommand` uses `dryRunWriteTarget()` on dry-run
+    // and does not call `getWriteTarget`, so the flag mirrors whether
+    // writes were intended.
+    if (!parsed.dryRun && disposeTarget !== undefined) {
+      try {
+        await disposeTarget();
+      } catch {
+        // Best-effort; do not mask import errors.
+      }
+    }
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -154,6 +154,11 @@ import { expandTilde, resolveHomeDir } from "./path-utils.js";
 export { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
 import { hasFlag, resolveFlag, stripResolveFlags, TAXONOMY_RESOLVE_BOOLEAN_FLAGS } from "./cli-args.js";
 import { parseConnectorConfig, stripConfigArgv } from "./parse-connector-config.js";
+// `remnic import` top-level command (issue #568 slice 1). The adapter packages
+// are optional à-la-carte installs loaded via computed-specifier dynamic
+// import; slice 1 ships only the dispatcher and surfaces a clean install hint
+// when an adapter package is absent.
+import { cmdImport, IMPORT_USAGE } from "./import-dispatch.js";
 
 export { parseConnectorConfig, stripConfigArgv };
 export {
@@ -197,7 +202,8 @@ type CommandName =
   | "enrich"
   | "openclaw"
   | "extensions"
-  | "training:export";
+  | "training:export"
+  | "import";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -6030,6 +6036,46 @@ Other:
       break;
     }
 
+    case "import": {
+      // Infrastructure-only in slice 1 (#568). The four adapter packages
+      // (@remnic/import-chatgpt/claude/gemini/mem0) land in slices 2-5 and
+      // are loaded via computed-specifier dynamic import — running
+      // `remnic import --adapter chatgpt` today surfaces a clean install
+      // hint rather than MODULE_NOT_FOUND.
+      if (rest.includes("--help") || rest.includes("-h") || rest.length === 0) {
+        console.log(IMPORT_USAGE);
+        break;
+      }
+
+      // Build the orchestrator lazily so `--help` / `--dry-run` without an
+      // installed adapter never incur memory-store I/O. We still construct
+      // it unconditionally for the actual run because adapter `writeTo`
+      // will need `ingestBulkImportBatch` even in slice 2+ integration runs.
+      const configPath = resolveConfigPath();
+      const raw = fs.existsSync(configPath)
+        ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+        : {};
+      const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+      const config = parseConfig(remnicCfg);
+      const orchestrator = new Orchestrator(config);
+      await orchestrator.initialize();
+      await orchestrator.deferredReady;
+      try {
+        await cmdImport(rest, orchestrator);
+      } finally {
+        // Orchestrator holds background timers / cache handles. Shutting
+        // it down keeps short-lived CLI runs from hanging the event loop.
+        if (typeof (orchestrator as unknown as { shutdown?: () => Promise<void> }).shutdown === "function") {
+          try {
+            await (orchestrator as unknown as { shutdown: () => Promise<void> }).shutdown();
+          } catch {
+            // Best effort — don't let a shutdown hiccup mask an import error.
+          }
+        }
+      }
+      break;
+    }
+
     case "openclaw": {
       const subAction = rest[0] ?? "help";
       const args = rest.slice(1);
@@ -6139,6 +6185,9 @@ Usage:
   remnic training:export --format <name> --output <path> [options]
     Export memories as a fine-tuning dataset (issue #459). Run
     'remnic training:export --help' for the full option list.
+  remnic import --adapter <name> --file <path> [--dry-run] [--batch-size <n>]
+    Import memory from ChatGPT/Claude/Gemini/Mem0 exports (issue #568).
+    Run 'remnic import --help' for the full adapter list.
 
 Options:
   --json    Output in JSON format

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -6047,32 +6047,41 @@ Other:
         break;
       }
 
-      // Build the orchestrator lazily so `--help` / `--dry-run` without an
-      // installed adapter never incur memory-store I/O. We still construct
-      // it unconditionally for the actual run because adapter `writeTo`
-      // will need `ingestBulkImportBatch` even in slice 2+ integration runs.
-      const configPath = resolveConfigPath();
-      const raw = fs.existsSync(configPath)
-        ? JSON.parse(fs.readFileSync(configPath, "utf8"))
-        : {};
-      const remnicCfg = raw.remnic ?? raw.engram ?? raw;
-      const config = parseConfig(remnicCfg);
-      const orchestrator = new Orchestrator(config);
-      await orchestrator.initialize();
-      await orchestrator.deferredReady;
-      try {
-        await cmdImport(rest, orchestrator);
-      } finally {
-        // Orchestrator holds background timers / cache handles. Shutting
-        // it down keeps short-lived CLI runs from hanging the event loop.
-        if (typeof (orchestrator as unknown as { shutdown?: () => Promise<void> }).shutdown === "function") {
+      // Lazy orchestrator factory: only invoked when the run actually needs
+      // to write memories. `--dry-run`, `--help`, and install-hint failures
+      // all short-circuit BEFORE touching the memory store, keeping
+      // responsiveness high for the common "preview what would be imported"
+      // path (Cursor review on PR #583).
+      let orchestratorSingleton: Orchestrator | undefined;
+      const targetFactory = async () => {
+        if (!orchestratorSingleton) {
+          const configPath = resolveConfigPath();
+          const raw = fs.existsSync(configPath)
+            ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+            : {};
+          const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+          const config = parseConfig(remnicCfg);
+          orchestratorSingleton = new Orchestrator(config);
+          await orchestratorSingleton.initialize();
+          await orchestratorSingleton.deferredReady;
+        }
+        return orchestratorSingleton;
+      };
+      const dispose = async () => {
+        if (!orchestratorSingleton) return;
+        const maybeShutdown = (
+          orchestratorSingleton as unknown as { shutdown?: () => Promise<void> }
+        ).shutdown;
+        if (typeof maybeShutdown === "function") {
           try {
-            await (orchestrator as unknown as { shutdown: () => Promise<void> }).shutdown();
+            await maybeShutdown.call(orchestratorSingleton);
           } catch {
-            // Best effort — don't let a shutdown hiccup mask an import error.
+            // Best effort — orchestrator shutdown errors must not mask
+            // import results on short-lived CLI runs.
           }
         }
-      }
+      };
+      await cmdImport(rest, targetFactory, dispose);
       break;
     }
 

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { describe, it, beforeEach } from "node:test";
+
+import {
+  SUPPORTED_IMPORTERS,
+  clearImporterModuleCacheForTesting,
+  isSupportedImporterName,
+  loadImporterModule,
+} from "./optional-importer.js";
+
+describe("optional-importer loader", () => {
+  beforeEach(() => {
+    clearImporterModuleCacheForTesting();
+  });
+
+  it("SUPPORTED_IMPORTERS lists the four canonical sources in a stable order", () => {
+    assert.deepEqual([...SUPPORTED_IMPORTERS], [
+      "chatgpt",
+      "claude",
+      "gemini",
+      "mem0",
+    ]);
+  });
+
+  it("isSupportedImporterName is false for unknown names", () => {
+    assert.equal(isSupportedImporterName("chatgpt"), true);
+    assert.equal(isSupportedImporterName("bogus"), false);
+    assert.equal(isSupportedImporterName(""), false);
+    assert.equal(isSupportedImporterName("chatgpt "), false);
+  });
+
+  it("loading a missing importer throws a user-facing install hint (slice 1: none installed)", async () => {
+    await assert.rejects(
+      () => loadImporterModule("chatgpt"),
+      (err: Error) => {
+        // Install hint must include the package name and an install
+        // command the user can actually run — not a raw MODULE_NOT_FOUND.
+        assert.ok(
+          err.message.includes("@remnic/import-chatgpt"),
+          `expected package name in message, got: ${err.message}`,
+        );
+        assert.ok(
+          err.message.includes("npm install") ||
+            err.message.includes("pnpm add"),
+          `expected install command in message, got: ${err.message}`,
+        );
+        return true;
+      },
+    );
+  });
+
+  it("loader caches negative results so repeated calls do not re-import", async () => {
+    // First call populates the cache with a null.
+    await assert.rejects(() => loadImporterModule("claude"));
+    // Second call must still throw — but the cache hit path is covered
+    // exclusively by the branch that rejects from cached null.
+    await assert.rejects(() => loadImporterModule("claude"));
+  });
+});

--- a/packages/remnic-cli/src/optional-importer.ts
+++ b/packages/remnic-cli/src/optional-importer.ts
@@ -1,0 +1,136 @@
+// Lazy loader for optional @remnic/import-<source> packages (issue #568).
+//
+// Each supported source (chatgpt, claude, gemini, mem0) ships as its own
+// optional workspace package so the CLI stays à la carte — users who only
+// need one importer should not have to install the other three. Loading goes
+// through this helper so the bundler cannot statically resolve the specifier
+// (computed-string-concatenation import) and so every importer gets the same
+// "install hint on miss, re-throw on every other error" treatment as the
+// existing bench / weclone-export loaders.
+//
+// Adding a new importer:
+//   1. Append its name to `SUPPORTED_IMPORTERS`.
+//   2. Publish the package as `@remnic/import-<name>`.
+//   3. The package MUST export an `adapter` conforming to
+//      `ImporterAdapter<unknown>` from `@remnic/core`. Register-on-import
+//      side effects are optional — the CLI prefers the named export because
+//      side-effect registration breaks à la carte testing.
+
+import type { ImporterAdapter } from "@remnic/core";
+
+import { isSpecifierNotFoundError } from "./optional-module-loader.js";
+
+/**
+ * Shape every `@remnic/import-*` package must export.
+ *
+ * The CLI only consumes the adapter, so packages may also export source-
+ * specific helpers (parsers, fixture types) for library use; those exports
+ * are not part of the loader contract.
+ */
+export interface ImporterModule {
+  adapter: ImporterAdapter<unknown>;
+}
+
+/**
+ * The canonical list of importer sources slice-2+ will land. Slice-1 ships
+ * the infrastructure only — so `remnic import --adapter chatgpt` returns a
+ * clean install hint until slice-2 merges `@remnic/import-chatgpt`.
+ */
+export const SUPPORTED_IMPORTERS = [
+  "chatgpt",
+  "claude",
+  "gemini",
+  "mem0",
+] as const;
+export type SupportedImporterName = (typeof SUPPORTED_IMPORTERS)[number];
+
+export function isSupportedImporterName(value: string): value is SupportedImporterName {
+  return (SUPPORTED_IMPORTERS as readonly string[]).includes(value);
+}
+
+const cached = new Map<string, ImporterModule | null>();
+
+/**
+ * Load a specific importer module. Returns the module when installed, throws
+ * a user-facing install hint when not installed, and re-throws any other
+ * error (syntax errors, transitive missing deps) so broken releases remain
+ * diagnosable. Results are cached per CLI invocation.
+ */
+export async function loadImporterModule(
+  name: SupportedImporterName,
+): Promise<ImporterModule> {
+  if (cached.has(name)) {
+    const hit = cached.get(name);
+    if (hit) return hit;
+    throw notInstalledError(name);
+  }
+
+  // Computed specifier so the bundler cannot statically resolve the
+  // dependency. CLAUDE.md rule 57: optional packages must not be present in
+  // the CLI's runtime `dependencies` or bundled `noExternal` list.
+  const specifier = "@remnic/" + "import-" + name;
+  try {
+    const mod = (await import(specifier)) as Partial<ImporterModule> & {
+      // Some packages export the adapter under a name-prefixed export; we
+      // accept either the canonical `adapter` export or a `<name>Adapter`
+      // alias to keep the contract flexible for slice-authoring ergonomics.
+      [key: string]: unknown;
+    };
+    const resolved = resolveAdapterExport(mod, name);
+    if (!resolved) {
+      throw new Error(
+        `The optional package '${specifier}' loaded but does not export an ImporterAdapter. ` +
+          `Expected either 'adapter' or '${name}Adapter' export.`,
+      );
+    }
+    cached.set(name, { adapter: resolved });
+    return { adapter: resolved };
+  } catch (err) {
+    if (isSpecifierNotFoundError(err, specifier)) {
+      cached.set(name, null);
+      throw notInstalledError(name);
+    }
+    throw err;
+  }
+}
+
+function resolveAdapterExport(
+  mod: Record<string, unknown>,
+  name: string,
+): ImporterAdapter<unknown> | undefined {
+  const candidates = [mod.adapter, mod[`${name}Adapter`], mod[`${name}ImportAdapter`]];
+  for (const candidate of candidates) {
+    if (isImporterAdapter(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+function isImporterAdapter(value: unknown): value is ImporterAdapter<unknown> {
+  if (!value || typeof value !== "object") return false;
+  const adapter = value as Partial<ImporterAdapter<unknown>>;
+  return (
+    typeof adapter.name === "string" &&
+    typeof adapter.sourceLabel === "string" &&
+    typeof adapter.parse === "function" &&
+    typeof adapter.transform === "function" &&
+    typeof adapter.writeTo === "function"
+  );
+}
+
+function notInstalledError(name: SupportedImporterName): Error {
+  const pkg = `@remnic/import-${name}`;
+  return new Error(
+    `The '${name}' importer requires the optional ${pkg} package.\n` +
+      "\n" +
+      "Install it alongside the CLI:\n" +
+      `  npm install -g ${pkg}\n` +
+      "\n" +
+      "Or add it to a project:\n" +
+      `  pnpm add ${pkg}\n`,
+  );
+}
+
+/** Visible for tests that need to reset the importer cache between cases. */
+export function clearImporterModuleCacheForTesting(): void {
+  cached.clear();
+}

--- a/packages/remnic-core/src/importers/base.test.ts
+++ b/packages/remnic-core/src/importers/base.test.ts
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  DEFAULT_IMPORT_BATCH_SIZE,
+  defaultWriteMemoriesToOrchestrator,
+  importedMemoryToTurn,
+  runImporter,
+  validateImportBatchSize,
+  validateImportRateLimit,
+  type ImportedMemory,
+  type ImporterAdapter,
+  type ImporterWriteTarget,
+} from "./base.js";
+import type { ImportTurn } from "../bulk-import/types.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeMemories(count: number, sourceLabel = "fake"): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  for (let i = 0; i < count; i += 1) {
+    out.push({
+      content: `Memory #${i + 1}`,
+      sourceLabel,
+      sourceId: `fake-${i + 1}`,
+      sourceTimestamp: new Date(
+        Date.UTC(2026, 0, 1, 0, i, 0),
+      ).toISOString(),
+      importedFromPath: "/tmp/fake-export.json",
+    });
+  }
+  return out;
+}
+
+function makeMockTarget(): {
+  target: ImporterWriteTarget;
+  received: ImportTurn[][];
+} {
+  const received: ImportTurn[][] = [];
+  const target: ImporterWriteTarget = {
+    async ingestBulkImportBatch(turns) {
+      // Snapshot turns so adapter mutations don't retroactively change the log.
+      received.push(turns.map((t) => ({ ...t })));
+    },
+    bulkImportWriteNamespace() {
+      return "default";
+    },
+  };
+  return { target, received };
+}
+
+function makeFakeAdapter(
+  memories: ImportedMemory[],
+): ImporterAdapter<ImportedMemory[]> {
+  return {
+    name: "fake",
+    sourceLabel: "fake",
+    parse(input: unknown): ImportedMemory[] {
+      if (!Array.isArray(input)) {
+        throw new Error("fake adapter expects an array input");
+      }
+      return input as ImportedMemory[];
+    },
+    transform(parsed: ImportedMemory[]): ImportedMemory[] {
+      // Forwards the already-shaped memories unchanged — slice-1 integration
+      // test drives the pipeline without source-specific shape wrangling.
+      return parsed;
+    },
+    async writeTo(target, batch) {
+      return defaultWriteMemoriesToOrchestrator(target, batch);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("validateImportBatchSize", () => {
+  it("returns the default when undefined", () => {
+    assert.equal(validateImportBatchSize(undefined), DEFAULT_IMPORT_BATCH_SIZE);
+  });
+
+  it("accepts values in range", () => {
+    assert.equal(validateImportBatchSize(10), 10);
+    assert.equal(validateImportBatchSize(500), 500);
+  });
+
+  it("rejects non-finite, non-integer, and out-of-range values", () => {
+    assert.throws(() => validateImportBatchSize(Number.NaN));
+    assert.throws(() => validateImportBatchSize(Number.POSITIVE_INFINITY));
+    assert.throws(() => validateImportBatchSize(1.5));
+    assert.throws(() => validateImportBatchSize(0));
+    assert.throws(() => validateImportBatchSize(-5));
+    assert.throws(() => validateImportBatchSize(100_000));
+  });
+});
+
+describe("validateImportRateLimit", () => {
+  it("returns undefined when undefined (no rate limit requested)", () => {
+    assert.equal(validateImportRateLimit(undefined), undefined);
+  });
+
+  it("accepts positive finite values", () => {
+    assert.equal(validateImportRateLimit(2), 2);
+    assert.equal(validateImportRateLimit(0.5), 0.5);
+  });
+
+  it("rejects zero, negative, and non-finite rates", () => {
+    assert.throws(() => validateImportRateLimit(0));
+    assert.throws(() => validateImportRateLimit(-1));
+    assert.throws(() => validateImportRateLimit(Number.NaN));
+    assert.throws(() => validateImportRateLimit(Number.POSITIVE_INFINITY));
+  });
+});
+
+describe("importedMemoryToTurn", () => {
+  it("uses sourceTimestamp when present", () => {
+    const memory: ImportedMemory = {
+      content: "hello",
+      sourceLabel: "chatgpt",
+      sourceTimestamp: "2026-04-10T14:25:07.000Z",
+    };
+    const turn = importedMemoryToTurn(memory);
+    assert.equal(turn.role, "user");
+    assert.equal(turn.content, "hello");
+    assert.equal(turn.timestamp, "2026-04-10T14:25:07.000Z");
+    assert.equal(turn.participantName, "chatgpt");
+  });
+
+  it("falls back to importedAt when sourceTimestamp is missing", () => {
+    const memory: ImportedMemory = {
+      content: "hello",
+      sourceLabel: "claude",
+      importedAt: "2026-04-20T00:00:00.000Z",
+    };
+    const turn = importedMemoryToTurn(memory);
+    assert.equal(turn.timestamp, "2026-04-20T00:00:00.000Z");
+    assert.equal(turn.participantName, "claude");
+  });
+
+  it("propagates sourceId as participantId", () => {
+    const memory: ImportedMemory = {
+      content: "hello",
+      sourceLabel: "chatgpt",
+      sourceId: "cg-abc-123",
+    };
+    const turn = importedMemoryToTurn(memory);
+    assert.equal(turn.participantId, "cg-abc-123");
+  });
+});
+
+describe("runImporter — slice 1 integration", () => {
+  it("dry-run with 3 memories produces a plan and never calls writeTo", async () => {
+    const memories = makeMemories(3);
+    const adapter = makeFakeAdapter(memories);
+    const { target, received } = makeMockTarget();
+    // Spy on writeTo explicitly.
+    let writeToCalls = 0;
+    const wrapped: ImporterAdapter<ImportedMemory[]> = {
+      ...adapter,
+      async writeTo(t, batch, opts) {
+        writeToCalls += 1;
+        return adapter.writeTo(t, batch, opts);
+      },
+    };
+
+    const progress: string[] = [];
+    const result = await runImporter(wrapped, memories, target, {
+      dryRun: true,
+      onProgress: (p) => progress.push(`${p.phase}:${p.processed}/${p.total}`),
+    });
+
+    assert.equal(writeToCalls, 0);
+    assert.equal(received.length, 0);
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(result.batchesProcessed, 0);
+    assert.equal(result.adapter, "fake");
+    assert.equal(result.sourceLabel, "fake");
+    // Progress should have visited parse → transform → dry-run phases.
+    assert.ok(
+      progress.some((p) => p.startsWith("parse:")),
+      `expected parse phase in ${progress.join(", ")}`,
+    );
+    assert.ok(progress.some((p) => p.startsWith("dry-run:3/3")));
+  });
+
+  it("non-dry-run calls orchestrator.ingestBulkImportBatch with all memories", async () => {
+    const memories = makeMemories(3, "chatgpt");
+    const adapter = makeFakeAdapter(memories);
+    const { target, received } = makeMockTarget();
+
+    const result = await runImporter(adapter, memories, target, {
+      batchSize: 2,
+    });
+
+    assert.equal(result.dryRun, false);
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 3);
+    // 3 memories, batch size 2 → 2 batches.
+    assert.equal(result.batchesProcessed, 2);
+    assert.equal(received.length, 2);
+    assert.equal(received[0].length, 2);
+    assert.equal(received[1].length, 1);
+    // Provenance: every turn carries the sourceLabel as participantName.
+    for (const batch of received) {
+      for (const turn of batch) {
+        assert.equal(turn.role, "user");
+        assert.equal(turn.participantName, "chatgpt");
+      }
+    }
+  });
+
+  it("stamps importedAt on memories that do not already set it", async () => {
+    const memories = makeMemories(2);
+    let seenMemories: ImportedMemory[] = [];
+    const adapter: ImporterAdapter<ImportedMemory[]> = {
+      ...makeFakeAdapter(memories),
+      async writeTo(target, batch) {
+        seenMemories = seenMemories.concat(batch);
+        return defaultWriteMemoriesToOrchestrator(target, batch);
+      },
+    };
+    const { target } = makeMockTarget();
+
+    const result = await runImporter(adapter, memories, target);
+    assert.equal(result.memoriesWritten, 2);
+    for (const m of seenMemories) {
+      assert.ok(
+        typeof m.importedAt === "string" && m.importedAt.length > 0,
+        "each memory must carry importedAt",
+      );
+    }
+  });
+
+  it("rejects an invalid batchSize before parsing", async () => {
+    const adapter = makeFakeAdapter([]);
+    const { target } = makeMockTarget();
+    await assert.rejects(
+      () => runImporter(adapter, [], target, { batchSize: 0 }),
+      /batchSize/,
+    );
+  });
+
+  it("rejects an invalid rateLimit before parsing", async () => {
+    const adapter = makeFakeAdapter([]);
+    const { target } = makeMockTarget();
+    await assert.rejects(
+      () => runImporter(adapter, [], target, { rateLimit: 0 }),
+      /rateLimit/,
+    );
+  });
+
+  it("throws a clear error if transform returns a non-array", async () => {
+    const { target } = makeMockTarget();
+    const adapter: ImporterAdapter<unknown> = {
+      name: "bad",
+      sourceLabel: "bad",
+      parse: (input) => input,
+      // @ts-expect-error — intentional bad return for runtime guard test.
+      transform: () => "not-an-array",
+      async writeTo(t, batch) {
+        return defaultWriteMemoriesToOrchestrator(t, batch);
+      },
+    };
+    await assert.rejects(
+      () => runImporter(adapter, {}, target),
+      /non-array/,
+    );
+  });
+
+  it("fills in a missing sourceLabel from the adapter default", async () => {
+    const memories: ImportedMemory[] = [
+      // sourceLabel deliberately empty — runImporter should fall back.
+      { content: "x", sourceLabel: "" },
+    ];
+    const adapter = makeFakeAdapter(memories);
+    let seen: ImportedMemory[] = [];
+    const wrapped: ImporterAdapter<ImportedMemory[]> = {
+      ...adapter,
+      async writeTo(target, batch) {
+        seen = seen.concat(batch);
+        return defaultWriteMemoriesToOrchestrator(target, batch);
+      },
+    };
+    const { target } = makeMockTarget();
+    await runImporter(wrapped, memories, target);
+    assert.equal(seen[0].sourceLabel, "fake");
+  });
+});

--- a/packages/remnic-core/src/importers/base.ts
+++ b/packages/remnic-core/src/importers/base.ts
@@ -1,0 +1,422 @@
+// ---------------------------------------------------------------------------
+// Shared importer base (issue #568)
+// ---------------------------------------------------------------------------
+//
+// The importer adapters defined by issue #568 (`@remnic/import-chatgpt`,
+// `@remnic/import-claude`, `@remnic/import-gemini`, `@remnic/import-mem0`) all
+// follow the same three-step shape:
+//
+//   1. parse(input)          — turn a raw file / API payload into a
+//                              source-specific intermediate structure.
+//   2. transform(parsed)     — flatten that structure into a uniform list of
+//                              `ImportedMemory` records with provenance
+//                              attached (sourceLabel, importedFromPath,
+//                              importedAt).
+//   3. writeTo(orchestrator) — hand each memory to the orchestrator via
+//                              `ingestBulkImportBatch`. Dry-run mode stops
+//                              after transform() and never calls writeTo().
+//
+// This file defines the shared `ImporterAdapter` interface plus a thin
+// `runImporter` helper that handles batching, dry-run plan reporting, and
+// progress callbacks so every adapter does not reimplement the same loop.
+//
+// The existing lower-level `BulkImportSourceAdapter` (weclone-shaped: produces
+// turn-structured transcripts) remains untouched and continues to drive
+// `runBulkImportCliCommand`. Importer adapters are the higher-level surface
+// intended for the four memory sources in #568 — they emit *memories*
+// (intent-level content) rather than raw conversation turns.
+
+import type { ImportTurn } from "../bulk-import/types.js";
+
+/**
+ * A single imported memory record with provenance.
+ *
+ * Every importer MUST attach a truthful `sourceLabel` (e.g. `"chatgpt"`,
+ * `"claude"`, `"gemini"`, `"mem0"`) and MAY attach the export's origin path or
+ * URL in `importedFromPath`. `importedAt` is always set by `runImporter` so
+ * adapters do not need to timestamp records themselves.
+ */
+export interface ImportedMemory {
+  /**
+   * The user-facing memory content. This is the string that will eventually
+   * land in the memory store (after extraction / orchestrator processing).
+   */
+  content: string;
+  /**
+   * Source-specific identifier for idempotent re-imports. Optional — when
+   * present, adapters SHOULD use the source's stable id (e.g. ChatGPT memory
+   * uuid); when absent, the orchestrator's own content hashing provides dedup.
+   */
+  sourceId?: string;
+  /**
+   * Source-specific timestamp at which the memory was originally created or
+   * last updated. ISO 8601. Optional — adapters fall back to `importedAt`
+   * when the source does not expose a creation timestamp.
+   */
+  sourceTimestamp?: string;
+  /**
+   * Human-readable short label identifying the origin platform
+   * (`"chatgpt"`, `"claude"`, `"gemini"`, `"mem0"`). Required so the
+   * orchestrator can attribute recalled memories correctly.
+   */
+  sourceLabel: string;
+  /**
+   * Path to the export file the memory was parsed from, OR the endpoint URL
+   * for API-based imports. Optional but strongly recommended so users can
+   * trace a memory back to the file they imported.
+   */
+  importedFromPath?: string;
+  /**
+   * ISO 8601 timestamp set by `runImporter` immediately before writeTo().
+   * Adapters MAY populate this themselves; `runImporter` will fill in the
+   * current wall-clock time when absent.
+   */
+  importedAt?: string;
+  /**
+   * Adapter-specific raw metadata preserved for debugging / future rehydration
+   * (e.g. conversation id, thread id, tags). Must be JSON-serializable;
+   * adapters MUST NOT stash functions or circular references here.
+   */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Options threaded through every importer run. Adapters receive this object
+ * from `runImporter`; the top-level CLI populates it from `--dry-run`,
+ * `--batch-size`, and `--rate-limit` flags.
+ */
+export interface RunImportOptions {
+  /**
+   * When true, parse + transform but skip writeTo(). `runImporter` prints a
+   * summary of what WOULD have been imported and returns early.
+   */
+  dryRun?: boolean;
+  /**
+   * Target batch size for writeTo(). Adapters that chunk memories into
+   * smaller orchestrator calls should honor this. Defaults to
+   * `DEFAULT_IMPORT_BATCH_SIZE` when undefined. Values outside the valid
+   * range throw from `validateImportBatchSize`.
+   */
+  batchSize?: number;
+  /**
+   * Optional rate limit for API-backed importers (mem0). Expressed as
+   * requests-per-second. Adapters that do not hit an external API may ignore
+   * this. When provided, `validateImportRateLimit` enforces the positive-
+   * finite contract.
+   */
+  rateLimit?: number;
+  /**
+   * Invoked after every chunk of memories is processed. `total` is the full
+   * count of memories produced by `transform`; `processed` counts memories
+   * already ingested (or skipped in dry-run mode). Adapters SHOULD call this
+   * incrementally — `runImporter` itself calls it once per batch.
+   */
+  onProgress?: (progress: ImportProgress) => void;
+}
+
+export interface ImportProgress {
+  processed: number;
+  total: number;
+  /** Current phase for human-readable logging. */
+  phase: "parse" | "transform" | "write" | "dry-run";
+}
+
+/**
+ * Interface every importer package implements.
+ *
+ * The three-method surface intentionally mirrors the issue #568 spec:
+ *
+ *   - `parse(input)`: raw payload → intermediate representation.
+ *   - `transform(parsed)`: intermediate representation → `ImportedMemory[]`.
+ *   - `writeTo(target, memories, options)`: actually commit to the
+ *     orchestrator (or whatever target the host provides).
+ *
+ * Adapters MAY keep `parse` and `transform` separate (e.g. ChatGPT conversions
+ * that need to split saved-memories from conversation summaries) or collapse
+ * them into a single operation — what matters is that the combined pipeline
+ * produces an array of `ImportedMemory` records with correct provenance.
+ *
+ * `Parsed` is generic so strongly-typed intermediate shapes survive through
+ * the adapter's own code without leaking to callers of `runImporter`.
+ */
+export interface ImporterAdapter<Parsed = unknown> {
+  /** Short stable name used by `remnic import --adapter <name>`. */
+  name: string;
+  /** Human-readable label surfaced in CLI output and source attribution. */
+  sourceLabel: string;
+
+  /**
+   * Parse a raw payload (file contents, API response, etc.) into the adapter
+   * intermediate representation. Pure — MUST NOT call the orchestrator.
+   */
+  parse(input: unknown, options?: ImporterParseOptions): Parsed | Promise<Parsed>;
+
+  /**
+   * Flatten parsed input into an array of importable memories. Pure — MUST
+   * NOT call the orchestrator. Provenance fields (`sourceLabel`,
+   * `importedFromPath`) should be populated here.
+   */
+  transform(parsed: Parsed, options?: ImporterTransformOptions): ImportedMemory[] | Promise<ImportedMemory[]>;
+
+  /**
+   * Commit the transformed memories to the orchestrator (or equivalent
+   * target). `runImporter` only invokes this when dryRun is false.
+   *
+   * Adapters typically call `orchestrator.ingestBulkImportBatch` once per
+   * batch after converting `ImportedMemory` records into `ImportTurn` shapes.
+   */
+  writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+    options: RunImportOptions,
+  ): Promise<ImporterWriteResult>;
+}
+
+/**
+ * Shape of the "target" passed to `writeTo`.
+ *
+ * This is intentionally narrower than the full `Orchestrator` class: importer
+ * adapters only need to push `ImportTurn[]` batches and read the active
+ * bulk-import namespace. Narrowing keeps test doubles simple (the slice-1
+ * integration test uses a pure in-memory mock) and prevents adapters from
+ * reaching into orchestrator internals that would make them harder to move
+ * between host environments.
+ */
+export interface ImporterWriteTarget {
+  ingestBulkImportBatch(
+    turns: ImportTurn[],
+    options?: { deadlineMs?: number },
+  ): Promise<void>;
+  bulkImportWriteNamespace?(): string;
+}
+
+export interface ImporterWriteResult {
+  memoriesIngested: number;
+  /** Optional: adapter-surfaced duplicates or skipped entries. */
+  skipped?: number;
+}
+
+/** Options forwarded to `parse`. Adapter-specific; additive by design. */
+export interface ImporterParseOptions {
+  strict?: boolean;
+  /** Source path passed through for provenance. */
+  filePath?: string;
+}
+
+/** Options forwarded to `transform`. */
+export interface ImporterTransformOptions {
+  /** When true, adapters that normally skip bulk conversations should include them. */
+  includeConversations?: boolean;
+  /** Maximum number of memories to emit. Primarily for tests. */
+  maxMemories?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+export const DEFAULT_IMPORT_BATCH_SIZE = 25;
+const MIN_IMPORT_BATCH_SIZE = 1;
+const MAX_IMPORT_BATCH_SIZE = 500;
+
+/**
+ * Coerce and validate the caller-supplied batch size. CLAUDE.md rule 14/51:
+ * reject invalid CLI input rather than silently defaulting.
+ */
+export function validateImportBatchSize(value: number | undefined): number {
+  if (value === undefined) return DEFAULT_IMPORT_BATCH_SIZE;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `batchSize must be a finite number, received ${String(value)}`,
+    );
+  }
+  if (!Number.isInteger(value)) {
+    throw new Error(`batchSize must be an integer, received ${value}`);
+  }
+  if (value < MIN_IMPORT_BATCH_SIZE || value > MAX_IMPORT_BATCH_SIZE) {
+    throw new Error(
+      `batchSize must be between ${MIN_IMPORT_BATCH_SIZE} and ${MAX_IMPORT_BATCH_SIZE}, ` +
+        `received ${value}`,
+    );
+  }
+  return value;
+}
+
+/**
+ * Validate the `--rate-limit` (requests per second) value used by API
+ * importers. Zero / negative / non-finite values throw — the CLI must reject
+ * them rather than silently import at unlimited speed.
+ */
+export function validateImportRateLimit(value: number | undefined): number | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "number" || !Number.isFinite(value)) {
+    throw new Error(
+      `rateLimit must be a finite number (requests per second), received ${String(value)}`,
+    );
+  }
+  if (value <= 0) {
+    throw new Error(
+      `rateLimit must be greater than 0 (requests per second), received ${value}`,
+    );
+  }
+  return value;
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Convert an `ImportedMemory` into an `ImportTurn` suitable for
+ * `orchestrator.ingestBulkImportBatch`. The resulting turn is always
+ * `role="user"` because every downstream source (saved memories, personal
+ * context, mem0 entries) represents a first-person statement rather than an
+ * assistant response.
+ *
+ * Keeps provenance on the turn via `participantName` so the extraction
+ * pipeline's transcript renderer labels the speaker with the source platform.
+ */
+export function importedMemoryToTurn(memory: ImportedMemory): ImportTurn {
+  const timestamp =
+    typeof memory.sourceTimestamp === "string" && memory.sourceTimestamp.length > 0
+      ? memory.sourceTimestamp
+      : (memory.importedAt ?? new Date().toISOString());
+  return {
+    role: "user",
+    content: memory.content,
+    timestamp,
+    participantName: memory.sourceLabel,
+    ...(memory.sourceId !== undefined ? { participantId: memory.sourceId } : {}),
+  };
+}
+
+export interface RunImporterResult {
+  adapter: string;
+  sourceLabel: string;
+  /**
+   * Total memories produced by `transform`. In dry-run mode this is the same
+   * as the number of memories that WOULD have been written.
+   */
+  memoriesPlanned: number;
+  /**
+   * Number of memories actually handed to writeTo(). Always zero in dry-run
+   * mode.
+   */
+  memoriesWritten: number;
+  batchesProcessed: number;
+  dryRun: boolean;
+  /** Mirrors the importedAt stamped on every memory. */
+  importedAt: string;
+}
+
+/**
+ * Orchestrate `parse → transform → writeTo` for an adapter. This is the
+ * default pipeline used by the CLI; adapters are free to implement their own
+ * orchestration when they need per-record rate-limiting or streaming parses
+ * that would not fit in the "produce full array before writing" shape.
+ *
+ * Mutates the supplied memory records by filling in `importedAt` when the
+ * adapter did not set it (CLAUDE.md rule 38: records are written in insertion
+ * order to keep the provenance log stable).
+ */
+export async function runImporter<Parsed>(
+  adapter: ImporterAdapter<Parsed>,
+  input: unknown,
+  target: ImporterWriteTarget,
+  options: RunImportOptions & {
+    parseOptions?: ImporterParseOptions;
+    transformOptions?: ImporterTransformOptions;
+  } = {},
+): Promise<RunImporterResult> {
+  const batchSize = validateImportBatchSize(options.batchSize);
+  validateImportRateLimit(options.rateLimit);
+
+  const importedAt = new Date().toISOString();
+  const dryRun = options.dryRun === true;
+  const onProgress = options.onProgress;
+
+  // Phase 1 — parse
+  onProgress?.({ processed: 0, total: 0, phase: "parse" });
+  const parsed = await adapter.parse(input, options.parseOptions);
+
+  // Phase 2 — transform
+  onProgress?.({ processed: 0, total: 0, phase: "transform" });
+  const memoriesRaw = await adapter.transform(parsed, options.transformOptions);
+  if (!Array.isArray(memoriesRaw)) {
+    throw new Error(
+      `Importer '${adapter.name}' transform() returned a non-array. ` +
+        "Adapters must produce ImportedMemory[].",
+    );
+  }
+  const memories = memoriesRaw.map((memory) => {
+    const sourceLabel =
+      typeof memory.sourceLabel === "string" && memory.sourceLabel.length > 0
+        ? memory.sourceLabel
+        : adapter.sourceLabel;
+    return {
+      ...memory,
+      sourceLabel,
+      importedAt: memory.importedAt ?? importedAt,
+    };
+  });
+
+  // Phase 3 — write (or dry-run plan)
+  if (dryRun) {
+    onProgress?.({
+      processed: memories.length,
+      total: memories.length,
+      phase: "dry-run",
+    });
+    return {
+      adapter: adapter.name,
+      sourceLabel: adapter.sourceLabel,
+      memoriesPlanned: memories.length,
+      memoriesWritten: 0,
+      batchesProcessed: 0,
+      dryRun: true,
+      importedAt,
+    };
+  }
+
+  let batchesProcessed = 0;
+  let memoriesWritten = 0;
+  for (let i = 0; i < memories.length; i += batchSize) {
+    const batch = memories.slice(i, i + batchSize);
+    const result = await adapter.writeTo(target, batch, options);
+    memoriesWritten += result.memoriesIngested;
+    batchesProcessed += 1;
+    onProgress?.({
+      processed: Math.min(i + batch.length, memories.length),
+      total: memories.length,
+      phase: "write",
+    });
+  }
+
+  return {
+    adapter: adapter.name,
+    sourceLabel: adapter.sourceLabel,
+    memoriesPlanned: memories.length,
+    memoriesWritten,
+    batchesProcessed,
+    dryRun: false,
+    importedAt,
+  };
+}
+
+/**
+ * Default `writeTo` implementation for importers that want to hand every
+ * memory to `orchestrator.ingestBulkImportBatch` without custom routing.
+ * Adapters that need per-record rate-limiting or conversation-thread linking
+ * are free to implement their own `writeTo`.
+ */
+export async function defaultWriteMemoriesToOrchestrator(
+  target: ImporterWriteTarget,
+  memories: ImportedMemory[],
+): Promise<ImporterWriteResult> {
+  if (memories.length === 0) {
+    return { memoriesIngested: 0 };
+  }
+  const turns = memories.map(importedMemoryToTurn);
+  await target.ingestBulkImportBatch(turns);
+  return { memoriesIngested: memories.length };
+}

--- a/packages/remnic-core/src/importers/index.ts
+++ b/packages/remnic-core/src/importers/index.ts
@@ -1,0 +1,21 @@
+// ---------------------------------------------------------------------------
+// @remnic/core — importers public surface (issue #568)
+// ---------------------------------------------------------------------------
+
+export {
+  DEFAULT_IMPORT_BATCH_SIZE,
+  validateImportBatchSize,
+  validateImportRateLimit,
+  importedMemoryToTurn,
+  defaultWriteMemoriesToOrchestrator,
+  runImporter,
+  type ImportedMemory,
+  type ImporterAdapter,
+  type ImporterParseOptions,
+  type ImporterTransformOptions,
+  type ImporterWriteResult,
+  type ImporterWriteTarget,
+  type ImportProgress,
+  type RunImporterResult,
+  type RunImportOptions,
+} from "./base.js";

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -604,6 +604,28 @@ export {
   type BulkImportCliCommandOptions,
 } from "./cli.js";
 
+// ---------------------------------------------------------------------------
+// Shared importer base (issue #568)
+// ---------------------------------------------------------------------------
+
+export {
+  DEFAULT_IMPORT_BATCH_SIZE,
+  validateImportBatchSize,
+  validateImportRateLimit,
+  importedMemoryToTurn,
+  defaultWriteMemoriesToOrchestrator,
+  runImporter,
+  type ImportedMemory,
+  type ImporterAdapter,
+  type ImporterParseOptions,
+  type ImporterTransformOptions,
+  type ImporterWriteResult,
+  type ImporterWriteTarget,
+  type ImportProgress,
+  type RunImporterResult,
+  type RunImportOptions,
+} from "./importers/index.js";
+
 export {
   FallbackLlmClient,
   type FallbackLlmOptions,


### PR DESCRIPTION
Part of #568 (slice 1 of 7). Ships the infrastructure for the four memory importers (ChatGPT, Claude, Gemini, Mem0) without any adapter packages. Slices 2-5 land the adapters; this PR is strictly contract + dispatcher.

## Summary

- Shared `ImporterAdapter<Parsed>` contract (`parse` / `transform` / `writeTo`) with `ImportedMemory` records carrying provenance (`sourceLabel`, `importedFromPath`, `importedAt`, `metadata`).
- `runImporter` helper in `@remnic/core` that handles batching, dry-run plan reporting, and progress callbacks so each adapter does not reimplement the loop. Exposed as `validateImportBatchSize` / `validateImportRateLimit` + `defaultWriteMemoriesToOrchestrator` for adapter ergonomics.
- `remnic import --adapter <name> --file <path> [--dry-run|--batch-size|--rate-limit|--include-conversations]` top-level CLI command.
- `optional-importer.ts` loader in `remnic-cli` that uses a computed specifier (`"@remnic/import-" + name`) dynamic import, caches per invocation, and throws a user-facing install hint on miss. Mirrors the `optional-bench.ts` / `optional-weclone-export.ts` pattern.

## À-la-carte invariant (CLAUDE.md rule 57)

- No `@remnic/import-*` package appears in `remnic-cli` `dependencies`, `devDependencies`, `peerDependencies`, or `tsup.config.ts` `noExternal`.
- Running `remnic import --adapter chatgpt --file x.json --dry-run` today prints the install hint for `@remnic/import-chatgpt` instead of `MODULE_NOT_FOUND`.
- Verified by inspecting the compiled bundle (`dist/index.js` contains the importer specifiers only in install-hint strings and the computed-concatenation specifier, never as a static `import` target).

## Input-guard coverage (CLAUDE.md rules 14, 51)

`parseImportArgs` rejects with actionable messages:
- Missing `--adapter`, unknown adapter (lists valid values).
- Bare `--file`, `--adapter`, `--batch-size`, `--rate-limit` (value required).
- Non-numeric `--batch-size`, non-positive `--rate-limit`.
- Unknown `--flag` tokens (rejects rather than silently ignoring).

## Test plan

- [x] `pnpm --filter @remnic/core run check-types` clean
- [x] New `@remnic/cli` `test` script covers `import-dispatch.test.ts` (12), `optional-importer.test.ts` (4), `bench-args.test.ts` (2). All 18 pass.
- [x] `packages/remnic-core/src/importers/base.test.ts` — 16 tests pass (batch/rate validators, turn mapping, dry-run integration, stamped `importedAt`, sourceLabel fallback, transform-return guard).
- [x] Existing 82 bulk-import tests and 88 `import-weclone` tests still pass — no regressions in sibling subsystems.
- [x] Smoke test: `node packages/remnic-cli/dist/index.js import --help` renders the usage block; `... import --adapter chatgpt --file /tmp/x.json --dry-run` prints the install hint (no `MODULE_NOT_FOUND`).

## Out of scope

- Actual source adapters — `@remnic/import-chatgpt` (PR 2), `@remnic/import-claude` (PR 3), `@remnic/import-gemini` (PR 4), `@remnic/import-mem0` (PR 5).
- Docs + site page (PR 6).
- `remnic import --all-from-bundle` auto-detect (PR 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new core importer execution pipeline and a new CLI command path that dynamically loads optional packages and can write to the orchestrator, so regressions could affect import workflows and CLI startup/teardown behavior.
> 
> **Overview**
> Introduces a new importer infrastructure across `@remnic/core` and `@remnic/cli` to support upcoming ChatGPT/Claude/Gemini/Mem0 memory imports.
> 
> In `@remnic/core`, adds the `ImporterAdapter`/`ImportedMemory` contract plus `runImporter` (batching, dry-run planning, progress callbacks) and related helpers (`validateImportBatchSize`, `validateImportRateLimit`, `defaultWriteMemoriesToOrchestrator`), and re-exports them from the package surface.
> 
> In `@remnic/cli`, adds the `remnic import` command with strict flag parsing (including `~` expansion and unknown-flag rejection), lazy orchestrator instantiation for non-`--dry-run` runs, and a new computed-specifier optional loader (`optional-importer.ts`) that caches results and throws user-facing install hints when `@remnic/import-*` packages are not installed. Adds targeted unit/integration tests and a CLI `test` script entry to cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1885d2d49bed6b9a6b1fcae117ba52facf639d5c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->