### PR TITLE
feat(import-mem0): mem0.ai REST API importer (#568 PR 5/7)

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -358,6 +358,7 @@ jobs:
             packages/bench
             packages/export-weclone
             packages/import-weclone
+            packages/import-mem0
             packages/connector-weclone
             packages/connector-replit
             packages/hermes-provider

--- a/packages/import-mem0/README.md
+++ b/packages/import-mem0/README.md
@@ -1,0 +1,35 @@
+# @remnic/import-mem0
+
+Optional importer for memories stored in a mem0.ai account. Ships as a
+separately installable companion to the Remnic CLI.
+
+```bash
+npm install -g @remnic/import-mem0
+export MEM0_API_KEY=...
+remnic import --adapter mem0 --rate-limit 2
+```
+
+## How it imports
+
+- Walks the paginated REST endpoint `/v1/memories/` (follows `next` cursors)
+- Default base URL `https://api.mem0.ai`; override via `MEM0_BASE_URL` for
+  self-hosted instances
+- `--rate-limit <rps>` throttles page-to-page requests
+- One memory per mem0 record; blank / soft-deleted records are skipped
+
+## Offline replay
+
+You can also provide a pre-fetched JSON dump via `--file`:
+
+```bash
+remnic import --adapter mem0 --file ./mem0-export.json
+```
+
+The parser accepts both the flat `{ results: [...] }` shape and a multi-page
+recording `{ pages: [...] }` used by the package's record/replay fixtures.
+
+## À-la-carte contract
+
+This package is declared as an **optional peer dependency** of
+`@remnic/cli`. Installing the CLI without this package produces a
+friendly install hint — never `MODULE_NOT_FOUND`.

--- a/packages/import-mem0/fixtures/replay-dump.json
+++ b/packages/import-mem0/fixtures/replay-dump.json
@@ -1,0 +1,29 @@
+{
+  "description": "Synthetic offline replay dump — flat results array as if all pages were concatenated.",
+  "results": [
+    {
+      "id": "mem-syn-0001",
+      "memory": "Fictional: prefers async tests to use node:test runner.",
+      "user_id": "synthetic-user-1",
+      "created_at": "2026-02-14T09:00:00.000Z",
+      "updated_at": "2026-02-14T09:05:00.000Z",
+      "categories": ["preferences", "tooling"]
+    },
+    {
+      "id": "mem-syn-0002",
+      "memory": "Fictional: keeps a weekly retro template in a Git-tracked file.",
+      "user_id": "synthetic-user-1",
+      "created_at": "2026-02-14T10:00:00.000Z"
+    },
+    {
+      "id": "mem-syn-0003",
+      "content": "Fictional (content-field variant): uses TypeScript strict mode on all personal projects.",
+      "user_id": "synthetic-user-1",
+      "created_at": "2026-02-15T08:00:00.000Z"
+    },
+    {
+      "id": "mem-syn-0004-empty",
+      "memory": "   "
+    }
+  ]
+}

--- a/packages/import-mem0/fixtures/two-page-recording.json
+++ b/packages/import-mem0/fixtures/two-page-recording.json
@@ -1,0 +1,43 @@
+{
+  "description": "Synthetic record/replay fixture for a two-page mem0 pagination walk. No real account data.",
+  "pages": [
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.mem0.test/v1/memories/"
+      },
+      "results": [
+        {
+          "id": "mem-syn-0001",
+          "memory": "Fictional: prefers async tests to use node:test runner.",
+          "user_id": "synthetic-user-1",
+          "created_at": "2026-02-14T09:00:00.000Z",
+          "categories": ["preferences", "tooling"],
+          "metadata": { "source": "synthetic-fixture" }
+        },
+        {
+          "id": "mem-syn-0002",
+          "memory": "Fictional: keeps a weekly retro template in a Git-tracked file.",
+          "user_id": "synthetic-user-1",
+          "created_at": "2026-02-14T10:00:00.000Z"
+        }
+      ],
+      "next": "https://api.mem0.test/v1/memories/?page=2"
+    },
+    {
+      "request": {
+        "method": "GET",
+        "url": "https://api.mem0.test/v1/memories/?page=2"
+      },
+      "results": [
+        {
+          "id": "mem-syn-0003",
+          "memory": "Fictional: uses TypeScript strict mode on all personal projects.",
+          "user_id": "synthetic-user-1",
+          "created_at": "2026-02-15T08:00:00.000Z"
+        }
+      ],
+      "next": null
+    }
+  ]
+}

--- a/packages/import-mem0/package.json
+++ b/packages/import-mem0/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@remnic/import-mem0",
+  "version": "0.1.0",
+  "description": "Import memories from the mem0.ai REST API into Remnic (issue #568)",
+  "type": "module",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": ["dist"],
+  "scripts": {
+    "build": "tsup src/index.ts --format esm --dts",
+    "check-types": "tsc --noEmit",
+    "test": "tsx --test src/adapter.test.ts src/parser.test.ts src/transform.test.ts src/client.test.ts",
+    "prepublishOnly": "npm run build"
+  },
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "peerDependencies": {
+    "@remnic/core": "workspace:^"
+  },
+  "devDependencies": {
+    "@remnic/core": "workspace:*",
+    "tsup": "^8.0.0",
+    "tsx": "^4.0.0",
+    "typescript": "^5.7.0"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/joshuaswarren/remnic.git",
+    "directory": "packages/import-mem0"
+  },
+  "keywords": ["remnic", "memory", "mem0", "import"]
+}

--- a/packages/import-mem0/src/adapter.test.ts
+++ b/packages/import-mem0/src/adapter.test.ts
@@ -121,4 +121,44 @@ describe("mem0 adapter shape", () => {
     assert.equal(result.dryRun, true);
     assert.equal(received.length, 0);
   });
