### PR TITLE
feat(xray): recall-explain gains markdown mode via shared xray renderer (#570 PR 7/7)

### DIFF
--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+
+import type { LastRecallSnapshot } from "./recall-state.js";
+import {
+  parseRecallExplainFormat,
+  renderRecallExplain,
+  toRecallXraySnapshotFromLegacy,
+} from "./recall-explain-renderer.js";
+
+function legacySnapshot(
+  overrides: Partial<LastRecallSnapshot> = {},
+): LastRecallSnapshot {
+  return {
+    sessionKey: "sess-42",
+    recordedAt: "2023-11-14T22:13:20.000Z",
+    queryHash: "deadbeef",
+    queryLen: 21,
+    memoryIds: ["mem-1", "mem-2"],
+    source: "hot_qmd",
+    sourcesUsed: ["hot_qmd", "memories"],
+    namespace: "workspace-a",
+    latencyMs: 42,
+    ...overrides,
+  };
+}
+
+// ─── parseRecallExplainFormat ────────────────────────────────────────────
+
+test("parseRecallExplainFormat accepts the original text+json formats", () => {
+  assert.equal(parseRecallExplainFormat("text"), "text");
+  assert.equal(parseRecallExplainFormat("json"), "json");
+});
+
+test("parseRecallExplainFormat accepts the new markdown format", () => {
+  assert.equal(parseRecallExplainFormat("markdown"), "markdown");
+  assert.equal(parseRecallExplainFormat("  MARKDOWN  "), "markdown");
+});
+
+test("parseRecallExplainFormat rejects unknown formats with a listed-options error", () => {
+  assert.throws(
+    () => parseRecallExplainFormat("xml"),
+    /--format expects "text", "json", or "markdown"/,
+  );
+});
+
+test("parseRecallExplainFormat defaults to text when absent", () => {
+  assert.equal(parseRecallExplainFormat(undefined), "text");
+  assert.equal(parseRecallExplainFormat(null), "text");
+});
+
+// ─── backward compatibility: text + json unchanged ───────────────────────
+
+test("renderRecallExplain text output is unchanged from pre-#570 behavior", () => {
+  const out = renderRecallExplain(legacySnapshot(), "text");
+  assert.ok(out.startsWith("=== Recall Explain ==="));
+  assert.ok(out.includes("session: sess-42"));
+  assert.ok(out.includes("source: hot_qmd"));
+  assert.ok(out.includes("memories: mem-1, mem-2"));
+  // The tier-explain section is absent because legacy snapshot has
+  // no tierExplain field populated.
+  assert.ok(out.includes("tier-explain: (not populated"));
+});
+
+test("renderRecallExplain json output is unchanged JSON shape", () => {
+  const out = renderRecallExplain(legacySnapshot(), "json");
+  const parsed = JSON.parse(out);
+  assert.equal(parsed.hasExplain, false);
+  assert.equal(parsed.snapshotFound, true);
+  assert.equal(parsed.sessionKey, "sess-42");
+  assert.deepEqual(parsed.memoryIds, ["mem-1", "mem-2"]);
+});
+
+// ─── markdown delegation ─────────────────────────────────────────────────
+
+test("renderRecallExplain markdown delegates to the shared X-ray renderer", () => {
+  const out = renderRecallExplain(legacySnapshot(), "markdown");
+  // X-ray markdown always opens with an H1.
+  assert.ok(out.startsWith("# Recall X-ray"));
+  // Session + namespace from the legacy snapshot round-trip into the
+  // markdown table.
+  assert.ok(out.includes("| Session | `sess-42` |"));
+  assert.ok(out.includes("| Namespace | `workspace-a` |"));
+  // Memory ids become H3 result sections.
+  assert.ok(out.includes("### 1. `mem-1` — served-by=hybrid"));
+  assert.ok(out.includes("### 2. `mem-2` — served-by=hybrid"));
+});
+
+test("renderRecallExplain markdown handles null snapshot via the renderer's placeholder", () => {
+  const out = renderRecallExplain(null, "markdown");
+  assert.equal(out, "# Recall X-ray\n\n_No X-ray snapshot captured._");
+});
+
+// ─── toRecallXraySnapshotFromLegacy adapter ──────────────────────────────
+
+test("toRecallXraySnapshotFromLegacy returns null for a null input", () => {
+  assert.equal(toRecallXraySnapshotFromLegacy(null), null);
+});
+
+test("toRecallXraySnapshotFromLegacy translates recordedAt to capturedAt epoch ms", () => {
+  const xray = toRecallXraySnapshotFromLegacy(legacySnapshot());
+  assert.ok(xray);
+  assert.equal(xray?.capturedAt, 1_700_000_000_000);
+});
+
+test("toRecallXraySnapshotFromLegacy preserves session / namespace / memory ids", () => {
+  const xray = toRecallXraySnapshotFromLegacy(legacySnapshot());
+  assert.equal(xray?.sessionKey, "sess-42");
+  assert.equal(xray?.namespace, "workspace-a");
+  assert.equal(xray?.results.length, 2);
+  assert.equal(xray?.results[0]?.memoryId, "mem-1");
+});
+
+test("toRecallXraySnapshotFromLegacy copes with malformed recordedAt", () => {
+  const xray = toRecallXraySnapshotFromLegacy(
+    legacySnapshot({ recordedAt: "not-a-date" }),
+  );
+  assert.equal(xray?.capturedAt, 0);
+});

--- a/packages/remnic-core/src/recall-explain-renderer.test.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.test.ts
@@ -117,3 +117,24 @@ test("toRecallXraySnapshotFromLegacy copes with malformed recordedAt", () => {
   );
   assert.equal(xray?.capturedAt, 0);
 });
