### PR TITLE
feat(procedural): stats CLI + HTTP + MCP surface (#567 PR 5/5)

### DIFF
--- a/docs/procedural-memory.md
+++ b/docs/procedural-memory.md
@@ -42,6 +42,22 @@ A dedicated miner clusters **causal trajectory** records (bounded lookback by `r
 
 Automation is **not** part of `runMemoryGovernance`. Use the MCP tool **`engram.procedure_mining_run`** (and optional cron registration mirroring other nightly jobs) so procedural mining stays isolated from shadow/apply governance.
 
+## Stats surface (issue #567 PR 5/5)
+
+Operators can inspect procedural memory health via three matched surfaces that all return the same `ProcedureStatsReport` JSON shape (schema v1):
+
+- **CLI:** `remnic procedural stats [--format json|text] [--memory-dir <path>]`
+- **HTTP:** `GET /engram/v1/procedural/stats?namespace=<optional>`
+- **MCP tool:** `remnic.procedural_stats` (with legacy alias `engram.procedural_stats`), argument `{ namespace?: string }`
+
+The report includes:
+
+- `counts` — procedure files by status: `total`, `active`, `pending_review`, `rejected`, `quarantined`, `superseded`, `archived`, `other`.
+- `recent` — `lastWriteAt` (ISO 8601 or `null`), `writesLast7Days` (exclusive upper bound per CLAUDE.md rule 35), and `minerSourced` count (procedures whose `source=procedure-miner`).
+- `config` — snapshot of the active `procedural.*` config so the caller can confirm the gate state and threshold floor in the same payload.
+
+All three surfaces are read-only and namespace-scoped (CLAUDE.md rule 42). The HTTP endpoint resolves the namespace through the same layer used by `/recall/explain` and `/trust-zones/status`; the MCP tool uses the authenticated principal. The CLI reads from whatever `memoryDir` the current config / active-space resolves to, or an explicit `--memory-dir` override.
+
 ## Benchmark
 
 The **`procedural-recall`** benchmark in `@remnic/bench` scores:

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2925,20 +2925,43 @@ Shared with:
   }
 
   const args = rest.slice(1);
+  // CLAUDE.md rules 14 + 51: --format must have a value if the flag is
+  // present. Previously `resolveFlag` returned `undefined` for `--format`
+  // with no value and we silently defaulted to "text", which hides
+  // operator typos (cursor review on #611).
+  const formatPresent = hasFlag(args, "--format");
+  const formatRaw = resolveFlag(args, "--format");
+  if (formatPresent && (formatRaw === undefined || formatRaw === null)) {
+    console.error(
+      "--format requires a value. Use `--format json` or `--format text`.",
+    );
+    process.exit(1);
+  }
   const format = (() => {
-    const raw = resolveFlag(args, "--format");
-    if (raw === undefined || raw === null) return "text";
-    const normalized = String(raw).trim().toLowerCase();
+    if (!formatPresent || formatRaw === undefined || formatRaw === null) {
+      return "text";
+    }
+    const normalized = String(formatRaw).trim().toLowerCase();
     if (normalized !== "text" && normalized !== "json") {
       console.error(
-        `Invalid --format "${raw}". Allowed: text, json.`,
+        `Invalid --format "${formatRaw}". Allowed: text, json.`,
       );
       process.exit(1);
     }
     return normalized;
   })();
 
+  const memoryDirPresent = hasFlag(args, "--memory-dir");
   const memoryDirOverride = resolveFlag(args, "--memory-dir");
+  if (
+    memoryDirPresent &&
+    (memoryDirOverride === undefined || memoryDirOverride === null)
+  ) {
+    console.error(
+      "--memory-dir requires a path. Omit the flag to use the resolved default.",
+    );
+    process.exit(1);
+  }
   const configPath = resolveConfigPath();
   const raw = fs.existsSync(configPath)
     ? JSON.parse(fs.readFileSync(configPath, "utf8"))

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -116,6 +116,9 @@ import {
   discoverMemoryExtensions,
   resolveExtensionsRoot,
   coerceInstallExtension,
+  StorageManager,
+  computeProcedureStats,
+  formatProcedureStatsText,
 } from "@remnic/core";
 // @remnic/export-weclone is an optional install surface (training:export
 // only uses it). Load lazily so the CLI works without it — see
@@ -200,6 +203,7 @@ type CommandName =
   | "binary"
   | "taxonomy"
   | "enrich"
+  | "procedural"
   | "openclaw"
   | "extensions"
   | "training:export"
@@ -2884,6 +2888,77 @@ async function cmdEnrich(rest: string[]): Promise<void> {
   if (totalPersisted > 0) {
     console.log(`\n  ${totalPersisted} candidate(s) persisted to memory store.`);
   }
+}
+
+/**
+ * `remnic procedural <subcommand>` (issue #567 PR 5/5). Currently supports:
+ *
+ *   remnic procedural stats [--format json|text] [--memory-dir <path>]
+ *
+ * Read-only — surfaces the same report as the HTTP
+ * `/engram/v1/procedural/stats` endpoint and the `remnic.procedural_stats`
+ * MCP tool so operators can quickly see procedural memory health.
+ */
+async function cmdProcedural(rest: string[]): Promise<void> {
+  initLogger();
+  const subcommand = rest[0];
+  if (!subcommand || subcommand === "--help" || subcommand === "-h") {
+    console.log(`remnic procedural — Procedural memory operations (issue #567)
+
+Usage:
+  remnic procedural stats [--format json|text] [--memory-dir <path>]
+
+Subcommands:
+  stats                Print counts by status + recent activity + active config.
+
+Shared with:
+  GET /engram/v1/procedural/stats
+  MCP remnic.procedural_stats (alias engram.procedural_stats)`);
+    return;
+  }
+
+  if (subcommand !== "stats") {
+    console.error(
+      `Unknown procedural subcommand "${subcommand}". Run \`remnic procedural --help\` for usage.`,
+    );
+    process.exit(1);
+  }
+
+  const args = rest.slice(1);
+  const format = (() => {
+    const raw = resolveFlag(args, "--format");
+    if (raw === undefined || raw === null) return "text";
+    const normalized = String(raw).trim().toLowerCase();
+    if (normalized !== "text" && normalized !== "json") {
+      console.error(
+        `Invalid --format "${raw}". Allowed: text, json.`,
+      );
+      process.exit(1);
+    }
+    return normalized;
+  })();
+
+  const memoryDirOverride = resolveFlag(args, "--memory-dir");
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const config = parseConfig(remnicCfg);
+
+  const memoryDir = expandTilde(
+    typeof memoryDirOverride === "string" && memoryDirOverride.length > 0
+      ? memoryDirOverride
+      : config.memoryDir ?? resolveMemoryDir(),
+  );
+
+  const storage = new StorageManager(memoryDir);
+  const report = await computeProcedureStats({ storage, config });
+  if (format === "json") {
+    process.stdout.write(JSON.stringify(report, null, 2) + "\n");
+    return;
+  }
+  process.stdout.write(formatProcedureStatsText(report));
 }
 
 async function cmdExtensions(action: string, rest: string[]): Promise<void> {
@@ -6109,6 +6184,11 @@ Options:
       break;
     }
 
