### PR TITLE
feat(memory-worth): recall filter, feature-flagged (issue #560 PR 4/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2032,6 +2032,17 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallMemoryWorthFilterEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral memories are untouched. Default off until PR 5 validates the lift."
+      },
+      "recallMemoryWorthHalfLifeMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
+      },
       "memoryLinkingEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1990,6 +1990,17 @@
         "default": ["decisions", "principles", "conventions", "runbooks", "entities"],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallMemoryWorthFilterEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral memories are untouched. Default off until PR 5 validates the lift."
+      },
+      "recallMemoryWorthHalfLifeMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
+      },
       "memoryLinkingEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1040,6 +1040,14 @@ export function parseConfig(raw: unknown): PluginConfig {
           (v): v is string => typeof v === "string" && v.length > 0,
         )
       : ["decisions", "principles", "conventions", "runbooks", "entities"],
+    // Memory Worth recall filter (issue #560 PR 4). Default off — PR 5
+    // flips the default after bench validation.
+    recallMemoryWorthFilterEnabled:
+      coerceBool(cfg.recallMemoryWorthFilterEnabled) ?? false,
+    recallMemoryWorthHalfLifeMs: (() => {
+      const n = coerceNumber(cfg.recallMemoryWorthHalfLifeMs);
+      return n !== undefined && n >= 0 ? n : 0;
+    })(),
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially
     // Conversation Threading (Phase 3B)

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -705,6 +705,19 @@ export {
 } from "./memory-worth-outcomes.js";
 
 // ---------------------------------------------------------------------------
