### PR TITLE
feat(extraction): recognize reasoning_trace chains (#564 PR 2/4)

### DIFF
--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -35,6 +35,7 @@ import { buildChatCompletionTokenLimit, shouldAssumeOpenAiChatCompletions } from
 import { formatDaySummaryMemories, loadDaySummaryPrompt, buildExtensionsFooterForSummary } from "./day-summary.js";
 import { ProfilingCollector } from "./profiling.js";
 import { normalizeProcedureSteps } from "./procedural/procedure-types.js";
+import { normalizeReasoningTrace } from "./reasoning-trace-types.js";
 
 type ExtractionQuestion = ExtractionResult["questions"][number];
 type ExtractedFactResult = ExtractionResult["facts"][number];
@@ -207,6 +208,10 @@ export class ExtractionEngine {
             procedureSteps: Array.isArray(f?.procedureSteps)
               ? normalizeProcedureSteps(f.procedureSteps)
               : undefined,
+            reasoningTrace:
+              f?.reasoningTrace && typeof f.reasoningTrace === "object" && !Array.isArray(f.reasoningTrace)
+                ? normalizeReasoningTrace(f.reasoningTrace) ?? undefined
+                : undefined,
           }))
           .filter((f: any) => f.content.length > 0)
       : [];
@@ -1038,6 +1043,7 @@ Memory categories — use the MOST SPECIFIC category that fits:
 - skill: Demonstrated capabilities
 - rule: Explicit operational rules or constraints
 - procedure: Repeatable workflows — use when the user describes a multi-step play (≥2 ordered steps). Put the human-readable trigger/context in "content" (e.g. "When you deploy…") and list steps in "procedureSteps" as [{"order":1,"intent":"…"}, …] mirroring the gateway extraction schema.
+- reasoning_trace: Stored solution chains — use when the user narrates HOW they solved a specific problem step-by-step ("here's how I figured out…", "the debugging went like this…"). Put a short title in "content" (e.g. "How I debugged the staging latency spike") and the chain in "reasoningTrace": {"steps":[{"order":1,"description":"…"}, …], "finalAnswer":"…", "observedOutcome":"…" (optional)}. Require ≥2 ordered steps and a finalAnswer. Do NOT use for ordinary decisions (prefer "decision") or reusable workflows (prefer "procedure").
 
 IMPORTANT: Do NOT label everything as "fact". Use "decision" for architectural choices, "commitment" for deadlines/promises, "principle" for reusable rules, "correction" for when the user rejects a suggestion, etc.
 
@@ -1099,7 +1105,7 @@ Also generate:
 
 Output JSON:
 {
-  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "procedure", "content": "When you cut a hotfix release, follow the checklist", "importance": 8, "confidence": 0.9, "procedureSteps": [{"order": 1, "intent": "Branch from main and cherry-pick the fix"}, {"order": 2, "intent": "Run CI and tag the release"}]}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9}],
+  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "procedure", "content": "When you cut a hotfix release, follow the checklist", "importance": 8, "confidence": 0.9, "procedureSteps": [{"order": 1, "intent": "Branch from main and cherry-pick the fix"}, {"order": 2, "intent": "Run CI and tag the release"}]}, {"category": "reasoning_trace", "content": "How I debugged the staging latency spike", "importance": 7, "confidence": 0.9, "reasoningTrace": {"steps": [{"order": 1, "description": "Checked CPU/memory dashboards — both were flat"}, {"order": 2, "description": "Ran a traceroute and saw retries against the cache tier"}, {"order": 3, "description": "Tailed cache-tier logs and spotted eviction storms"}], "finalAnswer": "Root cause was an undersized eviction policy on the session cache", "observedOutcome": "Increased cache size, p95 returned to baseline within 10 minutes"}}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9}],
   "entities": [{"name": "person-jane-doe", "type": "person", "facts": ["Works at Acme Corp", "Prefers Python over JavaScript"], "structuredSections": [{"key": "beliefs", "title": "Beliefs", "facts": ["Python is a better fit than JavaScript for backend work."]}]}, {"name": "project-acme-store", "type": "project", "facts": ["Built with Next.js", "Deployed on Vercel"]}],
   "profileUpdates": ["User prefers dark mode in all editors"],
   "questions": [{"question": "Which cloud provider hosts the staging environment?", "context": "Came up during deployment discussion", "priority": 0.5}],
