### PR TITLE
feat(xray): shared Recall X-ray renderer (#570 PR 2/7)

### DIFF
--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -107,6 +107,45 @@ export function toRecallExplainJson(
   };
 }
 
+/**
+ * Render the shared "--- tier explain ---" text block used by both the
+ * recall-explain surface and the Recall X-ray surface.  Callers provide
+ * the normalized `RecallTierExplain` (or `null` for the
+ * not-populated/disabled case) so the block stays character-for-character
+ * identical across surfaces (CLAUDE.md rule 22).  The returned strings do
+ * NOT include leading blank lines or headers — callers own that framing.
+ */
+export function renderTierExplainTextLines(
+  tierExplain: RecallTierExplain | null,
+): string[] {
+  const lines: string[] = [];
+  if (!tierExplain) {
+    lines.push(
+      "(not populated — direct-answer tier disabled or did not fire)",
+    );
+    return lines;
+  }
+  lines.push(`tier: ${tierExplain.tier}`);
+  lines.push(`reason: ${tierExplain.tierReason}`);
+  lines.push(`candidates-considered: ${tierExplain.candidatesConsidered}`);
+  lines.push(`latency-ms: ${tierExplain.latencyMs}`);
+  if (tierExplain.filteredBy.length > 0) {
+    lines.push(`filtered-by: ${tierExplain.filteredBy.join(", ")}`);
+  } else {
+    lines.push("filtered-by: (none)");
+  }
+  if (tierExplain.sourceAnchors && tierExplain.sourceAnchors.length > 0) {
+    lines.push("source-anchors:");
+    for (const anchor of tierExplain.sourceAnchors) {
+      const range = anchor.lineRange
+        ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
+        : "";
+      lines.push(`  - ${anchor.path}${range}`);
+    }
+  }
+  return lines;
+}
+
 export function toRecallExplainText(
   snapshot: LastRecallSnapshot | null,
 ): string {
@@ -153,23 +192,8 @@ export function toRecallExplainText(
 
   lines.push("");
   lines.push("--- tier explain ---");
-  lines.push(`tier: ${ex.tier}`);
-  lines.push(`reason: ${ex.tierReason}`);
-  lines.push(`candidates-considered: ${ex.candidatesConsidered}`);
-  lines.push(`latency-ms: ${ex.latencyMs}`);
-  if (ex.filteredBy.length > 0) {
-    lines.push(`filtered-by: ${ex.filteredBy.join(", ")}`);
-  } else {
-    lines.push("filtered-by: (none)");
-  }
-  if (ex.sourceAnchors && ex.sourceAnchors.length > 0) {
-    lines.push("source-anchors:");
-    for (const anchor of ex.sourceAnchors) {
-      const range = anchor.lineRange
-        ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
-        : "";
-      lines.push(`  - ${anchor.path}${range}`);
-    }
+  for (const line of renderTierExplainTextLines(ex)) {
+    lines.push(line);
   }
   return lines.join("\n");
 }

--- a/packages/remnic-core/src/recall-xray-renderer.test.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.test.ts
@@ -355,3 +355,20 @@ test("renderXray formats non-finite capturedAt as (unknown)", () => {
   const md = renderXrayMarkdown(snap);
   assert.ok(md.includes("| Captured at | (unknown) |"));
 });
+
+test("renderXray falls back to (unknown) for out-of-range finite capturedAt", () => {
+  // `new Date(1e20).toISOString()` throws RangeError.  The renderer
+  // must not crash on corrupted or custom-clock snapshots.
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    capturedAt: 1e20,
+  };
+  const text = renderXrayText(snap);
+  assert.ok(text.includes("captured-at: (unknown)"));
+  const md = renderXrayMarkdown(snap);
+  assert.ok(md.includes("| Captured at | (unknown) |"));
+  // Sanity: the JSON renderer is untouched — it serializes the raw
+  // number because JSON consumers want the value as captured.
+  const json = JSON.parse(renderXrayJson(snap));
+  assert.equal(json.capturedAt, 1e20);
+});

--- a/packages/remnic-core/src/recall-xray-renderer.test.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.test.ts
@@ -372,3 +372,34 @@ test("renderXray falls back to (unknown) for out-of-range finite capturedAt", ()
   const json = JSON.parse(renderXrayJson(snap));
   assert.equal(json.capturedAt, 1e20);
 });
