### PR TITLE
feat(import-claude): Claude.ai export importer (#568 PR 3/7)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -359,6 +359,7 @@ jobs:
             packages/export-weclone
             packages/import-weclone
             packages/import-chatgpt
+            packages/import-claude
             packages/import-mem0
             packages/connector-weclone
             packages/connector-replit

--- a/packages/import-claude/README.md
+++ b/packages/import-claude/README.md
@@ -1,0 +1,37 @@
+# @remnic/import-claude
+
+Optional importer for Claude.ai data exports. Ships as a separately
+installable companion to the Remnic CLI.
+
+```bash
+npm install -g @remnic/import-claude
+remnic import --adapter claude --file ~/claude-export/projects.json
+```
+
+## What it imports
+
+- **Project docs** (default): every `docs[].content` becomes one memory with
+  `metadata.kind = "project_doc"`.
+- **Project prompt templates** (default): every non-empty
+  `prompt_template` becomes one memory with `metadata.kind =
+  "project_prompt_template"`.
+- **Conversation summaries** (opt-in via `--include-conversations`): one
+  memory per conversation summarizing the human-authored turns. Assistant
+  turns are never imported verbatim.
+
+## Input shapes
+
+The adapter accepts either:
+
+- `projects.json` — array of Claude projects with `docs` and `prompt_template`
+- `conversations.json` — array of conversations with `chat_messages`
+- A combined bundle object `{ "projects": [...], "conversations": [...] }`
+
+Synthetic fixtures under `fixtures/` mirror the real shapes without any
+personal data.
+
+## À-la-carte contract
+
+This package is declared as an **optional peer dependency** of
+`@remnic/cli`. Installing the CLI without this package produces a
+friendly install hint — never `MODULE_NOT_FOUND`.

--- a/packages/import-claude/fixtures/bundle.json
+++ b/packages/import-claude/fixtures/bundle.json
@@ -1,0 +1,33 @@
+{
+  "projects": [
+    {
+      "uuid": "44444444-dddd-4000-8000-000000000001",
+      "name": "Bundle-format synthetic project",
+      "prompt_template": "Fictional: treat every question as coming from a TypeScript developer.",
+      "docs": [
+        {
+          "uuid": "doc-b-01",
+          "filename": "notes.md",
+          "content": "Fictional note: the importer must split docs and conversations correctly.",
+          "created_at": "2026-03-01T00:00:00.000Z"
+        }
+      ],
+      "created_at": "2026-03-01T00:00:00.000Z"
+    }
+  ],
+  "conversations": [
+    {
+      "uuid": "55555555-eeee-4000-8000-000000000001",
+      "name": "Bundle-format synthetic conversation",
+      "created_at": "2026-03-01T01:00:00.000Z",
+      "messages": [
+        {
+          "uuid": "m1",
+          "role": "human",
+          "text": "Hello bundle-world. This is a synthetic turn.",
+          "created_at": "2026-03-01T01:00:00.000Z"
+        }
+      ]
+    }
+  ]
+}

--- a/packages/import-claude/fixtures/conversations.json
+++ b/packages/import-claude/fixtures/conversations.json
@@ -1,0 +1,30 @@
+[
+  {
+    "uuid": "33333333-cccc-4000-8000-000000000001",
+    "name": "Fictional: planning an OSS release",
+    "summary": "Discussion of synthetic release steps",
+    "created_at": "2026-02-15T15:00:00.000Z",
+    "chat_messages": [
+      {
+        "uuid": "m1",
+        "sender": "human",
+        "text": "What is a good checklist for cutting a minor release?",
+        "created_at": "2026-02-15T15:00:00.000Z"
+      },
+      {
+        "uuid": "m2",
+        "sender": "assistant",
+        "text": "Sure, here is a checklist...",
+        "created_at": "2026-02-15T15:00:10.000Z"
+      },
+      {
+        "uuid": "m3",
+        "sender": "human",
+        "content": [
+          { "type": "text", "text": "Add a CHANGELOG step and a tag step." }
+        ],
+        "created_at": "2026-02-15T15:01:00.000Z"
+      }
+    ]
+  }
+]

--- a/packages/import-claude/fixtures/projects.json
+++ b/packages/import-claude/fixtures/projects.json
@@ -1,0 +1,32 @@
+[
+  {
+    "uuid": "22222222-bbbb-4000-8000-000000000001",
+    "name": "Synthetic weekend CLI",
+    "description": "Fictional side project for testing",
+    "prompt_template": "Always answer concisely and respond in TypeScript idioms.",
+    "created_at": "2026-01-10T12:00:00.000Z",
+    "updated_at": "2026-02-14T09:00:00.000Z",
+    "docs": [
+      {
+        "uuid": "doc-0001",
+        "filename": "architecture.md",
+        "content": "Fictional: the CLI parses synthetic JSON and prints a report.",
+        "created_at": "2026-01-10T12:05:00.000Z"
+      },
+      {
+        "uuid": "doc-0002",
+        "filename": "conventions.md",
+        "content": "Fictional: prefer named exports, strict mode, and explicit return types.",
+        "created_at": "2026-01-11T08:30:00.000Z"
+      }
+    ]
+  },
+  {
+    "uuid": "22222222-bbbb-4000-8000-000000000002",
+    "name": "Empty project example",
+    "description": "No docs, empty template; should produce zero memories.",
+    "prompt_template": "",
+    "docs": [],
+    "created_at": "2026-02-01T00:00:00.000Z"
+  }
+]

--- a/packages/import-claude/package.json
+++ b/packages/import-claude/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@remnic/import-claude",
+  "version": "0.1.0",
+  "description": "Import conversation history from Claude.ai data exports into Remnic (issue #568)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-claude"
+  },
+  "keywords": ["remnic", "memory", "claude", "anthropic", "import"]
+}

--- a/packages/import-claude/src/adapter.test.ts
+++ b/packages/import-claude/src/adapter.test.ts
@@ -1,0 +1,95 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ImportTurn, ImporterWriteTarget } from "@remnic/core";
+import { runImporter } from "@remnic/core";
+
+import { adapter, claudeAdapter } from "./adapter.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+function makeTarget(): {
+  target: ImporterWriteTarget;
+  received: ImportTurn[][];
+} {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+describe("claude adapter shape", () => {
+  it("exports a canonical adapter + name-prefixed alias", () => {
+    assert.equal(adapter.name, "claude");
+    assert.equal(adapter.sourceLabel, "claude");
+    assert.equal(claudeAdapter, adapter);
+    assert.equal(typeof adapter.parse, "function");
+    assert.equal(typeof adapter.transform, "function");
+    assert.equal(typeof adapter.writeTo, "function");
+  });
+
+  it("drives runImporter end-to-end with a synthetic projects fixture", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("projects.json"),
+      target,
+      { parseOptions: { filePath: "/tmp/claude-export.zip/projects.json" } },
+    );
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 3);
+    assert.equal(result.sourceLabel, "claude");
+    const allTurns = received.flat();
+    assert.equal(allTurns.length, 3);
+    for (const turn of allTurns) {
+      assert.equal(turn.role, "user");
+      assert.equal(turn.participantName, "claude");
+    }
+  });
+
+  it("dry-run does not hit the target", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("projects.json"),
+      target,
+      { dryRun: true },
+    );
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(received.length, 0);
+  });
+
+  it("skips conversations by default but imports them with includeConversations", async () => {
+    const conversations = loadFixture("conversations.json");
+    const t1 = makeTarget();
+    const r1 = await runImporter(adapter, conversations, t1.target);
+    assert.equal(r1.memoriesPlanned, 0);
+    assert.equal(t1.received.length, 0);
+
+    const t2 = makeTarget();
+    const r2 = await runImporter(adapter, conversations, t2.target, {
+      transformOptions: { includeConversations: true },
+    });
+    assert.equal(r2.memoriesPlanned, 1);
+    assert.equal(r2.memoriesWritten, 1);
+  });
+});

