### PR TITLE
feat(doctor): consolidation-provenance integrity check (issue #561 PR 4/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2088,6 +2088,29 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2088,29 +2088,6 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
-      "recallCrossNamespaceBudgetEnabled": {
-        "type": "boolean",
-        "default": false,
-        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
-      },
-      "recallCrossNamespaceBudgetWindowMs": {
-        "type": "number",
-        "minimum": 1,
-        "default": 60000,
-        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
-      },
-      "recallCrossNamespaceBudgetSoftLimit": {
-        "type": "number",
-        "minimum": 0,
-        "default": 10,
-        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
-      },
-      "recallCrossNamespaceBudgetHardLimit": {
-        "type": "number",
-        "minimum": 1,
-        "default": 30,
-        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
-      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2088,6 +2088,29 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -22,6 +22,10 @@ import { access, readFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import type { StorageManager } from "./storage.js";
 import { isConsolidationOperator } from "./consolidation-operator.js";
+// Import the canonical `sidecarKey` from page-versioning (PR #634
+// review, cursor Medium) so a future key-format change stays in
+// lock-step with the doctor scan.
+import { sidecarKey } from "./page-versioning.js";
 
 /**
  * Regex to spot a `derived_via: <value>` line in the raw YAML frontmatter
@@ -65,11 +69,6 @@ export interface ConsolidationProvenanceReport {
 }
 
 const DERIVED_FROM_ENTRY_RE = /^(.+):(\d+)$/;
-
-function sidecarKey(pageRelPath: string): string {
-  const withoutExt = pageRelPath.replace(/\.md$/i, "");
-  return withoutExt.replace(/[\\/]/g, "__");
-}
 
 /**
  * Build the on-disk snapshot path for a `"<relpath>:<version>"` entry,

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -263,15 +263,32 @@ export async function runConsolidationProvenanceCheck(options: {
     let rawDerivedFrom: string | undefined;
     let rawDerivedViaKeyPresent = false;
     let rawDerivedFromKeyPresent = false;
+    let duplicateViaKeys = false;
+    let duplicateFromKeys = false;
+    let viaMatchCount = 0;
+    let fromMatchCount = 0;
     let fmSlice = "";
     try {
       const raw = await readFile(memory.path, "utf-8");
       const frontmatterEnd = raw.indexOf("\n---", raw.indexOf("---") + 3);
       fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
-      const viaMatch = fmSlice.match(DERIVED_VIA_RAW_RE);
-      if (viaMatch) {
+      // Use matchAll to find ALL occurrences of `derived_via` / `derived_from`
+      // in the raw YAML.  `parseFrontmatter` keeps the LAST assignment when
+      // duplicate keys appear, so the doctor must read the last occurrence
+      // to match what the storage reader actually uses (PR #634 review,
+      // codex P2 — duplicate `derived_via` keys caused false-clean or
+      // false-unknown-operator warnings depending on order).
+      const viaMatches = [...fmSlice.matchAll(new RegExp(DERIVED_VIA_RAW_RE.source, DERIVED_VIA_RAW_RE.flags + "g"))];
+      viaMatchCount = viaMatches.length;
+      duplicateViaKeys = viaMatches.length > 1;
+      if (viaMatches.length > 0) {
         rawDerivedViaKeyPresent = true;
-        let val = viaMatch[1].trim();
+        // Use the last occurrence — `parseFrontmatter` keeps the last
+        // assignment when duplicate keys appear, so the doctor must
+        // match that behavior to produce accurate warnings (PR #634
+        // review, codex P2).
+        const lastVia = viaMatches[viaMatches.length - 1];
+        let val = lastVia[1].trim();
         if (
           (val.startsWith('"') && val.endsWith('"')) ||
           (val.startsWith("'") && val.endsWith("'"))
@@ -280,10 +297,13 @@ export async function runConsolidationProvenanceCheck(options: {
         }
         rawDerivedVia = val;
       }
-      const fromMatch = fmSlice.match(DERIVED_FROM_RAW_RE);
-      if (fromMatch) {
+      const fromMatches = [...fmSlice.matchAll(new RegExp(DERIVED_FROM_RAW_RE.source, DERIVED_FROM_RAW_RE.flags + "g"))];
+      fromMatchCount = fromMatches.length;
+      duplicateFromKeys = fromMatches.length > 1;
+      if (fromMatches.length > 0) {
         rawDerivedFromKeyPresent = true;
-        rawDerivedFrom = fromMatch[1].trim();
+        const lastFrom = fromMatches[fromMatches.length - 1];
+        rawDerivedFrom = lastFrom[1].trim();
       }
     } catch {
       // Fall through to the parsed values.
@@ -311,6 +331,27 @@ export async function runConsolidationProvenanceCheck(options: {
       !hasRawMalformedFrom && !hasBlankRawVia
     ) continue;
     report.withProvenance += 1;
+
+    // Duplicate-key detection (PR #634 review, codex P2): when the raw
+    // YAML contains multiple `derived_via` or `derived_from` lines,
+    // `parseFrontmatter` silently uses the last one.  Flag this as a
+    // malformed entry so operators can inspect and fix the file.
+    if (duplicateViaKeys) {
+      report.issues.push({
+        memoryPath: memory.path,
+        memoryId: fm.id,
+        kind: "derived_via_unknown_operator",
+        detail: `raw YAML contains ${viaMatchCount} "derived_via" keys; parseFrontmatter uses the last occurrence`,
+      });
+    }
+    if (duplicateFromKeys) {
+      report.issues.push({
+        memoryPath: memory.path,
+        memoryId: fm.id,
+        kind: "derived_from_malformed_entry",
+        detail: `raw YAML contains ${fromMatchCount} "derived_from" keys; parseFrontmatter uses the last occurrence`,
+      });
+    }
 
     if (hasRawMalformedFrom) {
       const display = rawDerivedFrom ?? "(blank)";

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -1,0 +1,180 @@
+/**
+ * Consolidation provenance integrity check (issue #561 PR 4).
+ *
+ * Validates that every memory carrying consolidation provenance frontmatter
+ * (`derived_from`, `derived_via`) resolves to real data:
+ *
+ *   - Each `derived_from` entry `"<path>:<version>"` must name a
+ *     page-version snapshot that exists on disk (via the sidecar layout
+ *     documented in `page-versioning.ts`).
+ *   - Each `derived_via` must be one of the known
+ *     `ConsolidationOperator` values — malformed values are surfaced as
+ *     warnings rather than crashes so legacy or future operators survive a
+ *     rollback.
+ *
+ * Non-fatal: every failure renders a warning with the offending file path
+ * and a human-readable reason.  Integrity problems are informational for
+ * now — we do not auto-heal or archive broken memories.
+ */
+
+import path from "node:path";
+import { access } from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import type { StorageManager } from "./storage.js";
+import { isConsolidationOperator } from "./consolidation-operator.js";
+
+/**
+ * One integrity warning attached to a specific memory.
+ */
+export interface ConsolidationProvenanceIssue {
+  /** Absolute path to the memory markdown file. */
+  memoryPath: string;
+  /** Memory id from frontmatter. */
+  memoryId: string;
+  /** Type of integrity issue. */
+  kind:
+    | "derived_from_missing_snapshot"
+    | "derived_from_malformed_entry"
+    | "derived_via_unknown_operator";
+  /** Human-readable detail — includes the offending value when relevant. */
+  detail: string;
+}
+
+/**
+ * Summary of a provenance-integrity scan.  Used by the operator-doctor
+ * report and surfaced in the CLI output.
+ */
+export interface ConsolidationProvenanceReport {
+  /** Total memories inspected. */
+  scanned: number;
+  /** Memories that carry `derived_from` and/or `derived_via`. */
+  withProvenance: number;
+  /** One entry per problem detected (may be empty). */
+  issues: ConsolidationProvenanceIssue[];
+}
+
+const DERIVED_FROM_ENTRY_RE = /^(.+):(\d+)$/;
+
+function sidecarKey(pageRelPath: string): string {
+  const withoutExt = pageRelPath.replace(/\.md$/i, "");
+  return withoutExt.replace(/[\\/]/g, "__");
+}
+
+/**
+ * Build the on-disk snapshot path for a `"<relpath>:<version>"` entry,
+ * relative to the given memory directory.  Mirrors the layout documented
+ * in `page-versioning.ts`:
+ *
+ *   memoryDir/<sidecarDir>/<sidecarKey>/<version><ext>
+ */
+function resolveSnapshotPath(
+  memoryDir: string,
+  sidecarDir: string,
+  entry: string,
+): { ok: true; snapshotPath: string } | { ok: false; reason: string } {
+  const match = entry.match(DERIVED_FROM_ENTRY_RE);
+  if (!match) {
+    return { ok: false, reason: `malformed entry (expected "<path>:<version>")` };
+  }
+  const pagePath = match[1];
+  const versionId = match[2];
+  const ext = path.extname(pagePath) || ".md";
+  const key = sidecarKey(pagePath);
+  const snapshotPath = path.join(memoryDir, sidecarDir, key, `${versionId}${ext}`);
+  return { ok: true, snapshotPath };
+}
+
+/**
+ * Scan every memory under `storage` and flag consolidation-provenance
+ * problems.  Does not throw on individual failures — collects them in the
+ * returned report.
+ */
+export async function runConsolidationProvenanceCheck(options: {
+  storage: StorageManager;
+  memoryDir: string;
+  /**
+   * Page-versioning sidecar directory name.  Defaults to `.versions` —
+   * matches the baked-in default used by `setVersioningConfig` when
+   * versioning is enabled via config.
+   */
+  sidecarDir?: string;
+}): Promise<ConsolidationProvenanceReport> {
+  const { storage, memoryDir } = options;
+  const sidecarDir = options.sidecarDir ?? ".versions";
+
+  const report: ConsolidationProvenanceReport = {
+    scanned: 0,
+    withProvenance: 0,
+    issues: [],
+  };
+
+  let memories;
+  try {
+    memories = await storage.readAllMemories();
+  } catch {
+    // If we can't enumerate memories at all, surface a single synthetic
+    // issue rather than throwing — the doctor wrapper treats an empty
+    // issues list as "ok" and we don't want a filesystem hiccup to crash
+    // the whole diagnostic.
+    return {
+      scanned: 0,
+      withProvenance: 0,
+      issues: [
+        {
+          memoryPath: memoryDir,
+          memoryId: "(unreadable)",
+          kind: "derived_from_malformed_entry",
+          detail: "Could not enumerate memory directory to scan provenance.",
+        },
+      ],
+    };
+  }
+
+  for (const memory of memories) {
+    report.scanned += 1;
+    const fm = memory.frontmatter;
+    const derivedFrom = fm.derived_from;
+    const derivedVia = fm.derived_via;
+
+    const hasFrom = Array.isArray(derivedFrom) && derivedFrom.length > 0;
+    const hasVia = derivedVia !== undefined && derivedVia !== null;
+    if (!hasFrom && !hasVia) continue;
+    report.withProvenance += 1;
+
+    if (hasFrom) {
+      for (const entry of derivedFrom!) {
+        const resolved = resolveSnapshotPath(memoryDir, sidecarDir, entry);
+        if (!resolved.ok) {
+          report.issues.push({
+            memoryPath: memory.path,
+            memoryId: fm.id,
+            kind: "derived_from_malformed_entry",
+            detail: `${JSON.stringify(entry)}: ${resolved.reason}`,
+          });
+          continue;
+        }
+        try {
+          await access(resolved.snapshotPath, fsConstants.F_OK);
+        } catch {
+          report.issues.push({
+            memoryPath: memory.path,
+            memoryId: fm.id,
+            kind: "derived_from_missing_snapshot",
+            detail: `${entry} → ${resolved.snapshotPath} (not found)`,
+          });
+        }
+      }
+    }
+
+    if (hasVia && !isConsolidationOperator(derivedVia)) {
+      report.issues.push({
+        memoryPath: memory.path,
+        memoryId: fm.id,
+        kind: "derived_via_unknown_operator",
+        detail: `unknown operator: ${JSON.stringify(derivedVia)}`,
+      });
+    }
+  }
+
+  return report;
+}

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -18,10 +18,20 @@
  */
 
 import path from "node:path";
-import { access } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import type { StorageManager } from "./storage.js";
 import { isConsolidationOperator } from "./consolidation-operator.js";
+
+/**
+ * Regex to spot a `derived_via: <value>` line in the raw YAML frontmatter
+ * between the opening and first closing `---` delimiters.  We use the raw
+ * text rather than the parsed `frontmatter.derived_via` because the
+ * read-path parser coerces unknown values back to `undefined` — that
+ * would silently hide corrupted-or-future operators from the doctor scan
+ * (PR #634 review feedback, codex P2).
+ */
+const DERIVED_VIA_RAW_RE = /^derived_via:\s*(.+)$/mu;
 
 /**
  * One integrity warning attached to a specific memory.
@@ -136,9 +146,37 @@ export async function runConsolidationProvenanceCheck(options: {
     const derivedFrom = fm.derived_from;
     const derivedVia = fm.derived_via;
 
+    // Raw `derived_via` from disk — the read-path parser coerces unknown
+    // values to `undefined`, so we re-extract from the raw YAML to flag
+    // corrupted or future operator values that would otherwise be hidden
+    // (PR #634 review feedback, codex P2).  Best-effort: if the file
+    // can't be read, we fall through to the parsed value and silently
+    // accept that we may miss a rare corruption case.
+    let rawDerivedVia: string | undefined;
+    try {
+      const raw = await readFile(memory.path, "utf-8");
+      const frontmatterEnd = raw.indexOf("\n---", raw.indexOf("---") + 3);
+      const fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
+      const match = fmSlice.match(DERIVED_VIA_RAW_RE);
+      if (match) {
+        // Strip surrounding quotes (single or double) and whitespace.
+        let val = match[1].trim();
+        if (
+          (val.startsWith('"') && val.endsWith('"')) ||
+          (val.startsWith("'") && val.endsWith("'"))
+        ) {
+          val = val.slice(1, -1);
+        }
+        rawDerivedVia = val;
+      }
+    } catch {
+      // Fall through to the parsed value.
+    }
+
     const hasFrom = Array.isArray(derivedFrom) && derivedFrom.length > 0;
     const hasVia = derivedVia !== undefined && derivedVia !== null;
-    if (!hasFrom && !hasVia) continue;
+    const hasRawVia = rawDerivedVia !== undefined && rawDerivedVia.length > 0;
+    if (!hasFrom && !hasVia && !hasRawVia) continue;
     report.withProvenance += 1;
 
     if (hasFrom) {
@@ -166,12 +204,15 @@ export async function runConsolidationProvenanceCheck(options: {
       }
     }
 
-    if (hasVia && !isConsolidationOperator(derivedVia)) {
+    // Check the RAW YAML value for unknown operators.  The parsed value
+    // (`fm.derived_via`) is always known-good because the read-path
+    // normalizer dropped anything else to undefined.
+    if (hasRawVia && !isConsolidationOperator(rawDerivedVia)) {
       report.issues.push({
         memoryPath: memory.path,
         memoryId: fm.id,
         kind: "derived_via_unknown_operator",
-        detail: `unknown operator: ${JSON.stringify(derivedVia)}`,
+        detail: `unknown operator: ${JSON.stringify(rawDerivedVia)}`,
       });
     }
   }

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -37,9 +37,11 @@ import { sidecarKey } from "./page-versioning.js";
  */
 // Allow empty capture groups so truncated/blank `derived_via:` and
 // `derived_from:` lines (key present, no value) are distinguishable
-// from "key missing entirely" (regex returns null).
-const DERIVED_VIA_RAW_RE = /^derived_via:[\t ]*(.*)$/mu;
-const DERIVED_FROM_RAW_RE = /^derived_from:[\t ]*(.*)$/mu;
+// from "key missing entirely" (regex returns null).  Optional
+// leading whitespace accepts indented keys which `parseFrontmatter`
+// also accepts (PR #634 round-6 review, codex P2).
+const DERIVED_VIA_RAW_RE = /^[\t ]*derived_via:[\t ]*(.*)$/mu;
+const DERIVED_FROM_RAW_RE = /^[\t ]*derived_from:[\t ]*(.*)$/mu;
 
 /**
  * Tokenize a YAML-block-style list under `key:` in the given

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -18,7 +18,7 @@
  */
 
 import path from "node:path";
-import { access, readFile } from "node:fs/promises";
+import { access, readdir, readFile, stat } from "node:fs/promises";
 import { constants as fsConstants } from "node:fs";
 import type { StorageManager } from "./storage.js";
 import { isConsolidationOperator } from "./consolidation-operator.js";
@@ -40,6 +40,60 @@ import { sidecarKey } from "./page-versioning.js";
 // from "key missing entirely" (regex returns null).
 const DERIVED_VIA_RAW_RE = /^derived_via:[\t ]*(.*)$/mu;
 const DERIVED_FROM_RAW_RE = /^derived_from:[\t ]*(.*)$/mu;
+
+/**
+ * Tokenize a YAML-flow-style list (`["a", "b", ...]`) into a flat
+ * string array.  Returns `null` when the input isn't a flow list.
+ * Best-effort — we don't implement a full YAML parser, just enough to
+ * detect mixed valid/invalid entries for the doctor integrity check.
+ */
+function tokenizeRawFlowList(raw: string): string[] | null {
+  const trimmed = raw.trim();
+  if (!trimmed.startsWith("[") || !trimmed.endsWith("]")) return null;
+  const inner = trimmed.slice(1, -1);
+  const parts: string[] = [];
+  let current = "";
+  let inSingle = false;
+  let inDouble = false;
+  for (let i = 0; i < inner.length; i++) {
+    const ch = inner[i];
+    if (inDouble) {
+      if (ch === "\\" && i + 1 < inner.length) {
+        current += inner[++i];
+        continue;
+      }
+      if (ch === '"') {
+        inDouble = false;
+        continue;
+      }
+      current += ch;
+    } else if (inSingle) {
+      if (ch === "'" && inner[i + 1] === "'") {
+        current += "'";
+        i++;
+        continue;
+      }
+      if (ch === "'") {
+        inSingle = false;
+        continue;
+      }
+      current += ch;
+    } else if (ch === '"') {
+      inDouble = true;
+    } else if (ch === "'") {
+      inSingle = true;
+    } else if (ch === ",") {
+      parts.push(current.trim());
+      current = "";
+    } else {
+      current += ch;
+    }
+  }
+  if (current.trim().length > 0 || parts.length > 0) {
+    parts.push(current.trim());
+  }
+  return parts;
+}
 
 /**
  * One integrity warning attached to a specific memory.
@@ -219,6 +273,42 @@ export async function runConsolidationProvenanceCheck(options: {
         detail: `raw YAML "derived_from: ${display}" could not be parsed as a list`,
       });
     }
+
+    // Mixed-list detection (PR #634 round-4 review, codex P2): when
+    // the parser DID return a valid list but the raw YAML includes
+    // additional tokens that got dropped (e.g. `"..." , ""` with an
+    // empty string among valid entries), flag those as malformed.  We
+    // tokenize the raw `derived_from` list in a minimal way: split on
+    // commas outside quotes, trim, and validate each piece.  If the
+    // tokenized count exceeds the parsed-array length, some entries
+    // were dropped — flag the remainder as malformed.
+    if (hasFrom && rawDerivedFromKeyPresent && rawDerivedFrom) {
+      const rawList = tokenizeRawFlowList(rawDerivedFrom);
+      if (rawList !== null && rawList.length > derivedFrom!.length) {
+        for (const tok of rawList) {
+          if (tok.length === 0) {
+            report.issues.push({
+              memoryPath: memory.path,
+              memoryId: fm.id,
+              kind: "derived_from_malformed_entry",
+              detail: `raw YAML derived_from contains an empty entry (mixed list)`,
+            });
+            continue;
+          }
+          if (!derivedFrom!.includes(tok)) {
+            // A non-empty token the parser dropped — surface it.
+            if (!/^(.+):(\d+)$/u.test(tok)) {
+              report.issues.push({
+                memoryPath: memory.path,
+                memoryId: fm.id,
+                kind: "derived_from_malformed_entry",
+                detail: `raw YAML derived_from contains a malformed entry: ${JSON.stringify(tok)}`,
+              });
+            }
+          }
+        }
+      }
+    }
     if (hasBlankRawVia) {
       report.issues.push({
         memoryPath: memory.path,
@@ -266,5 +356,64 @@ export async function runConsolidationProvenanceCheck(options: {
     }
   }
 
+  // Parse-failure detection (PR #634 round-4 review, codex P2):
+  // `readAllMemories()` silently drops files whose frontmatter
+  // doesn't parse.  Walk the facts/ and corrections/ directories for
+  // `.md` files that DO reference provenance frontmatter but didn't
+  // come back from the reader — those are the corruption cases the
+  // doctor is meant to surface.
+  try {
+    const seenPaths = new Set(memories.map((m) => m.path));
+    const scanRoots = ["facts", "corrections", "procedures"];
+    for (const rootName of scanRoots) {
+      const rootPath = path.join(memoryDir, rootName);
+      for await (const file of walkMarkdownFiles(rootPath)) {
+        if (seenPaths.has(file)) continue;
+        try {
+          const raw = await readFile(file, "utf-8");
+          if (
+            DERIVED_FROM_RAW_RE.test(raw) ||
+            DERIVED_VIA_RAW_RE.test(raw)
+          ) {
+            report.withProvenance += 1;
+            report.issues.push({
+              memoryPath: file,
+              memoryId: "(parse failed)",
+              kind: "derived_from_malformed_entry",
+              detail:
+                "frontmatter could not be parsed by storage reader; provenance fields visible in raw YAML",
+            });
+          }
+        } catch {
+          // Unreadable file — skip.
+        }
+      }
+    }
+  } catch {
+    // Best-effort; don't fail the whole scan on a filesystem hiccup.
+  }
+
   return report;
+}
+
+/**
+ * Recursively yield all `.md` file paths under `root`.  Silent on
+ * missing directories — the facts/corrections dirs may not exist in
+ * fresh installs.
+ */
+async function* walkMarkdownFiles(root: string): AsyncGenerator<string> {
+  let entries;
+  try {
+    entries = await readdir(root, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries) {
+    const full = path.join(root, entry.name);
+    if (entry.isDirectory()) {
+      yield* walkMarkdownFiles(full);
+    } else if (entry.isFile() && entry.name.endsWith(".md")) {
+      yield full;
+    }
+  }
 }

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -32,6 +32,7 @@ import { isConsolidationOperator } from "./consolidation-operator.js";
  * (PR #634 review feedback, codex P2).
  */
 const DERIVED_VIA_RAW_RE = /^derived_via:\s*(.+)$/mu;
+const DERIVED_FROM_RAW_RE = /^derived_from:\s*(.+)$/mu;
 
 /**
  * One integrity warning attached to a specific memory.
@@ -146,21 +147,22 @@ export async function runConsolidationProvenanceCheck(options: {
     const derivedFrom = fm.derived_from;
     const derivedVia = fm.derived_via;
 
-    // Raw `derived_via` from disk — the read-path parser coerces unknown
-    // values to `undefined`, so we re-extract from the raw YAML to flag
-    // corrupted or future operator values that would otherwise be hidden
-    // (PR #634 review feedback, codex P2).  Best-effort: if the file
-    // can't be read, we fall through to the parsed value and silently
-    // accept that we may miss a rare corruption case.
+    // Raw frontmatter values from disk — the read-path parser coerces
+    // malformed `derived_from` and unknown `derived_via` back to
+    // `undefined`, which would silently hide on-disk corruption from
+    // the doctor scan (PR #634 review feedback, codex P2).  We
+    // re-extract both via regex so integrity issues are reported even
+    // when the parser normalized them away.  Best-effort: if the file
+    // can't be read, we fall through to the parsed values.
     let rawDerivedVia: string | undefined;
+    let rawDerivedFrom: string | undefined;
     try {
       const raw = await readFile(memory.path, "utf-8");
       const frontmatterEnd = raw.indexOf("\n---", raw.indexOf("---") + 3);
       const fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
-      const match = fmSlice.match(DERIVED_VIA_RAW_RE);
-      if (match) {
-        // Strip surrounding quotes (single or double) and whitespace.
-        let val = match[1].trim();
+      const viaMatch = fmSlice.match(DERIVED_VIA_RAW_RE);
+      if (viaMatch) {
+        let val = viaMatch[1].trim();
         if (
           (val.startsWith('"') && val.endsWith('"')) ||
           (val.startsWith("'") && val.endsWith("'"))
@@ -169,15 +171,38 @@ export async function runConsolidationProvenanceCheck(options: {
         }
         rawDerivedVia = val;
       }
+      const fromMatch = fmSlice.match(DERIVED_FROM_RAW_RE);
+      if (fromMatch) {
+        rawDerivedFrom = fromMatch[1].trim();
+      }
     } catch {
-      // Fall through to the parsed value.
+      // Fall through to the parsed values.
     }
 
     const hasFrom = Array.isArray(derivedFrom) && derivedFrom.length > 0;
     const hasVia = derivedVia !== undefined && derivedVia !== null;
     const hasRawVia = rawDerivedVia !== undefined && rawDerivedVia.length > 0;
-    if (!hasFrom && !hasVia && !hasRawVia) continue;
+    // A raw `derived_from` that the parser dropped indicates on-disk
+    // corruption we must surface.  We detect this by: (a) the raw YAML
+    // contains a `derived_from:` key with a non-empty value, AND (b)
+    // the parsed frontmatter has no valid array.  A scalar like
+    // `derived_from: facts/a.md:7` (list brackets omitted) hits this
+    // branch because the parser requires flow or block list syntax.
+    const hasRawMalformedFrom =
+      rawDerivedFrom !== undefined &&
+      rawDerivedFrom.length > 0 &&
+      !hasFrom;
+    if (!hasFrom && !hasVia && !hasRawVia && !hasRawMalformedFrom) continue;
     report.withProvenance += 1;
+
+    if (hasRawMalformedFrom) {
+      report.issues.push({
+        memoryPath: memory.path,
+        memoryId: fm.id,
+        kind: "derived_from_malformed_entry",
+        detail: `raw YAML "derived_from: ${rawDerivedFrom}" could not be parsed as a list`,
+      });
+    }
 
     if (hasFrom) {
       for (const entry of derivedFrom!) {

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -42,6 +42,49 @@ const DERIVED_VIA_RAW_RE = /^derived_via:[\t ]*(.*)$/mu;
 const DERIVED_FROM_RAW_RE = /^derived_from:[\t ]*(.*)$/mu;
 
 /**
+ * Tokenize a YAML-block-style list under `key:` in the given
+ * frontmatter slice.  Looks for lines matching `^  - <value>` after a
+ * `key:` line and before the next non-list line.  Returns `null` when
+ * the key is missing or the value is a scalar / flow list (no block
+ * entries found).
+ *
+ * Only used for the mixed-list malformed-entry detection — it does
+ * not try to decode YAML escape sequences since we only need the
+ * entry count + raw token text to compare against the parsed array.
+ */
+function tokenizeRawBlockList(fmSlice: string, key: string): string[] | null {
+  const lines = fmSlice.split("\n");
+  const keyPrefix = `${key}:`;
+  let startIdx = -1;
+  for (let i = 0; i < lines.length; i++) {
+    if (lines[i].startsWith(keyPrefix)) {
+      const after = lines[i].slice(keyPrefix.length).trim();
+      if (after.length === 0) {
+        startIdx = i + 1;
+      }
+      break;
+    }
+  }
+  if (startIdx < 0) return null;
+  const items: string[] = [];
+  for (let i = startIdx; i < lines.length; i++) {
+    const line = lines[i];
+    if (!/^\s+-/.test(line)) break; // not a block-list entry
+    const m = line.match(/^\s+-\s*(.*)$/u);
+    if (!m) break;
+    let tok = m[1].trim();
+    if (
+      (tok.startsWith('"') && tok.endsWith('"') && tok.length >= 2) ||
+      (tok.startsWith("'") && tok.endsWith("'") && tok.length >= 2)
+    ) {
+      tok = tok.slice(1, -1);
+    }
+    items.push(tok);
+  }
+  return items.length > 0 ? items : null;
+}
+
+/**
  * Tokenize a YAML-flow-style list (`["a", "b", ...]`) into a flat
  * string array.  Returns `null` when the input isn't a flow list.
  * Best-effort — we don't implement a full YAML parser, just enough to
@@ -216,10 +259,11 @@ export async function runConsolidationProvenanceCheck(options: {
     let rawDerivedFrom: string | undefined;
     let rawDerivedViaKeyPresent = false;
     let rawDerivedFromKeyPresent = false;
+    let fmSlice = "";
     try {
       const raw = await readFile(memory.path, "utf-8");
       const frontmatterEnd = raw.indexOf("\n---", raw.indexOf("---") + 3);
-      const fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
+      fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
       const viaMatch = fmSlice.match(DERIVED_VIA_RAW_RE);
       if (viaMatch) {
         rawDerivedViaKeyPresent = true;
@@ -274,16 +318,22 @@ export async function runConsolidationProvenanceCheck(options: {
       });
     }
 
-    // Mixed-list detection (PR #634 round-4 review, codex P2): when
-    // the parser DID return a valid list but the raw YAML includes
-    // additional tokens that got dropped (e.g. `"..." , ""` with an
-    // empty string among valid entries), flag those as malformed.  We
-    // tokenize the raw `derived_from` list in a minimal way: split on
-    // commas outside quotes, trim, and validate each piece.  If the
-    // tokenized count exceeds the parsed-array length, some entries
-    // were dropped — flag the remainder as malformed.
-    if (hasFrom && rawDerivedFromKeyPresent && rawDerivedFrom) {
-      const rawList = tokenizeRawFlowList(rawDerivedFrom);
+    // Mixed-list detection (PR #634 round-4 + round-5 review, codex
+    // P2): when the parser DID return a valid list but the raw YAML
+    // includes additional tokens that got dropped, flag those as
+    // malformed.  Handles both flow-style (`["a", "", "b"]`) and
+    // block-style (`\n  - a\n  - \n  - b`) YAML lists.
+    if (hasFrom && rawDerivedFromKeyPresent) {
+      let rawList: string[] | null = null;
+      if (rawDerivedFrom && rawDerivedFrom.length > 0) {
+        rawList = tokenizeRawFlowList(rawDerivedFrom);
+      }
+      if (rawList === null) {
+        // Fall back to block-list tokenization by re-reading the full
+        // frontmatter (already loaded above as `raw`) and scanning
+        // the lines following `derived_from:`.
+        rawList = tokenizeRawBlockList(fmSlice, "derived_from");
+      }
       if (rawList !== null && rawList.length > derivedFrom!.length) {
         for (const tok of rawList) {
           if (tok.length === 0) {
@@ -296,7 +346,6 @@ export async function runConsolidationProvenanceCheck(options: {
             continue;
           }
           if (!derivedFrom!.includes(tok)) {
-            // A non-empty token the parser dropped — surface it.
             if (!/^(.+):(\d+)$/u.test(tok)) {
               report.issues.push({
                 memoryPath: memory.path,

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -56,12 +56,14 @@ const DERIVED_FROM_RAW_RE = /^[\t ]*derived_from:[\t ]*(.*)$/mu;
  */
 function tokenizeRawBlockList(fmSlice: string, key: string): string[] | null {
   const lines = fmSlice.split("\n");
-  const keyPrefix = `${key}:`;
+  // Accept indented keys too — parseFrontmatter does (PR #634 round-7
+  // review, codex P2 / cursor Low).
+  const keyRe = new RegExp(`^[\\t ]*${key}:[\\t ]*(.*)$`, "u");
   let startIdx = -1;
   for (let i = 0; i < lines.length; i++) {
-    if (lines[i].startsWith(keyPrefix)) {
-      const after = lines[i].slice(keyPrefix.length).trim();
-      if (after.length === 0) {
+    const m = lines[i].match(keyRe);
+    if (m) {
+      if (m[1].trim().length === 0) {
         startIdx = i + 1;
       }
       break;

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -35,8 +35,11 @@ import { sidecarKey } from "./page-versioning.js";
  * would silently hide corrupted-or-future operators from the doctor scan
  * (PR #634 review feedback, codex P2).
  */
-const DERIVED_VIA_RAW_RE = /^derived_via:\s*(.+)$/mu;
-const DERIVED_FROM_RAW_RE = /^derived_from:\s*(.+)$/mu;
+// Allow empty capture groups so truncated/blank `derived_via:` and
+// `derived_from:` lines (key present, no value) are distinguishable
+// from "key missing entirely" (regex returns null).
+const DERIVED_VIA_RAW_RE = /^derived_via:[\t ]*(.*)$/mu;
+const DERIVED_FROM_RAW_RE = /^derived_from:[\t ]*(.*)$/mu;
 
 /**
  * One integrity warning attached to a specific memory.
@@ -151,16 +154,21 @@ export async function runConsolidationProvenanceCheck(options: {
     // `undefined`, which would silently hide on-disk corruption from
     // the doctor scan (PR #634 review feedback, codex P2).  We
     // re-extract both via regex so integrity issues are reported even
-    // when the parser normalized them away.  Best-effort: if the file
-    // can't be read, we fall through to the parsed values.
+    // when the parser normalized them away.  `rawDerivedVia` /
+    // `rawDerivedFrom` being `""` (empty string) represents a
+    // corrupted file with the key present but the value truncated —
+    // that's distinct from "key missing entirely" (undefined).
     let rawDerivedVia: string | undefined;
     let rawDerivedFrom: string | undefined;
+    let rawDerivedViaKeyPresent = false;
+    let rawDerivedFromKeyPresent = false;
     try {
       const raw = await readFile(memory.path, "utf-8");
       const frontmatterEnd = raw.indexOf("\n---", raw.indexOf("---") + 3);
       const fmSlice = frontmatterEnd > 0 ? raw.slice(0, frontmatterEnd) : raw;
       const viaMatch = fmSlice.match(DERIVED_VIA_RAW_RE);
       if (viaMatch) {
+        rawDerivedViaKeyPresent = true;
         let val = viaMatch[1].trim();
         if (
           (val.startsWith('"') && val.endsWith('"')) ||
@@ -172,6 +180,7 @@ export async function runConsolidationProvenanceCheck(options: {
       }
       const fromMatch = fmSlice.match(DERIVED_FROM_RAW_RE);
       if (fromMatch) {
+        rawDerivedFromKeyPresent = true;
         rawDerivedFrom = fromMatch[1].trim();
       }
     } catch {
@@ -183,23 +192,39 @@ export async function runConsolidationProvenanceCheck(options: {
     const hasRawVia = rawDerivedVia !== undefined && rawDerivedVia.length > 0;
     // A raw `derived_from` that the parser dropped indicates on-disk
     // corruption we must surface.  We detect this by: (a) the raw YAML
-    // contains a `derived_from:` key with a non-empty value, AND (b)
-    // the parsed frontmatter has no valid array.  A scalar like
-    // `derived_from: facts/a.md:7` (list brackets omitted) hits this
-    // branch because the parser requires flow or block list syntax.
-    const hasRawMalformedFrom =
-      rawDerivedFrom !== undefined &&
-      rawDerivedFrom.length > 0 &&
-      !hasFrom;
-    if (!hasFrom && !hasVia && !hasRawVia && !hasRawMalformedFrom) continue;
+    // contains a `derived_from:` key, AND (b) the parsed frontmatter
+    // has no valid array.  A scalar like `derived_from: facts/a.md:7`
+    // (list brackets omitted) or a blank `derived_from:` both hit this
+    // branch.
+    const hasRawMalformedFrom = rawDerivedFromKeyPresent && !hasFrom;
+    // A blank `derived_via:` with no value is also corrupt — the
+    // parser drops it to undefined, but the raw key is still present
+    // on disk (PR #634 round-3 review, codex P2).
+    const hasBlankRawVia =
+      rawDerivedViaKeyPresent &&
+      (rawDerivedVia === undefined || rawDerivedVia.length === 0) &&
+      !hasVia;
+    if (
+      !hasFrom && !hasVia && !hasRawVia &&
+      !hasRawMalformedFrom && !hasBlankRawVia
+    ) continue;
     report.withProvenance += 1;
 
     if (hasRawMalformedFrom) {
+      const display = rawDerivedFrom ?? "(blank)";
       report.issues.push({
         memoryPath: memory.path,
         memoryId: fm.id,
         kind: "derived_from_malformed_entry",
-        detail: `raw YAML "derived_from: ${rawDerivedFrom}" could not be parsed as a list`,
+        detail: `raw YAML "derived_from: ${display}" could not be parsed as a list`,
+      });
+    }
+    if (hasBlankRawVia) {
+      report.issues.push({
+        memoryPath: memory.path,
+        memoryId: fm.id,
+        kind: "derived_via_unknown_operator",
+        detail: "raw YAML has `derived_via:` key with empty value",
       });
     }
 

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -467,7 +467,7 @@ export async function runConsolidationProvenanceCheck(options: {
   // doctor is meant to surface.
   try {
     const seenPaths = new Set(memories.map((m) => m.path));
-    const scanRoots = ["facts", "corrections", "procedures"];
+    const scanRoots = ["facts", "corrections", "procedures", "reasoning-traces"];
     for (const rootName of scanRoots) {
       const rootPath = path.join(memoryDir, rootName);
       for await (const file of walkMarkdownFiles(rootPath)) {

--- a/packages/remnic-core/src/consolidation-provenance-check.ts
+++ b/packages/remnic-core/src/consolidation-provenance-check.ts
@@ -383,14 +383,23 @@ export async function runConsolidationProvenanceCheck(options: {
           });
           continue;
         }
+        // Require a regular file at the snapshot path (PR #634
+        // round-8 review, codex P2) — a directory or device node at
+        // that path means the sidecar was corrupted and the snapshot
+        // is effectively missing.
+        let snapshotOk = false;
         try {
-          await access(resolved.snapshotPath, fsConstants.F_OK);
+          const st = await stat(resolved.snapshotPath);
+          snapshotOk = st.isFile();
         } catch {
+          snapshotOk = false;
+        }
+        if (!snapshotOk) {
           report.issues.push({
             memoryPath: memory.path,
             memoryId: fm.id,
             kind: "derived_from_missing_snapshot",
-            detail: `${entry} → ${resolved.snapshotPath} (not found)`,
+            detail: `${entry} → ${resolved.snapshotPath} (not a regular file)`,
           });
         }
       }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -35,6 +35,10 @@ import {
   listMemoryGovernanceRuns,
   readMemoryGovernanceRunArtifact,
 } from "./maintenance/memory-governance.js";
+import {
+  runConsolidationProvenanceCheck,
+  type ConsolidationProvenanceReport,
+} from "./consolidation-provenance-check.js";
 import type { FileHygieneConfig, MemoryFile, PluginConfig } from "./types.js";
 
 interface QmdRuntimeLike {
@@ -1175,6 +1179,15 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // This is an informational check, never an error.
   checks.push(await summarizeMemoryWorthLegacyCounters(new StorageManager(config.memoryDir)));
 
+  // Consolidation provenance integrity (issue #561 PR 4).
+  // Validates that every `derived_from` entry resolves to an on-disk
+  // page-version snapshot and every `derived_via` is a known operator.
+  // Broken provenance emits warnings with the offending file path — the
+  // check is informational (never an error) because a missing snapshot
+  // can legitimately occur after log pruning or versioning being disabled
+  // retroactively; operators need visibility, not a hard fail.
+  checks.push(await summarizeConsolidationProvenance(new StorageManager(config.memoryDir), config));
+
   const summary = checks.reduce(
     (acc, check) => {
       acc[check.status] += 1;
@@ -1266,6 +1279,59 @@ export async function summarizeMemoryWorthLegacyCounters(
         ? "No Memory Worth–eligible memories on disk yet — counters will populate as facts are extracted."
         : `${legacy} of ${total} eligible memories have no Memory Worth counters yet (${instrumented} instrumented).`,
     details: { legacy, instrumented, total, ineligible },
+  };
+}
+
+/**
+ * Summarize the consolidation-provenance integrity scan for the doctor
+ * report (issue #561 PR 4).  Returns an `ok` check when no issues are
+ * found, `warn` otherwise.  Never returns `error` — a broken provenance
+ * pointer is informational because it can legitimately result from log
+ * pruning, versioning being disabled retroactively, or operator-driven
+ * archive operations.
+ *
+ * Exported so unit tests can exercise the summarization without booting a
+ * full orchestrator.
+ */
+export async function summarizeConsolidationProvenance(
+  storage: StorageManager,
+  config: Pick<PluginConfig, "memoryDir">,
+): Promise<OperatorDoctorCheck> {
+  let report: ConsolidationProvenanceReport;
+  try {
+    report = await runConsolidationProvenanceCheck({
+      storage,
+      memoryDir: config.memoryDir,
+    });
+  } catch (err) {
+    return {
+      key: "consolidation_provenance",
+      status: "warn",
+      summary: "Could not run consolidation-provenance integrity check.",
+      remediation: "Ensure the memory directory is readable and rerun `remnic doctor`.",
+      details: { error: String(err) },
+    };
+  }
+
+  if (report.issues.length === 0) {
+    return {
+      key: "consolidation_provenance",
+      status: "ok",
+      summary:
+        report.withProvenance === 0
+          ? "No consolidation-provenance memories on disk yet."
+          : `${report.withProvenance} consolidation-provenance memories verified (no broken references).`,
+      details: report,
+    };
+  }
+
+  return {
+    key: "consolidation_provenance",
+    status: "warn",
+    summary: `${report.issues.length} consolidation-provenance integrity issue(s) detected across ${report.withProvenance} memories with provenance frontmatter.`,
+    remediation:
+      "Broken pointers are informational. Inspect flagged memories, and if they should resolve, re-snapshot via a consolidation pass or accept pruning.",
+    details: report,
   };
 }
 

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1299,7 +1299,7 @@ export async function summarizeMemoryWorthLegacyCounters(
  */
 export async function summarizeConsolidationProvenance(
   storage: StorageManager,
-  config: Pick<PluginConfig, "memoryDir" | "versioningSidecarDir">,
+  config: Pick<PluginConfig, "memoryDir"> & { versioningSidecarDir?: string },
 ): Promise<OperatorDoctorCheck> {
   let report: ConsolidationProvenanceReport;
   try {

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1185,7 +1185,11 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // Broken provenance emits warnings with the offending file path — the
   // check is informational (never an error) because a missing snapshot
   // can legitimately occur after log pruning or versioning being disabled
-  // retroactively; operators need visibility, not a hard fail.
+  // retroactively; operators need visibility, not a hard fail.  Review
+  // feedback (PR #634): the summarizer threads the configured
+  // `versioningSidecarDir` into the scan so deployments that override
+  // the default `.versions` directory get accurate results instead of
+  // false-missing warnings.
   checks.push(await summarizeConsolidationProvenance(new StorageManager(config.memoryDir), config));
 
   const summary = checks.reduce(
@@ -1295,13 +1299,18 @@ export async function summarizeMemoryWorthLegacyCounters(
  */
 export async function summarizeConsolidationProvenance(
   storage: StorageManager,
-  config: Pick<PluginConfig, "memoryDir">,
+  config: Pick<PluginConfig, "memoryDir" | "versioningSidecarDir">,
 ): Promise<OperatorDoctorCheck> {
   let report: ConsolidationProvenanceReport;
   try {
     report = await runConsolidationProvenanceCheck({
       storage,
       memoryDir: config.memoryDir,
+      // Honor the configured sidecar directory (PR #634 review): when an
+      // operator overrides `versioningSidecarDir`, the default `.versions`
+      // would point at the wrong location and every entry would report as
+      // missing.  Undefined falls back to the helper's default.
+      sidecarDir: config.versioningSidecarDir,
     });
   } catch (err) {
     return {

--- a/packages/remnic-core/src/page-versioning.ts
+++ b/packages/remnic-core/src/page-versioning.ts
@@ -92,8 +92,13 @@ function contentHash(content: string): string {
  * Derive a filesystem-safe sidecar key from a page path relative to memoryDir.
  *
  * `facts/2026-01-15/pref-001.md` -> `facts__2026-01-15__pref-001`
+ *
+ * Exported so the `remnic doctor` consolidation-provenance check (issue
+ * #561 PR 4) resolves snapshot locations using the canonical algorithm
+ * without re-implementing it — preventing silent drift if the key
+ * format ever changes.
  */
-function sidecarKey(pagePath: string): string {
+export function sidecarKey(pagePath: string): string {
   const withoutExt = pagePath.replace(/\.md$/i, "");
   return withoutExt.replace(/[\\/]/g, "__");
 }

--- a/src/consolidation-provenance-check.ts
+++ b/src/consolidation-provenance-check.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/consolidation-provenance-check.js";

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the consolidation-provenance integrity check (issue #561 PR 4).
+ *
+ * Covers:
+ *   - Memories with valid `derived_from` + `derived_via` produce zero
+ *     issues.
+ *   - Memories whose `derived_from` points at a missing snapshot surface
+ *     a `derived_from_missing_snapshot` warning.
+ *   - Malformed entries (e.g. wrong shape, non-numeric version) surface a
+ *     `derived_from_malformed_entry` warning.
+ *   - Unknown `derived_via` values surface a
+ *     `derived_via_unknown_operator` warning.
+ *   - The operator-doctor summary wrapper maps clean reports to "ok" and
+ *     issue-bearing reports to "warn".
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { StorageManager } from "../src/storage.ts";
+import {
+  runConsolidationProvenanceCheck,
+  type ConsolidationProvenanceReport,
+} from "../src/consolidation-provenance-check.ts";
+import { summarizeConsolidationProvenance } from "../src/operator-toolkit.ts";
+
+const versioning = { enabled: true, maxVersionsPerPage: 10, sidecarDir: ".versions" } as const;
+
+async function seedStorage(dir: string): Promise<StorageManager> {
+  const storage = new StorageManager(dir);
+  storage.setVersioningConfig({ ...versioning });
+  await storage.ensureDirectories();
+  return storage;
+}
+
+test("runConsolidationProvenanceCheck returns an empty report on a clean store", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-clean-"));
+  try {
+    const storage = await seedStorage(dir);
+    // Write a canonical memory whose derived_from entries match snapshots
+    // captured before writing — mirrors PR 2's happy path.
+    const srcAId = await storage.writeMemory("fact", "alpha", { source: "extraction" });
+    const srcBId = await storage.writeMemory("fact", "bravo", { source: "extraction" });
+    const all = await storage.readAllMemories();
+    const srcA = all.find((m) => m.frontmatter.id === srcAId);
+    const srcB = all.find((m) => m.frontmatter.id === srcBId);
+    assert.ok(srcA && srcB);
+
+    const entryA = await storage.snapshotForProvenance(srcA.path);
+    const entryB = await storage.snapshotForProvenance(srcB.path);
+    assert.ok(entryA && entryB);
+
+    await storage.writeMemory("fact", "canonical", {
+      source: "semantic-consolidation",
+      derivedFrom: [entryA, entryB],
+      derivedVia: "merge",
+    });
+
+    const report: ConsolidationProvenanceReport = await runConsolidationProvenanceCheck({
+      storage,
+      memoryDir: dir,
+    });
+
+    assert.equal(report.issues.length, 0, `clean store should produce zero issues; got ${JSON.stringify(report.issues)}`);
+    assert.equal(report.withProvenance, 1);
+    assert.ok(report.scanned >= 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runConsolidationProvenanceCheck flags derived_from entries pointing at missing snapshots", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-missing-"));
+  try {
+    const storage = await seedStorage(dir);
+
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-bad-ref";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      'tags: ["consolidation"]',
+      'derived_from: ["facts/ghost.md:99"]',
+      "derived_via: merge",
+      "---",
+      "",
+      "canonical body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    assert.equal(report.issues.length, 1);
+    const issue = report.issues[0];
+    assert.equal(issue.kind, "derived_from_missing_snapshot");
+    assert.equal(issue.memoryId, id);
+    assert.ok(issue.detail.includes("facts/ghost.md:99"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runConsolidationProvenanceCheck flags unknown derived_via operators", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-unknown-op-"));
+  try {
+    const storage = await seedStorage(dir);
+
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-unknown-op";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_via: annihilate",
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    // Parser drops unknown operators to undefined on read, so the scan
+    // sees no provenance on this memory — it won't be flagged.  That is
+    // the *intended* defence: unknown operators are also invisible to
+    // downstream logic.  Document this behavior so later revisions that
+    // change read-path tolerance catch the drift.
+    assert.equal(report.withProvenance, 0);
+    assert.equal(report.issues.length, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("summarizeConsolidationProvenance returns ok when no issues are found", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-summary-ok-"));
+  try {
+    const storage = await seedStorage(dir);
+    const check = await summarizeConsolidationProvenance(storage, { memoryDir: dir });
+    assert.equal(check.key, "consolidation_provenance");
+    assert.equal(check.status, "ok");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("summarizeConsolidationProvenance returns warn when integrity issues exist", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-summary-warn-"));
+  try {
+    const storage = await seedStorage(dir);
+
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-bad";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      'derived_from: ["facts/ghost.md:99"]',
+      "derived_via: merge",
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const check = await summarizeConsolidationProvenance(storage, { memoryDir: dir });
+    assert.equal(check.status, "warn");
+    assert.ok(check.remediation);
+    const detail = check.details as ConsolidationProvenanceReport;
+    assert.ok(detail.issues.length >= 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -331,6 +331,82 @@ test("runConsolidationProvenanceCheck flags blank derived_from key (truncated fr
   }
 });
 
+test("runConsolidationProvenanceCheck flags malformed entries inside a mixed-valid/invalid derived_from list", async () => {
+  // Regression for PR #634 round-4 review (codex P2): if the parser
+  // returned a valid list but dropped some empty / malformed tokens,
+  // the doctor must surface the loss rather than silently show ok.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-mixed-"));
+  try {
+    const storage = await seedStorage(dir);
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+    const id = "fact-mixed-list";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      // Mixed list: one valid + one empty + one malformed.
+      'derived_from: ["facts/a.md:1", "", "facts/b.md-no-version"]',
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    const malformed = report.issues.filter(
+      (i) => i.kind === "derived_from_malformed_entry",
+    );
+    // At least one malformed entry must be surfaced (empty token or
+    // the no-version entry).
+    assert.ok(malformed.length >= 1, `expected malformed issues; got ${JSON.stringify(report.issues)}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runConsolidationProvenanceCheck surfaces parse-failed files that carry provenance keys", async () => {
+  // Regression for PR #634 round-4 review (codex P2): `readAllMemories`
+  // silently drops files whose frontmatter doesn't parse, so the
+  // scan would miss corruption entirely.  A post-pass scans the
+  // facts directory for .md files carrying raw provenance keys that
+  // the reader didn't return, and surfaces them as malformed.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-parse-fail-"));
+  try {
+    const storage = await seedStorage(dir);
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+    const id = "fact-broken";
+    const filePath = path.join(factDir, `${id}.md`);
+    // Truncated frontmatter — missing closing `---` delimiter so the
+    // storage reader refuses the file.
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "derived_from: [\"facts/a.md:1\"]",
+      "derived_via: merge",
+      "body text with no closing delimiter",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    const parseFailed = report.issues.filter((i) => i.memoryId === "(parse failed)");
+    assert.equal(parseFailed.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("runConsolidationProvenanceCheck flags blank derived_via key (truncated frontmatter)", async () => {
   // Regression for PR #634 round-3 review (codex P2): a truncated
   // frontmatter that ends with `derived_via:` (key present, no

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -445,3 +445,54 @@ test("runConsolidationProvenanceCheck flags blank derived_via key (truncated fro
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("runConsolidationProvenanceCheck uses last derived_via when key appears multiple times", async () => {
+  // Regression for PR #634 review (codex P2): when `derived_via` appears
+  // multiple times in the raw YAML, `parseFrontmatter` keeps the last
+  // one.  The doctor must read the last occurrence (not the first) so
+  // that integrity warnings match the value the storage reader actually
+  // uses.  A file with `derived_via: merge` then `derived_via: annihilate`
+  // should flag "annihilate" (the effective value) as unknown, not report
+  // clean based on the first "merge" occurrence.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-dup-via-"));
+  try {
+    const storage = await seedStorage(dir);
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+    const id = "fact-dup-via";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_via: merge",
+      "derived_via: annihilate",
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    // Should flag the duplicate key AND the unknown operator "annihilate".
+    const dupIssues = report.issues.filter(
+      (i) => i.detail.includes("2") && i.detail.includes("derived_via"),
+    );
+    assert.ok(dupIssues.length >= 1, `expected duplicate-key issue; got ${JSON.stringify(report.issues)}`);
+    // The unknown-operator check must use the LAST occurrence ("annihilate"),
+    // not the first ("merge").
+    const unknownOps = report.issues.filter(
+      (i) => i.kind === "derived_via_unknown_operator" && i.detail.includes("annihilate"),
+    );
+    assert.ok(unknownOps.length >= 1, `expected unknown operator "annihilate"; got ${JSON.stringify(report.issues)}`);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -290,3 +290,82 @@ test("summarizeConsolidationProvenance honors versioningSidecarDir from config",
     await rm(dir, { recursive: true, force: true });
   }
 });
+
+test("runConsolidationProvenanceCheck flags blank derived_from key (truncated frontmatter)", async () => {
+  // Regression for PR #634 round-3 review (codex P2): a truncated
+  // frontmatter that ends with `derived_from:` (key present, no
+  // value) should surface as a malformed entry.  Previously the
+  // `rawDerivedFrom.length > 0` guard dropped this case.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-blank-from-"));
+  try {
+    const storage = await seedStorage(dir);
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+    const id = "fact-blank-from";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_from:", // blank value
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    const malformed = report.issues.filter(
+      (i) => i.kind === "derived_from_malformed_entry",
+    );
+    assert.equal(malformed.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("runConsolidationProvenanceCheck flags blank derived_via key (truncated frontmatter)", async () => {
+  // Regression for PR #634 round-3 review (codex P2): a truncated
+  // frontmatter that ends with `derived_via:` (key present, no
+  // value) should surface as an unknown-operator issue.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-blank-via-"));
+  try {
+    const storage = await seedStorage(dir);
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+    const id = "fact-blank-via";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_via:", // blank
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    const unknown = report.issues.filter(
+      (i) => i.kind === "derived_via_unknown_operator",
+    );
+    assert.equal(unknown.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -141,13 +141,13 @@ test("runConsolidationProvenanceCheck flags unknown derived_via operators", asyn
     await writeFile(filePath, raw, "utf-8");
 
     const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
-    // Parser drops unknown operators to undefined on read, so the scan
-    // sees no provenance on this memory — it won't be flagged.  That is
-    // the *intended* defence: unknown operators are also invisible to
-    // downstream logic.  Document this behavior so later revisions that
-    // change read-path tolerance catch the drift.
-    assert.equal(report.withProvenance, 0);
-    assert.equal(report.issues.length, 0);
+    // The normalized read-path parser drops unknown operators to
+    // undefined, but the doctor re-extracts the raw YAML value so
+    // on-disk corruption is still surfaced (PR #634 review feedback).
+    assert.equal(report.issues.length, 1);
+    const issue = report.issues[0];
+    assert.equal(issue.kind, "derived_via_unknown_operator");
+    assert.ok(issue.detail.includes("annihilate"));
   } finally {
     await rm(dir, { recursive: true, force: true });
   }
@@ -199,6 +199,45 @@ test("summarizeConsolidationProvenance returns warn when integrity issues exist"
     assert.ok(check.remediation);
     const detail = check.details as ConsolidationProvenanceReport;
     assert.ok(detail.issues.length >= 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("summarizeConsolidationProvenance honors versioningSidecarDir from config", async () => {
+  // Regression for PR #634 review feedback (codex P2 / cursor Medium):
+  // the summarizer must thread the configured `versioningSidecarDir`
+  // into the scan.  Deployments that override the default `.versions`
+  // directory would otherwise see false-missing warnings for every
+  // `derived_from` entry because the scan looks in the wrong directory.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-sidecar-"));
+  try {
+    const storage = new StorageManager(dir);
+    // Use a non-default sidecar directory to prove threading works.
+    storage.setVersioningConfig({
+      enabled: true,
+      maxVersionsPerPage: 10,
+      sidecarDir: ".custom-versions",
+    });
+    await storage.ensureDirectories();
+
+    const srcId = await storage.writeMemory("fact", "source body", { source: "extraction" });
+    const all = await storage.readAllMemories();
+    const src = all.find((m) => m.frontmatter.id === srcId)!;
+    const entry = await storage.snapshotForProvenance(src.path);
+    assert.ok(entry);
+
+    await storage.writeMemory("fact", "canonical", {
+      source: "semantic-consolidation",
+      derivedFrom: [entry],
+      derivedVia: "merge",
+    });
+
+    const check = await summarizeConsolidationProvenance(storage, {
+      memoryDir: dir,
+      versioningSidecarDir: ".custom-versions",
+    });
+    assert.equal(check.status, "ok", `got ${check.status}: ${check.summary}`);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/tests/consolidation-provenance-check.test.ts
+++ b/tests/consolidation-provenance-check.test.ts
@@ -204,6 +204,54 @@ test("summarizeConsolidationProvenance returns warn when integrity issues exist"
   }
 });
 
+test("runConsolidationProvenanceCheck flags raw derived_from that the parser dropped (scalar form)", async () => {
+  // Regression for PR #634 round-2 review feedback (codex P2): the
+  // read-path parser drops non-list `derived_from` values to
+  // `undefined`, so a scalar like `derived_from: facts/a.md:7` (no
+  // list brackets) was previously silently ignored by the scan.  The
+  // doctor re-extracts the raw YAML line and flags the drop as a
+  // `derived_from_malformed_entry` issue.
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-prov-scalar-"));
+  try {
+    const storage = await seedStorage(dir);
+
+    const day = "2026-04-20";
+    const factDir = path.join(dir, "facts", day);
+    await mkdir(factDir, { recursive: true });
+
+    const id = "fact-scalar-from";
+    const filePath = path.join(factDir, `${id}.md`);
+    const raw = [
+      "---",
+      `id: ${id}`,
+      "category: fact",
+      "created: 2026-04-20T01:00:00.000Z",
+      "updated: 2026-04-20T01:00:00.000Z",
+      "source: semantic-consolidation",
+      "confidence: 0.8",
+      "confidenceTier: implied",
+      "derived_from: facts/a.md:7", // scalar — not a list
+      "derived_via: merge",
+      "---",
+      "",
+      "body",
+      "",
+    ].join("\n");
+    await writeFile(filePath, raw, "utf-8");
+
+    const report = await runConsolidationProvenanceCheck({ storage, memoryDir: dir });
+    // One malformed_entry issue — the scalar form is preserved in
+    // the detail message so operators can grep the offending line.
+    const malformed = report.issues.filter(
+      (i) => i.kind === "derived_from_malformed_entry",
+    );
+    assert.equal(malformed.length, 1);
+    assert.ok(malformed[0].detail.includes("facts/a.md:7"));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("summarizeConsolidationProvenance honors versioningSidecarDir from config", async () => {
   // Regression for PR #634 review feedback (codex P2 / cursor Medium):
   // the summarizer must thread the configured `versioningSidecarDir`


### PR DESCRIPTION
## Summary

PR 4 of 5 for issue #561.  Adds a `remnic doctor` check that validates
the consolidation provenance metadata introduced in PR 1 + PR 2:

  - Every `derived_from` entry `"<path>:<version>"` must name a
    page-version snapshot that exists on disk.
  - Every `derived_via` must be a known `ConsolidationOperator`.

Broken provenance produces **warnings** (never errors) with the
offending memory path + human-readable reason.  The check is
informational — missing snapshots can legitimately result from log
pruning or versioning being disabled retroactively, so operators need
visibility, not a hard fail.

## Changes

- **`packages/remnic-core/src/consolidation-provenance-check.ts`** (new)
  - `runConsolidationProvenanceCheck(options)` walks every memory under
    the given `StorageManager`, resolves each `derived_from` entry via
    the sidecar layout from `page-versioning.ts`, and surfaces missing
    snapshots / malformed entries / unknown operators as a
    `ConsolidationProvenanceReport`.
- **`packages/remnic-core/src/operator-toolkit.ts`**
  - New `summarizeConsolidationProvenance()` wraps the scan as an
    `OperatorDoctorCheck` — `ok` when clean, `warn` with remediation
    text when issues exist.
  - `runOperatorDoctor()` appends the new check after the memory-worth
    legacy audit.
- **`src/consolidation-provenance-check.ts`** — re-export shim matching
  the workspace's existing pattern.

## Test plan

- [x] `tests/consolidation-provenance-check.test.ts` — 5 tests:
  clean store → no issues, missing snapshot → warning, unknown operator
  (read-path drops to undefined, documented behavior),
  `summarizeConsolidationProvenance` ok vs warn mapping.
- [x] `tsc --noEmit` — clean.

## Out of scope (follow-up)

- **PR 5** — `remnic consolidate undo <target>` CLI path that restores
  source memories from their `derived_from` snapshots.

Refs #561.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily adds diagnostic/doctor-only filesystem scanning and config-schema knobs; no core recall/write behavior changes, but the new scan could surface noisy warnings or add runtime cost when running `remnic doctor` on large stores.
> 
> **Overview**
> Adds a new `remnic doctor` check that scans all memories and **warns** when consolidation provenance is broken: `derived_from` entries that don’t resolve to a page-version snapshot on disk and raw `derived_via` values that aren’t known consolidation operators (including several corruption/edge cases like duplicate keys, mixed/blank lists, and parse-failed files).
> 
> Wires the scan into the doctor report via `summarizeConsolidationProvenance()` (honoring `versioningSidecarDir`), exports `sidecarKey()` from `page-versioning.ts` for canonical snapshot path resolution, adds a top-level re-export shim, and introduces a comprehensive test suite for the new check.
> 
> Separately extends `openclaw.plugin.json` with new (default-off) config schema options for a cross-namespace recall query-budget limiter (`recallCrossNamespaceBudget*`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 115834ed74e762e3f225d532163bf58faf2dcaca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->