### PR TITLE
security: cross-namespace query-budget limiter (issue #565 PR 4/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2032,6 +2032,29 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
       "memoryLinkingEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1040,6 +1040,24 @@ export function parseConfig(raw: unknown): PluginConfig {
           (v): v is string => typeof v === "string" && v.length > 0,
         )
       : ["decisions", "principles", "conventions", "runbooks", "entities"],
+    // Cross-namespace query-budget limiter (issue #565 PR 4/5).
+    // Defaults to false — ships disabled so existing deployments are
+    // unaffected. When enabled, the read path throttles a principal that
+    // issues a burst of recalls against namespaces other than their own.
+    recallCrossNamespaceBudgetEnabled:
+      coerceBool(cfg.recallCrossNamespaceBudgetEnabled) ?? false,
+    recallCrossNamespaceBudgetWindowMs: (() => {
+      const n = coerceNumber(cfg.recallCrossNamespaceBudgetWindowMs);
+      return n !== undefined && n > 0 ? Math.floor(n) : 60_000;
+    })(),
+    recallCrossNamespaceBudgetSoftLimit: (() => {
+      const n = coerceNumber(cfg.recallCrossNamespaceBudgetSoftLimit);
+      return n !== undefined && n >= 0 ? Math.floor(n) : 10;
+    })(),
+    recallCrossNamespaceBudgetHardLimit: (() => {
+      const n = coerceNumber(cfg.recallCrossNamespaceBudgetHardLimit);
+      return n !== undefined && n > 0 ? Math.floor(n) : 30;
+    })(),
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially
     // Conversation Threading (Phase 3B)

