### PR TITLE
feat(mcp): add engram.set_coding_context tool (#569 PR 7/8)

### DIFF
--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1,7 +1,7 @@
 import type { Readable, Writable } from "node:stream";
 import { readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import type { EngramAccessService, EngramAccessRecallResponse } from "./access-service.js";
+import { EngramAccessInputError, type EngramAccessService, type EngramAccessRecallResponse } from "./access-service.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
@@ -122,6 +122,39 @@ export class EngramMcpServer {
             sessionKey: { type: "string" },
             namespace: { type: "string" },
           },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.set_coding_context",
+        description:
+          "Attach a coding-agent context (project / branch) to a session so recall routes to a project- / branch-scoped namespace (issue #569). For MCP clients that do not ship cwd automatically (Cursor, generic agents, etc.). Also aliased as remnic.set_coding_context. Pass codingContext: null to clear.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sessionKey: {
+              type: "string",
+              description: "Session identifier the context should attach to.",
+            },
+            codingContext: {
+              anyOf: [
+                { type: "null" },
+                {
+                  type: "object",
+                  properties: {
+                    projectId: { type: "string", description: "Stable project id (origin:<hex> or root:<hex>)." },
+                    branch: { type: ["string", "null"], description: "Current branch, or null in detached HEAD." },
+                    rootPath: { type: "string", description: "Absolute path to the repo root." },
+                    defaultBranch: { type: ["string", "null"], description: "Default branch (usually main/master), or null when unknown." },
+                  },
+                  required: ["projectId", "branch", "rootPath", "defaultBranch"],
+                  additionalProperties: false,
+                },
+              ],
+              description: "The context to attach, or null to clear.",
+            },
+          },
+          required: ["sessionKey", "codingContext"],
           additionalProperties: false,
         },
       },
