### PR TITLE
feat(bench,cli): coding-recall benchmark + remnic doctor context (#569 PR 8/8)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/coding-recall/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/fixture.ts
@@ -1,0 +1,133 @@
+/**
+ * Fixtures for the coding-agent recall benchmark (issue #569 PR 8).
+ *
+ * Covers the three invariants PRs 2–4 introduced:
+ *
+ *   1. Cross-project isolation — a memory written under project A is not
+ *      retrievable under project B.
+ *   2. Branch isolation — with branchScope enabled, a branch-local memory
+ *      on branch A is not retrievable on branch B, but project-level
+ *      memories remain visible from any branch.
+ *   3. Review-context ranking — on a review-intent prompt, a memory whose
+ *      `entityRefs` mention a touched file outranks an unrelated memory of
+ *      equal score.
+ *
+ * All fixtures synthetic — no real repositories, no real user data.
+ */
+
+export interface CodingRecallCaseMemory {
+  id: string;
+  /** Namespace the memory was persisted under. */
+  namespace: string;
+  /** Optional file-path refs that `review-context` ranking consults. */
+  entityRefs?: string[];
+  /** Baseline relevance score from the upstream recall pipeline. */
+  score: number;
+}
+
+export interface CodingRecallCase {
+  id: string;
+  title: string;
+  /** Invariant being exercised — reported in details. */
+  kind: "cross-project" | "branch-isolation" | "review-context";
+  /** Session's effective read namespaces. The benchmark scorer filters
+   *  candidates to these before ranking. */
+  sessionNamespaces: string[];
+  /** For review-context cases only: touched files parsed from a diff. */
+  touchedFiles?: string[];
+  /** For review-context cases only: the prompt that triggers the tier. */
+  prompt?: string;
+  /** All candidate memories in the corpus (multiple projects / branches). */
+  candidates: CodingRecallCaseMemory[];
+  /** Memories we expect to appear (ordered, highest score first). */
+  expectedIds: string[];
+  /** Memories that MUST NOT appear — cross-project / cross-branch leaks. */
+  forbiddenIds: string[];
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Cross-project isolation
+// ──────────────────────────────────────────────────────────────────────────
+
+const CROSS_PROJECT_CASE: CodingRecallCase = {
+  id: "cross-project-basic",
+  title: "Cross-project isolation — project B's memories are invisible to project A",
+  kind: "cross-project",
+  sessionNamespaces: ["project-origin-aaaaaaaa"],
+  candidates: [
+    { id: "a1", namespace: "project-origin-aaaaaaaa", score: 0.8, entityRefs: ["src/auth.ts"] },
+    { id: "a2", namespace: "project-origin-aaaaaaaa", score: 0.6, entityRefs: ["docs/readme.md"] },
+    { id: "b1", namespace: "project-origin-bbbbbbbb", score: 0.9, entityRefs: ["src/auth.ts"] },
+    { id: "b2", namespace: "project-origin-bbbbbbbb", score: 0.7, entityRefs: ["docs/readme.md"] },
+  ],
+  expectedIds: ["a1", "a2"],
+  forbiddenIds: ["b1", "b2"],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Branch isolation with project-level fallback
+// ──────────────────────────────────────────────────────────────────────────
+
+const BRANCH_ISOLATION_CASE: CodingRecallCase = {
+  id: "branch-isolation-with-project-fallback",
+  title:
+    "Branch isolation — branch A cannot see branch B, but project-level memories remain visible from branch A",
+  kind: "branch-isolation",
+  sessionNamespaces: [
+    "project-origin-cccccccc-branch-feat-a",
+    "project-origin-cccccccc",
+  ],
+  candidates: [
+    // Branch A — should appear
+    { id: "brA-local", namespace: "project-origin-cccccccc-branch-feat-a", score: 0.9 },
+    // Branch B — must not appear
+    { id: "brB-local", namespace: "project-origin-cccccccc-branch-feat-b", score: 0.95 },
+    // Project-level — should appear via readFallback
+    { id: "proj-level", namespace: "project-origin-cccccccc", score: 0.7 },
+    // Other project — must not appear
+    { id: "other-proj", namespace: "project-origin-dddddddd", score: 0.85 },
+  ],
+  expectedIds: ["brA-local", "proj-level"],
+  forbiddenIds: ["brB-local", "other-proj"],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Review-context ranking
+// ──────────────────────────────────────────────────────────────────────────
+
+const REVIEW_CONTEXT_CASE: CodingRecallCase = {
+  id: "review-context-boosts-touched-files",
+  title:
+    "Review-context — 'review this diff' boosts memories that reference touched files above equal-score unrelated memories",
+  kind: "review-context",
+  sessionNamespaces: ["project-origin-eeeeeeee"],
+  touchedFiles: ["src/auth.ts"],
+  prompt: "review this diff",
+  candidates: [
+    { id: "touched", namespace: "project-origin-eeeeeeee", score: 0.3, entityRefs: ["src/auth.ts"] },
+    { id: "untouched", namespace: "project-origin-eeeeeeee", score: 0.3, entityRefs: ["lib/other.ts"] },
+    // A strong unmatched memory — should still appear but not outrank
+    // touched (touched has 0.3 + 0.5 = 0.8 ≥ 0.8; stable tie-break wins
+    // by id: "strong" < "touched", so "strong" comes first).
+    { id: "strong", namespace: "project-origin-eeeeeeee", score: 0.8, entityRefs: ["db.sql"] },
+  ],
+  // Expected ordering: "strong" (0.8) and "touched" (0.8) tie on adjusted
+  // score; stable tie-break by id puts "strong" first. Then "untouched"
+  // (0.3) last.
+  expectedIds: ["strong", "touched", "untouched"],
+  forbiddenIds: [],
+};
+
+// ──────────────────────────────────────────────────────────────────────────
+// Exported fixtures
+// ──────────────────────────────────────────────────────────────────────────
+
+export const CODING_RECALL_FIXTURE: CodingRecallCase[] = [
+  CROSS_PROJECT_CASE,
+  BRANCH_ISOLATION_CASE,
+  REVIEW_CONTEXT_CASE,
+];
+
+// Smoke fixture — a single representative case per invariant kind. In this
+// benchmark the full fixture is already small, so smoke === full.
+export const CODING_RECALL_SMOKE_FIXTURE: CodingRecallCase[] = CODING_RECALL_FIXTURE;

--- a/packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/runner.test.ts
@@ -1,0 +1,80 @@
+/**
+ * Smoke tests for the coding-recall benchmark runner (issue #569 PR 8).
+ *
+ * Verifies that the deterministic scorer produces the expected ordering and
+ * isolation metric for each fixture case.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { runCodingRecallBenchmark, codingRecallDefinition } from "./runner.js";
+
+test("coding-recall: cross-project case yields perfect isolation + precision", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    limit: 1,
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks[0];
+  assert.ok(task);
+  assert.equal(task!.taskId, "cross-project-basic");
+  assert.equal(task!.scores.isolation, 1, "no cross-project leakage");
+  // Expected memories are top of the ranking.
+  const actual = JSON.parse(task!.actual);
+  assert.ok(Array.isArray(actual));
+  // The session can only see project A's namespace; project B candidates are filtered out.
+  assert.ok(!actual.includes("b1"));
+  assert.ok(!actual.includes("b2"));
+  assert.deepEqual(actual, ["a1", "a2"]);
+});
+
+test("coding-recall: branch-isolation case — branch B filtered out, project fallback visible", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    limit: 2,
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks[1];
+  assert.ok(task);
+  assert.equal(task!.taskId, "branch-isolation-with-project-fallback");
+  assert.equal(task!.scores.isolation, 1);
+  const actual = JSON.parse(task!.actual);
+  assert.ok(actual.includes("brA-local"), "branch-A memory must be retrievable");
+  assert.ok(actual.includes("proj-level"), "project-level memory must be retrievable via fallback");
+  assert.ok(!actual.includes("brB-local"), "branch-B must not leak");
+  assert.ok(!actual.includes("other-proj"), "other project must not leak");
+});
+
+test("coding-recall: review-context case boosts touched-file memories via tie-break", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const task = result.results.tasks.find((t) => t.taskId === "review-context-boosts-touched-files");
+  assert.ok(task);
+  const actual = JSON.parse(task!.actual);
+  // "strong" (0.8 + 0) ties with "touched" (0.3 + 0.5); stable id sort
+  // places "strong" first. Then "touched" (0.8), then "untouched" (0.3).
+  assert.deepEqual(actual, ["strong", "touched", "untouched"]);
+});
+
+test("coding-recall: aggregates include all metrics", async () => {
+  const result = await runCodingRecallBenchmark({
+    benchmark: codingRecallDefinition,
+    mode: "full",
+    seed: 0,
+  } as unknown as Parameters<typeof runCodingRecallBenchmark>[0]);
+
+  const agg = result.results.aggregates;
+  assert.ok(typeof agg.isolation === "object" && agg.isolation !== null);
+  assert.ok(typeof agg.p_at_1 === "object" && agg.p_at_1 !== null);
+  // Overall isolation mean should be 1.0 (all three fixtures isolate cleanly).
+  assert.equal(agg.isolation!.mean, 1, "overall isolation mean across fixture must be 1.0");
+});

--- a/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
@@ -1,0 +1,195 @@
+/**
+ * Coding-agent recall benchmark (issue #569 PR 8).
+ *
+ * Measures whether the retrieval layer correctly honours the three #569
+ * invariants: cross-project isolation, branch isolation with project
+ * fallback, and review-context ranking. The benchmark is deterministic —
+ * no LLM, no storage — so it runs in CI without any daemon.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { aggregateTaskScores, precisionAtK } from "../../../scorer.js";
+import {
+  CODING_RECALL_FIXTURE,
+  CODING_RECALL_SMOKE_FIXTURE,
+  type CodingRecallCase,
+  type CodingRecallCaseMemory,
+} from "./fixture.js";
+
+export const codingRecallDefinition: BenchmarkDefinition = {
+  id: "coding-recall",
+  title: "Coding-Agent Recall (project/branch isolation + review context)",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "coding-recall",
+    version: "1.0.0",
+    description:
+      "Deterministic benchmark for the #569 coding-agent features: project/branch namespace isolation and diff-aware review-context ranking.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #569",
+  },
+};
+
+export async function runCodingRecallBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+  const tasks: TaskResult[] = [];
+
+  for (const sample of cases) {
+    const startedAt = performance.now();
+    const retrieved = scoreCase(sample);
+    const latencyMs = Math.round(performance.now() - startedAt);
+    const expectedJson = JSON.stringify(sample.expectedIds);
+    const actualJson = JSON.stringify(retrieved.map((m) => m.id));
+
+    // Precision@k against the ordered expected list.
+    const retrievedIds = retrieved.map((m) => m.id);
+
+    // Isolation metric — 1.0 when no forbidden id leaks, 0.0 on any leak.
+    const leaked = retrievedIds.filter((id) => sample.forbiddenIds.includes(id));
+    const isolationScore = leaked.length === 0 ? 1 : 0;
+
+    tasks.push({
+      taskId: sample.id,
+      question: sample.title,
+      expected: expectedJson,
+      actual: actualJson,
+      scores: {
+        p_at_1: precisionAtK(retrievedIds, sample.expectedIds, 1),
+        p_at_3: precisionAtK(retrievedIds, sample.expectedIds, 3),
+        p_at_5: precisionAtK(retrievedIds, sample.expectedIds, 5),
+        isolation: isolationScore,
+      },
+      latencyMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        kind: sample.kind,
+        sessionNamespaces: sample.sessionNamespaces,
+        forbiddenIds: sample.forbiddenIds,
+        leaked,
+        retrievedIds,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Scoring
+// ──────────────────────────────────────────────────────────────────────────
+
+const REVIEW_BOOST_PER_MATCH = 0.5;
+const REVIEW_MAX_BOOST = 1.0;
+
+function scoreCase(sample: CodingRecallCase): CodingRecallCaseMemory[] {
+  // 1. Filter candidates to the session's readable namespaces (rule 42).
+  const allowedNs = new Set(sample.sessionNamespaces);
+  const filtered = sample.candidates.filter((c) => allowedNs.has(c.namespace));
+
+  // 2. Compute review-context boosts when a touched-file list is present.
+  const touched = sample.touchedFiles ?? [];
+  const annotated = filtered.map((c) => {
+    const boost = touched.length > 0 ? computeReviewBoost(c.entityRefs, touched) : 0;
+    return { ...c, adjusted: c.score + boost, boost };
+  });
+
+  // 3. Sort by adjusted score desc, stable by id asc (CLAUDE.md #19).
+  annotated.sort((a, b) => {
+    if (a.adjusted !== b.adjusted) return b.adjusted - a.adjusted;
+    if (a.id < b.id) return -1;
+    if (a.id > b.id) return 1;
+    return 0;
+  });
+
+  return annotated.map(({ boost: _b, adjusted: _a, ...rest }) => rest);
+}
+
+function computeReviewBoost(entityRefs: string[] | undefined, touchedFiles: string[]): number {
+  if (!entityRefs || entityRefs.length === 0) return 0;
+  let hits = 0;
+  for (const ref of entityRefs) {
+    if (typeof ref !== "string" || !ref) continue;
+    const rlower = ref.toLowerCase();
+    for (const file of touchedFiles) {
+      const flower = file.toLowerCase();
+      if (rlower === flower || rlower.includes(flower) || flower.includes(rlower)) {
+        hits += 1;
+        break;
+      }
+    }
+  }
+  return Math.min(REVIEW_MAX_BOOST, hits * REVIEW_BOOST_PER_MATCH);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Fixture selection
+// ──────────────────────────────────────────────────────────────────────────
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): CodingRecallCase[] {
+  const baseCases = mode === "quick" ? CODING_RECALL_SMOKE_FIXTURE : CODING_RECALL_FIXTURE;
+
+  if (limit === undefined) return baseCases;
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error("coding-recall limit must be a positive integer");
+  }
+  const limited = baseCases.slice(0, limit);
+  if (limited.length === 0) {
+    throw new Error("coding-recall fixture is empty after applying the requested limit.");
+  }
+  return limited;
+}

--- a/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/coding-recall/runner.ts
@@ -9,6 +9,8 @@
 
 import { randomUUID } from "node:crypto";
 
+import { rankReviewCandidates } from "@remnic/core";
+
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -128,48 +130,35 @@ export async function runCodingRecallBenchmark(
 // ──────────────────────────────────────────────────────────────────────────
 // Scoring
 // ──────────────────────────────────────────────────────────────────────────
-
-const REVIEW_BOOST_PER_MATCH = 0.5;
-const REVIEW_MAX_BOOST = 1.0;
+//
+// The benchmark delegates the actual review-context ranking logic to
+// `@remnic/core`'s `rankReviewCandidates` so that the benchmark verdict
+// exercises the SAME code path production does. Previously the benchmark
+// reimplemented the boost + sort logic locally and could have diverged from
+// the shipped behavior; now an accidental change to production ranking
+// would be caught by the benchmark instead of hidden by a parallel copy.
 
 function scoreCase(sample: CodingRecallCase): CodingRecallCaseMemory[] {
   // 1. Filter candidates to the session's readable namespaces (rule 42).
   const allowedNs = new Set(sample.sessionNamespaces);
   const filtered = sample.candidates.filter((c) => allowedNs.has(c.namespace));
 
-  // 2. Compute review-context boosts when a touched-file list is present.
+  // 2. Delegate review-context boosting + deterministic ordering to the
+  //    canonical production ranker. When no touched files are supplied the
+  //    boost is 0 for every candidate and the original sort order is
+  //    preserved with the stable-id tiebreak.
   const touched = sample.touchedFiles ?? [];
-  const annotated = filtered.map((c) => {
-    const boost = touched.length > 0 ? computeReviewBoost(c.entityRefs, touched) : 0;
-    return { ...c, adjusted: c.score + boost, boost };
-  });
+  const ranked = rankReviewCandidates(
+    filtered.map((c) => ({ id: c.id, score: c.score, entityRefs: c.entityRefs })),
+    touched,
+  );
 
-  // 3. Sort by adjusted score desc, stable by id asc (CLAUDE.md #19).
-  annotated.sort((a, b) => {
-    if (a.adjusted !== b.adjusted) return b.adjusted - a.adjusted;
-    if (a.id < b.id) return -1;
-    if (a.id > b.id) return 1;
-    return 0;
-  });
-
-  return annotated.map(({ boost: _b, adjusted: _a, ...rest }) => rest);
-}
-
-function computeReviewBoost(entityRefs: string[] | undefined, touchedFiles: string[]): number {
-  if (!entityRefs || entityRefs.length === 0) return 0;
-  let hits = 0;
-  for (const ref of entityRefs) {
-    if (typeof ref !== "string" || !ref) continue;
-    const rlower = ref.toLowerCase();
-    for (const file of touchedFiles) {
-      const flower = file.toLowerCase();
-      if (rlower === flower || rlower.includes(flower) || flower.includes(rlower)) {
-        hits += 1;
-        break;
-      }
-    }
-  }
-  return Math.min(REVIEW_MAX_BOOST, hits * REVIEW_BOOST_PER_MATCH);
+  // 3. Re-project the candidate back to the benchmark's result shape
+  //    (rankReviewCandidates returns only the subset it needs).
+  const byId = new Map(filtered.map((c) => [c.id, c]));
+  return ranked
+    .map((r) => byId.get(r.id))
+    .filter((c): c is CodingRecallCaseMemory => c !== undefined);
 }
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -72,6 +72,10 @@ import {
   runRetrievalDirectAnswerBenchmark,
 } from "./benchmarks/remnic/retrieval-direct-answer/runner.js";
 import {
+  codingRecallDefinition,
+  runCodingRecallBenchmark,
+} from "./benchmarks/remnic/coding-recall/runner.js";
+import {
   proceduralRecallDefinition,
   runProceduralRecallBenchmark,
 } from "./benchmarks/remnic/procedural-recall/runner.js";
@@ -184,6 +188,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalDirectAnswerDefinition,
     run: runRetrievalDirectAnswerBenchmark,
+  },
+  {
+    ...codingRecallDefinition,
+    run: runCodingRecallBenchmark,
   },
   {
     ...proceduralRecallDefinition,

--- a/packages/plugin-claude-code/hooks/bin/session-start.sh
+++ b/packages/plugin-claude-code/hooks/bin/session-start.sh
@@ -171,7 +171,17 @@ REQUEST_BODY="$(REMNIC_CODING_CONTEXT_JSON="$CODING_CONTEXT_JSON" node -e "
   };
   const raw = process.env.REMNIC_CODING_CONTEXT_JSON || '';
   if (raw) {
-    try { body.codingContext = JSON.parse(raw); } catch (_) { /* ignore */ }
+    try { body.codingContext = JSON.parse(raw); } catch (_) {
+      // Context envelope was provided but failed to parse. Explicitly
+      // clear any previously-attached context for this session so a
+      // malformed envelope does not silently keep stale state.
+      body.codingContext = null;
+    }
+  } else {
+    // No git context resolvable for this cwd. Explicitly clear any
+    // previously-attached context so a session that moves out of a repo
+    // does not keep routing to the old project namespace.
+    body.codingContext = null;
   }
   process.stdout.write(JSON.stringify(body));
 " "$QUERY" "$SESSION_ID" 2>/dev/null)"

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3108,7 +3108,7 @@ async function cmdBriefing(rest: string[]): Promise<void> {
   }
 }
 
-function cmdDoctor(): void {
+async function cmdDoctor(): Promise<void> {
   const checks: Array<{ name: string; ok: boolean; warn?: boolean; detail: string; remediation?: string }> = [];
 
   const nodeVersion = process.version;
@@ -3322,6 +3322,67 @@ function cmdDoctor(): void {
         });
       }
     }
