### PR TITLE
feat(buffer): surprise-gated flush trigger (issue #563 PR 2/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -58,6 +58,30 @@
         "default": 15,
         "description": "Max minutes before forced extraction"
       },
+      "bufferSurpriseTriggerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
+      },
+      "bufferSurpriseThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
+      },
+      "bufferSurpriseK": {
+        "type": "number",
+        "default": 5,
+        "minimum": 1,
+        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      },
+      "bufferSurpriseRecentMemoryCount": {
+        "type": "number",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -82,6 +82,12 @@
         "minimum": 0,
         "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
       },
+      "bufferSurpriseProbeTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "minimum": 1,
+        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -58,6 +58,30 @@
         "default": 15,
         "description": "Max minutes before forced extraction"
       },
+      "bufferSurpriseTriggerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
+      },
+      "bufferSurpriseThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
+      },
+      "bufferSurpriseK": {
+        "type": "number",
+        "default": 5,
+        "minimum": 1,
+        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      },
+      "bufferSurpriseRecentMemoryCount": {
+        "type": "number",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -82,6 +82,12 @@
         "minimum": 0,
         "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
       },
+      "bufferSurpriseProbeTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "minimum": 1,
+        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,

--- a/packages/remnic-core/src/buffer-surprise-trigger.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-trigger.test.ts
@@ -420,3 +420,83 @@ test("config: string 'false' for bufferSurpriseTriggerEnabled disables the flag"
   });
   assert.equal(config.bufferSurpriseTriggerEnabled, false);
 });