@@ -1193,7 +1199,7 @@ ${truncatedConversation}`;
             this.buildExtractionInstructions(existingEntities) +
             `\n\nRespond with valid JSON matching this schema:
 {
-  "facts": [{"category": "decision", "content": "Chose React over Vue for the dashboard rewrite", "importance": 8, "confidence": 0.9, "tags": ["frontend"], "structuredAttributes": {"chosen": "React", "rejected": "Vue"}}, {"category": "fact", "content": "The API gateway uses rate limiting at 1000 req/min", "importance": 6, "confidence": 0.95, "tags": ["infra"], "entityRef": "project-dashboard", "structuredAttributes": {"rate_limit": "1000 req/min"}}],
+  "facts": [{"category": "decision", "content": "Chose React over Vue for the dashboard rewrite", "importance": 8, "confidence": 0.9, "tags": ["frontend"], "structuredAttributes": {"chosen": "React", "rejected": "Vue"}}, {"category": "fact", "content": "The API gateway uses rate limiting at 1000 req/min", "importance": 6, "confidence": 0.95, "tags": ["infra"], "entityRef": "project-dashboard", "structuredAttributes": {"rate_limit": "1000 req/min"}}, {"category": "reasoning_trace", "content": "How I chose the dashboard rewrite framework", "confidence": 0.9, "tags": ["frontend"], "reasoningTrace": {"steps": [{"order": 1, "description": "Listed constraints: SSR needed, team mostly JS"}, {"order": 2, "description": "Ran a spike in Vue 3 — worked, but ecosystem felt thin for our needs"}, {"order": 3, "description": "Ran the same spike in React — integrated faster with Next.js"}], "finalAnswer": "Picked React with Next.js for SSR + ecosystem fit"}}],
   "entities": [{"name": "person-sarah-chen", "type": "person", "facts": ["Leads the backend team", "Joined from Google in 2024"], "structuredSections": [{"key": "beliefs", "title": "Beliefs", "facts": ["Small teams should own whole systems."]}]}, {"name": "project-dashboard", "type": "project", "facts": ["React-based admin panel", "Deployed on AWS ECS"]}],
   "profileUpdates": ["User prefers TypeScript over plain JavaScript"],
   "questions": [{"question": "What database does the analytics service use?", "context": "Came up during discussion of migration plan", "priority": 0.5}],
@@ -1313,6 +1319,7 @@ Memory categories:
 - skill: Capabilities the user or agent has demonstrated (e.g., "user is proficient with Kubernetes")${this.config.causalRuleExtractionEnabled ? `
 - rule: Causal rules discovered through experience (format: "IF <condition> THEN <action/outcome>", e.g., "IF Shopify API returns 401 THEN the admin token is missing read_products scope")` : ""}
 - procedure: A reusable workflow the user wants remembered the same way across sessions. Set category to "procedure". Use "content" for a short title that includes explicit trigger phrasing (e.g. "When you deploy to production…", "Whenever you ship a release…"). Add "procedureSteps": an array of at least two objects {"order": number, "intent": "concrete step description"} in execution order. Optional per-step "toolCall": {"kind": "…", "signature": "…"}, "expectedOutcome", "optional": true.
+- reasoning_trace: A stored solution chain / chain-of-thought the user walked through to solve a problem (e.g. "Here's how I debugged the latency spike: first I checked…, then I…, finally I…"). Set category to "reasoning_trace". Use "content" for a short title summarising the problem (e.g. "How I debugged the staging latency spike"). Add "reasoningTrace": {"steps": [{"order": number, "description": "what happened at this step"}, …], "finalAnswer": "the conclusion or answer", "observedOutcome": "optional confirmation of how it played out"}. Require at least two ordered steps AND a finalAnswer. Use this category only when the user explicitly narrates their reasoning — not for ordinary decisions (use "decision") or reusable workflows (use "procedure").
 
 Rules:
 - Only extract genuinely NEW information worth remembering across sessions

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -985,8 +985,21 @@ export class ExtractionEngine {
         log.debug(
           `extracted ${result.facts.length} facts, ${result.entities.length} entities, ${(result.questions ?? []).length} questions via fallback (${detailed.modelUsed})`,
         );
+        // Zod schema accepts snake_case aliases (final_answer / observed_outcome)
+        // alongside camelCase for gateway-tolerance, but the downstream
+        // ExtractedFact contract only exposes camelCase. Collapse each fact's
+        // reasoningTrace through normalizeReasoningTrace before passing it on so
+        // gateway output matches the shape local/direct-client paths produce.
+        const normalizedFacts = result.facts.map((f: any) => {
+          if (!f?.reasoningTrace) return f;
+          return {
+            ...f,
+            reasoningTrace: normalizeReasoningTrace(f.reasoningTrace) ?? undefined,
+          };
+        });
         const sanitized = this.sanitizeExtractionResult({
           ...result,
+          facts: normalizedFacts,
           questions: result.questions ?? [],
           identityReflection: result.identityReflection ?? undefined,
         } as ExtractionResult, messageTimestamp);

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -208,10 +208,20 @@ export class ExtractionEngine {
             procedureSteps: Array.isArray(f?.procedureSteps)
               ? normalizeProcedureSteps(f.procedureSteps)
               : undefined,
-            reasoningTrace:
-              f?.reasoningTrace && typeof f.reasoningTrace === "object" && !Array.isArray(f.reasoningTrace)
-                ? normalizeReasoningTrace(f.reasoningTrace) ?? undefined
-                : undefined,
+            reasoningTrace: (() => {
+              // Accept both camelCase and snake_case payload keys. The
+              // category itself is snake_case and we already tolerate
+              // snake_case nested fields in normalizeReasoningTrace, so a
+              // loose local/direct LLM that outputs `reasoning_trace` on the
+              // fact should not silently drop the structured chain.
+              const candidate =
+                f?.reasoningTrace && typeof f.reasoningTrace === "object" && !Array.isArray(f.reasoningTrace)
+                  ? f.reasoningTrace
+                  : f?.reasoning_trace && typeof f.reasoning_trace === "object" && !Array.isArray(f.reasoning_trace)
+                    ? f.reasoning_trace
+                    : null;
+              return candidate ? normalizeReasoningTrace(candidate) ?? undefined : undefined;
+            })(),
           }))
           .filter((f: any) => f.content.length > 0)
       : [];

