### PR TITLE
feat(extraction-judge): defer-capable prompt + routing (issue #562 PR 2/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2324,6 +2324,12 @@
         "default": false,
         "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
       },
+      "extractionJudgeMaxDeferrals": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2282,6 +2282,12 @@
         "default": false,
         "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
       },
+      "extractionJudgeMaxDeferrals": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/buffer-session.test.ts
+++ b/packages/remnic-core/src/buffer-session.test.ts
@@ -183,6 +183,113 @@ test("SmartBuffer prunes stale logical session buffers to a bounded entry set", 
   assert.ok(!persistedKeys.includes("thread-0"));
 });
 
+// ---------------------------------------------------------------------------
+// Issue #562 PR 2 — defer retention
+// ---------------------------------------------------------------------------
+
+test("retainDeferredTurns preserves turns across clearAfterExtraction", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "deferred context one"));
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "deferred context two"));
+
+  const liveTurns = buffer.getTurns("thread-a");
+  assert.equal(liveTurns.length, 2);
+
+  await buffer.retainDeferredTurns("thread-a", liveTurns);
+  await buffer.clearAfterExtraction("thread-a");
+
+  const afterClear = buffer.getTurns("thread-a");
+  assert.equal(afterClear.length, 2, "Retained turns must survive clearAfterExtraction");
+  assert.equal(afterClear[0]?.content, "deferred context one");
+  assert.equal(afterClear[1]?.content, "deferred context two");
+});
+
+test("retainDeferredTurns respects the max tail size", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  const turns = Array.from({ length: 5 }, (_, i) =>
+    makeTurn("thread-a", `turn ${i}`),
+  );
+
+  await buffer.retainDeferredTurns("thread-a", turns, 2);
+  const retained = buffer.getRetainedDeferredTurns("thread-a");
+  assert.equal(retained.length, 2);
+  assert.equal(retained[0]?.content, "turn 3");
+  assert.equal(retained[1]?.content, "turn 4");
+});
+
+test("retainDeferredTurns with empty array clears the retention slot", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.retainDeferredTurns("thread-a", [makeTurn("thread-a", "x")], 5);
+  assert.equal(buffer.getRetainedDeferredTurns("thread-a").length, 1);
+
+  await buffer.retainDeferredTurns("thread-a", []);
+  assert.equal(buffer.getRetainedDeferredTurns("thread-a").length, 0);
+});
+
+test("retainDeferredTurns with max=0 clears the retention slot (slice -0 guard)", async () => {
+  // CLAUDE.md gotcha 27: `slice(-0)` equals `slice(0)` and would return all
+  // entries. The implementation must guard against this.
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.retainDeferredTurns("thread-a", [makeTurn("thread-a", "x")], 5);
+  assert.equal(buffer.getRetainedDeferredTurns("thread-a").length, 1);
+
+  await buffer.retainDeferredTurns(
+    "thread-a",
+    [makeTurn("thread-a", "should-not-appear")],
+    0,
+  );
+  assert.equal(
+    buffer.getRetainedDeferredTurns("thread-a").length,
+    0,
+    "max=0 must clear the slot, not return all turns",
+  );
+});
+
+test("getTurns prepends retained deferred turns before live turns", async () => {
+  const storage = new FakeStorage({
+    turns: [],
+    lastExtractionAt: null,
+    extractionCount: 0,
+  });
+  const buffer = new SmartBuffer(parseConfig({}), storage as any);
+
+  await buffer.retainDeferredTurns(
+    "thread-a",
+    [makeTurn("thread-a", "old deferred context")],
+    10,
+  );
+  await buffer.addTurn("thread-a", makeTurn("thread-a", "new live turn"));
+
+  const all = buffer.getTurns("thread-a");
+  assert.equal(all.length, 2);
+  assert.equal(all[0]?.content, "old deferred context");
+  assert.equal(all[1]?.content, "new live turn");
+});
+
 test("SmartBuffer never prunes logical session buffers that still have pending turns", async () => {
   const entries = Object.fromEntries(
     Array.from({ length: 205 }, (_, index) => [

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -226,7 +226,37 @@ export class SmartBuffer {
       // `slice(-0)` equals `slice(0)` and would return ALL entries. We
       // already early-return above when max <= 0.
       const tail = turns.slice(-max);
-      entry.retainedTurns = tail.map((t) => ({ ...t }));
+      // Copy explicit fields only — never spread an external object into a
+      // plain object because spread preserves any own `__proto__` /
+      // `constructor` keys that may have arrived via JSON deserialization
+      // of untrusted input (CodeQL js/prototype-polluting-assignment).
+      entry.retainedTurns = tail.map<BufferTurn>((t) => {
+        const copy: BufferTurn = {
+          role: t.role,
+          content: typeof t.content === "string" ? t.content : "",
+          timestamp:
+            typeof t.timestamp === "string"
+              ? t.timestamp
+              : new Date().toISOString(),
+        };
+        if (typeof t.sessionKey === "string") copy.sessionKey = t.sessionKey;
+        if (typeof t.logicalSessionKey === "string") {
+          copy.logicalSessionKey = t.logicalSessionKey;
+        }
+        if (
+          t.providerThreadId === null ||
+          typeof t.providerThreadId === "string"
+        ) {
+          copy.providerThreadId = t.providerThreadId;
+        }
+        if (typeof t.turnFingerprint === "string") {
+          copy.turnFingerprint = t.turnFingerprint;
+        }
+        if (typeof t.persistProcessedFingerprint === "boolean") {
+          copy.persistProcessedFingerprint = t.persistProcessedFingerprint;
+        }
+        return copy;
+      });
     }
     await this.save();
   }

--- a/packages/remnic-core/src/buffer.ts
+++ b/packages/remnic-core/src/buffer.ts
@@ -197,7 +197,47 @@ export class SmartBuffer {
   getTurns(bufferKey = "default"): BufferTurn[] {
     const entry = this.peekEntry(bufferKey);
     if (!entry) return [];
-    return [...entry.turns];
+    const retained = entry.retainedTurns ?? [];
+    // Retained turns (from a previous defer verdict, issue #562 PR 2) are
+    // prepended so the chronological order — oldest context first — is
+    // preserved for the next extraction pass.
+    return [...retained, ...entry.turns];
+  }
+
+  /**
+   * Retain a subset of the current turns across `clearAfterExtraction` so a
+   * future extraction pass sees the context behind a deferred candidate
+   * (issue #562, PR 2). Callers pass the turns that were seen during the
+   * current extraction; the buffer keeps the tail (latest `max` turns) as
+   * the retention window. Passing an empty array or `max <= 0` clears the
+   * retention slot instead.
+   */
+  async retainDeferredTurns(
+    bufferKey: string,
+    turns: BufferTurn[],
+    max = 10,
+  ): Promise<void> {
+    await this.load();
+    const entry = this.entryFor(bufferKey);
+    if (!Array.isArray(turns) || turns.length === 0 || max <= 0) {
+      delete entry.retainedTurns;
+    } else {
+      // Guard `slice(-max)` against `max === 0` (CLAUDE.md gotcha 27):
+      // `slice(-0)` equals `slice(0)` and would return ALL entries. We
+      // already early-return above when max <= 0.
+      const tail = turns.slice(-max);
+      entry.retainedTurns = tail.map((t) => ({ ...t }));
+    }
+    await this.save();
+  }
+
+  /**
+   * Return the current retention window (issue #562, PR 2). Primarily for
+   * tests and diagnostics.
+   */
+  getRetainedDeferredTurns(bufferKey = "default"): BufferTurn[] {
+    const entry = this.peekEntry(bufferKey);
+    return entry?.retainedTurns ? [...entry.retainedTurns] : [];
   }
 
   async findBufferKeyForSession(sessionKey: string): Promise<string | null> {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1496,6 +1496,14 @@ export function parseConfig(raw: unknown): PluginConfig {
         ? Math.max(1, Math.round(cfg.extractionJudgeBatchSize))
         : 20,
     extractionJudgeShadow: cfg.extractionJudgeShadow === true,
+    // Defer cap (issue #562 PR 2): max re-deferrals for the same candidate
+    // text before the verdict is forcibly converted to reject.
+    extractionJudgeMaxDeferrals:
+      typeof cfg.extractionJudgeMaxDeferrals === "number" &&
+      Number.isFinite(cfg.extractionJudgeMaxDeferrals) &&
+      cfg.extractionJudgeMaxDeferrals >= 1
+        ? Math.floor(cfg.extractionJudgeMaxDeferrals)
+        : 2,
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -164,6 +164,19 @@ export interface JudgeBatchResult {
   judged: number;
   /** Total wall-clock time in milliseconds. */
   elapsed: number;
+  /**
+   * Number of verdicts in this batch that resolved to `"defer"` (issue #562,
+   * PR 2). Callers can use this to decide whether to retain buffer turns for
+   * the next extraction pass.
+   */
+  deferred: number;
+  /**
+   * Number of defers that were forcibly converted to `"reject"` because the
+   * same candidate text had already been deferred at least
+   * `extractionJudgeMaxDeferrals` times. Rolled out of `deferred` — a
+   * candidate counted here is *not* also in `deferred`.
+   */
+  deferredCappedToReject: number;
 }
 
 // ---------------------------------------------------------------------------
@@ -174,7 +187,9 @@ const JUDGE_SYSTEM_PROMPT = `You are a memory curator evaluating whether extract
 
 A fact is **durable** if it will still be useful 30+ days from now and is relevant across multiple sessions, not just the current task.
 
-DURABLE examples (approve):
+Return one of three verdicts per candidate:
+
+ACCEPT — the fact is durable, persist it:
 - Personal preferences, identities, or relationships
 - Decisions with rationale that affect future work
 - Corrections to previously held beliefs
@@ -182,7 +197,7 @@ DURABLE examples (approve):
 - Stable facts about projects, tools, or workflows
 - Commitments, deadlines, or obligations
 
-NOT DURABLE examples (reject):
+REJECT — the fact is not durable, drop it:
 - Transient task details ("currently debugging line 42")
 - Ephemeral state ("the build is running now")
 - Routine operations ("ran npm install")
@@ -190,19 +205,29 @@ NOT DURABLE examples (reject):
 - Information that will be stale within hours
 - Step-by-step instructions for a one-time task
 
+DEFER — the fact MIGHT be durable but needs more context to decide. The candidate will be re-evaluated on a later extraction pass with fresh context; if it cannot be resolved within a small number of re-evaluations it will be rejected.
+- Ambiguous referents ("he said they'd follow up on it")
+- Partial or in-progress statements that might become durable once completed
+- Future-tense commitments whose subject or timeline is unclear
+- Facts whose durability hinges on context not present in the candidate text
+
+Do NOT use defer as a soft reject. Reject facts you are confident are transient. Only defer when another turn of context would genuinely change the verdict.
+
 Return a JSON array of objects with these fields:
 - index: number (the candidate index)
-- durable: boolean (true if the fact is durable)
-- reason: string (brief explanation)
+- kind: string — one of "accept", "reject", "defer"
+- reason: string (brief explanation, under 80 characters)
+
+You may also include durable (boolean) for backwards compatibility: true for accept, false for reject or defer. If kind is omitted, durable determines the verdict.
 
 Rules:
 1. Return exactly one verdict per input candidate, matched by index.
-2. The reason field must be a short phrase (under 80 characters).
-3. When in doubt lean toward durable — false negatives are worse than false positives.
+2. When in doubt between accept and reject, lean toward accept — false negatives (losing a useful fact) are worse than false positives (keeping a marginal one).
+3. Use defer only when another turn of context would genuinely change the verdict.
 4. Output valid JSON only. No markdown fences, no commentary.
 
 Example output:
-[{"index": 0, "durable": true, "reason": "Stable personal preference"}, {"index": 1, "durable": false, "reason": "Ephemeral build status"}]`;
+[{"index": 0, "kind": "accept", "durable": true, "reason": "Stable personal preference"}, {"index": 1, "kind": "reject", "durable": false, "reason": "Ephemeral build status"}, {"index": 2, "kind": "defer", "durable": false, "reason": "Ambiguous pronoun"}]`;
 
 // ---------------------------------------------------------------------------
 // Content-hash cache (in-memory, per-process fallback)
@@ -214,8 +239,35 @@ const VERDICT_CACHE_MAX_SIZE = 10_000;
 /** Module-level fallback cache, used when callers do not pass their own. */
 const defaultVerdictCache = new Map<string, JudgeVerdict>();
 
+/**
+ * Per-content-hash deferral counter (issue #562, PR 2).
+ *
+ * When the judge emits a `"defer"` verdict for a candidate whose content
+ * has already been deferred `extractionJudgeMaxDeferrals` times, the verdict
+ * is forcibly converted to `"reject"` so a pathological LLM response cannot
+ * produce an infinite defer loop.
+ *
+ * Module-level with a size cap so stale test state cannot leak between runs
+ * in the unlikely case a caller does not clear it between processes.
+ */
+const defaultDeferCounts = new Map<string, number>();
+const DEFER_COUNT_MAX_SIZE = 20_000;
+
 function cacheKey(text: string, category: string): string {
   return createHash("sha256").update(`${text}\0${category}`).digest("hex");
+}
+
+/**
+ * Resolve the effective defer cap from config, defaulting to 2 when the
+ * config value is missing or non-positive. Matches the PR 2 spec.
+ */
+function resolveDeferCap(config: PluginConfig): number {
+  const raw = (config as { extractionJudgeMaxDeferrals?: number })
+    .extractionJudgeMaxDeferrals;
+  if (typeof raw === "number" && Number.isFinite(raw) && raw >= 1) {
+    return Math.floor(raw);
+  }
+  return 2;
 }
 
 /**
@@ -281,18 +333,30 @@ export async function judgeFactDurability(
   localLlm: LocalLlmClient | null,
   fallbackLlm: FallbackLlmClient | null,
   cache?: Map<string, JudgeVerdict>,
+  deferCounts?: Map<string, number>,
 ): Promise<JudgeBatchResult> {
   const startMs = Date.now();
   const verdicts = new Map<number, JudgeVerdict>();
   let cached = 0;
   let judged = 0;
+  let deferred = 0;
+  let deferredCappedToReject = 0;
 
   // Use caller-provided cache for per-orchestrator scoping, or fall back
   // to the module-level default cache.
   const verdictCache = cache ?? defaultVerdictCache;
+  const deferCountMap = deferCounts ?? defaultDeferCounts;
+  const deferCap = resolveDeferCap(config);
 
   if (candidates.length === 0) {
-    return { verdicts, cached, judged, elapsed: 0 };
+    return {
+      verdicts,
+      cached,
+      judged,
+      elapsed: 0,
+      deferred,
+      deferredCappedToReject,
+    };
   }
 
   // Indices that need LLM judgment
@@ -333,7 +397,14 @@ export async function judgeFactDurability(
 
   // If all resolved without LLM, return early
   if (pendingIndices.length === 0) {
-    return { verdicts, cached, judged, elapsed: Date.now() - startMs };
+    return {
+      verdicts,
+      cached,
+      judged,
+      elapsed: Date.now() - startMs,
+      deferred,
+      deferredCappedToReject,
+    };
   }
 
   // Batch the pending candidates up to batchSize
@@ -359,12 +430,52 @@ export async function judgeFactDurability(
 
       if (llmResponse) {
         const parsed = parseJudgeResponse(llmResponse, batchIndices);
-        for (const [idx, verdict] of parsed.entries()) {
+        for (const [idx, rawVerdict] of parsed.entries()) {
+          const c = candidates[idx];
+          const key = cacheKey(c.text, c.category);
+          let verdict = rawVerdict;
+
+          // Defer cap (issue #562, PR 2). A candidate that has already been
+          // deferred `deferCap` times is forcibly rejected so a pathological
+          // LLM response cannot produce an infinite defer loop.
+          if (getVerdictKind(verdict) === "defer") {
+            const priorDefers = deferCountMap.get(key) ?? 0;
+            if (priorDefers >= deferCap) {
+              verdict = {
+                durable: false,
+                reason: `Defer cap reached (${deferCap} prior defers); rejecting`,
+                kind: "reject",
+              };
+              deferCountMap.delete(key);
+              deferredCappedToReject++;
+            } else {
+              deferCountMap.set(key, priorDefers + 1);
+              deferred++;
+              // Bound the per-process defer-counter map.
+              if (deferCountMap.size > DEFER_COUNT_MAX_SIZE) {
+                const drop = Math.floor(deferCountMap.size / 2);
+                let dropped = 0;
+                for (const k of deferCountMap.keys()) {
+                  if (dropped >= drop) break;
+                  deferCountMap.delete(k);
+                  dropped++;
+                }
+              }
+            }
+          } else {
+            // On accept/reject, clear any outstanding defer counter so a
+            // future reappearance of the same text starts fresh.
+            deferCountMap.delete(key);
+          }
+
           verdicts.set(idx, verdict);
           judged++;
-          // Cache the verdict
-          const c = candidates[idx];
-          verdictCache.set(cacheKey(c.text, c.category), verdict);
+          // Cache non-defer verdicts. Defer is intentionally NOT cached:
+          // caching it would short-circuit the re-evaluation pass that is
+          // the entire point of the defer verdict.
+          if (getVerdictKind(verdict) !== "defer") {
+            verdictCache.set(key, verdict);
+          }
         }
         // Evict oldest entries if cache exceeds max size
         enforceMaxCacheSize(verdictCache);
@@ -387,7 +498,14 @@ export async function judgeFactDurability(
     }
   }
 
-  return { verdicts, cached, judged, elapsed: Date.now() - startMs };
+  return {
+    verdicts,
+    cached,
+    judged,
+    elapsed: Date.now() - startMs,
+    deferred,
+    deferredCappedToReject,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -518,16 +636,50 @@ function parseJudgeResponse(
       const idx = (item as any).index as number;
       if (!expectedSet.has(idx)) continue;
 
-      const durable =
-        typeof (item as any).durable === "boolean"
-          ? (item as any).durable
-          : true; // fail-open
+      // Parse kind first — it's the primary signal in PR 2 and above.
+      // Fall back to durable for pre-PR-2 model responses that only return
+      // the boolean.
+      let kind: JudgeVerdictKind | undefined;
+      const rawKind = (item as any).kind;
+      const rawAction = (item as any).action;
+      if (rawKind === "accept" || rawKind === "reject" || rawKind === "defer") {
+        kind = rawKind;
+      } else if (
+        rawAction === "accept" ||
+        rawAction === "reject" ||
+        rawAction === "defer"
+      ) {
+        // Tolerate `action` as an alias — MemReader uses that word in the
+        // paper and models may echo it.
+        kind = rawAction;
+      }
+
+      const hasDurable = typeof (item as any).durable === "boolean";
+      const durableFromModel = hasDurable
+        ? ((item as any).durable as boolean)
+        : undefined;
+
+      // Resolve the durable flag from kind when present; otherwise trust
+      // the model's boolean; otherwise fail-open to durable=true.
+      let durable: boolean;
+      if (kind === "accept") {
+        durable = true;
+      } else if (kind === "reject" || kind === "defer") {
+        durable = false;
+      } else if (durableFromModel !== undefined) {
+        durable = durableFromModel;
+      } else {
+        durable = true; // fail-open
+      }
+
       const reason =
         typeof (item as any).reason === "string"
           ? ((item as any).reason as string).slice(0, 120)
           : "No reason provided";
 
-      result.set(idx, { durable, reason });
+      const verdict: JudgeVerdict = { durable, reason };
+      if (kind !== undefined) verdict.kind = kind;
+      result.set(idx, verdict);
     }
   } catch (err) {
     log.debug(
@@ -545,6 +697,7 @@ function parseJudgeResponse(
 /** Clear the in-memory default verdict cache. Primarily for tests. */
 export function clearVerdictCache(): void {
   defaultVerdictCache.clear();
+  defaultDeferCounts.clear();
 }
 
 /** Return the current default verdict cache size. Primarily for tests. */
@@ -555,4 +708,22 @@ export function verdictCacheSize(): number {
 /** Create a new per-instance verdict cache. Orchestrators should hold one. */
 export function createVerdictCache(): Map<string, JudgeVerdict> {
   return new Map();
+}
+
+/**
+ * Create a new per-instance defer-counter map. Orchestrators should hold one
+ * alongside their verdict cache so defer counts survive across extraction
+ * passes within a single orchestrator but do not leak across orchestrators.
+ */
+export function createDeferCountMap(): Map<string, number> {
+  return new Map();
+}
+
+/**
+ * Compute the cache/defer-counter key for a (text, category) pair. Exported
+ * so orchestrators and tests can inspect counter state for the same key the
+ * judge uses internally.
+ */
+export function deferCounterKey(text: string, category: string): string {
+  return cacheKey(text, category);
 }

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -430,6 +430,12 @@ export async function judgeFactDurability(
 
       if (llmResponse) {
         const parsed = parseJudgeResponse(llmResponse, batchIndices);
+        // Per-batch defer-increment dedupe (codex P2): a single extraction
+        // pass must not advance the cap more than once for identical
+        // candidate content, even if the same text appears multiple times
+        // in the same LLM response. Duplicate hits share the first
+        // increment's `priorDeferrals` snapshot.
+        const deferredThisBatch = new Set<string>();
         for (const [idx, rawVerdict] of parsed.entries()) {
           const c = candidates[idx];
           const key = cacheKey(c.text, c.category);
@@ -446,11 +452,18 @@ export async function judgeFactDurability(
                 reason: `Defer cap reached (${deferCap} prior defers); rejecting`,
                 kind: "reject",
               };
-              deferCountMap.delete(key);
-              deferredCappedToReject++;
-            } else {
+              // Only clear + count the cap conversion once per batch for
+              // this key — duplicates in the same response all resolve to
+              // reject but should not inflate the cap-rejection counter.
+              if (!deferredThisBatch.has(key)) {
+                deferCountMap.delete(key);
+                deferredCappedToReject++;
+                deferredThisBatch.add(key);
+              }
+            } else if (!deferredThisBatch.has(key)) {
               deferCountMap.set(key, priorDefers + 1);
               deferred++;
+              deferredThisBatch.add(key);
               // Bound the per-process defer-counter map.
               if (deferCountMap.size > DEFER_COUNT_MAX_SIZE) {
                 const drop = Math.floor(deferCountMap.size / 2);
@@ -462,6 +475,8 @@ export async function judgeFactDurability(
                 }
               }
             }
+            // else: duplicate defer for a key already counted this batch —
+            // no additional counter increment, verdict still marked defer.
           } else {
             // On accept/reject, clear any outstanding defer counter so a
             // future reappearance of the same text starts fresh.

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -718,12 +718,3 @@ export function createVerdictCache(): Map<string, JudgeVerdict> {
 export function createDeferCountMap(): Map<string, number> {
   return new Map();
 }
-
-/**
- * Compute the cache/defer-counter key for a (text, category) pair. Exported
- * so orchestrators and tests can inspect counter state for the same key the
- * judge uses internally.
- */
-export function deferCounterKey(text: string, category: string): string {
-  return cacheKey(text, category);
-}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9780,16 +9780,24 @@ export class Orchestrator {
     // deferred at least one candidate, retain the tail of the current turn
     // window so the next extraction pass has the surrounding context that
     // may disambiguate the deferred fact. Non-defer runs clear the slot.
+    //
+    // Gated on `clearBufferAfterExtraction` — replay / bulk-import paths
+    // call `runExtraction` with `clearBufferAfterExtraction: false` and do
+    // not operate on live buffer state. Writing retention there would
+    // create synthetic buffer entries and cross-contaminate future live
+    // extraction runs for the same bufferKey.
     try {
-      const deferredCount = this.lastPersistExtractionDeferredCount;
-      if (deferredCount > 0 && normalizedTurns.length > 0) {
-        await this.buffer.retainDeferredTurns(
-          bufferKey,
-          normalizedTurns as BufferTurn[],
-          10,
-        );
-      } else {
-        await this.buffer.retainDeferredTurns(bufferKey, [], 0);
+      if (clearBufferAfterExtraction) {
+        const deferredCount = this.lastPersistExtractionDeferredCount;
+        if (deferredCount > 0 && normalizedTurns.length > 0) {
+          await this.buffer.retainDeferredTurns(
+            bufferKey,
+            normalizedTurns as BufferTurn[],
+            10,
+          );
+        } else {
+          await this.buffer.retainDeferredTurns(bufferKey, [], 0);
+        }
       }
     } catch (err) {
       // Fail-open: retention is a nice-to-have. If it fails the judge will

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -9781,13 +9781,21 @@ export class Orchestrator {
     // window so the next extraction pass has the surrounding context that
     // may disambiguate the deferred fact. Non-defer runs clear the slot.
     //
-    // Gated on `clearBufferAfterExtraction` — replay / bulk-import paths
-    // call `runExtraction` with `clearBufferAfterExtraction: false` and do
-    // not operate on live buffer state. Writing retention there would
-    // create synthetic buffer entries and cross-contaminate future live
-    // extraction runs for the same bufferKey.
+    // Gated on:
+    //   - `clearBufferAfterExtraction` — replay / bulk-import paths call
+    //     `runExtraction` with this false and do not operate on live buffer
+    //     state. Writing retention there would create synthetic buffer
+    //     entries and cross-contaminate future live extractions.
+    //   - NOT `extractionJudgeShadow` — in shadow mode the judge is only
+    //     advisory; facts are still persisted regardless of verdict, so
+    //     retaining the turn window on top of a persisted write would both
+    //     waste buffer space and cause the same facts to re-enter the
+    //     pipeline on the next pass.
     try {
-      if (clearBufferAfterExtraction) {
+      if (
+        clearBufferAfterExtraction &&
+        !this.config.extractionJudgeShadow
+      ) {
         const deferredCount = this.lastPersistExtractionDeferredCount;
         if (deferredCount > 0 && normalizedTurns.length > 0) {
           await this.buffer.retainDeferredTurns(

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -22,6 +22,8 @@ import { isAboveImportanceThreshold, scoreImportance } from "./importance.js";
 import {
   judgeFactDurability,
   createVerdictCache,
+  createDeferCountMap,
+  getVerdictKind,
   validateProcedureExtraction,
   type JudgeBatchResult,
   type JudgeCandidate,
@@ -1195,6 +1197,20 @@ export class Orchestrator {
   readonly localLlm: LocalLlmClient;
   readonly fastLlm: LocalLlmClient;
   private readonly judgeVerdictCache: Map<string, JudgeVerdict>;
+  /**
+   * Per-orchestrator defer-counter map (issue #562, PR 2). Tracks how many
+   * times the judge has returned `"defer"` for a given candidate content
+   * hash so the defer cap can be enforced.
+   */
+  private readonly judgeDeferCounts: Map<string, number>;
+  /**
+   * Side-channel: number of facts deferred in the most recent
+   * `persistExtraction` call (issue #562, PR 2). The caller reads this after
+   * `persistExtraction` returns to decide whether to retain buffer turns for
+   * the next extraction pass. Not part of the return signature because many
+   * callers already destructure `persistedIds` by position.
+   */
+  private lastPersistExtractionDeferredCount: number = 0;
   private readonly _fastGatewayLlm: FallbackLlmClient | null;
 
   get fastGatewayLlm(): FallbackLlmClient | null {
@@ -1630,6 +1646,7 @@ export class Orchestrator {
       this.transcript,
     );
     this.judgeVerdictCache = createVerdictCache();
+    this.judgeDeferCounts = createDeferCountMap();
     this.localLlm = new LocalLlmClient(config, this.modelRegistry);
     // Issue #548: the main local-LLM client is used by extraction,
     // consolidation, and other structured-output tasks that gain
@@ -9758,6 +9775,30 @@ export class Orchestrator {
     } catch (error) {
       postPersistMetaError = error;
     }
+
+    // Buffer retention for defer verdicts (issue #562, PR 2). When the judge
+    // deferred at least one candidate, retain the tail of the current turn
+    // window so the next extraction pass has the surrounding context that
+    // may disambiguate the deferred fact. Non-defer runs clear the slot.
+    try {
+      const deferredCount = this.lastPersistExtractionDeferredCount;
+      if (deferredCount > 0 && normalizedTurns.length > 0) {
+        await this.buffer.retainDeferredTurns(
+          bufferKey,
+          normalizedTurns as BufferTurn[],
+          10,
+        );
+      } else {
+        await this.buffer.retainDeferredTurns(bufferKey, [], 0);
+      }
+    } catch (err) {
+      // Fail-open: retention is a nice-to-have. If it fails the judge will
+      // still cap deferrals and convert to reject on the next pass.
+      log.debug(
+        `extraction-judge: defer retention failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
     await clearBuffer({ ignoreAbort: true });
 
     // Build memory box from this extraction (v8.0 Phase 2A)
@@ -10701,6 +10742,10 @@ export class Orchestrator {
     // be persisted, not the raw extraction-time category.
     let judgeVerdictsByFactIndex: Map<number, import("./extraction-judge.js").JudgeVerdict> | null = null;
     let judgeGatedCount = 0;
+    // Reset the side-channel defer count at the start of every
+    // persistExtraction call so stale state from a prior call cannot leak
+    // into the caller's buffer-retention decision.
+    this.lastPersistExtractionDeferredCount = 0;
     if (this.config.extractionJudgeEnabled) {
       try {
         const judgeCandidates: JudgeCandidate[] = [];
@@ -10757,6 +10802,7 @@ export class Orchestrator {
           this.localLlm,
           new FallbackLlmClient(this.config.gatewayConfig),
           this.judgeVerdictCache,
+          this.judgeDeferCounts,
         );
         // Remap candidate-indexed verdicts to original fact indexes
         judgeVerdictsByFactIndex = new Map();
@@ -10768,8 +10814,16 @@ export class Orchestrator {
         }
         log.info(
           `extraction-judge: ${judgeResult.verdicts.size}/${judgeCandidates.length} facts evaluated, ` +
-            `${judgeResult.cached} cached, ${judgeResult.judged} judged, ${judgeResult.elapsed}ms`,
+            `${judgeResult.cached} cached, ${judgeResult.judged} judged, ` +
+            `${judgeResult.deferred} deferred` +
+            (judgeResult.deferredCappedToReject > 0
+              ? ` (${judgeResult.deferredCappedToReject} cap-rejected)`
+              : "") +
+            `, ${judgeResult.elapsed}ms`,
         );
+        // Expose defer count to the caller (issue #562 PR 2) so it can decide
+        // whether to retain buffer turns for the next extraction pass.
+        this.lastPersistExtractionDeferredCount = judgeResult.deferred;
       } catch (err) {
         // Fail-open: if the entire judge pipeline errors, proceed without filtering
         log.warn(
@@ -10901,17 +10955,30 @@ export class Orchestrator {
         continue;
       }
 
-      // Extraction judge gate (issue #376). After the local importance gate
-      // passes, consult the judge verdict (computed before the loop). In
-      // active mode, non-durable facts are dropped. In shadow mode, verdicts
-      // are logged but all facts proceed to write.
+      // Extraction judge gate (issue #376 + #562 PR 2). After the local
+      // importance gate passes, consult the judge verdict (computed before
+      // the loop). In active mode, non-durable facts are dropped. In shadow
+      // mode, verdicts are logged but all facts proceed to write.
+      //
+      // Defer verdicts (issue #562): do not persist now, but also do not
+      // cache the outcome so the candidate is re-evaluated on a later
+      // extraction pass. The judge module tracks how many times the same
+      // content has been deferred and converts to reject at the configured
+      // cap, so the orchestrator only needs to skip the write here.
       if (judgeVerdictsByFactIndex) {
         const verdict = judgeVerdictsByFactIndex.get(factLoopIndex);
         if (verdict && !verdict.durable) {
+          const verdictKind = getVerdictKind(verdict);
           if (this.config.extractionJudgeShadow) {
             log.info(
-              `extraction-judge[shadow]: would reject "${fact.content.slice(0, 60)}…" reason="${verdict.reason}"`,
+              `extraction-judge[shadow]: would ${verdictKind} "${fact.content.slice(0, 60)}…" reason="${verdict.reason}"`,
             );
+          } else if (verdictKind === "defer") {
+            judgeGatedCount++;
+            log.debug(
+              `extraction-judge: deferred "${fact.content.slice(0, 60)}…" reason="${verdict.reason}"`,
+            );
+            continue;
           } else {
             judgeGatedCount++;
             log.debug(

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -518,6 +518,13 @@ export interface PluginConfig {
   extractionJudgeBatchSize: number;
   /** Shadow mode: log judge verdicts but do not filter facts. Default false. */
   extractionJudgeShadow: boolean;
+  /**
+   * Maximum number of times the same candidate text may be deferred before
+   * the judge forcibly converts the verdict to `"reject"`. Prevents
+   * pathological LLM responses from looping forever on ambiguous facts.
+   * Defaults to 2 (issue #562, PR 2).
+   */
+  extractionJudgeMaxDeferrals: number;
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;
@@ -1313,6 +1320,13 @@ export interface BufferEntryState {
   turns: BufferTurn[];
   lastExtractionAt: string | null;
   extractionCount: number;
+  /**
+   * Turns retained across `clearAfterExtraction` so a later extraction pass
+   * sees the context that caused a defer verdict (issue #562, PR 2). Bounded
+   * to the configured retention cap by `retainDeferredTurns`. Empty / absent
+   * means no retention in effect.
+   */
+  retainedTurns?: BufferTurn[];
 }
 
 export interface BufferState {

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2306,6 +2306,12 @@
         "default": false,
         "description": "Shadow mode for the extraction judge. When true, judge verdicts are logged but all facts are still persisted regardless of the verdict."
       },
+      "extractionJudgeMaxDeferrals": {
+        "type": "number",
+        "default": 2,
+        "minimum": 1,
+        "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/prompts/extraction_judge.prompt.md
+++ b/prompts/extraction_judge.prompt.md
@@ -6,7 +6,7 @@ You are a memory curator evaluating whether extracted facts are **durable** — 
 
 A fact is **durable** if it will still be useful **30+ days from now** and is relevant **across multiple sessions**, not just the current task.
 
-### DURABLE examples (approve)
+### DURABLE examples (accept)
 - Personal preferences, identities, or relationships
 - Decisions with rationale that affect future work
 - Corrections to previously held beliefs
@@ -24,6 +24,18 @@ A fact is **durable** if it will still be useful **30+ days from now** and is re
 - Step-by-step instructions for a one-time task
 - Status updates about in-progress work
 
+### AMBIGUOUS examples (defer)
+
+When the fact **might** be durable but the current turn lacks enough context to decide, return a **defer** verdict. The candidate will be re-evaluated on a later extraction pass with fresh context; if it cannot be resolved within a small number of re-evaluations it will be rejected.
+
+Good signals to defer (not exhaustive):
+- Ambiguous referents — pronouns or demonstratives without a clear antecedent ("he said they'd follow up on it")
+- Partial or in-progress statements that might become durable once completed ("I'm planning to…", "we're about to…")
+- Future-tense commitments whose subject or timeline is unclear
+- Facts whose durability hinges on context that appears elsewhere in the session but is not present in the candidate text
+
+Do NOT use defer as a "soft reject." Reject facts you are confident are transient. Only defer when another turn of context would genuinely change the verdict.
+
 ## Input Format
 
 You will receive a JSON array of candidate facts:
@@ -37,12 +49,19 @@ You will receive a JSON array of candidate facts:
 
 ## Output Format
 
-Return a JSON array with one verdict per candidate:
+Return a JSON array with one verdict per candidate. Each verdict has:
+
+- `index` — the candidate index (number)
+- `kind` — one of `"accept"`, `"reject"`, `"defer"` (string)
+- `reason` — a short phrase (under 80 characters)
+
+For backwards compatibility you may also include `durable` (boolean) — `true` for accept, `false` for reject or defer. If `kind` is omitted, `durable` determines the verdict (accept when true, reject when false).
 
 ```json
 [
-  {"index": 0, "durable": true, "reason": "Stable project architecture decision"},
-  {"index": 1, "durable": false, "reason": "Transient debugging context"}
+  {"index": 0, "kind": "accept",  "durable": true,  "reason": "Stable project architecture decision"},
+  {"index": 1, "kind": "reject",  "durable": false, "reason": "Transient debugging context"},
+  {"index": 2, "kind": "defer",   "durable": false, "reason": "Ambiguous pronoun — who is 'they'?"}
 ]
 ```
 
@@ -50,6 +69,7 @@ Return a JSON array with one verdict per candidate:
 
 1. Return exactly one verdict per input candidate, matched by `index`.
 2. The `reason` field must be a short phrase (under 80 characters).
-3. When in doubt, lean toward **durable** — false negatives (losing a useful fact) are worse than false positives (keeping a marginal one).
-4. Do NOT evaluate corrections or principles — they are auto-approved upstream.
-5. Output valid JSON only. No markdown fences, no commentary.
+3. When in doubt between accept and reject, **lean toward accept** — false negatives (losing a useful fact) are worse than false positives (keeping a marginal one).
+4. Use **defer** only when another turn of context would genuinely change the verdict, not as a way to avoid a decision.
+5. Do NOT evaluate corrections or principles — they are auto-approved upstream.
+6. Output valid JSON only. No markdown fences, no commentary.

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -973,6 +973,69 @@ test("PR 2: JudgeBatchResult includes deferred + deferredCappedToReject counters
   assert.equal(result.deferredCappedToReject, 0);
 });
 
+test("PR 2: duplicate defer candidates in one batch increment counter once", async () => {
+  // Codex P2 review: duplicate `text+category` in the same LLM response
+  // must advance the defer cap only once per extraction pass. With cap=2
+  // and three duplicates in a single batch, the first two passes should
+  // all defer and the third pass should convert to reject — NOT the third
+  // duplicate within the first pass.
+  clearVerdictCache();
+  const cache = new Map<string, JudgeVerdict>();
+  const defers = new Map<string, number>();
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: "defer",
+            durable: false,
+            reason: "mock-defer",
+          })),
+        ),
+      };
+    },
+  };
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "Duplicate ambiguous content",
+      category: "fact",
+      confidence: 0.5,
+      importanceLevel: "normal",
+    },
+    {
+      text: "Duplicate ambiguous content",
+      category: "fact",
+      confidence: 0.5,
+      importanceLevel: "normal",
+    },
+    {
+      text: "Duplicate ambiguous content",
+      category: "fact",
+      confidence: 0.5,
+      importanceLevel: "normal",
+    },
+  ];
+  const cfg = makeConfig({ extractionJudgeMaxDeferrals: 2 });
+  const r = await judgeFactDurability(
+    candidates,
+    cfg,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(r.deferred, 1, "Defer counter must increment only once per batch");
+  assert.equal(defers.size, 1);
+  // The content hash should have a count of 1 — not 3.
+  assert.equal([...defers.values()][0], 1);
+  // All three verdicts are still defer in this pass.
+  for (const v of r.verdicts.values()) {
+    assert.equal(v.kind, "defer");
+  }
+});
+
 test("PR 2: auto-approved categories never emit defer", async () => {
   clearVerdictCache();
   const candidates: JudgeCandidate[] = [

--- a/tests/extraction-judge.test.ts
+++ b/tests/extraction-judge.test.ts
@@ -709,3 +709,286 @@ test("no emit path in current judge produces defer (PR 1 is type-only)", async (
     );
   }
 });
+
+// ---------------------------------------------------------------------------
+// Issue #562 PR 2 — defer-capable prompt + routing
+// ---------------------------------------------------------------------------
+
+test("PR 2: judge emits defer when LLM returns kind=defer", async () => {
+  clearVerdictCache();
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: "defer",
+            durable: false,
+            reason: "Ambiguous referent",
+          })),
+        ),
+      };
+    },
+  };
+
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "They said they'd follow up on it soon",
+      category: "fact",
+      confidence: 0.6,
+      importanceLevel: "normal",
+    },
+  ];
+  const config = makeConfig();
+  const result = await judgeFactDurability(
+    candidates,
+    config,
+    mockLocalLlm as any,
+    null,
+  );
+
+  const v = result.verdicts.get(0);
+  assert.ok(v);
+  assert.equal(v!.kind, "defer");
+  assert.equal(v!.durable, false);
+  assert.equal(getVerdictKind(v!), "defer");
+  assert.equal(result.deferred, 1);
+  assert.equal(result.deferredCappedToReject, 0);
+});
+
+test("PR 2: judge accepts 'action' as alias for 'kind'", async () => {
+  clearVerdictCache();
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            action: "defer",
+            reason: "Partial",
+          })),
+        ),
+      };
+    },
+  };
+
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "Planning to refactor…",
+      category: "fact",
+      confidence: 0.6,
+      importanceLevel: "normal",
+    },
+  ];
+  const result = await judgeFactDurability(
+    candidates,
+    makeConfig(),
+    mockLocalLlm as any,
+    null,
+  );
+  assert.equal(result.verdicts.get(0)?.kind, "defer");
+});
+
+test("PR 2: defer verdicts are NOT cached — re-evaluated on next pass", async () => {
+  clearVerdictCache();
+  let callCount = 0;
+  const cache = new Map<string, JudgeVerdict>();
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      callCount++;
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: "defer",
+            durable: false,
+            reason: "Still ambiguous",
+          })),
+        ),
+      };
+    },
+  };
+
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "It's about that thing we discussed",
+      category: "fact",
+      confidence: 0.6,
+      importanceLevel: "normal",
+    },
+  ];
+  const config = makeConfig();
+
+  // First pass: defer. The defer counter should increment; nothing cached.
+  await judgeFactDurability(candidates, config, mockLocalLlm as any, null, cache);
+  assert.equal(cache.size, 0, "Defer verdicts must not populate the verdict cache");
+
+  // Second pass: judge is called again (cache miss) and returns defer again.
+  await judgeFactDurability(candidates, config, mockLocalLlm as any, null, cache);
+  assert.equal(callCount, 2, "Second pass must call the LLM (defer was not cached)");
+});
+
+test("PR 2: defer cap converts to reject after N prior defers", async () => {
+  clearVerdictCache();
+  const cache = new Map<string, JudgeVerdict>();
+  const defers = new Map<string, number>();
+  let currentResponseKind: "defer" | "reject" = "defer";
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: currentResponseKind,
+            durable: false,
+            reason: "mock",
+          })),
+        ),
+      };
+    },
+  };
+
+  // Cap at 2 (the default). Passes 1 and 2 should defer; pass 3 should be
+  // forcibly rejected by the cap enforcement even though the LLM keeps
+  // returning defer.
+  const config = makeConfig({ extractionJudgeMaxDeferrals: 2 });
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "Pathologically ambiguous candidate text",
+      category: "fact",
+      confidence: 0.5,
+      importanceLevel: "normal",
+    },
+  ];
+
+  const r1 = await judgeFactDurability(
+    candidates,
+    config,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(r1.verdicts.get(0)?.kind, "defer");
+  assert.equal(r1.deferred, 1);
+  assert.equal(r1.deferredCappedToReject, 0);
+
+  const r2 = await judgeFactDurability(
+    candidates,
+    config,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(r2.verdicts.get(0)?.kind, "defer");
+  assert.equal(r2.deferred, 1);
+
+  const r3 = await judgeFactDurability(
+    candidates,
+    config,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(
+    r3.verdicts.get(0)?.kind,
+    "reject",
+    "Third defer must be converted to reject by the cap",
+  );
+  assert.equal(r3.deferred, 0);
+  assert.equal(r3.deferredCappedToReject, 1);
+  // After cap rejection the result must be cached so repeat candidates
+  // short-circuit without another LLM call.
+  assert.ok(cache.size > 0, "Cap-rejected verdict should be cached");
+});
+
+test("PR 2: accept after defer resets the defer counter", async () => {
+  clearVerdictCache();
+  const cache = new Map<string, JudgeVerdict>();
+  const defers = new Map<string, number>();
+  let kind: "defer" | "accept" = "defer";
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind,
+            durable: kind === "accept",
+            reason: "mock",
+          })),
+        ),
+      };
+    },
+  };
+
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "Context will sharpen this fact",
+      category: "fact",
+      confidence: 0.6,
+      importanceLevel: "normal",
+    },
+  ];
+
+  // Defer once.
+  const r1 = await judgeFactDurability(
+    candidates,
+    makeConfig({ extractionJudgeMaxDeferrals: 2 }),
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(r1.verdicts.get(0)?.kind, "defer");
+  assert.equal(defers.size, 1);
+
+  // Now accept — counter should clear.
+  kind = "accept";
+  const r2 = await judgeFactDurability(
+    candidates,
+    makeConfig({ extractionJudgeMaxDeferrals: 2 }),
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+  );
+  assert.equal(r2.verdicts.get(0)?.kind, "accept");
+  assert.equal(defers.size, 0, "Accept must clear the defer counter");
+});
+
+test("PR 2: JudgeBatchResult includes deferred + deferredCappedToReject counters", async () => {
+  clearVerdictCache();
+  const result = await judgeFactDurability([], makeConfig(), null, null);
+  assert.equal(typeof result.deferred, "number");
+  assert.equal(typeof result.deferredCappedToReject, "number");
+  assert.equal(result.deferred, 0);
+  assert.equal(result.deferredCappedToReject, 0);
+});
+
+test("PR 2: auto-approved categories never emit defer", async () => {
+  clearVerdictCache();
+  const candidates: JudgeCandidate[] = [
+    { text: "Correction content", category: "correction", confidence: 0.9 },
+    { text: "Principle content", category: "principle", confidence: 0.9 },
+    {
+      text: "Critical fact",
+      category: "fact",
+      confidence: 0.9,
+      importanceLevel: "critical",
+    },
+  ];
+  const result = await judgeFactDurability(candidates, makeConfig(), null, null);
+  for (const v of result.verdicts.values()) {
+    assert.notEqual(getVerdictKind(v), "defer");
+    assert.equal(v.durable, true);
+  }
+  assert.equal(result.deferred, 0);
+});