+  }
+
+  // ── Coding-agent context (issue #569) ──────────────────────────────────
+  // Acceptance criterion: `remnic doctor` inside a git repo prints the
+  // detected projectId, branch, and effective namespace. We invoke the
+  // pure GitContextResolver against process.cwd(); when the cwd is not a
+  // git repo the check is informational only (no failure).
+  try {
+    const core = (await import("@remnic/core")) as unknown as {
+      resolveGitContext?: (cwd: string) => Promise<null | {
+        projectId: string;
+        branch: string | null;
+        rootPath: string;
+        defaultBranch: string | null;
+      }>;
+      describeCodingScope?: (
+        ctx: unknown,
+        config: { projectScope: boolean; branchScope: boolean },
+      ) => {
+        scope: "none" | "project" | "branch";
+        effectiveNamespace: string | null;
+        readFallbacks: string[];
+      };
+    };
+    if (typeof core.resolveGitContext === "function") {
+      const gitCtx = await core.resolveGitContext(process.cwd());
+      if (gitCtx) {
+        const parts = [
+          `project=${gitCtx.projectId}`,
+          `branch=${gitCtx.branch ?? "(detached)"}`,
+          `root=${gitCtx.rootPath}`,
+          `defaultBranch=${gitCtx.defaultBranch ?? "(unknown)"}`,
+        ];
+        // Compute effective namespace using the same resolver the orchestrator
+        // uses, with the defaults that ship in `@remnic/core`. Operators can
+        // confirm the overlay is reachable even before the daemon sees the
+        // session.
+        let effective = `project-…`;
+        if (typeof core.describeCodingScope === "function") {
+          const desc = core.describeCodingScope(gitCtx, {
+            projectScope: true,
+            branchScope: false,
+          });
+          effective = desc.effectiveNamespace ?? "(no overlay)";
+        }
+        checks.push({
+          name: "Coding-agent context",
+          ok: true,
+          detail: `${parts.join(", ")}, effectiveNamespace=${effective}`,
+        });
+      } else {
+        checks.push({
+          name: "Coding-agent context",
+          ok: true,
+          warn: true,
+          detail: "cwd is not inside a git repo (project/branch scoping will not apply)",
+        });
+      }
+    }
+  } catch {
+    // Never fail doctor for detection errors.
   }
 
   for (const check of checks) {
@@ -5858,7 +5919,7 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
     }
 
     case "doctor":
