### PR TITLE
feat(buffer): surprise telemetry ledger + doctor distribution (issue #563 PR 3/4)

### DIFF
--- a/packages/remnic-core/src/buffer-surprise-report.ts
+++ b/packages/remnic-core/src/buffer-surprise-report.ts
@@ -91,6 +91,12 @@ export async function reportBufferSurpriseDistribution(
     if (typeof row.surpriseScore !== "number") return false;
     if (!Number.isFinite(row.surpriseScore)) return false;
     if (row.surpriseScore < 0 || row.surpriseScore > 1) return false;
+    // `triggeredFlush` must be a real boolean — not a string or other
+    // truthy value. A row with `triggeredFlush: "false"` (string from a
+    // JSON-parsing bug upstream) would otherwise be counted as
+    // triggered, inflating the rate and misleading operators tuning the
+    // threshold from real traffic.
+    if (typeof row.triggeredFlush !== "boolean") return false;
     if (Number.isFinite(sinceMs)) {
       const ts = Date.parse(row.timestamp);
       if (!Number.isFinite(ts) || ts <= sinceMs) return false;

--- a/packages/remnic-core/src/buffer-surprise-report.ts
+++ b/packages/remnic-core/src/buffer-surprise-report.ts
@@ -1,0 +1,162 @@
+/**
+ * Buffer-surprise telemetry report (issue #563 PR 3).
+ *
+ * Reads the append-only `state/buffer-surprise-ledger.jsonl` file written
+ * by `SmartBuffer` and summarizes the recent distribution of surprise
+ * scores for the Doctor surface. This module is intentionally standalone
+ * and pure — the only I/O is reading the ledger via the injected
+ * `readEvents` callback, so it can be exercised directly in tests
+ * without touching the filesystem.
+ *
+ * # Output shape
+ *
+ * `BufferSurpriseDistribution` has fields sized for a one-screen Doctor
+ * display:
+ *
+ *   - `count`            — rows considered in the summary window.
+ *   - `triggeredCount`   — rows whose `triggeredFlush === true`.
+ *   - `triggeredRate`    — `triggeredCount / count`, or `0` when empty.
+ *   - `mean`             — arithmetic mean of `surpriseScore`.
+ *   - `median`           — middle value (50th percentile).
+ *   - `p90`              — 90th percentile (tail of novelty).
+ *   - `min`, `max`       — window extremes.
+ *   - `currentThreshold` — threshold from the MOST RECENT row, or `null`.
+ *
+ * All percentile math uses the nearest-rank method (no interpolation) so
+ * the report is stable across small windows.
+ *
+ * # Why a pure function + injected reader?
+ *
+ * The Doctor surface is exercised both at runtime (through the CLI and
+ * gateway tools) and in tests. A pure distribution helper fed from an
+ * arbitrary `readEvents` callback keeps the report logic trivially
+ * testable without spinning up a real `StorageManager`.
+ */
+
+import type { BufferSurpriseEvent } from "./types.js";
+
+export interface BufferSurpriseDistribution {
+  count: number;
+  triggeredCount: number;
+  triggeredRate: number;
+  mean: number;
+  median: number;
+  p90: number;
+  min: number;
+  max: number;
+  currentThreshold: number | null;
+}
+
+export interface BufferSurpriseReportOptions {
+  /**
+   * Maximum number of recent rows to include. Defaults to `200` — large
+   * enough to see a distribution, small enough to read in one sitting.
+   */
+  limit?: number;
+  /** Lower-bound ISO timestamp; rows at or before this are excluded. */
+  since?: string;
+}
+
+/**
+ * Reader callback shape. The helper does not want to know whether the
+ * rows come from a file, a queue, or an in-memory buffer.
+ */
+export type BufferSurpriseReader = (
+  options: BufferSurpriseReportOptions,
+) => Promise<readonly BufferSurpriseEvent[]>;
+
+/**
+ * Summarize the recent buffer-surprise distribution. Returns the empty
+ * distribution shape when the ledger has no applicable rows — callers can
+ * detect this via `count === 0` and render "no data yet".
+ */
+export async function reportBufferSurpriseDistribution(
+  readEvents: BufferSurpriseReader,
+  options: BufferSurpriseReportOptions = {},
+): Promise<BufferSurpriseDistribution> {
+  const limit =
+    typeof options.limit === "number" && options.limit > 0
+      ? Math.floor(options.limit)
+      : 200;
+  const raw = await readEvents({ limit, since: options.since });
+
+  // Filter for sanity: finite numeric scores in [0, 1], event tag match,
+  // and the optional `since` lower bound. Malformed rows are skipped.
+  const sinceMs =
+    typeof options.since === "string" && options.since.length > 0
+      ? Date.parse(options.since)
+      : Number.NaN;
+  const rows = raw.filter((row): row is BufferSurpriseEvent => {
+    if (!row || row.event !== "BUFFER_SURPRISE") return false;
+    if (typeof row.surpriseScore !== "number") return false;
+    if (!Number.isFinite(row.surpriseScore)) return false;
+    if (row.surpriseScore < 0 || row.surpriseScore > 1) return false;
+    if (Number.isFinite(sinceMs)) {
+      const ts = Date.parse(row.timestamp);
+      if (!Number.isFinite(ts) || ts <= sinceMs) return false;
+    }
+    return true;
+  });
+
+  if (rows.length === 0) {
+    return {
+      count: 0,
+      triggeredCount: 0,
+      triggeredRate: 0,
+      mean: 0,
+      median: 0,
+      p90: 0,
+      min: 0,
+      max: 0,
+      currentThreshold: null,
+    };
+  }
+
+  const scores = rows.map((r) => r.surpriseScore).sort((a, b) => a - b);
+  const triggeredCount = rows.reduce(
+    (acc, r) => acc + (r.triggeredFlush ? 1 : 0),
+    0,
+  );
+  const sum = scores.reduce((acc, v) => acc + v, 0);
+  const mean = sum / scores.length;
+
+  // Nearest-rank percentiles keep the output stable for small windows.
+  const median = percentile(scores, 0.5);
+  const p90 = percentile(scores, 0.9);
+
+  // "Current" threshold is whichever was in force for the most recent row
+  // — not necessarily the one configured right now, but the value the
+  // ledger rows were judged against. That's what operators need to reason
+  // about the distribution.
+  const mostRecent = rows[rows.length - 1];
+  const currentThreshold =
+    mostRecent && typeof mostRecent.threshold === "number"
+      ? mostRecent.threshold
+      : null;
+
+  return {
+    count: scores.length,
+    triggeredCount,
+    triggeredRate: triggeredCount / scores.length,
+    mean,
+    median,
+    p90,
+    min: scores[0]!,
+    max: scores[scores.length - 1]!,
+    currentThreshold,
+  };
+}
+
+/**
+ * Nearest-rank percentile of a pre-sorted ascending array.
+ *
+ * Returns `sorted[ceil(p * n) - 1]`, with `p` clamped to `[0, 1]`.
+ * This avoids the interpolation ambiguity of R-7/R-8 percentiles and is
+ * stable when the window is small (e.g. 3-5 rows).
+ */
+function percentile(sorted: readonly number[], p: number): number {
+  if (sorted.length === 0) return 0;
+  const clamped = Math.max(0, Math.min(1, p));
+  const rank = Math.max(1, Math.ceil(clamped * sorted.length));
+  return sorted[rank - 1]!;
+}

--- a/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
@@ -241,6 +241,80 @@ test("works with legacy StorageManager lacking appendBufferSurpriseEvents", asyn
 });
 
 // ---------------------------------------------------------------------------
+// StorageManager read-ledger behavior
+// ---------------------------------------------------------------------------
+
+test("StorageManager.readBufferSurpriseEvents: limit over valid rows, not raw lines", async () => {
+  // A malformed tail row must not hide valid data above it when
+  // `limit: 1` is requested. Simulate an interrupted append by writing
+  // a valid row then a partial one, ask for limit=1, and expect the
+  // valid row back.
+  const { mkdtempSync, writeFileSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { StorageManager } = await import("./storage.js");
+
+  const dir = mkdtempSync(join(tmpdir(), "remnic-buffer-surprise-"));
+  const stateDir = join(dir, "state");
+  const { mkdirSync } = await import("node:fs");
+  mkdirSync(stateDir, { recursive: true });
+  const ledgerPath = join(stateDir, "buffer-surprise-ledger.jsonl");
+  const valid =
+    JSON.stringify({
+      event: "BUFFER_SURPRISE",
+      timestamp: "2026-04-20T12:00:00.000Z",
+      bufferKey: "a",
+      sessionKey: "a",
+      turnRole: "user",
+      surpriseScore: 0.5,
+      threshold: 0.35,
+      triggeredFlush: true,
+      turnCountInWindow: 1,
+    }) + "\n";
+  const truncated = '{"event":"BUFFER_SURPRISE","timestam'; // no newline, broken JSON
+  writeFileSync(ledgerPath, valid + truncated);
+
+  const storage = new StorageManager(dir);
+  const rows = await storage.readBufferSurpriseEvents({ limit: 1 });
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0]!.surpriseScore, 0.5);
+});
+
+test("StorageManager.readBufferSurpriseEvents: non-positive limit returns empty", async () => {
+  const { mkdtempSync, writeFileSync, mkdirSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const { StorageManager } = await import("./storage.js");
+
+  const dir = mkdtempSync(join(tmpdir(), "remnic-buffer-surprise-lim-"));
+  const stateDir = join(dir, "state");
+  mkdirSync(stateDir, { recursive: true });
+  const ledgerPath = join(stateDir, "buffer-surprise-ledger.jsonl");
+  writeFileSync(
+    ledgerPath,
+    JSON.stringify({
+      event: "BUFFER_SURPRISE",
+      timestamp: "2026-04-20T12:00:00.000Z",
+      bufferKey: "a",
+      sessionKey: "a",
+      turnRole: "user",
+      surpriseScore: 0.5,
+      threshold: 0.35,
+      triggeredFlush: true,
+      turnCountInWindow: 1,
+    }) + "\n",
+  );
+  const storage = new StorageManager(dir);
+
+  // 0, negative, fractional < 1 all return empty rather than silently
+  // devolving into "entire file".
+  for (const limit of [0, -1, 0.5]) {
+    const rows = await storage.readBufferSurpriseEvents({ limit });
+    assert.equal(rows.length, 0, `limit=${limit} should return empty`);
+  }
+});
+
+// ---------------------------------------------------------------------------
 // reportBufferSurpriseDistribution
 // ---------------------------------------------------------------------------
 
@@ -357,4 +431,39 @@ test("report: single-row ledger reports that row in every percentile", async () 
   assert.equal(dist.p90, 0.42);
   assert.equal(dist.mean, 0.42);
   assert.equal(dist.triggeredRate, 1);
+});
+
+test("report: non-boolean triggeredFlush is rejected, not coerced", async () => {
+  // A row with `triggeredFlush: "false"` (string) is truthy in
+  // JavaScript. Without strict type-checking, it would be counted as
+  // triggered and silently inflate the rate reported to operators.
+  const rows: any[] = [
+    syntheticRow(0.5, false),
+    {
+      event: "BUFFER_SURPRISE",
+      timestamp: "2026-04-20T12:00:00.000Z",
+      bufferKey: "x",
+      sessionKey: "x",
+      turnRole: "user",
+      surpriseScore: 0.9,
+      threshold: 0.35,
+      triggeredFlush: "false",
+      turnCountInWindow: 1,
+    },
+    {
+      event: "BUFFER_SURPRISE",
+      timestamp: "2026-04-20T12:00:00.000Z",
+      bufferKey: "x",
+      sessionKey: "x",
+      turnRole: "user",
+      surpriseScore: 0.8,
+      threshold: 0.35,
+      triggeredFlush: 1,
+      turnCountInWindow: 1,
+    },
+  ];
+  const dist = await reportBufferSurpriseDistribution(async () => rows);
+  assert.equal(dist.count, 1);
+  assert.equal(dist.triggeredCount, 0);
+  assert.equal(dist.triggeredRate, 0);
 });

--- a/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
@@ -85,6 +85,7 @@ test("emits one BUFFER_SURPRISE row per scored turn (triggering)", async () => {
   const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
 
   await buffer.addTurn("sess-1", makeTurn("sess-1", "novel"));
+  await buffer.flushSurpriseTelemetry();
 
   assert.equal(storage.events.length, 1);
   const row = storage.events[0]!;
@@ -115,6 +116,7 @@ test("emits BUFFER_SURPRISE row for non-triggering turns too", async () => {
   const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.1));
 
   await buffer.addTurn("sess-1", makeTurn("sess-1", "routine"));
+  await buffer.flushSurpriseTelemetry();
 
   assert.equal(storage.events.length, 1);
   assert.equal(storage.events[0]!.triggeredFlush, false);
@@ -204,13 +206,59 @@ test("does NOT emit when turn-count path already flushes (extract_batch)", async
   const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
 
   await buffer.addTurn("sess-1", makeTurn("sess-1", "first"));
+  await buffer.flushSurpriseTelemetry();
   // first turn WAS scored (decision was keep_buffering)
   assert.equal(storage.events.length, 1);
 
   const before = storage.events.length;
   await buffer.addTurn("sess-1", makeTurn("sess-1", "second"));
+  await buffer.flushSurpriseTelemetry();
   // second turn flushes via turn-count; probe is not consulted → no new row.
   assert.equal(storage.events.length, before);
+});
+
+test("telemetry writes are serialized in wall-clock order under variable latency", async () => {
+  // Reviewer concern: fire-and-forget appends could settle out of
+  // order on slow filesystems. Simulate this with a storage double
+  // whose append latency decreases with each call via microtask
+  // hops — without serialization, the later appends would land first.
+  // Using microtask chains instead of setTimeout keeps the test
+  // deterministic and does not leak timers into the node:test teardown.
+  const order: number[] = [];
+  let call = 0;
+  class ReorderingStorage {
+    async loadBuffer(): Promise<BufferState> {
+      return emptyBuffer();
+    }
+    async saveBuffer() {}
+    async appendBufferSurpriseEvents(events: BufferSurpriseEvent[]) {
+      const nth = ++call;
+      // First append hops the microtask queue more times than later
+      // ones, mimicking variable latency deterministically.
+      const hops = Math.max(1, 6 - nth * 2);
+      for (let i = 0; i < hops; i += 1) {
+        await Promise.resolve();
+      }
+      for (const ev of events) order.push(ev.turnCountInWindow);
+      return events.length;
+    }
+  }
+
+  const storage = new ReorderingStorage();
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferMaxTurns: 50,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.1));
+  for (const i of [1, 2, 3]) {
+    await buffer.addTurn(
+      "sess-1",
+      { ...makeTurn("sess-1", "turn " + i) },
+    );
+  }
+  await buffer.flushSurpriseTelemetry();
+  assert.deepEqual(order, [1, 2, 3]);
 });
 
 test("works with legacy StorageManager lacking appendBufferSurpriseEvents", async () => {

--- a/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
+++ b/packages/remnic-core/src/buffer-surprise-telemetry.test.ts
@@ -1,0 +1,360 @@
+/**
+ * Tests for buffer-surprise telemetry (issue #563 PR 3).
+ *
+ * Covers two concerns:
+ *
+ *  1. SmartBuffer emits one `BUFFER_SURPRISE` row per scored turn and
+ *     NEVER emits when the probe was not consulted (flag off, non-smart
+ *     trigger mode, high signal, or decision was not `keep_buffering`).
+ *     Probe returning `null`, throwing, or producing a non-finite score
+ *     must NOT write a row.
+ *
+ *  2. `reportBufferSurpriseDistribution` produces stable summary stats
+ *     over the recent window — mean, median, p90, triggered rate — and
+ *     returns the empty-distribution shape when no rows are available.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { SmartBuffer, type BufferSurpriseProbe } from "./buffer.js";
+import { parseConfig } from "./config.js";
+import { reportBufferSurpriseDistribution } from "./buffer-surprise-report.js";
+import type {
+  BufferState,
+  BufferSurpriseEvent,
+  BufferTurn,
+} from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Test doubles
+// ---------------------------------------------------------------------------
+
+class RecordingStorage {
+  public saved: BufferState | null = null;
+  public events: BufferSurpriseEvent[] = [];
+
+  constructor(private readonly initial: BufferState) {}
+
+  async loadBuffer(): Promise<BufferState> {
+    return structuredClone(this.initial);
+  }
+
+  async saveBuffer(state: BufferState): Promise<void> {
+    this.saved = structuredClone(state);
+  }
+
+  async appendBufferSurpriseEvents(events: BufferSurpriseEvent[]): Promise<number> {
+    this.events.push(...events);
+    return events.length;
+  }
+}
+
+function makeTurn(sessionKey: string, content: string): BufferTurn {
+  return {
+    role: "user",
+    content,
+    timestamp: "2026-04-20T12:00:00.000Z",
+    sessionKey,
+  };
+}
+
+function emptyBuffer(): BufferState {
+  return { turns: [], lastExtractionAt: null, extractionCount: 0 };
+}
+
+function fixedScoreProbe(score: number | null): BufferSurpriseProbe {
+  return {
+    async scoreTurn() {
+      return score;
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// SmartBuffer emission
+// ---------------------------------------------------------------------------
+
+test("emits one BUFFER_SURPRISE row per scored turn (triggering)", async () => {
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "novel"));
+
+  assert.equal(storage.events.length, 1);
+  const row = storage.events[0]!;
+  assert.equal(row.event, "BUFFER_SURPRISE");
+  assert.equal(row.triggeredFlush, true);
+  assert.equal(row.surpriseScore, 0.9);
+  assert.equal(row.threshold, 0.35);
+  assert.equal(row.turnRole, "user");
+  assert.equal(row.bufferKey, "sess-1");
+  assert.equal(row.sessionKey, "sess-1");
+  assert.equal(row.turnCountInWindow, 1);
+  assert.ok(
+    typeof row.timestamp === "string" && row.timestamp.length > 0,
+    "timestamp must be a non-empty ISO string",
+  );
+});
+
+test("emits BUFFER_SURPRISE row for non-triggering turns too", async () => {
+  // The whole point of telemetry is tuning the threshold from real
+  // distributions, so below-threshold scores must also be recorded.
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferSurpriseThreshold: 0.35,
+    bufferMaxTurns: 5,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.1));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "routine"));
+
+  assert.equal(storage.events.length, 1);
+  assert.equal(storage.events[0]!.triggeredFlush, false);
+  assert.equal(storage.events[0]!.surpriseScore, 0.1);
+});
+
+test("does NOT emit when flag is off", async () => {
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: false,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "anything"));
+  assert.equal(storage.events.length, 0);
+});
+
+test("does NOT emit when probe returns null", async () => {
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(null));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "anything"));
+  assert.equal(storage.events.length, 0);
+});
+
+test("does NOT emit when probe throws", async () => {
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    triggerMode: "smart",
+  });
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn() {
+      throw new Error("embedder down");
+    },
+  };
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "anything"));
+  assert.equal(storage.events.length, 0);
+});
+
+test("does NOT emit when probe returns NaN", async () => {
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(
+    config,
+    storage as any,
+    fixedScoreProbe(Number.NaN),
+  );
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "anything"));
+  assert.equal(storage.events.length, 0);
+});
+
+test("does NOT emit when high-signal path already flushes", async () => {
+  // High-signal decisions short-circuit before the probe is consulted,
+  // so no row must be recorded for them.
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    triggerMode: "smart",
+    highSignalPatterns: ["\\bURGENT\\b"],
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "URGENT heads up"));
+  assert.equal(storage.events.length, 0);
+});
+
+test("does NOT emit when turn-count path already flushes (extract_batch)", async () => {
+  // Additive invariant: existing batch flush does not consult the probe.
+  const storage = new RecordingStorage(emptyBuffer());
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    bufferMaxTurns: 2,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
+
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "first"));
+  // first turn WAS scored (decision was keep_buffering)
+  assert.equal(storage.events.length, 1);
+
+  const before = storage.events.length;
+  await buffer.addTurn("sess-1", makeTurn("sess-1", "second"));
+  // second turn flushes via turn-count; probe is not consulted → no new row.
+  assert.equal(storage.events.length, before);
+});
+
+test("works with legacy StorageManager lacking appendBufferSurpriseEvents", async () => {
+  // The buffer must feature-detect the sink and silently skip when the
+  // host's storage double is on the old surface.
+  class LegacyStorage {
+    public saved: BufferState | null = null;
+    async loadBuffer(): Promise<BufferState> {
+      return emptyBuffer();
+    }
+    async saveBuffer(state: BufferState) {
+      this.saved = state;
+    }
+  }
+  const storage = new LegacyStorage();
+  const config = parseConfig({
+    bufferSurpriseTriggerEnabled: true,
+    triggerMode: "smart",
+  });
+  const buffer = new SmartBuffer(config, storage as any, fixedScoreProbe(0.9));
+
+  const decision = await buffer.addTurn(
+    "sess-1",
+    makeTurn("sess-1", "anything"),
+  );
+  // Core decision still works — only the telemetry path no-ops.
+  assert.equal(decision, "extract_now");
+});
+
+// ---------------------------------------------------------------------------
+// reportBufferSurpriseDistribution
+// ---------------------------------------------------------------------------
+
+function syntheticRow(
+  score: number,
+  triggered: boolean,
+  ts = "2026-04-20T12:00:00.000Z",
+): BufferSurpriseEvent {
+  return {
+    event: "BUFFER_SURPRISE",
+    timestamp: ts,
+    bufferKey: "sess-x",
+    sessionKey: "sess-x",
+    turnRole: "user",
+    surpriseScore: score,
+    threshold: 0.35,
+    triggeredFlush: triggered,
+    turnCountInWindow: 1,
+  };
+}
+
+test("report: empty ledger returns zeros, currentThreshold=null", async () => {
+  const dist = await reportBufferSurpriseDistribution(async () => []);
+  assert.equal(dist.count, 0);
+  assert.equal(dist.triggeredCount, 0);
+  assert.equal(dist.triggeredRate, 0);
+  assert.equal(dist.mean, 0);
+  assert.equal(dist.median, 0);
+  assert.equal(dist.p90, 0);
+  assert.equal(dist.currentThreshold, null);
+});
+
+test("report: computes mean, median, p90 over recent rows", async () => {
+  const rows: BufferSurpriseEvent[] = [
+    syntheticRow(0.1, false),
+    syntheticRow(0.2, false),
+    syntheticRow(0.3, false),
+    syntheticRow(0.4, true),
+    syntheticRow(0.5, true),
+    syntheticRow(0.9, true),
+  ];
+  const dist = await reportBufferSurpriseDistribution(async () => rows);
+  assert.equal(dist.count, 6);
+  assert.equal(dist.triggeredCount, 3);
+  assert.ok(Math.abs(dist.triggeredRate - 0.5) < 1e-9);
+  assert.ok(Math.abs(dist.mean - (0.1 + 0.2 + 0.3 + 0.4 + 0.5 + 0.9) / 6) < 1e-9);
+  // nearest-rank p50 over 6 → rank 3 → 0.3
+  assert.equal(dist.median, 0.3);
+  // nearest-rank p90 over 6 → ceil(5.4)=6 → 0.9
+  assert.equal(dist.p90, 0.9);
+  assert.equal(dist.min, 0.1);
+  assert.equal(dist.max, 0.9);
+  assert.equal(dist.currentThreshold, 0.35);
+});
+
+test("report: skips malformed rows (wrong event tag, non-finite score, out of range)", async () => {
+  const rows: any[] = [
+    syntheticRow(0.1, false),
+    { event: "SOMETHING_ELSE", surpriseScore: 0.99 },
+    { event: "BUFFER_SURPRISE", surpriseScore: Number.POSITIVE_INFINITY },
+    { event: "BUFFER_SURPRISE", surpriseScore: -0.1 },
+    { event: "BUFFER_SURPRISE", surpriseScore: 1.1 },
+    syntheticRow(0.9, true),
+  ];
+  const dist = await reportBufferSurpriseDistribution(async () => rows);
+  assert.equal(dist.count, 2);
+  assert.equal(dist.min, 0.1);
+  assert.equal(dist.max, 0.9);
+});
+
+test("report: `since` filter excludes rows at or before the boundary", async () => {
+  const rows: BufferSurpriseEvent[] = [
+    syntheticRow(0.1, false, "2026-04-19T00:00:00.000Z"),
+    syntheticRow(0.5, true, "2026-04-20T00:00:00.000Z"),
+    syntheticRow(0.9, true, "2026-04-20T12:00:00.000Z"),
+  ];
+  const dist = await reportBufferSurpriseDistribution(async () => rows, {
+    since: "2026-04-20T00:00:00.000Z",
+  });
+  // Boundary is exclusive: the exactly-equal row at 00:00:00 is filtered.
+  assert.equal(dist.count, 1);
+  assert.equal(dist.min, 0.9);
+  assert.equal(dist.max, 0.9);
+});
+
+test("report: limit is forwarded to the reader callback", async () => {
+  let seen: number | undefined;
+  const reader = async (options: { limit?: number }) => {
+    seen = options.limit;
+    return [] as BufferSurpriseEvent[];
+  };
+  await reportBufferSurpriseDistribution(reader, { limit: 42 });
+  assert.equal(seen, 42);
+});
+
+test("report: defaults limit to 200 when omitted", async () => {
+  let seen: number | undefined;
+  await reportBufferSurpriseDistribution(
+    async (options) => {
+      seen = options.limit;
+      return [];
+    },
+  );
+  assert.equal(seen, 200);
+});
+
+test("report: single-row ledger reports that row in every percentile", async () => {
+  const rows: BufferSurpriseEvent[] = [syntheticRow(0.42, true)];
+  const dist = await reportBufferSurpriseDistribution(async () => rows);
+  assert.equal(dist.count, 1);
+  assert.equal(dist.min, 0.42);
+  assert.equal(dist.max, 0.42);
+  assert.equal(dist.median, 0.42);
+  assert.equal(dist.p90, 0.42);
+  assert.equal(dist.mean, 0.42);
+  assert.equal(dist.triggeredRate, 1);
+});

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -202,15 +202,22 @@ export class SmartBuffer {
         }
         // Emit telemetry on every scored turn — both triggering and
         // non-triggering — so operators can fit the threshold to real
-        // traffic distributions. Fire-and-forget: if the ledger write
-        // throws, we must not crash the hot path.
-        await this.emitSurpriseEventSafe({
-          bufferKey,
-          turn,
-          surpriseScore: surprise,
-          triggered,
-          turnCountInWindow: entry.turns.length,
-        });
+        // traffic distributions. True fire-and-forget: we do NOT await
+        // the ledger append. A slow or contended filesystem would
+        // otherwise add JSONL-append latency to every `processTurn`,
+        // which defeats the purpose of keeping the telemetry path
+        // cheap. The helper already swallows its own rejections, so
+        // there is no unhandled-rejection risk from dropping the
+        // promise; we attach a `.catch` as a belt-and-braces guard.
+        void this
+          .emitSurpriseEventSafe({
+            bufferKey,
+            turn,
+            surpriseScore: surprise,
+            triggered,
+            turnCountInWindow: entry.turns.length,
+          })
+          .catch(() => {});
       }
     }
 

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -45,6 +45,21 @@ export class SmartBuffer {
   private state: BufferState;
   private loaded = false;
   private readonly surpriseProbe: BufferSurpriseProbe | null;
+  /**
+   * Serialized write chain for `BUFFER_SURPRISE` telemetry events.
+   *
+   * The telemetry path is fire-and-forget (`addTurn` does not await the
+   * ledger append), but multiple concurrent appends would still settle
+   * out of order under variable filesystem latency. The report path
+   * assumes chronological ordering — it slices the tail of the ledger
+   * and treats the most recent entry as the current threshold in force.
+   * Chaining ensures each append only runs after the previous settles,
+   * preserving wall-clock order.
+   *
+   * We include a `.catch` on every link so a rejected append does not
+   * poison the chain (CLAUDE.md rule #40).
+   */
+  private surpriseTelemetryWriteChain: Promise<unknown> = Promise.resolve();
 
   constructor(
     private readonly config: PluginConfig,
@@ -202,22 +217,20 @@ export class SmartBuffer {
         }
         // Emit telemetry on every scored turn — both triggering and
         // non-triggering — so operators can fit the threshold to real
-        // traffic distributions. True fire-and-forget: we do NOT await
-        // the ledger append. A slow or contended filesystem would
-        // otherwise add JSONL-append latency to every `processTurn`,
-        // which defeats the purpose of keeping the telemetry path
-        // cheap. The helper already swallows its own rejections, so
-        // there is no unhandled-rejection risk from dropping the
-        // promise; we attach a `.catch` as a belt-and-braces guard.
-        void this
-          .emitSurpriseEventSafe({
-            bufferKey,
-            turn,
-            surpriseScore: surprise,
-            triggered,
-            turnCountInWindow: entry.turns.length,
-          })
-          .catch(() => {});
+        // traffic distributions. Fire-and-forget: `addTurn` does NOT
+        // await the ledger append, so slow/contended filesystems cannot
+        // add JSONL-append latency to every `processTurn`. But we DO
+        // serialize writes through a promise chain so concurrent
+        // appends settle in wall-clock order — the report path assumes
+        // chronological tail rows and reads the most recent as the
+        // "current" threshold.
+        this.queueSurpriseTelemetryWrite({
+          bufferKey,
+          turn,
+          surpriseScore: surprise,
+          triggered,
+          turnCountInWindow: entry.turns.length,
+        });
       }
     }
 
@@ -228,6 +241,36 @@ export class SmartBuffer {
     this.pruneEntries([bufferKey]);
     await this.save();
     return decision;
+  }
+
+  /**
+   * Enqueue a telemetry append on the serialized write chain.
+   *
+   * The chain is a classic `writeChain = writeChain.then(fn).catch(...)`
+   * — each link waits for the previous to settle before its append
+   * starts, so out-of-order chronology cannot happen even under
+   * variable filesystem latency. We always attach `.catch` so one
+   * rejection does not poison the chain for the rest of the session
+   * (CLAUDE.md rule #40). The error is logged through
+   * `emitSurpriseEventSafe` itself, which swallows its own rejections.
+   *
+   * Public surface is deliberately narrow — only `addTurn` should call
+   * this, so the surprise telemetry path stays centralized.
+   */
+  private queueSurpriseTelemetryWrite(params: {
+    bufferKey: string;
+    turn: BufferTurn;
+    surpriseScore: number;
+    triggered: boolean;
+    turnCountInWindow: number;
+  }): void {
+    this.surpriseTelemetryWriteChain = this.surpriseTelemetryWriteChain
+      .then(() => this.emitSurpriseEventSafe(params))
+      .catch(() => {
+        // `emitSurpriseEventSafe` already handles the logging. We
+        // swallow here only so one failure does not break the chain
+        // for future writes.
+      });
   }
 
   /**
@@ -428,6 +471,22 @@ export class SmartBuffer {
 
   getExtractionCount(bufferKey = "default"): number {
     return this.peekEntry(bufferKey)?.extractionCount ?? 0;
+  }
+
+  /**
+   * Await any pending `BUFFER_SURPRISE` telemetry writes.
+   *
+   * The telemetry path is fire-and-forget from the hot path's point of
+   * view, but tests and before-exit hooks sometimes need to make sure
+   * the ledger has been flushed before they assert on its contents or
+   * close the process. This method resolves once the current chain
+   * head has settled; new writes scheduled after this call return a
+   * separate, later settlement.
+   *
+   * Never throws — the chain already catches its own rejections.
+   */
+  async flushSurpriseTelemetry(): Promise<void> {
+    await this.surpriseTelemetryWriteChain;
   }
 }
 

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -66,6 +66,14 @@ interface SurpriseTelemetryQueueEntry {
    * inflated, current-threshold row misidentified).
    */
   timestamp: string;