+
+test("config: numeric surprise knobs coerce CLI string values", async () => {
+  const config = parseConfig({
+    bufferSurpriseThreshold: "0.9" as unknown as number,
+    bufferSurpriseK: "7" as unknown as number,
+    bufferSurpriseRecentMemoryCount: "10" as unknown as number,
+    bufferSurpriseProbeTimeoutMs: "500" as unknown as number,
+  });
+  assert.equal(config.bufferSurpriseThreshold, 0.9);
+  assert.equal(config.bufferSurpriseK, 7);
+  assert.equal(config.bufferSurpriseRecentMemoryCount, 10);
+  assert.equal(config.bufferSurpriseProbeTimeoutMs, 500);
+});
+
+test("config: invalid numeric values fall back to defaults", async () => {
+  const config = parseConfig({
+    bufferSurpriseThreshold: "not a number" as unknown as number,
+    bufferSurpriseK: "oops" as unknown as number,
+    bufferSurpriseRecentMemoryCount: NaN,
+    bufferSurpriseProbeTimeoutMs: "" as unknown as number,
+  });
+  assert.equal(config.bufferSurpriseThreshold, 0.35);
+  assert.equal(config.bufferSurpriseK, 5);
+  assert.equal(config.bufferSurpriseRecentMemoryCount, 20);
+  assert.equal(config.bufferSurpriseProbeTimeoutMs, 2000);
+});
+
+test("config: threshold is clamped to [0, 1]", async () => {
+  const high = parseConfig({ bufferSurpriseThreshold: 2.5 });
+  assert.equal(high.bufferSurpriseThreshold, 1);
+  const low = parseConfig({ bufferSurpriseThreshold: -0.5 });
+  assert.equal(low.bufferSurpriseThreshold, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Probe timeout
+// ---------------------------------------------------------------------------
+
+test("flag on: probe that never resolves is timed out, turn is still saved", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  // A probe that resolves well after the configured timeout. We clear
+  // the underlying timer explicitly at the end of the test so node:test
+  // does not wait for it during teardown.
+  let slowTimer: NodeJS.Timeout | null = null;
+  const slowResolver = new Promise<number | null>((resolve) => {
+    slowTimer = setTimeout(() => resolve(0.99), 5_000);
+  });
+  const probe: BufferSurpriseProbe = {
+    scoreTurn: () => slowResolver,
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferSurpriseProbeTimeoutMs: 30,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  try {
+    const startedAt = Date.now();
+    const decision = await buffer.addTurn(
+      "sess-1",
+      makeTurn("sess-1", "turn content"),
+    );
+    const elapsed = Date.now() - startedAt;
+    assert.equal(decision, "keep_buffering");
+    assert.ok(
+      elapsed < 2000,
+      `addTurn should have short-circuited via timeout; took ${elapsed}ms`,
+    );
+    const entry = storage.saved?.entries?.["sess-1"];
+    assert.ok(
+      entry && entry.turns.length === 1,
+      "turn must still be persisted after probe timeout",
+    );
+  } finally {
+    if (slowTimer) clearTimeout(slowTimer);
+  }
+});

--- a/packages/remnic-core/src/buffer-surprise-trigger.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-trigger.test.ts
@@ -1,0 +1,338 @@
+/**
+ * Tests for the surprise-gated flush trigger wired into SmartBuffer
+ * (issue #563 PR 2).
+ *
+ * The surprise probe is injected — these tests use a deterministic fake so
+ * the buffer's decision logic is exercised without touching embeddings,
+ * storage, or QMD.  Two invariants drive the suite:
+ *
+ *  1. When `bufferSurpriseTriggerEnabled` is `false`, the probe must not be
+ *     consulted at all and the buffer must behave exactly like pre-#563
+ *     code.
+ *  2. When enabled, a score strictly greater than the threshold upgrades
+ *     `keep_buffering` → `extract_now`.  A score at or below threshold, a
+ *     `null` score, or a thrown error must fall through unchanged.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SmartBuffer, type BufferSurpriseProbe } from "./buffer.js";
+import { parseConfig } from "./config.js";
+import type { BufferState, BufferTurn } from "./types.js";
+
+class FakeStorage {
+  public saved: BufferState | null = null;
+
+  constructor(private readonly initial: BufferState) {}
+
+  async loadBuffer(): Promise<BufferState> {
+    return structuredClone(this.initial);
+  }
+
+  async saveBuffer(state: BufferState): Promise<void> {
+    this.saved = structuredClone(state);
+  }
+}
+
+function makeTurn(sessionKey: string, content: string): BufferTurn {
+  return {
+    role: "user",
+    content,
+    timestamp: "2026-04-20T12:00:00.000Z",
+    sessionKey,
+  };
+}
+
+function emptyBuffer(): BufferState {
+  return { turns: [], lastExtractionAt: null, extractionCount: 0 };
+}
+
+interface RecordingProbe extends BufferSurpriseProbe {
+  calls: number;
+  lastPriorLength: number | null;
+}
+
+function fixedScoreProbe(score: number | null): RecordingProbe {
+  const probe: RecordingProbe = {
+    calls: 0,
+    lastPriorLength: null,
+    async scoreTurn(_key, _turn, prior) {
+      this.calls += 1;
+      this.lastPriorLength = prior.length;
+      return score;
+    },
+  };
+  return probe;
+}
+
+function throwingProbe(message = "embedder offline"): RecordingProbe {
+  const probe: RecordingProbe = {
+    calls: 0,
+    lastPriorLength: null,
+    async scoreTurn(_key, _turn, prior) {
+      this.calls += 1;
+      this.lastPriorLength = prior.length;
+      throw new Error(message);
+    },
+  };
+  return probe;
+}
+
+// ---------------------------------------------------------------------------
+// Flag gating
+// ---------------------------------------------------------------------------
+
+test("flag off: probe is not consulted, behavior matches pre-#563 baseline", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.99); // would flush if consulted
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: false,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "some ordinary content"),
+  );
+
+  assert.equal(decision, "keep_buffering");
+  assert.equal(probe.calls, 0, "probe must not be called when flag is off");
+});
+
+test("flag off: high signal still flushes immediately", async () => {
+  // Guards against a refactor that accidentally routes high-signal decisions
+  // through the surprise branch.
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: false,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+    highSignalPatterns: ["\\bURGENT\\b"],
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "URGENT please remember this"),
+  );
+  assert.equal(decision, "extract_now");
+  assert.equal(probe.calls, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Threshold behavior
+// ---------------------------------------------------------------------------
+
+test("flag on: surprise above threshold upgrades to extract_now", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.9);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "a novel topic shift"),
+  );
+  assert.equal(decision, "extract_now");
+  assert.equal(probe.calls, 1);
+});
+
+test("flag on: surprise at or below threshold keeps buffering", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  // Exactly the threshold must NOT flush — decision is strictly greater-than.
+  const probe = fixedScoreProbe(0.35);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "another routine turn"),
+  );
+  assert.equal(decision, "keep_buffering");
+  assert.equal(probe.calls, 1);
+});
+
+test("flag on: low-surprise turn does not flush", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.1);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "redundant with existing memory"),
+  );
+  assert.equal(decision, "keep_buffering");
+});
+
+// ---------------------------------------------------------------------------
+// Failure isolation
+// ---------------------------------------------------------------------------
+
+test("flag on: probe rejection is swallowed and existing decision stands", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = throwingProbe();
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "turn content"),
+  );
+  assert.equal(decision, "keep_buffering");
+  assert.equal(probe.calls, 1);
+});
+
+test("flag on: probe returning null is treated as 'no score, use existing triggers'", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(null);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "turn content"),
+  );
+  assert.equal(decision, "keep_buffering");
+});
+
+test("flag on: surprise does not suppress existing extract_batch flushes", async () => {
+  // If the turn-count rule already says flush, surprise must not demote to
+  // keep_buffering. Documented as additive-only in buffer.ts.
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0); // would "not flush" if consulted
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 2,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "first"));
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "second"),
+  );
+  assert.equal(decision, "extract_batch");
+  assert.equal(
+    probe.calls,
+    1,
+    "probe only consulted on the first (keep_buffering) turn",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Trigger mode isolation
+// ---------------------------------------------------------------------------
+
+test("flag on: non-smart modes ignore surprise", async () => {
+  // D-MEM-style novelty only makes sense inside the smart decision tree.
+  // `every_n` / `time_based` are explicit operator choices — do not override.
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.99);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 10,
+    triggerMode: "every_n",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "novel but every_n mode"),
+  );
+  assert.equal(decision, "keep_buffering");
+  assert.equal(probe.calls, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Corpus exclusion
+// ---------------------------------------------------------------------------
+
+test("flag on: probe never sees the turn being scored in the corpus", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.1);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferMaxTurns: 10,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "first"));
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "second"));
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "third"));
+  // prior length at third call must be 2 (first + second), not 3.
+  assert.equal(probe.lastPriorLength, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Probe-returned garbage handling
+// ---------------------------------------------------------------------------
+
+test("flag on: non-finite probe scores are ignored, not treated as 'always flush'", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(Number.NaN);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "turn"),
+  );
+  assert.equal(decision, "keep_buffering");
+});
+
+test("flag on: probe score >1 is clamped, >threshold still flushes", async () => {
+  const storage = new FakeStorage(emptyBuffer());
+  // A misbehaving probe returning 1.5 should still flush (surprise > 0.35),
+  // not crash, and not silently turn into "never flush".
+  const probe = fixedScoreProbe(1.5);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "turn"),
+  );
+  assert.equal(decision, "extract_now");
+});

--- a/packages/remnic-core/src/buffer-surprise-trigger.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-trigger.test.ts
@@ -336,3 +336,87 @@ test("flag on: probe score >1 is clamped, >threshold still flushes", async () =>
   );
   assert.equal(decision, "extract_now");
 });
+
+// ---------------------------------------------------------------------------
+// Defensive: non-Error throw values in the probe
+// ---------------------------------------------------------------------------
+
+async function assertProbeRejectionHandled(
+  rejection: unknown,
+): Promise<void> {
+  const storage = new FakeStorage(emptyBuffer());
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn() {
+      throw rejection;
+    },
+  };
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  // Must NOT itself throw when logging the failure. The decision falls
+  // through to the existing triggers and the turn is still saved. The
+  // "sess-1" buffer key lives under `entries`, not the default bucket.
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "turn content"),
+  );
+  assert.equal(decision, "keep_buffering");
+  const entry = storage.saved?.entries?.["sess-1"];
+  assert.ok(
+    entry && entry.turns.length === 1,
+    "turn must still be persisted despite probe failure",
+  );
+}
+
+test("flag on: non-Error probe rejections do not crash addTurn (null)", async () => {
+  await assertProbeRejectionHandled(null);
+});
+
+test("flag on: non-Error probe rejections do not crash addTurn (undefined)", async () => {
+  await assertProbeRejectionHandled(undefined);
+});
+
+test("flag on: non-Error probe rejections do not crash addTurn (string)", async () => {
+  await assertProbeRejectionHandled("embedder offline");
+});
+
+test("flag on: non-Error probe rejections do not crash addTurn (plain object)", async () => {
+  await assertProbeRejectionHandled({ reason: "timeout", code: 504 });
+});
+
+// ---------------------------------------------------------------------------
+// Boolean config coercion
+// ---------------------------------------------------------------------------
+
+test("config: string 'true' for bufferSurpriseTriggerEnabled enables the flag", async () => {
+  // `--config bufferSurpriseTriggerEnabled=true` passes the literal
+  // string "true" through parseConfig. The strict `=== true` form would
+  // leave the flag off and silently drop the operator's intent.
+  const storage = new FakeStorage(emptyBuffer());
+  const probe = fixedScoreProbe(0.9);
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: "true" as unknown as boolean,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  assert.equal(config.bufferSurpriseTriggerEnabled, true);
+
+  const buffer = new SmartBuffer(config, storage as any, probe);
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "novel"),
+  );
+  assert.equal(decision, "extract_now");
+});
+
+test("config: string 'false' for bufferSurpriseTriggerEnabled disables the flag", async () => {
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: "false" as unknown as boolean,
+  });
+  assert.equal(config.bufferSurpriseTriggerEnabled, false);
+});

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -245,8 +245,12 @@ export class SmartBuffer {
       if (score > 1) return 1;
       return score;
     } catch (err) {
+      // `err` may be any thrown value — `throw null` and
+      // `Promise.reject("x")` are both legal. Accessing `.message` on a
+      // non-Error would itself throw and defeat the failure-isolation
+      // contract, so describe the value safely.
       log.debug(
-        `buffer[${bufferKey}]: surprise probe failed, falling back to existing triggers: ${(err as Error).message}`,
+        `buffer[${bufferKey}]: surprise probe failed, falling back to existing triggers: ${describeError(err)}`,
       );
       return null;
     }
@@ -347,5 +351,27 @@ export class SmartBuffer {
 
   getExtractionCount(bufferKey = "default"): number {
     return this.peekEntry(bufferKey)?.extractionCount ?? 0;
+  }
+}
+
+/**
+ * Render an arbitrary thrown value as a short string for debug logging.
+ *
+ * JavaScript permits throwing *any* value (`throw null`,
+ * `Promise.reject("x")`, `throw { reason: "timeout" }`) — not just
+ * `Error` instances. The defensive catch blocks in `SmartBuffer` must
+ * never themselves throw while trying to log the failure, or they
+ * would defeat the whole point of isolating the surprise path from the
+ * core extraction decision.
+ */
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  if (err === null) return "null";
+  if (err === undefined) return "undefined";
+  if (typeof err === "string") return err;
+  try {
+    return JSON.stringify(err);
+  } catch {
+    return String(err);
   }
 }

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -11,17 +11,47 @@ import type {
 
 export type TriggerDecision = "extract_now" | "extract_batch" | "keep_buffering";
 
+/**
+ * Optional surprise probe injected into `SmartBuffer`.
+ *
+ * Computes a D-MEM-style novelty score in `[0, 1]` for an incoming turn.
+ * The buffer treats the probe as purely additive: if it is not provided, if
+ * the feature flag is off, or if the probe throws/times out, the buffer
+ * falls back to the existing signal/turn-count/time triggers unchanged.
+ *
+ * Callers are responsible for sampling recent memories and passing them
+ * through the embedding pipeline — the buffer does not want to know about
+ * storage, embeddings, or QMD.
+ *
+ * @param bufferKey Identifier for the active buffer (session/thread).
+ * @param turn      The incoming turn whose novelty is being scored.
+ * @param recentTurns Turns already buffered for this key (most recent first
+ *                    is NOT guaranteed — treat as unordered corpus).
+ * @returns A surprise score in `[0, 1]`, or `null` if no score could be
+ *          produced (e.g. empty corpus, probe declined to embed).
+ */
+export interface BufferSurpriseProbe {
+  scoreTurn(
+    bufferKey: string,
+    turn: BufferTurn,
+    recentTurns: readonly BufferTurn[],
+  ): Promise<number | null>;
+}
+
 const MAX_BUFFER_ENTRY_COUNT = 200;
 
 export class SmartBuffer {
   private state: BufferState;
   private loaded = false;
+  private readonly surpriseProbe: BufferSurpriseProbe | null;
 
   constructor(
     private readonly config: PluginConfig,
     private readonly storage: StorageManager,
+    surpriseProbe: BufferSurpriseProbe | null = null,
   ) {
     this.state = { turns: [], lastExtractionAt: null, extractionCount: 0 };
+    this.surpriseProbe = surpriseProbe;
   }
 
   private entryFor(key: string): BufferEntryState {
@@ -142,7 +172,35 @@ export class SmartBuffer {
     }
 
     const signal = scanSignals(turn.content, this.config.highSignalPatterns);
-    const decision = this.evaluate(entry, signal.level);
+    let decision = this.evaluate(entry, signal.level);
+
+    // Surprise-gated flush (issue #563). Additive only: if the probe is
+    // disabled, unavailable, or the score is below threshold, the decision
+    // from the existing trigger logic stands. The probe only ever *promotes*
+    // `keep_buffering` → `extract_now`; it never suppresses an existing
+    // flush. This preserves the invariant that enabling surprise cannot
+    // *reduce* extraction frequency.
+    if (
+      decision === "keep_buffering" &&
+      this.config.bufferSurpriseTriggerEnabled &&
+      this.surpriseProbe !== null &&
+      // Matching the existing "smart" branch: surprise is a lower-tier
+      // novelty signal that should not second-guess a high-signal hit
+      // (which already flushes) or fight `every_n` / `time_based` modes.
+      this.config.triggerMode === "smart" &&
+      signal.level !== "high"
+    ) {
+      const surprise = await this.computeSurpriseSafe(bufferKey, turn, entry);
+      if (
+        surprise !== null &&
+        surprise > this.config.bufferSurpriseThreshold
+      ) {
+        log.debug(
+          `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} > threshold=${this.config.bufferSurpriseThreshold} → extract_now`,
+        );
+        decision = "extract_now";
+      }
+    }
 
     log.debug(
       `buffer[${bufferKey}]: ${entry.turns.length} turns, signal=${signal.level}, decision=${decision}`,
@@ -151,6 +209,47 @@ export class SmartBuffer {
     this.pruneEntries([bufferKey]);
     await this.save();
     return decision;
+  }
+
+  /**
+   * Invoke the injected surprise probe defensively. Any error (probe throws,
+   * embedder unavailable, timeout) is swallowed and logged at debug: the
+   * surprise path must never crash the happy-path trigger evaluation. A
+   * `null` return indicates "no score available, fall through to existing
+   * triggers".
+   */
+  private async computeSurpriseSafe(
+    bufferKey: string,
+    turn: BufferTurn,
+    entry: BufferEntryState,
+  ): Promise<number | null> {
+    if (!this.surpriseProbe) return null;
+    // The current turn was just pushed into entry.turns; exclude it from the
+    // corpus so the probe never compares a turn to itself.
+    const prior = entry.turns.length > 0
+      ? entry.turns.slice(0, -1)
+      : [];
+    try {
+      const score = await this.surpriseProbe.scoreTurn(bufferKey, turn, prior);
+      if (score === null) return null;
+      if (typeof score !== "number" || !Number.isFinite(score)) {
+        log.debug(
+          `buffer[${bufferKey}]: surprise probe returned non-finite score (${String(score)}), ignoring`,
+        );
+        return null;
+      }
+      // Defensive clamp: formula lives in buffer-surprise.ts, but we never
+      // want a misbehaving probe to inject an out-of-range value into the
+      // threshold comparison.
+      if (score < 0) return 0;
+      if (score > 1) return 1;
+      return score;
+    } catch (err) {
+      log.debug(
+        `buffer[${bufferKey}]: surprise probe failed, falling back to existing triggers: ${(err as Error).message}`,
+      );
+      return null;
+    }
   }
 
   private evaluate(entry: BufferEntryState, signalLevel: SignalLevel): TriggerDecision {

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -230,7 +230,17 @@ export class SmartBuffer {
       ? entry.turns.slice(0, -1)
       : [];
     try {
-      const score = await this.surpriseProbe.scoreTurn(bufferKey, turn, prior);
+      // Hard timeout around the probe so a hung embedder cannot stall
+      // `addTurn()` before `save()`. A slow probe would otherwise
+      // prevent the just-appended turn from ever being persisted. The
+      // timeout is a soft bound — we race it against the probe, take
+      // whichever settles first, and treat the timeout as
+      // "probe unavailable, fall through" rather than an error that
+      // surfaces to the caller.
+      const score = await probeWithTimeout(
+        this.surpriseProbe.scoreTurn(bufferKey, turn, prior),
+        this.config.bufferSurpriseProbeTimeoutMs,
+      );
       if (score === null) return null;
       if (typeof score !== "number" || !Number.isFinite(score)) {
         log.debug(
@@ -374,4 +384,41 @@ function describeError(err: unknown): string {
   } catch {
     return String(err);
   }
+}
+
+/**
+ * Sentinel error class for the probe timeout path. Catching it via
+ * `instanceof` lets the buffer's surprise helper distinguish a timeout
+ * from a probe rejection (which could carry operational context the
+ * operator wants to see).
+ */
+class ProbeTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`probe exceeded ${timeoutMs}ms`);
+    this.name = "ProbeTimeoutError";
+  }
+}
+
+/**
+ * Race `inflight` against a timeout clock. Resolves with `inflight`'s
+ * value if it settles first, otherwise rejects with `ProbeTimeoutError`.
+ * The timer is cleared in both branches so a fast-resolving probe does
+ * not leak a handle that would keep the Node event loop alive.
+ */
+function probeWithTimeout<T>(
+  inflight: Promise<T>,
+  timeoutMs: number,
+): Promise<T> {
+  let timer: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timer = setTimeout(() => reject(new ProbeTimeoutError(timeoutMs)), timeoutMs);
+    // `.unref()` so the timer does not hold the event loop open if the
+    // caller decides the probe result is no longer interesting.
+    if (typeof (timer as NodeJS.Timeout).unref === "function") {
+      (timer as NodeJS.Timeout).unref();
+    }
+  });
+  return Promise.race([inflight, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -875,21 +875,26 @@ export function parseConfig(raw: unknown): PluginConfig {
     // other boolean config keys (CLAUDE.md rule #36).
     bufferSurpriseTriggerEnabled:
       coerceBool(cfg.bufferSurpriseTriggerEnabled) === true,
-    bufferSurpriseThreshold:
-      typeof cfg.bufferSurpriseThreshold === "number" &&
-      Number.isFinite(cfg.bufferSurpriseThreshold)
-        ? Math.min(1, Math.max(0, cfg.bufferSurpriseThreshold))
-        : 0.35,
-    bufferSurpriseK:
-      typeof cfg.bufferSurpriseK === "number" &&
-      Number.isFinite(cfg.bufferSurpriseK)
-        ? Math.max(1, Math.floor(cfg.bufferSurpriseK))
-        : 5,
-    bufferSurpriseRecentMemoryCount:
-      typeof cfg.bufferSurpriseRecentMemoryCount === "number" &&
-      Number.isFinite(cfg.bufferSurpriseRecentMemoryCount)
-        ? Math.max(0, Math.floor(cfg.bufferSurpriseRecentMemoryCount))
-        : 20,
+    // Numeric surprise knobs go through `coerceNumber` so CLI operators
+    // can pass `--config bufferSurpriseThreshold=0.5` without the string
+    // silently dropping to the default. Matches the coercion contract
+    // applied to other numeric config keys (CLAUDE.md rule #28).
+    bufferSurpriseThreshold: clampSurpriseThreshold(
+      coerceNumber(cfg.bufferSurpriseThreshold),
+      0.35,
+    ),
+    bufferSurpriseK: clampSurpriseK(
+      coerceNumber(cfg.bufferSurpriseK),
+      5,
+    ),
+    bufferSurpriseRecentMemoryCount: clampSurpriseRecentMemoryCount(
+      coerceNumber(cfg.bufferSurpriseRecentMemoryCount),
+      20,
+    ),
+    bufferSurpriseProbeTimeoutMs: clampSurpriseProbeTimeoutMs(
+      coerceNumber(cfg.bufferSurpriseProbeTimeoutMs),
+      2000,
+    ),
     consolidateEveryN:
       typeof cfg.consolidateEveryN === "number" ? cfg.consolidateEveryN : 3,
     highSignalPatterns: Array.isArray(cfg.highSignalPatterns)
@@ -2288,6 +2293,52 @@ function parseBriefingConfig(raw: unknown): import("./types.js").BriefingConfig 
 function clampNonNegativeNumber(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   return Math.max(0, Math.floor(value));
+}
+
+// -----------------------------------------------------------------------------
+// Issue #563 buffer-surprise knobs — shared clamp helpers
+// -----------------------------------------------------------------------------
+//
+// Each helper takes a post-`coerceNumber` value (number | undefined) and a
+// fallback. This keeps the coercion layer (coerce CLI strings → number) and
+// the range layer (clamp to valid domain) cleanly separated — a common
+// source of post-merge fixes when these were inlined (CLAUDE.md rule #28).
+
+function clampSurpriseThreshold(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  // [0, 1] inclusive. 0 means "always flush on any score"; 1 means "never
+  // flush on surprise alone" — both are valid-but-odd configurations.
+  return Math.min(1, Math.max(0, value));
+}
+
+function clampSurpriseK(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  return Math.max(1, Math.floor(value));
+}
+
+function clampSurpriseRecentMemoryCount(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  return Math.max(0, Math.floor(value));
+}
+
+function clampSurpriseProbeTimeoutMs(
+  value: number | undefined,
+  fallback: number,
+): number {
+  if (value === undefined) return fallback;
+  // A zero or negative timeout would either skip the probe entirely or
+  // fire instantly — both surprising behaviors that hide config errors.
+  // Clamp to a minimum of 1ms and round to integer.
+  return Math.max(1, Math.floor(value));
 }
 
 function parseRecallSectionEntry(raw: unknown): RecallSectionConfig {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -867,7 +867,14 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Surprise-gated buffer flush (issue #563, D-MEM). See types.ts for
     // semantics. Default off so PR 2 ships as a pure no-op until an operator
     // opts in. PR 4 benchmarks the flag and may flip the default.
-    bufferSurpriseTriggerEnabled: cfg.bufferSurpriseTriggerEnabled === true,
+    //
+    // Use `coerceBool` rather than a strict `=== true` check: CLI operators
+    // set booleans via `--config bufferSurpriseTriggerEnabled=true` which
+    // arrives as the string `"true"` — the strict form would silently
+    // leave the flag off. Matches the coercion contract established for
+    // other boolean config keys (CLAUDE.md rule #36).
+    bufferSurpriseTriggerEnabled:
+      coerceBool(cfg.bufferSurpriseTriggerEnabled) === true,
     bufferSurpriseThreshold:
       typeof cfg.bufferSurpriseThreshold === "number" &&
       Number.isFinite(cfg.bufferSurpriseThreshold)

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -864,6 +864,25 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.bufferMaxTurns === "number" ? cfg.bufferMaxTurns : 5,
     bufferMaxMinutes:
       typeof cfg.bufferMaxMinutes === "number" ? cfg.bufferMaxMinutes : 15,
+    // Surprise-gated buffer flush (issue #563, D-MEM). See types.ts for
+    // semantics. Default off so PR 2 ships as a pure no-op until an operator
+    // opts in. PR 4 benchmarks the flag and may flip the default.
+    bufferSurpriseTriggerEnabled: cfg.bufferSurpriseTriggerEnabled === true,
+    bufferSurpriseThreshold:
+      typeof cfg.bufferSurpriseThreshold === "number" &&
+      Number.isFinite(cfg.bufferSurpriseThreshold)
+        ? Math.min(1, Math.max(0, cfg.bufferSurpriseThreshold))
+        : 0.35,
+    bufferSurpriseK:
+      typeof cfg.bufferSurpriseK === "number" &&
+      Number.isFinite(cfg.bufferSurpriseK)
+        ? Math.max(1, Math.floor(cfg.bufferSurpriseK))
+        : 5,
+    bufferSurpriseRecentMemoryCount:
+      typeof cfg.bufferSurpriseRecentMemoryCount === "number" &&
+      Number.isFinite(cfg.bufferSurpriseRecentMemoryCount)
+        ? Math.max(0, Math.floor(cfg.bufferSurpriseRecentMemoryCount))
+        : 20,
     consolidateEveryN:
       typeof cfg.consolidateEveryN === "number" ? cfg.consolidateEveryN : 3,
     highSignalPatterns: Array.isArray(cfg.highSignalPatterns)

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -58,6 +58,23 @@ export { StorageManager } from "./storage.js";
 export { ExtractionEngine } from "./extraction.js";
 
 // ---------------------------------------------------------------------------
+// Smart buffer (issue #563)
+// ---------------------------------------------------------------------------
+
+export {
+  SmartBuffer,
+  type TriggerDecision,
+  type BufferSurpriseProbe,
+} from "./buffer.js";
+
+export {
+  computeSurprise,
+  DEFAULT_SURPRISE_K,
+  type RecentMemoryLike,
+  type ComputeSurpriseOptions,
+} from "./buffer-surprise.js";
+
+// ---------------------------------------------------------------------------
 // Extraction Judge (issue #376)
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -314,6 +314,39 @@ export interface PluginConfig {
   triggerMode: TriggerMode;
   bufferMaxTurns: number;
   bufferMaxMinutes: number;
+  /**
+   * Surprise-gated buffer flush (issue #563, D-MEM).
+   *
+   * When enabled, every turn added to the smart buffer is scored against a
+   * configurable window of recent memories using an embedding-distance proxy
+   * for novelty (see `buffer-surprise.ts`). A turn whose surprise score
+   * exceeds `bufferSurpriseThreshold` triggers an immediate extract flush,
+   * even if the existing signal/turn-count/time triggers would otherwise keep
+   * buffering. Disabled by default — when `false`, buffer behavior is
+   * identical to pre-#563 code. Additive only: existing triggers are never
+   * suppressed by this flag.
+   */
+  bufferSurpriseTriggerEnabled: boolean;
+  /**
+   * Threshold in `[0, 1]` above which a surprise score causes an immediate
+   * flush. `0.35` is a conservative default chosen to favor precision over
+   * recall during the opt-in phase. Ignored unless
+   * `bufferSurpriseTriggerEnabled` is `true`.
+   */
+  bufferSurpriseThreshold: number;
+  /**
+   * Number of nearest neighbors to average over when computing the surprise
+   * score (see `computeSurprise`). Default `5`. Clamped to the recent-memory
+   * window size at call time.
+   */
+  bufferSurpriseK: number;
+  /**
+   * Maximum number of recent memories to sample when computing the surprise
+   * score. Bounds embedding cost per turn. Default `20`. Set to `0` to
+   * disable the trigger even when the flag is on (no memories to compare
+   * against → treat as not-applicable rather than maximally surprising).
+   */
+  bufferSurpriseRecentMemoryCount: number;
   consolidateEveryN: number;
   highSignalPatterns: string[];
   maxMemoryTokens: number;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -347,6 +347,14 @@ export interface PluginConfig {
    * against → treat as not-applicable rather than maximally surprising).
    */
   bufferSurpriseRecentMemoryCount: number;
+  /**
+   * Hard timeout (ms) for the surprise probe. If the probe does not
+   * resolve within this window, the buffer treats the probe as failed,
+   * logs at debug, and falls through to the existing triggers. Ensures
+   * a slow or hung embedder cannot stall the turn-append path. Default
+   * `2000` (2s).
+   */
+  bufferSurpriseProbeTimeoutMs: number;
   consolidateEveryN: number;
   highSignalPatterns: string[];
   maxMemoryTokens: number;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -58,6 +58,30 @@
         "default": 15,
         "description": "Max minutes before forced extraction"
       },
+      "bufferSurpriseTriggerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Issue #563 (D-MEM). When true, the smart buffer flushes immediately on turns whose embedding-based surprise score exceeds bufferSurpriseThreshold, in addition to the existing turn-count / signal / time triggers. Additive only — never suppresses existing flushes. Off by default."
+      },
+      "bufferSurpriseThreshold": {
+        "type": "number",
+        "default": 0.35,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Threshold in [0, 1] above which a surprise score flushes the buffer. Higher = require more novelty to flush. Ignored when bufferSurpriseTriggerEnabled is false."
+      },
+      "bufferSurpriseK": {
+        "type": "number",
+        "default": 5,
+        "minimum": 1,
+        "description": "Number of nearest-neighbor memories to average over when computing the surprise score. Clamped to the recent-memory window size."
+      },
+      "bufferSurpriseRecentMemoryCount": {
+        "type": "number",
+        "default": 20,
+        "minimum": 0,
+        "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -82,6 +82,12 @@
         "minimum": 0,
         "description": "Maximum number of recent memories sampled for surprise scoring. Bounds embedding cost per turn. Set to 0 to effectively disable the trigger even when the flag is on."
       },
+      "bufferSurpriseProbeTimeoutMs": {
+        "type": "number",
+        "default": 2000,
+        "minimum": 1,
+        "description": "Hard timeout (ms) for the surprise probe. If the probe does not resolve within this window the buffer treats it as failed and falls through to the existing triggers — a slow or hung embedder cannot stall the turn-append path."
+      },
       "consolidateEveryN": {
         "type": "number",
         "default": 3,


### PR DESCRIPTION
## Summary

Wires the pure `computeSurprise` helper landed in #571 into `SmartBuffer` as a flag-gated, additive flush trigger (issue #563 D-MEM).

When `bufferSurpriseTriggerEnabled` is on and the smart path would otherwise keep buffering, the buffer consults an injected `BufferSurpriseProbe`. A score strictly greater than `bufferSurpriseThreshold` (default `0.35`) upgrades `keep_buffering` → `extract_now`. Probe errors, non-finite scores, and `null` returns all fall through to the existing triggers — the surprise path cannot crash extraction or suppress an already-decided flush.

## New config

All default off or conservative — with the flag off, behavior is byte-identical to pre-#563 code:

| Key | Type | Default | Purpose |
|---|---|---|---|
| `bufferSurpriseTriggerEnabled` | bool | `false` | Master switch |
| `bufferSurpriseThreshold` | number | `0.35` | Strict `>` comparator |
| `bufferSurpriseK` | number | `5` | kNN depth for the score |
| `bufferSurpriseRecentMemoryCount` | number | `20` | Embedding cost bound |

Wired into all 3 `openclaw.plugin.json` schemas with matching bounds.

## Notes

- Orchestrator wiring of a real embedder-backed probe is deferred to PR 3 (telemetry) — this PR ships the pure SmartBuffer mechanism and the probe contract, gated off.
- Additive-only invariant is tested: a probe returning `0` cannot demote an `extract_batch` decision from the turn-count rule.
- Non-smart trigger modes (`every_n`, `time_based`) intentionally ignore surprise — they are explicit operator choices.

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/buffer-surprise-trigger.test.ts` — 12/12 pass
- [x] `npx tsx --test packages/remnic-core/src/buffer-session.test.ts packages/remnic-core/src/buffer-surprise.test.ts` — 23/23 pass (no regressions)
- [x] `tsc --noEmit` clean in `@remnic/core`
- [x] All three `openclaw.plugin.json` files parse as JSON

Refs #563
Part 2 of 4 (follows #571).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new decision logic in `SmartBuffer.addTurn()` that can change extraction frequency when enabled, including async probe calls with timeouts and error handling. Risk is mitigated by being flag-gated and default-off, but incorrect probe integration/config could still affect buffering behavior and performance.
> 
> **Overview**
> Adds an **optional surprise-based flush trigger** to `SmartBuffer`: when `triggerMode` is `smart` and the existing logic would `keep_buffering`, the buffer can consult an injected `BufferSurpriseProbe` and upgrade the decision to `extract_now` when the returned score is strictly `>` `bufferSurpriseThreshold`.
> 
> Introduces new config knobs (`bufferSurpriseTriggerEnabled`, `bufferSurpriseThreshold`, `bufferSurpriseK`, `bufferSurpriseRecentMemoryCount`, `bufferSurpriseProbeTimeoutMs`) with coercion/clamping in `parseConfig`, publishes them in the `openclaw.plugin.json` schemas, and adds a comprehensive test suite covering gating, additive-only behavior, failure/timeout isolation, and config coercion. Also exports `SmartBuffer`/probe types and `computeSurprise` from `@remnic/core` for external probe wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc0a08146eb05ac3efa5149f62704a28887a5cc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->