--- a/packages/remnic-core/src/reasoning-trace-types.ts
+++ b/packages/remnic-core/src/reasoning-trace-types.ts
@@ -1,0 +1,218 @@
+/**
+ * Reasoning-trace memory structural types (issue #564).
+ *
+ * Captures stored solution chains / chain-of-thought the user walked through
+ * to solve a problem. Traces have an ordered list of steps, a final answer,
+ * and an optional observed outcome.
+ */
+
+export interface ReasoningTraceStep {
+  /** 1-based ordinal within the trace. */
+  order: number;
+  /** Human-readable description of what happened at this step. */
+  description: string;
+}
+
+export interface ReasoningTraceStructuredData {
+  steps: ReasoningTraceStep[];
+  finalAnswer: string;
+  /** Optional confirmation of how the answer played out in practice. */
+  observedOutcome?: string;
+}
+
+/** Normalize loose extraction JSON into ReasoningTraceStep records. */
+export function normalizeReasoningTraceSteps(raw: unknown): ReasoningTraceStep[] {
+  if (!Array.isArray(raw)) return [];
+  const out: ReasoningTraceStep[] = [];
+  for (let i = 0; i < raw.length; i++) {
+    const s = raw[i];
+    let description = "";
+    let orderRaw: unknown;
+    if (typeof s === "string") {
+      description = s.trim();
+    } else if (s && typeof s === "object") {
+      const o = s as Record<string, unknown>;
+      if (typeof o.description === "string") description = o.description.trim();
+      else if (typeof o.intent === "string") description = o.intent.trim();
+      else if (typeof o.step === "string") description = o.step.trim();
+      else if (typeof o.text === "string") description = o.text.trim();
+      orderRaw = o.order;
+    }
+    if (!description) continue;
+    const order =
+      typeof orderRaw === "number" && Number.isFinite(orderRaw)
+        ? Math.max(1, Math.floor(orderRaw))
+        : i + 1;
+    out.push({ order, description });
+  }
+  return out;
+}
+
+/**
+ * Normalize a loose reasoningTrace object (e.g. coming back from the LLM) to
+ * a strict ReasoningTraceStructuredData shape. Returns null when the data is
+ * clearly incomplete (no steps or no final answer).
+ */
+export function normalizeReasoningTrace(raw: unknown): ReasoningTraceStructuredData | null {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return null;
+  const o = raw as Record<string, unknown>;
+  const steps = normalizeReasoningTraceSteps(o.steps);
+  const finalAnswer =
+    typeof o.finalAnswer === "string"
+      ? o.finalAnswer.trim()
+      : typeof o.final_answer === "string"
+      ? (o.final_answer as string).trim()
+      : "";
+  if (steps.length === 0 || finalAnswer.length === 0) return null;
+  const observedRaw =
+    typeof o.observedOutcome === "string"
+      ? o.observedOutcome
+      : typeof o.observed_outcome === "string"
+      ? (o.observed_outcome as string)
+      : undefined;
+  const observedOutcome = observedRaw?.trim();
+  return {
+    steps,
+    finalAnswer,
+    observedOutcome: observedOutcome && observedOutcome.length > 0 ? observedOutcome : undefined,
+  };
+}
+
+/**
+ * Serialize a normalized reasoning trace into a human-readable markdown body.
+ * Output shape mirrors the procedure body format: ## Step N sections followed
+ * by final answer and optional observed outcome.
+ */
+export function buildReasoningTraceMarkdownBody(trace: ReasoningTraceStructuredData): string {
+  const sorted = [...trace.steps].sort((a, b) => a.order - b.order);
+  const lines: string[] = [];
+  for (const step of sorted) {
+    const n = Number.isFinite(step.order) ? Math.max(1, Math.floor(step.order)) : 1;
+    lines.push(`## Step ${n}`);
+    lines.push("");
+    lines.push(step.description.trim());
+    lines.push("");
+  }
+  lines.push("## Final Answer");
+  lines.push("");
+  lines.push(trace.finalAnswer.trim());
+  lines.push("");
+  if (trace.observedOutcome && trace.observedOutcome.trim().length > 0) {
+    lines.push("## Observed Outcome");
+    lines.push("");
+    lines.push(trace.observedOutcome.trim());
+    lines.push("");
+  }
+  return lines.join("\n").trimEnd() + "\n";
+}
+
+/**
+ * Combine a short title with the structured trace body. The title becomes the
+ * one-line content of the stored memory, and the full body is appended below.
+ */
+export function buildReasoningTracePersistBody(
+  title: string,
+  trace: ReasoningTraceStructuredData,
+): string {
+  const head = typeof title === "string" ? title.trim() : "";
+  const body = buildReasoningTraceMarkdownBody(trace);
+  if (!head) return body;
+  return `${head}\n\n${body}`.trimEnd() + "\n";
+}
+
+const STEP_HEADER_RE = /^##\s+Step\s+(\d+)\s*$/im;
+const FINAL_HEADER_RE = /^##\s+Final Answer\s*$/im;
+const OBSERVED_HEADER_RE = /^##\s+Observed Outcome\s*$/im;
+
+/**
+ * Best-effort parse of a reasoning-trace markdown body back into structured
+ * data. Returns null when the document does not look like a reasoning trace.
+ */
+export function parseReasoningTraceFromBody(content: string): ReasoningTraceStructuredData | null {
+  const text = content.replace(/\r\n/g, "\n").trim();
+  if (!text) return null;
+  const stepMatches = [...text.matchAll(new RegExp(STEP_HEADER_RE.source, "gim"))];
+  const finalMatch = FINAL_HEADER_RE.exec(text);
+  if (stepMatches.length === 0 || !finalMatch) return null;
+
+  const observedMatch = OBSERVED_HEADER_RE.exec(text);
+
+  const steps: ReasoningTraceStep[] = [];
+  for (let i = 0; i < stepMatches.length; i++) {
+    const m = stepMatches[i];
+    const order = Number.parseInt(m[1] ?? String(i + 1), 10);
+    const start = (m.index ?? 0) + m[0].length;
+    const nextStepStart =
+      i + 1 < stepMatches.length ? stepMatches[i + 1].index ?? text.length : text.length;
+    const end = Math.min(nextStepStart, finalMatch.index ?? text.length);
+    const block = text.slice(start, end).trim();
+    const description = block.split("\n").map((l) => l.trim()).filter((l) => l.length > 0).join(" ");
+    if (!description) continue;
+    steps.push({
+      order: Number.isFinite(order) ? order : i + 1,
+      description,
+    });
+  }
+
+  if (steps.length === 0) return null;
+
+  const finalStart = (finalMatch.index ?? 0) + finalMatch[0].length;
+  const finalEnd = observedMatch?.index ?? text.length;
+  const finalAnswer = text
+    .slice(finalStart, finalEnd)
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .join(" ")
+    .trim();
+  if (!finalAnswer) return null;
+
+  let observedOutcome: string | undefined;
+  if (observedMatch) {
+    const obsStart = (observedMatch.index ?? 0) + observedMatch[0].length;
+    const raw = text
+      .slice(obsStart)
+      .split("\n")
+      .map((l) => l.trim())
+      .filter((l) => l.length > 0)
+      .join(" ")
+      .trim();
+    if (raw) observedOutcome = raw;
+  }
+
+  return { steps, finalAnswer, observedOutcome };
+}
+
+/**
+ * Heuristic detector for whether a user message contains a chain-of-thought /
+ * solution trace that should be extracted. This is intentionally conservative:
+ * we require at least two explicitly-ordered steps and some form of final
+ * answer / resolution. Used by the extraction pipeline to decide whether to
+ * even consider emitting a reasoning_trace fact, so false positives are more
+ * costly than false negatives.
+ */
+export function looksLikeReasoningTrace(message: string): boolean {
+  if (typeof message !== "string") return false;
+  const text = message.trim();
+  if (text.length < 80) return false;
+
+  // Count step markers: "Step 1:", "1.", "1)", "First,", "First:"
+  const stepMarkers = [
+    /\bstep\s+\d+\s*[:.\-]/gi,
+    /(^|\n)\s*\d+[.)]\s+\S/g,
+    /(^|\n)\s*(first|second|third|fourth|finally|then|next)\b[,:]/gi,
+  ];
+  let stepCount = 0;
+  for (const re of stepMarkers) {
+    const matches = text.match(re);
+    if (matches) stepCount += matches.length;
+  }
+  if (stepCount < 2) return false;
+
+  // Final-answer / resolution marker
+  const finalMarker =
+    /\b(final answer|so the answer|therefore|conclusion|in the end|ended up|picked|chose|answer:|result:)\b/i;
+  if (!finalMarker.test(text)) return false;
+
+  return true;
+}