+// Memory Worth recall filter (issue #560 PR 4 of 5)
+// ---------------------------------------------------------------------------
+
+export {
+  applyMemoryWorthFilter,
+  buildMemoryWorthCounterMap,
+  type MemoryWorthCounters,
+  type MemoryWorthFilterCandidate,
+  type MemoryWorthFilterOptions,
+  type MemoryWorthFilterResultItem,
+} from "./memory-worth-filter.js";
+
+// ---------------------------------------------------------------------------
 // Graph retrieval types (issue #559, PR 1 of 5)
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/memory-worth-filter.test.ts
+++ b/packages/remnic-core/src/memory-worth-filter.test.ts
@@ -1,0 +1,185 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  applyMemoryWorthFilter,
+  buildMemoryWorthCounterMap,
+  type MemoryWorthCounters,
+} from "./memory-worth-filter.js";
+
+/**
+ * Issue #560 PR 4 — recall filter unit tests.
+ *
+ * These pin the behavior the orchestrator relies on when the feature flag
+ * is enabled:
+ *   - Uninstrumented memories are untouched (multiplier 1.0).
+ *   - Memories with many failures sink in the ranking.
+ *   - Memories with many successes rise in the ranking.
+ *   - Stable ordering among ties, including the neutral-prior tie.
+ *   - `buildMemoryWorthCounterMap` only indexes instrumented memories.
+ */
+
+const NOW = new Date("2026-01-01T00:00:00.000Z");
+
+test("uninstrumented memories pass through with multiplier 1.0", () => {
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "a.md", score: 10 },
+      { path: "b.md", score: 5 },
+      { path: "c.md", score: 1 },
+    ],
+    {
+      counters: new Map<string, MemoryWorthCounters>(),
+      now: NOW,
+    },
+  );
+  // All multipliers are 1.0 and scores are unchanged; order preserved.
+  for (const item of out) {
+    assert.equal(item.multiplier, 1);
+    assert.equal(item.score, item.originalScore);
+  }
+  assert.deepEqual(
+    out.map((o) => o.path),
+    ["a.md", "b.md", "c.md"],
+  );
+});
+
+test("memory with heavy failure history sinks below a neutral peer", () => {
+  const counters = new Map<string, MemoryWorthCounters>([
+    // 0 successes, 10 failures. Laplace score ≈ 1/12 ≈ 0.083.
+    // Multiplier ≈ 0.083 / 0.5 ≈ 0.167. Scaled score ≈ 10 * 0.167 = 1.67.
+    ["bad.md", { mw_success: 0, mw_fail: 10 }],
+  ]);
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "bad.md", score: 10 },
+      { path: "neutral.md", score: 5 },
+    ],
+    { counters, now: NOW },
+  );
+  assert.equal(out[0]!.path, "neutral.md", "neutral peer must outrank the bad memory");
+  const bad = out.find((o) => o.path === "bad.md")!;
+  assert.ok(bad.multiplier < 0.5, `bad multiplier ${bad.multiplier} should be < 0.5`);
+  assert.ok(bad.score < 5, `bad scaled score ${bad.score} should be < the neutral 5`);
+});
+
+test("memory with heavy success history rises above a neutral peer", () => {
+  const counters = new Map<string, MemoryWorthCounters>([
+    // 10 successes, 0 failures. Laplace score ≈ 11/12 ≈ 0.917.
+    // Multiplier ≈ 0.917 / 0.5 ≈ 1.833.
+    ["good.md", { mw_success: 10, mw_fail: 0 }],
+  ]);
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "neutral.md", score: 5 },
+      { path: "good.md", score: 3 },
+    ],
+    { counters, now: NOW },
+  );
+  // good.md was ranked second by raw score but should move up once its
+  // history kicks in (3 * ~1.83 ≈ 5.5 > 5).
+  assert.equal(out[0]!.path, "good.md");
+  const good = out.find((o) => o.path === "good.md")!;
+  assert.ok(good.multiplier > 1.5);
+});
+
+test("ordering is stable for ties on the neutral prior", () => {
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "a.md", score: 5 },
+      { path: "b.md", score: 5 },
+      { path: "c.md", score: 5 },
+    ],
+    { counters: new Map<string, MemoryWorthCounters>(), now: NOW },
+  );
+  assert.deepEqual(
+    out.map((o) => o.path),
+    ["a.md", "b.md", "c.md"],
+    "ties must preserve input order (stable sort, CLAUDE.md rule 19)",
+  );
+});
+
+test("reorder:false preserves original order but still applies multiplier", () => {
+  const counters = new Map<string, MemoryWorthCounters>([
+    ["good.md", { mw_success: 10, mw_fail: 0 }],
+  ]);
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "neutral.md", score: 5 },
+      { path: "good.md", score: 3 },
+    ],
+    { counters, now: NOW, reorder: false },
+  );
+  // Order preserved — good.md stays second even though its scaled score
+  // is higher.
+  assert.deepEqual(
+    out.map((o) => o.path),
+    ["neutral.md", "good.md"],
+  );
+  // But the score field still reflects the multiplier.
+  assert.ok(out[1]!.score > out[1]!.originalScore);
+});
+
+test("multiplier is exactly 1.0 for a memory with no counter data", () => {
+  const out = applyMemoryWorthFilter(
+    [{ path: "x.md", score: 7.25 }],
+    {
+      // Entry exists in the map but with empty counters (e.g. after
+      // decay wiped effective counts). Should still hit neutral.
+      counters: new Map<string, MemoryWorthCounters>([["x.md", {}]]),
+      now: NOW,
+    },
+  );
+  assert.equal(out[0]!.multiplier, 1);
+  assert.equal(out[0]!.score, 7.25);
+});
+
+test("worth block is populated for observability", () => {
+  const counters = new Map<string, MemoryWorthCounters>([
+    ["x.md", { mw_success: 3, mw_fail: 1 }],
+  ]);
+  const out = applyMemoryWorthFilter(
+    [{ path: "x.md", score: 10 }],
+    { counters, now: NOW },
+  );
+  const item = out[0]!;
+  assert.ok(item.worth.score > 0 && item.worth.score < 1);
+  assert.equal(item.worth.p_success, item.worth.score);
+  assert.equal(item.worth.confidence, 4);
+});
+
+test("decay is applied when halfLifeMs is supplied", () => {
+  const dayMs = 24 * 60 * 60 * 1000;
+  const tenDaysAgo = new Date(NOW.getTime() - 10 * dayMs).toISOString();
+  const counters = new Map<string, MemoryWorthCounters>([
+    ["stale.md", { mw_success: 10, mw_fail: 0, lastAccessed: tenDaysAgo }],
+  ]);
+  // With a 1-day half-life, 10-day-old outcomes decay by 2^-10 ≈ 1/1024,
+  // dragging the score back to ~prior and the multiplier back to ~1.
+  const decayed = applyMemoryWorthFilter(
+    [{ path: "stale.md", score: 5 }],
+    { counters, now: NOW, halfLifeMs: dayMs },
+  );
+  // And without decay, the same 10/0 counts boost the score.
+  const fresh = applyMemoryWorthFilter(
+    [{ path: "stale.md", score: 5 }],
+    { counters, now: NOW },
+  );
+  assert.ok(
+    decayed[0]!.multiplier < fresh[0]!.multiplier,
+    `decay should reduce multiplier (decayed=${decayed[0]!.multiplier}, fresh=${fresh[0]!.multiplier})`,
+  );
+  assert.ok(Math.abs(decayed[0]!.multiplier - 1) < 0.05, "extremely decayed ⇒ near-prior");
+});
+
+test("buildMemoryWorthCounterMap only indexes memories with counter data", () => {
+  const map = buildMemoryWorthCounterMap([
+    { path: "a.md", frontmatter: { mw_success: 1, mw_fail: 0 } },
+    { path: "b.md", frontmatter: {} }, // legacy, no counters
+    { path: "c.md", frontmatter: { mw_success: undefined, mw_fail: 2 } },
+  ]);
+  assert.equal(map.size, 2, "legacy memories must not bloat the map");
+  assert.ok(map.has("a.md"));
+  assert.ok(map.has("c.md"));
+  assert.ok(!map.has("b.md"));
+});

