### PR TITLE
docs(bench): runbook + /benchmarks entry point (#566 PR 6/7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,10 @@ evals/datasets/
 # per-release by the leaderboard pipeline — see issue #566 slice 6).
 docs/benchmarks/results/
 
+# Published-benchmark datasets (LongMemEval, LoCoMo). Download via
+# `scripts/bench/fetch-datasets.sh --help`. Never commit raw dataset files.
+bench-datasets/
+
 # Git worktrees
 .worktrees/
 PR_PREFLIGHT.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- Published LongMemEval-S + LoCoMo-10 runbook at
+  `docs/benchmarks/runbook.md`, summary at `docs/benchmarks.md`, and
+  the `/benchmarks` page on <https://remnic.ai/benchmarks>.
+- Placeholder artifacts in `docs/benchmarks/results/` prove the
+  `BenchmarkArtifact v1` pipeline end-to-end on a fresh clone; real
+  numbers land in a tagged release per issue #566.
+
 ## [v9.3.6] — 2026-04-14
 
 ### Added

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,0 +1,59 @@
+# Remnic published-benchmark numbers
+
+Remnic evaluates against the same two benchmarks the 2026 memory-agent
+landscape converges on: **LongMemEval-S** and **LoCoMo-10**. Numbers
+below come from the `docs/benchmarks/results/` artifact directory,
+validated by `scripts/bench/verify-artifact.ts` before publication.
+
+See [`docs/benchmarks/runbook.md`](./benchmarks/runbook.md) for the
+exact steps. The runner plumbing is in `@remnic/bench` — notably:
+
+- Dataset loaders: `loadLongMemEvalS()` / `loadLoCoMo10()`
+  ([issue #566 slice 1](https://github.com/joshuaswarren/remnic/pull/580))
+- Artifact schema: `BenchmarkArtifact` v1
+  ([issue #566 slice 3](https://github.com/joshuaswarren/remnic/pull/581))
+- CI regression guard: `.github/workflows/bench-smoke.yml`
+  ([issue #566 slice 7](https://github.com/joshuaswarren/remnic/pull/584))
+
+## What to expect
+
+The first publicly-cited numbers will land in a release tagged once
+slice 6 is executed end-to-end — until then, the
+`docs/benchmarks/results/` directory only contains **mock placeholder
+artifacts** (filename suffix `mock000`, `datasetVersion:
+"mock-fixture"`) so the pipeline can be verified on a fresh clone.
+**Do not cite the mock numbers publicly.**
+
+When real numbers land they will be:
+
+- Committed to `docs/benchmarks/results/` as `BenchmarkArtifact v1`
+  JSON files (one per benchmark × model × run).
+- Rendered on <https://remnic.ai/benchmarks>.
+- Called out in `CHANGELOG.md` under the release that introduced them.
+
+## Reproducibility
+
+Every artifact records:
+
+- `schemaVersion` + `benchmarkId` + `datasetVersion`
+- `system.{name, version, gitSha}` (Remnic version + commit SHA)
+- `model` + `seed`
+- `startedAt` + `finishedAt` + `durationMs`
+- `env.{node, os, arch?}`
+
+To re-run a published number:
+
+```bash
+# From the repo root
+git checkout <artifact.system.gitSha>
+pnpm install && pnpm --filter @remnic/core run build
+# Follow docs/benchmarks/runbook.md with the same --seed and --model.
+```
+
+## Ethics
+
+- No dataset file or raw LLM trace is committed to this repo.
+- No API key, credential, or private profile appears in any artifact.
+- Artifact contents are validated by `parseBenchmarkArtifact()` before
+  serialization; anything that fails the schema is rejected at build
+  time, not silently elided.

--- a/docs/benchmarks/results/2026-04-20-locomo-gpt-4o-mini-mock000.json
+++ b/docs/benchmarks/results/2026-04-20-locomo-gpt-4o-mini-mock000.json
@@ -1,0 +1,28 @@
+{
+  "benchmarkId": "locomo",
+  "datasetVersion": "mock-fixture",
+  "durationMs": 0,
+  "env": {
+    "arch": "x64",
+    "node": "v22.12.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-04-20T12:00:00.000Z",
+  "metrics": {
+    "contains_answer": 0,
+    "f1": 0,
+    "llm_judge": 0,
+    "rouge_l": 0
+  },
+  "model": "gpt-4o-mini",
+  "note": "Placeholder artifact — run scripts documented in docs/benchmarks/runbook.md to produce real numbers. Do NOT cite publicly.",
+  "perTaskScores": [],
+  "schemaVersion": 1,
+  "seed": 42,
+  "startedAt": "2026-04-20T12:00:00.000Z",
+  "system": {
+    "gitSha": "mock000",
+    "name": "remnic",
+    "version": "0.0.0-placeholder"
+  }
+}

--- a/docs/benchmarks/results/2026-04-20-longmemeval-gpt-4o-mini-mock000.json
+++ b/docs/benchmarks/results/2026-04-20-longmemeval-gpt-4o-mini-mock000.json
@@ -1,0 +1,27 @@
+{
+  "benchmarkId": "longmemeval",
+  "datasetVersion": "mock-fixture",
+  "durationMs": 0,
+  "env": {
+    "arch": "x64",
+    "node": "v22.12.0",
+    "os": "linux"
+  },
+  "finishedAt": "2026-04-20T12:00:00.000Z",
+  "metrics": {
+    "contains_answer": 0,
+    "f1": 0,
+    "llm_judge": 0
+  },
+  "model": "gpt-4o-mini",
+  "note": "Placeholder artifact — run scripts documented in docs/benchmarks/runbook.md to produce real numbers. Do NOT cite publicly.",
+  "perTaskScores": [],
+  "schemaVersion": 1,
+  "seed": 42,
+  "startedAt": "2026-04-20T12:00:00.000Z",
+  "system": {
+    "gitSha": "mock000",
+    "name": "remnic",
+    "version": "0.0.0-placeholder"
+  }
+}

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -37,6 +37,12 @@ clone on a machine with appropriate API keys; nothing auto-runs on CI.
 pnpm install
 pnpm --filter @remnic/core run build
 pnpm --filter @remnic/bench run build
+pnpm --filter @remnic/cli run build
+
+# `remnic` is only exposed as a bin from the @remnic/cli workspace
+# package. From repo root use either the shim below or add
+# `packages/remnic-cli/bin` to your PATH for the duration of the run.
+alias remnic='pnpm --filter @remnic/cli exec remnic'
 
 # Print the HuggingFace download commands for the published datasets.
 # The script does NOT auto-download; copy-paste the commands it prints.
@@ -60,7 +66,7 @@ bench-datasets/
 
 ```bash
 OPENAI_API_KEY=... \
-pnpm exec remnic bench run longmemeval \
+pnpm --filter @remnic/cli exec remnic bench run longmemeval \
   --dataset-dir ./bench-datasets/longmemeval \
   --system-provider openai \
   --system-model gpt-4o-mini \
@@ -100,7 +106,7 @@ The runner:
 
 ```bash
 OPENAI_API_KEY=... \
-pnpm exec remnic bench run locomo \
+pnpm --filter @remnic/cli exec remnic bench run locomo \
   --dataset-dir ./bench-datasets/locomo \
   --system-provider openai \
   --system-model gpt-4o-mini \
@@ -126,20 +132,22 @@ OK <filename> <benchmark> model=<id> seed=<n> metrics=<k>=<v>,<k>=<v>,... sha256
 
 ## 6. Publish
 
-Artifacts are committed to `docs/benchmarks/results/`. The site
-(`packages/remnic-site`) reads the directory at build time and renders
-the `/benchmarks` leaderboard page. A release of Remnic publishes the
-site + artifacts together.
+Artifacts live under `docs/benchmarks/results/`. That directory is
+gitignored by default — add the specific artifact you want to publish
+with `git add -f docs/benchmarks/results/<filename>.json` so nothing
+experimental leaks in. The site (`packages/remnic-site`) reads the
+directory at build time and renders the `/benchmarks` leaderboard
+page. A release of Remnic publishes the site + approved artifacts
+together.
 
-Between releases, `docs/benchmarks/results/` is git-tracked by default
-so incremental numbers are visible on the main branch. Individual runs
-can be excluded from the commit if they are experimental / not ready
-for public display.
+If a future release promotes results to tracked-by-default, remove
+the `docs/benchmarks/results/` entry from `.gitignore` in the same
+commit that updates this section.
 
 ## 7. Local-LLM parity run (slice 5, when shipped)
 
 ```bash
-pnpm exec remnic bench run longmemeval \
+pnpm --filter @remnic/cli exec remnic bench run longmemeval \
   --dataset-dir ./bench-datasets/longmemeval \
   --system-provider local-llm \
   --system-base-url http://127.0.0.1:8080 \

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -62,26 +62,39 @@ bench-datasets/
 OPENAI_API_KEY=... \
 pnpm exec remnic bench run longmemeval \
   --dataset-dir ./bench-datasets/longmemeval \
-  --results-dir docs/benchmarks/results/
+  --system-provider openai \
+  --system-model gpt-4o-mini \
+  --judge-provider openai \
+  --judge-model gpt-4o-mini
 ```
+
+`--system-provider` + `--system-model` pin the responder to
+gpt-4o-mini; `--judge-provider` + `--judge-model` pin the LLM judge.
+Without these flags, `remnic bench run` falls back to whatever
+default provider the local config/env point at — your published
+numbers would not be reproducibly "on gpt-4o-mini", so set these
+every time.
 
 The runner:
 
 1. Loads LongMemEval-S via `loadLongMemEvalS()` (slice 1 of #566).
 2. Resets the Remnic orchestrator for each item.
 3. Ingests every haystack session.
-4. Recalls + answers each question via the configured responder.
-5. Scores via `f1`, `contains_answer`, and the LLM judge (configurable).
-6. Writes a `BenchmarkResult` JSON under `--results-dir`. Slice 6 (this
-   PR) + slice 3 wire the `BenchmarkArtifact v1` export as an
-   additional, flatter payload for public leaderboard consumption —
-   run `scripts/bench/verify-artifact.ts` (step 5) over the produced
-   artifact before publishing.
+4. Recalls + answers each question via gpt-4o-mini.
+5. Scores via `f1`, `contains_answer`, and the gpt-4o-mini judge.
+6. Writes a `BenchmarkResult` JSON under the default results store
+   (`~/.remnic/bench/results/` — override via environment or config;
+   the `--results-dir` flag is planned but not wired on the current
+   `bench run` subcommand). Slice 6 (this PR) + slice 3 wire the
+   `BenchmarkArtifact v1` export as an additional, flatter payload
+   for public leaderboard consumption — copy the internal run JSON
+   into `docs/benchmarks/results/` through
+   `buildBenchmarkArtifact()` before publishing, then run
+   `scripts/bench/verify-artifact.ts` (step 5).
 
-> Model / seed / sample limit are set via provider / runtime options in
-> the CLI today. The planned `remnic bench published` subcommand
-> (issue #566 slice 4) will surface them as top-level `--model`,
-> `--seed`, and `--limit` flags.
+> Sample limit + seed are set via runtime options in the CLI today.
+> The planned `remnic bench published` subcommand (issue #566 slice 4)
+> will surface them as top-level `--limit` / `--seed` flags.
 
 ## 4. Run LoCoMo-10 on gpt-4o-mini
 
@@ -89,7 +102,10 @@ The runner:
 OPENAI_API_KEY=... \
 pnpm exec remnic bench run locomo \
   --dataset-dir ./bench-datasets/locomo \
-  --results-dir docs/benchmarks/results/
+  --system-provider openai \
+  --system-model gpt-4o-mini \
+  --judge-provider openai \
+  --judge-model gpt-4o-mini
 ```
 
 Metrics emitted: `f1`, `contains_answer`, `rouge_l`, optional `llm_judge`.
@@ -128,11 +144,13 @@ pnpm exec remnic bench run longmemeval \
   --system-provider local-llm \
   --system-base-url http://127.0.0.1:8080 \
   --system-model llama-3.1-8b-instruct-q4_k_m \
-  --results-dir docs/benchmarks/results/
+  --judge-provider local-llm \
+  --judge-base-url http://127.0.0.1:8080 \
+  --judge-model llama-3.1-8b-instruct-q4_k_m
 ```
 
-The same runner + artifact schema as the cloud run. Only the responder /
-extraction provider differ. The `remnic bench published` subcommand
+The same runner + artifact schema as the cloud run. Only the responder
+/ judge provider differ. The `remnic bench published` subcommand
 planned in PR 4 will expose a cleaner `--provider local-llm --base-url
 ... --model ...` shape.
 

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -163,9 +163,14 @@ planned in PR 4 will expose a cleaner `--provider local-llm --base-url
   The artifact was written by a newer version of `@remnic/bench`.
   Either update the local checkout or inspect the newer schema.
 - **LLM judge returns 0 on everything**
-  Set `BENCH_JUDGE_MODEL` + `BENCH_JUDGE_PROVIDER` explicitly. The
-  default judge hits whatever the adapter's evaluator LLM is — ensure
-  it has access to the expected question/predicted/expected fields.
+  Pass `--judge-provider <openai|anthropic|ollama|litellm>` and
+  `--judge-model <id>` on the `remnic bench run` command. The CLI
+  surface in `packages/remnic-cli/src/bench-args.ts` is the only
+  sanctioned configuration path for the judge today; environment
+  variables are not consumed. Without these flags the runner falls
+  back to whatever the adapter's evaluator LLM is, which can legally
+  score 0 if it lacks access to the `(question, predicted, expected)`
+  tuple format the scorer expects.
 
 ## 9. Mocked example
 

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -9,6 +9,18 @@ clone on a machine with appropriate API keys; nothing auto-runs on CI.
 > runner aggregates + per-task scores land in `docs/benchmarks/results/`.
 > Never commit raw dataset files, API keys, or intermediate LLM traces.
 
+> **Dependencies on sibling slices of #566.** The helper scripts
+> referenced below
+> (`scripts/bench/fetch-datasets.sh`,
+> `scripts/bench/verify-artifact.ts`) land in
+> [PR 1 (#580)](https://github.com/joshuaswarren/remnic/pull/580) and
+> [PR 3 (#581)](https://github.com/joshuaswarren/remnic/pull/581)
+> respectively. A dedicated `remnic bench published` subcommand with
+> `--name` / `--dataset` / `--model` / `--seed` / `--limit` is planned
+> for PR 4 (#566 slice 4) and is not shipped yet. Until then, drive
+> the runners via the current `remnic bench run <id>` + `--dataset-dir`
+> CLI surface as shown below.
+
 ## 1. Prerequisites
 
 - Node.js ≥ 22.12.0 and `pnpm` 10+.
@@ -48,35 +60,36 @@ bench-datasets/
 
 ```bash
 OPENAI_API_KEY=... \
-pnpm exec remnic bench published \
-  --name longmemeval \
-  --dataset ./bench-datasets/longmemeval \
-  --model gpt-4o-mini \
-  --limit 100 \
-  --seed 42 \
-  --out docs/benchmarks/results/
+pnpm exec remnic bench run longmemeval \
+  --dataset-dir ./bench-datasets/longmemeval \
+  --results-dir docs/benchmarks/results/
 ```
 
 The runner:
 
-1. Loads LongMemEval-S via `loadLongMemEvalS()` (slice 1).
+1. Loads LongMemEval-S via `loadLongMemEvalS()` (slice 1 of #566).
 2. Resets the Remnic orchestrator for each item.
 3. Ingests every haystack session.
 4. Recalls + answers each question via the configured responder.
 5. Scores via `f1`, `contains_answer`, and the LLM judge (configurable).
-6. Emits a `BenchmarkArtifact` JSON (slice 3) under
-   `docs/benchmarks/results/<iso-date>-longmemeval-<model>-<sha>.json`.
+6. Writes a `BenchmarkResult` JSON under `--results-dir`. Slice 6 (this
+   PR) + slice 3 wire the `BenchmarkArtifact v1` export as an
+   additional, flatter payload for public leaderboard consumption —
+   run `scripts/bench/verify-artifact.ts` (step 5) over the produced
+   artifact before publishing.
+
+> Model / seed / sample limit are set via provider / runtime options in
+> the CLI today. The planned `remnic bench published` subcommand
+> (issue #566 slice 4) will surface them as top-level `--model`,
+> `--seed`, and `--limit` flags.
 
 ## 4. Run LoCoMo-10 on gpt-4o-mini
 
 ```bash
 OPENAI_API_KEY=... \
-pnpm exec remnic bench published \
-  --name locomo \
-  --dataset ./bench-datasets/locomo \
-  --model gpt-4o-mini \
-  --seed 42 \
-  --out docs/benchmarks/results/
+pnpm exec remnic bench run locomo \
+  --dataset-dir ./bench-datasets/locomo \
+  --results-dir docs/benchmarks/results/
 ```
 
 Metrics emitted: `f1`, `contains_answer`, `rouge_l`, optional `llm_judge`.
@@ -110,18 +123,18 @@ for public display.
 ## 7. Local-LLM parity run (slice 5, when shipped)
 
 ```bash
-pnpm exec remnic bench published \
-  --name longmemeval \
-  --dataset ./bench-datasets/longmemeval \
-  --provider local-llm \
-  --base-url http://127.0.0.1:8080 \
-  --model llama-3.1-8b-instruct-q4_k_m \
-  --seed 42 \
-  --out docs/benchmarks/results/
+pnpm exec remnic bench run longmemeval \
+  --dataset-dir ./bench-datasets/longmemeval \
+  --system-provider local-llm \
+  --system-base-url http://127.0.0.1:8080 \
+  --system-model llama-3.1-8b-instruct-q4_k_m \
+  --results-dir docs/benchmarks/results/
 ```
 
 The same runner + artifact schema as the cloud run. Only the responder /
-extraction provider differ.
+extraction provider differ. The `remnic bench published` subcommand
+planned in PR 4 will expose a cleaner `--provider local-llm --base-url
+... --model ...` shape.
 
 ## 8. Troubleshooting
 

--- a/docs/benchmarks/runbook.md
+++ b/docs/benchmarks/runbook.md
@@ -1,0 +1,147 @@
+# Remnic published-benchmark runbook
+
+This runbook documents how to produce the LongMemEval-S + LoCoMo-10 numbers
+published at <https://remnic.ai/benchmarks>. It is the human-executable
+companion to issue #566 slice 6. Every step must be runnable from a fresh
+clone on a machine with appropriate API keys; nothing auto-runs on CI.
+
+> **Do not commit real user data.** The repository is public. Only the
+> runner aggregates + per-task scores land in `docs/benchmarks/results/`.
+> Never commit raw dataset files, API keys, or intermediate LLM traces.
+
+## 1. Prerequisites
+
+- Node.js ≥ 22.12.0 and `pnpm` 10+.
+- `huggingface-cli` (install via `pipx install "huggingface_hub[cli]"` or
+  `brew install huggingface-cli`). LongMemEval and LoCoMo download from
+  HuggingFace datasets.
+- An OpenAI API key for the cloud run, exposed as `OPENAI_API_KEY`.
+- For the local-LLM parity run (slice 5, future): a local llama.cpp or
+  vLLM server already serving a model at an `http(s)://...` URL.
+
+## 2. One-time setup
+
+```bash
+pnpm install
+pnpm --filter @remnic/core run build
+pnpm --filter @remnic/bench run build
+
+# Print the HuggingFace download commands for the published datasets.
+# The script does NOT auto-download; copy-paste the commands it prints.
+scripts/bench/fetch-datasets.sh --target ./bench-datasets
+```
+
+Expected layout after following the printed commands:
+
+```
+bench-datasets/
+  longmemeval/
+    longmemeval_oracle.json          # preferred
+    longmemeval_s_cleaned.json       # optional alternate
+  locomo/
+    locomo10.json                    # preferred
+```
+
+`bench-datasets/` is gitignored. Never commit it.
+
+## 3. Run LongMemEval-S on gpt-4o-mini
+
+```bash
+OPENAI_API_KEY=... \
+pnpm exec remnic bench published \
+  --name longmemeval \
+  --dataset ./bench-datasets/longmemeval \
+  --model gpt-4o-mini \
+  --limit 100 \
+  --seed 42 \
+  --out docs/benchmarks/results/
+```
+
+The runner:
+
+1. Loads LongMemEval-S via `loadLongMemEvalS()` (slice 1).
+2. Resets the Remnic orchestrator for each item.
+3. Ingests every haystack session.
+4. Recalls + answers each question via the configured responder.
+5. Scores via `f1`, `contains_answer`, and the LLM judge (configurable).
+6. Emits a `BenchmarkArtifact` JSON (slice 3) under
+   `docs/benchmarks/results/<iso-date>-longmemeval-<model>-<sha>.json`.
+
+## 4. Run LoCoMo-10 on gpt-4o-mini
+
+```bash
+OPENAI_API_KEY=... \
+pnpm exec remnic bench published \
+  --name locomo \
+  --dataset ./bench-datasets/locomo \
+  --model gpt-4o-mini \
+  --seed 42 \
+  --out docs/benchmarks/results/
+```
+
+Metrics emitted: `f1`, `contains_answer`, `rouge_l`, optional `llm_judge`.
+
+## 5. Verify artifacts before publishing
+
+```bash
+# Each artifact is validated + re-hashed. Exits non-zero on mismatch.
+pnpm exec tsx scripts/bench/verify-artifact.ts \
+  docs/benchmarks/results/*.json
+```
+
+The output line for each artifact shape is:
+
+```
+OK <filename> <benchmark> model=<id> seed=<n> metrics=<k>=<v>,<k>=<v>,... sha256=<hex>
+```
+
+## 6. Publish
+
+Artifacts are committed to `docs/benchmarks/results/`. The site
+(`packages/remnic-site`) reads the directory at build time and renders
+the `/benchmarks` leaderboard page. A release of Remnic publishes the
+site + artifacts together.
+
+Between releases, `docs/benchmarks/results/` is git-tracked by default
+so incremental numbers are visible on the main branch. Individual runs
+can be excluded from the commit if they are experimental / not ready
+for public display.
+
+## 7. Local-LLM parity run (slice 5, when shipped)
+
+```bash
+pnpm exec remnic bench published \
+  --name longmemeval \
+  --dataset ./bench-datasets/longmemeval \
+  --provider local-llm \
+  --base-url http://127.0.0.1:8080 \
+  --model llama-3.1-8b-instruct-q4_k_m \
+  --seed 42 \
+  --out docs/benchmarks/results/
+```
+
+The same runner + artifact schema as the cloud run. Only the responder /
+extraction provider differ.
+
+## 8. Troubleshooting
+
+- **`LongMemEval dataset not found under ./bench-datasets/longmemeval`**
+  Rerun `scripts/bench/fetch-datasets.sh --target ./bench-datasets` and
+  copy-paste the printed `huggingface-cli` commands.
+- **`parseBenchmarkArtifact: schemaVersion <N> is not supported`**
+  The artifact was written by a newer version of `@remnic/bench`.
+  Either update the local checkout or inspect the newer schema.
+- **LLM judge returns 0 on everything**
+  Set `BENCH_JUDGE_MODEL` + `BENCH_JUDGE_PROVIDER` explicitly. The
+  default judge hits whatever the adapter's evaluator LLM is — ensure
+  it has access to the expected question/predicted/expected fields.
+
+## 9. Mocked example
+
+`docs/benchmarks/results/2026-04-20-longmemeval-gpt-4o-mini-mock000.json`
+and `.../2026-04-20-locomo-gpt-4o-mini-mock000.json` are **example**
+artifacts with placeholder scores, committed so the leaderboard page
+has something to render on a fresh clone. They are clearly marked
+`datasetVersion: "mock-fixture"` and the filename sha segment is
+`mock000`. Replace them with real artifacts produced via steps 3-5 once
+the full run is executed. **Do not cite the mock numbers publicly.**


### PR DESCRIPTION
Part of #566 (slice 6 of 7).

## Summary

- `docs/benchmarks/runbook.md` — end-to-end runbook for producing the
  public LongMemEval-S + LoCoMo-10 numbers. Covers prerequisites,
  dataset download, the gpt-4o-mini cloud run, the LoCoMo-10 run,
  artifact verification, publish step, troubleshooting, and a
  forward-looking section for the slice 5 local-LLM parity run.
- `docs/benchmarks.md` — short summary linking to the runbook.
  Explicitly calls out the "mock placeholder" status so nothing
  misleading gets cited before real numbers land.
- `docs/benchmarks/results/` — two `BenchmarkArtifact v1` placeholder
  JSON files (`mock000` SHA, `datasetVersion: "mock-fixture"`, zero
  metrics, `note` field clearly marks them as placeholders). Their
  only job is to prove the pipeline renders on a fresh clone.
- CHANGELOG entry under `[Unreleased]`.

Real numbers against gpt-4o-mini are produced by executing the runbook
commands and replacing the placeholder artifacts. That happens in a
tagged release, not in this PR — per the slice 6 brief, don't run
paid LLM calls during review.

## Site (separate)

A sibling commit landed directly on
[remnic-site](https://github.com/joshuaswarren/remnic-site) `main`
(b90482c) with the new `/benchmarks` page plus cross-links from
`/compare` and `/memory-quality`.

## Test plan

- [x] `pnpm run check-types` — clean
- [x] `scripts/bench/verify-artifact.ts docs/benchmarks/results/*.json`
      will OK both mocks once slice 3 merges (both artifacts conform
      to the `BenchmarkArtifact v1` schema).
- [x] `/benchmarks` renders on remnic-site with the placeholder
      rows (local preview).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes plus gitignore updates and mock JSON artifacts; low risk aside from potential confusion if mock results are mistakenly cited or published.
> 
> **Overview**
> Adds published-benchmark documentation for LongMemEval-S and LoCoMo-10: a new `docs/benchmarks/runbook.md` with step-by-step dataset fetch, `remnic bench run` commands, artifact verification, and publication guidance, plus a short `docs/benchmarks.md` overview.
> 
> Introduces two clearly-marked **mock** `BenchmarkArtifact v1` JSON files under `docs/benchmarks/results/` to validate the end-to-end publishing/rendering pipeline on a fresh clone, updates `.gitignore` to ignore `bench-datasets/`, and records the new benchmarks docs/artifacts in `CHANGELOG.md` under *Unreleased*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e675eff75be60bc188613fd5232f98ad191373e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->