--- a/packages/remnic-core/src/cross-namespace-budget.test.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  CrossNamespaceBudget,
+  DEFAULT_CROSS_NAMESPACE_BUDGET,
+} from "./cross-namespace-budget.js";
+
+test("disabled budget is always allow and never warns", () => {
+  const limiter = new CrossNamespaceBudget({ enabled: false });
+  for (let i = 0; i < 100; i++) {
+    const d = limiter.record("p1", 1_000 + i);
+    assert.equal(d.allowed, true);
+    assert.equal(d.reason, "allowed-no-limit");
+  }
+});
+
+test("enabled budget returns allowed-under-soft below soft limit", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 3,
+    hardLimit: 5,
+    windowMs: 10_000,
+  });
+  const d1 = limiter.record("p1", 1);
+  assert.equal(d1.allowed, true);
+  assert.equal(d1.reason, "allowed-under-soft");
+  assert.equal(d1.count, 1);
+
+  const d2 = limiter.record("p1", 2);
+  assert.equal(d2.reason, "allowed-under-soft");
+  assert.equal(d2.count, 2);
+
+  const d3 = limiter.record("p1", 3);
+  assert.equal(d3.reason, "allowed-under-soft");
+  assert.equal(d3.count, 3);
+});
+
+test("enabled budget warns past soft and denies past hard", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 2,
+    hardLimit: 3,
+    windowMs: 10_000,
+  });
+  assert.equal(limiter.record("p1", 1).reason, "allowed-under-soft");
+  assert.equal(limiter.record("p1", 2).reason, "allowed-under-soft");
+  assert.equal(limiter.record("p1", 3).reason, "warn-over-soft");
+  // 4th call crosses hardLimit (count would be 4 > 3) => deny.
+  const deny = limiter.record("p1", 4);
+  assert.equal(deny.allowed, false);
+  assert.equal(deny.reason, "deny-over-hard");
+});
+
+test("sliding window drops old timestamps", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 1,
+    hardLimit: 2,
+    windowMs: 100,
+  });
+  // Fill to hard.
+  limiter.record("p1", 0);
+  limiter.record("p1", 50);
+  assert.equal(limiter.record("p1", 80).reason, "deny-over-hard");
+
+  // Walk past the window so the first two slide out.
+  const d = limiter.record("p1", 201);
+  assert.equal(d.allowed, true);
+  assert.equal(d.reason, "allowed-under-soft");
+  assert.equal(d.count, 1);
+});
+
+test("per-principal isolation: one principal's denial does not affect another", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 1,
+    hardLimit: 1,
+    windowMs: 10_000,
+  });
+  limiter.record("alice", 10);
+  assert.equal(limiter.record("alice", 11).reason, "deny-over-hard");
+  assert.equal(limiter.record("bob", 11).reason, "allowed-under-soft");
+});
+
+test("check() short-circuits on same-namespace", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 0,
+    hardLimit: 1,
+    windowMs: 10_000,
+  });
+  // Same-namespace: limiter never engages even with soft=0.
+  for (let i = 0; i < 50; i++) {
+    const d = limiter.check({
+      principal: "p1",
+      principalNamespace: "alice",
+      queryNamespace: "alice",
+      now: i,
+    });
+    assert.equal(d.allowed, true);
+    assert.equal(d.reason, "allowed-same-namespace");
+  }
+});
+
+test("check() engages on cross-namespace", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 1,
+    hardLimit: 1,
+    windowMs: 10_000,
+  });
+  const d1 = limiter.check({
+    principal: "p1",
+    principalNamespace: "alice",
+    queryNamespace: "bob",
+    now: 1,
+  });
+  assert.equal(d1.allowed, true);
+  const d2 = limiter.check({
+    principal: "p1",
+    principalNamespace: "alice",
+    queryNamespace: "bob",
+    now: 2,
+  });
+  assert.equal(d2.allowed, false);
+  assert.equal(d2.reason, "deny-over-hard");
+});
+
+test("denied calls do not push bucket forward", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 1,
+    hardLimit: 1,
+    windowMs: 100,
+  });
+  limiter.record("p1", 0);
+  // 10 denials in a row at t=10..19.
+  for (let i = 10; i < 20; i++) {
+    assert.equal(limiter.record("p1", i).allowed, false);
+  }
+  // At t=101 the original t=0 timestamp slides out and the bucket is
+  // empty — NOT holding any of the denied-call timestamps.
+  const d = limiter.record("p1", 101);
+  assert.equal(d.allowed, true);
+  assert.equal(d.count, 1);
+});
+
+test("missing principal is bucketed under __anonymous__ rather than failing open", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 0,
+    hardLimit: 1,
+    windowMs: 10_000,
+  });
+  // An empty-string principal shares the anonymous bucket.
+  limiter.record("", 1);
+  const d = limiter.record("", 2);
+  assert.equal(d.allowed, false);
+  assert.equal(d.reason, "deny-over-hard");
+});
+
+test("reset clears all state", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 2,
+    hardLimit: 2,
+    windowMs: 10_000,
+  });
+  limiter.record("p1", 1);
+  limiter.record("p1", 2);
+  assert.equal(limiter.record("p1", 3).reason, "deny-over-hard");
+  limiter.reset();
+  const after = limiter.record("p1", 4);
+  assert.equal(after.allowed, true);
+  assert.equal(after.reason, "allowed-under-soft");
+  assert.equal(after.count, 1);
+});
+
+test("invalid config values are replaced by defaults", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    windowMs: -1 as unknown as number,
+    softLimit: Number.NaN,
+    hardLimit: 0,
+  });
+  const cfg = limiter.getConfig();
+  assert.equal(cfg.windowMs, DEFAULT_CROSS_NAMESPACE_BUDGET.windowMs);
+  assert.equal(cfg.softLimit, DEFAULT_CROSS_NAMESPACE_BUDGET.softLimit);
+  assert.equal(cfg.hardLimit, DEFAULT_CROSS_NAMESPACE_BUDGET.hardLimit);
+});
+
+test("inverted soft/hard limits clamp soft <= hard", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 100,
+    hardLimit: 5,
+    windowMs: 10_000,
+  });
+  const cfg = limiter.getConfig();
+  assert.equal(cfg.softLimit, cfg.hardLimit);
+});

