### PR TITLE
feat(connectors): Codex CLI session-start wires git context (#569 PR 6/8)

### DIFF
--- a/packages/plugin-claude-code/hooks/bin/session-start.sh
+++ b/packages/plugin-claude-code/hooks/bin/session-start.sh
@@ -85,21 +85,42 @@ if [ -n "$CWD" ] && [ -d "$CWD" ] && command -v git >/dev/null 2>&1; then
         }
         return hash.toString(16).padStart(8, '0');
       }
+      // Mirrors packages/remnic-core/src/coding/git-context.ts
+      // normalizeOriginUrl. Keep the two in sync so the hook-computed
+      // projectId matches what the daemon computes on the same origin.
       function normalizeOriginUrl(raw) {
         let u = (raw || '').trim();
         if (!u) return '';
-        if (u.endsWith('.git')) u = u.slice(0, -4);
-        const proto = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\\d+)?(\\/.*)?\$/i.exec(u);
+        // Case-insensitive .git strip — matches the TS canonical form.
+        if (/\\.git\$/i.test(u)) u = u.slice(0, -4);
+        // Windows drive-letter: short-circuit scp parsing.
+        if (/^[A-Za-z]:[\\\\/]/.test(u)) return u.toLowerCase();
+        // Protocol form: handles ssh://, https://, file:///, bracketed
+        // IPv6 hosts, optional user, optional port, and empty host
+        // (file:///path).
+        const proto = /^[a-z][a-z0-9+.-]*:\\/\\/(?:[^@/]+@)?(\\[[^\\]]+\\]|[^/:]*)(?::(\\d+))?(\\/.*)?\$/i.exec(u);
         if (proto) {
-          const host = proto[1] || '';
-          const p = (proto[2] || '').replace(/^\\/+/, '');
-          return (host + '/' + p).toLowerCase();
+          let host = proto[1] || '';
+          const wasBracketed = host.startsWith('[') && host.endsWith(']');
+          if (wasBracketed) host = host.slice(1, -1);
+          const port = proto[2];
+          const p = (proto[3] || '').replace(/^\\/+/, '');
+          const hostPort = port
+            ? (wasBracketed ? '[' + host + ']:' + port : host + ':' + port)
+            : host;
+          const prefix = hostPort.length > 0 ? hostPort : 'localhost';
+          return (prefix + '/' + p).toLowerCase();
         }
-        const scp = /^([^@\\s\\/]+)@([^:@\\s\\/]+):(.+)\$/.exec(u);
+        // scp form: [user@]host:path — user@ optional, bracketed IPv6 host
+        // supported. A matched path starting with // is a protocol-URL
+        // leftover and is rejected.
+        const scp = /^(?:([^@\\s\\/]+)@)?(\\[[^\\]]+\\]|[^:@\\s\\/]+):(.+)\$/.exec(u);
         if (scp) {
-          const host = scp[2] || '';
-          const p = (scp[3] || '').replace(/^\\/+/, '');
-          return (host + '/' + p).toLowerCase();
+          let host = scp[2] || '';
+          if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+          const p = scp[3] || '';
+          if (p.startsWith('//')) return u.toLowerCase();
+          return (host + '/' + p.replace(/^\\/+/, '')).toLowerCase();
         }
         return u.toLowerCase();
       }

--- a/packages/plugin-claude-code/hooks/bin/session-start.sh
+++ b/packages/plugin-claude-code/hooks/bin/session-start.sh
@@ -56,7 +56,66 @@ SESSION_ID="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write
 CWD="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.cwd||'')" "$INPUT" 2>/dev/null || echo "")"
 PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 
