### PR TITLE
feat(bench): retrieval-reasoning-trace benchmark (#564 PR 4/4)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
@@ -1,0 +1,199 @@
+/**
+ * Synthetic fixture for the reasoning-trace retrieval benchmark
+ * (issue #564 PR 4).
+ *
+ * Each case simulates a recall scenario:
+ * - A seeded candidate pool of 15 past memories, two of which are stored
+ *   reasoning_trace chains (under reasoning-traces/) and the rest are
+ *   ordinary facts/decisions/entities.
+ * - A new query that may or may not match the semantics of a trace.
+ * - An expected winner id (the reasoning-trace we want boosted to rank 1
+ *   on problem-solving asks) and an expected verdict for the heuristic.
+ *
+ * Cases are split by expected behavior so the scorer can measure:
+ * - recall@1 gain on positive problem-solving queries,
+ * - false-positive rate on ordinary lookups (where the boost must not
+ *   shift results).
+ */
+
+export type BenchPathKind = "reasoning_trace" | "fact";
+
+export interface ReasoningTraceBenchCandidate {
+  docid: string;
+  /** Absolute-style path mimicking the real storage layout. */
+  path: string;
+  /** Pre-boost score from the upstream QMD/hybrid tier. */
+  score: number;
+  /** Short snippet used only for debugging output in failures. */
+  snippet: string;
+}
+
+export interface ReasoningTraceBenchCase {
+  id: string;
+  query: string;
+  candidates: ReasoningTraceBenchCandidate[];
+  /**
+   * When true, the boost must promote a reasoning_trace memory (any) to
+   * rank 1. When false, the boost must NOT change the top result
+   * (false-positive guard cases).
+   *
+   * We measure "any reasoning trace at rank 1" rather than a specific
+   * docid because the shipped boost is uniform across the category — if
+   * two traces share the boosted tier the higher-scored one wins, which
+   * is the intended behavior. Bench cases intentionally share a pool so
+   * the retrieval comparison stays apples-to-apples across queries.
+   */
+  expectsTraceTopAfterBoost: boolean;
+  /** Expected top docid when the boost is off (baseline). */
+  expectedTopWithoutBoost: string;
+  /**
+   * Whether the query should be classified as problem-solving by the
+   * shipped heuristic. Used by the scorer to verify classification.
+   */
+  expectedProblemSolving: boolean;
+}
+
+function trace(
+  docid: string,
+  score: number,
+  snippet: string,
+): ReasoningTraceBenchCandidate {
+  return {
+    docid,
+    path: `reasoning-traces/2026-04-18/${docid}.md`,
+    score,
+    snippet,
+  };
+}
+
+function fact(
+  docid: string,
+  score: number,
+  snippet: string,
+): ReasoningTraceBenchCandidate {
+  return {
+    docid,
+    path: `facts/2026-04-18/${docid}.md`,
+    score,
+    snippet,
+  };
+}
+
+/**
+ * Shared candidate pool — 15 memories, 2 are reasoning traces. Each case
+ * reuses this pool (cloned) with a relevant query so retrieval quality
+ * comparisons share a consistent baseline.
+ */
+function seedPool(): ReasoningTraceBenchCandidate[] {
+  // Scores mirror a realistic QMD hybrid-rank distribution where reasoning
+  // traces have non-trivial topical relevance (same keywords as the query)
+  // but sit just under the top fact until the boost fires. A default boost
+  // of 0.15 must be enough to promote them — that's exactly what we want
+  // to measure. Listed in descending-score order so the "baseline" (boost
+  // disabled) passes through the helper unchanged and rank 1 reflects the
+  // fact-pg-15 top expected by every case below.
+  return [
+    fact("fact-pg-15", 0.81, "remnic runs on Postgres 15"),
+    fact("fact-node-22", 0.78, "remnic requires Node 22.12 or newer"),
+    fact("fact-qmd", 0.74, "remnic uses qmd for hybrid retrieval"),
+    trace("trace-latency", 0.72, "How I debugged the staging latency spike"),
+    fact("fact-pnpm", 0.70, "remnic uses pnpm as the package manager"),
+    trace("trace-oauth-loop", 0.68, "How I untangled the OAuth redirect loop"),
+    fact("fact-monorepo", 0.67, "remnic lives in a pnpm workspace monorepo"),
+    fact("fact-tsx", 0.60, "tests run under tsx --test"),
+    fact("fact-release", 0.57, "release-please drives the release workflow"),
+    fact("fact-codeql", 0.55, "CodeQL scans run on every PR"),
+    fact("fact-review", 0.50, "PR reviews require both cursor and codex bots to post"),
+    fact("fact-hooks", 0.47, "pre-commit hooks run lint and quick tests"),
+    fact("fact-dash", 0.45, "admin console is built in the core package"),
+    fact("fact-docs", 0.40, "docs are in /docs, not per-package"),
+    fact("fact-export", 0.35, "@remnic/export-weclone is a separate optional package"),
+  ];
+}
+
+export const REASONING_TRACE_BENCH_FIXTURE: ReasoningTraceBenchCase[] = [
+  // Positive cases: query looks like a problem-solving ask, and one of the
+  // two reasoning traces in the pool is the most relevant memory.
+  {
+    id: "pos-latency-howto",
+    query: "How do I debug a latency spike in staging?",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-oauth-step-by-step",
+    query: "walk me through fixing an OAuth redirect loop step by step",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-troubleshoot-oauth",
+    query: "troubleshoot the OAuth loop we hit last quarter",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-figure-out-latency",
+    query: "how can I figure out why staging is slow",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  {
+    id: "pos-reason-through",
+    query: "Help me reason through the staging latency incident",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: true,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: true,
+  },
+  // Negative / guard cases: query is an ordinary lookup. The boost must be
+  // a no-op — top result stays whatever the baseline produced.
+  {
+    id: "neg-postgres-version",
+    query: "what postgres version does remnic use",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-node-requirement",
+    query: "node engine requirement",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-package-manager",
+    query: "package manager for remnic",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-monorepo-layout",
+    query: "monorepo workspace layout",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+  {
+    id: "neg-release-process",
+    query: "release automation tool",
+    candidates: seedPool(),
+    expectsTraceTopAfterBoost: false,
+    expectedTopWithoutBoost: "fact-pg-15",
+    expectedProblemSolving: false,
+  },
+];

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts
@@ -16,8 +16,6 @@
  *   shift results).
  */
 
-export type BenchPathKind = "reasoning_trace" | "fact";
-
 export interface ReasoningTraceBenchCandidate {
   docid: string;
   /** Absolute-style path mimicking the real storage layout. */

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
@@ -114,6 +114,27 @@ test("runner: full-mode run produces boost_recall_at_1 > 0 and boost_noop_preser
   );
 });
 
+test("runner: quick mode exercises at least one positive AND one negative case", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "quick",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  // In quick mode we should still see both `boost_recall_at_1` (from a
+  // positive case) and `boost_noop_preserved` (from a negative case) so a
+  // one-sided regression can't slip through a smoke run.
+  assert.ok(
+    result.results.aggregates.boost_recall_at_1,
+    "quick mode must exercise the positive boost path",
+  );
+  assert.ok(
+    result.results.aggregates.boost_noop_preserved,
+    "quick mode must exercise the negative guard path",
+  );
+});
+
 test("runner: latency p95 stays well under 5ms (pure helper)", async () => {
   const result = await runRetrievalReasoningTraceBenchmark({
     benchmark: retrievalReasoningTraceDefinition,

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts
@@ -1,0 +1,130 @@
+/**
+ * Tests for the reasoning-trace retrieval bench fixture + runner
+ * (issue #564 PR 4).
+ *
+ * The fixture itself is synthetic, but we verify:
+ * - fixture shape: 10+ cases, mix of positive and negative, unique ids, all
+ *   cases reference the shared 15-memory pool with 2 reasoning traces.
+ * - running the bench in full mode produces aggregates that show the boost
+ *   lifts recall@1 above baseline on positive cases and leaves negative
+ *   cases unchanged — i.e. the feature is actually doing something
+ *   measurable.
+ * - latency stays well under 1ms per case (pure helper call).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  REASONING_TRACE_BENCH_FIXTURE,
+  type ReasoningTraceBenchCase,
+} from "./fixture.ts";
+import {
+  retrievalReasoningTraceDefinition,
+  runRetrievalReasoningTraceBenchmark,
+} from "./runner.ts";
+
+function countWhere(
+  cases: ReasoningTraceBenchCase[],
+  predicate: (c: ReasoningTraceBenchCase) => boolean,
+): number {
+  return cases.filter(predicate).length;
+}
+
+test("fixture: at least 10 cases with unique ids", () => {
+  assert.ok(
+    REASONING_TRACE_BENCH_FIXTURE.length >= 10,
+    `expected at least 10 cases, got ${REASONING_TRACE_BENCH_FIXTURE.length}`,
+  );
+  const ids = new Set<string>();
+  for (const c of REASONING_TRACE_BENCH_FIXTURE) {
+    assert.ok(!ids.has(c.id), `duplicate case id: ${c.id}`);
+    ids.add(c.id);
+  }
+});
+
+test("fixture: each case has 15 candidates with exactly 2 reasoning traces", () => {
+  for (const c of REASONING_TRACE_BENCH_FIXTURE) {
+    assert.equal(
+      c.candidates.length,
+      15,
+      `case ${c.id}: expected 15 candidates, got ${c.candidates.length}`,
+    );
+    const traces = c.candidates.filter((cand) =>
+      cand.path.includes("reasoning-traces/"),
+    );
+    assert.equal(
+      traces.length,
+      2,
+      `case ${c.id}: expected 2 reasoning traces in pool, got ${traces.length}`,
+    );
+  }
+});
+
+test("fixture: has both positive and negative cases", () => {
+  const positives = countWhere(
+    REASONING_TRACE_BENCH_FIXTURE,
+    (c) => c.expectsTraceTopAfterBoost,
+  );
+  const negatives = countWhere(
+    REASONING_TRACE_BENCH_FIXTURE,
+    (c) => !c.expectsTraceTopAfterBoost,
+  );
+  assert.ok(positives >= 3, `expected >=3 positive cases, got ${positives}`);
+  assert.ok(negatives >= 3, `expected >=3 negative cases, got ${negatives}`);
+});
+
+test("definition: benchmark metadata is ready and available", () => {
+  assert.equal(retrievalReasoningTraceDefinition.id, "retrieval-reasoning-trace");
+  assert.equal(retrievalReasoningTraceDefinition.tier, "remnic");
+  assert.equal(retrievalReasoningTraceDefinition.status, "ready");
+  assert.equal(retrievalReasoningTraceDefinition.runnerAvailable, true);
+});
+
+test("runner: full-mode run produces boost_recall_at_1 > 0 and boost_noop_preserved > 0", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "full",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  const recall = result.results.aggregates.boost_recall_at_1;
+  const noop = result.results.aggregates.boost_noop_preserved;
+  const baselineMatch = result.results.aggregates.baseline_top_matches_fixture;
+  const classification = result.results.aggregates.heuristic_classification_correct;
+
+  assert.ok(recall, "boost_recall_at_1 aggregate missing");
+  assert.ok(noop, "boost_noop_preserved aggregate missing");
+  assert.ok(
+    recall.mean === 1,
+    `expected 100% boost_recall_at_1 on positive cases, got ${recall.mean}`,
+  );
+  assert.ok(
+    noop.mean === 1,
+    `expected 100% boost_noop_preserved on negative cases, got ${noop.mean}`,
+  );
+  assert.ok(
+    baselineMatch && baselineMatch.mean === 1,
+    `baseline_top_matches_fixture should be 1, got ${baselineMatch?.mean}`,
+  );
+  assert.ok(
+    classification && classification.mean === 1,
+    `heuristic_classification_correct should be 1, got ${classification?.mean}`,
+  );
+});
+
+test("runner: latency p95 stays well under 5ms (pure helper)", async () => {
+  const result = await runRetrievalReasoningTraceBenchmark({
+    benchmark: retrievalReasoningTraceDefinition,
+    mode: "full",
+    runCount: 1,
+    adapterMode: "direct",
+  } as Parameters<typeof runRetrievalReasoningTraceBenchmark>[0]);
+
+  const p95 = result.results.aggregates.latency_p95_ms?.mean ?? 0;
+  assert.ok(
+    p95 < 5,
+    `expected p95 boost latency < 5ms, got ${p95}ms`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
@@ -1,0 +1,233 @@
+/**
+ * Reasoning-trace retrieval benchmark (issue #564 PR 4).
+ *
+ * Feeds a synthetic fixture of 15 past memories (2 reasoning traces + 13
+ * ordinary facts) into the retrieval boost helper with the flag on and
+ * off, and reports:
+ *
+ * - `boost_recall_at_1`: on positive problem-solving cases, the reasoning
+ *   trace lands at rank 1 after boost.
+ * - `boost_false_positive_rate_at_1`: on negative / ordinary-lookup
+ *   cases, the boost must leave rank 1 unchanged.
+ * - `heuristic_classification_correct`: looksLikeProblemSolvingQuery
+ *   agrees with the fixture's labeled expectation.
+ * - `latency_p50_ms` / `latency_p95_ms`: pure boost-call latency.
+ *
+ * No orchestrator, no search backend — the bench exercises the pure
+ * `applyReasoningTraceBoost` helper directly so it stays fast and
+ * deterministic.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  applyReasoningTraceBoost,
+  isReasoningTracePath,
+  looksLikeProblemSolvingQuery,
+} from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  REASONING_TRACE_BENCH_FIXTURE,
+  type ReasoningTraceBenchCase,
+} from "./fixture.js";
+
+export const retrievalReasoningTraceDefinition: BenchmarkDefinition = {
+  id: "retrieval-reasoning-trace",
+  title: "Retrieval: Reasoning-Trace Boost",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retrieval-reasoning-trace",
+    version: "1.0.0",
+    description:
+      "Measures the reasoning_trace recall boost: recall@1 gain on problem-solving queries, false-positive rate on ordinary lookups, heuristic classification agreement, and boost-call latency (issue #564 PR 4).",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #564",
+  },
+};
+
+interface CaseOutcome {
+  baselineTop: string;
+  baselineTopPath: string;
+  boostedTop: string;
+  boostedTopPath: string;
+  classifiedAsProblemSolving: boolean;
+  latencyMs: number;
+}
+
+function runCase(benchCase: ReasoningTraceBenchCase): CaseOutcome {
+  // Baseline: the same helper with `enabled: false`, which is a no-op but
+  // goes through the same code path so latency measurement is apples to
+  // apples with the boosted call below.
+  const baseline = applyReasoningTraceBoost(benchCase.candidates, {
+    enabled: false,
+    query: benchCase.query,
+  });
+  const baselineTop = baseline[0]?.docid ?? "";
+  const baselineTopPath = baseline[0]?.path ?? "";
+
+  const classifiedAsProblemSolving = looksLikeProblemSolvingQuery(benchCase.query);
+
+  const start = performance.now();
+  const boosted = applyReasoningTraceBoost(benchCase.candidates, {
+    enabled: true,
+    query: benchCase.query,
+  });
+  const latencyMs = performance.now() - start;
+  const boostedTop = boosted[0]?.docid ?? "";
+  const boostedTopPath = boosted[0]?.path ?? "";
+
+  return {
+    baselineTop,
+    baselineTopPath,
+    boostedTop,
+    boostedTopPath,
+    classifiedAsProblemSolving,
+    latencyMs,
+  };
+}
+
+function scoreCase(
+  benchCase: ReasoningTraceBenchCase,
+  outcome: CaseOutcome,
+): Record<string, number> {
+  const scores: Record<string, number> = {};
+
+  // Heuristic classification: did looksLikeProblemSolvingQuery match the
+  // fixture's labeled expectation?
+  scores.heuristic_classification_correct =
+    outcome.classifiedAsProblemSolving === benchCase.expectedProblemSolving ? 1 : 0;
+
+  // Sanity: baseline top matches the fixture's expected pre-boost winner.
+  scores.baseline_top_matches_fixture =
+    outcome.baselineTop === benchCase.expectedTopWithoutBoost ? 1 : 0;
+
+  if (!benchCase.expectsTraceTopAfterBoost) {
+    // Guard case: boost must not change rank 1.
+    scores.boost_noop_preserved =
+      outcome.boostedTop === outcome.baselineTop ? 1 : 0;
+  } else {
+    // Positive case: the top-1 memory after boost must live under
+    // reasoning-traces/. We measure "any trace at rank 1" rather than a
+    // specific docid because the shipped boost is uniform across the
+    // category — when two traces share the boosted tier, the higher-scored
+    // one naturally wins.
+    scores.boost_recall_at_1 = isReasoningTracePath(outcome.boostedTopPath) ? 1 : 0;
+  }
+
+  scores.latency_under_1ms = outcome.latencyMs < 1 ? 1 : 0;
+  return scores;
+}
+
+function selectCases(
+  mode: "quick" | "full",
+  limit?: number,
+): ReasoningTraceBenchCase[] {
+  const effectiveLimit =
+    limit !== undefined ? limit : mode === "quick" ? 2 : undefined;
+  if (effectiveLimit === undefined) {
+    return REASONING_TRACE_BENCH_FIXTURE;
+  }
+  if (!Number.isInteger(effectiveLimit) || effectiveLimit <= 0) {
+    throw new Error(
+      "retrieval-reasoning-trace limit must be a positive integer",
+    );
+  }
+  const limited = REASONING_TRACE_BENCH_FIXTURE.slice(0, effectiveLimit);
+  if (limited.length === 0) {
+    throw new Error(
+      "retrieval-reasoning-trace fixture is empty after applying the requested limit.",
+    );
+  }
+  return limited;
+}
+
+export async function runRetrievalReasoningTraceBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const tasks: TaskResult[] = [];
+  const latencies: number[] = [];
+  const cases = selectCases(options.mode, options.limit);
+
+  for (const benchCase of cases) {
+    const outcome = runCase(benchCase);
+    latencies.push(outcome.latencyMs);
+    const scores = scoreCase(benchCase, outcome);
+    tasks.push({
+      taskId: benchCase.id,
+      question: benchCase.query,
+      expected: benchCase.expectsTraceTopAfterBoost
+        ? "top-is-reasoning-trace"
+        : `top-unchanged=${benchCase.expectedTopWithoutBoost}`,
+      actual: `baseline-top=${outcome.baselineTop};boosted-top=${outcome.boostedTop}`,
+      scores,
+      latencyMs: Math.round(outcome.latencyMs * 100) / 100,
+      tokens: { input: 0, output: 0 },
+      details: {
+        caseId: benchCase.id,
+        candidateCount: benchCase.candidates.length,
+        classifiedAsProblemSolving: outcome.classifiedAsProblemSolving,
+      },
+    });
+  }
+
+  latencies.sort((a, b) => a - b);
+  const p50Raw = latencies[Math.floor(latencies.length * 0.5)] ?? 0;
+  const p95Raw =
+    latencies[Math.min(latencies.length - 1, Math.floor(latencies.length * 0.95))] ?? 0;
+  const p50 = Math.round(p50Raw * 100) / 100;
+  const p95 = Math.round(p95Raw * 100) / 100;
+
+  const aggregated = aggregateTaskScores(tasks.map((task) => task.scores));
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs: tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: {
+        ...aggregated,
+        latency_p50_ms: { mean: p50, median: p50, stdDev: 0, min: p50, max: p50 },
+        latency_p95_ms: { mean: p95, median: p95, stdDev: 0, min: p95, max: p95 },
+      },
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.ts
@@ -37,6 +37,14 @@ import {
   type ReasoningTraceBenchCase,
 } from "./fixture.js";
 
+/**
+ * Metrics where a lower value represents better performance. Registered
+ * in `LOWER_IS_BETTER_BY_BENCHMARK` so `compareResults()` treats an
+ * increase in latency as a regression rather than an improvement.
+ */
+export const RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER: ReadonlySet<string> =
+  new Set(["latency_p50_ms", "latency_p95_ms"]);
+
 export const retrievalReasoningTraceDefinition: BenchmarkDefinition = {
   id: "retrieval-reasoning-trace",
   title: "Retrieval: Reasoning-Trace Boost",
@@ -130,23 +138,58 @@ function selectCases(
   mode: "quick" | "full",
   limit?: number,
 ): ReasoningTraceBenchCase[] {
-  const effectiveLimit =
-    limit !== undefined ? limit : mode === "quick" ? 2 : undefined;
-  if (effectiveLimit === undefined) {
+  if (limit === undefined && mode !== "quick") {
     return REASONING_TRACE_BENCH_FIXTURE;
   }
-  if (!Number.isInteger(effectiveLimit) || effectiveLimit <= 0) {
+
+  // Quick mode must exercise BOTH the positive recall path and the negative
+  // guard path — otherwise a regression that incorrectly boosts ordinary
+  // lookups silently passes smoke runs (the default mode in runBenchmark).
+  // Take 1 positive + 1 negative by default, or slice a balanced mix when
+  // an explicit limit is requested.
+  const positives = REASONING_TRACE_BENCH_FIXTURE.filter(
+    (c) => c.expectsTraceTopAfterBoost,
+  );
+  const negatives = REASONING_TRACE_BENCH_FIXTURE.filter(
+    (c) => !c.expectsTraceTopAfterBoost,
+  );
+
+  if (limit === undefined) {
+    // mode === "quick" and no explicit limit — take 1 of each.
+    const selected: ReasoningTraceBenchCase[] = [];
+    if (positives.length > 0) selected.push(positives[0]);
+    if (negatives.length > 0) selected.push(negatives[0]);
+    if (selected.length === 0) {
+      throw new Error(
+        "retrieval-reasoning-trace fixture has no cases to select in quick mode.",
+      );
+    }
+    return selected;
+  }
+
+  if (!Number.isInteger(limit) || limit <= 0) {
     throw new Error(
       "retrieval-reasoning-trace limit must be a positive integer",
     );
   }
-  const limited = REASONING_TRACE_BENCH_FIXTURE.slice(0, effectiveLimit);
-  if (limited.length === 0) {
+
+  // Interleave positives and negatives so any `limit` >= 2 produces a mix.
+  const interleaved: ReasoningTraceBenchCase[] = [];
+  const max = Math.max(positives.length, negatives.length);
+  for (let i = 0; i < max && interleaved.length < limit; i++) {
+    if (i < positives.length && interleaved.length < limit) {
+      interleaved.push(positives[i]);
+    }
+    if (i < negatives.length && interleaved.length < limit) {
+      interleaved.push(negatives[i]);
+    }
+  }
+  if (interleaved.length === 0) {
     throw new Error(
       "retrieval-reasoning-trace fixture is empty after applying the requested limit.",
     );
   }
-  return limited;
+  return interleaved;
 }
 
 export async function runRetrievalReasoningTraceBenchmark(

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -72,6 +72,10 @@ import {
   runRetrievalDirectAnswerBenchmark,
 } from "./benchmarks/remnic/retrieval-direct-answer/runner.js";
 import {
+  retrievalReasoningTraceDefinition,
+  runRetrievalReasoningTraceBenchmark,
+} from "./benchmarks/remnic/retrieval-reasoning-trace/runner.js";
+import {
   codingRecallDefinition,
   runCodingRecallBenchmark,
 } from "./benchmarks/remnic/coding-recall/runner.js";
@@ -188,6 +192,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...retrievalDirectAnswerDefinition,
     run: runRetrievalDirectAnswerBenchmark,
+  },
+  {
+    ...retrievalReasoningTraceDefinition,
+    run: runRetrievalReasoningTraceBenchmark,
   },
   {
     ...codingRecallDefinition,

--- a/packages/bench/src/stats/comparison.ts
+++ b/packages/bench/src/stats/comparison.ts
@@ -102,9 +102,11 @@ export function compareResults(
  * metrics as regressions when they increase.
  */
 import { INGESTION_SETUP_FRICTION_LOWER_IS_BETTER } from "../benchmarks/remnic/ingestion-setup-friction/runner.js";
+import { RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER } from "../benchmarks/remnic/retrieval-reasoning-trace/runner.js";
 
 const LOWER_IS_BETTER_BY_BENCHMARK: Record<string, ReadonlySet<string>> = {
   "ingestion-setup-friction": INGESTION_SETUP_FRICTION_LOWER_IS_BETTER,
+  "retrieval-reasoning-trace": RETRIEVAL_REASONING_TRACE_LOWER_IS_BETTER,
 };
 
 export function getBenchmarkLowerIsBetter(benchmarkId: string): ReadonlySet<string> {

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -121,6 +121,19 @@ export {
 } from "./direct-answer.js";
 
 // ---------------------------------------------------------------------------
+// Reasoning-trace retrieval boost (issue #564)
+// ---------------------------------------------------------------------------
+
+export {
+  applyReasoningTraceBoost,
+  isReasoningTracePath,
+  looksLikeProblemSolvingQuery,
+  DEFAULT_REASONING_TRACE_BOOST,
+  type ApplyReasoningTraceBoostOptions,
+  type BoostableResult,
+} from "./reasoning-trace-recall.js";
+
+// ---------------------------------------------------------------------------
 // Inline source attribution (issue #369)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Issue #564 PR 4 of 4 — synthetic benchmark measuring recall + latency gains from the reasoning_trace recall boost.

Stacked on top of PR #625; rebase onto main once #625 merges.

- **Fixture** (`packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/fixture.ts`): shared 15-memory candidate pool (2 reasoning traces + 13 ordinary facts, score-sorted to mimic a QMD hybrid rank), 10 cases — 5 positive problem-solving queries that should promote a trace to rank 1, 5 negative ordinary lookups that must leave rank 1 unchanged.
- **Runner**: calls `applyReasoningTraceBoost` twice per case (disabled / enabled) over the same pool so the comparison is apples-to-apples. Metrics:
  - `boost_recall_at_1` — reasoning trace lands at rank 1 on positive cases (any trace, since the shipped boost is uniform across the category).
  - `boost_noop_preserved` — rank 1 unchanged on negative cases.
  - `heuristic_classification_correct` — `looksLikeProblemSolvingQuery` agrees with the fixture label.
  - `baseline_top_matches_fixture` — sanity check.
  - `latency_p50_ms` / `latency_p95_ms`.
- Registered as `retrieval-reasoning-trace`, tier `remnic`, status `ready`.
- Exports the boost helpers from `@remnic/core` so the bench (and future consumers) can reuse them.

## Test plan
- [x] `npx tsx --test packages/bench/src/benchmarks/remnic/retrieval-reasoning-trace/runner.test.ts` — 6 tests, all green (100% recall_at_1, 100% noop_preserved, 100% heuristic match, p95 < 5ms)
- [x] `tsc --noEmit` — workspace clean
- [x] `listBenchmarks()` includes the new id

Refs #564.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds a new synthetic benchmark, registry wiring, and exports for existing boost helpers; main risk is test/benchmark plumbing or metrics interpretation, not production runtime behavior.
> 
> **Overview**
> Adds a new `retrieval-reasoning-trace` benchmark that measures the *reasoning-trace recall boost* by running a synthetic fixture with the boost disabled/enabled and reporting recall@1, no-op preservation on ordinary lookups, heuristic classification correctness, and p50/p95 latency.
> 
> Registers the benchmark in `packages/bench` (including lower-is-better latency metrics for result comparisons) and exports the reasoning-trace boost helpers (`applyReasoningTraceBoost`, `looksLikeProblemSolvingQuery`, etc.) from `@remnic/core` for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82bd11567ee8faea76e6eece8fe0ea84e2f1da47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->