--- a/packages/remnic-core/src/memory-worth-filter.test.ts
+++ b/packages/remnic-core/src/memory-worth-filter.test.ts
@@ -183,3 +183,27 @@ test("buildMemoryWorthCounterMap only indexes memories with counter data", () =>
   assert.ok(map.has("c.md"));
   assert.ok(!map.has("b.md"));
 });
+
+test("negative candidate scores do not invert filter direction", () => {
+  // Codex P2: if upstream penalties push a score below zero, the
+  // multiplier must not flip sign. A high-worth memory (multiplier > 1)
+  // must NOT move further negative (worse rank), and a low-worth memory
+  // (multiplier < 1) must NOT move toward zero (better rank). Clamping
+  // base at 0 before multiplying preserves "failure-prone sinks".
+  const counters = new Map<string, MemoryWorthCounters>([
+    ["good.md", { mw_success: 10, mw_fail: 0 }],
+    ["bad.md", { mw_success: 0, mw_fail: 10 }],
+  ]);
+  const out = applyMemoryWorthFilter(
+    [
+      { path: "good.md", score: -1 },
+      { path: "bad.md", score: -2 },
+      { path: "neutral.md", score: -3 },
+    ],
+    { counters, now: NOW, reorder: false },
+  );
+  // All scaled scores must be non-negative (bases clamped to 0).
+  for (const item of out) {
+    assert.ok(item.score >= 0, `${item.path} score should be >= 0, got ${item.score}`);
+  }
+});

--- a/packages/remnic-core/src/memory-worth-filter.ts
+++ b/packages/remnic-core/src/memory-worth-filter.ts
@@ -142,7 +142,15 @@ export function applyMemoryWorthFilter(
       halfLifeMs: options.halfLifeMs,
     });
     const multiplier = worth.score / NEUTRAL_PRIOR;