--- a/packages/remnic-core/src/reasoning-trace-types.ts
+++ b/packages/remnic-core/src/reasoning-trace-types.ts
@@ -158,7 +158,10 @@ export function parseReasoningTraceFromBody(content: string): ReasoningTraceStru
     });
   }
 
-  if (steps.length === 0) return null;
+  // Honor the >=2 ordered-steps invariant enforced everywhere else in the
+  // pipeline (prompts, normalizer, schema). A single-step manually-edited
+  // or corrupt file should not round-trip back in as a reasoning_trace.
+  if (steps.length < 2) return null;
 
   const finalStart = (finalMatch.index ?? 0) + finalMatch[0].length;
   const finalEnd = observedMatch?.index ?? text.length;
@@ -220,10 +223,13 @@ export function looksLikeReasoningTrace(message: string): boolean {
   }
   if (stepCount < 2) return false;
 
-  // Final-answer / resolution marker
-  const finalMarker =
-    /\b(final answer|so the answer|therefore|conclusion|in the end|ended up|picked|chose|answer:|result:)\b/i;
-  if (!finalMarker.test(text)) return false;
+  // Final-answer / resolution marker. Split into two checks so the trailing
+  // `\b` on the word-final alternatives doesn't accidentally require a word
+  // character after `answer:` / `result:` (both end in a non-word `:`).
+  const wordFinalMarker =
+    /\b(final answer|so the answer|therefore|conclusion|in the end|ended up|picked|chose)\b/i;
+  const colonMarker = /\b(answer:|result:)/i;
+  if (!wordFinalMarker.test(text) && !colonMarker.test(text)) return false;
 
   return true;
 }

--- a/packages/remnic-core/src/reasoning-trace-types.ts
+++ b/packages/remnic-core/src/reasoning-trace-types.ts
@@ -63,7 +63,11 @@ export function normalizeReasoningTrace(raw: unknown): ReasoningTraceStructuredD
       : typeof o.final_answer === "string"
       ? (o.final_answer as string).trim()
       : "";
-  if (steps.length === 0 || finalAnswer.length === 0) return null;
+  // Prompts describe reasoning_trace as requiring ≥2 ordered steps + a final
+  // answer. Rejecting one-step payloads here keeps the category semantically
+  // distinct from ordinary `decision` facts and prevents malformed traces
+  // from sneaking through loose local/direct extraction JSON.
+  if (steps.length < 2 || finalAnswer.length === 0) return null;
   const observedRaw =
     typeof o.observedOutcome === "string"
       ? o.observedOutcome
@@ -196,16 +200,23 @@ export function looksLikeReasoningTrace(message: string): boolean {
   const text = message.trim();
   if (text.length < 80) return false;
 
-  // Count step markers: "Step 1:", "1.", "1)", "First,", "First:"
-  const stepMarkers = [
-    /\bstep\s+\d+\s*[:.\-]/gi,
-    /(^|\n)\s*\d+[.)]\s+\S/g,
-    /(^|\n)\s*(first|second|third|fourth|finally|then|next)\b[,:]/gi,
+  // Count lines that carry at least one step marker, not the total number of
+  // marker matches. Summing across multiple regexes can let a single line
+  // contribute two "steps" (e.g. "Step 1: First,…" matches both patterns),
+  // which weakens the "false positives > false negatives" bias. Per-line
+  // counting keeps the gate symmetric with real step structure.
+  const stepMarkerRes = [
+    /\bstep\s+\d+\s*[:.\-]/i,
+    /^\s*\d+[.)]\s+\S/,
+    /^\s*(first|second|third|fourth|finally|then|next)\b[,:]/i,
   ];