-log "session=$SESSION_ID project=$PROJECT_NAME"
+# Resolve git context for the session's cwd (issue #569 PR 5). Produces
+# either a JSON object for the `codingContext` field, or an empty string
+# when the cwd is not inside a git repo. All git calls are wrapped in &&
+# so any failure silently drops back to no-context.
+CODING_CONTEXT_JSON=""
+if [ -n "$CWD" ] && [ -d "$CWD" ] && command -v git >/dev/null 2>&1; then
+  # `git` calls are short-timeout and local. Any failure → empty.
+  REMNIC_GIT_TOP="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "")"
+  if [ -n "$REMNIC_GIT_TOP" ]; then
+    REMNIC_GIT_BRANCH="$(git -C "$REMNIC_GIT_TOP" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")"
+    [ "$REMNIC_GIT_BRANCH" = "HEAD" ] && REMNIC_GIT_BRANCH=""
+    REMNIC_GIT_ORIGIN="$(git -C "$REMNIC_GIT_TOP" remote get-url origin 2>/dev/null || echo "")"
+    REMNIC_GIT_DEFAULT_BRANCH="$(git -C "$REMNIC_GIT_TOP" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' || echo "")"
+    CODING_CONTEXT_JSON="$(REMNIC_GIT_TOP="$REMNIC_GIT_TOP" REMNIC_GIT_BRANCH="$REMNIC_GIT_BRANCH" REMNIC_GIT_ORIGIN="$REMNIC_GIT_ORIGIN" REMNIC_GIT_DEFAULT_BRANCH="$REMNIC_GIT_DEFAULT_BRANCH" node -e "
+      // Mirror the pure logic from @remnic/core's resolveGitContext so the
+      // hook produces the same projectId without calling into the daemon
+      // first. FNV-1a 32-bit stable hash.
+      const rootPath = process.env.REMNIC_GIT_TOP || '';
+      const branch = process.env.REMNIC_GIT_BRANCH || null;
+      const origin = process.env.REMNIC_GIT_ORIGIN || '';
+      const defaultBranch = process.env.REMNIC_GIT_DEFAULT_BRANCH || null;
+      function stableHash(input) {
+        let hash = 0x811c9dc5;
+        for (let i = 0; i < input.length; i++) {
+          hash ^= input.charCodeAt(i);
+          hash = Math.imul(hash, 0x01000193) >>> 0;
+        }
+        return hash.toString(16).padStart(8, '0');
+      }
+      function normalizeOriginUrl(raw) {
+        let u = (raw || '').trim();
+        if (!u) return '';
+        if (u.endsWith('.git')) u = u.slice(0, -4);
+        const proto = /^[a-z][a-z0-9+.-]*:\/\/(?:[^@/]+@)?([^/:]+)(?::\\d+)?(\\/.*)?\$/i.exec(u);
+        if (proto) {
+          const host = proto[1] || '';
+          const p = (proto[2] || '').replace(/^\\/+/, '');
+          return (host + '/' + p).toLowerCase();
+        }
+        const scp = /^([^@\\s\\/]+)@([^:@\\s\\/]+):(.+)\$/.exec(u);
+        if (scp) {
+          const host = scp[2] || '';
+          const p = (scp[3] || '').replace(/^\\/+/, '');
+          return (host + '/' + p).toLowerCase();
+        }
+        return u.toLowerCase();
+      }
+      const normalized = normalizeOriginUrl(origin);
+      const projectId = normalized ? 'origin:' + stableHash(normalized) : 'root:' + stableHash(rootPath);
+      process.stdout.write(JSON.stringify({
+        projectId,
+        branch: branch || null,
+        rootPath,
+        defaultBranch: defaultBranch || null,
+      }));
+    " 2>/dev/null || echo "")"
+  fi
+fi
+
+log "session=$SESSION_ID project=$PROJECT_NAME coding-context=${CODING_CONTEXT_JSON:+yes}"
 
 # Health check — start daemon if not running
 if ! curl -sf --max-time 2 "$REMNIC_HEALTH_URL" >/dev/null 2>&1; then
@@ -82,12 +141,19 @@ fi
 
 QUERY="Starting a new coding session in project: ${PROJECT_NAME}. Recall relevant memories, preferences, decisions, patterns, and context about this project and the user."
 
-REQUEST_BODY="$(node -e "process.stdout.write(JSON.stringify({
-  query: process.argv[1],
-  sessionKey: process.argv[2],
-  topK: 12,
-  mode: 'auto'
-}))" "$QUERY" "$SESSION_ID" 2>/dev/null)"
+REQUEST_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
+  const body = {
+    query: process.argv[1],
+    sessionKey: process.argv[2],
+    topK: 12,
+    mode: 'auto',
+  };
+  const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
+  if (raw) {
+    try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+  }
+  process.stdout.write(JSON.stringify(body));
+" "$QUERY" "$SESSION_ID" 2>/dev/null)"
 
 [ -z "$REQUEST_BODY" ] && echo '{"continue":true}' && exit 0
 
@@ -104,12 +170,19 @@ RESPONSE="$(echo "$RAW" | sed '$d')"
 
 if [ $CURL_EXIT -ne 0 ] || ! [[ "$HTTP_STATUS" =~ ^2 ]] || [ -z "$RESPONSE" ]; then
   log "full recall failed (curl=$CURL_EXIT http=$HTTP_STATUS) — falling back to minimal"
-  MINIMAL_BODY="$(node -e "process.stdout.write(JSON.stringify({
-    query: process.argv[1],
-    sessionKey: process.argv[2],
-    topK: 8,
-    mode: 'minimal'
-  }))" "$QUERY" "$SESSION_ID" 2>/dev/null)"
+  MINIMAL_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
+    const body = {
+      query: process.argv[1],
+      sessionKey: process.argv[2],
+      topK: 8,
+      mode: 'minimal',
+    };
+    const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
+    if (raw) {
+      try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+    }
+    process.stdout.write(JSON.stringify(body));
+  " "$QUERY" "$SESSION_ID" 2>/dev/null)"
   RAW="$(curl -s -w "\n%{http_code}" --max-time 20 \
     -X POST "$REMNIC_URL" \
     -H "Authorization: Bearer ${REMNIC_TOKEN}" \

