### PR TITLE
feat(consolidation): operator-aware prompt emits SPLIT/MERGE/UPDATE (issue #561 PR 3/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2740,8 +2740,8 @@
       },
       "operatorAwareConsolidationEnabled": {
         "type": "boolean",
-        "default": true,
-        "description": "Ask the consolidation LLM to return a structured {operator, output} JSON object so SPLIT/MERGE/UPDATE is recorded on derived_via. Disable to fall back to the legacy plain-text prompt."
+        "default": false,
+        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "creationMemoryEnabled": {
         "type": "boolean",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -4519,7 +4519,7 @@
     "operatorAwareConsolidationEnabled": {
       "label": "Operator-Aware Consolidation Prompt",
       "advanced": true,
-      "help": "When enabled (default), the consolidation LLM picks SPLIT/MERGE/UPDATE per cluster and we record it on derived_via. Disable to use the legacy plain-text prompt."
+      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2738,6 +2738,11 @@
         "default": 100,
         "description": "Max memories to consolidate per run to limit LLM cost."
       },
+      "operatorAwareConsolidationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Ask the consolidation LLM to return a structured {operator, output} JSON object so SPLIT/MERGE/UPDATE is recorded on derived_via. Disable to fall back to the legacy plain-text prompt."
+      },
       "creationMemoryEnabled": {
         "type": "boolean",
         "default": false,
@@ -4510,6 +4515,11 @@
       "label": "Semantic Consolidation Max Per Run",
       "advanced": true,
       "help": "Max memories to consolidate per run to limit LLM cost."
+    },
+    "operatorAwareConsolidationEnabled": {
+      "label": "Operator-Aware Consolidation Prompt",
+      "advanced": true,
+      "help": "When enabled (default), the consolidation LLM picks SPLIT/MERGE/UPDATE per cluster and we record it on derived_via. Disable to use the legacy plain-text prompt."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2698,8 +2698,8 @@
       },
       "operatorAwareConsolidationEnabled": {
         "type": "boolean",
-        "default": true,
-        "description": "Ask the consolidation LLM to return a structured {operator, output} JSON object so SPLIT/MERGE/UPDATE is recorded on derived_via. Disable to fall back to the legacy plain-text prompt."
+        "default": false,
+        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "creationMemoryEnabled": {
         "type": "boolean",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -4477,7 +4477,7 @@
     "operatorAwareConsolidationEnabled": {
       "label": "Operator-Aware Consolidation Prompt",
       "advanced": true,
-      "help": "When enabled (default), the consolidation LLM picks SPLIT/MERGE/UPDATE per cluster and we record it on derived_via. Disable to use the legacy plain-text prompt."
+      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2696,6 +2696,11 @@
         "default": 100,
         "description": "Max memories to consolidate per run to limit LLM cost."
       },
+      "operatorAwareConsolidationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "Ask the consolidation LLM to return a structured {operator, output} JSON object so SPLIT/MERGE/UPDATE is recorded on derived_via. Disable to fall back to the legacy plain-text prompt."
+      },
       "creationMemoryEnabled": {
         "type": "boolean",
         "default": false,
@@ -4468,6 +4473,11 @@
       "label": "Semantic Consolidation Max Per Run",
       "advanced": true,
       "help": "Max memories to consolidate per run to limit LLM cost."
+    },
+    "operatorAwareConsolidationEnabled": {
+      "label": "Operator-Aware Consolidation Prompt",
+      "advanced": true,
+      "help": "When enabled (default), the consolidation LLM picks SPLIT/MERGE/UPDATE per cluster and we record it on derived_via. Disable to use the legacy plain-text prompt."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1352,16 +1352,18 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.semanticConsolidationMaxPerRun === "number"
         ? Math.max(0, Math.floor(cfg.semanticConsolidationMaxPerRun))
         : 100,
-    // Operator-aware consolidation prompt (issue #561 PR 3).  Defaults to
-    // true so new installs get SPLIT/MERGE/UPDATE operator selection on
-    // the `derived_via` frontmatter field.  Operators set the value to a
-    // falsey coercion ("false", "0", "no", "off", boolean `false`) to
-    // fall back to the legacy plain-text prompt (useful for older models
-    // that don't reliably return JSON).  Uses `coerceBool` per Gotcha #36
-    // so CLI `--config operatorAwareConsolidationEnabled=false` and
-    // env-substituted string values actually disable the feature.
+    // Operator-aware consolidation prompt (issue #561 PR 3).  Defaults
+    // to `false` to match sibling `*Enabled` flags' least-privileged
+    // convention.  Operators opt in by setting `true` (or truthy
+    // coercions like "true", "1", "yes", "on") when they want the
+    // consolidation LLM to emit SPLIT/MERGE/UPDATE operator selection
+    // on the `derived_via` frontmatter field.  Uses `coerceBool` per
+    // Gotcha #36 so CLI / env-string inputs coerce correctly.  When
+    // disabled, `derived_via` is still populated via the cluster-shape
+    // heuristic (chooseConsolidationOperator) so PR 2's provenance
+    // wiring keeps working without operator-aware prompts.
     operatorAwareConsolidationEnabled:
-      coerceBool(cfg.operatorAwareConsolidationEnabled) ?? true,
+      coerceBool(cfg.operatorAwareConsolidationEnabled) ?? false,
     creationMemoryEnabled: cfg.creationMemoryEnabled === true,
     memoryUtilityLearningEnabled: cfg.memoryUtilityLearningEnabled === true,
     promotionByOutcomeEnabled: cfg.promotionByOutcomeEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1352,6 +1352,16 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.semanticConsolidationMaxPerRun === "number"
         ? Math.max(0, Math.floor(cfg.semanticConsolidationMaxPerRun))
         : 100,
+    // Operator-aware consolidation prompt (issue #561 PR 3).  Defaults to
+    // true so new installs get SPLIT/MERGE/UPDATE operator selection on
+    // the `derived_via` frontmatter field.  Operators set `false`
+    // explicitly to fall back to the legacy plain-text prompt (useful for
+    // older models that don't reliably return JSON).  Gotcha #36: strings
+    // like "false" are coerced at the config-read boundary in parseConfig
+    // helpers; this field follows the same `=== false` pattern used by
+    // sibling consolidation toggles.
+    operatorAwareConsolidationEnabled:
+      cfg.operatorAwareConsolidationEnabled === false ? false : true,
     creationMemoryEnabled: cfg.creationMemoryEnabled === true,
     memoryUtilityLearningEnabled: cfg.memoryUtilityLearningEnabled === true,
     promotionByOutcomeEnabled: cfg.promotionByOutcomeEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1354,14 +1354,14 @@ export function parseConfig(raw: unknown): PluginConfig {
         : 100,
     // Operator-aware consolidation prompt (issue #561 PR 3).  Defaults to
     // true so new installs get SPLIT/MERGE/UPDATE operator selection on
-    // the `derived_via` frontmatter field.  Operators set `false`
-    // explicitly to fall back to the legacy plain-text prompt (useful for
-    // older models that don't reliably return JSON).  Gotcha #36: strings
-    // like "false" are coerced at the config-read boundary in parseConfig
-    // helpers; this field follows the same `=== false` pattern used by
-    // sibling consolidation toggles.
+    // the `derived_via` frontmatter field.  Operators set the value to a
+    // falsey coercion ("false", "0", "no", "off", boolean `false`) to
+    // fall back to the legacy plain-text prompt (useful for older models
+    // that don't reliably return JSON).  Uses `coerceBool` per Gotcha #36
+    // so CLI `--config operatorAwareConsolidationEnabled=false` and
+    // env-substituted string values actually disable the feature.
     operatorAwareConsolidationEnabled:
-      cfg.operatorAwareConsolidationEnabled === false ? false : true,
+      coerceBool(cfg.operatorAwareConsolidationEnabled) ?? true,
     creationMemoryEnabled: cfg.creationMemoryEnabled === true,
     memoryUtilityLearningEnabled: cfg.memoryUtilityLearningEnabled === true,
     promotionByOutcomeEnabled: cfg.promotionByOutcomeEnabled === true,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -224,6 +224,9 @@ import {
   findSimilarClusters,
   buildConsolidationPrompt,
   parseConsolidationResponse,
+  buildOperatorAwareConsolidationPrompt,
+  parseOperatorAwareConsolidationResponse,
+  chooseConsolidationOperator,
   buildExtensionsBlockForConsolidation,
   materializeAfterSemanticConsolidation,
   type SemanticConsolidationResult,
@@ -2777,15 +2780,25 @@ export class Orchestrator {
 
     for (const cluster of clusters) {
       try {
-        let prompt = buildConsolidationPrompt(cluster);
+        // Operator-aware prompt (issue #561 PR 3): ask the LLM to pick the
+        // SPLIT/MERGE/UPDATE operator alongside the canonical output.  Falls
+        // back to the legacy plain-blob prompt when operator-aware
+        // consolidation is explicitly disabled via config, so rollbacks stay
+        // clean.
+        const operatorAwareEnabled =
+          this.config.operatorAwareConsolidationEnabled !== false;
+        let prompt = operatorAwareEnabled
+          ? buildOperatorAwareConsolidationPrompt(cluster)
+          : buildConsolidationPrompt(cluster);
         if (extensionsBlock.length > 0) {
           prompt += "\n\n" + extensionsBlock;
         }
         const messages = [
           {
             role: "system" as const,
-            content:
-              "You are a memory consolidation system. Output only the consolidated memory text.",
+            content: operatorAwareEnabled
+              ? 'You are a memory consolidation system. Return ONLY a JSON object: {"operator":"merge|update|split","output":"..."}.'
+              : "You are a memory consolidation system. Output only the consolidated memory text.",
           },
           { role: "user" as const, content: prompt },
         ];
@@ -2816,7 +2829,22 @@ export class Orchestrator {
           continue;
         }
 
-        const canonicalContent = parseConsolidationResponse(response.content);
+        // Operator-aware parse (issue #561 PR 3).  In legacy mode we fall
+        // back to the plain-text parser and derive the operator from the
+        // cluster-shape heuristic so `derived_via` still lands.
+        let canonicalContent: string;
+        let operator: "split" | "merge" | "update";
+        if (operatorAwareEnabled) {
+          const parsed = parseOperatorAwareConsolidationResponse(
+            response.content,
+            cluster,
+          );
+          canonicalContent = parsed.output;
+          operator = parsed.operator;
+        } else {
+          canonicalContent = parseConsolidationResponse(response.content);
+          operator = chooseConsolidationOperator(cluster);
+        }
         cluster.canonicalContent = canonicalContent;
 
         // Pick the most recent memory's metadata as the basis for lineage
@@ -2828,17 +2856,17 @@ export class Orchestrator {
         const newest = sorted[0];
         const lineageIds = cluster.memories.map((m) => m.frontmatter.id);
 
-        // Consolidation provenance (issue #561 PR 2): snapshot each source
-        // memory BEFORE archiving it, collecting "<relpath>:<versionId>"
-        // pointers for the new canonical memory's `derived_from` frontmatter
-        // field.  Snapshots are best-effort — if page-versioning is disabled
-        // (the default in `config.ts`) or a single source fails to snapshot
-        // we omit that entry rather than abort the consolidation.  Review
-        // feedback (codex): `derived_via` is emitted unconditionally so
-        // downstream logic can still identify consolidation outputs by
-        // operator even when no `derived_from` snapshots could be
-        // captured.  PR 3 selects SPLIT/MERGE/UPDATE dynamically; here we
-        // hardcode `"merge"`.
+        // Consolidation provenance (issue #561 PR 2+3): snapshot each
+        // source memory BEFORE archiving it, collecting
+        // "<relpath>:<versionId>" pointers for the new canonical memory's
+        // `derived_from` frontmatter field.  Snapshots are best-effort — if
+        // page-versioning is disabled (default in `config.ts`) or a single
+        // source fails to snapshot we simply omit that entry rather than
+        // abort the consolidation.  The `derived_via` operator is chosen
+        // above (PR 3) from the LLM response or the cluster-shape
+        // heuristic fallback and emitted unconditionally so consolidation
+        // outputs stay identifiable even when no snapshots are captured
+        // (PR #624 review feedback).
         const derivedFromEntries: string[] = [];
         for (const m of cluster.memories) {
           if (!m.path) continue;
@@ -2861,7 +2889,7 @@ export class Orchestrator {
             source: "semantic-consolidation",
             lineage: lineageIds,
             derivedFrom: derivedFromEntries.length > 0 ? derivedFromEntries : undefined,
-            derivedVia: "merge",
+            derivedVia: operator,
           },
         );
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2797,7 +2797,7 @@ export class Orchestrator {
           {
             role: "system" as const,
             content: operatorAwareEnabled
-              ? 'You are a memory consolidation system. Return ONLY a JSON object: {"operator":"merge|update|split","output":"..."}.'
+              ? 'You are a memory consolidation system. Return ONLY a JSON object with two keys, "operator" and "output". The "operator" value MUST be one of the exact strings "merge", "update", or "split" — never a pipe-separated placeholder, never prose. The "output" value is the canonical memory text.'
               : "You are a memory consolidation system. Output only the consolidated memory text.",
           },
           { role: "user" as const, content: prompt },

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -2785,8 +2785,12 @@ export class Orchestrator {
         // back to the legacy plain-blob prompt when operator-aware
         // consolidation is explicitly disabled via config, so rollbacks stay
         // clean.
+        // Use the `=== true` idiom for default-false flags (PR #632
+        // review, cursor Low): sibling disabled-by-default flags like
+        // `semanticConsolidationEnabled` follow the same convention,
+        // while `!== false` is reserved for default-on flags.
         const operatorAwareEnabled =
-          this.config.operatorAwareConsolidationEnabled !== false;
+          this.config.operatorAwareConsolidationEnabled === true;
         let prompt = operatorAwareEnabled
           ? buildOperatorAwareConsolidationPrompt(cluster)
           : buildConsolidationPrompt(cluster);

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -237,9 +237,9 @@ Operator vocabulary:
   - "update" — one source memory carries a stale value that a newer source supersedes within the same logical fact.
   - "split"  — a single logical source really encodes multiple distinct facts that should be separated (rare; if you pick split, still emit ONE canonical body — the write path will chunk it later).
 
-Output JSON ONLY, no prose before or after.  Schema:
+Output JSON ONLY, no prose before or after.  The "operator" key MUST be set to exactly one of the three strings "merge", "update", or "split" — never a pipe-separated placeholder like "merge|update|split".  Example shape:
   {
-    "operator": "merge" | "update" | "split",
+    "operator": "merge",
     "output": "<the canonical memory text>"
   }
 
@@ -285,20 +285,14 @@ export function parseOperatorAwareConsolidationResponse(
   const fenced = /^```(?:json)?\s*([\s\S]*?)```\s*$/u.exec(trimmed);
   const payload = fenced ? fenced[1].trim() : trimmed;
 
-  // Find the first "{" — models sometimes prepend a sentence despite the
-  // instruction.  Parse from there to the matching outermost "}".
-  const firstBrace = payload.indexOf("{");
-  if (firstBrace < 0) return fallback;
-  const lastBrace = payload.lastIndexOf("}");
-  if (lastBrace <= firstBrace) return fallback;
-  const jsonSlice = payload.slice(firstBrace, lastBrace + 1);
-
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(jsonSlice);
-  } catch {
-    return fallback;
-  }
+  // Find a balanced brace-delimited JSON object that has an `operator`
+  // key (PR #632 round-4 review, codex P1).  A first/last-brace slice
+  // breaks when the model prepends an earlier brace block (e.g.
+  // `Example: {"note":"..."} ... {"operator":"merge",...}`).  Walk the
+  // payload tracking nesting + string/escape state and skip past
+  // objects that don't look like our target shape.
+  const parsed = findFirstJsonObjectWithOperator(payload);
+  if (parsed === undefined) return fallback;
   if (typeof parsed !== "object" || parsed === null) return fallback;
 
   const obj = parsed as Record<string, unknown>;
@@ -311,6 +305,73 @@ export function parseOperatorAwareConsolidationResponse(
   const output = rawOutput.trim().length > 0 ? rawOutput.trim() : response.trim();
 
   return { operator, output };
+}
+
+/**
+ * Walk `text`, find the first balanced top-level `{ ... }` block whose
+ * JSON.parse result is an object with an `operator` key, and return it.
+ * Returns `undefined` when nothing matches.  Tracks string state +
+ * escape sequences so braces inside string values don't throw off the
+ * depth counter.
+ *
+ * Used by `parseOperatorAwareConsolidationResponse` to tolerate models
+ * that prepend an explanatory JSON example block before the real
+ * payload (PR #632 round-4 review, codex P1).  Requiring the
+ * `operator` key lets us skip past unrelated brace blocks even when
+ * they parse successfully as JSON.
+ */
+function findFirstJsonObjectWithOperator(text: string): unknown {
+  let searchFrom = 0;
+  while (searchFrom < text.length) {
+    const start = text.indexOf("{", searchFrom);
+    if (start < 0) return undefined;
+    let depth = 0;
+    let inString = false;
+    let escape = false;
+    let closed = false;
+    let endIdx = -1;
+    for (let i = start; i < text.length; i++) {
+      const ch = text[i];
+      if (inString) {
+        if (escape) {
+          escape = false;
+        } else if (ch === "\\") {
+          escape = true;
+        } else if (ch === '"') {
+          inString = false;
+        }
+        continue;
+      }
+      if (ch === '"') {
+        inString = true;
+      } else if (ch === "{") {
+        depth += 1;
+      } else if (ch === "}") {
+        depth -= 1;
+        if (depth === 0) {
+          closed = true;
+          endIdx = i;
+          break;
+        }
+      }
+    }
+    if (!closed) return undefined;
+    const slice = text.slice(start, endIdx + 1);
+    try {
+      const parsed = JSON.parse(slice);
+      if (
+        typeof parsed === "object" &&
+        parsed !== null &&
+        "operator" in (parsed as Record<string, unknown>)
+      ) {
+        return parsed;
+      }
+    } catch {
+      // Fall through to the next candidate.
+    }
+    searchFrom = endIdx + 1;
+  }
+  return undefined;
 }
 
 // Silence unused-import warnings when tsup tree-shakes: these are used

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -291,7 +291,7 @@ export function parseOperatorAwareConsolidationResponse(
   // `Example: {"note":"..."} ... {"operator":"merge",...}`).  Walk the
   // payload tracking nesting + string/escape state and skip past
   // objects that don't look like our target shape.
-  const parsed = findFirstJsonObjectWithOperator(payload);
+  const parsed = findLastJsonObjectWithOperator(payload);
   if (parsed === undefined) return fallback;
   if (typeof parsed !== "object" || parsed === null) return fallback;
 
@@ -310,7 +310,8 @@ export function parseOperatorAwareConsolidationResponse(
 /**
  * Walk `text`, find all balanced top-level `{ ... }` blocks whose
  * JSON.parse result is an object with an `operator` key, and return
- * the LAST one.  Returns `undefined` when nothing matches.  Tracks
+ * the LAST one (function name reflects this — PR #632 review,
+ * cursor Low).  Returns `undefined` when nothing matches.  Tracks
  * string state + escape sequences so braces inside string values
  * don't throw off the depth counter.
  *
@@ -321,7 +322,7 @@ export function parseOperatorAwareConsolidationResponse(
  * key ahead of the real answer doesn't steal precedence — models
  * typically write the example first and the real answer last.
  */
-function findFirstJsonObjectWithOperator(text: string): unknown {
+function findLastJsonObjectWithOperator(text: string): unknown {
   let searchFrom = 0;
   let last: unknown = undefined;
   while (searchFrom < text.length) {

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -308,23 +308,25 @@ export function parseOperatorAwareConsolidationResponse(
 }
 
 /**
- * Walk `text`, find the first balanced top-level `{ ... }` block whose
- * JSON.parse result is an object with an `operator` key, and return it.
- * Returns `undefined` when nothing matches.  Tracks string state +
- * escape sequences so braces inside string values don't throw off the
- * depth counter.
+ * Walk `text`, find all balanced top-level `{ ... }` blocks whose
+ * JSON.parse result is an object with an `operator` key, and return
+ * the LAST one.  Returns `undefined` when nothing matches.  Tracks
+ * string state + escape sequences so braces inside string values
+ * don't throw off the depth counter.
  *
  * Used by `parseOperatorAwareConsolidationResponse` to tolerate models
  * that prepend an explanatory JSON example block before the real
- * payload (PR #632 round-4 review, codex P1).  Requiring the
- * `operator` key lets us skip past unrelated brace blocks even when
- * they parse successfully as JSON.
+ * payload (PR #632 round-4 + round-5 review, codex P1).  We take the
+ * LAST candidate so that an instructional example with an `operator`
+ * key ahead of the real answer doesn't steal precedence — models
+ * typically write the example first and the real answer last.
  */
 function findFirstJsonObjectWithOperator(text: string): unknown {
   let searchFrom = 0;
+  let last: unknown = undefined;
   while (searchFrom < text.length) {
     const start = text.indexOf("{", searchFrom);
-    if (start < 0) return undefined;
+    if (start < 0) return last;
     let depth = 0;
     let inString = false;
     let escape = false;
@@ -355,7 +357,7 @@ function findFirstJsonObjectWithOperator(text: string): unknown {
         }
       }
     }
-    if (!closed) return undefined;
+    if (!closed) return last;
     const slice = text.slice(start, endIdx + 1);
     try {
       const parsed = JSON.parse(slice);
@@ -364,14 +366,14 @@ function findFirstJsonObjectWithOperator(text: string): unknown {
         parsed !== null &&
         "operator" in (parsed as Record<string, unknown>)
       ) {
-        return parsed;
+        last = parsed;
       }
     } catch {
       // Fall through to the next candidate.
     }
     searchFrom = endIdx + 1;
   }
-  return undefined;
+  return last;
 }
 
 // Silence unused-import warnings when tsup tree-shakes: these are used

--- a/packages/remnic-core/src/semantic-consolidation.ts
+++ b/packages/remnic-core/src/semantic-consolidation.ts
@@ -29,6 +29,12 @@ export {
   type ConsolidationOperator,
 } from "./consolidation-operator.js";
 
+import {
+  CONSOLIDATION_OPERATORS as _CONSOLIDATION_OPERATORS,
+  isConsolidationOperator as _isConsolidationOperator,
+  type ConsolidationOperator as _ConsolidationOperator,
+} from "./consolidation-operator.js";
+
 export interface ConsolidationCluster {
   category: string;
   memories: MemoryFile[];
@@ -158,6 +164,158 @@ Write ONLY the consolidated memory content (no metadata, no explanation, no prea
 export function parseConsolidationResponse(response: string): string {
   return response.trim();
 }
+
+// ─── Operator-aware prompt / parse (issue #561 PR 3) ─────────────────────────
+
+/**
+ * Structured result from an operator-aware consolidation LLM call.
+ *
+ * - `operator` — the consolidation operator the LLM chose for this cluster.
+ *   Falls back to the heuristic default when the LLM omits or returns an
+ *   unknown value (the parser never surfaces an invalid operator; see
+ *   `parseOperatorAwareConsolidationResponse`).
+ * - `output` — the canonical content (same format the legacy prompt
+ *   returns).  Callers persist this as the body of the new memory.
+ */
+export interface OperatorAwareConsolidationResult {
+  operator: _ConsolidationOperator;
+  output: string;
+}
+
+/**
+ * Heuristic default operator for a cluster.  Used as the fallback when the
+ * LLM does not return a parseable operator, and as the "floor" decision in
+ * `parseOperatorAwareConsolidationResponse`.
+ *
+ * Current heuristic (kept deliberately conservative — PR 3 only):
+ *
+ *   - Two or more memories being collapsed into one canonical blob is a
+ *     MERGE by definition.  This is the path the current clustering
+ *     pipeline exercises.
+ *   - A cluster of size 1 that still reaches consolidation (future path,
+ *     e.g. supersession of a single older memory by a newer value) is an
+ *     UPDATE.
+ *   - SPLIT is never selected by the heuristic because the current write
+ *     path emits exactly one canonical memory per cluster.  The prompt
+ *     reserves SPLIT for future cluster shapes where the LLM decides one
+ *     logical source actually encodes several distinct facts — at which
+ *     point the orchestrator would need to write multiple outputs.
+ */
+export function chooseConsolidationOperator(
+  cluster: ConsolidationCluster,
+): _ConsolidationOperator {
+  if (cluster.memories.length <= 1) return "update";
+  return "merge";
+}
+
+/**
+ * Build the operator-aware LLM prompt.  The LLM is asked to return a
+ * JSON object `{ "operator": <split|merge|update>, "output": <content> }`.
+ *
+ * The prompt is additive: it still asks for a single canonical blob under
+ * `output`, so the upstream write path does not change.  Future expansions
+ * (SPLIT emitting multiple outputs) are explicitly documented as
+ * out-of-scope for the parser — `parseOperatorAwareConsolidationResponse`
+ * collapses any SPLIT response into a single canonical output for now.
+ */
+export function buildOperatorAwareConsolidationPrompt(
+  cluster: ConsolidationCluster,
+): string {
+  const memoryTexts = cluster.memories
+    .map(
+      (m, i) =>
+        `Memory ${i + 1} (${m.frontmatter.id}, created ${m.frontmatter.created}):\n${m.content}`,
+    )
+    .join("\n\n");
+
+  return `You are a memory consolidation system.  The following ${cluster.memories.length} memories in the "${cluster.category}" category contain overlapping information.
+
+Pick exactly ONE consolidation operator for this cluster and return a JSON object.
+
+Operator vocabulary:
+  - "merge"  — multiple distinct source memories overlap and should be collapsed into one canonical memory (most common).
+  - "update" — one source memory carries a stale value that a newer source supersedes within the same logical fact.
+  - "split"  — a single logical source really encodes multiple distinct facts that should be separated (rare; if you pick split, still emit ONE canonical body — the write path will chunk it later).
+
+Output JSON ONLY, no prose before or after.  Schema:
+  {
+    "operator": "merge" | "update" | "split",
+    "output": "<the canonical memory text>"
+  }
+
+The "output" value must:
+1. Preserve ALL unique information from every source memory
+2. Remove redundancy and repetition
+3. Use clear, concise language
+4. Match the "${cluster.category}" category and tone
+5. NOT add information that isn't in the sources
+
+${memoryTexts}
+
+Return ONLY the JSON object:`;
+}
+
+/**
+ * Parse an operator-aware consolidation response.
+ *
+ * Contract:
+ *   - Accepts strict JSON `{ "operator": "...", "output": "..." }`.
+ *   - Tolerates a JSON payload wrapped in a fenced code block (```json ...```).
+ *   - Falls back to the heuristic operator when the JSON is malformed,
+ *     the `operator` field is missing / unknown, or the raw response is
+ *     a plain blob with no JSON at all.  This keeps PR 3 backwards
+ *     compatible with older models that ignore the JSON instruction.
+ *   - Never throws.  A missing / empty `output` field falls back to the
+ *     trimmed raw response so the caller still writes something rather
+ *     than dropping the cluster.
+ */
+export function parseOperatorAwareConsolidationResponse(
+  response: string,
+  cluster: ConsolidationCluster,
+): OperatorAwareConsolidationResult {
+  const fallback: OperatorAwareConsolidationResult = {
+    operator: chooseConsolidationOperator(cluster),
+    output: response.trim(),
+  };
+
+  const trimmed = response.trim();
+  if (trimmed.length === 0) return fallback;
+
+  // Strip a fenced code block if present.
+  const fenced = /^```(?:json)?\s*([\s\S]*?)```\s*$/u.exec(trimmed);
+  const payload = fenced ? fenced[1].trim() : trimmed;
+
+  // Find the first "{" — models sometimes prepend a sentence despite the
+  // instruction.  Parse from there to the matching outermost "}".
+  const firstBrace = payload.indexOf("{");
+  if (firstBrace < 0) return fallback;
+  const lastBrace = payload.lastIndexOf("}");
+  if (lastBrace <= firstBrace) return fallback;
+  const jsonSlice = payload.slice(firstBrace, lastBrace + 1);
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(jsonSlice);
+  } catch {
+    return fallback;
+  }
+  if (typeof parsed !== "object" || parsed === null) return fallback;
+
+  const obj = parsed as Record<string, unknown>;
+  const rawOperator = typeof obj.operator === "string" ? obj.operator.trim().toLowerCase() : "";
+  const rawOutput = typeof obj.output === "string" ? obj.output : "";
+
+  const operator = _isConsolidationOperator(rawOperator)
+    ? rawOperator
+    : chooseConsolidationOperator(cluster);
+  const output = rawOutput.trim().length > 0 ? rawOutput.trim() : response.trim();
+
+  return { operator, output };
+}
+
+// Silence unused-import warnings when tsup tree-shakes: these are used
+// above in chooseConsolidationOperator + parse helpers.
+void _CONSOLIDATION_OPERATORS;
 
 /**
  * Discover extensions and build the block to append to a consolidation prompt.

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -591,6 +591,15 @@ export interface PluginConfig {
   semanticConsolidationExcludeCategories: string[];
   semanticConsolidationIntervalHours: number;
   semanticConsolidationMaxPerRun: number;
+  /**
+   * When true (default), semantic-consolidation prompts the LLM with an
+   * operator-aware format asking for JSON `{operator, output}` and records
+   * the resulting SPLIT/MERGE/UPDATE operator on `derived_via`.  When
+   * false, falls back to the legacy plain-text prompt — `derived_via` is
+   * still populated via the cluster-shape heuristic in
+   * `chooseConsolidationOperator`.  Issue #561 PR 3.
+   */
+  operatorAwareConsolidationEnabled: boolean;
   // Creation-memory foundation
   creationMemoryEnabled: boolean;
   memoryUtilityLearningEnabled: boolean;

--- a/tests/semantic-consolidation-operator.test.ts
+++ b/tests/semantic-consolidation-operator.test.ts
@@ -187,3 +187,28 @@ test("parseOperatorAwareConsolidationResponse handles mixed-case operator values
   assert.equal(res.operator, "merge");
   assert.equal(res.output, "upper case");
 });
+
+// ─── Config coercion (regression for PR #632 review feedback) ────────────────
+// codex P1 / cursor Medium: `operatorAwareConsolidationEnabled` must
+// coerce string-valued falsey config inputs (e.g.
+// `--config operatorAwareConsolidationEnabled=false`) so the documented
+// rollback escape hatch actually works when the CLI passes string
+// values.
+
+test("operatorAwareConsolidationEnabled coerces string 'false' to disabled", async () => {
+  const { parseConfig } = await import("../src/config.ts");
+  const parsed = parseConfig({ operatorAwareConsolidationEnabled: "false" } as any);
+  assert.equal(parsed.operatorAwareConsolidationEnabled, false);
+});
+
+test("operatorAwareConsolidationEnabled defaults to true when unset", async () => {
+  const { parseConfig } = await import("../src/config.ts");
+  const parsed = parseConfig({});
+  assert.equal(parsed.operatorAwareConsolidationEnabled, true);
+});
+
+test("operatorAwareConsolidationEnabled honors boolean false", async () => {
+  const { parseConfig } = await import("../src/config.ts");
+  const parsed = parseConfig({ operatorAwareConsolidationEnabled: false });
+  assert.equal(parsed.operatorAwareConsolidationEnabled, false);
+});

--- a/tests/semantic-consolidation-operator.test.ts
+++ b/tests/semantic-consolidation-operator.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for operator-aware consolidation prompt + parse (issue #561 PR 3).
+ *
+ * Covers:
+ *   - `chooseConsolidationOperator` heuristic (cluster size → operator).
+ *   - `buildOperatorAwareConsolidationPrompt` shape and operator vocab.
+ *   - `parseOperatorAwareConsolidationResponse` accepts strict JSON,
+ *     fenced code blocks, and prose-prefixed JSON — and falls back to the
+ *     heuristic for malformed / unknown / plain-text responses.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildOperatorAwareConsolidationPrompt,
+  parseOperatorAwareConsolidationResponse,
+  chooseConsolidationOperator,
+  type ConsolidationCluster,
+} from "../src/semantic-consolidation.ts";
+import type { MemoryFile } from "../src/types.ts";
+
+function makeMemory(id: string, content: string, created = "2026-04-19T00:00:00Z"): MemoryFile {
+  return {
+    path: `/memory/facts/${id}.md`,
+    frontmatter: {
+      id,
+      category: "fact" as any,
+      created,
+      updated: created,
+      source: "extraction",
+      confidence: 0.8,
+      confidenceTier: "implied" as any,
+      tags: [],
+    },
+    content,
+  };
+}
+
+function makeCluster(n: number): ConsolidationCluster {
+  return {
+    category: "fact",
+    memories: Array.from({ length: n }, (_, i) =>
+      makeMemory(`fact-${i + 1}`, `Source content #${i + 1}`),
+    ),
+    overlapScore: 0.8,
+  };
+}
+
+// ─── chooseConsolidationOperator ─────────────────────────────────────────────
+
+test("chooseConsolidationOperator returns update for single-memory clusters", () => {
+  assert.equal(chooseConsolidationOperator(makeCluster(1)), "update");
+});
+
+test("chooseConsolidationOperator returns merge for multi-memory clusters", () => {
+  assert.equal(chooseConsolidationOperator(makeCluster(2)), "merge");
+  assert.equal(chooseConsolidationOperator(makeCluster(5)), "merge");
+});
+
+// ─── buildOperatorAwareConsolidationPrompt ───────────────────────────────────
+
+test("buildOperatorAwareConsolidationPrompt names all three operators", () => {
+  const prompt = buildOperatorAwareConsolidationPrompt(makeCluster(3));
+  assert.ok(prompt.includes('"merge"'));
+  assert.ok(prompt.includes('"update"'));
+  assert.ok(prompt.includes('"split"'));
+});
+
+test("buildOperatorAwareConsolidationPrompt asks for JSON-only output", () => {
+  const prompt = buildOperatorAwareConsolidationPrompt(makeCluster(2));
+  assert.ok(prompt.includes('"operator"'));
+  assert.ok(prompt.includes('"output"'));
+  assert.ok(prompt.toLowerCase().includes("json"));
+});
+
+test("buildOperatorAwareConsolidationPrompt embeds every source memory", () => {
+  const cluster = makeCluster(3);
+  const prompt = buildOperatorAwareConsolidationPrompt(cluster);
+  for (const m of cluster.memories) {
+    assert.ok(prompt.includes(m.frontmatter.id));
+    assert.ok(prompt.includes(m.content));
+  }
+});
+
+// ─── parseOperatorAwareConsolidationResponse ─────────────────────────────────
+
+test("parseOperatorAwareConsolidationResponse accepts strict JSON", () => {
+  const cluster = makeCluster(3);
+  const res = parseOperatorAwareConsolidationResponse(
+    '{"operator":"merge","output":"canonical body"}',
+    cluster,
+  );
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, "canonical body");
+});
+
+test("parseOperatorAwareConsolidationResponse accepts update and split operators", () => {
+  const cluster = makeCluster(2);
+  for (const op of ["update", "split"] as const) {
+    const res = parseOperatorAwareConsolidationResponse(
+      `{"operator":"${op}","output":"body-${op}"}`,
+      cluster,
+    );
+    assert.equal(res.operator, op);
+    assert.equal(res.output, `body-${op}`);
+  }
+});
+
+test("parseOperatorAwareConsolidationResponse tolerates fenced code blocks", () => {
+  const cluster = makeCluster(2);
+  const fenced = [
+    "```json",
+    '{"operator":"merge","output":"fenced body"}',
+    "```",
+  ].join("\n");
+  const res = parseOperatorAwareConsolidationResponse(fenced, cluster);
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, "fenced body");
+});
+
+test("parseOperatorAwareConsolidationResponse tolerates prose-prefixed JSON", () => {
+  const cluster = makeCluster(2);
+  const withProse =
+    'Here is the consolidation result:\n\n{"operator":"update","output":"updated body"}\n';
+  const res = parseOperatorAwareConsolidationResponse(withProse, cluster);
+  assert.equal(res.operator, "update");
+  assert.equal(res.output, "updated body");
+});
+
+test("parseOperatorAwareConsolidationResponse falls back to heuristic on plain text", () => {
+  const cluster = makeCluster(3);
+  const plain = "Joshua prefers TypeScript for backend work.";
+  const res = parseOperatorAwareConsolidationResponse(plain, cluster);
+  // Multi-memory cluster → heuristic returns "merge".
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, plain);
+});
+
+test("parseOperatorAwareConsolidationResponse falls back to heuristic for unknown operator", () => {
+  const cluster = makeCluster(1);
+  // Single-memory cluster → heuristic returns "update".
+  const res = parseOperatorAwareConsolidationResponse(
+    '{"operator":"annihilate","output":"body"}',
+    cluster,
+  );
+  assert.equal(res.operator, "update");
+  assert.equal(res.output, "body");
+});
+
+test("parseOperatorAwareConsolidationResponse falls back on malformed JSON", () => {
+  const cluster = makeCluster(4);
+  const broken = '{"operator":"merge","output":"body"'; // missing closing brace
+  const res = parseOperatorAwareConsolidationResponse(broken, cluster);
+  // Heuristic fallback: multi-memory → merge; output is the raw trimmed text.
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, broken.trim());
+});
+
+test("parseOperatorAwareConsolidationResponse falls back when output field is empty", () => {
+  const cluster = makeCluster(2);
+  const res = parseOperatorAwareConsolidationResponse(
+    '{"operator":"merge","output":""}',
+    cluster,
+  );
+  assert.equal(res.operator, "merge");
+  // Empty output field → use raw trimmed response instead of dropping the
+  // cluster.  Callers still write something rather than losing data.
+  assert.equal(res.output, '{"operator":"merge","output":""}');
+});
+
+test("parseOperatorAwareConsolidationResponse never throws on weird inputs", () => {
+  const cluster = makeCluster(2);
+  const inputs = ["", "   ", "{}", "null", "[]", "not json at all"];
+  for (const input of inputs) {
+    const res = parseOperatorAwareConsolidationResponse(input, cluster);
+    assert.ok(res.operator === "merge" || res.operator === "update" || res.operator === "split");
+    assert.equal(typeof res.output, "string");
+  }
+});
+
+test("parseOperatorAwareConsolidationResponse handles mixed-case operator values", () => {
+  const cluster = makeCluster(2);
+  const res = parseOperatorAwareConsolidationResponse(
+    '{"operator":"MERGE","output":"upper case"}',
+    cluster,
+  );
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, "upper case");
+});

--- a/tests/semantic-consolidation-operator.test.ts
+++ b/tests/semantic-consolidation-operator.test.ts
@@ -73,6 +73,48 @@ test("buildOperatorAwareConsolidationPrompt asks for JSON-only output", () => {
   assert.ok(prompt.toLowerCase().includes("json"));
 });
 
+test("buildOperatorAwareConsolidationPrompt example uses a concrete operator, not the pipe placeholder", () => {
+  // PR #632 round-4 review (codex P2): the example JSON in the user
+  // prompt previously contained the literal `"operator": "merge" |
+  // "update" | "split"` placeholder, which some models would echo back
+  // verbatim.  The example must show a concrete value like "merge".
+  const prompt = buildOperatorAwareConsolidationPrompt(makeCluster(2));
+  // The schema example block must include `"operator": "merge"` (a
+  // concrete assignment).
+  assert.match(prompt, /"operator":\s*"merge"/u);
+  // Any mention of the pipe placeholder must be in a negative
+  // instruction (i.e. context that tells the model NOT to use it).
+  const pipeIdx = prompt.indexOf("merge|update|split");
+  if (pipeIdx >= 0) {
+    const context = prompt.slice(Math.max(0, pipeIdx - 100), pipeIdx);
+    assert.match(
+      context,
+      /never|not|forbidden|do not/iu,
+      "any pipe-placeholder mention must be framed negatively",
+    );
+  }
+});
+
+test("parseOperatorAwareConsolidationResponse tolerates JSON example blocks prepended by the model", () => {
+  // Regression for PR #632 round-4 review (codex P1): previously the
+  // parser sliced from first `{` to last `}`, which breaks when the
+  // model includes an earlier brace block.  Switched to balanced-brace
+  // scanning, so earlier blocks are skipped and the actual payload
+  // parses correctly.
+  const cluster = makeCluster(3);
+  const prefixed = [
+    "Here's what I'll emit:",
+    '```',
+    '{"note": "this is a per-operator example"}',
+    '```',
+    "Actual answer:",
+    '{"operator":"merge","output":"actual canonical body"}',
+  ].join("\n");
+  const res = parseOperatorAwareConsolidationResponse(prefixed, cluster);
+  assert.equal(res.operator, "merge");
+  assert.equal(res.output, "actual canonical body");
+});
+
 test("parseOperatorAwareConsolidationResponse falls back when LLM returns the pipe-delimited placeholder", () => {
   // Regression for PR #632 review feedback (codex P2): if a model
   // follows the system prompt literally and emits the

--- a/tests/semantic-consolidation-operator.test.ts
+++ b/tests/semantic-consolidation-operator.test.ts
@@ -73,6 +73,23 @@ test("buildOperatorAwareConsolidationPrompt asks for JSON-only output", () => {
   assert.ok(prompt.toLowerCase().includes("json"));
 });
 
+test("parseOperatorAwareConsolidationResponse falls back when LLM returns the pipe-delimited placeholder", () => {
+  // Regression for PR #632 review feedback (codex P2): if a model
+  // follows the system prompt literally and emits the
+  // `"merge|update|split"` placeholder string as the operator value,
+  // the parser must fall back to the heuristic rather than accept the
+  // malformed value.  The orchestrator now emits a system prompt that
+  // explicitly forbids the placeholder, but defense-in-depth demands
+  // the parser still reject it.
+  const cluster = makeCluster(3);
+  const res = parseOperatorAwareConsolidationResponse(
+    '{"operator":"merge|update|split","output":"placeholder body"}',
+    cluster,
+  );
+  assert.equal(res.operator, "merge"); // heuristic for multi-memory cluster
+  assert.equal(res.output, "placeholder body");
+});
+
 test("buildOperatorAwareConsolidationPrompt embeds every source memory", () => {
   const cluster = makeCluster(3);
   const prompt = buildOperatorAwareConsolidationPrompt(cluster);
@@ -201,10 +218,14 @@ test("operatorAwareConsolidationEnabled coerces string 'false' to disabled", asy
   assert.equal(parsed.operatorAwareConsolidationEnabled, false);
 });
 
-test("operatorAwareConsolidationEnabled defaults to true when unset", async () => {
+test("operatorAwareConsolidationEnabled defaults to false when unset", async () => {
+  // Least-privileged default per PR #632 review (cursor): the operator-
+  // aware prompt is opt-in so installs using older models don't hit
+  // the JSON-format prompt by default.  When disabled, `derived_via`
+  // still populates via the cluster-shape heuristic.
   const { parseConfig } = await import("../src/config.ts");
   const parsed = parseConfig({});
-  assert.equal(parsed.operatorAwareConsolidationEnabled, true);
+  assert.equal(parsed.operatorAwareConsolidationEnabled, false);
 });
 
 test("operatorAwareConsolidationEnabled honors boolean false", async () => {


### PR DESCRIPTION
## Summary

PR 3 of 5 for issue #561.  Builds on PR 2 (#624) to let the consolidation
LLM pick which SPLIT/MERGE/UPDATE operator produced each canonical memory
and records it on `derived_via`.  Operator selection is gated behind a
new config flag (default `true`) so rollbacks stay clean.

## Changes

- **`semantic-consolidation.ts`**
  - `buildOperatorAwareConsolidationPrompt(cluster)` — asks the LLM for
    strict JSON `{operator, output}` with the three-operator vocabulary.
  - `parseOperatorAwareConsolidationResponse(response, cluster)` —
    accepts strict JSON, fenced code blocks, prose-prefixed JSON; falls
    back to a cluster-shape heuristic on malformed / unknown / plain-text
    responses; never throws.
  - `chooseConsolidationOperator(cluster)` — heuristic default:
    `cluster.memories.length <= 1 → "update"`, otherwise `"merge"`.
    SPLIT is reserved for future cluster shapes.

- **`orchestrator.ts`**
  - New `operatorAwareConsolidationEnabled` config gate (default `true`).
  - When enabled, consolidation runs the operator-aware prompt and
    records the parsed operator on `derived_via`.
  - When disabled, falls back to the legacy plain-text prompt with the
    heuristic operator still populating `derived_via`.

- **`config.ts`, `types.ts`, `openclaw.plugin.json`** — declare
  `operatorAwareConsolidationEnabled` at every layer.

## Out of scope (follow-up PRs)

- **PR 4** — `remnic doctor` integrity check that validates every
  `derived_from` referent resolves on disk and every `derived_via` is a
  known operator.
- **PR 5** — `remnic consolidate undo <target>` CLI path that restores
  source memories from their `derived_from` snapshots.

## Test plan

- [x] `tests/semantic-consolidation-operator.test.ts` — 15 tests:
  heuristic on single vs multi clusters, prompt shape + operator
  vocabulary, parser on strict JSON / fenced / prose-prefixed / plain /
  malformed / empty-output / weird / mixed-case inputs.
- [x] PR 2 provenance tests + full core test suite — 622/622 green.
- [x] `tsc --noEmit` — clean.

Refs #561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the semantic-consolidation LLM prompt/parse path and the persisted provenance field `derived_via`, which could affect downstream tooling and consolidation behavior if parsing misclassifies outputs (mitigated by config gate + heuristic fallback + tests).
> 
> **Overview**
> Semantic consolidation can now run in an **operator-aware mode** that asks the LLM to return structured JSON `{operator, output}` and persists the chosen operator to the canonical memory’s `derived_via` (instead of always writing `merge`).
> 
> This introduces a new config/UI flag `operatorAwareConsolidationEnabled` (default **off**) that gates the new prompt/parse path; when disabled or when responses are malformed, consolidation falls back to the legacy prompt and uses a cluster-size heuristic (`chooseConsolidationOperator`) to still populate `derived_via`.
> 
> Adds robust parsing utilities to tolerate fenced/prose-prefixed JSON and a dedicated test suite covering prompt shape, parsing fallbacks, and config coercion.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a60a910d7a9af160064a5f900b085141a9ad0330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->