### PR TITLE
feat(xray): remnic xray CLI command (#570 PR 3/7)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -200,6 +200,8 @@ import { convertMemoriesToRecords } from "./training-export/converter.js";
 import { parseStrictCliDate as parseStrictCliDateShared } from "./training-export/date-parse.js";
 import { getTrainingExportAdapter, listTrainingExportAdapters } from "./training-export/registry.js";
 import { renderRecallExplain, parseRecallExplainFormat } from "./recall-explain-renderer.js";
+import { renderXray } from "./recall-xray-renderer.js";
+import { parseXrayCliOptions } from "./recall-xray-cli.js";
 
 interface CliApi {
   registerCli(
@@ -4008,6 +4010,76 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             snapshot = null;
           }
           console.log(renderRecallExplain(snapshot, format));
+        });
+
+      cmd
+        .command("xray")
+        .description(
+          "Run a recall with X-ray capture and print the unified snapshot (tier + audit + MMR + filters).  Part of #570.",
+        )
+        .argument("<query>", "Query to recall against")
+        .option(
+          "--format <fmt>",
+          "Output format: text (default), markdown, or json",
+          "text",
+        )
+        .option(
+          "--budget <chars>",
+          "Override recall character budget for this call (positive integer)",
+        )
+        .option(
+          "--namespace <ns>",
+          "Namespace to scope the recall to (defaults to configured namespace)",
+        )
+        .option(
+          "--out <path>",
+          "Write the rendered snapshot to a file instead of stdout",
+        )
+        .action(async (...args: unknown[]) => {
+          // Commander passes positional args first, then the options
+          // object as the last argument.  `parseXrayCliOptions` is a
+          // pure helper that throws listed-options errors for invalid
+          // --format / --budget / --namespace / --out values — it's
+          // imported from `recall-xray-cli.ts` so the validation path
+          // can be unit-tested without booting an orchestrator
+          // (CLAUDE.md rules 14 + 51).
+          const parsed = parseXrayCliOptions(
+            args[0],
+            (args[1] ?? {}) as Record<string, unknown>,
+          );
+          // Budget override is applied by temporarily swapping the
+          // config entry around the recall call.  The orchestrator
+          // reads `config.recallBudgetChars` each time
+          // `getRecallBudgetChars` runs, so a brief swap is enough to
+          // thread the override through without widening the public
+          // recall signature.  Restored in a finally block so a
+          // thrown recall cannot leave the config mutated.
+          const originalBudget = orchestrator.config.recallBudgetChars;
+          if (parsed.budget !== undefined) {
+            orchestrator.config.recallBudgetChars = parsed.budget;
+          }
+          try {
+            // Clear any prior snapshot so a capture failure surfaces
+            // as `null` rather than returning stale data from an
+            // earlier call in the same process.
+            orchestrator.clearLastXraySnapshot();
+            await orchestrator.recall(parsed.query, undefined, {
+              xrayCapture: true,
+              ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
+            });
+          } finally {
+            if (parsed.budget !== undefined) {
+              orchestrator.config.recallBudgetChars = originalBudget;
+            }
+          }
+          const snapshot = orchestrator.getLastXraySnapshot();
+          const rendered = renderXray(snapshot, parsed.format);
+          if (parsed.outPath) {
+            const { writeFile: fsWriteFile } = await import("node:fs/promises");
+            await fsWriteFile(expandTildePath(parsed.outPath), rendered, "utf8");
+          } else {
+            console.log(rendered);
+          }
         });
 
       cmd

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4047,26 +4047,25 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             args[0],
             (args[1] ?? {}) as Record<string, unknown>,
           );
