### PR TITLE
feat(import-chatgpt): ChatGPT export importer (#568 PR 2/7)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -358,6 +358,7 @@ jobs:
             packages/bench
             packages/export-weclone
             packages/import-weclone
+            packages/import-chatgpt
             packages/import-mem0
             packages/connector-weclone
             packages/connector-replit

--- a/packages/import-chatgpt/README.md
+++ b/packages/import-chatgpt/README.md
@@ -1,0 +1,49 @@
+# @remnic/import-chatgpt
+
+Import memory from ChatGPT data exports into [Remnic](https://github.com/joshuaswarren/remnic).
+
+This is an optional companion package for `@remnic/cli`. Install it when you
+want `remnic import --adapter chatgpt` to work.
+
+## Install
+
+```bash
+npm install -g @remnic/cli @remnic/import-chatgpt
+```
+
+## Usage
+
+```bash
+# Dry-run: preview what would be imported without writing.
+remnic import --adapter chatgpt --file ./chatgpt-export/memory.json --dry-run
+
+# Actual import.
+remnic import --adapter chatgpt --file ./chatgpt-export/memory.json
+
+# Also import a conversation summary per chat (default: off).
+remnic import --adapter chatgpt --file ./chatgpt-export/conversations.json \
+  --include-conversations
+```
+
+## What gets imported
+
+- **Saved memories** (the "Memory" feature inside ChatGPT) — 1:1 mapping.
+  Every entry becomes one Remnic memory with `sourceLabel: "chatgpt"` and
+  full provenance (file path, timestamp, and the original memory id).
+- **Conversation summaries** — only when `--include-conversations` is set.
+  Each conversation is reduced to a single memory consisting of the
+  user-side turns concatenated (assistant replies are not imported).
+
+## Export shape support
+
+Accepts all three shapes seen in ChatGPT exports from 2024-2026:
+
+- `{ "memory": [...] }` (2026 shape)
+- `{ "memories": [...] }` (2024/2025 shape)
+- Top-level array of memory records (legacy)
+- `conversations.json` (mapping or inline-messages form)
+
+## Privacy
+
+This package only reads the export file you point at. No network calls are
+made. The CLI writes to your Remnic memory store per your local config.

--- a/packages/import-chatgpt/fixtures/conversations-mapping.json
+++ b/packages/import-chatgpt/fixtures/conversations-mapping.json
@@ -1,0 +1,55 @@
+{
+  "conversations": [
+    {
+      "id": "synthetic-conv-0001",
+      "title": "Fictional: planning a synthetic demo",
+      "create_time": 1737763200,
+      "update_time": 1737763500,
+      "current_node": "msg-3",
+      "mapping": {
+        "msg-1": {
+          "id": "msg-1",
+          "message": {
+            "id": "msg-1",
+            "author": { "role": "user" },
+            "content": {
+              "parts": ["I want to build a synthetic weekend project."],
+              "content_type": "text"
+            },
+            "create_time": 1737763200
+          },
+          "parent": null,
+          "children": ["msg-2"]
+        },
+        "msg-2": {
+          "id": "msg-2",
+          "message": {
+            "id": "msg-2",
+            "author": { "role": "assistant" },
+            "content": {
+              "parts": ["Great, what technology do you have in mind?"],
+              "content_type": "text"
+            },
+            "create_time": 1737763260
+          },
+          "parent": "msg-1",
+          "children": ["msg-3"]
+        },
+        "msg-3": {
+          "id": "msg-3",
+          "message": {
+            "id": "msg-3",
+            "author": { "role": "user" },
+            "content": {
+              "parts": ["Something small, maybe a CLI that parses fake data."],
+              "content_type": "text"
+            },
+            "create_time": 1737763500
+          },
+          "parent": "msg-2",
+          "children": []
+        }
+      }
+    }
+  ]
+}

--- a/packages/import-chatgpt/fixtures/saved-memories-2026.json
+++ b/packages/import-chatgpt/fixtures/saved-memories-2026.json
@@ -1,0 +1,24 @@
+{
+  "memory": [
+    {
+      "id": "11111111-aaaa-4000-8000-000000000001",
+      "content": "Prefers concise answers over verbose explanations.",
+      "created_at": "2026-02-14T09:30:00.000Z",
+      "updated_at": "2026-02-14T09:30:00.000Z",
+      "pinned": false,
+      "tags": ["preferences"]
+    },
+    {
+      "id": "11111111-aaaa-4000-8000-000000000002",
+      "content": "Uses TypeScript with strict mode on all personal projects.",
+      "created_at": "2026-03-01T14:00:00.000Z",
+      "pinned": true
+    },
+    {
+      "id": "11111111-aaaa-4000-8000-000000000003",
+      "content": "Example soft-deleted entry that must be skipped.",
+      "created_at": "2025-12-01T00:00:00.000Z",
+      "deleted": true
+    }
+  ]
+}

--- a/packages/import-chatgpt/fixtures/saved-memories-legacy-array.json
+++ b/packages/import-chatgpt/fixtures/saved-memories-legacy-array.json
@@ -1,0 +1,12 @@
+[
+  {
+    "id": "1001",
+    "content": "Fictional example: prefers Celsius over Fahrenheit.",
+    "created_at": "2024-11-01T08:00:00.000Z"
+  },
+  {
+    "id": "1002",
+    "text": "Fictional example: reviewed a paper on retrieval-augmented generation.",
+    "created_at": "2024-11-05T10:30:00.000Z"
+  }
+]

--- a/packages/import-chatgpt/package.json
+++ b/packages/import-chatgpt/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@remnic/import-chatgpt",
+  "version": "0.1.0",
+  "description": "Import memory and conversation summaries from ChatGPT data exports into Remnic (issue #568)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-chatgpt"
+  },
+  "keywords": ["remnic", "memory", "chatgpt", "openai", "import"]
+}

--- a/packages/import-chatgpt/src/adapter.test.ts
+++ b/packages/import-chatgpt/src/adapter.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ImportTurn, ImporterWriteTarget } from "@remnic/core";
+import { runImporter } from "@remnic/core";
+
+import { adapter, chatgptAdapter } from "./adapter.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+function makeTarget(): { target: ImporterWriteTarget; received: ImportTurn[][] } {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+describe("chatgpt adapter shape", () => {
+  it("exports a canonical adapter + name-prefixed alias", () => {
+    assert.equal(adapter.name, "chatgpt");
+    assert.equal(adapter.sourceLabel, "chatgpt");
+    assert.equal(chatgptAdapter, adapter);
+    assert.equal(typeof adapter.parse, "function");
+    assert.equal(typeof adapter.transform, "function");
+    assert.equal(typeof adapter.writeTo, "function");
+  });
+
+  it("drives runImporter end-to-end with a synthetic saved-memories fixture", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("saved-memories-2026.json"),
+      target,
+      { parseOptions: { filePath: "/tmp/chatgpt-export.zip/memory.json" } },
+    );
+    assert.equal(result.memoriesPlanned, 2);
+    assert.equal(result.memoriesWritten, 2);
+    assert.equal(result.sourceLabel, "chatgpt");
+    assert.ok(received.length >= 1);
+    const allTurns = received.flat();
+    for (const turn of allTurns) {
+      assert.equal(turn.role, "user");
+      assert.equal(turn.participantName, "chatgpt");
+    }
+  });
+
+  it("dry-run does not hit the target", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("saved-memories-2026.json"),
+      target,
+      { dryRun: true },
+    );
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(received.length, 0);
+  });
+
+  it("skips conversations by default but imports them with --include-conversations", async () => {
+    const conversations = loadFixture("conversations-mapping.json");
+    const target1 = makeTarget();
+    const result1 = await runImporter(adapter, conversations, target1.target);
+    assert.equal(result1.memoriesPlanned, 0);
+    assert.equal(target1.received.length, 0);
+
+    const target2 = makeTarget();
+    const result2 = await runImporter(adapter, conversations, target2.target, {
+      transformOptions: { includeConversations: true },
+    });
+    assert.equal(result2.memoriesPlanned, 1);
+    assert.equal(result2.memoriesWritten, 1);
+  });
+});

