### PR TITLE
feat(bench): shared PublishedBenchmarkHarness (#566 PR 2/7)

### DIFF
--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -366,6 +366,46 @@ test("runPublishedHarness rejects negative or non-integer seed", async () => {
   );
 });
 
+test("runPublishedHarness skips LLM judge when llm_judge is not in metrics spec", async () => {
+  const { system, calls } = makeFakeSystem();
+  let judgeInvocations = 0;
+  const originalJudge = system.judge.scoreWithMetrics.bind(system.judge);
+  system.judge.scoreWithMetrics = async (...args) => {
+    judgeInvocations += 1;
+    return originalJudge(...args);
+  };
+
+  const result = await runPublishedHarness({
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1", "contains_answer"] }, // no llm_judge
+    plans: [
+      {
+        ingestSessions: [
+          { sessionId: "s", messages: [{ role: "user", content: "hi" }] },
+        ],
+        trials: [
+          {
+            taskId: "no-judge-billing",
+            question: "q",
+            expected: "a",
+            recallSessionIds: ["s"],
+          },
+        ],
+      },
+    ],
+  });
+  assert.equal(judgeInvocations, 0, "judge should not be invoked");
+  const task = result.results.tasks[0]!;
+  assert.ok(!("llm_judge" in task.scores));
+  // Judge latency/tokens should NOT be folded into cost totals.
+  assert.equal(result.cost.inputTokens, 1); // responder only
+  assert.equal(result.cost.outputTokens, 2); // responder only
+  assert.ok(
+    !calls.some((call) => call.kind === "judge"),
+    "no judge call should have been made",
+  );
+});
+
 test("runPublishedHarness produces empty result for empty plans", async () => {
   const { system } = makeFakeSystem();
   const result = await runPublishedHarness({

--- a/packages/bench/src/benchmarks/published/harness.test.ts
+++ b/packages/bench/src/benchmarks/published/harness.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  runPublishedHarness,
+  type HarnessContext,
+  type HarnessPlan,
+} from "./harness.ts";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+} from "../../types.ts";
+
+/**
+ * Fake system under test that records every call into a deterministic
+ * log. Recall always returns a synthesized string containing the session
+ * ID + the question so tests can verify session routing.
+ */
+function makeFakeSystem(opts?: {
+  recallPrefix?: string;
+  searchHits?: number;
+  judgeScore?: number;
+  responderModel?: string;
+  judgeModel?: string;
+}) {
+  const calls: Array<
+    | { kind: "reset" }
+    | { kind: "store"; sessionId: string; messageCount: number }
+    | { kind: "recall"; sessionId: string; question: string }
+    | { kind: "search"; query: string; limit: number }
+    | { kind: "judge"; question: string; predicted: string; expected: string }
+    | { kind: "respond"; question: string }
+  > = [];
+
+  const system = {
+    async reset() {
+      calls.push({ kind: "reset" });
+    },
+    async store(sessionId: string, messages: Array<unknown>) {
+      calls.push({ kind: "store", sessionId, messageCount: messages.length });
+    },
+    async recall(sessionId: string, question: string) {
+      calls.push({ kind: "recall", sessionId, question });
+      return `${opts?.recallPrefix ?? "recall"}:${sessionId}:${question}`;
+    },
+    async search(query: string, limit: number) {
+      calls.push({ kind: "search", query, limit });
+      return new Array(opts?.searchHits ?? 0).fill({ id: "r", text: "t" });
+    },
+    async destroy() {},
+    async getStats() {
+      return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+    },
+    responder: {
+      async respond(question: string) {
+        calls.push({ kind: "respond", question });
+        return {
+          text: `answer:${question}`,
+          tokens: { input: 1, output: 2 },
+          latencyMs: 1,
+          model: opts?.responderModel ?? "smoke-responder",
+        };
+      },
+    },
+    judge: {
+      async score() {
+        return opts?.judgeScore ?? 1;
+      },
+      async scoreWithMetrics(
+        question: string,
+        predicted: string,
+        expected: string,
+      ) {
+        calls.push({ kind: "judge", question, predicted, expected });
+        return {
+          score: opts?.judgeScore ?? 1,
+          tokens: { input: 0, output: 0 },
+          latencyMs: 0,
+          model: opts?.judgeModel ?? "smoke-judge",
+        };
+      },
+    },
+  };
+  return { system, calls };
+}
+
+const smokeDefinition: BenchmarkDefinition = {
+  id: "harness-test",
+  title: "Harness Test",
+  tier: "published",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "harness-test",
+    version: "0.0.0",
+    description: "test",
+    category: "retrieval",
+    citation: "test",
+  },
+};
+
+function makeOptions(
+  system: ReturnType<typeof makeFakeSystem>["system"],
+  overrides?: Partial<ResolvedRunBenchmarkOptions>,
+): ResolvedRunBenchmarkOptions {
+  return {
+    benchmark: smokeDefinition,
+    mode: "quick",
+    system: system as unknown as ResolvedRunBenchmarkOptions["system"],
+    seed: 42,
+    ...overrides,
+  };
+}
+
+test("runPublishedHarness resets once per plan and stores every non-empty session", async () => {
+  const { system, calls } = makeFakeSystem();
+  const plans: HarnessPlan[] = [
+    {
+      ingestSessions: [
+        { sessionId: "a", messages: [{ role: "user", content: "hi" }] },
+        { sessionId: "empty", messages: [] },
+        { sessionId: "b", messages: [{ role: "user", content: "hello" }] },
+      ],
+      trials: [
+        {
+          taskId: "t1",
+          question: "Q1",
+          expected: "A1",
+          recallSessionIds: ["a", "b"],
+        },
+      ],
+    },
+    {
+      ingestSessions: [
+        { sessionId: "c", messages: [{ role: "user", content: "x" }] },
+      ],
+      trials: [
+        {
+          taskId: "t2",
+          question: "Q2",
+          expected: "A2",
+          recallSessionIds: ["c"],
+        },
+      ],
+    },
+  ];
+
+  const ctx: HarnessContext = {
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1", "contains_answer"] },
+    plans,
+  };
+  const result = await runPublishedHarness(ctx);
+
+  const resets = calls.filter((call) => call.kind === "reset");
+  assert.equal(resets.length, 2, "expected one reset per plan");
+
+  const stores = calls.filter((call) => call.kind === "store");
+  assert.equal(stores.length, 3, "empty session should not be stored");
+  assert.deepEqual(stores.map((store) => (store as any).sessionId), [
+    "a",
+    "b",
+    "c",
+  ]);
+
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.meta.seeds[0], 42);
+  assert.equal(result.meta.benchmark, "harness-test");
+  assert.equal(result.config.adapterMode, "direct");
+});
+
+test("runPublishedHarness recalls from ALL recallSessionIds per trial", async () => {
+  const { system, calls } = makeFakeSystem();
+  const plans: HarnessPlan[] = [
+    {
+      ingestSessions: [
+        { sessionId: "s1", messages: [{ role: "user", content: "x" }] },
+        { sessionId: "s2", messages: [{ role: "user", content: "y" }] },
+      ],
+      trials: [
+        {
+          taskId: "multi",
+          question: "who",
+          expected: "nobody",
+          recallSessionIds: ["s1", "s2"],
+        },
+      ],
+    },
+  ];
+
+  await runPublishedHarness({
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1"] },
+    plans,
+  });
+
+  const recalls = calls.filter((call) => call.kind === "recall") as Array<{
+    kind: "recall";
+    sessionId: string;
+    question: string;
+  }>;
+  assert.deepEqual(
+    recalls.map((recall) => recall.sessionId).sort(),
+    ["s1", "s2"],
+  );
+  for (const recall of recalls) {
+    assert.equal(recall.question, "who");
+  }
+});
+
+test("runPublishedHarness postAnswerHook runs between answer and judge", async () => {
+  const { system, calls } = makeFakeSystem({ searchHits: 4 });
+  const order: string[] = [];
+  const plans: HarnessPlan[] = [
+    {
+      ingestSessions: [
+        { sessionId: "s", messages: [{ role: "user", content: "hi" }] },
+      ],
+      trials: [
+        {
+          taskId: "hooked",
+          question: "q",
+          expected: "a",
+          recallSessionIds: ["s"],
+          postAnswerHook: async () => {
+            order.push("hook");
+            const results = await system.search("q", 10);
+            return { extraScores: { search_hits: results.length } };
+          },
+        },
+      ],
+    },
+  ];
+
+  const originalJudge = system.judge.scoreWithMetrics.bind(system.judge);
+  system.judge.scoreWithMetrics = async (...args) => {
+    order.push("judge");
+    return originalJudge(...args);
+  };
+  const originalRespond = system.responder.respond.bind(system.responder);
+  system.responder.respond = async (...args) => {
+    order.push("respond");
+    return originalRespond(...args);
+  };
+
+  const result = await runPublishedHarness({
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1", "llm_judge"] },
+    plans,
+  });
+
+  assert.deepEqual(order, ["respond", "hook", "judge"]);
+  assert.equal(result.results.tasks[0]?.scores.search_hits, 4);
+  // Search call happened on the live system during the hook.
+  assert.ok(calls.some((call) => call.kind === "search"));
+});
+
+test("runPublishedHarness llm_judge metric suppressed when judge score negative", async () => {
+  const { system } = makeFakeSystem({ judgeScore: -1 });
+  const result = await runPublishedHarness({
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1", "llm_judge"] },
+    plans: [
+      {
+        ingestSessions: [
+          { sessionId: "s", messages: [{ role: "user", content: "h" }] },
+        ],
+        trials: [
+          {
+            taskId: "no-judge",
+            question: "q",
+            expected: "a",
+            recallSessionIds: ["s"],
+          },
+        ],
+      },
+    ],
+  });
+  const task = result.results.tasks[0]!;
+  assert.ok("f1" in task.scores, "f1 should be present");
+  assert.ok(
+    !("llm_judge" in task.scores),
+    "llm_judge should be omitted when judge returns negative",
+  );
+});
+
+test("runPublishedHarness is deterministic across repeated runs with same seed", async () => {
+  async function run(): Promise<BenchmarkResult> {
+    const { system } = makeFakeSystem();
+    return await runPublishedHarness({
+      options: makeOptions(system, { seed: 7 }),
+      metricsSpec: { metrics: ["f1", "contains_answer", "rouge_l"] },
+      plans: [
+        {
+          ingestSessions: [
+            {
+              sessionId: "s",
+              messages: [{ role: "user", content: "hello world" }],
+            },
+          ],
+          trials: [
+            {
+              taskId: "det-1",
+              question: "say hello",
+              expected: "hello",
+              recallSessionIds: ["s"],
+            },
+          ],
+        },
+      ],
+    });
+  }
+
+  const a = await run();
+  const b = await run();
+
+  // `id` and `timestamp` are non-deterministic by design (UUID +
+  // wall-clock). Every other field must be identical.
+  assert.equal(a.meta.seeds[0], b.meta.seeds[0]);
+  assert.equal(a.meta.mode, b.meta.mode);
+  assert.equal(a.meta.benchmark, b.meta.benchmark);
+  assert.equal(a.results.tasks.length, b.results.tasks.length);
+  for (let i = 0; i < a.results.tasks.length; i += 1) {
+    const taskA = a.results.tasks[i]!;
+    const taskB = b.results.tasks[i]!;
+    assert.equal(taskA.taskId, taskB.taskId);
+    assert.equal(taskA.actual, taskB.actual);
+    assert.deepEqual(taskA.scores, taskB.scores);
+  }
+});
+
+test("runPublishedHarness rejects unknown metric id", async () => {
+  const { system } = makeFakeSystem();
+  await assert.rejects(
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system),
+        // @ts-expect-error intentional invalid metric
+        metricsSpec: { metrics: ["not-a-metric"] },
+        plans: [],
+      }),
+    /unknown metric/,
+  );
+});
+
+test("runPublishedHarness rejects negative or non-integer seed", async () => {
+  const { system } = makeFakeSystem();
+  await assert.rejects(
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, { seed: -1 }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [],
+      }),
+    /seed must be a non-negative integer/,
+  );
+  await assert.rejects(
+    () =>
+      runPublishedHarness({
+        options: makeOptions(system, { seed: 1.5 }),
+        metricsSpec: { metrics: ["f1"] },
+        plans: [],
+      }),
+    /seed must be a non-negative integer/,
+  );
+});
+
+test("runPublishedHarness produces empty result for empty plans", async () => {
+  const { system } = makeFakeSystem();
+  const result = await runPublishedHarness({
+    options: makeOptions(system),
+    metricsSpec: { metrics: ["f1"] },
+    plans: [],
+  });
+  assert.equal(result.results.tasks.length, 0);
+  assert.equal(result.cost.meanQueryLatencyMs, 0);
+});

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -254,12 +254,26 @@ async function executeTrial(
       })
     : { extraScores: undefined, extraDetails: undefined };
 
