### PR TITLE
feat(xray): MCP engram.recall_xray + remnic.recall_xray tool (#570 PR 5/7)

### DIFF
--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1158,9 +1158,17 @@ export class EngramMcpServer {
             : undefined;
         // `budget` may arrive as a JSON number or a string ('4096')
         // from loosely-typed MCP clients; coerce + validate here so
-        // the service sees a number.
+        // the service sees a number.  Reject booleans, objects, and
+        // other non-string-non-number inputs explicitly — `Number()`
+        // otherwise coerces `true` to `1`, which would silently force
+        // an extremely small recall budget (CLAUDE.md rule 51).
         let budget: number | undefined;
         if (args.budget !== undefined && args.budget !== null) {
+          if (typeof args.budget !== "number" && typeof args.budget !== "string") {
+            throw new Error(
+              `engram.recall_xray: budget expects a positive integer; got ${JSON.stringify(args.budget)}`,
+            );
+          }
           const parsed =
             typeof args.budget === "number"
               ? args.budget

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -145,6 +145,40 @@ export class EngramMcpServer {
         },
       },
       {
+        // Registered as `engram.recall_xray`; `withToolAliases` below
+        // emits the canonical `remnic.recall_xray` alias automatically
+        // (dual-naming invariant for every new MCP tool).
+        name: "engram.recall_xray",
+        description:
+          "Run a recall with X-ray capture enabled and return the unified per-result attribution snapshot (tier + audit + MMR + filters in one view). Issue #570.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            query: {
+              type: "string",
+              description: "Query to recall against. Required; non-empty.",
+            },
+            sessionKey: {
+              type: "string",
+              description: "Optional session key to scope the recall.",
+            },
+            namespace: {
+              type: "string",
+              description:
+                "Optional namespace. Enforced against the caller's principal; a mismatch yields snapshotFound:false.",
+            },
+            budget: {
+              type: "integer",
+              minimum: 1,
+              description:
+                "Optional positive-integer override for the recall character budget.",
+            },
+          },
+          required: ["query"],
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.day_summary",
         description:
           "Generate a structured end-of-day summary. When memories is omitted or empty, auto-gathers today's facts and hourly summaries from storage.",
@@ -1107,6 +1141,49 @@ export class EngramMcpServer {
             : undefined,
           effectivePrincipal,
         );
+      case "engram.recall_xray": {
+        // `recallXray` throws on empty query / invalid budget; surface
+        // those as MCP errors with a listed-options message rather
+        // than silently returning `snapshotFound: false` (CLAUDE.md
+        // rule 51).  Namespace scope is enforced inside the service
+        // via `canReadNamespace`.
+        const query = typeof args.query === "string" ? args.query : "";
+        const sessionKey =
+          typeof args.sessionKey === "string" && args.sessionKey.length > 0
+            ? args.sessionKey
+            : undefined;
+        const namespace =
+          typeof args.namespace === "string" && args.namespace.length > 0
+            ? args.namespace
+            : undefined;
+        // `budget` may arrive as a JSON number or a string ('4096')
+        // from loosely-typed MCP clients; coerce + validate here so
+        // the service sees a number.
+        let budget: number | undefined;
+        if (args.budget !== undefined && args.budget !== null) {
+          const parsed =
+            typeof args.budget === "number"
+              ? args.budget
+              : Number(args.budget);
+          if (
+            !Number.isFinite(parsed)
+            || parsed <= 0
+            || !Number.isInteger(parsed)
+          ) {
+            throw new Error(
+              `engram.recall_xray: budget expects a positive integer; got ${JSON.stringify(args.budget)}`,
+            );
+          }
+          budget = parsed;
+        }
+        return this.service.recallXray({
+          query,
+          sessionKey,
+          namespace,
+          budget,
+          authenticatedPrincipal: effectivePrincipal,
+        });
+      }
       case "engram.day_summary":
         return this.service.daySummary({
           memories: typeof args.memories === "string" ? args.memories : "",

--- a/tests/access-mcp-recall-xray.test.ts
+++ b/tests/access-mcp-recall-xray.test.ts
@@ -155,3 +155,38 @@ test("MCP engram.recall_xray rejects invalid budget with a listed-options error"
   );
   assert.equal(capture.calls.length, 0, "service must NOT be called when validation fails");
 });
+
+test("MCP engram.recall_xray rejects non-string non-number budgets (e.g., booleans, objects)", async () => {
+  // Codex P2 on #604: `Number(true)` coerces to 1, so accepting
+  // boolean values would silently force a tiny recall budget.  The
+  // MCP handler must reject typed-incorrectly inputs up front instead
+  // of coercing them.  This exercises the boolean and object cases.
+  const capture = { calls: [] as any[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  for (const badBudget of [true, false, { v: 1 }, [4096]]) {
+    const response = await server.handleRequest({
+      jsonrpc: "2.0",
+      id: 2,
+      method: "tools/call",
+      params: {
+        name: "engram.recall_xray",
+        arguments: { query: "q", budget: badBudget as unknown },
+      },
+    });
+    const result = response?.result as {
+      isError?: boolean;
+      content?: Array<{ text?: string }>;
+    };
+    assert.equal(
+      result.isError,
+      true,
+      `expected an error response for budget=${JSON.stringify(badBudget)}`,
+    );
+    assert.match(
+      String(result.content?.[0]?.text ?? ""),
+      /budget expects a positive integer/,
+    );
+  }
+  assert.equal(capture.calls.length, 0, "service must NOT be called when validation fails");
+});

--- a/tests/access-mcp-recall-xray.test.ts
+++ b/tests/access-mcp-recall-xray.test.ts
@@ -1,0 +1,157 @@
+/**
+ * MCP dispatch tests for `engram.recall_xray` / `remnic.recall_xray`
+ * (issue #570 PR 5).  Verifies that:
+ *  - the tool is advertised under BOTH the legacy `engram.*` and the
+ *    canonical `remnic.*` names (dual-naming invariant);
+ *  - both aliases dispatch to the same service method with the same
+ *    payload;
+ *  - required field validation + namespace threading work.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EngramMcpServer } from "../src/access-mcp.js";
+import type { EngramAccessService } from "../src/access-service.js";
+
+function fakeService(capture: {
+  calls: Array<{
+    query: string;
+    sessionKey?: string;
+    namespace?: string;
+    budget?: number;
+    authenticatedPrincipal?: string;
+  }>;
+}): EngramAccessService {
+  return {
+    recallXray: async (req: {
+      query: string;
+      sessionKey?: string;
+      namespace?: string;
+      budget?: number;
+      authenticatedPrincipal?: string;
+    }) => {
+      capture.calls.push({ ...req });
+      return {
+        snapshotFound: true,
+        snapshot: {
+          schemaVersion: "1" as const,
+          query: req.query,
+          snapshotId: "snap-xray-1",
+          capturedAt: 1_700_000_000_000,
+          tierExplain: null,
+          results: [],
+          filters: [],
+          budget: { chars: 4096, used: 0 },
+        },
+      };
+    },
+  } as unknown as EngramAccessService;
+}
+
+test("MCP advertises both engram.recall_xray and remnic.recall_xray", async () => {
+  const server = new EngramMcpServer(fakeService({ calls: [] }));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  const tools = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/list",
+    params: {},
+  });
+  const names = (tools?.result as { tools: Array<{ name: string }> }).tools.map(
+    (t) => t.name,
+  );
+  assert.ok(names.includes("engram.recall_xray"), "legacy engram.* name is advertised");
+  assert.ok(names.includes("remnic.recall_xray"), "canonical remnic.* alias is advertised");
+});
+
+test("MCP engram.recall_xray dispatches to recallXray with threaded params", async () => {
+  const capture = { calls: [] as any[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.recall_xray",
+      arguments: {
+        query: "what editor do I use",
+        sessionKey: "sess-42",
+        namespace: "team-a",
+        budget: 2048,
+      },
+    },
+  });
+  const result = response?.result as {
+    structuredContent: { snapshotFound: boolean; snapshot?: { query: string } };
+  };
+  assert.equal(result.structuredContent.snapshotFound, true);
+  assert.equal(result.structuredContent.snapshot?.query, "what editor do I use");
+
+  assert.equal(capture.calls.length, 1);
+  assert.equal(capture.calls[0].query, "what editor do I use");
+  assert.equal(capture.calls[0].sessionKey, "sess-42");
+  assert.equal(capture.calls[0].namespace, "team-a");
+  assert.equal(capture.calls[0].budget, 2048);
+});
+
+test("MCP remnic.recall_xray alias dispatches identically", async () => {
+  const capture = { calls: [] as any[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "remnic.recall_xray",
+      arguments: { query: "q" },
+    },
+  });
+  assert.equal(capture.calls.length, 1);
+  assert.equal(capture.calls[0].query, "q");
+});
+
+test("MCP engram.recall_xray coerces string budget to integer", async () => {
+  const capture = { calls: [] as any[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.recall_xray",
+      arguments: { query: "q", budget: "2048" },
+    },
+  });
+  assert.equal(capture.calls[0].budget, 2048);
+});
+
+test("MCP engram.recall_xray rejects invalid budget with a listed-options error", async () => {
+  const capture = { calls: [] as any[] };
+  const server = new EngramMcpServer(fakeService(capture));
+  await server.handleRequest({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} });
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.recall_xray",
+      arguments: { query: "q", budget: -1 },
+    },
+  });
+  // MCP wraps handler errors in `result.isError=true` with a text
+  // content node carrying the message.
+  const result = response?.result as {
+    isError?: boolean;
+    content?: Array<{ text?: string }>;
+  };
+  assert.equal(result.isError, true, "expected an error response");
+  assert.match(
+    String(result.content?.[0]?.text ?? ""),
+    /budget expects a positive integer/,
+  );
+  assert.equal(capture.calls.length, 0, "service must NOT be called when validation fails");
+});

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -28,6 +28,19 @@ function createFakeService(): EngramAccessService {
       intent: null,
       graph: null,
     }),
+    recallXray: async ({ query }) => ({
+      snapshotFound: true,
+      snapshot: {
+        schemaVersion: "1" as const,
+        query,
+        snapshotId: "snap-1",
+        capturedAt: 1_700_000_000_000,
+        tierExplain: null,
+        results: [],
+        filters: [],
+        budget: { chars: 4096, used: 0 },
+      },
+    }),
     memoryGet: async (memoryId) => ({
       found: true,
       namespace: "global",
@@ -157,6 +170,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall",
     "engram.recall_explain",
     "engram.recall_tier_explain",
+    "engram.recall_xray",
     "engram.day_summary",
     "engram.memory_governance_run",
     "engram.procedure_mining_run",


### PR DESCRIPTION
## Summary

Slice 5 of the unified Recall X-ray observability surface (#570). Adds the MCP tool that calls the shared `EngramAccessService.recallXray` method from PR 4, so CLI + HTTP + MCP all return identical JSON (CLAUDE.md rule 22).

- `packages/remnic-core/src/access-mcp.ts`
  - New tool registration for `engram.recall_xray`. The existing `withToolAliases` helper automatically emits the canonical `remnic.recall_xray` alias (dual-naming invariant for every new MCP tool).
  - Input schema: `query` required, `sessionKey`, `namespace`, `budget` optional (`type: "integer", minimum: 1`).
  - Dispatch case coerces `budget` from JSON number or string, rejects zero / negative / fractional / non-finite / non-numeric values with an explicit listed-options error (CLAUDE.md rule 51). The underlying service enforces namespace scope via the same `canReadNamespace` check used by recall-tier-explain (rule 42).

- `tests/access-mcp.test.ts` — updated dual-naming advertising test to include both names; added `recallXray` to the fake service.
- New `tests/access-mcp-recall-xray.test.ts` — 5 dedicated dispatch tests: both names advertised, `engram.*` dispatch threads params, `remnic.*` alias dispatches identically, string budget coerced to integer, invalid budget returns an MCP error without invoking the service.

## No behavior change

No changes to existing MCP tools. No behavior change for any existing CLI or HTTP surface.

## Stacking

Based on `feat/issue-570-pr4-http` (PR #601) which added `EngramAccessService.recallXray`. Retargets to `main` after PR #601 merges.

## Test plan

- [x] 5 new dispatch tests pass.
- [x] Existing `tests/access-mcp.test.ts` still passes with the updated tool list.
- [x] `tsc --noEmit` clean for the core package.

Part of #570 (slice 5 of 7).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new MCP tool surface that triggers recall execution and introduces stricter input coercion/validation for `budget`, which could affect client behavior and error handling.
> 
> **Overview**
> Adds a new MCP tool, `engram.recall_xray` (auto-aliased to `remnic.recall_xray`), to run Recall X-ray and return the unified attribution snapshot via `EngramAccessService.recallXray`.
> 
> The MCP dispatch now threads `query`, optional `sessionKey`/`namespace`, and a validated/coerced integer `budget` (accepting string/number, rejecting invalid and non-scalar inputs with explicit MCP errors). Tests are updated/added to assert dual-name advertisement, identical alias dispatch, parameter threading, and budget validation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91fdbcab015f87868194ea8e1dd088f684e68ab8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->