### PR TITLE
feat(procedural): bench ablation harness (#567 PR 1/5)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
@@ -100,6 +100,19 @@ test("runProceduralAblation: lift >= 0 on matching-positive fixture", async () =
   assert.equal(artifact.confidenceInterval.level, 0.95);
 });
 
+test("runProceduralAblation: deterministic CI by default (no random/seed supplied)", async () => {
+  const a = await runProceduralAblation({
+    scenarios: ABLATION_FIXTURE,
+    bootstrapIterations: 200,
+  });
+  const b = await runProceduralAblation({
+    scenarios: ABLATION_FIXTURE,
+    bootstrapIterations: 200,
+  });
+  assert.equal(a.confidenceInterval.lower, b.confidenceInterval.lower);
+  assert.equal(a.confidenceInterval.upper, b.confidenceInterval.upper);
+});
+
 test("runProceduralAblation: deterministic CI under seeded RNG", async () => {
   const a = await runProceduralAblation({
     scenarios: ABLATION_FIXTURE,
@@ -223,6 +236,82 @@ test("loadAblationFixture rejects invalid input", async () => {
       () => loadAblationFixture(p),
       /procedureTags\[1\] must be a string/,
     );
+
+    // Rejects non-integer step.order — Math.floor coercion silently mutates
+    // benchmark input. Strict rejection prevents hidden drift.
+    const withFractionalOrder = [
+      {
+        id: "x",
+        prompt: "p",
+        procedurePreamble: "pp",
+        procedureSteps: [{ order: 1.5, intent: "do" }],
+        procedureTags: [],
+        expectMatch: true,
+      },
+    ];
+    await writeFile(p, JSON.stringify(withFractionalOrder), "utf8");
+    await assert.rejects(
+      () => loadAblationFixture(p),
+      /order must be a positive integer/,
+    );
+
+    // Rejects non-number step.order (e.g. "1") — should not fall back to
+    // positional index.
+    const withStringOrder = [
+      {
+        id: "x",
+        prompt: "p",
+        procedurePreamble: "pp",
+        procedureSteps: [{ order: "1", intent: "do" }],
+        procedureTags: [],
+        expectMatch: true,
+      },
+    ];
+    await writeFile(p, JSON.stringify(withStringOrder), "utf8");
+    await assert.rejects(
+      () => loadAblationFixture(p),
+      /order must be a positive integer/,
+    );
+
+    // Rejects zero / negative step.order.
+    const withNegativeOrder = [
+      {
+        id: "x",
+        prompt: "p",
+        procedurePreamble: "pp",
+        procedureSteps: [{ order: 0, intent: "do" }],
+        procedureTags: [],
+        expectMatch: true,
+      },
+    ];
+    await writeFile(p, JSON.stringify(withNegativeOrder), "utf8");
+    await assert.rejects(
+      () => loadAblationFixture(p),
+      /order must be a positive integer/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAblationFixture accepts missing step.order (falls back to positional)", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-fixture-"));
+  try {
+    const p = path.join(dir, "fixture.json");
+    const withoutOrder = [
+      {
+        id: "x",
+        prompt: "deploy now",
+        procedurePreamble: "pp",
+        procedureSteps: [{ intent: "step1" }, { intent: "step2" }],
+        procedureTags: [],
+        expectMatch: true,
+      },
+    ];
+    await writeFile(p, JSON.stringify(withoutOrder), "utf8");
+    const loaded = await loadAblationFixture(p);
+    assert.equal(loaded[0]!.procedureSteps[0]!.order, 1);
+    assert.equal(loaded[0]!.procedureSteps[1]!.order, 2);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
@@ -1,0 +1,241 @@
+/**
+ * Tests for the procedural recall ablation harness (issue #567 PR 1/5).
+ */
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  fixtureToAblationScenarios,
+  loadAblationFixture,
+  runProceduralAblation,
+  runProceduralAblationCli,
+  type ProceduralAblationScenario,
+} from "./ablation.ts";
+import { PROCEDURAL_RECALL_E2E_FIXTURE } from "./fixture.ts";
+
+function mulberry32(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Canonical ablation fixture for tests: prompts that look like task
+ * initiation and DO have matching procedures should recall when procedural is
+ * on (and not when it's off). A distractor prompt ("What is our usual…")
+ * should reject on both sides.
+ */
+const ABLATION_FIXTURE: ProceduralAblationScenario[] = [
+  {
+    id: "deploy-gateway",
+    prompt: "Let's deploy the gateway to production today",
+    procedurePreamble: "When you deploy the gateway",
+    procedureSteps: [
+      { order: 1, intent: "Run deploy checks for production gateway" },
+      { order: 2, intent: "Push the release tag" },
+    ],
+    procedureTags: ["deploy", "gateway"],
+    expectMatch: true,
+  },
+  {
+    id: "open-pr",
+    prompt: "Open a PR for the regression fix",
+    procedurePreamble: "PR opening procedure",
+    procedureSteps: [
+      { order: 1, intent: "Open a pull request for the regression fix" },
+      { order: 2, intent: "Link the issue" },
+    ],
+    procedureTags: ["pr", "regression"],
+    expectMatch: true,
+  },
+  {
+    id: "no-task-init",
+    prompt: "What is our usual process for production deploys?",
+    procedurePreamble: "Production deploy runbook",
+    procedureSteps: [
+      { order: 1, intent: "Notify on-call" },
+      { order: 2, intent: "Apply change window" },
+    ],
+    procedureTags: ["deploy", "runbook"],
+    expectMatch: false,
+  },
+];
+
+test("runProceduralAblation: lift >= 0 on matching-positive fixture", async () => {
+  const artifact = await runProceduralAblation({
+    scenarios: ABLATION_FIXTURE,
+    random: mulberry32(42),
+    bootstrapIterations: 200,
+  });
+
+  assert.equal(artifact.schemaVersion, 1);
+  assert.equal(artifact.fixture.scenarioCount, ABLATION_FIXTURE.length);
+  assert.equal(artifact.perCase.length, ABLATION_FIXTURE.length);
+  assert.ok(artifact.onScore >= artifact.offScore, "on should not regress");
+  assert.ok(artifact.lift >= 0, `lift was ${artifact.lift}`);
+  // The positive-match scenarios should recall when procedural is on.
+  const onMatched = artifact.perCase
+    .filter((c) => c.expectMatch === true)
+    .every((c) => c.onMatched === true);
+  const offNotMatched = artifact.perCase.every((c) => c.offMatched === false);
+  assert.equal(onMatched, true, "on should recall every positive scenario");
+  assert.equal(
+    offNotMatched,
+    true,
+    "off should never recall (gate is disabled)",
+  );
+  // Confidence interval should be well-formed.
+  assert.ok(
+    artifact.confidenceInterval.lower <= artifact.confidenceInterval.upper,
+    "CI bounds must be ordered",
+  );
+  assert.equal(artifact.confidenceInterval.level, 0.95);
+});
+
+test("runProceduralAblation: deterministic CI under seeded RNG", async () => {
+  const a = await runProceduralAblation({
+    scenarios: ABLATION_FIXTURE,
+    random: mulberry32(1),
+    bootstrapIterations: 200,
+  });
+  const b = await runProceduralAblation({
+    scenarios: ABLATION_FIXTURE,
+    random: mulberry32(1),
+    bootstrapIterations: 200,
+  });
+  assert.equal(a.onScore, b.onScore);
+  assert.equal(a.offScore, b.offScore);
+  assert.equal(a.lift, b.lift);
+  assert.equal(a.confidenceInterval.lower, b.confidenceInterval.lower);
+  assert.equal(a.confidenceInterval.upper, b.confidenceInterval.upper);
+});
+
+test("runProceduralAblation: rejects empty scenarios", async () => {
+  await assert.rejects(
+    () =>
+      runProceduralAblation({
+        scenarios: [],
+        random: mulberry32(1),
+        bootstrapIterations: 100,
+      }),
+    /non-empty scenarios/,
+  );
+});
+
+test("fixtureToAblationScenarios maps from the existing e2e fixture", () => {
+  const mapped = fixtureToAblationScenarios(PROCEDURAL_RECALL_E2E_FIXTURE);
+  assert.equal(mapped.length, PROCEDURAL_RECALL_E2E_FIXTURE.length);
+  for (const row of mapped) {
+    assert.equal(typeof row.expectMatch, "boolean");
+    assert.equal(typeof row.prompt, "string");
+    assert.ok(Array.isArray(row.procedureSteps));
+  }
+});
+
+test("loadAblationFixture parses a valid JSON array", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-fixture-"));
+  try {
+    const p = path.join(dir, "fixture.json");
+    await writeFile(p, JSON.stringify(ABLATION_FIXTURE), "utf8");
+    const loaded = await loadAblationFixture(p);
+    assert.equal(loaded.length, ABLATION_FIXTURE.length);
+    assert.equal(loaded[0]!.id, "deploy-gateway");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAblationFixture parses { scenarios: [...] } wrapper", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-fixture-"));
+  try {
+    const p = path.join(dir, "fixture.json");
+    await writeFile(
+      p,
+      JSON.stringify({ scenarios: ABLATION_FIXTURE }),
+      "utf8",
+    );
+    const loaded = await loadAblationFixture(p);
+    assert.equal(loaded.length, ABLATION_FIXTURE.length);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("loadAblationFixture rejects invalid input", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-fixture-"));
+  try {
+    const p = path.join(dir, "fixture.json");
+    await writeFile(p, "null", "utf8");
+    await assert.rejects(() => loadAblationFixture(p), /must be a JSON object/);
+
+    await writeFile(p, "{}", "utf8");
+    await assert.rejects(() => loadAblationFixture(p), /scenarios.*array/);
+
+    await writeFile(p, "[{}]", "utf8");
+    await assert.rejects(() => loadAblationFixture(p), /missing one of/);
+
+    await writeFile(p, "not-json", "utf8");
+    await assert.rejects(() => loadAblationFixture(p), /parse fixture JSON/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runProceduralAblationCli writes an artifact to --out", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-cli-"));
+  try {
+    const fixturePath = path.join(dir, "fixture.json");
+    const outPath = path.join(dir, "artifact.json");
+    await writeFile(fixturePath, JSON.stringify(ABLATION_FIXTURE), "utf8");
+
+    const artifact = await runProceduralAblationCli({
+      fixturePath,
+      outPath,
+      random: mulberry32(7),
+      bootstrapIterations: 100,
+    });
+    assert.equal(artifact.fixture.path, fixturePath);
+    assert.equal(artifact.fixture.scenarioCount, ABLATION_FIXTURE.length);
+
+    const disk = JSON.parse(await readFile(outPath, "utf8")) as {
+      schemaVersion: number;
+      onScore: number;
+      offScore: number;
+      lift: number;
+    };
+    assert.equal(disk.schemaVersion, 1);
+    assert.equal(disk.onScore, artifact.onScore);
+    assert.equal(disk.offScore, artifact.offScore);
+    assert.equal(disk.lift, artifact.lift);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runProceduralAblationCli falls back to built-in fixture when --fixture omitted", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-cli-"));
+  try {
+    const outPath = path.join(dir, "artifact.json");
+    const artifact = await runProceduralAblationCli({
+      fixturePath: null,
+      outPath,
+      random: mulberry32(7),
+      bootstrapIterations: 100,
+    });
+    assert.equal(artifact.fixture.path, null);
+    assert.equal(
+      artifact.fixture.scenarioCount,
+      PROCEDURAL_RECALL_E2E_FIXTURE.length,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
@@ -130,9 +130,29 @@ test("runProceduralAblation: rejects empty scenarios", async () => {
   );
 });
 
-test("fixtureToAblationScenarios maps from the existing e2e fixture", () => {
+test("fixtureToAblationScenarios skips gate-control rows and preserves on-side rows", () => {
   const mapped = fixtureToAblationScenarios(PROCEDURAL_RECALL_E2E_FIXTURE);
-  assert.equal(mapped.length, PROCEDURAL_RECALL_E2E_FIXTURE.length);
+  const eligible = PROCEDURAL_RECALL_E2E_FIXTURE.filter(
+    (c) => c.proceduralEnabled !== false,
+  );
+  assert.equal(mapped.length, eligible.length);
+  // Every mapped row must derive from a row where procedural was ON (or
+  // unset), so `expectMatch` reflects ON-side ground truth.
+  const mappedIds = new Set(mapped.map((m) => m.id));
+  for (const c of eligible) {
+    assert.ok(
+      mappedIds.has(c.id),
+      `eligible row ${c.id} should map through`,
+    );
+  }
+  for (const c of PROCEDURAL_RECALL_E2E_FIXTURE) {
+    if (c.proceduralEnabled === false) {
+      assert.ok(
+        !mappedIds.has(c.id),
+        `gate-control row ${c.id} must NOT appear in mapped scenarios`,
+      );
+    }
+  }
   for (const row of mapped) {
     assert.equal(typeof row.expectMatch, "boolean");
     assert.equal(typeof row.prompt, "string");
@@ -184,6 +204,25 @@ test("loadAblationFixture rejects invalid input", async () => {
 
     await writeFile(p, "not-json", "utf8");
     await assert.rejects(() => loadAblationFixture(p), /parse fixture JSON/);
+
+    // Rejects non-string tags instead of silently filtering them. Dropping a
+    // malformed tag changes recall scoring (tags are used in overlap text),
+    // so strict rejection prevents silently corrupted benchmark scores.
+    const withBadTag = [
+      {
+        id: "x",
+        prompt: "p",
+        procedurePreamble: "pp",
+        procedureSteps: [{ order: 1, intent: "do" }],
+        procedureTags: ["deploy", 42],
+        expectMatch: true,
+      },
+    ];
+    await writeFile(p, JSON.stringify(withBadTag), "utf8");
+    await assert.rejects(
+      () => loadAblationFixture(p),
+      /procedureTags\[1\] must be a string/,
+    );
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -231,10 +270,10 @@ test("runProceduralAblationCli falls back to built-in fixture when --fixture omi
       bootstrapIterations: 100,
     });
     assert.equal(artifact.fixture.path, null);
-    assert.equal(
-      artifact.fixture.scenarioCount,
-      PROCEDURAL_RECALL_E2E_FIXTURE.length,
-    );
+    const expected = PROCEDURAL_RECALL_E2E_FIXTURE.filter(
+      (c) => c.proceduralEnabled !== false,
+    ).length;
+    assert.equal(artifact.fixture.scenarioCount, expected);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts
@@ -367,3 +367,25 @@ test("runProceduralAblationCli falls back to built-in fixture when --fixture omi
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("runProceduralAblationCli creates missing parent directories for --out", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "remnic-ablation-cli-mkdir-"));
+  try {
+    // Nested, not-yet-existing output directory.
+    const outPath = path.join(dir, "nested", "deeper", "artifact.json");
+    const artifact = await runProceduralAblationCli({
+      fixturePath: null,
+      outPath,
+      random: mulberry32(7),
+      bootstrapIterations: 50,
+    });
+    const disk = JSON.parse(await readFile(outPath, "utf8")) as {
+      schemaVersion: number;
+      onScore: number;
+    };
+    assert.equal(disk.schemaVersion, 1);
+    assert.equal(disk.onScore, artifact.onScore);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
@@ -1,0 +1,350 @@
+/**
+ * Procedural recall ablation harness (issue #567 PR 1/5).
+ *
+ * Runs the same fixture twice — once with `procedural.enabled=false`, once
+ * with `procedural.enabled=true` — and emits a diff artifact:
+ *
+ *   { onScore, offScore, lift, confidenceInterval }
+ *
+ * The harness is deterministic and uses no LLM calls: the "stub LLM adapter"
+ * requirement is satisfied because the scoring function is a pure, local
+ * check (`buildProcedureRecallSection` returns markdown when gating + token
+ * overlap thresholds pass). Downstream slices (PR 2) plug in a stub response
+ * adapter via `StubLlmAdapter` for scenarios that need free-form generation.
+ *
+ * CLI: `remnic bench procedural-ablation --fixture <path> --out <path>`
+ */
+import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import {
+  StorageManager,
+  parseConfig,
+  buildProcedureRecallSection,
+  buildProcedureMarkdownBody,
+} from "@remnic/core";
+import { pairedDeltaConfidenceInterval } from "../../../stats/bootstrap.js";
+import type { ConfidenceInterval } from "../../../types.js";
+import {
+  PROCEDURAL_RECALL_E2E_FIXTURE,
+  type ProceduralRecallE2eCase,
+} from "./fixture.js";
+
+/**
+ * Scenario shape for the ablation harness. A superset of
+ * `ProceduralRecallE2eCase` with an `expectMatch` alias so downstream fixtures
+ * can be expressed in either vocabulary.
+ */
+export interface ProceduralAblationScenario {
+  id: string;
+  prompt: string;
+  procedurePreamble: string;
+  procedureSteps: Array<{ order: number; intent: string }>;
+  procedureTags: string[];
+  /**
+   * True when the prompt should recall the procedure. False for distractor /
+   * non-task-initiation prompts where we expect the gate to reject.
+   */
+  expectMatch: boolean;
+}
+
+export interface ProceduralAblationPerCase {
+  id: string;
+  prompt: string;
+  expectMatch: boolean;
+  onMatched: boolean;
+  offMatched: boolean;
+  onScore: number;
+  offScore: number;
+}
+
+export interface ProceduralAblationArtifact {
+  schemaVersion: 1;
+  fixture: {
+    path: string | null;
+    scenarioCount: number;
+  };
+  onScore: number;
+  offScore: number;
+  lift: number;
+  confidenceInterval: ConfidenceInterval;
+  perCase: ProceduralAblationPerCase[];
+  generatedAt: string;
+}
+
+/**
+ * Score a single scenario: 1 if the observed recall matches expectation, else 0.
+ * This is a binary correctness metric, so `lift = onScore - offScore` is
+ * directly interpretable as points of accuracy gained by turning procedural
+ * recall on.
+ */
+function scoreCase(expectMatch: boolean, observedMatch: boolean): number {
+  return observedMatch === expectMatch ? 1 : 0;
+}
+
+/**
+ * Convert the existing `ProceduralRecallE2eCase` fixture into
+ * ablation-scenario shape. A case `expects` a match iff its gold label was
+ * `expectNonNullSection=true` AND the original fixture intended procedural to
+ * be on for that row (we normalize the ablation to always sweep both sides).
+ */
+export function fixtureToAblationScenarios(
+  fixture: ProceduralRecallE2eCase[],
+): ProceduralAblationScenario[] {
+  return fixture.map((c) => ({
+    id: c.id,
+    prompt: c.prompt,
+    procedurePreamble: c.procedurePreamble,
+    procedureSteps: c.procedureSteps,
+    procedureTags: c.procedureTags,
+    // When the original fixture row had proceduralEnabled=false it was
+    // testing the "gate rejects when disabled" invariant; for the ablation we
+    // always want to know if a task-initiation prompt *should* recall given
+    // procedural is on, so we fall back to the non-null expectation directly.
+    expectMatch: c.expectNonNullSection === true,
+  }));
+}
+
+/**
+ * Run one side of the ablation: seed a temp store with each scenario's
+ * procedure, then invoke `buildProcedureRecallSection` with the requested
+ * gating and observe whether a non-null section was returned.
+ */
+async function runSide(
+  scenarios: ProceduralAblationScenario[],
+  proceduralEnabled: boolean,
+): Promise<boolean[]> {
+  const observed: boolean[] = [];
+  for (const scenario of scenarios) {
+    const dir = await mkdtemp(
+      path.join(os.tmpdir(), "remnic-bench-proc-ablation-"),
+    );
+    try {
+      const storage = new StorageManager(dir);
+      await storage.ensureDirectories();
+      const body = buildProcedureMarkdownBody(scenario.procedureSteps);
+      await storage.writeMemory(
+        "procedure",
+        `${scenario.procedurePreamble}\n\n${body}`,
+        { source: "bench", tags: scenario.procedureTags },
+      );
+
+      const config = parseConfig({
+        memoryDir: dir,
+        workspaceDir: path.join(dir, "ws"),
+        openaiApiKey: "bench-key",
+        procedural: {
+          enabled: proceduralEnabled,
+          recallMaxProcedures: 3,
+        },
+      });
+
+      const section = await buildProcedureRecallSection(
+        storage,
+        scenario.prompt,
+        config,
+      );
+      observed.push(section !== null && section.length > 0);
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  }
+  return observed;
+}
+
+export interface RunProceduralAblationOptions {
+  scenarios: ProceduralAblationScenario[];
+  /** Path the ablation was loaded from (echoed back into the artifact). */
+  fixturePath?: string | null;
+  /** Bootstrap iterations for CI on the paired delta (default: 1_000). */
+  bootstrapIterations?: number;
+  /** Seeded RNG for deterministic CI in tests / CI. */
+  random?: () => number;
+}
+
+/**
+ * Pure entrypoint — accepts a scenario list and returns the artifact. Reads
+ * and writes are isolated to the StorageManager temp directories the sides
+ * create and remove internally.
+ */
+export async function runProceduralAblation(
+  options: RunProceduralAblationOptions,
+): Promise<ProceduralAblationArtifact> {
+  const { scenarios } = options;
+  if (!Array.isArray(scenarios) || scenarios.length === 0) {
+    throw new Error(
+      "runProceduralAblation requires a non-empty scenarios array",
+    );
+  }
+
+  const onMatched = await runSide(scenarios, true);
+  const offMatched = await runSide(scenarios, false);
+
+  const onPer = scenarios.map((s, i) => scoreCase(s.expectMatch, onMatched[i]!));
+  const offPer = scenarios.map((s, i) =>
+    scoreCase(s.expectMatch, offMatched[i]!),
+  );
+
+  const onScore =
+    onPer.reduce((sum, value) => sum + value, 0) / onPer.length;
+  const offScore =
+    offPer.reduce((sum, value) => sum + value, 0) / offPer.length;
+  const lift = onScore - offScore;
+
+  const confidenceInterval = pairedDeltaConfidenceInterval(onPer, offPer, {
+    iterations: options.bootstrapIterations ?? 1_000,
+    random: options.random ?? Math.random,
+  });
+
+  const perCase: ProceduralAblationPerCase[] = scenarios.map((s, i) => ({
+    id: s.id,
+    prompt: s.prompt,
+    expectMatch: s.expectMatch,
+    onMatched: onMatched[i]!,
+    offMatched: offMatched[i]!,
+    onScore: onPer[i]!,
+    offScore: offPer[i]!,
+  }));
+
+  return {
+    schemaVersion: 1,
+    fixture: {
+      path: options.fixturePath ?? null,
+      scenarioCount: scenarios.length,
+    },
+    onScore,
+    offScore,
+    lift,
+    confidenceInterval,
+    perCase,
+    generatedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Load a scenario list from a JSON file. Validates the JSON is an object with
+ * a `scenarios` array (or a bare array) and each entry has the required
+ * fields. Rejects invalid input per CLAUDE.md rule 51 rather than silently
+ * defaulting.
+ */
+export async function loadAblationFixture(
+  fixturePath: string,
+): Promise<ProceduralAblationScenario[]> {
+  const raw = await readFile(fixturePath, "utf8");
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `Failed to parse fixture JSON at ${fixturePath}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error(`Fixture at ${fixturePath} must be a JSON object or array`);
+  }
+  const scenariosRaw = Array.isArray(parsed)
+    ? parsed
+    : Array.isArray((parsed as { scenarios?: unknown }).scenarios)
+      ? (parsed as { scenarios: unknown[] }).scenarios
+      : null;
+  if (!Array.isArray(scenariosRaw)) {
+    throw new Error(
+      `Fixture at ${fixturePath} must contain a \"scenarios\" array or be an array at the top level`,
+    );
+  }
+
+  const scenarios: ProceduralAblationScenario[] = [];
+  for (let i = 0; i < scenariosRaw.length; i++) {
+    const row = scenariosRaw[i];
+    if (!row || typeof row !== "object") {
+      throw new Error(`Fixture scenario at index ${i} must be an object`);
+    }
+    const r = row as Record<string, unknown>;
+    const id = typeof r.id === "string" ? r.id : null;
+    const prompt = typeof r.prompt === "string" ? r.prompt : null;
+    const preamble =
+      typeof r.procedurePreamble === "string" ? r.procedurePreamble : null;
+    const steps = Array.isArray(r.procedureSteps) ? r.procedureSteps : null;
+    const tags = Array.isArray(r.procedureTags)
+      ? (r.procedureTags as unknown[]).filter(
+          (t): t is string => typeof t === "string",
+        )
+      : null;
+    const expect = typeof r.expectMatch === "boolean" ? r.expectMatch : null;
+    if (
+      id === null ||
+      prompt === null ||
+      preamble === null ||
+      steps === null ||
+      tags === null ||
+      expect === null
+    ) {
+      throw new Error(
+        `Fixture scenario at index ${i} is missing one of: id, prompt, procedurePreamble, procedureSteps, procedureTags, expectMatch`,
+      );
+    }
+    const normalizedSteps: Array<{ order: number; intent: string }> = [];
+    for (let j = 0; j < steps.length; j++) {
+      const s = steps[j];
+      if (!s || typeof s !== "object") {
+        throw new Error(
+          `Fixture scenario ${id} step ${j} must be an object with order and intent`,
+        );
+      }
+      const obj = s as Record<string, unknown>;
+      const order =
+        typeof obj.order === "number" && Number.isFinite(obj.order)
+          ? Math.floor(obj.order)
+          : j + 1;
+      const intent = typeof obj.intent === "string" ? obj.intent : null;
+      if (intent === null) {
+        throw new Error(
+          `Fixture scenario ${id} step ${j} is missing string \"intent\"`,
+        );
+      }
+      normalizedSteps.push({ order, intent });
+    }
+    scenarios.push({
+      id,
+      prompt,
+      procedurePreamble: preamble,
+      procedureSteps: normalizedSteps,
+      procedureTags: tags,
+      expectMatch: expect,
+    });
+  }
+  return scenarios;
+}
+
+/**
+ * CLI entrypoint. Resolves `--fixture <path>` (defaults to the built-in e2e
+ * fixture converted to ablation scenarios when unset) and writes the artifact
+ * to `--out <path>`. Validates inputs per CLAUDE.md rules 14 / 17 / 51.
+ */
+export interface RunProceduralAblationCliArgs {
+  fixturePath: string | null;
+  outPath: string;
+  bootstrapIterations?: number;
+  random?: () => number;
+}
+
+export async function runProceduralAblationCli(
+  args: RunProceduralAblationCliArgs,
+): Promise<ProceduralAblationArtifact> {
+  const scenarios =
+    args.fixturePath !== null
+      ? await loadAblationFixture(args.fixturePath)
+      : fixtureToAblationScenarios(PROCEDURAL_RECALL_E2E_FIXTURE);
+
+  const artifact = await runProceduralAblation({
+    scenarios,
+    fixturePath: args.fixturePath,
+    bootstrapIterations: args.bootstrapIterations,
+    random: args.random,
+  });
+
+  await writeFile(args.outPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
+  return artifact;
+}

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
@@ -84,25 +84,38 @@ function scoreCase(expectMatch: boolean, observedMatch: boolean): number {
 
 /**
  * Convert the existing `ProceduralRecallE2eCase` fixture into
- * ablation-scenario shape. A case `expects` a match iff its gold label was
- * `expectNonNullSection=true` AND the original fixture intended procedural to
- * be on for that row (we normalize the ablation to always sweep both sides).
+ * ablation-scenario shape. The ablation ALWAYS sweeps procedural on and off,
+ * so `expectMatch` must reflect what the prompt + procedure pair should do
+ * WHEN PROCEDURAL IS ON — not what the original row's `proceduralEnabled`
+ * flag produced.
+ *
+ * Gate-control rows in the e2e fixture (where `proceduralEnabled=false`
+ * produces `expectNonNullSection=false` only because of the gate, not the
+ * content) are excluded here: their ON-side outcome is content-dependent and
+ * not something this mapper can label correctly without re-running
+ * `buildProcedureRecallSection`. Callers that need those rows should write
+ * the scenario directly with an explicit `expectMatch`.
  */
 export function fixtureToAblationScenarios(
   fixture: ProceduralRecallE2eCase[],
 ): ProceduralAblationScenario[] {
-  return fixture.map((c) => ({
-    id: c.id,
-    prompt: c.prompt,
-    procedurePreamble: c.procedurePreamble,
-    procedureSteps: c.procedureSteps,
-    procedureTags: c.procedureTags,
-    // When the original fixture row had proceduralEnabled=false it was
-    // testing the "gate rejects when disabled" invariant; for the ablation we
-    // always want to know if a task-initiation prompt *should* recall given
-    // procedural is on, so we fall back to the non-null expectation directly.
-    expectMatch: c.expectNonNullSection === true,
-  }));
+  const scenarios: ProceduralAblationScenario[] = [];
+  for (const c of fixture) {
+    // Skip rows whose `expectNonNullSection` only expresses gate-off
+    // behavior — we cannot derive ON-side ground truth from them.
+    if (c.proceduralEnabled === false) continue;
+    scenarios.push({
+      id: c.id,
+      prompt: c.prompt,
+      procedurePreamble: c.procedurePreamble,
+      procedureSteps: c.procedureSteps,
+      procedureTags: c.procedureTags,
+      // `proceduralEnabled` was true (or undefined), so
+      // `expectNonNullSection` reflects the ON-side ground truth.
+      expectMatch: c.expectNonNullSection === true,
+    });
+  }
+  return scenarios;
 }
 
 /**
@@ -267,11 +280,18 @@ export async function loadAblationFixture(
     const preamble =
       typeof r.procedurePreamble === "string" ? r.procedurePreamble : null;
     const steps = Array.isArray(r.procedureSteps) ? r.procedureSteps : null;
-    const tags = Array.isArray(r.procedureTags)
-      ? (r.procedureTags as unknown[]).filter(
-          (t): t is string => typeof t === "string",
-        )
-      : null;
+    let tags: string[] | null = null;
+    if (Array.isArray(r.procedureTags)) {
+      const raw = r.procedureTags as unknown[];
+      for (let k = 0; k < raw.length; k++) {
+        if (typeof raw[k] !== "string") {
+          throw new Error(
+            `Fixture scenario at index ${i}: procedureTags[${k}] must be a string (got ${typeof raw[k]})`,
+          );
+        }
+      }
+      tags = raw as string[];
+    }
     const expect = typeof r.expectMatch === "boolean" ? r.expectMatch : null;
     if (
       id === null ||

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
@@ -14,7 +14,7 @@
  *
  * CLI: `remnic bench procedural-ablation --fixture <path> --out <path>`
  */
-import { mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile, readFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import {
@@ -427,6 +427,8 @@ export async function runProceduralAblationCli(
     seed: args.seed,
   });
 
+  const outDir = path.dirname(path.resolve(args.outPath));
+  await mkdir(outDir, { recursive: true });
   await writeFile(args.outPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");
   return artifact;
 }

--- a/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
+++ b/packages/bench/src/benchmarks/remnic/procedural-recall/ablation.ts
@@ -165,14 +165,46 @@ async function runSide(
   return observed;
 }
 
+/**
+ * Default bootstrap seed used when no `random` / `seed` override is supplied.
+ * Fixing this makes CI bounds reproducible across CLI invocations — flaky CI
+ * bounds would break artifact-based comparisons and saved baselines.
+ */
+export const DEFAULT_ABLATION_BOOTSTRAP_SEED = 0x72656d6e; // ASCII "remn"
+
+/**
+ * Mulberry32 seeded RNG. Inlined (and re-used from tests) so callers can get a
+ * deterministic default without needing an external dependency.
+ */
+export function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0;
+  return () => {
+    state = (state + 0x6d2b79f5) >>> 0;
+    let t = state;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
 export interface RunProceduralAblationOptions {
   scenarios: ProceduralAblationScenario[];
   /** Path the ablation was loaded from (echoed back into the artifact). */
   fixturePath?: string | null;
   /** Bootstrap iterations for CI on the paired delta (default: 1_000). */
   bootstrapIterations?: number;
-  /** Seeded RNG for deterministic CI in tests / CI. */
+  /**
+   * Seeded RNG for the bootstrap. Defaults to
+   * `createSeededRandom(DEFAULT_ABLATION_BOOTSTRAP_SEED)` so CI bounds are
+   * deterministic across repeated CLI invocations. Pass `Math.random`
+   * explicitly to opt into non-deterministic sampling.
+   */
   random?: () => number;
+  /**
+   * Convenience alternative to `random`: if provided (and `random` is not),
+   * a seeded mulberry32 RNG is built from this integer.
+   */
+  seed?: number;
 }
 
 /**
@@ -204,9 +236,14 @@ export async function runProceduralAblation(
     offPer.reduce((sum, value) => sum + value, 0) / offPer.length;
   const lift = onScore - offScore;
 
+  const rng =
+    options.random ??
+    (typeof options.seed === "number"
+      ? createSeededRandom(options.seed)
+      : createSeededRandom(DEFAULT_ABLATION_BOOTSTRAP_SEED));
   const confidenceInterval = pairedDeltaConfidenceInterval(onPer, offPer, {
     iterations: options.bootstrapIterations ?? 1_000,
-    random: options.random ?? Math.random,
+    random: rng,
   });
 
   const perCase: ProceduralAblationPerCase[] = scenarios.map((s, i) => ({
@@ -314,10 +351,28 @@ export async function loadAblationFixture(
         );
       }
       const obj = s as Record<string, unknown>;
-      const order =
-        typeof obj.order === "number" && Number.isFinite(obj.order)
-          ? Math.floor(obj.order)
-          : j + 1;
+      // Reject non-integer / non-positive `order` values explicitly instead
+      // of coercing via Math.floor or defaulting to positional index. Step
+      // order is load-bearing for serialized procedure bodies; a silently
+      // rounded 1.7 → 1 changes both the written markdown and the recall
+      // scoring text.
+      let order: number;
+      if (obj.order === undefined) {
+        order = j + 1;
+      } else if (
+        typeof obj.order !== "number" ||
+        !Number.isFinite(obj.order) ||
+        !Number.isInteger(obj.order) ||
+        obj.order < 1
+      ) {
+        throw new Error(
+          `Fixture scenario ${id} step ${j}: order must be a positive integer (got ${JSON.stringify(
+            obj.order,
+          )})`,
+        );
+      } else {
+        order = obj.order;
+      }
       const intent = typeof obj.intent === "string" ? obj.intent : null;
       if (intent === null) {
         throw new Error(
@@ -348,6 +403,12 @@ export interface RunProceduralAblationCliArgs {
   outPath: string;
   bootstrapIterations?: number;
   random?: () => number;
+  /**
+   * Optional seed for the bootstrap RNG. When omitted the harness uses
+   * `DEFAULT_ABLATION_BOOTSTRAP_SEED` so CLI runs are reproducible by
+   * default.
+   */
+  seed?: number;
 }
 
 export async function runProceduralAblationCli(
@@ -363,6 +424,7 @@ export async function runProceduralAblationCli(
     fixturePath: args.fixturePath,
     bootstrapIterations: args.bootstrapIterations,
     random: args.random,
+    seed: args.seed,
   });
 
   await writeFile(args.outPath, JSON.stringify(artifact, null, 2) + "\n", "utf8");

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -309,6 +309,8 @@ export {
   runProceduralAblationCli,
   loadAblationFixture,
   fixtureToAblationScenarios,
+  createSeededRandom as createProceduralAblationSeededRandom,
+  DEFAULT_ABLATION_BOOTSTRAP_SEED,
 } from "./benchmarks/remnic/procedural-recall/ablation.js";
 export type {
   ProceduralAblationArtifact,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -302,3 +302,18 @@ export {
   assistantSynthesisDefinition,
   runAssistantSynthesisBenchmark,
 } from "./benchmarks/remnic/assistant-synthesis/runner.js";
+
+// Procedural recall ablation harness (issue #567 PR 1/5).
+export {
+  runProceduralAblation,
+  runProceduralAblationCli,
+  loadAblationFixture,
+  fixtureToAblationScenarios,
+} from "./benchmarks/remnic/procedural-recall/ablation.js";
+export type {
+  ProceduralAblationArtifact,
+  ProceduralAblationPerCase,
+  ProceduralAblationScenario,
+  RunProceduralAblationCliArgs,
+  RunProceduralAblationOptions,
+} from "./benchmarks/remnic/procedural-recall/ablation.js";

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -510,6 +510,8 @@ Commands:
   providers discover       Auto-detect available local provider backends
   check                    Legacy latency regression gate (compatibility)
   report                   Legacy latency report generator (compatibility)
+  procedural-ablation --out <path> [--fixture <path>]
+                           Run the procedural recall ablation harness (issue #567)
 
 Options:
   --quick                  Run a lightweight quick pass (maps to --lightweight --limit 1)
@@ -568,6 +570,7 @@ Examples:
   remnic bench publish --target remnic-ai
   remnic bench providers discover
   remnic bench run --custom ./my-bench.yaml
+  remnic bench procedural-ablation --out ./artifacts/procedural-ablation.json
   remnic benchmark run --quick longmemeval`;
 }
 
@@ -4024,6 +4027,14 @@ async function cmdLegacyBenchmark(action: string, rest: string[], json: boolean)
 }
 
 async function cmdBench(rest: string[]): Promise<void> {
+  // Procedural ablation subcommand (issue #567 PR 1/5). Routed before the
+  // standard bench dispatcher because `procedural-ablation` is an ad-hoc
+  // harness, not a registered benchmark catalogue entry.
+  if (rest[0] === "procedural-ablation") {
+    await cmdBenchProceduralAblation(rest.slice(1));
+    return;
+  }
+
   const benchAction = parseBenchActionArgs(rest);
   let parsed: ParsedBenchArgs;
   try {
@@ -4150,6 +4161,85 @@ async function cmdBench(rest: string[]): Promise<void> {
       }
     }
   }
+}
+
+/**
+ * `remnic bench procedural-ablation --fixture <path> --out <path>` (issue
+ * #567 PR 1/5). Runs the procedural recall ablation harness and writes a
+ * JSON artifact containing onScore / offScore / lift / CI.
+ */
+async function cmdBenchProceduralAblation(rest: string[]): Promise<void> {
+  if (rest.includes("--help") || rest.includes("-h")) {
+    console.log(`remnic bench procedural-ablation — Procedural recall ablation harness (issue #567)
+
+Usage:
+  remnic bench procedural-ablation --out <path> [--fixture <path>]
+
+Options:
+  --fixture <path>   JSON fixture file; either a top-level array of scenarios
+                     or { "scenarios": [...] }. Each scenario requires
+                     id, prompt, procedurePreamble, procedureSteps,
+                     procedureTags, expectMatch. When omitted, the built-in
+                     procedural-recall fixture is used.
+  --out <path>       Path to write the ablation artifact JSON.
+`);
+    return;
+  }
+
+  let fixturePathRaw: string | undefined;
+  let outPathRaw: string | undefined;
+  try {
+    fixturePathRaw = resolveRequiredValueFlag(rest, "--fixture");
+    outPathRaw =
+      resolveRequiredValueFlag(rest, "--out") ??
+      resolveRequiredValueFlag(rest, "--output");
+  } catch (err) {
+    console.error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (!outPathRaw) {
+    console.error(
+      "--out <path> is required. Run `remnic bench procedural-ablation --help`.",
+    );
+    process.exit(1);
+  }
+
+  const fixturePath = fixturePathRaw
+    ? path.resolve(expandTilde(fixturePathRaw))
+    : null;
+  const outPath = path.resolve(expandTilde(outPathRaw));
+
+  const benchModule = await loadBenchModule();
+  const runner = (
+    benchModule as unknown as {
+      runProceduralAblationCli?: (args: {
+        fixturePath: string | null;
+        outPath: string;
+      }) => Promise<{
+        onScore: number;
+        offScore: number;
+        lift: number;
+        fixture: { scenarioCount: number };
+      }>;
+    }
+  ).runProceduralAblationCli;
+  if (typeof runner !== "function") {
+    console.error(
+      "The installed @remnic/bench build does not expose runProceduralAblationCli. Upgrade to a build that includes issue #567 PR 1.",
+    );
+    process.exit(1);
+  }
+
+  const artifact = await runner({ fixturePath, outPath });
+  console.log(
+    `procedural-ablation complete: scenarios=${artifact.fixture.scenarioCount} onScore=${artifact.onScore.toFixed(
+      4,
+    )} offScore=${artifact.offScore.toFixed(4)} lift=${artifact.lift.toFixed(
+      4,
+    )}`,
+  );
+  console.log(`wrote ${outPath}`);
 }
 
 // ── Daemon management ────────────────────────────────────────────────────────

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4219,9 +4219,17 @@ Options:
     seed = parsedSeed;
   }
 
-  const fixturePath = fixturePathRaw
-    ? path.resolve(expandTilde(fixturePathRaw))
-    : null;
+  let fixturePath: string | null;
+  if (fixturePathRaw === undefined) {
+    fixturePath = null;
+  } else if (fixturePathRaw.trim() === "") {
+    console.error(
+      "--fixture requires a non-empty path. Omit the flag to use the built-in fixture.",
+    );
+    process.exit(1);
+  } else {
+    fixturePath = path.resolve(expandTilde(fixturePathRaw));
+  }
   const outPath = path.resolve(expandTilde(outPathRaw));
 
   const benchModule = await loadBenchModule();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4173,7 +4173,7 @@ async function cmdBenchProceduralAblation(rest: string[]): Promise<void> {
     console.log(`remnic bench procedural-ablation — Procedural recall ablation harness (issue #567)
 
 Usage:
-  remnic bench procedural-ablation --out <path> [--fixture <path>]
+  remnic bench procedural-ablation --out <path> [--fixture <path>] [--seed <n>]
 
 Options:
   --fixture <path>   JSON fixture file; either a top-level array of scenarios
@@ -4182,17 +4182,21 @@ Options:
                      procedureTags, expectMatch. When omitted, the built-in
                      procedural-recall fixture is used.
   --out <path>       Path to write the ablation artifact JSON.
+  --seed <n>         Integer seed for the bootstrap RNG. Defaults to a fixed
+                     seed so CI bounds are reproducible across runs.
 `);
     return;
   }
 
   let fixturePathRaw: string | undefined;
   let outPathRaw: string | undefined;
+  let seedRaw: string | undefined;
   try {
     fixturePathRaw = resolveRequiredValueFlag(rest, "--fixture");
     outPathRaw =
       resolveRequiredValueFlag(rest, "--out") ??
       resolveRequiredValueFlag(rest, "--output");
+    seedRaw = resolveRequiredValueFlag(rest, "--seed");
   } catch (err) {
     console.error(err instanceof Error ? err.message : String(err));
     process.exit(1);
@@ -4203,6 +4207,16 @@ Options:
       "--out <path> is required. Run `remnic bench procedural-ablation --help`.",
     );
     process.exit(1);
+  }
+
+  let seed: number | undefined;
+  if (seedRaw !== undefined) {
+    const parsedSeed = Number(seedRaw);
+    if (!Number.isFinite(parsedSeed) || !Number.isInteger(parsedSeed)) {
+      console.error(`--seed must be an integer (got "${seedRaw}").`);
+      process.exit(1);
+    }
+    seed = parsedSeed;
   }
 
   const fixturePath = fixturePathRaw
@@ -4216,6 +4230,7 @@ Options:
       runProceduralAblationCli?: (args: {
         fixturePath: string | null;
         outPath: string;
+        seed?: number;
       }) => Promise<{
         onScore: number;
         offScore: number;
@@ -4231,7 +4246,7 @@ Options:
     process.exit(1);
   }
 
-  const artifact = await runner({ fixturePath, outPath });
+  const artifact = await runner({ fixturePath, outPath, seed });
   console.log(
     `procedural-ablation complete: scenarios=${artifact.fixture.scenarioCount} onScore=${artifact.onScore.toFixed(
       4,


### PR DESCRIPTION
Part of #567 (slice 1 of 5).

## Summary

- Adds a deterministic procedural-recall ablation harness in `@remnic/bench` that runs the same fixture twice (`procedural.enabled=true` vs `false`) and emits a diff artifact `{ onScore, offScore, lift, confidenceInterval, perCase }`.
- New CLI `remnic bench procedural-ablation --out <path> [--fixture <path>]`. Falls back to the built-in `PROCEDURAL_RECALL_E2E_FIXTURE` when `--fixture` is omitted.
- No LLM calls; the "stub LLM" requirement is satisfied because scoring is a pure, local check through `buildProcedureRecallSection` against a per-scenario temp `StorageManager`. Slice 2 will bring the full 20+ scenario fixture and the `procedural-recall-baseline.json` artifact.

Exports (new, all from `@remnic/bench`):
- `runProceduralAblation`
- `runProceduralAblationCli`
- `loadAblationFixture`
- `fixtureToAblationScenarios`
- types: `ProceduralAblationArtifact`, `ProceduralAblationScenario`, `ProceduralAblationPerCase`, `RunProceduralAblationCliArgs`, `RunProceduralAblationOptions`

CLAUDE.md invariants honored:
- Rule 14 / 51: missing `--out` and missing `--fixture` value throw with an actionable message instead of silently defaulting.
- Rule 17: `--fixture` and `--out` go through `expandTilde`.
- Rule 18: `loadAblationFixture` rejects `null`, bare empty objects, bad types, and missing required fields before any property access.

## Test plan

- [x] `node --test packages/bench/src/benchmarks/remnic/procedural-recall/ablation.test.ts` — 9/9 passing.
- [x] `pnpm --filter @remnic/bench run check-types` — no new errors (3 pre-existing `FallbackLlmRuntimeContext` errors in `responders.ts`/`runtime-profiles.ts` are unrelated to this slice).
- [x] `pnpm --filter @remnic/cli run check-types` — no new errors (1 pre-existing `category !== "ingestion"` narrowing error is unrelated).
- [x] Manual E2E: `remnic bench procedural-ablation --out /tmp/ablation.json` writes a v1 artifact with lift / CI populated.
- [x] Deterministic: seeded RNG reproduces identical `onScore`, `offScore`, `lift`, and CI bounds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new benchmark harness plus a new `remnic bench` subcommand that creates temp storage and writes artifacts, so failures would mainly show up as CLI/bench breakage or flaky filesystem behavior. No runtime/LLM or core feature paths are modified beyond invoking existing procedural recall logic.
> 
> **Overview**
> Adds a deterministic procedural-recall **ablation harness** in `@remnic/bench` that runs each scenario twice (`procedural.enabled` on vs off), scores binary correctness, and emits a v1 artifact with `onScore`, `offScore`, `lift`, paired-bootstrap confidence interval, and per-case breakdown.
> 
> Introduces strict JSON fixture loading/validation (top-level array or `{ scenarios: [...] }`) and a CLI helper that writes the artifact to `--out`, creating parent directories and defaulting to the built-in procedural-recall fixture (excluding gate-control rows).
> 
> Wires the harness into `@remnic/bench` exports and adds a new CLI entrypoint `remnic bench procedural-ablation --out <path> [--fixture <path>] [--seed <n>]`, routed ahead of the standard bench dispatcher; includes comprehensive unit tests covering determinism and input validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f2ee159be5d4d267d5906a4c49c1ebc78917395. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->