### PR DESCRIPTION
## Summary

PR 2 of 4 for issue #562 (MemReader-inspired defer action on the extraction judge).

- Judge now emits `kind: "defer"` when a candidate is ambiguous and another turn of context would change the outcome
- Parser accepts `kind` and `action` aliases from the LLM; falls back to `durable` for legacy responses
- Per-content-hash defer counter enforces a cap (`extractionJudgeMaxDeferrals`, default 2) and forcibly converts further defers to reject
- Defer verdicts are intentionally NOT cached — caching would defeat re-evaluation on a future pass
- Buffer retains the tail of the current turn window across `clearAfterExtraction` when any fact was deferred, so the next extraction pass sees the surrounding context
- New `JudgeBatchResult.deferred` / `deferredCappedToReject` counters
- New config `extractionJudgeMaxDeferrals` (default 2, minimum 1) wired in three plugin manifests

Prompt updated to describe the three verdict kinds with concrete defer examples (ambiguous referents, partial/future-tense statements, context-dependent facts). Defer is explicitly discouraged as a "soft reject."

## Test plan

- [x] `npx tsx --test tests/extraction-judge.test.ts` — 41 tests pass (7 new PR 2 tests)
- [x] `npx tsx --test packages/remnic-core/src/buffer-session.test.ts` — 12 tests pass (5 new defer-retention tests including the `slice(-0)` guard)
- [x] `npm run build` — clean
- [x] Auto-approved categories (corrections, principles) and critical-importance facts continue to bypass the judge and never emit defer

## Follow-ups

- PR 3 — telemetry (defer rate, observation ledger integration)
- PR 4 — opt-in JSONL training-pair collection shim

Closes part of #562.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the extraction-judge gating path and buffer lifecycle around persistence, which can affect what memories are written and when. Risk is moderated by explicit caps/defaults plus extensive new unit tests, but behavior changes could impact downstream extraction outcomes.
> 
> **Overview**
> Adds a third extraction-judge verdict, **`defer`**, to skip persisting ambiguous facts and re-evaluate them on a later extraction pass, while updating the prompt and parser to handle `kind` (and `action` alias) with legacy `durable` fallback.
> 
> Introduces a new config `extractionJudgeMaxDeferrals` (default 2) and per-content deferral counters to cap repeated defers by converting them to `reject`, while ensuring defer verdicts are **not cached** and exposing new judge metrics (`deferred`, `deferredCappedToReject`).
> 
> When any facts are deferred, the orchestrator now retains a tail of recent buffer turns across `clearAfterExtraction` (and prepends retained turns on the next `getTurns`) so the next pass has the context needed to resolve deferrals; includes new tests covering retention semantics and edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 08f44e5e2ed52806e363c156d8eff1ffa17143eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->