### PR TITLE
feat(import-gemini): Google Takeout Gemini Apps importer (#568 PR 4/7)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -360,6 +360,7 @@ jobs:
             packages/import-weclone
             packages/import-chatgpt
             packages/import-claude
+            packages/import-gemini
             packages/import-mem0
             packages/connector-weclone
             packages/connector-replit

--- a/packages/import-gemini/README.md
+++ b/packages/import-gemini/README.md
@@ -1,0 +1,32 @@
+# @remnic/import-gemini
+
+Optional importer for Google Takeout "Gemini Apps Activity" exports. Ships
+as a separately installable companion to the Remnic CLI.
+
+```bash
+npm install -g @remnic/import-gemini
+remnic import --adapter gemini --file ~/takeout/My\ Activity.json
+```
+
+## What it imports
+
+- **One memory per prompt** — every Gemini Apps activity record becomes one
+  memory containing the user prompt text. Assistant responses are NOT
+  imported because Google Takeout does not export them.
+- Legacy "Bard" records are included (pre-rebrand exports).
+- Short prompts (under 10 characters by default) are dropped because they
+  rarely carry durable intent.
+
+## Input shapes
+
+- `My Activity.json` — Google Takeout's Gemini activity export
+- A combined bundle object `{ "activities": [...] }`
+
+Synthetic fixtures under `fixtures/` mirror the real shapes without any
+personal data.
+
+## À-la-carte contract
+
+This package is declared as an **optional peer dependency** of
+`@remnic/cli`. Installing the CLI without this package produces a
+friendly install hint — never `MODULE_NOT_FOUND`.

--- a/packages/import-gemini/fixtures/bundle.json
+++ b/packages/import-gemini/fixtures/bundle.json
@@ -1,0 +1,10 @@
+{
+  "activities": [
+    {
+      "header": "Gemini Apps",
+      "text": "Fictional bundle-format prompt: what are three advantages of type-safe parsers?",
+      "time": "2026-03-01T10:00:00.000Z",
+      "products": ["Gemini Apps"]
+    }
+  ]
+}

--- a/packages/import-gemini/fixtures/my-activity.json
+++ b/packages/import-gemini/fixtures/my-activity.json
@@ -1,0 +1,32 @@
+[
+  {
+    "header": "Gemini Apps",
+    "title": "Fictional: explain topological sort in 3 sentences",
+    "titleUrl": "https://gemini.google.com/app/synthetic-0001",
+    "time": "2026-02-14T09:30:00.000Z",
+    "products": ["Gemini Apps"],
+    "subtitles": [{ "name": "Model: Gemini 2.5 Pro" }]
+  },
+  {
+    "header": "Gemini Apps",
+    "text": "Fictional: draft a synthetic test plan for a CLI parser with edge cases.",
+    "titleUrl": "https://gemini.google.com/app/synthetic-0002",
+    "time": "2026-02-15T11:15:00.000Z",
+    "products": ["Gemini Apps"]
+  },
+  {
+    "header": "Bard",
+    "title": "Asked: Fictional legacy-export prompt about TypeScript generics.",
+    "time": "2025-12-01T08:00:00.000Z"
+  },
+  {
+    "header": "Search",
+    "title": "unrelated search activity that should be filtered",
+    "time": "2026-02-14T10:00:00.000Z"
+  },
+  {
+    "header": "Gemini Apps",
+    "text": "ok",
+    "time": "2026-02-15T12:00:00.000Z"
+  }
+]

--- a/packages/import-gemini/package.json
+++ b/packages/import-gemini/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@remnic/import-gemini",
+  "version": "0.1.0",
+  "description": "Import activity history from Google Takeout (Gemini Apps) exports into Remnic (issue #568)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "dependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-gemini"
+  },
+  "keywords": ["remnic", "memory", "gemini", "google", "takeout", "import"]
+}

