### PR TITLE
docs: add coding-agent.md + xray.md (#569, #570)

### DIFF
--- a/docs/coding-agent.md
+++ b/docs/coding-agent.md
@@ -1,0 +1,274 @@
+# Coding agent mode
+
+Issue [#569](https://github.com/joshuaswarren/remnic/issues/569) teaches
+Remnic to auto-scope memory by git project — and optionally by branch —
+so that what an agent learns while working on project A does not surface
+while working on project B. No environment variables, no per-client
+scripting, no manual namespace flags. If the session has a working
+directory inside a git repository, coding mode activates automatically.
+
+This document covers the surfaces that ship today:
+
+1. The `codingMode.projectScope` and `codingMode.branchScope` config
+   knobs and their defaults.
+2. How the overlay is computed from git (`GitContext`) and combined
+   with the principal's base namespace.
+3. How `remnic doctor` renders the effective scope.
+4. The `engram.set_coding_context` MCP tool (with the
+   `remnic.set_coding_context` alias) for MCP clients that do not ship
+   `cwd` automatically.
+5. The diff-aware **review-context** recall tier that boosts memories
+   whose `entityRefs` mention a touched file.
+6. Per-connector behavior (Claude Code, Codex CLI, Cursor / MCP).
+7. How to opt out.
+
+## Overview
+
+Session-scoped overlay. When a session attaches a `CodingContext`
+(`{ projectId, branch, rootPath, defaultBranch }`) Remnic computes an
+overlay namespace using the pure resolver in
+[`packages/remnic-core/src/coding/coding-namespace.ts`](../packages/remnic-core/src/coding/coding-namespace.ts).
+The overlay is then combined with the principal's existing base
+namespace so that principal isolation (rule 42) still holds:
+
+```text
+alice + project-origin-ab12  →  alice-project-origin-ab12
+bob   + project-origin-ab12  →  bob-project-origin-ab12
+```
+
+Writes always land in the combined overlay namespace. Reads use the
+overlay plus any declared read-fallbacks, which is how branch-scoped
+sessions stay able to see project-level history.
+
+Pure functions, deterministic hashes, no per-call I/O. The overlay only
+changes when the connector hands Remnic a new `CodingContext`.
+
+## Config surface
+
+`codingMode` is a nested object under the plugin config:
+
+| Key                       | Default | Behavior |
+|---------------------------|---------|----------|
+| `codingMode.projectScope` | `true`  | When true, every session with a resolved `CodingContext` uses a project-scoped namespace. When false, the principal's default namespace is used unchanged — exact pre-#569 behavior (CLAUDE.md rule 30 escape hatch). |
+| `codingMode.branchScope`  | `false` | When true, additionally overlay the current branch on top of the project namespace. Project-level reads remain visible to a branch-scoped session through `readFallbacks`; branch writes do not leak up to project scope. |
+
+Branch scope depends on project scope being on — there is no
+branch-only mode. In detached-HEAD state (`branch === null`) the
+branch overlay silently degrades to project-only; Remnic never
+fabricates a branch name.
+
+The types live in
+[`packages/remnic-core/src/types.ts`](../packages/remnic-core/src/types.ts)
+(`CodingModeConfig`, lines 215-229).
+
+## How projectId is derived
+
+[`packages/remnic-core/src/coding/git-context.ts`](../packages/remnic-core/src/coding/git-context.ts)
+contains `resolveGitContext(cwd)` which, given a tilde-expanded
+absolute cwd, runs a short sequence of `git` commands (2s timeout
+each, see line 86) and returns a `GitContext`:
+
+- `projectId` — a stable identifier for the repo. Formatted as
+  `origin:<8hex>` when a remote origin is configured, or
+  `root:<8hex>` when only a local repo exists. The hash is FNV-1a
+  32-bit (line 120). Two clones of the same `github.com/foo/bar`
+  repo collapse to the same id because the origin URL is normalized
+  (`normalizeOriginUrl`, line 145): SSH, HTTPS, protocol-prefixed and
+  scp-style forms of the same repo all produce one id.
+- `branch` — the current branch, or `null` in detached HEAD.
+- `rootPath` — the absolute repo root, tilde-expanded.
+- `defaultBranch` — derived from
+  `refs/remotes/origin/HEAD` when available, otherwise `null`.
+
+`resolveGitContext` is documented as "never throws" (line 252). When
+`git` is not on PATH, when the cwd is outside a git worktree, or when
+an invoker fails, the resolver returns `null` and coding mode remains
+inactive for that session.
+
+## `remnic doctor` output
+
+`remnic doctor` surfaces the effective coding scope. The description is
+built by `describeCodingScope()` in
+[`coding-namespace.ts`](../packages/remnic-core/src/coding/coding-namespace.ts)
+(lines 327-387) and shows:
+
+- The raw `projectId` / `branch` from the attached `CodingContext`.
+- The resolved `scope` — `"none"`, `"project"`, or `"branch"`.
+- The `effectiveNamespace` that writes will route through (the
+  principal-combined form).
+- Any `readFallbacks` (only populated when branch-scope is active).
+- A `disabledReason` when `scope === "none"`, one of:
+  - `"no-context"` — the connector did not attach a `CodingContext`
+    (session started outside a repo, or using a connector that can't
+    ship `cwd`).
+  - `"disabled"` — `codingMode.projectScope` is `false`.
+  - `"empty-project"` — the attached `CodingContext.projectId` was
+    empty or whitespace (defensive).
+
+Example doctor block (synthetic):
+
+```
+- [OK] coding_scope: project scope active
+  projectId: origin:ab12cd34
+  branch: feat/issue-569
+  scope: project
+  effectiveNamespace: alice-project-origin-ab12cd34
+  readFallbacks: (none)
+```
+
+When branch-scope is on:
+
+```
+- [OK] coding_scope: branch scope active
+  projectId: origin:ab12cd34
+  branch: feat/issue-569
+  scope: branch
+  effectiveNamespace: alice-project-origin-ab12cd34-branch-feat-issue-569
+  readFallbacks: alice-project-origin-ab12cd34
+```
+
+When the overlay is disabled:
+
+```
+- [WARN] coding_scope: no overlay applied
+  disabledReason: no-context
+```
+
+## MCP tool: `engram.set_coding_context`
+
+Registered by the MCP access surface at
+[`packages/remnic-core/src/access-mcp.ts`](../packages/remnic-core/src/access-mcp.ts)
+(lines 128-160, handler at 1182-1217). Canonical name
+`engram.set_coding_context`; `withToolAliases` emits the canonical
+`remnic.set_coding_context` alias automatically so both names work.
+
+Purpose: attach or clear a session's `CodingContext` from an MCP client
+that cannot ship `cwd` on its own (Cursor, generic MCP agents, etc.).
+
+Input schema:
+
+```json
+{
+  "sessionKey": "string",
+  "codingContext": {
+    "projectId": "origin:<8hex> or root:<8hex>",
+    "branch": "main | null",
+    "rootPath": "/abs/path",
+    "defaultBranch": "main | null"
+  }
+}
+```
+
+Pass `codingContext: null` to clear the session's context — useful when
+an agent moves between projects mid-session or when an operator wants to
+drop back to the principal's default namespace without restarting.
+
+Validation happens in
+[`access-service.ts`](../packages/remnic-core/src/access-service.ts)
+`setCodingContext(...)`; invalid inputs surface as
+`EngramAccessInputError` (structured MCP tool-call errors) instead of
+silent no-ops.
+
+## Review-context recall tier
+
+[`packages/remnic-core/src/coding/review-context.ts`](../packages/remnic-core/src/coding/review-context.ts)
+(PR 4 of #569) ships a pure diff-aware packer that piggybacks on a
+normal recall:
+
+1. `isReviewPrompt(prompt)` — a case-insensitive whole-word match on
+   `review`, `diff`, `what changed`, `look at this PR`, `code review`,
+   and paraphrases (lines 75-82). When false, the tier is skipped.
+2. `parseTouchedFiles(diff)` — accepts both `diff --git a/foo b/bar`
+   and `--- a/foo / +++ b/bar` forms, honors git's C-quoted path
+   escapes, and strips `a/` / `b/` prefixes. Returns deduplicated,
+   sorted, repo-root-relative paths.
+3. `rankReviewCandidates(candidates, touchedFiles)` — additive boost
+   (`+0.5` per matching touched file, capped at `+1.0`) applied to
+   candidates whose `entityRefs` substring-match any touched file.
+   Sort is `(score + boost)` descending with a stable secondary key
+   on the memory id (rule 19).
+
+The tier is a **bias, not a filter**: it re-orders the existing
+recall candidate list; it never removes candidates. Memories whose
+`entityRefs` mention a touched file float up, so an agent reviewing a
+PR sees prior decisions about those exact files first.
+
+## Per-connector behavior
+
+### Claude Code (ships today)
+
+[`packages/plugin-claude-code/hooks/bin/session-start.sh`](../packages/plugin-claude-code/hooks/bin/session-start.sh)
+(lines 54-150) reads `cwd` from the session-start payload, runs a
+short local `git` sequence, and posts an
+`engram.set_coding_context` tool call to the Remnic daemon. The hook
+intentionally mirrors the pure logic of `resolveGitContext` in-shell
+so it does not round-trip through the daemon before the first recall.
+On any failure (`git` missing, cwd outside a repo, daemon unreachable)
+it silently clears the context rather than blocking session startup.
+
+### Codex CLI (ships today)
+
+The Codex CLI connector's session-start hook follows the same pattern:
+resolve the git context for the shell's cwd, post
+`engram.set_coding_context`, silently no-op on failure. See
+[`packages/plugin-codex/`](../packages/plugin-codex/) for the hook.
+
+### Cursor / generic MCP (manual)
+
+Cursor and other MCP clients that do not expose a cwd hook can still
+attach a coding context by calling `engram.set_coding_context` as their
+first action in a session. The operator (or the agent itself) passes a
+`CodingContext` object matching the schema above. Pass
+`codingContext: null` to clear it before switching projects.
+
+## Opting out
+
+Two paths:
+
+- **Per-install:** set `codingMode.projectScope: false` in plugin
+  config. No project overlay is applied anywhere. This exactly restores
+  pre-#569 behavior (rule 30 escape hatch).
+- **Per-session:** call `engram.set_coding_context` with
+  `codingContext: null`. The session reverts to the principal's
+  default namespace until a new context is attached.
+
+`codingMode.branchScope` inherits the project-scope gate: setting
+`projectScope: false` disables branch scope too, regardless of
+`branchScope`.
+
+## Troubleshooting
+
+- **Cross-principal isolation** — two principals working in the same
+  repo get distinct namespaces because the overlay is *combined* with
+  the principal's base fragment (`sanitizeBaseFragment` preserves case
+  so `Alice` and `alice` do not collapse). If you see two principals
+  sharing memories, confirm `namespacesEnabled: true` — with
+  namespaces disabled the storage router maps every namespace to the
+  same `memoryDir`, so the overlay is deliberately a no-op to avoid a
+  false-isolation trap (orchestrator lines 1420-1425).
+- **Case-insensitive filesystems** — the overlay is always
+  lowercased and `[A-Za-z0-9._-]`-sanitized, so a repo cloned with
+  different casing on a case-insensitive filesystem produces the same
+  `projectId` (origin URL is normalized) and the same overlay
+  namespace.
+- **Git timeouts** — each git invocation is bounded at 2 seconds
+  (`DEFAULT_GIT_TIMEOUT_MS`, line 86). If `git` hangs longer than that
+  the resolver returns `null` and the session proceeds without an
+  overlay. Spurious "no overlay" entries in `remnic doctor` across
+  slow filesystems usually trace here; increase filesystem responsiveness
+  or pre-warm the repo rather than raising the timeout.
+- **Detached HEAD** — `branch` is `null`. With `branchScope: true`
+  the overlay silently falls back to project-only; the doctor output
+  will show `scope: project` with `branch: null` as a hint.
+- **Long branch names** — overlay namespaces are capped at 64
+  characters with a deterministic hash suffix (`capLength`, line 113),
+  so two distinct long branches never collapse to one namespace through
+  simple prefix truncation.
+
+## Related reading
+
+- [`docs/namespaces.md`](./namespaces.md) — the underlying namespace
+  system coding mode overlays on top of.
+- [`packages/remnic-core/src/coding/git-context.ts`](../packages/remnic-core/src/coding/git-context.ts) — `resolveGitContext` and origin URL normalization.
+- [`packages/remnic-core/src/coding/coding-namespace.ts`](../packages/remnic-core/src/coding/coding-namespace.ts) — overlay resolver and diagnostic surface.
+- [`packages/remnic-core/src/coding/review-context.ts`](../packages/remnic-core/src/coding/review-context.ts) — diff-aware review-context packer.

--- a/docs/xray.md
+++ b/docs/xray.md
@@ -1,0 +1,301 @@
+# Recall X-ray
+
+Issue [#570](https://github.com/joshuaswarren/remnic/issues/570) adds a
+unified per-result attribution snapshot for recalls. After any recall,
+an X-ray capture tells you **exactly why each memory surfaced** — which
+retrieval tier served it, how its score decomposed, every filter it
+passed (and the first filter that would have rejected it), any graph
+path traversed, the audit-log entry id, and the character budget the
+final payload consumed.
+
+Most competitors treat retrieval as a black box. Remnic X-ray makes the
+whole ladder legible in one snapshot that is rendered identically by
+the CLI, HTTP, and MCP surfaces — so what an operator reads in a
+terminal matches byte-for-byte what an agent reads over MCP.
+
+## How to run
+
+```sh
+remnic xray "<query>" [--format json|text|markdown] [--budget N] [--namespace ns] [--out file]
+```
+
+CLI surface defined in
+[`packages/remnic-core/src/cli.ts`](../packages/remnic-core/src/cli.ts)
+(lines 4015-4076). The handler delegates to a shared
+`EngramAccessService.recallXray(...)` so the CLI, HTTP, and MCP
+surfaces share the same `xrayQueue` mutex and cannot race each other
+(rules 40 and 47).
+
+Flags:
+
+- `<query>` (required, non-empty). Validated by `parseXrayCliOptions`
+  in
+  [`packages/remnic-core/src/recall-xray-cli.ts`](../packages/remnic-core/src/recall-xray-cli.ts)
+  (lines 52-77) — an empty or missing query throws a listed-options
+  error rather than silently defaulting.
+- `--format` — `text` (default), `markdown`, or `json`. Unknown
+  values raise an error that lists the valid options
+  (`parseXrayFormat`, `recall-xray-renderer.ts` lines 40-52).
+- `--budget <chars>` — positive integer override for the recall
+  character budget on this single call. Not a positive integer →
+  rejected at the CLI boundary (rules 14 and 51).
+- `--namespace <ns>` — override the namespace to scope this recall
+  against.
+- `--out <path>` — write the rendered snapshot to a file instead of
+  stdout. The path is tilde-expanded (rule 17).
+
+### Sample output
+
+The following is a synthetic example of a text-format X-ray for a
+review-context-augmented recall. Exact field ordering and spacing are
+stable under the renderer's golden tests (lines 93-139 of
+`recall-xray-renderer.ts`).
+
+```
+=== Recall X-ray ===
+query: what did we decide about the recall cache TTL
+snapshot-id: 5f6b1a2c-9d8e-4c01-8f3a-1b2c3d4e5f60
+captured-at: 2026-04-20T17:30:00.000Z
+session: agent-session-42
+namespace: alice-project-origin-ab12cd34
+trace-id: trace-7c1f
+budget: 5284 / 8192 chars
+
+--- filters ---
+- namespace-scope: 12/12 admitted
+- status-active: 11/12 admitted (rejected superseded)
+- trust-zone: 11/11 admitted
+- token-overlap: 7/11 admitted (below-token-overlap-floor)
+- mmr-diversify: 4/7 admitted
+- budget-fit: 4/4 admitted
+
+--- results ---
+[1] decisions/recall-cache-ttl — served-by=direct-answer
+    path: decisions/recall-cache-ttl.md
+    score: final=0.8912 importance=0.6000 tier_prior=0.3000
+    admitted-by: namespace-scope, status-active, trust-zone, token-overlap
+    audit-entry: audit-0e4a1b
+[2] decisions/recall-cache-eviction — served-by=hybrid
+    path: decisions/recall-cache-eviction.md
+    score: final=0.7204 vector=0.5812 bm25=0.4733 mmr_penalty=0.0400
+    admitted-by: namespace-scope, status-active, trust-zone, token-overlap, mmr-diversify
+    audit-entry: audit-0e4a1c
+[3] notes/perf-regression-2026-03 — served-by=graph
+    path: notes/perf-regression-2026-03.md
+    score: final=0.6187 vector=0.4910 tier_prior=0.1500
+    graph-path: recall-cache-ttl -> related-to -> perf-regression-2026-03
+    admitted-by: namespace-scope, status-active, trust-zone, mmr-diversify
+    audit-entry: audit-0e4a1d
+[4] notes/branch-observations — served-by=review-context
+    path: notes/branch-observations.md
+    score: final=0.5500 vector=0.3200 importance=0.3000
+    admitted-by: namespace-scope, status-active, trust-zone, mmr-diversify
+    rejected-by: below-token-overlap-floor
+    audit-entry: audit-0e4a1e
+
+--- tier explain ---
+tier: direct-answer
+reason: trusted decisions, unambiguous, token-overlap 0.86
+candidates-considered: 4
+latency-ms: 8
+filtered-by: below-token-overlap-floor
+source-anchors:
+  - decisions/recall-cache-ttl.md:10-14
+```
+
+The markdown format is structurally identical but rendered as GitHub
+tables + H2/H3 sections; the JSON format is the raw
+`RecallXraySnapshot` serialized under a `{ snapshotFound: true, ... }`
+envelope.
+
+## JSON schema
+
+The canonical v1 shape lives in
+[`packages/remnic-core/src/recall-xray.ts`](../packages/remnic-core/src/recall-xray.ts).
+A stable `schemaVersion: "1"` tag on every snapshot (line 118) lets
+downstream consumers version-gate their parsers.
+
+### `RecallXraySnapshot` (lines 116-142)
+
+```ts
+interface RecallXraySnapshot {
+  schemaVersion: "1";
+  query: string;
+  snapshotId: string;          // UUID minted per capture
+  capturedAt: number;          // epoch ms
+  tierExplain: RecallTierExplain | null;
+  results: RecallXrayResult[];
+  filters: RecallFilterTrace[];
+  budget: { chars: number; used: number };  // non-negative ints
+  sessionKey?: string;
+  namespace?: string;
+  traceId?: string;
+}
+```
+
+### `RecallXrayResult` (lines 80-96)
+
+```ts
+interface RecallXrayResult {
+  memoryId: string;
+  path: string;
+  servedBy:
+    | "direct-answer"
+    | "hybrid"
+    | "graph"
+    | "recent-scan"
+    | "procedural"
+    | "review-context";
+  scoreDecomposition: RecallXrayScoreDecomposition;
+  graphPath?: string[];
+  auditEntryId?: string;
+  admittedBy: string[];      // filters the candidate passed
+  rejectedBy?: string;       // first filter that would have rejected
+}
+```
+
+### `RecallXrayScoreDecomposition` (lines 68-75)
+
+```ts
+interface RecallXrayScoreDecomposition {
+  vector?: number;
+  bm25?: number;
+  importance?: number;
+  mmrPenalty?: number;
+  tierPrior?: number;
+  final: number;             // the only guaranteed field
+}
+```
+
+Different tiers populate different terms. `hybrid` typically reports
+`vector` + `bm25` + `mmrPenalty`; `direct-answer` reports `importance`
++ `tierPrior`. The renderer formats each known field with four decimal
+places and keeps the line stable across missing fields.
+
+### `RecallFilterTrace` (lines 104-110)
+
+```ts
+interface RecallFilterTrace {
+  name: string;
+  considered: number;        // admitted + rejected
+  admitted: number;
+  reason?: string;           // human-readable rejection summary
+}
+```
+
+The `servedBy` union is orthogonal to the `RetrievalTier` enum used by
+issue #518's tier-explain surface. The two sets stay separate on
+purpose so the observability contracts can evolve independently;
+`tierExplain` is carried verbatim inside the X-ray snapshot when the
+direct-answer tier ran.
+
+## HTTP surface
+
+```
+GET /engram/v1/recall/xray?q=<query>[&session=<key>][&namespace=<ns>][&budget=<chars>]
+```
+
+Defined in
+[`packages/remnic-core/src/access-http.ts`](../packages/remnic-core/src/access-http.ts)
+(lines 403-477). The route is `GET` so proxies can cache the response
+by full URL; all recall parameters are query-string fields. Bearer
+auth is enforced identically to the rest of `/engram/v1/*`, and the
+namespace is resolved through `resolveNamespace(...)` before the
+orchestrator runs — the same scope layer the write path uses, so there
+is no cross-namespace read leak (rule 42).
+
+Content negotiation: the endpoint currently returns JSON
+(`respondJson`). CLI and operator callers who want the markdown or
+text rendering compute it locally via `renderXray(snapshot, format)`
+from the shared renderer.
+
+Validation errors surface as `400`s with an `error`/`code`/`message`
+triple (missing query, invalid budget). Backend faults bubble to the
+global `handle()` catch so they return `500` with a logged trace id.
+
+## MCP tool
+
+Registered as `engram.recall_xray` in
+[`packages/remnic-core/src/access-mcp.ts`](../packages/remnic-core/src/access-mcp.ts)
+(lines 180-207, handler at 1228-1280). `withToolAliases` emits
+`remnic.recall_xray` as the canonical alias automatically — the
+dual-name invariant that every new MCP tool ships with.
+
+Input schema accepts `query` (required), `sessionKey`, `namespace`,
+and `budget`. Validation errors are surfaced as MCP tool-call errors
+listing the valid options instead of silently returning
+`snapshotFound: false`.
+
+Response shape matches the HTTP surface exactly:
+
+```json
+{
+  "snapshotFound": true,
+  "snapshot": { /* RecallXraySnapshot */ }
+}
+```
+
+When the orchestrator does not produce a snapshot (capture disabled,
+session scope mismatch), the response is `{ "snapshotFound": false }`.
+
+## Legacy `/recall/explain` markdown delegation
+
+Issue #518 introduced `recall/explain` with `text` and `json` formats
+that surface a single-session tier snapshot. Issue #570 PR 7 adds a
+`markdown` format to that same surface — and rather than duplicate the
+rendering logic, the explain renderer delegates to the shared X-ray
+markdown renderer when `format === "markdown"`. See
+[`packages/remnic-core/src/recall-explain-renderer.ts`](../packages/remnic-core/src/recall-explain-renderer.ts)
+(lines 29-35, 239-340).
+
+This is backwards-compatible. Existing `text` and `json` callers see
+no change — the markdown branch is additive. The adapter at
+`toRecallXraySnapshotFromLegacy(...)` maps the
+`LastRecallSnapshot` shape into the X-ray snapshot shape so the
+renderer's single code path handles both surfaces (CLAUDE.md rule 22:
+one renderer, not three).
+
+The orthogonality from #518 is preserved: `recall/explain` still
+returns a single-session snapshot; `recall/xray` captures a fresh
+snapshot against an arbitrary query. They answer different questions
+and live at different URLs.
+
+## Observability positioning
+
+Most memory / retrieval systems treat recall as a black box. You see
+what the system returned; you do not see why, which filters it applied,
+or how close a rejected candidate came to being admitted. X-ray makes
+the retrieval ladder legible:
+
+- **Per-result attribution** — every returned memory carries its
+  `servedBy` tier, score decomposition, and the ordered list of
+  filters it passed, with the first rejecting filter tracked even for
+  admitted results (when one exists).
+- **Filter ladder** — the snapshot records every gate the orchestrator
+  ran with `considered` and `admitted` counts, so you can see exactly
+  where candidates are being dropped.
+- **Budget accounting** — `budget.used` / `budget.chars` shows what
+  fraction of the recall budget the final payload consumed, so
+  over-long or too-sparse recalls are diagnosable without log diving.
+- **Audit correlation** — each result carries an `auditEntryId` that
+  cross-references the standard audit log; you can follow a recall
+  from X-ray to the recall-audit trail to the storage operation.
+- **Tier-explain inline** — when the direct-answer tier ran, its
+  `RecallTierExplain` block is carried verbatim inside the snapshot
+  so the filter ladder and the tier verdict live side by side.
+
+For one-off investigations operators run `remnic xray "<query>"`. For
+systemic observability they consume the MCP tool or HTTP endpoint and
+stream snapshots into their own analytics pipeline — the JSON shape is
+stable under `schemaVersion: "1"`.
+
+## Related reading
+
+- [Retrieval Explain](./retrieval-explain.md) — issue #518's
+  single-session tier-explain surface. The `markdown` format there now
+  delegates to the X-ray renderer.
+- [Advanced Retrieval](./advanced-retrieval.md) — the tiers whose
+  output X-ray attributes.
+- [`packages/remnic-core/src/recall-xray.ts`](../packages/remnic-core/src/recall-xray.ts) — schema, builder, and pure factories.
+- [`packages/remnic-core/src/recall-xray-renderer.ts`](../packages/remnic-core/src/recall-xray-renderer.ts) — shared text / markdown / JSON renderer used by CLI, HTTP, and MCP.
+- [`packages/remnic-core/src/recall-xray-cli.ts`](../packages/remnic-core/src/recall-xray-cli.ts) — `--format` / `--budget` / `--namespace` / `--out` validation.


### PR DESCRIPTION
## Summary

Closes documentation gaps for two shipped subsystems identified by the #569/#570 audit. Docs-only PR; no code changes.

- `docs/coding-agent.md` — covers issue #569: `codingMode.projectScope`/`branchScope` defaults and semantics, how `GitContext` + `projectId` is derived, the `engram.set_coding_context` MCP tool (with `remnic.*` alias), the diff-aware review-context recall tier, `remnic doctor` effective-scope rendering, per-connector behavior (Claude Code + Codex session-start hooks, Cursor/MCP manual), and opt-out paths. Cites line numbers in `packages/remnic-core/src/coding/git-context.ts`, `coding/review-context.ts`, and `coding-namespace.ts`.
- `docs/xray.md` — covers issue #570: `remnic xray` CLI with `--format`/`--budget`/`--namespace`/`--out`, `GET /engram/v1/recall/xray`, the `engram.recall_xray` MCP tool (with `remnic.*` alias), full `RecallXraySnapshot` / `RecallXrayResult` / `RecallXrayScoreDecomposition` / `RecallFilterTrace` schemas, how legacy `/recall/explain` markdown mode now delegates to the shared X-ray renderer (backwards-compatible), and observability positioning. Cites line numbers in `packages/remnic-core/src/recall-xray.ts`, `recall-xray-renderer.ts`, `recall-xray-cli.ts`, `access-http.ts`, `access-mcp.ts`, `cli.ts`, and `recall-explain-renderer.ts`.

Synthetic sample output only (markdown + text X-ray renderings); no personal data.

## Test plan

- [x] New markdown files render without broken relative links (all references point to in-repo paths).
- [x] No code changes; `check-types` trivially passes for docs-only PR.
- [x] No personal data, no secrets, no API keys. Synthetic examples use `origin:ab12cd34`-style placeholders.
- [ ] CI docs checks green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change adding two new guides; no runtime behavior or API contracts are modified.
> 
> **Overview**
> Adds two new documentation pages: `docs/coding-agent.md` (git project/branch-scoped “coding mode” namespaces, `engram.set_coding_context`, review-context recall biasing, and `remnic doctor` scope output) and `docs/xray.md` (how to use the Recall X-ray CLI/HTTP/MCP surfaces plus the snapshot schema and legacy `recall/explain` markdown delegation).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a9f9fd994d65be539646921fc5f3341c3b2c56c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->