### PR TITLE
feat(import): --all-from-bundle auto-detect (#568 PR 7/7)

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -27,7 +27,7 @@
     "prebuild": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/import-dispatch.test.ts src/optional-importer.test.ts src/bench-args.test.ts",
+    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/remnic-cli/src/import-bundle-detect.test.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.test.ts
@@ -1,0 +1,149 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import {
+  detectBundleEntries,
+  type BundleDetectOptions,
+} from "./import-bundle-detect.js";
+
+/**
+ * Build a fake filesystem map that the detect helpers can query through
+ * injected `readdirImpl` / `readFileImpl` / `isDirectoryImpl` hooks. Keys
+ * ending in `/` are directories; every other path is a file whose contents
+ * live in `files[path]` (or default to `{}`).
+ */
+function makeFs(files: Record<string, string>, dirs: string[]): BundleDetectOptions {
+  const dirSet = new Set(dirs);
+  return {
+    readdirImpl: (dir: string) => {
+      const normalized = dir.endsWith("/") ? dir : dir + "/";
+      const all = new Set<string>();
+      for (const key of [...Object.keys(files), ...dirs]) {
+        if (key === dir) continue;
+        if (key.startsWith(normalized)) {
+          const rest = key.slice(normalized.length);
+          if (rest.length === 0) continue;
+          const head = rest.split("/")[0]!;
+          if (head.length > 0) all.add(head);
+        }
+      }
+      return [...all];
+    },
+    readFileImpl: (p: string) => files[p] ?? "{}",
+    isDirectoryImpl: (p: string) => dirSet.has(p),
+  };
+}
+
+describe("detectBundleEntries", () => {
+  it("finds a ChatGPT saved-memories file at the bundle root", () => {
+    const fs = makeFs(
+      { "/bundle/memory.json": "{}" },
+      ["/bundle"],
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.adapter, "chatgpt");
+    assert.equal(entries[0]?.filePath, "/bundle/memory.json");
+  });
+
+  it("finds Claude projects.json and classifies correctly", () => {
+    const fs = makeFs(
+      { "/bundle/projects.json": "[]" },
+      ["/bundle"],
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.adapter, "claude");
+  });
+
+  it("finds Gemini activity file and accepts both naming conventions", () => {
+    const fs = makeFs(
+      {
+        "/bundle/Takeout/Gemini/My Activity.json": "[]",
+      },
+      ["/bundle", "/bundle/Takeout", "/bundle/Takeout/Gemini"],
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 1);
+    assert.equal(entries[0]?.adapter, "gemini");
+    assert.equal(entries[0]?.filePath, "/bundle/Takeout/Gemini/My Activity.json");
+  });
+
+  it("disambiguates ChatGPT vs Claude conversations.json by content", () => {
+    const fsChatgpt = makeFs(
+      {
+        "/bundle/conversations.json": JSON.stringify([
+          { id: "c1", mapping: { "m-1": { id: "m-1" } } },
+        ]),
+      },
+      ["/bundle"],
+    );
+    const chatgpt = detectBundleEntries("/bundle", fsChatgpt);
+    assert.equal(chatgpt[0]?.adapter, "chatgpt");
+    assert.equal(chatgpt[0]?.includeConversations, true);
+
+    const fsClaude = makeFs(
+      {
+        "/bundle/conversations.json": JSON.stringify([
+          { uuid: "c1", chat_messages: [] },
+        ]),
+      },
+      ["/bundle"],
+    );
+    const claude = detectBundleEntries("/bundle", fsClaude);
+    assert.equal(claude[0]?.adapter, "claude");
+    assert.equal(claude[0]?.includeConversations, true);
+  });
+
+  it("produces a stable order across adapters and file paths", () => {
+    const fs = makeFs(
+      {
+        "/bundle/My Activity.json": "[]",
+        "/bundle/memory.json": "{}",
+        "/bundle/projects.json": "[]",
+        "/bundle/mem0.json": "{}",
+      },
+      ["/bundle"],
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.deepEqual(
+      entries.map((e) => e.adapter),
+      ["chatgpt", "claude", "gemini", "mem0"],
+    );
+  });
+
+  it("returns an empty array when no known files are present", () => {
+    const fs = makeFs(
+      { "/bundle/random.txt": "" },
+      ["/bundle"],
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 0);
+  });
+
+  it("throws a user-facing error when the directory is unreadable", () => {
+    const fs: BundleDetectOptions = {
+      readdirImpl: () => {
+        throw new Error("ENOENT");
+      },
+      readFileImpl: () => "",
+      isDirectoryImpl: () => false,
+    };
+    assert.throws(
+      () => detectBundleEntries("/missing", fs),
+      /could not be read/,
+    );
+  });
+
+  it("does not double-count identical file paths surfaced by the scan", () => {
+    // Even if the scan returns the same path twice (symlink-style), the
+    // entry list must not duplicate.
+    const fs: BundleDetectOptions = {
+      readdirImpl: () => ["memory.json"],
+      readFileImpl: () => "{}",
+      isDirectoryImpl: () => false,
+    };
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 1);
+  });
+});

--- a/packages/remnic-cli/src/import-bundle-detect.test.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.test.ts
@@ -12,13 +12,19 @@ import {
  * ending in `/` are directories; every other path is a file whose contents
  * live in `files[path]` (or default to `{}`).
  */
-function makeFs(files: Record<string, string>, dirs: string[]): BundleDetectOptions {
+function makeFs(
+  files: Record<string, string>,
+  dirs: string[],
+  symlinks: string[] = [],
+): BundleDetectOptions {
   const dirSet = new Set(dirs);
+  const fileSet = new Set(Object.keys(files));
+  const symlinkSet = new Set(symlinks);
   return {
     readdirImpl: (dir: string) => {
       const normalized = dir.endsWith("/") ? dir : dir + "/";
       const all = new Set<string>();
-      for (const key of [...Object.keys(files), ...dirs]) {
+      for (const key of [...Object.keys(files), ...dirs, ...symlinks]) {
         if (key === dir) continue;
         if (key.startsWith(normalized)) {
           const rest = key.slice(normalized.length);
@@ -30,7 +36,12 @@ function makeFs(files: Record<string, string>, dirs: string[]): BundleDetectOpti
       return [...all];
     },
     readFileImpl: (p: string) => files[p] ?? "{}",
-    isDirectoryImpl: (p: string) => dirSet.has(p),
+    // Codex review on PR #610 — symlinks never report as directories OR
+    // as regular files, so the walker refuses to follow them. This
+    // matches defaultIsDirectory / defaultIsRegularFile in the
+    // production module.
+    isDirectoryImpl: (p: string) => dirSet.has(p) && !symlinkSet.has(p),
+    isRegularFileImpl: (p: string) => fileSet.has(p) && !symlinkSet.has(p),
   };
 }
 
@@ -142,8 +153,37 @@ describe("detectBundleEntries", () => {
       readdirImpl: () => ["memory.json"],
       readFileImpl: () => "{}",
       isDirectoryImpl: () => false,
+      isRegularFileImpl: () => true,
     };
     const entries = detectBundleEntries("/bundle", fs);
     assert.equal(entries.length, 1);
+  });
+
+  // Codex review on PR #610 — a bundle containing a symlink named
+  // memory.json / projects.json must NOT be followed, or the importer
+  // could be tricked into reading arbitrary filesystem locations.
+  // defaultIsRegularFile rejects symlinks; verify through the injected
+  // BundleDetectOptions surface.
+  it("rejects symlinked files even when their name matches a known shape", () => {
+    const fs = makeFs(
+      {
+        "/bundle/real.json": "{}",
+        "/bundle/memory.json": "{}",
+      },
+      ["/bundle"],
+      ["/bundle/memory.json"], // mark memory.json as a symlink
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 0);
+  });
+
+  it("rejects symlinked directories and does not recurse into them", () => {
+    const fs = makeFs(
+      { "/bundle/inner/memory.json": "{}" },
+      ["/bundle", "/bundle/inner"],
+      ["/bundle/inner"], // mark inner/ as a symlink
+    );
+    const entries = detectBundleEntries("/bundle", fs);
+    assert.equal(entries.length, 0);
   });
 });

--- a/packages/remnic-cli/src/import-bundle-detect.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.ts
@@ -18,7 +18,7 @@
 // The scan walks one level deep (plus a single nested directory like
 // `Takeout/Gemini/`) so users don't have to flatten their unzipped bundles.
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
 import path from "node:path";
 
 import type { SupportedImporterName } from "./optional-importer.js";
@@ -191,7 +191,13 @@ function defaultReadFile(p: string): string {
 
 function defaultIsDirectory(p: string): boolean {
   try {
-    return statSync(p).isDirectory();
+    // Use lstatSync so symlinks never report as directories — we refuse
+    // to recurse through them so a bundle can't contain a symlinked
+    // directory that escapes to arbitrary filesystem locations. Codex
+    // review on PR #610.
+    const s = lstatSync(p);
+    if (s.isSymbolicLink()) return false;
+    return s.isDirectory();
   } catch {
     return false;
   }

--- a/packages/remnic-cli/src/import-bundle-detect.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.ts
@@ -61,7 +61,43 @@ export function detectBundleEntries(
   const readdir = options.readdirImpl ?? defaultReaddir;
   const readFileImpl = options.readFileImpl ?? defaultReadFile;
   const isDirectory = options.isDirectoryImpl ?? defaultIsDirectory;
-  const isRegularFile = options.isRegularFileImpl ?? defaultIsRegularFile;
+  // Codex review on PR #610 — when callers inject readdir/isDirectory
+  // (the testing seam), we must NOT fall back to `lstatSync`-on-disk for
+  // isRegularFile. That probes the real filesystem and filters out the
+  // virtual paths produced by the injected walker, breaking the seam.
+  // Derive a consistent regular-file probe from the injected traversal
+  // layer: any entry that is not a directory (per `isDirectory`) and
+  // appears in its parent's readdir listing is treated as a regular
+  // file. Only fall back to `defaultIsRegularFile` (which probes disk)
+  // when neither `readdir` nor `isDirectory` is injected.
+  const isRegularFile =
+    options.isRegularFileImpl ??
+    (options.readdirImpl !== undefined || options.isDirectoryImpl !== undefined
+      ? (p: string) => !isDirectory(p)
+      : defaultIsRegularFile);
+
+  // Codex review on PR #610 — reject a bundle root that is itself a
+  // symlink. Otherwise a user-supplied `--all-from-bundle <symlink>`
+  // would silently traverse into the symlink target, picking up files
+  // outside the intended bundle tree. Tests inject walkers and skip
+  // this check — only the default `lstatSync`-backed walker needs to
+  // enforce it.
+  if (options.readdirImpl === undefined && options.isDirectoryImpl === undefined) {
+    try {
+      const rootStat = lstatSync(bundleDir);
+      if (rootStat.isSymbolicLink()) {
+        throw new Error(
+          `Bundle directory '${bundleDir}' is a symbolic link. Pass the resolved directory path instead.`,
+        );
+      }
+    } catch (err) {
+      if (err instanceof Error && err.message.startsWith("Bundle directory")) {
+        throw err;
+      }
+      // `lstatSync` throwing for a missing path is handled by the
+      // readdir error path below.
+    }
+  }
 
   const roots = collectCandidatePaths(
     bundleDir,

--- a/packages/remnic-cli/src/import-bundle-detect.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.ts
@@ -1,0 +1,198 @@
+// ---------------------------------------------------------------------------
+// `remnic import --all-from-bundle <dir>` auto-detect (issue #568 slice 7)
+// ---------------------------------------------------------------------------
+//
+// Given a directory, scan for known export-file names and match each one to
+// the correct importer adapter. This lets users drop an unzipped ChatGPT /
+// Claude / Takeout bundle into a single folder and run one command to
+// import everything.
+//
+// Detection is intentionally simple and file-name-based:
+//   - `memory.json`              → chatgpt (saved memories)
+//   - `conversations.json`       → chatgpt OR claude; we pick by sibling
+//                                  shape (prefer chatgpt mapping, else claude)
+//   - `projects.json`            → claude
+//   - `My Activity.json`         → gemini (also handles legacy `MyActivity.json`)
+//   - `mem0.json`                → mem0 (offline replay dump)
+//
+// The scan walks one level deep (plus a single nested directory like
+// `Takeout/Gemini/`) so users don't have to flatten their unzipped bundles.
+
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import path from "node:path";
+
+import type { SupportedImporterName } from "./optional-importer.js";
+
+export interface DetectedBundleEntry {
+  adapter: SupportedImporterName;
+  filePath: string;
+  /**
+   * Optional transform hint — e.g. a ChatGPT `conversations.json` should
+   * typically be imported with `--include-conversations`, otherwise the
+   * user paid the disk cost of a scan that produced zero memories.
+   */
+  includeConversations?: boolean;
+}
+
+export interface BundleDetectOptions {
+  /** Override the default file walker for tests. */
+  readdirImpl?: (dir: string) => string[];
+  readFileImpl?: (p: string) => string;
+  isDirectoryImpl?: (p: string) => boolean;
+}
+
+/**
+ * Walk `bundleDir` (one level deep, plus one nested directory layer) and
+ * return the list of importer entries to run. The order is stable
+ * (chatgpt, claude, gemini, mem0) so re-scans produce identical output.
+ *
+ * Returns an empty array when no known files are found. Callers are
+ * responsible for surfacing "bundle was empty" to the user.
+ */
+export function detectBundleEntries(
+  bundleDir: string,
+  options: BundleDetectOptions = {},
+): DetectedBundleEntry[] {
+  const readdir = options.readdirImpl ?? defaultReaddir;
+  const readFileImpl = options.readFileImpl ?? defaultReadFile;
+  const isDirectory = options.isDirectoryImpl ?? defaultIsDirectory;
+
+  const roots = collectCandidatePaths(bundleDir, readdir, isDirectory);
+  const entries: DetectedBundleEntry[] = [];
+  const seenFiles = new Set<string>();
+  for (const filePath of roots) {
+    if (seenFiles.has(filePath)) continue;
+    seenFiles.add(filePath);
+    const name = path.basename(filePath);
+    const match = classifyFile(name, filePath, readFileImpl);
+    if (match) entries.push(match);
+  }
+
+  // Stable sort by (adapter preference order, file path).
+  const adapterOrder: Record<SupportedImporterName, number> = {
+    chatgpt: 0,
+    claude: 1,
+    gemini: 2,
+    mem0: 3,
+  };
+  entries.sort((a, b) => {
+    const delta = adapterOrder[a.adapter] - adapterOrder[b.adapter];
+    if (delta !== 0) return delta;
+    if (a.filePath < b.filePath) return -1;
+    if (a.filePath > b.filePath) return 1;
+    return 0;
+  });
+  return entries;
+}
+
+const MAX_WALK_DEPTH = 4; // Takeout bundles nest ≥3 levels (Takeout/Gemini/…)
+
+function collectCandidatePaths(
+  root: string,
+  readdir: (p: string) => string[],
+  isDirectory: (p: string) => boolean,
+): string[] {
+  // Validate top-level readability with a descriptive error; inner
+  // directories that fail to read are skipped silently so a partial bundle
+  // walk completes. Cursor's rule for CLAUDE.md rule 24: accept only real
+  // directories; surfacing the failure here gives the user an immediate
+  // actionable error.
+  try {
+    readdir(root);
+  } catch {
+    throw new Error(
+      `Bundle directory '${root}' could not be read. Pass an existing directory.`,
+    );
+  }
+
+  const out: string[] = [];
+  const walk = (dir: string, depth: number): void => {
+    if (depth > MAX_WALK_DEPTH) return;
+    let entries: string[];
+    try {
+      entries = readdir(dir);
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      const full = path.join(dir, entry);
+      if (isDirectory(full)) {
+        walk(full, depth + 1);
+      } else {
+        out.push(full);
+      }
+    }
+  };
+  walk(root, 0);
+  return out;
+}
+
+function classifyFile(
+  name: string,
+  filePath: string,
+  readFileImpl: (p: string) => string,
+): DetectedBundleEntry | undefined {
+  const lower = name.toLowerCase();
+  if (lower === "memory.json") {
+    return { adapter: "chatgpt", filePath };
+  }
+  if (lower === "projects.json") {
+    return { adapter: "claude", filePath };
+  }
+  if (lower === "my activity.json" || lower === "myactivity.json") {
+    return { adapter: "gemini", filePath };
+  }
+  if (lower === "mem0.json" || lower === "mem0-export.json") {
+    return { adapter: "mem0", filePath };
+  }
+  if (lower === "conversations.json") {
+    // ChatGPT vs Claude disambiguation: peek at the first element. ChatGPT
+    // uses `mapping` objects; Claude uses `chat_messages` / `messages`.
+    const adapter = disambiguateConversations(filePath, readFileImpl);
+    return { adapter, filePath, includeConversations: true };
+  }
+  return undefined;
+}
+
+function disambiguateConversations(
+  filePath: string,
+  readFileImpl: (p: string) => string,
+): SupportedImporterName {
+  try {
+    const content = readFileImpl(filePath);
+    const parsed = JSON.parse(content);
+    const first = Array.isArray(parsed)
+      ? parsed[0]
+      : parsed && typeof parsed === "object"
+        ? (parsed as Record<string, unknown>).conversations
+        : undefined;
+    const sample = Array.isArray(first) ? first[0] : first;
+    if (sample && typeof sample === "object") {
+      const obj = sample as Record<string, unknown>;
+      if (obj.mapping && typeof obj.mapping === "object") return "chatgpt";
+      if (Array.isArray(obj.chat_messages) || Array.isArray(obj.messages)) {
+        return "claude";
+      }
+    }
+  } catch {
+    // If the file is unreadable or unparseable, default to chatgpt — the
+    // adapter will surface its own error.
+  }
+  return "chatgpt";
+}
+
+function defaultReaddir(dir: string): string[] {
+  return readdirSync(dir);
+}
+
+function defaultReadFile(p: string): string {
+  return readFileSync(p, "utf-8");
+}
+
+function defaultIsDirectory(p: string): boolean {
+  try {
+    return statSync(p).isDirectory();
+  } catch {
+    return false;
+  }
+}

--- a/packages/remnic-cli/src/import-bundle-detect.ts
+++ b/packages/remnic-cli/src/import-bundle-detect.ts
@@ -18,7 +18,7 @@
 // The scan walks one level deep (plus a single nested directory like
 // `Takeout/Gemini/`) so users don't have to flatten their unzipped bundles.
 
-import { lstatSync, readdirSync, readFileSync, statSync } from "node:fs";
+import { lstatSync, readdirSync, readFileSync } from "node:fs";
 import path from "node:path";
 
 import type { SupportedImporterName } from "./optional-importer.js";
@@ -39,6 +39,11 @@ export interface BundleDetectOptions {
   readdirImpl?: (dir: string) => string[];
   readFileImpl?: (p: string) => string;
   isDirectoryImpl?: (p: string) => boolean;
+  /**
+   * Report whether `p` is a regular file (not a symlink, device, etc.).
+   * Defaults to `lstatSync(p).isFile()`. Injected for tests.
+   */
+  isRegularFileImpl?: (p: string) => boolean;
 }
 
 /**
@@ -56,8 +61,14 @@ export function detectBundleEntries(
   const readdir = options.readdirImpl ?? defaultReaddir;
   const readFileImpl = options.readFileImpl ?? defaultReadFile;
   const isDirectory = options.isDirectoryImpl ?? defaultIsDirectory;
+  const isRegularFile = options.isRegularFileImpl ?? defaultIsRegularFile;
 
-  const roots = collectCandidatePaths(bundleDir, readdir, isDirectory);
+  const roots = collectCandidatePaths(
+    bundleDir,
+    readdir,
+    isDirectory,
+    isRegularFile,
+  );
   const entries: DetectedBundleEntry[] = [];
   const seenFiles = new Set<string>();
   for (const filePath of roots) {
@@ -91,6 +102,7 @@ function collectCandidatePaths(
   root: string,
   readdir: (p: string) => string[],
   isDirectory: (p: string) => boolean,
+  isRegularFile: (p: string) => boolean,
 ): string[] {
   // Validate top-level readability with a descriptive error; inner
   // directories that fail to read are skipped silently so a partial bundle
@@ -118,7 +130,12 @@ function collectCandidatePaths(
       const full = path.join(dir, entry);
       if (isDirectory(full)) {
         walk(full, depth + 1);
-      } else {
+      } else if (isRegularFile(full)) {
+        // Codex review on PR #610 — reject symlink files as well as
+        // symlink directories. A bundle containing e.g. a symlinked
+        // `memory.json` could otherwise be followed to an arbitrary
+        // filesystem location and imported as if it were part of the
+        // bundle.
         out.push(full);
       }
     }
@@ -198,6 +215,22 @@ function defaultIsDirectory(p: string): boolean {
     const s = lstatSync(p);
     if (s.isSymbolicLink()) return false;
     return s.isDirectory();
+  } catch {
+    return false;
+  }
+}
+
+function defaultIsRegularFile(p: string): boolean {
+  try {
+    // Use lstatSync so symlinks never report as regular files. Codex
+    // review on PR #610: a bundle containing a symlinked `memory.json`
+    // (or any other known filename) must NOT be followed — otherwise
+    // the importer could be tricked into reading arbitrary filesystem
+    // locations. Reject symlink files here so classifyFile() never
+    // sees them.
+    const s = lstatSync(p);
+    if (s.isSymbolicLink()) return false;
+    return s.isFile();
   } catch {
     return false;
   }

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -13,10 +13,13 @@ import {
 import {
   cmdImport,
   parseImportArgs,
+  parseImportBundleArgs,
+  runBundleImportCommand,
   runImportCommand,
   type ImportDispatchArgs,
   type ImportDispatchIO,
 } from "./import-dispatch.js";
+import type { DetectedBundleEntry } from "./import-bundle-detect.js";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -391,5 +394,163 @@ describe("cmdImport dispose contract", () => {
     } finally {
       process.exitCode = savedExitCode;
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Slice 7: --all-from-bundle <dir> auto-detect
+// ---------------------------------------------------------------------------
+
+describe("parseImportBundleArgs", () => {
+  it("returns undefined when --all-from-bundle is absent", () => {
+    assert.equal(parseImportBundleArgs(["--adapter", "chatgpt"]), undefined);
+  });
+
+  it("parses --all-from-bundle with a directory argument", () => {
+    const args = parseImportBundleArgs([
+      "--all-from-bundle",
+      "/tmp/bundle",
+      "--dry-run",
+    ]);
+    assert.ok(args);
+    assert.equal(args.bundleDir, "/tmp/bundle");
+    assert.equal(args.dryRun, true);
+  });
+
+  it("rejects --all-from-bundle without a directory argument", () => {
+    // `takeValue` throws the generic "--all-from-bundle requires a value"
+    // before parseImportBundleArgs can produce the more specific message.
+    // Either form satisfies CLAUDE.md rule 14 (no silent defaults).
+    assert.throws(
+      () => parseImportBundleArgs(["--all-from-bundle"]),
+      /--all-from-bundle.*requires (?:a value|a directory)/,
+    );
+  });
+
+  it("rejects --adapter combined with --all-from-bundle", () => {
+    assert.throws(
+      () =>
+        parseImportBundleArgs([
+          "--all-from-bundle",
+          "/tmp/bundle",
+          "--adapter",
+          "chatgpt",
+        ]),
+      /not valid with --all-from-bundle/,
+    );
+  });
+
+  it("rejects --file combined with --all-from-bundle", () => {
+    assert.throws(
+      () =>
+        parseImportBundleArgs([
+          "--all-from-bundle",
+          "/tmp/bundle",
+          "--file",
+          "/tmp/x.json",
+        ]),
+      /not valid with --all-from-bundle/,
+    );
+  });
+
+  it("rejects unknown flags even in bundle mode", () => {
+    assert.throws(
+      () =>
+        parseImportBundleArgs([
+          "--all-from-bundle",
+          "/tmp/bundle",
+          "--bogus",
+        ]),
+      /Unknown flag/,
+    );
+  });
+});
+
+describe("runBundleImportCommand", () => {
+  it("runs one adapter per detected entry and accumulates results", async () => {
+    const memories = [{ content: "bundle memory", sourceLabel: "chatgpt" }];
+    const adapter = makeFakeAdapter(memories);
+    const { target, received } = makeTarget();
+    const { io, stdoutLines, getWriteTargetCalls } = makeIo({ adapter, target });
+
+    const detector = (): DetectedBundleEntry[] => [
+      { adapter: "chatgpt", filePath: "/bundle/memory.json" },
+      { adapter: "chatgpt", filePath: "/bundle/conversations.json", includeConversations: true },
+    ];
+
+    const results = await runBundleImportCommand(
+      {
+        bundleDir: "/bundle",
+        dryRun: false,
+        includeConversations: false,
+      },
+      io,
+      detector,
+    );
+    assert.equal(results.length, 2);
+    // Every entry invoked runImportCommand → one getWriteTarget per entry.
+    assert.equal(getWriteTargetCalls.count, 2);
+    assert.ok(
+      stdoutLines.some((l) => l.includes("Detected 2 imports")),
+      `expected detection summary, got: ${stdoutLines.join("\n")}`,
+    );
+    assert.ok(received.length > 0);
+  });
+
+  it("reports an empty bundle gracefully", async () => {
+    const adapter = makeFakeAdapter([]);
+    const { target } = makeTarget();
+    const { io, stdoutLines } = makeIo({ adapter, target });
+
+    const results = await runBundleImportCommand(
+      { bundleDir: "/empty", dryRun: false, includeConversations: false },
+      io,
+      () => [],
+    );
+    assert.deepEqual(results, []);
+    assert.ok(
+      stdoutLines.some((l) => l.includes("No known exports found")),
+      `expected empty-bundle message, got: ${stdoutLines.join("\n")}`,
+    );
+  });
+
+  it("surfaces per-entry errors to stderr without aborting remaining entries", async () => {
+    // First entry will fail (adapter loader throws), second one succeeds.
+    let callCount = 0;
+    const goodAdapter = makeFakeAdapter([
+      { content: "ok", sourceLabel: "claude" },
+    ]);
+    const { target } = makeTarget();
+    const stdoutLines: string[] = [];
+    const stderrLines: string[] = [];
+    const io: ImportDispatchIO = {
+      readFile: async () => "{}",
+      loadAdapter: async () => {
+        callCount += 1;
+        if (callCount === 1) {
+          throw new Error("boom: chatgpt adapter missing");
+        }
+        return goodAdapter;
+      },
+      runImporter,
+      getWriteTarget: async () => target,
+      stdout: (l) => stdoutLines.push(l),
+      stderr: (l) => stderrLines.push(l),
+    };
+
+    const results = await runBundleImportCommand(
+      { bundleDir: "/bundle", dryRun: false, includeConversations: false },
+      io,
+      () => [
+        { adapter: "chatgpt", filePath: "/bundle/memory.json" },
+        { adapter: "claude", filePath: "/bundle/projects.json" },
+      ],
+    );
+    // Only the good adapter's result is collected.
+    assert.equal(results.length, 1);
+    assert.ok(
+      stderrLines.some((l) => l.includes("adapter 'chatgpt' failed")),
+      `expected failure surfaced to stderr, got: ${stderrLines.join("\n")}`,
+    );
   });
 });

--- a/packages/remnic-cli/src/import-dispatch.test.ts
+++ b/packages/remnic-cli/src/import-dispatch.test.ts
@@ -478,7 +478,7 @@ describe("runBundleImportCommand", () => {
       { adapter: "chatgpt", filePath: "/bundle/conversations.json", includeConversations: true },
     ];
 
-    const results = await runBundleImportCommand(
+    const outcome = await runBundleImportCommand(
       {
         bundleDir: "/bundle",
         dryRun: false,
@@ -487,7 +487,8 @@ describe("runBundleImportCommand", () => {
       io,
       detector,
     );
-    assert.equal(results.length, 2);
+    assert.equal(outcome.results.length, 2);
+    assert.equal(outcome.failedCount, 0);
     // Every entry invoked runImportCommand → one getWriteTarget per entry.
     assert.equal(getWriteTargetCalls.count, 2);
     assert.ok(
@@ -502,12 +503,13 @@ describe("runBundleImportCommand", () => {
     const { target } = makeTarget();
     const { io, stdoutLines } = makeIo({ adapter, target });
 
-    const results = await runBundleImportCommand(
+    const outcome = await runBundleImportCommand(
       { bundleDir: "/empty", dryRun: false, includeConversations: false },
       io,
       () => [],
     );
-    assert.deepEqual(results, []);
+    assert.deepEqual(outcome.results, []);
+    assert.equal(outcome.failedCount, 0);
     assert.ok(
       stdoutLines.some((l) => l.includes("No known exports found")),
       `expected empty-bundle message, got: ${stdoutLines.join("\n")}`,
@@ -538,7 +540,7 @@ describe("runBundleImportCommand", () => {
       stderr: (l) => stderrLines.push(l),
     };
 
-    const results = await runBundleImportCommand(
+    const outcome = await runBundleImportCommand(
       { bundleDir: "/bundle", dryRun: false, includeConversations: false },
       io,
       () => [
@@ -547,7 +549,10 @@ describe("runBundleImportCommand", () => {
       ],
     );
     // Only the good adapter's result is collected.
-    assert.equal(results.length, 1);
+    assert.equal(outcome.results.length, 1);
+    // Failure count must reflect the one that threw — this is what
+    // cmdImport uses to set a non-zero exit code for automation.
+    assert.equal(outcome.failedCount, 1);
     assert.ok(
       stderrLines.some((l) => l.includes("adapter 'chatgpt' failed")),
       `expected failure surfaced to stderr, got: ${stderrLines.join("\n")}`,

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -38,6 +38,10 @@ import {
 } from "@remnic/core";
 
 import {
+  detectBundleEntries,
+  type DetectedBundleEntry,
+} from "./import-bundle-detect.js";
+import {
   isSupportedImporterName,
   loadImporterModule,
   SUPPORTED_IMPORTERS,
@@ -48,6 +52,19 @@ import { expandTilde } from "./path-utils.js";
 export interface ImportDispatchArgs {
   adapter: SupportedImporterName;
   file?: string;
+  dryRun: boolean;
+  batchSize?: number;
+  rateLimit?: number;
+  includeConversations: boolean;
+}
+
+/**
+ * Separate args struct for `remnic import --all-from-bundle <dir>` (slice 7).
+ * Unlike single-adapter mode, bundle mode derives the adapter from files
+ * discovered in the directory and does not accept `--adapter`.
+ */
+export interface ImportBundleArgs {
+  bundleDir: string;
   dryRun: boolean;
   batchSize?: number;
   rateLimit?: number;
@@ -92,6 +109,12 @@ Options:
   --include-conversations     Adapter hint: opt into conversation imports
                               (e.g. ChatGPT bulk conversation summaries).
   --help, -h                  Show this help.
+
+Bulk mode (slice 7):
+  remnic import --all-from-bundle <dir>
+                              Auto-detect ChatGPT / Claude / Takeout /
+                              mem0 exports inside <dir> and run each
+                              matching adapter. Replaces --adapter/--file.
 
 Slice 1 ships infrastructure only. The four adapter packages
 (@remnic/import-chatgpt, @remnic/import-claude, @remnic/import-gemini,
@@ -273,6 +296,144 @@ export async function runImportCommand(
   return result;
 }
 
+// ---------------------------------------------------------------------------
+// Bundle mode (slice 7): --all-from-bundle <dir>
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse `remnic import --all-from-bundle <dir> [options]`. Returns a struct
+ * with the bundle directory path (tilde-expanded) and the shared import
+ * options. Throws with a user-facing error on missing / malformed args.
+ *
+ * When `--all-from-bundle` is not present in the args, returns `undefined`
+ * so the caller can fall back to single-adapter mode.
+ */
+export function parseImportBundleArgs(
+  rest: readonly string[],
+): ImportBundleArgs | undefined {
+  const args = [...rest];
+  if (!args.includes("--all-from-bundle")) return undefined;
+
+  const rawDir = takeValue(args, "--all-from-bundle");
+  if (!rawDir) {
+    throw new Error(
+      "--all-from-bundle <dir> requires a directory path. Example: " +
+        "remnic import --all-from-bundle ~/chatgpt-export",
+    );
+  }
+  const bundleDir = expandTilde(rawDir);
+
+  // Bundle mode cannot combine with per-adapter flags — reject them loudly
+  // rather than silently ignoring (CLAUDE.md rule 51).
+  for (const incompatible of ["--adapter", "--file"] as const) {
+    if (args.includes(incompatible)) {
+      throw new Error(
+        `${incompatible} is not valid with --all-from-bundle. Use one or the other.`,
+      );
+    }
+  }
+
+  const batchSizeRaw = takeOptionalValue(args, "--batch-size");
+  let batchSize: number | undefined;
+  if (batchSizeRaw !== undefined) {
+    const parsed = Number(batchSizeRaw);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(
+        `--batch-size must be an integer. Received '${batchSizeRaw}'.`,
+      );
+    }
+    batchSize = validateImportBatchSize(parsed);
+  }
+
+  const rateLimitRaw = takeOptionalValue(args, "--rate-limit");
+  let rateLimit: number | undefined;
+  if (rateLimitRaw !== undefined) {
+    const parsed = Number(rateLimitRaw);
+    if (!Number.isFinite(parsed)) {
+      throw new Error(
+        `--rate-limit must be a positive number. Received '${rateLimitRaw}'.`,
+      );
+    }
+    rateLimit = validateImportRateLimit(parsed);
+  }
+
+  const dryRun = consumeFlag(args, "--dry-run");
+  const includeConversations = consumeFlag(args, "--include-conversations");
+
+  const unknownFlags = args.filter((a) => a.startsWith("--"));
+  if (unknownFlags.length > 0) {
+    throw new Error(
+      `Unknown flag(s) for 'remnic import --all-from-bundle': ${unknownFlags.join(", ")}.`,
+    );
+  }
+
+  return {
+    bundleDir,
+    dryRun,
+    batchSize,
+    rateLimit,
+    includeConversations,
+  };
+}
+
+/**
+ * Execute a bundle import. For each detected file we run the single-adapter
+ * pipeline via `runImportCommand`, accumulating the per-adapter results and
+ * returning a summary. Failures on individual entries do NOT abort the
+ * remaining imports — each is surfaced to stderr and the walk continues so
+ * a bad chatgpt file doesn't block claude + gemini imports that would have
+ * succeeded.
+ */
+export async function runBundleImportCommand(
+  args: ImportBundleArgs,
+  io: ImportDispatchIO,
+  detector: (dir: string) => DetectedBundleEntry[] = detectBundleEntries,
+): Promise<RunImporterResult[]> {
+  const entries = detector(args.bundleDir);
+  if (entries.length === 0) {
+    io.stdout(
+      `No known exports found in '${args.bundleDir}'. Supported filenames: ` +
+        "memory.json, projects.json, conversations.json, My Activity.json, mem0.json.",
+    );
+    return [];
+  }
+
+  io.stdout(
+    `Detected ${entries.length} import${entries.length === 1 ? "" : "s"} in '${args.bundleDir}':`,
+  );
+  for (const entry of entries) {
+    io.stdout(`  - ${entry.adapter} → ${entry.filePath}`);
+  }
+
+  const results: RunImporterResult[] = [];
+  for (const entry of entries) {
+    io.stdout("");
+    io.stdout(`Running '${entry.adapter}' adapter on ${entry.filePath} ...`);
+    const perEntryArgs: ImportDispatchArgs = {
+      adapter: entry.adapter,
+      file: entry.filePath,
+      dryRun: args.dryRun,
+      ...(args.batchSize !== undefined ? { batchSize: args.batchSize } : {}),
+      ...(args.rateLimit !== undefined ? { rateLimit: args.rateLimit } : {}),
+      // The per-file hint wins (e.g. conversations.json → true) but the
+      // top-level flag overrides when the user passed it explicitly.
+      includeConversations:
+        args.includeConversations || entry.includeConversations === true,
+    };
+    try {
+      const result = await runImportCommand(perEntryArgs, io);
+      results.push(result);
+    } catch (err) {
+      io.stderr(
+        `  adapter '${entry.adapter}' failed on ${entry.filePath}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
+  return results;
+}
+
 /**
  * Write target used during `--dry-run`. `runImporter` short-circuits before
  * invoking `writeTo`, but adapters may still pass this target around; every
@@ -305,20 +466,37 @@ export async function cmdImport(
   rest: string[],
   targetFactory: () => Promise<ImporterWriteTarget>,
   disposeTarget?: () => Promise<void>,
-): Promise<RunImporterResult | undefined> {
+): Promise<RunImporterResult | RunImporterResult[] | undefined> {
   if (rest.includes("--help") || rest.includes("-h")) {
     process.stdout.write(IMPORT_USAGE);
     return undefined;
   }
-  let parsed: ImportDispatchArgs;
+
+  // Slice 7: `--all-from-bundle <dir>` routes to the bundle pipeline
+  // instead of single-adapter parse. We detect it BEFORE parseImportArgs
+  // because `--adapter` is not required in bundle mode.
+  let bundleArgs: ImportBundleArgs | undefined;
   try {
-    parsed = parseImportArgs(rest);
+    bundleArgs = parseImportBundleArgs(rest);
   } catch (err) {
     process.stderr.write(
       (err instanceof Error ? err.message : String(err)) + "\n",
     );
     process.exitCode = 1;
     return undefined;
+  }
+
+  let parsed: ImportDispatchArgs | undefined;
+  if (!bundleArgs) {
+    try {
+      parsed = parseImportArgs(rest);
+    } catch (err) {
+      process.stderr.write(
+        (err instanceof Error ? err.message : String(err)) + "\n",
+      );
+      process.exitCode = 1;
+      return undefined;
+    }
   }
 
   // Track whether `getWriteTarget` was actually called so dispose only runs
@@ -339,7 +517,10 @@ export async function cmdImport(
   };
 
   try {
-    return await runImportCommand(parsed, io);
+    if (bundleArgs) {
+      return await runBundleImportCommand(bundleArgs, io);
+    }
+    return await runImportCommand(parsed!, io);
   } catch (err) {
     process.stderr.write(
       (err instanceof Error ? err.message : String(err)) + "\n",

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -376,26 +376,34 @@ export function parseImportBundleArgs(
   };
 }
 
+export interface BundleImportOutcome {
+  results: RunImporterResult[];
+  /** Number of detected entries that threw during their per-file run. */
+  failedCount: number;
+}
+
 /**
  * Execute a bundle import. For each detected file we run the single-adapter
  * pipeline via `runImportCommand`, accumulating the per-adapter results and
  * returning a summary. Failures on individual entries do NOT abort the
  * remaining imports — each is surfaced to stderr and the walk continues so
  * a bad chatgpt file doesn't block claude + gemini imports that would have
- * succeeded.
+ * succeeded. The return value reports how many entries failed so callers
+ * can signal a non-zero exit status to automation (Codex review on
+ * PR #610).
  */
 export async function runBundleImportCommand(
   args: ImportBundleArgs,
   io: ImportDispatchIO,
   detector: (dir: string) => DetectedBundleEntry[] = detectBundleEntries,
-): Promise<RunImporterResult[]> {
+): Promise<BundleImportOutcome> {
   const entries = detector(args.bundleDir);
   if (entries.length === 0) {
     io.stdout(
       `No known exports found in '${args.bundleDir}'. Supported filenames: ` +
         "memory.json, projects.json, conversations.json, My Activity.json, mem0.json.",
     );
-    return [];
+    return { results: [], failedCount: 0 };
   }
 
   io.stdout(
@@ -406,6 +414,7 @@ export async function runBundleImportCommand(
   }
 
   const results: RunImporterResult[] = [];
+  let failedCount = 0;
   for (const entry of entries) {
     io.stdout("");
     io.stdout(`Running '${entry.adapter}' adapter on ${entry.filePath} ...`);
@@ -424,6 +433,7 @@ export async function runBundleImportCommand(
       const result = await runImportCommand(perEntryArgs, io);
       results.push(result);
     } catch (err) {
+      failedCount += 1;
       io.stderr(
         `  adapter '${entry.adapter}' failed on ${entry.filePath}: ${
           err instanceof Error ? err.message : String(err)
@@ -431,7 +441,7 @@ export async function runBundleImportCommand(
       );
     }
   }
-  return results;
+  return { results, failedCount };
 }
 
 /**
@@ -518,7 +528,19 @@ export async function cmdImport(
 
   try {
     if (bundleArgs) {
-      return await runBundleImportCommand(bundleArgs, io);
+      const outcome = await runBundleImportCommand(bundleArgs, io);
+      // Signal partial failure to automation. The walk kept going on
+      // error (so the user sees every failure in one pass), but the
+      // process must exit non-zero when any entry failed so shell
+      // pipelines (`remnic import --all-from-bundle ... && ...`) don't
+      // falsely treat the run as success. Codex review on PR #610.
+      if (outcome.failedCount > 0) {
+        process.exitCode = 1;
+        process.stderr.write(
+          `Bundle import completed with ${outcome.failedCount} failed entr${outcome.failedCount === 1 ? "y" : "ies"} (see above).\n`,
+        );
+      }
+      return outcome.results;
     }
     return await runImportCommand(parsed!, io);
   } catch (err) {

--- a/packages/remnic-cli/src/import-dispatch.ts
+++ b/packages/remnic-cli/src/import-dispatch.ts
@@ -513,14 +513,30 @@ export async function cmdImport(
   // when a target was materialized. An install-hint miss (loadAdapter throws)
   // must NOT trigger dispose — there's nothing to dispose and disposing may
   // itself throw, masking the original error.
-  let targetMaterialized = false;
+  //
+  // Cursor review on PR #610 — memoize the materialized target across all
+  // calls to `getWriteTarget`. `runBundleImportCommand` invokes
+  // `runImportCommand` once per detected bundle entry and each invocation
+  // calls `io.getWriteTarget()`. Without memoization a non-singleton
+  // `targetFactory` would construct N separate resources while
+  // `disposeTarget` only runs once, leaking N-1. The single-construct
+  // invariant is now enforced at the io boundary rather than implicitly
+  // at the call site.
+  let materializedTarget: ImporterWriteTarget | undefined;
+  let materializePromise: Promise<ImporterWriteTarget> | undefined;
   const io: ImportDispatchIO = {
     readFile: async (p) => fs.promises.readFile(p, "utf-8"),
     loadAdapter: async (name) => (await loadImporterModule(name)).adapter,
     runImporter,
     getWriteTarget: async () => {
-      targetMaterialized = true;
-      return targetFactory();
+      if (materializedTarget !== undefined) return materializedTarget;
+      if (materializePromise === undefined) {
+        materializePromise = Promise.resolve(targetFactory()).then((t) => {
+          materializedTarget = t;
+          return t;
+        });
+      }
+      return materializePromise;
     },
     stdout: (line) => process.stdout.write(line + "\n"),
     stderr: (line) => process.stderr.write(line + "\n"),
@@ -553,7 +569,7 @@ export async function cmdImport(
     // Only dispose when the write target was actually constructed. Checking
     // `parsed.dryRun` alone would incorrectly dispose after install-hint
     // misses or parse errors that happen BEFORE `getWriteTarget` is called.
-    if (targetMaterialized && disposeTarget !== undefined) {
+    if (materializedTarget !== undefined && disposeTarget !== undefined) {
       try {
         await disposeTarget();
       } catch {


### PR DESCRIPTION
Part of #568 (slice 7 of 7).

## Summary
- New \`remnic import --all-from-bundle <dir>\` mode walks an unzipped export bundle, detects supported files by name, and runs each matching adapter in sequence.
- Detection walks up to four directory levels (enough to reach Takeout's \`Takeout/Gemini/My Activity.json\`).
- \`conversations.json\` is disambiguated between ChatGPT and Claude by peeking at the first conversation's shape (\`mapping\` → chatgpt, \`chat_messages\` → claude).
- Bundle mode is mutually exclusive with \`--adapter\` / \`--file\` — combining them throws a user-facing error (CLAUDE.md rule 51).
- Per-entry failures surface to stderr without aborting the walk.

## Filename map

| Filename                                  | Adapter   |
|-------------------------------------------|-----------|
| \`memory.json\`                             | chatgpt   |
| \`projects.json\`                           | claude    |
| \`conversations.json\`                      | chatgpt / claude (by content) |
| \`My Activity.json\` / \`MyActivity.json\`    | gemini    |
| \`mem0.json\` / \`mem0-export.json\`          | mem0      |

## Test plan
- [x] \`pnpm run check-types\` clean
- [x] \`packages/remnic-cli\` tests: 36 pass (new: 9 import-bundle-detect tests + 7 parseImportBundleArgs + 3 runBundleImportCommand integration tests)
- [x] Bundle detection is filesystem-injected for tests so no real file-system is touched

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new multi-import execution path that walks user-supplied directories and changes `cmdImport` return shape; mistakes could affect CLI behavior, resource cleanup, or filesystem safety (mitigated by explicit symlink rejection and tests).
> 
> **Overview**
> Adds a new `remnic import --all-from-bundle <dir>` mode that scans an unzipped export directory, auto-detects supported export files, and runs the appropriate importer adapters sequentially while continuing past per-entry failures and reporting an aggregate failure count.
> 
> Introduces `detectBundleEntries` with stable ordering, `conversations.json` content-based disambiguation (ChatGPT vs Claude), and explicit **symlink rejection** (including symlinked bundle roots) to prevent importing from unintended filesystem locations. Updates `cmdImport` to route to bundle mode, memoize the write target across multiple per-entry runs, and expands the test suite (new detector tests + bundle-args/runner tests) and CLI test script.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ac55b3095ad331fe5b6cc7086fee65d0d6abc10. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->