### PR TITLE
feat(bench): LongMemEval + LoCoMo smoke regression gate (#566 PR 7/7)

### DIFF
--- a/.github/workflows/bench-smoke.yml
+++ b/.github/workflows/bench-smoke.yml
@@ -1,0 +1,39 @@
+name: Bench Smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  bench-smoke:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22.12.0'
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run bench-smoke regression gate
+        # Runs both LongMemEval + LoCoMo smoke fixtures against the
+        # committed baseline with the default 5% tolerance. Does NOT
+        # touch real datasets or LLM APIs (CLAUDE.md rule 50: no `|| true`).
+        run: pnpm exec tsx scripts/bench/bench-smoke.ts --seed 1

--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -61,6 +61,22 @@ remnic bench publish --target remnic-ai
 
 Dataset markers match the runner's accepted filenames, so `datasets status` reports "downloaded" exactly when the runner will load successfully.
 
+## CI regression gate (smoke fixtures)
+
+`.github/workflows/bench-smoke.yml` runs `scripts/bench/bench-smoke.ts`
+on every PR. The script exercises the LongMemEval + LoCoMo runners
+against their bundled smoke fixtures with a fixed seed and a
+deterministic in-memory adapter (no real datasets, no LLM calls, no
+network). Metrics are compared to the committed baseline at
+`tests/fixtures/bench-smoke/baseline.json`; any drop greater than 5%
+fails the job.
+
+Regenerate the baseline after an intentional runner change:
+
+```bash
+pnpm exec tsx scripts/bench/bench-smoke.ts --update-baseline
+```
+
 ## Programmatic API
 
 ```ts

--- a/scripts/bench/bench-smoke.ts
+++ b/scripts/bench/bench-smoke.ts
@@ -1,0 +1,381 @@
+#!/usr/bin/env -S npx tsx
+/**
+ * bench-smoke.ts — Deterministic, side-effect-free smoke harness that
+ * exercises the LongMemEval + LoCoMo published-benchmark runners
+ * against their bundled smoke fixtures. Intended for CI regression
+ * guarding only — do NOT run this against real datasets or real LLMs.
+ *
+ * The smoke harness uses:
+ *   - The runner's built-in `LONG_MEM_EVAL_SMOKE_FIXTURE` and
+ *     `LOCOMO_SMOKE_FIXTURE` (no network, no dataset files).
+ *   - A deterministic in-memory adapter that echoes the stored
+ *     messages back on recall/search.
+ *   - A deterministic responder that returns the `recalledText`
+ *     verbatim so scoring is reproducible (`contains_answer` + `f1`).
+ *   - A deterministic judge that returns a fixed score.
+ *
+ * Usage:
+ *   scripts/bench/bench-smoke.ts --seed 1 \
+ *     --baseline tests/fixtures/bench-smoke/baseline.json
+ *   scripts/bench/bench-smoke.ts --seed 1 --update-baseline
+ *
+ * Exit codes:
+ *   0 — all metrics within tolerance
+ *   1 — regression detected OR CLI usage error
+ */
+
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+
+import {
+  locomoDefinition,
+  runLoCoMoBenchmark,
+} from "../../packages/bench/src/benchmarks/published/locomo/runner.js";
+import {
+  longMemEvalDefinition,
+  runLongMemEvalBenchmark,
+} from "../../packages/bench/src/benchmarks/published/longmemeval/runner.js";
+import type {
+  BenchJudge,
+  BenchMemoryAdapter,
+  BenchResponder,
+  Message,
+  SearchResult,
+} from "../../packages/bench/src/adapters/types.js";
+
+// Tolerance for each metric. Issue #566 spec: fail if score drops > 5% vs
+// committed baseline. We compare per-metric means; higher-is-better
+// metrics regress when current < baseline - 0.05.
+const REGRESSION_TOLERANCE = 0.05;
+
+interface SmokeBaseline {
+  schemaVersion: 1;
+  /**
+   * Baseline metrics keyed by benchmark ID. Intentionally carries NO
+   * timestamp so the committed file is stable across runs — CI
+   * compares the current metrics against these numbers.
+   */
+  benchmarks: Record<
+    string,
+    {
+      metrics: Record<string, number>;
+    }
+  >;
+}
+
+interface CliArgs {
+  seed: number;
+  baselinePath: string;
+  updateBaseline: boolean;
+  tolerance: number;
+}
+
+function parseArgs(argv: readonly string[]): CliArgs {
+  let seed = 1;
+  let baselinePath = path.resolve(
+    process.cwd(),
+    "tests/fixtures/bench-smoke/baseline.json",
+  );
+  let updateBaseline = false;
+  let tolerance = REGRESSION_TOLERANCE;
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index];
+    switch (arg) {
+      case "--seed": {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error("--seed requires an integer argument");
+        }
+        const parsed = Number(value);
+        if (!Number.isInteger(parsed) || parsed < 0) {
+          throw new Error(`--seed must be a non-negative integer; got ${value}`);
+        }
+        seed = parsed;
+        index += 1;
+        break;
+      }
+      case "--baseline": {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error("--baseline requires a file path");
+        }
+        baselinePath = path.resolve(process.cwd(), value);
+        index += 1;
+        break;
+      }
+      case "--tolerance": {
+        const value = argv[index + 1];
+        if (!value) {
+          throw new Error("--tolerance requires a number");
+        }
+        const parsed = Number(value);
+        if (!Number.isFinite(parsed) || parsed < 0) {
+          throw new Error(
+            `--tolerance must be a non-negative number; got ${value}`,
+          );
+        }
+        tolerance = parsed;
+        index += 1;
+        break;
+      }
+      case "--update-baseline":
+        updateBaseline = true;
+        break;
+      case "-h":
+      case "--help":
+        printUsage();
+        process.exit(0);
+        break;
+      default:
+        throw new Error(
+          `Unknown argument: ${arg}. Run --help for usage.`,
+        );
+    }
+  }
+
+  return { seed, baselinePath, updateBaseline, tolerance };
+}
+
+function printUsage(): void {
+  process.stdout.write(
+    [
+      "bench-smoke.ts — LongMemEval + LoCoMo smoke regression gate",
+      "",
+      "Usage:",
+      "  scripts/bench/bench-smoke.ts [--seed N] [--baseline PATH] [--tolerance N] [--update-baseline]",
+      "",
+      "Flags:",
+      "  --seed N             RNG seed (default 1)",
+      "  --baseline PATH      Baseline JSON path (default tests/fixtures/bench-smoke/baseline.json)",
+      "  --tolerance N        Max allowed metric drop (default 0.05)",
+      "  --update-baseline    Overwrite the baseline JSON with current run",
+      "",
+    ].join("\n"),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Deterministic adapter + responder + judge
+// ---------------------------------------------------------------------------
+
+function createDeterministicAdapter(): BenchMemoryAdapter {
+  const store = new Map<string, Message[]>();
+  const responder: BenchResponder = {
+    async respond(_question, recalledText) {
+      // Echo the recalled text verbatim so scoring is deterministic.
+      return {
+        text: recalledText,
+        model: "smoke-responder",
+        latencyMs: 0,
+        tokens: { input: 0, output: 0 },
+      };
+    },
+  };
+  const judge: BenchJudge = {
+    async score() {
+      return 1;
+    },
+    async scoreWithMetrics() {
+      return {
+        score: 1,
+        tokens: { input: 0, output: 0 },
+        latencyMs: 0,
+        model: "smoke-judge",
+      };
+    },
+  };
+
+  return {
+    responder,
+    judge,
+    async store(sessionId, messages) {
+      store.set(sessionId, [...messages]);
+    },
+    async recall(sessionId) {
+      const messages = store.get(sessionId) ?? [];
+      return messages.map((message) => message.content).join("\n");
+    },
+    async search(query, limit) {
+      const results: SearchResult[] = [];
+      const lowered = query.toLowerCase();
+      for (const [sessionId, messages] of store) {
+        for (let turnIndex = 0; turnIndex < messages.length; turnIndex += 1) {
+          const message = messages[turnIndex]!;
+          if (
+            typeof message.content === "string" &&
+            message.content.toLowerCase().includes(lowered)
+          ) {
+            results.push({
+              turnIndex,
+              role: message.role,
+              snippet: message.content,
+              sessionId,
+              score: 1,
+            });
+            if (results.length >= limit) {
+              return results;
+            }
+          }
+        }
+      }
+      return results;
+    },
+    async reset() {
+      store.clear();
+    },
+    async destroy() {
+      store.clear();
+    },
+    async getStats() {
+      return {
+        totalMessages: [...store.values()].reduce(
+          (total, messages) => total + messages.length,
+          0,
+        ),
+        totalSummaryNodes: 0,
+        maxDepth: 0,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(argv: readonly string[]): Promise<number> {
+  let args: CliArgs;
+  try {
+    args = parseArgs(argv);
+  } catch (error) {
+    process.stderr.write(
+      `bench-smoke: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    printUsage();
+    return 1;
+  }
+
+  const adapter = createDeterministicAdapter();
+
+  process.stdout.write(
+    `bench-smoke: running LongMemEval + LoCoMo smoke fixtures (seed=${args.seed})\n`,
+  );
+
+  const longmemeval = await runLongMemEvalBenchmark({
+    benchmark: longMemEvalDefinition,
+    mode: "quick",
+    seed: args.seed,
+    system: adapter,
+  });
+
+  const locomo = await runLoCoMoBenchmark({
+    benchmark: locomoDefinition,
+    mode: "quick",
+    seed: args.seed,
+    system: adapter,
+  });
+
+  const current: SmokeBaseline = {
+    schemaVersion: 1,
+    benchmarks: {
+      longmemeval: { metrics: extractMetrics(longmemeval.results.aggregates) },
+      locomo: { metrics: extractMetrics(locomo.results.aggregates) },
+    },
+  };
+
+  if (args.updateBaseline) {
+    await writeFile(
+      args.baselinePath,
+      JSON.stringify(current, null, 2) + "\n",
+      "utf8",
+    );
+    process.stdout.write(
+      `bench-smoke: wrote baseline → ${args.baselinePath}\n`,
+    );
+    return 0;
+  }
+
+  let baseline: SmokeBaseline;
+  try {
+    baseline = JSON.parse(
+      await readFile(args.baselinePath, "utf8"),
+    ) as SmokeBaseline;
+  } catch (error) {
+    process.stderr.write(
+      `bench-smoke: failed to read baseline from ${args.baselinePath}: ${error instanceof Error ? error.message : String(error)}\n`,
+    );
+    process.stderr.write(
+      "bench-smoke: run with --update-baseline to generate one.\n",
+    );
+    return 1;
+  }
+
+  const regressions: string[] = [];
+  for (const [benchmarkId, bench] of Object.entries(current.benchmarks)) {
+    const baselineMetrics = baseline.benchmarks[benchmarkId]?.metrics ?? {};
+    for (const [metric, value] of Object.entries(bench.metrics)) {
+      const baselineValue = baselineMetrics[metric];
+      if (baselineValue === undefined) {
+        process.stdout.write(
+          `bench-smoke: [${benchmarkId}] ${metric}=${value.toFixed(4)} (new metric, no baseline)\n`,
+        );
+        continue;
+      }
+      const delta = value - baselineValue;
+      const verdict =
+        delta < -args.tolerance
+          ? `REGRESSION (tol=${args.tolerance})`
+          : "ok";
+      process.stdout.write(
+        `bench-smoke: [${benchmarkId}] ${metric} baseline=${baselineValue.toFixed(4)} current=${value.toFixed(4)} delta=${delta >= 0 ? "+" : ""}${delta.toFixed(4)} ${verdict}\n`,
+      );
+      if (delta < -args.tolerance) {
+        regressions.push(
+          `${benchmarkId}.${metric} dropped ${Math.abs(delta).toFixed(4)} (baseline=${baselineValue.toFixed(4)}, current=${value.toFixed(4)}, tolerance=${args.tolerance})`,
+        );
+      }
+    }
+  }
+
+  if (regressions.length > 0) {
+    process.stderr.write(
+      `\nbench-smoke: REGRESSION detected (${regressions.length} metric${regressions.length === 1 ? "" : "s"}):\n`,
+    );
+    for (const regression of regressions) {
+      process.stderr.write(`  - ${regression}\n`);
+    }
+    process.stderr.write(
+      "\nIf this drop is intentional, re-run with --update-baseline.\n",
+    );
+    return 1;
+  }
+
+  process.stdout.write("\nbench-smoke: all metrics within tolerance\n");
+  return 0;
+}
+
+function extractMetrics(
+  aggregates: Record<string, { mean: number }>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const key of Object.keys(aggregates).sort()) {
+    const mean = aggregates[key]?.mean;
+    if (typeof mean === "number" && Number.isFinite(mean)) {
+      out[key] = Number(mean.toFixed(6));
+    }
+  }
+  return out;
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exitCode = code;
+  })
+  .catch((error) => {
+    process.stderr.write(
+      `bench-smoke crashed: ${error instanceof Error ? error.stack ?? error.message : String(error)}\n`,
+    );
+    process.exitCode = 1;
+  });