+
+test("toRecallXraySnapshotFromLegacy propagates snapshot.source to servedBy", () => {
+  // Codex P2 + Cursor Medium on #605: every converted result used to
+  // be stamped with `servedBy: "hybrid"`, misattributing legacy
+  // snapshots from a non-hybrid source (notably `recent_scan`).
+  const recent = toRecallXraySnapshotFromLegacy(
+    legacySnapshot({ source: "recent_scan" }),
+  );
+  assert.equal(recent?.results[0]?.servedBy, "recent-scan");
+  assert.equal(recent?.results[1]?.servedBy, "recent-scan");
+
+  for (const source of ["hot_qmd", "hot_embedding", "cold_fallback", "none"]) {
+    const xray = toRecallXraySnapshotFromLegacy(legacySnapshot({ source }));
+    assert.equal(xray?.results[0]?.servedBy, "hybrid", `source=${source}`);
+  }
+  const unknown = toRecallXraySnapshotFromLegacy(
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    legacySnapshot({ source: "future_tier" as any }),
+  );
+  assert.equal(unknown?.results[0]?.servedBy, "hybrid");
+});

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -252,7 +252,12 @@ export function toRecallXraySnapshotFromLegacy(
         : "(legacy explain)",
     snapshotId: `legacy-${snapshot.sessionKey ?? "unknown"}-${capturedAt}`,
     capturedAt,
-    tierExplain: snapshot.tierExplain ?? null,
+    // Run the raw on-disk value through the same normalizer the text
+    // and JSON paths use so the markdown adapter cannot render
+    // unvalidated tier-explain payloads (cursor / codex review on
+    // #605).  A malformed tierExplain is dropped to null, matching the
+    // behavior of the non-markdown surfaces.
+    tierExplain: normalizeTierExplain(snapshot.tierExplain) ?? null,
     results,
     filters,
     budget: { chars: 0, used: 0 },

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -220,6 +220,18 @@ export function toRecallExplainText(
  * left empty because the legacy snapshot doesn't carry them.  The
  * renderer handles missing fields gracefully.
  */
+/**
+ * Strip backticks, pipes, and newlines from a host-provided string so it
+ * cannot escape its enclosing markdown code span, break the surrounding
+ * table row, or inject extra rows when it lands in
+ * `renderXrayMarkdown`.  Applied at the adapter boundary because
+ * `LastRecallSnapshot` is hydrated from on-disk JSON without schema
+ * validation (codex P2 review on #605).
+ */
+function sanitizeForMarkdownInline(value: string): string {
+  return value.replace(/[`|\r\n]/g, " ").trim();
+}
+
 export function toRecallXraySnapshotFromLegacy(
   snapshot: LastRecallSnapshot | null,
 ): RecallXraySnapshot | null {
@@ -250,7 +262,10 @@ export function toRecallXraySnapshotFromLegacy(
       snapshot.queryHash
         ? `(legacy explain; queryHash=${snapshot.queryHash})`
         : "(legacy explain)",
-    snapshotId: `legacy-${snapshot.sessionKey ?? "unknown"}-${capturedAt}`,
+    // `snapshotId` is synthesized here; `sessionKey` is already
+    // sanitized before it reaches the ID because we re-use the
+    // sanitized string below.
+    snapshotId: `legacy-${sanitizeForMarkdownInline(snapshot.sessionKey ?? "unknown") || "unknown"}-${capturedAt}`,
     capturedAt,
     // Run the raw on-disk value through the same normalizer the text
     // and JSON paths use so the markdown adapter cannot render
@@ -261,8 +276,23 @@ export function toRecallXraySnapshotFromLegacy(
     results,
     filters,
     budget: { chars: 0, used: 0 },
-    ...(snapshot.sessionKey ? { sessionKey: snapshot.sessionKey } : {}),
-    ...(snapshot.namespace ? { namespace: snapshot.namespace } : {}),
+    // Sanitize legacy session metadata at the adapter boundary so a
+    // malformed on-disk value (containing backticks, pipes, or
+    // newlines) cannot break the enclosing markdown table when
+    // `renderXrayMarkdown` prints it in a raw code-span cell (codex P2
+    // review on #605).
+    ...(snapshot.sessionKey
+      ? (() => {
+          const clean = sanitizeForMarkdownInline(snapshot.sessionKey);
+          return clean ? { sessionKey: clean } : {};
+        })()
+      : {}),
+    ...(snapshot.namespace
+      ? (() => {
+          const clean = sanitizeForMarkdownInline(snapshot.namespace);
+          return clean ? { namespace: clean } : {};
+        })()
+      : {}),
   };
 }
 

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -11,6 +11,12 @@
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type { RecallTierExplain } from "./types.js";
 import { isRetrievalTier } from "./retrieval-tiers.js";
+import type {
+  RecallXraySnapshot,
+  RecallFilterTrace,
+  RecallXrayResult,
+} from "./recall-xray.js";
+import { renderXrayMarkdown } from "./recall-xray-renderer.js";
 
 function sanitizeString(v: unknown): string | null {
   return typeof v === "string" && v.length > 0 ? v : null;
@@ -20,7 +26,13 @@ function sanitizeFiniteNumber(v: unknown): number | null {
   return typeof v === "number" && Number.isFinite(v) ? v : null;
 }
 
-export type RecallExplainFormat = "text" | "json";
+/**
+ * `text` and `json` are the original formats (backwards-compatible
+ * since issue #518).  `markdown` was added in issue #570 PR 7 and
+ * delegates to the shared X-ray renderer so the three observability
+ * surfaces stay in lock-step (CLAUDE.md rule 22).
+ */
+export type RecallExplainFormat = "text" | "json" | "markdown";
 
 export interface RecallExplainJsonPayload {
   hasExplain: boolean;
@@ -198,12 +210,70 @@ export function toRecallExplainText(
   return lines.join("\n");
 }
 
+/**
+ * Adapter: convert a `LastRecallSnapshot` into a best-effort
+ * `RecallXraySnapshot` so the markdown renderer can produce a
+ * consistent, richly-formatted document for callers that have asked
+ * for `markdown` format.  The LastRecallSnapshot and the X-ray
+ * snapshot share session/namespace/memoryIds; additional X-ray-only
+ * fields (filters, score decomposition, graph path, audit id) are
+ * left empty because the legacy snapshot doesn't carry them.  The
+ * renderer handles missing fields gracefully.
+ */
+export function toRecallXraySnapshotFromLegacy(
+  snapshot: LastRecallSnapshot | null,
+): RecallXraySnapshot | null {
+  if (!snapshot) return null;
+  const capturedAt = (() => {
+    if (typeof snapshot.recordedAt !== "string") return 0;
+    const ms = Date.parse(snapshot.recordedAt);
+    return Number.isFinite(ms) && ms >= 0 ? ms : 0;
+  })();
+  const memoryIds = Array.isArray(snapshot.memoryIds)
+    ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
+    : [];
+  const results: RecallXrayResult[] = memoryIds.map((memoryId) => ({
+    memoryId,
+    path: "",
+    servedBy: "hybrid",
+    scoreDecomposition: { final: 0 },
+    admittedBy: [],
+  }));
+  const filters: RecallFilterTrace[] = [];
+  return {
+    schemaVersion: "1",
+    // `LastRecallSnapshot` does not preserve the original query text;
+    // synthesize a placeholder so the renderer has a non-empty
+    // string to print.  `queryHash` + `queryLen` stay in the JSON
+    // payload via `toRecallExplainJson` for callers that need them.
+    query:
+      snapshot.queryHash
+        ? `(legacy explain; queryHash=${snapshot.queryHash})`
+        : "(legacy explain)",
+    snapshotId: `legacy-${snapshot.sessionKey ?? "unknown"}-${capturedAt}`,
+    capturedAt,
+    tierExplain: snapshot.tierExplain ?? null,
+    results,
+    filters,
+    budget: { chars: 0, used: 0 },
+    ...(snapshot.sessionKey ? { sessionKey: snapshot.sessionKey } : {}),
+    ...(snapshot.namespace ? { namespace: snapshot.namespace } : {}),
+  };
+}
+
 export function renderRecallExplain(
   snapshot: LastRecallSnapshot | null,
   format: RecallExplainFormat,
 ): string {
   if (format === "json") {
     return JSON.stringify(toRecallExplainJson(snapshot), null, 2);
+  }
+  if (format === "markdown") {
+    // Delegate to the shared X-ray renderer so CLI / HTTP / MCP
+    // markdown output all share one implementation (CLAUDE.md rule
+    // 22).  The JSON and text paths remain byte-for-byte
+    // backwards-compatible with pre-#570 behavior.
+    return renderXrayMarkdown(toRecallXraySnapshotFromLegacy(snapshot));
   }
   return toRecallExplainText(snapshot);
 }
@@ -212,12 +282,12 @@ export function parseRecallExplainFormat(value: unknown): RecallExplainFormat {
   if (value === undefined || value === null) return "text";
   if (typeof value !== "string") {
     throw new Error(
-      `--format expects "text" or "json", got ${typeof value}`,
+      `--format expects "text", "json", or "markdown", got ${typeof value}`,
     );
   }
   const v = value.trim().toLowerCase();
-  if (v === "text" || v === "json") return v;
+  if (v === "text" || v === "json" || v === "markdown") return v;
   throw new Error(
-    `--format expects "text" or "json", got ${JSON.stringify(value)}`,
+    `--format expects "text", "json", or "markdown", got ${JSON.stringify(value)}`,
   );
 }

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -221,14 +221,20 @@ export function toRecallExplainText(
  * renderer handles missing fields gracefully.
  */
 /**
- * Strip backticks, pipes, and newlines from a host-provided string so it
+ * Strip backticks, pipes, and newlines from a host-provided value so it
  * cannot escape its enclosing markdown code span, break the surrounding
  * table row, or inject extra rows when it lands in
  * `renderXrayMarkdown`.  Applied at the adapter boundary because
  * `LastRecallSnapshot` is hydrated from on-disk JSON without schema
  * validation (codex P2 review on #605).
+ *
+ * Accepts `unknown` so non-string truthy values (numbers, objects,
+ * booleans, arrays) coming from a corrupted snapshot are coerced to
+ * the empty string rather than crashing on `.replace(...)`.  Callers
+ * should treat an empty return as "drop this field."
  */
-function sanitizeForMarkdownInline(value: string): string {
+function sanitizeForMarkdownInline(value: unknown): string {
+  if (typeof value !== "string") return "";
   return value.replace(/[`|\r\n]/g, " ").trim();
 }
 

--- a/packages/remnic-core/src/recall-explain-renderer.ts
+++ b/packages/remnic-core/src/recall-explain-renderer.ts
@@ -238,6 +238,21 @@ function sanitizeForMarkdownInline(value: unknown): string {
   return value.replace(/[`|\r\n]/g, " ").trim();
 }
 
+/**
+ * Map the legacy `LastRecallSnapshot.source` field to the
+ * `RecallXrayServedBy` union used by the unified x-ray renderer.
+ * Mirrors the `mapRecallSourceToXrayServedBy` helper inside
+ * `orchestrator.ts` (which is private).  Keep the two in sync when a
+ * new source lands — unknown values collapse to `"hybrid"` to preserve
+ * backwards compatibility with older on-disk snapshots.
+ */
+function mapLegacySourceToServedBy(
+  source: unknown,
+): "hybrid" | "recent-scan" {
+  if (source === "recent_scan") return "recent-scan";
+  return "hybrid";
+}
+
 export function toRecallXraySnapshotFromLegacy(
   snapshot: LastRecallSnapshot | null,
 ): RecallXraySnapshot | null {
@@ -250,10 +265,17 @@ export function toRecallXraySnapshotFromLegacy(
   const memoryIds = Array.isArray(snapshot.memoryIds)
     ? snapshot.memoryIds.filter((x): x is string => typeof x === "string")
     : [];
+  // Codex P2 + Cursor Medium on #605: every converted result used to
+  // be stamped with `servedBy: "hybrid"`, misattributing legacy
+  // snapshots that came from `recent_scan` (or any future source).
+  // Propagate the recorded `source` so markdown `recall-explain`
+  // output matches the `served-by=` string the native x-ray capture
+  // would emit for the same recall.
+  const servedBy = mapLegacySourceToServedBy(snapshot.source);
   const results: RecallXrayResult[] = memoryIds.map((memoryId) => ({
     memoryId,
     path: "",
-    servedBy: "hybrid",
+    servedBy,
     scoreDecomposition: { final: 0 },
     admittedBy: [],
   }));


### PR DESCRIPTION
## Summary

Final slice of the unified Recall X-ray observability surface (#570). Adds a `markdown` format to the legacy recall-explain CLI/API that delegates to the shared X-ray renderer, while leaving the existing `text` and `json` outputs byte-for-byte backwards-compatible.

- `packages/remnic-core/src/recall-explain-renderer.ts`
  - `RecallExplainFormat` widened from `\"text\" | \"json\"` to `\"text\" | \"json\" | \"markdown\"`.
  - `parseRecallExplainFormat` accepts the new `markdown` value (case-insensitive, whitespace-trimmed) and rejects unknowns with a listed-options error (CLAUDE.md rule 51).
  - New `toRecallXraySnapshotFromLegacy(snapshot)` adapter translates a `LastRecallSnapshot` into a best-effort `RecallXraySnapshot`. Session, namespace, memory ids, and `tierExplain` carry across. `recordedAt` ISO string maps to `capturedAt` epoch ms; malformed dates coerce to 0.
  - `renderRecallExplain(snapshot, \"markdown\")` delegates to `renderXrayMarkdown` (CLAUDE.md rule 22 — single source of truth for formatting). The `text` and `json` paths continue calling `toRecallExplainText` / `toRecallExplainJson` verbatim.

## Backwards compatibility

Every existing caller that uses `text` or `json` sees unchanged output — the test suite includes explicit byte-shape assertions for both.

## Stacking

Based on `feat/issue-570-pr2-renderer` (PR #599). Retargets to `main` after PR #599 merges.

## Test plan

- [x] 12 unit tests in `packages/remnic-core/src/recall-explain-renderer.test.ts` — format validator accepts new `markdown` and original formats, rejects unknowns; text + json outputs verified unchanged; markdown delegates through renderer; null snapshot collapses to placeholder; adapter handles null input, ISO recordedAt, malformed recordedAt.
- [x] `tsc --noEmit` clean for the core package.

Part of #570 (slice 7 of 7 — final slice).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds a new `markdown` output path and a legacy→X-ray adapter while leaving existing `text`/`json` output unchanged; main risk is minor output formatting or source-mapping regressions.
> 
> **Overview**
> Legacy `recall-explain` now supports **`markdown` output** by adapting a `LastRecallSnapshot` into a best-effort `RecallXraySnapshot` and delegating to `renderXrayMarkdown`.
> 
> The adapter sanitizes session/namespace fields for safe markdown table rendering, maps `recordedAt` to `capturedAt` (with malformed dates coerced to `0`), and propagates legacy `source` to X-ray `servedBy` (notably mapping `recent_scan` → `recent-scan`).
> 
> `parseRecallExplainFormat` now accepts `markdown` and errors list all valid options; new unit tests assert markdown behavior and explicitly verify `text` and `json` outputs remain backwards-compatible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb11895884129f1d71cd28f428d3182c9b1423e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->