--- a/packages/import-gemini/src/adapter.test.ts
+++ b/packages/import-gemini/src/adapter.test.ts
@@ -1,0 +1,84 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ImportTurn, ImporterWriteTarget } from "@remnic/core";
+import { runImporter } from "@remnic/core";
+
+import { adapter, geminiAdapter } from "./adapter.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+function makeTarget(): {
+  target: ImporterWriteTarget;
+  received: ImportTurn[][];
+} {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+describe("gemini adapter shape", () => {
+  it("exports a canonical adapter + name-prefixed alias", () => {
+    assert.equal(adapter.name, "gemini");
+    assert.equal(adapter.sourceLabel, "gemini");
+    assert.equal(geminiAdapter, adapter);
+    assert.equal(typeof adapter.parse, "function");
+    assert.equal(typeof adapter.transform, "function");
+    assert.equal(typeof adapter.writeTo, "function");
+  });
+
+  it("drives runImporter end-to-end with a synthetic My Activity fixture", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("my-activity.json"),
+      target,
+      {
+        parseOptions: {
+          filePath: "/tmp/takeout-2026/Gemini/My Activity.json",
+        },
+      },
+    );
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 3);
+    assert.equal(result.sourceLabel, "gemini");
+    const allTurns = received.flat();
+    assert.equal(allTurns.length, 3);
+    for (const turn of allTurns) {
+      assert.equal(turn.role, "user");
+      assert.equal(turn.participantName, "gemini");
+    }
+  });
+
+  it("dry-run does not hit the target", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("my-activity.json"),
+      target,
+      { dryRun: true },
+    );
+    assert.equal(result.dryRun, true);
+    assert.equal(result.memoriesWritten, 0);
+    assert.equal(received.length, 0);
+  });
+});

--- a/packages/import-gemini/src/adapter.ts
+++ b/packages/import-gemini/src/adapter.ts
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// Gemini importer adapter (issue #568 slice 4)
+// ---------------------------------------------------------------------------
+
+import type {
+  ImportedMemory,
+  ImporterAdapter,
+  ImporterParseOptions,
+  ImporterTransformOptions,
+  ImporterWriteResult,
+  ImporterWriteTarget,
+} from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import { parseGeminiExport, type ParsedGeminiExport } from "./parser.js";
+import { GEMINI_SOURCE_LABEL, transformGeminiExport } from "./transform.js";
+
+/**
+ * Canonical `ImporterAdapter` exposed by `@remnic/import-gemini`.
+ *
+ * Loaded by `remnic-cli/optional-importer.ts` via a computed-specifier dynamic
+ * import. The CLI drives `adapter.parse` → `adapter.transform` →
+ * `adapter.writeTo` through the shared `runImporter` helper in `@remnic/core`.
+ */
+export const adapter: ImporterAdapter<ParsedGeminiExport> = {
+  name: "gemini",
+  sourceLabel: GEMINI_SOURCE_LABEL,
+
+  parse(input: unknown, options?: ImporterParseOptions): ParsedGeminiExport {
+    return parseGeminiExport(input, {
+      ...(options?.strict !== undefined ? { strict: options.strict } : {}),
+      ...(options?.filePath !== undefined ? { filePath: options.filePath } : {}),
+    });
+  },
+
+  transform(
+    parsed: ParsedGeminiExport,
+    options?: ImporterTransformOptions,
+  ): ImportedMemory[] {
+    return transformGeminiExport(parsed, {
+      ...(options?.maxMemories !== undefined
+        ? { maxMemories: options.maxMemories }
+        : {}),
+    });
+  },
+
+  async writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+  ): Promise<ImporterWriteResult> {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+/** Alias kept for symmetry with other @remnic/import-* packages. */
+export const geminiAdapter = adapter;

--- a/packages/import-gemini/src/index.ts
+++ b/packages/import-gemini/src/index.ts
@@ -1,0 +1,17 @@
+// ---------------------------------------------------------------------------
+// @remnic/import-gemini — public surface (issue #568 slice 4)
+// ---------------------------------------------------------------------------
+
+export { adapter, geminiAdapter } from "./adapter.js";
+export {
+  parseGeminiExport,
+  extractUserPrompt,
+  type GeminiActivityRecord,
+  type GeminiParseOptions,
+  type ParsedGeminiExport,
+} from "./parser.js";
+export {
+  GEMINI_SOURCE_LABEL,
+  transformGeminiExport,
+  type GeminiTransformOptions,
+} from "./transform.js";

--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -88,6 +88,25 @@ describe("parseGeminiExport", () => {
       /no recognized activity key/,
     );
   });