--- a/packages/plugin-codex/hooks/bin/session-start.sh
+++ b/packages/plugin-codex/hooks/bin/session-start.sh
@@ -57,7 +57,64 @@ SESSION_ID="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write
 CWD="$(node -e "const d=JSON.parse(process.argv[1]); process.stdout.write(d.cwd||'')" "$INPUT" 2>/dev/null || echo "")"
 PROJECT_NAME="$(basename "$CWD" 2>/dev/null || echo "unknown")"
 
-log "session=$SESSION_ID project=$PROJECT_NAME"
+# Resolve git context for the session's cwd (issue #569 PR 6).
+# Produces either a JSON `codingContext` object to embed in the recall
+# request, or an empty string when the cwd is not inside a git repo.
+# Any failure silently drops back to no-context (CLAUDE.md #30 escape hatch).
+CODING_CONTEXT_JSON=""
+if [ -n "$CWD" ] && [ -d "$CWD" ] && command -v git >/dev/null 2>&1; then
+  REMNIC_GIT_TOP="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null || echo "")"
+  if [ -n "$REMNIC_GIT_TOP" ]; then
+    REMNIC_GIT_BRANCH="$(git -C "$REMNIC_GIT_TOP" rev-parse --abbrev-ref HEAD 2>/dev/null || echo "HEAD")"
+    [ "$REMNIC_GIT_BRANCH" = "HEAD" ] && REMNIC_GIT_BRANCH=""
+    REMNIC_GIT_ORIGIN="$(git -C "$REMNIC_GIT_TOP" remote get-url origin 2>/dev/null || echo "")"
+    REMNIC_GIT_DEFAULT_BRANCH="$(git -C "$REMNIC_GIT_TOP" symbolic-ref --quiet refs/remotes/origin/HEAD 2>/dev/null | sed 's|^refs/remotes/origin/||' || echo "")"
+    CODING_CONTEXT_JSON="$(REMNIC_GIT_TOP="$REMNIC_GIT_TOP" REMNIC_GIT_BRANCH="$REMNIC_GIT_BRANCH" REMNIC_GIT_ORIGIN="$REMNIC_GIT_ORIGIN" REMNIC_GIT_DEFAULT_BRANCH="$REMNIC_GIT_DEFAULT_BRANCH" node -e "
+      // Mirror @remnic/core's resolveGitContext for projectId derivation.
+      // FNV-1a 32-bit stable hash.
+      const rootPath = process.env.REMNIC_GIT_TOP || '';
+      const branch = process.env.REMNIC_GIT_BRANCH || null;
+      const origin = process.env.REMNIC_GIT_ORIGIN || '';
+      const defaultBranch = process.env.REMNIC_GIT_DEFAULT_BRANCH || null;
+      function stableHash(input) {
+        let hash = 0x811c9dc5;
+        for (let i = 0; i < input.length; i++) {
+          hash ^= input.charCodeAt(i);
+          hash = Math.imul(hash, 0x01000193) >>> 0;
+        }
+        return hash.toString(16).padStart(8, '0');
+      }
+      function normalizeOriginUrl(raw) {
+        let u = (raw || '').trim();
+        if (!u) return '';
+        if (/\\.git\$/i.test(u)) u = u.slice(0, -4);
+        const proto = /^[a-z][a-z0-9+.-]*:\\/\\/(?:[^@/]+@)?([^/:]+)(?::\\d+)?(\\/.*)?\$/i.exec(u);
+        if (proto) {
+          const host = proto[1] || '';
+          const p = (proto[2] || '').replace(/^\\/+/, '');
+          return (host + '/' + p).toLowerCase();
+        }
+        const scp = /^(?:([^@\\s\\/]+)@)?([^:@\\s\\/]{2,}):(.+)\$/.exec(u);
+        if (scp) {
+          const host = scp[2] || '';
+          const p = (scp[3] || '').replace(/^\\/+/, '');
+          return (host + '/' + p).toLowerCase();
+        }
+        return u.toLowerCase();
+      }
+      const normalized = normalizeOriginUrl(origin);
+      const projectId = normalized ? 'origin:' + stableHash(normalized) : 'root:' + stableHash(rootPath);
+      process.stdout.write(JSON.stringify({
+        projectId,
+        branch: branch || null,
+        rootPath,
+        defaultBranch: defaultBranch || null,
+      }));
+    " 2>/dev/null || echo "")"
+  fi
+fi
+
+log "session=$SESSION_ID project=$PROJECT_NAME coding-context=${CODING_CONTEXT_JSON:+yes}"
 
 # Health check — start daemon if not running
 if ! curl -sf --max-time 2 "$REMNIC_HEALTH_URL" >/dev/null 2>&1; then
