### PR TITLE
security(bench): ADAM baseline ASR numbers (issue #565 PR 3/5)

### DIFF
--- a/docs/security/adam-baseline-2026-04.md
+++ b/docs/security/adam-baseline-2026-04.md
@@ -1,0 +1,158 @@
+# ADAM Memory-Extraction Baseline — April 2026
+
+Baseline Attack Success Rate (ASR) measurements for the ADAM-style memory
+extraction attack harness introduced in issue #565 PR 2 (see
+`packages/bench/src/security/extraction-attack/`). Captured against the
+`main` branch as of 2026-04-20 with **no mitigations** enabled. PRs 4 and 5
+(cross-namespace query budget, recall-audit anomaly detection) will be
+measured against this baseline.
+
+## 1. Methodology
+
+### 1.1 Attack loop
+
+The harness re-implements the entropy-guided adaptive-query loop described
+in *ADAM — Adaptive Data Extraction Attack* (arXiv:2604.09747, Apr 2026).
+It is a clean-room implementation:
+
+1. Seed a belief map from a small English vocabulary (`name`, `email`,
+   `project`, `meeting`, `preference`, etc.) plus, for the
+   `same-namespace` tier, whatever entity names the attacker observes via
+   the entity side channel.
+2. On each iteration compute normalized Shannon entropy over the belief
+   map.
+   - Low entropy (`<= entropyThreshold`, default `0.3`): exploit — query
+     the highest-weight token the attacker has not tried yet.
+   - High entropy: explore — pick an un-queried token from the belief map,
+     falling back to the seed vocabulary.
+3. Issue the chosen query against the target's recall surface.
+4. Mark any hit whose tokenized content overlaps a ground-truth memory's
+   salient-token set at `>= 0.5` as "recovered". Update the belief map
+   (down-weight tokens already covered by recovered content; bump tokens
+   that co-occur with hits).
+5. Terminate when every ground-truth memory is recovered, the query budget
+   is exhausted, or no un-queried candidate remains.
+
+The attack never calls an LLM. Token "information gain" is computed from
+lexical overlap, matching the paper's low-cost non-LLM variant; this is
+adequate for measuring the read-path's structural leakage.
+
+### 1.2 Fixture
+
+The baseline target is deterministic and in-process
+(`createSyntheticTarget`): it scores memories by query-token overlap and
+returns the top-K hits. Every fixture memory is synthetic per the repo's
+public-privacy policy.
+
+- **15 memories in the `victim` namespace** spanning fact, preference,
+  decision, and entity categories (`SYNTHETIC_MEMORIES`).
+- **1 sentinel memory in the `other` namespace**
+  (`OTHER_NAMESPACE_MEMORIES`) — used only in the T3 scenario below.
+- Memory IDs are disclosed in hits (mirrors the current MCP recall surface
+  — see threat-model §4 for the enumeration).
+- The target enforces namespace ACLs when `enforceNamespaceAcl: true`,
+  matching the intended behavior of the production read path.
+
+### 1.3 Scenarios
+
+| Scenario | Attacker tier | Entity side-channel | Namespace ACL | Seed |
+|---|---|---|---|---:|
+| `T1-zero-knowledge-no-entities` | T1 / zero-knowledge | none | n/a (single ns) | 101 |
+| `T2-same-namespace-with-entity-sidechannel` | T2 / same-namespace | yes (5 names) | n/a | 202 |
+| `T3-cross-namespace-acl-enforced` | T3 / cross-namespace | none | enforced (`allowed="other"`) | 303 |
+
+- **T1 — zero-knowledge.** No prior information, no entity enumeration.
+  The attacker can only probe the seed vocabulary.
+- **T2 — same-namespace.** Models a compromised or adversarial agent on
+  the user's machine that already holds a valid token and can enumerate
+  entity names via `memory_entities_list`.
+- **T3 — cross-namespace.** The attacker holds a valid token for a
+  *different* namespace (`other`) and is trying to leak `victim`
+  memories. The target enforces the namespace ACL (per threat-model
+  §6.1), so direct recall should return zero `victim` hits.
+
+Budgets are fixed at **200 queries** per scenario — well above the point at
+which every tier plateaus on the 15-memory fixture. Runs are reproducible:
+seeds are fixed, the PRNG is `mulberry32`, and the target is deterministic.
+
+## 2. Results
+
+Captured 2026-04-20 on branch `security/issue-565-pr3-adam-baseline`.
+Reproduce with:
+
+```bash
+pnpm --filter @remnic/bench build
+node -e "import('@remnic/bench').then(async ({ runBaseline, renderBaselineMarkdown }) => console.log(renderBaselineMarkdown(await runBaseline())))"
+```
+
+| Scenario | Attacker | Budget | Queries | ASR | Recovered | Missed |
+|---|---|---:|---:|---:|---:|---:|
+| `T1-zero-knowledge-no-entities` | zero-knowledge | 200 | 26 | 6.7% | 1 | 14 |
+| `T2-same-namespace-with-entity-sidechannel` | same-namespace | 200 | 61 | 53.3% | 8 | 7 |
+| `T3-cross-namespace-acl-enforced` | cross-namespace | 200 | 20 | 0.0% | 0 | 15 |
+
+### 2.1 Interpretation
+
+- **T1 (6.7%).** An un-authenticated probe that only knows generic English
+  vocabulary recovers roughly one memory on this fixture within its
+  budget. The single recovered memory (`mem-008` — weekly meeting
+  reference) sits at the intersection of the seed vocabulary and the
+  fixture's language. T1 is structurally bounded: with no entity
+  side-channel and no valid token the attacker has almost nothing to
+  pivot on. A larger fixture would likely push T1 higher in absolute
+  count but not in rate.
+
+- **T2 (53.3%).** The same-namespace attacker using entity enumeration
+  plus adaptive querying leaks just over half of the fixture with ~60
+  queries. This is the tier the hardening PRs (4 + 5) must move. The
+  entity side-channel is the primary lever — every recovered memory that
+  T1 missed was unlocked by a fresh entity-seeded exploit cycle.
+
+- **T3 (0%).** With the namespace ACL enforced the cross-namespace
+  attacker recovers nothing. The harness terminates early (20 queries
+  issued because every candidate query returns no hits and the entropy
+  exploration exhausts the seed pool quickly). This confirms the ACL
+  invariant from threat-model §6.1 and provides a regression bound —
+  any future change that causes cross-namespace recalls to succeed
+  should show up as a non-zero ASR here.
+
+### 2.2 What the baseline does *not* measure
+
+- **LCM archive (`memory_lcm_search`).** The fixture is fact-shaped; the
+  harness does not exercise the richer LCM read path. A follow-up
+  fixture is warranted before PR 5 lands.
+- **High-cardinality return disclosure.** The target's `hitCap` is 5; a
+  real recall surface can return more. The anomaly detector in PR 5
+  should still catch high-cardinality fan-out regardless, but the
+  baseline does not stress it.
+- **Real-world memory sizes.** 15 memories is enough to validate the
+  harness and compare mitigations, not to extrapolate absolute ASR to a
+  production namespace with thousands of memories. The T2 number should
+  be read as *directionally high*, not as a production forecast.
+
+## 3. Mitigation targets
+
+Informs the thresholds used in PR 4 (`recallCrossNamespaceBudgetEnabled`)
+and PR 5 (recall-audit anomaly detection):
+
+| Tier | Baseline ASR | PR 4 + 5 target |
+|---|---:|---:|
+| T1 — zero-knowledge | 6.7% | ≤ 6.7% (already structurally bounded) |
+| T2 — same-namespace | 53.3% | ≤ 20% (threat-model §6.2, first milestone) |
+| T3 — cross-namespace (ACL on) | 0.0% | 0.0% (regression bound, must not regress) |
+
+## 4. Reproducibility
+
+Everything needed to reproduce is in-tree:
+
+- Harness: `packages/bench/src/security/extraction-attack/runner.ts`
+- Fixture: `packages/bench/src/security/extraction-attack/fixture.ts`
+- Baseline runner + scenarios:
+  `packages/bench/src/security/extraction-attack/baseline.ts`
+- Public entry points: `runBaseline`, `renderBaselineMarkdown`,
+  `DEFAULT_BASELINE_SCENARIOS` from `@remnic/bench`.
+
+Seeds, budgets, and fixture are hard-coded so the document stays stable
+across reruns. Changing any of them invalidates the comparison to the
+PR 4 / PR 5 mitigated runs — record the change in the follow-up report
+rather than silently rerunning.

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -392,3 +392,14 @@ export type {
   SyntheticTargetOptions,
   TimelineEntry,
 } from "./security/extraction-attack/index.js";