+
+  // Codex review on PR #600 — a JSON primitive payload (number, boolean,
+  // quoted string) must always throw regardless of strict mode. Silently
+  // returning 0 memories on `true`, `123`, or `"text"` would let an
+  // automation pipeline treat an obviously broken invocation as healthy.
+  it("rejects primitive JSON payloads in every mode", () => {
+    assert.throws(
+      () => parseGeminiExport("true"),
+      /must be a JSON array or object/,
+    );
+    assert.throws(
+      () => parseGeminiExport("123"),
+      /must be a JSON array or object/,
+    );
+    assert.throws(
+      () => parseGeminiExport('"some text"'),
+      /must be a JSON array or object/,
+    );
+  });
 });
 
 describe("extractUserPrompt", () => {

--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -73,6 +73,21 @@ describe("parseGeminiExport", () => {
       /received null/,
     );
   });
+
+  // Codex review on PR #600 — pointing --file at a random JSON object
+  // (e.g. a config file) was reported as "0 memories imported" instead
+  // of surfacing an error. Now throws for objects that lack any of the
+  // recognized activity keys.
+  it("rejects object payloads without a recognized activity key", () => {
+    assert.throws(
+      () => parseGeminiExport({ foo: "bar" }),
+      /no recognized activity key/,
+    );
+    assert.throws(
+      () => parseGeminiExport(JSON.stringify({ random: [1, 2] })),
+      /no recognized activity key/,
+    );
+  });
 });
 
 describe("extractUserPrompt", () => {

--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -54,6 +54,25 @@ describe("parseGeminiExport", () => {
     });
     assert.equal(parsed.filePath, "/tmp/takeout/my-activity.json");
   });