+  const lines = text.split(/\r?\n/);
   let stepCount = 0;
-  for (const re of stepMarkers) {
-    const matches = text.match(re);
-    if (matches) stepCount += matches.length;
+  for (const line of lines) {
+    if (stepMarkerRes.some((re) => re.test(line))) {
+      stepCount += 1;
+      if (stepCount >= 2) break;
+    }
   }
   if (stepCount < 2) return false;
 

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -98,6 +98,30 @@ export const ExtractedFactSchema = z.object({
     .describe(
       'For category "procedure" only: ordered steps (intent per step). At least two steps; include explicit trigger phrasing in content (e.g. "When you deploy…").',
     ),
+  reasoningTrace: z
+    .object({
+      steps: z
+        .array(
+          z.object({
+            order: z.number(),
+            description: z.string(),
+          }),
+        )
+        .describe("Ordered reasoning steps the user walked through."),
+      finalAnswer: z
+        .string()
+        .describe("The conclusion, decision, or answer the chain arrived at."),
+      observedOutcome: z
+        .string()
+        .optional()
+        .nullable()
+        .describe("Optional note about how the answer actually played out."),
+    })
+    .optional()
+    .nullable()
+    .describe(
+      'For category "reasoning_trace" only: a stored solution chain with ordered steps, a final answer, and an optional observed outcome. Require at least two steps.',
+    ),
 });
 
 export const EntityMentionSchema = z.object({

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -107,16 +107,46 @@ export const ExtractedFactSchema = z.object({
             description: z.string(),
           }),
         )
-        .describe("Ordered reasoning steps the user walked through."),
+        // Prompts and normalizer require >=2 ordered steps; enforce it at
+        // the schema layer so gateway-path parsing rejects malformed traces
+        // rather than persisting them (local/direct-client normalization
+        // already enforces this, keeping the two paths symmetric).
+        .min(2)
+        .describe("Ordered reasoning steps the user walked through (require >=2)."),
+      // Accept snake_case aliases so a loose gateway model using
+      // `final_answer` / `observed_outcome` does not fail schema parsing
+      // and drop the entire extraction result. Local/direct-client
+      // normalization already tolerates these keys; the gateway path must
+      // too. Zod's `union` keeps the parse successful either way.
       finalAnswer: z
         .string()
+        .optional()
+        .nullable()
         .describe("The conclusion, decision, or answer the chain arrived at."),
+      final_answer: z
+        .string()
+        .optional()
+        .nullable()
+        .describe("Alias for finalAnswer (snake_case). Gateway-tolerance shim."),
       observedOutcome: z
         .string()
         .optional()
         .nullable()
         .describe("Optional note about how the answer actually played out."),
+      observed_outcome: z
+        .string()
+        .optional()
+        .nullable()
+        .describe("Alias for observedOutcome (snake_case). Gateway-tolerance shim."),
     })
