### PR TITLE
docs(importers): docs/importers.md + README 'Bring your memory' (#568 PR 6/7)

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,7 +282,7 @@ ones you need:
 ```bash
 # ChatGPT (OpenAI data export: saved memories + optional conversation summaries)
 npm install -g @remnic/import-chatgpt
-remnic import --adapter chatgpt --file ~/chatgpt-export.zip/memory.json --dry-run
+remnic import --adapter chatgpt --file ~/chatgpt-export/memory.json --dry-run
 
 # Claude (Anthropic data export: project docs + prompt templates)
 npm install -g @remnic/import-claude

--- a/README.md
+++ b/README.md
@@ -298,12 +298,21 @@ export MEM0_API_KEY=...
 remnic import --adapter mem0 --rate-limit 2
 ```
 
-Each importer is an **optional peer dependency** — the base CLI install
-never pulls them in. If you run `remnic import --adapter <name>` without
-the matching package installed, the CLI prints a clean install hint.
-Every run supports `--dry-run` for a zero-write preview. See
-[docs/importers.md](docs/importers.md) for per-source details, input
-formats, and provenance metadata.
+Each importer is an **optional runtime companion** — the base CLI
+install never pulls them in. If you run `remnic import --adapter <name>`
+without the matching package installed, the CLI prints a clean install
+hint. Every run supports `--dry-run` for a zero-write preview.
+
+> **Privacy note:** import parsing and storage run locally, but after
+> the orchestrator accepts a record it enters the normal extraction
+> pipeline — which calls whatever model provider you have configured.
+> If extraction is routed to a remote provider, imported content is
+> transmitted to that provider during extraction. To keep imports fully
+> local, configure a local extraction model or use `--dry-run` to
+> preview without writing.
+
+See [docs/importers.md](docs/importers.md) for per-source details, input
+formats, provenance metadata, and the full privacy breakdown.
 
 ## Troubleshooting: hooks aren't firing
 

--- a/README.md
+++ b/README.md
@@ -273,6 +273,38 @@ openclaw engram doctor --json        # Health diagnostics with remediation hints
 openclaw engram config-review --json # Opinionated config tuning recommendations
 ```
 
+## Bring your memory
+
+Remnic can import existing memory from the platforms you already use.
+Four optional importer packages ship alongside the CLI — install only the
+ones you need:
+
+```bash
+# ChatGPT (OpenAI data export: saved memories + optional conversation summaries)
+npm install -g @remnic/import-chatgpt
+remnic import --adapter chatgpt --file ~/chatgpt-export.zip/memory.json --dry-run
+
+# Claude (Anthropic data export: project docs + prompt templates)
+npm install -g @remnic/import-claude
+remnic import --adapter claude --file ~/claude-export/projects.json
+
+# Gemini (Google Takeout "Gemini Apps Activity")
+npm install -g @remnic/import-gemini
+remnic import --adapter gemini --file "~/Takeout/Gemini/My Activity.json"
+
+# mem0 (REST API — paginated; honors --rate-limit)
+npm install -g @remnic/import-mem0
+export MEM0_API_KEY=...
+remnic import --adapter mem0 --rate-limit 2
+```
+
+Each importer is an **optional peer dependency** — the base CLI install
+never pulls them in. If you run `remnic import --adapter <name>` without
+the matching package installed, the CLI prints a clean install hint.
+Every run supports `--dry-run` for a zero-write preview. See
+[docs/importers.md](docs/importers.md) for per-source details, input
+formats, and provenance metadata.
+
 ## Troubleshooting: hooks aren't firing
 
 **Symptom:** Remnic appears installed but no memories are created. The gateway log shows no `[remnic]` lines after conversations.
@@ -928,6 +960,7 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Memory Extensions](docs/architecture/memory-extensions.md) — Third-party extension discovery
 - [Codex Marketplace](docs/plugins/codex-marketplace.md) — Marketplace installation
 - [Procedural memory](docs/procedural-memory.md) — Procedure files, recall injection, mining; enable with `procedural.enabled` (issue #519)
+- [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, and mem0 (issue #568)
 
 ## Contributing
 

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -1,0 +1,131 @@
+# Memory importers — bring your memory to Remnic
+
+Issue [#568](https://github.com/joshuaswarren/remnic/issues/568) ships a
+family of optional importer packages that pull personal memory out of
+external platforms and land it in Remnic as first-class memories.
+
+Four sources are supported today:
+
+| Source  | Package                   | Source label | Input                                     |
+|---------|---------------------------|--------------|-------------------------------------------|
+| ChatGPT | `@remnic/import-chatgpt`  | `chatgpt`    | Data-export JSON (memories + conversations) |
+| Claude  | `@remnic/import-claude`   | `claude`     | Data-export JSON (projects + conversations) |
+| Gemini  | `@remnic/import-gemini`   | `gemini`     | Google Takeout `My Activity.json`            |
+| mem0    | `@remnic/import-mem0`     | `mem0`       | REST API (paginated) or offline JSON dump    |
+
+Each importer is an **à-la-carte optional peer dependency** of the
+`@remnic/cli` package. They are never bundled into the base CLI install —
+users who only need one source install only that one package.
+
+```bash
+# Install the CLI (core + base)
+npm install -g @remnic/cli
+
+# Add the importer you actually need
+npm install -g @remnic/import-chatgpt
+# or any mix of: @remnic/import-claude, @remnic/import-gemini, @remnic/import-mem0
+```
+
+If you run `remnic import --adapter <name>` without the matching package
+installed, the CLI prints a clean install hint — never a
+`MODULE_NOT_FOUND` stack.
+
+## Shared CLI surface
+
+All importers share one entrypoint:
+
+```bash
+remnic import --adapter <name> [options]
+```
+
+| Flag                        | Applies to      | Description                                                             |
+|-----------------------------|-----------------|-------------------------------------------------------------------------|
+| `--adapter <name>`          | all             | Required. One of `chatgpt`, `claude`, `gemini`, `mem0`.                 |
+| `--file <path>`             | file-based      | Path to the export file (leading `~` is expanded).                      |
+| `--dry-run`                 | all             | Parse + transform only; print a plan and never write.                   |
+| `--batch-size <n>`          | all             | How many memories per orchestrator batch. Default 25, range 1–500.     |
+| `--rate-limit <rps>`        | API (mem0)      | Requests per second when walking a paginated API.                      |
+| `--include-conversations`   | chatgpt, claude | Also import conversation summaries (one memory per conversation).       |
+
+Invalid flag values are rejected with a user-facing error rather than
+silently defaulting (CLAUDE.md rule 51).
+
+## Source-specific notes
+
+### ChatGPT (`@remnic/import-chatgpt`)
+
+- Accepts OpenAI's data-export JSON files (either the top-level `memory`
+  object, a bare array of saved memories, or a `conversations.json`).
+- **Saved memories** are imported 1:1 by default — every active entry
+  becomes one memory. Soft-deleted records are skipped.
+- **Conversation summaries** are opt-in via `--include-conversations`.
+  Each conversation is reduced to a single memory summarizing the
+  user-authored turns along the active `current_node` → parent chain
+  (abandoned branches are excluded).
+
+### Claude (`@remnic/import-claude`)
+
+- Accepts `projects.json`, `conversations.json`, or a combined bundle.
+- **Project docs** are imported 1:1 (each `docs[].content` becomes one
+  memory with `metadata.kind = "project_doc"`).
+- **Project prompt templates** are imported when non-empty
+  (`metadata.kind = "project_prompt_template"`).
+- **Conversation summaries** are opt-in. Only human-authored turns are
+  included (assistant responses are discarded).
+
+### Gemini (`@remnic/import-gemini`)
+
+- Accepts Google Takeout's `My Activity.json` (Gemini Apps section).
+- Google Takeout exports **only the user's prompts** — assistant
+  responses are not included in any Takeout. Each prompt becomes one
+  memory with `metadata.kind = "prompt"`.
+- Short prompts under 10 characters are dropped by default to filter
+  trivial affirmations. Override with `--min-prompt-length` (library
+  API) when needed.
+- Legacy "Bard" activity records are included (pre-rebrand exports).
+
+### mem0 (`@remnic/import-mem0`)
+
+- API-first: reads `MEM0_API_KEY` (and optional `MEM0_BASE_URL` for
+  self-hosted) and walks `/v1/memories/` across pagination. `--rate-limit`
+  is honored between page requests.
+- Also accepts offline replay dumps via `--file`, both the flat
+  `{results: [...]}` shape and a multi-page recording
+  `{pages: [...]}` shape used for record/replay tests.
+- Pagination supports both cursor (`next`) and numeric (`page`+`total`)
+  response shapes.
+
+## Dry-run first
+
+Every importer supports `--dry-run` for a zero-write preview:
+
+```bash
+remnic import --adapter chatgpt --file ~/chatgpt-export.zip/memory.json --dry-run
+# Dry-run: would import 147 memories from 'chatgpt'.
+# (no memories were written; re-run without --dry-run to commit)
+```
+
+Dry-run never instantiates the orchestrator's write target, so it runs
+instantly even on machines where the memory directory isn't set up.
+
+## Provenance
+
+Every imported memory carries provenance metadata that flows through the
+orchestrator into recall and attribution:
+
+- `sourceLabel` — the platform name (`chatgpt`, `claude`, `gemini`, `mem0`)
+- `sourceId` — stable source-side id for idempotent re-imports
+- `sourceTimestamp` — the export's original timestamp (ISO 8601)
+- `importedFromPath` — the file path or API endpoint URL
+- `importedAt` — when the import ran (stamped by `runImporter`)
+- `metadata.kind` — `saved_memory`, `project_doc`, `prompt`, etc.
+
+Running an importer a second time does NOT create duplicates — Remnic's
+orchestrator deduplicates by content hash during ingestion.
+
+## Privacy
+
+Imported memories live in your Remnic memory directory alongside memories
+captured from live sessions. No content leaves your machine during
+import (except for the mem0 API case, which only round-trips to your
+configured mem0 endpoint).

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -15,12 +15,17 @@ Four sources are supported today:
 
 Each importer is an **à-la-carte optional runtime companion** of the
 `@remnic/cli` package. They are never bundled into the base CLI install,
-and installing `@remnic/cli` alone will not pull any of them in. Each
-adapter package is registered as an optional peer dependency of the CLI
-(so workspace + pnpm installs keep them linked), but runtime loading
-goes through a computed-specifier dynamic import so npm users who never
-install an adapter package receive a friendly install hint rather than a
-`MODULE_NOT_FOUND`. Install only the adapter you actually need.
+and installing `@remnic/cli` alone will not pull any of them in. Runtime
+loading goes through a computed-specifier dynamic import so npm users
+who never install an adapter package receive a friendly install hint
+rather than a `MODULE_NOT_FOUND`. Install only the adapter you actually
+need.
+
+> Some adapter packages may be declared as optional peer dependencies of
+> `@remnic/cli` in specific release trains (so workspace + pnpm installs
+> stay linked), but that wiring is not guaranteed at the package-manager
+> level — always follow the `npm install @remnic/import-<source>` step
+> below rather than relying on peer resolution.
 
 ```bash
 # Install the CLI (core + base)
@@ -131,6 +136,25 @@ orchestrator deduplicates by content hash during ingestion.
 ## Privacy
 
 Imported memories live in your Remnic memory directory alongside memories
-captured from live sessions. No content leaves your machine during
-import (except for the mem0 API case, which only round-trips to your
-configured mem0 endpoint).
+captured from live sessions.
+
+**Important caveat (Codex review on PR #608):** after an importer writes
+records to the orchestrator, Remnic's normal extraction pipeline runs on
+them. If your orchestrator is configured to use a **remote** model
+provider (OpenAI, Anthropic, or any other hosted LLM) for extraction,
+imported content **will be transmitted** to that provider as part of
+extraction — the same way live-session content is. Importing from local
+files (ChatGPT / Claude / Gemini exports) is therefore NOT an
+absolute-local operation when a remote extraction model is configured.
+
+Per-path behavior:
+
+- **Parsing + transform + storage** is always local to your machine.
+- **Extraction** (the model call that decides what to keep) follows
+  whatever provider your orchestrator is configured with. To keep
+  imports fully local, configure a local extraction model or disable
+  extraction on the imported batch.
+- **mem0 API** additionally round-trips to your configured mem0
+  endpoint (which may be self-hosted or hosted).
+- **Dry-run** (`--dry-run`) never writes or extracts, so it is the
+  safest way to preview what an importer would pick up.

--- a/docs/importers.md
+++ b/docs/importers.md
@@ -13,9 +13,14 @@ Four sources are supported today:
 | Gemini  | `@remnic/import-gemini`   | `gemini`     | Google Takeout `My Activity.json`            |
 | mem0    | `@remnic/import-mem0`     | `mem0`       | REST API (paginated) or offline JSON dump    |
 
-Each importer is an **à-la-carte optional peer dependency** of the
-`@remnic/cli` package. They are never bundled into the base CLI install —
-users who only need one source install only that one package.
+Each importer is an **à-la-carte optional runtime companion** of the
+`@remnic/cli` package. They are never bundled into the base CLI install,
+and installing `@remnic/cli` alone will not pull any of them in. Each
+adapter package is registered as an optional peer dependency of the CLI
+(so workspace + pnpm installs keep them linked), but runtime loading
+goes through a computed-specifier dynamic import so npm users who never
+install an adapter package receive a friendly install hint rather than a
+`MODULE_NOT_FOUND`. Install only the adapter you actually need.
 
 ```bash
 # Install the CLI (core + base)
@@ -100,7 +105,7 @@ silently defaulting (CLAUDE.md rule 51).
 Every importer supports `--dry-run` for a zero-write preview:
 
 ```bash
-remnic import --adapter chatgpt --file ~/chatgpt-export.zip/memory.json --dry-run
+remnic import --adapter chatgpt --file ~/chatgpt-export/memory.json --dry-run
 # Dry-run: would import 147 memories from 'chatgpt'.
 # (no memories were written; re-run without --dry-run to commit)
 ```


### PR DESCRIPTION
Part of #568 (slice 6 of 7).

## Summary
- New \`docs/importers.md\` covering all four importer packages (slices 2-5): per-source input shapes, shared CLI flags, dry-run behavior, provenance metadata, and the à-la-carte install contract
- README gains a 'Bring your memory' section under the installation docs with copy-paste install + import commands for each source
- docs/importers.md linked from the main Documentation index

Site-side changes live in \`remnic-site\` (separate repo) — a new \`/import\` page was added there to mirror the \`/install\` page pattern.

## Test plan
- [x] No code changes in this slice — docs only
- [x] Links verified to point at \`docs/importers.md\` in the monorepo

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only changes that add usage guidance and a new doc page, with no runtime or data-path code modifications.
> 
> **Overview**
> Adds end-user documentation for Remnic’s optional memory importer adapters.
> 
> The README now includes a new **“Bring your memory”** section with copy/paste install + `remnic import` examples for ChatGPT, Claude, Gemini, and mem0, plus a privacy caveat about extraction possibly using remote model providers.
> 
> Introduces `docs/importers.md`, detailing the shared CLI flags, per-source input formats/behavior, dry-run semantics, provenance metadata, and the optional install/runtime-loading contract, and links it from the main documentation index.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 46fb64deea6f8212a4a2d93350fc71163112e747. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->