@@ -1097,6 +1130,42 @@ export class EngramMcpServer {
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      case "engram.set_coding_context": {
+        // Issue #569 PR 7 — MCP tool for clients that don't ship cwd.
+        // Validation lives in EngramAccessService.setCodingContext; any
+        // EngramAccessInputError surfaces as a structured tool-call error.
+        const sessionKey = typeof args.sessionKey === "string" ? args.sessionKey : "";
+        const rawCtx = args.codingContext;
+        let codingContext: {
+          projectId: string;
+          branch: string | null;
+          rootPath: string;
+          defaultBranch: string | null;
+        } | null = null;
+        if (rawCtx !== null) {
+          if (typeof rawCtx !== "object" || rawCtx === undefined) {
+            throw new EngramAccessInputError("codingContext must be an object or null");
+          }
+          const obj = rawCtx as Record<string, unknown>;
+          const projectId = typeof obj.projectId === "string" ? obj.projectId : "";
+          const rootPath = typeof obj.rootPath === "string" ? obj.rootPath : "";
+          const branch = obj.branch === null
+            ? null
+            : typeof obj.branch === "string" ? obj.branch : undefined;
+          const defaultBranch = obj.defaultBranch === null
+            ? null
+            : typeof obj.defaultBranch === "string" ? obj.defaultBranch : undefined;
+          if (branch === undefined) {
+            throw new EngramAccessInputError("codingContext.branch must be a string or null");
+          }
+          if (defaultBranch === undefined) {
+            throw new EngramAccessInputError("codingContext.defaultBranch must be a string or null");
+          }
+          codingContext = { projectId, branch, rootPath, defaultBranch };
+        }
+        this.service.setCodingContext({ sessionKey, codingContext });
+        return { ok: true };
+      }
       case "engram.recall_tier_explain":
         return this.service.recallTierExplain(
           typeof args.sessionKey === "string" && args.sessionKey.length > 0

--- a/packages/remnic-core/src/coding/mcp-set-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/mcp-set-coding-context.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the MCP `engram.set_coding_context` tool (issue #569 PR 7).
+ *
+ * The MCP server is accessed by Cursor, generic agents, and any client that
+ * doesn't ship `cwd` in its session-start handshake. This tool lets those
+ * clients set the coding context explicitly.
+ *
+ * Tests drive the tool through `callTool` directly — no JSON-RPC transport —
+ * so we cover the handler's input validation and alias handling without
+ * needing a stdio mock.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramMcpServer } from "../access-mcp.js";
+import { EngramAccessInputError, type EngramAccessService } from "../access-service.js";
+import type { CodingContext } from "../types.js";
+
+function makeMcp(): {
+  mcp: EngramMcpServer;
+  calls: Array<{ sessionKey: string; ctx: CodingContext | null }>;
+} {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const service = {
+    setCodingContext(request: { sessionKey: string; codingContext: CodingContext | null }) {
+      if (!request.sessionKey || request.sessionKey.trim().length === 0) {
+        throw new EngramAccessInputError("sessionKey is required for setCodingContext");
+      }
+      if (request.codingContext && !request.codingContext.projectId) {
+        throw new EngramAccessInputError("codingContext.projectId must be a non-empty string");
+      }
+      calls.push({ sessionKey: request.sessionKey, ctx: request.codingContext });
+    },
+  } as unknown as EngramAccessService;
+  const mcp = new EngramMcpServer(service);
+  return { mcp, calls };
+}
+
+// Helper — bypass JSON-RPC layer.
+async function call(mcp: EngramMcpServer, name: string, args: Record<string, unknown>): Promise<unknown> {
+  const anyMcp = mcp as unknown as {
+    callTool(n: string, a: Record<string, unknown>): Promise<unknown>;
+  };
+  return anyMcp.callTool(name, args);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tool listing — advertises both canonical and legacy names
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context is listed in the tool catalogue", () => {
+  const { mcp } = makeMcp();
+  const tools = (mcp as unknown as { tools: Array<{ name: string }> }).tools;
+  const names = tools.map((t) => t.name);
+  assert.ok(
+    names.includes("engram.set_coding_context"),
+    `expected engram.set_coding_context in catalogue, got: ${names.join(", ")}`,
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Happy path
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context: attaches a full context", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd1234",
+      branch: "main",
+      rootPath: "/work/proj",
+      defaultBranch: "main",
+    },
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionKey, "session-A");
+  assert.equal(calls[0]!.ctx?.projectId, "origin:abcd1234");
+  assert.equal(calls[0]!.ctx?.branch, "main");
+});
+
+test("engram.set_coding_context: codingContext=null clears the session", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: null,
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx, null);
+});
+
+test("engram.set_coding_context: branch=null (detached HEAD) accepted", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd",
+      branch: null,
+      rootPath: "/work/proj",
+      defaultBranch: null,
+    },
+  });
+  assert.equal(calls[0]!.ctx?.branch, null);
+  assert.equal(calls[0]!.ctx?.defaultBranch, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Canonical alias — remnic.set_coding_context resolves to the same handler
+// ──────────────────────────────────────────────────────────────────────────
+
+test("remnic.set_coding_context: canonical name is aliased to the engram.* handler", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "remnic.set_coding_context", {
+    sessionKey: "session-B",
+    codingContext: {
+      projectId: "origin:deadbeef",
+      branch: "feat/x",
+      rootPath: "/work/x",
+      defaultBranch: "main",
+    },
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionKey, "session-B");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Validation — CLAUDE.md #51
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context: empty sessionKey → throws EngramAccessInputError", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "",
+      codingContext: {
+        projectId: "origin:abcd",
+        branch: "main",
+        rootPath: "/work",
+        defaultBranch: "main",
+      },
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+});
+
+test("engram.set_coding_context: non-null non-object codingContext → rejects", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "s",
+      codingContext: "not-an-object",
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+});
+
+test("engram.set_coding_context: branch missing (undefined) → rejects", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "s",
+      codingContext: {
+        projectId: "origin:abcd",
+        rootPath: "/work",
+        defaultBranch: "main",
+        // branch field missing
+      },
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError && /branch/i.test((err as Error).message),
+  );
+});

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -156,6 +156,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
   const legacyListed = [
     "engram.recall",
     "engram.recall_explain",
+    "engram.set_coding_context",
     "engram.recall_tier_explain",
     "engram.day_summary",
     "engram.memory_governance_run",


### PR DESCRIPTION
## Summary

Exposes the coding-context set/clear surface as an MCP tool so clients that don't ship `cwd` in their session-start handshake (Cursor, generic agents) can declare the session's project + branch explicitly.

**Stacked on #590 (PR 6).**

## Tool

- **Name:** `engram.set_coding_context` (also aliased as `remnic.set_coding_context`)
- **Params:** `{ sessionKey, codingContext: { projectId, branch, rootPath, defaultBranch } | null }`
- **Returns:** `{ ok: true }`
- **Errors:** `EngramAccessInputError` on missing/invalid fields

Handler delegates validation to `EngramAccessService.setCodingContext` (PR 5). `branch` and `defaultBranch` may be `null` (detached HEAD / no default branch symref). Passing `codingContext: null` clears.

## Test plan

- [x] 8 cases — catalogue listing, happy path, null clear, detached HEAD, `remnic.*` alias, 3 validation rejections
- [x] `pnpm run check-types` clean
- [x] 112 coding-subsystem tests green

Part of #569 (slice 7 of 8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new MCP tool and input validation path that routes into existing `setCodingContext` service logic; risk is limited to tool dispatch/validation and tool-list ordering expectations in tests.
> 
> **Overview**
> Adds a new MCP tool, `engram.set_coding_context` (aliased as `remnic.set_coding_context`), to attach or clear a session’s coding context (project/branch/root/default branch) so recall can be scoped appropriately for clients that don’t provide `cwd`.
> 
> Implements request parsing/validation in `EngramMcpServer.callTool`, returning `{ ok: true }` and surfacing invalid inputs as `EngramAccessInputError`, and updates MCP tool-list tests plus adds focused unit tests covering listing, aliasing, null-clear, detached-HEAD, and validation failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfc8d5b42707e6a8409ab9441fb941d7c2da45e8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->