+  /**
+   * Threshold value in force when `triggered` was computed. Must be
+   * snapshot here rather than read from `config` at emit time — a
+   * concurrent config change between queue and write would otherwise
+   * record `triggered=true` against a newer threshold the operator
+   * never set, distorting precision/recall interpretation.
+   */
+  threshold: number;
 }
 
 export class SmartBuffer {
@@ -269,6 +277,10 @@ export class SmartBuffer {
           // does not shift the event's apparent moment away from when
           // the turn was actually scored.
           timestamp: new Date().toISOString(),
+          // Snapshot the threshold used to compute `triggered` so a
+          // concurrent config mutation cannot retroactively change
+          // what the ledger row claims the decision was against.
+          threshold: this.config.bufferSurpriseThreshold,
         });
       }
     }
@@ -338,7 +350,10 @@ export class SmartBuffer {
       sessionKey: params.sessionKey,
       turnRole: params.turnRole,
       surpriseScore: params.surpriseScore,
-      threshold: this.config.bufferSurpriseThreshold,
+      // Use the snapshotted threshold from the queue entry, not the
+      // live config — see `SurpriseTelemetryQueueEntry.threshold`
+      // doc for the rationale.
+      threshold: params.threshold,
       triggeredFlush: params.triggered,
       turnCountInWindow: params.turnCountInWindow,
     };

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -262,8 +262,11 @@ export class SmartBuffer {
     try {
       await storage.appendBufferSurpriseEvents([event]);
     } catch (err) {
+      // Same guard as `computeSurpriseSafe`: non-Error rejections must
+      // not crash the telemetry helper, which would defeat the whole
+      // point of isolating the ledger write from the hot path.
       log.debug(
-        `buffer[${params.bufferKey}]: surprise telemetry write failed, continuing: ${(err as Error).message}`,
+        `buffer[${params.bufferKey}]: surprise telemetry write failed, continuing: ${describeError(err)}`,
       );
     }
   }

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -58,6 +58,14 @@ interface SurpriseTelemetryQueueEntry {
   surpriseScore: number;
   triggered: boolean;
   turnCountInWindow: number;
+  /**
+   * ISO timestamp captured at the moment the turn was scored, NOT when
+   * the ledger append eventually runs. Backpressure on the serialized
+   * write chain could otherwise shift event timestamps away from the
+   * real decision moment and distort the distribution report (p90
+   * inflated, current-threshold row misidentified).
+   */
+  timestamp: string;
 }
 
 export class SmartBuffer {
@@ -257,6 +265,10 @@ export class SmartBuffer {
           surpriseScore: surprise,
           triggered,
           turnCountInWindow: entry.turns.length,
+          // Stamp at decision time so backpressure on the write chain
+          // does not shift the event's apparent moment away from when
+          // the turn was actually scored.
+          timestamp: new Date().toISOString(),
         });
       }
     }
