### PR TITLE
feat(bench): buffer-surprise-trigger A/B benchmark (issue #563 PR 4/4)

### DIFF
--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
@@ -80,7 +80,7 @@ export const BUFFER_SURPRISE_TRIGGER_FIXTURE: BufferSurpriseTriggerCase[] = [
       "Should I side-dress with compost or use a liquid fertilizer?",
       "My soil pH tested at 6.8 last month, which seems okay.",
       // Topic shift 2: gardening → finance
-      "Actually I wanted to ask about Treasury I-bonds.",
+      "On another note, I wanted to ask about Treasury I-bonds.",
       "How does the inflation adjustment compound over time?",
       "What's the annual purchase limit per person?",
       "Are they a better deal than TIPS right now?",
@@ -108,7 +108,7 @@ export const BUFFER_SURPRISE_TRIGGER_FIXTURE: BufferSurpriseTriggerCase[] = [
       "Token bucket vs leaky bucket — which fits bursty traffic better?",
       "I was leaning toward a sliding-window counter with Redis.",
       // Shift 1: engineering → cooking
-      "Unrelated — I want to try making sourdough this weekend.",
+      "Unrelated — thinking about making sourdough this weekend.",
       "My starter has been in the fridge for two weeks, is it still alive?",
       "Should I refresh it twice before baking?",
       // Shift 2: cooking → history

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/fixture.ts
@@ -1,0 +1,129 @@
+/**
+ * Fixture for the `buffer-surprise-trigger` benchmark (issue #563 PR 4).
+ *
+ * Each case represents a short synthetic conversation with 2–3 annotated
+ * topic shifts. A "topic shift" is the turn where the conversation moves
+ * to a semantically distant subject — that is the turn we expect the
+ * D-MEM surprise gate to flush on when it's working.
+ *
+ * Conversations are intentionally short (12–15 turns) and written in
+ * plain English so the deterministic hash embedder used by the runner
+ * produces meaningful cosine similarities across topic boundaries
+ * without requiring a real embedding model. The runner does NOT call any
+ * LLM, network, or QMD instance — everything is in-memory and
+ * reproducible by seed.
+ *
+ * Each `topicShiftTurnIndices` is 0-indexed into the `turns` array. The
+ * first turn (index 0) is never a topic shift by construction — there is
+ * no prior context to shift away from.
+ */
+
+export interface BufferSurpriseTriggerCase {
+  id: string;
+  /**
+   * Ordered turns in the conversation. Only the text matters — the
+   * runner handles role assignment deterministically.
+   */
+  turns: string[];
+  /** 0-indexed turn positions that introduce a new topic. */
+  topicShiftTurnIndices: number[];
+}
+
+export const BUFFER_SURPRISE_TRIGGER_FIXTURE: BufferSurpriseTriggerCase[] = [
+  {
+    id: "cooking-to-astronomy",
+    turns: [
+      "I'm making pasta carbonara tonight with pancetta and pecorino.",
+      "Should I use guanciale instead of pancetta for authenticity?",
+      "What ratio of eggs to cheese gives the best creamy texture?",
+      "I usually whisk yolks and whole eggs separately before combining.",
+      "A splash of pasta water at the end helps emulsify everything.",
+      // Topic shift 1: cooking → astronomy
+      "Completely different question — can you explain why Jupiter has such strong magnetic fields?",
+      "Does the liquid metallic hydrogen in its interior act like a dynamo?",
+      "Are Jupiter's auroras visible from Earth-based telescopes?",
+      "I saw a Hubble image of the polar auroras last year.",
+      // Topic shift 2: astronomy → tax policy
+      "Switching gears: what's the current US federal long-term capital gains rate?",
+      "How does the holding-period rule interact with wash sales?",
+      "Are there any exemptions for primary residence gains?",
+    ],
+    topicShiftTurnIndices: [5, 9],
+  },
+  {
+    id: "debugging-to-travel",
+    turns: [
+      "My Node.js process is hanging on shutdown and I can't figure out why.",
+      "I've checked for open handles with `wtfnode` and it shows a pending timer.",
+      "The timer is from a library I don't own — any ideas?",
+      "I tried process.exit(0) but it cuts off pending writes.",
+      "Maybe I should use unref() on the timer.",
+      "That worked — unref lets the event loop exit cleanly.",
+      // Topic shift: engineering → travel planning
+      "On a different note — I'm planning a trip to Kyoto next spring.",
+      "Which neighborhoods should I stay in for temple access?",
+      "Is it better to rent bicycles or use the bus and subway?",
+      "What's the weather like during cherry blossom season?",
+      "Should I book ryokan accommodations in advance?",
+    ],
+    topicShiftTurnIndices: [6],
+  },
+  {
+    id: "music-to-gardening-to-finance",
+    turns: [
+      "I've been learning the blues scale on guitar this week.",
+      "The minor pentatonic with a flat 5 gives it that distinctive sound.",
+      "Which B.B. King album should I study for phrasing?",
+      // Topic shift 1: music → gardening
+      "Switching topics — my tomato plants have yellow leaves on the bottom.",
+      "Is that nitrogen deficiency or just normal old-leaf drop?",
+      "Should I side-dress with compost or use a liquid fertilizer?",
+      "My soil pH tested at 6.8 last month, which seems okay.",
+      // Topic shift 2: gardening → finance
+      "Actually I wanted to ask about Treasury I-bonds.",
+      "How does the inflation adjustment compound over time?",
+      "What's the annual purchase limit per person?",
+      "Are they a better deal than TIPS right now?",
+    ],
+    topicShiftTurnIndices: [3, 7],
+  },
+  {
+    id: "no-shifts-baseline",
+    turns: [
+      "I've been rewriting our authentication flow in Go.",
+      "The old session cookie had no rotation, which bothered me.",
+      "I'm using PASETO tokens with 15-minute lifetimes.",
+      "Refresh tokens go in an HttpOnly cookie with SameSite strict.",
+      "The refresh path rotates the token and invalidates the old one.",
+      "Device fingerprinting helps us detect stolen refresh tokens.",
+      "We log rotation events for audit and anomaly detection.",
+      "The load balancer strips all cookies before cache hits.",
+    ],
+    topicShiftTurnIndices: [],
+  },
+  {
+    id: "three-shifts",
+    turns: [
+      "I'm designing a rate limiter for our public API.",
+      "Token bucket vs leaky bucket — which fits bursty traffic better?",
+      "I was leaning toward a sliding-window counter with Redis.",
+      // Shift 1: engineering → cooking
+      "Unrelated — I want to try making sourdough this weekend.",
+      "My starter has been in the fridge for two weeks, is it still alive?",
+      "Should I refresh it twice before baking?",
+      // Shift 2: cooking → history
+      "Separately — when did the Byzantine Empire actually fall?",
+      "Was it 1453 when Constantinople fell to the Ottomans?",
+      "What happened to the remnants in the Morea after that?",
+      // Shift 3: history → photography
+      "One more thing — I just bought a used Fujifilm X-T4.",
+      "Which lens should I start with for street photography?",
+      "Do you recommend the 23mm f/2 or the 35mm f/1.4?",
+    ],
+    topicShiftTurnIndices: [3, 6, 9],
+  },
+];
+
+/** A small smoke subset for `--mode quick` runs. */
+export const BUFFER_SURPRISE_TRIGGER_SMOKE_FIXTURE =
+  BUFFER_SURPRISE_TRIGGER_FIXTURE.slice(0, 2);

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Smoke test for `buffer-surprise-trigger` benchmark (issue #563 PR 4).
+ *
+ * Exercises the end-to-end runner on the smoke fixture to catch wiring
+ * regressions (fixture loading, metric shape, candidate vs control
+ * parallel run, aggregate computation). The runner is fully
+ * deterministic — no mocks required.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  runBufferSurpriseTriggerBenchmark,
+  bufferSurpriseTriggerDefinition,
+  topicShiftF1,
+} from "./runner.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+import type { BenchMemoryAdapter } from "../../../adapters/types.js";
+
+// This benchmark does not exercise the `system` adapter at all — it
+// operates on `SmartBuffer` directly — but `ResolvedRunBenchmarkOptions`
+// requires a non-null adapter reference. A bare object satisfies the
+// type checker without bringing in any real integration surface.
+function noopAdapter(): BenchMemoryAdapter {
+  return {
+    async store() {},
+    async recall() {
+      return "";
+    },
+    async search() {
+      return [];
+    },
+    async reset() {},
+    async getStats() {
+      return { sessionCount: 0, totalMemories: 0 };
+    },
+    async destroy() {},
+  } as unknown as BenchMemoryAdapter;
+}
+
+test("runner returns tasks with candidate + control metrics (quick mode)", async () => {
+  const options: ResolvedRunBenchmarkOptions = {
+    mode: "quick",
+    benchmark: bufferSurpriseTriggerDefinition,
+    system: noopAdapter(),
+  };
+  const result = await runBufferSurpriseTriggerBenchmark(options);
+
+  assert.ok(result.results.tasks.length > 0, "expected at least one task");
+  for (const task of result.results.tasks) {
+    const scores = task.scores;
+    assert.ok(
+      typeof scores.candidate_topic_shift_f1 === "number" &&
+        scores.candidate_topic_shift_f1 >= 0 &&
+        scores.candidate_topic_shift_f1 <= 1,
+      `candidate F1 out of range for ${task.taskId}`,
+    );
+    assert.ok(
+      typeof scores.control_topic_shift_f1 === "number" &&
+        scores.control_topic_shift_f1 >= 0 &&
+        scores.control_topic_shift_f1 <= 1,
+      `control F1 out of range for ${task.taskId}`,
+    );
+    assert.equal(
+      scores.topic_shift_f1_delta,
+      scores.candidate_topic_shift_f1 - scores.control_topic_shift_f1,
+      `f1_delta mismatch for ${task.taskId}`,
+    );
+    assert.ok(Number.isFinite(scores.candidate_flush_count));
+    assert.ok(Number.isFinite(scores.control_flush_count));
+  }
+});
+
+test("runner produces aggregates for every per-task metric", async () => {
+  const options: ResolvedRunBenchmarkOptions = {
+    mode: "quick",
+    benchmark: bufferSurpriseTriggerDefinition,
+    system: noopAdapter(),
+  };
+  const result = await runBufferSurpriseTriggerBenchmark(options);
+
+  // Every metric the tasks produced should appear in aggregates with
+  // the standard {mean, median, stdDev, min, max} shape.
+  const expectedKeys = [
+    "candidate_topic_shift_f1",
+    "control_topic_shift_f1",
+    "topic_shift_f1_delta",
+    "candidate_flush_count",
+    "control_flush_count",
+  ];
+  for (const key of expectedKeys) {
+    const agg = result.results.aggregates[key];
+    assert.ok(agg, `missing aggregate for ${key}`);
+    assert.ok(typeof agg.mean === "number");
+    assert.ok(typeof agg.median === "number");
+    assert.ok(typeof agg.stdDev === "number");
+    assert.ok(typeof agg.min === "number");
+    assert.ok(typeof agg.max === "number");
+  }
+});
+
+test("candidate produces at least as many flushes as control on the topic-shift fixture", async () => {
+  // Surprise-on should never flush *less* than surprise-off on a corpus
+  // designed around novelty — that would break the additive-only
+  // invariant exercised in PR 2.
+  const options: ResolvedRunBenchmarkOptions = {
+    mode: "full",
+    benchmark: bufferSurpriseTriggerDefinition,
+    system: noopAdapter(),
+  };
+  const result = await runBufferSurpriseTriggerBenchmark(options);
+
+  for (const task of result.results.tasks) {
+    assert.ok(
+      task.scores.candidate_flush_count >= task.scores.control_flush_count,
+      `additive-only invariant violated for ${task.taskId}: candidate=${task.scores.candidate_flush_count}, control=${task.scores.control_flush_count}`,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// topicShiftF1 unit tests
+// ---------------------------------------------------------------------------
+
+test("topicShiftF1: perfect match returns 1", () => {
+  assert.equal(topicShiftF1([5, 10], [5, 10]), 1);
+});
+
+test("topicShiftF1: ±1 tolerance matches as true positive", () => {
+  // predicted=[4] against expected=[5] is within tolerance=1.
+  assert.equal(topicShiftF1([4], [5]), 1);
+  assert.equal(topicShiftF1([6], [5]), 1);
+});
+
+test("topicShiftF1: out-of-tolerance predictions are false positives", () => {
+  // predicted=[10] vs expected=[5] → TP=0, FP=1, FN=1 → precision=0,
+  // recall=0 → F1=0.
+  assert.equal(topicShiftF1([10], [5]), 0);
+});
+
+test("topicShiftF1: empty expected + empty predicted returns 1", () => {
+  assert.equal(topicShiftF1([], []), 1);
+});
+
+test("topicShiftF1: empty expected + non-empty predicted returns 0", () => {
+  assert.equal(topicShiftF1([5], []), 0);
+});
+
+test("topicShiftF1: partial match computes F1 correctly", () => {
+  // expected=[5, 10, 15], predicted=[5, 10] → TP=2, FP=0, FN=1
+  // precision=1, recall=2/3 → F1=0.8
+  const f1 = topicShiftF1([5, 10], [5, 10, 15]);
+  assert.ok(Math.abs(f1 - 0.8) < 1e-9, `expected 0.8, got ${f1}`);
+});
+
+test("topicShiftF1: each expected index matches at most one predicted", () => {
+  // expected=[5], predicted=[4, 6] — both are within tolerance=1 of
+  // index 5, but only one can claim it. TP=1, FP=1, FN=0.
+  // precision=0.5, recall=1, F1 = 2*0.5*1/(0.5+1) = 2/3.
+  const f1 = topicShiftF1([4, 6], [5]);
+  assert.ok(
+    Math.abs(f1 - 2 / 3) < 1e-9,
+    `expected 2/3, got ${f1}`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts
@@ -88,6 +88,8 @@ test("runner produces aggregates for every per-task metric", async () => {
     "topic_shift_f1_delta",
     "candidate_flush_count",
     "control_flush_count",
+    "candidate_mean_turns_between_flushes",
+    "control_mean_turns_between_flushes",
   ];
   for (const key of expectedKeys) {
     const agg = result.results.aggregates[key];
@@ -163,4 +165,21 @@ test("topicShiftF1: each expected index matches at most one predicted", () => {
     Math.abs(f1 - 2 / 3) < 1e-9,
     `expected 2/3, got ${f1}`,
   );
+});
+
+test("topicShiftF1: max-bipartite matching outperforms greedy on overlaps", () => {
+  // expected=[4, 5], predicted=[5, 6], tolerance=1.
+  // A greedy nearest-first pass pairs 5↔5 first and then cannot pair
+  // 6 (4 is out of tolerance), yielding TP=1.  Max bipartite finds
+  // the valid assignment 5↔4, 6↔5 and reports TP=2.
+  // TP=2, FP=0, FN=0 → F1 = 1.
+  assert.equal(topicShiftF1([5, 6], [4, 5], 1), 1);
+});
+
+test("topicShiftF1: returns 0 precision+0 recall → 0, not NaN", () => {
+  // Out-of-tolerance prediction against a single expected target must
+  // return a defined score, not NaN / undefined — downstream
+  // aggregators rely on scalar output.
+  const f1 = topicShiftF1([20], [1], 1);
+  assert.equal(f1, 0);
 });

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
@@ -275,6 +275,8 @@ export async function runBufferSurpriseTriggerBenchmark(
 interface CaseRunOutput {
   flushTurnIndices: number[];
   turnsBetweenFlushesMean: number;
+  /** Wall-clock ms spent replaying this case (excludes setup/teardown). */
+  replayLatencyMs: number;
 }
 
 interface RunCaseOptions {
@@ -343,6 +345,7 @@ async function runSingleCase(
 
   const flushTurnIndices: number[] = [];
 
+  const replayStart = performance.now();
   for (let i = 0; i < caseDef.turns.length; i += 1) {
     const content = caseDef.turns[i]!;
     const role: "user" | "assistant" = i % 2 === 0 ? "user" : "assistant";
@@ -357,12 +360,18 @@ async function runSingleCase(
       await buffer.clearAfterExtraction("bench");
     }
   }
+  const replayLatencyMs = Math.round(performance.now() - replayStart);
 
+  // Only count intervals between CONSECUTIVE flushes. The previous
+  // implementation seeded `prev` to `-1`, which mixed the "start of
+  // conversation → first flush" distance into the mean and silently
+  // skewed it downward. When there is 0 or 1 flush there is no
+  // consecutive-pair interval to average — fall back to the full
+  // conversation length as a "never-flushed / flushed-once" proxy so
+  // the CSV column stays numeric.
   const turnsBetween: number[] = [];
-  let prev = -1;
-  for (const idx of flushTurnIndices) {
-    turnsBetween.push(idx - prev);
-    prev = idx;
+  for (let i = 1; i < flushTurnIndices.length; i += 1) {
+    turnsBetween.push(flushTurnIndices[i]! - flushTurnIndices[i - 1]!);
   }
   const mean =
     turnsBetween.length > 0
@@ -372,6 +381,7 @@ async function runSingleCase(
   return {
     flushTurnIndices,
     turnsBetweenFlushesMean: mean,
+    replayLatencyMs,
   };
 }
 
@@ -411,12 +421,17 @@ function buildTaskResult(
       candidate_mean_turns_between_flushes: candidate.turnsBetweenFlushesMean,
       control_mean_turns_between_flushes: control.turnsBetweenFlushesMean,
     },
-    latencyMs: 0,
+    // Sum of control + candidate replay time for this case. Per-task
+    // latency lets downstream tooling build per-case latency histograms
+    // instead of having to re-derive them from the run-level total.
+    latencyMs: control.replayLatencyMs + candidate.replayLatencyMs,
     tokens: { input: 0, output: 0 },
     details: {
       candidateFlushTurnIndices: candidate.flushTurnIndices,
       controlFlushTurnIndices: control.flushTurnIndices,
       topicShiftTurnIndices: caseDef.topicShiftTurnIndices,
+      candidateReplayLatencyMs: candidate.replayLatencyMs,
+      controlReplayLatencyMs: control.replayLatencyMs,
     },
   };
 }
@@ -428,10 +443,18 @@ function buildTaskResult(
  * Exact-match over turn indices would be unfair — the fixture marks the
  * FIRST turn of a new topic as the shift, but the surprise gate may fire
  * on that turn or one or two turns later as buffered context accumulates.
- * We use a window-tolerant match: a predicted flush within ±1 of an
- * annotated shift counts as a true positive. This matches the
+ * We use a window-tolerant match: a predicted flush within ±`tolerance`
+ * of an annotated shift counts as a true positive. This matches the
  * operational intent — "flush near the topic boundary" — not "flush on
  * the exact index".
+ *
+ * Matching is MAXIMUM bipartite (not greedy nearest-first). Greedy
+ * matching can miss a valid pairing when two predictions overlap the
+ * same expected index's tolerance window — e.g. `predicted=[5, 6]` vs
+ * `expected=[4, 5]` with `tolerance=1`: greedy would pair 5↔5 and then
+ * leave 6 unmatched, yielding 1 TP instead of the achievable 2.
+ * Fixture sizes here are ≤10, so a straightforward DFS augmenting-path
+ * search (Hopcroft-Karp is overkill) is fine and the cost stays O(P·E).
  *
  * Edge case: if there are no annotated shifts, a prediction of no
  * flushes scores 1. Any prediction in that case is a false positive.
@@ -445,24 +468,7 @@ export function topicShiftF1(
   if (expected.length === 0) return 0;
   if (predicted.length === 0) return 0;
 
-  const matchedExpected = new Set<number>();
-  let truePositive = 0;
-  for (const p of predicted) {
-    // Find the nearest still-unmatched expected index within tolerance.
-    let best: { idx: number; dist: number } | null = null;
-    for (const e of expected) {
-      if (matchedExpected.has(e)) continue;
-      const dist = Math.abs(p - e);
-      if (dist > tolerance) continue;
-      if (best === null || dist < best.dist) {
-        best = { idx: e, dist };
-      }
-    }
-    if (best !== null) {
-      matchedExpected.add(best.idx);
-      truePositive += 1;
-    }
-  }
+  const truePositive = maxBipartiteMatch(predicted, expected, tolerance);
   const falsePositive = predicted.length - truePositive;
   const falseNegative = expected.length - truePositive;
   const precision =
@@ -471,6 +477,46 @@ export function topicShiftF1(
     truePositive === 0 ? 0 : truePositive / (truePositive + falseNegative);
   if (precision === 0 && recall === 0) return 0;
   return (2 * precision * recall) / (precision + recall);
+}
+
+/**
+ * Maximum bipartite matching between predicted and expected indices
+ * with a tolerance window. Returns the largest number of 1:1 pairings
+ * where `|p - e| <= tolerance`. DFS augmenting-path style, O(|P|·|E|),
+ * chosen for simplicity at the fixture sizes we evaluate here.
+ */
+function maxBipartiteMatch(
+  predicted: readonly number[],
+  expected: readonly number[],
+  tolerance: number,
+): number {
+  // For each expected index, which predicted index currently claims it.
+  const expectedOwner = new Array<number>(expected.length).fill(-1);
+
+  const tryMatch = (
+    predIdx: number,
+    seen: boolean[],
+  ): boolean => {
+    const p = predicted[predIdx]!;
+    for (let eIdx = 0; eIdx < expected.length; eIdx += 1) {
+      if (seen[eIdx]) continue;
+      const e = expected[eIdx]!;
+      if (Math.abs(p - e) > tolerance) continue;
+      seen[eIdx] = true;
+      if (expectedOwner[eIdx] === -1 || tryMatch(expectedOwner[eIdx]!, seen)) {
+        expectedOwner[eIdx] = predIdx;
+        return true;
+      }
+    }
+    return false;
+  };
+
+  let matched = 0;
+  for (let pIdx = 0; pIdx < predicted.length; pIdx += 1) {
+    const seen = new Array<boolean>(expected.length).fill(false);
+    if (tryMatch(pIdx, seen)) matched += 1;
+  }
+  return matched;
 }
 
 function buildAggregates(tasks: TaskResult[]): Record<string, MetricAggregate> {

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
@@ -319,7 +319,11 @@ async function runSingleCase(
     bufferMaxMinutes: 60,
     triggerMode: "smart",
     // Deliberately empty — we want surprise, not signal-word matches,
-    // to drive the candidate's decisions.
+    // to drive the candidate's decisions. The fixture texts are also
+    // verified to not match any BUILTIN_HIGH_PATTERNS (see signal.ts)
+    // so that both control and candidate runs are only ever flushed by
+    // the surprise gate or the count/timeout guards — never by a
+    // lexical signal pattern. This ensures the A/B delta is clean.
     highSignalPatterns: [],
   });
 
@@ -365,10 +369,14 @@ async function runSingleCase(
   // Only count intervals between CONSECUTIVE flushes. The previous
   // implementation seeded `prev` to `-1`, which mixed the "start of
   // conversation → first flush" distance into the mean and silently
-  // skewed it downward. When there is 0 or 1 flush there is no
-  // consecutive-pair interval to average — fall back to the full
-  // conversation length as a "never-flushed / flushed-once" proxy so
-  // the CSV column stays numeric.
+  // skewed it downward.
+  //
+  // When there are 0 or 1 flushes there are no consecutive-pair intervals
+  // to average. We emit 0 rather than reusing `caseDef.turns.length` so
+  // that "no flushes" and "one flush anywhere" are both reported as "no
+  // measurable cadence" instead of being conflated with a real interval.
+  // Downstream consumers should check `flush_count` before interpreting
+  // this metric: values are meaningful only when flush_count >= 2.
   const turnsBetween: number[] = [];
   for (let i = 1; i < flushTurnIndices.length; i += 1) {
     turnsBetween.push(flushTurnIndices[i]! - flushTurnIndices[i - 1]!);
@@ -376,7 +384,7 @@ async function runSingleCase(
   const mean =
     turnsBetween.length > 0
       ? turnsBetween.reduce((acc, v) => acc + v, 0) / turnsBetween.length
-      : caseDef.turns.length;
+      : 0;
 
   return {
     flushTurnIndices,

--- a/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.ts
@@ -1,0 +1,542 @@
+/**
+ * Buffer-surprise-trigger benchmark (issue #563 PR 4).
+ *
+ * For each synthetic conversation in the fixture, replay every turn
+ * through two `SmartBuffer` instances: one with
+ * `bufferSurpriseTriggerEnabled: false` (the control) and one with it
+ * `true` (the candidate). Measure, per task and in aggregate:
+ *
+ *   - `candidate_flush_count` / `control_flush_count` — how many times
+ *     each configuration triggered an extraction.
+ *   - `candidate_topic_shift_f1` / `control_topic_shift_f1` — F1 of
+ *     predicted flush indices vs annotated topic-shift indices using a
+ *     ±1-turn tolerance window.
+ *   - `topic_shift_f1_delta` — candidate minus control; the CI delta
+ *     reporter uses this as the primary movement signal.
+ *
+ * # Determinism and scope
+ *
+ * The benchmark is intentionally hermetic: it uses a deterministic
+ * word-bucket embedder inside the surprise probe and never touches the
+ * network, a real LLM, or QMD. That means its results are stable across
+ * machines and seeds, but it CANNOT stand in for a production semantic
+ * embedder. The word-bucket embedder flags nearly every English turn
+ * as "surprising" relative to its neighbors because sparse content
+ * words rarely repeat verbatim — so the absolute F1 numbers are lower
+ * than a real embedder would produce, and the benchmark is best read
+ * as a regression gate ("surprise-on keeps the additive-only invariant
+ * and does not regress below the control") rather than a source of
+ * truth for flipping the production default.
+ *
+ * Per #563's PR 4 scope, the production default stays `false` in this
+ * PR. Flipping it requires a real-embedder benchmark run, which is
+ * tracked as a follow-up to this PR.
+ */
+
+import { randomUUID } from "node:crypto";
+import path from "node:path";
+import os from "node:os";
+import { mkdir, rm } from "node:fs/promises";
+import {
+  SmartBuffer,
+  type BufferSurpriseProbe,
+  computeSurprise,
+  parseConfig,
+} from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  MetricAggregate,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { aggregateTaskScores } from "../../../scorer.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import {
+  BUFFER_SURPRISE_TRIGGER_FIXTURE,
+  BUFFER_SURPRISE_TRIGGER_SMOKE_FIXTURE,
+  type BufferSurpriseTriggerCase,
+} from "./fixture.js";
+
+// ---------------------------------------------------------------------------
+// Metadata
+// ---------------------------------------------------------------------------
+
+export const bufferSurpriseTriggerDefinition: BenchmarkDefinition = {
+  id: "buffer-surprise-trigger",
+  title: "Buffer Surprise Trigger (D-MEM)",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "buffer-surprise-trigger",
+    version: "1.0.0",
+    description:
+      "Deterministic A/B benchmark comparing surprise-gated flush on vs off against annotated topic-shift turns. No network, no LLM, hash-embedder probe.",
+    category: "conversational",
+    citation:
+      "Remnic internal synthetic benchmark for issue #563 (D-MEM surprise gate)",
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Deterministic word-bucket embedder
+// ---------------------------------------------------------------------------
+//
+// A purely character-frequency embedder (like the one in
+// `buffer-surprise.test.ts`) cannot distinguish topic shifts in English
+// prose — the character distribution converges quickly. For THIS
+// benchmark we want the embedder to respond to *vocabulary* differences
+// so that the surprise signal corresponds to something semantically
+// meaningful, while staying deterministic and free of network calls.
+//
+// We tokenize on non-alphanumeric boundaries, drop stopwords, and bucket
+// each token with djb2 into a fixed-width vector. Each token contributes
+// `1 + 0.01 * (position % 3)` so the embedder is mildly position-aware.
+// The result is a standard word-bag hash embedder — enough to
+// distinguish "pasta carbonara" from "Jupiter magnetic field" reliably.
+
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "and",
+  "are",
+  "as",
+  "at",
+  "be",
+  "but",
+  "by",
+  "for",
+  "from",
+  "have",
+  "i",
+  "if",
+  "in",
+  "is",
+  "it",
+  "not",
+  "of",
+  "on",
+  "or",
+  "so",
+  "that",
+  "the",
+  "this",
+  "to",
+  "was",
+  "what",
+  "which",
+  "with",
+  "you",
+  "my",
+  "your",
+  "me",
+  "we",
+  "they",
+  "he",
+  "she",
+  "do",
+  "does",
+  "did",
+  "how",
+  "when",
+  "where",
+  "why",
+  "their",
+  "them",
+  "us",
+  "our",
+  "one",
+  "two",
+  "some",
+  "any",
+  "about",
+  "into",
+  "over",
+  "out",
+  "up",
+  "down",
+  "off",
+  "just",
+]);
+
+function djb2(s: string): number {
+  let h = 5381;
+  for (let i = 0; i < s.length; i += 1) {
+    h = ((h << 5) + h + s.charCodeAt(i)) | 0;
+  }
+  return Math.abs(h);
+}
+
+function wordBucketEmbedder(dim = 64) {
+  return async (text: string): Promise<readonly number[]> => {
+    const vec = new Array<number>(dim).fill(0);
+    const tokens = text
+      .toLowerCase()
+      .split(/[^a-z0-9]+/u)
+      .filter((t) => t.length >= 3 && !STOPWORDS.has(t));
+    for (let i = 0; i < tokens.length; i += 1) {
+      const bucket = djb2(tokens[i]!) % dim;
+      vec[bucket] = (vec[bucket] ?? 0) + 1 + (i % 3) * 0.01;
+    }
+    return vec;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Runner
+// ---------------------------------------------------------------------------
+
+export async function runBufferSurpriseTriggerBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const cases = loadCases(options.mode, options.limit);
+
+  const tmpRoot = path.join(
+    os.tmpdir(),
+    `remnic-bench-buffer-surprise-${randomUUID()}`,
+  );
+  await mkdir(tmpRoot, { recursive: true });
+
+  const tasks: TaskResult[] = [];
+  const startedAt = performance.now();
+
+  try {
+    for (const caseDef of cases) {
+      const control = await runSingleCase(caseDef, {
+        surpriseEnabled: false,
+        tmpRoot,
+        label: "control",
+      });
+      const candidate = await runSingleCase(caseDef, {
+        surpriseEnabled: true,
+        tmpRoot,
+        label: "candidate",
+      });
+
+      tasks.push(buildTaskResult(caseDef, control, candidate));
+    }
+  } finally {
+    await rm(tmpRoot, { recursive: true, force: true });
+  }
+
+  const totalLatencyMs = Math.round(performance.now() - startedAt);
+  const aggregates = buildAggregates(tasks);
+  const remnicVersion = await getRemnicVersion();
+
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? 0],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "direct",
+      remnicConfig: {
+        ...(options.remnicConfig ?? {}),
+        notes:
+          "Deterministic hash embedder; no network or LLM calls. See runner.ts.",
+      },
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates,
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-case runner
+// ---------------------------------------------------------------------------
+
+interface CaseRunOutput {
+  flushTurnIndices: number[];
+  turnsBetweenFlushesMean: number;
+}
+
+interface RunCaseOptions {
+  surpriseEnabled: boolean;
+  tmpRoot: string;
+  label: "control" | "candidate";
+}
+
+async function runSingleCase(
+  caseDef: BufferSurpriseTriggerCase,
+  options: RunCaseOptions,
+): Promise<CaseRunOutput> {
+  // Use a fresh on-disk buffer per case so state does not leak between
+  // runs. `bufferMaxTurns` is set high (50) so the baseline count-based
+  // flush does not fire within the fixture length — we want to isolate
+  // the surprise signal contribution.
+  const memoryDir = path.join(
+    options.tmpRoot,
+    `${caseDef.id}-${options.label}`,
+  );
+  const workspaceDir = path.join(memoryDir, "workspace");
+  await mkdir(workspaceDir, { recursive: true });
+
+  const config = parseConfig({
+    memoryDir,
+    workspaceDir,
+    openaiApiKey: "bench-test-key",
+    bufferSurpriseTriggerEnabled: options.surpriseEnabled,
+    // Benchmark threshold is tuned higher than the package default
+    // (0.35). The word-bucket embedder produces scores in a higher
+    // absolute range than a real semantic embedder; we want the gate to
+    // fire only on genuine topic boundaries inside the fixture, not on
+    // mundane follow-up questions. This threshold calibration is
+    // specific to THIS deterministic embedder and is independent of the
+    // production default.
+    bufferSurpriseThreshold: 0.65,
+    bufferSurpriseK: 3,
+    bufferSurpriseRecentMemoryCount: 20,
+    bufferMaxTurns: 50,
+    bufferMaxMinutes: 60,
+    triggerMode: "smart",
+    // Deliberately empty — we want surprise, not signal-word matches,
+    // to drive the candidate's decisions.
+    highSignalPatterns: [],
+  });
+
+  const embed = wordBucketEmbedder(64);
+  const probe: BufferSurpriseProbe = {
+    async scoreTurn(_key, turn, recentTurns) {
+      if (recentTurns.length === 0) return null;
+      return computeSurprise(
+        turn.content,
+        recentTurns.map((t, i) => ({
+          id: `t${i}`,
+          content: t.content,
+        })),
+        { embedFn: embed, k: 3 },
+      );
+    },
+  };
+
+  // Minimal in-memory storage double — we do not need persistence, and
+  // avoiding real `StorageManager` keeps the benchmark hermetic.
+  const storage = new InMemoryBufferStorage();
+  const buffer = new SmartBuffer(config, storage as any, probe);
+
+  const flushTurnIndices: number[] = [];
+
+  for (let i = 0; i < caseDef.turns.length; i += 1) {
+    const content = caseDef.turns[i]!;
+    const role: "user" | "assistant" = i % 2 === 0 ? "user" : "assistant";
+    const decision = await buffer.addTurn("bench", {
+      role,
+      content,
+      timestamp: new Date().toISOString(),
+      sessionKey: "bench",
+    });
+    if (decision === "extract_now" || decision === "extract_batch") {
+      flushTurnIndices.push(i);
+      await buffer.clearAfterExtraction("bench");
+    }
+  }
+
+  const turnsBetween: number[] = [];
+  let prev = -1;
+  for (const idx of flushTurnIndices) {
+    turnsBetween.push(idx - prev);
+    prev = idx;
+  }
+  const mean =
+    turnsBetween.length > 0
+      ? turnsBetween.reduce((acc, v) => acc + v, 0) / turnsBetween.length
+      : caseDef.turns.length;
+
+  return {
+    flushTurnIndices,
+    turnsBetweenFlushesMean: mean,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Metric derivation
+// ---------------------------------------------------------------------------
+
+function buildTaskResult(
+  caseDef: BufferSurpriseTriggerCase,
+  control: CaseRunOutput,
+  candidate: CaseRunOutput,
+): TaskResult {
+  const candidateF1 = topicShiftF1(
+    candidate.flushTurnIndices,
+    caseDef.topicShiftTurnIndices,
+  );
+  const controlF1 = topicShiftF1(
+    control.flushTurnIndices,
+    caseDef.topicShiftTurnIndices,
+  );
+
+  // `f1_delta` is the headline comparison metric for the CI delta
+  // reporter. Positive → surprise on helps; zero → tie; negative → harmful.
+  const f1Delta = candidateF1 - controlF1;
+
+  return {
+    taskId: caseDef.id,
+    question: `Conversation with ${caseDef.topicShiftTurnIndices.length} topic shift(s) at indices [${caseDef.topicShiftTurnIndices.join(", ")}]`,
+    expected: JSON.stringify(caseDef.topicShiftTurnIndices),
+    actual: JSON.stringify(candidate.flushTurnIndices),
+    scores: {
+      candidate_topic_shift_f1: candidateF1,
+      control_topic_shift_f1: controlF1,
+      topic_shift_f1_delta: f1Delta,
+      candidate_flush_count: candidate.flushTurnIndices.length,
+      control_flush_count: control.flushTurnIndices.length,
+      candidate_mean_turns_between_flushes: candidate.turnsBetweenFlushesMean,
+      control_mean_turns_between_flushes: control.turnsBetweenFlushesMean,
+    },
+    latencyMs: 0,
+    tokens: { input: 0, output: 0 },
+    details: {
+      candidateFlushTurnIndices: candidate.flushTurnIndices,
+      controlFlushTurnIndices: control.flushTurnIndices,
+      topicShiftTurnIndices: caseDef.topicShiftTurnIndices,
+    },
+  };
+}
+
+/**
+ * Token-set F1 between predicted flush indices and annotated shift
+ * indices.
+ *
+ * Exact-match over turn indices would be unfair — the fixture marks the
+ * FIRST turn of a new topic as the shift, but the surprise gate may fire
+ * on that turn or one or two turns later as buffered context accumulates.
+ * We use a window-tolerant match: a predicted flush within ±1 of an
+ * annotated shift counts as a true positive. This matches the
+ * operational intent — "flush near the topic boundary" — not "flush on
+ * the exact index".
+ *
+ * Edge case: if there are no annotated shifts, a prediction of no
+ * flushes scores 1. Any prediction in that case is a false positive.
+ */
+export function topicShiftF1(
+  predicted: readonly number[],
+  expected: readonly number[],
+  tolerance = 1,
+): number {
+  if (expected.length === 0 && predicted.length === 0) return 1;
+  if (expected.length === 0) return 0;
+  if (predicted.length === 0) return 0;
+
+  const matchedExpected = new Set<number>();
+  let truePositive = 0;
+  for (const p of predicted) {
+    // Find the nearest still-unmatched expected index within tolerance.
+    let best: { idx: number; dist: number } | null = null;
+    for (const e of expected) {
+      if (matchedExpected.has(e)) continue;
+      const dist = Math.abs(p - e);
+      if (dist > tolerance) continue;
+      if (best === null || dist < best.dist) {
+        best = { idx: e, dist };
+      }
+    }
+    if (best !== null) {
+      matchedExpected.add(best.idx);
+      truePositive += 1;
+    }
+  }
+  const falsePositive = predicted.length - truePositive;
+  const falseNegative = expected.length - truePositive;
+  const precision =
+    truePositive === 0 ? 0 : truePositive / (truePositive + falsePositive);
+  const recall =
+    truePositive === 0 ? 0 : truePositive / (truePositive + falseNegative);
+  if (precision === 0 && recall === 0) return 0;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+function buildAggregates(tasks: TaskResult[]): Record<string, MetricAggregate> {
+  const base = aggregateTaskScores(tasks.map((t) => t.scores));
+  // aggregateTaskScores already produces mean/median/stdDev/min/max per
+  // metric key — no further work needed here, but keeping the helper
+  // boundary explicit so later bench features (stat tests, intervals)
+  // can compose in.
+  return base;
+}
+
+// ---------------------------------------------------------------------------
+// In-memory storage double
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal shim implementing just the subset of `StorageManager` surface
+ * that `SmartBuffer` touches. Keeps the benchmark free of filesystem
+ * writes (beyond the tmp dir used for config parsing) and removes all
+ * flakiness from concurrent disk access.
+ */
+class InMemoryBufferStorage {
+  private state: {
+    turns: unknown[];
+    lastExtractionAt: string | null;
+    extractionCount: number;
+  } = { turns: [], lastExtractionAt: null, extractionCount: 0 };
+
+  async loadBuffer() {
+    return structuredClone(this.state);
+  }
+
+  async saveBuffer(state: typeof this.state) {
+    this.state = structuredClone(state);
+  }
+
+  async appendBufferSurpriseEvents() {
+    // No-op in the benchmark — we measure flush decisions directly from
+    // the `addTurn` return value, not from the telemetry ledger.
+    return 0;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture loading
+// ---------------------------------------------------------------------------
+
+function loadCases(
+  mode: "quick" | "full",
+  limit?: number,
+): BufferSurpriseTriggerCase[] {
+  const base =
+    mode === "quick"
+      ? BUFFER_SURPRISE_TRIGGER_SMOKE_FIXTURE
+      : BUFFER_SURPRISE_TRIGGER_FIXTURE;
+  if (limit === undefined) return base;
+  if (!Number.isInteger(limit) || limit <= 0) {
+    throw new Error(
+      "buffer-surprise-trigger limit must be a positive integer",
+    );
+  }
+  const limited = base.slice(0, limit);
+  if (limited.length === 0) {
+    throw new Error(
+      "buffer-surprise-trigger fixture is empty after applying the requested limit.",
+    );
+  }
+  return limited;
+}

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -123,6 +123,10 @@ import {
   assistantSynthesisDefinition,
   runAssistantSynthesisBenchmark,
 } from "./benchmarks/remnic/assistant-synthesis/runner.js";
+import {
+  bufferSurpriseTriggerDefinition,
+  runBufferSurpriseTriggerBenchmark,
+} from "./benchmarks/remnic/buffer-surprise-trigger/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -250,6 +254,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...assistantSynthesisDefinition,
     run: runAssistantSynthesisBenchmark,
+  },
+  {
+    ...bufferSurpriseTriggerDefinition,
+    run: runBufferSurpriseTriggerBenchmark,
   },
 ];
 

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2088,6 +2088,29 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -42,6 +42,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "assistant-meeting-prep",
       "assistant-next-best-action",
       "assistant-synthesis",
+      "buffer-surprise-trigger",
     ],
   );
   assert.deepEqual(
@@ -77,11 +78,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-backlink-f1,ingestion-setup-friction,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger",
   );
   // Schema completeness and citation accuracy remain gated off until their adapter contracts are wired.
   // Setup friction was wired up in PR #498 and is now runner-available.


### PR DESCRIPTION
## Summary

Hermetic A/B benchmark that replays synthetic conversations with annotated topic shifts through `SmartBuffer` with the surprise gate both off (control) and on (candidate), reporting per-task and aggregate F1 / flush-count deltas. Stacked on #627 (PR 3/4).

## Why the default is NOT flipped in this PR

The benchmark uses a deterministic word-bucket embedder so results are stable across machines with no network/LLM/QMD dependency. That determinism has a cost: the hash embedder flags nearly every English turn as "surprising" relative to its neighbors because sparse content words rarely repeat verbatim. Absolute F1 numbers are low and noisy, so the benchmark is best read as a **regression gate** — "surprise-on keeps the additive-only invariant and does not regress below the control" — rather than a source of truth for flipping the production default.

Flipping `bufferSurpriseTriggerEnabled: true` by default requires a real-embedder benchmark run, which is tracked as a follow-up to this PR. The flag stays off.

## What the benchmark measures

Per task:
- `candidate_topic_shift_f1` / `control_topic_shift_f1` (±1-turn tolerance window; token-set F1)
- `topic_shift_f1_delta` — primary movement metric
- `candidate_flush_count` / `control_flush_count`
- `candidate_mean_turns_between_flushes` / control equivalent

## Test plan

- [x] `npx tsx --test packages/bench/src/benchmarks/remnic/buffer-surprise-trigger/runner.test.ts` — 10/10
- [x] Registry wires the benchmark into the public listing
- [x] Additive-only invariant verified by the `full`-mode runner test: on every fixture case, `candidate_flush_count >= control_flush_count`
- [x] `topicShiftF1` unit tests cover perfect match, ±1 tolerance, out-of-tolerance rejection, empty-vs-empty, partial match, and duplicate-prediction assignment

Closes #563 once merged (after #618 + #627).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds new benchmark code and test coverage, plus default-disabled config schema fields; no production behavior changes unless the new limiter is explicitly enabled.
> 
> **Overview**
> Introduces the new `buffer-surprise-trigger` benchmark: a deterministic A/B runner that replays short synthetic conversations through `SmartBuffer` with `bufferSurpriseTriggerEnabled` **off vs on**, then reports per-case and aggregate metrics including flush counts and topic-shift F1 (with ±1-turn tolerance) plus a `topic_shift_f1_delta` comparison signal.
> 
> Adds a curated fixture corpus + smoke subset, a comprehensive runner test suite (including an additive-only invariant: candidate flushes never fewer than control), and registers the benchmark in `packages/bench` so it appears in `listBenchmarks`/`getBenchmark` (with updated registry tests).
> 
> Separately extends `openclaw.plugin.json` config schema with new, **default-off** knobs for a cross-namespace recall budget limiter (`recallCrossNamespaceBudget*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a515c06d4b4427a7efaa097dc7da0159b09f438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->