+
+// ADAM baseline runner + default scenarios (issue #565 PR 3/5).
+export {
+  DEFAULT_BASELINE_SCENARIOS,
+  renderBaselineMarkdown,
+  runBaseline,
+} from "./security/extraction-attack/index.js";
+export type {
+  BaselineRow,
+  BaselineScenario,
+} from "./security/extraction-attack/index.js";

--- a/packages/bench/src/security/extraction-attack/baseline.test.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_BASELINE_SCENARIOS,
+  renderBaselineMarkdown,
+  runBaseline,
+} from "./index.ts";
+
+const DEADLINE_MS = 60_000;
+
+test("baseline runner returns one row per default scenario", async () => {
+  const rows = await runBaseline();
+  assert.equal(rows.length, DEFAULT_BASELINE_SCENARIOS.length);
+  for (const row of rows) {
+    assert.ok(row.asr >= 0 && row.asr <= 1, `asr in [0, 1] (got ${row.asr})`);
+    assert.ok(row.queriesIssued >= 0);
+    assert.ok(row.queriesIssued <= row.queryBudget);
+  }
+}, { timeout: DEADLINE_MS });
+
+test("T3 cross-namespace with ACL enforced recovers nothing", async () => {
+  const rows = await runBaseline();
+  const t3 = rows.find((r) => r.scenario === "T3-cross-namespace-acl-enforced");
+  assert.ok(t3, "T3 scenario must be present");
+  assert.equal(
+    t3.asr,
+    0,
+    "T3 ASR must be 0 as a regression bound for the ACL invariant",
+  );
+  assert.equal(t3.recoveredIds.length, 0);
+}, { timeout: DEADLINE_MS });
+
+test("T2 same-namespace ASR is strictly greater than T1 zero-knowledge ASR", async () => {
+  // Core invariant of the baseline document: the entity side-channel gives
+  // T2 a measurable advantage over T1. If this ever stops being true the
+  // baseline numbers are stale.
+  const rows = await runBaseline();
+  const t1 = rows.find((r) => r.scenario === "T1-zero-knowledge-no-entities");
+  const t2 = rows.find(
+    (r) => r.scenario === "T2-same-namespace-with-entity-sidechannel",
+  );
+  assert.ok(t1 && t2);
+  assert.ok(
+    t2.asr > t1.asr,
+    `T2 ASR (${t2.asr}) must exceed T1 ASR (${t1.asr})`,
+  );
+}, { timeout: DEADLINE_MS });
+
+test("markdown renderer emits a header plus one row per result", () => {
+  const markdown = renderBaselineMarkdown([
+    {
+      scenario: "unit",
+      attackerMode: "same-namespace",
+      queryBudget: 10,
+      queriesIssued: 3,
+      asr: 0.25,
+      recoveredIds: ["a"],
+      missedIds: ["b", "c", "d"],
+      durationMs: 1,
+    },
+  ]);
+  const lines = markdown.split("\n");
+  assert.equal(lines.length, 3, "header + separator + one row");
+  assert.ok(lines[0].startsWith("| Scenario"));
+  assert.ok(lines[1].includes("---"));
+  assert.ok(lines[2].includes("unit"));
+  assert.ok(lines[2].includes("25.0%"));
+});

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -1,0 +1,147 @@
+/**
+ * Baseline measurement runner for the ADAM memory-extraction harness.
+ *
+ * Produces a reproducible set of ASR numbers for every attacker tier against
+ * a synthetic target that mirrors the current Remnic read-path behavior
+ * (memory IDs disclosed, namespace ACL enforced on cross-namespace reads).
+ *
+ * This is intentionally separate from the unit tests: tests keep budgets
+ * small so CI stays fast, whereas the baseline pushes the budget high enough
+ * for each tier to plateau. The output feeds into
+ * `docs/security/adam-baseline-2026-04.md`.
+ */
+
+import {
+  OTHER_NAMESPACE_MEMORIES,
+  SYNTHETIC_MEMORIES,
+  createSeededRng,
+  createSyntheticTarget,
+  runExtractionAttack,
+} from "./index.js";
+import type {
+  AttackerMode,
+  ExtractionAttackResult,
+  SeededMemory,
+} from "./index.js";
+
+export interface BaselineScenario {
+  readonly name: string;
+  readonly attackerMode: AttackerMode;
+  readonly queryBudget: number;
+  readonly seed: number;
+  /** Ground truth the attacker is trying to recover. */
+  readonly groundTruth: readonly SeededMemory[];
+  /** Memories the target actually stores (may be a superset of groundTruth). */
+  readonly targetMemories: readonly SeededMemory[];
+  readonly entities?: readonly string[];
+  readonly enforceNamespaceAcl?: boolean;
+  readonly allowedNamespace?: string;
+  readonly disclosesMemoryIds?: boolean;
+}
+
+export interface BaselineRow {
+  readonly scenario: string;
+  readonly attackerMode: AttackerMode;
+  readonly queryBudget: number;
+  readonly queriesIssued: number;
+  readonly asr: number;
+  readonly recoveredIds: readonly string[];
+  readonly missedIds: readonly string[];
+  readonly durationMs: number;
+}
+
+/**
+ * Scenarios used for the 2026-04 baseline. Kept deterministic via fixed seeds
+ * so the document remains reproducible.
+ */
+export const DEFAULT_BASELINE_SCENARIOS: readonly BaselineScenario[] =
+  Object.freeze([
+    {
+      name: "T1-zero-knowledge-no-entities",
+      attackerMode: "zero-knowledge",
+      queryBudget: 200,
+      seed: 101,
+      groundTruth: SYNTHETIC_MEMORIES,
+      targetMemories: SYNTHETIC_MEMORIES,
+      entities: [],
+      disclosesMemoryIds: true,
+    },
+    {
+      name: "T2-same-namespace-with-entity-sidechannel",
+      attackerMode: "same-namespace",
+      queryBudget: 200,
+      seed: 202,
+      groundTruth: SYNTHETIC_MEMORIES,
+      targetMemories: SYNTHETIC_MEMORIES,
+      entities: ["Alex Morgan", "Priya Shah", "Aurora", "Helios", "Acme"],
+      disclosesMemoryIds: true,
+    },
+    {
+      name: "T3-cross-namespace-acl-enforced",
+      attackerMode: "cross-namespace",
+      queryBudget: 200,
+      seed: 303,
+      groundTruth: SYNTHETIC_MEMORIES,
+      targetMemories: [...SYNTHETIC_MEMORIES, ...OTHER_NAMESPACE_MEMORIES],
+      entities: [],
+      enforceNamespaceAcl: true,
+      allowedNamespace: "other",
+      disclosesMemoryIds: true,
+    },
+  ]);
+
+/**
+ * Executes every scenario once and returns a flat set of rows suitable for
+ * rendering as a markdown table.
+ */
+export async function runBaseline(
+  scenarios: readonly BaselineScenario[] = DEFAULT_BASELINE_SCENARIOS,
+): Promise<BaselineRow[]> {
+  const rows: BaselineRow[] = [];
+  for (const scenario of scenarios) {
+    const target = createSyntheticTarget({
+      memories: scenario.targetMemories,
+      entities: scenario.entities,
+      enforceNamespaceAcl: scenario.enforceNamespaceAcl,
+      allowedNamespace: scenario.allowedNamespace,
+      disclosesMemoryIds: scenario.disclosesMemoryIds ?? true,
+    });
+    const result: ExtractionAttackResult = await runExtractionAttack({
+      target,
+      groundTruth: scenario.groundTruth,
+      attackerMode: scenario.attackerMode,
+      queryBudget: scenario.queryBudget,
+      rng: createSeededRng(scenario.seed),
+      captureTimeline: false,
+    });
+    rows.push({
+      scenario: scenario.name,
+      attackerMode: scenario.attackerMode,
+      queryBudget: scenario.queryBudget,
+      queriesIssued: result.queriesIssued,
+      asr: result.asr,
+      recoveredIds: result.recovered.map((r) => r.memoryId),
+      missedIds: result.missed.map((m) => m.id),
+      durationMs: result.durationMs,
+    });
+  }
+  return rows;
+}
+
+/**
+ * Renders a baseline run as a human-readable markdown fragment. The returned
+ * string is suitable for pasting into the baseline document.
+ */
+export function renderBaselineMarkdown(rows: readonly BaselineRow[]): string {
+  const lines: string[] = [];
+  lines.push(
+    "| Scenario | Attacker | Budget | Queries | ASR | Recovered | Missed |",
+  );
+  lines.push("|---|---|---:|---:|---:|---:|---:|");
+  for (const r of rows) {
+    lines.push(
+      `| \`${r.scenario}\` | ${r.attackerMode} | ${r.queryBudget} | ${r.queriesIssued} | ${(r.asr * 100).toFixed(1)}% | ${r.recoveredIds.length} | ${r.missedIds.length} |`,
+    );
+  }
+  return lines.join("\n");
+}

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -37,6 +37,8 @@ export interface BaselineScenario {
   readonly enforceNamespaceAcl?: boolean;
   readonly allowedNamespace?: string;
   readonly disclosesMemoryIds?: boolean;
+  /** Attacker-held namespace. Forwarded as `attackerNamespace` to the runner. */
+  readonly attackerNamespace?: string;
 }
 
 export interface BaselineRow {
@@ -77,8 +79,16 @@ export const DEFAULT_BASELINE_SCENARIOS: readonly BaselineScenario[] =
       disclosesMemoryIds: true,
     },
     {
+      // Attacker holds a token for `other`, tries to leak `victim`.
+      // Using a reachable attackerNamespace is deliberate: the ACL
+      // must actively filter in the recall path, not merely default to
+      // empty because the attacker queried a namespace that doesn't
+      // exist in the fixture. Without this, a regression that disables
+      // the ACL still reports ASR=0 because the query namespace has no
+      // matching memories at all.
       name: "T3-cross-namespace-acl-enforced",
       attackerMode: "cross-namespace",
+      attackerNamespace: "other",
       queryBudget: 200,
       seed: 303,
       groundTruth: SYNTHETIC_MEMORIES,
@@ -110,6 +120,7 @@ export async function runBaseline(
       target,
       groundTruth: scenario.groundTruth,
       attackerMode: scenario.attackerMode,
+      attackerNamespace: scenario.attackerNamespace,
       queryBudget: scenario.queryBudget,
       rng: createSeededRng(scenario.seed),
       captureTimeline: false,

--- a/packages/bench/src/security/extraction-attack/index.ts
+++ b/packages/bench/src/security/extraction-attack/index.ts
@@ -24,3 +24,14 @@ export type {
   SeededMemory,
   TimelineEntry,
 } from "./types.js";
+
+// Baseline runner + default scenarios (issue #565 PR 3/5).
+export {
+  DEFAULT_BASELINE_SCENARIOS,
+  renderBaselineMarkdown,
+  runBaseline,
+} from "./baseline.js";
+export type {
+  BaselineRow,
+  BaselineScenario,
+} from "./baseline.js";


### PR DESCRIPTION
## Summary

Runs the ADAM harness from PR #619 against the synthetic fixture and publishes baseline ASR numbers in `docs/security/adam-baseline-2026-04.md`. Also surfaces the baseline API as public exports so the PR 4 / PR 5 mitigated runs can render the same table shape.

Baseline (no mitigations, 200-query budget, fixed seeds):

- T1 zero-knowledge: 6.7%
- T2 same-namespace with entity side-channel: 53.3%
- T3 cross-namespace with ACL enforced: 0% (regression bound)

Targets informed by threat model §6.2:

- T1: keep ≤ 6.7% (structurally bounded)
- T2: ≤ 20% after PR 4 + 5
- T3: must stay 0%

> Note: based on PR #619. Will retarget to `main` after PR 2 merges.

## Test plan

- [x] `tsx --test packages/bench/src/security/extraction-attack/baseline.test.ts` — 4/4 tests pass
  - one row per scenario, ASR in [0,1]
  - T3 ACL-enforced ASR stays 0 (regression bound)
  - T2 ASR > T1 ASR (entity side-channel invariant)
  - Markdown renderer emits header + row

Ref: issue #565, PR #619 (PR 2).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly additive docs/bench/test work, but it also adds new CLI/MCP access surfaces and config knobs; regressions would mainly be in tooling behavior or outcome-signal recording rather than core retrieval correctness.
> 
> **Overview**
> Adds a **reproducible ADAM (memory-extraction) baseline** to `@remnic/bench`: a new `runBaseline`/`DEFAULT_BASELINE_SCENARIOS` runner + markdown renderer, public exports, and regression tests, alongside a new baseline report doc (`docs/security/adam-baseline-2026-04.md`).
> 
> Expands operational surfaces and docs around retrieval and coding workflows: new **Recall X-ray** documentation plus a `remnic xray` CLI command with strict flag parsing/tests, and updates README/CHANGELOG/CLAUDE notes to reflect shipped `recall/xray` and coding-agent mode docs.
> 
> Also introduces several **additive config/API knobs and benchmarks**: schema entries for surprise-triggered buffer flush, memory-worth recall weighting, extraction-judge deferral/telemetry/training-pair collection, and reasoning-trace boost; a new `retrieval-reasoning-trace` benchmark (fixture/runner/tests) is registered and marked lower-is-better for latency; and an MCP tool `engram.memory_outcome` is wired through `access-mcp.ts` → `EngramAccessService.memoryOutcome()`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5fe73fe2a39982bcc5280b3791384b01900121fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->