### PR TITLE
feat(bench): local-llm provider path parity (issue #566 PR 5/7)

### DIFF
--- a/packages/bench/src/fixtures/local-llm/chat-completion.json
+++ b/packages/bench/src/fixtures/local-llm/chat-completion.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Canned /v1/chat/completions response for the local-llm CI smoke test. Recorded from a llama.cpp-compatible mock server (issue #566 slice 5). The `model` field is generic so record/replay works across llama.cpp / vLLM / LM Studio hosts.",
+  "id": "chatcmpl-local-llm-fixture-0001",
+  "object": "chat.completion",
+  "created": 1700000000,
+  "model": "local-llm-fixture",
+  "choices": [
+    {
+      "index": 0,
+      "message": {
+        "role": "assistant",
+        "content": "The canonical bench smoke response is: ok."
+      },
+      "finish_reason": "stop"
+    }
+  ],
+  "usage": {
+    "prompt_tokens": 9,
+    "completion_tokens": 7,
+    "total_tokens": 16
+  }
+}

--- a/packages/bench/src/fixtures/local-llm/mock-server.ts
+++ b/packages/bench/src/fixtures/local-llm/mock-server.ts
@@ -1,0 +1,143 @@
+/**
+ * Local-LLM record/replay mock server (issue #566 slice 5).
+ *
+ * Spins up a tiny HTTP server that serves canned `/v1/chat/completions`
+ * and `/v1/models` responses recorded from an OpenAI-compatible server
+ * (llama.cpp / vLLM / LM Studio). Used by the local-llm CI smoke test
+ * so that `remnic bench published --provider local-llm` exercises the
+ * real fetch → JSON → usage-accounting path without a paid API call.
+ *
+ * Usage:
+ *
+ *   const server = await startLocalLlmMockServer();
+ *   try {
+ *     const provider = createLocalLlmProvider({
+ *       provider: "local-llm",
+ *       model: "local-llm-fixture-small",
+ *       baseUrl: server.baseUrl,
+ *     });
+ *     await provider.complete("hello");
+ *   } finally {
+ *     await server.close();
+ *   }
+ *
+ * The server also records each request's path + body on `server.requests`
+ * so the smoke test can assert that the bench actually reached the mock
+ * (rather than, say, silently falling through to api.openai.com).
+ */
+
+import { readFile } from "node:fs/promises";
+import { createServer, type IncomingMessage, type Server } from "node:http";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const FIXTURE_DIR = path.dirname(fileURLToPath(import.meta.url));
+
+export interface RecordedRequest {
+  method: string;
+  pathname: string;
+  body: string;
+}
+
+export interface LocalLlmMockServer {
+  /** Full base URL (e.g. `http://127.0.0.1:56789/v1`). */
+  baseUrl: string;
+  /** Observed requests, in order. Cleared by `reset()`. */
+  requests: RecordedRequest[];
+  /** Shut down the server. Idempotent. */
+  close: () => Promise<void>;
+  /** Clear `requests` between test cases without restarting. */
+  reset: () => void;
+}
+
+async function readBody(req: IncomingMessage): Promise<string> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(chunk as Buffer);
+  }
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+/**
+ * Start the mock server. Returns a handle whose `close()` must be
+ * called to release the port. Listens on `127.0.0.1:<ephemeral>`.
+ */
+export async function startLocalLlmMockServer(): Promise<LocalLlmMockServer> {
+  const chatFixture = await readFile(
+    path.join(FIXTURE_DIR, "chat-completion.json"),
+    "utf8",
+  );
+  const modelsFixture = await readFile(
+    path.join(FIXTURE_DIR, "models.json"),
+    "utf8",
+  );
+
+  const recorded: RecordedRequest[] = [];
+
+  const server: Server = createServer((req, res) => {
+    // Strip any query string so `?stream=false` etc. still route
+    // correctly. Mirrors how llama.cpp/vLLM route ignore query params.
+    const rawUrl = req.url ?? "/";
+    const pathname = rawUrl.split("?", 1)[0];
+
+    void readBody(req).then((body) => {
+      recorded.push({
+        method: req.method ?? "GET",
+        pathname,
+        body,
+      });
+
+      // `/v1/chat/completions` — replay the canned completion.
+      if (
+        req.method === "POST" &&
+        (pathname === "/v1/chat/completions" || pathname === "/chat/completions")
+      ) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(chatFixture);
+        return;
+      }
+
+      // `/v1/models` — replay the canned model list.
+      if (
+        req.method === "GET" &&
+        (pathname === "/v1/models" || pathname === "/models")
+      ) {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(modelsFixture);
+        return;
+      }
+
+      // Any other route is a test bug, not a real local-llm request.
+      res.writeHead(404, { "content-type": "application/json" });
+      res.end(
+        JSON.stringify({
+          error: `local-llm mock: unknown route ${req.method} ${pathname}`,
+        }),
+      );
+    });
+  });
+
+  await new Promise<void>((resolve) => {
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    throw new Error("local-llm mock: failed to bind an ephemeral port");
+  }
+
+  const baseUrl = `http://127.0.0.1:${address.port}/v1`;
+
+  return {
+    baseUrl,
+    requests: recorded,
+    reset: () => {
+      recorded.length = 0;
+    },
+    close: async () => {
+      await new Promise<void>((resolve, reject) => {
+        server.close((err) => (err ? reject(err) : resolve()));
+      });
+    },
+  };
+}