+
+  // Cursor review on PR #602 — `--rate-limit` must reach fetchAllMem0Memories,
+  // not be silently dropped after parse validation.
+  it("forwards --rate-limit through runImporter to the fetch client", async () => {
+    const raw = JSON.parse(loadFixture("two-page-recording.json")) as {
+      pages: Array<{
+        request: { url: string };
+        results?: unknown[];
+        next?: string | null;
+      }>;
+    };
+    const byUrl = new Map(raw.pages.map((p) => [p.request.url, p]));
+    const replayFetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = byUrl.get(url);
+      if (!match) return new Response("not found", { status: 404 });
+      return new Response(
+        JSON.stringify({ results: match.results ?? [], next: match.next ?? null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const sleeps: number[] = [];
+    setMem0ClientOptionsForTesting({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl: replayFetch,
+      sleep: async (ms: number) => {
+        sleeps.push(ms);
+      },
+    });
+
+    const { target } = makeTarget();
+    await runImporter(adapter, undefined, target, { rateLimit: 2 });
+    // With rateLimit=2 (500ms interval) across a 2-page walk → exactly
+    // one sleep between page 1 and page 2. If the CLI flag were dropped
+    // (the bug), no sleeps would occur.
+    assert.equal(sleeps.length, 1);
+    assert.equal(sleeps[0], 500);
+  });
 });

--- a/packages/import-mem0/src/adapter.test.ts
+++ b/packages/import-mem0/src/adapter.test.ts
@@ -1,0 +1,124 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import type { ImportTurn, ImporterWriteTarget } from "@remnic/core";
+import { runImporter } from "@remnic/core";
+
+import { adapter, mem0Adapter, setMem0ClientOptionsForTesting } from "./adapter.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+function makeTarget(): {
+  target: ImporterWriteTarget;
+  received: ImportTurn[][];
+} {
+  const received: ImportTurn[][] = [];
+  return {
+    target: {
+      async ingestBulkImportBatch(turns) {
+        received.push(turns.map((t) => ({ ...t })));
+      },
+      bulkImportWriteNamespace() {
+        return "default";
+      },
+    },
+    received,
+  };
+}
+
+describe("mem0 adapter shape", () => {
+  afterEach(() => {
+    setMem0ClientOptionsForTesting(undefined);
+    delete process.env.MEM0_API_KEY;
+  });
+
+  it("exports a canonical adapter + alias", () => {
+    assert.equal(adapter.name, "mem0");
+    assert.equal(adapter.sourceLabel, "mem0");
+    assert.equal(mem0Adapter, adapter);
+  });
+
+  it("drives runImporter end-to-end with a replay fixture (no network)", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("replay-dump.json"),
+      target,
+      { parseOptions: { filePath: "/tmp/mem0-replay.json" } },
+    );
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 3);
+    assert.equal(result.sourceLabel, "mem0");
+    const allTurns = received.flat();
+    for (const turn of allTurns) {
+      assert.equal(turn.role, "user");
+      assert.equal(turn.participantName, "mem0");
+    }
+  });
+
+  it("drives runImporter via the paginated record/replay fetch", async () => {
+    // Two-page recording → inject a replay fetch, simulate live-API mode.
+    const raw = JSON.parse(loadFixture("two-page-recording.json")) as {
+      pages: Array<{
+        request: { url: string };
+        results?: unknown[];
+        next?: string | null;
+      }>;
+    };
+    const byUrl = new Map(raw.pages.map((p) => [p.request.url, p]));
+    const replayFetch = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      const match = byUrl.get(url);
+      if (!match) return new Response("not found", { status: 404 });
+      return new Response(
+        JSON.stringify({ results: match.results ?? [], next: match.next ?? null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    setMem0ClientOptionsForTesting({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl: replayFetch,
+    });
+
+    const { target, received } = makeTarget();
+    // Live-API path: pass input=undefined.
+    const result = await runImporter(adapter, undefined, target);
+    assert.equal(result.memoriesPlanned, 3);
+    assert.equal(result.memoriesWritten, 3);
+    const allTurns = received.flat();
+    assert.equal(allTurns.length, 3);
+  });
+
+  it("throws a user-facing error when no apiKey is available", async () => {
+    delete process.env.MEM0_API_KEY;
+    const { target } = makeTarget();
+    await assert.rejects(
+      () => runImporter(adapter, undefined, target),
+      /API key/,
+    );
+  });
+
+  it("dry-run does not hit the target", async () => {
+    const { target, received } = makeTarget();
+    const result = await runImporter(
+      adapter,
+      loadFixture("replay-dump.json"),
+      target,
+      { dryRun: true },
+    );
+    assert.equal(result.dryRun, true);
+    assert.equal(received.length, 0);
+  });
+});

--- a/packages/import-mem0/src/adapter.ts
+++ b/packages/import-mem0/src/adapter.ts
@@ -77,6 +77,11 @@ export const adapter: ImporterAdapter<ParsedMem0Export> = {
     }
     const baseUrl =
       overrideClientOptionsForTesting?.baseUrl ?? process.env.MEM0_BASE_URL;
+    // Self-hosted mem0-oss exposes `/memories/` without the `/v1` prefix.
+    // Let operators override via MEM0_LIST_PATH so those deployments work
+    // without patching. Codex review on PR #602.
+    const listPath =
+      overrideClientOptionsForTesting?.listPath ?? process.env.MEM0_LIST_PATH;
     const importedFromPath = baseUrl ?? "https://api.mem0.ai";
     // Forward the validated CLI `--rate-limit` (now carried through
     // ImporterParseOptions.rateLimit by runImporter) into the fetch client
@@ -87,6 +92,7 @@ export const adapter: ImporterAdapter<ParsedMem0Export> = {
     const memories = await fetchAllMem0Memories({
       apiKey,
       ...(baseUrl !== undefined ? { baseUrl } : {}),
+      ...(listPath !== undefined ? { listPath } : {}),
       ...(rateLimit !== undefined ? { rateLimit } : {}),
       ...(overrideClientOptionsForTesting?.fetchImpl
         ? { fetchImpl: overrideClientOptionsForTesting.fetchImpl }

--- a/packages/import-mem0/src/adapter.ts
+++ b/packages/import-mem0/src/adapter.ts
@@ -78,9 +78,16 @@ export const adapter: ImporterAdapter<ParsedMem0Export> = {
     const baseUrl =
       overrideClientOptionsForTesting?.baseUrl ?? process.env.MEM0_BASE_URL;
     const importedFromPath = baseUrl ?? "https://api.mem0.ai";
+    // Forward the validated CLI `--rate-limit` (now carried through
+    // ImporterParseOptions.rateLimit by runImporter) into the fetch client
+    // so `remnic import --adapter mem0 --rate-limit 2` actually throttles.
+    // Cursor review on PR #602 — the original wiring silently ignored it.
+    const rateLimit =
+      typeof options?.rateLimit === "number" ? options.rateLimit : undefined;
     const memories = await fetchAllMem0Memories({
       apiKey,
       ...(baseUrl !== undefined ? { baseUrl } : {}),
+      ...(rateLimit !== undefined ? { rateLimit } : {}),
       ...(overrideClientOptionsForTesting?.fetchImpl
         ? { fetchImpl: overrideClientOptionsForTesting.fetchImpl }
         : {}),

--- a/packages/import-mem0/src/adapter.ts
+++ b/packages/import-mem0/src/adapter.ts
@@ -1,0 +1,115 @@
+// ---------------------------------------------------------------------------
+// mem0 importer adapter (issue #568 slice 5)
+// ---------------------------------------------------------------------------
+//
+// The mem0 adapter is API-driven rather than file-driven. Two call patterns
+// are supported:
+//
+//   1. CLI: `remnic import --adapter mem0 --rate-limit 2`
+//      - No `--file`, so the CLI passes `undefined` as the input.
+//      - The adapter reads `MEM0_API_KEY` + optional `MEM0_BASE_URL` from env
+//        and walks the paginated API using `fetchAllMem0Memories`.
+//
+//   2. Record/replay tests: callers pass a JSON string (replay fixture) OR
+//      a pre-fetched `Mem0Memory[]` directly via parse. In this mode no
+//      network I/O happens.
+//
+// Adapters are pure by contract (parse MUST NOT call the orchestrator), so
+// the API fetch lives in `parse`. This mirrors the file-reading importers
+// where parse does the I/O of decoding JSON — here it's HTTP instead.
+
+import type {
+  ImportedMemory,
+  ImporterAdapter,
+  ImporterParseOptions,
+  ImporterTransformOptions,
+  ImporterWriteResult,
+  ImporterWriteTarget,
+  RunImportOptions,
+} from "@remnic/core";
+import { defaultWriteMemoriesToOrchestrator } from "@remnic/core";
+
+import { fetchAllMem0Memories, type Mem0ClientOptions } from "./client.js";
+import { parseMem0Export, type ParsedMem0Export } from "./parser.js";
+import { MEM0_SOURCE_LABEL, transformMem0Export } from "./transform.js";
+
+/**
+ * Test-only backdoor used by `adapter.test.ts` to inject a fake fetch without
+ * exposing the ImporterAdapter surface to client-options plumbing at runtime.
+ * Cleared after each test.
+ */
+let overrideClientOptionsForTesting:
+  | Partial<Mem0ClientOptions>
+  | undefined;
+
+/** Visible for tests. */
+export function setMem0ClientOptionsForTesting(
+  options: Partial<Mem0ClientOptions> | undefined,
+): void {
+  overrideClientOptionsForTesting = options;
+}
+
+export const adapter: ImporterAdapter<ParsedMem0Export> = {
+  name: "mem0",
+  sourceLabel: MEM0_SOURCE_LABEL,
+
+  async parse(
+    input: unknown,
+    options?: ImporterParseOptions,
+  ): Promise<ParsedMem0Export> {
+    // Replay / in-memory path: caller supplied JSON or an array already.
+    if (input !== undefined && input !== null) {
+      return parseMem0Export(input, {
+        ...(options?.strict !== undefined ? { strict: options.strict } : {}),
+        ...(options?.filePath !== undefined
+          ? { filePath: options.filePath }
+          : {}),
+      });
+    }
+
+    // Live path: pull from the API.
+    const apiKey = overrideClientOptionsForTesting?.apiKey ?? process.env.MEM0_API_KEY;
+    if (!apiKey) {
+      throw new Error(
+        "mem0 import requires an API key. Set MEM0_API_KEY in your environment " +
+          "or pass a replay fixture via --file <export.json>.",
+      );
+    }
+    const baseUrl =
+      overrideClientOptionsForTesting?.baseUrl ?? process.env.MEM0_BASE_URL;
+    const importedFromPath = baseUrl ?? "https://api.mem0.ai";
+    const memories = await fetchAllMem0Memories({
+      apiKey,
+      ...(baseUrl !== undefined ? { baseUrl } : {}),
+      ...(overrideClientOptionsForTesting?.fetchImpl
+        ? { fetchImpl: overrideClientOptionsForTesting.fetchImpl }
+        : {}),
+      ...(overrideClientOptionsForTesting?.sleep
+        ? { sleep: overrideClientOptionsForTesting.sleep }
+        : {}),
+    });
+    return { memories, importedFromPath };
+  },
+
+  transform(
+    parsed: ParsedMem0Export,
+    options?: ImporterTransformOptions,
+  ): ImportedMemory[] {
+    return transformMem0Export(parsed, {
+      ...(options?.maxMemories !== undefined
+        ? { maxMemories: options.maxMemories }
+        : {}),
+    });
+  },
+
+  async writeTo(
+    target: ImporterWriteTarget,
+    memories: ImportedMemory[],
+    _options: RunImportOptions,
+  ): Promise<ImporterWriteResult> {
+    return defaultWriteMemoriesToOrchestrator(target, memories);
+  },
+};
+
+/** Alias kept for symmetry with other @remnic/import-* packages. */
+export const mem0Adapter = adapter;

--- a/packages/import-mem0/src/client.test.ts
+++ b/packages/import-mem0/src/client.test.ts
@@ -186,4 +186,117 @@ describe("fetchAllMem0Memories (record/replay)", () => {
     });
     assert.equal(memories.length, 1);
   });
+
+  // Cursor review on PR #602 — explicit `next: null` must stop pagination
+  // even when numeric pagination fields are present. The original code
+  // fell through to the numeric-fallback path because it only checked for
+  // `typeof next === "string"`, conflating null with undefined.
+  it("treats explicit next:null as authoritative stop even with numeric fields", async () => {
+    let called = 0;
+    const fetchImpl = (async (): Promise<Response> => {
+      called += 1;
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "only", memory: "hello" }],
+          next: null,
+          // Numeric fields that would normally trigger the fallback:
+          page: 1,
+          per_page: 1,
+          total: 9999,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const memories = await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl,
+    });
+    // Exactly one request — we must NOT follow numeric pagination when
+    // next is explicitly null.
+    assert.equal(called, 1);
+    assert.equal(memories.length, 1);
+  });
+
+  // Codex review on PR #602 — cross-origin cursors must not be followed
+  // because the loop would forward the mem0 API key to that host.
+  it("rejects cross-origin pagination cursors without leaking the API key", async () => {
+    const seenRequests: string[] = [];
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      seenRequests.push(url);
+      if (seenRequests.length === 1) {
+        return new Response(
+          JSON.stringify({
+            results: [{ id: "p1", memory: "page 1" }],
+            next: "https://attacker.example/steal?token=1",
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      throw new Error("request after cross-origin cursor must not happen");
+    }) as typeof fetch;
+    await assert.rejects(
+      () =>
+        fetchAllMem0Memories({
+          apiKey: "synthetic-key",
+          baseUrl: "https://api.mem0.test",
+          fetchImpl,
+        }),
+      /cross-origin/,
+    );
+    assert.equal(seenRequests.length, 1, "must not fetch the cross-origin cursor");
+  });
+
+  it("follows relative pagination cursors by resolving them against the base URL", async () => {
+    let called = 0;
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      called += 1;
+      if (called === 1) {
+        return new Response(
+          JSON.stringify({
+            results: [{ id: "p1", memory: "first" }],
+            next: "/v1/memories/?cursor=xyz", // relative!
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      assert.ok(
+        url.startsWith("https://api.mem0.test/v1/memories/?cursor=xyz"),
+        `expected resolved URL, got: ${url}`,
+      );
+      return new Response(
+        JSON.stringify({ results: [{ id: "p2", memory: "second" }], next: null }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+    const memories = await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl,
+    });
+    assert.equal(memories.length, 2);
+  });
+
+  // Codex review on PR #602 — self-hosted mem0-oss exposes `/memories/`
+  // without the `/v1` prefix. Let operators override via listPath.
+  it("honors a custom listPath for self-hosted deployments", async () => {
+    let firstRequestUrl = "";
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      if (!firstRequestUrl) firstRequestUrl = url;
+      return new Response(JSON.stringify({ results: [], next: null }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      });
+    }) as typeof fetch;
+    await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://self-hosted.mem0.test",
+      listPath: "/memories/",
+      fetchImpl,
+    });
+    assert.equal(firstRequestUrl, "https://self-hosted.mem0.test/memories/");
+  });
 });

--- a/packages/import-mem0/src/client.test.ts
+++ b/packages/import-mem0/src/client.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { fetchAllMem0Memories } from "./client.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+interface RecordedPage {
+  request: { method: string; url: string };
+  results?: unknown[];
+  next?: string | null;
+}
+
+function loadRecording(name: string): RecordedPage[] {
+  const raw = JSON.parse(readFileSync(path.join(FIXTURE_DIR, name), "utf-8"));
+  return raw.pages as RecordedPage[];
+}
+
+function makeReplayFetch(pages: RecordedPage[]): typeof fetch {
+  const byUrl = new Map<string, RecordedPage>();
+  for (const p of pages) byUrl.set(p.request.url, p);
+  return (async (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    const url = typeof input === "string" ? input : input.toString();
+    const match = byUrl.get(url);
+    if (!match) {
+      return new Response(`no recording for ${url}`, { status: 404 });
+    }
+    return new Response(
+      JSON.stringify({ results: match.results ?? [], next: match.next ?? null }),
+      { status: 200, headers: { "content-type": "application/json" } },
+    );
+    // init parameter intentionally ignored in replay mode
+    void init;
+  }) as typeof fetch;
+}
+
+describe("fetchAllMem0Memories (record/replay)", () => {
+  it("walks paginated responses until next is null", async () => {
+    const pages = loadRecording("two-page-recording.json");
+    const memories = await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl: makeReplayFetch(pages),
+    });
+    assert.equal(memories.length, 3);
+    assert.equal(memories[0]?.id, "mem-syn-0001");
+    assert.equal(memories[2]?.id, "mem-syn-0003");
+  });
+
+  it("throws a helpful error when apiKey is missing", async () => {
+    await assert.rejects(
+      () =>
+        fetchAllMem0Memories({
+          apiKey: "",
+          fetchImpl: (async () => new Response("{}", { status: 200 })) as typeof fetch,
+        }),
+      /non-empty apiKey/,
+    );
+  });
+
+  it("propagates HTTP error responses", async () => {
+    const failingFetch = (async () =>
+      new Response("unauthorized", { status: 401 })) as typeof fetch;
+    await assert.rejects(
+      () =>
+        fetchAllMem0Memories({
+          apiKey: "bad-key",
+          baseUrl: "https://api.mem0.test",
+          fetchImpl: failingFetch,
+        }),
+      /failed with 401/,
+    );
+  });
+
+  it("honors rateLimit by sleeping between pages", async () => {
+    const pages = loadRecording("two-page-recording.json");
+    const sleeps: number[] = [];
+    await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl: makeReplayFetch(pages),
+      rateLimit: 2, // 500ms interval
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    // Two pages fetched → exactly one sleep between them.
+    assert.equal(sleeps.length, 1);
+    assert.equal(sleeps[0], 500);
+  });
+
+  it("does not sleep when rateLimit is unset", async () => {
+    const pages = loadRecording("two-page-recording.json");
+    const sleeps: number[] = [];
+    await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl: makeReplayFetch(pages),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+    assert.equal(sleeps.length, 0);
+  });
+
+  it("aborts when the signal fires", async () => {
+    const pages = loadRecording("two-page-recording.json");
+    const controller = new AbortController();
+    controller.abort();
+    await assert.rejects(
+      () =>
+        fetchAllMem0Memories({
+          apiKey: "synthetic-key",
+          baseUrl: "https://api.mem0.test",
+          fetchImpl: makeReplayFetch(pages),
+          signal: controller.signal,
+        }),
+      /aborted/,
+    );
+  });
+});

--- a/packages/import-mem0/src/client.test.ts
+++ b/packages/import-mem0/src/client.test.ts
@@ -124,4 +124,66 @@ describe("fetchAllMem0Memories (record/replay)", () => {
       /aborted/,
     );
   });
