### PR TITLE
fix(bench-cli-tests): avoid backslash-escape in computed provider regex (CodeQL #70)

### DIFF
--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -1042,24 +1042,48 @@ test("parseBenchArgs rejects --judge-provider local-llm without --judge-base-url
 test("parseBenchArgs rejects unknown providers across all three flags with listed options", async () => {
   const { parseBenchArgs } = await import("../packages/remnic-cli/src/bench-args.ts");
 
-  for (const flag of [
-    "--system-provider",
-    "--judge-provider",
-    "--provider",
-  ]) {
-    assert.throws(
-      () => {
-        const args =
-          flag === "--provider"
-            ? ["published", "--name", "longmemeval", flag, "bogus", "--model", "m"]
-            : ["run", "longmemeval", flag, "bogus", flag.replace("provider", "model"), "m"];
-        parseBenchArgs(args);
-      },
-      new RegExp(
-        `ERROR: ${flag.replace(/-/g, "\\-")} must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\\.`,
-      ),
-    );
-  }
+  // CLAUDE.md rule 52: the allow-list for --provider, --system-provider,
+  // and --judge-provider must be identical. Using three explicit cases
+  // (rather than a computed regex) keeps the assertions readable and
+  // dodges a CodeQL "incomplete string escaping" finding from building
+  // a regex out of a dash-containing flag name.
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "published",
+        "--name",
+        "longmemeval",
+        "--provider",
+        "bogus",
+        "--model",
+        "m",
+      ]),
+    /ERROR: --provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+  );
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "longmemeval",
+        "--system-provider",
+        "bogus",
+        "--system-model",
+        "m",
+      ]),
+    /ERROR: --system-provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+  );
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "longmemeval",
+        "--judge-provider",
+        "bogus",
+        "--judge-model",
+        "m",
+      ]),
+    /ERROR: --judge-provider must be one of "openai", "anthropic", "ollama", "litellm", or "local-llm"\./,
+  );
 });
 
 test("CLI uses the package BenchmarkDefinition contract instead of a local benchmark metadata clone", async () => {


### PR DESCRIPTION
## Summary

CodeQL alert #70 ("Incomplete string escaping or encoding") was opened
on `tests/remnic-cli-bench-surface.test.ts` during PR #613 but was
not fixed before that PR was merged. The alert still exists on `main`.

The original test built a RegExp from a dash-containing flag name via
`flag.replace(/-/g, "\\-")` — which does not escape backslash characters
in the input, exactly what CodeQL flags. The computed regex only
existed to DRY up three nearly-identical `assert.throws` calls, which
was marginal value.

Replace with three explicit, readable `assert.throws` calls — one per
provider flag — and drop the computed regex entirely. No behavioral
change to the validator logic itself.

## Test plan
- [x] `npx tsx --test tests/remnic-cli-bench-surface.test.ts` — 36/36 pass
- [x] CodeQL alert #70 resolves once this merges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: test-only changes that replace a computed RegExp with explicit assertions; no runtime/CLI behavior is modified.
> 
> **Overview**
> Updates `tests/remnic-cli-bench-surface.test.ts` to stop building a dynamic RegExp from provider flag names (addressing CodeQL “incomplete string escaping”).
> 
> The provider allow-list validation test is rewritten as three explicit `assert.throws` cases for `--provider`, `--system-provider`, and `--judge-provider`, keeping the same expected error messages/allow-list.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 00f0542cf0f7b008d4d9681d9e0647b5c8c2083b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->