--- a/packages/import-claude/src/adapter.ts
+++ b/packages/import-claude/src/adapter.ts
@@ -1,0 +1,60 @@
+// ---------------------------------------------------------------------------
+// Claude importer adapter (issue #568 slice 3)
+// ---------------------------------------------------------------------------
+
+import type {
+  ImportedMemory,
+  ImporterAdapter,
+  ImporterParseOptions,
+  ImporterTransformOptions,
+  ImporterWriteResult,
+  ImporterWriteTarget,
+} from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import {
+  parseClaudeExport,
+  type ParsedClaudeExport,
+} from "./parser.js";
+import { CLAUDE_SOURCE_LABEL, transformClaudeExport } from "./transform.js";
+
+/**
+ * Canonical `ImporterAdapter` exposed by `@remnic/import-claude`.
+ *
+ * Loaded by `remnic-cli/optional-importer.ts` via a computed-specifier dynamic
+ * import. The CLI drives `adapter.parse` → `adapter.transform` →
+ * `adapter.writeTo` through the shared `runImporter` helper in `@remnic/core`.
+ */
+export const adapter: ImporterAdapter<ParsedClaudeExport> = {
+  name: "claude",
+  sourceLabel: CLAUDE_SOURCE_LABEL,
+
+  parse(input: unknown, options?: ImporterParseOptions): ParsedClaudeExport {
+    return parseClaudeExport(input, {
+      ...(options?.strict !== undefined ? { strict: options.strict } : {}),
+      ...(options?.filePath !== undefined ? { filePath: options.filePath } : {}),
+    });
+  },
+
+  transform(
+    parsed: ParsedClaudeExport,
+    options?: ImporterTransformOptions,
+  ): ImportedMemory[] {
+    return transformClaudeExport(parsed, {
+      includeConversations: options?.includeConversations === true,
+      ...(options?.maxMemories !== undefined
+        ? { maxMemories: options.maxMemories }
+        : {}),
+    });
+  },
+
+  async writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+  ): Promise<ImporterWriteResult> {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+/** Alias kept for symmetry with other @remnic/import-* packages. */
+export const claudeAdapter = adapter;

--- a/packages/import-claude/src/index.ts
+++ b/packages/import-claude/src/index.ts
@@ -1,0 +1,20 @@
+// ---------------------------------------------------------------------------
+// @remnic/import-claude — public surface (issue #568 slice 3)
+// ---------------------------------------------------------------------------
+
+export { adapter, claudeAdapter } from "./adapter.js";
+export {
+  parseClaudeExport,
+  collectHumanTurnsFromConversation,
+  type ClaudeConversation,
+  type ClaudeConversationMessage,
+  type ClaudeParseOptions,
+  type ClaudeProject,
+  type ClaudeProjectDoc,
+  type ParsedClaudeExport,
+} from "./parser.js";
+export {
+  CLAUDE_SOURCE_LABEL,
+  transformClaudeExport,
+  type ClaudeTransformOptions,
+} from "./transform.js";

--- a/packages/import-claude/src/parser.test.ts
+++ b/packages/import-claude/src/parser.test.ts
@@ -94,6 +94,48 @@ describe("parseClaudeExport", () => {
     assert.equal(parsed.projects.length, 0);
   });
 
+  // Codex review on PR #598 — when `--file` is omitted, the parser receives
+  // `undefined`; we must throw a user-facing hint instead of returning an
+  // empty result that looks like a successful zero-memory import.
+  it("throws when called without any input (undefined / null)", () => {
+    assert.throws(() => parseClaudeExport(undefined), /requires a --file/);
+    assert.throws(() => parseClaudeExport(null), /requires a --file/);
+  });
+
+  // Codex review on PR #598 — primitive payloads (numbers, booleans,
+  // strings) must always throw regardless of strict mode.
+  it("rejects primitive (non-object, non-array) input in every mode", () => {
+    assert.throws(() => parseClaudeExport(42), /must be a JSON array or object/);
+    assert.throws(() => parseClaudeExport(true), /must be a JSON array or object/);
+    assert.throws(
+      () => parseClaudeExport("42"),
+      /must be a JSON array or object/,
+    );
+  });
+
+  // Codex review on PR #598 — the `name`-only project fallback is too
+  // loose for strict mode; an arbitrary `[{"name": "foo"}]` would slip past
+  // strict validation. In strict mode we require an unambiguous project
+  // signal (`prompt_template` or `docs`).
+  it("strict mode rejects name-only project fallback", () => {
+    assert.throws(
+      () => parseClaudeExport([{ name: "foo" }], { strict: true }),
+      /Unknown Claude export array shape/,
+    );
+    // Object form: an array of `name`-only entries under `projects` must
+    // also be rejected in strict mode.
+    assert.throws(
+      () =>
+        parseClaudeExport({ projects: [{ name: "foo" }] }, { strict: true }),
+      /Non-project entry/,
+    );
+  });
+
+  it("non-strict mode still accepts the name-only project fallback", () => {
+    const parsed = parseClaudeExport([{ name: "foo" }]);
+    assert.equal(parsed.projects.length, 1);
+  });
+
   // Cursor review on PR #598 — collectHumanTurnsFromConversation must fall
   // back to `messages` when `chat_messages` is an empty array (not just
   // when it's undefined).

--- a/packages/import-claude/src/parser.test.ts
+++ b/packages/import-claude/src/parser.test.ts
@@ -77,4 +77,40 @@ describe("parseClaudeExport", () => {
     assert.equal(turns.length, 1);
     assert.ok(turns[0]?.content.includes("bundle-world"));
   });
+
+  // Cursor review on PR #598 — strict mode should reject object payloads
+  // that have none of the recognized Claude export sections rather than
+  // silently returning an empty struct.
+  it("strict mode rejects unknown object shapes", () => {
+    assert.throws(
+      () => parseClaudeExport({ foo: "bar" }, { strict: true }),
+      /Unknown Claude export object shape/,
+    );
+  });
+
+  it("non-strict mode returns an empty result for unknown object shapes", () => {
+    const parsed = parseClaudeExport({ foo: "bar" });
+    assert.equal(parsed.conversations.length, 0);
+    assert.equal(parsed.projects.length, 0);
+  });
+
+  // Cursor review on PR #598 — collectHumanTurnsFromConversation must fall
+  // back to `messages` when `chat_messages` is an empty array (not just
+  // when it's undefined).
+  it("falls back to `messages` when `chat_messages` is an empty array", () => {
+    const conv = {
+      uuid: "legacy",
+      name: "Legacy-shape conversation",
+      chat_messages: [],
+      messages: [
+        {
+          role: "human",
+          text: "I only live in the messages array.",
+        },
+      ],
+    };
+    const turns = collectHumanTurnsFromConversation(conv);
+    assert.equal(turns.length, 1);
+    assert.equal(turns[0]?.content, "I only live in the messages array.");
+  });
 });