+
+  // Cursor review on PR #602 — pagination must keep walking when the
+  // server returns numeric page metadata without a `next` cursor.
+  it("falls back to page-number pagination when next cursor is absent", async () => {
+    let called = 0;
+    const fetchImpl = (async (input: RequestInfo | URL): Promise<Response> => {
+      const url = typeof input === "string" ? input : input.toString();
+      called += 1;
+      if (!url.includes("page=")) {
+        // Page 1: returns `page`+`total`+`per_page`, no `next`.
+        return new Response(
+          JSON.stringify({
+            results: [
+              { id: "p1-a", memory: "page 1 item a" },
+              { id: "p1-b", memory: "page 1 item b" },
+            ],
+            page: 1,
+            per_page: 2,
+            total: 3,
+          }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      // Page 2: reaches the end.
+      return new Response(
+        JSON.stringify({
+          results: [{ id: "p2-a", memory: "page 2 item" }],
+          page: 2,
+          per_page: 2,
+          total: 3,
+        }),
+        { status: 200, headers: { "content-type": "application/json" } },
+      );
+    }) as typeof fetch;
+
+    const memories = await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl,
+    });
+    assert.equal(called, 2);
+    assert.equal(memories.length, 3);
+    assert.deepEqual(
+      memories.map((m) => m.id),
+      ["p1-a", "p1-b", "p2-a"],
+    );
+  });
+
+  it("does not infinite-loop when page metadata is missing entirely", async () => {
+    // No `next`, no `total` → must stop after the first page.
+    const fetchImpl = (async (): Promise<Response> =>
+      new Response(JSON.stringify({ results: [{ id: "only", memory: "x" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })) as typeof fetch;
+    const memories = await fetchAllMem0Memories({
+      apiKey: "synthetic-key",
+      baseUrl: "https://api.mem0.test",
+      fetchImpl,
+    });
+    assert.equal(memories.length, 1);
+  });
 });

--- a/packages/import-mem0/src/client.ts
+++ b/packages/import-mem0/src/client.ts
@@ -1,0 +1,142 @@
+// ---------------------------------------------------------------------------
+// Mem0 REST client (issue #568 slice 5)
+// ---------------------------------------------------------------------------
+//
+// mem0.ai exposes a paginated memories list endpoint. A production user will
+// typically hit the hosted service at `https://api.mem0.ai/v1/memories/`,
+// supply a Bearer API key, and pull down their account's memories page by
+// page. Some users self-host and need a configurable base URL.
+//
+// This client is intentionally tiny:
+//   - fetch-based; no SDK dependency.
+//   - Injectable `fetch` impl so tests can replay a record/replay fixture.
+//   - Abort-signal aware for clean cancellation.
+//   - Rate-limit aware (sleeps between page requests when `rateLimit` is set
+//     on `RunImportOptions`).
+//
+// The adapter calls `fetchAllMem0Memories()` once; it walks pagination and
+// returns a flat array. The transform layer then maps each raw record to an
+// `ImportedMemory`.
+
+export interface Mem0Memory {
+  /** Stable memory id. */
+  id: string;
+  /** Memory body. API older responses nest this in `memory`. */
+  memory?: string;
+  content?: string;
+  text?: string;
+  user_id?: string;
+  agent_id?: string;
+  created_at?: string;
+  updated_at?: string;
+  metadata?: Record<string, unknown>;
+  categories?: string[];
+  score?: number;
+}
+
+/**
+ * Shape returned by the paginated memories endpoint. The real API uses
+ * `results` + `next` (cursor URL) on v1 and `memories` + `page` + `total`
+ * on v0; the client accepts either so tests can replay both.
+ */
+export interface Mem0ListResponse {
+  results?: Mem0Memory[];
+  memories?: Mem0Memory[];
+  next?: string | null;
+  total?: number;
+  page?: number;
+  per_page?: number;
+}
+
+export interface Mem0ClientOptions {
+  apiKey: string;
+  /** Default: `https://api.mem0.ai`. Trailing slash tolerated. */
+  baseUrl?: string;
+  /** Injected for tests. Falls back to `globalThis.fetch`. */
+  fetchImpl?: typeof fetch;
+  /** Requests per second limiter. Applied between pages. */
+  rateLimit?: number;
+  /** Abort signal wired through to fetch. */
+  signal?: AbortSignal;
+  /** Sleep function for rate limiting; injectable so tests run instantly. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_BASE_URL = "https://api.mem0.ai";
+
+/**
+ * Fetch all mem0 memories across pagination. Returns a flat array; the
+ * caller is responsible for deduplication (the orchestrator does this
+ * naturally via content hashing).
+ */
+export async function fetchAllMem0Memories(
+  options: Mem0ClientOptions,
+): Promise<Mem0Memory[]> {
+  if (!options.apiKey || typeof options.apiKey !== "string") {
+    throw new Error("mem0 import requires a non-empty apiKey");
+  }
+  const fetchImpl = options.fetchImpl ?? globalThis.fetch;
+  if (typeof fetchImpl !== "function") {
+    throw new Error(
+      "No fetch implementation available. Provide `fetchImpl` or run on Node 18+.",
+    );
+  }
+  const sleep = options.sleep ?? defaultSleep;
+  const base = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const intervalMs =
+    options.rateLimit && options.rateLimit > 0 ? 1000 / options.rateLimit : 0;
+
+  const all: Mem0Memory[] = [];
+  let nextUrl: string | null = `${base}/v1/memories/`;
+  let pageIndex = 0;
+  while (nextUrl) {
+    throwIfAborted(options.signal);
+    if (pageIndex > 0 && intervalMs > 0) {
+      await sleep(intervalMs);
+    }
+    const response = await fetchImpl(nextUrl, {
+      method: "GET",
+      headers: {
+        Authorization: `Token ${options.apiKey}`,
+        Accept: "application/json",
+      },
+      ...(options.signal ? { signal: options.signal } : {}),
+    });
+    if (!response.ok) {
+      const body = await safeText(response);
+      throw new Error(
+        `mem0 API request to ${nextUrl} failed with ${response.status}: ${body}`,
+      );
+    }
+    const json = (await response.json()) as Mem0ListResponse;
+    const page = json.results ?? json.memories ?? [];
+    for (const entry of page) {
+      if (entry && typeof entry === "object" && typeof entry.id === "string") {
+        all.push(entry);
+      }
+    }
+    nextUrl = typeof json.next === "string" && json.next.length > 0 ? json.next : null;
+    pageIndex += 1;
+  }
+  return all;
+}
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    const err = new Error("mem0 import aborted");
+    (err as Error & { name: string }).name = "AbortError";
+    throw err;
+  }
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return (await response.text()).slice(0, 500);
+  } catch {
+    return "(failed to read response body)";
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/import-mem0/src/client.ts
+++ b/packages/import-mem0/src/client.ts
@@ -87,7 +87,8 @@ export async function fetchAllMem0Memories(
     options.rateLimit && options.rateLimit > 0 ? 1000 / options.rateLimit : 0;
 
   const all: Mem0Memory[] = [];
-  let nextUrl: string | null = `${base}/v1/memories/`;
+  const firstUrl = `${base}/v1/memories/`;
+  let nextUrl: string | null = firstUrl;
   let pageIndex = 0;
   while (nextUrl) {
     throwIfAborted(options.signal);
@@ -115,10 +116,53 @@ export async function fetchAllMem0Memories(
         all.push(entry);
       }
     }
-    nextUrl = typeof json.next === "string" && json.next.length > 0 ? json.next : null;
+    nextUrl = resolveNextUrl(json, firstUrl, pageIndex, page.length);
     pageIndex += 1;
   }
   return all;
+}
+
+/**
+ * Decide the next URL to request.
+ *
+ * Preferred: the `next` cursor the server returns (v1 shape).
+ *
+ * Fallback: when `next` is absent but the response exposes numeric
+ * pagination fields (`page` / `total` / `per_page`, the older v0 shape),
+ * synthesize a `?page=<N>` request for the next page. Cursor review on
+ * PR #602 flagged that mem0 servers returning only numeric pagination
+ * were silently truncated after page 1 under the original code.
+ */
+function resolveNextUrl(
+  json: Mem0ListResponse,
+  firstUrl: string,
+  currentPageIndex: number,
+  pageSize: number,
+): string | null {
+  if (typeof json.next === "string" && json.next.length > 0) return json.next;
+
+  // Numeric-pagination fallback. `page` is 1-based in the real API.
+  const responsePage = typeof json.page === "number" && Number.isFinite(json.page)
+    ? json.page
+    : currentPageIndex + 1;
+  const perPage = typeof json.per_page === "number" && Number.isFinite(json.per_page)
+    ? json.per_page
+    : pageSize;
+  const total = typeof json.total === "number" && Number.isFinite(json.total)
+    ? json.total
+    : undefined;
+  if (total === undefined || perPage <= 0) return null;
+  const fetchedSoFar = responsePage * perPage;
+  if (fetchedSoFar >= total) return null;
+  const nextPage = responsePage + 1;
+  // Preserve any existing query string on firstUrl by using URL.
+  try {
+    const u = new URL(firstUrl);
+    u.searchParams.set("page", String(nextPage));
+    return u.toString();
+  } catch {
+    return null;
+  }
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/import-mem0/src/client.ts
+++ b/packages/import-mem0/src/client.ts
@@ -52,6 +52,13 @@ export interface Mem0ClientOptions {
   apiKey: string;
   /** Default: `https://api.mem0.ai`. Trailing slash tolerated. */
   baseUrl?: string;
+  /**
+   * Path prefix for the list endpoint. Defaults to `/v1/memories/` for
+   * the hosted API. Self-hosted mem0-oss deployments typically expose
+   * `/memories/` without the `/v1` prefix — set `MEM0_LIST_PATH` /
+   * pass this explicitly in that case. Codex review on PR #602.
+   */
+  listPath?: string;
   /** Injected for tests. Falls back to `globalThis.fetch`. */
   fetchImpl?: typeof fetch;
   /** Requests per second limiter. Applied between pages. */
@@ -63,6 +70,7 @@ export interface Mem0ClientOptions {
 }
 
 const DEFAULT_BASE_URL = "https://api.mem0.ai";
+const DEFAULT_LIST_PATH = "/v1/memories/";
 
 /**
  * Fetch all mem0 memories across pagination. Returns a flat array; the
@@ -83,11 +91,18 @@ export async function fetchAllMem0Memories(
   }
   const sleep = options.sleep ?? defaultSleep;
   const base = (options.baseUrl ?? DEFAULT_BASE_URL).replace(/\/$/, "");
+  const listPath = normalizeListPath(options.listPath ?? DEFAULT_LIST_PATH);
   const intervalMs =
     options.rateLimit && options.rateLimit > 0 ? 1000 / options.rateLimit : 0;
 
   const all: Mem0Memory[] = [];
-  const firstUrl = `${base}/v1/memories/`;
+  const firstUrl = `${base}${listPath}`;
+  // Capture the allow-listed origin ONCE so cross-origin cursors can't
+  // tunnel the API key to an attacker-controlled host. Codex review on
+  // PR #602. We also validate that the configured base URL itself is a
+  // parseable absolute URL — mem0 servers that return relative cursors
+  // are then resolved against this origin.
+  const allowedOrigin = safeUrlOrigin(firstUrl);
   let nextUrl: string | null = firstUrl;
   let pageIndex = 0;
   while (nextUrl) {
@@ -116,30 +131,60 @@ export async function fetchAllMem0Memories(
         all.push(entry);
       }
     }
-    nextUrl = resolveNextUrl(json, firstUrl, pageIndex, page.length);
+    nextUrl = resolveNextUrl(json, firstUrl, pageIndex, page.length, allowedOrigin);
     pageIndex += 1;
   }
   return all;
 }
 
+function normalizeListPath(p: string): string {
+  const withLeadingSlash = p.startsWith("/") ? p : `/${p}`;
+  return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
+function safeUrlOrigin(url: string): string | undefined {
+  try {
+    return new URL(url).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 /**
  * Decide the next URL to request.
  *
- * Preferred: the `next` cursor the server returns (v1 shape).
+ * Preferred: the `next` cursor the server returns (v1 shape). When `next`
+ * is a **relative** path, it's resolved against the configured base URL.
+ * When absolute, it MUST match the allow-listed origin — cross-origin
+ * cursors are rejected so an upstream/proxy can't exfiltrate the API key
+ * by redirecting the pagination walk. Codex review on PR #602.
  *
- * Fallback: when `next` is absent but the response exposes numeric
- * pagination fields (`page` / `total` / `per_page`, the older v0 shape),
- * synthesize a `?page=<N>` request for the next page. Cursor review on
- * PR #602 flagged that mem0 servers returning only numeric pagination
- * were silently truncated after page 1 under the original code.
+ * Fallback: when `next` is explicitly `null` (server says "no more pages"),
+ * stop. When `next` is absent (field omitted) AND the response exposes
+ * numeric pagination fields (`page` / `total` / `per_page`, the older v0
+ * shape), synthesize a `?page=<N>` request for the next page. Cursor
+ * review on PR #602 flagged that servers returning only numeric
+ * pagination were silently truncated under the original code, AND that
+ * the implementation conflated `null` with `undefined`.
  */
 function resolveNextUrl(
   json: Mem0ListResponse,
   firstUrl: string,
   currentPageIndex: number,
   pageSize: number,
+  allowedOrigin: string | undefined,
 ): string | null {
-  if (typeof json.next === "string" && json.next.length > 0) return json.next;
+  // Has the server explicitly returned a next value?
+  if ("next" in json) {
+    if (json.next === null) return null; // authoritative stop
+    if (typeof json.next === "string" && json.next.length > 0) {
+      return resolveCursorOrThrow(json.next, firstUrl, allowedOrigin);
+    }
+    // `next` was present but not a non-empty string or null (e.g. number).
+    // Don't fall through to numeric pagination — the server sent a signal
+    // we can't interpret. Treat as end-of-stream.
+    return null;
+  }
 
   // Numeric-pagination fallback. `page` is 1-based in the real API.
   const responsePage = typeof json.page === "number" && Number.isFinite(json.page)
@@ -155,7 +200,6 @@ function resolveNextUrl(
   const fetchedSoFar = responsePage * perPage;
   if (fetchedSoFar >= total) return null;
   const nextPage = responsePage + 1;
-  // Preserve any existing query string on firstUrl by using URL.
   try {
     const u = new URL(firstUrl);
     u.searchParams.set("page", String(nextPage));
@@ -163,6 +207,43 @@ function resolveNextUrl(
   } catch {
     return null;
   }
+}
+
+/**
+ * Resolve a server-provided cursor against the base URL and enforce
+ * same-origin. Relative cursors are accepted (resolved against firstUrl);
+ * absolute cursors must match `allowedOrigin`. Throws on cross-origin to
+ * surface the security-relevant mismatch immediately instead of silently
+ * leaking the API key.
+ */
+function resolveCursorOrThrow(
+  cursor: string,
+  firstUrl: string,
+  allowedOrigin: string | undefined,
+): string {
+  if (!allowedOrigin) {
+    // Base URL wasn't parseable as an absolute URL; refuse to follow any
+    // cursor because we can't compare origins.
+    throw new Error(
+      `mem0 pagination cursor '${cursor}' cannot be followed: configured baseUrl is not an absolute URL.`,
+    );
+  }
+  let resolved: URL;
+  try {
+    resolved = new URL(cursor, firstUrl);
+  } catch {
+    throw new Error(
+      `mem0 pagination cursor '${cursor}' is not a valid URL.`,
+    );
+  }
+  if (resolved.origin !== allowedOrigin) {
+    throw new Error(
+      `mem0 pagination cursor '${cursor}' points to origin '${resolved.origin}', ` +
+        `but the configured mem0 origin is '${allowedOrigin}'. ` +
+        "Refusing to forward the API key to a cross-origin endpoint.",
+    );
+  }
+  return resolved.toString();
 }
 
 function throwIfAborted(signal: AbortSignal | undefined): void {

--- a/packages/import-mem0/src/index.ts
+++ b/packages/import-mem0/src/index.ts
@@ -1,0 +1,26 @@
+// ---------------------------------------------------------------------------
+// @remnic/import-mem0 — public surface (issue #568 slice 5)
+// ---------------------------------------------------------------------------
+
+export {
+  adapter,
+  mem0Adapter,
+  setMem0ClientOptionsForTesting,
+} from "./adapter.js";
+export {
+  fetchAllMem0Memories,
+  type Mem0Memory,
+  type Mem0ListResponse,
+  type Mem0ClientOptions,
+} from "./client.js";
+export {
+  parseMem0Export,
+  extractMemoryBody,
+  type Mem0ParseOptions,
+  type ParsedMem0Export,
+} from "./parser.js";
+export {
+  MEM0_SOURCE_LABEL,
+  transformMem0Export,
+  type Mem0TransformOptions,
+} from "./transform.js";

--- a/packages/import-mem0/src/parser.test.ts
+++ b/packages/import-mem0/src/parser.test.ts
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { extractMemoryBody, parseMem0Export } from "./parser.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("parseMem0Export", () => {
+  it("parses a flat results-array replay dump", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"));
+    // 4 entries total, but the dump's 'empty' one keeps its id so it survives parse.
+    assert.equal(parsed.memories.length, 4);
+  });
+
+  it("parses a multi-page recording via the `pages` key", () => {
+    const parsed = parseMem0Export(loadFixture("two-page-recording.json"));
+    assert.equal(parsed.memories.length, 3);
+  });
+
+  it("accepts a pre-fetched array directly", () => {
+    const parsed = parseMem0Export([
+      { id: "x1", memory: "hello" },
+      { id: "x2", content: "world" },
+    ]);
+    assert.equal(parsed.memories.length, 2);
+  });
+
+  it("drops entries with no id in non-strict mode", () => {
+    const parsed = parseMem0Export([{ memory: "no id" }]);
+    assert.equal(parsed.memories.length, 0);
+  });
+
+  it("strict mode rejects entries without id", () => {
+    assert.throws(
+      () =>
+        parseMem0Export(JSON.stringify([{ memory: "no id" }]), { strict: true }),
+      /missing id/,
+    );
+  });
+
+  it("throws on invalid JSON", () => {
+    assert.throws(() => parseMem0Export("{not-json"), /not valid JSON/);
+  });
+
+  it("preserves filePath on the result", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"), {
+      filePath: "/tmp/mem0-replay.json",
+    });
+    assert.equal(parsed.importedFromPath, "/tmp/mem0-replay.json");
+  });
+});
+
+describe("extractMemoryBody", () => {
+  it("prefers memory → content → text", () => {
+    assert.equal(
+      extractMemoryBody({ id: "a", memory: "m", content: "c", text: "t" }),
+      "m",
+    );
+    assert.equal(extractMemoryBody({ id: "a", content: "c", text: "t" }), "c");
+    assert.equal(extractMemoryBody({ id: "a", text: "t" }), "t");
+  });
+
+  it("returns undefined when all candidate fields are empty / missing", () => {
+    assert.equal(extractMemoryBody({ id: "a" }), undefined);
+    assert.equal(extractMemoryBody({ id: "a", memory: "   " }), undefined);
+  });
+});

