### PR TITLE
Fix benchmark QMD shutdown abort handling

### DIFF
--- a/packages/remnic-core/src/conversation-index/backend.ts
+++ b/packages/remnic-core/src/conversation-index/backend.ts
@@ -1,4 +1,4 @@
-import type { SearchBackend } from "../search/port.js";
+import type { SearchBackend, SearchExecutionOptions } from "../search/port.js";
 import type { ConversationChunk } from "./chunker.js";
 import { failOpenFaissHealth, type FaissConversationIndexAdapter } from "./faiss-adapter.js";
 import {
@@ -13,7 +13,8 @@ export interface ConversationQmdRuntime extends SearchBackend {
   isAvailable(): boolean;
   probe(): Promise<boolean>;
   ensureCollection(baseDir: string): Promise<CollectionState>;
-  update(): Promise<void>;
+  update(execution?: SearchExecutionOptions): Promise<void>;
+  updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void>;
   embed(): Promise<void>;
   debugStatus(): string;
 }

--- a/packages/remnic-core/src/namespaces/search.ts
+++ b/packages/remnic-core/src/namespaces/search.ts
@@ -105,13 +105,16 @@ export class NamespaceSearchRouter {
    * signal that no backend was eligible — useful for success-verification in
    * startup-sync when namespacesEnabled is true.
    */
-  async updateNamespaces(namespaces: string[]): Promise<number> {
+  async updateNamespaces(
+    namespaces: string[],
+    execution?: SearchExecutionOptions,
+  ): Promise<number> {
     const unique = Array.from(new Set(namespaces.map((value) => value.trim()).filter(Boolean)));
     const results = await Promise.all(
       unique.map(async (namespace) => {
         const record = await this.backendRecordFor(namespace);
         if (!record.available || record.collectionState === "missing") return 0;
-        await record.backend.update();
+        await record.backend.update(execution);
         return 1;
       }),
     );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1242,15 +1242,7 @@ export class Orchestrator {
   }
 
   private async disposeSearchBackendIfNeeded(): Promise<void> {
-    const backends = [this.qmd, this.conversationQmd];
-    const disposed = new Set<object>();
-
-    for (const backend of backends) {
-      if (!backend || typeof backend !== "object") continue;
-      if (disposed.has(backend)) continue;
-      disposed.add(backend);
-      await (backend as { dispose?: () => void | Promise<void> }).dispose?.();
-    }
+    await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
   }
 
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
@@ -2003,9 +1995,10 @@ export class Orchestrator {
         if (this.config.namespacesEnabled) {
           await this.namespaceSearchRouter.updateNamespaces(
             this.configuredNamespaces(),
+            { signal },
           );
         } else {
-          await this.qmd.update(signal);
+          await this.qmd.update({ signal });
         }
         log.info("QMD startup sync: complete");
         this.deferredSyncSucceeded = true;
@@ -2232,9 +2225,12 @@ export class Orchestrator {
         log.info("startupSearchSync: updating index to match current disk state");
         let namespacesUpdated = 0;
         if (this.config.namespacesEnabled) {
-          namespacesUpdated = await this.namespaceSearchRouter.updateNamespaces(namespaces);
+          namespacesUpdated = await this.namespaceSearchRouter.updateNamespaces(
+            namespaces,
+            { signal },
+          );
         } else {
-          await (this.qmd as any).update(signal);
+          await this.qmd.update({ signal });
         }
         if (signal?.aborted) {
           log.debug("startupSearchSync: aborted after update");

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1242,7 +1242,15 @@ export class Orchestrator {
   }
 
   private async disposeSearchBackendIfNeeded(): Promise<void> {
-    await (this.qmd as { dispose?: () => void | Promise<void> }).dispose?.();
+    const backends = [this.qmd, this.conversationQmd];
+    const disposed = new Set<object>();
+
+    for (const backend of backends) {
+      if (!backend || typeof backend !== "object") continue;
+      if (disposed.has(backend)) continue;
+      disposed.add(backend);
+      await (backend as { dispose?: () => void | Promise<void> }).dispose?.();
+    }
   }
 
   /** Set per-session workspace for the next recall() call (compaction reset). @internal */
@@ -1997,7 +2005,7 @@ export class Orchestrator {
             this.configuredNamespaces(),
           );
         } else {
-          await this.qmd.update();
+          await this.qmd.update(signal);
         }
         log.info("QMD startup sync: complete");
         this.deferredSyncSucceeded = true;
@@ -2022,7 +2030,7 @@ export class Orchestrator {
       log.info("QMD warmup: pre-loading models with a test search");
       warmupPromises.push(
         this.qmd
-          .search("warmup", warmupNs, 1)
+          .search("warmup", warmupNs, 1, undefined, { signal })
           .then(() => {
             log.info("QMD warmup: complete");
           })

--- a/packages/remnic-core/src/qmd.ts
+++ b/packages/remnic-core/src/qmd.ts
@@ -1653,12 +1653,23 @@ export class QmdClient implements SearchBackend {
     }
   }
 
-  async update(signal?: AbortSignal): Promise<void> {
-    await this.runUpdateForCollection(this.collection, { perCollectionThrottle: false }, signal);
+  async update(execution?: SearchExecutionOptions): Promise<void> {
+    await this.runUpdateForCollection(
+      this.collection,
+      { perCollectionThrottle: false },
+      execution?.signal,
+    );
   }
 
-  async updateCollection(collection: string): Promise<void> {
-    await this.runUpdateForCollection(collection, { perCollectionThrottle: true });
+  async updateCollection(
+    collection: string,
+    execution?: SearchExecutionOptions,
+  ): Promise<void> {
+    await this.runUpdateForCollection(
+      collection,
+      { perCollectionThrottle: true },
+      execution?.signal,
+    );
   }
 
   private async runUpdateForCollection(

--- a/packages/remnic-core/src/search/lancedb-backend.ts
+++ b/packages/remnic-core/src/search/lancedb-backend.ts
@@ -110,11 +110,11 @@ export class LanceDbBackend implements SearchBackend {
     return this.searchTable(table, query, "hybrid", maxResults ?? 10);
   }
 
-  async update(): Promise<void> {
-    await this.updateCollection(this.collection);
+  async update(execution?: SearchExecutionOptions): Promise<void> {
+    await this.updateCollection(this.collection, execution);
   }
 
-  async updateCollection(collection: string): Promise<void> {
+  async updateCollection(collection: string, _execution?: SearchExecutionOptions): Promise<void> {
     const table = await this.ensureTableForCollection(collection);
     if (!table) return;
 

--- a/packages/remnic-core/src/search/meilisearch-backend.ts
+++ b/packages/remnic-core/src/search/meilisearch-backend.ts
@@ -113,11 +113,11 @@ export class MeilisearchBackend implements SearchBackend {
     return this.doSearch(query, maxResults ?? 10, { hybrid: { semanticRatio: 0.5, embedder: "default" } }, collection);
   }
 
-  async update(): Promise<void> {
-    await this.updateCollection(this.collection);
+  async update(execution?: SearchExecutionOptions): Promise<void> {
+    await this.updateCollection(this.collection, execution);
   }
 
-  async updateCollection(collection: string): Promise<void> {
+  async updateCollection(collection: string, _execution?: SearchExecutionOptions): Promise<void> {
     if (!this.autoIndex || !this.memoryDir) return;
     if (!this.available) return;
 

--- a/packages/remnic-core/src/search/noop-backend.ts
+++ b/packages/remnic-core/src/search/noop-backend.ts
@@ -43,8 +43,8 @@ export class NoopSearchBackend implements SearchBackend {
     return [];
   }
 
-  async update(): Promise<void> {}
-  async updateCollection(_collection: string): Promise<void> {}
+  async update(_execution?: SearchExecutionOptions): Promise<void> {}
+  async updateCollection(_collection: string, _execution?: SearchExecutionOptions): Promise<void> {}
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 

--- a/packages/remnic-core/src/search/orama-backend.ts
+++ b/packages/remnic-core/src/search/orama-backend.ts
@@ -107,11 +107,11 @@ export class OramaBackend implements SearchBackend {
     return this.searchDb(db, query, "hybrid", maxResults ?? 10);
   }
 
-  async update(): Promise<void> {
-    await this.updateCollection(this.collection);
+  async update(execution?: SearchExecutionOptions): Promise<void> {
+    await this.updateCollection(this.collection, execution);
   }
 
-  async updateCollection(collection: string): Promise<void> {
+  async updateCollection(collection: string, _execution?: SearchExecutionOptions): Promise<void> {
     const db = await this.ensureDbForCollection(collection);
     if (!db) return;
     const { search: oramaSearch, insert, remove, count } = this.oramaModule;

--- a/packages/remnic-core/src/search/port.ts
+++ b/packages/remnic-core/src/search/port.ts
@@ -60,8 +60,8 @@ export interface SearchBackend {
   ): Promise<SearchResult[]>;
 
   // ── Maintenance ──
-  update(): Promise<void>;
-  updateCollection(collection: string): Promise<void>;
+  update(execution?: SearchExecutionOptions): Promise<void>;
+  updateCollection(collection: string, execution?: SearchExecutionOptions): Promise<void>;
   embed(): Promise<void>;
   embedCollection(collection: string): Promise<void>;
 

--- a/packages/remnic-core/src/search/remote-backend.ts
+++ b/packages/remnic-core/src/search/remote-backend.ts
@@ -77,8 +77,8 @@ export class RemoteSearchBackend implements SearchBackend {
     return this.post("/search/hybrid", { query, collection, maxResults }, execution);
   }
 
-  async update(): Promise<void> {}
-  async updateCollection(_collection: string): Promise<void> {}
+  async update(_execution?: SearchExecutionOptions): Promise<void> {}
+  async updateCollection(_collection: string, _execution?: SearchExecutionOptions): Promise<void> {}
   async embed(): Promise<void> {}
   async embedCollection(_collection: string): Promise<void> {}
 

--- a/tests/namespace-search-router.test.ts
+++ b/tests/namespace-search-router.test.ts
@@ -4,7 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import type { PluginConfig } from "../src/types.js";
 import { NamespaceSearchRouter, namespaceCollectionName } from "../src/namespaces/search.js";
-import type { SearchBackend, SearchQueryOptions } from "../src/search/port.js";
+import type { SearchBackend, SearchExecutionOptions, SearchQueryOptions } from "../src/search/port.js";
 
 function tmpDir(prefix: string): string {
   return path.join(os.tmpdir(), `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`);
@@ -239,6 +239,7 @@ function baseConfig(memoryDir: string): PluginConfig {
 type FakeSearchBackend = SearchBackend & {
   calls: string[];
   lastSearchOptions?: SearchQueryOptions;
+  lastUpdateExecution?: SearchExecutionOptions;
 };
 
 function backendForResultSet(resultSet: Array<{ docid: string; path: string; score: number; snippet: string }>): FakeSearchBackend {
@@ -267,8 +268,9 @@ function backendForResultSet(resultSet: Array<{ docid: string; path: string; sco
       calls.push("hybrid");
       return resultSet;
     },
-    update: async () => {
+    update: async (execution) => {
       calls.push("update");
+      backend.lastUpdateExecution = execution;
     },
     updateCollection: async () => {
       calls.push("updateCollection");
@@ -507,6 +509,27 @@ test("NamespaceSearchRouter runs maintenance only for present namespace collecti
 
   assert.deepEqual(backends.get("openclaw-engram")?.calls, ["update", "embed"]);
   assert.deepEqual(backends.get("openclaw-engram--ns--shared")?.calls ?? [], []);
+});
+
+test("NamespaceSearchRouter forwards execution options to namespace updates", async () => {
+  const memoryDir = tmpDir("engram-ns-search-update-execution");
+  const cfg = baseConfig(memoryDir);
+  const backend = backendForResultSet([]);
+  const signal = new AbortController().signal;
+  const router = new NamespaceSearchRouter(
+    cfg,
+    {
+      async storageFor() {
+        return { dir: memoryDir };
+      },
+    } as any,
+    () => backend,
+  );
+
+  await router.updateNamespaces(["default"], { signal });
+
+  assert.deepEqual(backend.calls, ["update"]);
+  assert.equal(backend.lastUpdateExecution?.signal, signal);
 });
 
 test("NamespaceSearchRouter ensureNamespaceCollection returns cached availability without re-ensuring", async () => {

--- a/tests/qmd-sync-after-store.test.ts
+++ b/tests/qmd-sync-after-store.test.ts
@@ -24,7 +24,7 @@ test("QmdClient.update() passes collection flag to qmd subprocess", async () => 
   // update() should route through collection-aware update path
   assert.match(
     qmdSource,
-    /async update\(signal\?: AbortSignal\): Promise<void>\s*\{\s*await this\.runUpdateForCollection\(this\.collection,\s*\{\s*perCollectionThrottle:\s*false\s*\},\s*signal\);/s,
+    /async update\(execution\?: SearchExecutionOptions\): Promise<void>\s*\{\s*await this\.runUpdateForCollection\(\s*this\.collection,\s*\{\s*perCollectionThrottle:\s*false\s*\},\s*execution\?\.signal,\s*\);/s,
     "update() should route through runUpdateForCollection(this.collection)",
   );
 


### PR DESCRIPTION
## Summary
- dispose both primary and conversation-index QMD backends during orchestrator shutdown
- propagate the deferred-init abort signal into startup QMD update and warmup search work
- stop benchmark teardown from leaving `qmd update` subprocesses alive, which forced the CLI watchdog to exit the process after successful runs

## Verification
- `pnpm exec tsx packages/remnic-cli/src/index.ts bench run taxonomy-accuracy --runtime-profile real --remnic-config ~/.config/remnic/config.json --system-provider openai --system-base-url http://127.0.0.1:1234/v1 --system-model google/gemma-4-26b-a4b --judge-provider openai --judge-base-url http://127.0.0.1:1234/v1 --judge-model google/gemma-4-26b-a4b`
- `pnpm exec tsx packages/remnic-cli/src/index.ts bench run --quick longmemeval --runtime-profile real --remnic-config ~/.config/remnic/config.json --system-provider openai --system-base-url http://127.0.0.1:1234/v1 --system-model google/gemma-4-26b-a4b --judge-provider openai --judge-base-url http://127.0.0.1:1234/v1 --judge-model google/gemma-4-26b-a4b`
- ad hoc handle inspection after `system.destroy()` showed only a killed `qmd` child remaining, with no live `qmd update` subprocess
- a patched `bench run --all ... --system-model google/gemma-4-26b-a4b` reached LM Studio with Gemma in `GENERATING` state

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core search maintenance APIs (`SearchBackend.update*`) and orchestrator startup sync/warmup behavior, so mistakes could break indexing updates or cancellation handling across backends. Changes are mostly signature/option plumbing with tests, limiting risk.
> 
> **Overview**
> Propagates cancellable execution context into index maintenance by extending `SearchBackend.update()`/`updateCollection()` (and `ConversationQmdRuntime`) to accept optional `SearchExecutionOptions`.
> 
> Updates orchestrator startup sync and warmup search to pass the deferred-init abort `signal` into QMD update and warmup search calls (including namespace-based updates), reducing the chance of orphaned `qmd update` work during shutdown/bench teardown.
> 
> Adjusts all built-in backends to the new method signatures (mostly ignoring the execution options except QMD) and adds/updates regression tests to ensure execution options are forwarded and QMD update remains collection-scoped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 453baf297a100a6804d889869a46a6b2fdba8960. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->