+    case "procedural": {
+      await cmdProcedural(rest);
+      break;
+    }
+
     case "extensions": {
       const action = rest[0] ?? "help";
       await cmdExtensions(action, rest.slice(1));
@@ -6316,6 +6396,10 @@ Usage:
   remnic enrich --dry-run        Preview what would be enriched
   remnic enrich audit            Show recent enrichment audit log
   remnic enrich providers        List registered providers and their status
+  remnic procedural stats [--format json|text] [--memory-dir <path>]
+    Print procedural memory stats (counts + recency + config). Mirrors
+    GET /engram/v1/procedural/stats and remnic.procedural_stats MCP tool
+    (issue #567).
   remnic training:export --format <name> --output <path> [options]
     Export memories as a fine-tuning dataset (issue #459). Run
     'remnic training:export --help' for the full option list.

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -557,6 +557,29 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // Procedural memory stats (issue #567 PR 5/5). Read-only; namespace is
+    // scoped via the same resolver used by recall/trust-zones so cross-
+    // tenant reads aren't possible (CLAUDE.md rule 42).
+    if (req.method === "GET" && pathname === "/engram/v1/procedural/stats") {
+      const namespaceParam = parsed.searchParams.get("namespace");
+      this.respondJson(
+        res,
+        200,
+        await this.service.procedureStats(
+          {
+            namespace: this.resolveNamespace(
+              req,
+              namespaceParam && namespaceParam.length > 0
+                ? namespaceParam
+                : undefined,
+            ),
+          },
+          this.resolveRequestPrincipal(req),
+        ),
+      );
+      return;
+    }
+
     if (req.method === "GET" && pathname === "/engram/v1/trust-zones/records") {
       const limitRaw = parseInt(parsed.searchParams.get("limit") ?? "25", 10);
       const offsetRaw = parseInt(parsed.searchParams.get("offset") ?? "0", 10);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -187,6 +187,21 @@ export class EngramMcpServer {
         },
       },
       {
+        // The canonical `remnic.procedural_stats` alias is added automatically
+        // by `withToolAliases` — the dual-naming invariant keeps both names
+        // alive for the legacy surface.
+        name: "engram.procedural_stats",
+        description:
+          "Procedural memory stats (issue #567): counts by status, recent write activity, and the active procedural.* config. Read-only, namespace-scoped.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: { type: "string" },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.memory_get",
         description: "Fetch one Remnic memory by id.",
         inputSchema: {
@@ -1127,6 +1142,15 @@ export class EngramMcpServer {
           {
             namespace: typeof args.namespace === "string" ? args.namespace : undefined,
             authenticatedPrincipal: effectivePrincipal,
+          },
+          effectivePrincipal,
+        );
+      case "remnic.procedural_stats":
+      case "engram.procedural_stats":
+        return this.service.procedureStats(
+          {
+            namespace:
+              typeof args.namespace === "string" ? args.namespace : undefined,
           },
           effectivePrincipal,
         );

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -25,6 +25,10 @@ import {
 } from "./maintenance/memory-governance.js";
 import { runProcedureMining } from "./procedural/procedure-miner.js";
 import {
+  computeProcedureStats,
+  type ProcedureStatsReport,
+} from "./procedural/procedure-stats.js";
+import {
   normalizeProjectionPreview,
   normalizeProjectionTags,
 } from "./memory-projection-format.js";
@@ -1694,6 +1698,27 @@ export class EngramAccessService {
       proceduresWritten: result.proceduresWritten,
       skippedReason: result.skippedReason,
     };
+  }
+
+  /**
+   * Procedural memory stats (issue #567 PR 5/5). Read-only — resolves the
+   * namespace via the same path used by `recallExplain` / `trustZoneStatus`
+   * so cross-tenant reads are impossible (CLAUDE.md rule 42).
+   */
+  async procedureStats(
+    request: { namespace?: string } = {},
+    principal?: string,
+  ): Promise<ProcedureStatsReport & { namespace: string }> {
+    const resolvedNamespace = this.resolveReadableNamespace(
+      request.namespace,
+      principal,
+    );
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const report = await computeProcedureStats({
+      storage,
+      config: this.orchestrator.config,
+    });
+    return { namespace: resolvedNamespace, ...report };
   }
 
   async trustZoneStatus(namespace?: string, principal?: string): Promise<EngramAccessTrustZoneStatusResponse> {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -94,6 +94,18 @@ export {
   parseProcedureStepsFromBody,
 } from "./procedural/procedure-types.js";
 
+// Procedural stats surface (issue #567 PR 5/5).
+export {
+  computeProcedureStats,
+  formatProcedureStatsText,
+} from "./procedural/procedure-stats.js";
+export type {
+  ProcedureStatsReport,
+  ProcedureStatusCounts,
+  ProcedureStatsConfigSnapshot,
+  ProcedureStatsRecent,
+} from "./procedural/procedure-stats.js";
+
 // ---------------------------------------------------------------------------
 // Direct-answer retrieval tier (issue #518)
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/procedural/procedure-stats.ts
+++ b/packages/remnic-core/src/procedural/procedure-stats.ts
@@ -10,7 +10,7 @@
  *   - HTTP `GET /engram/v1/procedural/stats`
  *   - MCP `remnic.procedural_stats` (+ `engram.procedural_stats` alias)
  */
-import type { MemoryStatus, PluginConfig } from "../types.js";
+import type { MemoryFile, MemoryStatus, PluginConfig } from "../types.js";
 import type { StorageManager } from "../storage.js";
 
 export interface ProcedureStatusCounts {
@@ -112,9 +112,21 @@ export async function computeProcedureStats(options: {
     "archived",
   ];
 
-  const all = await storage.readAllMemories();
-  for (const m of all) {
+  // Iterate both live and archived memories so the counts surface matches
+  // what operators expect when procedures have been archived via
+  // `archiveMemory` (Codex P2 on #611). `readAllMemories` alone skips
+  // `archive/`, which would otherwise underreport `counts.archived` and
+  // `counts.total`.
+  const seen = new Set<string>();
+  const live = await storage.readAllMemories();
+  const archived = await storage.readArchivedMemories();
+  const pool: MemoryFile[] = [...live, ...archived];
+  for (const m of pool) {
     if (m.frontmatter.category !== "procedure") continue;
+    // Dedupe by id so a procedure appearing in both live + archive (mid-
+    // archive race) isn't counted twice.
+    if (seen.has(m.frontmatter.id)) continue;
+    seen.add(m.frontmatter.id);
     counts.total += 1;
     const status = m.frontmatter.status ?? "active";
     if ((known as string[]).includes(status)) {
@@ -124,14 +136,22 @@ export async function computeProcedureStats(options: {
       counts.other += 1;
     }
 
-    // Prefer `created`, fall back to `updated` for recency. Both are ISO 8601.
-    const createdMs = tsMs(m.frontmatter.created) ?? tsMs(m.frontmatter.updated);
-    if (createdMs !== null) {
-      if (lastWriteMs === null || createdMs > lastWriteMs) {
-        lastWriteMs = createdMs;
+    // Recency semantics (Codex P2 on #611): use the latest of `updated` and
+    // `created`, not a fallback chain, so recently-edited procedures are
+    // reflected in `lastWriteAt` and `writesLast7Days`. Missing timestamps
+    // skip the row.
+    const createdMs = tsMs(m.frontmatter.created);
+    const updatedMs = tsMs(m.frontmatter.updated);
+    const latestMs =
+      createdMs !== null && updatedMs !== null
+        ? Math.max(createdMs, updatedMs)
+        : (updatedMs ?? createdMs);
+    if (latestMs !== null) {
+      if (lastWriteMs === null || latestMs > lastWriteMs) {
+        lastWriteMs = latestMs;
       }
       // Exclusive upper bound per CLAUDE.md rule 35 — use half-open window.
-      if (createdMs >= nowMs - sevenDaysMs && createdMs < nowMs) {
+      if (latestMs >= nowMs - sevenDaysMs && latestMs < nowMs) {
         writesLast7Days += 1;
       }
     }

--- a/packages/remnic-core/src/procedural/procedure-stats.ts
+++ b/packages/remnic-core/src/procedural/procedure-stats.ts
@@ -1,0 +1,193 @@
+/**
+ * Procedural memory stats surface (issue #567 PR 5/5).
+ *
+ * Pure helper that tallies procedure memories by status and summarizes the
+ * current `procedural.*` config so operators (and the dashboard) can see,
+ * in one call, how procedural memory is behaving in a namespace.
+ *
+ * Consumed by:
+ *   - CLI `remnic procedural stats`
+ *   - HTTP `GET /engram/v1/procedural/stats`
+ *   - MCP `remnic.procedural_stats` (+ `engram.procedural_stats` alias)
+ */
+import type { MemoryStatus, PluginConfig } from "../types.js";
+import type { StorageManager } from "../storage.js";
+
+export interface ProcedureStatusCounts {
+  total: number;
+  active: number;
+  pending_review: number;
+  rejected: number;
+  quarantined: number;
+  superseded: number;
+  archived: number;
+  /** Any status the enum doesn't yet cover. */
+  other: number;
+}
+
+export interface ProcedureStatsConfigSnapshot {
+  enabled: boolean;
+  minOccurrences: number;
+  successFloor: number;
+  autoPromoteOccurrences: number;
+  autoPromoteEnabled: boolean;
+  lookbackDays: number;
+  recallMaxProcedures: number;
+}
+
+export interface ProcedureStatsRecent {
+  /** ISO 8601 timestamp of the most recent procedure write, or null. */
+  lastWriteAt: string | null;
+  /** Count of procedure files with `created` (or `updated`) in the last 7 days. */
+  writesLast7Days: number;
+  /** Count of procedures whose `source` is the procedure miner. */
+  minerSourced: number;
+}
+
+export interface ProcedureStatsReport {
+  schemaVersion: 1;
+  generatedAt: string;
+  counts: ProcedureStatusCounts;
+  recent: ProcedureStatsRecent;
+  config: ProcedureStatsConfigSnapshot;
+}
+
+function snapshotConfig(config: PluginConfig): ProcedureStatsConfigSnapshot {
+  const p = config.procedural;
+  return {
+    enabled: p?.enabled === true,
+    minOccurrences: typeof p?.minOccurrences === "number" ? p.minOccurrences : 0,
+    successFloor: typeof p?.successFloor === "number" ? p.successFloor : 0,
+    autoPromoteOccurrences:
+      typeof p?.autoPromoteOccurrences === "number"
+        ? p.autoPromoteOccurrences
+        : 0,
+    autoPromoteEnabled: p?.autoPromoteEnabled === true,
+    lookbackDays: typeof p?.lookbackDays === "number" ? p.lookbackDays : 0,
+    recallMaxProcedures:
+      typeof p?.recallMaxProcedures === "number" ? p.recallMaxProcedures : 0,
+  };
+}
+
+function tsMs(value: unknown): number | null {
+  if (typeof value !== "string") return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * Read all memories from storage and tally procedures by status + recency.
+ * `nowMs` is injectable so tests can pin the "last 7 days" window.
+ */
+export async function computeProcedureStats(options: {
+  storage: StorageManager;
+  config: PluginConfig;
+  nowMs?: number;
+}): Promise<ProcedureStatsReport> {
+  const { storage, config } = options;
+  const nowMs = options.nowMs ?? Date.now();
+  const sevenDaysMs = 7 * 24 * 60 * 60 * 1000;
+
+  const counts: ProcedureStatusCounts = {
+    total: 0,
+    active: 0,
+    pending_review: 0,
+    rejected: 0,
+    quarantined: 0,
+    superseded: 0,
+    archived: 0,
+    other: 0,
+  };
+
+  let lastWriteMs: number | null = null;
+  let writesLast7Days = 0;
+  let minerSourced = 0;
+
+  const known: MemoryStatus[] = [
+    "active",
+    "pending_review",
+    "rejected",
+    "quarantined",
+    "superseded",
+    "archived",
+  ];
+
+  const all = await storage.readAllMemories();
+  for (const m of all) {
+    if (m.frontmatter.category !== "procedure") continue;
+    counts.total += 1;
+    const status = m.frontmatter.status ?? "active";
+    if ((known as string[]).includes(status)) {
+      // Safe index: the status enum values are the counts keys.
+      (counts as unknown as Record<string, number>)[status] += 1;
+    } else {
+      counts.other += 1;
+    }
+
+    // Prefer `created`, fall back to `updated` for recency. Both are ISO 8601.
+    const createdMs = tsMs(m.frontmatter.created) ?? tsMs(m.frontmatter.updated);
+    if (createdMs !== null) {
+      if (lastWriteMs === null || createdMs > lastWriteMs) {
+        lastWriteMs = createdMs;
+      }
+      // Exclusive upper bound per CLAUDE.md rule 35 — use half-open window.
+      if (createdMs >= nowMs - sevenDaysMs && createdMs < nowMs) {
+        writesLast7Days += 1;
+      }
+    }
+
+    if (m.frontmatter.source === "procedure-miner") {
+      minerSourced += 1;
+    }
+  }
+
+  return {
+    schemaVersion: 1,
+    generatedAt: new Date(nowMs).toISOString(),
+    counts,
+    recent: {
+      lastWriteAt: lastWriteMs !== null ? new Date(lastWriteMs).toISOString() : null,
+      writesLast7Days,
+      minerSourced,
+    },
+    config: snapshotConfig(config),
+  };
+}
+
+/**
+ * Render `ProcedureStatsReport` as a human-friendly plain-text block for CLI
+ * operators. Keep it deterministic — no colors, no ANSI. Used by `--format text`.
+ */
+export function formatProcedureStatsText(report: ProcedureStatsReport): string {
+  const { counts, recent, config } = report;
+  const lines: string[] = [];
+  lines.push(`Procedural memory stats (schema v${report.schemaVersion})`);
+  lines.push(`  generated: ${report.generatedAt}`);
+  lines.push("");
+  lines.push(`  config:`);
+  lines.push(`    enabled:                 ${config.enabled}`);
+  lines.push(`    minOccurrences:          ${config.minOccurrences}`);
+  lines.push(`    successFloor:            ${config.successFloor}`);
+  lines.push(`    autoPromoteOccurrences:  ${config.autoPromoteOccurrences}`);
+  lines.push(`    autoPromoteEnabled:      ${config.autoPromoteEnabled}`);
+  lines.push(`    lookbackDays:            ${config.lookbackDays}`);
+  lines.push(`    recallMaxProcedures:     ${config.recallMaxProcedures}`);
+  lines.push("");
+  lines.push(`  counts:`);
+  lines.push(`    total:           ${counts.total}`);
+  lines.push(`    active:          ${counts.active}`);
+  lines.push(`    pending_review:  ${counts.pending_review}`);
+  lines.push(`    rejected:        ${counts.rejected}`);
+  lines.push(`    quarantined:     ${counts.quarantined}`);
+  lines.push(`    superseded:      ${counts.superseded}`);
+  lines.push(`    archived:        ${counts.archived}`);
+  if (counts.other > 0) {
+    lines.push(`    other:           ${counts.other}`);
+  }
+  lines.push("");
+  lines.push(`  recent:`);
+  lines.push(`    lastWriteAt:      ${recent.lastWriteAt ?? "(none)"}`);
+  lines.push(`    writesLast7Days:  ${recent.writesLast7Days}`);
+  lines.push(`    minerSourced:     ${recent.minerSourced}`);
+  return lines.join("\n") + "\n";
+}

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -340,6 +340,35 @@ function createFakeService(): EngramAccessService {
       status,
       previousStatus: "pending_review",
     }),
+    procedureStats: async (request: { namespace?: string } = {}) => ({
+      namespace: request.namespace ?? "global",
+      schemaVersion: 1,
+      generatedAt: "2026-04-20T12:00:00.000Z",
+      counts: {
+        total: 4,
+        active: 2,
+        pending_review: 1,
+        rejected: 0,
+        quarantined: 0,
+        superseded: 1,
+        archived: 0,
+        other: 0,
+      },
+      recent: {
+        lastWriteAt: "2026-04-20T11:59:59.000Z",
+        writesLast7Days: 3,
+        minerSourced: 2,
+      },
+      config: {
+        enabled: true,
+        minOccurrences: 3,
+        successFloor: 0.75,
+        autoPromoteOccurrences: 8,
+        autoPromoteEnabled: false,
+        lookbackDays: 14,
+        recallMaxProcedures: 2,
+      },
+    }),
   } as unknown as EngramAccessService;
 }
 
@@ -470,6 +499,24 @@ test("access HTTP server enforces bearer auth and serves phase 1 routes", async 
     assert.equal(trustZoneStatusRes.status, 200);
     const trustZoneStatus = await trustZoneStatusRes.json() as { status: { records: { valid: number } } };
     assert.equal(trustZoneStatus.status.records.valid, 3);
+
+    // Procedural stats (issue #567 PR 5/5). Namespace is optional.
+    const proceduralStatsRes = await fetch(
+      `${base}/engram/v1/procedural/stats`,
+      { headers },
+    );
+    assert.equal(proceduralStatsRes.status, 200);
+    const proceduralStats = (await proceduralStatsRes.json()) as {
+      schemaVersion: number;
+      counts: { total: number; active: number; pending_review: number };
+      config: { enabled: boolean; recallMaxProcedures: number };
+    };
+    assert.equal(proceduralStats.schemaVersion, 1);
+    assert.equal(proceduralStats.counts.total, 4);
+    assert.equal(proceduralStats.counts.active, 2);
+    assert.equal(proceduralStats.counts.pending_review, 1);
+    assert.equal(proceduralStats.config.enabled, true);
+    assert.equal(proceduralStats.config.recallMaxProcedures, 2);
 
     const trustZoneBrowseRes = await fetch(`${base}/engram/v1/trust-zones/records?zone=working`, { headers });
     assert.equal(trustZoneBrowseRes.status, 200);

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -160,6 +160,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.day_summary",
     "engram.memory_governance_run",
     "engram.procedure_mining_run",
+    "engram.procedural_stats",
     "engram.memory_get",
     "engram.memory_timeline",
     "engram.memory_store",

--- a/tests/procedure-stats.test.ts
+++ b/tests/procedure-stats.test.ts
@@ -179,6 +179,114 @@ test("computeProcedureStats writesLast7Days uses a half-open window (CLAUDE.md r
   }
 });
 
+test("computeProcedureStats counts archived procedures (Codex P2 on #611)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-proc-stats-archived-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const body = buildProcedureMarkdownBody([
+      { order: 1, intent: "Step A" },
+      { order: 2, intent: "Step B" },
+    ]);
+
+    // One live active procedure…
+    await storage.writeMemory("procedure", `Live active\n\n${body}`, {
+      source: "user",
+      status: "active",
+      tags: [],
+    });
+    // …and one that we then archive via `archiveMemory`.
+    await storage.writeMemory(
+      "procedure",
+      `To archive\n\n${body}`,
+      {
+        source: "user",
+        status: "active",
+        tags: [],
+      },
+    );
+    // Find the just-written procedure file and archive it.
+    const live = await storage.readAllMemories();
+    const toArchive = live.find(
+      (m) =>
+        m.frontmatter.category === "procedure" &&
+        m.content.includes("To archive"),
+    );
+    assert.ok(toArchive, "procedure to archive must exist on disk");
+    await storage.archiveMemory(toArchive);
+
+    const config = parseConfig({
+      memoryDir: dir,
+      openaiApiKey: "test-key",
+      procedural: { enabled: true },
+    });
+
+    const report = await computeProcedureStats({ storage, config });
+    // Both procedures should count. `readAllMemories` alone would have
+    // missed the archived one.
+    assert.equal(report.counts.total, 2);
+    assert.equal(report.counts.active, 1);
+    assert.equal(report.counts.archived, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("computeProcedureStats recency uses latest of created/updated (Codex P2 on #611)", async () => {
+  // Synthetic MemoryFile-shaped entries so we can pin both timestamps.
+  // Rather than set up a real edit cycle in StorageManager (which would
+  // only produce `updated >= created`), we mock a storage stub.
+  const mkEntry = (id: string, created: string, updated: string) => ({
+    path: `/tmp/${id}.md`,
+    content: "",
+    frontmatter: {
+      id,
+      category: "procedure" as const,
+      created,
+      updated,
+      source: "user",
+      confidence: 1,
+      confidenceTier: "high" as const,
+      tags: [] as string[],
+    },
+  });
+
+  const fakeStorage = {
+    readAllMemories: async () => [
+      // `updated` is MORE RECENT than `created`; the report must key off
+      // `updated`, not `created`, so this row lands in the 7-day window.
+      mkEntry(
+        "procA",
+        "2026-04-10T00:00:00.000Z",
+        "2026-04-20T10:00:00.000Z",
+      ),
+    ],
+    readArchivedMemories: async () => [],
+  } as unknown as StorageManager;
+
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    procedural: { enabled: true },
+  });
+
+  const report = await computeProcedureStats({
+    storage: fakeStorage,
+    config,
+    nowMs: Date.parse("2026-04-20T12:00:00.000Z"),
+  });
+
+  assert.equal(
+    report.recent.lastWriteAt,
+    "2026-04-20T10:00:00.000Z",
+    "lastWriteAt must reflect the most recent of created/updated",
+  );
+  assert.equal(
+    report.recent.writesLast7Days,
+    1,
+    "row updated 2h ago must be inside the 7-day window",
+  );
+});
+
 test("formatProcedureStatsText is deterministic for a known report", () => {
   const text = formatProcedureStatsText({
     schemaVersion: 1,

--- a/tests/procedure-stats.test.ts
+++ b/tests/procedure-stats.test.ts
@@ -1,0 +1,219 @@
+/**
+ * Tests for the procedural stats surface (issue #567 PR 5/5).
+ */
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import { StorageManager } from "../src/storage.ts";
+import { parseConfig } from "../packages/remnic-core/src/config.ts";
+import { buildProcedureMarkdownBody } from "../packages/remnic-core/src/procedural/procedure-types.ts";
+import {
+  computeProcedureStats,
+  formatProcedureStatsText,
+} from "../packages/remnic-core/src/procedural/procedure-stats.ts";
+
+test("computeProcedureStats returns zeroed counts for an empty storage", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-proc-stats-empty-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const config = parseConfig({
+      memoryDir: dir,
+      openaiApiKey: "test-key",
+      procedural: { enabled: true },
+    });
+
+    const report = await computeProcedureStats({
+      storage,
+      config,
+      nowMs: Date.parse("2026-04-20T12:00:00Z"),
+    });
+
+    assert.equal(report.schemaVersion, 1);
+    assert.equal(report.counts.total, 0);
+    assert.equal(report.counts.active, 0);
+    assert.equal(report.counts.pending_review, 0);
+    assert.equal(report.recent.lastWriteAt, null);
+    assert.equal(report.recent.writesLast7Days, 0);
+    assert.equal(report.recent.minerSourced, 0);
+    assert.equal(report.config.enabled, true);
+    assert.equal(report.generatedAt, "2026-04-20T12:00:00.000Z");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("computeProcedureStats tallies procedures by status and recency", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-proc-stats-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    // Seed three procedures: two from the miner (one active, one pending),
+    // one user-authored active. Then one non-procedure for the "only count
+    // procedures" invariant.
+    const body = buildProcedureMarkdownBody([
+      { order: 1, intent: "Step one" },
+      { order: 2, intent: "Step two" },
+    ]);
+
+    await storage.writeMemory("procedure", `Active miner proc\n\n${body}`, {
+      source: "procedure-miner",
+      status: "active",
+      tags: ["deploy"],
+    });
+    await storage.writeMemory("procedure", `Pending miner proc\n\n${body}`, {
+      source: "procedure-miner",
+      status: "pending_review",
+      tags: ["ship"],
+    });
+    await storage.writeMemory("procedure", `Hand-authored proc\n\n${body}`, {
+      source: "user",
+      status: "active",
+      tags: ["release"],
+    });
+    // Non-procedure category — must NOT appear in counts.
+    await storage.writeMemory("fact", "some fact", {
+      source: "user",
+      status: "active",
+      tags: [],
+    });
+
+    const config = parseConfig({
+      memoryDir: dir,
+      openaiApiKey: "test-key",
+      procedural: {
+        enabled: true,
+        minOccurrences: 3,
+        successFloor: 0.75,
+        recallMaxProcedures: 2,
+      },
+    });
+
+    // Fix `nowMs` ~ 1 minute after the writes. All three procedures should
+    // land in the "last 7 days" window.
+    const report = await computeProcedureStats({
+      storage,
+      config,
+      nowMs: Date.now() + 60_000,
+    });
+
+    assert.equal(report.counts.total, 3);
+    assert.equal(report.counts.active, 2);
+    assert.equal(report.counts.pending_review, 1);
+    assert.equal(report.counts.rejected, 0);
+    assert.equal(report.counts.other, 0);
+    assert.equal(report.recent.minerSourced, 2);
+    assert.equal(
+      report.recent.writesLast7Days,
+      3,
+      "all three writes are within the 7-day window",
+    );
+    assert.ok(
+      report.recent.lastWriteAt !== null,
+      "lastWriteAt should be set when procedures exist",
+    );
+    // Config snapshot reflects caller-supplied values.
+    assert.equal(report.config.enabled, true);
+    assert.equal(report.config.minOccurrences, 3);
+    assert.equal(report.config.successFloor, 0.75);
+    assert.equal(report.config.recallMaxProcedures, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("computeProcedureStats writesLast7Days uses a half-open window (CLAUDE.md rule 35)", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-proc-stats-window-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const body = buildProcedureMarkdownBody([
+      { order: 1, intent: "Only step" },
+      { order: 2, intent: "Second step" },
+    ]);
+    await storage.writeMemory("procedure", `Single proc\n\n${body}`, {
+      source: "user",
+      status: "active",
+      tags: [],
+    });
+
+    const config = parseConfig({
+      memoryDir: dir,
+      openaiApiKey: "test-key",
+      procedural: { enabled: true },
+    });
+
+    // nowMs == write timestamp. With `createdMs < nowMs` the write must NOT
+    // count (the window is [now-7d, now), half-open).
+    const reports = await storage.readAllMemories();
+    const procMemory = reports.find(
+      (r) => r.frontmatter.category === "procedure",
+    );
+    assert.ok(procMemory, "procedure was persisted");
+    const writeMs = Date.parse(procMemory.frontmatter.created);
+    assert.ok(Number.isFinite(writeMs));
+
+    const onBoundary = await computeProcedureStats({
+      storage,
+      config,
+      nowMs: writeMs,
+    });
+    assert.equal(
+      onBoundary.recent.writesLast7Days,
+      0,
+      "writes exactly at nowMs are outside the half-open window",
+    );
+
+    const oneMillisLater = await computeProcedureStats({
+      storage,
+      config,
+      nowMs: writeMs + 1,
+    });
+    assert.equal(oneMillisLater.recent.writesLast7Days, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("formatProcedureStatsText is deterministic for a known report", () => {
+  const text = formatProcedureStatsText({
+    schemaVersion: 1,
+    generatedAt: "2026-04-20T12:00:00.000Z",
+    counts: {
+      total: 2,
+      active: 1,
+      pending_review: 1,
+      rejected: 0,
+      quarantined: 0,
+      superseded: 0,
+      archived: 0,
+      other: 0,
+    },
+    recent: {
+      lastWriteAt: "2026-04-19T23:59:59.000Z",
+      writesLast7Days: 2,
+      minerSourced: 1,
+    },
+    config: {
+      enabled: true,
+      minOccurrences: 3,
+      successFloor: 0.75,
+      autoPromoteOccurrences: 8,
+      autoPromoteEnabled: false,
+      lookbackDays: 14,
+      recallMaxProcedures: 2,
+    },
+  });
+
+  assert.match(text, /Procedural memory stats \(schema v1\)/);
+  assert.match(text, /total:\s+2/);
+  assert.match(text, /pending_review:\s+1/);
+  assert.match(text, /enabled:\s+true/);
+  assert.match(text, /lastWriteAt:\s+2026-04-19T23:59:59\.000Z/);
+  // No ANSI escapes — CLI output is deterministic and pipe-safe.
+  assert.doesNotMatch(text, /\u001b\[/);
+});


### PR DESCRIPTION
Part of #567 (slice 5 of 5).

## Summary

Adds operator-facing procedural memory stats through three matched surfaces. All three return the same `ProcedureStatsReport` JSON shape (schema v1):

- **CLI:** `remnic procedural stats [--format json|text] [--memory-dir <path>]`
- **HTTP:** `GET /engram/v1/procedural/stats?namespace=<optional>`
- **MCP tool:** `engram.procedural_stats` (canonical `remnic.procedural_stats` alias added automatically by `withToolAliases`), argument `{ namespace?: string }`

Report fields:

- `counts` — procedures by status: `total`, `active`, `pending_review`, `rejected`, `quarantined`, `superseded`, `archived`, `other`.
- `recent` — `lastWriteAt` (ISO 8601 or `null`), `writesLast7Days` (half-open window per CLAUDE.md rule 35), `minerSourced`.
- `config` — snapshot of the active `procedural.*` config.

## Test plan

- [x] `tests/procedure-stats.test.ts` (new) — 4 cases: empty storage, status tallies, rule-35 half-open window boundary, deterministic text rendering.
- [x] `tests/access-http.test.ts` — added assertion on the new HTTP route.
- [x] `tests/access-mcp.test.ts` — `engram.procedural_stats` added to the expected legacy tool list (auto-aliased to `remnic.procedural_stats`).
- [x] `pnpm --filter @remnic/core run check-types` — clean.
- [x] CLI smoke-tested: `remnic procedural --help`, `remnic procedural stats --format json` against an empty memoryDir both return expected payloads.

## CLAUDE.md invariants honored

- **Rule 35** (exclusive upper bound) — `writesLast7Days` uses `[now-7d, now)` and has a unit test for the boundary.
- **Rule 42** (namespace-scoped reads) — `procedureStats` routes through `resolveReadableNamespace` the same as `recallExplain` / `trustZoneStatus`.
- **Rule 51** (reject invalid input) — CLI rejects unknown subcommands and invalid `--format` values instead of silently defaulting.
- **Rule 55** (wired + tested) — every surface has a corresponding test.
- **À-la-carte packaging** — only `@remnic/core` / `@remnic/cli` touched. No new bench / weclone dependency.
- **Public-repo privacy** — no user-specific fixtures; tests seed synthetic procedures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new operator-facing API/CLI/MCP surfaces and new storage-scanning logic to compute stats; while read-only, mistakes could leak cross-namespace data or misreport counts/recency.
> 
> **Overview**
> Adds a read-only **procedural memory stats** report (`ProcedureStatsReport` v1) and exposes it consistently via `remnic procedural stats`, `GET /engram/v1/procedural/stats`, and the MCP tool `remnic.procedural_stats` (legacy `engram.procedural_stats`).
> 
> Introduces `computeProcedureStats`/`formatProcedureStatsText` to scan live + archived procedure memories, tally counts by status, compute recent write activity (half-open 7-day window), and include a snapshot of active `procedural.*` config; wires namespace-scoped resolution in the HTTP/service/MCP layers and adds coverage in HTTP/MCP tests plus new unit tests for stats computation/formatting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 78724d2c8bfa922d061b0c74a26d814cf4357b28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->