--- a/scripts/bench/bench-smoke.ts
+++ b/scripts/bench/bench-smoke.ts
@@ -44,9 +44,15 @@ import type {
   SearchResult,
 } from "../../packages/bench/src/adapters/types.js";
 
-// Tolerance for each metric. Issue #566 spec: fail if score drops > 5% vs
-// committed baseline. We compare per-metric means; higher-is-better
-// metrics regress when current < baseline - 0.05.
+// Tolerance for each metric. Issue #566 spec: fail if score drops > 5%
+// vs committed baseline. This is a RELATIVE drop: a metric regresses
+// when `(baseline - current) / |baseline| > tolerance`. Using a
+// relative tolerance means the same 5% threshold is meaningful for
+// both small-scale metrics (`f1` in [0, 1]) and larger unbounded
+// metrics (`search_hits`, token counts) — an absolute 0.05 drop would
+// be a silent no-op for a metric whose baseline is 100.
+// When the baseline value is exactly 0 we fall back to an absolute
+// delta threshold of `tolerance` to avoid divide-by-zero.
 const REGRESSION_TOLERANCE = 0.05;
 
 interface SmokeBaseline {
@@ -163,7 +169,7 @@ function printUsage(): void {
       "Flags:",
       "  --seed N             RNG seed (default 1)",
       "  --baseline PATH      Baseline JSON path (default tests/fixtures/bench-smoke/baseline.json)",
-      "  --tolerance N        Max allowed metric drop (default 0.05)",
+      "  --tolerance N        Max allowed RELATIVE metric drop (default 0.05 = 5%)",
       "  --update-baseline    Overwrite the baseline JSON with current run",
       "",
     ].join("\n"),
@@ -313,9 +319,51 @@ async function main(argv: readonly string[]): Promise<number> {
 
   let baseline: SmokeBaseline;
   try {
-    baseline = JSON.parse(
-      await readFile(args.baselinePath, "utf8"),
-    ) as SmokeBaseline;
+    const raw = await readFile(args.baselinePath, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    // CLAUDE.md rule 18: JSON.parse("null") succeeds but is not a
+    // valid config. Validate shape before trusting it.
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      throw new Error("baseline JSON must be a non-null object");
+    }
+    const record = parsed as Record<string, unknown>;
+    if (record.schemaVersion !== 1) {
+      throw new Error(
+        `baseline schemaVersion must be 1; got ${String(record.schemaVersion)}`,
+      );
+    }
+    if (
+      !record.benchmarks ||
+      typeof record.benchmarks !== "object" ||
+      Array.isArray(record.benchmarks)
+    ) {
+      throw new Error("baseline.benchmarks must be an object");
+    }
+    for (const [benchmarkId, bench] of Object.entries(
+      record.benchmarks as Record<string, unknown>,
+    )) {
+      if (!bench || typeof bench !== "object" || Array.isArray(bench)) {
+        throw new Error(
+          `baseline.benchmarks.${benchmarkId} must be an object`,
+        );
+      }
+      const metrics = (bench as { metrics?: unknown }).metrics;
+      if (!metrics || typeof metrics !== "object" || Array.isArray(metrics)) {
+        throw new Error(
+          `baseline.benchmarks.${benchmarkId}.metrics must be an object`,
+        );
+      }
+      for (const [metric, value] of Object.entries(
+        metrics as Record<string, unknown>,
+      )) {
+        if (typeof value !== "number" || !Number.isFinite(value)) {
+          throw new Error(
+            `baseline.benchmarks.${benchmarkId}.metrics.${metric} must be a finite number`,
+          );
+        }
+      }
+    }
+    baseline = parsed as SmokeBaseline;
   } catch (error) {
     process.stderr.write(
       `bench-smoke: failed to read baseline from ${args.baselinePath}: ${error instanceof Error ? error.message : String(error)}\n`,
@@ -341,16 +389,25 @@ async function main(argv: readonly string[]): Promise<number> {
         continue;
       }
       const delta = value - baselineValue;
-      const verdict =
-        delta < -args.tolerance
-          ? `REGRESSION (tol=${args.tolerance})`
-          : "ok";
+      // Relative drop: `(baseline - current) / |baseline|`. Fall back
+      // to an absolute threshold when baseline === 0 to avoid
+      // divide-by-zero; a 0-baseline metric regresses only if it
+      // goes negative by more than `tolerance` in absolute terms.
+      const denom = Math.abs(baselineValue);
+      const relativeDrop = denom === 0 ? -delta : (baselineValue - value) / denom;
+      const regressed = relativeDrop > args.tolerance;
+      const verdict = regressed
+        ? `REGRESSION (tol=${args.tolerance} relative)`
+        : "ok";
+      const relDisplay = denom === 0
+        ? `abs-delta=${delta.toFixed(4)}`
+        : `rel-drop=${(relativeDrop * 100).toFixed(2)}%`;
       process.stdout.write(
-        `bench-smoke: [${benchmarkId}] ${metric} baseline=${baselineValue.toFixed(4)} current=${value.toFixed(4)} delta=${delta >= 0 ? "+" : ""}${delta.toFixed(4)} ${verdict}\n`,
+        `bench-smoke: [${benchmarkId}] ${metric} baseline=${baselineValue.toFixed(4)} current=${value.toFixed(4)} delta=${delta >= 0 ? "+" : ""}${delta.toFixed(4)} ${relDisplay} ${verdict}\n`,
       );
-      if (delta < -args.tolerance) {
+      if (regressed) {
         regressions.push(
-          `${benchmarkId}.${metric} dropped ${Math.abs(delta).toFixed(4)} (baseline=${baselineValue.toFixed(4)}, current=${value.toFixed(4)}, tolerance=${args.tolerance})`,
+          `${benchmarkId}.${metric} dropped ${Math.abs(delta).toFixed(4)} (baseline=${baselineValue.toFixed(4)}, current=${value.toFixed(4)}, relative=${(relativeDrop * 100).toFixed(2)}%, tolerance=${(args.tolerance * 100).toFixed(2)}%)`,
         );
       }
     }

--- a/scripts/bench/bench-smoke.ts
+++ b/scripts/bench/bench-smoke.ts
@@ -71,6 +71,29 @@ interface CliArgs {
   tolerance: number;
 }
 
+/**
+ * Consume the argument that follows a flag, rejecting option-looking
+ * tokens (`--foo`, `-x`). This prevents `--baseline --update-baseline`
+ * from silently swallowing the next flag as a path (CLAUDE.md rule 14).
+ */
+function requireFlagValue(
+  argv: readonly string[],
+  index: number,
+  flag: string,
+  kind: string,
+): string {
+  const value = argv[index + 1];
+  if (value === undefined || value.length === 0) {
+    throw new Error(`${flag} requires ${kind}`);
+  }
+  if (value.startsWith("-")) {
+    throw new Error(
+      `${flag} requires ${kind}; got option-like token "${value}"`,
+    );
+  }
+  return value;
+}
+
 function parseArgs(argv: readonly string[]): CliArgs {
   let seed = 1;
   let baselinePath = path.resolve(
@@ -84,10 +107,7 @@ function parseArgs(argv: readonly string[]): CliArgs {
     const arg = argv[index];
     switch (arg) {
       case "--seed": {
-        const value = argv[index + 1];
-        if (!value) {
-          throw new Error("--seed requires an integer argument");
-        }
+        const value = requireFlagValue(argv, index, "--seed", "an integer argument");
         const parsed = Number(value);
         if (!Number.isInteger(parsed) || parsed < 0) {
           throw new Error(`--seed must be a non-negative integer; got ${value}`);
@@ -97,19 +117,13 @@ function parseArgs(argv: readonly string[]): CliArgs {
         break;
       }
       case "--baseline": {
-        const value = argv[index + 1];
-        if (!value) {
-          throw new Error("--baseline requires a file path");
-        }
+        const value = requireFlagValue(argv, index, "--baseline", "a file path");
         baselinePath = path.resolve(process.cwd(), value);
         index += 1;
         break;
       }
       case "--tolerance": {
-        const value = argv[index + 1];
-        if (!value) {
-          throw new Error("--tolerance requires a number");
-        }
+        const value = requireFlagValue(argv, index, "--tolerance", "a number");
         const parsed = Number(value);
         if (!Number.isFinite(parsed) || parsed < 0) {
           throw new Error(
@@ -313,6 +327,9 @@ async function main(argv: readonly string[]): Promise<number> {
   }
 
   const regressions: string[] = [];
+  const missing: string[] = [];
+
+  // 1) Compare every current metric against the baseline. Log deltas.
   for (const [benchmarkId, bench] of Object.entries(current.benchmarks)) {
     const baselineMetrics = baseline.benchmarks[benchmarkId]?.metrics ?? {};
     for (const [metric, value] of Object.entries(bench.metrics)) {
@@ -339,15 +356,53 @@ async function main(argv: readonly string[]): Promise<number> {
     }
   }
 
-  if (regressions.length > 0) {
-    process.stderr.write(
-      `\nbench-smoke: REGRESSION detected (${regressions.length} metric${regressions.length === 1 ? "" : "s"}):\n`,
-    );
-    for (const regression of regressions) {
-      process.stderr.write(`  - ${regression}\n`);
+  // 2) Verify every baseline benchmark + metric still exists in the
+  // current run. A silently vanished metric (e.g. scorer bug drops
+  // `f1`) must fail the gate instead of passing quietly.
+  for (const [benchmarkId, benchBaseline] of Object.entries(
+    baseline.benchmarks,
+  )) {
+    const currentBench = current.benchmarks[benchmarkId];
+    if (!currentBench) {
+      missing.push(
+        `${benchmarkId}: entire benchmark missing from current run`,
+      );
+      process.stdout.write(
+        `bench-smoke: [${benchmarkId}] MISSING (benchmark absent from current run)\n`,
+      );
+      continue;
+    }
+    for (const metric of Object.keys(benchBaseline.metrics)) {
+      if (currentBench.metrics[metric] === undefined) {
+        missing.push(
+          `${benchmarkId}.${metric}: present in baseline, absent in current run`,
+        );
+        process.stdout.write(
+          `bench-smoke: [${benchmarkId}] ${metric} MISSING (metric absent from current run)\n`,
+        );
+      }
+    }
+  }
+
+  if (regressions.length > 0 || missing.length > 0) {
+    if (regressions.length > 0) {
+      process.stderr.write(
+        `\nbench-smoke: REGRESSION detected (${regressions.length} metric${regressions.length === 1 ? "" : "s"}):\n`,
+      );
+      for (const regression of regressions) {
+        process.stderr.write(`  - ${regression}\n`);
+      }
+    }
+    if (missing.length > 0) {
+      process.stderr.write(
+        `\nbench-smoke: MISSING metric(s) present in baseline but absent in current run (${missing.length}):\n`,
+      );
+      for (const entry of missing) {
+        process.stderr.write(`  - ${entry}\n`);
+      }
     }
     process.stderr.write(
-      "\nIf this drop is intentional, re-run with --update-baseline.\n",
+      "\nIf this change is intentional, re-run with --update-baseline.\n",
     );
     return 1;
   }

--- a/tests/bench-smoke.test.ts
+++ b/tests/bench-smoke.test.ts
@@ -146,6 +146,93 @@ test("bench-smoke rejects option-like tokens as flag values", () => {
   assert.match(stderr, /option-like token "--update-baseline"/);
 });
 
+test("bench-smoke uses relative tolerance (5% default)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-relative-"));
+  try {
+    // Baseline: raise every metric to 10.0. Current run produces <=1.0,
+    // so every metric drops >90% relative — well over the 5% default.
+    // An absolute-delta gate of 0.05 would silently pass a small
+    // metric whose delta sits under 0.05; the relative gate correctly
+    // fires here.
+    const baseline = {
+      schemaVersion: 1,
+      benchmarks: {
+        longmemeval: {
+          metrics: {
+            contains_answer: 10,
+            f1: 10,
+            llm_judge: 10,
+            search_hits: 10,
+          },
+        },
+        locomo: {
+          metrics: {
+            contains_answer: 10,
+            f1: 10,
+            llm_judge: 10,
+            rouge_l: 10,
+          },
+        },
+      },
+    };
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
+    const { code, stdout, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /REGRESSION/);
+    assert.match(stdout, /rel-drop=/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke rejects null baseline JSON (CLAUDE.md rule 18)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-null-"));
+  try {
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(tamperedPath, "null", "utf8");
+    const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /non-null object/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke rejects baseline with bad schemaVersion", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-shape-"));
+  try {
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(
+      tamperedPath,
+      JSON.stringify({ schemaVersion: 99, benchmarks: {} }),
+      "utf8",
+    );
+    const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /schemaVersion must be 1/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke rejects baseline with non-finite metric", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-infinite-"));
+  try {
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(
+      tamperedPath,
+      '{"schemaVersion":1,"benchmarks":{"longmemeval":{"metrics":{"f1":1e309}}}}',
+      "utf8",
+    );
+    const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /must be a finite number/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("bench-smoke --update-baseline writes a stable file (no timestamp)", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-update-"));
   try {

--- a/tests/bench-smoke.test.ts
+++ b/tests/bench-smoke.test.ts
@@ -95,6 +95,57 @@ test("bench-smoke regression detection fires when baseline metrics are raised", 
   }
 });
 
+test("bench-smoke fails when a baseline metric disappears from the current run", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-missing-metric-"));
+  try {
+    const raw = await readFile(committedBaseline, "utf8");
+    const baseline = JSON.parse(raw) as {
+      benchmarks: Record<string, { metrics: Record<string, number> }>;
+    };
+    // Inject a phantom metric into the baseline that the current run
+    // will never produce. This simulates a runner-side regression that
+    // stops emitting a metric.
+    for (const benchmarkId of Object.keys(baseline.benchmarks)) {
+      baseline.benchmarks[benchmarkId]!.metrics["phantom_metric"] = 0.5;
+    }
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
+    const { code, stderr, stdout } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /MISSING metric/);
+    assert.match(stderr, /phantom_metric/);
+    assert.match(stdout, /MISSING \(metric absent from current run\)/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke fails when an entire baseline benchmark disappears", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-missing-bench-"));
+  try {
+    const raw = await readFile(committedBaseline, "utf8");
+    const baseline = JSON.parse(raw) as {
+      benchmarks: Record<string, { metrics: Record<string, number> }>;
+    };
+    // Inject a phantom benchmark entirely.
+    baseline.benchmarks["phantom_bench"] = { metrics: { score: 0.5 } };
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
+    const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /phantom_bench/);
+    assert.match(stderr, /entire benchmark missing from current run/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke rejects option-like tokens as flag values", () => {
+  const { code, stderr } = runSmoke(["--baseline", "--update-baseline"]);
+  assert.equal(code, 1);
+  assert.match(stderr, /option-like token "--update-baseline"/);
+});
+
 test("bench-smoke --update-baseline writes a stable file (no timestamp)", async () => {
   const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-update-"));
   try {

--- a/tests/bench-smoke.test.ts
+++ b/tests/bench-smoke.test.ts
@@ -1,0 +1,128 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+import test from "node:test";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, "..");
+const scriptPath = path.join(repoRoot, "scripts", "bench", "bench-smoke.ts");
+const committedBaseline = path.join(
+  repoRoot,
+  "tests",
+  "fixtures",
+  "bench-smoke",
+  "baseline.json",
+);
+
+function runSmoke(args: readonly string[], cwd: string = repoRoot): {
+  code: number;
+  stdout: string;
+  stderr: string;
+} {
+  const result = spawnSync(
+    process.execPath,
+    [
+      path.join(repoRoot, "node_modules", "tsx", "dist", "cli.mjs"),
+      scriptPath,
+      ...args,
+    ],
+    {
+      cwd,
+      env: process.env,
+      encoding: "utf8",
+    },
+  );
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+test("bench-smoke passes against the committed baseline", () => {
+  const { code, stdout } = runSmoke([]);
+  assert.equal(
+    code,
+    0,
+    `bench-smoke exited non-zero:\n${stdout}`,
+  );
+  assert.match(stdout, /all metrics within tolerance/);
+});
+
+test("bench-smoke rejects invalid --seed", () => {
+  const { code, stderr } = runSmoke(["--seed", "not-a-number"]);
+  assert.equal(code, 1);
+  assert.match(stderr, /--seed must be a non-negative integer/);
+});
+
+test("bench-smoke rejects --seed with no value", () => {
+  const { code, stderr } = runSmoke(["--seed"]);
+  assert.equal(code, 1);
+  assert.match(stderr, /--seed requires an integer argument/);
+});
+
+test("bench-smoke rejects unknown flags", () => {
+  const { code, stderr } = runSmoke(["--nope"]);
+  assert.equal(code, 1);
+  assert.match(stderr, /Unknown argument: --nope/);
+});
+
+test("bench-smoke regression detection fires when baseline metrics are raised", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-tamper-"));
+  try {
+    const raw = await readFile(committedBaseline, "utf8");
+    const baseline = JSON.parse(raw) as {
+      benchmarks: Record<string, { metrics: Record<string, number> }>;
+    };
+    // Raise every metric to 0.99 so any current run scores well below it.
+    for (const benchmarkId of Object.keys(baseline.benchmarks)) {
+      const metrics = baseline.benchmarks[benchmarkId]!.metrics;
+      for (const key of Object.keys(metrics)) {
+        metrics[key] = 0.99;
+      }
+    }
+    const tamperedPath = path.join(dir, "baseline.json");
+    await writeFile(tamperedPath, JSON.stringify(baseline, null, 2), "utf8");
+    const { code, stderr } = runSmoke(["--baseline", tamperedPath]);
+    assert.equal(code, 1);
+    assert.match(stderr, /REGRESSION/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("bench-smoke --update-baseline writes a stable file (no timestamp)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "bench-smoke-update-"));
+  try {
+    const outPath = path.join(dir, "baseline.json");
+    const first = runSmoke(["--baseline", outPath, "--update-baseline"]);
+    assert.equal(first.code, 0);
+    const firstRaw = await readFile(outPath, "utf8");
+
+    // Re-run immediately; committed baseline must be byte-identical since
+    // the smoke runner is deterministic and the baseline carries no
+    // `generatedAt` timestamp.
+    const second = runSmoke(["--baseline", outPath, "--update-baseline"]);
+    assert.equal(second.code, 0);
+    const secondRaw = await readFile(outPath, "utf8");
+    assert.equal(firstRaw, secondRaw);
+
+    const parsed = JSON.parse(firstRaw) as {
+      schemaVersion: number;
+      benchmarks: Record<string, unknown>;
+    };
+    assert.equal(parsed.schemaVersion, 1);
+    assert.ok(parsed.benchmarks.longmemeval);
+    assert.ok(parsed.benchmarks.locomo);
+    assert.ok(
+      !Object.prototype.hasOwnProperty.call(parsed, "generatedAt"),
+      "baseline must not carry a generatedAt timestamp",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/fixtures/bench-smoke/baseline.json
+++ b/tests/fixtures/bench-smoke/baseline.json
@@ -1,0 +1,21 @@
+{
+  "schemaVersion": 1,
+  "benchmarks": {
+    "longmemeval": {
+      "metrics": {
+        "contains_answer": 1,
+        "f1": 0.2,
+        "llm_judge": 1,
+        "search_hits": 0
+      }
+    },
+    "locomo": {
+      "metrics": {
+        "contains_answer": 1,
+        "f1": 0.055556,
+        "llm_judge": 1,
+        "rouge_l": 0.055556
+      }
+    }
+  }
+}


### PR DESCRIPTION
Part of #566 (slice 7 of 7).

## Summary

- Adds a smoke-only, deterministic regression gate that runs the
  LongMemEval + LoCoMo published-benchmark runners against their
  bundled smoke fixtures on every PR and push to `main`.
- No real datasets, no LLM API calls, no network dependencies. Real
  dataset runs require manual download and model credentials (see
  issue #566 PR 1 dataset loaders and PR 6 runbook).

New surface:

- `scripts/bench/bench-smoke.ts` — deterministic harness driving
  `runLongMemEvalBenchmark` + `runLoCoMoBenchmark` with a small
  in-memory adapter (echoes stored content on recall) and a stub
  responder. Metrics captured: `f1`, `contains_answer`,
  `llm_judge`, `rouge_l`, `search_hits`.
- `tests/fixtures/bench-smoke/baseline.json` — committed baseline.
  Stable across runs (no `generatedAt` timestamp, sorted keys,
  6-decimal rounding).
- `.github/workflows/bench-smoke.yml` — runs the gate on every PR
  and push to main (10-min timeout). No `|| true` silencing
  (CLAUDE.md rule 50).
- `tests/bench-smoke.test.ts` — 6 unit tests.
- `packages/bench/README.md` gains a "CI regression gate" section
  documenting how to regenerate the baseline after an intentional
  runner change.

The gate fails if any metric drops more than 5% vs the committed
baseline (issue #566 deliverable 7). Tolerance is configurable via
`--tolerance`.

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `tsx scripts/bench/bench-smoke.ts` — exits 0 against committed
      baseline, emits per-metric delta lines.
- [x] `tsx scripts/bench/bench-smoke.ts --update-baseline` — rewrites
      baseline; repeated runs produce byte-identical files.
- [x] 6 new unit tests:
  - passes against committed baseline (stdout includes "all metrics
    within tolerance")
  - rejects `--seed` with non-integer value (CLAUDE.md rule 51)
  - rejects `--seed` without a following value (CLAUDE.md rule 14)
  - rejects unknown flags
  - regression detection fires when tampered baseline raises all
    metrics to 0.99
  - `--update-baseline` determinism check (byte-identical across
    consecutive runs; baseline has no `generatedAt` timestamp)
- [x] CI workflow `bench-smoke` runs on this PR itself.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces a new CI workflow that can block merges based on benchmark metric comparisons, and adds new baseline/CLI logic that must stay deterministic and in sync with runner outputs.
> 
> **Overview**
> Adds a **new CI regression gate** (`.github/workflows/bench-smoke.yml`) that runs a deterministic smoke benchmark on every PR (non-draft) and pushes to `main`.
> 
> Introduces `scripts/bench/bench-smoke.ts`, which runs the LongMemEval + LoCoMo *quick/smoke fixtures* using a deterministic in-memory adapter, compares aggregate metrics against a committed baseline with a default **5% relative-drop tolerance**, and can rewrite the baseline via `--update-baseline`.
> 
> Adds a committed baseline file (`tests/fixtures/bench-smoke/baseline.json`), a comprehensive test suite for the smoke gate behavior (`tests/bench-smoke.test.ts`), and documents baseline regeneration in `packages/bench/README.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 310ef95ecfb171933ee5ec48393dc502175d9f4e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->