+    // Either finalAnswer OR final_answer must be present — enforce here so
+    // the rest of the pipeline can assume a usable string downstream.
+    .refine(
+      (v) =>
+        (typeof v.finalAnswer === "string" && v.finalAnswer.trim().length > 0) ||
+        (typeof v.final_answer === "string" && v.final_answer.trim().length > 0),
+      { message: "reasoningTrace requires finalAnswer (or final_answer)" },
+    )
     .optional()
     .nullable()
     .describe(

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1566,6 +1566,22 @@ export interface ExtractedFact {
   structuredAttributes?: Record<string, string>;
   /** When category is `procedure`, ordered steps with intents (persisted under procedures/). */
   procedureSteps?: ExtractedProcedureStep[];
+  /**
+   * When category is `reasoning_trace`, the stored solution chain the user
+   * walked through. Persisted under reasoning-traces/.
+   */
+  reasoningTrace?: ExtractedReasoningTrace;
+}
+
+export interface ExtractedReasoningTraceStep {
+  order: number;
+  description: string;
+}
+
+export interface ExtractedReasoningTrace {
+  steps: ExtractedReasoningTraceStep[];
+  finalAnswer: string;
+  observedOutcome?: string;
 }
 
 export interface MemoryIntent {

--- a/tests/reasoning-trace-extraction.test.ts
+++ b/tests/reasoning-trace-extraction.test.ts
@@ -149,7 +149,18 @@ describe("normalizeReasoningTrace", () => {
 
   it("returns null when finalAnswer is missing", () => {
     const trace = normalizeReasoningTrace({
-      steps: [{ order: 1, description: "step" }],
+      steps: [
+        { order: 1, description: "step a" },
+        { order: 2, description: "step b" },
+      ],
+    });
+    assert.equal(trace, null);
+  });
+
+  it("rejects single-step traces (category requires >=2 ordered steps)", () => {
+    const trace = normalizeReasoningTrace({
+      steps: [{ order: 1, description: "only one step" }],
+      finalAnswer: "done",
     });
     assert.equal(trace, null);
   });
@@ -259,6 +270,17 @@ describe("looksLikeReasoningTrace heuristic", () => {
     ].join("\n");
     assert.equal(looksLikeReasoningTrace(msg), false);
   });
+
+  it("does not double-count when multiple marker styles appear on one line", () => {
+    // Single real step with both "Step 1:" and a "First," marker on one
+    // physical line; the heuristic must not treat this as two steps.
+    const msg = [
+      "Here's a single step but with multiple marker styles blended in.",
+      "Step 1: First, I checked the metrics and saw a flat CPU.",
+      "So the answer is we had a slow downstream service.",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(msg), false);
+  });
 });
 
 describe("extraction prompt includes reasoning_trace guidance", () => {
@@ -285,6 +307,20 @@ describe("extraction prompt includes reasoning_trace guidance", () => {
     assert.ok(
       src.includes('"reasoningTrace"'),
       "prompt JSON example should include a reasoningTrace field",
+    );
+  });
+
+  it("normalizeExtractionResultPayload accepts snake_case reasoning_trace key", async () => {
+    const src = await (await import("node:fs/promises")).readFile(
+      new URL("../packages/remnic-core/src/extraction.ts", import.meta.url),
+      "utf-8",
+    );
+    // Source-level guarantee: the normalize path must also read
+    // `reasoning_trace` so loose local/direct-client LLM output that uses
+    // snake_case keys still surfaces the structured chain.
+    assert.ok(
+      src.includes("f?.reasoning_trace"),
+      "normalizeExtractionResultPayload should fall back to snake_case reasoning_trace",
     );
   });
 });

--- a/tests/reasoning-trace-extraction.test.ts
+++ b/tests/reasoning-trace-extraction.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Tests for reasoning_trace extraction recognition (issue #564 PR 2).
+ *
+ * Covers:
+ * - ExtractedFactSchema accepts a reasoningTrace payload with steps[],
+ *   finalAnswer, and optional observedOutcome.
+ * - normalizeReasoningTrace handles both camelCase (finalAnswer,
+ *   observedOutcome) and snake_case (final_answer, observed_outcome) keys
+ *   coming from loose LLM output.
+ * - normalizeReasoningTrace rejects payloads without steps or without a
+ *   final answer (conservative gate).
+ * - buildReasoningTraceMarkdownBody + parseReasoningTraceFromBody round-trip.
+ * - looksLikeReasoningTrace heuristic recognizes ordered multi-step traces
+ *   with a final answer, and rejects short / unstructured prose.
+ * - The gateway + local-LLM extraction prompts mention reasoning_trace so
+ *   the model actually emits it.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { ExtractedFactSchema } from "../packages/remnic-core/src/schemas.js";
+import {
+  buildReasoningTraceMarkdownBody,
+  buildReasoningTracePersistBody,
+  looksLikeReasoningTrace,
+  normalizeReasoningTrace,
+  normalizeReasoningTraceSteps,
+  parseReasoningTraceFromBody,
+} from "../packages/remnic-core/src/reasoning-trace-types.js";
+
+describe("ExtractedFactSchema reasoningTrace", () => {
+  it("accepts a reasoningTrace with steps and finalAnswer", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "How I picked route-b for the low-latency path",
+      confidence: 0.9,
+      tags: ["routing"],
+      reasoningTrace: {
+        steps: [
+          { order: 1, description: "Enumerated candidate routes" },
+          { order: 2, description: "Measured round-trip times" },
+          { order: 3, description: "Picked the lowest p95 under SLO" },
+        ],
+        finalAnswer: "route-b wins and was pinned",
+      },
+    });
+    assert.equal(parsed.success, true);
+  });
+
+  it("accepts reasoningTrace with observedOutcome", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "How I debugged the latency spike",
+      confidence: 0.85,
+      tags: [],
+      reasoningTrace: {
+        steps: [
+          { order: 1, description: "Checked dashboards" },
+          { order: 2, description: "Tailed cache logs" },
+        ],
+        finalAnswer: "Root cause was undersized cache eviction policy",
+        observedOutcome: "Bumped cache size; p95 dropped back within 10m",
+      },
+    });
+    assert.equal(parsed.success, true);
+  });
+
+  it("also accepts facts without reasoningTrace (optional field)", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "fact",
+      content: "The user runs Postgres 15",
+      confidence: 0.95,
+      tags: [],
+    });
+    assert.equal(parsed.success, true);
+  });
+});
+
+describe("normalizeReasoningTraceSteps", () => {
+  it("normalizes string-array steps into numbered step records", () => {
+    const steps = normalizeReasoningTraceSteps([
+      "First I listed the constraints",
+      "Then I ran the spike",
+      "Finally I picked React",
+    ]);
+    assert.equal(steps.length, 3);
+    assert.deepEqual(steps.map((s) => s.order), [1, 2, 3]);
+    assert.equal(steps[2].description, "Finally I picked React");
+  });
+
+  it("accepts object steps with intent / step / text aliases", () => {
+    const steps = normalizeReasoningTraceSteps([
+      { order: 1, description: "checked dashboards" },
+      { intent: "tailed logs" },
+      { step: "found the issue" },
+    ]);
+    assert.equal(steps.length, 3);
+    assert.equal(steps[1].description, "tailed logs");
+    assert.equal(steps[1].order, 2);
+    assert.equal(steps[2].description, "found the issue");
+  });
+
+  it("filters out empty / malformed entries", () => {
+    const steps = normalizeReasoningTraceSteps([
+      { order: 1, description: "" },
+      { order: 2, description: "real step" },
+      null,
+      42,
+    ] as unknown as unknown[]);
+    assert.equal(steps.length, 1);
+    assert.equal(steps[0].description, "real step");
+  });
+});
+
+describe("normalizeReasoningTrace", () => {
+  it("accepts camelCase keys", () => {
+    const trace = normalizeReasoningTrace({
+      steps: [
+        { order: 1, description: "Checked metrics" },
+        { order: 2, description: "Rolled back" },
+      ],
+      finalAnswer: "Deploy had a regression",
+      observedOutcome: "Rollback restored service",
+    });
+    assert.ok(trace);
+    assert.equal(trace?.steps.length, 2);
+    assert.equal(trace?.finalAnswer, "Deploy had a regression");
+    assert.equal(trace?.observedOutcome, "Rollback restored service");
+  });
+
+  it("accepts snake_case keys from loose LLM output", () => {
+    const trace = normalizeReasoningTrace({
+      steps: ["ran tests", "saw failure"],
+      final_answer: "Tests flaked because of shared fixtures",
+      observed_outcome: "Isolating the fixture fixed it",
+    });
+    assert.ok(trace);
+    assert.equal(trace?.finalAnswer, "Tests flaked because of shared fixtures");
+    assert.equal(trace?.observedOutcome, "Isolating the fixture fixed it");
+  });
+
+  it("returns null when steps are missing", () => {
+    const trace = normalizeReasoningTrace({
+      finalAnswer: "yes",
+    });
+    assert.equal(trace, null);
+  });
+
+  it("returns null when finalAnswer is missing", () => {
+    const trace = normalizeReasoningTrace({
+      steps: [{ order: 1, description: "step" }],
+    });
+    assert.equal(trace, null);
+  });
+
+  it("returns null for non-objects", () => {
+    assert.equal(normalizeReasoningTrace(null), null);
+    assert.equal(normalizeReasoningTrace("string"), null);
+    assert.equal(normalizeReasoningTrace([1, 2, 3]), null);
+  });
+});
+
+describe("buildReasoningTraceMarkdownBody / parseReasoningTraceFromBody", () => {
+  it("round-trips a normalized trace", () => {
+    const trace = {
+      steps: [
+        { order: 1, description: "Enumerated candidate routes" },
+        { order: 2, description: "Measured round-trip times" },
+        { order: 3, description: "Picked the lowest p95 under SLO" },
+      ],
+      finalAnswer: "route-b wins and was pinned",
+      observedOutcome: "Latency-budget alarm cleared within the hour",
+    };
+    const body = buildReasoningTraceMarkdownBody(trace);
+    const parsed = parseReasoningTraceFromBody(body);
+    assert.ok(parsed);
+    assert.equal(parsed?.steps.length, 3);
+    assert.equal(parsed?.steps[0].order, 1);
+    assert.equal(parsed?.finalAnswer, "route-b wins and was pinned");
+    assert.equal(parsed?.observedOutcome, "Latency-budget alarm cleared within the hour");
+  });
+
+  it("round-trips a trace without observed outcome", () => {
+    const trace = {
+      steps: [
+        { order: 1, description: "A" },
+        { order: 2, description: "B" },
+      ],
+      finalAnswer: "answer",
+    };
+    const body = buildReasoningTraceMarkdownBody(trace);
+    const parsed = parseReasoningTraceFromBody(body);
+    assert.ok(parsed);
+    assert.equal(parsed?.observedOutcome, undefined);
+  });
+
+  it("parseReasoningTraceFromBody returns null for unrelated markdown", () => {
+    assert.equal(parseReasoningTraceFromBody(""), null);
+    assert.equal(
+      parseReasoningTraceFromBody("Just a random paragraph with no structure."),
+      null,
+    );
+  });
+
+  it("buildReasoningTracePersistBody prepends a title", () => {
+    const body = buildReasoningTracePersistBody("How I picked route-b", {
+      steps: [
+        { order: 1, description: "A" },
+        { order: 2, description: "B" },
+      ],
+      finalAnswer: "route-b",
+    });
+    assert.ok(body.startsWith("How I picked route-b"));
+    assert.ok(body.includes("## Step 1"));
+    assert.ok(body.includes("## Final Answer"));
+  });
+});
+
+describe("looksLikeReasoningTrace heuristic", () => {
+  it("recognizes explicit numbered steps with a final answer", () => {
+    const msg = [
+      "Here's how I debugged the latency spike:",
+      "Step 1: I checked the dashboards and CPU was flat.",
+      "Step 2: I tailed the cache logs.",
+      "Step 3: I saw eviction storms.",
+      "Final answer: the cache was undersized.",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(msg), true);
+  });
+
+  it("recognizes first/second/finally ordinal markers", () => {
+    const msg = [
+      "Let me walk through what I did.",
+      "First, I looked at the metrics panel to get a baseline.",
+      "Then, I ran a traceroute through the cache tier.",
+      "Finally, I verified eviction counters and confirmed the spike.",
+      "So the answer is: we had an undersized cache.",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(msg), true);
+  });
+
+  it("rejects short one-liners", () => {
+    assert.equal(looksLikeReasoningTrace("Just a single sentence."), false);
+  });
+
+  it("rejects prose without ordered steps", () => {
+    const msg =
+      "I thought about it for a while and decided to switch to Postgres. It felt like the right call.";
+    assert.equal(looksLikeReasoningTrace(msg), false);
+  });
+
+  it("rejects ordered steps with no resolution marker", () => {
+    const msg = [
+      "I did a few things:",
+      "1. ran the tests",
+      "2. reviewed the diff",
+      "3. opened a PR",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(msg), false);
+  });
+});
+
+describe("extraction prompt includes reasoning_trace guidance", () => {
+  it("gateway and local prompts mention reasoning_trace with schema hints", async () => {
+    const src = await (await import("node:fs/promises")).readFile(
+      new URL("../packages/remnic-core/src/extraction.ts", import.meta.url),
+      "utf-8",
+    );
+    // Local prompt branch
+    assert.ok(
+      /reasoning_trace: Stored solution chains/.test(src),
+      "local LLM prompt should describe reasoning_trace",
+    );
+    // Gateway prompt branch
+    assert.ok(
+      /reasoning_trace: A stored solution chain/.test(src),
+      "gateway prompt should describe reasoning_trace",
+    );
+    // Both prompt JSON examples must reference reasoningTrace
+    assert.ok(
+      src.includes('"category": "reasoning_trace"'),
+      "prompt JSON example should include a reasoning_trace fact",
+    );
+    assert.ok(
+      src.includes('"reasoningTrace"'),
+      "prompt JSON example should include a reasoningTrace field",
+    );
+  });
+});