-      cmdDoctor();
+      await cmdDoctor();
       break;
 
     case "config":

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -3356,17 +3356,37 @@ async function cmdDoctor(): Promise<void> {
           `defaultBranch=${gitCtx.defaultBranch ?? "(unknown)"}`,
         ];
         // Compute effective namespace using the same resolver the orchestrator
-        // uses, with the defaults that ship in `@remnic/core`. Operators can
-        // confirm the overlay is reachable even before the daemon sees the
-        // session.
+        // uses, with the operator's ACTUAL configured codingMode values so
+        // that the reported effectiveNamespace matches what recall + writes
+        // will use at runtime. Falls back to the ship defaults
+        // (projectScope on, branchScope off) only when no codingMode is
+        // configured in openclaw.plugin.json.
+        const pluginRemnic =
+          typeof openclawConfig.remnic === "object" && openclawConfig.remnic !== null
+            ? (openclawConfig.remnic as Record<string, unknown>)
+            : (openclawConfig as Record<string, unknown>);
+        const pluginCodingMode =
+          typeof pluginRemnic.codingMode === "object" && pluginRemnic.codingMode !== null
+            ? (pluginRemnic.codingMode as Record<string, unknown>)
+            : {};
+        const projectScopeCfg =
+          typeof pluginCodingMode.projectScope === "boolean"
+            ? pluginCodingMode.projectScope
+            : true;
+        const branchScopeCfg =
+          typeof pluginCodingMode.branchScope === "boolean"
+            ? pluginCodingMode.branchScope
+            : false;
         let effective = `project-…`;
         if (typeof core.describeCodingScope === "function") {
           const desc = core.describeCodingScope(gitCtx, {
-            projectScope: true,
-            branchScope: false,
+            projectScope: projectScopeCfg,
+            branchScope: branchScopeCfg,
           });
           effective = desc.effectiveNamespace ?? "(no overlay)";
         }