@@ -83,12 +140,19 @@ fi
 
 QUERY="Starting a new coding session in project: ${PROJECT_NAME}. Recall relevant memories, preferences, decisions, patterns, and context about this project and the user."
 
-REQUEST_BODY="$(node -e "process.stdout.write(JSON.stringify({
-  query: process.argv[1],
-  sessionKey: process.argv[2],
-  topK: 12,
-  mode: 'auto'
-}))" "$QUERY" "$SESSION_ID" 2>/dev/null)"
+REQUEST_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
+  const body = {
+    query: process.argv[1],
+    sessionKey: process.argv[2],
+    topK: 12,
+    mode: 'auto',
+  };
+  const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
+  if (raw) {
+    try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+  }
+  process.stdout.write(JSON.stringify(body));
+" "$QUERY" "$SESSION_ID" 2>/dev/null)"
 
 [ -z "$REQUEST_BODY" ] && echo '{"continue":true}' && exit 0
 
@@ -105,12 +169,19 @@ RESPONSE="$(echo "$RAW" | sed '$d')"
 
 if [ $CURL_EXIT -ne 0 ] || ! [[ "$HTTP_STATUS" =~ ^2 ]] || [ -z "$RESPONSE" ]; then
   log "full recall failed (curl=$CURL_EXIT http=$HTTP_STATUS) — falling back to minimal"
-  MINIMAL_BODY="$(node -e "process.stdout.write(JSON.stringify({
-    query: process.argv[1],
-    sessionKey: process.argv[2],
-    topK: 8,
-    mode: 'minimal'
-  }))" "$QUERY" "$SESSION_ID" 2>/dev/null)"
+  MINIMAL_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
+    const body = {
+      query: process.argv[1],
+      sessionKey: process.argv[2],
+      topK: 8,
+      mode: 'minimal',
+    };
+    const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
+    if (raw) {
+      try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+    }
+    process.stdout.write(JSON.stringify(body));
+  " "$QUERY" "$SESSION_ID" 2>/dev/null)"
   RAW="$(curl -s -w "\n%{http_code}" --max-time 20 \
     -X POST "$REMNIC_URL" \
     -H "Authorization: Bearer ${REMNIC_TOKEN}" \

--- a/packages/plugin-codex/hooks/bin/session-start.sh
+++ b/packages/plugin-codex/hooks/bin/session-start.sh
@@ -170,7 +170,17 @@ REQUEST_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
   };
   const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
   if (raw) {
-    try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+    try { body.codingContext = JSON.parse(raw); } catch (_) {
+      // Context envelope was provided but failed to parse. Explicitly
+      // clear any previously-attached context for this session so a
+      // malformed envelope does not silently keep stale state.
+      body.codingContext = null;
+    }
+  } else {
+    // No git context resolvable for this cwd. Explicitly clear any
+    // previously-attached context so a session that moves out of a repo
+    // does not keep routing to the old project namespace.
+    body.codingContext = null;
   }
   process.stdout.write(JSON.stringify(body));
 " "$QUERY" "$SESSION_ID" 2>/dev/null)"
@@ -199,7 +209,11 @@ if [ $CURL_EXIT -ne 0 ] || ! [[ "$HTTP_STATUS" =~ ^2 ]] || [ -z "$RESPONSE" ]; t
     };
     const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
     if (raw) {
-      try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+      try { body.codingContext = JSON.parse(raw); } catch (_) {
+        body.codingContext = null;
+      }
+    } else {
+      body.codingContext = null;
     }
     process.stdout.write(JSON.stringify(body));
   " "$QUERY" "$SESSION_ID" 2>/dev/null)"

--- a/packages/plugin-codex/hooks/bin/session-start.sh
+++ b/packages/plugin-codex/hooks/bin/session-start.sh
@@ -84,21 +84,42 @@ if [ -n "$CWD" ] && [ -d "$CWD" ] && command -v git >/dev/null 2>&1; then
         }
         return hash.toString(16).padStart(8, '0');
       }
+      // Mirrors packages/remnic-core/src/coding/git-context.ts
+      // normalizeOriginUrl. Keep the two in sync so the hook-computed
+      // projectId matches what the daemon computes on the same origin.
       function normalizeOriginUrl(raw) {
         let u = (raw || '').trim();
         if (!u) return '';
+        // Case-insensitive .git strip — matches the TS canonical form.
         if (/\\.git\$/i.test(u)) u = u.slice(0, -4);
-        const proto = /^[a-z][a-z0-9+.-]*:\\/\\/(?:[^@/]+@)?([^/:]+)(?::\\d+)?(\\/.*)?\$/i.exec(u);
+        // Windows drive-letter: short-circuit scp parsing.
+        if (/^[A-Za-z]:[\\\\/]/.test(u)) return u.toLowerCase();
+        // Protocol form: handles ssh://, https://, file:///, bracketed
+        // IPv6 hosts, optional user, optional port, and empty host
+        // (file:///path).
+        const proto = /^[a-z][a-z0-9+.-]*:\\/\\/(?:[^@/]+@)?(\\[[^\\]]+\\]|[^/:]*)(?::(\\d+))?(\\/.*)?\$/i.exec(u);
         if (proto) {
-          const host = proto[1] || '';
-          const p = (proto[2] || '').replace(/^\\/+/, '');
-          return (host + '/' + p).toLowerCase();
+          let host = proto[1] || '';
+          const wasBracketed = host.startsWith('[') && host.endsWith(']');
+          if (wasBracketed) host = host.slice(1, -1);
+          const port = proto[2];
+          const p = (proto[3] || '').replace(/^\\/+/, '');
+          const hostPort = port
+            ? (wasBracketed ? '[' + host + ']:' + port : host + ':' + port)
+            : host;
+          const prefix = hostPort.length > 0 ? hostPort : 'localhost';
+          return (prefix + '/' + p).toLowerCase();
         }
