### PR TITLE
feat(bench): `remnic bench published` CLI surface (#566 PR 4/7)

### DIFF
--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -17,3 +17,201 @@ test("parseBenchArgs keeps validated matrix profiles typed and ordered", () => {
     "openclaw-chain",
   ]);
 });
+
+// ---------- `bench published` (issue #566 PR 4/7) ----------
+
+test("parseBenchArgs accepts published action with --name, --dataset, --model", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "longmemeval",
+    "--dataset",
+    "/tmp/bench-datasets/longmemeval",
+    "--model",
+    "gpt-4o-mini",
+    "--seed",
+    "42",
+    "--limit",
+    "100",
+    "--out",
+    "/tmp/out",
+  ]);
+
+  assert.equal(parsed.action, "published");
+  assert.equal(parsed.publishedName, "longmemeval");
+  // `--dataset` aliases to `--dataset-dir`.
+  assert.equal(
+    parsed.datasetDir,
+    "/tmp/bench-datasets/longmemeval",
+  );
+  assert.equal(parsed.systemModel, "gpt-4o-mini");
+  assert.equal(parsed.publishedSeed, 42);
+  assert.equal(parsed.publishedLimit, 100);
+  assert.equal(parsed.publishedOut, "/tmp/out");
+});
+
+test("parseBenchArgs rejects unknown published --name", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "not-a-benchmark",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+      ]),
+    /--name must be one of longmemeval, locomo/,
+  );
+});
+
+test("parseBenchArgs rejects non-integer --limit", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--limit",
+        "3.14",
+      ]),
+    /--limit must be a non-negative integer/,
+  );
+});
+
+test("parseBenchArgs rejects non-integer --seed", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--seed",
+        "1.5",
+      ]),
+    /--seed must be a non-negative integer/,
+  );
+});
+
+test("parseBenchArgs rejects --model without value (CLAUDE.md rule 14)", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+      ]),
+    /--model requires a value/,
+  );
+});
+
+test("parseBenchArgs rejects empty --model string", () => {
+  // Feeding an empty string via `--model=` is not our flag syntax
+  // (we don't support =), but an explicitly empty next-token is tested.
+  // We use `" "` to make this robust: `trim().length === 0`.
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "   ",
+      ]),
+    /--model must not be empty/,
+  );
+});
+
+test("parseBenchArgs accepts --provider shorthand", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "longmemeval",
+    "--dataset",
+    "/tmp",
+    "--model",
+    "gpt-4o-mini",
+    "--provider",
+    "openai",
+    "--base-url",
+    "https://api.openai.com",
+  ]);
+  assert.equal(parsed.systemProvider, "openai");
+  assert.equal(parsed.systemBaseUrl, "https://api.openai.com");
+});
+
+test("parseBenchArgs rejects unknown --provider", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "locomo",
+        "--dataset",
+        "/tmp",
+        "--model",
+        "m",
+        "--provider",
+        "not-a-provider",
+      ]),
+    /--provider must be "openai", "anthropic", "ollama", or "litellm"/,
+  );
+});
+
+test("parseBenchArgs honors --dataset-dir over --dataset when both are set", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "longmemeval",
+    "--dataset",
+    "/alias",
+    "--dataset-dir",
+    "/canonical",
+    "--model",
+    "gpt-4o-mini",
+  ]);
+  assert.equal(parsed.datasetDir, "/canonical");
+});
+
+test("parseBenchArgs --dry-run sets publishedDryRun = true", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "locomo",
+    "--dataset",
+    "/tmp",
+    "--model",
+    "m",
+    "--dry-run",
+  ]);
+  assert.equal(parsed.publishedDryRun, true);
+});
+
+test("parseBenchArgs --limit 0 preserved (CLAUDE.md rule 27 slice-negative-zero)", () => {
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "locomo",
+    "--dataset",
+    "/tmp",
+    "--model",
+    "m",
+    "--limit",
+    "0",
+  ]);
+  assert.equal(parsed.publishedLimit, 0);
+});

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -240,7 +240,11 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       ? args.slice(1)
       : args;
   const benchmarks = collectBenchmarks(benchmarkArgs);
-  const datasetDir = readBenchOptionValue(args, "--dataset-dir");
+  // `--dataset` is an alias for `--dataset-dir`. `--dataset-dir` wins
+  // if both are supplied.
+  const datasetDir =
+    readBenchOptionValue(args, "--dataset-dir") ??
+    readBenchOptionValue(args, "--dataset");
   const resultsDir = readBenchOptionValue(args, "--results-dir");
   const baselinesDir = readBenchOptionValue(args, "--baselines-dir");
   const runtimeProfileRaw = readBenchOptionValue(args, "--runtime-profile");
@@ -351,7 +355,6 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   // etc. raise consistent errors even when used outside the `published`
   // action (mirrors CLAUDE.md rule 14: validate flag args at input boundaries).
   const publishedNameRaw = readBenchOptionValue(args, "--name");
-  const publishedDatasetRaw = readBenchOptionValue(args, "--dataset");
   const publishedModelRaw = readBenchOptionValue(args, "--model");
   const publishedLimitRaw = readBenchOptionValue(args, "--limit");
   const publishedSeedRaw = readBenchOptionValue(args, "--seed");