--- a/packages/import-chatgpt/src/adapter.ts
+++ b/packages/import-chatgpt/src/adapter.ts
@@ -1,0 +1,64 @@
+// ---------------------------------------------------------------------------
+// ChatGPT importer adapter (issue #568 slice 2)
+// ---------------------------------------------------------------------------
+
+import type {
+  ImportedMemory,
+  ImporterAdapter,
+  ImporterParseOptions,
+  ImporterTransformOptions,
+  ImporterWriteResult,
+  ImporterWriteTarget,
+} from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import {
+  parseChatGPTExport,
+  type ParsedChatGPTExport,
+} from "./parser.js";
+import {
+  CHATGPT_SOURCE_LABEL,
+  transformChatGPTExport,
+} from "./transform.js";
+
+/**
+ * Canonical `ImporterAdapter` exposed by `@remnic/import-chatgpt`.
+ *
+ * Loaded by `remnic-cli/optional-importer.ts` via a computed-specifier
+ * dynamic import. The CLI calls `adapter.parse` → `adapter.transform` →
+ * `adapter.writeTo` through the shared `runImporter` helper in
+ * `@remnic/core`.
+ */
+export const adapter: ImporterAdapter<ParsedChatGPTExport> = {
+  name: "chatgpt",
+  sourceLabel: CHATGPT_SOURCE_LABEL,
+
+  parse(input: unknown, options?: ImporterParseOptions): ParsedChatGPTExport {
+    return parseChatGPTExport(input, {
+      ...(options?.strict !== undefined ? { strict: options.strict } : {}),
+      ...(options?.filePath !== undefined ? { filePath: options.filePath } : {}),
+    });
+  },
+
+  transform(
+    parsed: ParsedChatGPTExport,
+    options?: ImporterTransformOptions,
+  ): ImportedMemory[] {
+    return transformChatGPTExport(parsed, {
+      includeConversations: options?.includeConversations === true,
+      ...(options?.maxMemories !== undefined
+        ? { maxMemories: options.maxMemories }
+        : {}),
+    });
+  },
+
+  async writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+  ): Promise<ImporterWriteResult> {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+/** Alias kept for symmetry with other @remnic/import-* packages. */
+export const chatgptAdapter = adapter;

--- a/packages/import-chatgpt/src/index.ts
+++ b/packages/import-chatgpt/src/index.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// @remnic/import-chatgpt — public surface (issue #568 slice 2)
+// ---------------------------------------------------------------------------
+
+export { adapter, chatgptAdapter } from "./adapter.js";
+export {
+  parseChatGPTExport,
+  collectUserTurnsFromConversation,
+  type ChatGPTConversation,
+  type ChatGPTConversationMessage,
+  type ChatGPTConversationNode,
+  type ChatGPTParseOptions,
+  type ChatGPTSavedMemory,
+  type ParsedChatGPTExport,
+} from "./parser.js";
+export {
+  CHATGPT_SOURCE_LABEL,
+  transformChatGPTExport,
+  type ChatGPTTransformOptions,
+} from "./transform.js";

--- a/packages/import-chatgpt/src/parser.test.ts
+++ b/packages/import-chatgpt/src/parser.test.ts
@@ -281,6 +281,15 @@ describe("parseChatGPTExport", () => {
     );
   });
 
+  // Codex review on PR #595 — parseChatGPTExport MUST reject undefined /
+  // null input (what runImportCommand passes when --file is omitted) with
+  // a user-facing error. Silently returning 0 memories masks bad CLI
+  // invocations. Matches the gemini/claude slices.
+  it("rejects missing input with a user-facing error", () => {
+    assert.throws(() => parseChatGPTExport(undefined), /requires a file/);
+    assert.throws(() => parseChatGPTExport(null), /requires a file/);
+  });
+
   // Cursor review on PR #595 — asIsoString must not throw on corrupted
   // timestamps that overflow Date.toISOString's valid range.
   it("returns undefined for timestamps beyond Date's valid range", () => {

--- a/packages/import-chatgpt/src/parser.test.ts
+++ b/packages/import-chatgpt/src/parser.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  collectUserTurnsFromConversation,
+  parseChatGPTExport,
+} from "./parser.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("parseChatGPTExport", () => {
+  it("reads the 2026 `memory` object shape", () => {
+    const parsed = parseChatGPTExport(loadFixture("saved-memories-2026.json"));
+    // Two active memories + one soft-deleted (skipped).
+    assert.equal(parsed.savedMemories.length, 2);
+    assert.equal(parsed.conversations.length, 0);
+    assert.equal(parsed.savedMemories[0].id, "11111111-aaaa-4000-8000-000000000001");
+    assert.equal(parsed.savedMemories[1].pinned, true);
+    // Soft-deleted entry must not leak through.
+    assert.ok(!parsed.savedMemories.some((m) => m.id?.endsWith("0003")));
+  });
+
+  it("reads the legacy array shape with mixed content/text fields", () => {
+    const parsed = parseChatGPTExport(
+      loadFixture("saved-memories-legacy-array.json"),
+    );
+    assert.equal(parsed.savedMemories.length, 2);
+    assert.equal(
+      parsed.savedMemories[1].content,
+      "Fictional example: reviewed a paper on retrieval-augmented generation.",
+    );
+  });
+
+  it("reads the conversations mapping shape", () => {
+    const parsed = parseChatGPTExport(
+      loadFixture("conversations-mapping.json"),
+    );
+    assert.equal(parsed.savedMemories.length, 0);
+    assert.equal(parsed.conversations.length, 1);
+    const [conv] = parsed.conversations;
+    assert.equal(conv.id, "synthetic-conv-0001");
+    const userTurns = collectUserTurnsFromConversation(conv);
+    assert.equal(userTurns.length, 2);
+    assert.equal(
+      userTurns[0].content,
+      "I want to build a synthetic weekend project.",
+    );
+    // createdAt is derived from the numeric create_time field → ISO.
+    assert.ok(
+      userTurns[0].createdAt &&
+        /\d{4}-\d{2}-\d{2}T/.test(userTurns[0].createdAt),
+    );
+  });
+
+  it("accepts already-parsed objects without double-parsing", () => {
+    const obj = { memory: [{ id: "x", content: "hello" }] };
+    const parsed = parseChatGPTExport(obj);
+    assert.equal(parsed.savedMemories.length, 1);
+    assert.equal(parsed.savedMemories[0].content, "hello");
+  });
+
+  it("skips entries missing content in non-strict mode", () => {
+    const parsed = parseChatGPTExport({
+      memory: [{ id: "x" }, { id: "y", content: "kept" }],
+    });
+    assert.equal(parsed.savedMemories.length, 1);
+    assert.equal(parsed.savedMemories[0].content, "kept");
+  });
+
+  it("throws in strict mode on missing content", () => {
+    assert.throws(() =>
+      parseChatGPTExport(
+        { memory: [{ id: "x" }] },
+        { strict: true },
+      ),
+    );
+  });
+
+  it("throws on malformed JSON string input", () => {
+    assert.throws(() => parseChatGPTExport("{not valid"));
+  });
+
+  it("distinguishes a top-level conversations array from a memories array", () => {
+    const convArray = [
+      {
+        id: "c-1",
+        mapping: {
+          "m-1": {
+            id: "m-1",
+            message: {
+              id: "m-1",
+              author: { role: "user" },
+              content: { parts: ["Hello"] },
+              create_time: 1737763200,
+            },
+          },
+        },
+      },
+    ];
+    const parsed = parseChatGPTExport(convArray);
+    assert.equal(parsed.conversations.length, 1);
+    assert.equal(parsed.savedMemories.length, 0);
+  });
+});

--- a/packages/import-chatgpt/src/parser.test.ts
+++ b/packages/import-chatgpt/src/parser.test.ts
@@ -242,6 +242,45 @@ describe("parseChatGPTExport", () => {
     );
   });
 