--- a/packages/bench/src/fixtures/local-llm/models.json
+++ b/packages/bench/src/fixtures/local-llm/models.json
@@ -1,0 +1,22 @@
+{
+  "_comment": "Canned /v1/models response for the local-llm CI smoke test (issue #566 slice 5). Two models so the smoke test can verify the array-fanout path without being tied to a real model id.",
+  "object": "list",
+  "data": [
+    {
+      "id": "local-llm-fixture-small",
+      "name": "local-llm-fixture-small",
+      "context_length": 8192,
+      "capabilities": ["completion"],
+      "quantization": "Q4_K_M",
+      "parameter_count": "7B"
+    },
+    {
+      "id": "local-llm-fixture-large",
+      "name": "local-llm-fixture-large",
+      "context_length": 32768,
+      "capabilities": ["completion"],
+      "quantization": "Q8_0",
+      "parameter_count": "70B"
+    }
+  ]
+}

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -89,6 +89,7 @@ export type {
   DiscoveredModel,
   TokenUsage,
   LlmProvider,
+  LocalLlmProviderConfig,
   OllamaProviderConfig,
   OpenAiCompatibleProviderConfig,
   ProviderBaseConfig,
@@ -133,6 +134,7 @@ export {
   createStructuredJudgeFromProvider,
 } from "./responders.js";
 export { createLiteLlmProvider } from "./providers/litellm.js";
+export { createLocalLlmProvider } from "./providers/local-llm.js";
 export { createOllamaProvider } from "./providers/ollama.js";
 export { createOpenAiCompatibleProvider } from "./providers/openai-compatible.js";
 export type {

--- a/packages/bench/src/providers/factory.ts
+++ b/packages/bench/src/providers/factory.ts
@@ -5,6 +5,7 @@ import type {
 } from "./types.js";
 import { createAnthropicProvider } from "./anthropic.js";
 import { createLiteLlmProvider } from "./litellm.js";
+import { createLocalLlmProvider } from "./local-llm.js";
 import { createOllamaProvider } from "./ollama.js";
 import { createOpenAiCompatibleProvider } from "./openai-compatible.js";
 
@@ -18,6 +19,8 @@ export function createProvider(config: ProviderFactoryConfig): LlmProvider {
       return createOllamaProvider(config);
     case "litellm":
       return createLiteLlmProvider(config);
+    case "local-llm":
+      return createLocalLlmProvider(config);
     default: {
       const exhaustive: never = config;
       throw new Error(`Unknown provider: ${JSON.stringify(exhaustive)}`);

--- a/packages/bench/src/providers/local-llm.test.ts
+++ b/packages/bench/src/providers/local-llm.test.ts
@@ -101,6 +101,52 @@ test("local-llm provider surfaces non-2xx errors with base-url + model in the me
   }
 });
 
+test("local-llm provider auto-appends /v1 when baseUrl omits it (Codex P1 on PR #613)", async () => {
+  const server = await startLocalLlmMockServer();
+  try {
+    // The mock server serves /v1/chat/completions; the real complaint
+    // was that a user passing the bare host (`http://host:port`) would
+    // hit /chat/completions which 404s on most OpenAI-compatible
+    // servers. Strip `/v1` from the mock's baseUrl and confirm the
+    // provider re-appends it before the request is dispatched.
+    const strippedBase = server.baseUrl.replace(/\/v1$/, "");
+    assert.ok(!strippedBase.endsWith("/v1"), "fixture must strip /v1");
+
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "local-llm-fixture-small",
+      baseUrl: strippedBase,
+    });
+
+    const result = await provider.complete("hello");
+    assert.equal(result.text, "The canonical bench smoke response is: ok.");
+    assert.equal(server.requests.length, 1);
+    assert.equal(server.requests[0].pathname, "/v1/chat/completions");
+  } finally {
+    await server.close();
+  }
+});
+
+test("local-llm provider does not double-apply /v1 when baseUrl already ends with it", async () => {
+  const server = await startLocalLlmMockServer();
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "local-llm-fixture-small",
+      baseUrl: server.baseUrl, // already ends in /v1
+    });
+
+    await provider.complete("hello");
+    assert.equal(server.requests[0].pathname, "/v1/chat/completions");
+    assert.ok(
+      !server.requests[0].pathname.startsWith("/v1/v1/"),
+      "must not produce /v1/v1/",
+    );
+  } finally {
+    await server.close();
+  }
+});
+
 test("local-llm provider forwards Authorization header when apiKey is set", async () => {
   let seenAuth: string | null = null;
   const originalFetch = globalThis.fetch;

--- a/packages/bench/src/providers/local-llm.test.ts
+++ b/packages/bench/src/providers/local-llm.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { startLocalLlmMockServer } from "../fixtures/local-llm/mock-server.ts";
+import { createLocalLlmProvider } from "./local-llm.ts";
+
+test("local-llm provider rejects missing baseUrl with a listed-option error", () => {
+  assert.throws(
+    () =>
+      createLocalLlmProvider({
+        provider: "local-llm",
+        model: "local-llm-fixture-small",
+        baseUrl: "",
+      }),
+    /requires --base-url[\s\S]*llama\.cpp[\s\S]*vLLM[\s\S]*LM Studio/,
+  );
+});
+
+test("local-llm provider replays chat completions against the mock server", async () => {
+  const server = await startLocalLlmMockServer();
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "local-llm-fixture-small",
+      baseUrl: server.baseUrl,
+    });
+
+    const result = await provider.complete("hello");
+
+    assert.equal(result.text, "The canonical bench smoke response is: ok.");
+    assert.equal(result.tokens.input, 9);
+    assert.equal(result.tokens.output, 7);
+    assert.equal(result.model, "local-llm-fixture");
+    assert.ok(result.latencyMs >= 0);
+
+    // The provider must have talked to THIS mock, not api.openai.com.
+    // CLAUDE.md rule 55: end-to-end wiring needs a test.
+    assert.equal(server.requests.length, 1);
+    assert.equal(server.requests[0].method, "POST");
+    assert.equal(server.requests[0].pathname, "/v1/chat/completions");
+    const payload = JSON.parse(server.requests[0].body);
+    assert.equal(payload.model, "local-llm-fixture-small");
+    assert.deepEqual(payload.messages, [{ role: "user", content: "hello" }]);
+
+    const usage = provider.getUsage();
+    assert.equal(usage.inputTokens, 9);
+    assert.equal(usage.outputTokens, 7);
+    assert.equal(usage.totalTokens, 16);
+  } finally {
+    await server.close();
+  }
+});
+
+test("local-llm provider discovers models from the mock /v1/models route", async () => {
+  const server = await startLocalLlmMockServer();
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "local-llm-fixture-small",
+      baseUrl: server.baseUrl,
+    });
+
+    const models = await provider.discover?.();
+    assert.ok(models, "discover() should return models for local-llm");
+    assert.equal(models.length, 2);
+    assert.equal(models[0].id, "local-llm-fixture-small");
+    assert.equal(models[0].contextLength, 8192);
+    assert.equal(models[1].id, "local-llm-fixture-large");
+    assert.equal(models[1].contextLength, 32768);
+
+    assert.equal(server.requests.length, 1);
+    assert.equal(server.requests[0].method, "GET");
+    assert.equal(server.requests[0].pathname, "/v1/models");
+  } finally {
+    await server.close();
+  }
+});
+
+test("local-llm provider surfaces non-2xx errors with base-url + model in the message", async () => {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () =>
+    new Response("model not loaded", {
+      status: 503,
+      statusText: "Service Unavailable",
+      headers: { "content-type": "text/plain" },
+    });
+
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "my-local-model",
+      baseUrl: "http://127.0.0.1:9876/v1",
+    });
+
+    await assert.rejects(
+      provider.complete("hello"),
+      /local-llm completion failed: 503 Service Unavailable — model not loaded \(base-url=http:\/\/127\.0\.0\.1:9876\/v1, model=my-local-model\)/,
+    );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("local-llm provider forwards Authorization header when apiKey is set", async () => {
+  let seenAuth: string | null = null;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (url, init) => {
+    const headers = new Headers(init?.headers as HeadersInit | undefined);
+    seenAuth = headers.get("authorization");
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "any",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "m",
+      baseUrl: "http://127.0.0.1:8080/v1",
+      apiKey: "test-token",
+    });
+    await provider.complete("hi");
+    assert.equal(seenAuth, "Bearer test-token");
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -193,9 +193,16 @@ class LocalLlmProvider implements LlmProvider {
   }
 
   private urlFor(pathname: string): string {
-    const normalizedBase = this.config.baseUrl.endsWith("/")
+    // Codex P1 on PR #613: if the user passed a bare host like
+    // `http://localhost:8080` (no `/v1`), concatenating
+    // `chat/completions` would 404 on every OpenAI-compatible server
+    // that only exposes `/v1/*`. Tolerate both forms so `--base-url`
+    // behaves the same as the plugin's `localLlmUrl`.
+    const stripped = this.config.baseUrl.endsWith("/")
       ? this.config.baseUrl.slice(0, -1)
       : this.config.baseUrl;
+    const hasV1Suffix = /\/v\d+$/.test(stripped);
+    const normalizedBase = hasV1Suffix ? stripped : `${stripped}/v1`;
     const normalizedPath = pathname.startsWith("/")
       ? pathname.slice(1)
       : pathname;

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -1,0 +1,236 @@
+/**
+ * Local-LLM bench provider — issue #566 slice 5.
+ *
+ * Talks to a user-hosted OpenAI-compatible endpoint (llama.cpp,
+ * vLLM, LM Studio, etc.) using the exact same wire contract
+ * (`/v1/chat/completions` + `/v1/models`) that the Remnic core
+ * `LocalLlmClient` uses. The goal is transport-level parity:
+ * anything `remnic bench published --provider local-llm` can reach
+ * is something the running plugin can also reach.
+ *
+ * Why this is a distinct provider from `openai`:
+ *
+ *   - The OpenAI-compatible provider treats `baseUrl` as optional
+ *     and defaults to `https://api.openai.com/v1`. That default is
+ *     wrong for local servers, and silently falling through to it
+ *     violates CLAUDE.md rule 51 (reject invalid user input).
+ *   - `local-llm` REQUIRES `baseUrl` at the CLI boundary so the
+ *     user must explicitly point at their server. A missing
+ *     base URL is a user error, not a default.
+ *   - Discovery for `local-llm` is reserved for the future — the
+ *     built-in `discoverAllProviders` probe does not assume a
+ *     local-llm URL is reachable. Users opt in with `--base-url`.
+ *
+ * See `packages/remnic-core/src/summarizer.ts` for the core-side
+ * `LocalLlmClient` invocation pattern and
+ * `packages/plugin-openclaw/openclaw.plugin.json` for the
+ * `localLlmUrl` / `localLlmModel` config that this provider
+ * mirrors.
+ */
+
+import type {
+  CompletionOpts,
+  CompletionResult,
+  DiscoveredModel,
+  LlmProvider,
+  LocalLlmProviderConfig,
+  TokenUsage,
+} from "./types.js";
+
+interface ChatCompletionResponse {
+  model?: string;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+  choices?: Array<{
+    message?: {
+      content?: string | Array<{ type?: string; text?: string }>;
+    };
+  }>;
+}
+
+interface ModelsResponse {
+  data?: Array<{
+    id: string;
+    name?: string;
+    context_length?: number;
+    capabilities?: Array<"completion" | "embedding" | "vision">;
+    quantization?: string;
+    parameter_count?: string;
+  }>;
+}
+
+class LocalLlmProvider implements LlmProvider {
+  readonly provider = "local-llm" as const;
+  readonly id: string;
+  readonly name: string;
+
+  private readonly config: LocalLlmProviderConfig;
+  private usage: TokenUsage = {
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+  };
+
+  constructor(config: LocalLlmProviderConfig) {
+    if (!config.baseUrl || config.baseUrl.trim().length === 0) {
+      // CLAUDE.md rule 51: reject invalid input at the boundary with
+      // a concrete hint rather than silently defaulting to OpenAI.
+      throw new Error(
+        "local-llm provider requires --base-url (e.g. http://localhost:8080/v1). " +
+          "Valid examples: llama.cpp (http://localhost:8080/v1), " +
+          "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
+      );
+    }
+    this.config = config;
+    this.id = `local-llm:${config.model}`;
+    this.name = config.model;
+  }
+
+  async complete(
+    prompt: string,
+    opts: CompletionOpts = {},
+  ): Promise<CompletionResult> {
+    const startedAt = performance.now();
+    const response = await fetch(this.urlFor("chat/completions"), {
+      method: "POST",
+      headers: this.headers(opts.headers),
+      body: JSON.stringify({
+        model: this.config.model,
+        messages: [
+          ...(opts.systemPrompt
+            ? [{ role: "system", content: opts.systemPrompt }]
+            : []),
+          { role: "user", content: prompt },
+        ],
+        temperature: opts.temperature,
+        max_tokens: opts.maxTokens,
+      }),
+    });
+
+    if (!response.ok) {
+      const errorBody = await readErrorBody(response);
+      throw new Error(
+        `local-llm completion failed: ${response.status} ${response.statusText}${errorBody ? ` — ${errorBody}` : ""} ` +
+          `(base-url=${this.config.baseUrl}, model=${this.config.model})`,
+      );
+    }
+
+    const payload = (await response.json()) as ChatCompletionResponse;
+    const promptTokens = payload.usage?.prompt_tokens ?? 0;
+    const completionTokens = payload.usage?.completion_tokens ?? 0;
+
+    this.recordUsage(promptTokens, completionTokens);
+
+    return {
+      text: readMessageText(payload),
+      tokens: {
+        input: promptTokens,
+        output: completionTokens,
+      },
+      latencyMs: Math.round(performance.now() - startedAt),
+      model: payload.model ?? this.config.model,
+    };
+  }
+
+  async discover(): Promise<DiscoveredModel[]> {
+    const response = await fetch(this.urlFor("models"), {
+      method: "GET",
+      headers: this.headers(),
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `local-llm model discovery failed: ${response.status} ${response.statusText}`,
+      );
+    }
+
+    const payload = (await response.json()) as ModelsResponse;
+    return (payload.data ?? []).map((model) => ({
+      id: model.id,
+      name: model.name ?? model.id,
+      contextLength: model.context_length ?? 0,
+      capabilities: model.capabilities ?? ["completion"],
+      ...(model.quantization ? { quantization: model.quantization } : {}),
+      ...(model.parameter_count
+        ? { parameterCount: model.parameter_count }
+        : {}),
+    }));
+  }
+
+  getUsage(): TokenUsage {
+    return { ...this.usage };
+  }
+
+  resetUsage(): void {
+    this.usage = {
+      inputTokens: 0,
+      outputTokens: 0,
+      totalTokens: 0,
+    };
+  }
+
+  private headers(
+    extraHeaders: Record<string, string> = {},
+  ): Record<string, string> {
+    return {
+      "content-type": "application/json",
+      ...(this.config.apiKey
+        ? { authorization: `Bearer ${this.config.apiKey}` }
+        : {}),
+      ...(this.config.headers ?? {}),
+      ...extraHeaders,
+    };
+  }
+
+  private recordUsage(inputTokens: number, outputTokens: number): void {
+    this.usage = {
+      inputTokens: this.usage.inputTokens + inputTokens,
+      outputTokens: this.usage.outputTokens + outputTokens,
+      totalTokens: this.usage.totalTokens + inputTokens + outputTokens,
+    };
+  }
+
+  private urlFor(pathname: string): string {
+    const normalizedBase = this.config.baseUrl.endsWith("/")
+      ? this.config.baseUrl.slice(0, -1)
+      : this.config.baseUrl;
+    const normalizedPath = pathname.startsWith("/")
+      ? pathname.slice(1)
+      : pathname;
+    return `${normalizedBase}/${normalizedPath}`;
+  }
+}
+
+async function readErrorBody(response: Response): Promise<string> {
+  try {
+    const text = (await response.text()).trim();
+    if (text.length === 0) {
+      return "";
+    }
+    return text.replace(/\s+/g, " ").slice(0, 400);
+  } catch {
+    return "";
+  }
+}
+
+function readMessageText(payload: ChatCompletionResponse): string {
+  const content = payload.choices?.[0]?.message?.content;
+  if (typeof content === "string") {
+    return content;
+  }
+  if (Array.isArray(content)) {
+    return content
+      .map((part) => part.text ?? "")
+      .join("")
+      .trim();
+  }
+  return "";
+}
+
+export function createLocalLlmProvider(
+  config: LocalLlmProviderConfig,
+): LlmProvider {
+  return new LocalLlmProvider(config);
+}

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -47,10 +47,24 @@ export interface OllamaProviderConfig extends ProviderBaseConfig {
   provider?: "ollama";
 }
 
+/**
+ * `local-llm` targets a user-hosted OpenAI-compatible endpoint
+ * (llama.cpp, vLLM, LM Studio, etc.). `baseUrl` is required at the
+ * CLI layer — it mirrors the plugin's `localLlmUrl` config and is
+ * what tells the bench which local server to talk to. The transport
+ * is intentionally OpenAI-compatible: `/v1/chat/completions` +
+ * `/v1/models`. Issue #566 slice 5.
+ */
+export interface LocalLlmProviderConfig extends ProviderBaseConfig {
+  provider?: "local-llm";
+  baseUrl: string;
+}
+
 export type ProviderFactoryConfig =
   | (OpenAiCompatibleProviderConfig & { provider: "openai" | "litellm" })
   | (AnthropicProviderConfig & { provider: "anthropic" })
-  | (OllamaProviderConfig & { provider: "ollama" });
+  | (OllamaProviderConfig & { provider: "ollama" })
+  | (LocalLlmProviderConfig & { provider: "local-llm" });
 
 export interface ProviderDiscoveryResult {
   provider: BuiltInProvider;

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -326,6 +326,18 @@ function resolveProviderConfig(
     throw new Error(`${kind} provider requires both provider and model`);
   }
 
+  // Issue #566 slice 5 — defense in depth: the CLI rejects
+  // `--provider local-llm` without `--base-url`, but programmatic
+  // callers that bypass the CLI must also get a clear error rather
+  // than silently falling through to an OpenAI default URL in the
+  // provider factory.
+  if (provider === "local-llm" && !hasBaseUrl) {
+    throw new Error(
+      `${kind} provider "local-llm" requires a baseUrl ` +
+        "(e.g. http://localhost:8080/v1 for llama.cpp).",
+    );
+  }
+
   return {
     provider,
     model: model.trim(),

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -12,7 +12,21 @@ export type BenchmarkTier = "published" | "remnic" | "custom";
 export type BenchmarkStatus = "ready" | "planned";
 export type BenchmarkCategory = "agentic" | "retrieval" | "conversational" | "ingestion";
 export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
-export type BuiltInProvider = "openai" | "anthropic" | "ollama" | "litellm";
+/**
+ * Built-in LLM providers supported by the bench harness.
+ *
+ * `local-llm` targets a user-hosted OpenAI-compatible endpoint
+ * (llama.cpp, vLLM, LM Studio, etc.) via `--base-url`. It mirrors
+ * the `localLlm*` plugin config on the Remnic core side so that
+ * `remnic bench published --provider local-llm` actually exercises
+ * the same transport path as the running plugin. Issue #566 slice 5.
+ */
+export type BuiltInProvider =
+  | "openai"
+  | "anthropic"
+  | "ollama"
+  | "litellm"
+  | "local-llm";
 
 export interface ProviderConfig {
   provider: BuiltInProvider;

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -168,7 +168,7 @@ test("parseBenchArgs rejects unknown --provider", () => {
         "--provider",
         "not-a-provider",
       ]),
-    /--provider must be "openai", "anthropic", "ollama", or "litellm"/,
+    /--provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"/,
   );
 });
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -103,6 +103,34 @@ function parseBenchRuntimeProfile(
   );
 }
 
+/**
+ * Shared allow-list for `--provider`, `--system-provider`, and
+ * `--judge-provider`. Keeping these in lockstep is a CLAUDE.md rule 52
+ * concern: if one flag accepts "local-llm" but another rejects it,
+ * behavior becomes path-dependent. Issue #566 slice 5 added
+ * "local-llm"; the single source of truth is here.
+ */
+const BENCH_PROVIDER_ALLOWED: readonly BuiltInProvider[] = Object.freeze([
+  "openai",
+  "anthropic",
+  "ollama",
+  "litellm",
+  "local-llm",
+]);
+
+function isBuiltInProvider(value: string): value is BuiltInProvider {
+  return (BENCH_PROVIDER_ALLOWED as readonly string[]).includes(value);
+}
+
+function parseBenchProvider(raw: string, flag: string): BuiltInProvider {
+  if (!isBuiltInProvider(raw)) {
+    throw new Error(
+      `ERROR: ${flag} must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm".`,
+    );
+  }
+  return raw;
+}
+
 export function readBenchOptionValue(argv: string[], flag: string): string | undefined {
   const index = argv.indexOf(flag);
   if (index === -1) {
@@ -299,32 +327,12 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
 
   let systemProvider: BuiltInProvider | undefined;
   if (systemProviderRaw !== undefined) {
-    if (
-      systemProviderRaw !== "openai" &&
-      systemProviderRaw !== "anthropic" &&
-      systemProviderRaw !== "ollama" &&
-      systemProviderRaw !== "litellm"
-    ) {
-      throw new Error(
-        'ERROR: --system-provider must be "openai", "anthropic", "ollama", or "litellm".',
-      );
-    }
-    systemProvider = systemProviderRaw;
+    systemProvider = parseBenchProvider(systemProviderRaw, "--system-provider");
   }
 
   let judgeProvider: BuiltInProvider | undefined;
   if (judgeProviderRaw !== undefined) {
-    if (
-      judgeProviderRaw !== "openai" &&
-      judgeProviderRaw !== "anthropic" &&
-      judgeProviderRaw !== "ollama" &&
-      judgeProviderRaw !== "litellm"
-    ) {
-      throw new Error(
-        'ERROR: --judge-provider must be "openai", "anthropic", "ollama", or "litellm".',
-      );
-    }
-    judgeProvider = judgeProviderRaw;
+    judgeProvider = parseBenchProvider(judgeProviderRaw, "--judge-provider");
   }
 
   let threshold: number | undefined;
@@ -404,23 +412,13 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   }
 
   // `--provider` is validated against the same allow-list as
-  // `--system-provider` so the two surfaces stay in lockstep.
-  // `bench published` callers that prefer the legacy flags can keep
-  // using `--system-provider`; `--provider` is a shorthand specific to
-  // the published action.
+  // `--system-provider` so the two surfaces stay in lockstep
+  // (CLAUDE.md rule 52). `bench published` callers that prefer the
+  // legacy flags can keep using `--system-provider`; `--provider`
+  // is a shorthand specific to the published action.
   let publishedProvider: BuiltInProvider | undefined;
   if (publishedProviderRaw !== undefined) {
-    if (
-      publishedProviderRaw !== "openai" &&
-      publishedProviderRaw !== "anthropic" &&
-      publishedProviderRaw !== "ollama" &&
-      publishedProviderRaw !== "litellm"
-    ) {
-      throw new Error(
-        'ERROR: --provider must be "openai", "anthropic", "ollama", or "litellm".',
-      );
-    }
-    publishedProvider = publishedProviderRaw;
+    publishedProvider = parseBenchProvider(publishedProviderRaw, "--provider");
   }
 
   // Published action aliases: `--system-*` takes precedence; the
@@ -430,6 +428,26 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const effectiveSystemProvider = systemProvider ?? publishedProvider;
   const effectiveSystemModel = systemModel ?? publishedModelRaw;
   const effectiveSystemBaseUrl = systemBaseUrl ?? publishedBaseUrlRaw;
+
+  // Issue #566 slice 5 — when the effective provider is `local-llm`,
+  // a base URL is REQUIRED at the boundary. Silently defaulting to
+  // an OpenAI URL violates CLAUDE.md rule 51 (reject invalid user
+  // input with a listed option) and makes the `--provider local-llm`
+  // contract untrustworthy. The same rule applies to `--judge-provider`.
+  if (effectiveSystemProvider === "local-llm" && !effectiveSystemBaseUrl) {
+    throw new Error(
+      "ERROR: --provider local-llm requires --base-url (or --system-base-url). " +
+        "Examples: llama.cpp (http://localhost:8080/v1), " +
+        "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
+    );
+  }
+  if (judgeProvider === "local-llm" && !judgeBaseUrl) {
+    throw new Error(
+      "ERROR: --judge-provider local-llm requires --judge-base-url. " +
+        "Examples: llama.cpp (http://localhost:8080/v1), " +
+        "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
+    );
+  }
   return {
     action,
     benchmarks,

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -962,6 +962,106 @@ test("parseBenchArgs rejects unknown bench publish targets", async () => {
   );
 });
 
+// Issue #566 slice 5 — local-llm provider parity. `--provider`,
+// `--system-provider`, and `--judge-provider` must all accept
+// "local-llm" (CLAUDE.md rule 52: allow-lists in lockstep). When
+// the chosen provider is local-llm, a base URL is REQUIRED at the
+// boundary — silent OpenAI fallback violates rule 51.
+test("parseBenchArgs accepts --provider local-llm with --base-url", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  const parsed = parseBenchArgs([
+    "published",
+    "--name",
+    "longmemeval",
+    "--provider",
+    "local-llm",
+    "--base-url",
+    "http://127.0.0.1:8080/v1",
+    "--model",
+    "qwen3-8b",
+  ]);
+
+  assert.equal(parsed.systemProvider, "local-llm");
+  assert.equal(parsed.systemBaseUrl, "http://127.0.0.1:8080/v1");
+  assert.equal(parsed.systemModel, "qwen3-8b");
+});
+
+test("parseBenchArgs rejects --provider local-llm without --base-url", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "longmemeval",
+        "--provider",
+        "local-llm",
+        "--model",
+        "qwen3-8b",
+      ]),
+    /ERROR: --provider local-llm requires --base-url/,
+  );
+});
+
+test("parseBenchArgs rejects --system-provider local-llm without --system-base-url", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "longmemeval",
+        "--system-provider",
+        "local-llm",
+        "--system-model",
+        "qwen3-8b",
+      ]),
+    /ERROR: --provider local-llm requires --base-url/,
+  );
+});
+
+test("parseBenchArgs rejects --judge-provider local-llm without --judge-base-url", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "longmemeval",
+        "--judge-provider",
+        "local-llm",
+        "--judge-model",
+        "qwen3-8b",
+      ]),
+    /ERROR: --judge-provider local-llm requires --judge-base-url/,
+  );
+});
+
+test("parseBenchArgs rejects unknown providers across all three flags with listed options", async () => {
+  const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
+
+  for (const flag of [
+    "--system-provider",
+    "--judge-provider",
+    "--provider",
+  ]) {
+    assert.throws(
+      () => {
+        const args =
+          flag === "--provider"
+            ? ["published", "--name", "longmemeval", flag, "bogus", "--model", "m"]
+            : ["run", "longmemeval", flag, "bogus", flag.replace("provider", "model"), "m"];
+        parseBenchArgs(args);
+      },
+      new RegExp(
+        `ERROR: ${flag.replace(/-/g, "\\-")} must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\\.`,
+      ),
+    );
+  }
+});
+
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {
   const source = await readFile("packages/remnic-cli/src/index.ts", "utf8");
 


### PR DESCRIPTION
## Summary

Plumbs `--provider local-llm --base-url <url> --model <id>` through the
`PublishedBenchmarkHarness` so `remnic bench published` can be run
against a user-hosted OpenAI-compatible endpoint (llama.cpp, vLLM,
LM Studio) using the same wire contract as the plugin's running
`localLlm*` config. Slice 5 of 7 for issue #566.

## What's new

1. `BuiltInProvider` gains `"local-llm"`. The provider factory
   dispatches to a new `createLocalLlmProvider()` that targets
   `/v1/chat/completions` + `/v1/models` with a REQUIRED `baseUrl`.
   Missing `baseUrl` throws at construction time rather than silently
   defaulting to api.openai.com (CLAUDE.md rule 51).

2. The CLI allow-list for `--provider`, `--system-provider`, and
   `--judge-provider` is centralized in a shared `parseBenchProvider`
   helper so the three flags stay in lockstep (CLAUDE.md rule 52).
   Unknown values throw with all five options listed.

3. `--provider local-llm` without `--base-url` throws a listed-option
   error at the CLI boundary (rule 51). The same rule applies to
   `--system-provider` and `--judge-provider`. Defense in depth in
   `resolveProviderConfig` catches programmatic bypasses.

4. Record/replay CI smoke — no paid API calls:
   - `fixtures/local-llm/chat-completion.json` + `models.json`: canned
     OpenAI-compatible responses.
   - `fixtures/local-llm/mock-server.ts`: tiny HTTP server that replays
     those fixtures and records each request so tests can assert the
     bench actually hit the mock.
   - `providers/local-llm.test.ts`: five unit tests covering
     construction validation, chat replay, model discovery, non-2xx
     error surfacing, and auth-header forwarding.

5. CLI-surface tests verify the new allow-list behavior across all
   three provider flags and the required-base-url pairing.

## Stacking note

This PR is stacked on top of #603 (slice 4). The first three commits
belong to #603 and will disappear from the diff once #603 merges.

## Test plan
- [x] `pnpm run check-types` clean
- [x] `npx tsx --test packages/bench/src/providers/local-llm.test.ts` — 5/5 pass
- [x] `npx tsx --test tests/remnic-cli-bench-surface.test.ts` — 36/36 pass
- [x] `npx tsx --test packages/bench/src/runtime-profiles.test.ts` — 8/8 pass

## CLAUDE.md compliance
- Rule 14: all new flag arguments throw when value missing.
- Rule 51: unknown `--provider`/`--system-provider`/`--judge-provider`
  values throw with all valid options listed; `local-llm` without
  base-url throws.
- Rule 52: allow-list for the three provider flags is a single
  `BENCH_PROVIDER_ALLOWED` constant.
- Rule 55: documented `--provider local-llm` behavior has both the
  runtime-profile wiring AND a mock-server smoke test proving the
  provider reaches the configured base URL (not api.openai.com).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `local-llm` provider path and tightens CLI/runtime validation around provider/base-url wiring, which can affect bench execution and error behavior but is scoped to the bench harness.
> 
> **Overview**
> Adds a new built-in `local-llm` bench provider that targets user-hosted OpenAI-compatible servers via `/v1/chat/completions` and `/v1/models`, **requiring** `baseUrl` (no silent OpenAI fallback) and handling auth headers, usage accounting, and `/v1` URL normalization.
> 
> Updates provider plumbing (`BuiltInProvider`, provider factory, exports, and runtime-profile resolution) plus CLI parsing to accept `local-llm` across `--provider`/`--system-provider`/`--judge-provider` from a shared allow-list, and to **hard-error** when `local-llm` is selected without the corresponding base URL.
> 
> Introduces record/replay fixtures and a tiny mock HTTP server to support CI smoke tests, alongside new unit and CLI-surface tests covering request routing, discovery, error surfacing, and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8a707a1a6891ec1251a5b71ea98d2c4296405754. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->