--- a/packages/import-claude/src/parser.test.ts
+++ b/packages/import-claude/src/parser.test.ts
@@ -1,0 +1,80 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  collectHumanTurnsFromConversation,
+  parseClaudeExport,
+} from "./parser.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("parseClaudeExport", () => {
+  it("parses a projects-array fixture", () => {
+    const parsed = parseClaudeExport(loadFixture("projects.json"));
+    assert.equal(parsed.projects.length, 2);
+    assert.equal(parsed.conversations.length, 0);
+    assert.equal(parsed.projects[0]?.docs?.length, 2);
+  });
+
+  it("parses a conversations-array fixture", () => {
+    const parsed = parseClaudeExport(loadFixture("conversations.json"));
+    assert.equal(parsed.conversations.length, 1);
+    assert.equal(parsed.projects.length, 0);
+    assert.equal(parsed.conversations[0]?.chat_messages?.length, 3);
+  });
+
+  it("parses a combined bundle object", () => {
+    const parsed = parseClaudeExport(loadFixture("bundle.json"));
+    assert.equal(parsed.projects.length, 1);
+    assert.equal(parsed.conversations.length, 1);
+  });
+
+  it("returns empty arrays on an empty input array (non-strict)", () => {
+    const parsed = parseClaudeExport("[]");
+    assert.equal(parsed.conversations.length, 0);
+    assert.equal(parsed.projects.length, 0);
+  });
+
+  it("throws on invalid JSON", () => {
+    assert.throws(() => parseClaudeExport("{not-json"), /not valid JSON/);
+  });
+
+  it("strict mode rejects unknown array shapes", () => {
+    assert.throws(
+      () => parseClaudeExport(JSON.stringify([{ hello: "world" }]), { strict: true }),
+      /Unknown Claude export array shape/,
+    );
+  });
+
+  it("preserves filePath in parsed output when provided", () => {
+    const parsed = parseClaudeExport(loadFixture("bundle.json"), {
+      filePath: "/tmp/claude-export.zip",
+    });
+    assert.equal(parsed.filePath, "/tmp/claude-export.zip");
+  });
+
+  it("collects only human turns from structured and plain content", () => {
+    const parsed = parseClaudeExport(loadFixture("conversations.json"));
+    const turns = collectHumanTurnsFromConversation(parsed.conversations[0]!);
+    assert.equal(turns.length, 2);
+    assert.ok(turns[0]?.content.includes("checklist"));
+    assert.ok(turns[1]?.content.includes("CHANGELOG"));
+  });
+
+  it("accepts the `role` alias used by older exports", () => {
+    const parsed = parseClaudeExport(loadFixture("bundle.json"));
+    const turns = collectHumanTurnsFromConversation(parsed.conversations[0]!);
+    assert.equal(turns.length, 1);
+    assert.ok(turns[0]?.content.includes("bundle-world"));
+  });
+});

