### PR TITLE
fix(bench): retry, error isolation, progress logging, partial results

### DIFF
--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -47,6 +47,7 @@ export async function runAmaBenchBenchmark(
 ): Promise<BenchmarkResult> {
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
+  const totalQaPairs = dataset.reduce((sum, ep) => sum + ep.qa_pairs.length, 0);
 
   for (const episode of dataset) {
     await options.system.reset();
@@ -65,56 +66,73 @@ export async function runAmaBenchBenchmark(
     }
 
     for (const qa of episode.qa_pairs) {
-      const { result: recalledText, durationMs } = await timed(async () =>
-        options.system.recall(sessionId, qa.question),
-      );
-      const answered = await answerBenchmarkQuestion({
-        question: qa.question,
-        recalledText,
-        responder: options.system.responder,
-      });
-      const judgeResult = await llmJudgeScoreDetailed(
-        options.system.judge,
-        qa.question,
-        answered.finalAnswer,
-        qa.answer,
-      );
+      try {
+        const { result: recalledText, durationMs } = await timed(async () =>
+          options.system.recall(sessionId, qa.question),
+        );
+        const answered = await answerBenchmarkQuestion({
+          question: qa.question,
+          recalledText,
+          responder: options.system.responder,
+        });
+        const judgeResult = await llmJudgeScoreDetailed(
+          options.system.judge,
+          qa.question,
+          answered.finalAnswer,
+          qa.answer,
+        );
 
-      const scores: Record<string, number> = {
-        f1: f1Score(answered.finalAnswer, qa.answer),
-        contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
-      };
-      if (judgeResult.score >= 0) {
-        scores.llm_judge = judgeResult.score;
+        const scores: Record<string, number> = {
+          f1: f1Score(answered.finalAnswer, qa.answer),
+          contains_answer: containsAnswer(answered.finalAnswer, qa.answer),
+        };
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
+        }
+
+        tasks.push({
+          taskId: qa.question_uuid,
+          question: qa.question,
+          expected: qa.answer,
+          actual: answered.finalAnswer,
+          scores,
+          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          tokens: {
+            input: answered.tokens.input + judgeResult.tokens.input,
+            output: answered.tokens.output + judgeResult.tokens.output,
+          },
+          details: {
+            qaType: qa.type,
+            domain: episode.domain,
+            episodeId: episode.episode_id,
+            task: episode.task,
+            taskType: episode.task_type,
+            numTurns: episode.num_turns,
+            totalTokens: episode.total_tokens,
+            recalledLength: recalledText.length,
+            answeredLength: answered.finalAnswer.length,
+            recalledText,
+            answeredText: answered.finalAnswer,
+            responderModel: answered.model,
+            judgeModel: judgeResult.model,
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  [WARN] ama-bench task ${qa.question_uuid} failed: ${message}`);
+        tasks.push({
+          taskId: qa.question_uuid,
+          question: qa.question,
+          expected: qa.answer,
+          actual: `(error: ${message})`,
+          scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: { error: message },
+        });
       }
 
-      tasks.push({
-        taskId: qa.question_uuid,
-        question: qa.question,
-        expected: qa.answer,
-        actual: answered.finalAnswer,
-        scores,
-        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-        tokens: {
-          input: answered.tokens.input + judgeResult.tokens.input,
-          output: answered.tokens.output + judgeResult.tokens.output,
-        },
-        details: {
-          qaType: qa.type,
-          domain: episode.domain,
-          episodeId: episode.episode_id,
-          task: episode.task,
-          taskType: episode.task_type,
-          numTurns: episode.num_turns,
-          totalTokens: episode.total_tokens,
-          recalledLength: recalledText.length,
-          answeredLength: answered.finalAnswer.length,
-          recalledText,
-          answeredText: answered.finalAnswer,
-          responderModel: answered.model,
-          judgeModel: judgeResult.model,
-        },
-      });
+      options.onTaskComplete?.(tasks[tasks.length - 1], tasks.length, totalQaPairs);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -74,6 +74,8 @@ export async function runAMemGymBenchmark(
   const profiles = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalTasks = profiles.reduce((sum, profile) => sum + profile.qas.length, 0);
+
   for (let profileIndex = 0; profileIndex < profiles.length; profileIndex += 1) {
     const profile = profiles[profileIndex]!;
     await options.system.reset();
@@ -98,56 +100,74 @@ export async function runAMemGymBenchmark(
       questionIndex += 1
     ) {
       const qa = profile.qas[questionIndex]!;
+      const taskResultId = `${profile.id}-q${questionIndex}`;
       const expectedAnswer = findBestAnswer(qa, finalState);
 
-      const { result: recallText, durationMs } = await timed(async () => {
-        return options.system.recall(sessionId, qa.query);
-      });
-      const answered = await answerBenchmarkQuestion({
-        question: qa.query,
-        recalledText: recallText,
-        responder: options.system.responder,
-      });
+      try {
+        const { result: recallText, durationMs } = await timed(async () => {
+          return options.system.recall(sessionId, qa.query);
+        });
+        const answered = await answerBenchmarkQuestion({
+          question: qa.query,
+          recalledText: recallText,
+          responder: options.system.responder,
+        });
 
-      const scores: Record<string, number> = {
-        f1: f1Score(answered.finalAnswer, expectedAnswer),
-        contains_answer: containsAnswer(answered.finalAnswer, expectedAnswer),
-      };
-      const judgeResult = await llmJudgeScoreDetailed(
-        options.system.judge,
-        qa.query,
-        answered.finalAnswer,
-        expectedAnswer,
-      );
-      if (judgeResult.score >= 0) {
-        scores.llm_judge = judgeResult.score;
+        const scores: Record<string, number> = {
+          f1: f1Score(answered.finalAnswer, expectedAnswer),
+          contains_answer: containsAnswer(answered.finalAnswer, expectedAnswer),
+        };
+        const judgeResult = await llmJudgeScoreDetailed(
+          options.system.judge,
+          qa.query,
+          answered.finalAnswer,
+          expectedAnswer,
+        );
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
+        }
+
+        tasks.push({
+          taskId: taskResultId,
+          question: qa.query,
+          expected: expectedAnswer,
+          actual: answered.finalAnswer,
+          scores,
+          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          tokens: {
+            input: answered.tokens.input + judgeResult.tokens.input,
+            output: answered.tokens.output + judgeResult.tokens.output,
+          },
+          details: {
+            profileId: profile.id,
+            profileName: profile.user_profile.name,
+            questionIndex,
+            periodCount: profile.periods.length,
+            requiredInfo: qa.required_info,
+            recalledLength: recallText.length,
+            answeredLength: answered.finalAnswer.length,
+            recalledText: recallText,
+            answeredText: answered.finalAnswer,
+            responderModel: answered.model,
+            judgeModel: judgeResult.model,
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  [WARN] amemgym task ${taskResultId} failed: ${message}`);
+        tasks.push({
+          taskId: taskResultId,
+          question: qa.query,
+          expected: expectedAnswer,
+          actual: `(error: ${message})`,
+          scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: { error: message },
+        });
       }
 
-      tasks.push({
-        taskId: `${profile.id}-q${questionIndex}`,
-        question: qa.query,
-        expected: expectedAnswer,
-        actual: answered.finalAnswer,
-        scores,
-        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-        tokens: {
-          input: answered.tokens.input + judgeResult.tokens.input,
-          output: answered.tokens.output + judgeResult.tokens.output,
-        },
-        details: {
-          profileId: profile.id,
-          profileName: profile.user_profile.name,
-          questionIndex,
-          periodCount: profile.periods.length,
-          requiredInfo: qa.required_info,
-          recalledLength: recallText.length,
-          answeredLength: answered.finalAnswer.length,
-          recalledText: recallText,
-          answeredText: answered.finalAnswer,
-          responderModel: answered.model,
-          judgeModel: judgeResult.model,
-        },
-      });
+      options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -71,6 +71,16 @@ export async function runBeamBenchmark(
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalTasks = dataset.reduce(
+    (sum, entry) =>
+      sum +
+      Object.values(normalizeQuestionMap(entry.conversation.probing_questions)).reduce(
+        (qSum, questions) => qSum + questions.length,
+        0,
+      ),
+    0,
+  );
+
   for (const entry of dataset) {
     await options.system.reset();
 
@@ -89,73 +99,91 @@ export async function runBeamBenchmark(
     let taskIndex = 0;
     for (const [ability, questions] of Object.entries(questionMap)) {
       for (const probe of questions) {
+        const taskResultId = `${entry.scale}-${entry.conversation.conversation_id}-${ability}-${taskIndex}`;
         const expected = buildExpectedAnswer(probe);
-        const rubricTargets = normalizeRubricTargets(probe.rubric);
-        const { result: recalledText, durationMs } = await timed(async () => {
-          const recalledSessions = await Promise.all(
-            sessionIds.map((sessionId) =>
-              options.system.recall(sessionId, probe.question),
-            ),
-          );
-          return recalledSessions.filter(Boolean).join("\n\n");
-        });
-        const answered = await answerBenchmarkQuestion({
-          question: probe.question,
-          recalledText,
-          responder: options.system.responder,
-        });
-        const searchResults = await options.system.search(probe.question, 10);
-        const judgeResult = await llmJudgeScoreDetailed(
-          options.system.judge,
-          probe.question,
-          answered.finalAnswer,
-          expected,
-        );
-
-        const scores: Record<string, number> = {
-          f1: f1Score(answered.finalAnswer, expected),
-          contains_answer: containsAnswer(answered.finalAnswer, expected),
-          rouge_l: rougeL(answered.finalAnswer, expected),
-          search_hits: searchResults.length,
-        };
-        if (rubricTargets.length > 0) {
-          scores.rubric_coverage = computeRubricCoverage(
-            answered.finalAnswer,
-            rubricTargets,
-          );
-        }
-        if (judgeResult.score >= 0) {
-          scores.llm_judge = judgeResult.score;
-        }
-
-        tasks.push({
-          taskId: `${entry.scale}-${entry.conversation.conversation_id}-${ability}-${taskIndex}`,
-          question: probe.question,
-          expected,
-          actual: answered.finalAnswer,
-          scores,
-          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-          tokens: {
-            input: answered.tokens.input + judgeResult.tokens.input,
-            output: answered.tokens.output + judgeResult.tokens.output,
-          },
-          details: {
-            ability,
-            scale: entry.scale,
-            difficulty: probe.difficulty,
-            conversationId: entry.conversation.conversation_id,
-            sessionCount: sessionIds.length,
-            planReference: probe.plan_reference,
-            sourceChatIds: probe.source_chat_ids,
-            rubric: probe.rubric,
-            recalledLength: recalledText.length,
-            answeredLength: answered.finalAnswer.length,
+        try {
+          const rubricTargets = normalizeRubricTargets(probe.rubric);
+          const { result: recalledText, durationMs } = await timed(async () => {
+            const recalledSessions = await Promise.all(
+              sessionIds.map((sessionId) =>
+                options.system.recall(sessionId, probe.question),
+              ),
+            );
+            return recalledSessions.filter(Boolean).join("\n\n");
+          });
+          const answered = await answerBenchmarkQuestion({
+            question: probe.question,
             recalledText,
-            answeredText: answered.finalAnswer,
-            responderModel: answered.model,
-            judgeModel: judgeResult.model,
-          },
-        });
+            responder: options.system.responder,
+          });
+          const searchResults = await options.system.search(probe.question, 10);
+          const judgeResult = await llmJudgeScoreDetailed(
+            options.system.judge,
+            probe.question,
+            answered.finalAnswer,
+            expected,
+          );
+
+          const scores: Record<string, number> = {
+            f1: f1Score(answered.finalAnswer, expected),
+            contains_answer: containsAnswer(answered.finalAnswer, expected),
+            rouge_l: rougeL(answered.finalAnswer, expected),
+            search_hits: searchResults.length,
+          };
+          if (rubricTargets.length > 0) {
+            scores.rubric_coverage = computeRubricCoverage(
+              answered.finalAnswer,
+              rubricTargets,
+            );
+          }
+          if (judgeResult.score >= 0) {
+            scores.llm_judge = judgeResult.score;
+          }
+
+          tasks.push({
+            taskId: taskResultId,
+            question: probe.question,
+            expected,
+            actual: answered.finalAnswer,
+            scores,
+            latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+            tokens: {
+              input: answered.tokens.input + judgeResult.tokens.input,
+              output: answered.tokens.output + judgeResult.tokens.output,
+            },
+            details: {
+              ability,
+              scale: entry.scale,
+              difficulty: probe.difficulty,
+              conversationId: entry.conversation.conversation_id,
+              sessionCount: sessionIds.length,
+              planReference: probe.plan_reference,
+              sourceChatIds: probe.source_chat_ids,
+              rubric: probe.rubric,
+              recalledLength: recalledText.length,
+              answeredLength: answered.finalAnswer.length,
+              recalledText,
+              answeredText: answered.finalAnswer,
+              responderModel: answered.model,
+              judgeModel: judgeResult.model,
+            },
+          });
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`  [WARN] beam task ${taskResultId} failed: ${message}`);
+          tasks.push({
+            taskId: taskResultId,
+            question: probe.question,
+            expected,
+            actual: `(error: ${message})`,
+            scores: { f1: -1, contains_answer: -1, rouge_l: -1, search_hits: -1, llm_judge: -1 },
+            latencyMs: 0,
+            tokens: { input: 0, output: 0 },
+            details: { error: message },
+          });
+        }
+
+        options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
         taskIndex += 1;
       }
     }

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -180,8 +180,26 @@ export async function runPublishedHarness(
         await ctx.options.system.store(session.sessionId, session.messages);
       }
     }
+    const planIndex = tasks.length;
     for (const trial of plan.trials) {
-      tasks.push(await executeTrial(ctx, trial));
+      const trialId = trial.taskId ?? trial.question.slice(0, 60);
+      try {
+        tasks.push(await executeTrial(ctx, trial));
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  [WARN] harness trial plan-${planIndex}/${trialId} failed: ${message}`);
+        tasks.push({
+          taskId: trial.taskId,
+          question: trial.question,
+          expected: trial.expected,
+          actual: `(error: ${message})`,
+          scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: { error: message },
+        });
+      }
+      ctx.options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -181,7 +181,6 @@ export async function runPublishedHarness(
       }
     }
     const planIndex = tasks.length;
-    const totalInPlan = plan.trials.length;
     for (const trial of plan.trials) {
       const trialId = trial.taskId ?? trial.question.slice(0, 60);
       try {
@@ -200,7 +199,10 @@ export async function runPublishedHarness(
           details: { error: message },
         });
       }
-      ctx.options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalInPlan);
+      // Pass the GLOBAL total (ctx.totalCount), not a per-plan total —
+      // `tasks.length` is cumulative across every plan in ctx.plans, so a
+      // per-plan divisor would overflow to "N/3" nonsense in plan 2+.
+      ctx.options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, ctx.totalCount);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -181,6 +181,7 @@ export async function runPublishedHarness(
       }
     }
     const planIndex = tasks.length;
+    const totalInPlan = plan.trials.length;
     for (const trial of plan.trials) {
       const trialId = trial.taskId ?? trial.question.slice(0, 60);
       try {
@@ -199,7 +200,7 @@ export async function runPublishedHarness(
           details: { error: message },
         });
       }
-      ctx.options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length);
+      ctx.options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalInPlan);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -66,61 +66,80 @@ export async function runMemBenchBenchmark(
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalTasks = dataset.length;
+
   for (const testCase of dataset) {
-    await options.system.reset();
+    try {
+      await options.system.reset();
 
-    const sessionId = `membench-${testCase.id}`;
-    if (testCase.turns.length > 0) {
-      await options.system.store(sessionId, testCase.turns);
-    }
+      const sessionId = `membench-${testCase.id}`;
+      if (testCase.turns.length > 0) {
+        await options.system.store(sessionId, testCase.turns);
+      }
 
-    const { result: recalledText, durationMs } = await timed(async () =>
-      options.system.recall(sessionId, testCase.question),
-    );
-    const answered = await answerBenchmarkQuestion({
-      question: testCase.question,
-      recalledText,
-      responder: options.system.responder,
-    });
-    const judgeResult = await llmJudgeScoreDetailed(
-      options.system.judge,
-      testCase.question,
-      answered.finalAnswer,
-      testCase.answer,
-    );
-
-    const scores: Record<string, number> = {
-      f1: f1Score(answered.finalAnswer, testCase.answer),
-      contains_answer: containsAnswer(answered.finalAnswer, testCase.answer),
-    };
-    if (judgeResult.score >= 0) {
-      scores.llm_judge = judgeResult.score;
-    }
-
-    tasks.push({
-      taskId: testCase.id,
-      question: testCase.question,
-      expected: testCase.answer,
-      actual: answered.finalAnswer,
-      scores,
-      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-      tokens: {
-        input: answered.tokens.input + judgeResult.tokens.input,
-        output: answered.tokens.output + judgeResult.tokens.output,
-      },
-      details: {
-        memoryType: testCase.memoryType,
-        scenario: testCase.scenario,
-        level: testCase.level,
-        turnCount: testCase.turns.length,
-        recalledLength: recalledText.length,
-        answeredLength: answered.finalAnswer.length,
+      const { result: recalledText, durationMs } = await timed(async () =>
+        options.system.recall(sessionId, testCase.question),
+      );
+      const answered = await answerBenchmarkQuestion({
+        question: testCase.question,
         recalledText,
-        answeredText: answered.finalAnswer,
-        responderModel: answered.model,
-        judgeModel: judgeResult.model,
-      },
-    });
+        responder: options.system.responder,
+      });
+      const judgeResult = await llmJudgeScoreDetailed(
+        options.system.judge,
+        testCase.question,
+        answered.finalAnswer,
+        testCase.answer,
+      );
+
+      const scores: Record<string, number> = {
+        f1: f1Score(answered.finalAnswer, testCase.answer),
+        contains_answer: containsAnswer(answered.finalAnswer, testCase.answer),
+      };
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
+      }
+
+      tasks.push({
+        taskId: testCase.id,
+        question: testCase.question,
+        expected: testCase.answer,
+        actual: answered.finalAnswer,
+        scores,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
+        details: {
+          memoryType: testCase.memoryType,
+          scenario: testCase.scenario,
+          level: testCase.level,
+          turnCount: testCase.turns.length,
+          recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
+          judgeModel: judgeResult.model,
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  [WARN] membench task ${testCase.id} failed: ${message}`);
+      tasks.push({
+        taskId: testCase.id,
+        question: testCase.question,
+        expected: testCase.answer,
+        actual: `(error: ${message})`,
+        scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+        latencyMs: 0,
+        tokens: { input: 0, output: 0 },
+        details: { error: message },
+      });
+    }
+
+    options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
   }
 
   const remnicVersion = await getRemnicVersion();

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -51,6 +51,12 @@ export async function runMemoryArenaBenchmark(
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalTasks = dataset.reduce(
+    (sum, { tasks: domainTasks }) =>
+      sum + domainTasks.reduce((tSum, task) => tSum + task.questions.length, 0),
+    0,
+  );
+
   for (const { domain, tasks: domainTasks } of dataset) {
     for (const task of domainTasks) {
       await options.system.reset();
@@ -70,68 +76,91 @@ export async function runMemoryArenaBenchmark(
         }
 
         const expected = answerToString(expectedAnswer);
-        await options.system.store(sessionId, [
-          { role: "user", content: question },
-          {
-            role: "assistant",
-            content: `Processing subtask ${questionIndex + 1}: ${question.slice(0, 100)}...`,
-          },
-        ]);
+        const taskResultId = `${domain}-t${task.id}-q${questionIndex}`;
 
-        const { result: recalledText, durationMs } = await timed(async () =>
-          options.system.recall(sessionId, question),
-        );
-        const answered = await answerBenchmarkQuestion({
-          question,
-          recalledText,
-          responder: options.system.responder,
-        });
-        const judgeResult = await llmJudgeScoreDetailed(
-          options.system.judge,
-          question,
-          answered.finalAnswer,
-          expected,
-        );
+        try {
+          await options.system.store(sessionId, [
+            { role: "user", content: question },
+            {
+              role: "assistant",
+              content: `Processing subtask ${questionIndex + 1}: ${question.slice(0, 100)}...`,
+            },
+          ]);
 
-        const scores: Record<string, number> = {
-          f1: f1Score(answered.finalAnswer, expected),
-          contains_answer: containsAnswer(answered.finalAnswer, expected),
-        };
-        if (judgeResult.score >= 0) {
-          scores.llm_judge = judgeResult.score;
+          const { result: recalledText, durationMs } = await timed(async () =>
+            options.system.recall(sessionId, question),
+          );
+          const answered = await answerBenchmarkQuestion({
+            question,
+            recalledText,
+            responder: options.system.responder,
+          });
+          const judgeResult = await llmJudgeScoreDetailed(
+            options.system.judge,
+            question,
+            answered.finalAnswer,
+            expected,
+          );
+
+          const scores: Record<string, number> = {
+            f1: f1Score(answered.finalAnswer, expected),
+            contains_answer: containsAnswer(answered.finalAnswer, expected),
+          };
+          if (judgeResult.score >= 0) {
+            scores.llm_judge = judgeResult.score;
+          }
+
+          tasks.push({
+            taskId: taskResultId,
+            question,
+            expected,
+            actual: answered.finalAnswer,
+            scores,
+            latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+            tokens: {
+              input: answered.tokens.input + judgeResult.tokens.input,
+              output: answered.tokens.output + judgeResult.tokens.output,
+            },
+            details: {
+              domain,
+              taskId: task.id,
+              subtaskIndex: questionIndex,
+              category: task.category,
+              recalledLength: recalledText.length,
+              answeredLength: answered.finalAnswer.length,
+              recalledText,
+              answeredText: answered.finalAnswer,
+              responderModel: answered.model,
+              judgeModel: judgeResult.model,
+            },
+          });
+
+          try {
+            await options.system.store(sessionId, [
+              {
+                role: "assistant",
+                content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
+              },
+            ]);
+          } catch (storeErr) {
+            console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`  [WARN] memory-arena task ${taskResultId} failed: ${message}`);
+          tasks.push({
+            taskId: taskResultId,
+            question,
+            expected,
+            actual: `(error: ${message})`,
+            scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+            latencyMs: 0,
+            tokens: { input: 0, output: 0 },
+            details: { error: message },
+          });
         }
 
-        tasks.push({
-          taskId: `${domain}-t${task.id}-q${questionIndex}`,
-          question,
-          expected,
-          actual: answered.finalAnswer,
-          scores,
-          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-          tokens: {
-            input: answered.tokens.input + judgeResult.tokens.input,
-            output: answered.tokens.output + judgeResult.tokens.output,
-          },
-          details: {
-            domain,
-            taskId: task.id,
-            subtaskIndex: questionIndex,
-            category: task.category,
-            recalledLength: recalledText.length,
-            answeredLength: answered.finalAnswer.length,
-            recalledText,
-            answeredText: answered.finalAnswer,
-            responderModel: answered.model,
-            judgeModel: judgeResult.model,
-          },
-        });
-
-        await options.system.store(sessionId, [
-          {
-            role: "assistant",
-            content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
-          },
-        ]);
+        options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
       }
     }
   }

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -107,6 +107,11 @@ export async function runMemoryAgentBenchBenchmark(
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalQuestions = dataset.reduce(
+    (sum, item) => sum + item.questions.length,
+    0,
+  );
+
   for (const [itemIndex, item] of dataset.entries()) {
     await options.system.reset();
 
@@ -120,71 +125,90 @@ export async function runMemoryAgentBenchBenchmark(
         );
       }
 
-      const { result: recalledText, durationMs } = await timed(async () => {
-        const recalledSessions = await Promise.all(
-          sessionIds.map((sessionId) => options.system.recall(sessionId, question)),
-        );
-        return recalledSessions.filter(Boolean).join("\n\n");
-      });
-      const answered = await answerBenchmarkQuestion({
-        question,
-        recalledText,
-        responder: options.system.responder,
-      });
-      const bestExpectedAnswer = selectBestMatchingAnswer(answered.finalAnswer, answerVariants);
-      const judgeResult = await llmJudgeScoreDetailed(
-        options.system.judge,
-        question,
-        answered.finalAnswer,
-        bestExpectedAnswer,
-      );
+      const taskResultId =
+        item.metadata.qa_pair_ids?.[questionIndex] ??
+        `${item.metadata.source}-q${questionIndex}`;
 
-      const scores: Record<string, number> = {
-        f1: scoreAgainstVariants(answered.finalAnswer, answerVariants, f1Score),
-        contains_answer: answerVariants.some((variant) =>
-          containsAnswer(answered.finalAnswer, variant),
-        )
-          ? 1
-          : 0,
-        rouge_l: scoreAgainstVariants(answered.finalAnswer, answerVariants, rougeL),
-      };
-      if (judgeResult.score >= 0) {
-        scores.llm_judge = judgeResult.score;
+      try {
+        const { result: recalledText, durationMs } = await timed(async () => {
+          const recalledSessions = await Promise.all(
+            sessionIds.map((sessionId) => options.system.recall(sessionId, question)),
+          );
+          return recalledSessions.filter(Boolean).join("\n\n");
+        });
+        const answered = await answerBenchmarkQuestion({
+          question,
+          recalledText,
+          responder: options.system.responder,
+        });
+        const bestExpectedAnswer = selectBestMatchingAnswer(answered.finalAnswer, answerVariants);
+        const judgeResult = await llmJudgeScoreDetailed(
+          options.system.judge,
+          question,
+          answered.finalAnswer,
+          bestExpectedAnswer,
+        );
+
+        const scores: Record<string, number> = {
+          f1: scoreAgainstVariants(answered.finalAnswer, answerVariants, f1Score),
+          contains_answer: answerVariants.some((variant) =>
+            containsAnswer(answered.finalAnswer, variant),
+          )
+            ? 1
+            : 0,
+          rouge_l: scoreAgainstVariants(answered.finalAnswer, answerVariants, rougeL),
+        };
+        if (judgeResult.score >= 0) {
+          scores.llm_judge = judgeResult.score;
+        }
+
+        tasks.push({
+          taskId: taskResultId,
+          question,
+          expected: answerVariants[0]!,
+          actual: answered.finalAnswer,
+          scores,
+          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          tokens: {
+            input: answered.tokens.input + judgeResult.tokens.input,
+            output: answered.tokens.output + judgeResult.tokens.output,
+          },
+          details: {
+            competency: item.metadata.competency,
+            source: item.metadata.source,
+            questionType: item.metadata.question_types?.[questionIndex],
+            questionId: item.metadata.question_ids?.[questionIndex],
+            questionDate: item.metadata.question_dates?.[questionIndex],
+            previousEvent: item.metadata.previous_events?.[questionIndex],
+            keypoints: item.metadata.keypoints ?? [],
+            answerVariants,
+            bestExpectedAnswer,
+            sessionIds,
+            storedSessionCount: sessionIds.length,
+            recalledLength: recalledText.length,
+            answeredLength: answered.finalAnswer.length,
+            recalledText,
+            answeredText: answered.finalAnswer,
+            responderModel: answered.model,
+            judgeModel: judgeResult.model,
+          },
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  [WARN] memoryagentbench task ${taskResultId} failed: ${message}`);
+        tasks.push({
+          taskId: taskResultId,
+          question,
+          expected: answerVariants[0]!,
+          actual: `(error: ${message})`,
+          scores: { f1: -1, contains_answer: -1, rouge_l: -1, llm_judge: -1 },
+          latencyMs: 0,
+          tokens: { input: 0, output: 0 },
+          details: { error: message },
+        });
       }
 
-      tasks.push({
-        taskId:
-          item.metadata.qa_pair_ids?.[questionIndex] ??
-          `${item.metadata.source}-q${questionIndex}`,
-        question,
-        expected: answerVariants[0]!,
-        actual: answered.finalAnswer,
-        scores,
-        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-        tokens: {
-          input: answered.tokens.input + judgeResult.tokens.input,
-          output: answered.tokens.output + judgeResult.tokens.output,
-        },
-        details: {
-          competency: item.metadata.competency,
-          source: item.metadata.source,
-          questionType: item.metadata.question_types?.[questionIndex],
-          questionId: item.metadata.question_ids?.[questionIndex],
-          questionDate: item.metadata.question_dates?.[questionIndex],
-          previousEvent: item.metadata.previous_events?.[questionIndex],
-          keypoints: item.metadata.keypoints ?? [],
-          answerVariants,
-          bestExpectedAnswer,
-          sessionIds,
-          storedSessionCount: sessionIds.length,
-          recalledLength: recalledText.length,
-          answeredLength: answered.finalAnswer.length,
-          recalledText,
-          answeredText: answered.finalAnswer,
-          responderModel: answered.model,
-          judgeModel: judgeResult.model,
-        },
-      });
+      options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalQuestions);
     }
   }
 

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -77,77 +77,97 @@ export async function runPersonaMemBenchmark(
   const samples = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
 
+  const totalTasks = samples.length;
+
   for (let sampleIndex = 0; sampleIndex < samples.length; sampleIndex += 1) {
     const sample = samples[sampleIndex]!;
-    await options.system.reset();
+    const taskId = `${sample.personaId}-q${sampleIndex}`;
+    try {
+      await options.system.reset();
 
-    const sessionId = `personamem-${sample.personaId}`;
-    const messages = buildMessages(sample.chatHistory.chat_history);
-    if (messages.length > 0) {
-      await options.system.store(sessionId, messages);
-    }
+      const sessionId = `personamem-${sample.personaId}`;
+      const messages = buildMessages(sample.chatHistory.chat_history);
+      if (messages.length > 0) {
+        await options.system.store(sessionId, messages);
+      }
 
-    const { result: recalledText, durationMs } = await timed(async () =>
-      options.system.recall(sessionId, sample.userQuery),
-    );
-    const searchResults = await options.system.search(
-      sample.userQuery,
-      10,
-      sessionId,
-    );
-    const answered = await answerBenchmarkQuestion({
-      question: sample.userQuery,
-      recalledText,
-      responder: options.system.responder,
-    });
-    const judgeResult = await llmJudgeScoreDetailed(
-      options.system.judge,
-      sample.userQuery,
-      answered.finalAnswer,
-      sample.correctAnswer,
-    );
-
-    const scores: Record<string, number> = {
-      f1: f1Score(answered.finalAnswer, sample.correctAnswer),
-      contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
-      search_hits: searchResults.length,
-    };
-    if (judgeResult.score >= 0) {
-      scores.llm_judge = judgeResult.score;
-    }
-
-    tasks.push({
-      taskId: `${sample.personaId}-q${sampleIndex}`,
-      question: sample.userQuery,
-      expected: sample.correctAnswer,
-      actual: answered.finalAnswer,
-      scores,
-      latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
-      tokens: {
-        input: answered.tokens.input + judgeResult.tokens.input,
-        output: answered.tokens.output + judgeResult.tokens.output,
-      },
-      details: {
-        personaId: sample.personaId,
-        topicQuery: sample.topicQuery,
-        preference: sample.preference,
-        topicPreference: sample.topicPreference,
-        prefType: sample.prefType,
-        relatedConversationSnippet: sample.relatedConversationSnippet,
-        who: sample.who,
-        updated: sample.updated,
-        prevPref: sample.prevPref,
-        chatHistoryMessageCount: sample.chatHistory.chat_history.length,
-        chatHistory32kLink: sample.chatHistory32kLink,
-        chatHistory128kLink: sample.chatHistory128kLink,
-        recalledLength: recalledText.length,
-        answeredLength: answered.finalAnswer.length,
+      const { result: recalledText, durationMs } = await timed(async () =>
+        options.system.recall(sessionId, sample.userQuery),
+      );
+      const searchResults = await options.system.search(
+        sample.userQuery,
+        10,
+        sessionId,
+      );
+      const answered = await answerBenchmarkQuestion({
+        question: sample.userQuery,
         recalledText,
-        answeredText: answered.finalAnswer,
-        responderModel: answered.model,
-        judgeModel: judgeResult.model,
-      },
-    });
+        responder: options.system.responder,
+      });
+      const judgeResult = await llmJudgeScoreDetailed(
+        options.system.judge,
+        sample.userQuery,
+        answered.finalAnswer,
+        sample.correctAnswer,
+      );
+
+      const scores: Record<string, number> = {
+        f1: f1Score(answered.finalAnswer, sample.correctAnswer),
+        contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
+        search_hits: searchResults.length,
+      };
+      if (judgeResult.score >= 0) {
+        scores.llm_judge = judgeResult.score;
+      }
+
+      tasks.push({
+        taskId,
+        question: sample.userQuery,
+        expected: sample.correctAnswer,
+        actual: answered.finalAnswer,
+        scores,
+        latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+        tokens: {
+          input: answered.tokens.input + judgeResult.tokens.input,
+          output: answered.tokens.output + judgeResult.tokens.output,
+        },
+        details: {
+          personaId: sample.personaId,
+          topicQuery: sample.topicQuery,
+          preference: sample.preference,
+          topicPreference: sample.topicPreference,
+          prefType: sample.prefType,
+          relatedConversationSnippet: sample.relatedConversationSnippet,
+          who: sample.who,
+          updated: sample.updated,
+          prevPref: sample.prevPref,
+          chatHistoryMessageCount: sample.chatHistory.chat_history.length,
+          chatHistory32kLink: sample.chatHistory32kLink,
+          chatHistory128kLink: sample.chatHistory128kLink,
+          recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
+          judgeModel: judgeResult.model,
+        },
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`  [WARN] personamem task ${taskId} failed: ${message}`);
+      tasks.push({
+        taskId,
+        question: sample.userQuery,
+        expected: sample.correctAnswer,
+        actual: `(error: ${message})`,
+        scores: { f1: -1, contains_answer: -1, search_hits: -1, llm_judge: -1 },
+        latencyMs: 0,
+        tokens: { input: 0, output: 0 },
+        details: { error: message },
+      });
+    }
+
+    options.onTaskComplete?.(tasks[tasks.length - 1]!, tasks.length, totalTasks);
   }
 
   const remnicVersion = await getRemnicVersion();

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -117,6 +117,7 @@ export type {
   WriteBenchmarkArtifactResult,
 } from "./published-artifact.js";
 export { createAnthropicProvider } from "./providers/anthropic.js";
+export { getRemnicVersion } from "./reporter.js";
 export {
   createProvider,
   discoverAllProviders,

--- a/packages/bench/src/providers/anthropic.ts
+++ b/packages/bench/src/providers/anthropic.ts
@@ -5,6 +5,7 @@ import type {
   LlmProvider,
   TokenUsage,
 } from "./types.js";
+import { retryFetch } from "./retry-fetch.js";
 
 interface AnthropicMessageResponse {
   model?: string;
@@ -38,17 +39,21 @@ class AnthropicProvider implements LlmProvider {
     opts: CompletionOpts = {},
   ): Promise<CompletionResult> {
     const startedAt = performance.now();
-    const response = await fetch(this.urlFor("messages"), {
-      method: "POST",
-      headers: this.headers(opts.headers),
-      body: JSON.stringify({
-        model: this.config.model,
-        system: opts.systemPrompt,
-        max_tokens: opts.maxTokens ?? 1_024,
-        temperature: opts.temperature,
-        messages: [{ role: "user", content: prompt }],
-      }),
-    });
+    const response = await retryFetch(
+      this.urlFor("messages"),
+      {
+        method: "POST",
+        headers: this.headers(opts.headers),
+        body: JSON.stringify({
+          model: this.config.model,
+          system: opts.systemPrompt,
+          max_tokens: opts.maxTokens ?? 1_024,
+          temperature: opts.temperature,
+          messages: [{ role: "user", content: prompt }],
+        }),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       throw new Error(

--- a/packages/bench/src/providers/ollama.ts
+++ b/packages/bench/src/providers/ollama.ts
@@ -6,6 +6,7 @@ import type {
   OllamaProviderConfig,
   TokenUsage,
 } from "./types.js";
+import { retryFetch } from "./retry-fetch.js";
 
 interface OllamaGenerateResponse {
   model?: string;
@@ -47,20 +48,24 @@ class OllamaProvider implements LlmProvider {
     opts: CompletionOpts = {},
   ): Promise<CompletionResult> {
     const startedAt = performance.now();
-    const response = await fetch(this.urlFor("generate"), {
-      method: "POST",
-      headers: this.headers(opts.headers),
-      body: JSON.stringify({
-        model: this.config.model,
-        prompt,
-        system: opts.systemPrompt,
-        stream: false,
-        options: {
-          temperature: opts.temperature,
-          num_predict: opts.maxTokens,
-        },
-      }),
-    });
+    const response = await retryFetch(
+      this.urlFor("generate"),
+      {
+        method: "POST",
+        headers: this.headers(opts.headers),
+        body: JSON.stringify({
+          model: this.config.model,
+          prompt,
+          system: opts.systemPrompt,
+          stream: false,
+          options: {
+            temperature: opts.temperature,
+            num_predict: opts.maxTokens,
+          },
+        }),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       throw new Error(
@@ -85,10 +90,14 @@ class OllamaProvider implements LlmProvider {
   }
 
   async discover(): Promise<DiscoveredModel[]> {
-    const response = await fetch(this.urlFor("tags"), {
-      method: "GET",
-      headers: this.headers(),
-    });
+    const response = await retryFetch(
+      this.urlFor("tags"),
+      {
+        method: "GET",
+        headers: this.headers(),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       throw new Error(

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -10,6 +10,7 @@ import type {
   OpenAiCompatibleProviderConfig,
   TokenUsage,
 } from "./types.js";
+import { retryFetch } from "./retry-fetch.js";
 
 interface ChatCompletionResponse {
   model?: string;
@@ -60,21 +61,25 @@ class OpenAiCompatibleProvider implements LlmProvider {
     opts: CompletionOpts = {},
   ): Promise<CompletionResult> {
     const startedAt = performance.now();
-    const response = await fetch(this.urlFor("chat/completions"), {
-      method: "POST",
-      headers: this.headers(opts.headers),
-      body: JSON.stringify({
-        model: this.config.model,
-        messages: [
-          ...(opts.systemPrompt
-            ? [{ role: "system", content: opts.systemPrompt }]
-            : []),
-          { role: "user", content: prompt },
-        ],
-        temperature: opts.temperature,
-        max_tokens: opts.maxTokens,
-      }),
-    });
+    const response = await retryFetch(
+      this.urlFor("chat/completions"),
+      {
+        method: "POST",
+        headers: this.headers(opts.headers),
+        body: JSON.stringify({
+          model: this.config.model,
+          messages: [
+            ...(opts.systemPrompt
+              ? [{ role: "system", content: opts.systemPrompt }]
+              : []),
+            { role: "user", content: prompt },
+          ],
+          temperature: opts.temperature,
+          max_tokens: opts.maxTokens,
+        }),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       const errorBody = await readErrorBody(response);
@@ -102,10 +107,14 @@ class OpenAiCompatibleProvider implements LlmProvider {
   }
 
   async discover(): Promise<DiscoveredModel[]> {
-    const response = await fetch(this.urlFor("models"), {
-      method: "GET",
-      headers: this.headers(),
-    });
+    const response = await retryFetch(
+      this.urlFor("models"),
+      {
+        method: "GET",
+        headers: this.headers(),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       throw new Error(

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -1,0 +1,78 @@
+/**
+ * Fetch wrapper with retry for transient failures.
+ * Retries on ECONNREFUSED, ECONNRESET, ETIMEDOUT, and HTTP 5xx.
+ * Does NOT retry on 4xx (client errors) or auth errors.
+ */
+
+export interface RetryFetchOptions {
+  maxAttempts?: number;
+  baseBackoffMs?: number;
+  timeoutMs?: number;
+}
+
+const DEFAULTS: Required<RetryFetchOptions> = {
+  maxAttempts: 3,
+  baseBackoffMs: 1000,
+  timeoutMs: 120_000,
+};
+
+function isTransientError(err: unknown): boolean {
+  if (!(err instanceof Error)) return false;
+  const msg = err.message.toLowerCase();
+  return (
+    msg.includes("econnrefused") ||
+    msg.includes("econnreset") ||
+    msg.includes("etimedout") ||
+    msg.includes("econnaborted") ||
+    msg.includes("socket hang up") ||
+    msg.includes("fetch failed") ||
+    err.name === "AbortError"
+  );
+}
+
+export async function retryFetch(
+  url: string,
+  init: RequestInit,
+  options?: RetryFetchOptions,
+): Promise<Response> {
+  const opts = { ...DEFAULTS, ...options };
+  let lastError: Error | null = null;
+
+  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
+    if ((init.signal as AbortSignal | undefined)?.aborted) {
+      throw new DOMException("The operation was aborted.", "AbortError");
+    }
+
+    const controller = new AbortController();
+    const callerSignal = init.signal as AbortSignal | undefined;
+    callerSignal?.addEventListener("abort", () => controller.abort(), { once: true });
+    const timeout = setTimeout(() => controller.abort(), opts.timeoutMs);
+
+    try {
+      const { signal: _callerSignal, ...initWithoutSignal } = init;
+      const response = await fetch(url, { ...initWithoutSignal, signal: controller.signal });
+      clearTimeout(timeout);
+
+      if (response.ok || response.status < 500) {
+        return response;
+      }
+
+      await response.body?.cancel().catch(() => {});
+      lastError = new Error(
+        `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts})`,
+      );
+    } catch (err) {
+      clearTimeout(timeout);
+      if (callerSignal?.aborted) throw err;
+      if (!isTransientError(err)) throw err;
+      lastError = err instanceof Error ? err : new Error(String(err));
+    }
+
+    if (attempt < opts.maxAttempts) {
+      const backoffMs = opts.baseBackoffMs * Math.pow(2, attempt - 1);
+      await new Promise((resolve) => setTimeout(resolve, backoffMs));
+    }
+  }
+
+  throw lastError ?? new Error("retryFetch: all attempts exhausted");
+}

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -16,6 +16,15 @@ const DEFAULTS: Required<RetryFetchOptions> = {
   timeoutMs: 120_000,
 };
 
+async function readBodyPreview(response: Response, maxBytes: number): Promise<string> {
+  try {
+    const text = await response.text();
+    return text.slice(0, maxBytes);
+  } catch {
+    return "";
+  }
+}
+
 function isTransientError(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const msg = err.message.toLowerCase();
@@ -57,9 +66,9 @@ export async function retryFetch(
         return response;
       }
 
-      await response.body?.cancel().catch(() => {});
+      const bodyPreview = await readBodyPreview(response, 512);
       lastError = new Error(
-        `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts})`,
+        `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,
       );
     } catch (err) {
       clearTimeout(timeout);

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -54,7 +54,8 @@ export async function retryFetch(
 
     const controller = new AbortController();
     const callerSignal = init.signal as AbortSignal | undefined;
-    callerSignal?.addEventListener("abort", () => controller.abort(), { once: true });
+    const onCallerAbort = () => controller.abort();
+    callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
     const timeout = setTimeout(() => controller.abort(), opts.timeoutMs);
 
     try {
@@ -63,6 +64,7 @@ export async function retryFetch(
       clearTimeout(timeout);
 
       if (response.ok || response.status < 500) {
+        callerSignal?.removeEventListener("abort", onCallerAbort);
         return response;
       }
 
@@ -72,8 +74,14 @@ export async function retryFetch(
       );
     } catch (err) {
       clearTimeout(timeout);
-      if (callerSignal?.aborted) throw err;
-      if (!isTransientError(err)) throw err;
+      if (callerSignal?.aborted) {
+        callerSignal?.removeEventListener("abort", onCallerAbort);
+        throw err;
+      }
+      if (!isTransientError(err)) {
+        callerSignal?.removeEventListener("abort", onCallerAbort);
+        throw err;
+      }
       lastError = err instanceof Error ? err : new Error(String(err));
     }
 

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -32,6 +32,7 @@ export interface ProviderBaseConfig {
   baseUrl?: string;
   apiKey?: string;
   headers?: Record<string, string>;
+  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
 }
 
 export interface OpenAiCompatibleProviderConfig extends ProviderBaseConfig {

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -123,6 +123,10 @@ export interface BenchmarkResult {
      * Must stay below the benchmark's canary floor.
      */
     canaryScore?: number;
+    /** "partial" if the benchmark was interrupted; absent or "complete" otherwise. */
+    status?: "complete" | "partial";
+    /** If partial, the error that caused interruption. */
+    failureReason?: string;
   };
   config: {
     runtimeProfile?: BenchRuntimeProfile | null;
@@ -194,6 +198,8 @@ export interface RunBenchmarkOptions {
 export interface ResolvedRunBenchmarkOptions extends RunBenchmarkOptions {
   mode: BenchmarkMode;
   benchmark: BenchmarkDefinition;
+  /** Called after each task completes for progress logging and partial result tracking. */
+  onTaskComplete?: (task: TaskResult, completedCount: number, totalCount?: number) => void;
 }
 
 // Legacy latency-benchmark surface retained for CLI compatibility while the

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4695,7 +4695,7 @@ async function cmdBench(rest: string[]): Promise<void> {
   }
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
-  const failures: string[] = [];
+  const failures = new Set<string>();
   for (const benchmarkId of selectedBenchmarks) {
     for (const runtimeProfile of runtimeProfiles) {
       try {
@@ -4710,13 +4710,13 @@ async function cmdBench(rest: string[]): Promise<void> {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
         console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
-        failures.push(benchmarkId);
+        failures.add(benchmarkId);
       }
     }
   }
-  if (failures.length > 0) {
-    console.error(`\nFailed benchmarks: ${failures.join(", ")}`);
-    if (failures.length === selectedBenchmarks.length) {
+  if (failures.size > 0) {
+    console.error(`\nFailed benchmarks: ${[...failures].join(", ")}`);
+    if (failures.size === selectedBenchmarks.length) {
       process.exit(1);
     }
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -303,6 +303,7 @@ type PackageBenchModule = {
     system: {
       destroy(): Promise<void>;
     };
+    onTaskComplete?: (task: { taskId: string; scores: Record<string, number>; latencyMs: number; tokens: { input: number; output: number } }, completedCount: number, totalCount?: number) => void;
   }) => Promise<{
     meta: { benchmark: string; mode: string };
     config: {
@@ -383,6 +384,7 @@ type PackageBenchModule = {
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   }, outputDir: string) => Promise<string>;
+  getRemnicVersion?: () => Promise<string>;
   createLightweightAdapter?: (options?: {
     configOverrides?: Record<string, unknown>;
     preserveRuntimeDefaults?: boolean;
@@ -2055,6 +2057,8 @@ async function runBenchViaPackage(
   );
 
   const system = await plan.createAdapter(plan.runtime.adapterOptions);
+  const benchStartTime = Date.now();
+  const partialTasks: import("@remnic/bench").TaskResult[] = [];
 
   try {
     // `publishedLimit` (from `bench published --limit N`) takes
@@ -2079,6 +2083,16 @@ async function runBenchViaPackage(
       judgeProvider: plan.runtime.judgeProvider,
       remnicConfig: plan.runtime.effectiveRemnicConfig,
       system,
+      onTaskComplete: (task, completed, total) => {
+        partialTasks.push(task);
+        if (completed % 50 === 0 || completed === total) {
+          const elapsed = Math.round((Date.now() - benchStartTime) / 1000);
+          const remaining = total && elapsed > 0 ? Math.round((total - completed) / (completed / elapsed)) : "?";
+          console.log(
+            `  [${benchmarkId}] ${completed}/${total ?? "?"} tasks (${elapsed}s elapsed, ~${remaining}s remaining)`,
+          );
+        }
+      },
     });
     result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
@@ -2088,9 +2102,79 @@ async function runBenchViaPackage(
       printBenchPackageSummary(result, writtenPath);
     }
     return { ok: true, writtenPath };
+  } catch (err) {
+    if (partialTasks.length > 0) {
+      const remnicVersion = await benchModule.getRemnicVersion?.() ?? "unknown";
+      const partialResult = buildPartialBenchmarkResult(
+        benchmarkId,
+        definition,
+        partialTasks,
+        plan,
+        remnicVersion,
+        err instanceof Error ? err.message : String(err),
+        parsed.quick ? "quick" : "full",
+      );
+      try {
+        const partialPath = await benchModule.writeBenchmarkResult(partialResult, outputDir);
+        console.error(`  Partial results (${partialTasks.length} tasks) written to ${partialPath}`);
+      } catch (writeErr) {
+        console.error(`  Failed to write partial results: ${writeErr instanceof Error ? writeErr.message : String(writeErr)}`);
+      }
+    }
+    throw err;
   } finally {
     await system.destroy();
   }
+}
+
+function buildPartialBenchmarkResult(
+  benchmarkId: string,
+  definition: { tier?: string; meta?: { category?: string; version?: string } } | undefined,
+  tasks: Array<{ taskId: string; scores: Record<string, number>; latencyMs: number; tokens: { input: number; output: number } }>,
+  plan: PackageBenchExecutionPlan,
+  remnicVersion: string,
+  failureReason: string,
+  mode: "full" | "quick",
+) {
+  const totalLatencyMs = tasks.reduce((sum, t) => sum + t.latencyMs, 0);
+  const totalInput = tasks.reduce((sum, t) => sum + t.tokens.input, 0);
+  const totalOutput = tasks.reduce((sum, t) => sum + t.tokens.output, 0);
+  return {
+    meta: {
+      id: "partial",
+      benchmark: benchmarkId,
+      benchmarkTier: (definition?.tier ?? "remnic") as "published" | "remnic" | "custom",
+      version: definition?.meta?.version ?? "0.0.0",
+      remnicVersion,
+      gitSha: "unknown",
+      timestamp: new Date().toISOString(),
+      mode,
+      runCount: 1,
+      seeds: [0],
+      status: "partial" as const,
+      failureReason,
+    },
+    config: {
+      systemProvider: plan.runtime.systemProvider ?? null,
+      judgeProvider: plan.runtime.judgeProvider ?? null,
+      adapterMode: plan.adapterMode,
+      remnicConfig: plan.runtime.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: totalInput + totalOutput,
+      inputTokens: totalInput,
+      outputTokens: totalOutput,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: { tasks: tasks as never[], aggregates: {} },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
 }
 
 async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolean> {
@@ -4611,16 +4695,29 @@ async function cmdBench(rest: string[]): Promise<void> {
   }
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
+  const failures: string[] = [];
   for (const benchmarkId of selectedBenchmarks) {
     for (const runtimeProfile of runtimeProfiles) {
-      const handledByPackage = await runBenchViaPackage(
-        parsed,
-        benchmarkId,
-        runtimeProfile,
-      );
-      if (!handledByPackage.ok) {
-        await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
+      try {
+        const handledByPackage = await runBenchViaPackage(
+          parsed,
+          benchmarkId,
+          runtimeProfile,
+        );
+        if (!handledByPackage.ok) {
+          await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
+        }
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
+        failures.push(benchmarkId);
       }
+    }
+  }
+  if (failures.length > 0) {
+    console.error(`\nFailed benchmarks: ${failures.join(", ")}`);
+    if (failures.length === selectedBenchmarks.length) {
+      process.exit(1);
     }
   }
 }


### PR DESCRIPTION
## Summary

A 3+ hour `bench run --all` against Gemma in LM Studio died on a single transient `fetch()` failure (ECONNREFUSED), producing zero result files. All progress was lost.

- **`retryFetch` wrapper** — exponential backoff (3 attempts, 1s→2s→4s), 120s per-attempt timeout via AbortController, retries on ECONN*/socket hang up/fetch failed/HTTP 5xx, does NOT retry 4xx
- **Provider retry** — wired into openai-compatible, anthropic, and ollama providers
- **Per-benchmark error isolation** — CLI loop catches per-benchmark failures, logs them, continues to next benchmark, only exits 1 if ALL fail
- **Per-task error isolation** — all 9 published runners wrap individual tasks in try/catch, push sentinel scores (-1), continue to next task
- **Progress logging** — `onTaskComplete` callback logs every 50 tasks with elapsed/remaining time estimates
- **Partial result persistence** — on interruption, writes a result file with `status: "partial"` so no progress is lost

## Test plan

- [x] `pnpm run build` passes
- [x] `tsx --test packages/bench/src/providers/openai-compatible.test.ts` — 2/2 pass (mock returns 4xx which retryFetch passes through without retrying)
- [ ] Manual: `remnic bench run ama-bench --quick` against LM Studio — verify progress logs and result file
- [ ] Failure test: kill LM Studio mid-run, verify partial result file is written and remaining benchmarks attempted

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark execution control flow and provider networking behavior (retries/timeouts) across multiple runners and the CLI, which could mask failures or affect run timing/metrics if misconfigured.
> 
> **Overview**
> Makes published benchmark runs **resilient to transient failures** by adding `retryFetch` (timeout + exponential backoff, retries on network errors/HTTP 5xx) and wiring it into the `openai-compatible`, `anthropic`, and `ollama` providers.
> 
> Adds **progress + fault isolation** across the bench stack: published runners and the shared `published/harness` now catch per-task/trial errors, emit a sentinel `TaskResult` (scores `-1`) and continue; runners also report task progress via a new `ResolvedRunBenchmarkOptions.onTaskComplete` callback with total task counts.
> 
> Updates the CLI to log progress every 50 tasks, **persist partial results** on interruption (new `BenchmarkResult.meta.status`/`failureReason`), continue running remaining benchmarks when one fails, and exports `getRemnicVersion` from `@remnic/bench` for partial result metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31bc74eca8880fec4c97ac322dd0aeae54424652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->