### PR TITLE
feat(core): extractGraphEdges for retrieval graph (issue #559 PR 2/5)

### DIFF
--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -3,11 +3,14 @@ import test from "node:test";
 
 import {
   type EdgeType,
+  type MemoryEdgeSource,
   type NodeType,
   type QueryGraphResult,
   type RemnicGraph,
   type RemnicGraphEdge,
   type RemnicGraphNode,
+  buildGraphFromMemories,
+  extractGraphEdges,
   isEdgeType,
   isNodeType,
   queryGraph,
@@ -123,4 +126,230 @@ test("isEdgeType rejects unknown values", () => {
   assert.equal(isEdgeType(undefined), false);
   assert.equal(isEdgeType(0), false);
   assert.equal(isEdgeType({ type: "references" }), false);
+});
+
+// ---------------------------------------------------------------------------
+// Edge extraction (PR 2)
+// ---------------------------------------------------------------------------
+
+test("extractGraphEdges returns empty result for empty input", () => {
+  const { nodes, edges } = extractGraphEdges([]);
+  assert.equal(nodes.size, 0);
+  assert.equal(edges.length, 0);
+});
+
+test("extractGraphEdges registers a memory node per input", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1" },
+    { id: "m2" },
+    { id: "m3" },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  assert.equal(nodes.size, 3);
+  assert.equal(nodes.get("m1")?.type, "memory");
+  assert.equal(nodes.get("m2")?.type, "memory");
+  assert.equal(nodes.get("m3")?.type, "memory");
+  assert.equal(edges.length, 0);
+});
+
+test("extractGraphEdges produces a supersedes edge when target is known", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-new", supersedes: "m-old" },
+    { id: "m-old" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  assert.equal(edges.length, 1);
+  assert.deepEqual(edges[0], { from: "m-new", to: "m-old", type: "supersedes" });
+});
+
+test("extractGraphEdges skips dangling supersedes unless includeDanglingEdges is set", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-new", supersedes: "m-missing" },
+  ];
+  const skipped = extractGraphEdges(memories);
+  assert.equal(skipped.edges.length, 0);
+
+  const kept = extractGraphEdges(memories, { includeDanglingEdges: true });
+  assert.equal(kept.edges.length, 1);
+  assert.equal(kept.edges[0]?.type, "supersedes");
+  assert.equal(kept.nodes.get("m-missing")?.type, "memory");
+});
+
+test("extractGraphEdges emits derived-from edges from lineage and derived_from", () => {
+  const memories: MemoryEdgeSource[] = [
+    {
+      id: "m-child",
+      lineage: ["m-parent-1"],
+      derived_from: ["m-parent-2:3", "m-parent-3"],
+    },
+    { id: "m-parent-1" },
+    { id: "m-parent-2" },
+    { id: "m-parent-3" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  const derived = edges.filter((e) => e.type === "derived-from");
+  assert.equal(derived.length, 3);
+  const targets = derived.map((e) => e.to).sort();
+  assert.deepEqual(targets, ["m-parent-1", "m-parent-2", "m-parent-3"]);
+});
+
+test("extractGraphEdges strips trailing :<version> only when numeric", () => {
+  const memories: MemoryEdgeSource[] = [
+    {
+      id: "m-child",
+      derived_from: ["facts/preferences.md:7", "entity:person:Jane"],
+    },
+    { id: "facts/preferences.md" },
+    { id: "entity:person:Jane" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  const derived = edges.filter((e) => e.type === "derived-from").map((e) => e.to).sort();
+  assert.deepEqual(derived, ["entity:person:Jane", "facts/preferences.md"]);
+});
+
+test("extractGraphEdges dedupes identical edges from overlapping lineage and derived_from", () => {
+  const memories: MemoryEdgeSource[] = [
+    {
+      id: "m-child",
+      lineage: ["m-parent"],
+      derived_from: ["m-parent:1", "m-parent:2"],
+    },
+    { id: "m-parent" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  const derived = edges.filter((e) => e.type === "derived-from");
+  assert.equal(derived.length, 1);
+});
+
+test("extractGraphEdges creates entity nodes and mentions edges from entityRef / entityRefs", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", entityRef: "person:Jane" },
+    { id: "m2", entityRefs: ["person:Jane", "org:Acme"] },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  assert.equal(nodes.get("person:Jane")?.type, "entity");
+  assert.equal(nodes.get("org:Acme")?.type, "entity");
+
+  const mentions = edges.filter((e) => e.type === "mentions");
+  assert.equal(mentions.length, 3);
+  const pairs = mentions.map((e) => `${e.from}->${e.to}`).sort();
+  assert.deepEqual(pairs, [
+    "m1->person:Jane",
+    "m2->org:Acme",
+    "m2->person:Jane",
+  ]);
+});
+
+test("extractGraphEdges parses inline [Source: agent=...] blocks into authored-by edges", () => {
+  const memories: MemoryEdgeSource[] = [
+    {
+      id: "m1",
+      content: "Fact body. [Source: agent=planner, session=abc, ts=2026-04-10T14:25:07Z]",
+    },
+    {
+      id: "m2",
+      content: "Multi-citation [Source: agent=extractor] and [Source: agent=judge]",
+    },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  const authored = edges.filter((e) => e.type === "authored-by");
+  const pairs = authored.map((e) => `${e.from}->${e.to}`).sort();
+  assert.deepEqual(pairs, [
+    "m1->agent:planner",
+    "m2->agent:extractor",
+    "m2->agent:judge",
+  ]);
+  assert.equal(nodes.get("agent:planner")?.type, "entity");
+  assert.equal(nodes.get("agent:extractor")?.type, "entity");
+  assert.equal(nodes.get("agent:judge")?.type, "entity");
+});
+
+test("extractGraphEdges ignores malformed citations with no agent field", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", content: "[Source: session=abc, ts=2026-01-01T00:00:00Z]" },
+    { id: "m2", content: "[Source:]" },
+    { id: "m3", content: "[Source: agent=]" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  assert.equal(edges.filter((e) => e.type === "authored-by").length, 0);
+});
+
+test("extractGraphEdges does not emit self-loops", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", supersedes: "m1", lineage: ["m1"], derived_from: ["m1:1"] },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  assert.equal(edges.length, 0);
+});
+
+test("extractGraphEdges is deterministic across invocations", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-a", lineage: ["m-b", "m-c"], entityRefs: ["x", "y"] },
+    { id: "m-b" },
+    { id: "m-c" },
+    { id: "m-d", supersedes: "m-a", content: "[Source: agent=alpha]" },
+  ];
+  const first = extractGraphEdges(memories);
+  const second = extractGraphEdges(memories);
+  assert.deepEqual(first.edges, second.edges);
+  assert.deepEqual([...first.nodes.keys()], [...second.nodes.keys()]);
+});
+
+test("extractGraphEdges returns a realistic 8-memory fixture end-to-end", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", entityRef: "person:Jane" },
+    { id: "m2", entityRef: "person:Jane", content: "[Source: agent=extractor]" },
+    { id: "m3", lineage: ["m1", "m2"], entityRefs: ["person:Jane", "org:Acme"] },
+    { id: "m4", supersedes: "m3", derived_from: ["m3:1"] },
+    { id: "m5", entityRef: "org:Acme", content: "[Source: agent=judge]" },
+    { id: "m6", lineage: ["m4"], entityRefs: ["person:Bob"] },
+    { id: "m7", derived_from: ["m6:2"] },
+    { id: "m8" },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+
+  // 8 memory nodes + 3 distinct entities + 2 distinct agents = 13 nodes.
+  assert.equal(nodes.size, 13);
+  const memoryNodes = [...nodes.values()].filter((n) => n.type === "memory");
+  assert.equal(memoryNodes.length, 8);
+  const entityNodes = [...nodes.values()].filter((n) => n.type === "entity");
+  assert.equal(entityNodes.length, 5);
+
+  // Count edges by type for clarity.
+  const counts: Record<string, number> = {};
+  for (const e of edges) counts[e.type] = (counts[e.type] ?? 0) + 1;
+  // m4 → m3 supersedes
+  assert.equal(counts["supersedes"], 1);
+  // m3 lineage → m1, m2 (2); m4 derived_from m3:1 → m3 (1); m6 lineage → m4 (1);
+  // m7 derived_from m6:2 → m6 (1). Total: 5 derived-from edges.
+  assert.equal(counts["derived-from"], 5);
+  // m1→Jane, m2→Jane, m3→Jane, m3→Acme, m5→Acme, m6→Bob = 6 mentions.
+  assert.equal(counts["mentions"], 6);
+  // m2 → agent:extractor; m5 → agent:judge = 2 authored-by.
+  assert.equal(counts["authored-by"], 2);
+});
+
+test("buildGraphFromMemories wraps extractGraphEdges into a RemnicGraph", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", entityRef: "person:Jane" },
+    { id: "m2", supersedes: "m1" },
+  ];
+  const graph: RemnicGraph = buildGraphFromMemories(memories);
+  assert.ok(graph.nodes instanceof Map);
+  assert.ok(Array.isArray(graph.edges));
+  assert.equal(graph.nodes.size, 3); // m1, m2, person:Jane
+  assert.equal(graph.edges.length, 2); // m1→Jane mentions, m2→m1 supersedes
+});
+
+test("extractGraphEdges skips memories with no id", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1" },
+    { id: "", supersedes: "m1" } as MemoryEdgeSource,
+    { id: "m2", lineage: ["m1"] },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  assert.equal(nodes.size, 2);
+  assert.ok(!nodes.has(""));
+  assert.equal(edges.length, 1); // m2 → m1 derived-from only
+  assert.equal(edges[0]?.type, "derived-from");
 });