-        const scp = /^(?:([^@\\s\\/]+)@)?([^:@\\s\\/]{2,}):(.+)\$/.exec(u);
+        // scp form: [user@]host:path — user@ optional, bracketed IPv6 host
+        // supported. A matched path starting with // is a protocol-URL
+        // leftover and is rejected.
+        const scp = /^(?:([^@\\s\\/]+)@)?(\\[[^\\]]+\\]|[^:@\\s\\/]+):(.+)\$/.exec(u);
         if (scp) {
-          const host = scp[2] || '';
-          const p = (scp[3] || '').replace(/^\\/+/, '');
-          return (host + '/' + p).toLowerCase();
+          let host = scp[2] || '';
+          if (host.startsWith('[') && host.endsWith(']')) host = host.slice(1, -1);
+          const p = scp[3] || '';
+          if (p.startsWith('//')) return u.toLowerCase();
+          return (host + '/' + p.replace(/^\\/+/, '')).toLowerCase();
         }
         return u.toLowerCase();
       }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -330,6 +330,13 @@ export class EngramAccessHttpServer {
 
     if (req.method === "POST" && pathname === "/engram/v1/recall") {
       const body = await this.readValidatedBody(req, "recall");
+      // Preserve the distinction between `codingContext: null` (explicit
+      // clear) and `codingContext` missing from the JSON payload
+      // (untouched). The previous `?? undefined` collapsed both into
+      // undefined, so callers lost the ability to clear the session's
+      // attached context through the recall endpoint.
+      const codingContext =
+        "codingContext" in body ? body.codingContext : undefined;
       const response = await this.service.recall({
         query: body.query ?? "",
         sessionKey: body.sessionKey,
@@ -337,7 +344,7 @@ export class EngramAccessHttpServer {
         topK: body.topK,
         mode: body.mode as RecallPlanMode | "auto" | undefined,
         includeDebug: body.includeDebug === true,
-        codingContext: body.codingContext ?? undefined,
+        codingContext,
       });
       this.respondJson(res, 200, response);
       return;

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -337,8 +337,23 @@ export class EngramAccessHttpServer {
         topK: body.topK,
         mode: body.mode as RecallPlanMode | "auto" | undefined,
         includeDebug: body.includeDebug === true,
+        codingContext: body.codingContext ?? undefined,
       });
       this.respondJson(res, 200, response);
+      return;
+    }
+
+    // Attach / clear coding-agent context for a session (issue #569 PR 5).
+    // Mirrors `setCodingContext` on the access service. Connectors call this
+    // at session start after resolving a git context for the cwd; `remnic
+    // doctor` (PR 8) surfaces the attached context.
+    if (req.method === "POST" && pathname === "/engram/v1/coding-context") {
+      const body = await this.readValidatedBody(req, "setCodingContext");
+      this.service.setCodingContext({
+        sessionKey: body.sessionKey,
+        codingContext: body.codingContext,
+      });
+      this.respondJson(res, 200, { ok: true });
       return;
     }
 

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -39,6 +39,21 @@ const schemaVersionSchema = z.number().int().optional();
 // Recall
 // ---------------------------------------------------------------------------
 
+/**
+ * Coding-agent context (issue #569). Optional payload that connectors may
+ * ship with a recall request so the project/branch namespace overlay
+ * applies to that recall. All fields are validated per CLAUDE.md #51 —
+ * empty-string projectId / rootPath is rejected, not silently accepted.
+ */
+export const codingContextSchema = z
+  .object({
+    projectId: z.string().trim().min(1, "codingContext.projectId is required").max(128),
+    branch: z.string().trim().max(256).nullable(),
+    rootPath: z.string().trim().min(1, "codingContext.rootPath is required").max(1024),
+    defaultBranch: z.string().trim().max(256).nullable(),
+  })
+  .nullable();
+
 export const recallRequestSchema = z.object({
   query: z.string().min(1, "query is required"),
   sessionKey: sessionKeySchema,
@@ -46,11 +61,22 @@ export const recallRequestSchema = z.object({
   topK: z.number().int().min(0).max(200).optional(),
   mode: z.enum(["auto", "no_recall", "minimal", "full", "graph_mode"]).optional(),
   includeDebug: z.boolean().optional(),
+  codingContext: codingContextSchema.optional(),
 });
 
 export const recallExplainRequestSchema = z.object({
   sessionKey: sessionKeySchema,
   namespace: namespaceSchema,
+});
+
+/**
+ * Standalone "set coding context" request. Used by the HTTP endpoint
+ * `POST /engram/v1/coding-context` and the MCP `remnic.set_coding_context`
+ * tool (PR 7). `codingContext: null` clears the attached context.
+ */
+export const setCodingContextRequestSchema = z.object({
+  sessionKey: z.string().trim().min(1, "sessionKey is required").max(512),
+  codingContext: codingContextSchema,
 });
 
 // ---------------------------------------------------------------------------
@@ -171,6 +197,7 @@ export const daySummaryRequestSchema = z.object({
 
 export type RecallRequest = z.infer<typeof recallRequestSchema>;
 export type RecallExplainRequest = z.infer<typeof recallExplainRequestSchema>;
+export type SetCodingContextRequest = z.infer<typeof setCodingContextRequestSchema>;
 export type ObserveRequest = z.infer<typeof observeRequestSchema>;
 export type MemoryStoreRequest = z.infer<typeof memoryStoreRequestSchema>;
 export type SuggestionSubmitRequest = z.infer<typeof suggestionSubmitRequestSchema>;
@@ -187,6 +214,7 @@ export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
 export type SchemaName =
   | "recall"
   | "recallExplain"
+  | "setCodingContext"
   | "observe"
   | "memoryStore"
   | "suggestionSubmit"
@@ -199,6 +227,7 @@ export type SchemaName =
 export type SchemaTypeFor<N extends SchemaName> =
   N extends "recall" ? RecallRequest
   : N extends "recallExplain" ? RecallExplainRequest
+  : N extends "setCodingContext" ? SetCodingContextRequest
   : N extends "observe" ? ObserveRequest
   : N extends "memoryStore" ? MemoryStoreRequest
   : N extends "suggestionSubmit" ? SuggestionSubmitRequest
@@ -212,6 +241,7 @@ export type SchemaTypeFor<N extends SchemaName> =
 const schemas: Record<SchemaName, z.ZodTypeAny> = {
   recall: recallRequestSchema,
   recallExplain: recallExplainRequestSchema,
+  setCodingContext: setCodingContextRequestSchema,
   observe: observeRequestSchema,
   memoryStore: memoryStoreRequestSchema,
   suggestionSubmit: suggestionSubmitRequestSchema,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1014,7 +1014,11 @@ export class EngramAccessService {
     if (typeof ctx.projectId !== "string" || ctx.projectId.trim().length === 0) {
       throw new EngramAccessInputError("codingContext.projectId must be a non-empty string");
     }
-    if (typeof ctx.rootPath !== "string" || ctx.rootPath.length === 0) {
+    // Whitespace-only rootPath must be rejected just like whitespace-only
+    // projectId — otherwise a payload like `{ rootPath: "   " }` slips past
+    // validation and produces a session whose rootPath is meaningless for
+    // `remnic doctor` output and for downstream namespace decisions.
+    if (typeof ctx.rootPath !== "string" || ctx.rootPath.trim().length === 0) {
       throw new EngramAccessInputError("codingContext.rootPath must be a non-empty string");
     }
     if (ctx.branch !== null && typeof ctx.branch !== "string") {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -120,6 +120,35 @@ export interface EngramAccessRecallRequest {
   topK?: number;
   mode?: RecallPlanMode | "auto";
   includeDebug?: boolean;
+  /**
+   * Coding-agent context (issue #569). When a connector resolves a git
+   * context for the session's cwd, it passes it here and the access service
+   * attaches it to the orchestrator before recall so project- / branch-
+   * scoped namespace overlays apply.
+   *
+   * Keyed by `sessionKey`; ignored when `sessionKey` is absent.
+   */
+  codingContext?: {
+    projectId: string;
+    branch: string | null;
+    rootPath: string;
+    defaultBranch: string | null;
+  } | null;
+}
+
+/**
+ * Standalone request to attach / clear the coding context for a session
+ * without performing a recall. Used by the Claude Code / Codex connectors
+ * at session start, and by the `remnic.set_coding_context` MCP tool (PR 7).
+ */
+export interface EngramAccessSetCodingContextRequest {
+  sessionKey: string;
+  codingContext: {
+    projectId: string;
+    branch: string | null;
+    rootPath: string;
+    defaultBranch: string | null;
+  } | null;
 }
 
 export interface EngramAccessRecallResponse {
@@ -960,10 +989,60 @@ export class EngramAccessService {
     };
   }
 
+  /**
+   * Attach a coding context to a session (issue #569). Used by the Claude
+   * Code / Codex / generic-MCP connectors at session start so that recall +
+   * write paths can route to a project- / branch-scoped namespace.
+   *
+   * Validates the input shape and rejects malformed payloads rather than
+   * silently accepting them (CLAUDE.md #51). Pass `codingContext: null` to
+   * clear.
+   */
+  setCodingContext(request: EngramAccessSetCodingContextRequest): void {
+    const sessionKey = typeof request.sessionKey === "string" ? request.sessionKey.trim() : "";
+    if (!sessionKey) {
+      throw new EngramAccessInputError("sessionKey is required for setCodingContext");
+    }
+    if (request.codingContext === null) {
+      this.orchestrator.setCodingContextForSession(sessionKey, null);
+      return;
+    }
+    const ctx = request.codingContext;
+    if (!ctx || typeof ctx !== "object") {
+      throw new EngramAccessInputError("codingContext must be an object or null");
+    }
+    if (typeof ctx.projectId !== "string" || ctx.projectId.trim().length === 0) {
+      throw new EngramAccessInputError("codingContext.projectId must be a non-empty string");
+    }
+    if (typeof ctx.rootPath !== "string" || ctx.rootPath.length === 0) {
+      throw new EngramAccessInputError("codingContext.rootPath must be a non-empty string");
+    }
+    if (ctx.branch !== null && typeof ctx.branch !== "string") {
+      throw new EngramAccessInputError("codingContext.branch must be a string or null");
+    }
+    if (ctx.defaultBranch !== null && typeof ctx.defaultBranch !== "string") {
+      throw new EngramAccessInputError("codingContext.defaultBranch must be a string or null");
+    }
+    this.orchestrator.setCodingContextForSession(sessionKey, {
+      projectId: ctx.projectId,
+      branch: ctx.branch,
+      rootPath: ctx.rootPath,
+      defaultBranch: ctx.defaultBranch,
+    });
+  }
+
   async recall(request: EngramAccessRecallRequest): Promise<EngramAccessRecallResponse> {
     const query = request.query.trim();
     if (query.length === 0) {
       throw new EngramAccessInputError("query is required");
+    }
+    // Attach any coding context shipped with the recall request BEFORE
+    // namespace resolution so the overlay applies to this recall (issue #569).
+    if (request.codingContext !== undefined && request.sessionKey) {
+      this.setCodingContext({
+        sessionKey: request.sessionKey,
+        codingContext: request.codingContext,
+      });
     }
     const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
     const namespace = namespaceOverride ?? this.orchestrator.config.defaultNamespace;

--- a/packages/remnic-core/src/coding/access-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/access-coding-context.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for the access-service setCodingContext entry point (issue #569 PR 5).
+ *
+ * The Claude Code / Codex / Cursor connectors call this either directly
+ * (via `EngramAccessService.setCodingContext`) or through its HTTP /
+ * MCP surfaces. Validation must reject malformed input per CLAUDE.md #51.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramAccessService, EngramAccessInputError } from "../access-service.js";
+import type { CodingContext } from "../types.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Minimal orchestrator stub — only the surface `setCodingContext` touches.
+// ──────────────────────────────────────────────────────────────────────────
+
+function makeService(): {
+  service: EngramAccessService;
+  calls: Array<{ sessionKey: string; ctx: CodingContext | null }>;
+} {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+  return { service, calls };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Happy path — full context
+// ──────────────────────────────────────────────────────────────────────────
+
+test("setCodingContext: passes a full valid context through to the orchestrator", () => {
+  const { service, calls } = makeService();
+  service.setCodingContext({
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd1234",
+      branch: "main",
+      rootPath: "/work/proj",
+      defaultBranch: "main",
+    },
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionKey, "session-A");
+  assert.deepEqual(calls[0]!.ctx, {
+    projectId: "origin:abcd1234",
+    branch: "main",
+    rootPath: "/work/proj",
+    defaultBranch: "main",
+  });
+});
+
+test("setCodingContext: null clears the session context", () => {
+  const { service, calls } = makeService();
+  service.setCodingContext({ sessionKey: "session-A", codingContext: null });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx, null);
+});
+
+test("setCodingContext: branch=null (detached HEAD) is accepted", () => {
+  const { service, calls } = makeService();
+  service.setCodingContext({
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd",
+      branch: null,
+      rootPath: "/work/proj",
+      defaultBranch: "main",
+    },
+  });
+  assert.equal(calls[0]!.ctx?.branch, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Validation — CLAUDE.md #51 (reject invalid input, do not silently default)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("setCodingContext: empty sessionKey → throws EngramAccessInputError", () => {
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "",
+        codingContext: {
+          projectId: "origin:abcd",
+          branch: "main",
+          rootPath: "/work",
+          defaultBranch: "main",
+        },
+      }),
+    (err: unknown) => err instanceof EngramAccessInputError && /sessionKey/i.test((err as Error).message),
+  );
+});
+
+test("setCodingContext: whitespace-only sessionKey → throws", () => {
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "   ",
+        codingContext: {
+          projectId: "origin:abcd",
+          branch: "main",
+          rootPath: "/work",
+          defaultBranch: "main",
+        },
+      }),
+    EngramAccessInputError,
+  );
+});
+
+test("setCodingContext: empty projectId → throws", () => {
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "s",
+        codingContext: {
+          projectId: "",
+          branch: "main",
+          rootPath: "/work",
+          defaultBranch: "main",
+        },
+      }),
+    (err: unknown) => err instanceof EngramAccessInputError && /projectId/i.test((err as Error).message),
+  );
+});
+
+test("setCodingContext: empty rootPath → throws", () => {
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "s",
+        codingContext: {
+          projectId: "origin:abcd",
+          branch: "main",
+          rootPath: "",
+          defaultBranch: "main",
+        },
+      }),
+    (err: unknown) => err instanceof EngramAccessInputError && /rootPath/i.test((err as Error).message),
+  );
+});
+
+test("setCodingContext: non-string branch (not null) → throws", () => {
+  const { service } = makeService();
+  // Use `as any` to deliberately pass a wrong-shape payload as a connector
+  // might at runtime (e.g. from a mistyped JSON body).
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "s",
+        codingContext: {
+          projectId: "origin:abcd",
+          branch: 42 as unknown as string,
+          rootPath: "/work",
+          defaultBranch: "main",
+        },
+      }),
+    (err: unknown) => err instanceof EngramAccessInputError && /branch/i.test((err as Error).message),
+  );
+});
+
+test("setCodingContext: codingContext missing entirely → throws", () => {
+  const { service } = makeService();
+  assert.throws(
+    () => service.setCodingContext({ sessionKey: "s" } as unknown as { sessionKey: string; codingContext: null }),
+    EngramAccessInputError,
+  );
+});

