### PR TITLE
feat(xray): HTTP GET /recall/xray route + access-service plumbing (#570 PR 4/7)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -394,6 +394,74 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // Recall X-ray (issue #570 PR 4): unified per-result attribution
+    // snapshot.  Requires bearer auth (same as every other endpoint
+    // here) and enforces namespace scope before the recall fires
+    // (CLAUDE.md rule 42).  Query comes from the `q` search param so
+    // GET stays cacheable; `namespace` / `session` / `budget` are
+    // optional.
+    if (req.method === "GET" && pathname === "/engram/v1/recall/xray") {
+      const queryParam = parsed.searchParams.get("q");
+      if (!queryParam || queryParam.trim().length === 0) {
+        this.respondJson(res, 400, {
+          error: "missing_query",
+          code: "missing_query",
+          message: "q search parameter is required and must be non-empty",
+        });
+        return;
+      }
+      const sessionParam = parsed.searchParams.get("session");
+      const sessionKey = sessionParam && sessionParam.length > 0
+        ? sessionParam
+        : undefined;
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const namespace = this.resolveNamespace(
+        req,
+        namespaceParam && namespaceParam.length > 0
+          ? namespaceParam
+          : undefined,
+      );
+      const budgetParam = parsed.searchParams.get("budget");
+      // Reject invalid `budget` with 400 rather than silently
+      // defaulting (CLAUDE.md rules 14 + 51).
+      let budget: number | undefined;
+      if (budgetParam !== null && budgetParam !== "") {
+        const parsedBudget = Number(budgetParam);
+        if (
+          !Number.isFinite(parsedBudget)
+          || parsedBudget <= 0
+          || !Number.isInteger(parsedBudget)
+        ) {
+          this.respondJson(res, 400, {
+            error: "invalid_budget",
+            code: "invalid_budget",
+            message:
+              "budget expects a positive integer",
+          });
+          return;
+        }
+        budget = parsedBudget;
+      }
+      try {
+        const payload = await this.service.recallXray({
+          query: queryParam,
+          sessionKey,
+          namespace,
+          budget,
+          authenticatedPrincipal: this.resolveRequestPrincipal(req),
+        });
+        this.respondJson(res, 200, payload);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        this.respondJson(res, 400, {
+          error: "invalid_request",
+          code: "invalid_request",
+          message,
+        });
+      }
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/observe") {
       const body = await this.readValidatedBody(req, "observe");
       this.ensureWriteRateLimitAvailable();

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -442,23 +442,37 @@ export class EngramAccessHttpServer {
         }
         budget = parsedBudget;
       }
+      // Only translate validation errors (empty query, bad budget)
+      // into 400s.  Backend faults (timeouts, storage errors,
+      // unexpected orchestrator failures) must bubble to the global
+      // `handle()` error handler so they return 500 and get logged
+      // properly.  `service.recallXray` prefixes its validation
+      // errors with "recallXray:" so we key off that prefix rather
+      // than catching everything.
+      let payload: Awaited<ReturnType<typeof this.service.recallXray>>;
       try {
-        const payload = await this.service.recallXray({
+        payload = await this.service.recallXray({
           query: queryParam,
           sessionKey,
           namespace,
           budget,
           authenticatedPrincipal: this.resolveRequestPrincipal(req),
         });
-        this.respondJson(res, 200, payload);
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
-        this.respondJson(res, 400, {
-          error: "invalid_request",
-          code: "invalid_request",
-          message,
-        });
+        if (message.startsWith("recallXray:")) {
+          this.respondJson(res, 400, {
+            error: "invalid_request",
+            code: "invalid_request",
+            message,
+          });
+          return;
+        }
+        // Anything else is a server-side fault; rethrow so the
+        // outer `handle()` catch returns 500 + logs the error.
+        throw err;
       }
+      this.respondJson(res, 200, payload);
       return;
     }
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1170,6 +1170,114 @@ export class EngramAccessService {
     return toRecallExplainJson(snapshot);
   }
 
+  /**
+   * Recall X-ray (issue #570).  Runs a recall with `xrayCapture: true`
+   * and returns the resulting snapshot as structured JSON so every
+   * surface (CLI / HTTP / MCP) gets the same payload.  Namespace scope
+   * is enforced before the recall fires (CLAUDE.md rule 42 — read and
+   * write paths must resolve through the same namespace layer) so an
+   * unauthorized principal cannot capture an x-ray for a namespace it
+   * cannot read.
+   */
+  async recallXray(request: {
+    query: string;
+    sessionKey?: string;
+    namespace?: string;
+    budget?: number;
+    authenticatedPrincipal?: string;
+  }): Promise<{
+    snapshotFound: boolean;
+    snapshot?: import("./recall-xray.js").RecallXraySnapshot;
+  }> {
+    const query = typeof request.query === "string" ? request.query : "";
+    if (query.trim().length === 0) {
+      // Match the CLI contract (CLAUDE.md rule 51): reject empty
+      // input with an explicit error rather than silently producing
+      // an empty snapshot.
+      throw new Error("recallXray: query is required and must be non-empty");
+    }
+
+    const namespacesEnabled = this.orchestrator.config.namespacesEnabled;
+    const requestedNamespace = request.namespace?.trim()
+      ? this.resolveNamespace(request.namespace)
+      : undefined;
+    const principal =
+      request.authenticatedPrincipal?.trim()
+      || resolvePrincipal(request.sessionKey, this.orchestrator.config);
+
+    if (requestedNamespace) {
+      if (
+        !canReadNamespace(
+          principal,
+          requestedNamespace,
+          this.orchestrator.config,
+        )
+      ) {
+        return { snapshotFound: false };
+      }
+    } else if (
+      namespacesEnabled
+      && !request.authenticatedPrincipal?.trim()
+      && !request.sessionKey?.trim()
+    ) {
+      // Namespaces enabled but no identity supplied — reject rather
+      // than scanning the global namespace (CLAUDE.md rule 48:
+      // least-privileged default).
+      return { snapshotFound: false };
+    }
+
+    // Optional `--budget` override must be a positive integer.  Invalid
+    // values throw rather than silently defaulting (CLAUDE.md rule 51).
+    let budgetOverride: number | undefined;
+    if (request.budget !== undefined && request.budget !== null) {
+      const parsed =
+        typeof request.budget === "number"
+          ? request.budget
+          : Number(request.budget);
+      if (
+        !Number.isFinite(parsed)
+        || parsed <= 0
+        || !Number.isInteger(parsed)
+      ) {
+        throw new Error(
+          `recallXray: budget expects a positive integer; got ${JSON.stringify(request.budget)}`,
+        );
+      }
+      budgetOverride = parsed;
+    }
+
+    const originalBudget = this.orchestrator.config.recallBudgetChars;
+    if (budgetOverride !== undefined) {
+      this.orchestrator.config.recallBudgetChars = budgetOverride;
+    }
+    try {
+      // Clear any prior snapshot so a capture failure surfaces as
+      // `{snapshotFound: false}` rather than returning stale data
+      // from an earlier call on the same orchestrator.
+      this.orchestrator.clearLastXraySnapshot();
+      await this.orchestrator.recall(query, request.sessionKey, {
+        xrayCapture: true,
+        ...(requestedNamespace ? { namespace: requestedNamespace } : {}),
+      });
+    } finally {
+      if (budgetOverride !== undefined) {
+        this.orchestrator.config.recallBudgetChars = originalBudget;
+      }
+    }
+
+    const snapshot = this.orchestrator.getLastXraySnapshot();
+    if (!snapshot) return { snapshotFound: false };
+    // Re-check namespace after capture: the recall may have served
+    // from a different namespace (default/global) than the caller
+    // requested.  Drop the snapshot rather than leak cross-tenant
+    // data (CLAUDE.md rule 42 + 47).
+    if (requestedNamespace && snapshot.namespace
+        && snapshot.namespace !== requestedNamespace) {
+      return { snapshotFound: false };
+    }
+    return { snapshotFound: true, snapshot };
+  }
+
   async memoryStore(request: EngramAccessMemoryStoreRequest): Promise<EngramAccessWriteResponse> {
     const namespace = this.resolveWritableNamespace(
       request.namespace,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1248,12 +1248,13 @@ export class EngramAccessService {
     }
 
     // Serialize x-ray invocations behind a per-service mutex so the
-    // shared `orchestrator.config.recallBudgetChars` swap cannot
-    // interleave across concurrent callers.  Global mutation is
-    // unavoidable here because `orchestrator.recall()` does not
-    // accept a per-call budget — the mutex keeps request isolation
-    // intact until that signature widens.  `getLastXraySnapshot`
-    // is also per-process state this serialization protects.
+    // per-process `getLastXraySnapshot()` slot cannot be clobbered by
+    // a concurrent capturing call before this caller reads it back.
+    // Budget and principal are now threaded through
+    // `RecallInvocationOptions`, so global config mutation is gone
+    // (CLAUDE.md rule 47: no shared mutable state across async
+    // boundaries).  The mutex stays only for the snapshot-slot
+    // ordering guarantee.
     const previousQueue = this.xrayQueue;
     let release: () => void = () => {};
     this.xrayQueue = new Promise<void>((resolve) => {
@@ -1261,30 +1262,30 @@ export class EngramAccessService {
     });
     await previousQueue;
 
-    // When the caller supplies an authenticated principal but no
-    // sessionKey, thread the principal in as the sessionKey so the
-    // downstream `resolvePrincipal(sessionKey)` in the orchestrator
-    // evaluates ACLs against the SAME principal that the pre-check
-    // above authorized.  Otherwise the orchestrator would default to
-    // the unauthenticated principal and could reject or serve the
-    // wrong scope despite the pre-check passing.
-    const recallSessionKey =
-      request.sessionKey?.trim()
-      || authenticatedPrincipal
-      || undefined;
-
-    const originalBudget = this.orchestrator.config.recallBudgetChars;
-    if (budgetOverride !== undefined) {
-      this.orchestrator.config.recallBudgetChars = budgetOverride;
-    }
     try {
       // Clear any prior snapshot so a capture failure surfaces as
       // `{snapshotFound: false}` rather than returning stale data
       // from an earlier call on the same orchestrator.
       this.orchestrator.clearLastXraySnapshot();
-      await this.orchestrator.recall(query, recallSessionKey, {
+      await this.orchestrator.recall(query, request.sessionKey?.trim() || undefined, {
         xrayCapture: true,
         ...(requestedNamespace ? { namespace: requestedNamespace } : {}),
+        ...(budgetOverride !== undefined
+          ? { budgetCharsOverride: budgetOverride }
+          : {}),
+        // When the caller supplies an authenticated principal, forward
+        // it via the dedicated override channel so orchestrator-side
+        // ACL decisions use the SAME principal the access-surface
+        // pre-check above authorized.  Threading an
+        // `authenticatedPrincipal` through `sessionKey` would be wrong:
+        // `resolvePrincipal(sessionKey)` only maps configured raw
+        // session keys and otherwise collapses to `"default"`, which
+        // in namespace-enabled deployments produces false denials /
+        // wrong-scope serving despite the pre-check passing
+        // (CLAUDE.md rule 42).
+        ...(authenticatedPrincipal
+          ? { principalOverride: authenticatedPrincipal }
+          : {}),
       });
 
       const snapshot = this.orchestrator.getLastXraySnapshot();
@@ -1300,9 +1301,6 @@ export class EngramAccessService {
       }
       return { snapshotFound: true, snapshot };
     } finally {
-      if (budgetOverride !== undefined) {
-        this.orchestrator.config.recallBudgetChars = originalBudget;
-      }
       release();
     }
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1201,8 +1201,9 @@ export class EngramAccessService {
     const requestedNamespace = request.namespace?.trim()
       ? this.resolveNamespace(request.namespace)
       : undefined;
+    const authenticatedPrincipal = request.authenticatedPrincipal?.trim();
     const principal =
-      request.authenticatedPrincipal?.trim()
+      authenticatedPrincipal
       || resolvePrincipal(request.sessionKey, this.orchestrator.config);
 
     if (requestedNamespace) {
@@ -1217,7 +1218,7 @@ export class EngramAccessService {
       }
     } else if (
       namespacesEnabled
-      && !request.authenticatedPrincipal?.trim()
+      && !authenticatedPrincipal
       && !request.sessionKey?.trim()
     ) {
       // Namespaces enabled but no identity supplied — reject rather
@@ -1246,6 +1247,32 @@ export class EngramAccessService {
       budgetOverride = parsed;
     }
 
+    // Serialize x-ray invocations behind a per-service mutex so the
+    // shared `orchestrator.config.recallBudgetChars` swap cannot
+    // interleave across concurrent callers.  Global mutation is
+    // unavoidable here because `orchestrator.recall()` does not
+    // accept a per-call budget — the mutex keeps request isolation
+    // intact until that signature widens.  `getLastXraySnapshot`
+    // is also per-process state this serialization protects.
+    const previousQueue = this.xrayQueue;
+    let release: () => void = () => {};
+    this.xrayQueue = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    await previousQueue;
+
+    // When the caller supplies an authenticated principal but no
+    // sessionKey, thread the principal in as the sessionKey so the
+    // downstream `resolvePrincipal(sessionKey)` in the orchestrator
+    // evaluates ACLs against the SAME principal that the pre-check
+    // above authorized.  Otherwise the orchestrator would default to
+    // the unauthenticated principal and could reject or serve the
+    // wrong scope despite the pre-check passing.
+    const recallSessionKey =
+      request.sessionKey?.trim()
+      || authenticatedPrincipal
+      || undefined;
+
     const originalBudget = this.orchestrator.config.recallBudgetChars;
     if (budgetOverride !== undefined) {
       this.orchestrator.config.recallBudgetChars = budgetOverride;
@@ -1255,28 +1282,35 @@ export class EngramAccessService {
       // `{snapshotFound: false}` rather than returning stale data
       // from an earlier call on the same orchestrator.
       this.orchestrator.clearLastXraySnapshot();
-      await this.orchestrator.recall(query, request.sessionKey, {
+      await this.orchestrator.recall(query, recallSessionKey, {
         xrayCapture: true,
         ...(requestedNamespace ? { namespace: requestedNamespace } : {}),
       });
+
+      const snapshot = this.orchestrator.getLastXraySnapshot();
+      if (!snapshot) return { snapshotFound: false };
+      // Re-check namespace after capture: the recall may have served
+      // from a different namespace than the caller requested.  Drop
+      // the snapshot rather than leak cross-tenant data (CLAUDE.md
+      // rules 42 + 47).  The comparison is strict so a snapshot whose
+      // namespace is `undefined` cannot bypass the scope the caller
+      // asked for.
+      if (requestedNamespace && snapshot.namespace !== requestedNamespace) {
+        return { snapshotFound: false };
+      }
+      return { snapshotFound: true, snapshot };
     } finally {
       if (budgetOverride !== undefined) {
         this.orchestrator.config.recallBudgetChars = originalBudget;
       }
+      release();
     }
-
-    const snapshot = this.orchestrator.getLastXraySnapshot();
-    if (!snapshot) return { snapshotFound: false };
-    // Re-check namespace after capture: the recall may have served
-    // from a different namespace (default/global) than the caller
-    // requested.  Drop the snapshot rather than leak cross-tenant
-    // data (CLAUDE.md rule 42 + 47).
-    if (requestedNamespace && snapshot.namespace
-        && snapshot.namespace !== requestedNamespace) {
-      return { snapshotFound: false };
-    }
-    return { snapshotFound: true, snapshot };
   }
+  // Sequence lock for `recallXray` — see comment inside the method.
+  // Lives on the instance so every x-ray call on the same service
+  // shares it, and so separate services in the same process (e.g.
+  // per-tenant) do not block each other.
+  private xrayQueue: Promise<void> = Promise.resolve();
 
   async memoryStore(request: EngramAccessMemoryStoreRequest): Promise<EngramAccessWriteResponse> {
     const namespace = this.resolveWritableNamespace(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -526,6 +526,27 @@ export interface RecallInvocationOptions {
    * captured and recall behavior is unchanged (schema-only slice).
    */
   xrayCapture?: boolean;
+  /**
+   * Per-invocation override for `recallBudgetChars` (issue #570 PR 3/4).
+   * Flows through `getRecallBudgetChars()` for this recall only — no
+   * shared config mutation, so concurrent recalls on the same
+   * orchestrator are not affected (CLAUDE.md rule 47: no shared
+   * mutable state across async boundaries).  Must be a non-negative
+   * finite integer; non-conforming values are ignored and the
+   * configured budget is used.
+   */
+  budgetCharsOverride?: number;
+  /**
+   * Per-invocation principal override (issue #570 PR 4).  When set,
+   * the orchestrator uses this principal for ACL / namespace checks
+   * instead of `resolvePrincipal(sessionKey, config)`.  This is the
+   * escape hatch for access surfaces (HTTP / MCP) that have already
+   * authenticated the caller upstream — threading an unmapped
+   * principal through the session-key-based resolver would otherwise
+   * collapse it to `"default"` and produce false denials in
+   * namespace-enabled deployments (CLAUDE.md rule 42).
+   */
+  principalOverride?: string;
 }
 
 type QueryAwarePrefilter = {
@@ -5276,7 +5297,14 @@ export class Orchestrator {
     return reserved;
   }
 
-  private getRecallBudgetChars(): number {
+  private getRecallBudgetChars(override?: number): number {
+    if (
+      typeof override === "number" &&
+      Number.isFinite(override) &&
+      override >= 0
+    ) {
+      return Math.floor(override);
+    }
     const configuredBudget = this.config.recallBudgetChars;
     if (
       typeof configuredBudget === "number" &&
@@ -5296,7 +5324,10 @@ export class Orchestrator {
     return 0;
   }
 
-  private assembleRecallSections(sectionBuckets: Map<string, string[]>): {
+  private assembleRecallSections(
+    sectionBuckets: Map<string, string[]>,
+    budgetOverride?: number,
+  ): {
     sections: string[];
     includedIds: string[];
     omittedIds: string[];
@@ -5325,7 +5356,7 @@ export class Orchestrator {
       orderedEntries.push({ id, content: chunks.join("\n\n") });
     }
 
-    const budget = this.getRecallBudgetChars();
+    const budget = this.getRecallBudgetChars(budgetOverride);
     if (budget === 0) {
       return {
         sections: [],
@@ -5601,7 +5632,18 @@ export class Orchestrator {
       this.config.verbatimArtifactsMaxRecall,
     );
     const embeddingFetchLimit = computedFetchLimit;
-    const principal = resolvePrincipal(sessionKey, this.config);
+    // Principal resolution honours the access-surface override (issue
+    // #570 PR 4).  Access surfaces that have already authenticated the
+    // caller at the transport layer (HTTP / MCP) pass their resolved
+    // principal directly so namespace ACL decisions use the same
+    // identity the surface authorized, instead of re-running
+    // `resolvePrincipal(sessionKey)` which only maps raw session keys
+    // through configured rules and otherwise collapses to `"default"`.
+    const principal =
+      typeof options.principalOverride === "string"
+        && options.principalOverride.length > 0
+        ? options.principalOverride
+        : resolvePrincipal(sessionKey, this.config);
     const namespaceOverride = options.namespace?.trim() || undefined;
     const readableRecallNamespaces = recallNamespacesForPrincipal(
       principal,
@@ -5740,7 +5782,10 @@ export class Orchestrator {
                 reason: "no_recall",
               },
             ],
-            budget: { chars: this.getRecallBudgetChars(), used: 0 },
+            budget: {
+              chars: this.getRecallBudgetChars(options.budgetCharsOverride),
+              used: 0,
+            },
             sessionKey,
             namespace: selfNamespace,
             traceId,
@@ -8759,7 +8804,10 @@ export class Orchestrator {
       .join(", ");
     log.info(`recall timings: ${timingParts}`);
 
-    const assembledRecall = this.assembleRecallSections(sectionBuckets);
+    const assembledRecall = this.assembleRecallSections(
+      sectionBuckets,
+      options.budgetCharsOverride,
+    );
     const context =
       assembledRecall.sections.length === 0
         ? ""
@@ -8874,7 +8922,7 @@ export class Orchestrator {
           results,
           filters,
           budget: {
-            chars: this.getRecallBudgetChars(),
+            chars: this.getRecallBudgetChars(options.budgetCharsOverride),
             used: assembledRecall.finalChars,
           },
           sessionKey,

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Integration tests for `EngramAccessService.recallXray` (issue #570 PR 4).
+ *
+ * These tests use lightweight orchestrator stubs so the HTTP surface
+ * and access-service logic can be exercised without spinning up a
+ * full retrieval stack.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { EngramAccessService } from "../src/access-service.js";
+import type { RecallXraySnapshot } from "../src/recall-xray.js";
+
+function fakeSnapshot(
+  overrides: Partial<RecallXraySnapshot> = {},
+): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "q",
+    snapshotId: "snap-1",
+    capturedAt: 1_700_000_000_000,
+    tierExplain: null,
+    results: [],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+    ...overrides,
+  };
+}
+
+function stubOrchestrator(opts: {
+  recallBudgetChars?: number;
+  namespacesEnabled?: boolean;
+  namespacePolicies?: Array<{
+    name: string;
+    readPrincipals: string[];
+    writePrincipals: string[];
+  }>;
+  snapshot?: RecallXraySnapshot | null;
+  onRecall?: (
+    prompt: string,
+    sessionKey: string | undefined,
+    options: Record<string, unknown>,
+  ) => void;
+}) {
+  const state = {
+    clearedSnapshot: 0,
+    lastOptions: undefined as Record<string, unknown> | undefined,
+    snapshot: opts.snapshot ?? null,
+  };
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: opts.namespacesEnabled ?? false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: opts.namespacePolicies ?? [],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallBudgetChars: opts.recallBudgetChars ?? 4096,
+    },
+    recall: async (
+      prompt: string,
+      sessionKey: string | undefined,
+      options: Record<string, unknown>,
+    ) => {
+      state.lastOptions = options;
+      opts.onRecall?.(prompt, sessionKey, options);
+      return "ctx";
+    },
+    clearLastXraySnapshot: () => {
+      state.clearedSnapshot += 1;
+      state.snapshot = null;
+    },
+    getLastXraySnapshot: () => state.snapshot,
+    setSnapshot: (snap: RecallXraySnapshot | null) => {
+      state.snapshot = snap;
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+  return { orchestrator, state };
+}
+
+test("recallXray rejects empty query with an explicit error", async () => {
+  const { orchestrator } = stubOrchestrator({});
+  const service = new EngramAccessService(orchestrator as any);
+  await assert.rejects(
+    () => service.recallXray({ query: "   " }),
+    /query is required and must be non-empty/,
+  );
+});
+
+test("recallXray returns snapshotFound=false when capture yields nothing", async () => {
+  const { orchestrator } = stubOrchestrator({ snapshot: null });
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({ query: "q" });
+  assert.equal(response.snapshotFound, false);
+  assert.equal(response.snapshot, undefined);
+});
+
+test("recallXray returns the captured snapshot when present", async () => {
+  const snap = fakeSnapshot();
+  const { orchestrator, state } = stubOrchestrator({ snapshot: snap });
+  // Stash the snapshot inside the stub so getLastXraySnapshot returns
+  // it AFTER the recall call is invoked.  Simulates the real capture
+  // path: recall() runs → orchestrator stores snapshot →
+  // getLastXraySnapshot() reads it.
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: any[]) => {
+    const result = await originalRecall.apply(orchestrator, args as any);
+    state.snapshot = snap;
+    return result;
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({ query: "q" });
+  assert.equal(response.snapshotFound, true);
+  assert.ok(response.snapshot);
+  assert.equal(response.snapshot?.snapshotId, "snap-1");
+});
+
+test("recallXray forwards xrayCapture:true to orchestrator.recall", async () => {
+  const { orchestrator, state } = stubOrchestrator({ snapshot: null });
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({ query: "q" });
+  assert.equal(state.lastOptions?.xrayCapture, true);
+});
+
+test("recallXray clears any prior snapshot before capturing", async () => {
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: fakeSnapshot({ snapshotId: "stale" }),
+  });
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({ query: "q" });
+  assert.equal(state.clearedSnapshot, 1);
+});
+
+test("recallXray threads budget override and restores config afterwards", async () => {
+  const { orchestrator } = stubOrchestrator({
+    recallBudgetChars: 1000,
+    snapshot: null,
+  });
+  let observedBudgetDuringRecall = 0;
+  orchestrator.recall = async () => {
+    observedBudgetDuringRecall = orchestrator.config.recallBudgetChars;
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({ query: "q", budget: 2048 });
+  assert.equal(observedBudgetDuringRecall, 2048);
+  assert.equal(orchestrator.config.recallBudgetChars, 1000);
+});
+
+test("recallXray restores the budget even when recall throws", async () => {
+  const { orchestrator } = stubOrchestrator({ recallBudgetChars: 1000 });
+  orchestrator.recall = async () => {
+    throw new Error("boom");
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  await assert.rejects(
+    () => service.recallXray({ query: "q", budget: 2048 }),
+    /boom/,
+  );
+  assert.equal(orchestrator.config.recallBudgetChars, 1000);
+});
+
+test("recallXray rejects non-positive, fractional, and non-numeric budgets", async () => {
+  const { orchestrator } = stubOrchestrator({});
+  const service = new EngramAccessService(orchestrator as any);
+  for (const bad of [0, -1, 1.5, Number.NaN, "not-a-number" as unknown as number]) {
+    await assert.rejects(
+      () => service.recallXray({ query: "q", budget: bad as number }),
+      /budget expects a positive integer/,
+    );
+  }
+});
+
+test("recallXray enforces namespace read permissions", async () => {
+  const { orchestrator, state } = stubOrchestrator({
+    namespacesEnabled: true,
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["team-a"],
+        writePrincipals: ["team-a"],
+      },
+    ],
+    snapshot: fakeSnapshot(),
+  });
+  // Populate snapshot on capture for the authorized case.
+  orchestrator.recall = async () => {
+    state.snapshot = fakeSnapshot({ namespace: "team-a" });
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+
+  // Unauthorized principal is rejected *before* recall fires.
+  state.lastOptions = undefined;
+  const deniedResp = await service.recallXray({
+    query: "q",
+    namespace: "team-a",
+    authenticatedPrincipal: "intruder",
+  });
+  assert.equal(deniedResp.snapshotFound, false);
+  assert.equal(state.lastOptions, undefined, "recall must NOT run for unauthorized namespace");
+
+  // Authorized principal gets the captured snapshot.
+  const allowedResp = await service.recallXray({
+    query: "q",
+    namespace: "team-a",
+    authenticatedPrincipal: "team-a",
+  });
+  assert.equal(allowedResp.snapshotFound, true);
+  assert.equal(allowedResp.snapshot?.namespace, "team-a");
+});
+
+test("recallXray drops the snapshot when the captured namespace differs from the requested one", async () => {
+  // Even if the orchestrator ran a recall that served from a different
+  // namespace, the service must not leak that snapshot when a specific
+  // namespace was requested.
+  const { orchestrator, state } = stubOrchestrator({
+    namespacesEnabled: true,
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["team-a"],
+        writePrincipals: ["team-a"],
+      },
+    ],
+  });
+  orchestrator.recall = async () => {
+    state.snapshot = fakeSnapshot({ namespace: "team-b" });
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({
+    query: "q",
+    namespace: "team-a",
+    authenticatedPrincipal: "team-a",
+  });
+  assert.equal(response.snapshotFound, false);
+});
+
+test("recallXray requires an identity when namespaces are enabled and no namespace is requested", async () => {
+  const { orchestrator, state } = stubOrchestrator({
+    namespacesEnabled: true,
+    namespacePolicies: [],
+  });
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({ query: "q" });
+  assert.equal(response.snapshotFound, false);
+  assert.equal(state.lastOptions, undefined, "no recall must fire without an identity");
+});

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -261,3 +261,89 @@ test("recallXray requires an identity when namespaces are enabled and no namespa
   assert.equal(response.snapshotFound, false);
   assert.equal(state.lastOptions, undefined, "no recall must fire without an identity");
 });
+
+test("recallXray threads authenticatedPrincipal as sessionKey when no sessionKey given", async () => {
+  const capturedSessionKeys: Array<string | undefined> = [];
+  const { orchestrator } = stubOrchestrator({
+    namespacesEnabled: true,
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["team-a"],
+        writePrincipals: ["team-a"],
+      },
+    ],
+  });
+  orchestrator.recall = async (_prompt: string, sessionKey: string | undefined) => {
+    capturedSessionKeys.push(sessionKey);
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  await service.recallXray({
+    query: "q",
+    namespace: "team-a",
+    authenticatedPrincipal: "team-a",
+  });
+  // Orchestrator must see the authenticated principal so its internal
+  // `resolvePrincipal(sessionKey)` evaluates ACLs against the same
+  // principal that the pre-check authorized.
+  assert.equal(capturedSessionKeys[0], "team-a");
+});
+
+test("recallXray drops a snapshot whose namespace is undefined when a namespace was requested", async () => {
+  const { orchestrator, state } = stubOrchestrator({
+    namespacesEnabled: true,
+    namespacePolicies: [
+      {
+        name: "team-a",
+        readPrincipals: ["team-a"],
+        writePrincipals: ["team-a"],
+      },
+    ],
+  });
+  orchestrator.recall = async () => {
+    state.snapshot = fakeSnapshot(); // no namespace set
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  const response = await service.recallXray({
+    query: "q",
+    namespace: "team-a",
+    authenticatedPrincipal: "team-a",
+  });
+  assert.equal(response.snapshotFound, false);
+});
+
+test("recallXray serializes concurrent budget overrides so the config is never left in a stale state", async () => {
+  const { orchestrator } = stubOrchestrator({ recallBudgetChars: 1000 });
+  const observed: number[] = [];
+  let resolveFirst: () => void = () => {};
+  const firstRunning = new Promise<void>((resolve) => {
+    resolveFirst = resolve;
+  });
+  let firstCall = true;
+  orchestrator.recall = async () => {
+    observed.push(orchestrator.config.recallBudgetChars);
+    if (firstCall) {
+      firstCall = false;
+      // Block the first recall until the second invocation has been
+      // queued.  If the second invocation raced and mutated the
+      // config, the first would observe the wrong "original" on
+      // restore.
+      await firstRunning;
+    }
+    return "ctx";
+  };
+  const service = new EngramAccessService(orchestrator as any);
+  const firstCallPromise = service.recallXray({ query: "a", budget: 2048 });
+  // Queue the second call while the first is mid-flight.
+  const secondCallPromise = service.recallXray({ query: "b", budget: 4096 });
+  resolveFirst();
+  await firstCallPromise;
+  await secondCallPromise;
+  // Both calls must observe THEIR budget, not whichever got
+  // clobbered by the interleaving.
+  assert.deepEqual(observed, [2048, 4096]);
+  // And the config must be fully restored afterwards.
+  assert.equal(orchestrator.config.recallBudgetChars, 1000);
+});

--- a/tests/access-service-recall-xray.test.ts
+++ b/tests/access-service-recall-xray.test.ts
@@ -145,23 +145,35 @@ test("recallXray clears any prior snapshot before capturing", async () => {
   assert.equal(state.clearedSnapshot, 1);
 });
 
-test("recallXray threads budget override and restores config afterwards", async () => {
-  const { orchestrator } = stubOrchestrator({
+test("recallXray threads budget via RecallInvocationOptions, never mutates shared config", async () => {
+  const { orchestrator, state } = stubOrchestrator({
     recallBudgetChars: 1000,
     snapshot: null,
   });
-  let observedBudgetDuringRecall = 0;
-  orchestrator.recall = async () => {
-    observedBudgetDuringRecall = orchestrator.config.recallBudgetChars;
+  const observedConfigDuringRecall: number[] = [];
+  const observedOptions: Array<Record<string, unknown>> = [];
+  orchestrator.recall = async (
+    _prompt: string,
+    _sessionKey: string | undefined,
+    options: Record<string, unknown>,
+  ) => {
+    observedConfigDuringRecall.push(orchestrator.config.recallBudgetChars);
+    observedOptions.push(options);
+    state.lastOptions = options;
     return "ctx";
   };
   const service = new EngramAccessService(orchestrator as any);
   await service.recallXray({ query: "q", budget: 2048 });
-  assert.equal(observedBudgetDuringRecall, 2048);
+  // Codex P1 on #601: the shared config must NOT be mutated — both
+  // the observed value during the recall and the value after are the
+  // original config.  The override flows through the options bag only.
+  assert.deepEqual(observedConfigDuringRecall, [1000]);
   assert.equal(orchestrator.config.recallBudgetChars, 1000);
+  // Budget override is forwarded via RecallInvocationOptions.
+  assert.equal(observedOptions[0]?.budgetCharsOverride, 2048);
 });
 
-test("recallXray restores the budget even when recall throws", async () => {
+test("recallXray does not mutate shared config even when recall throws", async () => {
   const { orchestrator } = stubOrchestrator({ recallBudgetChars: 1000 });
   orchestrator.recall = async () => {
     throw new Error("boom");
@@ -262,8 +274,18 @@ test("recallXray requires an identity when namespaces are enabled and no namespa
   assert.equal(state.lastOptions, undefined, "no recall must fire without an identity");
 });
 
-test("recallXray threads authenticatedPrincipal as sessionKey when no sessionKey given", async () => {
+test("recallXray forwards authenticatedPrincipal via principalOverride, NOT as sessionKey", async () => {
+  // Codex P1 on #601: threading `authenticatedPrincipal` through
+  // `sessionKey` was wrong.  The orchestrator's
+  // `resolvePrincipal(sessionKey)` only maps configured raw session
+  // keys (via prefix/map/regex rules) and otherwise collapses to
+  // `"default"`.  In namespace-enabled deployments that produces
+  // false denials or wrong-scope serving for
+  // `recallXray` calls that omit `sessionKey`.  Pass the principal
+  // through `principalOverride` so the orchestrator evaluates ACLs
+  // against the SAME principal the access surface authorized.
   const capturedSessionKeys: Array<string | undefined> = [];
+  const capturedOptions: Array<Record<string, unknown>> = [];
   const { orchestrator } = stubOrchestrator({
     namespacesEnabled: true,
     namespacePolicies: [
@@ -274,8 +296,13 @@ test("recallXray threads authenticatedPrincipal as sessionKey when no sessionKey
       },
     ],
   });
-  orchestrator.recall = async (_prompt: string, sessionKey: string | undefined) => {
+  orchestrator.recall = async (
+    _prompt: string,
+    sessionKey: string | undefined,
+    options: Record<string, unknown>,
+  ) => {
     capturedSessionKeys.push(sessionKey);
+    capturedOptions.push(options);
     return "ctx";
   };
   const service = new EngramAccessService(orchestrator as any);
@@ -284,10 +311,10 @@ test("recallXray threads authenticatedPrincipal as sessionKey when no sessionKey
     namespace: "team-a",
     authenticatedPrincipal: "team-a",
   });
-  // Orchestrator must see the authenticated principal so its internal
-  // `resolvePrincipal(sessionKey)` evaluates ACLs against the same
-  // principal that the pre-check authorized.
-  assert.equal(capturedSessionKeys[0], "team-a");
+  // sessionKey must NOT be polluted with the principal.
+  assert.equal(capturedSessionKeys[0], undefined);
+  // principalOverride carries the identity to the orchestrator.
+  assert.equal(capturedOptions[0]?.principalOverride, "team-a");
 });
 
 test("recallXray drops a snapshot whose namespace is undefined when a namespace was requested", async () => {
@@ -314,36 +341,41 @@ test("recallXray drops a snapshot whose namespace is undefined when a namespace 
   assert.equal(response.snapshotFound, false);
 });
 
-test("recallXray serializes concurrent budget overrides so the config is never left in a stale state", async () => {
+test("concurrent recallXray calls each carry their own budget via options, never mutate shared config", async () => {
   const { orchestrator } = stubOrchestrator({ recallBudgetChars: 1000 });
-  const observed: number[] = [];
+  const observedBudgets: Array<number | undefined> = [];
+  const observedConfigs: number[] = [];
   let resolveFirst: () => void = () => {};
   const firstRunning = new Promise<void>((resolve) => {
     resolveFirst = resolve;
   });
   let firstCall = true;
-  orchestrator.recall = async () => {
-    observed.push(orchestrator.config.recallBudgetChars);
+  orchestrator.recall = async (
+    _prompt: string,
+    _sessionKey: string | undefined,
+    options: Record<string, unknown>,
+  ) => {
+    // Each invocation carries its own per-call budget override and
+    // sees the untouched shared config.  This is the core property
+    // the Codex P1 review required.
+    observedBudgets.push(options.budgetCharsOverride as number | undefined);
+    observedConfigs.push(orchestrator.config.recallBudgetChars);
     if (firstCall) {
       firstCall = false;
-      // Block the first recall until the second invocation has been
-      // queued.  If the second invocation raced and mutated the
-      // config, the first would observe the wrong "original" on
-      // restore.
       await firstRunning;
     }
     return "ctx";
   };
   const service = new EngramAccessService(orchestrator as any);
   const firstCallPromise = service.recallXray({ query: "a", budget: 2048 });
-  // Queue the second call while the first is mid-flight.
   const secondCallPromise = service.recallXray({ query: "b", budget: 4096 });
   resolveFirst();
   await firstCallPromise;
   await secondCallPromise;
-  // Both calls must observe THEIR budget, not whichever got
-  // clobbered by the interleaving.
-  assert.deepEqual(observed, [2048, 4096]);
-  // And the config must be fully restored afterwards.
+  // Per-call override is observed correctly for each caller.
+  assert.deepEqual(observedBudgets, [2048, 4096]);
+  // The shared config is never mutated — both recalls observe the
+  // same untouched 1000 value in `orchestrator.config.recallBudgetChars`.
+  assert.deepEqual(observedConfigs, [1000, 1000]);
   assert.equal(orchestrator.config.recallBudgetChars, 1000);
 });


### PR DESCRIPTION
## Summary

Slice 4 of the unified Recall X-ray observability surface (#570). Adds the HTTP surface and the shared `EngramAccessService.recallXray` method that CLI / HTTP / MCP will all call into so the three surfaces return identical JSON (CLAUDE.md rule 22).

- `packages/remnic-core/src/access-service.ts` — new `recallXray({query, sessionKey?, namespace?, budget?, authenticatedPrincipal?})` method.
  - Resolves namespace scope through the same `canReadNamespace` path as `recallTierExplain` (CLAUDE.md rule 42) so an unauthorized principal cannot capture an x-ray for a namespace it cannot read.
  - Drops the captured snapshot when the served namespace differs from the requested one so cross-tenant data cannot leak (CLAUDE.md rules 42 + 47).
  - Requires an identity when namespaces are enabled and no namespace is explicitly requested (least-privileged default — rule 48).
  - Rejects empty query and invalid `budget` (not a positive integer) with explicit errors (CLAUDE.md rules 14 + 51).
  - Swaps `orchestrator.config.recallBudgetChars` in a try/finally so a thrown recall cannot leave the config mutated.
  - Always calls `clearLastXraySnapshot()` first so capture failures surface as `{snapshotFound: false}` rather than returning stale data.

- `packages/remnic-core/src/access-http.ts` — new `GET /engram/v1/recall/xray` route.
  - Query params: `q` (required), `session`, `namespace`, `budget`.
  - Sits behind the existing bearer-auth middleware.
  - Invalid `budget` returns 400 with an explicit message; empty `q` returns 400; service-level validation errors surface as 400 `invalid_request`.

## No behavior change

No changes to existing `/recall`, `/recall/explain`, or `/recall/tier-explain` endpoints. The new route is purely additive.

## Test plan

- [x] 11 integration tests in `tests/access-service-recall-xray.test.ts` using lightweight orchestrator stubs — empty-query rejection, absent snapshot → `snapshotFound: false`, present snapshot round-trips, `xrayCapture: true` is forwarded, prior snapshot is cleared before capture, budget override is restored even when recall throws, invalid budgets rejected, namespace read permissions enforced before recall fires, cross-namespace capture drops the snapshot, identity required when namespaces are enabled without a requested namespace.
- [x] `tsc --noEmit` clean for the core package.

## Stacking

Based on `main`. Independent of PRs #597 and #599 — HTTP returns the `RecallXraySnapshot` as-is, it does not invoke the renderer.

Part of #570 (slice 4 of 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches recall invocation and namespace/ACL enforcement paths, including new principal and budget overrides; mistakes could leak cross-namespace data or change recall budgeting behavior. Changes are additive but affect core recall plumbing used by multiple access surfaces.
> 
> **Overview**
> Adds a new bearer-authenticated `GET /engram/v1/recall/xray` route that returns a structured Recall X-ray snapshot, with explicit 400s for missing `q` and invalid `budget`.
> 
> Introduces `EngramAccessService.recallXray()` to run recalls with `xrayCapture: true`, validate inputs, enforce namespace read access *before* recall, and drop snapshots if the captured namespace doesn’t exactly match the requested one; includes a per-service mutex to prevent snapshot-slot races.
> 
> Extends `RecallInvocationOptions` with per-call `budgetCharsOverride` and `principalOverride`, and threads these through orchestrator budgeting and principal resolution so x-ray calls avoid mutating shared config; adds integration tests covering validation, ACL behavior, override forwarding, and concurrency safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 183896ef1e748db7ac520487552d4ac57a5b2b6f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->