+        parts.push(`projectScope=${projectScopeCfg}`);
+        parts.push(`branchScope=${branchScopeCfg}`);
         checks.push({
           name: "Coding-agent context",
           ok: true,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1,7 +1,7 @@
 import type { Readable, Writable } from "node:stream";
 import { readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
-import type { EngramAccessService, EngramAccessRecallResponse } from "./access-service.js";
+import { EngramAccessInputError, type EngramAccessService, type EngramAccessRecallResponse } from "./access-service.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
@@ -122,6 +122,39 @@ export class EngramMcpServer {
             sessionKey: { type: "string" },
             namespace: { type: "string" },
           },
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.set_coding_context",
+        description:
+          "Attach a coding-agent context (project / branch) to a session so recall routes to a project- / branch-scoped namespace (issue #569). For MCP clients that do not ship cwd automatically (Cursor, generic agents, etc.). Also aliased as remnic.set_coding_context. Pass codingContext: null to clear.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            sessionKey: {
+              type: "string",
+              description: "Session identifier the context should attach to.",
+            },
+            codingContext: {
+              anyOf: [
+                { type: "null" },
+                {
+                  type: "object",
+                  properties: {
+                    projectId: { type: "string", description: "Stable project id (origin:<hex> or root:<hex>)." },
+                    branch: { type: ["string", "null"], description: "Current branch, or null in detached HEAD." },
+                    rootPath: { type: "string", description: "Absolute path to the repo root." },
+                    defaultBranch: { type: ["string", "null"], description: "Default branch (usually main/master), or null when unknown." },
+                  },
+                  required: ["projectId", "branch", "rootPath", "defaultBranch"],
+                  additionalProperties: false,
+                },
+              ],
+              description: "The context to attach, or null to clear.",
+            },
+          },
+          required: ["sessionKey", "codingContext"],
           additionalProperties: false,
         },
       },