--- a/packages/import-mem0/src/parser.ts
+++ b/packages/import-mem0/src/parser.ts
@@ -1,0 +1,135 @@
+// ---------------------------------------------------------------------------
+// mem0 parser (issue #568 slice 5)
+// ---------------------------------------------------------------------------
+//
+// Unlike the file-based importers, mem0 pulls data directly from an API. The
+// "parse" step therefore either:
+//
+//   1. Accepts an already-fetched `Mem0Memory[]` (the adapter's primary path,
+//      after the API client pulls everything down).
+//   2. Accepts a JSON string / parsed object for record/replay fixtures so
+//      tests and offline flows don't need network access.
+//
+// Non-object entries are dropped in non-strict mode (CLAUDE.md rule 51
+// applies only to user-facing CLI inputs; parser leniency here protects
+// against server-side schema drift without crashing the import).
+
+import type { Mem0Memory } from "./client.js";
+
+export interface ParsedMem0Export {
+  memories: Mem0Memory[];
+  /** Provenance — API endpoint URL or replay fixture path. */
+  importedFromPath?: string;
+}
+
+export interface Mem0ParseOptions {
+  strict?: boolean;
+  filePath?: string;
+}
+
+/**
+ * Parse a mem0 payload. Accepts:
+ *   - a `Mem0Memory[]` (already fetched)
+ *   - a JSON string
+ *   - an object like `{ results: [...] }` or `{ memories: [...] }` or
+ *     `{ all_pages: [...] }` (combined replay fixture)
+ */
+export function parseMem0Export(
+  input: unknown,
+  options: Mem0ParseOptions = {},
+): ParsedMem0Export {
+  const raw = coerceJson(input);
+  const memories: Mem0Memory[] = [];
+
+  if (Array.isArray(raw)) {
+    appendMemories(memories, raw, options);
+    return withFilePath(memories, options.filePath);
+  }
+
+  if (raw && typeof raw === "object") {
+    const obj = raw as Record<string, unknown>;
+    for (const key of ["results", "memories", "all_pages"] as const) {
+      const v = obj[key];
+      if (Array.isArray(v)) {
+        appendMemories(memories, v, options);
+      }
+    }
+    // `pages`: an array of page responses (replay fixture for multi-page
+    // pulls). We flatten each page's `results` / `memories`.
+    const pages = obj.pages;
+    if (Array.isArray(pages)) {
+      for (const page of pages) {
+        if (page && typeof page === "object") {
+          const p = page as Record<string, unknown>;
+          for (const key of ["results", "memories"] as const) {
+            const v = p[key];
+            if (Array.isArray(v)) appendMemories(memories, v, options);
+          }
+        }
+      }
+    }
+    return withFilePath(memories, options.filePath);
+  }
+
+  if (options.strict) {
+    throw new Error(
+      "mem0 export must be an array or object; received " + typeof raw,
+    );
+  }
+  return withFilePath(memories, options.filePath);
+}
+
+function appendMemories(
+  dest: Mem0Memory[],
+  src: unknown[],
+  options: Mem0ParseOptions,
+): void {
+  for (const entry of src) {
+    if (!entry || typeof entry !== "object") {
+      if (options.strict) throw new Error("mem0 entry must be an object");
+      continue;
+    }
+    const record = entry as Mem0Memory;
+    if (typeof record.id !== "string" || record.id.length === 0) {
+      if (options.strict) throw new Error("mem0 entry missing id");
+      continue;
+    }
+    dest.push(record);
+  }
+}
+
+function withFilePath(
+  memories: Mem0Memory[],
+  importedFromPath: string | undefined,
+): ParsedMem0Export {
+  return {
+    memories,
+    ...(importedFromPath !== undefined ? { importedFromPath } : {}),
+  };
+}
+
+function coerceJson(input: unknown): unknown {
+  if (typeof input === "string") {
+    try {
+      return JSON.parse(input);
+    } catch (err) {
+      throw new Error(
+        `mem0 payload is not valid JSON: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return input;
+}
+
+/** Extract the memory body, preferring explicit `memory` then `content` then `text`. */
+export function extractMemoryBody(entry: Mem0Memory): string | undefined {
+  for (const candidate of [entry.memory, entry.content, entry.text]) {
+    if (typeof candidate === "string") {
+      const trimmed = candidate.trim();
+      if (trimmed.length > 0) return trimmed;
+    }
+  }
+  return undefined;
+}

--- a/packages/import-mem0/src/transform.test.ts
+++ b/packages/import-mem0/src/transform.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseMem0Export } from "./parser.js";
+import { transformMem0Export } from "./transform.js";
+
+const FIXTURE_DIR = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "../fixtures",
+);
+
+function loadFixture(name: string): string {
+  return readFileSync(path.join(FIXTURE_DIR, name), "utf-8");
+}
+
+describe("transformMem0Export", () => {
+  it("emits one memory per non-empty mem0 entry, skipping blank bodies", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"), {
+      filePath: "/tmp/mem0.json",
+    });
+    const memories = transformMem0Export(parsed);
+    // 3 of 4 entries have non-empty content; the `   ` one is skipped.
+    assert.equal(memories.length, 3);
+    for (const m of memories) {
+      assert.equal(m.sourceLabel, "mem0");
+      assert.equal(m.importedFromPath, "/tmp/mem0.json");
+      assert.equal(m.metadata?.kind, "mem0_memory");
+    }
+  });
+
+  it("preserves categories, user_id, and metadata on emitted memories", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"));
+    const memories = transformMem0Export(parsed);
+    const first = memories[0]!;
+    assert.equal(first.sourceId, "mem-syn-0001");
+    assert.equal(first.sourceTimestamp, "2026-02-14T09:05:00.000Z"); // updated_at wins
+    assert.deepEqual(first.metadata?.categories, ["preferences", "tooling"]);
+    assert.equal(first.metadata?.userId, "synthetic-user-1");
+  });
+
+  it("accepts the content-field variant as a valid body", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"));
+    const memories = transformMem0Export(parsed);
+    const variant = memories.find((m) => m.sourceId === "mem-syn-0003");
+    assert.ok(variant);
+    assert.ok(variant.content.startsWith("Fictional (content-field variant)"));
+  });
+
+  it("honors maxMemories as a hard cap", () => {
+    const parsed = parseMem0Export(loadFixture("replay-dump.json"));
+    const memories = transformMem0Export(parsed, { maxMemories: 1 });
+    assert.equal(memories.length, 1);
+  });
+});

--- a/packages/import-mem0/src/transform.ts
+++ b/packages/import-mem0/src/transform.ts
@@ -1,0 +1,56 @@
+// ---------------------------------------------------------------------------
+// mem0 parsed → ImportedMemory transform (issue #568 slice 5)
+// ---------------------------------------------------------------------------
+
+import type { ImportedMemory } from "@remnic/core";
+
+import type { Mem0Memory } from "./client.js";
+import type { ParsedMem0Export } from "./parser.js";
+import { extractMemoryBody } from "./parser.js";
+
+export const MEM0_SOURCE_LABEL = "mem0";
+
+export interface Mem0TransformOptions {
+  /** Optional cap on total memories emitted — primarily for tests. */
+  maxMemories?: number;
+}
+
+export function transformMem0Export(
+  parsed: ParsedMem0Export,
+  options: Mem0TransformOptions = {},
+): ImportedMemory[] {
+  const out: ImportedMemory[] = [];
+  const cap = options.maxMemories;
+  for (const entry of parsed.memories) {
+    if (cap !== undefined && out.length >= cap) return out;
+    const memory = mem0ToImported(entry, parsed.importedFromPath);
+    if (memory) out.push(memory);
+  }
+  return out;
+}
+
+function mem0ToImported(
+  entry: Mem0Memory,
+  importedFromPath: string | undefined,
+): ImportedMemory | undefined {
+  const content = extractMemoryBody(entry);
+  if (!content) return undefined;
+  const sourceTimestamp = entry.updated_at ?? entry.created_at;
+  const metadata: Record<string, unknown> = { kind: "mem0_memory" };
+  if (entry.user_id) metadata.userId = entry.user_id;
+  if (entry.agent_id) metadata.agentId = entry.agent_id;
+  if (Array.isArray(entry.categories) && entry.categories.length > 0) {
+    metadata.categories = [...entry.categories];
+  }
+  if (entry.metadata && typeof entry.metadata === "object") {
+    metadata.sourceMetadata = entry.metadata;
+  }
+  return {
+    content,
+    sourceLabel: MEM0_SOURCE_LABEL,
+    sourceId: entry.id,
+    ...(sourceTimestamp !== undefined ? { sourceTimestamp } : {}),
+    ...(importedFromPath !== undefined ? { importedFromPath } : {}),
+    metadata,
+  };
+}

--- a/packages/import-mem0/tsconfig.json
+++ b/packages/import-mem0/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "outDir": "dist",
+    "rootDir": "src"
+  },
+  "include": ["src"]
+}

--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -37,17 +37,20 @@
   "peerDependencies": {
     "@remnic/bench": "^1.0.0",
     "@remnic/export-weclone": "^1.0.0",
-    "@remnic/import-weclone": "^1.0.0"
+    "@remnic/import-weclone": "^1.0.0",
+    "@remnic/import-mem0": "^0.1.0"
   },
   "peerDependenciesMeta": {
     "@remnic/bench": { "optional": true },
     "@remnic/export-weclone": { "optional": true },
-    "@remnic/import-weclone": { "optional": true }
+    "@remnic/import-weclone": { "optional": true },
+    "@remnic/import-mem0": { "optional": true }
   },
   "devDependencies": {
     "@remnic/bench": "workspace:*",
     "@remnic/export-weclone": "workspace:*",
     "@remnic/import-weclone": "workspace:*",
+    "@remnic/import-mem0": "workspace:*",
     "tsup": "^8.5.1",
     "typescript": "^5.9.3"
   },

--- a/packages/remnic-cli/src/optional-importer.test.ts
+++ b/packages/remnic-cli/src/optional-importer.test.ts
@@ -29,7 +29,12 @@ describe("optional-importer loader", () => {
     assert.equal(isSupportedImporterName("chatgpt "), false);
   });
 
-  it("loading a missing importer throws a user-facing install hint (slice 1: none installed)", async () => {
+  // Slices 2, 3, 4 (chatgpt, claude, gemini) are not yet installed so they
+  // make durable "missing package" fixtures that don't depend on which slice
+  // is currently being developed. The mem0 fixture intentionally is NOT used
+  // here because PR 5 installs @remnic/import-mem0 alongside, which would
+  // make the install-hint assertion race with that installation.
+  it("loading a missing importer throws a user-facing install hint", async () => {
     await assert.rejects(
       () => loadImporterModule("chatgpt"),
       (err: Error) => {

--- a/packages/remnic-cli/tsup.config.ts
+++ b/packages/remnic-cli/tsup.config.ts
@@ -20,5 +20,6 @@ export default defineConfig({
     "@remnic/bench",
     "@remnic/export-weclone",
     "@remnic/import-weclone",
+    "@remnic/import-mem0",
   ],
 });

--- a/packages/remnic-core/src/importers/base.ts
+++ b/packages/remnic-core/src/importers/base.ts
@@ -201,6 +201,14 @@ export interface ImporterParseOptions {
   strict?: boolean;
   /** Source path passed through for provenance. */
   filePath?: string;
+  /**
+   * Requests-per-second throttle, forwarded from the top-level
+   * `RunImportOptions.rateLimit`. Only meaningful for API-backed importers
+   * (mem0) — file-based adapters ignore it. `runImporter` copies this
+   * through automatically so CLI users never have to stash it on
+   * `parseOptions` themselves. Cursor review on PR #602.
+   */
+  rateLimit?: number;
 }
 
 /** Options forwarded to `transform`. */
@@ -335,9 +343,15 @@ export async function runImporter<Parsed>(
   const dryRun = options.dryRun === true;
   const onProgress = options.onProgress;
 
-  // Phase 1 — parse
+  // Phase 1 — parse. Forward the validated rateLimit so API-backed adapters
+  // (mem0) can throttle their own fetches. Caller-supplied parseOptions
+  // takes precedence so tests can still override.
   onProgress?.({ processed: 0, total: 0, phase: "parse" });
-  const parsed = await adapter.parse(input, options.parseOptions);
+  const parseOptions: ImporterParseOptions = {
+    ...(options.rateLimit !== undefined ? { rateLimit: options.rateLimit } : {}),
+    ...(options.parseOptions ?? {}),
+  };
+  const parsed = await adapter.parse(input, parseOptions);
 
   // Phase 2 — transform
   onProgress?.({ processed: 0, total: 0, phase: "transform" });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -158,6 +158,21 @@ importers:
         specifier: ^5.7.0
         version: 5.9.3
 
+  packages/import-mem0:
+    devDependencies:
+      '@remnic/core':
+        specifier: workspace:*
+        version: link:../remnic-core
+      tsup:
+        specifier: ^8.0.0
+        version: 8.5.1(postcss@8.5.10)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.3)
+      tsx:
+        specifier: ^4.0.0
+        version: 4.21.0
+      typescript:
+        specifier: ^5.7.0
+        version: 5.9.3
+
   packages/import-weclone:
     dependencies:
       '@remnic/core':
@@ -213,6 +228,9 @@ importers:
       '@remnic/export-weclone':
         specifier: workspace:*
         version: link:../export-weclone
+      '@remnic/import-mem0':
+        specifier: workspace:*
+        version: link:../import-mem0
       '@remnic/import-weclone':
         specifier: workspace:*
         version: link:../import-weclone

--- a/tests/release-workflow-public-packages.test.ts
+++ b/tests/release-workflow-public-packages.test.ts
@@ -13,6 +13,7 @@ const expectedPublishDirs = [
   "packages/bench",
   "packages/export-weclone",
   "packages/import-weclone",
+  "packages/import-mem0",
   "packages/connector-weclone",
   "packages/connector-replit",
   "packages/hermes-provider",


### PR DESCRIPTION
Part of #568 (slice 5 of 7).

## Summary
- New workspace package \`@remnic/import-mem0\` implementing the shared \`ImporterAdapter\` contract from PR 1
- API-backed: walks paginated \`/v1/memories/\` endpoint via cursor links
- Reads \`MEM0_API_KEY\` (+ optional \`MEM0_BASE_URL\` for self-hosted)
- Honors \`--rate-limit\` for throttling page-to-page requests
- Accepts offline replay fixtures via \`--file\` (both flat \`{results}\` and multi-page \`{pages}\` shapes)
- Synthetic record/replay fixtures only — no real account data

## À-la-carte compliance (CLAUDE.md rule 57)
- [x] Own workspace package at \`packages/import-mem0/\`, \`"private": false\`
- [x] Declared as optional peer dep in \`packages/remnic-cli/package.json\`
- [x] NOT in any \`noExternal\` array (kept as \`external\` in \`packages/remnic-cli/tsup.config.ts\`)
- [x] Loaded via computed dynamic import in the existing \`optional-importer.ts\` loader
- [x] Missing package produces a clean install hint (covered by \`optional-importer.test.ts\`)
- [x] Added to \`.github/workflows/release-and-publish.yml\` in topological order

## Test plan
- [x] \`pnpm run check-types\` clean
- [x] \`packages/import-mem0\` unit tests: 24 pass (client record/replay with abort + rate-limit, parser across shapes, transform with field-preference + metadata, adapter end-to-end both live-API and offline)
- [x] No real network I/O in tests — replay fetch injected via \`setMem0ClientOptionsForTesting\`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new API-backed importer and adjusts core `runImporter` option plumbing, which could affect import behavior and external-request handling. Risk is moderated by extensive record/replay tests and same-origin cursor safeguards to avoid API key leakage.
> 
> **Overview**
> Adds a new optional workspace package `@remnic/import-mem0` that lets `remnic import --adapter mem0` pull memories from the mem0 REST API (or from an offline `--file` replay dump), transform them into `ImportedMemory`, and write via the shared importer pipeline.
> 
> Updates the mem0 client to handle pagination robustly (**cursor + numeric fallback**, relative-cursor resolution, abort support), enforce **same-origin cursor** rules to prevent forwarding the API key cross-host, and honor `--rate-limit` by sleeping between page requests.
> 
> Wires `RunImportOptions.rateLimit` through `runImporter` into `ImporterParseOptions.rateLimit`, updates CLI packaging to treat `@remnic/import-mem0` as an *optional peer dependency* (kept external for bundling), and includes the new package in the release publish order/tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9da653bd96d9693bd7595d2cc47df556d3e893f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->