### PR TITLE
feat(recall): reasoning_trace retrieval boost + dedicated subtree (#564 PR 3/4)

### DIFF
--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/joshuawarren/src/remnic/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/joshuawarren/src/remnic/node_modules

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3516,6 +3516,11 @@
         "minimum": 0,
         "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
       },
+      "recallReasoningTraceBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+      },
       "recallPipeline": {
         "type": "array",
         "description": "Ordered recall sections with per-section budgets and feature knobs.",
@@ -4821,6 +4826,11 @@
       "advanced": true,
       "placeholder": "40",
       "help": "Number of top candidates per section over which MMR is applied"
+    },
+    "recallReasoningTraceBoostEnabled": {
+      "label": "Boost Reasoning Traces on Problem-Solving Queries",
+      "advanced": true,
+      "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
   }
 }

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
@@ -1,0 +1,197 @@
+/**
+ * Synthetic fixture for the reasoning-trace retrieval benchmark
+ * (issue #564 PR 4).
+ *
+ * Each case simulates a recall scenario:
+ * - A seeded candidate pool of 15 past memories, two of which are stored
+ *   reasoning_trace chains (under reasoning-traces/) and the rest are
+ *   ordinary facts/decisions/entities.
+ * - A new query that may or may not match the semantics of a trace.
+ * - An expected winner id (the reasoning-trace we want boosted to rank 1
+ *   on problem-solving asks) and an expected verdict for the heuristic.
+ *
+ * Cases are split by expected behavior so the scorer can measure:
+ * - recall@1 gain on positive problem-solving queries,
+ * - false-positive rate on ordinary lookups (where the boost must not
+ *   shift results).
+ */
+
+export interface ReasoningTraceBenchCandidate {
+  docid: string;
+  /** Absolute-style path mimicking the real storage layout. */
+  path: string;
+  /** Pre-boost score from the upstream QMD/hybrid tier. */
+  score: number;
+  /** Short snippet used only for debugging output in failures. */
+  snippet: string;
+}
+
+export interface ReasoningTraceBenchCase {
+  id: string;
+  query: string;
+  candidates: ReasoningTraceBenchCandidate[];
+  /**
+   * When true, the boost must promote a reasoning_trace memory (any) to
+   * rank 1. When false, the boost must NOT change the top result
+   * (false-positive guard cases).
+   *
+   * We measure "any reasoning trace at rank 1" rather than a specific
+   * docid because the shipped boost is uniform across the category — if
+   * two traces share the boosted tier the higher-scored one wins, which
+   * is the intended behavior. Bench cases intentionally share a pool so
+   * the retrieval comparison stays apples-to-apples across queries.
+   */
+  expectsTraceTopAfterBoost: boolean;
+  /** Expected top docid when the boost is off (baseline). */
+  expectedTopWithoutBoost: string;
+  /**
+   * Whether the query should be classified as problem-solving by the
+   * shipped heuristic. Used by the scorer to verify classification.
+   */
+  expectedProblemSolving: boolean;
+}
+
+function trace(
+  docid: string,
+  score: number,
+  snippet: string,
+): ReasoningTraceBenchCandidate {
+  return {
+    docid,
+    path: `reasoning-traces/2026-04-18/${docid}.md`,
+    score,
+    snippet,
+  };
+}
+
+function fact(
+  docid: string,
+  score: number,
+  snippet: string,
+): ReasoningTraceBenchCandidate {
+  return {
+    docid,
+    path: `facts/2026-04-18/${docid}.md`,
+    score,
+    snippet,
+  };
+}
+
+/**
+ * Shared candidate pool — 15 memories, 2 are reasoning traces. Each case
+ * reuses this pool (cloned) with a relevant query so retrieval quality
+ * comparisons share a consistent baseline.
+ */
+function seedPool(): ReasoningTraceBenchCandidate[] {
+  // Scores mirror a realistic QMD hybrid-rank distribution where reasoning
+  // traces have non-trivial topical relevance (same keywords as the query)
+  // but sit just under the top fact until the boost fires. A default boost
+  // of 0.15 must be enough to promote them — that's exactly what we want
+  // to measure. Listed in descending-score order so the "baseline" (boost
+  // disabled) passes through the helper unchanged and rank 1 reflects the
+  // fact-pg-15 top expected by every case below.
+  return [
+    fact("fact-pg-15", 0.81, "remnic runs on Postgres 15"),
+    fact("fact-node-22", 0.78, "remnic requires Node 22.12 or newer"),
+    fact("fact-qmd", 0.74, "remnic uses qmd for hybrid retrieval"),
+    trace("trace-latency", 0.72, "How I debugged the staging latency spike"),
+    fact("fact-pnpm", 0.70, "remnic uses pnpm as the package manager"),
+    trace("trace-oauth-loop", 0.68, "How I untangled the OAuth redirect loop"),
+    fact("fact-monorepo", 0.67, "remnic lives in a pnpm workspace monorepo"),
+    fact("fact-tsx", 0.60, "tests run under tsx --test"),
+    fact("fact-release", 0.57, "release-please drives the release workflow"),
+    fact("fact-codeql", 0.55, "CodeQL scans run on every PR"),
+    fact("fact-review", 0.50, "PR reviews require both cursor and codex bots to post"),
+    fact("fact-hooks", 0.47, "pre-commit hooks run lint and quick tests"),
+    fact("fact-dash", 0.45, "admin console is built in the core package"),
+    fact("fact-docs", 0.40, "docs are in /docs, not per-package"),
+    fact("fact-export", 0.35, "@remnic/export-weclone is a separate optional package"),
+  ];
+}
+
+export const REASONING_TRACE_BENCH_FIXTURE: ReasoningTraceBenchCase[] = [
+  // Positive cases: query looks like a problem-solving ask, and one of the
+  // two reasoning traces in the pool is the most relevant memory.
+  {
+    id: "pos-latency-howto",
+    query: "How do I debug a latency spike in staging?",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-oauth-step-by-step",
+    query: "walk me through fixing an OAuth redirect loop step by step",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-troubleshoot-oauth",
+    query: "troubleshoot the OAuth loop we hit last quarter",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-figure-out-latency",
+    query: "how can I figure out why staging is slow",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-reason-through",
+    query: "Help me reason through the staging latency incident",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  // Negative / guard cases: query is an ordinary lookup. The boost must be
+  // a no-op — top result stays whatever the baseline produced.
+  {
+    id: "neg-postgres-version",
+    query: "what postgres version does remnic use",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-node-requirement",
+    query: "node engine requirement",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-package-manager",
+    query: "package manager for remnic",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-monorepo-layout",
+    query: "monorepo workspace layout",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-release-process",
+    query: "release automation tool",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+];

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests for the reasoning-trace retrieval bench fixture + runner
+ * (issue #564 PR 4).
+ *
+ * The fixture itself is synthetic, but we verify:
+ * - fixture shape: 10+ cases, mix of positive and negative, unique ids, all
+ *   cases reference the shared 15-memory pool with 2 reasoning traces.
+ * - running the bench in full mode produces aggregates that show the boost
+ *   lifts recall@1 above baseline on positive cases and leaves negative
+ *   cases unchanged — i.e. the feature is actually doing something
+ *   measurable.
+ * - latency stays well under 1ms per case (pure helper call).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  REASONING_TRACE_BENCH_FIXTURE,
+  type ReasoningTraceBenchCase,
+} from "./fixture.ts";
+import {
+  retrievalReasoningTraceDefinition,
+  runRetrievalReasoningTraceBenchmark,
+} from "./runner.ts";
+
+function countWhere(
+  cases: ReasoningTraceBenchCase[],
+  predicate: (c: ReasoningTraceBenchCase) => boolean,
+): number {
+  return cases.filter(predicate).length;
+}
+
+test("fixture: at least 10 cases with unique ids", () => {
+  assert.ok(
+    REASONING_TRACE_BENCH_FIXTURE.length >= 10,
+    `expected at least 10 cases, got ${REASONING_TRACE_BENCH_FIXTURE.length}`,
+  );
+  const ids = new Set<string>();
+  for (const c of REASONING_TRACE_BENCH_FIXTURE) {
+    assert.ok(!ids.has(c.id), `duplicate case id: ${c.id}`);
+    ids.add(c.id);
+  }
+});
+
+test("fixture: each case has 15 candidates with exactly 2 reasoning traces", () => {
+  for (const c of REASONING_TRACE_BENCH_FIXTURE) {
+    assert.equal(
+      c.candidates.length,
+      15,
+      `case ${c.id}: expected 15 candidates, got ${c.candidates.length}`,
+    );
+    const traces = c.candidates.filter((cand) =>
+      cand.path.includes("reasoning-traces/"),
+    );
+    assert.equal(
+      traces.length,
+      2,
+      `case ${c.id}: expected 2 reasoning traces in pool, got ${traces.length}`,
+    );
+  }
+});
+
+test("fixture: has both positive and negative cases", () => {
+  const positives = countWhere(
+    REASONING_TRACE_BENCH_FIXTURE,
+    (c) => c.expectsTraceTopAfterBoost,
+  );
+  const negatives = countWhere(
+    REASONING_TRACE_BENCH_FIXTURE,
+    (c) => !c.expectsTraceTopAfterBoost,
+  );
+  assert.ok(positives >= 3, `expected >=3 positive cases, got ${positives}`);
+  assert.ok(negatives >= 3, `expected >=3 negative cases, got ${negatives}`);
+});
+
+test("definition: benchmark metadata is ready and available", () => {
+  assert.equal(retrievalReasoningTraceDefinition.id, "retrieval-reasoning-trace");
+  assert.equal(retrievalReasoningTraceDefinition.tier, "remnic");
+  assert.equal(retrievalReasoningTraceDefinition.status, "ready");
+  assert.equal(retrievalReasoningTraceDefinition.runnerAvailable, true);
+});
+
+test("runner: full-mode run produces boost_recall_at_1 > 0 and boost_noop_preserved > 0", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "full",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  const recall = result.results.aggregates.boost_recall_at_1;
+  const noop = result.results.aggregates.boost_noop_preserved;
+  const baselineMatch = result.results.aggregates.baseline_top_matches_fixture;
+  const classification = result.results.aggregates.heuristic_classification_correct;
+
+  assert.ok(recall, "boost_recall_at_1 aggregate missing");
+  assert.ok(noop, "boost_noop_preserved aggregate missing");
+  assert.ok(
+    recall.mean === 1,
+    `expected 100% boost_recall_at_1 on positive cases, got ${recall.mean}`,
+  );
+  assert.ok(
+    noop.mean === 1,
+    `expected 100% boost_noop_preserved on negative cases, got ${noop.mean}`,
+  );
+  assert.ok(
+    baselineMatch && baselineMatch.mean === 1,
+    `baseline_top_matches_fixture should be 1, got ${baselineMatch?.mean}`,
+  );
+  assert.ok(
+    classification && classification.mean === 1,
+    `heuristic_classification_correct should be 1, got ${classification?.mean}`,
+  );
+});
+
+test("runner: quick mode exercises at least one positive AND one negative case", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "quick",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  // In quick mode we should still see both `boost_recall_at_1` (from a
+  // positive case) and `boost_noop_preserved` (from a negative case) so a
+  // one-sided regression can't slip through a smoke run.
+  assert.ok(
+    result.results.aggregates.boost_recall_at_1,
+    "quick mode must exercise the positive boost path",
+  );
+  assert.ok(
+    result.results.aggregates.boost_noop_preserved,
+    "quick mode must exercise the negative guard path",
+  );
+});
+
+test("runner: latency p95 stays well under 5ms (pure helper)", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "full",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  const p95 = result.results.aggregates.latency_p95_ms?.mean ?? 0;
+  assert.ok(
+    p95 < 5,
+    `expected p95 boost latency < 5ms, got ${p95}ms`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
@@ -1,0 +1,276 @@
+/**
+ * Reasoning-trace retrieval benchmark (issue #564 PR 4).
+ *
+ * Feeds a synthetic fixture of 15 past memories (2 reasoning traces + 13
+ * ordinary facts) into the retrieval boost helper with the flag on and
+ * off, and reports:
+ *
+ * - `boost_recall_at_1`: on positive problem-solving cases, the reasoning
+ *   trace lands at rank 1 after boost.
+ * - `boost_false_positive_rate_at_1`: on negative / ordinary-lookup
+ *   cases, the boost must leave rank 1 unchanged.
+ * - `heuristic_classification_correct`: looksLikeProblemSolvingQuery
+ *   agrees with the fixture's labeled expectation.
+ * - `latency_p50_ms` / `latency_p95_ms`: pure boost-call latency.
+ *
+ * No orchestrator, no search backend — the bench exercises the pure
+ * `applyReasoningTraceBoost` helper directly so it stays fast and
+ * deterministic.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  applyReasoningTraceBoost,
+  isReasoningTracePath,
+  looksLikeProblemSolvingQuery,
+} from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  REASONING_TRACE_BENCH_FIXTURE,
+  type ReasoningTraceBenchCase,
+} from "./fixture.js";
+
+/**
+ * Metrics where a lower value represents better performance. Registered
+ * in `LOWER_IS_BETTER_BY_BENCHMARK` so `compareResults()` treats an
+ * increase in latency as a regression rather than an improvement.
+ */
+export const RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER: ReadonlySet<string> =
+  new Set(["latency_p50_ms", "latency_p95_ms"]);
+
+export const retrievalReasoningTraceDefinition: BenchmarkDefinition = {
+  id: "retrieval-reasoning-trace",
+  title: "Retrieval: Reasoning-Trace Boost",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retrieval-reasoning-trace",
+    version: "1.0.0",
+    description:
+      "Measures the reasoning_trace recall boost: recall@1 gain on problem-solving queries, false-positive rate on ordinary lookups, heuristic classification agreement, and boost-call latency (issue #564 PR 4).",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #564",
+  },
+};
+
+interface CaseOutcome {
+  baselineTop: string;
+  baselineTopPath: string;
+  boostedTop: string;
+  boostedTopPath: string;
+  classifiedAsProblemSolving: boolean;
+  latencyMs: number;
+}
+
+function runCase(benchCase: ReasoningTraceBenchCase): CaseOutcome {
+  // Baseline: the same helper with `enabled: false`, which is a no-op but
+  // goes through the same code path so latency measurement is apples to
+  // apples with the boosted call below.
+  const baseline = applyReasoningTraceBoost(benchCase.candidates, {
+    enabled: false,
+    query: benchCase.query,
+  });
+  const baselineTop = baseline[0]?.docid ?? "";
+  const baselineTopPath = baseline[0]?.path ?? "";
+
+  const classifiedAsProblemSolving = looksLikeProblemSolvingQuery(benchCase.query);
+
+  const start = performance.now();
+  const boosted = applyReasoningTraceBoost(benchCase.candidates, {
+    enabled: true,
+    query: benchCase.query,
+  });
+  const latencyMs = performance.now() - start;
+  const boostedTop = boosted[0]?.docid ?? "";
+  const boostedTopPath = boosted[0]?.path ?? "";
+
+  return {
+    baselineTop,
+    baselineTopPath,
+    boostedTop,
+    boostedTopPath,
+    classifiedAsProblemSolving,
+    latencyMs,
+  };
+}
+
+function scoreCase(
+  benchCase: ReasoningTraceBenchCase,
+  outcome: CaseOutcome,
+): Record<string, number> {
+  const scores: Record<string, number> = {};
+
+  // Heuristic classification: did looksLikeProblemSolvingQuery match the
+  // fixture's labeled expectation?
+  scores.heuristic_classification_correct =
+    outcome.classifiedAsProblemSolving === benchCase.expectedProblemSolving ? 1 : 0;
+
+  // Sanity: baseline top matches the fixture's expected pre-boost winner.
+  scores.baseline_top_matches_fixture =
+    outcome.baselineTop === benchCase.expectedTopWithoutBoost ? 1 : 0;
+
+  if (!benchCase.expectsTraceTopAfterBoost) {
+    // Guard case: boost must not change rank 1.
+    scores.boost_noop_preserved =
+      outcome.boostedTop === outcome.baselineTop ? 1 : 0;
+  } else {
+    // Positive case: the top-1 memory after boost must live under
+    // reasoning-traces/. We measure "any trace at rank 1" rather than a
+    // specific docid because the shipped boost is uniform across the
+    // category — when two traces share the boosted tier, the higher-scored
+    // one naturally wins.
+    scores.boost_recall_at_1 = isReasoningTracePath(outcome.boostedTopPath) ? 1 : 0;
+  }
+
+  scores.latency_under_1ms = outcome.latencyMs < 1 ? 1 : 0;
+  return scores;
+}
+
+function selectCases(
+  mode: "quick" | "full",
+  limit?: number,
+): ReasoningTraceBenchCase[] {
+  if (limit === undefined && mode !== "quick") {
+    return REASONING_TRACE_BENCH_FIXTURE;
+  }
+
+  // Quick mode must exercise BOTH the positive recall path and the negative
+  // guard path — otherwise a regression that incorrectly boosts ordinary
+  // lookups silently passes smoke runs (the default mode in runBenchmark).
+  // Take 1 positive + 1 negative by default, or slice a balanced mix when
+  // an explicit limit is requested.
+  const positives = REASONING_TRACE_BENCH_FIXTURE.filter(
+    (c) => c.expectsTraceTopAfterBoost,
+  );
+  const negatives = REASONING_TRACE_BENCH_FIXTURE.filter(
+    (c) => !c.expectsTraceTopAfterBoost,
+  );
+
+  if (limit === undefined) {
+    // mode === "quick" and no explicit limit — take 1 of each.
+    const selected: ReasoningTraceBenchCase[] = [];
+    if (positives.length > 0) selected.push(positives[0]);
+    if (negatives.length > 0) selected.push(negatives[0]);
+    if (selected.length === 0) {
+      throw new Error(
+        "retrieval-reasoning-trace fixture has no cases to select in quick mode.",
+      );
+    }
+    return selected;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(
+      "retrieval-reasoning-trace limit must be a positive integer",
+    );
+  }
+
+  // Interleave positives and negatives so any `limit` >= 2 produces a mix.
+  const interleaved: ReasoningTraceBenchCase[] = [];
+  const max = Math.max(positives.length, negatives.length);
+  for (let i = 0; i < max && interleaved.length < limit; i++) {
+    if (i < positives.length && interleaved.length < limit) {
+      interleaved.push(positives[i]);
+    }
+    if (i < negatives.length && interleaved.length < limit) {
+      interleaved.push(negatives[i]);
+    }
+  }
+  if (interleaved.length === 0) {
+    throw new Error(
+      "retrieval-reasoning-trace fixture is empty after applying the requested limit.",
+    );
+  }
+  return interleaved;
+}
+
+export async function runRetrievalReasoningTraceBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const tasks: TaskResult[] = [];
+  const latencies: number[] = [];
+  const cases = selectCases(options.mode, options.limit);
+
+  for (const benchCase of cases) {
+    const outcome = runCase(benchCase);
+    latencies.push(outcome.latencyMs);
+    const scores = scoreCase(benchCase, outcome);
+    tasks.push({
+      taskId: benchCase.id,
+      question: benchCase.query,
+      expected: benchCase.expectsTraceTopAfterBoost
+        ? "top-is-reasoning-trace"
+        : `top-unchanged=${benchCase.expectedTopWithoutBoost}`,
+      actual: `baseline-top=${outcome.baselineTop};boosted-top=${outcome.boostedTop}`,
+      scores,
+      latencyMs: Math.round(outcome.latencyMs * 100) / 100,
+      tokens: { input: 0, output: 0 },
+      details: {
+        caseId: benchCase.id,
+        candidateCount: benchCase.candidates.length,
+        classifiedAsProblemSolving: outcome.classifiedAsProblemSolving,
+      },
+    });
+  }
+
+  latencies.sort((a, b) => a - b);
+  const p50Raw = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
+  const p95Raw =
+    latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] ?? 0;
+  const p50 = Math.round(p50Raw * 100) / 100;
+  const p95 = Math.round(p95Raw * 100) / 100;
+
+  const aggregated = aggregateTaskScores(tasks.map((task) => task.scores));
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: {
+        ...aggregated,
+        latency_p50_ms: { mean: p50, median: p50, stdDev: 0, min: p50, max: p50 },
+        latency_p95_ms: { mean: p95, median: p95, stdDev: 0, min: p95, max: p95 },
+      },
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -72,6 +72,10 @@ import {
   runRetrievalDirectAnswerBenchmark,
 } from "./benchmarks/remnic/retrieval-direct-answer/runner.js";
 import {
+  retrievalReasoningTraceDefinition,
+  runRetrievalReasoningTraceBenchmark,
+} from "./benchmarks/remnic/retrieval-reasoning-trace/runner.js";
+import {
   codingRecallDefinition,
   runCodingRecallBenchmark,
 } from "./benchmarks/remnic/coding-recall/runner.js";
