### PR TITLE
docs: CHANGELOG + README coverage for #568/#569/#570

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,47 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
+### Added
+
+- **Memory importers for ChatGPT, Claude, Gemini, Mem0** (issue #568).
+  Ship as optional peer-dep packages: `@remnic/import-chatgpt`,
+  `@remnic/import-claude`, `@remnic/import-gemini`, `@remnic/import-mem0`.
+  Load via computed dynamic import from `remnic-cli` so the base install
+  stays small; missing adapter yields a clean install hint, never
+  `MODULE_NOT_FOUND`. CLI: `remnic import --adapter <source> --file <path>`
+  with `--dry-run`, `--rate-limit`, `--batch-size` flags. The
+  `--all-from-bundle <dir>` auto-detects every export format in one
+  directory. See [`docs/importers.md`](docs/importers.md) and the
+  [`/import`](https://remnic.ai/import) page.
+- **Coding agent mode** (issue #569) auto-scopes memory to the git
+  project (origin-URL hash) and optionally to the current branch. New
+  `codingMode.projectScope` (default `true`) and `codingMode.branchScope`
+  (default `false`) config keys. Branch scope falls back to project-level
+  reads so project memories stay visible from any branch while branch
+  writes don't leak. `remnic doctor` now prints detected `projectId`,
+  `branch`, and effective namespace. New MCP tool
+  `remnic.set_coding_context` (with `engram.*` alias) for clients that
+  don't send `cwd`. Claude Code and Codex CLI session-start hooks
+  auto-detect git context with a 2s timeout so wedged filesystems can't
+  stall launch. Diff-aware review-context recall tier activates on
+  review keywords (`review`, `diff`, `what changed`, `look at this PR`)
+  and boosts memories whose `entityRefs` touch the modified files. See
+  [`docs/coding-agent.md`](docs/coding-agent.md) and the
+  [`/coding-agent`](https://remnic.ai/coding-agent) page.
+- **Recall X-ray observability** (issue #570): know exactly why each
+  memory surfaced. New `RecallXraySnapshot` schema captures per-result
+  tier (`direct-answer` / `hybrid` / `graph` / `recent-scan` /
+  `procedural` / `review-context`), score decomposition, filter ladder,
+  graph path, and audit entry ID. Shared renderer
+  (`recall-xray-renderer.ts`) emits JSON, text, or markdown. New CLI
+  `remnic xray "<query>"` with `--format`, `--budget`, `--namespace`,
+  `--out`. HTTP `GET /engram/v1/recall/xray` with bearer + namespace
+  scope. MCP tool `remnic.recall_xray` (with `engram.*` alias). Legacy
+  `/recall/explain` gains a markdown mode that delegates to the xray
+  renderer; existing text/json responses are unchanged and
+  backwards-compatible. See [`docs/xray.md`](docs/xray.md) and the
+  [`/observability`](https://remnic.ai/observability) page.
+
 ### Changed
 
 - **Procedural memory is now enabled by default** (issue #567 PR 4/5;

--- a/README.md
+++ b/README.md
@@ -608,6 +608,8 @@ Run Engram as a standalone HTTP server that multiple agent harnesses share. Isol
 - **Semantic Chunking** — Smoothing-based topic boundary detection using sentence embeddings and cosine similarity, as an alternative to recursive chunking. Opt-in via `semanticChunkingEnabled`. (issue #368)
 - **OAI-mem-citation Blocks** — Recall responses emit `<oai-mem-citation>` blocks matching the Codex citation format for memory attribution and usage tracking. Opt-in via `citationsEnabled`. (issue #379)
 - **Procedural memory** — Stores repeatable **how-to** memories as `category: procedure` markdown under `procedures/`, mines candidates from causal trajectories, and can inject a **Relevant procedures** section on task-initiation prompts. **On by default** since issue #567 PR 4/5 (previously off); set `procedural.enabled` to `false` in plugin config to opt out. See [Procedural memory](docs/procedural-memory.md). (issue #519)
+- **Coding agent mode** — Auto-scopes memory to the current git project (origin-URL hash) and optionally to the current branch, so memories from project A never surface in project B and feature-branch experiments don't leak into `main`. Claude Code and Codex CLI session-start hooks detect git context automatically; Cursor and other MCP clients can call the `remnic.set_coding_context` MCP tool. Diff-aware review-context recall tier boosts memories touching the files in a reviewed diff. `remnic doctor` prints detected `projectId`, branch, and effective namespace. Opt out with `codingMode.projectScope: false`. See [Coding agent mode](docs/coding-agent.md). (issue #569)
+- **Recall X-ray** — `remnic xray "<query>"` prints a per-result breakdown showing which retrieval tier served each memory, the score decomposition, the graph path (when graph retrieval fired), the filter ladder that admitted it, and the audit entry ID. Same snapshot via HTTP `GET /engram/v1/recall/xray` and MCP tool `remnic.recall_xray`. Legacy `/recall/explain` gains a markdown mode that delegates to the same renderer (backwards-compatible). See [Recall X-ray](docs/xray.md). (issue #570)
 
 ### Organization & Taxonomy (opt-in)
 
@@ -929,6 +931,8 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | `enrichmentEnabled` | `false` | External entity enrichment pipeline |
 | `binaryLifecycleEnabled` | `false` | Binary file lifecycle management (mirror/redirect/clean) |
 | `procedural.enabled` | `true` | **Procedural memory (issue #519):** master gate for procedure extraction, task-init recall injection, and trajectory mining. Default-on since issue #567 PR 4/5; set nested `procedural: { "enabled": false }` to opt out (see [Procedural memory](docs/procedural-memory.md)). |
+| `codingMode.projectScope` | `true` | **Coding agent mode (issue #569):** auto-scope memory to the git project (stable origin-URL hash, falls back to root path). Set to `false` to disable project-based namespace isolation. See [Coding agent mode](docs/coding-agent.md). |
+| `codingMode.branchScope` | `false` | **Coding agent mode (issue #569):** additionally scope writes to the current git branch; reads fall back to the project-level namespace so project memories stay visible from any branch while branch writes don't leak. Enable for per-branch experimentation. |
 
 **[See the full config reference for all 60+ settings](docs/config-reference.md)** including search backend configuration, namespace policies, Memory OS features, governance, evaluation harness, trust zones, causal trajectories, and more.
 
@@ -969,6 +973,8 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Memory Extensions](docs/architecture/memory-extensions.md) — Third-party extension discovery
 - [Codex Marketplace](docs/plugins/codex-marketplace.md) — Marketplace installation
 - [Procedural memory](docs/procedural-memory.md) — Procedure files, recall injection, mining; enable with `procedural.enabled` (issue #519)
+- [Coding agent mode](docs/coding-agent.md) — Auto-scope memory to git project / branch, review-context recall, `set_coding_context` MCP tool (issue #569)
+- [Recall X-ray](docs/xray.md) — `remnic xray` CLI, HTTP endpoint, MCP tool for per-result retrieval attribution (issue #570)
 - [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, and mem0 (issue #568)
 
 ## Contributing


### PR DESCRIPTION
## Summary

Closes the documentation gap identified by the #566-#570 audit pass.

- `CHANGELOG.md`: add `[Unreleased]` entries for memory importers (#568), coding agent mode (#569), and recall X-ray observability (#570).
- `README.md`: add bullets for "Coding agent mode" and "Recall X-ray" to the features section, cross-linked to the new `docs/coding-agent.md` and `docs/xray.md` (shipping in #621).
- `README.md` Configuration table: add `codingMode.projectScope` (default `true`) and `codingMode.branchScope` (default `false`) rows.
- `README.md` Documentation list: link the two new docs pages.

## Test plan

- [x] `git diff --cached --stat` confirms only `CHANGELOG.md` and `README.md` touched
- [x] No code changed — check-types trivially clean
- [x] Manual review of rendered CHANGELOG entries against issue bodies for accuracy

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation-only updates in `CHANGELOG.md` and `README.md` with no runtime or configuration parsing changes.
> 
> **Overview**
> Updates docs to cover three recently added capabilities: **memory importers** (ChatGPT/Claude/Gemini/mem0), **coding agent mode** (git project/branch scoping + `remnic.set_coding_context`), and **Recall X-ray** observability (`remnic xray`, HTTP endpoint, MCP tool, and markdown explain output).
> 
> Extends the README’s config table with `codingMode.projectScope` and `codingMode.branchScope`, and adds links to the new `docs/coding-agent.md` and `docs/xray.md` pages; the changelog gains corresponding `[Unreleased]` entries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14d98d2d9fa666fb3fd50be7a63ffda1547fc74a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->