--- a/tests/reasoning-trace-extraction.test.ts
+++ b/tests/reasoning-trace-extraction.test.ts
@@ -75,6 +75,54 @@ describe("ExtractedFactSchema reasoningTrace", () => {
     });
     assert.equal(parsed.success, true);
   });
+
+  it("rejects reasoningTrace with only one step at the schema layer", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "Not a real chain",
+      confidence: 0.8,
+      tags: [],
+      reasoningTrace: {
+        steps: [{ order: 1, description: "only one" }],
+        finalAnswer: "done",
+      },
+    });
+    assert.equal(parsed.success, false);
+  });
+
+  it("accepts snake_case final_answer and observed_outcome at the schema layer", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "Gateway-loose JSON with snake_case keys",
+      confidence: 0.8,
+      tags: [],
+      reasoningTrace: {
+        steps: [
+          { order: 1, description: "a" },
+          { order: 2, description: "b" },
+        ],
+        final_answer: "answer",
+        observed_outcome: "outcome",
+      },
+    });
+    assert.equal(parsed.success, true);
+  });
+
+  it("rejects reasoningTrace missing finalAnswer in both camel and snake forms", () => {
+    const parsed = ExtractedFactSchema.safeParse({
+      category: "reasoning_trace",
+      content: "Missing final answer",
+      confidence: 0.8,
+      tags: [],
+      reasoningTrace: {
+        steps: [
+          { order: 1, description: "a" },
+          { order: 2, description: "b" },
+        ],
+      },
+    });
+    assert.equal(parsed.success, false);
+  });
 });
 
 describe("normalizeReasoningTraceSteps", () => {
@@ -214,6 +262,19 @@ describe("buildReasoningTraceMarkdownBody / parseReasoningTraceFromBody", () => 
     );
   });
 