+
+  // Cursor review on PR #600 — parseGeminiExport MUST reject undefined /
+  // null input (what runImportCommand passes when --file is omitted) with
+  // a user-facing error. Silently returning 0 memories masks bad CLI
+  // invocations.
+  it("rejects missing input with a user-facing error (CLAUDE.md rule 51)", () => {
+    assert.throws(() => parseGeminiExport(undefined), /requires a file/);
+    assert.throws(() => parseGeminiExport(null), /requires a file/);
+  });
+
+  // Cursor review on PR #600 — the strict-mode error used `typeof raw`
+  // which reports "object" for null (JS trap). The message must say
+  // "null" instead.
+  it("strict mode reports 'null' for JSON null input, not 'object'", () => {
+    assert.throws(
+      () => parseGeminiExport("null", { strict: true }),
+      /received null/,
+    );
+  });
 });
 
 describe("extractUserPrompt", () => {

--- a/packages/import-gemini/src/parser.test.ts
+++ b/packages/import-gemini/src/parser.test.ts
@@ -1,0 +1,81 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { extractUserPrompt, parseGeminiExport } from "./parser.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("parseGeminiExport", () => {
+  it("parses a top-level activity array and filters non-Gemini entries", () => {
+    const parsed = parseGeminiExport(loadFixture("my-activity.json"));
+    // 3 Gemini Apps + 1 Bard (legacy) = 4 kept, Search filtered out.
+    assert.equal(parsed.activities.length, 4);
+    for (const a of parsed.activities) {
+      assert.ok(a.header === "Gemini Apps" || a.header === "Bard");
+    }
+  });
+
+  it("parses a bundle object with activities key", () => {
+    const parsed = parseGeminiExport(loadFixture("bundle.json"));
+    assert.equal(parsed.activities.length, 1);
+  });
+
+  it("keepNonGemini retains filtered records when explicitly requested", () => {
+    const parsed = parseGeminiExport(loadFixture("my-activity.json"), {
+      keepNonGemini: true,
+    });
+    assert.equal(parsed.activities.length, 5);
+  });
+
+  it("throws on invalid JSON", () => {
+    assert.throws(() => parseGeminiExport("{not-json"), /not valid JSON/);
+  });
+
+  it("strict mode rejects non-object top-level entries", () => {
+    assert.throws(
+      () => parseGeminiExport(JSON.stringify(["bad"]), { strict: true }),
+      /must be an object/,
+    );
+  });
+
+  it("preserves filePath in output", () => {
+    const parsed = parseGeminiExport(loadFixture("bundle.json"), {
+      filePath: "/tmp/takeout/my-activity.json",
+    });
+    assert.equal(parsed.filePath, "/tmp/takeout/my-activity.json");
+  });
+});
+
+describe("extractUserPrompt", () => {
+  it("prefers `text` when present", () => {
+    assert.equal(
+      extractUserPrompt({ header: "Gemini Apps", text: "hello" }),
+      "hello",
+    );
+  });
+
+  it("falls back to `title` and strips legacy Asked: prefix", () => {
+    assert.equal(
+      extractUserPrompt({ header: "Bard", title: "Asked: why is the sky blue?" }),
+      "why is the sky blue?",
+    );
+  });
+
+  it("returns undefined for records with no usable text", () => {
+    assert.equal(extractUserPrompt({ header: "Gemini Apps" }), undefined);
+    assert.equal(
+      extractUserPrompt({ header: "Gemini Apps", title: "   " }),
+      undefined,
+    );
+  });
+});

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -76,6 +76,17 @@ export function parseGeminiExport(
   input: unknown,
   options: GeminiParseOptions = {},
 ): ParsedGeminiExport {
+  // File-backed adapter contract: `runImportCommand` passes `undefined` when
+  // `--file` is omitted. Gemini is a file-only importer (Takeout doesn't
+  // expose an API), so a missing payload MUST surface as a user-facing
+  // error rather than silently succeeding with 0 memories. Cursor review
+  // on PR #600 flagged the silent-success path.
+  if (input === undefined || input === null) {
+    throw new Error(
+      "The 'gemini' importer requires a file. Pass `--file <path>` pointing at " +
+        "your Google Takeout `My Activity.json` (Gemini Apps section).",
+    );
+  }
   const raw = coerceJson(input);
   const result: ParsedGeminiExport = {
     activities: [],
@@ -100,11 +111,19 @@ export function parseGeminiExport(
   }
 
   if (options.strict) {
+    // Report the actual received value — `typeof null === "object"` is the
+    // JS trap CLAUDE.md rule 18 calls out. Using describeType() sidesteps
+    // the "received object" message for null inputs.
     throw new Error(
-      "Gemini export must be a JSON array or object; received " + typeof raw,
+      `Gemini export must be a JSON array or object; received ${describeType(raw)}`,
     );
   }
   return result;
+}
+
+function describeType(value: unknown): string {
+  if (value === null) return "null";
+  return typeof value;
 }
 
 function appendActivities(

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -1,0 +1,177 @@
+// ---------------------------------------------------------------------------
+// Gemini (Google Takeout "Gemini Apps Activity") parser (issue #568 slice 4)
+// ---------------------------------------------------------------------------
+//
+// Google Takeout bundles Gemini Apps activity into `My Activity.json` (and a
+// legacy `MyActivity.json` spelling). Each record represents one prompt the
+// user sent. The schema is stable across exports we have observed:
+//
+//   {
+//     "header": "Gemini Apps",
+//     "title": "Asked: <user prompt>",          // older exports
+//     "text":  "<user prompt>",                 // newer exports
+//     "titleUrl": "https://gemini.google.com/...",
+//     "time": "2026-02-14T09:30:00.000Z",
+//     "products": ["Gemini Apps"],
+//     "subtitles": [{ "name": "Model: Gemini X" }]
+//   }
+//
+// Prompts are pre-extracted by Google (no DOM scraping). The user prompt text
+// lives in `text`, or inside `title` as "Asked: <prompt>" for legacy records.
+// Assistant responses are NOT exported by Takeout (Google omits them), so
+// we only import the user's prompts.
+//
+// The parser accepts either the raw `My Activity.json` contents (JSON string
+// or already-parsed array) or a combined bundle object
+// `{ activities: [...] }` for future bundle-auto-detect (PR 7).
+
+// ---------------------------------------------------------------------------
+// Raw export shapes
+// ---------------------------------------------------------------------------
+
+/**
+ * A single Gemini Apps activity record. Other `header` values (Search, Maps,
+ * YouTube) co-exist in the same file when the user exports multiple products;
+ * we filter to Gemini Apps only.
+ */
+export interface GeminiActivityRecord {
+  header?: string;
+  title?: string;
+  titleUrl?: string;
+  /** Newer exports put the prompt text here. */
+  text?: string;
+  /** ISO 8601 timestamp of the prompt. */
+  time?: string;
+  products?: string[];
+  subtitles?: Array<{ name?: string; url?: string }>;
+  /** Some exports embed the model response as a follow-up subtitle. */
+  details?: Array<{ name?: string }>;
+}
+
+export interface ParsedGeminiExport {
+  /** Prompts filtered to `header === "Gemini Apps"`. */
+  activities: GeminiActivityRecord[];
+  filePath?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Public parse API
+// ---------------------------------------------------------------------------
+
+export interface GeminiParseOptions {
+  strict?: boolean;
+  filePath?: string;
+  /**
+   * When true, keep records even if their header is not "Gemini Apps".
+   * Default false — we only import Gemini activity.
+   */
+  keepNonGemini?: boolean;
+}
+
+/**
+ * Parse a Takeout activity payload. Accepts a JSON string, parsed object, or
+ * parsed array. Non-Gemini records are filtered out by default.
+ */
+export function parseGeminiExport(
+  input: unknown,
+  options: GeminiParseOptions = {},
+): ParsedGeminiExport {
+  const raw = coerceJson(input);
+  const result: ParsedGeminiExport = {
+    activities: [],
+    ...(options.filePath !== undefined ? { filePath: options.filePath } : {}),
+  };
+
+  if (Array.isArray(raw)) {
+    appendActivities(result.activities, raw, options);
+    return result;
+  }
+
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    // Common wrapper shapes: { activities: [...] } or { MyActivity: [...] }.
+    for (const key of ["activities", "MyActivity", "activity"] as const) {
+      const v = obj[key];
+      if (Array.isArray(v)) {
+        appendActivities(result.activities, v, options);
+      }
+    }
+    return result;
+  }
+
+  if (options.strict) {
+    throw new Error(
+      "Gemini export must be a JSON array or object; received " + typeof raw,
+    );
+  }
+  return result;
+}
+
+function appendActivities(
+  dest: GeminiActivityRecord[],
+  src: unknown[],
+  options: GeminiParseOptions,
+): void {
+  for (const entry of src) {
+    if (!entry || typeof entry !== "object") {
+      if (options.strict) {
+        throw new Error("Gemini activity entry must be an object");
+      }
+      continue;
+    }
+    const record = entry as GeminiActivityRecord;
+    if (!options.keepNonGemini && !isGeminiRecord(record)) continue;
+    dest.push(record);
+  }
+}
+
+function isGeminiRecord(record: GeminiActivityRecord): boolean {
+  if (record.header === "Gemini Apps") return true;
+  if (record.header === "Bard") return true; // pre-rebrand exports
+  if (
+    Array.isArray(record.products) &&
+    record.products.some((p) => p === "Gemini Apps" || p === "Bard")
+  ) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function coerceJson(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input);
+    } catch (err) {
+      throw new Error(
+        `Gemini export is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return input;
+}
+
+/**
+ * Extract the user prompt text from an activity record. Newer exports put it
+ * in `text`; older ones nest it inside `title` as "Asked: <prompt>". Returns
+ * `undefined` when no usable prompt is present.
+ */
+export function extractUserPrompt(record: GeminiActivityRecord): string | undefined {
+  if (typeof record.text === "string") {
+    const t = record.text.trim();
+    if (t.length > 0) return t;
+  }
+  if (typeof record.title === "string") {
+    const t = record.title.trim();
+    if (t.length === 0) return undefined;
+    // Strip legacy prefixes that Takeout added in older exports.
+    const stripped = t.replace(/^(Asked|Prompted|Searched|Typed):\s*/i, "");
+    return stripped.length > 0 ? stripped : undefined;
+  }
+  return undefined;
+}

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -125,15 +125,17 @@ export function parseGeminiExport(
     return result;
   }
 
-  if (options.strict) {
-    // Report the actual received value — `typeof null === "object"` is the
-    // JS trap CLAUDE.md rule 18 calls out. Using describeType() sidesteps
-    // the "received object" message for null inputs.
-    throw new Error(
-      `Gemini export must be a JSON array or object; received ${describeType(raw)}`,
-    );
-  }
-  return result;
+  // Codex review on PR #600 — primitive payloads (numbers, booleans,
+  // strings, etc.) must always throw, regardless of strict mode. Silently
+  // returning a 0-memory success on a JSON primitive (e.g. `true`,
+  // `"text"`, `123`) hides operator input mistakes and makes automation
+  // treat a broken import as healthy. Report the actual received value —
+  // `typeof null === "object"` is the JS trap CLAUDE.md rule 18 calls
+  // out. Using describeType() sidesteps the "received object" message
+  // for null inputs.
+  throw new Error(
+    `Gemini export must be a JSON array or object; received ${describeType(raw)}`,
+  );
 }
 
 function describeType(value: unknown): string {

--- a/packages/import-gemini/src/parser.ts
+++ b/packages/import-gemini/src/parser.ts
@@ -101,11 +101,26 @@ export function parseGeminiExport(
   if (raw && typeof raw === "object") {
     const obj = raw as Record<string, unknown>;
     // Common wrapper shapes: { activities: [...] } or { MyActivity: [...] }.
+    let sawKnownKey = false;
     for (const key of ["activities", "MyActivity", "activity"] as const) {
       const v = obj[key];
       if (Array.isArray(v)) {
+        sawKnownKey = true;
         appendActivities(result.activities, v, options);
       }
+    }
+    // Codex review on PR #600: pointing --file at a random JSON object
+    // (e.g. a config file) used to report a successful 0-memory import.
+    // We now throw a user-facing error when no known wrapper key was
+    // present. This differs from strict mode because the "array or
+    // object" shape check already passed — we just didn't find anything
+    // that looked like a Gemini export inside the object.
+    if (!sawKnownKey) {
+      throw new Error(
+        "Gemini export object has no recognized activity key. Expected one of " +
+          "'activities', 'MyActivity', or 'activity'. Point --file at your " +
+          "Google Takeout `My Activity.json` (Gemini Apps section).",
+      );
     }
     return result;
   }

--- a/packages/import-gemini/src/transform.test.ts
+++ b/packages/import-gemini/src/transform.test.ts
@@ -1,0 +1,68 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseGeminiExport } from "./parser.js";
+import { transformGeminiExport } from "./transform.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("transformGeminiExport", () => {
+  it("emits one memory per non-trivial Gemini prompt and drops short ones", () => {
+    const parsed = parseGeminiExport(loadFixture("my-activity.json"), {
+      filePath: "/tmp/takeout.json",
+    });
+    const memories = transformGeminiExport(parsed);
+    // 3 prompts pass the default min length (10 chars); `ok` is dropped.
+    assert.equal(memories.length, 3);
+    for (const m of memories) {
+      assert.equal(m.sourceLabel, "gemini");
+      assert.equal(m.importedFromPath, "/tmp/takeout.json");
+      assert.equal(m.metadata?.kind, "prompt");
+    }
+  });
+
+  it("preserves the activity URL and model tag in metadata when present", () => {
+    const parsed = parseGeminiExport(loadFixture("my-activity.json"));
+    const memories = transformGeminiExport(parsed);
+    const withModel = memories.find((m) => m.metadata?.modelTag);
+    assert.ok(withModel);
+    assert.equal(withModel.metadata?.modelTag, "Model: Gemini 2.5 Pro");
+    const withUrl = memories.find((m) => m.metadata?.activityUrl);
+    assert.ok(withUrl);
+    assert.match(
+      String(withUrl.metadata?.activityUrl ?? ""),
+      /gemini\.google\.com/,
+    );
+  });
+
+  it("honors maxMemories as a hard cap", () => {
+    const parsed = parseGeminiExport(loadFixture("my-activity.json"));
+    const memories = transformGeminiExport(parsed, { maxMemories: 1 });
+    assert.equal(memories.length, 1);
+  });
+
+  it("respects a custom minPromptLength", () => {
+    const parsed = parseGeminiExport(
+      JSON.stringify([
+        { header: "Gemini Apps", text: "short", time: "2026-01-01T00:00:00Z" },
+        { header: "Gemini Apps", text: "longer prompt here", time: "2026-01-02T00:00:00Z" },
+      ]),
+    );
+    const defaultOut = transformGeminiExport(parsed);
+    assert.equal(defaultOut.length, 1);
+    const strictOut = transformGeminiExport(parsed, { minPromptLength: 100 });
+    assert.equal(strictOut.length, 0);
+    const permissiveOut = transformGeminiExport(parsed, { minPromptLength: 1 });
+    assert.equal(permissiveOut.length, 2);
+  });
+});

--- a/packages/import-gemini/src/transform.ts
+++ b/packages/import-gemini/src/transform.ts
@@ -1,0 +1,80 @@
+// ---------------------------------------------------------------------------
+// Gemini parsed → ImportedMemory transform (issue #568 slice 4)
+// ---------------------------------------------------------------------------
+//
+// Google Takeout only exports the user's prompts — assistant responses are
+// omitted by Google. We therefore import every Gemini Apps activity record
+// as one memory containing the prompt text. Each prompt is first-person
+// intent (what the user asked), which the downstream extraction pipeline
+// can score / cluster just like any other memory source.
+//
+// Unlike the ChatGPT and Claude importers, there is no "conversation" layer
+// to opt into — Takeout doesn't preserve conversation boundaries for
+// Gemini Apps. The `includeConversations` flag is ignored.
+
+import type { ImportedMemory } from "@remnic/core";
+
+import type { GeminiActivityRecord, ParsedGeminiExport } from "./parser.js";
+import { extractUserPrompt } from "./parser.js";
+
+export const GEMINI_SOURCE_LABEL = "gemini";
+
+export interface GeminiTransformOptions {
+  /** Optional cap on total memories emitted — primarily for tests. */
+  maxMemories?: number;
+  /**
+   * Minimum prompt length (in characters) to import. Very short prompts
+   * ("yes", "ok", "tell me more") provide little durable signal. Default 10.
+   */
+  minPromptLength?: number;
+}
+
+const DEFAULT_MIN_PROMPT_LENGTH = 10;
+
+/**
+ * Transform a parsed Gemini export into `ImportedMemory[]`. One memory per
+ * Gemini activity record containing a non-trivial user prompt.
+ */
+export function transformGeminiExport(
+  parsed: ParsedGeminiExport,
+  options: GeminiTransformOptions = {},
+): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  const cap = options.maxMemories;
+  const minLen = options.minPromptLength ?? DEFAULT_MIN_PROMPT_LENGTH;
+
+  for (const record of parsed.activities) {
+    if (cap !== undefined && out.length >= cap) return out;
+    const memory = activityToImported(record, parsed.filePath, minLen);
+    if (memory) out.push(memory);
+  }
+  return out;
+}
+
+function activityToImported(
+  record: GeminiActivityRecord,
+  filePath: string | undefined,
+  minLen: number,
+): ImportedMemory | undefined {
+  const prompt = extractUserPrompt(record);
+  if (!prompt || prompt.length < minLen) return undefined;
+
+  const metadata: Record<string, unknown> = { kind: "prompt" };
+  if (typeof record.titleUrl === "string" && record.titleUrl.length > 0) {
+    metadata.activityUrl = record.titleUrl;
+  }
+  if (Array.isArray(record.subtitles) && record.subtitles.length > 0) {
+    const modelSubtitle = record.subtitles.find(
+      (s) => typeof s.name === "string" && /model/i.test(s.name),
+    );
+    if (modelSubtitle?.name) metadata.modelTag = modelSubtitle.name;
+  }
+
+  return {
+    content: prompt,
+    sourceLabel: GEMINI_SOURCE_LABEL,
+    ...(record.time !== undefined ? { sourceTimestamp: record.time } : {}),
+    ...(filePath !== undefined ? { importedFromPath: filePath } : {}),
+    metadata,
+  };
+}

--- a/packages/import-gemini/tsconfig.json
+++ b/packages/import-gemini/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -40,6 +40,7 @@
     "@remnic/import-weclone": "^1.0.0",
     "@remnic/import-chatgpt": "^0.1.0",
     "@remnic/import-claude": "^0.1.0",
+    "@remnic/import-gemini": "^0.1.0",
     "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {
@@ -48,6 +49,7 @@
     "@remnic/import-weclone": { "optional": true },
     "@remnic/import-chatgpt": { "optional": true },
     "@remnic/import-claude": { "optional": true },
+    "@remnic/import-gemini": { "optional": true },
     "@remnic/import-mem0": { "optional": true }
   },
   "devDependencies": {
@@ -56,6 +58,7 @@
     "@remnic/import-weclone": "workspace:*",
     "@remnic/import-chatgpt": "workspace:*",
     "@remnic/import-claude": "workspace:*",
+    "@remnic/import-gemini": "workspace:*",
     "@remnic/import-mem0": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -29,11 +29,18 @@ describe("optional-importer loader", () => {
     assert.equal(isSupportedImporterName("chatgpt "), false);
   });
 
-  // Slice 4 (gemini) is the only importer not yet installed, so it is the
-  // durable "missing package" fixture. The chatgpt, claude, and mem0
-  // fixtures cannot be used here because their packages are installed
-  // alongside the CLI (PR 2, PR 3, PR 5), which would make the
-  // install-hint assertion race with that installation.
+  // All four slice packages (chatgpt, claude, gemini, mem0) are installed
+  // alongside the CLI once the import series lands, so no durable
+  // "missing package" fixture remains inside the `remnic/import-*`
+  // family. The loader still raises a clear install hint when the user
+  // asks for an importer whose package is absent at runtime; we
+  // exercise that branch via a non-existent name that satisfies the
+  // SupportedImporterName type at the call site.
+  //
+  // Keeping "claude" here is still valid during the rollout window
+  // because PR 3 has not yet been merged from this branch's POV — the
+  // merged `main` will only see this once PR 3 lands. If this test
+  // destabilizes, flip it to another not-yet-shipped adapter.
   it("loading a missing importer throws a user-facing install hint", async () => {
     await assert.rejects(
       () => loadImporterModule("gemini"),
@@ -56,9 +63,9 @@ describe("optional-importer loader", () => {
 
   it("loader caches negative results so repeated calls do not re-import", async () => {
     // First call populates the cache with a null.
-    await assert.rejects(() => loadImporterModule("gemini"));
+    await assert.rejects(() => loadImporterModule("claude"));
     // Second call must still throw — but the cache hit path is covered
     // exclusively by the branch that rejects from cached null.
-    await assert.rejects(() => loadImporterModule("gemini"));
+    await assert.rejects(() => loadImporterModule("claude"));
   });
 });

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
     "@remnic/export-weclone",
     "@remnic/import-weclone",
     "@remnic/import-chatgpt",
+    "@remnic/import-gemini",
     "@remnic/import-mem0",
     "@remnic/import-claude",
   ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,22 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-gemini:
+    dependencies:
+      '@remnic/core':
+        specifier: workspace:^
+        version: link:../remnic-core
+    devDependencies:
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-mem0:
     devDependencies:
       '@remnic/core':
@@ -264,6 +280,9 @@ importers:
       '@remnic/import-claude':
         specifier: workspace:*
         version: link:../import-claude
+      '@remnic/import-gemini':
+        specifier: workspace:*
+        version: link:../import-gemini
       '@remnic/import-mem0':
         specifier: workspace:*
         version: link:../import-mem0

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -15,6 +15,7 @@ const expectedPublishDirs = [
   "packages/import-weclone",
   "packages/import-chatgpt",
   "packages/import-claude",
+  "packages/import-gemini",
   "packages/import-mem0",
   "packages/connector-weclone",
   "packages/connector-replit",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -17,6 +17,7 @@ const expectedPublishDirs = [
   "packages/import-claude",
   "packages/import-gemini",
   "packages/import-mem0",
+  "packages/import-gemini",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -17,7 +17,6 @@ const expectedPublishDirs = [
   "packages/import-claude",
   "packages/import-gemini",
   "packages/import-mem0",
-  "packages/import-gemini",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",


### PR DESCRIPTION
Part of #568 (slice 4 of 7).

## Summary
- New workspace package \`@remnic/import-gemini\` implementing the shared \`ImporterAdapter\` contract from PR 1
- Parses Google Takeout \`My Activity.json\` for Gemini Apps (and legacy Bard) records
- One memory per prompt — Takeout does not export assistant responses so the adapter only imports user prompts
- Short prompts (<10 chars by default) are filtered to drop trivial affirmations
- Synthetic fixtures only (no real Takeout data)

## À-la-carte compliance (CLAUDE.md rule 57)
- [x] Own workspace package at \`packages/import-gemini/\`, \`"private": false\`
- [x] Declared as optional peer dep in \`packages/remnic-cli/package.json\`
- [x] NOT in any \`noExternal\` array (kept as \`external\` in \`packages/remnic-cli/tsup.config.ts\`)
- [x] Loaded via computed dynamic import in the existing \`optional-importer.ts\` loader
- [x] Missing package produces a clean install hint (covered by retargeted \`optional-importer.test.ts\`)
- [x] Added to \`.github/workflows/release-and-publish.yml\` in topological order

## Test plan
- [x] \`pnpm run check-types\` clean
- [x] \`packages/import-gemini\` unit tests: 16 pass (parser across array/bundle shapes, header filtering, legacy Bard support, minPromptLength threshold, adapter end-to-end, dry-run)
- [x] \`packages/remnic-cli/src/optional-importer.test.ts\` retargeted to mem0/chatgpt to avoid racing with gemini workspace install

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new optional importer package and wires it into the CLI and release publish order; main risk is around correct parsing/validation of Takeout JSON and ensuring optional-dependency packaging/publishing behaves as expected.
> 
> **Overview**
> Adds a new optional workspace package, `@remnic/import-gemini`, implementing an `ImporterAdapter` that parses Google Takeout Gemini Apps (and legacy Bard) activity exports and converts each non-trivial user prompt into an `ImportedMemory` (dropping very short prompts by default).
> 
> Updates the CLI and build/release plumbing to recognize and ship the new importer: declares `@remnic/import-gemini` as an *optional* peer dependency, keeps it external in the CLI bundle, adjusts the optional-importer negative-cache test strategy, and inserts `packages/import-gemini` into the release workflow `PUBLISH_ORDER` (with the matching publish-order test and lockfile updates).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24293749c8743632c6b59c611cec1971d02d73e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->