-    const scored = candidate.score * multiplier;
+    // Clamp the candidate score at zero before multiplying. A negative
+    // base score (can happen when upstream penalties push a candidate
+    // below zero) would flip the intended direction: a multiplier > 1
+    // would move the score further negative (worse rank), while a
+    // multiplier < 1 would move it toward zero (better rank). That's the
+    // opposite of "failure-prone memories sink". Treat negatives as zero
+    // so the filter's semantics hold regardless of upstream arithmetic.
+    const safeBase = candidate.score < 0 ? 0 : candidate.score;
+    const scored = safeBase * multiplier;
     result.push({
       path: candidate.path,
       score: scored,

--- a/packages/remnic-core/src/memory-worth-filter.ts
+++ b/packages/remnic-core/src/memory-worth-filter.ts
@@ -1,0 +1,196 @@
+/**
+ * Issue #560 PR 4 — Memory Worth recall filter.
+ *
+ * Pure helper that multiplies candidate recall scores by a Memory Worth
+ * factor (from `computeMemoryWorth`, PR 2) so memories with a history of
+ * failed sessions sink in the ranking. Reading the per-memory counters is
+ * the caller's job — this module does no I/O and depends only on PR 2's
+ * pure scorer.
+ *
+ * The filter is feature-flagged (`recallMemoryWorthFilterEnabled` on
+ * PluginConfig, default `false` in this PR) so operators can A/B it safely
+ * before PR 5 flips the default.
+ *
+ * Intentional properties:
+ *   - Pure function. No side effects, no I/O. Tested directly.
+ *   - Candidates with no counters (empty `counters` map entry) score exactly
+ *     the same as they did pre-filter (multiplier = 0.5, but we renormalize
+ *     so the neutral prior stays neutral — see the "neutral prior preserves
+ *     ranking among unseen memories" test below).
+ *   - Stable: a strictly sorted input stays in its original order among
+ *     items that all score to the prior. This matters because an ad-hoc
+ *     sort that returns 0 for ties on some comparators but not others
+ *     produces non-deterministic ordering (CLAUDE.md rule 19).
+ *   - Does not mutate inputs — returns a new array.
+ *
+ * How the multiplier is applied:
+ *   `new_score = old_score * (p_success / PRIOR)`
+ *   where PRIOR = 0.5. This way an uninstrumented memory (p_success = 0.5)
+ *   gets a multiplier of exactly 1.0 (no penalty, no boost), a memory that
+ *   always succeeds gets a multiplier approaching 2.0 (boosted) and a
+ *   memory that always fails gets a multiplier approaching 0.0 (sunk).
+ *   Using the ratio instead of raw `p_success` keeps the filter from
+ *   accidentally halving every un-instrumented memory the moment it ships.
+ *
+ * Out of scope:
+ *   - Reading counters from storage (caller does that once per recall).
+ *   - Orchestrator wiring / config plumbing (separate commit in this PR).
+ *   - Default flip to `true` (PR 5 once benchmark confirms a win).
+ */
+
+import { computeMemoryWorth, type MemoryWorthResult } from "./memory-worth.js";
+
+/**
+ * One memory's outcome history, keyed by memory path so the filter can look
+ * up a candidate's counters in O(1). `lastAccessed` is passed through to
+ * `computeMemoryWorth` where it drives optional recency decay.
+ */
+export interface MemoryWorthCounters {
+  mw_success?: number;
+  mw_fail?: number;
+  lastAccessed?: string | null;
+}
+
+/**
+ * A scored recall candidate. Defined locally (rather than importing
+ * `QmdSearchResult`) so the filter can be reused by any caller that has a
+ * `{ path, score }` shape — e.g. unit tests, bench fixtures, and future
+ * non-QMD retrieval backends.
+ */
+export interface MemoryWorthFilterCandidate {
+  path: string;
+  score: number;
+}
+
+export interface MemoryWorthFilterOptions {
+  /**
+   * Map from memory path → outcome counters. Candidates whose path is not
+   * in this map score at the neutral prior (multiplier = 1.0).
+   */
+  counters: ReadonlyMap<string, MemoryWorthCounters>;
+  /**
+   * Current time reference — passed through to `computeMemoryWorth` for
+   * decay math. Required (not defaulted) so tests and deterministic bench
+   * runs don't depend on the wall clock.
+   */
+  now: Date;
+  /**
+   * Half-life for outcome decay, in milliseconds. Optional; when omitted,
+   * decay is disabled and raw counters are used.
+   */
+  halfLifeMs?: number;
+  /**
+   * Re-sort the candidates by descending filtered score before returning.
+   * When `false`, the original input order is preserved (but the `.score`
+   * fields still reflect the multiplier). Default `true` because most
+   * callers want a ranked result; a few tests / bench fixtures want the
+   * order preserved so they can assert on position.
+   */
+  reorder?: boolean;
+}
+
+/**
+ * Output of `applyMemoryWorthFilter`. `worth` surfaces the computed
+ * `{ score, p_success, confidence }` for each candidate so observability /
+ * xray layers can report why each item moved without re-deriving it.
+ */
+export interface MemoryWorthFilterResultItem {
+  path: string;
+  /** Final score after the Memory Worth multiplier is applied. */
+  score: number;
+  /** The untouched input score — useful for telemetry and xray. */
+  originalScore: number;
+  /** The multiplier that was applied (1.0 for uninstrumented memories). */
+  multiplier: number;
+  /** The Memory Worth result (`score`, `p_success`, `confidence`). */
+  worth: MemoryWorthResult;
+}
+
+/**
+ * Neutral prior from `computeMemoryWorth`. Uninstrumented memories score
+ * exactly 0.5, so dividing by this value makes the multiplier land on 1.0
+ * for candidates with no history.
+ */
+const NEUTRAL_PRIOR = 0.5;
+
+/**
+ * Apply the Memory Worth multiplier to each candidate's score and (by
+ * default) re-sort the list by descending score.
+ *
+ * When `counters` is empty, every candidate gets a multiplier of 1.0 — the
+ * function is safe to call unconditionally when the feature flag is on,
+ * even for namespaces that have zero instrumented memories.
+ */
+export function applyMemoryWorthFilter(
+  candidates: readonly MemoryWorthFilterCandidate[],
+  options: MemoryWorthFilterOptions,
+): MemoryWorthFilterResultItem[] {
+  const reorder = options.reorder !== false;
+  const result: MemoryWorthFilterResultItem[] = [];
+
+  // Walk candidates in input order so the pre-sort ordering can act as a
+  // stable tiebreaker below. Record each candidate's position so we can
+  // break score ties deterministically (CLAUDE.md rule 19).
+  for (let i = 0; i < candidates.length; i += 1) {
+    const candidate = candidates[i]!;
+    const counters = options.counters.get(candidate.path) ?? {};
+    const worth = computeMemoryWorth({
+      mw_success: counters.mw_success,
+      mw_fail: counters.mw_fail,
+      lastAccessed: counters.lastAccessed,
+      now: options.now,
+      halfLifeMs: options.halfLifeMs,
+    });
+    const multiplier = worth.score / NEUTRAL_PRIOR;
+    const scored = candidate.score * multiplier;
+    result.push({
+      path: candidate.path,
+      score: scored,
+      originalScore: candidate.score,
+      multiplier,
+      worth,
+    });
+  }
+
+  if (!reorder) return result;
+
+  // Attach original position for stable sort. Node's Array.sort is stable
+  // by spec since ES2019, but we encode the tiebreaker explicitly so a
+  // comparator reviewer can see the contract.
+  const indexed = result.map((r, i) => ({ r, i }));
+  indexed.sort((a, b) => {
+    if (b.r.score !== a.r.score) return b.r.score - a.r.score;
+    return a.i - b.i;
+  });
+  return indexed.map((x) => x.r);
+}
+
+/**
+ * Convenience lookup helper for callers that already have an array of
+ * memory files with `path` and frontmatter fields on each. Keeps the map
+ * construction in one place so call sites don't drift.
+ */
+export function buildMemoryWorthCounterMap(
+  memories: readonly {
+    path: string;
+    frontmatter: {
+      mw_success?: number;
+      mw_fail?: number;
+      lastAccessed?: string | null;
+    };
+  }[],
+): Map<string, MemoryWorthCounters> {
+  const map = new Map<string, MemoryWorthCounters>();
+  for (const m of memories) {
+    const fm = m.frontmatter;
+    // Only add entries with at least one counter present — keeps the map
+    // small when the instrumented fraction is still low.
+    if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
+    map.set(m.path, {
+      mw_success: fm.mw_success,
+      mw_fail: fm.mw_fail,
+      lastAccessed: fm.lastAccessed,
+    });
+  }
+  return map;
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -81,6 +81,11 @@ import {
   type ParallelSearchResult,
 } from "./retrieval-agents.js";
 import { RerankCache, rerankLocalOrNoop } from "./rerank.js";
+import {
+  applyMemoryWorthFilter,
+  buildMemoryWorthCounterMap,
+  type MemoryWorthCounters,
+} from "./memory-worth-filter.js";
 import { reorderRecallResultsWithMmr } from "./recall-mmr.js";
 import {
   applyTemporalSupersession,
@@ -8122,6 +8127,20 @@ export class Orchestrator {
         );
       }
 
+      // Memory Worth recall filter (issue #560 PR 4). When enabled, multiply
+      // each candidate's score by its Memory Worth factor so memories with
+      // a history of failed outcomes sink. Default off in this PR; PR 5
+      // flips the default once bench shows tie-or-win. Fail-open: any
+      // lookup error leaves the original scores untouched rather than
+      // breaking recall for the whole namespace.
+      if (this.config.recallMemoryWorthFilterEnabled && memoryResults.length > 0) {
+        try {
+          memoryResults = await this.applyMemoryWorthRerank(memoryResults, recallNamespaces);
+        } catch (err) {
+          log.debug("memory-worth filter failed open", { error: (err as Error).message });
+        }
+      }
+
       // Synapse-inspired confidence gate: check scores BEFORE slicing so
       // reranking doesn't affect which score the gate evaluates.
       //
@@ -13489,6 +13508,59 @@ export class Orchestrator {
    *
    * Callers must pass the full candidate pool (post-rerank, pre-slice).
    */
+  private async applyMemoryWorthRerank(
+    results: QmdSearchResult[],
+    namespaces: string[],
+  ): Promise<QmdSearchResult[]> {
+    // Build the counter lookup once per call. We union frontmatter counters
+    // across every namespace the recall spans — the recall path itself
+    // already aggregates candidates from multiple namespaces, so we must
+    // do the same when looking up the counters.
+    const counters = new Map<string, MemoryWorthCounters>();
+    const seenNamespaces = new Set<string>();
+    for (const ns of namespaces) {
+      if (seenNamespaces.has(ns)) continue;
+      seenNamespaces.add(ns);
+      try {
+        const storage = await this.getStorage(ns);
+        const memories = await storage.readAllMemories();
+        const nsMap = buildMemoryWorthCounterMap(memories);
+        for (const [path, c] of nsMap) counters.set(path, c);
+      } catch (err) {
+        log.debug("memory-worth: failed to read namespace, skipping", {
+          namespace: ns,
+          error: (err as Error).message,
+        });
+      }
+    }
+
+    // If no memory in the candidate set has any counter data, the filter
+    // would be a no-op — skip the reorder to avoid spurious log spam.
+    if (counters.size === 0) return results;
+
+    const filtered = applyMemoryWorthFilter(
+      results.map((r) => ({ path: r.path, score: r.score })),
+      {
+        counters,
+        now: new Date(),
+        halfLifeMs:
+          this.config.recallMemoryWorthHalfLifeMs > 0
+            ? this.config.recallMemoryWorthHalfLifeMs
+            : undefined,
+      },
+    );
+
+    // Reconstruct the QmdSearchResult list in the new order, updating
+    // `.score` and preserving every other field (snippet, explain, etc.).
+    const byPath = new Map(results.map((r) => [r.path, r]));
+    const reordered: QmdSearchResult[] = [];
+    for (const item of filtered) {
+      const original = byPath.get(item.path);
+      if (original) reordered.push({ ...original, score: item.score });
+    }
+    return reordered;
+  }
+
   private diversifyAndLimitRecallResults(
     sectionId: string,
     results: QmdSearchResult[],

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1235,6 +1235,20 @@ export class Orchestrator {
   /** Lossless Context Management engine — proactive session archive + DAG summarization. */
   readonly lcmEngine: LcmEngine | null = null;
   private readonly rerankCache = new RerankCache();
+
+  /**
+   * Short-TTL cache for Memory Worth counter lookups so interactive recall
+   * doesn't trigger a full `readAllMemories` scan per query. Keyed by
+   * namespace; the filter unions across namespaces at query time. The TTL
+   * is intentionally short (seconds, not minutes) because counters are
+   * mutated by `recordMemoryOutcome` asynchronously and we'd rather serve
+   * a 30-second-stale worth score than a stable-but-wrong one.
+   */
+  private readonly memoryWorthCounterCache = new Map<
+    string,
+    { at: number; counters: ReadonlyMap<string, MemoryWorthCounters> }
+  >();
+  private static readonly MEMORY_WORTH_CACHE_TTL_MS = 30_000;
   /**
    * Per-session workspace overrides keyed by sessionKey.
    * Set by the before_agent_start hook so recall() uses the correct
@@ -13512,19 +13526,32 @@ export class Orchestrator {
     results: QmdSearchResult[],
     namespaces: string[],
   ): Promise<QmdSearchResult[]> {
-    // Build the counter lookup once per call. We union frontmatter counters
-    // across every namespace the recall spans — the recall path itself
-    // already aggregates candidates from multiple namespaces, so we must
-    // do the same when looking up the counters.
+    // Build the counter lookup. We union frontmatter counters across every
+    // namespace the recall spans — the recall path itself already
+    // aggregates candidates from multiple namespaces, so we must do the
+    // same when looking up counters. Per-namespace results are cached with
+    // a short TTL so interactive recall doesn't trigger a full
+    // `readAllMemories` scan per query (addresses codex P2 on PR 4).
     const counters = new Map<string, MemoryWorthCounters>();
     const seenNamespaces = new Set<string>();
+    const nowMs = Date.now();
     for (const ns of namespaces) {
       if (seenNamespaces.has(ns)) continue;
       seenNamespaces.add(ns);
       try {
-        const storage = await this.getStorage(ns);
-        const memories = await storage.readAllMemories();
-        const nsMap = buildMemoryWorthCounterMap(memories);
+        const cached = this.memoryWorthCounterCache.get(ns);
+        let nsMap: ReadonlyMap<string, MemoryWorthCounters> | undefined;
+        if (
+          cached &&
+          nowMs - cached.at < Orchestrator.MEMORY_WORTH_CACHE_TTL_MS
+        ) {
+          nsMap = cached.counters;
+        } else {
+          const storage = await this.getStorage(ns);
+          const memories = await storage.readAllMemories();
+          nsMap = buildMemoryWorthCounterMap(memories);
+          this.memoryWorthCounterCache.set(ns, { at: nowMs, counters: nsMap });
+        }
         for (const [path, c] of nsMap) counters.set(path, c);
       } catch (err) {
         log.debug("memory-worth: failed to read namespace, skipping", {
@@ -14027,6 +14054,19 @@ export class Orchestrator {
       log.debug(
         "rerankProvider=cloud is reserved/experimental in v2.2.0; skipping rerank",
       );
+    }
+
+    // Memory Worth filter — must fire on the cold fallback path too, or the
+    // feature flag produces divergent behavior by retrieval path (CLAUDE.md
+    // rule 39). Fail-open on lookup errors.
+    if (this.config.recallMemoryWorthFilterEnabled && results.length > 0) {
+      try {
+        results = await this.applyMemoryWorthRerank(results, options.recallNamespaces);
+      } catch (err) {
+        log.debug("memory-worth filter (cold) failed open", {
+          error: (err as Error).message,
+        });
+      }
     }
 
     // Apply MMR before final truncation so the cold fallback path mirrors

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -13535,6 +13535,18 @@ export class Orchestrator {
     const counters = new Map<string, MemoryWorthCounters>();
     const seenNamespaces = new Set<string>();
     const nowMs = Date.now();
+
+    // Evict all expired entries on every call so long-running processes
+    // touching a high-cardinality namespace set (coding/project overlays,
+    // per-branch) don't grow the cache unboundedly. Without this, an entry
+    // for a namespace that's never looked up again would pin its full
+    // counter map forever.
+    for (const [key, entry] of this.memoryWorthCounterCache) {
+      if (nowMs - entry.at >= Orchestrator.MEMORY_WORTH_CACHE_TTL_MS) {
+        this.memoryWorthCounterCache.delete(key);
+      }
+    }
+
     for (const ns of namespaces) {
       if (seenNamespaces.has(ns)) continue;
       seenNamespaces.add(ns);
@@ -13561,29 +13573,87 @@ export class Orchestrator {
       }
     }
 
+    // For candidates whose path didn't show up in any hot-tier namespace
+    // scan (typical of cold-tier / archive fallback), try a direct
+    // per-path read. Without this, cold-tier candidates always stay at
+    // multiplier 1.0 even when they have outcome history. Errors are
+    // swallowed so a single unreadable archive entry can't break the
+    // whole recall.
+    const missing = results.filter((r) => !counters.has(r.path));
+    if (missing.length > 0) {
+      // Use the first-seen namespace's storage as the reader — all
+      // StorageManagers share the same on-disk format, and
+      // `readMemoryByPath` takes an absolute path so the baseDir doesn't
+      // have to match.
+      let reader: StorageManager | null = null;
+      for (const ns of namespaces) {
+        try {
+          reader = await this.getStorage(ns);
+          break;
+        } catch {
+          // try next namespace
+        }
+      }
+      if (reader) {
+        for (const r of missing) {
+          try {
+            const memory = await reader.readMemoryByPath(r.path);
+            if (!memory) continue;
+            const fm = memory.frontmatter;
+            if (fm.mw_success === undefined && fm.mw_fail === undefined) continue;
+            counters.set(r.path, {
+              mw_success: fm.mw_success,
+              mw_fail: fm.mw_fail,
+              lastAccessed: fm.lastAccessed,
+            });
+          } catch (err) {
+            log.debug("memory-worth: direct path lookup failed", {
+              path: r.path,
+              error: (err as Error).message,
+            });
+          }
+        }
+      }
+    }
+
     // If no memory in the candidate set has any counter data, the filter
     // would be a no-op — skip the reorder to avoid spurious log spam.
     if (counters.size === 0) return results;
 
-    const filtered = applyMemoryWorthFilter(
-      results.map((r) => ({ path: r.path, score: r.score })),
-      {
-        counters,
-        now: new Date(),
-        halfLifeMs:
-          this.config.recallMemoryWorthHalfLifeMs > 0
-            ? this.config.recallMemoryWorthHalfLifeMs
-            : undefined,
-      },
-    );
+    // Preserve upstream ordering (reranker, specialized tiers, etc.) for
+    // neutral candidates. The upstream stages set `memoryResults` in their
+    // intended order but often leave `r.score` as the raw QMD score. If we
+    // sorted by `r.score * multiplier` directly, neutral candidates
+    // (multiplier 1.0) would snap back to raw-QMD order and silently undo
+    // the reranker. Feed the filter a synthetic monotone-decreasing rank
+    // score so it uses input position as the baseline, then applies the
+    // multiplier on top. Ties fall back to the stable secondary key in
+    // `applyMemoryWorthFilter`.
+    const rankedInputs = results.map((r, i) => ({
+      path: r.path,
+      // Large positive rank score so multiplier math stays well-scaled and
+      // we never hit zero; descending so earlier items rank higher.
+      score: results.length - i,
+    }));
+    const filtered = applyMemoryWorthFilter(rankedInputs, {
+      counters,
+      now: new Date(),
+      halfLifeMs:
+        this.config.recallMemoryWorthHalfLifeMs > 0
+          ? this.config.recallMemoryWorthHalfLifeMs
+          : undefined,
+    });
 
-    // Reconstruct the QmdSearchResult list in the new order, updating
-    // `.score` and preserving every other field (snippet, explain, etc.).
+    // Reconstruct the QmdSearchResult list in the new order. `.score` is
+    // preserved from the upstream pipeline (rerank, tier scoring, etc.) —
+    // we only reorder. Writing the synthetic rank-weighted score back
+    // would contaminate downstream logic (telemetry, confidence gates)
+    // that expects the original QMD/rerank score semantics.
     const byPath = new Map(results.map((r) => [r.path, r]));
     const reordered: QmdSearchResult[] = [];
     for (const item of filtered) {
       const original = byPath.get(item.path);
-      if (original) reordered.push({ ...original, score: item.score });
+      if (original) reordered.push(original);
     }
     return reordered;
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -438,6 +438,23 @@ export interface PluginConfig {
    * whose resolved taxonomy category is not in this list never qualify.
    */
   recallDirectAnswerEligibleTaxonomyBuckets: string[];
+  // Memory Worth recall filter (issue #560 PR 4)
+  /**
+   * When true, recall multiplies candidate scores by the Memory Worth
+   * factor computed from `mw_success` / `mw_fail` counters on each
+   * memory's frontmatter (see `computeMemoryWorth`). Memories with a
+   * history of failed sessions sink; neutral / uninstrumented memories
+   * are untouched (multiplier 1.0). Default false — flip to true in PR 5
+   * once the benchmark shows precision tie-or-win.
+   */
+  recallMemoryWorthFilterEnabled: boolean;
+  /**
+   * Optional half-life for Memory Worth decay, in milliseconds. When
+   * positive, older outcome observations are exponentially decayed toward
+   * the uniform prior. Set to 0 (default) to disable decay and use raw
+   * counter values.
+   */
+  recallMemoryWorthHalfLifeMs: number;
   // Memory Linking (Phase 3A)
   memoryLinkingEnabled: boolean;
   // Conversation Threading (Phase 3B)


### PR DESCRIPTION
## Summary

Fourth slice of issue #560 (outcome-conditioned Memory Worth counters).

> **Base branch:** `feat/issue-560-pr2-compute-memory-worth` — this PR depends on `computeMemoryWorth` from PR 2 (#616). Will be retargeted to `main` once #616 merges.

Adds the recall-time filter that uses the counters from PR 1 and the scorer from PR 2, behind a feature flag so operators can A/B it before PR 5 flips the default.

- **Pure helper** `applyMemoryWorthFilter` multiplies candidate scores by `p_success / 0.5`. A memory at the neutral prior (uninstrumented or 50/50) has multiplier exactly 1.0 — no change. Consistently-successful memories get boosted toward 2x; consistently-failing memories get multiplied by near-zero.
- **Orchestrator wiring** runs post-rerank / pre-confidence-gate: unions counters across every namespace the recall spans, applies the filter, reorders `memoryResults`. Fail-open: any lookup error leaves scores untouched.
- **Stable sort**: score ties fall back to original input index (CLAUDE.md rule 19).
- **Config flag** `recallMemoryWorthFilterEnabled` (default `false`) + `recallMemoryWorthHalfLifeMs` (default `0`, decay disabled). Added to `PluginConfig`, config parser, and `openclaw.plugin.json` `configSchema`.

Out of scope:
- PR 5: benchmark fixture + default flip.

## Test plan

- [x] 9 unit tests in `memory-worth-filter.test.ts` cover: uninstrumented passthrough, failure sink, success boost, tie stability, `reorder:false`, empty counters, worth-block observability, decay, and `buildMemoryWorthCounterMap` filtering legacy rows.
- [x] `tsx --test` → 9/9 pass.
- [x] Existing `config.test.ts` still passes (53/53) — new flags don't break defaults.
- [x] `tsc --noEmit` on `@remnic/core` → clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the recall ranking pipeline and adds storage reads/caching to support a new rerank step; while default-off and fail-open, enabling it could change retrieval ordering and add I/O overhead if caching misses.
> 
> **Overview**
> Adds a new **feature-flagged** Memory Worth recall filter (`recallMemoryWorthFilterEnabled`) that reorders recall candidates based on per-memory `mw_success`/`mw_fail` history (with optional half-life decay via `recallMemoryWorthHalfLifeMs`).
> 
> Wires the filter into the orchestrator on both hot and cold recall paths *post-rerank / pre-confidence gate*, including a short-TTL per-namespace counter cache plus a per-path fallback lookup, and fails open on lookup errors.
> 
> Exposes the new helper (`applyMemoryWorthFilter`, `buildMemoryWorthCounterMap`) from `@remnic/core`, adds unit tests for filter behavior (stable ties, decay, negative-score clamping), and extends the plugin config schema + config parsing/types to include the two new settings (default off).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90570a4e1a74075da15a06989e4f9f571a725b72. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->