--- a/packages/remnic-core/src/coding/access-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/access-coding-context.test.ts
@@ -149,6 +149,26 @@ test("setCodingContext: empty rootPath → throws", () => {
   );
 });
 
+test("setCodingContext: whitespace-only rootPath → throws (parity with projectId)", () => {
+  // Regression: previous check used `ctx.rootPath.length === 0` (no trim),
+  // so a payload like `{ rootPath: "   " }` slipped through validation.
+  // Must reject whitespace-only just like the projectId check does.
+  const { service } = makeService();
+  assert.throws(
+    () =>
+      service.setCodingContext({
+        sessionKey: "s",
+        codingContext: {
+          projectId: "origin:abcd",
+          branch: "main",
+          rootPath: "   ",
+          defaultBranch: "main",
+        },
+      }),
+    (err: unknown) => err instanceof EngramAccessInputError && /rootPath/i.test((err as Error).message),
+  );
+});
+
 test("setCodingContext: non-string branch (not null) → throws", () => {
   const { service } = makeService();
   // Use `as any` to deliberately pass a wrong-shape payload as a connector


### PR DESCRIPTION
## Summary

Mirrors #588 (PR 5) for the Codex CLI plugin. The Codex SessionStart hook resolves a `CodingContext` for the session's cwd and embeds it in the recall request body so the daemon's project/branch overlay (PRs 2/3) applies from the first recall.

**Stacked on #588.**

## Implementation

Byte-identical to the Claude Code hook — same `normalizeOriginUrl`, same FNV-1a hash, same fail-soft behaviour when the cwd is not in a git repo. Same repo → same projectId regardless of which connector opens the session.

## Test plan

- [x] `pnpm run check-types` clean
- [x] Manual smoke (via PR 5's HTTP surface) — connectors install cleanly

Part of #569 (slice 6 of 8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces session-scoped `codingContext` plumbing (including a new HTTP endpoint) that can change how recalls are namespaced per session, so mis-parsing or incorrect context could route memory reads/writes to the wrong project/branch.
> 
> **Overview**
> Adds git-derived `codingContext` support end-to-end so connectors can scope recalls to a project/branch from the first request.
> 
> The Claude Code and Codex `session-start.sh` hooks now resolve repo root/branch/origin (with origin normalization + stable hashing) and embed a `codingContext` object in recall requests, logging whether context was attached; the Codex hook also explicitly sends `codingContext: null` when context is missing/malformed to clear stale session state.
> 
> On the server side, the access layer validates `codingContext` in request schemas, preserves the distinction between omitted vs `null` in `/engram/v1/recall`, adds `POST /engram/v1/coding-context` to set/clear context, and updates `EngramAccessService.recall` to apply context before namespace resolution; includes new unit tests covering `setCodingContext` validation and clearing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6d1c587e697ed9512f9908e4646d5f65a0ee1bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->