+  // Codex review on PR #595 — when current_node's parent chain is broken
+  // (dangling reference to a node that doesn't exist in mapping),
+  // followCurrentNodeChain must return [] rather than a partial tail, so
+  // the caller falls back to a timestamp-sorted traversal of ALL nodes.
+  it("falls back to sorted traversal when current_node's parent chain is broken", () => {
+    const conv = {
+      current_node: "msg-3",
+      mapping: {
+        // msg-3 → parent "missing-id" which is NOT in the mapping.
+        "msg-3": {
+          id: "msg-3",
+          parent: "missing-id",
+          message: {
+            id: "msg-3",
+            author: { role: "user" },
+            content: { parts: ["latest"] },
+            create_time: 300,
+          },
+        },
+        // These should still appear because we fall back to timestamp sort.
+        "msg-1": {
+          id: "msg-1",
+          parent: null,
+          message: {
+            id: "msg-1",
+            author: { role: "user" },
+            content: { parts: ["oldest"] },
+            create_time: 100,
+          },
+        },
+      },
+    };
+    const turns = collectUserTurnsFromConversation(conv);
+    assert.deepEqual(
+      turns.map((t) => t.content),
+      ["oldest", "latest"],
+    );
+  });
+
   // Cursor review on PR #595 — asIsoString must not throw on corrupted
   // timestamps that overflow Date.toISOString's valid range.
   it("returns undefined for timestamps beyond Date's valid range", () => {

--- a/packages/import-chatgpt/src/parser.test.ts
+++ b/packages/import-chatgpt/src/parser.test.ts
@@ -111,4 +111,158 @@ describe("parseChatGPTExport", () => {
     assert.equal(parsed.conversations.length, 1);
     assert.equal(parsed.savedMemories.length, 0);
   });
+
+  // Cursor review on PR #595 — strict mode should reject object payloads
+  // that have none of the recognized ChatGPT export sections rather than
+  // silently returning an empty struct.
+  it("strict mode rejects unknown object shapes", () => {
+    assert.throws(
+      () => parseChatGPTExport({ foo: "bar" }, { strict: true }),
+      /Unknown ChatGPT export object shape/,
+    );
+  });
+
+  it("non-strict mode returns an empty result for unknown object shapes", () => {
+    const parsed = parseChatGPTExport({ foo: "bar" });
+    assert.equal(parsed.savedMemories.length, 0);
+    assert.equal(parsed.conversations.length, 0);
+  });
+
+  // Cursor review on PR #595 — collectUserTurnsFromConversation should
+  // follow the current_node → parent chain rather than flattening every
+  // node in the mapping, which would include abandoned branches.
+  it("follows current_node chain and ignores abandoned mapping branches", () => {
+    const conv = {
+      current_node: "msg-3",
+      mapping: {
+        "msg-1": {
+          id: "msg-1",
+          parent: null,
+          message: {
+            id: "msg-1",
+            author: { role: "user" },
+            content: { parts: ["First user turn (active)"] },
+            create_time: 1000,
+          },
+        },
+        "msg-2": {
+          id: "msg-2",
+          parent: "msg-1",
+          message: {
+            id: "msg-2",
+            author: { role: "assistant" },
+            content: { parts: ["Reply"] },
+            create_time: 1100,
+          },
+        },
+        "msg-3": {
+          id: "msg-3",
+          parent: "msg-2",
+          message: {
+            id: "msg-3",
+            author: { role: "user" },
+            content: { parts: ["Second user turn (active)"] },
+            create_time: 1200,
+          },
+        },
+        "msg-abandoned": {
+          id: "msg-abandoned",
+          parent: "msg-1",
+          message: {
+            id: "msg-abandoned",
+            author: { role: "user" },
+            content: { parts: ["ABANDONED branch — must NOT appear"] },
+            create_time: 1050,
+          },
+        },
+      },
+    };
+    const turns = collectUserTurnsFromConversation(conv);
+    assert.equal(turns.length, 2);
+    assert.equal(turns[0]?.content, "First user turn (active)");
+    assert.equal(turns[1]?.content, "Second user turn (active)");
+  });
+
+  it("falls back to sorted traversal when current_node is missing", () => {
+    const conv = {
+      mapping: {
+        "msg-1": {
+          id: "msg-1",
+          parent: null,
+          message: {
+            id: "msg-1",
+            author: { role: "user" },
+            content: { parts: ["alpha"] },
+            create_time: 200,
+          },
+        },
+        "msg-2": {
+          id: "msg-2",
+          parent: "msg-1",
+          message: {
+            id: "msg-2",
+            author: { role: "user" },
+            content: { parts: ["beta"] },
+            create_time: 100,
+          },
+        },
+      },
+    };
+    const turns = collectUserTurnsFromConversation(conv);
+    // Sorted by create_time ascending.
+    assert.deepEqual(
+      turns.map((t) => t.content),
+      ["beta", "alpha"],
+    );
+  });
+
+  it("uses node id as a stable secondary sort key when timestamps tie", () => {
+    const mkNode = (id: string) => ({
+      id,
+      parent: null,
+      message: {
+        id,
+        author: { role: "user" },
+        content: { parts: [`turn-${id}`] },
+        create_time: 500, // all same timestamp
+      },
+    });
+    const conv = {
+      mapping: {
+        "msg-c": mkNode("msg-c"),
+        "msg-a": mkNode("msg-a"),
+        "msg-b": mkNode("msg-b"),
+      },
+    };
+    const turns = collectUserTurnsFromConversation(conv);
+    // Stable order: node id ascending.
+    assert.deepEqual(
+      turns.map((t) => t.content),
+      ["turn-msg-a", "turn-msg-b", "turn-msg-c"],
+    );
+  });
+
+  // Cursor review on PR #595 — asIsoString must not throw on corrupted
+  // timestamps that overflow Date.toISOString's valid range.
+  it("returns undefined for timestamps beyond Date's valid range", () => {
+    const conv = {
+      current_node: "m1",
+      mapping: {
+        m1: {
+          id: "m1",
+          parent: null,
+          message: {
+            id: "m1",
+            author: { role: "user" },
+            content: { parts: ["hello"] },
+            // 1e20 seconds → vastly beyond Date's safe range
+            create_time: 1e20,
+          },
+        },
+      },
+    };
+    const turns = collectUserTurnsFromConversation(conv);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0]?.createdAt, undefined);
+  });
 });