@@ -1097,6 +1130,42 @@ export class EngramMcpServer {
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      case "engram.set_coding_context": {
+        // Issue #569 PR 7 — MCP tool for clients that don't ship cwd.
+        // Validation lives in EngramAccessService.setCodingContext; any
+        // EngramAccessInputError surfaces as a structured tool-call error.
+        const sessionKey = typeof args.sessionKey === "string" ? args.sessionKey : "";
+        const rawCtx = args.codingContext;
+        let codingContext: {
+          projectId: string;
+          branch: string | null;
+          rootPath: string;
+          defaultBranch: string | null;
+        } | null = null;
+        if (rawCtx !== null) {
+          if (typeof rawCtx !== "object" || rawCtx === undefined) {
+            throw new EngramAccessInputError("codingContext must be an object or null");
+          }
+          const obj = rawCtx as Record<string, unknown>;
+          const projectId = typeof obj.projectId === "string" ? obj.projectId : "";
+          const rootPath = typeof obj.rootPath === "string" ? obj.rootPath : "";
+          const branch = obj.branch === null
+            ? null
+            : typeof obj.branch === "string" ? obj.branch : undefined;
+          const defaultBranch = obj.defaultBranch === null
+            ? null
+            : typeof obj.defaultBranch === "string" ? obj.defaultBranch : undefined;
+          if (branch === undefined) {
+            throw new EngramAccessInputError("codingContext.branch must be a string or null");
+          }
+          if (defaultBranch === undefined) {
+            throw new EngramAccessInputError("codingContext.defaultBranch must be a string or null");
+          }
+          codingContext = { projectId, branch, rootPath, defaultBranch };
+        }
+        this.service.setCodingContext({ sessionKey, codingContext });
+        return { ok: true };
+      }
       case "engram.recall_tier_explain":
         return this.service.recallTierExplain(
           typeof args.sessionKey === "string" && args.sessionKey.length > 0

--- a/packages/remnic-core/src/coding/mcp-set-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/mcp-set-coding-context.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for the MCP `engram.set_coding_context` tool (issue #569 PR 7).
+ *
+ * The MCP server is accessed by Cursor, generic agents, and any client that
+ * doesn't ship `cwd` in its session-start handshake. This tool lets those
+ * clients set the coding context explicitly.
+ *
+ * Tests drive the tool through `callTool` directly — no JSON-RPC transport —
+ * so we cover the handler's input validation and alias handling without
+ * needing a stdio mock.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramMcpServer } from "../access-mcp.js";
+import { EngramAccessInputError, type EngramAccessService } from "../access-service.js";
+import type { CodingContext } from "../types.js";
+
+function makeMcp(): {
+  mcp: EngramMcpServer;
+  calls: Array<{ sessionKey: string; ctx: CodingContext | null }>;
+} {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const service = {
+    setCodingContext(request: { sessionKey: string; codingContext: CodingContext | null }) {
+      if (!request.sessionKey || request.sessionKey.trim().length === 0) {
+        throw new EngramAccessInputError("sessionKey is required for setCodingContext");
+      }
+      if (request.codingContext && !request.codingContext.projectId) {
+        throw new EngramAccessInputError("codingContext.projectId must be a non-empty string");
+      }
+      calls.push({ sessionKey: request.sessionKey, ctx: request.codingContext });
+    },
+  } as unknown as EngramAccessService;
+  const mcp = new EngramMcpServer(service);
+  return { mcp, calls };
+}
+
+// Helper — bypass JSON-RPC layer.
+async function call(mcp: EngramMcpServer, name: string, args: Record<string, unknown>): Promise<unknown> {
+  const anyMcp = mcp as unknown as {
+    callTool(n: string, a: Record<string, unknown>): Promise<unknown>;
+  };
+  return anyMcp.callTool(name, args);
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Tool listing — advertises both canonical and legacy names
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context is listed in the tool catalogue", () => {
+  const { mcp } = makeMcp();
+  const tools = (mcp as unknown as { tools: Array<{ name: string }> }).tools;
+  const names = tools.map((t) => t.name);
+  assert.ok(
+    names.includes("engram.set_coding_context"),
+    `expected engram.set_coding_context in catalogue, got: ${names.join(", ")}`,
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Happy path
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context: attaches a full context", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd1234",
+      branch: "main",
+      rootPath: "/work/proj",
+      defaultBranch: "main",
+    },
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionKey, "session-A");
+  assert.equal(calls[0]!.ctx?.projectId, "origin:abcd1234");
+  assert.equal(calls[0]!.ctx?.branch, "main");
+});
+
+test("engram.set_coding_context: codingContext=null clears the session", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: null,
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx, null);
+});
+
+test("engram.set_coding_context: branch=null (detached HEAD) accepted", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd",
+      branch: null,
+      rootPath: "/work/proj",
+      defaultBranch: null,
+    },
+  });
+  assert.equal(calls[0]!.ctx?.branch, null);
+  assert.equal(calls[0]!.ctx?.defaultBranch, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Canonical alias — remnic.set_coding_context resolves to the same handler
+// ──────────────────────────────────────────────────────────────────────────
+
+test("remnic.set_coding_context: canonical name is aliased to the engram.* handler", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "remnic.set_coding_context", {
+    sessionKey: "session-B",
+    codingContext: {
+      projectId: "origin:deadbeef",
+      branch: "feat/x",
+      rootPath: "/work/x",
+      defaultBranch: "main",
+    },
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.sessionKey, "session-B");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// Validation — CLAUDE.md #51
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.set_coding_context: empty sessionKey → throws EngramAccessInputError", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "",
+      codingContext: {
+        projectId: "origin:abcd",
+        branch: "main",
+        rootPath: "/work",
+        defaultBranch: "main",
+      },
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+});
+
+test("engram.set_coding_context: non-null non-object codingContext → rejects", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "s",
+      codingContext: "not-an-object",
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+});
+
+test("engram.set_coding_context: branch missing (undefined) → rejects", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "s",
+      codingContext: {
+        projectId: "origin:abcd",
+        rootPath: "/work",
+        defaultBranch: "main",
+        // branch field missing
+      },
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError && /branch/i.test((err as Error).message),
+  );
+});

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -162,6 +162,32 @@ export { EngramAccessService, EngramAccessInputError } from "./access-service.js
 export { EngramAccessHttpServer } from "./access-http.js";
 export { EngramMcpServer } from "./access-mcp.js";
 