--- a/packages/import-claude/src/parser.ts
+++ b/packages/import-claude/src/parser.ts
@@ -151,8 +151,10 @@ export function parseClaudeExport(
   // Shape 2: an object. Look for the known keys.
   if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
+    let sawKnownSection = false;
     const convs = obj.conversations;
     if (Array.isArray(convs)) {
+      sawKnownSection = true;
       for (const entry of convs) {
         if (looksLikeConversation(entry)) {
           result.conversations.push(entry as ClaudeConversation);
@@ -163,6 +165,7 @@ export function parseClaudeExport(
     }
     const projects = obj.projects;
     if (Array.isArray(projects)) {
+      sawKnownSection = true;
       for (const entry of projects) {
         if (looksLikeProject(entry)) {
           result.projects.push(entry as ClaudeProject);
@@ -170,6 +173,14 @@ export function parseClaudeExport(
           throw new Error("Non-project entry in projects array");
         }
       }
+    }
+    // Strict mode: if the object has neither `conversations` nor `projects`,
+    // bail rather than silently returning an empty struct. Non-strict mode
+    // keeps the lenient behavior to survive future-shape changes.
+    if (!sawKnownSection && options.strict) {
+      throw new Error(
+        "Unknown Claude export object shape: expected 'conversations' or 'projects' keys.",
+      );
     }
     return result;
   }
@@ -237,7 +248,17 @@ export function collectHumanTurnsFromConversation(
   conversation: ClaudeConversation,
 ): Array<{ content: string; createdAt?: string }> {
   const collected: Array<{ content: string; createdAt?: string }> = [];
-  const messages = conversation.chat_messages ?? conversation.messages ?? [];
+  // Prefer chat_messages when it has entries; fall back to the legacy
+  // `messages` field. `??` alone is insufficient because an empty
+  // `chat_messages` array is non-null but has no content — without the
+  // length check, we would miss turns that only live in the legacy
+  // `messages` array. Cursor review on PR #598.
+  let messages: ClaudeConversationMessage[] = [];
+  if (Array.isArray(conversation.chat_messages) && conversation.chat_messages.length > 0) {
+    messages = conversation.chat_messages;
+  } else if (Array.isArray(conversation.messages) && conversation.messages.length > 0) {
+    messages = conversation.messages;
+  }
   for (const msg of messages) {
     if (!isHumanSender(msg)) continue;
     const text = extractMessageText(msg);

--- a/packages/import-claude/src/parser.ts
+++ b/packages/import-claude/src/parser.ts
@@ -106,6 +106,17 @@ export function parseClaudeExport(
   input: unknown,
   options: ClaudeParseOptions = {},
 ): ParsedClaudeExport {
+  // Codex review on PR #598 — missing input (undefined / null) must NEVER
+  // succeed as an empty import. The CLI passes `undefined` when `--file`
+  // is omitted; silently returning a zero-memory success would make
+  // `remnic import --adapter claude` without --file look healthy in
+  // automation logs while the user's export was never read.
+  if (input === undefined || input === null) {
+    throw new Error(
+      "Claude import requires a --file argument pointing at conversations.json, " +
+        "projects.json, or the exported bundle.",
+    );
+  }
   const raw = coerceJson(input);
   const result: ParsedClaudeExport = {
     conversations: [],
@@ -130,9 +141,9 @@ export function parseClaudeExport(
       }
       return result;
     }
-    if (looksLikeProject(first)) {
+    if (looksLikeProject(first, { strict: options.strict })) {
       for (const entry of raw) {
-        if (looksLikeProject(entry)) {
+        if (looksLikeProject(entry, { strict: options.strict })) {
           result.projects.push(entry as ClaudeProject);
         } else if (options.strict) {
           throw new Error("Non-project entry in projects array");
@@ -167,7 +178,7 @@ export function parseClaudeExport(
     if (Array.isArray(projects)) {
       sawKnownSection = true;
       for (const entry of projects) {
-        if (looksLikeProject(entry)) {
+        if (looksLikeProject(entry, { strict: options.strict })) {
           result.projects.push(entry as ClaudeProject);
         } else if (options.strict) {
           throw new Error("Non-project entry in projects array");
@@ -185,12 +196,13 @@ export function parseClaudeExport(
     return result;
   }
 
-  if (options.strict) {
-    throw new Error(
-      "Claude export must be a JSON array or object; received " + typeof raw,
-    );
-  }
-  return result;
+  // Codex review on PR #598 — primitive payloads (numbers, booleans,
+  // strings, etc.) must always throw regardless of strict mode. A silent
+  // empty result on garbage input would let automation mistake a broken
+  // import for a healthy zero-memory run.
+  throw new Error(
+    "Claude export must be a JSON array or object; received " + typeof raw,
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -221,14 +233,23 @@ function looksLikeConversation(value: unknown): value is ClaudeConversation {
   return false;
 }
 
-function looksLikeProject(value: unknown): value is ClaudeProject {
+function looksLikeProject(
+  value: unknown,
+  opts: { strict?: boolean } = {},
+): value is ClaudeProject {
   if (!value || typeof value !== "object") return false;
   const v = value as Record<string, unknown>;
   // Projects are recognised by the presence of `prompt_template` OR `docs`
-  // (or `name` + absence of chat_messages). We prefer the structural signals.
+  // — unambiguous structural signals unique to project exports.
   if (typeof v.prompt_template === "string") return true;
   if (Array.isArray(v.docs)) return true;
-  // Guard against a conversation being misclassified: require NO message array.
+  // Codex review on PR #598 — the `name`-only fallback is too loose for
+  // strict mode. An arbitrary array like `[{"name": "foo"}]` would slip
+  // past strict validation and produce empty imports. In strict mode we
+  // require an unambiguous project signal (prompt_template or docs) and
+  // reject name-only entries. Non-strict mode keeps the lenient fallback
+  // for future-shape safety.
+  if (opts.strict) return false;
   if (
     typeof v.name === "string" &&
     !Array.isArray(v.chat_messages) &&

--- a/packages/import-claude/src/parser.ts
+++ b/packages/import-claude/src/parser.ts
@@ -1,0 +1,279 @@
+// ---------------------------------------------------------------------------
+// Claude.ai data-export parser (issue #568 slice 3)
+// ---------------------------------------------------------------------------
+//
+// Claude.ai's "Export data" feature produces a ZIP containing several JSON
+// files. The two relevant to memory import are:
+//
+//   1. `conversations.json` — array of Conversation objects. Each has a
+//      `chat_messages` array with `sender` (human/assistant) and `text` (plus
+//      `content` blocks in newer exports). Text content is plain, not the
+//      graph shape ChatGPT uses.
+//   2. `projects.json` — array of Project objects, each with an optional
+//      `prompt_template` and a list of `docs` (the durable context documents
+//      the user attached to the project). These are high-signal personal
+//      artifacts and are imported as one memory per doc / project.
+//
+// The parser accepts either file individually (JSON text or object) or a
+// combined bundle object (`{ conversations: [...], projects: [...] }`) used
+// by the future bundle-auto-detect flow (PR 7).
+//
+// We do NOT read ZIP archives here — the CLI reads the file contents and
+// passes them in. Synthetic fixtures in `fixtures/` mirror the real shapes.
+
+// ---------------------------------------------------------------------------
+// Raw export shapes (subset we care about)
+// ---------------------------------------------------------------------------
+
+/**
+ * Message inside a Claude conversation. `sender` is either "human" or
+ * "assistant"; older exports used `role` instead.
+ */
+export interface ClaudeConversationMessage {
+  uuid?: string;
+  sender?: "human" | "assistant" | string;
+  role?: "human" | "assistant" | string;
+  /** Plain-text transcript of this message. */
+  text?: string;
+  /** Newer exports expose structured content blocks. */
+  content?: Array<{ type?: string; text?: string }>;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ClaudeConversation {
+  uuid?: string;
+  name?: string;
+  summary?: string;
+  created_at?: string;
+  updated_at?: string;
+  chat_messages?: ClaudeConversationMessage[];
+  /** Some exports also expose `messages` alongside chat_messages. */
+  messages?: ClaudeConversationMessage[];
+  /** Associated project id, when the conversation lives inside a Project. */
+  project_uuid?: string;
+}
+
+export interface ClaudeProjectDoc {
+  uuid?: string;
+  filename?: string;
+  content?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface ClaudeProject {
+  uuid?: string;
+  name?: string;
+  description?: string;
+  /** User-authored free-form instructions for the project. */
+  prompt_template?: string;
+  docs?: ClaudeProjectDoc[];
+  created_at?: string;
+  updated_at?: string;
+}
+
+/**
+ * Unified parsed shape passed into `transform()`.
+ */
+export interface ParsedClaudeExport {
+  conversations: ClaudeConversation[];
+  projects: ClaudeProject[];
+  /** Source path the export came from (for provenance). */
+  filePath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public parse API
+// ---------------------------------------------------------------------------
+
+export interface ClaudeParseOptions {
+  strict?: boolean;
+  filePath?: string;
+}
+
+/**
+ * Parse a raw Claude export payload. Accepts:
+ *   - a JSON string (`conversations.json`, `projects.json`, or a combined
+ *     bundle like `{conversations, projects}`)
+ *   - an already-parsed object or array.
+ *
+ * Returns the unified `ParsedClaudeExport`. Non-export payloads throw in
+ * strict mode; otherwise the returned struct holds empty arrays so the
+ * transform layer can no-op.
+ */
+export function parseClaudeExport(
+  input: unknown,
+  options: ClaudeParseOptions = {},
+): ParsedClaudeExport {
+  const raw = coerceJson(input);
+  const result: ParsedClaudeExport = {
+    conversations: [],
+    projects: [],
+    ...(options.filePath !== undefined ? { filePath: options.filePath } : {}),
+  };
+
+  // Shape 1: a top-level array.
+  //   - `conversations.json` is an array of conversations.
+  //   - `projects.json` is an array of projects.
+  // We branch on the first element's shape.
+  if (Array.isArray(raw)) {
+    if (raw.length === 0) return result;
+    const first = raw[0];
+    if (looksLikeConversation(first)) {
+      for (const entry of raw) {
+        if (looksLikeConversation(entry)) {
+          result.conversations.push(entry as ClaudeConversation);
+        } else if (options.strict) {
+          throw new Error("Non-conversation entry in conversations array");
+        }
+      }
+      return result;
+    }
+    if (looksLikeProject(first)) {
+      for (const entry of raw) {
+        if (looksLikeProject(entry)) {
+          result.projects.push(entry as ClaudeProject);
+        } else if (options.strict) {
+          throw new Error("Non-project entry in projects array");
+        }
+      }
+      return result;
+    }
+    if (options.strict) {
+      throw new Error(
+        "Unknown Claude export array shape (neither conversations nor projects).",
+      );
+    }
+    return result;
+  }
+
+  // Shape 2: an object. Look for the known keys.
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    const convs = obj.conversations;
+    if (Array.isArray(convs)) {
+      for (const entry of convs) {
+        if (looksLikeConversation(entry)) {
+          result.conversations.push(entry as ClaudeConversation);
+        } else if (options.strict) {
+          throw new Error("Non-conversation entry in conversations array");
+        }
+      }
+    }
+    const projects = obj.projects;
+    if (Array.isArray(projects)) {
+      for (const entry of projects) {
+        if (looksLikeProject(entry)) {
+          result.projects.push(entry as ClaudeProject);
+        } else if (options.strict) {
+          throw new Error("Non-project entry in projects array");
+        }
+      }
+    }
+    return result;
+  }
+
+  if (options.strict) {
+    throw new Error(
+      "Claude export must be a JSON array or object; received " + typeof raw,
+    );
+  }
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function coerceJson(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input);
+    } catch (err) {
+      throw new Error(
+        `Claude export is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return input;
+}
+
+function looksLikeConversation(value: unknown): value is ClaudeConversation {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  // Every conversation has either chat_messages or messages.
+  if (Array.isArray(v.chat_messages)) return true;
+  if (Array.isArray(v.messages)) return true;
+  return false;
+}
+
+function looksLikeProject(value: unknown): value is ClaudeProject {
+  if (!value || typeof value !== "object") return false;
+  const v = value as Record<string, unknown>;
+  // Projects are recognised by the presence of `prompt_template` OR `docs`
+  // (or `name` + absence of chat_messages). We prefer the structural signals.
+  if (typeof v.prompt_template === "string") return true;
+  if (Array.isArray(v.docs)) return true;
+  // Guard against a conversation being misclassified: require NO message array.
+  if (
+    typeof v.name === "string" &&
+    !Array.isArray(v.chat_messages) &&
+    !Array.isArray(v.messages)
+  ) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * Walk a conversation and return only human-authored user turns in
+ * chronological order. Exported so the transform layer can build conversation
+ * summaries from the same source of truth.
+ */
+export function collectHumanTurnsFromConversation(
+  conversation: ClaudeConversation,
+): Array<{ content: string; createdAt?: string }> {
+  const collected: Array<{ content: string; createdAt?: string }> = [];
+  const messages = conversation.chat_messages ?? conversation.messages ?? [];
+  for (const msg of messages) {
+    if (!isHumanSender(msg)) continue;
+    const text = extractMessageText(msg);
+    if (text) {
+      collected.push({
+        content: text,
+        ...(typeof msg.created_at === "string" && msg.created_at.length > 0
+          ? { createdAt: msg.created_at }
+          : {}),
+      });
+    }
+  }
+  return collected;
+}
+
+function isHumanSender(msg: ClaudeConversationMessage): boolean {
+  const sender = msg.sender ?? msg.role;
+  return sender === "human" || sender === "user";
+}
+
+function extractMessageText(
+  msg: ClaudeConversationMessage,
+): string | undefined {
+  // Prefer structured content blocks (newer exports).
+  if (Array.isArray(msg.content)) {
+    const joined = msg.content
+      .filter((b) => !b.type || b.type === "text")
+      .map((b) => (typeof b.text === "string" ? b.text : ""))
+      .filter((s) => s.length > 0)
+      .join("\n")
+      .trim();
+    if (joined.length > 0) return joined;
+  }
+  if (typeof msg.text === "string") {
+    const trimmed = msg.text.trim();
+    if (trimmed.length > 0) return trimmed;
+  }
+  return undefined;
+}

--- a/packages/import-claude/src/transform.test.ts
+++ b/packages/import-claude/src/transform.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseClaudeExport } from "./parser.js";
+import { transformClaudeExport } from "./transform.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("transformClaudeExport", () => {
+  it("emits project docs + prompt_template by default (skips conversations)", () => {
+    const parsed = parseClaudeExport(loadFixture("projects.json"), {
+      filePath: "/tmp/claude.zip",
+    });
+    const memories = transformClaudeExport(parsed);
+    // project[0]: 2 docs + 1 template. project[1]: empty. Total = 3.
+    assert.equal(memories.length, 3);
+    for (const m of memories) {
+      assert.equal(m.sourceLabel, "claude");
+      assert.equal(m.importedFromPath, "/tmp/claude.zip");
+    }
+    const kinds = memories.map((m) => m.metadata?.kind);
+    assert.deepEqual(kinds, ["project_doc", "project_doc", "project_prompt_template"]);
+  });
+
+  it("skips empty docs and empty prompt_template", () => {
+    const parsed = parseClaudeExport(
+      JSON.stringify([
+        {
+          uuid: "p-empty",
+          name: "Empty",
+          prompt_template: "   ",
+          docs: [{ uuid: "d", filename: "blank.md", content: "" }],
+        },
+      ]),
+    );
+    const memories = transformClaudeExport(parsed);
+    assert.equal(memories.length, 0);
+  });
+
+  it("does not emit conversations unless includeConversations is true", () => {
+    const parsed = parseClaudeExport(loadFixture("conversations.json"));
+    const defaultOut = transformClaudeExport(parsed);
+    assert.equal(defaultOut.length, 0);
+    const withConvs = transformClaudeExport(parsed, {
+      includeConversations: true,
+    });
+    assert.equal(withConvs.length, 1);
+    assert.equal(withConvs[0]?.metadata?.kind, "conversation_summary");
+    assert.equal(withConvs[0]?.metadata?.humanTurns, 2);
+  });
+
+  it("truncates long conversation summaries at maxConversationSummaryChars", () => {
+    const longText = "x".repeat(500);
+    const parsed = parseClaudeExport(
+      JSON.stringify([
+        {
+          uuid: "c1",
+          name: "Long convo",
+          chat_messages: Array.from({ length: 10 }, (_, i) => ({
+            uuid: `m${i}`,
+            sender: "human",
+            text: longText,
+          })),
+        },
+      ]),
+    );
+    const [memory] = transformClaudeExport(parsed, {
+      includeConversations: true,
+      maxConversationSummaryChars: 100,
+    });
+    assert.ok(memory);
+    assert.ok(memory.content.length <= 100);
+    assert.ok(memory.content.endsWith("..."));
+  });
+
+  it("honors maxMemories as a hard cap", () => {
+    const parsed = parseClaudeExport(loadFixture("projects.json"));
+    const memories = transformClaudeExport(parsed, { maxMemories: 1 });
+    assert.equal(memories.length, 1);
+  });
+
+  it("preserves project + doc metadata on emitted memories", () => {
+    const parsed = parseClaudeExport(loadFixture("projects.json"));
+    const memories = transformClaudeExport(parsed);
+    const doc = memories.find((m) => m.metadata?.kind === "project_doc");
+    assert.ok(doc);
+    assert.equal(doc.metadata?.projectName, "Synthetic weekend CLI");
+    assert.equal(doc.metadata?.filename, "architecture.md");
+    const tpl = memories.find((m) => m.metadata?.kind === "project_prompt_template");
+    assert.ok(tpl);
+    assert.equal(tpl.metadata?.projectName, "Synthetic weekend CLI");
+  });
+});

--- a/packages/import-claude/src/transform.test.ts
+++ b/packages/import-claude/src/transform.test.ts
@@ -132,4 +132,34 @@ describe("transformClaudeExport", () => {
     );
     assert.ok(memory.content.endsWith("..."));
   });
+
+  // Cursor review on PR #598 — even when maxChars is below the suffix
+  // length (3), content.length must never exceed maxChars. The earlier
+  // fix unconditionally appended "..." which produced 3-char output for
+  // maxChars=2.
+  it("honors maxChars below the suffix length", () => {
+    const longTitle = "T".repeat(500);
+    const parsed = parseClaudeExport(
+      JSON.stringify([
+        {
+          uuid: "tiny-cap",
+          name: longTitle,
+          chat_messages: [
+            { uuid: "m1", sender: "human", text: "body" },
+          ],
+        },
+      ]),
+    );
+    for (const cap of [0, 1, 2]) {
+      const [memory] = transformClaudeExport(parsed, {
+        includeConversations: true,
+        maxConversationSummaryChars: cap,
+      });
+      assert.ok(memory);
+      assert.ok(
+        memory.content.length <= cap,
+        `content.length ${memory.content.length} must be <= ${cap}`,
+      );
+    }
+  });
 });

--- a/packages/import-claude/src/transform.test.ts
+++ b/packages/import-claude/src/transform.test.ts
@@ -100,4 +100,36 @@ describe("transformClaudeExport", () => {
     assert.ok(tpl);
     assert.equal(tpl.metadata?.projectName, "Synthetic weekend CLI");
   });
+
+  // Cursor review on PR #598 — when the title alone is longer than
+  // maxChars, the previous truncation logic produced content that
+  // exceeded the cap.
+  it("truncation never exceeds maxConversationSummaryChars with a long title", () => {
+    const longTitle = "T".repeat(500);
+    const parsed = parseClaudeExport(
+      JSON.stringify([
+        {
+          uuid: "long-title",
+          name: longTitle,
+          chat_messages: [
+            {
+              uuid: "m1",
+              sender: "human",
+              text: "short body",
+            },
+          ],
+        },
+      ]),
+    );
+    const [memory] = transformClaudeExport(parsed, {
+      includeConversations: true,
+      maxConversationSummaryChars: 100,
+    });
+    assert.ok(memory);
+    assert.ok(
+      memory.content.length <= 100,
+      `content length ${memory.content.length} must be <= 100`,
+    );
+    assert.ok(memory.content.endsWith("..."));
+  });
 });

--- a/packages/import-claude/src/transform.ts
+++ b/packages/import-claude/src/transform.ts
@@ -163,7 +163,13 @@ function conversationToSummary(
       content = titleLine + bodyTruncated + effectiveSuffix;
     }
   }
-  const sourceTimestamp = firstTimestamp(turns);
+  // Codex review on PR #598 — when per-turn timestamps are absent, fall
+  // back to the conversation-level `updated_at`/`created_at`. Without
+  // this fallback, exports that omit message-level timestamps lose their
+  // original time metadata entirely, which makes old conversations look
+  // newly imported and skews recency-based retrieval.
+  const sourceTimestamp =
+    firstTimestamp(turns) ?? conversation.updated_at ?? conversation.created_at;
   const metadata: Record<string, unknown> = {
     kind: "conversation_summary",
     humanTurns: turns.length,

--- a/packages/import-claude/src/transform.ts
+++ b/packages/import-claude/src/transform.ts
@@ -147,17 +147,20 @@ function conversationToSummary(
   const body = turns.map((t) => `- ${t.content}`).join("\n");
   let content = titleLine + body;
   if (content.length > maxChars) {
-    // Reserve 3 chars for the "..." suffix. When the titleLine alone
-    // already exceeds maxChars (pathological — a very long title with a
-    // small cap), truncate the titleLine itself rather than letting
-    // content exceed maxChars. Cursor review on PR #598.
-    const suffix = "...";
-    if (titleLine.length + suffix.length >= maxChars) {
-      content = titleLine.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
+    // Reserve up to 3 chars for the "..." suffix, but truncate the suffix
+    // itself when `maxChars` is below 3 so the final content.length is
+    // strictly ≤ maxChars. Cursor reviews on PR #598 flagged both the
+    // long-title case (titleLine alone exceeds maxChars) and the
+    // pathologically small cap (maxChars < suffix.length).
+    const effectiveSuffix = maxChars >= 3 ? "..." : "";
+    if (titleLine.length + effectiveSuffix.length >= maxChars) {
+      content =
+        titleLine.slice(0, Math.max(0, maxChars - effectiveSuffix.length)) +
+        effectiveSuffix;
     } else {
-      const remaining = maxChars - titleLine.length - suffix.length;
+      const remaining = maxChars - titleLine.length - effectiveSuffix.length;
       const bodyTruncated = body.slice(0, Math.max(0, remaining));
-      content = titleLine + bodyTruncated + suffix;
+      content = titleLine + bodyTruncated + effectiveSuffix;
     }
   }
   const sourceTimestamp = firstTimestamp(turns);

--- a/packages/import-claude/src/transform.ts
+++ b/packages/import-claude/src/transform.ts
@@ -1,0 +1,181 @@
+// ---------------------------------------------------------------------------
+// Claude parsed → ImportedMemory transform (issue #568 slice 3)
+// ---------------------------------------------------------------------------
+//
+// Claude exports contain two distinct memory-worthy surfaces:
+//
+//   1. Project docs + `prompt_template` — durable personal context the user
+//      explicitly pinned to a project. These are imported 1:1 by default;
+//      each doc becomes one memory, and each project's prompt_template (if
+//      non-empty) becomes one memory.
+//   2. Conversations — per-conversation summaries, only emitted when the
+//      caller opts in via `includeConversations: true`. The summary
+//      concatenates human-side turns (user messages) so downstream
+//      extraction has coherent content to score. One memory per conversation
+//      keeps the footprint bounded.
+
+import type { ImportedMemory } from "@remnic/core";
+
+import type {
+  ClaudeConversation,
+  ClaudeProject,
+  ClaudeProjectDoc,
+  ParsedClaudeExport,
+} from "./parser.js";
+import { collectHumanTurnsFromConversation } from "./parser.js";
+
+export const CLAUDE_SOURCE_LABEL = "claude";
+
+export interface ClaudeTransformOptions {
+  /** When true, emit conversation-summary memories. */
+  includeConversations?: boolean;
+  /** Optional cap on total memories emitted — primarily for tests. */
+  maxMemories?: number;
+  /** Max characters for a conversation summary. */
+  maxConversationSummaryChars?: number;
+}
+
+const DEFAULT_CONVERSATION_SUMMARY_CHARS = 2000;
+
+/**
+ * Transform a parsed Claude export into `ImportedMemory[]`. Project docs are
+ * emitted first (in parse order), then project prompt templates, then
+ * conversation summaries when opted in.
+ */
+export function transformClaudeExport(
+  parsed: ParsedClaudeExport,
+  options: ClaudeTransformOptions = {},
+): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  const cap = options.maxMemories;
+
+  for (const project of parsed.projects) {
+    if (cap !== undefined && out.length >= cap) return out;
+    const docs = Array.isArray(project.docs) ? project.docs : [];
+    for (const doc of docs) {
+      if (cap !== undefined && out.length >= cap) return out;
+      const memory = docToImported(project, doc, parsed.filePath);
+      if (memory) out.push(memory);
+    }
+    if (cap !== undefined && out.length >= cap) return out;
+    const templateMemory = projectTemplateToImported(project, parsed.filePath);
+    if (templateMemory) out.push(templateMemory);
+  }
+
+  if (options.includeConversations) {
+    const maxSummaryChars =
+      options.maxConversationSummaryChars ?? DEFAULT_CONVERSATION_SUMMARY_CHARS;
+    for (const conversation of parsed.conversations) {
+      if (cap !== undefined && out.length >= cap) return out;
+      const summary = conversationToSummary(
+        conversation,
+        parsed.filePath,
+        maxSummaryChars,
+      );
+      if (summary) out.push(summary);
+    }
+  }
+  return out;
+}
+
+function docToImported(
+  project: ClaudeProject,
+  doc: ClaudeProjectDoc,
+  filePath: string | undefined,
+): ImportedMemory | undefined {
+  const content = typeof doc.content === "string" ? doc.content.trim() : "";
+  if (content.length === 0) return undefined;
+  const sourceTimestamp = doc.updated_at ?? doc.created_at;
+  const metadata: Record<string, unknown> = { kind: "project_doc" };
+  if (typeof doc.filename === "string" && doc.filename.length > 0) {
+    metadata.filename = doc.filename;
+  }
+  if (typeof project.name === "string" && project.name.length > 0) {
+    metadata.projectName = project.name;
+  }
+  if (typeof project.uuid === "string") {
+    metadata.projectUuid = project.uuid;
+  }
+  return {
+    content,
+    sourceLabel: CLAUDE_SOURCE_LABEL,
+    ...(doc.uuid !== undefined ? { sourceId: doc.uuid } : {}),
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata,
+  };
+}
+
+function projectTemplateToImported(
+  project: ClaudeProject,
+  filePath: string | undefined,
+): ImportedMemory | undefined {
+  const template =
+    typeof project.prompt_template === "string"
+      ? project.prompt_template.trim()
+      : "";
+  if (template.length === 0) return undefined;
+  const sourceTimestamp = project.updated_at ?? project.created_at;
+  const metadata: Record<string, unknown> = { kind: "project_prompt_template" };
+  if (typeof project.name === "string" && project.name.length > 0) {
+    metadata.projectName = project.name;
+  }
+  if (typeof project.uuid === "string") {
+    metadata.projectUuid = project.uuid;
+  }
+  return {
+    content: template,
+    sourceLabel: CLAUDE_SOURCE_LABEL,
+    ...(project.uuid !== undefined ? { sourceId: project.uuid } : {}),
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata,
+  };
+}
+
+function conversationToSummary(
+  conversation: ClaudeConversation,
+  filePath: string | undefined,
+  maxChars: number,
+): ImportedMemory | undefined {
+  const turns = collectHumanTurnsFromConversation(conversation);
+  if (turns.length === 0) return undefined;
+
+  const title =
+    typeof conversation.name === "string" ? conversation.name.trim() : "";
+  const titleLine = title.length > 0 ? `Conversation: ${title}\n\n` : "";
+  const body = turns.map((t) => `- ${t.content}`).join("\n");
+  let content = titleLine + body;
+  if (content.length > maxChars) {
+    const remaining = maxChars - titleLine.length - 3;
+    const bodyTruncated = body.slice(0, Math.max(0, remaining));
+    content = titleLine + bodyTruncated + "...";
+  }
+  const sourceTimestamp = firstTimestamp(turns);
+  const metadata: Record<string, unknown> = {
+    kind: "conversation_summary",
+    humanTurns: turns.length,
+  };
+  if (title.length > 0) metadata.title = title;
+  return {
+    content,
+    sourceLabel: CLAUDE_SOURCE_LABEL,
+    ...(typeof conversation.uuid === "string"
+      ? { sourceId: conversation.uuid }
+      : {}),
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata,
+  };
+}
+
+function firstTimestamp(
+  turns: Array<{ content: string; createdAt?: string }>,
+): string | undefined {
+  for (const turn of turns) {
+    if (typeof turn.createdAt === "string" && turn.createdAt.length > 0) {
+      return turn.createdAt;
+    }
+  }
+  return undefined;
+}

--- a/packages/import-claude/src/transform.ts
+++ b/packages/import-claude/src/transform.ts
@@ -147,9 +147,18 @@ function conversationToSummary(
   const body = turns.map((t) => `- ${t.content}`).join("\n");
   let content = titleLine + body;
   if (content.length > maxChars) {
-    const remaining = maxChars - titleLine.length - 3;
-    const bodyTruncated = body.slice(0, Math.max(0, remaining));
-    content = titleLine + bodyTruncated + "...";
+    // Reserve 3 chars for the "..." suffix. When the titleLine alone
+    // already exceeds maxChars (pathological — a very long title with a
+    // small cap), truncate the titleLine itself rather than letting
+    // content exceed maxChars. Cursor review on PR #598.
+    const suffix = "...";
+    if (titleLine.length + suffix.length >= maxChars) {
+      content = titleLine.slice(0, Math.max(0, maxChars - suffix.length)) + suffix;
+    } else {
+      const remaining = maxChars - titleLine.length - suffix.length;
+      const bodyTruncated = body.slice(0, Math.max(0, remaining));
+      content = titleLine + bodyTruncated + suffix;
+    }
   }
   const sourceTimestamp = firstTimestamp(turns);
   const metadata: Record<string, unknown> = {

--- a/packages/import-claude/tsconfig.json
+++ b/packages/import-claude/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -39,6 +39,7 @@
     "@remnic/export-weclone": "^1.0.0",
     "@remnic/import-weclone": "^1.0.0",
     "@remnic/import-chatgpt": "^0.1.0",
+    "@remnic/import-claude": "^0.1.0",
     "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {
@@ -46,6 +47,7 @@
     "@remnic/export-weclone": { "optional": true },
     "@remnic/import-weclone": { "optional": true },
     "@remnic/import-chatgpt": { "optional": true },
+    "@remnic/import-claude": { "optional": true },
     "@remnic/import-mem0": { "optional": true }
   },
   "devDependencies": {
@@ -53,6 +55,7 @@
     "@remnic/export-weclone": "workspace:*",
     "@remnic/import-weclone": "workspace:*",
     "@remnic/import-chatgpt": "workspace:*",
+    "@remnic/import-claude": "workspace:*",
     "@remnic/import-mem0": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -29,20 +29,19 @@ describe("optional-importer loader", () => {
     assert.equal(isSupportedImporterName("chatgpt "), false);
   });
 
-  // Slices 3 and 4 (claude, gemini) are not yet installed, so they make
-  // durable "missing package" fixtures that do not depend on which slice is
-  // currently being developed. The chatgpt and mem0 fixtures intentionally
-  // are NOT used here because PR 2 installs @remnic/import-chatgpt and PR 5
-  // installs @remnic/import-mem0 alongside, which would make the
+  // Slice 4 (gemini) is the only importer not yet installed, so it is the
+  // durable "missing package" fixture. The chatgpt, claude, and mem0
+  // fixtures cannot be used here because their packages are installed
+  // alongside the CLI (PR 2, PR 3, PR 5), which would make the
   // install-hint assertion race with that installation.
   it("loading a missing importer throws a user-facing install hint", async () => {
     await assert.rejects(
-      () => loadImporterModule("claude"),
+      () => loadImporterModule("gemini"),
       (err: Error) => {
         // Install hint must include the package name and an install
         // command the user can actually run — not a raw MODULE_NOT_FOUND.
         assert.ok(
-          err.message.includes("@remnic/import-claude"),
+          err.message.includes("@remnic/import-gemini"),
           `expected package name in message, got: ${err.message}`,
         );
         assert.ok(

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -22,5 +22,6 @@ export default defineConfig({
     "@remnic/import-weclone",
     "@remnic/import-chatgpt",
     "@remnic/import-mem0",
+    "@remnic/import-claude",
   ],
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -173,6 +173,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-claude:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-mem0:
     devDependencies:
       '@remnic/core':
@@ -246,6 +261,9 @@ importers:
       '@remnic/import-chatgpt':
         specifier: workspace:*
         version: link:../import-chatgpt
+      '@remnic/import-claude':
+        specifier: workspace:*
+        version: link:../import-claude
       '@remnic/import-mem0':
         specifier: workspace:*
         version: link:../import-mem0

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -14,6 +14,7 @@ const expectedPublishDirs = [
   "packages/export-weclone",
   "packages/import-weclone",
   "packages/import-chatgpt",
+  "packages/import-claude",
   "packages/import-mem0",
   "packages/connector-weclone",
   "packages/connector-replit",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -16,6 +16,7 @@ const expectedPublishDirs = [
   "packages/import-chatgpt",
   "packages/import-claude",
   "packages/import-mem0",
+  "packages/import-claude",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -16,7 +16,6 @@ const expectedPublishDirs = [
   "packages/import-chatgpt",
   "packages/import-claude",
   "packages/import-mem0",
-  "packages/import-claude",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",


### PR DESCRIPTION
Part of #568 (slice 3 of 7).

## Summary
- New workspace package \`@remnic/import-claude\` implementing the shared \`ImporterAdapter\` contract from PR 1
- Parses Claude.ai exports: projects (docs + prompt_template), conversations (chat_messages / messages with structured or plain text content), and combined bundle objects
- Transforms to \`ImportedMemory[]\`: project docs + prompt templates by default, conversation summaries behind \`--include-conversations\`
- Synthetic fixtures only — no real export data

## À-la-carte compliance (CLAUDE.md rule 57)
- [x] Own workspace package at \`packages/import-claude/\`, \`"private": false\`
- [x] Declared as optional peer dep in \`packages/remnic-cli/package.json\` (\`peerDependenciesMeta.@remnic/import-claude.optional = true\`)
- [x] NOT in any \`noExternal\` array (kept as \`external\` in \`packages/remnic-cli/tsup.config.ts\`)
- [x] Loaded via computed dynamic import in the existing \`optional-importer.ts\` loader (\`@remnic/\" + \"import-\" + name\`)
- [x] Missing package produces a clean install hint (covered by retargeted \`optional-importer.test.ts\`)
- [x] Added to \`.github/workflows/release-and-publish.yml\` in topological order

## Test plan
- [x] \`pnpm run check-types\` clean
- [x] \`packages/import-claude\` unit tests: 19 pass (parser across 3 shapes, transform skips empty docs + honors maxMemories, adapter end-to-end, dry-run, conversation gating)
- [x] \`packages/remnic-cli/src/optional-importer.test.ts\` retargeted to gemini/mem0 (not-yet-installed adapters) so slice 3 doesn't race with its own install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new import surface that parses and transforms user export data into memories and wires it into the CLI/release pipeline; mistakes could lead to incorrect imports or missing/overly permissive parsing, though changes are largely additive.
> 
> **Overview**
> Introduces a new optional workspace package, `@remnic/import-claude`, that implements the shared `ImporterAdapter` contract to import Claude.ai exports into Remnic.
> 
> The importer supports `projects.json`, `conversations.json`, and combined `{projects, conversations}` bundles, emitting project doc + prompt-template memories by default and gated conversation-summary memories via `includeConversations`, with additional strict-mode validation and truncation/timestamp handling.
> 
> Integrates the package into publishing and CLI à-la-carte wiring by adding it to the release `PUBLISH_ORDER`, marking it as an optional peer dep of `@remnic/cli` (kept external in `tsup`), and updating the CLI missing-importer test fixture to target `gemini` now that `claude` is installed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1f50c76c2f6c8419059d38ca94e77bffd39358ec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->