@@ -427,14 +430,6 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const effectiveSystemProvider = systemProvider ?? publishedProvider;
   const effectiveSystemModel = systemModel ?? publishedModelRaw;
   const effectiveSystemBaseUrl = systemBaseUrl ?? publishedBaseUrlRaw;
-  // `--dataset` is an alias for `--dataset-dir`. `--dataset-dir` wins
-  // if both are supplied.
-  const effectiveDatasetDir = datasetDir
-    ? path.resolve(expandTilde(datasetDir))
-    : publishedDatasetRaw
-      ? path.resolve(expandTilde(publishedDatasetRaw))
-      : undefined;
-
   return {
     action,
     benchmarks,
@@ -442,7 +437,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     all: args.includes("--all"),
     json: args.includes("--json"),
     detail: args.includes("--detail"),
-    datasetDir: effectiveDatasetDir,
+    datasetDir: datasetDir ? path.resolve(expandTilde(datasetDir)) : undefined,
     resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
     baselinesDir: baselinesDir ? path.resolve(expandTilde(baselinesDir)) : undefined,
     runtimeProfile,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -15,6 +15,7 @@ export type BenchAction =
   | "export"
   | "providers"
   | "publish"
+  | "published"
   | "check"
   | "report";
 
@@ -59,7 +60,21 @@ export interface ParsedBenchArgs {
   output?: string;
   custom?: string;
   target?: BenchPublishTarget;
+  /** `bench published` — specific benchmark to run (longmemeval|locomo). */
+  publishedName?: PublishedBenchmarkName;
+  /** `bench published` — seed forwarded into the harness context. */
+  publishedSeed?: number;
+  /** `bench published` — item limit forwarded into the dataset loader. */
+  publishedLimit?: number;
+  /** `bench published` — published artifact output directory. */
+  publishedOut?: string;
+  /** `bench published` — dry-run: validate + load but do NOT call the model. */
+  publishedDryRun?: boolean;
 }
+
+export type PublishedBenchmarkName = "longmemeval" | "locomo";
+export const PUBLISHED_BENCHMARK_NAMES: readonly PublishedBenchmarkName[] =
+  Object.freeze(["longmemeval", "locomo"]);
 
 function isBenchRuntimeProfile(value: string): value is BenchRuntimeProfile {
   return (
@@ -127,7 +142,15 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--custom" ||
       arg === "--format" ||
       arg === "--output" ||
-      arg === "--target"
+      arg === "--target" ||
+      arg === "--name" ||
+      arg === "--dataset" ||
+      arg === "--model" ||
+      arg === "--limit" ||
+      arg === "--seed" ||
+      arg === "--out" ||
+      arg === "--provider" ||
+      arg === "--base-url"
     ) {
       index += 1;
       continue;
@@ -156,6 +179,7 @@ export function parseBenchActionArgs(argv: string[]): {
     first === "export" ||
     first === "providers" ||
     first === "publish" ||
+    first === "published" ||
     first === "check" ||
     first === "report"
       ? first
@@ -323,6 +347,94 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     target = targetRaw;
   }
 
+  // `bench published` flags. Parsed unconditionally so `--name`, `--model`,
+  // etc. raise consistent errors even when used outside the `published`
+  // action (mirrors CLAUDE.md rule 14: validate flag args at input boundaries).
+  const publishedNameRaw = readBenchOptionValue(args, "--name");
+  const publishedDatasetRaw = readBenchOptionValue(args, "--dataset");
+  const publishedModelRaw = readBenchOptionValue(args, "--model");
+  const publishedLimitRaw = readBenchOptionValue(args, "--limit");
+  const publishedSeedRaw = readBenchOptionValue(args, "--seed");
+  const publishedOutRaw = readBenchOptionValue(args, "--out");
+  const publishedProviderRaw = readBenchOptionValue(args, "--provider");
+  const publishedBaseUrlRaw = readBenchOptionValue(args, "--base-url");
+
+  let publishedName: PublishedBenchmarkName | undefined;
+  if (publishedNameRaw !== undefined) {
+    if (!PUBLISHED_BENCHMARK_NAMES.includes(
+      publishedNameRaw as PublishedBenchmarkName,
+    )) {
+      throw new Error(
+        `ERROR: --name must be one of ${PUBLISHED_BENCHMARK_NAMES.join(", ")}.`,
+      );
+    }
+    publishedName = publishedNameRaw as PublishedBenchmarkName;
+  }
+
+  let publishedLimit: number | undefined;
+  if (publishedLimitRaw !== undefined) {
+    const parsed = Number(publishedLimitRaw);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new Error(
+        "ERROR: --limit must be a non-negative integer (use 0 to load zero items).",
+      );
+    }
+    publishedLimit = parsed;
+  }
+
+  let publishedSeed: number | undefined;
+  if (publishedSeedRaw !== undefined) {
+    const parsed = Number(publishedSeedRaw);
+    if (!Number.isInteger(parsed) || parsed < 0) {
+      throw new Error(
+        "ERROR: --seed must be a non-negative integer.",
+      );
+    }
+    publishedSeed = parsed;
+  }
+
+  // `--model` is free-form (any provider-specific model ID), but we
+  // reject empty strings so it doesn't silently fall through to a
+  // default at a later stage.
+  if (publishedModelRaw !== undefined && publishedModelRaw.trim().length === 0) {
+    throw new Error("ERROR: --model must not be empty.");
+  }
+
+  // `--provider` is validated against the same allow-list as
+  // `--system-provider` so the two surfaces stay in lockstep.
+  // `bench published` callers that prefer the legacy flags can keep
+  // using `--system-provider`; `--provider` is a shorthand specific to
+  // the published action.
+  let publishedProvider: BuiltInProvider | undefined;
+  if (publishedProviderRaw !== undefined) {
+    if (
+      publishedProviderRaw !== "openai" &&
+      publishedProviderRaw !== "anthropic" &&
+      publishedProviderRaw !== "ollama" &&
+      publishedProviderRaw !== "litellm"
+    ) {
+      throw new Error(
+        'ERROR: --provider must be "openai", "anthropic", "ollama", or "litellm".',
+      );
+    }
+    publishedProvider = publishedProviderRaw;
+  }
+
+  // Published action aliases: `--system-*` takes precedence; the
+  // shorthand `--provider` / `--base-url` / `--model` only fill in
+  // when the legacy flags are absent so the two code paths stay
+  // behaviorally identical.
+  const effectiveSystemProvider = systemProvider ?? publishedProvider;
+  const effectiveSystemModel = systemModel ?? publishedModelRaw;
+  const effectiveSystemBaseUrl = systemBaseUrl ?? publishedBaseUrlRaw;
+  // `--dataset` is an alias for `--dataset-dir`. `--dataset-dir` wins
+  // if both are supplied.
+  const effectiveDatasetDir = datasetDir
+    ? path.resolve(expandTilde(datasetDir))
+    : publishedDatasetRaw
+      ? path.resolve(expandTilde(publishedDatasetRaw))
+      : undefined;
+
   return {
     action,
     benchmarks,
@@ -330,7 +442,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     all: args.includes("--all"),
     json: args.includes("--json"),
     detail: args.includes("--detail"),
-    datasetDir: datasetDir ? path.resolve(expandTilde(datasetDir)) : undefined,
+    datasetDir: effectiveDatasetDir,
     resultsDir: resultsDir ? path.resolve(expandTilde(resultsDir)) : undefined,
     baselinesDir: baselinesDir ? path.resolve(expandTilde(baselinesDir)) : undefined,
     runtimeProfile,
@@ -340,9 +452,9 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     modelSource,
     gatewayAgentId,
     fastGatewayAgentId,
-    systemProvider,
-    systemModel,
-    systemBaseUrl,
+    systemProvider: effectiveSystemProvider,
+    systemModel: effectiveSystemModel,
+    systemBaseUrl: effectiveSystemBaseUrl,
     judgeProvider,
     judgeModel,
     judgeBaseUrl,
@@ -355,5 +467,12 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     format,
     output: output ? path.resolve(expandTilde(output)) : undefined,
     target,
+    publishedName,
+    publishedSeed,
+    publishedLimit,
+    publishedOut: publishedOutRaw
+      ? path.resolve(expandTilde(publishedOutRaw))
+      : undefined,
+    publishedDryRun: args.includes("--dry-run"),
   };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1897,32 +1897,43 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
   const benchmarkId = parsed.publishedName;
+  // Collect artifact paths written by each runtime profile so the
+  // --out promotion step copies the exact file just produced rather
+  // than scanning the whole results directory (Cursor Medium + Codex
+  // P1 on PR #603: the previous newest-mtime scan could silently
+  // publish unrelated or older artifacts under the new canonical
+  // filename).
+  const writtenPaths: string[] = [];
   for (const runtimeProfile of runtimeProfiles) {
     // Forward `--limit` + `--seed` through the existing package
     // runner. `--out` is handled below in the artifact write step.
-    const ok = await runBenchViaPackage(
+    const result = await runBenchViaPackage(
       parsed,
       benchmarkId,
       runtimeProfile,
     );
-    if (!ok) {
+    if (!result.ok) {
       console.error(
         `ERROR: unable to run ${benchmarkId} via @remnic/bench. Update the @remnic/bench install to a version that exports a runner for this benchmark.`,
       );
       process.exit(1);
     }
+    if (result.writtenPath) {
+      writtenPaths.push(result.writtenPath);
+    }
   }
 
-  // When `--out` is supplied, copy the newest result artifact into the
-  // directory under a canonical leaderboard filename. We keep the
-  // primary result file under `~/.remnic/bench/results/` (set by
-  // `resolveBenchOutputDir`) and only publish a flatter copy to the
-  // user-specified directory so the dev environment stays in sync.
+  // When `--out` is supplied, copy the result artifact we just wrote
+  // into the directory under a canonical leaderboard filename. We
+  // keep the primary result file under `~/.remnic/bench/results/`
+  // (set by `resolveBenchOutputDir`) and only publish a flatter copy
+  // to the user-specified directory so the dev environment stays in
+  // sync.
   if (parsed.publishedOut) {
-    const { promoteLatestArtifactToPublished } = await loadPublishedPromotionHelpers();
-    await promoteLatestArtifactToPublished({
+    const { promoteArtifactsToPublished } = await loadPublishedPromotionHelpers();
+    await promoteArtifactsToPublished({
       benchmarkId,
-      outputDir: resolveBenchOutputDir(),
+      artifactPaths: writtenPaths,
       publishedOutDir: parsed.publishedOut,
       model: parsed.systemModel,
     });
@@ -1932,47 +1943,49 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
 async function loadPublishedPromotionHelpers() {
   const benchModule = (await loadBenchModule()) as unknown as PackageBenchModule;
   return {
-    async promoteLatestArtifactToPublished(args: {
+    async promoteArtifactsToPublished(args: {
       benchmarkId: string;
-      outputDir: string;
+      artifactPaths: string[];
       publishedOutDir: string;
       model: string;
     }) {
-      const { mkdirSync, readdirSync, readFileSync, writeFileSync } = await import(
+      const { mkdirSync, readFileSync, writeFileSync } = await import(
         "node:fs"
       );
       const path = await import("node:path");
       mkdirSync(args.publishedOutDir, { recursive: true });
-      const entries = readdirSync(args.outputDir)
-        .filter((entry) => entry.endsWith(".json"))
-        .map((entry) => ({
-          name: entry,
-          mtimeMs: 0,
-          full: path.join(args.outputDir, entry),
-        }));
-      if (entries.length === 0) {
+      if (args.artifactPaths.length === 0) {
         console.warn(
-          `[bench published] No artifacts found under ${args.outputDir} to promote.`,
+          `[bench published] No artifacts produced for ${args.benchmarkId}; nothing to promote.`,
         );
         return;
       }
-      const { statSync } = await import("node:fs");
-      for (const entry of entries) {
-        entry.mtimeMs = statSync(entry.full).mtimeMs;
+      for (const artifactPath of args.artifactPaths) {
+        const raw = readFileSync(artifactPath, "utf8");
+        // Cursor Low on PR #603: `JSON.parse(null JSON literal)`
+        // returns `null`, which the old `as` cast hid. Validate the
+        // shape before dereferencing `.meta` to avoid a TypeError
+        // crashing the promotion step for a corrupted or empty
+        // artifact.
+        const parsedUnknown: unknown = JSON.parse(raw);
+        const parsedObj =
+          parsedUnknown !== null &&
+          typeof parsedUnknown === "object" &&
+          !Array.isArray(parsedUnknown)
+            ? (parsedUnknown as { meta?: { gitSha?: string } })
+            : {};
+        const gitShaShort = (parsedObj.meta?.gitSha ?? "unknown").slice(0, 7);
+        const today = new Date().toISOString().slice(0, 10);
+        const modelSlug = args.model.replace(/[^a-zA-Z0-9_.-]/g, "-");
+        const target = path.join(
+          args.publishedOutDir,
+          `${today}-${args.benchmarkId}-${modelSlug}-${gitShaShort}.json`,
+        );
+        writeFileSync(target, raw, "utf8");
+        console.log(
+          `[bench published] Promoted ${path.basename(artifactPath)} → ${target}`,
+        );
       }
-      entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
-      const latest = entries[0]!;
-      const raw = readFileSync(latest.full, "utf8");
-      const parsed = JSON.parse(raw) as { meta?: { gitSha?: string } };
-      const gitShaShort = (parsed.meta?.gitSha ?? "unknown").slice(0, 7);
-      const today = new Date().toISOString().slice(0, 10);
-      const modelSlug = args.model.replace(/[^a-zA-Z0-9_.-]/g, "-");
-      const target = path.join(
-        args.publishedOutDir,
-        `${today}-${args.benchmarkId}-${modelSlug}-${gitShaShort}.json`,
-      );
-      writeFileSync(target, raw, "utf8");
-      console.log(`[bench published] Promoted ${latest.name} → ${target}`);
       // Reference the bench module so the import isn't tree-shaken if
       // a future refactor wants to call into it from here.
       void benchModule;
@@ -1984,14 +1997,14 @@ async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
   runtimeProfile: BenchRuntimeProfile,
-): Promise<boolean> {
+): Promise<{ ok: boolean; writtenPath?: string }> {
   const loaded = await tryLoadBenchModule();
-  if (!loaded) return false;
+  if (!loaded) return { ok: false };
   const benchModule = loaded as unknown as PackageBenchModule;
 
   const definition = benchModule.getBenchmark?.(benchmarkId);
   if (!definition?.runnerAvailable || !benchModule.runBenchmark || !benchModule.writeBenchmarkResult) {
-    return false;
+    return { ok: false };
   }
 
   if (definition.meta?.category === "ingestion") {
@@ -2007,11 +2020,11 @@ async function runBenchViaPackage(
     [runtimeProfile],
   );
   if (!plans) {
-    return false;
+    return { ok: false };
   }
   const [plan] = plans;
   if (!plan) {
-    return false;
+    return { ok: false };
   }
 
   const outputDir = resolveBenchOutputDir();
@@ -2054,7 +2067,7 @@ async function runBenchViaPackage(
     } else {
       printBenchPackageSummary(result, writtenPath);
     }
-    return true;
+    return { ok: true, writtenPath };
   } finally {
     await system.destroy();
   }
@@ -4585,7 +4598,7 @@ async function cmdBench(rest: string[]): Promise<void> {
         benchmarkId,
         runtimeProfile,
       );
-      if (!handledByPackage) {
+      if (!handledByPackage.ok) {
         await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
       }
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -1845,6 +1845,13 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     const benchModule = loaded as unknown as PackageBenchModule;
     const benchmarkId = parsed.publishedName;
     const mode = parsed.quick ? "quick" : "full";
+    // Codex P2 review on PR #603: keep dry-run's effective limit in
+    // sync with the real run so preflight item counts match what will
+    // actually execute. Previously `limit: parsed.publishedLimit`
+    // alone meant `--quick` without `--limit` dry-ran the full smoke
+    // sample while the real run loaded only one item.
+    const effectiveLimit =
+      parsed.publishedLimit ?? (parsed.quick ? 1 : undefined);
     let itemCount: number | undefined;
     // Codex P2 review on PR #603: when the loader returns
     // `source: "missing"` (full mode and the dataset file is absent or
@@ -1864,7 +1871,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       loadResult = await benchModule.loadLongMemEvalS({
         mode,
         datasetDir: parsed.datasetDir,
-        limit: parsed.publishedLimit,
+        limit: effectiveLimit,
       });
       itemCount = loadResult.items.length;
       console.log(
@@ -1874,7 +1881,7 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       loadResult = await benchModule.loadLoCoMo10({
         mode,
         datasetDir: parsed.datasetDir,
-        limit: parsed.publishedLimit,
+        limit: effectiveLimit,
       });
       itemCount = loadResult.items.length;
       console.log(
@@ -1972,14 +1979,27 @@ async function loadPublishedPromotionHelpers() {
           parsedUnknown !== null &&
           typeof parsedUnknown === "object" &&
           !Array.isArray(parsedUnknown)
-            ? (parsedUnknown as { meta?: { gitSha?: string } })
+            ? (parsedUnknown as {
+                meta?: { gitSha?: string };
+                config?: { runtimeProfile?: string | null };
+              })
             : {};
         const gitShaShort = (parsedObj.meta?.gitSha ?? "unknown").slice(0, 7);
         const today = new Date().toISOString().slice(0, 10);
         const modelSlug = args.model.replace(/[^a-zA-Z0-9_.-]/g, "-");
+        // Codex P2 on PR #603: include the runtime profile in the
+        // published filename so multi-profile (e.g. --matrix) runs do
+        // not silently overwrite one another. The profile lives in
+        // `result.config.runtimeProfile` and is "baseline", "real",
+        // or "openclaw-chain" in practice.
+        const rawProfile = parsedObj.config?.runtimeProfile;
+        const profileSlug =
+          typeof rawProfile === "string" && rawProfile.length > 0
+            ? `-${rawProfile.replace(/[^a-zA-Z0-9_.-]/g, "-")}`
+            : "";
         const target = path.join(
           args.publishedOutDir,
-          `${today}-${args.benchmarkId}-${modelSlug}-${gitShaShort}.json`,
+          `${today}-${args.benchmarkId}-${modelSlug}${profileSlug}-${gitShaShort}.json`,
         );
         writeFileSync(target, raw, "utf8");
         console.log(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -394,6 +394,26 @@ type PackageBenchModule = {
     responder?: unknown;
     judge?: unknown;
   }) => Promise<{ destroy(): Promise<void> }>;
+  loadLongMemEvalS?: (options: {
+    mode: "full" | "quick";
+    datasetDir?: string;
+    limit?: number;
+  }) => Promise<{
+    source: "dataset" | "smoke" | "missing";
+    filename?: string;
+    items: unknown[];
+    errors: string[];
+  }>;
+  loadLoCoMo10?: (options: {
+    mode: "full" | "quick";
+    datasetDir?: string;
+    limit?: number;
+  }) => Promise<{
+    source: "dataset" | "smoke" | "missing";
+    filename?: string;
+    items: unknown[];
+    errors: string[];
+  }>;
 };
 
 interface TrainingExportOptions {
@@ -497,12 +517,16 @@ export interface PackageBenchExecutionPlan {
 }
 
 export function getBenchUsageText(): string {
-  return `Usage: remnic bench <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
-       remnic benchmark <list|run|datasets|runs|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
+  return `Usage: remnic bench <list|run|published|datasets|runs|compare|results|baseline|export|publish|ui|providers> [options] [benchmark...]
+       remnic benchmark <list|run|published|datasets|runs|compare|results|baseline|export|publish|ui|providers|check|report> [options] [benchmark...]
 
 Commands:
   list                     List published benchmark packs
   run [benchmark...]       Run one or more benchmark packs
+  published --name <longmemeval|locomo> --dataset <path> --model <id>
+                           Run a published benchmark with leaderboard-friendly flags
+                           (see issue #566 slice 4). Accepts --limit, --seed,
+                           --out, --dry-run, --provider, --base-url.
   datasets download [benchmark...]
                            Download local datasets for supported published benchmarks
   datasets status          Show local dataset availability for supported benchmarks
@@ -1764,6 +1788,177 @@ async function publishBenchPackageResults(parsed: ParsedBenchArgs): Promise<void
   );
 }
 
+/**
+ * `remnic bench published --name <longmemeval|locomo> --dataset <path>
+ *    --model <id> --limit <n> --seed <n> --out <dir> [--dry-run]
+ *    [--provider openai|anthropic|ollama|litellm] [--base-url <url>]`
+ *
+ * Issue #566 PR 4/7. Thin wrapper that routes the user's flags into the
+ * existing `runBenchViaPackage` machinery. The wrapper is deliberately
+ * narrow: it only accepts the two published benchmark IDs, enforces the
+ * `--name` + `--dataset` invariants at the boundary, and — in `--dry-run`
+ * — loads the dataset and prints a preview without calling any LLM.
+ *
+ * Validation is upstream in `parseBenchArgs`, per CLAUDE.md rules 14
+ * (validate CLI flag args) and 51 (reject invalid input with listed
+ * options). `--model` / `--limit` / `--seed` without a value throw
+ * instead of silently defaulting.
+ */
+async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
+  if (!parsed.publishedName) {
+    console.error(
+      "ERROR: `bench published` requires --name longmemeval|locomo.",
+    );
+    process.exit(1);
+  }
+  if (!parsed.datasetDir) {
+    console.error(
+      "ERROR: `bench published` requires --dataset <path> (or --dataset-dir <path>) pointing at the dataset directory.",
+    );
+    process.exit(1);
+  }
+  if (!parsed.systemModel) {
+    console.error(
+      "ERROR: `bench published` requires --model <id> (or --system-model <id>).",
+    );
+    process.exit(1);
+  }
+  if (parsed.benchmarks.length > 0) {
+    console.error(
+      "ERROR: `bench published` does not accept positional benchmark arguments; use --name instead.",
+    );
+    process.exit(1);
+  }
+
+  // Dry-run: validate config and load the dataset, but never touch the
+  // model. Useful for pre-flight checking a long run. Prints a single
+  // summary line per benchmark.
+  if (parsed.publishedDryRun) {
+    const loaded = await tryLoadBenchModule();
+    if (!loaded) {
+      console.error(
+        "ERROR: @remnic/bench package is not installed. Run `npm install @remnic/bench`.",
+      );
+      process.exit(1);
+    }
+    const benchModule = loaded as unknown as PackageBenchModule;
+    const benchmarkId = parsed.publishedName;
+    const mode = parsed.quick ? "quick" : "full";
+    let itemCount: number | undefined;
+    if (benchmarkId === "longmemeval" && benchModule.loadLongMemEvalS) {
+      const result = await benchModule.loadLongMemEvalS({
+        mode,
+        datasetDir: parsed.datasetDir,
+        limit: parsed.publishedLimit,
+      });
+      itemCount = result.items.length;
+      console.log(
+        `[dry-run] longmemeval: source=${result.source} filename=${result.filename ?? "<smoke>"} items=${itemCount} errors=${result.errors.length}`,
+      );
+    } else if (benchmarkId === "locomo" && benchModule.loadLoCoMo10) {
+      const result = await benchModule.loadLoCoMo10({
+        mode,
+        datasetDir: parsed.datasetDir,
+        limit: parsed.publishedLimit,
+      });
+      itemCount = result.items.length;
+      console.log(
+        `[dry-run] locomo: source=${result.source} filename=${result.filename ?? "<smoke>"} items=${itemCount} errors=${result.errors.length}`,
+      );
+    } else {
+      console.error(
+        `ERROR: installed @remnic/bench version does not export a loader for "${benchmarkId}".`,
+      );
+      process.exit(1);
+    }
+    return;
+  }
+
+  const runtimeProfiles = resolveBenchRunProfiles(parsed);
+  const benchmarkId = parsed.publishedName;
+  for (const runtimeProfile of runtimeProfiles) {
+    // Forward `--limit` + `--seed` through the existing package
+    // runner. `--out` is handled below in the artifact write step.
+    const ok = await runBenchViaPackage(
+      parsed,
+      benchmarkId,
+      runtimeProfile,
+    );
+    if (!ok) {
+      console.error(
+        `ERROR: unable to run ${benchmarkId} via @remnic/bench. Update the @remnic/bench install to a version that exports a runner for this benchmark.`,
+      );
+      process.exit(1);
+    }
+  }
+
+  // When `--out` is supplied, copy the newest result artifact into the
+  // directory under a canonical leaderboard filename. We keep the
+  // primary result file under `~/.remnic/bench/results/` (set by
+  // `resolveBenchOutputDir`) and only publish a flatter copy to the
+  // user-specified directory so the dev environment stays in sync.
+  if (parsed.publishedOut) {
+    const { promoteLatestArtifactToPublished } = await loadPublishedPromotionHelpers();
+    await promoteLatestArtifactToPublished({
+      benchmarkId,
+      outputDir: resolveBenchOutputDir(),
+      publishedOutDir: parsed.publishedOut,
+      model: parsed.systemModel,
+    });
+  }
+}
+
+async function loadPublishedPromotionHelpers() {
+  const benchModule = (await loadBenchModule()) as unknown as PackageBenchModule;
+  return {
+    async promoteLatestArtifactToPublished(args: {
+      benchmarkId: string;
+      outputDir: string;
+      publishedOutDir: string;
+      model: string;
+    }) {
+      const { mkdirSync, readdirSync, readFileSync, writeFileSync } = await import(
+        "node:fs"
+      );
+      const path = await import("node:path");
+      mkdirSync(args.publishedOutDir, { recursive: true });
+      const entries = readdirSync(args.outputDir)
+        .filter((entry) => entry.endsWith(".json"))
+        .map((entry) => ({
+          name: entry,
+          mtimeMs: 0,
+          full: path.join(args.outputDir, entry),
+        }));
+      if (entries.length === 0) {
+        console.warn(
+          `[bench published] No artifacts found under ${args.outputDir} to promote.`,
+        );
+        return;
+      }
+      const { statSync } = await import("node:fs");
+      for (const entry of entries) {
+        entry.mtimeMs = statSync(entry.full).mtimeMs;
+      }
+      entries.sort((a, b) => b.mtimeMs - a.mtimeMs);
+      const latest = entries[0]!;
+      const raw = readFileSync(latest.full, "utf8");
+      const parsed = JSON.parse(raw) as { meta?: { gitSha?: string } };
+      const gitShaShort = (parsed.meta?.gitSha ?? "unknown").slice(0, 7);
+      const today = new Date().toISOString().slice(0, 10);
+      const modelSlug = args.model.replace(/[^a-zA-Z0-9_.-]/g, "-");
+      const target = path.join(
+        args.publishedOutDir,
+        `${today}-${args.benchmarkId}-${modelSlug}-${gitShaShort}.json`,
+      );
+      writeFileSync(target, raw, "utf8");
+      console.log(`[bench published] Promoted ${latest.name} → ${target}`);
+      // Reference the bench module so the import isn't tree-shaken if
+      // a future refactor wants to call into it from here.
+      void benchModule;
+    },
+  };
+}
+
 async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
@@ -1808,11 +2003,15 @@ async function runBenchViaPackage(
   const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
   try {
+    // `publishedLimit` (from `bench published --limit N`) takes
+    // precedence over the implicit quick-mode limit of 1.
+    const effectiveLimit =
+      parsed.publishedLimit ?? (parsed.quick ? 1 : undefined);
     const result = await benchModule.runBenchmark(benchmarkId, {
       mode: parsed.quick ? "quick" : "full",
       datasetDir,
       outputDir,
-      limit: parsed.quick ? 1 : undefined,
+      limit: effectiveLimit,
       adapterMode: plan.adapterMode,
       runtimeProfile: plan.runtime.profile,
       systemProvider: plan.runtime.systemProvider,
@@ -4283,6 +4482,11 @@ async function cmdBench(rest: string[]): Promise<void> {
 
   if (parsed.action === "publish") {
     await publishBenchPackageResults(parsed);
+    return;
+  }
+
+  if (parsed.action === "published") {
+    await runBenchPublished(parsed);
     return;
   }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -286,6 +286,7 @@ type PackageBenchModule = {
     datasetDir?: string;
     outputDir?: string;
     limit?: number;
+    seed?: number;
     adapterMode?: string;
     runtimeProfile?: BenchRuntimeProfile | null;
     systemProvider?: {
@@ -1845,29 +1846,49 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
     const benchmarkId = parsed.publishedName;
     const mode = parsed.quick ? "quick" : "full";
     let itemCount: number | undefined;
+    // Codex P2 review on PR #603: when the loader returns
+    // `source: "missing"` (full mode and the dataset file is absent or
+    // unreadable), dry-run must fail loudly. Previously the script
+    // logged the line and exited 0, so CI/users could not trust
+    // `--dry-run` as a preflight gate — the real run would later crash
+    // with the same missing dataset.
+    let loadResult:
+      | {
+          source: string;
+          filename?: string;
+          items: unknown[];
+          errors: unknown[];
+        }
+      | undefined;
     if (benchmarkId === "longmemeval" && benchModule.loadLongMemEvalS) {
-      const result = await benchModule.loadLongMemEvalS({
+      loadResult = await benchModule.loadLongMemEvalS({
         mode,
         datasetDir: parsed.datasetDir,
         limit: parsed.publishedLimit,
       });
-      itemCount = result.items.length;
+      itemCount = loadResult.items.length;
       console.log(
-        `[dry-run] longmemeval: source=${result.source} filename=${result.filename ?? "<smoke>"} items=${itemCount} errors=${result.errors.length}`,
+        `[dry-run] longmemeval: source=${loadResult.source} filename=${loadResult.filename ?? "<smoke>"} items=${itemCount} errors=${loadResult.errors.length}`,
       );
     } else if (benchmarkId === "locomo" && benchModule.loadLoCoMo10) {
-      const result = await benchModule.loadLoCoMo10({
+      loadResult = await benchModule.loadLoCoMo10({
         mode,
         datasetDir: parsed.datasetDir,
         limit: parsed.publishedLimit,
       });
-      itemCount = result.items.length;
+      itemCount = loadResult.items.length;
       console.log(
-        `[dry-run] locomo: source=${result.source} filename=${result.filename ?? "<smoke>"} items=${itemCount} errors=${result.errors.length}`,
+        `[dry-run] locomo: source=${loadResult.source} filename=${loadResult.filename ?? "<smoke>"} items=${itemCount} errors=${loadResult.errors.length}`,
       );
     } else {
       console.error(
         `ERROR: installed @remnic/bench version does not export a loader for "${benchmarkId}".`,
+      );
+      process.exit(1);
+    }
+    if (loadResult && loadResult.source === "missing") {
+      console.error(
+        `ERROR: [dry-run] ${benchmarkId}: dataset missing or unreadable under ${parsed.datasetDir}. Provide a valid --dataset path before running without --dry-run.`,
       );
       process.exit(1);
     }
@@ -2007,11 +2028,18 @@ async function runBenchViaPackage(
     // precedence over the implicit quick-mode limit of 1.
     const effectiveLimit =
       parsed.publishedLimit ?? (parsed.quick ? 1 : undefined);
+    // Forward `--seed` through to the runner so the determinism contract
+    // advertised by `bench published --seed N` is actually honored.
+    // Cursor + Codex review on PR #603: without this, `publishedSeed` was
+    // parsed but dropped, and the harness recorded `ctx.options.seed ?? 0`
+    // instead of the user-specified seed, breaking reproducibility.
+    const effectiveSeed = parsed.publishedSeed;
     const result = await benchModule.runBenchmark(benchmarkId, {
       mode: parsed.quick ? "quick" : "full",
       datasetDir,
       outputDir,
       limit: effectiveLimit,
+      seed: effectiveSeed,
       adapterMode: plan.adapterMode,
       runtimeProfile: plan.runtime.profile,
       systemProvider: plan.runtime.systemProvider,

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -304,7 +304,7 @@ test("bench providers discovery is exposed as a package-backed CLI surface", asy
   const readme = await readFile("packages/remnic-cli/README.md", "utf8");
 
   assert.match(source, /\bdiscoverAllProviders\b/);
-  assert.match(source, /Usage: remnic bench <list\|run\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
+  assert.match(source, /Usage: remnic bench <list\|run\|published\|datasets\|runs\|compare\|results\|baseline\|export\|publish\|ui\|providers>/);
   assert.match(source, /remnic bench providers discover/);
   assert.match(source, /async function discoverBenchProviders\(parsed: ParsedBenchArgs\): Promise<void>/);
   assert.match(source, /providers discover does not accept positional arguments/);
@@ -950,7 +950,7 @@ test("bench publish routes through the stored package feed helpers", async () =>
   assert.match(parserSource, /arg === "--target"/);
   assert.match(parserSource, /const targetRaw = readBenchOptionValue\(args, "--target"\);/);
   assert.match(parserSource, /ERROR: --target must be "remnic-ai"\./);
-  assert.match(parserSource, /target,\s*\n\s*\};/s);
+  assert.match(parserSource, /target,/);
 });
 
 test("parseBenchArgs rejects unknown bench publish targets", async () => {


### PR DESCRIPTION
## Summary

- Adds `remnic bench published --name <longmemeval|locomo> --dataset <path> --model <id> [--limit N] [--seed N] [--out <dir>] [--dry-run] [--provider openai|anthropic|ollama|litellm] [--base-url <url>]`.
- Thin wrapper on top of existing `runBenchViaPackage` machinery — no new runner code path.
- `--dry-run` loads the dataset via the shared loader and prints a preview without calling any LLM, so paid-API runs can be pre-flighted.
- `--out` promotes the newest artifact into a canonical `<date>-<benchmark>-<modelSlug>-<gitShaShort>.json` filename for leaderboard publishing.
- CLAUDE.md rules 14 (flag requires value), 27 (`--limit 0` preserved), 51 (invalid input rejected with listed values) enforced at the CLI boundary.

## Dependency

Stacks on top of #596 (PR 2/7 — shared harness). Merge after #596.

## Test plan

- [x] `pnpm run check-types` clean.
- [x] `bench-args.test.ts` — 12 pass covering `--name`, `--dataset`, `--model`, `--limit`, `--seed`, `--out`, `--dry-run`, `--provider`, `--base-url`, `--dataset-dir` precedence, empty `--model` rejection, `--limit 0`.

Part of #566.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI command and adjusts package-backed benchmark execution to pass through `--seed`/`--limit` and to promote result artifacts to user-specified directories, which can affect run reproducibility and filesystem outputs. Core benchmark execution remains routed through existing `@remnic/bench` runners, limiting blast radius to the CLI surface.
> 
> **Overview**
> Adds a new `remnic bench published` command for running curated published benchmarks (`longmemeval`/`locomo`) with leaderboard-friendly flags (`--name`, `--dataset`, `--model`, plus `--limit`, `--seed`, `--provider`, `--base-url`, `--out`, `--dry-run`).
> 
> Updates CLI arg parsing to validate these flags (including `--dataset` as an alias for `--dataset-dir`, non-negative integer enforcement for `--limit`/`--seed`, and non-empty `--model`) and to map the shorthand provider/model/base-url flags onto the existing `--system-*` options.
> 
> Implements `--dry-run` dataset loading (no model calls) and an `--out` promotion step that copies the just-written result artifacts into canonical filenames (including runtime profile) for publishing; `runBenchViaPackage` now returns the written path and forwards `seed`/effective `limit` into `@remnic/bench.runBenchmark`. Tests are expanded to cover the new parser behavior and help/CLI surface updates.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e6d3361a4d1c92de78b40d6b6498f98e293f46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->