+// Coding-agent subsystem (issue #569)
+export {
+  resolveGitContext,
+  normalizeOriginUrl,
+  stableHash,
+  expandTildePath,
+  type GitContext,
+  type GitInvoker,
+} from "./coding/git-context.js";
+export {
+  resolveCodingNamespaceOverlay,
+  projectNamespaceName,
+  branchNamespaceName,
+  describeCodingScope,
+  type CodingNamespaceOverlay,
+  type CodingScopeDescription,
+} from "./coding/coding-namespace.js";
+export {
+  isReviewPrompt,
+  parseTouchedFiles,
+  rankReviewCandidates,
+  packReviewContext,
+  type ReviewContext,
+  type ReviewCandidate,
+} from "./coding/review-context.js";
+
 export {
   validateRequest,
   formatZodError,

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -156,6 +156,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
   const legacyListed = [
     "engram.recall",
     "engram.recall_explain",
+    "engram.set_coding_context",
     "engram.recall_tier_explain",
     "engram.day_summary",
     "engram.memory_governance_run",

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -29,6 +29,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "retrieval-personalization",
       "retrieval-temporal",
       "retrieval-direct-answer",
+      "coding-recall",
       "procedural-recall",
       "ingestion-entity-recall",
       "ingestion-schema-completeness",
@@ -71,11 +72,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.


### PR DESCRIPTION
## Summary

Closes #569 by shipping the acceptance-level surface area: the benchmark fixture, the `remnic doctor` check, and the `@remnic/core` exports needed by the CLI.

**Stacked on #591 (PR 7).**

## Benchmark — `packages/bench/src/benchmarks/remnic/coding-recall/`

Deterministic fixture + runner covering the three #569 invariants:
1. **Cross-project isolation** — project B's memories filtered when the session resolves to project A.
2. **Branch isolation with project-level fallback** — branch A reads its own namespace + project fallback, never branch B's namespace.
3. **Review-context ranking** — "review this diff" boosts memories mentioning touched files, with stable tie-break by id.

Reports `p_at_{1,3,5}` and an explicit `isolation` score (1.0 = no forbidden id leaked, 0.0 on any leak). 4 smoke tests in `runner.test.ts`.

## `remnic doctor`

Adds a `Coding-agent context` check that calls `resolveGitContext(process.cwd())` and prints `projectId` / `branch` / `rootPath` / `defaultBranch` / `effectiveNamespace`. Satisfies the issue acceptance criterion:

> Running `remnic doctor` inside a git repo prints the detected `projectId`, branch, and effective namespace.

Never fails the doctor run — cwd outside a repo emits a warn-level informational line.

## Core exports

Surfaces the coding subsystem from `@remnic/core` so the CLI (and third-party bench harnesses) can import it: `resolveGitContext`, `describeCodingScope`, `packReviewContext`, the related types, and the name helpers.

## Site changes (separate push to `remnic-site` main)

- Adds `/coding-agent` marketing page with the four capability cards (project isolation, branch scoping, review context, connector coverage) and the escape-hatch config snippet.
- Updates `/compare` with a **Project / branch scoping** row — Remnic is the only system that ships this.

## Test plan

- [x] `pnpm run check-types` clean
- [x] 4 coding-recall bench tests green
- [x] CLI builds
- [x] 112+ coding-subsystem tests still pass from earlier slices

Part of #569 (final slice 8 of 8).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new MCP tool and CLI behavior around coding context, which affects session scoping and client/server interoperability; also introduces a new benchmark runner wired into the registry. Changes are mostly additive but touch the access layer and CLI command flow.
> 
> **Overview**
> Introduces a new deterministic `coding-recall` benchmark (fixture + runner + tests) that scores **project/branch namespace isolation** and **diff-aware review-context ranking**, and registers it in the bench registry/catalog.
> 
> Extends `remnic doctor` to detect git coding context via `@remnic/core` and report the computed effective namespace using configured `codingMode` (without failing when outside a repo).
> 
> Adds an MCP tool `engram.set_coding_context` (aliased as `remnic.set_coding_context`) to explicitly attach/clear coding context for clients that don’t send `cwd`, updates tool listings/tests accordingly, and exports the coding subsystem APIs from `@remnic/core` for CLI/bench consumers.
> 
> Hardens the Claude Code session-start hook to explicitly clear `codingContext` when missing or malformed to avoid stale session scoping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0d77f3344a45272816381e768ef61c98ad6e681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->