--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -137,12 +137,24 @@ export function parseChatGPTExport(
 
   // Shape 1: a top-level array. ChatGPT's `conversations.json` is literally
   // an array of conversations. Older memory exports are also arrays (each
-  // entry a ChatGPTSavedMemory). We differentiate by inspecting the first
-  // element shape.
+  // entry a ChatGPTSavedMemory). A leading tombstone / malformed element
+  // (null, {}, etc.) would defeat a `raw[0]`-only classifier and cause us
+  // to silently drop every later valid entry. Scan the full array for the
+  // first recognized shape instead. Codex review on PR #595.
   if (Array.isArray(raw)) {
     if (raw.length === 0) return result;
-    const first = raw[0];
-    if (looksLikeConversation(first)) {
+    let classification: "conversation" | "memory" | undefined;
+    for (const entry of raw) {
+      if (looksLikeConversation(entry)) {
+        classification = "conversation";
+        break;
+      }
+      if (looksLikeSavedMemory(entry)) {
+        classification = "memory";
+        break;
+      }
+    }
+    if (classification === "conversation") {
       for (const entry of raw) {
         if (looksLikeConversation(entry)) {
           result.conversations.push(entry as ChatGPTConversation);
@@ -152,7 +164,7 @@ export function parseChatGPTExport(
       }
       return result;
     }
-    if (looksLikeSavedMemory(first)) {
+    if (classification === "memory") {
       for (const entry of raw) {
         const mem = normalizeSavedMemory(entry, options.strict);
         if (mem) result.savedMemories.push(mem);
@@ -216,12 +228,13 @@ export function parseChatGPTExport(
     return result;
   }
 
-  if (options.strict) {
-    throw new Error(
-      "ChatGPT export must be a JSON array or object; received " + typeof raw,
-    );
-  }
-  return result;
+  // Primitive / unparseable payloads must NEVER return an empty success —
+  // that would mask operator mistakes and allow automation to treat a
+  // broken import as a clean "0 memories" import. Throw regardless of
+  // strict mode. Codex review on PR #595.
+  throw new Error(
+    "ChatGPT export must be a JSON array or object; received " + typeof raw,
+  );
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -372,10 +372,20 @@ function followCurrentNodeChain(
   const visited = new Set<string>();
   const chain: ChatGPTConversationNode[] = [];
   let cursor: string | null | undefined = currentNode;
-  while (cursor && !visited.has(cursor)) {
+  while (cursor) {
+    if (visited.has(cursor)) {
+      // Cycle — refuse to trust the chain. Fall back to timestamp sort.
+      return [];
+    }
     visited.add(cursor);
     const node = mapping[cursor];
-    if (!node) break;
+    if (!node) {
+      // Broken parent link (dangling reference). Don't return a partial
+      // tail — it would silently omit the root and leave the caller with
+      // an inconsistent view. Fall back to the timestamp-sorted walk.
+      // Codex review on PR #595.
+      return [];
+    }
     chain.push(node);
     cursor = node.parent ?? null;
   }

--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -1,0 +1,373 @@
+// ---------------------------------------------------------------------------
+// ChatGPT data-export parser (issue #568 slice 2)
+// ---------------------------------------------------------------------------
+//
+// OpenAI publishes each account's export as a ZIP. Inside are several JSON
+// files; this parser understands the two that carry durable user-level
+// content:
+//
+//   1. Saved memories ("memories" in OpenAI parlance). Location varies by
+//      export vintage — we accept any of:
+//         - a top-level `memory` array (current 2026 shape)
+//         - a top-level `memories` array (earlier 2024/2025 shapes)
+//         - a `"memory"` section inside `user.json` (some exports embed it)
+//      Each record is a single first-person fact the user confirmed.
+//   2. `conversations.json` — array of `Conversation` objects, each holding
+//      a graph of messages keyed by id with parent links. Bulk messages are
+//      NOT imported by default; a `--include-conversations` opt-in produces
+//      one memory per conversation summarizing the user-side turns.
+//
+// The parser accepts either the raw JSON text of a specific file OR a bundle
+// object (already-parsed envelope) that contains the known keys. This lets
+// the CLI pass either the plain `conversations.json` contents or a combined
+// manifest when a future bundle-auto-detect (PR 7) lands.
+//
+// We do not read ZIP archives directly here — the CLI parses the JSON
+// contents of whichever file the user points at with `--file`. A follow-up
+// may add a ZIP-aware reader; until then, users unzip manually.
+
+// ---------------------------------------------------------------------------
+// Raw export shapes (subset we care about)
+// ---------------------------------------------------------------------------
+
+/**
+ * A single saved memory entry. OpenAI has changed the shape several times;
+ * we accept the union of fields observed across 2024-2026 exports.
+ */
+export interface ChatGPTSavedMemory {
+  /** Stable identifier — uuid in recent exports, numeric string in older ones. */
+  id?: string;
+  /** The memory body. Required. */
+  content: string;
+  /** ISO 8601 create timestamp. */
+  created_at?: string;
+  /** ISO 8601 last-update timestamp, if different from created_at. */
+  updated_at?: string;
+  /** Soft-delete flag seen in 2025+ exports. When true, we skip the record. */
+  deleted?: boolean;
+  /** Whether the memory is pinned / manually curated. */
+  pinned?: boolean;
+  /** Tags the user applied to the memory. */
+  tags?: string[];
+}
+
+export interface ChatGPTConversationMessage {
+  /** Message id. */
+  id?: string;
+  /** Author role: user / assistant / system / tool. */
+  author?: { role?: string; name?: string | null };
+  /** Content envelope — we read `parts[]` for text content. */
+  content?: { parts?: unknown[]; content_type?: string } | null;
+  create_time?: number | string | null;
+  update_time?: number | string | null;
+  parent?: string | null;
+}
+
+export interface ChatGPTConversationNode {
+  id: string;
+  message?: ChatGPTConversationMessage | null;
+  parent?: string | null;
+  children?: string[];
+}
+
+export interface ChatGPTConversation {
+  id?: string;
+  title?: string;
+  create_time?: number | string | null;
+  update_time?: number | string | null;
+  /** Messages by id. Present in 2023+ conversation exports. */
+  mapping?: Record<string, ChatGPTConversationNode> | null;
+  /** Some older exports inline messages as an array instead. */
+  messages?: ChatGPTConversationMessage[];
+  /** Root message id (for graph traversal). */
+  current_node?: string | null;
+}
+
+/**
+ * Unified parsed shape we pass into `transform()`. Holds both saved memories
+ * and (optionally) conversations; either may be empty.
+ */
+export interface ParsedChatGPTExport {
+  savedMemories: ChatGPTSavedMemory[];
+  conversations: ChatGPTConversation[];
+  /** Source path the export came from (for provenance). */
+  filePath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public parse API
+// ---------------------------------------------------------------------------
+
+export interface ChatGPTParseOptions {
+  /** When true, throw on any validation failure instead of skipping. */
+  strict?: boolean;
+  /** File path of the source — preserved for provenance in transformed memories. */
+  filePath?: string;
+}
+
+/**
+ * Parse a raw export payload. Accepts either:
+ *   - A JSON string (common CLI path — the CLI reads the file contents).
+ *   - An already-parsed object or array (`JSON.parse` result).
+ *
+ * Returns the unified `ParsedChatGPTExport`. Non-export payloads throw a
+ * descriptive error; silently ignoring them would mask user errors
+ * (CLAUDE.md rule 51).
+ */
+export function parseChatGPTExport(
+  input: unknown,
+  options: ChatGPTParseOptions = {},
+): ParsedChatGPTExport {
+  const raw = coerceJson(input);
+  const result: ParsedChatGPTExport = {
+    savedMemories: [],
+    conversations: [],
+    ...(options.filePath !== undefined ? { filePath: options.filePath } : {}),
+  };
+
+  // Shape 1: a top-level array. ChatGPT's `conversations.json` is literally
+  // an array of conversations. Older memory exports are also arrays (each
+  // entry a ChatGPTSavedMemory). We differentiate by inspecting the first
+  // element shape.
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return result;
+    const first = raw[0];
+    if (looksLikeConversation(first)) {
+      for (const entry of raw) {
+        if (looksLikeConversation(entry)) {
+          result.conversations.push(entry as ChatGPTConversation);
+        } else if (options.strict) {
+          throw new Error("Non-conversation entry in conversations array");
+        }
+      }
+      return result;
+    }
+    if (looksLikeSavedMemory(first)) {
+      for (const entry of raw) {
+        const mem = normalizeSavedMemory(entry, options.strict);
+        if (mem) result.savedMemories.push(mem);
+      }
+      return result;
+    }
+    if (options.strict) {
+      throw new Error(
+        "Unknown ChatGPT export array shape (neither memories nor conversations).",
+      );
+    }
+    return result;
+  }
+
+  // Shape 2: an object. We look for the known keys.
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    // Saved memories — accept `memory`, `memories`, or nested `user.memory`.
+    for (const key of ["memory", "memories"] as const) {
+      const v = obj[key];
+      if (Array.isArray(v)) {
+        for (const entry of v) {
+          const mem = normalizeSavedMemory(entry, options.strict);
+          if (mem) result.savedMemories.push(mem);
+        }
+      }
+    }
+    if (obj.user && typeof obj.user === "object") {
+      const userMem = (obj.user as Record<string, unknown>).memory;
+      if (Array.isArray(userMem)) {
+        for (const entry of userMem) {
+          const mem = normalizeSavedMemory(entry, options.strict);
+          if (mem) result.savedMemories.push(mem);
+        }
+      }
+    }
+    // Conversations — top-level `conversations` array is the canonical shape.
+    const convs = obj.conversations;
+    if (Array.isArray(convs)) {
+      for (const entry of convs) {
+        if (looksLikeConversation(entry)) {
+          result.conversations.push(entry as ChatGPTConversation);
+        } else if (options.strict) {
+          throw new Error("Non-conversation entry in conversations array");
+        }
+      }
+    }
+    return result;
+  }
+
+  if (options.strict) {
+    throw new Error(
+      "ChatGPT export must be a JSON array or object; received " + typeof raw,
+    );
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function coerceJson(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input);
+    } catch (err) {
+      throw new Error(
+        `ChatGPT export is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return input;
+}
+
+function looksLikeSavedMemory(value: unknown): value is ChatGPTSavedMemory {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  // At minimum a memory has a content string. Some exports use `text`
+  // instead — we normalize in `normalizeSavedMemory`.
+  if (typeof v.content === "string" && v.content.length > 0) return true;
+  if (typeof v.text === "string" && v.text.length > 0) return true;
+  return false;
+}
+
+function looksLikeConversation(value: unknown): value is ChatGPTConversation {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  // A conversation always has either `mapping` (new shape) or `messages`
+  // (legacy shape). Title alone is insufficient because saved-memory
+  // exports may also carry a `title` field in some vintages.
+  if (v.mapping && typeof v.mapping === "object") return true;
+  if (Array.isArray(v.messages)) return true;
+  return false;
+}
+
+function normalizeSavedMemory(
+  value: unknown,
+  strict: boolean | undefined,
+): ChatGPTSavedMemory | undefined {
+  if (!value || typeof value !== "object") {
+    if (strict) throw new Error("Saved memory entry must be an object");
+    return undefined;
+  }
+  const v = value as Record<string, unknown>;
+  const content =
+    typeof v.content === "string"
+      ? v.content
+      : typeof v.text === "string"
+        ? v.text
+        : undefined;
+  if (!content || content.trim().length === 0) {
+    if (strict) throw new Error("Saved memory entry missing content");
+    return undefined;
+  }
+  if (v.deleted === true) {
+    // Soft-deleted; skip even in strict mode (it's a valid shape, just not a
+    // memory the user wants imported).
+    return undefined;
+  }
+  const normalized: ChatGPTSavedMemory = {
+    content: content.trim(),
+    ...(typeof v.id === "string" ? { id: v.id } : {}),
+    ...(typeof v.created_at === "string" ? { created_at: v.created_at } : {}),
+    ...(typeof v.updated_at === "string" ? { updated_at: v.updated_at } : {}),
+    ...(v.pinned === true ? { pinned: true } : {}),
+    ...(Array.isArray(v.tags)
+      ? { tags: v.tags.filter((t): t is string => typeof t === "string") }
+      : {}),
+  };
+  return normalized;
+}
+
+/**
+ * Walk a conversation's message graph and return only the user-authored text
+ * turns in chronological order. Exported so the transform layer can build
+ * conversation summaries from the same graph.
+ */
+export function collectUserTurnsFromConversation(
+  conversation: ChatGPTConversation,
+): Array<{ content: string; createdAt?: string }> {
+  const collected: Array<{ content: string; createdAt?: string }> = [];
+
+  if (Array.isArray(conversation.messages) && conversation.messages.length > 0) {
+    for (const msg of conversation.messages) {
+      const text = extractMessageText(msg);
+      if (text) {
+        collected.push({
+          content: text,
+          ...(asIsoString(msg.create_time ?? msg.update_time) !== undefined
+            ? { createdAt: asIsoString(msg.create_time ?? msg.update_time) as string }
+            : {}),
+        });
+      }
+    }
+    return collected;
+  }
+
+  if (conversation.mapping && typeof conversation.mapping === "object") {
+    // Build a parent → children map by traversing in any order then sorting.
+    const nodes = Object.values(conversation.mapping);
+    const ordered = [...nodes].sort((a, b) => {
+      const at = a.message?.create_time;
+      const bt = b.message?.create_time;
+      return toNumericTime(at) - toNumericTime(bt);
+    });
+    for (const node of ordered) {
+      const msg = node.message;
+      if (!msg) continue;
+      if (msg.author?.role !== "user") continue;
+      const text = extractMessageText(msg);
+      if (text) {
+        collected.push({
+          content: text,
+          ...(asIsoString(msg.create_time ?? msg.update_time) !== undefined
+            ? { createdAt: asIsoString(msg.create_time ?? msg.update_time) as string }
+            : {}),
+        });
+      }
+    }
+  }
+  return collected;
+}
+
+function extractMessageText(msg: ChatGPTConversationMessage): string | undefined {
+  if (!msg) return undefined;
+  if (msg.author?.role !== "user") {
+    // Even in inline-messages shape, only return user-authored text.
+    return undefined;
+  }
+  const parts = msg.content?.parts;
+  if (!Array.isArray(parts)) return undefined;
+  const text = parts
+    .filter((p): p is string => typeof p === "string" && p.length > 0)
+    .join("\n")
+    .trim();
+  return text.length > 0 ? text : undefined;
+}
+
+function toNumericTime(value: number | string | null | undefined): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (typeof value === "string") {
+    const n = Number(value);
+    if (Number.isFinite(n)) return n;
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return parsed / 1000;
+  }
+  return 0;
+}
+
+function asIsoString(value: number | string | null | undefined): string | undefined {
+  if (value === null || value === undefined) return undefined;
+  if (typeof value === "string") {
+    // Already ISO? Accept.
+    if (/\d{4}-\d{2}-\d{2}T/.test(value)) return value;
+    const asNum = Number(value);
+    if (Number.isFinite(asNum)) return new Date(asNum * 1000).toISOString();
+    return undefined;
+  }
+  if (Number.isFinite(value)) {
+    // ChatGPT exports store epoch seconds. Detect ms by magnitude.
+    const ms = value > 1e12 ? value : value * 1000;
+    return new Date(ms).toISOString();
+  }
+  return undefined;
+}

--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -160,10 +160,12 @@ export function parseChatGPTExport(
   // Shape 2: an object. We look for the known keys.
   if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
+    let sawKnownSection = false;
     // Saved memories — accept `memory`, `memories`, or nested `user.memory`.
     for (const key of ["memory", "memories"] as const) {
       const v = obj[key];
       if (Array.isArray(v)) {
+        sawKnownSection = true;
         for (const entry of v) {
           const mem = normalizeSavedMemory(entry, options.strict);
           if (mem) result.savedMemories.push(mem);
@@ -173,6 +175,7 @@ export function parseChatGPTExport(
     if (obj.user && typeof obj.user === "object") {
       const userMem = (obj.user as Record<string, unknown>).memory;
       if (Array.isArray(userMem)) {
+        sawKnownSection = true;
         for (const entry of userMem) {
           const mem = normalizeSavedMemory(entry, options.strict);
           if (mem) result.savedMemories.push(mem);
@@ -182,6 +185,7 @@ export function parseChatGPTExport(
     // Conversations — top-level `conversations` array is the canonical shape.
     const convs = obj.conversations;
     if (Array.isArray(convs)) {
+      sawKnownSection = true;
       for (const entry of convs) {
         if (looksLikeConversation(entry)) {
           result.conversations.push(entry as ChatGPTConversation);
@@ -189,6 +193,15 @@ export function parseChatGPTExport(
           throw new Error("Non-conversation entry in conversations array");
         }
       }
+    }
+    // Strict mode: if the object has none of the recognized sections, bail
+    // rather than silently returning an empty result. Non-strict mode keeps
+    // the lenient "returns empty struct" behavior for future-shape safety.
+    if (!sawKnownSection && options.strict) {
+      throw new Error(
+        "Unknown ChatGPT export object shape: expected one of 'memory', " +
+          "'memories', 'user.memory', or 'conversations' keys.",
+      );
     }
     return result;
   }
@@ -304,13 +317,29 @@ export function collectUserTurnsFromConversation(
   }
 
   if (conversation.mapping && typeof conversation.mapping === "object") {
-    // Build a parent → children map by traversing in any order then sorting.
-    const nodes = Object.values(conversation.mapping);
-    const ordered = [...nodes].sort((a, b) => {
-      const at = a.message?.create_time;
-      const bt = b.message?.create_time;
-      return toNumericTime(at) - toNumericTime(bt);
-    });
+    // Prefer walking the active chain from `current_node` up to the root via
+    // `parent` links, then reverse so we visit in chronological order. This
+    // mirrors how ChatGPT renders the conversation and excludes abandoned
+    // branches the user backed out of. If `current_node` is missing, fall
+    // back to a deterministic traversal of all nodes sorted by create_time
+    // with node id as the stable secondary key.
+    const mapping = conversation.mapping;
+    const chainNodes = followCurrentNodeChain(mapping, conversation.current_node);
+    const ordered =
+      chainNodes.length > 0
+        ? chainNodes
+        : [...Object.values(mapping)].sort((a, b) => {
+            const delta = toNumericTime(a.message?.create_time) -
+              toNumericTime(b.message?.create_time);
+            if (delta !== 0) return delta;
+            // Stable secondary key: node id. Without this, nodes with equal
+            // or missing timestamps order non-deterministically.
+            const aid = typeof a.id === "string" ? a.id : "";
+            const bid = typeof b.id === "string" ? b.id : "";
+            if (aid < bid) return -1;
+            if (aid > bid) return 1;
+            return 0;
+          });
     for (const node of ordered) {
       const msg = node.message;
       if (!msg) continue;
@@ -327,6 +356,30 @@ export function collectUserTurnsFromConversation(
     }
   }
   return collected;
+}
+
+/**
+ * Walk the mapping graph from `current_node` back to the root via each
+ * node's `parent` pointer, then reverse so the returned array is in
+ * chronological order. Returns empty when `current_node` is missing or the
+ * chain is broken so callers can fall back to timestamp sort.
+ */
+function followCurrentNodeChain(
+  mapping: Record<string, ChatGPTConversationNode>,
+  currentNode: string | null | undefined,
+): ChatGPTConversationNode[] {
+  if (typeof currentNode !== "string" || currentNode.length === 0) return [];
+  const visited = new Set<string>();
+  const chain: ChatGPTConversationNode[] = [];
+  let cursor: string | null | undefined = currentNode;
+  while (cursor && !visited.has(cursor)) {
+    visited.add(cursor);
+    const node = mapping[cursor];
+    if (!node) break;
+    chain.push(node);
+    cursor = node.parent ?? null;
+  }
+  return chain.reverse();
 }
 
 function extractMessageText(msg: ChatGPTConversationMessage): string | undefined {
@@ -361,13 +414,34 @@ function asIsoString(value: number | string | null | undefined): string | undefi
     // Already ISO? Accept.
     if (/\d{4}-\d{2}-\d{2}T/.test(value)) return value;
     const asNum = Number(value);
-    if (Number.isFinite(asNum)) return new Date(asNum * 1000).toISOString();
+    if (Number.isFinite(asNum)) return epochToIso(asNum);
     return undefined;
   }
   if (Number.isFinite(value)) {
-    // ChatGPT exports store epoch seconds. Detect ms by magnitude.
-    const ms = value > 1e12 ? value : value * 1000;
-    return new Date(ms).toISOString();
+    return epochToIso(value);
   }
   return undefined;
+}
+
+/**
+ * Convert an epoch value (seconds or ms) to an ISO string. Guards against
+ * corrupted inputs that would crash `new Date(x).toISOString()` — the
+ * `Date` constructor accepts arbitrarily large numbers but `toISOString`
+ * throws RangeError for values beyond the platform's representable range
+ * (±100,000,000 days from the epoch). Returns `undefined` for unusable
+ * timestamps rather than propagating a crash.
+ */
+function epochToIso(value: number): string | undefined {
+  // ChatGPT exports store epoch seconds. Detect ms by magnitude.
+  const ms = Math.abs(value) > 1e12 ? value : value * 1000;
+  // JS Date range: ±8,640,000,000,000,000 ms. Clamp well inside that.
+  const MAX_SAFE_MS = 8640000000000000;
+  if (!Number.isFinite(ms) || Math.abs(ms) > MAX_SAFE_MS) return undefined;
+  const d = new Date(ms);
+  if (Number.isNaN(d.getTime())) return undefined;
+  try {
+    return d.toISOString();
+  } catch {
+    return undefined;
+  }
 }

--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -118,6 +118,16 @@ export function parseChatGPTExport(
   input: unknown,
   options: ChatGPTParseOptions = {},
 ): ParsedChatGPTExport {
+  // File-backed adapter contract: `runImportCommand` passes `undefined`
+  // when `--file` is omitted. ChatGPT is a file-only importer — a
+  // missing payload MUST surface as a user-facing error rather than
+  // silently succeeding with 0 memories. Codex review on PR #595.
+  if (input === undefined || input === null) {
+    throw new Error(
+      "The 'chatgpt' importer requires a file. Pass `--file <path>` pointing at " +
+        "your ChatGPT data-export `memory.json` or `conversations.json`.",
+    );
+  }
   const raw = coerceJson(input);
   const result: ParsedChatGPTExport = {
     savedMemories: [],

--- a/packages/import-chatgpt/src/transform.test.ts
+++ b/packages/import-chatgpt/src/transform.test.ts
@@ -111,4 +111,38 @@ describe("transformChatGPTExport", () => {
     const memories = transformChatGPTExport(parsed, { maxMemories: 1 });
     assert.equal(memories.length, 1);
   });
+
+  // Cursor review on PR #595 — when the title alone is longer than maxChars,
+  // the previous truncation logic produced content that exceeded the cap.
+  it("truncation never exceeds maxConversationSummaryChars even with a long title", () => {
+    const longTitle = "T".repeat(500);
+    const parsed = parseChatGPTExport({
+      conversations: [
+        {
+          id: "long-title",
+          title: longTitle,
+          mapping: {
+            a: {
+              id: "a",
+              message: {
+                author: { role: "user" },
+                content: { parts: ["short body"] },
+                create_time: 1737763200,
+              },
+            },
+          },
+        },
+      ],
+    });
+    const memories = transformChatGPTExport(parsed, {
+      includeConversations: true,
+      maxConversationSummaryChars: 100,
+    });
+    assert.equal(memories.length, 1);
+    assert.ok(
+      memories[0].content.length <= 100,
+      `content length ${memories[0].content.length} must be <= 100, got: ${memories[0].content.slice(0, 50)}...`,
+    );
+    assert.ok(memories[0].content.endsWith("..."));
+  });
 });

--- a/packages/import-chatgpt/src/transform.test.ts
+++ b/packages/import-chatgpt/src/transform.test.ts
@@ -1,0 +1,114 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseChatGPTExport } from "./parser.js";
+import { transformChatGPTExport, CHATGPT_SOURCE_LABEL } from "./transform.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixtureJson(name: string): unknown {
+  return JSON.parse(readFileSync(path.join(FIXTURE_DIR, name), "utf-8"));
+}
+
+describe("transformChatGPTExport", () => {
+  it("emits one memory per saved-memory entry with provenance", () => {
+    const parsed = parseChatGPTExport(loadFixtureJson("saved-memories-2026.json"), {
+      filePath: "/tmp/chatgpt.zip/memory.json",
+    });
+    const memories = transformChatGPTExport(parsed);
+    assert.equal(memories.length, 2);
+    for (const memory of memories) {
+      assert.equal(memory.sourceLabel, CHATGPT_SOURCE_LABEL);
+      assert.equal(memory.importedFromPath, "/tmp/chatgpt.zip/memory.json");
+      assert.equal(
+        (memory.metadata as { kind?: string } | undefined)?.kind,
+        "saved_memory",
+      );
+    }
+    assert.equal(
+      memories[0].sourceId,
+      "11111111-aaaa-4000-8000-000000000001",
+    );
+    assert.equal(
+      (memories[1].metadata as { pinned?: boolean }).pinned,
+      true,
+    );
+  });
+
+  it("skips conversations by default", () => {
+    const parsed = parseChatGPTExport(
+      loadFixtureJson("conversations-mapping.json"),
+    );
+    const memories = transformChatGPTExport(parsed);
+    assert.equal(memories.length, 0);
+  });
+
+  it("emits one memory per conversation when includeConversations is true", () => {
+    const parsed = parseChatGPTExport(
+      loadFixtureJson("conversations-mapping.json"),
+    );
+    const memories = transformChatGPTExport(parsed, {
+      includeConversations: true,
+    });
+    assert.equal(memories.length, 1);
+    const [memory] = memories;
+    assert.equal(memory.sourceLabel, CHATGPT_SOURCE_LABEL);
+    assert.equal(memory.sourceId, "synthetic-conv-0001");
+    assert.ok(
+      memory.content.includes("synthetic weekend project"),
+      `expected user turn text in: ${memory.content}`,
+    );
+    assert.equal(
+      (memory.metadata as { kind?: string }).kind,
+      "conversation_summary",
+    );
+    assert.equal(
+      (memory.metadata as { userTurns?: number }).userTurns,
+      2,
+    );
+  });
+
+  it("respects maxConversationSummaryChars truncation", () => {
+    // Build a synthetic parsed shape with a long user turn.
+    const longTurn = "x".repeat(5000);
+    const parsed = parseChatGPTExport({
+      conversations: [
+        {
+          id: "synth-truncate",
+          title: "truncate me",
+          mapping: {
+            a: {
+              id: "a",
+              message: {
+                author: { role: "user" },
+                content: { parts: [longTurn] },
+                create_time: 1737763200,
+              },
+            },
+          },
+        },
+      ],
+    });
+    const memories = transformChatGPTExport(parsed, {
+      includeConversations: true,
+      maxConversationSummaryChars: 200,
+    });
+    assert.equal(memories.length, 1);
+    assert.ok(memories[0].content.endsWith("..."));
+    assert.ok(memories[0].content.length <= 210);
+  });
+
+  it("honors maxMemories as a hard cap", () => {
+    const parsed = parseChatGPTExport(
+      loadFixtureJson("saved-memories-2026.json"),
+    );
+    const memories = transformChatGPTExport(parsed, { maxMemories: 1 });
+    assert.equal(memories.length, 1);
+  });
+});

--- a/packages/import-chatgpt/src/transform.ts
+++ b/packages/import-chatgpt/src/transform.ts
@@ -114,9 +114,18 @@ function conversationToSummary(
   const body = userTurns.map((t) => `- ${t.content}`).join("\n");
   let content = titleLine + body;
   if (content.length > maxChars) {
-    const remaining = maxChars - titleLine.length - 3; // leave room for "..."
-    const bodyTruncated = body.slice(0, Math.max(0, remaining));
-    content = titleLine + bodyTruncated + "...";
+    // Reserve 3 chars for the "..." suffix. If the titleLine alone already
+    // exceeds maxChars (pathological — a very long title with a small cap),
+    // truncate the titleLine itself rather than letting content exceed
+    // maxChars.
+    const suffix = "...";
+    if (titleLine.length + suffix.length >= maxChars) {
+      content = titleLine.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
+    } else {
+      const remaining = maxChars - titleLine.length - suffix.length;
+      const bodyTruncated = body.slice(0, Math.max(0, remaining));
+      content = titleLine + bodyTruncated + suffix;
+    }
   }
 
   const sourceTimestamp = firstTimestamp(userTurns);

--- a/packages/import-chatgpt/src/transform.ts
+++ b/packages/import-chatgpt/src/transform.ts
@@ -1,0 +1,146 @@
+// ---------------------------------------------------------------------------
+// ChatGPT parsed → ImportedMemory transform (issue #568 slice 2)
+// ---------------------------------------------------------------------------
+//
+// Two shapes of memory come out of a ChatGPT export:
+//
+//   1. Saved memories — first-person facts the user confirmed. 1:1 mapping:
+//      every entry becomes one `ImportedMemory`. This is the default.
+//   2. Conversation summaries — only produced when the caller opts in via
+//      `includeConversations: true`. Each conversation is reduced to a
+//      single "user said X, Y, Z" summary (user-side turns concatenated),
+//      not uploaded verbatim. The rationale is that the conversation
+//      bodies mix transient and durable content, and the extraction
+//      pipeline downstream will score them — but we need SOMETHING
+//      coherent to hand it. One memory per conversation keeps the import
+//      footprint bounded when users have thousands of chats.
+//
+// The adapter runs `parse()` first, then `transform()` produces the final
+// `ImportedMemory[]`. Provenance (sourceLabel, importedFromPath, metadata)
+// is attached here; `runImporter` stamps `importedAt`.
+
+import type { ImportedMemory } from "@remnic/core";
+
+import type {
+  ChatGPTConversation,
+  ChatGPTSavedMemory,
+  ParsedChatGPTExport,
+} from "./parser.js";
+import { collectUserTurnsFromConversation } from "./parser.js";
+
+export const CHATGPT_SOURCE_LABEL = "chatgpt";
+
+export interface ChatGPTTransformOptions {
+  /** When true, produce conversation-summary memories in addition to saved memories. */
+  includeConversations?: boolean;
+  /** Optional cap on total memories emitted — primarily for tests. */
+  maxMemories?: number;
+  /** Maximum characters for a conversation summary memory. */
+  maxConversationSummaryChars?: number;
+}
+
+const DEFAULT_CONVERSATION_SUMMARY_CHARS = 2000;
+
+/**
+ * Transform a parsed ChatGPT export into `ImportedMemory[]`.
+ * Saved memories are emitted first (in parse order), then conversation
+ * summaries when opted in.
+ */
+export function transformChatGPTExport(
+  parsed: ParsedChatGPTExport,
+  options: ChatGPTTransformOptions = {},
+): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  const cap = options.maxMemories;
+
+  for (const entry of parsed.savedMemories) {
+    if (cap !== undefined && out.length >= cap) return out;
+    const memory = savedMemoryToImported(entry, parsed.filePath);
+    if (memory) out.push(memory);
+  }
+
+  if (options.includeConversations) {
+    const maxSummaryChars =
+      options.maxConversationSummaryChars ?? DEFAULT_CONVERSATION_SUMMARY_CHARS;
+    for (const conversation of parsed.conversations) {
+      if (cap !== undefined && out.length >= cap) return out;
+      const summary = conversationToSummary(
+        conversation,
+        parsed.filePath,
+        maxSummaryChars,
+      );
+      if (summary) out.push(summary);
+    }
+  }
+  return out;
+}
+
+function savedMemoryToImported(
+  entry: ChatGPTSavedMemory,
+  filePath: string | undefined,
+): ImportedMemory | undefined {
+  const content = entry.content.trim();
+  if (content.length === 0) return undefined;
+  const sourceTimestamp = entry.updated_at ?? entry.created_at;
+  return {
+    content,
+    sourceLabel: CHATGPT_SOURCE_LABEL,
+    ...(entry.id !== undefined ? { sourceId: entry.id } : {}),
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata: buildMetadata(entry),
+  };
+}
+
+function buildMetadata(entry: ChatGPTSavedMemory): Record<string, unknown> {
+  const meta: Record<string, unknown> = { kind: "saved_memory" };
+  if (entry.pinned === true) meta.pinned = true;
+  if (Array.isArray(entry.tags) && entry.tags.length > 0) {
+    meta.tags = [...entry.tags];
+  }
+  return meta;
+}
+
+function conversationToSummary(
+  conversation: ChatGPTConversation,
+  filePath: string | undefined,
+  maxChars: number,
+): ImportedMemory | undefined {
+  const userTurns = collectUserTurnsFromConversation(conversation);
+  if (userTurns.length === 0) return undefined;
+
+  const title = typeof conversation.title === "string" ? conversation.title.trim() : "";
+  const titleLine = title.length > 0 ? `Conversation: ${title}\n\n` : "";
+  const body = userTurns.map((t) => `- ${t.content}`).join("\n");
+  let content = titleLine + body;
+  if (content.length > maxChars) {
+    const remaining = maxChars - titleLine.length - 3; // leave room for "..."
+    const bodyTruncated = body.slice(0, Math.max(0, remaining));
+    content = titleLine + bodyTruncated + "...";
+  }
+
+  const sourceTimestamp = firstTimestamp(userTurns);
+  return {
+    content,
+    sourceLabel: CHATGPT_SOURCE_LABEL,
+    ...(typeof conversation.id === "string" ? { sourceId: conversation.id } : {}),
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata: {
+      kind: "conversation_summary",
+      ...(title.length > 0 ? { title } : {}),
+      userTurns: userTurns.length,
+    },
+  };
+}
+
+function firstTimestamp(
+  turns: Array<{ content: string; createdAt?: string }>,
+): string | undefined {
+  for (const turn of turns) {
+    if (typeof turn.createdAt === "string" && turn.createdAt.length > 0) {
+      return turn.createdAt;
+    }
+  }
+  return undefined;
+}

--- a/packages/import-chatgpt/tsconfig.json
+++ b/packages/import-chatgpt/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -38,18 +38,21 @@
     "@remnic/bench": "^1.0.0",
     "@remnic/export-weclone": "^1.0.0",
     "@remnic/import-weclone": "^1.0.0",
+    "@remnic/import-chatgpt": "^0.1.0",
     "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": { "optional": true },
     "@remnic/export-weclone": { "optional": true },
     "@remnic/import-weclone": { "optional": true },
+    "@remnic/import-chatgpt": { "optional": true },
     "@remnic/import-mem0": { "optional": true }
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",
     "@remnic/export-weclone": "workspace:*",
     "@remnic/import-weclone": "workspace:*",
+    "@remnic/import-chatgpt": "workspace:*",
     "@remnic/import-mem0": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -29,19 +29,20 @@ describe("optional-importer loader", () => {
     assert.equal(isSupportedImporterName("chatgpt "), false);
   });
 
-  // Slices 2, 3, 4 (chatgpt, claude, gemini) are not yet installed so they
-  // make durable "missing package" fixtures that don't depend on which slice
-  // is currently being developed. The mem0 fixture intentionally is NOT used
-  // here because PR 5 installs @remnic/import-mem0 alongside, which would
-  // make the install-hint assertion race with that installation.
+  // Slices 3 and 4 (claude, gemini) are not yet installed, so they make
+  // durable "missing package" fixtures that do not depend on which slice is
+  // currently being developed. The chatgpt and mem0 fixtures intentionally
+  // are NOT used here because PR 2 installs @remnic/import-chatgpt and PR 5
+  // installs @remnic/import-mem0 alongside, which would make the
+  // install-hint assertion race with that installation.
   it("loading a missing importer throws a user-facing install hint", async () => {
     await assert.rejects(
-      () => loadImporterModule("chatgpt"),
+      () => loadImporterModule("claude"),
       (err: Error) => {
         // Install hint must include the package name and an install
         // command the user can actually run — not a raw MODULE_NOT_FOUND.
         assert.ok(
-          err.message.includes("@remnic/import-chatgpt"),
+          err.message.includes("@remnic/import-claude"),
           `expected package name in message, got: ${err.message}`,
         );
         assert.ok(
@@ -56,9 +57,9 @@ describe("optional-importer loader", () => {
 
   it("loader caches negative results so repeated calls do not re-import", async () => {
     // First call populates the cache with a null.
-    await assert.rejects(() => loadImporterModule("claude"));
+    await assert.rejects(() => loadImporterModule("gemini"));
     // Second call must still throw — but the cache hit path is covered
     // exclusively by the branch that rejects from cached null.
-    await assert.rejects(() => loadImporterModule("claude"));
+    await assert.rejects(() => loadImporterModule("gemini"));
   });
 });

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     "@remnic/bench",
     "@remnic/export-weclone",
     "@remnic/import-weclone",
+    "@remnic/import-chatgpt",
     "@remnic/import-mem0",
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-chatgpt:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-mem0:
     devDependencies:
       '@remnic/core':
@@ -228,6 +243,9 @@ importers:
       '@remnic/export-weclone':
         specifier: workspace:*
         version: link:../export-weclone
+      '@remnic/import-chatgpt':
+        specifier: workspace:*
+        version: link:../import-chatgpt
       '@remnic/import-mem0':
         specifier: workspace:*
         version: link:../import-mem0

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -13,6 +13,7 @@ const expectedPublishDirs = [
   "packages/bench",
   "packages/export-weclone",
   "packages/import-weclone",
+  "packages/import-chatgpt",
   "packages/import-mem0",
   "packages/connector-weclone",
   "packages/connector-replit",


### PR DESCRIPTION
Part of #568 (slice 2 of 7).

## Summary
- New workspace package \`@remnic/import-chatgpt\` implementing the shared \`ImporterAdapter\` contract from PR 1
- Parses ChatGPT data-export JSON (saved memories across 2024/2025/2026 vintages + conversation mapping graph)
- Transforms parsed data to \`ImportedMemory[]\` — saved memories by default, conversation summaries behind \`--include-conversations\`
- Synthetic fixtures only (no real export data)
- À-la-carte packaged: \`peerDependenciesMeta.@remnic/import-chatgpt.optional = true\` on remnic-cli, declared \`external\` in tsup config, loaded lazily via computed-specifier dynamic import

## À-la-carte compliance (CLAUDE.md rule 57)
- [x] Own workspace package at \`packages/import-chatgpt/\`, \`"private": false\`
- [x] Declared as optional peer dep in \`packages/remnic-cli/package.json\`
- [x] NOT added to any \`noExternal\` array (kept as \`external\` in \`packages/remnic-cli/tsup.config.ts\`)
- [x] Loaded via computed dynamic import in the existing \`optional-importer.ts\` loader
- [x] Missing package produces a clean install hint (covered by existing \`optional-importer.test.ts\`)
- [x] Added to \`.github/workflows/release-and-publish.yml\` in topological order

## Test plan
- [x] \`pnpm run check-types\` clean
- [x] \`packages/import-chatgpt\` unit tests: 17 pass (adapter end-to-end, parser across 3 export shapes, transform with saved memories + optional conversations + maxMemories cap)
- [x] \`packages/remnic-cli\` optional-importer tests retargeted to a still-uninstalled adapter (claude/gemini) so slice 2 doesn't race with its own install

## Notes
Stacked on PR #583 (slice 1/7) — merge after that lands.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional import surface and publishing/release wiring, plus non-trivial parsing/transform logic for multiple export shapes; risk is mainly in import correctness and release workflow ordering, not core runtime behavior for existing users.
> 
> **Overview**
> Adds a new optional workspace package, `@remnic/import-chatgpt`, enabling `remnic import --adapter chatgpt` to ingest ChatGPT data-export JSON.
> 
> The importer implements the shared `ImporterAdapter` flow: it parses multiple saved-memory export vintages (including legacy array forms) and optionally emits one *conversation summary* memory per chat when `--include-conversations` is set, with provenance metadata and defensive validation/truncation.
> 
> Integrates the package into distribution by adding it to the release publish order, declaring it as an optional peer dependency of `@remnic/cli` (kept external in `tsup`), updating CLI tests to avoid “missing package” races, and updating the release-workflow publish-order test/lockfile.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit abc51f84d3def04cf9bd9caeb4c889d8b7b7c4bc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->