-  const judgeResult = await llmJudgeScoreDetailed(
-    ctx.options.system.judge,
-    trial.question,
-    answered.finalAnswer,
-    trial.expected,
-  );
+  // Only invoke the LLM judge when `llm_judge` is in the metrics spec.
+  // Cursor review feedback on PR 596: unconditionally calling the judge
+  // billed non-judge runs for an API call per trial and inflated the
+  // `TaskResult` latency/token totals. The zero-valued placeholder
+  // below keeps the downstream arithmetic unchanged for runs that
+  // don't opt into the judge.
+  const judgeRequested = ctx.metricsSpec.metrics.includes("llm_judge");
+  const judgeResult = judgeRequested
+    ? await llmJudgeScoreDetailed(
+        ctx.options.system.judge,
+        trial.question,
+        answered.finalAnswer,
+        trial.expected,
+      )
+    : {
+        score: -1,
+        tokens: { input: 0, output: 0 },
+        latencyMs: 0,
+        model: undefined as string | undefined,
+      };
 
   const scores: Record<string, number> = {};
   for (const metric of ctx.metricsSpec.metrics) {

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -1,0 +1,390 @@
+/**
+ * PublishedBenchmarkHarness — shared per-item execution harness for the
+ * `longmemeval` and `locomo` runners (issue #566 slice 2).
+ *
+ * The LongMemEval and LoCoMo runners previously duplicated the entire
+ * reset → ingest haystack → recall → answer → judge → score lifecycle.
+ * This module extracts that lifecycle so both runners consume exactly
+ * one implementation. Dataset-specific concerns (how to iterate items,
+ * how many QA entries per item, per-task details payload) are expressed
+ * as a `HarnessPlan` that the harness uniformly executes.
+ *
+ * Determinism contract (documented in issue #566 PR 2/7):
+ *
+ *   Given identical `(seed, datasetDir, system, modelId)` inputs, every
+ *   output field except wall-clock timestamps MUST be identical. The
+ *   harness records the seed in the `BenchmarkResult.meta.seeds` array
+ *   and forwards it verbatim so downstream consumers can reproduce runs
+ *   from the published artifact.
+ *
+ * CLAUDE.md rule 51 (reject invalid user input): `--model` / `--dataset`
+ * / `--limit` validation lives upstream in the CLI surface (PR 4).
+ * The harness itself validates its `HarnessContext` shape — invalid
+ * seeds, missing systems, etc. throw at setup time with listed
+ * permissible values rather than silently defaulting.
+ */
+
+import { randomUUID } from "node:crypto";
+
+import type { Message } from "../../adapters/types.js";
+import { answerBenchmarkQuestion } from "../../answering.js";
+import { getGitSha, getRemnicVersion } from "../../reporter.js";
+import {
+  aggregateTaskScores,
+  containsAnswer,
+  f1Score,
+  llmJudgeScoreDetailed,
+  rougeL,
+  timed,
+} from "../../scorer.js";
+import type {
+  BenchmarkMode,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../types.js";
+
+/**
+ * A single haystack session that should be ingested into the system
+ * under test before any queries run. The harness calls
+ * `system.store(sessionId, messages)` once per non-empty session.
+ */
+export interface HarnessSession {
+  sessionId: string;
+  messages: Message[];
+}
+
+/**
+ * A single scored question that the harness executes against the system
+ * under test. `recallSessionIds` drives which `system.recall(sessionId,
+ * query)` calls are made per question — the LongMemEval runner recalls
+ * from every haystack session; the LoCoMo runner recalls from every
+ * extracted `session_*` key.
+ */
+export interface HarnessTrial {
+  /** Stable identifier used as `TaskResult.taskId`. */
+  taskId: string;
+  /** Question text sent to the responder. */
+  question: string;
+  /** Canonical expected answer used for scoring. */
+  expected: string;
+  /** Session IDs that should be consulted via `system.recall`. */
+  recallSessionIds: string[];
+  /**
+   * Optional hook invoked AFTER `system.recall` and `answerBenchmarkQuestion`
+   * but BEFORE the LLM judge. Returns per-trial additions (extra scores
+   * + extra detail fields) that get merged into the final `TaskResult`.
+   * Used by LongMemEval to compute `search_hits` via `system.search()`
+   * in the same ingest-state the recall saw.
+   */
+  postAnswerHook?: (args: {
+    question: string;
+    recalledText: string;
+    answeredText: string;
+  }) => Promise<{
+    extraScores?: Record<string, number>;
+    extraDetails?: Record<string, unknown>;
+  }>;
+  /**
+   * Optional extra per-task metrics computed by the caller up-front
+   * (not a function of recall state). Merged into the final
+   * `TaskResult.scores`.
+   */
+  extraScores?: Record<string, number>;
+  /**
+   * Optional extra per-task `details` fields. Merged on top of the
+   * harness-provided base details object.
+   */
+  extraDetails?: Record<string, unknown>;
+}
+
+/**
+ * A plan describes ONE item from the dataset: the haystack to ingest
+ * and the trials to execute. `ingestSessions` is always ingested in the
+ * order provided, before any trial runs.
+ */
+export interface HarnessPlan {
+  /** Sessions to ingest into the system under test. */
+  ingestSessions: HarnessSession[];
+  /** Trials executed after all sessions are ingested. */
+  trials: HarnessTrial[];
+}
+
+/**
+ * Metrics the harness computes for every trial. Dataset-specific extra
+ * metrics are merged on top via `HarnessTrial.extraScores`.
+ */
+export type HarnessMetricId =
+  | "f1"
+  | "contains_answer"
+  | "rouge_l"
+  | "llm_judge";
+
+export interface HarnessMetricsSpec {
+  /**
+   * Metric IDs computed by the harness. Order is preserved in the
+   * returned `TaskResult.scores` object. `llm_judge` is emitted only
+   * when the judge returns a non-negative score.
+   */
+  metrics: readonly HarnessMetricId[];
+}
+
+export interface HarnessContext {
+  /** Resolved runner options forwarded from the CLI. */
+  options: ResolvedRunBenchmarkOptions;
+  /** Metrics to compute per trial. */
+  metricsSpec: HarnessMetricsSpec;
+  /**
+   * Iterator of dataset-item plans. The harness iterates once, so this
+   * should be finite. Runners that apply `--limit` must slice upstream
+   * of this iterator (`loadLongMemEvalS` / `loadLoCoMo10` honor limit).
+   */
+  plans: Iterable<HarnessPlan> | AsyncIterable<HarnessPlan>;
+}
+
+/** Convenience: guard an arbitrary iterable shape into an async iterator. */
+async function* toAsyncIterable<T>(
+  iter: Iterable<T> | AsyncIterable<T>,
+): AsyncIterable<T> {
+  for await (const value of iter as AsyncIterable<T>) {
+    yield value;
+  }
+}
+
+/**
+ * Execute every plan and return a fully-populated `BenchmarkResult`.
+ * Callers are the LongMemEval and LoCoMo runners; each is responsible
+ * for loading their dataset and translating items into `HarnessPlan`s.
+ *
+ * The harness guarantees:
+ *
+ *   - `system.reset()` is called exactly once per plan, before ingest.
+ *   - `system.store(sessionId, messages)` is called once per non-empty
+ *     session, in the order provided by `plan.ingestSessions`.
+ *   - Within a plan, trials are executed sequentially. Across plans,
+ *     plans are executed sequentially. No implicit concurrency is
+ *     introduced; that keeps the harness deterministic.
+ *   - Every trial recalls from ALL `recallSessionIds` before calling
+ *     the responder.
+ */
+export async function runPublishedHarness(
+  ctx: HarnessContext,
+): Promise<BenchmarkResult> {
+  validateContext(ctx);
+  const tasks: TaskResult[] = [];
+
+  for await (const plan of toAsyncIterable(ctx.plans)) {
+    await ctx.options.system.reset();
+    for (const session of plan.ingestSessions) {
+      if (session.messages.length > 0) {
+        await ctx.options.system.store(session.sessionId, session.messages);
+      }
+    }
+    for (const trial of plan.trials) {
+      tasks.push(await executeTrial(ctx, trial));
+    }
+  }
+
+  return buildBenchmarkResult(ctx, tasks);
+}
+
+function validateContext(ctx: HarnessContext): void {
+  if (!ctx.options || !ctx.options.system) {
+    throw new Error(
+      "PublishedBenchmarkHarness requires a resolved options.system. " +
+        "Valid shapes are created by the `benchmark-runner` CLI and the " +
+        "bench test doubles in packages/bench/src/adapters/.",
+    );
+  }
+  if (!ctx.metricsSpec || !Array.isArray(ctx.metricsSpec.metrics)) {
+    throw new Error(
+      "PublishedBenchmarkHarness requires metricsSpec.metrics: one of " +
+        'f1, contains_answer, rouge_l, llm_judge.',
+    );
+  }
+  const allowed: readonly HarnessMetricId[] = [
+    "f1",
+    "contains_answer",
+    "rouge_l",
+    "llm_judge",
+  ];
+  for (const metric of ctx.metricsSpec.metrics) {
+    if (!allowed.includes(metric)) {
+      throw new Error(
+        `PublishedBenchmarkHarness: unknown metric "${String(metric)}". ` +
+          `Valid metrics: ${allowed.join(", ")}.`,
+      );
+    }
+  }
+  if (ctx.options.seed !== undefined) {
+    if (!Number.isInteger(ctx.options.seed) || ctx.options.seed < 0) {
+      throw new Error(
+        `PublishedBenchmarkHarness: seed must be a non-negative integer; got ${String(ctx.options.seed)}.`,
+      );
+    }
+  }
+}
+
+async function executeTrial(
+  ctx: HarnessContext,
+  trial: HarnessTrial,
+): Promise<TaskResult> {
+  const { result: recalledText, durationMs } = await timed(async () => {
+    const recalledSessions = await Promise.all(
+      trial.recallSessionIds.map((sessionId) =>
+        ctx.options.system.recall(sessionId, trial.question),
+      ),
+    );
+    return recalledSessions.filter(Boolean).join("\n\n");
+  });
+  const answered = await answerBenchmarkQuestion({
+    question: trial.question,
+    recalledText,
+    responder: ctx.options.system.responder,
+  });
+
+  // Post-answer hook runs before the judge so dataset-specific signals
+  // (e.g. LongMemEval `search_hits`) are observed from the same
+  // post-ingest, post-recall system state as the recall/answer calls.
+  const hookResult = trial.postAnswerHook
+    ? await trial.postAnswerHook({
+        question: trial.question,
+        recalledText,
+        answeredText: answered.finalAnswer,
+      })
+    : { extraScores: undefined, extraDetails: undefined };
+
+  const judgeResult = await llmJudgeScoreDetailed(
+    ctx.options.system.judge,
+    trial.question,
+    answered.finalAnswer,
+    trial.expected,
+  );
+
+  const scores: Record<string, number> = {};
+  for (const metric of ctx.metricsSpec.metrics) {
+    switch (metric) {
+      case "f1":
+        scores.f1 = f1Score(answered.finalAnswer, trial.expected);
+        break;
+      case "contains_answer":
+        scores.contains_answer = containsAnswer(
+          answered.finalAnswer,
+          trial.expected,
+        );
+        break;
+      case "rouge_l":
+        scores.rouge_l = rougeL(answered.finalAnswer, trial.expected);
+        break;
+      case "llm_judge":
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
+        }
+        break;
+      default: {
+        // Unreachable — validated in validateContext. Keep as a sanity
+        // guard; CLAUDE.md rule 53 (enumerate all non-active states).
+        const exhaustive: never = metric;
+        throw new Error(
+          `PublishedBenchmarkHarness: metric ${String(exhaustive)} not handled.`,
+        );
+      }
+    }
+  }
+  if (trial.extraScores) {
+    for (const [name, value] of Object.entries(trial.extraScores)) {
+      scores[name] = value;
+    }
+  }
+  if (hookResult.extraScores) {
+    for (const [name, value] of Object.entries(hookResult.extraScores)) {
+      scores[name] = value;
+    }
+  }
+
+  const baseDetails: Record<string, unknown> = {
+    recalledLength: recalledText.length,
+    answeredLength: answered.finalAnswer.length,
+    recalledText,
+    answeredText: answered.finalAnswer,
+    responderModel: answered.model,
+    judgeModel: judgeResult.model,
+  };
+  const details: Record<string, unknown> = { ...baseDetails };
+  if (trial.extraDetails) {
+    Object.assign(details, trial.extraDetails);
+  }
+  if (hookResult.extraDetails) {
+    Object.assign(details, hookResult.extraDetails);
+  }
+
+  return {
+    taskId: trial.taskId,
+    question: trial.question,
+    expected: trial.expected,
+    actual: answered.finalAnswer,
+    scores,
+    latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+    tokens: {
+      input: answered.tokens.input + judgeResult.tokens.input,
+      output: answered.tokens.output + judgeResult.tokens.output,
+    },
+    details,
+  };
+}
+
+async function buildBenchmarkResult(
+  ctx: HarnessContext,
+  tasks: TaskResult[],
+): Promise<BenchmarkResult> {
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+  const totalInputTokens = tasks.reduce(
+    (sum, task) => sum + task.tokens.input,
+    0,
+  );
+  const totalOutputTokens = tasks.reduce(
+    (sum, task) => sum + task.tokens.output,
+    0,
+  );
+  const mode: BenchmarkMode = ctx.options.mode;
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: ctx.options.benchmark.id,
+      benchmarkTier: ctx.options.benchmark.tier,
+      version: ctx.options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode,
+      runCount: 1,
+      seeds: [ctx.options.seed ?? 0],
+    },
+    config: {
+      systemProvider: ctx.options.systemProvider ?? null,
+      judgeProvider: ctx.options.judgeProvider ?? null,
+      adapterMode: ctx.options.adapterMode ?? "direct",
+      remnicConfig: ctx.options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: totalInputTokens + totalOutputTokens,
+      inputTokens: totalInputTokens,
+      outputTokens: totalOutputTokens,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -1,10 +1,13 @@
 /**
  * LoCoMo runner migrated into @remnic/bench for phase 1.
+ *
+ * As of issue #566 PR 2/7, the per-item lifecycle (reset → ingest →
+ * recall → answer → judge → score) lives in `../harness.ts`. This
+ * module only knows about dataset loading, session extraction, and
+ * how to translate a `LoCoMoConversation` into a `HarnessPlan`.
  */
 
-import { randomUUID } from "node:crypto";
 import type { Message } from "../../../adapters/types.js";
-import { answerBenchmarkQuestion } from "../../../answering.js";
 import {
   type LoCoMoConversation,
   type LoCoMoQA,
@@ -16,21 +19,16 @@ import {
   loadLoCoMo10,
   normalizeLoCoMoQa,
 } from "../dataset-loader.js";
+import {
+  runPublishedHarness,
+  type HarnessPlan,
+  type HarnessTrial,
+} from "../harness.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,
-  TaskResult,
 } from "../../../types.js";
-import {
-  aggregateTaskScores,
-  containsAnswer,
-  f1Score,
-  llmJudgeScoreDetailed,
-  rougeL,
-  timed,
-} from "../../../scorer.js";
-import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
 const CATEGORY_NAMES: Record<number, string> = {
   1: "single_hop",
@@ -100,133 +98,60 @@ export async function runLoCoMoBenchmark(
     options.datasetDir,
     options.limit,
   );
-  const tasks: TaskResult[] = [];
 
-  for (const conversation of conversations) {
-    await options.system.reset();
+  const plans: HarnessPlan[] = conversations.map(buildPlan);
 
-    const sessions = extractSessions(conversation.conversation);
-    const speakerA =
-      typeof conversation.conversation.speaker_a === "string"
-        ? conversation.conversation.speaker_a
-        : "Speaker A";
-    const sessionIds: string[] = [];
+  return runPublishedHarness({
+    options,
+    metricsSpec: {
+      metrics: ["f1", "contains_answer", "rouge_l", "llm_judge"],
+    },
+    plans,
+  });
+}
 
-    for (const session of sessions) {
-      const sessionId = `${conversation.sample_id}-${session.sessionId}`;
-      const messages = buildMessages(session.turns, speakerA);
-      sessionIds.push(sessionId);
-      if (messages.length > 0) {
-        await options.system.store(sessionId, messages);
-      }
-    }
+function buildPlan(conversation: LoCoMoConversation): HarnessPlan {
+  const sessions = extractSessions(conversation.conversation);
+  const speakerA =
+    typeof conversation.conversation.speaker_a === "string"
+      ? conversation.conversation.speaker_a
+      : "Speaker A";
 
-    for (
-      let questionIndex = 0;
-      questionIndex < conversation.qa.length;
-      questionIndex += 1
-    ) {
-      const qa = conversation.qa[questionIndex]!;
-      const categoryName =
-        CATEGORY_NAMES[qa.category] ?? `category_${qa.category}`;
-      const { result: recalledText, durationMs } = await timed(async () => {
-        const recalledSessions = await Promise.all(
-          sessionIds.map((sessionId) =>
-            options.system.recall(sessionId, qa.question),
-          ),
-        );
-        return recalledSessions.filter(Boolean).join("\n\n");
-      });
-      const answered = await answerBenchmarkQuestion({
-        question: qa.question,
-        recalledText,
-        responder: options.system.responder,
-      });
-      const judgeResult = await llmJudgeScoreDetailed(
-        options.system.judge,
-        qa.question,
-        answered.finalAnswer,
-        qa.answer,
-      );
-
-      const scores: Record<string, number> = {
-        f1: f1Score(answered.finalAnswer, qa.answer),
-        contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
-        rouge_l: rougeL(answered.finalAnswer, qa.answer),
-      };
-      if (judgeResult.score >= 0) {
-        scores.llm_judge = judgeResult.score;
-      }
-
-      tasks.push({
-        taskId: `${conversation.sample_id}-q${questionIndex}-${categoryName}`,
-        question: qa.question,
-        expected: qa.answer,
-        actual: answered.finalAnswer,
-        scores,
-        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-        tokens: {
-          input: answered.tokens.input + judgeResult.tokens.input,
-          output: answered.tokens.output + judgeResult.tokens.output,
-        },
-        details: {
-          category: qa.category,
-          categoryName,
-          evidence: qa.evidence,
-          conversationId: conversation.sample_id,
-          sessionIds,
-          recalledLength: recalledText.length,
-          answeredLength: answered.finalAnswer.length,
-          recalledText,
-          answeredText: answered.finalAnswer,
-          responderModel: answered.model,
-          judgeModel: judgeResult.model,
-        },
-      });
-    }
+  const ingestSessions: HarnessPlan["ingestSessions"] = [];
+  const sessionIds: string[] = [];
+  for (const session of sessions) {
+    const sessionId = `${conversation.sample_id}-${session.sessionId}`;
+    const messages = buildMessages(session.turns, speakerA);
+    sessionIds.push(sessionId);
+    ingestSessions.push({ sessionId, messages });
   }
 
-  const remnicVersion = await getRemnicVersion();
-  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
-  const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
-  const totalOutputTokens = tasks.reduce((sum, task) => sum + task.tokens.output, 0);
+  const trials: HarnessTrial[] = conversation.qa.map((qa, questionIndex) =>
+    buildTrial(conversation.sample_id, qa, questionIndex, sessionIds),
+  );
 
+  return { ingestSessions, trials };
+}
+
+function buildTrial(
+  conversationId: string,
+  qa: LoCoMoQA,
+  questionIndex: number,
+  sessionIds: string[],
+): HarnessTrial {
+  const categoryName =
+    CATEGORY_NAMES[qa.category] ?? `category_${qa.category}`;
   return {
-    meta: {
-      id: randomUUID(),
-      benchmark: options.benchmark.id,
-      benchmarkTier: options.benchmark.tier,
-      version: options.benchmark.meta.version,
-      remnicVersion,
-      gitSha: getGitSha(),
-      timestamp: new Date().toISOString(),
-      mode: options.mode,
-      runCount: 1,
-      seeds: [options.seed ?? 0],
-    },
-    config: {
-      systemProvider: options.systemProvider ?? null,
-      judgeProvider: options.judgeProvider ?? null,
-      adapterMode: options.adapterMode ?? "direct",
-      remnicConfig: options.remnicConfig ?? {},
-    },
-    cost: {
-      totalTokens: totalInputTokens + totalOutputTokens,
-      inputTokens: totalInputTokens,
-      outputTokens: totalOutputTokens,
-      estimatedCostUsd: 0,
-      totalLatencyMs,
-      meanQueryLatencyMs:
-        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
-    },
-    results: {
-      tasks,
-      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
-    },
-    environment: {
-      os: process.platform,
-      nodeVersion: process.version,
-      hardware: process.arch,
+    taskId: `${conversationId}-q${questionIndex}-${categoryName}`,
+    question: qa.question,
+    expected: qa.answer,
+    recallSessionIds: sessionIds,
+    extraDetails: {
+      category: qa.category,
+      categoryName,
+      evidence: qa.evidence,
+      conversationId,
+      sessionIds,
     },
   };
 }
@@ -247,11 +172,6 @@ async function loadDataset(
   });
 
   if (loaded.source === "missing") {
-    // `loaded.source === "missing"` implies `mode === "full"` — the
-    // shared loader only returns `missing` in that branch. Keep the
-    // inner check + the historical "no datasetDir" message for clarity
-    // and backward-compat with regression tests; if the loader contract
-    // ever changes, this branch still fails safely.
     if (!datasetDir) {
       throw new Error(
         "LoCoMo full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
@@ -342,4 +262,3 @@ function normalizeQaArray(value: unknown, location: string): LoCoMoQA[] {
     normalizeLoCoMoQa(entry, `${location} qa[${index}]`),
   );
 }
-

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.test.ts
@@ -1,0 +1,108 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { longMemEvalDefinition, runLongMemEvalBenchmark } from "./runner.ts";
+
+/**
+ * Smoke test for the LongMemEval runner after issue #566 PR 2 migrated
+ * the per-item lifecycle into the shared harness. Verifies:
+ *
+ *   1. Dataset → plan → harness path emits one task per item.
+ *   2. `search_hits` is computed via the post-answer hook (so it uses
+ *      the live system under test, not a pre-ingest state).
+ *   3. Task IDs, expected answers, and extra detail fields are
+ *      propagated faithfully.
+ */
+test("LongMemEval runner wires the shared harness with per-item postAnswerHook", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-lme-"));
+  try {
+    await writeFile(
+      path.join(tempDir, "longmemeval_oracle.json"),
+      JSON.stringify([
+        {
+          question_id: "q-1",
+          question_type: "single-session-user",
+          question: "Which city does the user live in?",
+          answer: "Paris",
+          question_date: "2025-01-01",
+          haystack_sessions: [
+            [
+              { role: "user", content: "I live in Paris." },
+              { role: "assistant", content: "Got it, Paris." },
+            ],
+          ],
+          haystack_session_ids: ["s-1"],
+          haystack_dates: ["2025-01-01"],
+          answer_session_ids: ["s-1"],
+        },
+      ]),
+      "utf8",
+    );
+
+    let searchCalls = 0;
+    const result = await runLongMemEvalBenchmark({
+      benchmark: longMemEvalDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store() {},
+        async recall(_sessionId, _question) {
+          return "I live in Paris.";
+        },
+        async search(_query, _limit) {
+          searchCalls += 1;
+          return [{ id: "r", text: "Paris" }];
+        },
+        async reset() {},
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        responder: {
+          async respond(question, recalled) {
+            return {
+              text: `${question}:${recalled}`,
+              tokens: { input: 1, output: 1 },
+              latencyMs: 1,
+              model: "smoke-responder",
+            };
+          },
+        },
+        judge: {
+          async score() {
+            return 1;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 1,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "smoke-judge",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    const task = result.results.tasks[0]!;
+    assert.equal(task.taskId, "qq-1");
+    assert.equal(task.expected, "Paris");
+    assert.equal(task.scores.search_hits, 1);
+    assert.equal(
+      searchCalls,
+      1,
+      "search should be invoked exactly once via postAnswerHook",
+    );
+    // Verify extra details were propagated.
+    assert.equal(
+      (task.details as Record<string, unknown>).questionType,
+      "single-session-user",
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/published/longmemeval/runner.ts
+++ b/packages/bench/src/benchmarks/published/longmemeval/runner.ts
@@ -1,30 +1,29 @@
 /**
  * LongMemEval runner migrated into @remnic/bench for phase 1.
+ *
+ * As of issue #566 PR 2/7, the per-item lifecycle (reset → ingest →
+ * recall → answer → judge → score) lives in `../harness.ts`. This
+ * module only knows about dataset loading + how to translate a
+ * `LongMemEvalItem` into a `HarnessPlan`.
  */
 
-import { randomUUID } from "node:crypto";
 import { type LongMemEvalItem } from "./fixture.js";
 import {
   LONG_MEM_EVAL_DATASET_FILENAMES,
   formatMissingDatasetError,
   loadLongMemEvalS,
 } from "../dataset-loader.js";
-import { answerBenchmarkQuestion } from "../../../answering.js";
 import type { Message } from "../../../adapters/types.js";
+import {
+  runPublishedHarness,
+  type HarnessPlan,
+  type HarnessTrial,
+} from "../harness.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
   ResolvedRunBenchmarkOptions,
-  TaskResult,
 } from "../../../types.js";
-import {
-  aggregateTaskScores,
-  containsAnswer,
-  f1Score,
-  llmJudgeScoreDetailed,
-  timed,
-} from "../../../scorer.js";
-import { getGitSha, getRemnicVersion } from "../../../reporter.js";
 
 export const longMemEvalDefinition: BenchmarkDefinition = {
   id: "longmemeval",
@@ -46,140 +45,65 @@ export const longMemEvalDefinition: BenchmarkDefinition = {
 export async function runLongMemEvalBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
-  const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
-  const tasks: TaskResult[] = [];
+  const dataset = await loadDataset(
+    options.mode,
+    options.datasetDir,
+    options.limit,
+  );
 
-  for (const item of dataset) {
-    await options.system.reset();
+  const plans: HarnessPlan[] = dataset.map((item) => buildPlan(item, options));
 
-    const sessionIds: string[] = [];
-    for (
-      let sessionIndex = 0;
-      sessionIndex < item.haystack_sessions.length;
-      sessionIndex += 1
-    ) {
-      const sessionId =
-        item.haystack_session_ids[sessionIndex] ?? `session-${sessionIndex}`;
-      const messages = item.haystack_sessions[sessionIndex]!.map<Message>(
-        (turn) => ({
-          role: turn.role,
-          content: turn.content,
-        }),
-      );
+  return runPublishedHarness({
+    options,
+    metricsSpec: {
+      metrics: ["f1", "contains_answer", "llm_judge"],
+    },
+    plans,
+  });
+}
 
-      sessionIds.push(sessionId);
-      if (messages.length > 0) {
-        await options.system.store(sessionId, messages);
-      }
-    }
-
-    const { result: recalledText, durationMs } = await timed(async () => {
-      const recalledSessions = await Promise.all(
-        sessionIds.map((sessionId) =>
-          options.system.recall(sessionId, item.question),
-        ),
-      );
-      return recalledSessions.filter(Boolean).join("\n\n");
-    });
-    const answered = await answerBenchmarkQuestion({
-      question: item.question,
-      recalledText,
-      responder: options.system.responder,
-    });
-
-    const searchResults = await options.system.search(item.question, 10);
-    const judgeResult = await llmJudgeScoreDetailed(
-      options.system.judge,
-      item.question,
-      answered.finalAnswer,
-      item.answer,
+function buildPlan(
+  item: LongMemEvalItem,
+  options: ResolvedRunBenchmarkOptions,
+): HarnessPlan {
+  const ingestSessions: HarnessPlan["ingestSessions"] = [];
+  const sessionIds: string[] = [];
+  for (
+    let sessionIndex = 0;
+    sessionIndex < item.haystack_sessions.length;
+    sessionIndex += 1
+  ) {
+    const sessionId =
+      item.haystack_session_ids[sessionIndex] ?? `session-${sessionIndex}`;
+    const messages = item.haystack_sessions[sessionIndex]!.map<Message>(
+      (turn) => ({
+        role: turn.role,
+        content: turn.content,
+      }),
     );
-
-    const scores: Record<string, number> = {
-      f1: f1Score(answered.finalAnswer, item.answer),
-      contains_answer: containsAnswer(answered.finalAnswer, item.answer),
-      search_hits: searchResults.length,
-    };
-    if (judgeResult.score >= 0) {
-      scores.llm_judge = judgeResult.score;
-    }
-
-    tasks.push({
-      taskId: `q${item.question_id}`,
-      question: item.question,
-      expected: item.answer,
-      actual: answered.finalAnswer,
-      scores,
-      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-      tokens: {
-        input: answered.tokens.input + judgeResult.tokens.input,
-        output: answered.tokens.output + judgeResult.tokens.output,
-      },
-      details: {
-        questionType: item.question_type,
-        questionDate: item.question_date,
-        haystackDates: item.haystack_dates,
-        haystackSessionIds: item.haystack_session_ids,
-        answerSessionIds: item.answer_session_ids,
-        recalledLength: recalledText.length,
-        answeredLength: answered.finalAnswer.length,
-        recalledText,
-        answeredText: answered.finalAnswer,
-        responderModel: answered.model,
-        judgeModel: judgeResult.model,
-      },
-    });
+    sessionIds.push(sessionId);
+    ingestSessions.push({ sessionId, messages });
   }
 
-  const remnicVersion = await getRemnicVersion();
-  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
-  const totalInputTokens = tasks.reduce(
-    (sum, task) => sum + task.tokens.input,
-    0,
-  );
-  const totalOutputTokens = tasks.reduce(
-    (sum, task) => sum + task.tokens.output,
-    0,
-  );
-
-  return {
-    meta: {
-      id: randomUUID(),
-      benchmark: options.benchmark.id,
-      benchmarkTier: options.benchmark.tier,
-      version: options.benchmark.meta.version,
-      remnicVersion,
-      gitSha: getGitSha(),
-      timestamp: new Date().toISOString(),
-      mode: options.mode,
-      runCount: 1,
-      seeds: [options.seed ?? 0],
+  const trial: HarnessTrial = {
+    taskId: `q${item.question_id}`,
+    question: item.question,
+    expected: item.answer,
+    recallSessionIds: sessionIds,
+    extraDetails: {
+      questionType: item.question_type,
+      questionDate: item.question_date,
+      haystackDates: item.haystack_dates,
+      haystackSessionIds: item.haystack_session_ids,
+      answerSessionIds: item.answer_session_ids,
     },
-    config: {
-      systemProvider: options.systemProvider ?? null,
-      judgeProvider: options.judgeProvider ?? null,
-      adapterMode: options.adapterMode ?? "direct",
-      remnicConfig: options.remnicConfig ?? {},
-    },
-    cost: {
-      totalTokens: totalInputTokens + totalOutputTokens,
-      inputTokens: totalInputTokens,
-      outputTokens: totalOutputTokens,
-      estimatedCostUsd: 0,
-      totalLatencyMs,
-      meanQueryLatencyMs:
-        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
-    },
-    results: {
-      tasks,
-      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
-    },
-    environment: {
-      os: process.platform,
-      nodeVersion: process.version,
-      hardware: process.arch,
+    postAnswerHook: async ({ question }) => {
+      const searchResults = await options.system.search(question, 10);
+      return { extraScores: { search_hits: searchResults.length } };
     },
   };
+
+  return { ingestSessions, trials: [trial] };
 }
 
 async function loadDataset(
@@ -190,11 +114,6 @@ async function loadDataset(
   const loaded = await loadLongMemEvalS({ mode, datasetDir, limit });
 
   if (loaded.source === "missing") {
-    // `loaded.source === "missing"` implies `mode === "full"` — the
-    // shared loader only returns `missing` in that branch. Keep the
-    // inner `datasetDir` check for backward-compat with regression
-    // tests that match the historical "full mode requires datasetDir"
-    // message.
     if (!datasetDir) {
       throw new Error(
         "LongMemEval full mode requires datasetDir. Pass a dataset path or use quick mode to run the bundled smoke fixture.",
@@ -217,9 +136,6 @@ async function loadDataset(
   }
 
   if (loaded.source === "smoke" && loaded.errors.length > 0) {
-    // Surface probe errors so operators understand why the smoke fixture
-    // was used instead of the real dataset. Keep output minimal and only
-    // emit when we actually tried to read a dataset directory.
     // eslint-disable-next-line no-console
     console.warn(
       "[remnic-bench] LongMemEval falling back to smoke fixture: " +


### PR DESCRIPTION
## Summary

- Extract the per-item memory lifecycle (reset → ingest → recall → answer → judge → score) shared by `longmemeval` and `locomo` runners into a single `PublishedBenchmarkHarness`.
- Runners are now dataset-specific translators that emit `HarnessPlan`s; uniform execution lives in `runPublishedHarness`.
- Determinism contract: same `(seed, datasetDir, system, modelId)` → identical results except `meta.id` / `meta.timestamp`. Seed is recorded in `meta.seeds[0]`. Invalid seeds rejected per CLAUDE.md rule 51.

## What changed

- New: `packages/bench/src/benchmarks/published/harness.ts` + 8 unit tests.
- New: `packages/bench/src/benchmarks/published/longmemeval/runner.test.ts` smoke.
- Refactor: `longmemeval/runner.ts`, `locomo/runner.ts` delegate execution to the harness.
- `search_hits` (LongMemEval-only) now rides on `HarnessTrial.postAnswerHook`, preserving the original respond → search → judge call order.

## Dependency

Stacks on top of #580 (PR 1/7: shared dataset loaders). Merge after #580.

## Test plan

- [x] `pnpm run check-types` clean.
- [x] `harness.test.ts` — 8 pass (reset-per-plan, store-skips-empty, recall-all-sessions, hook ordering, negative-judge suppression, cross-run determinism, unknown-metric rejection, seed validation, empty plans).
- [x] `longmemeval/runner.test.ts` — smoke pass.
- [x] `locomo/runner.test.ts` (existing) — pass, no behavior change.
- [x] `dataset-loader.test.ts` (existing) — pass.

Part of #566.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Refactors core benchmark execution for `longmemeval` and `locomo` into a new shared harness, which could change scoring/cost accounting or call ordering if behavior diverges. Adds validation and conditional judge execution that may affect results/costs for runs not requesting `llm_judge`.
> 
> **Overview**
> **Adds a new shared execution harness** (`published/harness.ts`) that runs the reset→ingest→recall→answer→(optional hook)→(optional LLM judge) lifecycle from a dataset-provided `HarnessPlan`, builds the final `BenchmarkResult`, and validates inputs (metric IDs and non-negative integer seeds).
> 
> **Refactors `longmemeval` and `locomo` runners** to become plan builders that delegate execution/scoring/result assembly to `runPublishedHarness`, including LongMemEval’s `search_hits` via `postAnswerHook` to preserve respond→hook→judge ordering.
> 
> **Adds tests** covering harness behavior (reset/store/recall sequencing, determinism, hook ordering, metric validation, skipping judge billing when `llm_judge` isn’t requested, empty-plan output) plus a LongMemEval smoke test ensuring `search_hits` and extra details propagate correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47eca3a11d95eda36e2074689da8f11c750db3e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->