### PR TITLE
feat(consolidation): emit derived_from + derived_via on consolidation writes (issue #561 PR 2/5)

### DIFF
--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2828,6 +2828,21 @@ export class Orchestrator {
         const newest = sorted[0];
         const lineageIds = cluster.memories.map((m) => m.frontmatter.id);
 
+        // Consolidation provenance (issue #561 PR 2): snapshot each source
+        // memory BEFORE archiving it, collecting "<relpath>:<versionId>"
+        // pointers for the new canonical memory's `derived_from` frontmatter
+        // field.  Snapshots are best-effort — if page-versioning is disabled
+        // or a single source fails to snapshot we simply omit that entry
+        // rather than abort the consolidation.  `derived_via` is hardcoded
+        // to `"merge"` here; operator selection (SPLIT/MERGE/UPDATE) lands
+        // in PR 3.
+        const derivedFromEntries: string[] = [];
+        for (const m of cluster.memories) {
+          if (!m.path) continue;
+          const entry = await this.storage.snapshotForProvenance(m.path);
+          if (entry) derivedFromEntries.push(entry);
+        }
+
         // Write the canonical memory
         const canonicalId = await this.storage.writeMemory(
           newest.frontmatter.category,
@@ -2842,6 +2857,8 @@ export class Orchestrator {
             ],
             source: "semantic-consolidation",
             lineage: lineageIds,
+            derivedFrom: derivedFromEntries.length > 0 ? derivedFromEntries : undefined,
+            derivedVia: derivedFromEntries.length > 0 ? "merge" : undefined,
           },
         );
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2832,10 +2832,13 @@ export class Orchestrator {
         // memory BEFORE archiving it, collecting "<relpath>:<versionId>"
         // pointers for the new canonical memory's `derived_from` frontmatter
         // field.  Snapshots are best-effort — if page-versioning is disabled
-        // or a single source fails to snapshot we simply omit that entry
-        // rather than abort the consolidation.  `derived_via` is hardcoded
-        // to `"merge"` here; operator selection (SPLIT/MERGE/UPDATE) lands
-        // in PR 3.
+        // (the default in `config.ts`) or a single source fails to snapshot
+        // we omit that entry rather than abort the consolidation.  Review
+        // feedback (codex): `derived_via` is emitted unconditionally so
+        // downstream logic can still identify consolidation outputs by
+        // operator even when no `derived_from` snapshots could be
+        // captured.  PR 3 selects SPLIT/MERGE/UPDATE dynamically; here we
+        // hardcode `"merge"`.
         const derivedFromEntries: string[] = [];
         for (const m of cluster.memories) {
           if (!m.path) continue;
@@ -2858,7 +2861,7 @@ export class Orchestrator {
             source: "semantic-consolidation",
             lineage: lineageIds,
             derivedFrom: derivedFromEntries.length > 0 ? derivedFromEntries : undefined,
-            derivedVia: derivedFromEntries.length > 0 ? "merge" : undefined,
+            derivedVia: "merge",
           },
         );
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -10,6 +10,7 @@ import { createVersion as createPageVersion, type VersioningConfig, type Version
 import {
   isConsolidationOperator,
   isValidDerivedFromEntry,
+  type ConsolidationOperator,
 } from "./consolidation-operator.js";
 import {
   matchEntitySchemaSection,
@@ -2013,6 +2014,48 @@ export class StorageManager {
     }
   }
 
+  /**
+   * Consolidation provenance helper (issue #561 PR 2).
+   *
+   * Captures the current on-disk content of a source memory as a
+   * page-version snapshot so the downstream consolidated write can record a
+   * `derived_from` pointer that actually resolves.  Returns the
+   * `"<relative-path>:<versionId>"` entry expected by the `derived_from`
+   * frontmatter field.
+   *
+   * Returns `null` when versioning is disabled (snapshots would not be
+   * created), when the file does not exist (nothing to snapshot), or when
+   * the snapshot write itself fails (best-effort — callers skip the entry
+   * rather than block the consolidation).
+   */
+  async snapshotForProvenance(filePath: string): Promise<string | null> {
+    if (!this._versioningConfig || !this._versioningConfig.enabled) return null;
+    let existing: string;
+    try {
+      existing = await readFile(filePath, "utf-8");
+    } catch {
+      return null;
+    }
+    try {
+      const version = await createPageVersion(
+        filePath,
+        existing,
+        "consolidation",
+        this._versioningConfig,
+        log,
+        undefined,
+        this.baseDir,
+      );
+      const rel = path.relative(this.baseDir, filePath).split(path.sep).join("/");
+      return `${rel}:${version.versionId}`;
+    } catch (err) {
+      log.warn(
+        `storage.snapshotForProvenance: failed to snapshot ${filePath}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return null;
+    }
+  }
+
   constructor(
     private readonly baseDir: string,
     private readonly entitySchemas?: PluginConfig["entitySchemas"],
@@ -2350,6 +2393,15 @@ export class StorageManager {
        */
       contentHashSource?: string;
       status?: MemoryStatus;
+      /**
+       * Consolidation provenance (issue #561 PR 2).  When the caller is a
+       * consolidation / supersession / dedup-merge path, these fields wire
+       * the page-version snapshots the new memory was derived from and the
+       * operator that produced it.  Persisted onto frontmatter as
+       * `derived_from` + `derived_via`; validated at serialize time.
+       */
+      derivedFrom?: string[];
+      derivedVia?: ConsolidationOperator;
     } = {},
   ): Promise<string> {
     await this.ensureDirectories();
@@ -2394,6 +2446,16 @@ export class StorageManager {
     };
     if (options.status !== undefined) {
       fm.status = options.status;
+    }
+    // Consolidation provenance (issue #561 PR 2).  We filter empty arrays to
+    // avoid serializing a no-op `derived_from: []` on legacy write paths that
+    // pass an explicit empty array.  Missing values survive the roundtrip as
+    // undefined.
+    if (options.derivedFrom !== undefined && options.derivedFrom.length > 0) {
+      fm.derived_from = options.derivedFrom;
+    }
+    if (options.derivedVia !== undefined) {
+      fm.derived_via = options.derivedVia;
     }
 
     // Append structured attributes as searchable suffix so QMD indexes them.

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2447,10 +2447,16 @@ export class StorageManager {
     if (options.status !== undefined) {
       fm.status = options.status;
     }
-    // Consolidation provenance (issue #561 PR 2).  We filter empty arrays to
-    // avoid serializing a no-op `derived_from: []` on legacy write paths that
-    // pass an explicit empty array.  Missing values survive the roundtrip as
-    // undefined.
+    // Consolidation provenance (issue #561 PR 2).  Fields are independent
+    // at the storage layer:
+    //   - `derivedFrom: []` → coerced to undefined so we never emit the
+    //     invalid `derived_from: []` form the write validator rejects.
+    //   - `derivedVia` may stand alone: an orphan operator marker (e.g.
+    //     `derived_via: merge` with no `derived_from`) is the correct
+    //     serialization when page-versioning is disabled and snapshots
+    //     can't be captured.  Downstream logic still needs to identify
+    //     the memory as a consolidation output.  Review feedback: PR #624
+    //     codex / cursor threads.
     if (options.derivedFrom !== undefined && options.derivedFrom.length > 0) {
       fm.derived_from = options.derivedFrom;
     }

--- a/tests/orchestrator-consolidation-provenance-wiring.test.ts
+++ b/tests/orchestrator-consolidation-provenance-wiring.test.ts
@@ -1,0 +1,81 @@
+/**
+ * Structural wiring test for semantic-consolidation provenance (issue #561
+ * PR 2).
+ *
+ * PR 2 adds a call to `storage.snapshotForProvenance(m.path)` for every
+ * source memory in a consolidation cluster, and threads the resulting
+ * entries through to `storage.writeMemory(...)` via the `derivedFrom` +
+ * `derivedVia` options.  The full orchestrator is too heavy to spin up in
+ * a unit test, so we verify the wiring structurally: the call sites must
+ * exist in the expected file, adjacent to the consolidation write path.
+ *
+ * If someone refactors the consolidation loop and drops the snapshot call,
+ * the new memory loses its `derived_from` pointers silently — these
+ * assertions fail loudly instead.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..");
+
+test("orchestrator semantic-consolidation loop snapshots sources before the canonical write", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/orchestrator.ts"),
+    "utf-8",
+  );
+  // The consolidation block must call snapshotForProvenance on each
+  // source memory.  We look for the distinctive call site rather than the
+  // method name alone so refactors that move the call elsewhere still
+  // flag up.
+  assert.match(
+    src,
+    /snapshotForProvenance\(m\.path\)/u,
+    "orchestrator must call storage.snapshotForProvenance(m.path) inside the consolidation loop",
+  );
+
+  // The derivedFrom + derivedVia options must be passed to writeMemory in
+  // the same function body.  We anchor by the semantic-consolidation
+  // source tag to avoid matching unrelated call sites (e.g. future PRs
+  // that wire supersession or dedup paths).
+  const sourceAnchor = src.indexOf('source: "semantic-consolidation"');
+  assert.ok(sourceAnchor >= 0, "consolidation writeMemory call must survive");
+  const window = src.slice(Math.max(0, sourceAnchor - 2000), sourceAnchor + 2000);
+  assert.match(
+    window,
+    /derivedFrom:/u,
+    "consolidation writeMemory call must pass derivedFrom",
+  );
+  assert.match(
+    window,
+    /derivedVia:/u,
+    "consolidation writeMemory call must pass derivedVia",
+  );
+});
+
+test("storage.ts declares derivedFrom + derivedVia on the writeMemory options surface", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/storage.ts"),
+    "utf-8",
+  );
+  assert.match(
+    src,
+    /derivedFrom\?:\s*string\[\]/u,
+    "writeMemory options must accept derivedFrom: string[]",
+  );
+  assert.match(
+    src,
+    /derivedVia\?:\s*ConsolidationOperator/u,
+    "writeMemory options must accept derivedVia: ConsolidationOperator",
+  );
+  assert.match(
+    src,
+    /async snapshotForProvenance\(/u,
+    "storage must expose snapshotForProvenance()",
+  );
+});

--- a/tests/storage-derived-write-paths.test.ts
+++ b/tests/storage-derived-write-paths.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Write-path tests for consolidation provenance (issue #561 PR 2).
+ *
+ * PR 1 added read/write round-trip for `derived_from` and `derived_via` on
+ * memory frontmatter.  PR 2 wires the fields into the `writeMemory()`
+ * options surface and adds the `snapshotForProvenance()` helper that
+ * captures a page-version of a source memory and returns a matching
+ * `"<relative-path>:<versionId>"` entry.
+ *
+ * These tests cover the storage-level contract directly so the PR-2 wiring
+ * can be validated without spinning up the full orchestrator.  The
+ * orchestrator-level call site is exercised structurally in
+ * `orchestrator-consolidation-provenance-wiring.test.ts`.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+import type { VersioningConfig } from "../src/page-versioning.ts";
+
+function versioningConfig(): VersioningConfig {
+  return { enabled: true, maxVersionsPerPage: 10, sidecarDir: ".versions" };
+}
+
+test("writeMemory persists derivedFrom + derivedVia through to frontmatter", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-write-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "consolidated payload", {
+      source: "semantic-consolidation",
+      derivedFrom: ["facts/a.md:2", "facts/b.md:5"],
+      derivedVia: "merge",
+    });
+
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory, "memory should be readable");
+    assert.deepEqual(memory.frontmatter.derived_from, [
+      "facts/a.md:2",
+      "facts/b.md:5",
+    ]);
+    assert.equal(memory.frontmatter.derived_via, "merge");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeMemory omits derived_from when the array is empty", async () => {
+  // Empty `derivedFrom` arrays must not serialize as `derived_from: []`
+  // because that would be rejected by the validator on subsequent reads.
+  // PR 2 coerces the empty case back to undefined.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-empty-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "payload without sources", {
+      source: "extraction",
+      derivedFrom: [],
+    });
+
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+    assert.equal(memory.frontmatter.derived_from, undefined);
+    assert.equal(memory.frontmatter.derived_via, undefined);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeMemory accepts all three ConsolidationOperator values via derivedVia", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-ops-write-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const operators: Array<"split" | "merge" | "update"> = ["split", "merge", "update"];
+    const writtenIds: Record<string, string> = {};
+    for (const op of operators) {
+      const id = await storage.writeMemory("fact", `${op} payload`, {
+        source: "semantic-consolidation",
+        derivedFrom: [`facts/source-${op}.md:1`],
+        derivedVia: op,
+      });
+      writtenIds[op] = id;
+    }
+
+    const all = await storage.readAllMemories();
+    for (const op of operators) {
+      const memory = all.find((m) => m.frontmatter.id === writtenIds[op]);
+      assert.ok(memory, `memory for operator ${op} should load`);
+      assert.equal(memory.frontmatter.derived_via, op);
+      assert.deepEqual(memory.frontmatter.derived_from, [`facts/source-${op}.md:1`]);
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotForProvenance captures a version and returns a valid derived_from entry", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-provenance-snapshot-"));
+  try {
+    const storage = new StorageManager(dir);
+    storage.setVersioningConfig(versioningConfig());
+    await storage.ensureDirectories();
+
+    // Write a source memory.  The first write snapshots any existing
+    // content (none yet) so the file itself starts un-versioned; the
+    // snapshot below creates version 1.
+    const sourceId = await storage.writeMemory("fact", "source body", {
+      source: "extraction",
+    });
+    const all = await storage.readAllMemories();
+    const source = all.find((m) => m.frontmatter.id === sourceId);
+    assert.ok(source);
+
+    const entry = await storage.snapshotForProvenance(source.path);
+    assert.ok(entry, "snapshot entry should be returned when versioning is enabled");
+    // Entry must match the derived_from format: "<relpath>:<version>"
+    assert.match(entry, /^facts\/.+\.md:\d+$/u);
+
+    // The snapshot file must exist on disk at the sidecar path.
+    const [rel, version] = entry.split(":");
+    const relWithoutExt = rel.replace(/\.md$/, "");
+    const sidecarFile = path.join(
+      dir,
+      ".versions",
+      relWithoutExt.replace(/\//g, "__"),
+      `${version}.md`,
+    );
+    const snapshotContent = await readFile(sidecarFile, "utf-8");
+    assert.ok(snapshotContent.includes("source body"), "snapshot file must preserve source body");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotForProvenance returns null when versioning is disabled", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-provenance-disabled-"));
+  try {
+    const storage = new StorageManager(dir);
+    // Intentionally skip setVersioningConfig — versioning stays disabled.
+    await storage.ensureDirectories();
+
+    const sourceId = await storage.writeMemory("fact", "source body", {
+      source: "extraction",
+    });
+    const all = await storage.readAllMemories();
+    const source = all.find((m) => m.frontmatter.id === sourceId);
+    assert.ok(source);
+
+    const entry = await storage.snapshotForProvenance(source.path);
+    assert.equal(entry, null, "should return null when versioning disabled");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("snapshotForProvenance returns null when the file does not exist", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-provenance-missing-"));
+  try {
+    const storage = new StorageManager(dir);
+    storage.setVersioningConfig(versioningConfig());
+    await storage.ensureDirectories();
+
+    const nonExistent = path.join(dir, "facts", "2026-04-20", "fact-does-not-exist.md");
+    const entry = await storage.snapshotForProvenance(nonExistent);
+    assert.equal(entry, null, "missing files must snapshot to null");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("round-trip: writeMemory with snapshotForProvenance entries survives read", async () => {
+  // End-to-end: snapshot two sources, write a canonical memory that
+  // references them via derivedFrom, read the canonical memory back and
+  // verify the entries survived serialization + parsing.  This is the
+  // happy-path contract the consolidation pipeline depends on.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-provenance-roundtrip-"));
+  try {
+    const storage = new StorageManager(dir);
+    storage.setVersioningConfig(versioningConfig());
+    await storage.ensureDirectories();
+
+    const srcAId = await storage.writeMemory("fact", "alpha source body", {
+      source: "extraction",
+    });
+    const srcBId = await storage.writeMemory("fact", "bravo source body", {
+      source: "extraction",
+    });
+
+    const allBefore = await storage.readAllMemories();
+    const srcA = allBefore.find((m) => m.frontmatter.id === srcAId);
+    const srcB = allBefore.find((m) => m.frontmatter.id === srcBId);
+    assert.ok(srcA);
+    assert.ok(srcB);
+
+    const entryA = await storage.snapshotForProvenance(srcA.path);
+    const entryB = await storage.snapshotForProvenance(srcB.path);
+    assert.ok(entryA);
+    assert.ok(entryB);
+
+    const canonicalId = await storage.writeMemory("fact", "canonical merged body", {
+      source: "semantic-consolidation",
+      derivedFrom: [entryA, entryB],
+      derivedVia: "merge",
+    });
+
+    const allAfter = await storage.readAllMemories();
+    const canonical = allAfter.find((m) => m.frontmatter.id === canonicalId);
+    assert.ok(canonical);
+    assert.deepEqual(canonical.frontmatter.derived_from, [entryA, entryB]);
+    assert.equal(canonical.frontmatter.derived_via, "merge");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/storage-derived-write-paths.test.ts
+++ b/tests/storage-derived-write-paths.test.ts
@@ -74,6 +74,33 @@ test("writeMemory omits derived_from when the array is empty", async () => {
   }
 });
 
+test("writeMemory emits derived_via alone when page-versioning is unavailable", async () => {
+  // Review feedback (PR #624 codex): `derived_via` must stand alone so
+  // downstream logic can still identify consolidation outputs by operator
+  // even when page-versioning is disabled and no `derived_from` entries
+  // could be captured.  The storage layer intentionally does NOT enforce
+  // a `derived_via requires derived_from` invariant.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-orphan-via-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+
+    const id = await storage.writeMemory("fact", "orphan consolidation output", {
+      source: "semantic-consolidation",
+      derivedVia: "merge",
+      // deliberately omit derivedFrom to simulate versioning-disabled case
+    });
+
+    const all = await storage.readAllMemories();
+    const memory = all.find((m) => m.frontmatter.id === id);
+    assert.ok(memory);
+    assert.equal(memory.frontmatter.derived_from, undefined);
+    assert.equal(memory.frontmatter.derived_via, "merge");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("writeMemory accepts all three ConsolidationOperator values via derivedVia", async () => {
   const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-derived-ops-write-"));
   try {


### PR DESCRIPTION
## Summary

PR 2 of 5 for issue #561 (SPLIT/MERGE/UPDATE operators + `derived_from`
provenance).  Wires the frontmatter fields introduced in PR 1 (merged as
#574) through the semantic-consolidation write path.

Every consolidated memory now carries `derived_from` pointers into
page-version snapshots of its source memories and `derived_via: "merge"`
marking the operator.  Operator selection (SPLIT vs MERGE vs UPDATE based
on cluster shape) is deferred to PR 3.

## Changes

- **`packages/remnic-core/src/storage.ts`**
  - `writeMemory()` accepts new `derivedFrom?: string[]` and
    `derivedVia?: ConsolidationOperator` options.  Empty arrays are
    coerced to undefined so we never emit an invalid `derived_from: []`.
  - `snapshotForProvenance(filePath)` helper creates a page-versioning
    snapshot with trigger `"consolidation"` and returns the
    `"<relative-path>:<versionId>"` entry used by `derived_from`.
    Returns `null` when versioning is disabled or the file does not
    exist — callers skip the entry rather than abort.
- **`packages/remnic-core/src/orchestrator.ts`**
  - `runSemanticConsolidation` loop snapshots each source memory before
    archiving and passes the collected entries + `"merge"` to
    `writeMemory()`.

## Out of scope (follow-up PRs)

- **PR 3** — Explicit operator emission: refactor the consolidation
  prompt to return structured `{ operator, sources, output }` triples so
  the LLM picks SPLIT vs MERGE vs UPDATE based on cluster shape.
- **PR 4** — `remnic doctor` integrity check that validates every
  `derived_from` referent actually exists at the named version.
- **PR 5** — `remnic consolidate undo <target>` CLI path that restores
  source memories from their `derived_from` snapshots.

## Test plan

- [x] `tsx --test tests/storage-derived-write-paths.test.ts` — 7 tests:
  writeMemory option surface, empty-array coercion, all three operator
  values, snapshotForProvenance happy-path + disabled + missing file,
  and a full round-trip write→snapshot→canonical→read.
- [x] `tsx --test tests/orchestrator-consolidation-provenance-wiring.test.ts` —
  2 structural tests pinning the snapshot + writeMemory options wiring
  inside the semantic-consolidation loop.
- [x] `tsx --test tests/storage-derived-frontmatter.test.ts` (PR 1
  round-trip suite) — 9/9 still pass.
- [x] `tsc --noEmit` — clean.

Refs #561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new provenance metadata to consolidation outputs and introduces a best-effort snapshotting path that depends on page-versioning behavior; failures are intentionally non-fatal but could affect traceability/undo workflows.
> 
> **Overview**
> Semantic consolidation now snapshots each source memory *before* archiving and writes the canonical memory with provenance metadata: `derived_from` entries pointing at page-version snapshots plus `derived_via: "merge"`.
> 
> `StorageManager.writeMemory()` gains `derivedFrom`/`derivedVia` options and serializes them to frontmatter (omitting empty `derived_from`, allowing `derived_via` without sources), plus a new `snapshotForProvenance()` helper that creates the consolidation-triggered page-version snapshot and returns a `"<relpath>:<versionId>"` pointer. New tests cover the storage write/snapshot contract and enforce the orchestrator wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4de345a155ebffe4f8e106e0e600b610714fada6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->