@@ -317,7 +329,11 @@ export class SmartBuffer {
     }
     const event: BufferSurpriseEvent = {
       event: "BUFFER_SURPRISE",
-      timestamp: new Date().toISOString(),
+      // Use the decision-time stamp captured when the event was
+      // queued, NOT `Date.now()` here — backpressure on the write
+      // chain could otherwise shift timestamps into the future relative
+      // to when the turn was scored.
+      timestamp: params.timestamp,
       bufferKey: params.bufferKey,
       sessionKey: params.sessionKey,
       turnRole: params.turnRole,

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -4,6 +4,7 @@ import type { StorageManager } from "./storage.js";
 import type {
   BufferEntryState,
   BufferState,
+  BufferSurpriseEvent,
   BufferTurn,
   PluginConfig,
   SignalLevel,
@@ -191,14 +192,25 @@ export class SmartBuffer {
       signal.level !== "high"
     ) {
       const surprise = await this.computeSurpriseSafe(bufferKey, turn, entry);
-      if (
-        surprise !== null &&
-        surprise > this.config.bufferSurpriseThreshold
-      ) {
-        log.debug(
-          `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} > threshold=${this.config.bufferSurpriseThreshold} → extract_now`,
-        );
-        decision = "extract_now";
+      if (surprise !== null) {
+        const triggered = surprise > this.config.bufferSurpriseThreshold;
+        if (triggered) {
+          log.debug(
+            `buffer[${bufferKey}]: surprise=${surprise.toFixed(3)} > threshold=${this.config.bufferSurpriseThreshold} → extract_now`,
+          );
+          decision = "extract_now";
+        }
+        // Emit telemetry on every scored turn — both triggering and
+        // non-triggering — so operators can fit the threshold to real
+        // traffic distributions. Fire-and-forget: if the ledger write
+        // throws, we must not crash the hot path.
+        await this.emitSurpriseEventSafe({
+          bufferKey,
+          turn,
+          surpriseScore: surprise,
+          triggered,
+          turnCountInWindow: entry.turns.length,
+        });
       }
     }
 
@@ -209,6 +221,51 @@ export class SmartBuffer {
     this.pruneEntries([bufferKey]);
     await this.save();
     return decision;
+  }
+
+  /**
+   * Append a single `BUFFER_SURPRISE` telemetry row (issue #563 PR 3).
+   *
+   * Deliberately swallows write errors: the buffer must never fail to
+   * record a turn because the observation ledger is read-only, out of
+   * disk, or otherwise unhappy. The log line at debug lets operators
+   * confirm the path fired without polluting the error channel.
+   */
+  private async emitSurpriseEventSafe(params: {
+    bufferKey: string;
+    turn: BufferTurn;
+    surpriseScore: number;
+    triggered: boolean;
+    turnCountInWindow: number;
+  }): Promise<void> {
+    const storage = this.storage as StorageManager & {
+      appendBufferSurpriseEvents?: (
+        events: BufferSurpriseEvent[],
+      ) => Promise<number>;
+    };
+    if (typeof storage.appendBufferSurpriseEvents !== "function") {
+      // Older StorageManager / test double without the telemetry sink.
+      // Silently skip — core path is still covered by the log line above.
+      return;
+    }
+    const event: BufferSurpriseEvent = {
+      event: "BUFFER_SURPRISE",
+      timestamp: new Date().toISOString(),
+      bufferKey: params.bufferKey,
+      sessionKey: typeof params.turn.sessionKey === "string" ? params.turn.sessionKey : null,
+      turnRole: params.turn.role,
+      surpriseScore: params.surpriseScore,
+      threshold: this.config.bufferSurpriseThreshold,
+      triggeredFlush: params.triggered,
+      turnCountInWindow: params.turnCountInWindow,
+    };
+    try {
+      await storage.appendBufferSurpriseEvents([event]);
+    } catch (err) {
+      log.debug(
+        `buffer[${params.bufferKey}]: surprise telemetry write failed, continuing: ${(err as Error).message}`,
+      );
+    }
   }
 
   /**

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -41,6 +41,25 @@ export interface BufferSurpriseProbe {
 
 const MAX_BUFFER_ENTRY_COUNT = 200;
 
+/**
+ * Minimal data carried on the serialized telemetry write chain
+ * (issue #563 PR 3).
+ *
+ * We intentionally do NOT capture the full `BufferTurn` here: under
+ * slow filesystem latency the chain can back up, and retaining
+ * `turn.content` for every pending append causes memory pressure on
+ * large conversations. Only the fields the ledger row actually needs
+ * cross the chain boundary.
+ */
+interface SurpriseTelemetryQueueEntry {
+  bufferKey: string;
+  turnRole: "user" | "assistant";
+  sessionKey: string | null;
+  surpriseScore: number;
+  triggered: boolean;
+  turnCountInWindow: number;
+}
+
 export class SmartBuffer {
   private state: BufferState;
   private loaded = false;
@@ -224,9 +243,17 @@ export class SmartBuffer {
         // appends settle in wall-clock order — the report path assumes
         // chronological tail rows and reads the most recent as the
         // "current" threshold.
+        //
+        // Project only the fields we need into the queue entry rather
+        // than capturing the full `BufferTurn` — under slow filesystem
+        // latency the chain can back up, and we must not retain the
+        // (potentially large) `turn.content` string for every pending
+        // append.
         this.queueSurpriseTelemetryWrite({
           bufferKey,
-          turn,
+          turnRole: turn.role,
+          sessionKey:
+            typeof turn.sessionKey === "string" ? turn.sessionKey : null,
           surpriseScore: surprise,
           triggered,
           turnCountInWindow: entry.turns.length,
@@ -257,13 +284,7 @@ export class SmartBuffer {
    * Public surface is deliberately narrow — only `addTurn` should call
    * this, so the surprise telemetry path stays centralized.
    */
-  private queueSurpriseTelemetryWrite(params: {
-    bufferKey: string;
-    turn: BufferTurn;
-    surpriseScore: number;
-    triggered: boolean;
-    turnCountInWindow: number;
-  }): void {
+  private queueSurpriseTelemetryWrite(params: SurpriseTelemetryQueueEntry): void {
     this.surpriseTelemetryWriteChain = this.surpriseTelemetryWriteChain
       .then(() => this.emitSurpriseEventSafe(params))
       .catch(() => {
@@ -281,13 +302,9 @@ export class SmartBuffer {
    * disk, or otherwise unhappy. The log line at debug lets operators
    * confirm the path fired without polluting the error channel.
    */
-  private async emitSurpriseEventSafe(params: {
-    bufferKey: string;
-    turn: BufferTurn;
-    surpriseScore: number;
-    triggered: boolean;
-    turnCountInWindow: number;
-  }): Promise<void> {
+  private async emitSurpriseEventSafe(
+    params: SurpriseTelemetryQueueEntry,
+  ): Promise<void> {
     const storage = this.storage as StorageManager & {
       appendBufferSurpriseEvents?: (
         events: BufferSurpriseEvent[],
@@ -302,8 +319,8 @@ export class SmartBuffer {
       event: "BUFFER_SURPRISE",
       timestamp: new Date().toISOString(),
       bufferKey: params.bufferKey,
-      sessionKey: typeof params.turn.sessionKey === "string" ? params.turn.sessionKey : null,
-      turnRole: params.turn.role,
+      sessionKey: params.sessionKey,
+      turnRole: params.turnRole,
       surpriseScore: params.surpriseScore,
       threshold: this.config.bufferSurpriseThreshold,
       triggeredFlush: params.triggered,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -74,6 +74,15 @@ export {
   type ComputeSurpriseOptions,
 } from "./buffer-surprise.js";
 
+export {
+  reportBufferSurpriseDistribution,
+  type BufferSurpriseDistribution,
+  type BufferSurpriseReader,
+  type BufferSurpriseReportOptions,
+} from "./buffer-surprise-report.js";
+
+export type { BufferSurpriseEvent } from "./types.js";
+
 // ---------------------------------------------------------------------------
 // Extraction Judge (issue #376)
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -35,7 +35,13 @@ import {
   listMemoryGovernanceRuns,
   readMemoryGovernanceRunArtifact,
 } from "./maintenance/memory-governance.js";
-import type { FileHygieneConfig, MemoryFile, PluginConfig } from "./types.js";
+import type {
+  BufferSurpriseEvent,
+  FileHygieneConfig,
+  MemoryFile,
+  PluginConfig,
+} from "./types.js";
+import { reportBufferSurpriseDistribution } from "./buffer-surprise-report.js";
 
 interface QmdRuntimeLike {
   probe(): Promise<boolean>;
@@ -1175,6 +1181,14 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // This is an informational check, never an error.
   checks.push(await summarizeMemoryWorthLegacyCounters(new StorageManager(config.memoryDir)));
 
+  // Buffer surprise telemetry distribution (issue #563 PR 3).
+  // Surfaces recent surprise scores so operators can calibrate the
+  // `bufferSurpriseThreshold` from real traffic. Never an error — an empty
+  // ledger is the expected state until the flag is turned on.
+  checks.push(
+    await summarizeBufferSurpriseDistribution(new StorageManager(config.memoryDir), config),
+  );
+
   const summary = checks.reduce(
     (acc, check) => {
       acc[check.status] += 1;
@@ -1267,6 +1281,82 @@ export async function summarizeMemoryWorthLegacyCounters(
         : `${legacy} of ${total} eligible memories have no Memory Worth counters yet (${instrumented} instrumented).`,
     details: { legacy, instrumented, total, ineligible },
   };
+}
+
+/**
+ * Summarize the recent buffer-surprise telemetry distribution for the
+ * Doctor report (issue #563 PR 3).
+ *
+ * Reports mean/median/p90 surprise scores and the triggered-flush rate
+ * over the most recent window of ledger rows. An empty ledger is the
+ * expected state until `bufferSurpriseTriggerEnabled` is turned on — the
+ * check never escalates beyond `ok` / `warn` (ledger unreadable).
+ *
+ * Exported so tests can exercise the formatting without booting a real
+ * orchestrator.
+ */
+export async function summarizeBufferSurpriseDistribution(
+  storage: StorageManager,
+  config: PluginConfig,
+): Promise<OperatorDoctorCheck> {
+  const storageWithLedger = storage as StorageManager & {
+    readBufferSurpriseEvents?: (
+      opts: { limit?: number },
+    ) => Promise<BufferSurpriseEvent[]>;
+  };
+
+  // Defensive: older StorageManager builds (not yet rebuilt) may lack the
+  // reader. Do not fail the entire Doctor run in that case.
+  if (typeof storageWithLedger.readBufferSurpriseEvents !== "function") {
+    return {
+      key: "buffer_surprise_distribution",
+      status: "ok",
+      summary: "Buffer-surprise telemetry reader unavailable in this build.",
+      details: { available: false },
+    };
+  }
+
+  try {
+    const dist = await reportBufferSurpriseDistribution(
+      async (opts) =>
+        storageWithLedger.readBufferSurpriseEvents!({ limit: opts.limit }),
+      { limit: 200 },
+    );
+
+    if (dist.count === 0) {
+      return {
+        key: "buffer_surprise_distribution",
+        status: "ok",
+        summary: config.bufferSurpriseTriggerEnabled
+          ? "Surprise trigger is enabled but no telemetry has been recorded yet."
+          : "Surprise trigger is disabled; no telemetry expected.",
+        details: {
+          enabled: config.bufferSurpriseTriggerEnabled,
+          distribution: dist,
+        },
+      };
+    }
+
+    const pct = (value: number) => (value * 100).toFixed(1);
+    return {
+      key: "buffer_surprise_distribution",
+      status: "ok",
+      summary: `Recent surprise: mean=${dist.mean.toFixed(3)}, median=${dist.median.toFixed(3)}, p90=${dist.p90.toFixed(3)}, triggered=${pct(dist.triggeredRate)}% over ${dist.count} turns (threshold=${dist.currentThreshold ?? config.bufferSurpriseThreshold}).`,
+      details: {
+        enabled: config.bufferSurpriseTriggerEnabled,
+        distribution: dist,
+      },
+    };
+  } catch (err) {
+    return {
+      key: "buffer_surprise_distribution",
+      status: "warn",
+      summary: "Could not read buffer-surprise telemetry ledger.",
+      remediation:
+        "Retry `remnic doctor` after ensuring the memory state directory is readable.",
+      details: { error: String(err) },
+    };
+  }
 }
 
 function getMemoryAgeBand(memory: MemoryFile, now: Date): string {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1921,6 +1921,39 @@ function buildEntitySchemaCacheKey(entitySchemas?: PluginConfig["entitySchemas"]
   return JSON.stringify(normalized);
 }
 
+/**
+ * Full-schema type guard for a `BUFFER_SURPRISE` telemetry row
+ * (issue #563 PR 3).
+ *
+ * The reader applies `limit` over the count of VALID rows, so
+ * applying only a partial check (e.g. "has a finite surpriseScore")
+ * and then deferring the rest of validation to
+ * `reportBufferSurpriseDistribution` would silently count
+ * schema-incomplete rows toward the limit, pushing genuinely-valid
+ * earlier rows out of the report window. Validate everything the
+ * downstream report requires at read time so the limit semantics and
+ * the distribution semantics stay consistent.
+ */
+function isValidBufferSurpriseEvent(value: unknown): value is BufferSurpriseEvent {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const v = value as Record<string, unknown>;
+  if (v.event !== "BUFFER_SURPRISE") return false;
+  if (typeof v.timestamp !== "string" || v.timestamp.length === 0) return false;
+  if (!Number.isFinite(Date.parse(v.timestamp))) return false;
+  if (typeof v.bufferKey !== "string" || v.bufferKey.length === 0) return false;
+  if (v.sessionKey !== null && typeof v.sessionKey !== "string") return false;
+  if (v.turnRole !== "user" && v.turnRole !== "assistant") return false;
+  if (typeof v.surpriseScore !== "number" || !Number.isFinite(v.surpriseScore)) {
+    return false;
+  }
+  if (typeof v.threshold !== "number" || !Number.isFinite(v.threshold)) return false;
+  if (typeof v.triggeredFlush !== "boolean") return false;
+  if (typeof v.turnCountInWindow !== "number" || !Number.isFinite(v.turnCountInWindow)) {
+    return false;
+  }
+  return true;
+}
+
 export class StorageManager {
   private knowledgeIndexCache: { result: string; builtAt: number } | null = null;
   private static readonly KNOWLEDGE_INDEX_CACHE_TTL_MS = 600_000; // 10 minutes (entity mutations invalidate)
@@ -4015,14 +4048,9 @@ export class StorageManager {
       const trimmed = line.trim();
       if (trimmed.length === 0) continue;
       try {
-        const parsed = JSON.parse(trimmed) as Partial<BufferSurpriseEvent>;
-        if (
-          parsed &&
-          typeof parsed === "object" &&
-          typeof parsed.surpriseScore === "number" &&
-          Number.isFinite(parsed.surpriseScore)
-        ) {
-          events.push(parsed as BufferSurpriseEvent);
+        const parsed = JSON.parse(trimmed);
+        if (isValidBufferSurpriseEvent(parsed)) {
+          events.push(parsed);
         }
       } catch {
         // Malformed row — fail open, skip.

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3972,10 +3972,12 @@ export class StorageManager {
     }
 
     // Resolve the effective limit up front. Any non-finite / non-positive
-    // value returns no rows — callers who want "everything" can pass
-    // Number.POSITIVE_INFINITY or simply omit the key (treated as "no
-    // bound" below). Fractional values <1 floor to 0, which would make
-    // `slice(-0)` return the entire file — guard against that too.
+    // value returns no rows — callers who want "everything" should OMIT
+    // the `limit` key (treated as "no bound" below). We intentionally
+    // reject `Infinity` too, because the slice math `events.slice(-Inf)`
+    // is surprising and ambiguous; omit the key instead. Fractional
+    // values <1 floor to 0, which would make `slice(-0)` return the
+    // entire file — guard against that too.
     let effectiveLimit: number | null = null;
     if (options.limit !== undefined) {
       if (

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3958,6 +3958,23 @@ export class StorageManager {
    * than the entire file, matching the other ledger readers in this
    * class and protecting against `slice(-0.5)` → `slice(-0)` silently
    * devolving into an unbounded parse.
+   *
+   * # Performance note
+   *
+   * For very large ledgers (issue #563 follow-up), a tail-first reader
+   * would avoid parsing the full file when only a recent window is
+   * needed. We keep the full-scan implementation here because:
+   *
+   *   - the ledger is opt-in (flag off by default), so early deployments
+   *     accumulate rows slowly;
+   *   - telemetry rows are small (~200 bytes), so even 100k rows parse
+   *     in well under a second;
+   *   - the governance archive/cleanup flow can trim the ledger when
+   *     size becomes a concern, reusing the existing maintenance hooks.
+   *
+   * Swap to a chunked tail-reader if production logs show this is a
+   * hot path — leaving that work for a follow-up keeps this PR scoped
+   * to correctness, not optimization.
    */
   async readBufferSurpriseEvents(
     options: { limit?: number } = {},

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -3946,10 +3946,18 @@ export class StorageManager {
   }
 
   /**
-   * Read the buffer-surprise ledger, most recent rows last. `limit` bounds
-   * the number of rows parsed from the tail of the file — reports typically
-   * need a recent window rather than the entire history. Malformed rows
-   * are skipped silently (same policy as other ledger readers).
+   * Read the buffer-surprise ledger, most recent rows last.
+   *
+   * `limit` bounds the number of **valid rows** returned (not the
+   * number of raw lines parsed). We parse every row, discard malformed
+   * ones, then take the tail — so a partial/truncated trailing line
+   * (the common failure mode after an interrupted append) cannot hide
+   * otherwise-valid recent data above it.
+   *
+   * Non-positive / non-integer / non-finite limits return `[]` rather
+   * than the entire file, matching the other ledger readers in this
+   * class and protecting against `slice(-0.5)` → `slice(-0)` silently
+   * devolving into an unbounded parse.
    */
   async readBufferSurpriseEvents(
     options: { limit?: number } = {},
@@ -3962,17 +3970,33 @@ export class StorageManager {
       if (code === "ENOENT") return [];
       throw err;
     }
-    const lines = raw.split("\n").filter((line) => line.trim().length > 0);
-    // Take from the tail when a limit is supplied — the Doctor surface
-    // wants a recent-window summary, not the full history.
-    const slice =
-      typeof options.limit === "number" && options.limit > 0
-        ? lines.slice(-options.limit)
-        : lines;
+
+    // Resolve the effective limit up front. Any non-finite / non-positive
+    // value returns no rows — callers who want "everything" can pass
+    // Number.POSITIVE_INFINITY or simply omit the key (treated as "no
+    // bound" below). Fractional values <1 floor to 0, which would make
+    // `slice(-0)` return the entire file — guard against that too.
+    let effectiveLimit: number | null = null;
+    if (options.limit !== undefined) {
+      if (
+        typeof options.limit !== "number" ||
+        !Number.isFinite(options.limit) ||
+        options.limit <= 0
+      ) {
+        return [];
+      }
+      const floored = Math.floor(options.limit);
+      if (floored <= 0) return [];
+      effectiveLimit = floored;
+    }
+
+    const lines = raw.split("\n");
     const events: BufferSurpriseEvent[] = [];
-    for (const line of slice) {
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (trimmed.length === 0) continue;
       try {
-        const parsed = JSON.parse(line) as Partial<BufferSurpriseEvent>;
+        const parsed = JSON.parse(trimmed) as Partial<BufferSurpriseEvent>;
         if (
           parsed &&
           typeof parsed === "object" &&
@@ -3985,7 +4009,11 @@ export class StorageManager {
         // Malformed row — fail open, skip.
       }
     }
-    return events;
+
+    if (effectiveLimit === null) return events;
+    // Slice over VALID rows, not raw lines, so malformed tails cannot
+    // mask good data above them.
+    return events.slice(-effectiveLimit);
   }
 
   async appendBehaviorSignals(events: BehaviorSignalEvent[]): Promise<number> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -54,6 +54,7 @@ import type {
   MemoryLifecycleStateSummary,
   MemoryProjectionCurrentState,
   BehaviorSignalEvent,
+  BufferSurpriseEvent,
   MemorySummary,
   MetaState,
   CompressionGuidelineOptimizerState,
@@ -2321,6 +2322,19 @@ export class StorageManager {
   private get behaviorSignalsPath(): string {
     return path.join(this.stateDir, "behavior-signals.jsonl");
   }
+  /**
+   * Buffer surprise telemetry ledger (issue #563 PR 3).
+   *
+   * Append-only JSONL of per-turn `BUFFER_SURPRISE` events emitted by
+   * `SmartBuffer` when `bufferSurpriseTriggerEnabled` is on. Each row
+   * captures the score, the threshold in force at the time, whether the
+   * turn caused an extract_now upgrade, and the buffer size. Kept in
+   * `state/` alongside the other append-only ledgers so cleanup and
+   * governance sweeps can treat it uniformly.
+   */
+  private get bufferSurpriseLedgerPath(): string {
+    return path.join(this.stateDir, "buffer-surprise-ledger.jsonl");
+  }
 
   /**
    * Load user-defined entity aliases from config/aliases.json in the memory store.
@@ -3895,6 +3909,83 @@ export class StorageManager {
 
     await appendFile(this.memoryLifecycleLedgerPath, payload, "utf-8");
     return events.length;
+  }
+
+  /**
+   * Append a batch of `BUFFER_SURPRISE` telemetry events (issue #563 PR 3).
+   *
+   * Each event records a single buffer flush decision driven by the
+   * surprise gate. The ledger is consumed by
+   * `reportBufferSurpriseDistribution` (Doctor report) and by downstream
+   * benchmark analysis. This method is fire-and-forget by contract:
+   * callers log but do not fail the hot path if the append throws.
+   */
+  async appendBufferSurpriseEvents(
+    events: BufferSurpriseEvent[],
+  ): Promise<number> {
+    if (events.length === 0) return 0;
+    await this.ensureDirectories();
+
+    const nowIso = new Date().toISOString();
+    const payload = events
+      .map((event) => {
+        const normalized: BufferSurpriseEvent = {
+          ...event,
+          event: "BUFFER_SURPRISE",
+          timestamp:
+            event.timestamp && event.timestamp.length > 0
+              ? event.timestamp
+              : nowIso,
+        };
+        return `${JSON.stringify(normalized)}\n`;
+      })
+      .join("");
+
+    await appendFile(this.bufferSurpriseLedgerPath, payload, "utf-8");
+    return events.length;
+  }
+
+  /**
+   * Read the buffer-surprise ledger, most recent rows last. `limit` bounds
+   * the number of rows parsed from the tail of the file — reports typically
+   * need a recent window rather than the entire history. Malformed rows
+   * are skipped silently (same policy as other ledger readers).
+   */
+  async readBufferSurpriseEvents(
+    options: { limit?: number } = {},
+  ): Promise<BufferSurpriseEvent[]> {
+    let raw: string;
+    try {
+      raw = await readFile(this.bufferSurpriseLedgerPath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return [];
+      throw err;
+    }
+    const lines = raw.split("\n").filter((line) => line.trim().length > 0);
+    // Take from the tail when a limit is supplied — the Doctor surface
+    // wants a recent-window summary, not the full history.
+    const slice =
+      typeof options.limit === "number" && options.limit > 0
+        ? lines.slice(-options.limit)
+        : lines;
+    const events: BufferSurpriseEvent[] = [];
+    for (const line of slice) {
+      try {
+        const parsed = JSON.parse(line) as Partial<BufferSurpriseEvent>;
+        if (
+          parsed &&
+          typeof parsed === "object" &&
+          typeof parsed.surpriseScore === "number" &&
+          Number.isFinite(parsed.surpriseScore)
+        ) {
+          events.push(parsed as BufferSurpriseEvent);
+        }
+      } catch {
+        // Malformed row — fail open, skip.
+      }
+    }
+    return events;
   }
 
   async appendBehaviorSignals(events: BehaviorSignalEvent[]): Promise<number> {

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -1946,7 +1946,11 @@ function isValidBufferSurpriseEvent(value: unknown): value is BufferSurpriseEven
   if (typeof v.surpriseScore !== "number" || !Number.isFinite(v.surpriseScore)) {
     return false;
   }
+  // Surprise is documented as a value in [0, 1] — reject out-of-range
+  // rows at read time so they do not consume the caller's `limit`.
+  if (v.surpriseScore < 0 || v.surpriseScore > 1) return false;
   if (typeof v.threshold !== "number" || !Number.isFinite(v.threshold)) return false;
+  if (v.threshold < 0 || v.threshold > 1) return false;
   if (typeof v.triggeredFlush !== "boolean") return false;
   if (typeof v.turnCountInWindow !== "number" || !Number.isFinite(v.turnCountInWindow)) {
     return false;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1399,6 +1399,41 @@ export interface BehaviorSignalEvent {
   source: "extraction" | "correction";
 }
 
+/**
+ * One row of the buffer-surprise telemetry ledger (issue #563 PR 3).
+ *
+ * Emitted by `SmartBuffer` each time the surprise probe produces a score
+ * for an incoming turn (i.e. the feature flag is on and the existing
+ * trigger-logic path called through to the probe). Not written when the
+ * probe is skipped — the absence of a row is meaningful and matches the
+ * "probe was not consulted" state.
+ *
+ * The ledger is intentionally lean: we record the score, the threshold in
+ * force, whether the turn caused a flush, and the turn count so operators
+ * can re-derive precision/recall without replaying traffic. Turn content
+ * is never persisted — this ledger is safe to commit to shared storage.
+ */
+export interface BufferSurpriseEvent {
+  /** Literal tag to simplify multiplexed log consumers. */
+  event: "BUFFER_SURPRISE";
+  /** ISO timestamp when the decision was made. Server-side, not turn ts. */
+  timestamp: string;
+  /** Buffer identifier (session / thread). Opaque string. */
+  bufferKey: string;
+  /** Session key if available; null when the turn has no session binding. */
+  sessionKey: string | null;
+  /** Role of the scored turn. */
+  turnRole: "user" | "assistant";
+  /** Surprise score in `[0, 1]`, already clamped. */
+  surpriseScore: number;
+  /** Threshold in force when the decision was made. */
+  threshold: number;
+  /** Whether this turn upgraded `keep_buffering` → `extract_now`. */
+  triggeredFlush: boolean;
+  /** Number of turns in the buffer (including the current turn). */
+  turnCountInWindow: number;
+}
+
 /** Memory status for lifecycle management */
 export type MemoryStatus = "active" | "pending_review" | "rejected" | "quarantined" | "superseded" | "archived";
 export type LifecycleState = "candidate" | "validated" | "active" | "stale" | "archived";


### PR DESCRIPTION
## Summary

Emits one `BUFFER_SURPRISE` telemetry row per scored turn to `state/buffer-surprise-ledger.jsonl` and surfaces the recent distribution through the `remnic doctor` report. Stacked on #618 (PR 2/4).

Rows carry `{bufferKey, sessionKey, turnRole, surpriseScore, threshold, triggeredFlush, turnCountInWindow, timestamp}`. Turn content is never persisted. Written on every scored turn — below-threshold rows are the distribution data the threshold calibration actually needs.

## New surfaces

- `StorageManager.appendBufferSurpriseEvents(events)` / `readBufferSurpriseEvents({ limit })`
- `reportBufferSurpriseDistribution(reader, {limit, since})` — pure helper returning `{count, triggeredCount, triggeredRate, mean, median, p90, min, max, currentThreshold}`. Uses nearest-rank percentiles for stability on small windows.
- `summarizeBufferSurpriseDistribution(...)` — wires the helper into `runOperatorDoctor` as the `buffer_surprise_distribution` check (always informational; empty ledger is expected until operators enable the flag).

## Failure isolation

Telemetry is fire-and-forget: if the ledger write throws, the buffer logs at debug and the trigger decision still lands. `SmartBuffer` feature-detects the sink so legacy storage doubles in pre-existing tests continue to work — only the telemetry path no-ops.

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/buffer-surprise-telemetry.test.ts` — 16/16
- [x] Full buffer suite (51 tests across PR 1/PR 2/PR 3 files) passes with no regressions
- [x] `tsc --noEmit` clean

Refs #563
Part 3 of 4, stacked on #618.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core buffering flow by adding asynchronous telemetry emission and new filesystem ledger read/write paths; while guarded and failure-isolated, ordering/limit validation changes could affect operational reporting correctness.
> 
> **Overview**
> Adds a new append-only `BUFFER_SURPRISE` telemetry ledger and reports its recent score distribution in `remnic doctor` to help calibrate `bufferSurpriseThreshold`.
> 
> `SmartBuffer` now emits a telemetry row for every turn that is actually scored by the surprise probe (including below-threshold scores), using a fire-and-forget but serialized write chain and feature-detecting storage support to avoid breaking legacy storage doubles.
> 
> Introduces `StorageManager.appendBufferSurpriseEvents` / `readBufferSurpriseEvents` (with strict row validation and `limit` applied over valid rows) and a standalone `reportBufferSurpriseDistribution` helper (mean/median/p90/min/max + triggered rate/threshold), with new tests covering emission rules, ordering under variable latency, reader limit semantics, and distribution math.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebb63c07405d510f2a531ce17770da2124b3eb0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->