-          // Budget override is threaded through `RecallInvocationOptions`
-          // so it applies only to this recall invocation.  Previously the
-          // CLI mutated `orchestrator.config.recallBudgetChars` around
-          // the await, which would leak into any concurrent recall
-          // running on the same orchestrator (e.g., gateway agents) and
-          // produce nondeterministic truncation.  CLAUDE.md rule 47
-          // (no shared mutable state across async boundaries).
-          //
-          // Clear any prior snapshot so a capture failure surfaces
-          // as `null` rather than returning stale data from an
-          // earlier call in the same process.
-          orchestrator.clearLastXraySnapshot();
-          await orchestrator.recall(parsed.query, undefined, {
-            xrayCapture: true,
+          // Route the xray capture through `EngramAccessService` so
+          // the CLI shares the same `xrayQueue` mutex that the HTTP
+          // and MCP surfaces use — otherwise the
+          // `clearLastXraySnapshot() → recall() → getLastXraySnapshot()`
+          // sequence races with concurrent callers (e.g., a gateway
+          // agent hitting the same orchestrator) and could swap in
+          // their snapshot mid-flight, or our capture could overwrite
+          // theirs (cursor Medium + codex P1 review on #597).  The
+          // service enforces CLAUDE.md rules 40 (serialized state) and
+          // 47 (no shared mutable state across async boundaries).
+          const xrayService = new EngramAccessService(orchestrator);
+          const response = await xrayService.recallXray({
+            query: parsed.query,
             ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
-            ...(parsed.budget !== undefined
-              ? { budgetCharsOverride: parsed.budget }
-              : {}),
+            ...(parsed.budget !== undefined ? { budget: parsed.budget } : {}),
           });
-          const snapshot = orchestrator.getLastXraySnapshot();
+          const snapshot = response.snapshotFound
+            ? response.snapshot ?? null
+            : null;
           const rendered = renderXray(snapshot, parsed.format);
           if (parsed.outPath) {
             const { writeFile: fsWriteFile } = await import("node:fs/promises");

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4047,31 +4047,25 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             args[0],
             (args[1] ?? {}) as Record<string, unknown>,
           );
-          // Budget override is applied by temporarily swapping the
-          // config entry around the recall call.  The orchestrator
-          // reads `config.recallBudgetChars` each time
-          // `getRecallBudgetChars` runs, so a brief swap is enough to
-          // thread the override through without widening the public
-          // recall signature.  Restored in a finally block so a
-          // thrown recall cannot leave the config mutated.
-          const originalBudget = orchestrator.config.recallBudgetChars;
-          if (parsed.budget !== undefined) {
-            orchestrator.config.recallBudgetChars = parsed.budget;
-          }
-          try {
-            // Clear any prior snapshot so a capture failure surfaces
-            // as `null` rather than returning stale data from an
-            // earlier call in the same process.
-            orchestrator.clearLastXraySnapshot();
-            await orchestrator.recall(parsed.query, undefined, {
-              xrayCapture: true,
-              ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
-            });
-          } finally {
-            if (parsed.budget !== undefined) {
-              orchestrator.config.recallBudgetChars = originalBudget;
-            }
-          }
+          // Budget override is threaded through `RecallInvocationOptions`
+          // so it applies only to this recall invocation.  Previously the
+          // CLI mutated `orchestrator.config.recallBudgetChars` around
+          // the await, which would leak into any concurrent recall
+          // running on the same orchestrator (e.g., gateway agents) and
+          // produce nondeterministic truncation.  CLAUDE.md rule 47
+          // (no shared mutable state across async boundaries).
+          //
+          // Clear any prior snapshot so a capture failure surfaces
+          // as `null` rather than returning stale data from an
+          // earlier call in the same process.
+          orchestrator.clearLastXraySnapshot();
+          await orchestrator.recall(parsed.query, undefined, {
+            xrayCapture: true,
+            ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
+            ...(parsed.budget !== undefined
+              ? { budgetCharsOverride: parsed.budget }
+              : {}),
+          });
           const snapshot = orchestrator.getLastXraySnapshot();
           const rendered = renderXray(snapshot, parsed.format);
           if (parsed.outPath) {

--- a/packages/remnic-core/src/recall-xray-cli.test.ts
+++ b/packages/remnic-core/src/recall-xray-cli.test.ts
@@ -1,0 +1,118 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import {
+  parseXrayBudgetFlag,
+  parseXrayCliOptions,
+} from "./recall-xray-cli.js";
+
+// ─── parseXrayBudgetFlag ─────────────────────────────────────────────────
+
+test("parseXrayBudgetFlag returns undefined for missing values", () => {
+  assert.equal(parseXrayBudgetFlag(undefined), undefined);
+  assert.equal(parseXrayBudgetFlag(null), undefined);
+});
+
+test("parseXrayBudgetFlag coerces numeric strings to integers", () => {
+  assert.equal(parseXrayBudgetFlag("4096"), 4096);
+  assert.equal(parseXrayBudgetFlag(1024), 1024);
+});
+
+test("parseXrayBudgetFlag rejects non-numeric values", () => {
+  assert.throws(
+    () => parseXrayBudgetFlag("abc"),
+    /--budget expects a positive integer; got "abc"/,
+  );
+});
+
+test("parseXrayBudgetFlag rejects zero, negative, and fractional values", () => {
+  assert.throws(() => parseXrayBudgetFlag(0), /--budget expects a positive integer/);
+  assert.throws(() => parseXrayBudgetFlag(-1), /--budget expects a positive integer/);
+  assert.throws(
+    () => parseXrayBudgetFlag(10.5),
+    /--budget expects a positive integer/,
+  );
+});
+
+test("parseXrayBudgetFlag rejects non-finite values", () => {
+  assert.throws(
+    () => parseXrayBudgetFlag("Infinity"),
+    /--budget expects a positive integer/,
+  );
+  assert.throws(
+    () => parseXrayBudgetFlag(Number.NaN),
+    /--budget expects a positive integer/,
+  );
+});
+
+// ─── parseXrayCliOptions ─────────────────────────────────────────────────
+
+test("parseXrayCliOptions defaults format to text when absent", () => {
+  const parsed = parseXrayCliOptions("hi", {});
+  assert.equal(parsed.query, "hi");
+  assert.equal(parsed.format, "text");
+  assert.equal(parsed.budget, undefined);
+  assert.equal(parsed.namespace, undefined);
+  assert.equal(parsed.outPath, undefined);
+});
+
+test("parseXrayCliOptions threads every valid option through", () => {
+  const parsed = parseXrayCliOptions("what editor", {
+    format: "markdown",
+    budget: "2048",
+    namespace: "  workspace-a  ",
+    out: "  /tmp/out.md  ",
+  });
+  assert.equal(parsed.query, "what editor");
+  assert.equal(parsed.format, "markdown");
+  assert.equal(parsed.budget, 2048);
+  assert.equal(parsed.namespace, "workspace-a");
+  assert.equal(parsed.outPath, "/tmp/out.md");
+});
+
+test("parseXrayCliOptions rejects empty/whitespace/non-string query", () => {
+  assert.throws(
+    () => parseXrayCliOptions("", {}),
+    /xray: <query> is required and must be non-empty/,
+  );
+  assert.throws(
+    () => parseXrayCliOptions("   ", {}),
+    /xray: <query> is required and must be non-empty/,
+  );
+  assert.throws(
+    () => parseXrayCliOptions(42 as unknown, {}),
+    /xray: <query> is required and must be non-empty/,
+  );
+});
+
+test("parseXrayCliOptions rejects unknown --format with a listed-options error", () => {
+  assert.throws(
+    () => parseXrayCliOptions("q", { format: "xml" }),
+    /--format expects one of json, text, markdown; got "xml"/,
+  );
+});
+
+test("parseXrayCliOptions rejects malformed --budget", () => {
+  assert.throws(
+    () => parseXrayCliOptions("q", { budget: "0" }),
+    /--budget expects a positive integer/,
+  );
+  assert.throws(
+    () => parseXrayCliOptions("q", { budget: "not-a-number" }),
+    /--budget expects a positive integer/,
+  );
+});
+
+test("parseXrayCliOptions treats blank --namespace and --out as absent", () => {
+  const parsed = parseXrayCliOptions("q", {
+    namespace: "   ",
+    out: "\t\n",
+  });
+  assert.equal(parsed.namespace, undefined);
+  assert.equal(parsed.outPath, undefined);
+});
+
+test("parseXrayCliOptions normalizes format casing via parseXrayFormat", () => {
+  const parsed = parseXrayCliOptions("q", { format: "  JSON  " });
+  assert.equal(parsed.format, "json");
+});

--- a/packages/remnic-core/src/recall-xray-cli.ts
+++ b/packages/remnic-core/src/recall-xray-cli.ts
@@ -1,0 +1,77 @@
+/**
+ * Input-validation helpers for the `remnic xray` CLI command (issue
+ * #570, PR 3).
+ *
+ * Pulled out of `cli.ts` so the validation paths can be unit-tested in
+ * isolation — the full CLI handler is hard to exercise without booting
+ * an orchestrator.  CLAUDE.md rules 14 + 51 require that `--format`,
+ * `--budget`, `--namespace`, and `--out` reject missing-value /
+ * unknown / non-positive arguments with a listed-options error, rather
+ * than silently defaulting.
+ */
+
+import {
+  parseXrayFormat,
+  type RecallXrayFormat,
+} from "./recall-xray-renderer.js";
+
+export interface ParsedXrayCliOptions {
+  format: RecallXrayFormat;
+  /** Positive integer override, or undefined when not specified. */
+  budget?: number;
+  /** Trimmed namespace, or undefined when not specified. */
+  namespace?: string;
+  /** Trimmed, tilde-unexpanded output path, or undefined when stdout. */
+  outPath?: string;
+}
+
+/**
+ * Validate and coerce `--budget <chars>`.  Must be a positive integer;
+ * throws a listed-options error otherwise.
+ */
+export function parseXrayBudgetFlag(value: unknown): number | undefined {
+  if (value === undefined || value === null) return undefined;
+  const parsed = typeof value === "number" ? value : Number(value);
+  if (
+    !Number.isFinite(parsed) ||
+    parsed <= 0 ||
+    !Number.isInteger(parsed)
+  ) {
+    throw new Error(
+      `--budget expects a positive integer; got ${JSON.stringify(value)}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Parse and validate the full option bag for `remnic xray`.  Extracted
+ * so the CLI handler in `cli.ts` can stay thin and the validation can
+ * be unit-tested without booting an orchestrator.
+ */
+export function parseXrayCliOptions(
+  rawQuery: unknown,
+  options: Record<string, unknown>,
+): { query: string } & ParsedXrayCliOptions {
+  if (typeof rawQuery !== "string" || rawQuery.trim().length === 0) {
+    throw new Error("xray: <query> is required and must be non-empty");
+  }
+  const format = parseXrayFormat(options.format);
+  const budget = parseXrayBudgetFlag(options.budget);
+  const namespace =
+    typeof options.namespace === "string" &&
+    options.namespace.trim().length > 0
+      ? options.namespace.trim()
+      : undefined;
+  const outPath =
+    typeof options.out === "string" && options.out.trim().length > 0
+      ? options.out.trim()
+      : undefined;
+  return {
+    query: rawQuery,
+    format,
+    ...(budget !== undefined ? { budget } : {}),
+    ...(namespace !== undefined ? { namespace } : {}),
+    ...(outPath !== undefined ? { outPath } : {}),
+  };
+}


### PR DESCRIPTION
## Summary

Slice 3 of the unified Recall X-ray observability surface (#570). Adds the `remnic xray \"<query>\"` CLI command that runs a recall with X-ray capture enabled, fetches the resulting `RecallXraySnapshot`, and renders it through the shared renderer from PR 2. CLI / HTTP / MCP all consume the same renderer (CLAUDE.md rule 22).

- New `packages/remnic-core/src/recall-xray-cli.ts` — pure input-validation helpers extracted from the CLI handler so option-parsing paths can be unit-tested without booting an orchestrator.
  - `parseXrayBudgetFlag`: coerces numeric strings to positive integers; rejects zero, negative, fractional, non-finite, and non-numeric values with a listed-options error (CLAUDE.md rules 14 + 51).
  - `parseXrayCliOptions`: validates `<query>`, `--format`, `--budget`, `--namespace`, `--out`. Empty or whitespace-only values collapse to documented defaults; invalid values throw with explicit error messages.

- `packages/remnic-core/src/cli.ts` — new `xray` subcommand alongside `recall-explain`.
  - Flags: `--format {text|markdown|json}`, `--budget <chars>`, `--namespace <ns>`, `--out <path>`.
  - Applies `--budget` by swapping `orchestrator.config.recallBudgetChars` around the recall call in a try/finally so a thrown recall cannot leave the config mutated.
  - Clears any prior x-ray snapshot before the recall so capture failures surface as `null` rather than returning stale data from a prior call.
  - Expands `~` in `--out` via the existing `expandTildePath` helper (CLAUDE.md rule 17).

## No behavior change

No changes to existing recall, recall-explain, or any other CLI surface.

## Stacking

Based on `feat/issue-570-pr2-renderer` (PR #594). Retargets to `main` after PRs #578 and #594 merge.

## Test plan

- [x] 12 unit tests in `packages/remnic-core/src/recall-xray-cli.test.ts` — default format, full option bag, empty/whitespace/non-string query, unknown format, malformed budget (zero, negative, fractional, non-numeric, non-finite), blank namespace/out coercion, case-insensitive format normalization.
- [x] All renderer tests from PR 2 still pass.
- [x] `tsc --noEmit` clean.

Part of #570 (slice 3 of 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI surface that triggers a recall with X-ray capture and optional file output; main risk is incorrect option validation or snapshot capture/serialization behavior affecting concurrent recall workflows.
> 
> **Overview**
> Adds a new `remnic xray <query>` CLI command that runs a recall with X-ray capture, renders the unified X-ray snapshot via the shared `renderXray` renderer, and optionally writes output to a user-specified `--out` file.
> 
> Extracts CLI option parsing/validation into new pure helpers (`parseXrayCliOptions`, `parseXrayBudgetFlag`) and adds unit tests covering format normalization, budget coercion/rejection, and handling of blank query/namespace/out inputs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72c21dddceff07e6d3344c505708e4f667e2d918. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->