+  it("parseReasoningTraceFromBody rejects single-step bodies (>=2 invariant)", () => {
+    const body = [
+      "## Step 1",
+      "",
+      "only one step",
+      "",
+      "## Final Answer",
+      "",
+      "done",
+    ].join("\n");
+    assert.equal(parseReasoningTraceFromBody(body), null);
+  });
+
   it("buildReasoningTracePersistBody prepends a title", () => {
     const body = buildReasoningTracePersistBody("How I picked route-b", {
       steps: [
@@ -269,6 +330,24 @@ describe("looksLikeReasoningTrace heuristic", () => {
       "3. opened a PR",
     ].join("\n");
     assert.equal(looksLikeReasoningTrace(msg), false);
+  });
+
+  it("recognizes `answer:` and `result:` final markers in prose (no trailing word required)", () => {
+    const withAnswer = [
+      "Walk-through:",
+      "Step 1: I pulled the logs.",
+      "Step 2: I narrowed down the stack trace.",
+      "answer: a NullPointerException in the cache layer.",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(withAnswer), true);
+
+    const withResult = [
+      "Here is how I looked into it.",
+      "First, I checked dashboards.",
+      "Then, I correlated with the deploy log.",
+      "result: a stuck canary blocked promotion.",
+    ].join("\n");
+    assert.equal(looksLikeReasoningTrace(withResult), true);
   });
 
   it("does not double-count when multiple marker styles appear on one line", () => {


### PR DESCRIPTION
## Summary

Issue #564 PR 2 of 4 — extraction recognition for stored solution chains.

- Adds an optional `reasoningTrace` structural field to `ExtractedFact` (zod + TS): `steps[]` (order + description), `finalAnswer`, optional `observedOutcome`.
- Adds `packages/remnic-core/src/reasoning-trace-types.ts` with normalizers, a markdown round-trip (`buildReasoningTraceMarkdownBody` / `parseReasoningTraceFromBody`), and a conservative `looksLikeReasoningTrace` heuristic.
- Teaches both the gateway (`buildExtractionInstructions`) and local-LLM extraction prompts to recognize `reasoning_trace` and emit it in JSON output, including explicit guardrails distinguishing it from `decision` and `procedure`.
- Threads the new field through `normalizeExtractionResultPayload` so downstream consumers get the structured shape directly.

Scope is extraction-only — persistence under `reasoning-traces/` and the retrieval boost land in PR 3, benchmark coverage in PR 4.

## Test plan
- [x] `npx tsx --test tests/reasoning-trace-extraction.test.ts` — 21 tests, all green
- [x] `npx tsx --test tests/reasoning-trace-category.test.ts` — PR 1 tests still pass
- [x] `tsc --noEmit` — workspace clean

Refs #564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the extraction contract and schema validation, which can change what data gets accepted/normalized across local vs gateway paths and may impact downstream consumers expecting prior shapes.
> 
> **Overview**
> Adds first-class support for a new `reasoning_trace` memory category by extending `ExtractedFact` with an optional structured `reasoningTrace` (steps + required final answer + optional observed outcome).
> 
> Updates extraction to *retain and normalize* `reasoningTrace` from both camelCase and snake_case payloads (including gateway outputs), and updates both local and direct/gateway prompts to elicit `reasoning_trace` facts.
> 
> Introduces `reasoning-trace-types.ts` utilities for normalization, markdown round-tripping, and a conservative `looksLikeReasoningTrace` detector, with comprehensive tests covering schema acceptance, normalization rules, and prompt inclusion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 540fad05119596c915fb32e594248d907a96d545. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->