+
+test("renderXrayText tier-explain block matches shared helper output", async () => {
+  // CLAUDE.md rule 22: the tier-explain text block must be a single
+  // source of truth shared between recall-explain-renderer and
+  // recall-xray-renderer.  Assert the output lines match the shared
+  // helper byte-for-byte so a future edit to either surface can't drift
+  // without a test failure.
+  const { renderTierExplainTextLines } = await import(
+    "./recall-explain-renderer.js"
+  );
+  const snap = fullSnapshot();
+  const text = renderXrayText(snap);
+  const sharedLines = renderTierExplainTextLines(snap.tierExplain ?? null);
+  for (const line of sharedLines) {
+    assert.ok(
+      text.includes(line),
+      `xray text is missing shared tier-explain line: ${line}`,
+    );
+  }
+
+  // Also exercise the null-tierExplain branch.
+  const nullSnap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    tierExplain: null,
+  };
+  const nullText = renderXrayText(nullSnap);
+  const nullShared = renderTierExplainTextLines(null);
+  for (const line of nullShared) {
+    assert.ok(nullText.includes(line));
+  }
+});

--- a/packages/remnic-core/src/recall-xray-renderer.test.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { RecallXraySnapshot } from "./recall-xray.js";
+import {
+  RECALL_XRAY_FORMATS,
+  parseXrayFormat,
+  renderXray,
+  renderXrayJson,
+  renderXrayMarkdown,
+  renderXrayText,
+} from "./recall-xray-renderer.js";
+
+// ─── fixtures ─────────────────────────────────────────────────────────────
+
+function minimalSnapshot(): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "what is my favorite editor?",
+    snapshotId: "11111111-1111-1111-1111-111111111111",
+    capturedAt: 1_700_000_000_000,
+    tierExplain: null,
+    results: [],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  };
+}
+
+function fullSnapshot(): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "what is my favorite editor?",
+    snapshotId: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    capturedAt: 1_700_000_000_000,
+    sessionKey: "sess-42",
+    namespace: "workspace-a",
+    traceId: "trace-xyz",
+    tierExplain: {
+      tier: "direct-answer",
+      tierReason: "high-trust match",
+      filteredBy: ["trustZone", "importance"],
+      candidatesConsidered: 7,
+      latencyMs: 42,
+      sourceAnchors: [
+        { path: "facts/tools/editor.md", lineRange: [12, 18] },
+        { path: "facts/tools/misc.md" },
+      ],
+    },
+    filters: [
+      { name: "namespace", considered: 120, admitted: 30 },
+      {
+        name: "recall-result-limit",
+        considered: 30,
+        admitted: 5,
+        reason: "cap=5",
+      },
+    ],
+    results: [
+      {
+        memoryId: "mem-1",
+        path: "facts/tools/editor.md",
+        servedBy: "direct-answer",
+        scoreDecomposition: {
+          final: 0.87,
+          vector: 0.81,
+          bm25: 0.42,
+          importance: 0.9,
+          mmrPenalty: 0.05,
+          tierPrior: 0.2,
+        },
+        admittedBy: ["namespace", "trustZone", "importance"],
+        graphPath: ["mem-root", "mem-1"],
+        auditEntryId: "audit-2026-04-20-abc",
+      },
+      {
+        memoryId: "mem-2",
+        path: "facts/tools/editor-historical.md",
+        servedBy: "hybrid",
+        scoreDecomposition: { final: 0.55 },
+        admittedBy: ["namespace"],
+        rejectedBy: "mmr",
+      },
+    ],
+    budget: { chars: 4096, used: 1234 },
+  };
+}
+
+// ─── parseXrayFormat ─────────────────────────────────────────────────────
+
+test("parseXrayFormat defaults undefined/null to text", () => {
+  assert.equal(parseXrayFormat(undefined), "text");
+  assert.equal(parseXrayFormat(null), "text");
+});
+
+test("parseXrayFormat accepts each valid format", () => {
+  for (const f of RECALL_XRAY_FORMATS) {
+    assert.equal(parseXrayFormat(f), f);
+  }
+});
+
+test("parseXrayFormat accepts case-insensitive strings with surrounding whitespace", () => {
+  assert.equal(parseXrayFormat("  JSON  "), "json");
+  assert.equal(parseXrayFormat("Markdown"), "markdown");
+  assert.equal(parseXrayFormat("TEXT"), "text");
+});
+
+test("parseXrayFormat rejects unknown format strings with an options list", () => {
+  assert.throws(
+    () => parseXrayFormat("xml"),
+    /--format expects one of json, text, markdown; got "xml"/,
+  );
+});
+
+test("parseXrayFormat rejects non-string values", () => {
+  assert.throws(
+    () => parseXrayFormat(42 as unknown),
+    /--format expects one of json, text, markdown; got number/,
+  );
+});
+
+// ─── renderXrayJson ──────────────────────────────────────────────────────
+
+test("renderXrayJson returns stable envelope for null snapshot", () => {
+  const out = renderXrayJson(null);
+  const parsed = JSON.parse(out);
+  assert.deepEqual(parsed, { schemaVersion: "1", snapshotFound: false });
+});
+
+test("renderXrayJson emits snapshotFound=true and preserves snapshot fields", () => {
+  const snap = fullSnapshot();
+  const out = renderXrayJson(snap);
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.snapshotFound, true);
+  assert.equal(parsed.schemaVersion, "1");
+  assert.equal(parsed.snapshotId, snap.snapshotId);
+  assert.equal(parsed.query, snap.query);
+  assert.equal(parsed.budget.chars, 4096);
+  assert.equal(parsed.budget.used, 1234);
+  assert.equal(parsed.results.length, 2);
+  assert.equal(parsed.filters.length, 2);
+  assert.equal(parsed.tierExplain.tier, "direct-answer");
+});
+
+// ─── renderXrayText golden ───────────────────────────────────────────────
+
+test("renderXrayText matches golden output for a full snapshot", () => {
+  const out = renderXrayText(fullSnapshot());
+  const expected = [
+    "=== Recall X-ray ===",
+    "query: what is my favorite editor?",
+    "snapshot-id: aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    "captured-at: 2023-11-14T22:13:20.000Z",
+    "session: sess-42",
+    "namespace: workspace-a",
+    "trace-id: trace-xyz",
+    "budget: 1234 / 4096 chars",
+    "",
+    "--- filters ---",
+    "- namespace: 30/120 admitted",
+    "- recall-result-limit: 5/30 admitted (cap=5)",
+    "",
+    "--- results ---",
+    "[1] mem-1 — served-by=direct-answer",
+    "    path: facts/tools/editor.md",
+    "    score: final=0.8700 vector=0.8100 bm25=0.4200 importance=0.9000 mmr_penalty=0.0500 tier_prior=0.2000",
+    "    admitted-by: namespace, trustZone, importance",
+    "    graph-path: mem-root -> mem-1",
+    "    audit-entry: audit-2026-04-20-abc",
+    "[2] mem-2 — served-by=hybrid",
+    "    path: facts/tools/editor-historical.md",
+    "    score: final=0.5500",
+    "    admitted-by: namespace",
+    "    rejected-by: mmr",
+    "",
+    "--- tier explain ---",
+    "tier: direct-answer",
+    "reason: high-trust match",
+    "candidates-considered: 7",
+    "latency-ms: 42",
+    "filtered-by: trustZone, importance",
+    "source-anchors:",
+    "  - facts/tools/editor.md:12-18",
+    "  - facts/tools/misc.md",
+  ].join("\n");
+  assert.equal(out, expected);
+});
+
+test("renderXrayText handles the minimal/empty case", () => {
+  const out = renderXrayText(minimalSnapshot());
+  const expected = [
+    "=== Recall X-ray ===",
+    "query: what is my favorite editor?",
+    "snapshot-id: 11111111-1111-1111-1111-111111111111",
+    "captured-at: 2023-11-14T22:13:20.000Z",
+    "budget: 0 / 4096 chars",
+    "",
+    "--- filters ---",
+    "(no filter traces recorded)",
+    "",
+    "--- results ---",
+    "(no results admitted)",
+    "",
+    "--- tier explain ---",
+    "(not populated — direct-answer tier disabled or did not fire)",
+  ].join("\n");
+  assert.equal(out, expected);
+});
+
+test("renderXrayText returns a placeholder for a null snapshot", () => {
+  const out = renderXrayText(null);
+  assert.equal(out, "=== Recall X-ray ===\nNo X-ray snapshot captured.");
+});
+
+// ─── renderXrayMarkdown golden ───────────────────────────────────────────
+
+test("renderXrayMarkdown matches golden output for a full snapshot", () => {
+  const out = renderXrayMarkdown(fullSnapshot());
+  const expected = [
+    "# Recall X-ray",
+    "",
+    "**Query:** `what is my favorite editor?`",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    "| Snapshot ID | `aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee` |",
+    "| Captured at | 2023-11-14T22:13:20.000Z |",
+    "| Session | `sess-42` |",
+    "| Namespace | `workspace-a` |",
+    "| Trace ID | `trace-xyz` |",
+    "| Budget | 1234 / 4096 chars |",
+    "",
+    "## Filters",
+    "",
+    "| Filter | Considered | Admitted | Reason |",
+    "| --- | ---: | ---: | --- |",
+    "| namespace | 120 | 30 |  |",
+    "| recall-result-limit | 30 | 5 | cap=5 |",
+    "",
+    "## Results",
+    "",
+    "### 1. `mem-1` — served-by=direct-answer",
+    "",
+    "- **Path:** `facts/tools/editor.md`",
+    "- **Score:** final=0.8700 vector=0.8100 bm25=0.4200 importance=0.9000 mmr_penalty=0.0500 tier_prior=0.2000",
+    "- **Admitted by:** `namespace`, `trustZone`, `importance`",
+    "- **Graph path:** `mem-root` → `mem-1`",
+    "- **Audit entry:** `audit-2026-04-20-abc`",
+    "",
+    "### 2. `mem-2` — served-by=hybrid",
+    "",
+    "- **Path:** `facts/tools/editor-historical.md`",
+    "- **Score:** final=0.5500",
+    "- **Admitted by:** `namespace`",
+    "- **Rejected by:** `mmr`",
+    "",
+    "## Tier Explain",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    "| Tier | `direct-answer` |",
+    "| Reason | high-trust match |",
+    "| Candidates considered | 7 |",
+    "| Latency (ms) | 42 |",
+    "| Filtered by | `trustZone`, `importance` |",
+    "",
+    "**Source anchors:**",
+    "- `facts/tools/editor.md:12-18`",
+    "- `facts/tools/misc.md`",
+  ].join("\n");
+  assert.equal(out, expected);
+});
+
+test("renderXrayMarkdown handles the minimal/empty case", () => {
+  const out = renderXrayMarkdown(minimalSnapshot());
+  const expected = [
+    "# Recall X-ray",
+    "",
+    "**Query:** `what is my favorite editor?`",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    "| Snapshot ID | `11111111-1111-1111-1111-111111111111` |",
+    "| Captured at | 2023-11-14T22:13:20.000Z |",
+    "| Budget | 0 / 4096 chars |",
+    "",
+    "## Filters",
+    "",
+    "_No filter traces recorded._",
+    "",
+    "## Results",
+    "",
+    "_No results admitted._",
+    "",
+    "## Tier Explain",
+    "",
+    "_Not populated — direct-answer tier disabled or did not fire._",
+  ].join("\n");
+  assert.equal(out, expected);
+});
+
+test("renderXrayMarkdown returns a placeholder for a null snapshot", () => {
+  const out = renderXrayMarkdown(null);
+  assert.equal(out, "# Recall X-ray\n\n_No X-ray snapshot captured._");
+});
+
+// ─── renderXray dispatcher ───────────────────────────────────────────────
+
+test("renderXray dispatches to the format-specific renderer", () => {
+  const snap = fullSnapshot();
+  assert.equal(renderXray(snap, "json"), renderXrayJson(snap));
+  assert.equal(renderXray(snap, "text"), renderXrayText(snap));
+  assert.equal(renderXray(snap, "markdown"), renderXrayMarkdown(snap));
+});
+
+// ─── escaping and edge cases ─────────────────────────────────────────────
+
+test("renderXrayMarkdown escapes pipes in filter names and reasons to keep the table valid", () => {
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    filters: [
+      { name: "ns|pipe", considered: 10, admitted: 2, reason: "why|not" },
+    ],
+  };
+  const out = renderXrayMarkdown(snap);
+  assert.ok(out.includes("| ns\\|pipe | 10 | 2 | why\\|not |"));
+});
+
+test("renderXray formats scores deterministically to 4 decimals", () => {
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    results: [
+      {
+        memoryId: "mem-score",
+        path: "p.md",
+        servedBy: "hybrid",
+        scoreDecomposition: {
+          final: 0.123456789,
+          vector: 0,
+        },
+        admittedBy: [],
+      },
+    ],
+  };
+  const out = renderXrayText(snap);
+  assert.ok(out.includes("final=0.1235 vector=0.0000"));
+});
+
+test("renderXray formats non-finite capturedAt as (unknown)", () => {
+  const snap: RecallXraySnapshot = {
+    ...minimalSnapshot(),
+    capturedAt: Number.NaN,
+  };
+  const text = renderXrayText(snap);
+  assert.ok(text.includes("captured-at: (unknown)"));
+  const md = renderXrayMarkdown(snap);
+  assert.ok(md.includes("| Captured at | (unknown) |"));
+});

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -1,0 +1,376 @@
+/**
+ * Unified Recall X-ray renderer (issue #570, PR 2).
+ *
+ * Pure functions that format a `RecallXraySnapshot` for human text,
+ * GitHub-flavored markdown, and machine JSON consumption.  CLI / HTTP
+ * / MCP surfaces all call into this module — they do NOT format X-ray
+ * output themselves, so rendering is tested in one place (CLAUDE.md
+ * rule 22).
+ *
+ * Scope for PR 2 (this slice):
+ *   - Pure rendering.  No IO, no transport, no capture.
+ *   - `renderXray(snapshot, format)` with format ∈
+ *     `{"json", "text", "markdown"}`.
+ *   - `parseXrayFormat(value)` — input validator that rejects unknown
+ *     formats with a listed-options error (CLAUDE.md rule 51).
+ *   - Golden-file-style tests in `recall-xray-renderer.test.ts`.
+ */
+
+import type {
+  RecallFilterTrace,
+  RecallXrayResult,
+  RecallXraySnapshot,
+  RecallXrayServedBy,
+} from "./recall-xray.js";
+
+export type RecallXrayFormat = "json" | "text" | "markdown";
+
+export const RECALL_XRAY_FORMATS: readonly RecallXrayFormat[] = [
+  "json",
+  "text",
+  "markdown",
+] as const;
+
+/**
+ * Validate and coerce a user-provided `--format` / `format` argument to
+ * `RecallXrayFormat`.  Unknown values throw an error listing valid
+ * options (CLAUDE.md rule 51).  `undefined`/`null` defaults to `"text"`.
+ */
+export function parseXrayFormat(value: unknown): RecallXrayFormat {
+  if (value === undefined || value === null) return "text";
+  if (typeof value !== "string") {
+    throw new Error(
+      `--format expects one of ${RECALL_XRAY_FORMATS.join(", ")}; got ${typeof value}`,
+    );
+  }
+  const v = value.trim().toLowerCase();
+  if (v === "json" || v === "text" || v === "markdown") return v;
+  throw new Error(
+    `--format expects one of ${RECALL_XRAY_FORMATS.join(", ")}; got ${JSON.stringify(value)}`,
+  );
+}
+
+/**
+ * Top-level dispatcher.  CLI / HTTP / MCP callers should always route
+ * through this function so the three formats stay in lock-step.
+ */
+export function renderXray(
+  snapshot: RecallXraySnapshot | null,
+  format: RecallXrayFormat,
+): string {
+  if (format === "json") return renderXrayJson(snapshot);
+  if (format === "markdown") return renderXrayMarkdown(snapshot);
+  return renderXrayText(snapshot);
+}
+
+// ─── JSON ─────────────────────────────────────────────────────────────────
+
+/**
+ * Deterministic JSON encoding of an X-ray snapshot.  Returns a stable
+ * v1 envelope when the snapshot is absent so consumers can pattern-match
+ * on `snapshotFound` rather than distinguishing `null` vs `{}`.
+ */
+export function renderXrayJson(snapshot: RecallXraySnapshot | null): string {
+  if (!snapshot) {
+    return JSON.stringify(
+      { schemaVersion: "1", snapshotFound: false },
+      null,
+      2,
+    );
+  }
+  // `snapshotFound` is injected *before* the rest so downstream JSON
+  // consumers see it near the top of the document.
+  return JSON.stringify(
+    { snapshotFound: true, ...snapshot },
+    null,
+    2,
+  );
+}
+
+// ─── Text ─────────────────────────────────────────────────────────────────
+
+export function renderXrayText(snapshot: RecallXraySnapshot | null): string {
+  const lines: string[] = ["=== Recall X-ray ==="];
+  if (!snapshot) {
+    lines.push("No X-ray snapshot captured.");
+    return lines.join("\n");
+  }
+
+  lines.push(`query: ${snapshot.query}`);
+  lines.push(`snapshot-id: ${snapshot.snapshotId}`);
+  lines.push(`captured-at: ${formatCapturedAt(snapshot.capturedAt)}`);
+  if (snapshot.sessionKey) lines.push(`session: ${snapshot.sessionKey}`);
+  if (snapshot.namespace) lines.push(`namespace: ${snapshot.namespace}`);
+  if (snapshot.traceId) lines.push(`trace-id: ${snapshot.traceId}`);
+  lines.push(
+    `budget: ${snapshot.budget.used} / ${snapshot.budget.chars} chars`,
+  );
+
+  lines.push("");
+  lines.push("--- filters ---");
+  if (snapshot.filters.length === 0) {
+    lines.push("(no filter traces recorded)");
+  } else {
+    for (const f of snapshot.filters) {
+      lines.push(renderFilterTextLine(f));
+    }
+  }
+
+  lines.push("");
+  lines.push("--- results ---");
+  if (snapshot.results.length === 0) {
+    lines.push("(no results admitted)");
+  } else {
+    snapshot.results.forEach((result, idx) => {
+      for (const line of renderResultTextLines(result, idx + 1)) {
+        lines.push(line);
+      }
+    });
+  }
+
+  lines.push("");
+  lines.push("--- tier explain ---");
+  if (!snapshot.tierExplain) {
+    lines.push("(not populated — direct-answer tier disabled or did not fire)");
+  } else {
+    const te = snapshot.tierExplain;
+    lines.push(`tier: ${te.tier}`);
+    lines.push(`reason: ${te.tierReason}`);
+    lines.push(`candidates-considered: ${te.candidatesConsidered}`);
+    lines.push(`latency-ms: ${te.latencyMs}`);
+    if (te.filteredBy.length > 0) {
+      lines.push(`filtered-by: ${te.filteredBy.join(", ")}`);
+    } else {
+      lines.push("filtered-by: (none)");
+    }
+    if (te.sourceAnchors && te.sourceAnchors.length > 0) {
+      lines.push("source-anchors:");
+      for (const anchor of te.sourceAnchors) {
+        const range = anchor.lineRange
+          ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
+          : "";
+        lines.push(`  - ${anchor.path}${range}`);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderFilterTextLine(f: RecallFilterTrace): string {
+  const base = `- ${f.name}: ${f.admitted}/${f.considered} admitted`;
+  return f.reason ? `${base} (${f.reason})` : base;
+}
+
+function renderResultTextLines(
+  result: RecallXrayResult,
+  rank: number,
+): string[] {
+  const lines: string[] = [];
+  lines.push(`[${rank}] ${result.memoryId} — ${servedByLabel(result.servedBy)}`);
+  if (result.path) lines.push(`    path: ${result.path}`);
+  lines.push(`    score: ${renderScoreDecomposition(result)}`);
+  if (result.admittedBy.length > 0) {
+    lines.push(`    admitted-by: ${result.admittedBy.join(", ")}`);
+  }
+  if (result.rejectedBy) {
+    lines.push(`    rejected-by: ${result.rejectedBy}`);
+  }
+  if (result.graphPath && result.graphPath.length > 0) {
+    lines.push(`    graph-path: ${result.graphPath.join(" -> ")}`);
+  }
+  if (result.auditEntryId) {
+    lines.push(`    audit-entry: ${result.auditEntryId}`);
+  }
+  return lines;
+}
+
+// ─── Markdown ─────────────────────────────────────────────────────────────
+
+export function renderXrayMarkdown(
+  snapshot: RecallXraySnapshot | null,
+): string {
+  const lines: string[] = ["# Recall X-ray"];
+  if (!snapshot) {
+    lines.push("");
+    lines.push("_No X-ray snapshot captured._");
+    return lines.join("\n");
+  }
+
+  lines.push("");
+  lines.push(`**Query:** ${mdInlineCode(snapshot.query)}`);
+  lines.push("");
+  lines.push("| Field | Value |");
+  lines.push("| --- | --- |");
+  lines.push(`| Snapshot ID | \`${snapshot.snapshotId}\` |`);
+  lines.push(`| Captured at | ${formatCapturedAt(snapshot.capturedAt)} |`);
+  if (snapshot.sessionKey) {
+    lines.push(`| Session | \`${snapshot.sessionKey}\` |`);
+  }
+  if (snapshot.namespace) {
+    lines.push(`| Namespace | \`${snapshot.namespace}\` |`);
+  }
+  if (snapshot.traceId) {
+    lines.push(`| Trace ID | \`${snapshot.traceId}\` |`);
+  }
+  lines.push(
+    `| Budget | ${snapshot.budget.used} / ${snapshot.budget.chars} chars |`,
+  );
+
+  lines.push("");
+  lines.push("## Filters");
+  if (snapshot.filters.length === 0) {
+    lines.push("");
+    lines.push("_No filter traces recorded._");
+  } else {
+    lines.push("");
+    lines.push("| Filter | Considered | Admitted | Reason |");
+    lines.push("| --- | ---: | ---: | --- |");
+    for (const f of snapshot.filters) {
+      const reason = f.reason ? mdEscape(f.reason) : "";
+      lines.push(`| ${mdEscape(f.name)} | ${f.considered} | ${f.admitted} | ${reason} |`);
+    }
+  }
+
+  lines.push("");
+  lines.push("## Results");
+  if (snapshot.results.length === 0) {
+    lines.push("");
+    lines.push("_No results admitted._");
+  } else {
+    snapshot.results.forEach((result, idx) => {
+      for (const line of renderResultMarkdownLines(result, idx + 1)) {
+        lines.push(line);
+      }
+    });
+  }
+
+  lines.push("");
+  lines.push("## Tier Explain");
+  if (!snapshot.tierExplain) {
+    lines.push("");
+    lines.push(
+      "_Not populated — direct-answer tier disabled or did not fire._",
+    );
+  } else {
+    const te = snapshot.tierExplain;
+    lines.push("");
+    lines.push("| Field | Value |");
+    lines.push("| --- | --- |");
+    lines.push(`| Tier | \`${te.tier}\` |`);
+    lines.push(`| Reason | ${mdEscape(te.tierReason)} |`);
+    lines.push(`| Candidates considered | ${te.candidatesConsidered} |`);
+    lines.push(`| Latency (ms) | ${te.latencyMs} |`);
+    lines.push(
+      `| Filtered by | ${
+        te.filteredBy.length > 0
+          ? te.filteredBy.map(mdInlineCode).join(", ")
+          : "_(none)_"
+      } |`,
+    );
+    if (te.sourceAnchors && te.sourceAnchors.length > 0) {
+      lines.push("");
+      lines.push("**Source anchors:**");
+      for (const anchor of te.sourceAnchors) {
+        const range = anchor.lineRange
+          ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
+          : "";
+        lines.push(`- \`${anchor.path}${range}\``);
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function renderResultMarkdownLines(
+  result: RecallXrayResult,
+  rank: number,
+): string[] {
+  const lines: string[] = [];
+  lines.push("");
+  lines.push(
+    `### ${rank}. \`${result.memoryId}\` — ${servedByLabel(result.servedBy)}`,
+  );
+  if (result.path) {
+    lines.push("");
+    lines.push(`- **Path:** \`${result.path}\``);
+  } else {
+    lines.push("");
+  }
+  lines.push(`- **Score:** ${renderScoreDecomposition(result)}`);
+  if (result.admittedBy.length > 0) {
+    lines.push(
+      `- **Admitted by:** ${result.admittedBy.map(mdInlineCode).join(", ")}`,
+    );
+  }
+  if (result.rejectedBy) {
+    lines.push(`- **Rejected by:** ${mdInlineCode(result.rejectedBy)}`);
+  }
+  if (result.graphPath && result.graphPath.length > 0) {
+    lines.push(
+      `- **Graph path:** ${result.graphPath
+        .map(mdInlineCode)
+        .join(" → ")}`,
+    );
+  }
+  if (result.auditEntryId) {
+    lines.push(`- **Audit entry:** \`${result.auditEntryId}\``);
+  }
+  return lines;
+}
+
+// ─── Shared helpers ───────────────────────────────────────────────────────
+
+function servedByLabel(servedBy: RecallXrayServedBy): string {
+  return `served-by=${servedBy}`;
+}
+
+function renderScoreDecomposition(result: RecallXrayResult): string {
+  const parts: string[] = [`final=${formatScore(result.scoreDecomposition.final)}`];
+  const s = result.scoreDecomposition;
+  if (s.vector !== undefined) parts.push(`vector=${formatScore(s.vector)}`);
+  if (s.bm25 !== undefined) parts.push(`bm25=${formatScore(s.bm25)}`);
+  if (s.importance !== undefined) {
+    parts.push(`importance=${formatScore(s.importance)}`);
+  }
+  if (s.mmrPenalty !== undefined) {
+    parts.push(`mmr_penalty=${formatScore(s.mmrPenalty)}`);
+  }
+  if (s.tierPrior !== undefined) {
+    parts.push(`tier_prior=${formatScore(s.tierPrior)}`);
+  }
+  return parts.join(" ");
+}
+
+function formatScore(value: number): string {
+  // Deterministic 4-decimal formatting keeps golden files stable
+  // without printing spurious trailing zeros via toString().
+  if (!Number.isFinite(value)) return "0.0000";
+  return value.toFixed(4);
+}
+
+function formatCapturedAt(ts: number): string {
+  if (!Number.isFinite(ts) || ts < 0) return "(unknown)";
+  return new Date(ts).toISOString();
+}
+
+function mdEscape(value: string): string {
+  // Pipe is the only character that breaks GFM table rendering; escape
+  // backslash first so we do not re-escape the escape character.
+  return value.replace(/\\/g, "\\\\").replace(/\|/g, "\\|");
+}
+
+function mdInlineCode(value: string): string {
+  if (value.length === 0) return "``";
+  // Use exactly enough backticks to unambiguously wrap content that
+  // itself contains backticks (GFM rule).
+  const longestRun = /`+/g;
+  let maxLen = 0;
+  for (const match of value.matchAll(longestRun)) {
+    if (match[0].length > maxLen) maxLen = match[0].length;
+  }
+  const fence = "`".repeat(maxLen + 1);
+  const pad = value.startsWith("`") || value.endsWith("`") ? " " : "";
+  return `${fence}${pad}${value}${pad}${fence}`;
+}

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -22,6 +22,7 @@ import type {
   RecallXraySnapshot,
   RecallXrayServedBy,
 } from "./recall-xray.js";
+import { renderTierExplainTextLines } from "./recall-explain-renderer.js";
 
 export type RecallXrayFormat = "json" | "text" | "markdown";
 
@@ -130,28 +131,8 @@ export function renderXrayText(snapshot: RecallXraySnapshot | null): string {
 
   lines.push("");
   lines.push("--- tier explain ---");
-  if (!snapshot.tierExplain) {
-    lines.push("(not populated — direct-answer tier disabled or did not fire)");
-  } else {
-    const te = snapshot.tierExplain;
-    lines.push(`tier: ${te.tier}`);
-    lines.push(`reason: ${te.tierReason}`);
-    lines.push(`candidates-considered: ${te.candidatesConsidered}`);
-    lines.push(`latency-ms: ${te.latencyMs}`);
-    if (te.filteredBy.length > 0) {
-      lines.push(`filtered-by: ${te.filteredBy.join(", ")}`);
-    } else {
-      lines.push("filtered-by: (none)");
-    }
-    if (te.sourceAnchors && te.sourceAnchors.length > 0) {
-      lines.push("source-anchors:");
-      for (const anchor of te.sourceAnchors) {
-        const range = anchor.lineRange
-          ? `:${anchor.lineRange[0]}-${anchor.lineRange[1]}`
-          : "";
-        lines.push(`  - ${anchor.path}${range}`);
-      }
-    }
+  for (const line of renderTierExplainTextLines(snapshot.tierExplain ?? null)) {
+    lines.push(line);
   }
 
   return lines.join("\n");

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -352,7 +352,16 @@ function formatScore(value: number): string {
 
 function formatCapturedAt(ts: number): string {
   if (!Number.isFinite(ts) || ts < 0) return "(unknown)";
-  return new Date(ts).toISOString();
+  // `new Date(n).toISOString()` throws a RangeError for finite numbers
+  // outside the valid Date range (roughly |n| > 8.64e15).  That case
+  // can surface when snapshots are corrupted or captured with a
+  // custom clock, so coerce it to the same "(unknown)" fallback
+  // rather than crashing the renderer.
+  try {
+    return new Date(ts).toISOString();
+  } catch {
+    return "(unknown)";
+  }
 }
 
 function mdEscape(value: string): string {


### PR DESCRIPTION
## Summary

Slice 2 of the unified Recall X-ray observability surface (#570). Pure renderer only — CLI / HTTP / MCP wiring land in PRs 3-5, which all consume this module (CLAUDE.md rule 22 — single source of truth for formatting).

_Successor to the now-closed #594 (auto-closed when slice 1's base branch was deleted on merge of #578).  The branch has been rebased onto `main` and only contains slice 2's commits._

- New `packages/remnic-core/src/recall-xray-renderer.ts`
  - `renderXray(snapshot, format)` top-level dispatcher. `format ∈ {"json", "text", "markdown"}`.
  - `renderXrayJson`: stable v1 envelope. `{schemaVersion: "1", snapshotFound: false}` for null snapshots, otherwise `{snapshotFound: true, ...snapshot}` as pretty-printed JSON.
  - `renderXrayText`: human-readable plain-text layout — top-level fields, filter ladder (considered/admitted with optional reason), per-result breakdown (served-by, path, score decomposition, admitted-by, rejected-by, graph-path, audit-entry), and a tier-explain block.
  - `renderXrayMarkdown`: GFM equivalent with tables for the summary / filters / tier-explain blocks, H3 sections per result, pipe-escaping so filter names and reasons cannot break the table layout.
  - `parseXrayFormat`: strict input validator that rejects unknown values with a listed-options error (CLAUDE.md rule 51). `undefined` / `null` default to `"text"`.
  - Deterministic 4-decimal score formatting and ISO-8601 timestamp formatting so golden-file tests stay stable across environments.  Out-of-range finite timestamps coerce to `(unknown)` so a corrupted or custom-clock snapshot cannot crash the renderer.

## No behavior change

No existing surface consumes this module yet. Default recall behavior is unchanged from `main`.

## Test plan

- [x] 18 unit tests in `packages/remnic-core/src/recall-xray-renderer.test.ts` — every format, full + minimal + null snapshots, golden text and golden markdown, dispatcher parity, format validator errors, pipe escaping, score formatting, non-finite and out-of-range `capturedAt` fallbacks.
- [x] `pnpm run check-types` clean.

Part of #570 (slice 2 of 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly additive rendering + unit tests; the only behavior change is a small refactor of Recall Explain tier-explain text rendering which should remain byte-identical via the new shared helper.
> 
> **Overview**
> Adds a new shared `recall-xray-renderer` module that formats `RecallXraySnapshot` as **text**, **GitHub-flavored markdown**, or **stable JSON**, including strict `parseXrayFormat` validation, deterministic score/timestamp formatting, and safe fallbacks for invalid timestamps.
> 
> Refactors `recall-explain-renderer` to export `renderTierExplainTextLines()` and reuses it so the plain-text "tier explain" block stays identical between Recall Explain and X-ray, with comprehensive golden/edge-case tests covering all formats and escaping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ce667ce3e820c47023f725709ef1423a78138321. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->