@@ -188,6 +192,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalDirectAnswerDefinition,
     run: runRetrievalDirectAnswerBenchmark,
+  },
+  {
+    ...retrievalReasoningTraceDefinition,
+    run: runRetrievalReasoningTraceBenchmark,
   },
   {
     ...codingRecallDefinition,

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -102,9 +102,11 @@ export function compareResults(
  * metrics as regressions when they increase.
  */
 import { INGESTION_SETUP_FRICTION_LOWER_IS_BETTER } from "../benchmarks/remnic/ingestion-setup-friction/runner.js";
+import { RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER } from "../benchmarks/remnic/retrieval-reasoning-trace/runner.js";
 
 const LOWER_IS_BETTER_BY_BENCHMARK: Record<string, ReadonlySet<string>> = {
   "ingestion-setup-friction": INGESTION_SETUP_FRICTION_LOWER_IS_BETTER,
+  "retrieval-reasoning-trace": RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER,
 };
 
 export function getBenchmarkLowerIsBetter(benchmarkId: string): ReadonlySet<string> {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3474,6 +3474,11 @@
         "minimum": 0,
         "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
       },
+      "recallReasoningTraceBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+      },
       "recallPipeline": {
         "type": "array",
         "description": "Ordered recall sections with per-section budgets and feature knobs.",
@@ -4779,6 +4784,11 @@
       "advanced": true,
       "placeholder": "40",
       "help": "Number of top candidates per section over which MMR is applied"
+    },
+    "recallReasoningTraceBoostEnabled": {
+      "label": "Boost Reasoning Traces on Problem-Solving Queries",
+      "advanced": true,
+      "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
   }
 }

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1725,6 +1725,9 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.recallMmrTopN === "number" && Number.isFinite(cfg.recallMmrTopN)
         ? Math.max(0, Math.floor(cfg.recallMmrTopN))
         : 40,
+    // Issue #564 PR 3: off by default; enable explicitly after bench validation.
+    recallReasoningTraceBoostEnabled:
+      coerceBool(cfg.recallReasoningTraceBoostEnabled) ?? false,
     qmdRecallCacheTtlMs:
       typeof cfg.qmdRecallCacheTtlMs === "number" ? Math.max(0, Math.floor(cfg.qmdRecallCacheTtlMs)) : 60_000,
     qmdRecallCacheStaleTtlMs:

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -121,6 +121,19 @@ export {
 } from "./direct-answer.js";
 
 // ---------------------------------------------------------------------------
+// Reasoning-trace retrieval boost (issue #564)
+// ---------------------------------------------------------------------------
+
+export {
+  applyReasoningTraceBoost,
+  isReasoningTracePath,
+  looksLikeProblemSolvingQuery,
+  DEFAULT_REASONING_TRACE_BOOST,
+  type ApplyReasoningTraceBoostOptions,
+  type BoostableResult,
+} from "./reasoning-trace-recall.js";
+
+// ---------------------------------------------------------------------------
 // Inline source attribution (issue #369)
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/namespaces/migrate.ts
+++ b/packages/remnic-core/src/namespaces/migrate.ts
@@ -15,6 +15,11 @@ const LEGACY_NAMESPACE_CHILDREN = [
   "state",
   "config",
   "summaries",
+  "procedures",
+  // Issue #564 PR 3: reasoning_trace memories live in their own subtree.
+  // Must be included here so namespace migration moves existing traces
+  // into the target namespace root alongside other memory data.
+  "reasoning-traces",
   "profile.md",
 ] as const;
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1168,13 +1168,25 @@ export function resolvePersistedMemoryRelativePath(options: {
   if (options.category === "correction") {
     return path.join("corrections", `${options.memoryId}.md`);
   }
+  // Pick the subtree that matches the StorageManager.writeMemory routing
+  // so fallback paths (used before memoryPathById has seen the fresh
+  // write) agree with where the file actually lives. Without this branch,
+  // reasoning_trace graph edges point at facts/<date>/, and subsequent
+  // graph expansion silently drops those nodes when readMemoryByPath
+  // cannot resolve them (issue #564 PR 3 review).
+  const subtree =
+    options.category === "procedure"
+      ? "procedures"
+      : options.category === "reasoning_trace"
+        ? "reasoning-traces"
+        : "facts";
   const idParts = options.memoryId.split("-");
   const maybeTimestamp = Number(idParts[1]);
   if (Number.isFinite(maybeTimestamp) && maybeTimestamp > 0) {
     const day = new Date(maybeTimestamp).toISOString().slice(0, 10);
-    return path.join("facts", day, `${options.memoryId}.md`);
+    return path.join(subtree, day, `${options.memoryId}.md`);
   }
-  return path.join("facts", `${options.memoryId}.md`);
+  return path.join(subtree, `${options.memoryId}.md`);
 }
 
 export class Orchestrator {

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -82,6 +82,7 @@ import {
 } from "./retrieval-agents.js";
 import { RerankCache, rerankLocalOrNoop } from "./rerank.js";
 import { reorderRecallResultsWithMmr } from "./recall-mmr.js";
+import { applyReasoningTraceBoost } from "./reasoning-trace-recall.js";
 import {
   applyTemporalSupersession,
   normalizeSupersessionKey,
@@ -8149,6 +8150,7 @@ export class Orchestrator {
         "memories",
         memoryResults,
         recallResultLimit,
+        retrievalQuery,
       );
 
       // E-Mem-inspired memory reconstruction: fill gaps for referenced entities
@@ -8257,6 +8259,7 @@ export class Orchestrator {
           "memories",
           boostedScoped,
           recallResultLimit,
+          retrievalQuery,
         );
         if (scoped.length > 0) {
           if (shouldPersistGraphSnapshot) {
@@ -8395,6 +8398,7 @@ export class Orchestrator {
         "memories",
         boostedScoped,
         recallResultLimit,
+        retrievalQuery,
       );
       if (scoped.length > 0) {
         if (shouldPersistGraphSnapshot) {
@@ -8541,6 +8545,7 @@ export class Orchestrator {
               "memories",
               boostedRecent,
               recallResultLimit,
+              retrievalQuery,
             );
 
             if (recent.length > 0) {
@@ -13473,6 +13478,7 @@ export class Orchestrator {
     sectionId: string,
     results: QmdSearchResult[],
     limit: number,
+    retrievalQuery?: string,
   ): QmdSearchResult[] {
     const safeLimit =
       typeof limit === "number" && Number.isFinite(limit)
@@ -13484,7 +13490,18 @@ export class Orchestrator {
     // the memories section is genuinely skipped. This mirrors the
     // `slice(0, 0)` semantics of every call site this helper replaced.
     if (safeLimit === 0) return [];
-    const diversified = this.applyMmrToQmdResults(sectionId, results);
+    // Issue #564 PR 3: when the feature flag is on, boost reasoning_trace
+    // memories for problem-solving asks so they bubble up ahead of ordinary
+    // facts/decisions before MMR picks the final section. No-op when the
+    // flag is off or the query is not a problem-solving ask.
+    const boosted =
+      this.config.recallReasoningTraceBoostEnabled && typeof retrievalQuery === "string"
+        ? applyReasoningTraceBoost(results, {
+            enabled: true,
+            query: retrievalQuery,
+          })
+        : results;
+    const diversified = this.applyMmrToQmdResults(sectionId, boosted);
     return diversified.slice(0, safeLimit);
   }
 
@@ -13951,6 +13968,7 @@ export class Orchestrator {
       "memories",
       results,
       options.recallResultLimit,
+      options.prompt,
     );
   }
 

--- a/packages/remnic-core/src/reasoning-trace-recall.ts
+++ b/packages/remnic-core/src/reasoning-trace-recall.ts
@@ -1,0 +1,160 @@
+/**
+ * Reasoning-trace recall boost (issue #564 PR 3).
+ *
+ * Pure helpers for:
+ * - detecting whether a user query looks like a problem-solving ask
+ *   ("how do I…", "step by step", etc.)
+ * - boosting stored reasoning_trace memories within a result list when that
+ *   condition matches.
+ *
+ * Callers gate these helpers behind the `recallReasoningTraceBoostEnabled`
+ * config flag (default false); the helpers themselves are also no-ops when
+ * `enabled` is false so they can be safely chained into the recall pipeline.
+ */
+
+/**
+ * Heuristic: does the incoming query read like the user wants a stored
+ * solution chain (reasoning trace)?
+ *
+ * Positive signals:
+ *  - starts with "how do I", "how can I", "how would I", "how to"
+ *  - contains "step by step", "walk me through", "work through"
+ *  - contains "reasoning", "think through", "figure out", "debug"
+ *  - explicitly mentions "trace" or "chain of thought"
+ *
+ * This is intentionally conservative — the boost is OFF by default, so false
+ * negatives are cheap, but false positives would shift retrieval for ordinary
+ * queries on an opt-in install.
+ */
+export function looksLikeProblemSolvingQuery(query: string): boolean {
+  if (typeof query !== "string") return false;
+  const q = query.trim().toLowerCase();
+  if (q.length === 0) return false;
+
+  // Starts-with patterns.
+  const startsWithPatterns = [
+    /^how\s+do\s+i\b/,
+    /^how\s+can\s+i\b/,
+    /^how\s+would\s+i\b/,
+    /^how\s+should\s+i\b/,
+    /^how\s+to\b/,
+    /^what'?s?\s+the\s+best\s+way\s+to\b/,
+    /^can\s+you\s+walk\s+me\s+through\b/,
+    /^walk\s+me\s+through\b/,
+    /^help\s+me\s+debug\b/,
+    /^help\s+me\s+figure\s+out\b/,
+    /^why\s+(does|is|did)\b/,
+  ];
+  for (const re of startsWithPatterns) {
+    if (re.test(q)) return true;
+  }
+
+  // Anywhere-in-string phrases.
+  const phrases = [
+    "step by step",
+    "step-by-step",
+    "work through this",
+    "walk through this",
+    "walk me through",
+    "reason through",
+    "think through",
+    "figure out how",
+    "chain of thought",
+    "reasoning trace",
+    "solution chain",
+    "troubleshoot",
+  ];
+  for (const phrase of phrases) {
+    if (q.includes(phrase)) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Minimal shape the boost helper needs to read from a recall result. Matches
+ * QmdSearchResult as of issue #564 but kept structural so tests and future
+ * callers don't have to import orchestrator-level types.
+ */
+export interface BoostableResult {
+  path: string;
+  score: number;
+  docid?: string;
+}
+
+/**
+ * Path-based marker for memories that live in the dedicated
+ * reasoning-traces/ subtree. Using a path segment keeps this cheap: no
+ * frontmatter parsing or extra I/O is needed.
+ */
+export function isReasoningTracePath(candidatePath: string): boolean {
+  if (typeof candidatePath !== "string") return false;
+  // Match "/reasoning-traces/" as a full path segment to avoid false
+  // positives like "my-reasoning-traces-notes/".
+  return /(^|[\\/])reasoning-traces([\\/]|$)/.test(candidatePath);
+}
+
+/**
+ * Default additive boost applied to a reasoning_trace candidate when the
+ * current query looks like a problem-solving ask.
+ *
+ * Chosen to be roughly the same magnitude as the existing CATEGORY_BOOSTS
+ * entry for reasoning_trace (0.09 in importance scoring), keeping the signal
+ * visible but not overwhelming stronger lexical/vector matches.
+ */
+export const DEFAULT_REASONING_TRACE_BOOST = 0.15;
+
+export interface ApplyReasoningTraceBoostOptions {
+  enabled: boolean;
+  query: string;
+  boost?: number;
+}
+
+/**
+ * Apply a score boost to results whose path sits under reasoning-traces/
+ * when the query looks like a problem-solving ask. Returns a new array
+ * re-sorted by descending score; the input array is not mutated.
+ *
+ * No-ops (returns the input unchanged) when:
+ *  - `enabled` is false,
+ *  - `query` is empty / not a problem-solving ask,
+ *  - the result list contains no reasoning-trace paths.
+ */
+export function applyReasoningTraceBoost<R extends BoostableResult>(
+  results: readonly R[],
+  options: ApplyReasoningTraceBoostOptions,
+): R[] {
+  if (!options.enabled) return [...results];
+  if (!Array.isArray(results) || results.length === 0) return [...results];
+  if (!looksLikeProblemSolvingQuery(options.query)) return [...results];
+
+  const boostAmount =
+    typeof options.boost === "number" && Number.isFinite(options.boost) && options.boost >= 0
+      ? options.boost
+      : DEFAULT_REASONING_TRACE_BOOST;
+
+  let changed = false;
+  const annotated = results.map((r, originalIndex) => {
+    if (isReasoningTracePath(r.path)) {
+      changed = true;
+      const baseScore = typeof r.score === "number" && Number.isFinite(r.score) ? r.score : 0;
+      return {
+        result: { ...r, score: baseScore + boostAmount } as R,
+        originalIndex,
+      };
+    }
+    return { result: r, originalIndex };
+  });
+
+  if (!changed) return [...results];
+
+  annotated.sort((a, b) => {
+    const as = typeof a.result.score === "number" ? a.result.score : 0;
+    const bs = typeof b.result.score === "number" ? b.result.score : 0;
+    if (bs !== as) return bs - as;
+    // Stable tie-break: original order.
+    return a.originalIndex - b.originalIndex;
+  });
+
+  return annotated.map((a) => a.result);
+}

--- a/packages/remnic-core/src/reasoning-trace-recall.ts
+++ b/packages/remnic-core/src/reasoning-trace-recall.ts
@@ -49,20 +49,28 @@ export function looksLikeProblemSolvingQuery(query: string): boolean {
     if (re.test(q)) return true;
   }
 
-  // Anywhere-in-string phrases.
+  // Anywhere-in-string phrases. These mirror the doc-comment's stated
+  // positive signals: broader variants ("work through", "figure out",
+  // "debug this") are included so "how do I debug this" doesn't have to
+  // lean on the `help me debug` starts-with entry alone, and so queries
+  // like "work through the problem" or "figure out why it broke" trigger
+  // the heuristic as the docstring claims.
   const phrases = [
     "step by step",
     "step-by-step",
-    "work through this",
-    "walk through this",
+    "work through",
+    "walk through",
     "walk me through",
     "reason through",
     "think through",
-    "figure out how",
+    "figure out",
     "chain of thought",
     "reasoning trace",
     "solution chain",
     "troubleshoot",
+    "debug this",
+    "debug the",
+    " debug ",
   ];
   for (const phrase of phrases) {
     if (q.includes(phrase)) return true;

--- a/packages/remnic-core/src/reasoning-trace-recall.ts
+++ b/packages/remnic-core/src/reasoning-trace-recall.ts
@@ -112,13 +112,32 @@ export interface ApplyReasoningTraceBoostOptions {
 
 /**
  * Apply a score boost to results whose path sits under reasoning-traces/
- * when the query looks like a problem-solving ask. Returns a new array
- * re-sorted by descending score; the input array is not mutated.
+ * when the query looks like a problem-solving ask. Returns a new array;
+ * the input array is not mutated.
  *
- * No-ops (returns the input unchanged) when:
+ * Ordering policy: the helper walks the results in order, boosts every
+ * matching reasoning trace in place, then promotes each boosted trace
+ * upward PAST any non-boosted neighbor whose score is strictly lower
+ * than the trace's boosted score. Non-matching results keep their
+ * incoming relative order — so reranker-driven path ordering and any
+ * other upstream nudges on non-trace items are preserved. We do NOT
+ * re-sort the full list, which would wipe out rerank priority on
+ * non-trace items (whose numeric scores may have been left stale by the
+ * rerank pass). This matters because MMR runs immediately after and
+ * truncates to a topN window — globally re-sorting would silently drop
+ * reranker-promoted items below the cutoff.
+ *
+ * No-ops (returns a copy of the input unchanged) when:
  *  - `enabled` is false,
  *  - `query` is empty / not a problem-solving ask,
  *  - the result list contains no reasoning-trace paths.
+ *
+ * Note on legacy paths: this helper intentionally only matches paths
+ * under the dedicated `reasoning-traces/` subtree introduced by PR 3.
+ * Historical reasoning_trace memories (if any) written before that
+ * subtree existed were routed to `facts/<date>/` and are NOT
+ * boost-eligible. Operators upgrading across that boundary should run
+ * the migration CLI or rewrite old paths before enabling the boost.
  */
 export function applyReasoningTraceBoost<R extends BoostableResult>(
   results: readonly R[],
@@ -133,28 +152,42 @@ export function applyReasoningTraceBoost<R extends BoostableResult>(
       ? options.boost
       : DEFAULT_REASONING_TRACE_BOOST;
 
+  // Step 1: boost the scores of matching traces, preserving positions.
+  const boosted: R[] = [];
   let changed = false;
-  const annotated = results.map((r, originalIndex) => {
+  for (const r of results) {
     if (isReasoningTracePath(r.path)) {
       changed = true;
       const baseScore = typeof r.score === "number" && Number.isFinite(r.score) ? r.score : 0;
-      return {
-        result: { ...r, score: baseScore + boostAmount } as R,
-        originalIndex,
-      };
+      boosted.push({ ...r, score: baseScore + boostAmount } as R);
+    } else {
+      boosted.push(r);
     }
-    return { result: r, originalIndex };
-  });
+  }
+  if (!changed) return boosted;
 
-  if (!changed) return [...results];
+  // Step 2: promote each boosted trace upward past any non-trace neighbor
+  // whose score is strictly lower than the boosted score. Non-trace items
+  // never move past each other, so reranker-driven ordering on non-trace
+  // items is preserved.
+  const out = boosted.slice();
+  for (let i = 0; i < out.length; i++) {
+    if (!isReasoningTracePath(out[i].path)) continue;
+    const trace = out[i];
+    const traceScore =
+      typeof trace.score === "number" && Number.isFinite(trace.score) ? trace.score : 0;
+    let j = i;
+    while (j > 0) {
+      const prev = out[j - 1];
+      if (isReasoningTracePath(prev.path)) break; // don't reorder traces vs each other
+      const prevScore =
+        typeof prev.score === "number" && Number.isFinite(prev.score) ? prev.score : 0;
+      if (prevScore >= traceScore) break;
+      out[j] = prev;
+      j -= 1;
+    }
+    if (j !== i) out[j] = trace;
+  }
 
-  annotated.sort((a, b) => {
-    const as = typeof a.result.score === "number" ? a.result.score : 0;
-    const bs = typeof b.result.score === "number" ? b.result.score : 0;
-    if (bs !== as) return bs - as;
-    // Stable tie-break: original order.
-    return a.originalIndex - b.originalIndex;
-  });
-
-  return annotated.map((a) => a.result);
+  return out;
 }

--- a/packages/remnic-core/src/search/document-scanner.ts
+++ b/packages/remnic-core/src/search/document-scanner.ts
@@ -73,16 +73,24 @@ async function scanDir(dir: string): Promise<IndexableDocument[]> {
 }
 
 /**
- * Scan `facts/`, `corrections/`, and `procedures/` subdirs of memoryDir for indexable markdown documents.
+ * Scan `facts/`, `corrections/`, `procedures/`, and `reasoning-traces/`
+ * subdirs of memoryDir for indexable markdown documents.
+ *
+ * Note: reasoning-traces live under their own subtree (issue #564 PR 3).
+ * Non-QMD backends (Orama / Meilisearch / LanceDB) build their index
+ * through this helper, so any new category subtree must be listed here
+ * or those backends silently stop seeing the new memories.
  */
 export async function scanMemoryDir(memoryDir: string): Promise<IndexableDocument[]> {
   const factsDir = path.join(memoryDir, "facts");
   const correctionsDir = path.join(memoryDir, "corrections");
   const proceduresDir = path.join(memoryDir, "procedures");
-  const [facts, corrections, procedures] = await Promise.all([
+  const reasoningTracesDir = path.join(memoryDir, "reasoning-traces");
+  const [facts, corrections, procedures, reasoningTraces] = await Promise.all([
     scanDir(factsDir),
     scanDir(correctionsDir),
     scanDir(proceduresDir),
+    scanDir(reasoningTracesDir),
   ]);
-  return [...facts, ...corrections, ...procedures];
+  return [...facts, ...corrections, ...procedures, ...reasoningTraces];
 }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3369,6 +3369,13 @@ export class StorageManager {
     if (memory.frontmatter.category === "procedure") {
       return path.join(root, "procedures", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
     }
+    if (memory.frontmatter.category === "reasoning_trace") {
+      // Issue #564 PR 3: preserve the dedicated reasoning-traces/ subtree
+      // across tier moves. Without this branch, hot→cold migration would
+      // funnel the memory into facts/, breaking isReasoningTracePath() and
+      // silently disabling the recall boost for migrated traces.
+      return path.join(root, "reasoning-traces", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
+    }
     return path.join(root, "facts", this.resolveMemoryDateDir(memory), `${memory.frontmatter.id}.md`);
   }
 

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2095,6 +2095,9 @@ export class StorageManager {
   private get proceduresDir(): string {
     return path.join(this.baseDir, "procedures");
   }
+  private get reasoningTracesDir(): string {
+    return path.join(this.baseDir, "reasoning-traces");
+  }
   private get entitiesDir(): string {
     return path.join(this.baseDir, "entities");
   }
@@ -2303,6 +2306,7 @@ export class StorageManager {
     const today = new Date().toISOString().slice(0, 10);
     await mkdir(path.join(this.factsDir, today), { recursive: true });
     await mkdir(path.join(this.proceduresDir, today), { recursive: true });
+    await mkdir(path.join(this.reasoningTracesDir, today), { recursive: true });
     await mkdir(this.correctionsDir, { recursive: true });
     await mkdir(this.entitiesDir, { recursive: true });
     await mkdir(this.stateDir, { recursive: true });
@@ -2431,6 +2435,11 @@ export class StorageManager {
     } else if (category === "procedure") {
       await mkdir(path.join(this.proceduresDir, today), { recursive: true });
       filePath = path.join(this.proceduresDir, today, `${id}.md`);
+    } else if (category === "reasoning_trace") {
+      // Issue #564 PR 3: reasoning traces live in their own subtree so recall
+      // can filter on path cheaply without parsing frontmatter.
+      await mkdir(path.join(this.reasoningTracesDir, today), { recursive: true });
+      filePath = path.join(this.reasoningTracesDir, today, `${id}.md`);
     } else {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }
@@ -2956,6 +2965,7 @@ export class StorageManager {
 
     await collectPaths(this.factsDir);
     await collectPaths(this.proceduresDir);
+    await collectPaths(this.reasoningTracesDir);
     await collectPaths(this.correctionsDir);
     return filePaths;
   }
@@ -5600,6 +5610,11 @@ export class StorageManager {
     } else if (category === "procedure") {
       await mkdir(path.join(this.proceduresDir, today), { recursive: true });
       filePath = path.join(this.proceduresDir, today, `${id}.md`);
+    } else if (category === "reasoning_trace") {
+      // Issue #564 PR 3: chunks of a reasoning_trace memory live alongside the
+      // parent in reasoning-traces/<date>/.
+      await mkdir(path.join(this.reasoningTracesDir, today), { recursive: true });
+      filePath = path.join(this.reasoningTracesDir, today, `${id}.md`);
     } else {
       filePath = path.join(this.factsDir, today, `${id}.md`);
     }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -847,6 +847,13 @@ export interface PluginConfig {
   recallMmrLambda: number;
   /** MMR is applied over the top N candidates per section. Default 40. */
   recallMmrTopN: number;
+  /**
+   * Boost stored `reasoning_trace` memories in recall results when the
+   * incoming query reads like a problem-solving ask (e.g. "how do I…",
+   * "step by step", "walk me through…"). Default false — opt in after
+   * benchmarking (issue #564 PR 3).
+   */
+  recallReasoningTraceBoostEnabled: boolean;
   qmdRecallCacheTtlMs: number;
   qmdRecallCacheStaleTtlMs: number;
   qmdRecallCacheMaxEntries: number;

--- a/packages/remnic-core/src/utils/category-dir.ts
+++ b/packages/remnic-core/src/utils/category-dir.ts
@@ -19,6 +19,7 @@ export const CATEGORY_DIR_MAP: Record<string, string> = {
   skill: "skills",
   relationship: "relationships",
   procedure: "procedures",
+  reasoning_trace: "reasoning-traces",
 };
 
 /** All directory names derived from CATEGORY_DIR_MAP, plus "facts" (the default). */

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -29,6 +29,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "retrieval-personalization",
       "retrieval-temporal",
       "retrieval-direct-answer",
+      "retrieval-reasoning-trace",
       "coding-recall",
       "procedural-recall",
       "ingestion-entity-recall",
@@ -73,11 +74,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.

--- a/tests/reasoning-trace-recall.test.ts
+++ b/tests/reasoning-trace-recall.test.ts
@@ -116,30 +116,65 @@ describe("applyReasoningTraceBoost", () => {
     );
   });
 
-  it("re-sorts traces to the top on a matching query", () => {
+  it("promotes traces past lower-scored neighbors without re-sorting the full list", () => {
+    // Lower-boost case: default 0.15 boost bumps b to 0.75 and d to 0.65,
+    // but fact-a (0.9) and fact-c (0.8) both still outscore them, so the
+    // order shouldn't change — critically, we do NOT globally re-sort
+    // (which would move b ahead of c by pure score). Non-trace items keep
+    // their incoming relative order so reranker-driven ordering survives.
     const out = applyReasoningTraceBoost(fixture, {
       enabled: true,
       query: "how do I debug the latency spike?",
     });
-    // With default boost 0.15, b: 0.6+0.15=0.75, d: 0.5+0.15=0.65
-    // Expected order: a(0.9) > b(0.75) > c(0.8) → actually a(0.9) > c(0.8) > b(0.75) > d(0.65)
-    // Wait: a=0.9, c=0.8, b=0.75, d=0.65
     assert.deepEqual(
       out.map((r) => r.docid),
-      ["a", "c", "b", "d"],
+      ["a", "b", "c", "d"],
     );
     const b = out.find((r) => r.docid === "b");
     assert.equal(b?.score, 0.6 + DEFAULT_REASONING_TRACE_BOOST);
   });
 
-  it("honors a custom boost amount", () => {
+  it("honors a custom boost amount and promotes traces past lower-scored facts", () => {
     const out = applyReasoningTraceBoost(fixture, {
       enabled: true,
       query: "walk me through the debug",
-      boost: 1.0, // enormous — pushes traces to the top
+      boost: 1.0, // enormous — trace scores beat every fact
     });
-    assert.equal(out[0].docid, "b");
-    assert.equal(out[1].docid, "d");
+    // b (trace, 0.6+1.0=1.6) promotes past a (0.9). d (trace, 0.5+1.0=1.5)
+    // promotes past c (0.8). Trace-vs-trace order preserved (b before d
+    // since it appeared earlier in the input).
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["b", "d", "a", "c"],
+    );
+  });
+
+  it("preserves rerank order on non-trace items when traces move up", () => {
+    // Input simulates a reranker output: fact-a has stale low score but
+    // higher position, fact-b has a higher numeric score but lower
+    // position (classic rerank-rewrites-order-not-scores shape). The
+    // boost must promote the trace past fact-b (whose score is lower
+    // than the boosted trace) without globally re-sorting, so the
+    // reranker-preferred order [fact-a, fact-b] is kept.
+    const rerankShape = [
+      { docid: "fact-a-reranked", path: "facts/a.md", score: 0.40 },
+      { docid: "fact-b-lower-rank", path: "facts/b.md", score: 0.60 },
+      { docid: "the-trace", path: "reasoning-traces/t.md", score: 0.50 },
+    ];
+    const out = applyReasoningTraceBoost(rerankShape, {
+      enabled: true,
+      query: "how do I debug",
+    });
+    // trace: 0.50+0.15=0.65. Walk back: prev=fact-b-lower-rank(0.60)
+    // which is strictly less than 0.65 → promote past. prev=fact-a
+    // -reranked(0.40) which is also strictly less → promote past. Final
+    // order puts trace first. Critically, fact-a-reranked stays ahead
+    // of fact-b-lower-rank (the reranker's intended order) rather than
+    // being re-sorted by score.
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["the-trace", "fact-a-reranked", "fact-b-lower-rank"],
+    );
   });
 
   it("preserves stable tie-break on equal scores", () => {

--- a/tests/reasoning-trace-recall.test.ts
+++ b/tests/reasoning-trace-recall.test.ts
@@ -246,4 +246,56 @@ describe("StorageManager reasoning_trace routing", () => {
       await rm(dir, { recursive: true, force: true });
     }
   });
+
+  it("buildTierMemoryPath preserves the reasoning-traces/ subtree across tier moves", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-reasoning-trace-tier-"));
+    try {
+      const storage = new StorageManager(dir);
+      const body = [
+        "How I picked route-b",
+        "",
+        "## Step 1",
+        "",
+        "Enumerated candidate routes.",
+        "",
+        "## Step 2",
+        "",
+        "Measured round-trip times.",
+        "",
+        "## Final Answer",
+        "",
+        "route-b pinned.",
+      ].join("\n");
+      const id = await storage.writeMemory("reasoning_trace", body, {
+        source: "test",
+      });
+      const memories = await storage.readAllMemories();
+      const found = memories.find((m) => m.frontmatter.id === id);
+      assert.ok(found, "stored reasoning_trace should be readable");
+
+      // Both hot and cold migration targets must live under reasoning-traces/.
+      const hot = storage.buildTierMemoryPath(found, "hot");
+      const cold = storage.buildTierMemoryPath(found, "cold");
+      assert.ok(
+        hot.includes(`${path.sep}reasoning-traces${path.sep}`),
+        `hot tier path should remain under reasoning-traces/, got: ${hot}`,
+      );
+      assert.ok(
+        cold.includes(`${path.sep}reasoning-traces${path.sep}`),
+        `cold tier path should remain under reasoning-traces/, got: ${cold}`,
+      );
+      // And it must NOT be funneled into facts/ — that would break
+      // isReasoningTracePath() and silently disable the recall boost.
+      assert.ok(
+        !/[\\/]facts[\\/]/.test(hot),
+        `reasoning_trace must not be migrated into facts/: ${hot}`,
+      );
+      assert.ok(
+        !/[\\/]facts[\\/]/.test(cold),
+        `reasoning_trace must not be migrated into facts/: ${cold}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
 });

--- a/tests/reasoning-trace-recall.test.ts
+++ b/tests/reasoning-trace-recall.test.ts
@@ -1,0 +1,249 @@
+/**
+ * Tests for reasoning_trace recall boost + storage routing (issue #564 PR 3).
+ *
+ * Covers:
+ * - looksLikeProblemSolvingQuery heuristic accept/reject matrix.
+ * - isReasoningTracePath path-segment detection.
+ * - applyReasoningTraceBoost: no-op when disabled / wrong query / no traces
+ *   in results; re-sorts boosted traces to the top when enabled + matching.
+ * - Config parsing: recallReasoningTraceBoostEnabled defaults false, accepts
+ *   explicit true, and tolerates the usual coerceBool string variants.
+ * - StorageManager.writeMemory routes category="reasoning_trace" into a
+ *   dedicated reasoning-traces/<date>/ subtree and ensureDirectories
+ *   pre-creates that tree.
+ * - readAllMemories discovers memories written to reasoning-traces/ so they
+ *   show up for downstream retrieval.
+ */
+
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { access, mkdtemp, rm } from "node:fs/promises";
+
+import {
+  applyReasoningTraceBoost,
+  isReasoningTracePath,
+  looksLikeProblemSolvingQuery,
+  DEFAULT_REASONING_TRACE_BOOST,
+} from "../packages/remnic-core/src/reasoning-trace-recall.js";
+import { parseConfig } from "../packages/remnic-core/src/config.js";
+import { StorageManager } from "../src/storage.ts";
+
+describe("looksLikeProblemSolvingQuery", () => {
+  it("accepts 'how do I' style starts", () => {
+    assert.equal(looksLikeProblemSolvingQuery("How do I debug this deadlock?"), true);
+    assert.equal(looksLikeProblemSolvingQuery("how can I make this faster"), true);
+    assert.equal(looksLikeProblemSolvingQuery("How would I approach sharding?"), true);
+    assert.equal(looksLikeProblemSolvingQuery("how to configure Vite with TS"), true);
+  });
+
+  it("accepts 'step by step' and 'walk me through' variants", () => {
+    assert.equal(looksLikeProblemSolvingQuery("show me step by step"), true);
+    assert.equal(looksLikeProblemSolvingQuery("walk me through the refactor"), true);
+    assert.equal(looksLikeProblemSolvingQuery("let's work through this"), true);
+  });
+
+  it("accepts reasoning/chain-of-thought phrasing", () => {
+    assert.equal(looksLikeProblemSolvingQuery("reason through the tradeoffs"), true);
+    assert.equal(looksLikeProblemSolvingQuery("show me the chain of thought"), true);
+    assert.equal(looksLikeProblemSolvingQuery("help me troubleshoot the deploy"), true);
+  });
+
+  it("rejects ordinary queries", () => {
+    assert.equal(looksLikeProblemSolvingQuery("What's the user's favorite editor?"), false);
+    assert.equal(looksLikeProblemSolvingQuery("Acme Corp address"), false);
+    assert.equal(looksLikeProblemSolvingQuery("latest commitment about the release"), false);
+    assert.equal(looksLikeProblemSolvingQuery(""), false);
+  });
+});
+
+describe("isReasoningTracePath", () => {
+  it("matches reasoning-traces subtree (both separators)", () => {
+    assert.equal(isReasoningTracePath("reasoning-traces/2026-04-20/foo.md"), true);
+    assert.equal(isReasoningTracePath("/base/reasoning-traces/2026-04-20/foo.md"), true);
+    assert.equal(isReasoningTracePath("C\\base\\reasoning-traces\\x.md"), true);
+  });
+
+  it("does not match confusables", () => {
+    assert.equal(isReasoningTracePath("my-reasoning-traces-notes/foo.md"), false);
+    assert.equal(isReasoningTracePath("facts/2026-04-20/foo.md"), false);
+    assert.equal(isReasoningTracePath(""), false);
+  });
+});
+
+describe("applyReasoningTraceBoost", () => {
+  const fixture = [
+    { docid: "a", path: "facts/2026-04-20/a.md", score: 0.9 },
+    { docid: "b", path: "reasoning-traces/2026-04-20/b.md", score: 0.6 },
+    { docid: "c", path: "facts/2026-04-20/c.md", score: 0.8 },
+    { docid: "d", path: "reasoning-traces/2026-04-19/d.md", score: 0.5 },
+  ];
+
+  it("is a no-op when disabled", () => {
+    const out = applyReasoningTraceBoost(fixture, {
+      enabled: false,
+      query: "how do I debug",
+    });
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["a", "b", "c", "d"],
+    );
+    // Input not mutated.
+    assert.equal(fixture[1].score, 0.6);
+  });
+
+  it("is a no-op for non-problem-solving queries", () => {
+    const out = applyReasoningTraceBoost(fixture, {
+      enabled: true,
+      query: "what's Alice's favorite editor",
+    });
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["a", "b", "c", "d"],
+    );
+  });
+
+  it("is a no-op when no reasoning traces are in the result list", () => {
+    const facts = fixture.filter((r) => !isReasoningTracePath(r.path));
+    const out = applyReasoningTraceBoost(facts, {
+      enabled: true,
+      query: "how do I debug",
+    });
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      facts.map((r) => r.docid),
+    );
+  });
+
+  it("re-sorts traces to the top on a matching query", () => {
+    const out = applyReasoningTraceBoost(fixture, {
+      enabled: true,
+      query: "how do I debug the latency spike?",
+    });
+    // With default boost 0.15, b: 0.6+0.15=0.75, d: 0.5+0.15=0.65
+    // Expected order: a(0.9) > b(0.75) > c(0.8) → actually a(0.9) > c(0.8) > b(0.75) > d(0.65)
+    // Wait: a=0.9, c=0.8, b=0.75, d=0.65
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["a", "c", "b", "d"],
+    );
+    const b = out.find((r) => r.docid === "b");
+    assert.equal(b?.score, 0.6 + DEFAULT_REASONING_TRACE_BOOST);
+  });
+
+  it("honors a custom boost amount", () => {
+    const out = applyReasoningTraceBoost(fixture, {
+      enabled: true,
+      query: "walk me through the debug",
+      boost: 1.0, // enormous — pushes traces to the top
+    });
+    assert.equal(out[0].docid, "b");
+    assert.equal(out[1].docid, "d");
+  });
+
+  it("preserves stable tie-break on equal scores", () => {
+    const ties = [
+      { docid: "x", path: "facts/a.md", score: 0.5 },
+      { docid: "y", path: "reasoning-traces/a.md", score: 0.35 },
+      { docid: "z", path: "facts/b.md", score: 0.5 },
+    ];
+    const out = applyReasoningTraceBoost(ties, {
+      enabled: true,
+      query: "how do I",
+    });
+    // y boosts to 0.5 → three-way tie; stable order preserves original index.
+    assert.deepEqual(
+      out.map((r) => r.docid),
+      ["x", "y", "z"],
+    );
+  });
+});
+
+describe("config recallReasoningTraceBoostEnabled", () => {
+  it("defaults to false", () => {
+    const cfg = parseConfig({ memoryDir: "/tmp/remnic-cfg-default" });
+    assert.equal(cfg.recallReasoningTraceBoostEnabled, false);
+  });
+
+  it("accepts boolean true", () => {
+    const cfg = parseConfig({
+      memoryDir: "/tmp/remnic-cfg-on",
+      recallReasoningTraceBoostEnabled: true,
+    });
+    assert.equal(cfg.recallReasoningTraceBoostEnabled, true);
+  });
+
+  it("accepts string 'true'", () => {
+    const cfg = parseConfig({
+      memoryDir: "/tmp/remnic-cfg-str",
+      recallReasoningTraceBoostEnabled: "true",
+    });
+    assert.equal(cfg.recallReasoningTraceBoostEnabled, true);
+  });
+
+  it("stays false for string 'false'", () => {
+    const cfg = parseConfig({
+      memoryDir: "/tmp/remnic-cfg-str-false",
+      recallReasoningTraceBoostEnabled: "false",
+    });
+    assert.equal(cfg.recallReasoningTraceBoostEnabled, false);
+  });
+});
+
+describe("StorageManager reasoning_trace routing", () => {
+  it("routes a reasoning_trace memory under reasoning-traces/<date>/", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-reasoning-trace-route-"));
+    try {
+      const storage = new StorageManager(dir);
+      const body = [
+        "How I picked route-b for the low-latency path",
+        "",
+        "## Step 1",
+        "",
+        "Enumerated candidate routes.",
+        "",
+        "## Step 2",
+        "",
+        "Measured round-trip times.",
+        "",
+        "## Final Answer",
+        "",
+        "route-b won and was pinned.",
+      ].join("\n");
+
+      const id = await storage.writeMemory("reasoning_trace", body, {
+        source: "test",
+        tags: ["reasoning"],
+        confidence: 0.9,
+      });
+
+      const today = new Date().toISOString().slice(0, 10);
+      const expected = path.join(dir, "reasoning-traces", today, `${id}.md`);
+      await access(expected); // throws if not present
+
+      const memories = await storage.readAllMemories();
+      const found = memories.find((m) => m.frontmatter.id === id);
+      assert.ok(found, "written reasoning-trace memory should be discoverable");
+      assert.equal(found.frontmatter.category, "reasoning_trace");
+      assert.ok(
+        found.path.includes(path.join("reasoning-traces", today)),
+        `expected path to include reasoning-traces/${today}/, got: ${found.path}`,
+      );
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it("ensureDirectories pre-creates the reasoning-traces/<date>/ tree", async () => {
+    const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-reasoning-trace-ensure-"));
+    try {
+      const storage = new StorageManager(dir);
+      await storage.ensureDirectories();
+      const today = new Date().toISOString().slice(0, 10);
+      await access(path.join(dir, "reasoning-traces", today));
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Issue #564 PR 3 of 4 — retrieval-path wiring for reasoning_trace memories.

- Dedicated `reasoning-traces/<date>/` storage subtree so recall can filter cheaply on path (no frontmatter parse). `writeMemory`, chunk writes, `ensureDirectories`, and `collectActiveMemoryPaths` all updated.
- Pure helper module `packages/remnic-core/src/reasoning-trace-recall.ts`:
  - `looksLikeProblemSolvingQuery(query)` — "how do I…", "step by step", "walk me through", "reason through", "troubleshoot", etc.
  - `isReasoningTracePath(path)` — path-segment detector, rejects confusables like `my-reasoning-traces-notes/`.
  - `applyReasoningTraceBoost(results, { enabled, query, boost })` — pure additive boost + stable re-sort, no-op when the flag is off or the query doesn't match.
- New feature flag `recallReasoningTraceBoostEnabled` (default **false** — opt in after benchmarking). Parsed via `coerceBool` so it handles the usual string variants.
- Orchestrator: `diversifyAndLimitRecallResults` now accepts an optional `retrievalQuery` and runs the boost before MMR at the four memories-section entry points that had the query in scope.

PR 4 will add a bench fixture measuring recall quality + latency with/without the boost.

## Test plan
- [x] `npx tsx --test tests/reasoning-trace-recall.test.ts` — 18 tests, all green
- [x] `npx tsx --test tests/reasoning-trace-category.test.ts` — PR 1 still green
- [x] `npx tsx --test tests/storage-procedure-write.test.ts` — unrelated storage routing still green
- [x] `tsc --noEmit` — workspace clean

Refs #564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches storage layout and recall ranking (MMR pre-slice) logic; while gated by a default-off flag, mistakes could misroute memories or change retrieval ordering when enabled.
> 
> **Overview**
> Adds an **opt-in** `recallReasoningTraceBoostEnabled` feature that boosts `reasoning_trace` memories to the top of recall results for queries that look like problem-solving asks (new `looksLikeProblemSolvingQuery` + `applyReasoningTraceBoost` helper).
> 
> Moves `reasoning_trace` persistence into a dedicated `reasoning-traces/<date>/` subtree and wires that path through directory creation, scanning/indexing, tier migration, namespace migration, and fallback path resolution so traces remain discoverable and boost-eligible.
> 
> Introduces a new synthetic benchmark `retrieval-reasoning-trace` (fixture + runner + tests) and registers it for comparison/registry, including latency metrics marked as *lower-is-better*.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7fc9334cbe01056c48dc2446b7b22090a04b75da. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->