--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -355,6 +355,23 @@ test("extractGraphEdges rejects type mismatch: supersedes points at entity, not 
   assert.equal(edges.filter((e) => e.type === "mentions").length, 1);
 });
 
+test("extractGraphEdges type-mismatch guard applies even with includeDanglingEdges=true", () => {
+  // Fresh evidence: with dangling edges enabled, the guard must still
+  // reject memory → entity cross-type references. The entity node for
+  // "shared-id" is created first via m-A's entityRef; m-B's supersedes
+  // reference must NOT overwrite or attach to that entity node.
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-A", entityRef: "shared-id" },
+    { id: "m-B", supersedes: "shared-id", lineage: ["shared-id"] },
+    { id: "m-C", derived_from: ["shared-id:1"] },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories, { includeDanglingEdges: true });
+  assert.equal(edges.filter((e) => e.type === "supersedes").length, 0);
+  assert.equal(edges.filter((e) => e.type === "derived-from").length, 0);
+  // The shared id remains an entity node, not promoted to memory.
+  assert.equal(nodes.get("shared-id")?.type, "entity");
+});
+
 test("extractGraphEdges rejects type mismatch: derived-from points at entity, not memory", () => {
   const memories: MemoryEdgeSource[] = [
     { id: "m-A", entityRef: "shared-id" },

--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -355,6 +355,36 @@ test("extractGraphEdges rejects type mismatch: supersedes points at entity, not 
   assert.equal(edges.filter((e) => e.type === "mentions").length, 1);
 });
 
+test("extractGraphEdges is order-independent with includeDanglingEdges=true (Codex P2)", () => {
+  // With dangling edges enabled, the order in which the extractor
+  // encounters `{supersedes: "shared"}` vs `{entityRef: "shared"}`
+  // must NOT change the output. In both orderings, the entity mention
+  // claims the id so the supersedes edge is rejected and the mentions
+  // edge fires.
+  const forward: MemoryEdgeSource[] = [
+    { id: "m-A", supersedes: "shared" },
+    { id: "m-B", entityRef: "shared" },
+  ];
+  const reverse: MemoryEdgeSource[] = [
+    { id: "m-B", entityRef: "shared" },
+    { id: "m-A", supersedes: "shared" },
+  ];
+
+  const fwd = extractGraphEdges(forward, { includeDanglingEdges: true });
+  const rev = extractGraphEdges(reverse, { includeDanglingEdges: true });
+
+  const count = (edges: typeof fwd.edges) =>
+    edges.reduce<Record<string, number>>((acc, e) => {
+      acc[e.type] = (acc[e.type] ?? 0) + 1;
+      return acc;
+    }, {});
+  assert.deepEqual(count(fwd.edges), count(rev.edges));
+  assert.equal(fwd.edges.filter((e) => e.type === "supersedes").length, 0);
+  assert.equal(rev.edges.filter((e) => e.type === "supersedes").length, 0);
+  assert.equal(fwd.nodes.get("shared")?.type, "entity");
+  assert.equal(rev.nodes.get("shared")?.type, "entity");
+});
+
 test("extractGraphEdges type-mismatch guard applies even with includeDanglingEdges=true", () => {
   // Fresh evidence: with dangling edges enabled, the guard must still
   // reject memory → entity cross-type references. The entity node for

--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -382,6 +382,30 @@ test("extractGraphEdges rejects type mismatch: derived-from points at entity, no
   assert.equal(edges.filter((e) => e.type === "derived-from").length, 0);
 });
 
+test("extractGraphEdges drops mentions edge when target id collides with an existing memory", () => {
+  // A memory with id "person:Jane" collides with a downstream entityRef
+  // "person:Jane". The existing node stays a memory; the mentions edge
+  // is dropped rather than retyping the node. This preserves the
+  // extractor's typed-node contract.
+  const memories: MemoryEdgeSource[] = [
+    { id: "person:Jane" },
+    { id: "m-A", entityRef: "person:Jane" },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  assert.equal(nodes.get("person:Jane")?.type, "memory");
+  assert.equal(edges.filter((e) => e.type === "mentions").length, 0);
+});
+
+test("extractGraphEdges drops authored-by edge when agent id collides with an existing memory", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "agent:planner" },
+    { id: "m-A", content: "[Source: agent=planner]" },
+  ];
+  const { nodes, edges } = extractGraphEdges(memories);
+  assert.equal(nodes.get("agent:planner")?.type, "memory");
+  assert.equal(edges.filter((e) => e.type === "authored-by").length, 0);
+});
+
 test("extractGraphEdges lowercases citation keys (case-insensitive match)", () => {
   const memories: MemoryEdgeSource[] = [
     { id: "m1", content: "[Source: Agent=Planner, SESSION=abc]" },

--- a/packages/remnic-core/src/graph-retrieval.test.ts
+++ b/packages/remnic-core/src/graph-retrieval.test.ts
@@ -341,6 +341,41 @@ test("buildGraphFromMemories wraps extractGraphEdges into a RemnicGraph", () => 
   assert.equal(graph.edges.length, 2); // m1→Jane mentions, m2→m1 supersedes
 });
 
+test("extractGraphEdges rejects type mismatch: supersedes points at entity, not memory", () => {
+  // memory-A carries entityRef "shared-id" (creates an entity node).
+  // memory-B carries supersedes: "shared-id" — must NOT emit the edge,
+  // because the only existing "shared-id" node is an entity, not a memory.
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-A", entityRef: "shared-id" },
+    { id: "m-B", supersedes: "shared-id" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  assert.equal(edges.filter((e) => e.type === "supersedes").length, 0);
+  // The mention edge must still fire.
+  assert.equal(edges.filter((e) => e.type === "mentions").length, 1);
+});
+
+test("extractGraphEdges rejects type mismatch: derived-from points at entity, not memory", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m-A", entityRef: "shared-id" },
+    { id: "m-B", lineage: ["shared-id"] },
+    { id: "m-C", derived_from: ["shared-id:1"] },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  assert.equal(edges.filter((e) => e.type === "derived-from").length, 0);
+});
+
+test("extractGraphEdges lowercases citation keys (case-insensitive match)", () => {
+  const memories: MemoryEdgeSource[] = [
+    { id: "m1", content: "[Source: Agent=Planner, SESSION=abc]" },
+    { id: "m2", content: "[source: agent=judge]" },
+  ];
+  const { edges } = extractGraphEdges(memories);
+  const authored = edges.filter((e) => e.type === "authored-by");
+  const pairs = authored.map((e) => `${e.from}->${e.to}`).sort();
+  assert.deepEqual(pairs, ["m1->agent:Planner", "m2->agent:judge"]);
+});
+
 test("extractGraphEdges skips memories with no id", () => {
   const memories: MemoryEdgeSource[] = [
     { id: "m1" },

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -356,6 +356,49 @@ export function extractGraphEdges(
     addNode(memory.id, "memory");
   }
 
+  // Pre-scan every memory for entity / agent references so the
+  // memory-target guard can reject ids that are "claimed" by entity
+  // mentions in the same batch — regardless of iteration order.
+  // Without this, with `includeDanglingEdges: true`, processing
+  // `{supersedes: "shared"}` before `{entityRef: "shared"}` would
+  // materialize a memory node for "shared" and then the later entity
+  // mention would be silently dropped (and vice versa), producing
+  // order-dependent output.
+  const entityClaimed = new Set<string>();
+  for (const memory of memories) {
+    if (!memory?.id) continue;
+    if (typeof memory.entityRef === "string" && memory.entityRef) {
+      if (memory.entityRef !== memory.id) entityClaimed.add(memory.entityRef);
+    }
+    if (Array.isArray(memory.entityRefs)) {
+      for (const ref of memory.entityRefs) {
+        if (typeof ref === "string" && ref && ref !== memory.id) {
+          entityClaimed.add(ref);
+        }
+      }
+    }
+    if (typeof memory.content === "string" && memory.content.length > 0) {
+      CITATION_REGEX.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = CITATION_REGEX.exec(memory.content)) !== null) {
+        const body = match[1];
+        if (!body) continue;
+        const agent = parseCitationFields(body).agent;
+        if (!agent) continue;
+        const agentId = `agent:${agent}`;
+        if (agentId !== memory.id) entityClaimed.add(agentId);
+      }
+    }
+  }
+  // Ids claimed by both roles (memory + entity) stay memory — an
+  // explicit memory node with a given id always wins over an entity
+  // mention of the same id in a different memory. Drop any memory ids
+  // out of `entityClaimed` so the memory-target guard does not reject
+  // cross-memory supersedes / lineage references to them.
+  for (const memory of memories) {
+    if (memory?.id) entityClaimed.delete(memory.id);
+  }
+
   // Second pass — walk each memory's relationship fields.
   for (const memory of memories) {
     if (!memory?.id) continue;
@@ -368,14 +411,17 @@ export function extractGraphEdges(
     //
     //   - If the target is already registered under a non-memory type,
     //     reject the edge (type mismatch).
-    //   - If the target is not yet known, accept only when
-    //     `includeDanglingEdges` is `true`. A new memory node is
-    //     registered for the dangling reference.
+    //   - If the target will be claimed by an entity mention in this
+    //     batch (pre-scan above), reject the edge.
+    //   - If the target is not yet known and is not entity-claimed,
+    //     accept only when `includeDanglingEdges` is `true`. A new
+    //     memory node is registered for the dangling reference.
     //   - If the target is already registered as a memory, accept.
     const canTargetMemory = (id: string): boolean => {
       const existing = nodes.get(id);
-      if (existing === undefined) return includeDangling;
-      return existing.type === "memory";
+      if (existing !== undefined) return existing.type === "memory";
+      if (entityClaimed.has(id)) return false;
+      return includeDangling;
     };
 
     // supersedes: memory → older memory

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -409,7 +409,11 @@ export function extractGraphEdges(
       }
     }
 
-    // entityRef / entityRefs: memory → entity (always register entity node)
+    // entityRef / entityRefs: memory → entity. The target must either be
+    // absent (we register a new entity node) or already an entity node
+    // (no type conflict). If the id is already a memory node, drop the
+    // edge rather than mis-typing it — the extractor never mutates an
+    // existing node's type.
     const entitySet = new Set<string>();
     if (typeof memory.entityRef === "string" && memory.entityRef) {
       entitySet.add(memory.entityRef);
@@ -420,11 +424,14 @@ export function extractGraphEdges(
       }
     }
     for (const ref of entitySet) {
-      addNode(ref, "entity");
+      const existing = nodes.get(ref);
+      if (existing !== undefined && existing.type !== "entity") continue;
+      if (!existing) addNode(ref, "entity");
       addEdge(from, ref, "mentions");
     }
 
     // Inline [Source: agent=..., ...] citations → authored-by edge.
+    // Same type-collision guard as the entity block above.
     if (typeof memory.content === "string" && memory.content.length > 0) {
       // Reset the regex's lastIndex on each memory since it is a global regex.
       CITATION_REGEX.lastIndex = 0;
@@ -436,7 +443,9 @@ export function extractGraphEdges(
         const agent = fields.agent;
         if (!agent) continue;
         const agentId = `agent:${agent}`;
-        addNode(agentId, "entity");
+        const existing = nodes.get(agentId);
+        if (existing !== undefined && existing.type !== "entity") continue;
+        if (!existing) addNode(agentId, "entity");
         addEdge(from, agentId, "authored-by");
       }
     }

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -255,12 +255,16 @@ export interface ExtractGraphEdgesOptions {
  * template configuration — it only recognizes the default shape plus minor
  * whitespace / ordering variants.
  */
-// Non-greedy quantifiers on classes like `[^\]\n]+?` can be polynomial on
-// pathological inputs (CodeQL rule js/polynomial-redos). Using a greedy
-// quantifier with a negated character class that also excludes `[` prevents
-// nested-bracket inputs from forcing catastrophic backtracking, and the `\s*`
-// after `Source:` is bounded by the terminal `]`.
-const CITATION_REGEX = /\[Source:[ \t]*([^\]\n[]+)\]/gi;
+// Match the `[Source: ...]` citation block without ambiguous whitespace
+// quantifiers (CodeQL rule js/polynomial-redos). Keeping `[^\]\n[]+` as
+// the only quantified group — a negated class excluding `]`, `[`, and
+// newline — means every character in the body is consumed in a single,
+// non-backtracking pass. The preceding `[ \t]*` was flagged as
+// polynomial-redos too, so we accept any whitespace as the first char
+// of the body instead of pre-consuming it; `parseCitationFields` trims
+// each key/value pair anyway, so leading whitespace inside the body is
+// harmless.
+const CITATION_REGEX = /\[Source:([^\]\n[]+)\]/gi;
 
 /**
  * Parse `key=value` pairs out of a citation body. Whitespace-tolerant and

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -362,19 +362,26 @@ export function extractGraphEdges(
     const from = memory.id;
 
     // `supersedes`, `lineage`, and `derived_from` edges must point at a
-    // memory node specifically — when `includeDanglingEdges` is false we
-    // require the target to already be registered as a memory (never just
-    // "present in the map", because an entity node may share the same id
-    // as a referenced memory that did not make it into the input batch).
-    const isKnownMemory = (id: string): boolean => {
+    // memory node specifically — never an entity / episode / concept /
+    // reflection node that happens to share an id. The guard applies
+    // regardless of `includeDanglingEdges`:
+    //
+    //   - If the target is already registered under a non-memory type,
+    //     reject the edge (type mismatch).
+    //   - If the target is not yet known, accept only when
+    //     `includeDanglingEdges` is `true`. A new memory node is
+    //     registered for the dangling reference.
+    //   - If the target is already registered as a memory, accept.
+    const canTargetMemory = (id: string): boolean => {
       const existing = nodes.get(id);
-      return existing !== undefined && existing.type === "memory";
+      if (existing === undefined) return includeDangling;
+      return existing.type === "memory";
     };
 
     // supersedes: memory → older memory
     if (typeof memory.supersedes === "string" && memory.supersedes) {
       const to = memory.supersedes;
-      if (includeDangling || isKnownMemory(to)) {
+      if (canTargetMemory(to)) {
         if (!nodes.has(to)) addNode(to, "memory");
         addEdge(from, to, "supersedes");
       }
@@ -384,7 +391,7 @@ export function extractGraphEdges(
     if (Array.isArray(memory.lineage)) {
       for (const parent of memory.lineage) {
         if (typeof parent !== "string" || !parent) continue;
-        if (!includeDangling && !isKnownMemory(parent)) continue;
+        if (!canTargetMemory(parent)) continue;
         if (!nodes.has(parent)) addNode(parent, "memory");
         addEdge(from, parent, "derived-from");
       }
@@ -396,7 +403,7 @@ export function extractGraphEdges(
         if (typeof raw !== "string" || !raw) continue;
         const to = stripDerivedFromVersion(raw);
         if (!to) continue;
-        if (!includeDangling && !isKnownMemory(to)) continue;
+        if (!canTargetMemory(to)) continue;
         if (!nodes.has(to)) addNode(to, "memory");
         addEdge(from, to, "derived-from");
       }

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -255,12 +255,17 @@ export interface ExtractGraphEdgesOptions {
  * template configuration — it only recognizes the default shape plus minor
  * whitespace / ordering variants.
  */
-const CITATION_REGEX = /\[Source:\s*([^\]\n]+?)\]/gi;
+// Non-greedy quantifiers on classes like `[^\]\n]+?` can be polynomial on
+// pathological inputs (CodeQL rule js/polynomial-redos). Using a greedy
+// quantifier with a negated character class that also excludes `[` prevents
+// nested-bracket inputs from forcing catastrophic backtracking, and the `\s*`
+// after `Source:` is bounded by the terminal `]`.
+const CITATION_REGEX = /\[Source:[ \t]*([^\]\n[]+)\]/gi;
 
 /**
- * Parse `key=value` pairs out of a citation body. Whitespace-tolerant.
- * Returns a plain object — callers should defensively check for the keys
- * they care about.
+ * Parse `key=value` pairs out of a citation body. Whitespace-tolerant and
+ * case-insensitive: keys are normalized to lowercase so callers can do
+ * `fields.agent` without worrying about `[Source: Agent=...]` variants.
  */
 function parseCitationFields(body: string): Record<string, string> {
   const out: Record<string, string> = {};
@@ -269,7 +274,7 @@ function parseCitationFields(body: string): Record<string, string> {
     if (!part) continue;
     const eq = part.indexOf("=");
     if (eq <= 0) continue;
-    const key = part.slice(0, eq).trim();
+    const key = part.slice(0, eq).trim().toLowerCase();
     const value = part.slice(eq + 1).trim();
     if (key && value) out[key] = value;
   }
@@ -356,10 +361,20 @@ export function extractGraphEdges(
     if (!memory?.id) continue;
     const from = memory.id;
 
+    // `supersedes`, `lineage`, and `derived_from` edges must point at a
+    // memory node specifically — when `includeDanglingEdges` is false we
+    // require the target to already be registered as a memory (never just
+    // "present in the map", because an entity node may share the same id
+    // as a referenced memory that did not make it into the input batch).
+    const isKnownMemory = (id: string): boolean => {
+      const existing = nodes.get(id);
+      return existing !== undefined && existing.type === "memory";
+    };
+
     // supersedes: memory → older memory
     if (typeof memory.supersedes === "string" && memory.supersedes) {
       const to = memory.supersedes;
-      if (includeDangling || nodes.has(to)) {
+      if (includeDangling || isKnownMemory(to)) {
         if (!nodes.has(to)) addNode(to, "memory");
         addEdge(from, to, "supersedes");
       }
@@ -369,7 +384,7 @@ export function extractGraphEdges(
     if (Array.isArray(memory.lineage)) {
       for (const parent of memory.lineage) {
         if (typeof parent !== "string" || !parent) continue;
-        if (!includeDangling && !nodes.has(parent)) continue;
+        if (!includeDangling && !isKnownMemory(parent)) continue;
         if (!nodes.has(parent)) addNode(parent, "memory");
         addEdge(from, parent, "derived-from");
       }
@@ -381,7 +396,7 @@ export function extractGraphEdges(
         if (typeof raw !== "string" || !raw) continue;
         const to = stripDerivedFromVersion(raw);
         if (!to) continue;
-        if (!includeDangling && !nodes.has(to)) continue;
+        if (!includeDangling && !isKnownMemory(to)) continue;
         if (!nodes.has(to)) addNode(to, "memory");
         addEdge(from, to, "derived-from");
       }

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -205,3 +205,237 @@ export function isNodeType(value: unknown): value is NodeType {
 export function isEdgeType(value: unknown): value is EdgeType {
   return typeof value === "string" && EDGE_TYPES.has(value as EdgeType);
 }
+
+// ---------------------------------------------------------------------------
+// Edge extraction (issue #559, PR 2 of 5)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimum fields the edge extractor reads from a memory record. Structural
+ * typing is used so callers can pass any subset of `MemoryFrontmatter`
+ * (including richer loaded memories) without a cast.
+ *
+ * All reference fields are optional — memories written before earlier slices
+ * landed will simply contribute no edges for those dimensions.
+ */
+export interface MemoryEdgeSource {
+  /** Stable identifier for the memory (typically the file path). */
+  id: string;
+  /** Older memory id this memory supersedes (1:1). */
+  supersedes?: string;
+  /** Parent memory ids this memory was derived from (lineage). */
+  lineage?: string[];
+  /**
+   * Consolidation provenance — `"<memory-id>:<version-number>"` strings.
+   * The memory-id portion before the last `:` is used as the edge target.
+   */
+  derived_from?: string[];
+  /** Primary entity reference on the memory (e.g. `person:Jane Doe`). */
+  entityRef?: string;
+  /** Additional entity references (used by episodes and ledger records). */
+  entityRefs?: string[];
+  /** Raw memory body — scanned for inline `[Source: ...]` citation blocks. */
+  content?: string;
+}
+
+/** Options controlling edge extraction. */
+export interface ExtractGraphEdgesOptions {
+  /**
+   * When true, include edges whose `to` endpoint is not present in the
+   * provided node index. Defaults to `false` — dangling edges are silently
+   * skipped because PPR cannot propagate mass through a missing node.
+   */
+  includeDanglingEdges?: boolean;
+}
+
+/**
+ * Regex that matches the `[Source: ...]` citation block emitted by
+ * `source-attribution.ts`. Kept local (rather than importing) because the
+ * extractor intentionally has no dependency on the citation module's mutable
+ * template configuration — it only recognizes the default shape plus minor
+ * whitespace / ordering variants.
+ */
+const CITATION_REGEX = /\[Source:\s*([^\]\n]+?)\]/gi;
+
+/**
+ * Parse `key=value` pairs out of a citation body. Whitespace-tolerant.
+ * Returns a plain object — callers should defensively check for the keys
+ * they care about.
+ */
+function parseCitationFields(body: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const rawPart of body.split(",")) {
+    const part = rawPart.trim();
+    if (!part) continue;
+    const eq = part.indexOf("=");
+    if (eq <= 0) continue;
+    const key = part.slice(0, eq).trim();
+    const value = part.slice(eq + 1).trim();
+    if (key && value) out[key] = value;
+  }
+  return out;
+}
+
+/**
+ * Strip the trailing `:<version>` from a `derived_from` entry. Returns the
+ * original string if no colon is present. We intentionally use `lastIndexOf`
+ * because memory ids may themselves contain colons (e.g. entity-prefixed
+ * ids), but the version suffix — when present — is always the final
+ * `:<digits>` segment.
+ */
+function stripDerivedFromVersion(ref: string): string {
+  const colon = ref.lastIndexOf(":");
+  if (colon < 0) return ref;
+  const tail = ref.slice(colon + 1);
+  if (tail.length === 0) return ref.slice(0, colon);
+  // Only strip when the tail is purely numeric; otherwise keep the full ref.
+  if (/^\d+$/.test(tail)) return ref.slice(0, colon);
+  return ref;
+}
+
+/**
+ * Extract retrieval-graph edges from a collection of memories.
+ *
+ * Pure function — no I/O, no config access, no time-based side effects.
+ * Given the same inputs, always produces the same edges in the same order
+ * so dedup downstream is deterministic.
+ *
+ * Source → target semantics by edge type:
+ *
+ *   - `supersedes`:    memory → older memory (from `supersedes` field).
+ *   - `derived-from`:  memory → each parent in `lineage` OR `derived_from`.
+ *   - `mentions`:      memory → each entity in `entityRef` / `entityRefs`.
+ *   - `authored-by`:   memory → agent id parsed from inline `[Source: ...]`.
+ *
+ * `temporal-next`, `references`, `related-to`, and `concept` / `reflection`
+ * node synthesis are deferred to later slices — they require either episode
+ * sequencing or an abstraction synthesis pass that is out of scope for PR 2.
+ *
+ * @param memories     Memories to scan. Order is preserved; duplicates are
+ *                     not deduped (the caller controls the input set).
+ * @param options      Extraction knobs. See `ExtractGraphEdgesOptions`.
+ * @returns            A `{ nodes, edges }` pair. `nodes` contains one
+ *                     `memory` node per input memory plus one `entity` node
+ *                     per distinct entity discovered across all mentions.
+ *                     Edges reference ids in the returned node map unless
+ *                     `includeDanglingEdges` is set.
+ */
+export function extractGraphEdges(
+  memories: readonly MemoryEdgeSource[],
+  options: ExtractGraphEdgesOptions = {},
+): { nodes: Map<string, RemnicGraphNode>; edges: RemnicGraphEdge[] } {
+  const includeDangling = options.includeDanglingEdges === true;
+
+  const nodes = new Map<string, RemnicGraphNode>();
+  const edges: RemnicGraphEdge[] = [];
+  // Dedupe within this extraction pass. Key is `${from}\u0000${to}\u0000${type}`
+  // — using a NUL separator avoids collisions with ids that contain `|`.
+  const seenEdgeKeys = new Set<string>();
+
+  const addNode = (id: string, type: NodeType) => {
+    if (!nodes.has(id)) nodes.set(id, { id, type });
+  };
+
+  const addEdge = (from: string, to: string, type: EdgeType) => {
+    if (!from || !to || from === to) return;
+    const key = `${from}\u0000${to}\u0000${type}`;
+    if (seenEdgeKeys.has(key)) return;
+    seenEdgeKeys.add(key);
+    edges.push({ from, to, type });
+  };
+
+  // First pass — register every memory as a node so cross-references can
+  // resolve regardless of input ordering.
+  for (const memory of memories) {
+    if (!memory?.id) continue;
+    addNode(memory.id, "memory");
+  }
+
+  // Second pass — walk each memory's relationship fields.
+  for (const memory of memories) {
+    if (!memory?.id) continue;
+    const from = memory.id;
+
+    // supersedes: memory → older memory
+    if (typeof memory.supersedes === "string" && memory.supersedes) {
+      const to = memory.supersedes;
+      if (includeDangling || nodes.has(to)) {
+        if (!nodes.has(to)) addNode(to, "memory");
+        addEdge(from, to, "supersedes");
+      }
+    }
+
+    // lineage: memory → each parent memory
+    if (Array.isArray(memory.lineage)) {
+      for (const parent of memory.lineage) {
+        if (typeof parent !== "string" || !parent) continue;
+        if (!includeDangling && !nodes.has(parent)) continue;
+        if (!nodes.has(parent)) addNode(parent, "memory");
+        addEdge(from, parent, "derived-from");
+      }
+    }
+
+    // derived_from: memory → parent memory (strip `:<version>` suffix)
+    if (Array.isArray(memory.derived_from)) {
+      for (const raw of memory.derived_from) {
+        if (typeof raw !== "string" || !raw) continue;
+        const to = stripDerivedFromVersion(raw);
+        if (!to) continue;
+        if (!includeDangling && !nodes.has(to)) continue;
+        if (!nodes.has(to)) addNode(to, "memory");
+        addEdge(from, to, "derived-from");
+      }
+    }
+
+    // entityRef / entityRefs: memory → entity (always register entity node)
+    const entitySet = new Set<string>();
+    if (typeof memory.entityRef === "string" && memory.entityRef) {
+      entitySet.add(memory.entityRef);
+    }
+    if (Array.isArray(memory.entityRefs)) {
+      for (const ref of memory.entityRefs) {
+        if (typeof ref === "string" && ref) entitySet.add(ref);
+      }
+    }
+    for (const ref of entitySet) {
+      addNode(ref, "entity");
+      addEdge(from, ref, "mentions");
+    }
+
+    // Inline [Source: agent=..., ...] citations → authored-by edge.
+    if (typeof memory.content === "string" && memory.content.length > 0) {
+      // Reset the regex's lastIndex on each memory since it is a global regex.
+      CITATION_REGEX.lastIndex = 0;
+      let match: RegExpExecArray | null;
+      while ((match = CITATION_REGEX.exec(memory.content)) !== null) {
+        const body = match[1];
+        if (!body) continue;
+        const fields = parseCitationFields(body);
+        const agent = fields.agent;
+        if (!agent) continue;
+        const agentId = `agent:${agent}`;
+        addNode(agentId, "entity");
+        addEdge(from, agentId, "authored-by");
+      }
+    }
+  }
+
+  return { nodes, edges };
+}
+
+/**
+ * Build a `RemnicGraph` from a collection of memories by delegating to
+ * `extractGraphEdges()`. Convenience wrapper so callers do not have to
+ * re-wrap the `{ nodes, edges }` pair into the `RemnicGraph` interface.
+ *
+ * Pure function — no I/O. Persisting the graph (e.g. writing
+ * `~/.remnic/graph.json`) is left to the caller; that decision belongs with
+ * the maintenance / consolidation pass in PR 4, not the extractor.
+ */
+export function buildGraphFromMemories(
+  memories: readonly MemoryEdgeSource[],
+  options: ExtractGraphEdgesOptions = {},
+): RemnicGraph {
+  const { nodes, edges } = extractGraphEdges(memories, options);
+  return { nodes, edges };
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -690,6 +690,8 @@ export {
   queryGraph,
   isNodeType,
   isEdgeType,
+  extractGraphEdges,
+  buildGraphFromMemories,
   type NodeType,
   type EdgeType,
   type RemnicGraphNode,
@@ -698,6 +700,8 @@ export {
   type QueryGraphOptions,
   type QueryGraphResult,
   type RankedGraphNode,
+  type MemoryEdgeSource,
+  type ExtractGraphEdgesOptions,
 } from "./graph-retrieval.js";
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Second slice of issue #559 (graph-based retrieval with PPR). Builds on the type contract from PR #576.

Adds `extractGraphEdges()` — a pure function that walks memory frontmatter and produces `RemnicGraphEdge` objects.

### New exports from `@remnic/core`

- `extractGraphEdges(memories, options?)` — pure, no I/O. Reads:
  - `supersedes` → `supersedes` edge
  - `lineage` → `derived-from` edges
  - `derived_from` (with `:<version>` stripping) → `derived-from` edges
  - `entityRef` / `entityRefs` → `mentions` edges (entity nodes created)
  - Inline `[Source: agent=...]` citation blocks → `authored-by` edges
- `buildGraphFromMemories(memories, options?)` — convenience wrapper returning a `RemnicGraph`.
- `MemoryEdgeSource` — structural type accepting any subset of `MemoryFrontmatter`.
- `ExtractGraphEdgesOptions` — `{ includeDanglingEdges?: boolean }`.

### Design notes

- **Pure function.** No I/O, no config, no time. Same input → same output, edges in deterministic order. Persistence (e.g. `~/.remnic/graph.json`) is deferred to the maintenance wiring in PR 4, keeping this PR narrow per AGENTS.md's narrow-PR rule.
- **Self-loops dropped.** Supersession / lineage loops on the same id are silently skipped.
- **Dangling edges skipped by default.** PPR can't propagate mass through a missing node. Opt-in via `includeDanglingEdges: true`.
- **Edge dedup within a pass.** `from+to+type` is the dedup key (NUL-separated to avoid collisions in ids containing `|`).
- **`derived_from` version stripping.** Trailing `:<digits>` is stripped (matches `page-versioning.ts` format); non-numeric tails are preserved so entity-prefixed ids aren't mangled.
- **Citation parsing.** Matches the default `[Source: agent=X, session=Y, ts=Z]` shape from `source-attribution.ts`. Agent ids are namespaced as `agent:<name>` entity nodes.

### Behavior change: none

No module in the codebase calls `extractGraphEdges` yet. PR 3 implements `queryGraph()` PPR. PR 4 wires the extractor into the maintenance/recall pipeline behind a feature flag.

## Out of scope (future PRs on #559)

- **PR 3 — PPR implementation.** Power iteration with damping=0.85, 20 iter max, L1 convergence <1e-6.
- **PR 4 — Retrieval integration (feature-flagged).** Wire edge extractor into maintenance + PPR into recall behind `recallGraphEnabled: false`.
- **PR 5 — Benchmark + default flip.** `retrieval-graph` bench fixture; flip default if graph-on wins or ties.

## Test plan

- `npx tsx --test packages/remnic-core/src/graph-retrieval.test.ts` — 26 tests, all pass (15 new). Covers:
  - Empty input, memory-node registration
  - `supersedes` with known + missing target (default skip vs `includeDanglingEdges`)
  - `lineage` + `derived_from` with numeric-only `:<version>` stripping
  - Edge dedup across overlapping `lineage` / `derived_from`
  - `entityRef` + `entityRefs` → entity node + mentions edges
  - Inline citation parsing, including malformed citations
  - Self-loop rejection
  - Determinism across invocations
  - 8-memory end-to-end fixture with exact counts by edge type
  - `buildGraphFromMemories` wrapper
  - Empty-id memory rejection
- `npx tsc --noEmit` in `packages/remnic-core` — clean.
- `npm run preflight:quick` — passes.

Refs #559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new graph-construction logic that infers nodes/edges from memory metadata and parses inline citations; mistakes here could skew retrieval ranking once wired in. Currently low blast radius because nothing in the runtime calls these helpers yet.
> 
> **Overview**
> Implements `extractGraphEdges()` to build a deterministic `{nodes, edges}` graph from memory-like inputs, generating `supersedes`, `derived-from`, `mentions`, and `authored-by` edges (including `derived_from` version stripping, edge de-duping, optional dangling-edge materialization, and type-collision guards to avoid retyping ids).
> 
> Adds `buildGraphFromMemories()` as a convenience wrapper returning a `RemnicGraph`, exports the new APIs/types from `@remnic/core`, and significantly expands `graph-retrieval.test.ts` with coverage for empty inputs, determinism, dangling-edge behavior, citation parsing, and id/type collision cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8f9cc7efcfd5e1d1222d5b847dd9b186aeef817. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->