### PR TITLE
feat(procedural): safer-by-default thresholds (#567 PR 3/5)

### DIFF
--- a/docs/procedural-memory.md
+++ b/docs/procedural-memory.md
@@ -36,7 +36,7 @@ On prompts that look like **starting hands-on work** (deploy, ship, open a PR, r
 
 Relevant config keys include:
 
-- `procedural.recallMaxProcedures` — cap on injected procedure previews. **Default `2`** (raised from the earlier `3` in issue #567 PR 3/5 to keep procedural injection from crowding out other recall sections once the feature is enabled by default).
+- `procedural.recallMaxProcedures` — cap on injected procedure previews. **Default `2`** (lowered from the earlier `3` in issue #567 PR 3/5 to keep procedural injection from crowding out other recall sections once the feature is enabled by default).
 
 See also: [Advanced retrieval](./advanced-retrieval.md) and [Retrieval pipeline](./architecture/retrieval-pipeline.md).
 

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -306,6 +306,7 @@ test("parseConfig applies safer-by-default procedural thresholds (issue #567 PR 
   assert.equal(result.procedural.lookbackDays, 14);
   assert.equal(result.procedural.recallMaxProcedures, 2);
 });
+<<<<<<< HEAD
 
 test("buildDefaultRecallPipeline enables procedure-recall when procedural default-on (issue #567 PR 4/5)", () => {
   // Codex P2 on #609: the master gate defaulting to `true` must also flip

--- a/packages/remnic-core/src/config.test.ts
+++ b/packages/remnic-core/src/config.test.ts
@@ -306,7 +306,6 @@ test("parseConfig applies safer-by-default procedural thresholds (issue #567 PR 
   assert.equal(result.procedural.lookbackDays, 14);
   assert.equal(result.procedural.recallMaxProcedures, 2);
 });
-<<<<<<< HEAD
 
 test("buildDefaultRecallPipeline enables procedure-recall when procedural default-on (issue #567 PR 4/5)", () => {
   // Codex P2 on #609: the master gate defaulting to `true` must also flip

--- a/packages/remnic-core/src/procedural/procedure-recall.ts
+++ b/packages/remnic-core/src/procedural/procedure-recall.ts
@@ -58,7 +58,11 @@ export async function buildProcedureRecallSection(
       typeof config.procedural.recallMaxProcedures === "number" &&
         Number.isFinite(config.procedural.recallMaxProcedures)
         ? Math.floor(config.procedural.recallMaxProcedures)
-        : 3,
+        // Safer-by-default fallback (issue #567 PR 3/5): must match
+        // config.ts's canonical default (2). Cursor review on PR #607:
+        // divergent fallbacks silently regressed the safer cap whenever
+        // the config value was missing or non-finite at this call site.
+        : 2,
     ),
   );
 


### PR DESCRIPTION
Part of #567 (slice 3 of 5).

## Summary

Raises the floor for procedural mining + recall so the slice-4 default-on flip is safe. This slice only tunes defaults — it does NOT touch `procedural.enabled`.

| Key | Before | After |
| --- | ------ | ----- |
| `procedural.successFloor` | 0.7 | **0.75** |
| `procedural.lookbackDays` | 30 | **14** |
| `procedural.recallMaxProcedures` | 3 | **2** |

`minOccurrences` (3) and `autoPromoteOccurrences` (8) already matched the issue spec; no change there.

Touches:

- `packages/remnic-core/src/config.ts` — new defaults in `parseConfig`. `0` disable path for `minOccurrences` is preserved (CLAUDE.md rule 45).
- Both plugin manifests (`packages/plugin-openclaw/openclaw.plugin.json` + auto-synced `packages/shim-openclaw-engram/openclaw.plugin.json`) now advertise the new defaults in the config schema.
- `packages/remnic-core/src/config.test.ts` — new anti-drift test `parseConfig applies safer-by-default procedural thresholds (issue #567 PR 3/5)`. `procedural.enabled` still asserts `false` here; the flip-to-true test lives in slice 4.
- `docs/procedural-memory.md` — new "Safer-by-default thresholds" table with every default + rationale.

## Test plan

- [x] `node --test --import tsx packages/remnic-core/src/config.test.ts` → 46/46 pass (45 existing + 1 new).
- [x] `pnpm --filter @remnic/core run check-types` → clean.
- [x] Shim manifest re-synced via `packages/shim-openclaw-engram/scripts/sync-openclaw-plugin.mjs` so defaults stay consistent across both.

No behavioral change until `procedural.enabled=true` — current default is still `false`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small behavioral change only when `procedural.recallMaxProcedures` is missing or invalid, reducing injected procedure previews from 3 to 2 to match the canonical default.
> 
> **Overview**
> Ensures procedural recall uses the **safer-by-default** cap when `procedural.recallMaxProcedures` is absent or non-finite by changing the fallback in `buildProcedureRecallSection` from `3` to `2` (matching `config.ts`).
> 
> Updates the procedural memory docs to correctly describe the default as being *lowered* from `3` to `2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 47a65a0bf0a50c19bed3fcdb81e2cab40080cbd2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->