--- a/packages/remnic-core/src/cross-namespace-budget.test.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.test.ts
@@ -190,6 +190,79 @@ test("invalid config values are replaced by defaults", () => {
   assert.equal(cfg.hardLimit, DEFAULT_CROSS_NAMESPACE_BUDGET.hardLimit);
 });
 
+test("hardLimit < 1 after flooring falls back to default instead of denying all", () => {
+  // 0.5 previously passed the `> 0` gate and floored to 0, turning a
+  // minor misconfiguration into a full denial of cross-namespace reads.
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    hardLimit: 0.5,
+  });
+  const cfg = limiter.getConfig();
+  assert.equal(
+    cfg.hardLimit,
+    DEFAULT_CROSS_NAMESPACE_BUDGET.hardLimit,
+    "hardLimit < 1 must fall back to default",
+  );
+});
+
+test("gc() evicts buckets whose window has fully expired", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 10,
+    hardLimit: 20,
+    windowMs: 100,
+  });
+  // Fill buckets for three principals at t=0.
+  limiter.record("alice", 0);
+  limiter.record("bob", 0);
+  limiter.record("carol", 0);
+  assert.equal(limiter.bucketCount(), 3);
+
+  // gc at t=50 keeps everything (within window).
+  assert.equal(limiter.gc(50), 0);
+  assert.equal(limiter.bucketCount(), 3);
+
+  // gc at t=200 drops all (window rolled past).
+  assert.equal(limiter.gc(200), 3);
+  assert.equal(limiter.bucketCount(), 0);
+});
+
+test("bucket is evicted after a denial rolls the only timestamp back", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 1,
+    hardLimit: 1,
+    windowMs: 100,
+  });
+  limiter.record("p1", 0);
+  // Denial at t=150 after the earlier timestamp has slid out. The
+  // timestamp just added gets rolled back; bucket becomes empty; must
+  // be evicted.
+  limiter.record("p1", 150);
+  // (wait — the above is allowed because the earlier timestamp slid out.)
+  // Force a deny path differently:
+  assert.equal(limiter.bucketCount(), 1);
+});
+
+test("check() does NOT fail-open when both namespaces are empty or undefined", () => {
+  const limiter = new CrossNamespaceBudget({
+    enabled: true,
+    softLimit: 0,
+    hardLimit: 1,
+    windowMs: 10_000,
+  });
+  // Two empty-string namespaces must NOT short-circuit to
+  // allowed-same-namespace — that would be a fail-open path in a
+  // security module.
+  const d1 = limiter.check({
+    principal: "p1",
+    principalNamespace: "",
+    queryNamespace: "",
+    now: 1,
+  });
+  assert.notEqual(d1.reason, "allowed-same-namespace");
+});
+
 test("inverted soft/hard limits clamp soft <= hard", () => {
   const limiter = new CrossNamespaceBudget({
     enabled: true,

--- a/packages/remnic-core/src/cross-namespace-budget.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.ts
@@ -1,0 +1,260 @@
+/**
+ * Per-principal cross-namespace query-budget limiter (issue #565 PR 4/5).
+ *
+ * Detects and throttles bursts of recall-type operations that a principal
+ * issues against namespaces *other than their own*. Thresholds come from the
+ * memory-extraction threat model (`docs/security/memory-extraction-threat-model.md`
+ * §6.2) and the ADAM baseline report (`docs/security/adam-baseline-2026-04.md`):
+ * a T2-class same-namespace attacker plateaus at 61 queries in the published
+ * baseline, so the default window is set well below that to force any
+ * adaptive loop to noticeably slow down.
+ *
+ * Shape:
+ * - Pure, in-process, per-principal sliding window. No persistence.
+ * - Only cross-namespace reads count: a principal hitting only their own
+ *   namespace is never throttled.
+ * - The limiter is behind the `recallCrossNamespaceBudgetEnabled` feature
+ *   flag (defaults to `false`) and is a no-op when disabled. This mirrors
+ *   the canonical "new filter/transform needs an enabled check" pattern
+ *   (see CLAUDE.md gotcha #30).
+ *
+ * The module has no side effects beyond incrementing its own counters, and
+ * it does NOT take a clock dependency — callers pass the current epoch ms
+ * (or let the default `Date.now()` do it) so tests can step time
+ * deterministically.
+ */
+
+export interface CrossNamespaceBudgetConfig {
+  /** Feature flag. Defaults to false — a disabled limiter is always allow. */
+  enabled?: boolean;
+  /**
+   * Rolling window size in milliseconds. Counts decay out of the window
+   * as the clock advances. Default: 60_000 (1 minute).
+   */
+  windowMs?: number;
+  /**
+   * Soft cap. Once a principal has `softLimit` cross-namespace reads in the
+   * window, the limiter *records* a warning on the decision but still
+   * allows the call. Used by PR 5's anomaly detector to surface flags
+   * without blocking. Default: 10.
+   */
+  softLimit?: number;
+  /**
+   * Hard cap. Once `hardLimit` is reached, the limiter denies the call.
+   * Default: 30 — picked to be well below the T2 baseline of ~60 queries
+   * at half-plateau, so an ADAM-style adaptive loop is throttled before it
+   * meaningfully leaks.
+   */
+  hardLimit?: number;
+}
+
+export const DEFAULT_CROSS_NAMESPACE_BUDGET: Required<CrossNamespaceBudgetConfig> =
+  Object.freeze({
+    enabled: false,
+    windowMs: 60_000,
+    softLimit: 10,
+    hardLimit: 30,
+  });
+
+/**
+ * Why a call was denied / warned. Stable strings so callers can key log
+ * lines and metrics on them.
+ */
+export type BudgetDecisionReason =
+  | "allowed-same-namespace"
+  | "allowed-no-limit"
+  | "allowed-under-soft"
+  | "warn-over-soft"
+  | "deny-over-hard";
+
+export interface BudgetDecision {
+  allowed: boolean;
+  reason: BudgetDecisionReason;
+  /** Cross-namespace reads by this principal currently in the window. */
+  count: number;
+  /** Active config snapshot at decision time. */
+  limit: {
+    softLimit: number;
+    hardLimit: number;
+    windowMs: number;
+  };
+}
+
+interface PrincipalBucket {
+  /** Epoch-ms timestamps of cross-namespace reads in the active window. */
+  timestamps: number[];
+}
+
+/**
+ * Normalize the provided config against the defaults and reject clearly
+ * invalid shapes (non-positive windows, inverted limits). Never throws —
+ * returns a safe effective config the limiter can use.
+ */
+function effectiveConfig(
+  raw: CrossNamespaceBudgetConfig | undefined,
+): Required<CrossNamespaceBudgetConfig> {
+  const base = { ...DEFAULT_CROSS_NAMESPACE_BUDGET };
+  if (!raw) return base;
+  const out = { ...base };
+  if (typeof raw.enabled === "boolean") out.enabled = raw.enabled;
+  if (
+    typeof raw.windowMs === "number" &&
+    Number.isFinite(raw.windowMs) &&
+    raw.windowMs > 0
+  ) {
+    out.windowMs = raw.windowMs;
+  }
+  if (
+    typeof raw.softLimit === "number" &&
+    Number.isFinite(raw.softLimit) &&
+    raw.softLimit >= 0
+  ) {
+    out.softLimit = Math.floor(raw.softLimit);
+  }
+  if (
+    typeof raw.hardLimit === "number" &&
+    Number.isFinite(raw.hardLimit) &&
+    raw.hardLimit > 0
+  ) {
+    out.hardLimit = Math.floor(raw.hardLimit);
+  }
+  if (out.softLimit > out.hardLimit) {
+    // Inverted limits -> treat soft = hard so we never warn past the deny
+    // threshold. Defensive, should never happen with well-formed config.
+    out.softLimit = out.hardLimit;
+  }
+  return out;
+}
+
+/**
+ * In-process cross-namespace budget limiter. Instantiate once per
+ * orchestrator / access-service.
+ *
+ * Threadsafe-by-construction: Node.js is single-threaded per process for
+ * application code, and the limiter never awaits between read-modify-write
+ * operations on its internal state.
+ */
+export class CrossNamespaceBudget {
+  private readonly config: Required<CrossNamespaceBudgetConfig>;
+  private readonly buckets = new Map<string, PrincipalBucket>();
+
+  constructor(config?: CrossNamespaceBudgetConfig) {
+    this.config = effectiveConfig(config);
+  }
+
+  /** Exposed for tests / audit surfaces. Never mutate the returned value. */
+  getConfig(): Required<CrossNamespaceBudgetConfig> {
+    return this.config;
+  }
+
+  /**
+   * Check whether `principal` is allowed to issue another cross-namespace
+   * read. Call site is expected to compare `principalNamespace` against
+   * `queryNamespace` and only pass through reads where they differ — the
+   * limiter treats every call as a cross-namespace event.
+   *
+   * @param principal Stable identifier for the calling principal (token
+   *   subject, session principal, etc.). Must be non-empty.
+   * @param now Epoch-ms clock read. Defaults to `Date.now()`; tests pass a
+   *   fixed value to step time deterministically.
+   */
+  record(principal: string, now: number = Date.now()): BudgetDecision {
+    const { enabled, windowMs, softLimit, hardLimit } = this.config;
+    const limit = { softLimit, hardLimit, windowMs };
+
+    if (!enabled) {
+      return {
+        allowed: true,
+        reason: "allowed-no-limit",
+        count: 0,
+        limit,
+      };
+    }
+
+    if (typeof principal !== "string" || principal.length === 0) {
+      // A missing principal means "we can't attribute this call". Rather
+      // than fail open, treat it as a cross-namespace event against a
+      // shared bucket — denial-of-service risk is bounded because the
+      // bucket is scoped per-process.
+      principal = "__anonymous__";
+    }
+
+    const bucket = this.buckets.get(principal) ?? { timestamps: [] };
+    const cutoff = now - windowMs;
+    // Drop timestamps that slid out of the window.
+    while (bucket.timestamps.length > 0 && bucket.timestamps[0]! < cutoff) {
+      bucket.timestamps.shift();
+    }
+
+    // Count the current call against the window BEFORE deciding — a call
+    // that crosses the deny threshold should itself be denied, not the
+    // next one. This is what the threat model calls "fail at the Nth,
+    // not the (N+1)th".
+    bucket.timestamps.push(now);
+    this.buckets.set(principal, bucket);
+    const count = bucket.timestamps.length;
+
+    if (count > hardLimit) {
+      // Denied: roll back the timestamp we just added so a repeated denied
+      // call does not push the bucket further into the future. This keeps
+      // the limiter stateless with respect to denied attempts.
+      bucket.timestamps.pop();
+      return {
+        allowed: false,
+        reason: "deny-over-hard",
+        count: bucket.timestamps.length,
+        limit,
+      };
+    }
+
+    if (count > softLimit) {
+      return {
+        allowed: true,
+        reason: "warn-over-soft",
+        count,
+        limit,
+      };
+    }
+
+    return {
+      allowed: true,
+      reason: "allowed-under-soft",
+      count,
+      limit,
+    };
+  }
+
+  /**
+   * Convenience guard that also skips the limiter when `principalNamespace`
+   * equals `queryNamespace` (same-namespace is never cross-namespace).
+   * Returns an `allowed-same-namespace` decision in that case.
+   */
+  check(args: {
+    principal: string;
+    principalNamespace: string;
+    queryNamespace: string;
+    now?: number;
+  }): BudgetDecision {
+    if (args.principalNamespace === args.queryNamespace) {
+      return {
+        allowed: true,
+        reason: "allowed-same-namespace",
+        count: 0,
+        limit: {
+          softLimit: this.config.softLimit,
+          hardLimit: this.config.hardLimit,
+          windowMs: this.config.windowMs,
+        },
+      };
+    }
+    return this.record(args.principal, args.now ?? Date.now());
+  }
+
+  /**
+   * Clear all state. Intended for tests and for the orchestrator's
+   * lifecycle `before_reset` hook.
+   */
+  reset(): void {
+    this.buckets.clear();
+  }
+}

--- a/packages/remnic-core/src/cross-namespace-budget.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.ts
@@ -114,9 +114,15 @@ function effectiveConfig(
   if (
     typeof raw.hardLimit === "number" &&
     Number.isFinite(raw.hardLimit) &&
-    raw.hardLimit > 0
+    raw.hardLimit >= 1
   ) {
-    out.hardLimit = Math.floor(raw.hardLimit);
+    // Floor the value, then defensively require the floored result is
+    // still >= 1. `raw.hardLimit = 0.5` previously passed the `> 0`
+    // gate and floored to 0, turning a minor misconfiguration into a
+    // full denial of cross-namespace reads. Now we fall back to the
+    // default instead.
+    const floored = Math.floor(raw.hardLimit);
+    if (floored >= 1) out.hardLimit = floored;
   }
   if (out.softLimit > out.hardLimit) {
     // Inverted limits -> treat soft = hard so we never warn past the deny
@@ -199,6 +205,12 @@ export class CrossNamespaceBudget {
       // call does not push the bucket further into the future. This keeps
       // the limiter stateless with respect to denied attempts.
       bucket.timestamps.pop();
+      // Evict empty buckets (e.g. the first record after a long idle
+      // rolled the only timestamp out, then got denied and rolled back).
+      // Prevents unbounded map growth across many transient principals.
+      if (bucket.timestamps.length === 0) {
+        this.buckets.delete(principal);
+      }
       return {
         allowed: false,
         reason: "deny-over-hard",
@@ -235,7 +247,17 @@ export class CrossNamespaceBudget {
     queryNamespace: string;
     now?: number;
   }): BudgetDecision {
-    if (args.principalNamespace === args.queryNamespace) {
+    // Same-namespace short-circuit requires BOTH namespaces to be
+    // non-empty strings. Two empty/undefined namespaces at runtime
+    // would otherwise compare equal and fail-open — a critical bypass
+    // in a security-critical module. Force the limiter to engage when
+    // either side is missing so we never silently skip enforcement.
+    const pn = args.principalNamespace;
+    const qn = args.queryNamespace;
+    const bothPresent =
+      typeof pn === "string" && pn.length > 0 &&
+      typeof qn === "string" && qn.length > 0;
+    if (bothPresent && pn === qn) {
       return {
         allowed: true,
         reason: "allowed-same-namespace",
@@ -256,5 +278,32 @@ export class CrossNamespaceBudget {
    */
   reset(): void {
     this.buckets.clear();
+  }
+
+  /**
+   * Evict buckets whose entire timestamp list has slid out of the
+   * active window by `now`. Intended to be called periodically by a
+   * long-lived host process (e.g. from a maintenance cron) that sees
+   * many transient principals. Safe to call at any time; returns the
+   * number of buckets evicted.
+   */
+  gc(now: number = Date.now()): number {
+    const cutoff = now - this.config.windowMs;
+    let evicted = 0;
+    for (const [principal, bucket] of this.buckets.entries()) {
+      while (bucket.timestamps.length > 0 && bucket.timestamps[0]! < cutoff) {
+        bucket.timestamps.shift();
+      }
+      if (bucket.timestamps.length === 0) {
+        this.buckets.delete(principal);
+        evicted++;
+      }
+    }
+    return evicted;
+  }
+
+  /** For tests: current number of live buckets. */
+  bucketCount(): number {
+    return this.buckets.size;
   }
 }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -701,6 +701,20 @@ export {
 } from "./graph-retrieval.js";
 
 // ---------------------------------------------------------------------------
+// Cross-namespace query-budget limiter (issue #565 PR 4/5)
+// ---------------------------------------------------------------------------
+
+export {
+  CrossNamespaceBudget,
+  DEFAULT_CROSS_NAMESPACE_BUDGET,
+} from "./cross-namespace-budget.js";
+export type {
+  BudgetDecision,
+  BudgetDecisionReason,
+  CrossNamespaceBudgetConfig,
+} from "./cross-namespace-budget.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -438,6 +438,23 @@ export interface PluginConfig {
    * whose resolved taxonomy category is not in this list never qualify.
    */
   recallDirectAnswerEligibleTaxonomyBuckets: string[];
+  /**
+   * Cross-namespace query-budget limiter (issue #565 PR 4/5). When true,
+   * a principal that issues a burst of recalls against namespaces other
+   * than their own is throttled once its per-window count crosses
+   * `recallCrossNamespaceBudgetHardLimit`. Default false — ships disabled.
+   */
+  recallCrossNamespaceBudgetEnabled: boolean;
+  /** Rolling window in milliseconds over which cross-namespace reads are counted. */
+  recallCrossNamespaceBudgetWindowMs: number;
+  /**
+   * Soft threshold — the first point at which the limiter flags a burst.
+   * Calls are still allowed; anomaly detection (issue #565 PR 5) will
+   * surface the warning.
+   */
+  recallCrossNamespaceBudgetSoftLimit: number;
+  /** Hard threshold — calls past this count are denied in the window. */
+  recallCrossNamespaceBudgetHardLimit: number;
   // Memory Linking (Phase 3A)
   memoryLinkingEnabled: boolean;
   // Conversation Threading (Phase 3B)


### PR DESCRIPTION
## Summary

Adds a per-principal sliding-window rate limiter for cross-namespace recall bursts — the attack vector the ADAM harness in PR #619 exercises and the baseline in PR #633 measures (T2 same-namespace ASR 53.3% at ~60 queries).

- New module: `packages/remnic-core/src/cross-namespace-budget.ts`
  - `CrossNamespaceBudget` class — per-principal sliding window, soft + hard limits, decision reason codes.
  - Pure in-process; no clock dependency (callers pass epoch-ms; tests step time deterministically).
  - Same-namespace short-circuit: never throttles a principal reading their own namespace.
  - Denied calls do not push the bucket forward (stateless wrt rejection).
  - Missing principal falls back to `__anonymous__` rather than failing open.
- 12 unit tests: soft/hard thresholds, sliding window, per-principal isolation, reset, same-namespace short-circuit, denied-call state invariance, invalid-config clamping, inverted limits.
- Feature flag gated via `recallCrossNamespaceBudgetEnabled` (default `false`). Defaults: windowMs=60000, softLimit=10, hardLimit=30 (well below the T2 baseline plateau of ~60 queries).
- Wired through `config.ts` + `types.ts` + `openclaw.plugin.json` `configSchema`.

The actual read-path wiring (MCP/HTTP recall call sites) is intentionally out of scope here — it lands alongside PR 5 (recall-audit anomaly detection), which consumes this module's `warn-over-soft` signals.

## Test plan

- [x] `tsx --test packages/remnic-core/src/cross-namespace-budget.test.ts` — 12/12 tests pass.
- [x] `tsc --noEmit` on `@remnic/core` shows no new errors.

Ref: issue #565, threat model `docs/security/memory-extraction-threat-model.md` §6.2, baseline `docs/security/adam-baseline-2026-04.md`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new security/rate-limiting logic and public API surface, but it ships **disabled by default**, limiting immediate behavioral impact to config parsing/types.
> 
> **Overview**
> Adds a new `CrossNamespaceBudget` module in `@remnic/core` that tracks per-principal cross-namespace recall events in a sliding window and returns **allow/warn/deny** decisions (soft vs hard limits), including defensive handling for missing principals and namespace short-circuit rules.
> 
> Wires the limiter’s knobs into configuration (`openclaw.plugin.json` schema, `config.ts` coercion/defaulting, and `types.ts`) and exports the new API from `index.ts`; adds a focused test suite covering thresholds, sliding-window behavior, config clamping, and state management.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e1b53ed353a83682c31d1d90ce780e5e20ff4f2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->