### PR TITLE
security: recall-audit anomaly detection + access audit adapter (issue #565 PR 5/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2032,6 +2032,41 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Recall-audit anomaly detector (issue #565). When true, access surfaces run the detector over a tail of the audit trail after each recall and surface any flags. Ships disabled."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query flag: a normalized query repeated more than this many times in the window trips."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk flag: more than this many distinct candidate namespaces in the window trips."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return flag: a single recall surfacing more than this many candidate IDs trips."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire flag: more than this many audit entries in the window trips, regardless of content."
+      },
       "memoryLinkingEnabled": {
         "type": "boolean",
         "default": false,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2111,6 +2111,41 @@
         "default": 30,
         "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
       },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2088,6 +2088,64 @@
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Recall-audit anomaly detector (issue #565). When true, access surfaces run the detector over a tail of the audit trail after each recall and surface any flags. Ships disabled."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query flag: a normalized query repeated more than this many times in the window trips."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk flag: more than this many distinct candidate namespaces in the window trips."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return flag: a single recall surfacing more than this many candidate IDs trips."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire flag: more than this many audit entries in the window trips, regardless of content."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2111,6 +2111,41 @@
         "default": 30,
         "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
       },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+      },
       "recallMemoryWorthFilterEnabled": {
         "type": "boolean",
         "default": true,

--- a/packages/remnic-core/src/access-audit.test.ts
+++ b/packages/remnic-core/src/access-audit.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { AccessAuditAdapter } from "./access-audit.js";
+import type { RecallAuditEntry } from "./recall-audit.js";
+
+function makeEntry(q: string, ts = new Date().toISOString()): RecallAuditEntry {
+  return {
+    ts,
+    sessionKey: "session-a",
+    agentId: "agent-a",
+    trigger: "test",
+    queryText: q,
+    candidateMemoryIds: [],
+    summary: null,
+    injectedChars: 0,
+    toggleState: "enabled",
+  };
+}
+
+test("adapter with audit off and detection off is a no-op", async () => {
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: false, rootDir: "/dev/null" },
+    detection: { enabled: false },
+  });
+  const r = await adapter.record("p1", makeEntry("hi"));
+  assert.equal(r.appendedAt, undefined);
+  assert.equal(r.anomalies, undefined);
+});
+
+test("adapter runs detector in-memory when detection-only is enabled", async () => {
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: false, rootDir: "/dev/null" },
+    detection: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 2,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const now = Date.now();
+  for (let i = 0; i < 5; i++) {
+    await adapter.record(
+      "p1",
+      makeEntry("ALEX", new Date(now + i).toISOString()),
+      now + i,
+    );
+  }
+  const final = await adapter.record(
+    "p1",
+    makeEntry("ALEX", new Date(now + 100).toISOString()),
+    now + 100,
+  );
+  assert.ok(final.anomalies);
+  const repeat = final.anomalies.flags.find((f) => f.kind === "repeat-query");
+  assert.ok(repeat, "repeat-query flag should fire");
+});
+
+test("adapter buckets tail per-principal so bursts do not cross principals", async () => {
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: false, rootDir: "/dev/null" },
+    detection: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 2,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const now = Date.now();
+  // Alice bursts.
+  for (let i = 0; i < 5; i++) {
+    await adapter.record(
+      "alice",
+      makeEntry("x", new Date(now + i).toISOString()),
+      now + i,
+    );
+  }
+  // Bob issues a single query. The detector must not see Alice's entries
+  // in Bob's tail.
+  const bob = await adapter.record(
+    "bob",
+    makeEntry("x", new Date(now + 10).toISOString()),
+    now + 10,
+  );
+  assert.ok(bob.anomalies);
+  assert.equal(bob.anomalies.windowEntryCount, 1);
+  assert.equal(bob.anomalies.flags.length, 0);
+});
+
+test("adapter writes JSONL when audit is enabled and tolerates write failures", async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), "access-audit-"));
+  try {
+    const adapter = new AccessAuditAdapter({
+      audit: { enabled: true, rootDir: dir },
+      detection: { enabled: false },
+    });
+    const r = await adapter.record("p1", makeEntry("hi"));
+    assert.ok(r.appendedAt, "audit file path should be returned");
+    assert.ok(r.appendedAt.startsWith(dir));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("audit write failure does not throw — the enclosing recall continues", async () => {
+  // Point at a path we expect to be unwritable — a file path used as a
+  // directory. appendRecallAuditEntry will ENOTDIR on mkdir; the adapter
+  // must swallow.
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: true, rootDir: "/dev/null/not-a-dir" },
+    detection: { enabled: false },
+  });
+  const r = await adapter.record("p1", makeEntry("hi"));
+  assert.equal(r.appendedAt, undefined);
+});
+
+test("trail buffer respects trailBufferSize", async () => {
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: false, rootDir: "/dev/null" },
+    detection: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 1_000,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+    trailBufferSize: 3,
+  });
+  const now = Date.now();
+  for (let i = 0; i < 10; i++) {
+    await adapter.record(
+      "p1",
+      makeEntry(`q-${i}`, new Date(now + i).toISOString()),
+      now + i,
+    );
+  }
+  const final = await adapter.record(
+    "p1",
+    makeEntry("final", new Date(now + 20).toISOString()),
+    now + 20,
+  );
+  assert.ok(final.anomalies);
+  assert.equal(final.anomalies.windowEntryCount, 3);
+});
+
+test("reset clears all tails", async () => {
+  const adapter = new AccessAuditAdapter({
+    audit: { enabled: false, rootDir: "/dev/null" },
+    detection: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 1,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const now = Date.now();
+  await adapter.record("p1", makeEntry("x", new Date(now).toISOString()), now);
+  await adapter.record("p1", makeEntry("x", new Date(now + 1).toISOString()), now + 1);
+  adapter.reset();
+  const r = await adapter.record(
+    "p1",
+    makeEntry("x", new Date(now + 2).toISOString()),
+    now + 2,
+  );
+  assert.ok(r.anomalies);
+  assert.equal(r.anomalies.windowEntryCount, 1);
+  assert.equal(r.anomalies.flags.length, 0);
+});

--- a/packages/remnic-core/src/access-audit.ts
+++ b/packages/remnic-core/src/access-audit.ts
@@ -91,17 +91,21 @@ export class AccessAuditAdapter {
       }
     }
 
-    // Update the in-memory tail whether or not audit writes landed, so
-    // detection still works in read-only deployments.
-    const key = principalKey.length > 0 ? principalKey : "__anonymous__";
-    const tail = this.trails.get(key) ?? { entries: [] };
-    tail.entries.push(entry);
-    if (tail.entries.length > this.trailBufferSize) {
-      tail.entries.splice(0, tail.entries.length - this.trailBufferSize);
-    }
-    this.trails.set(key, tail);
-
+    // Only maintain the in-memory tail when detection is actually
+    // enabled — otherwise a long-lived MCP/HTTP service with many
+    // transient session keys accumulates unbounded `trails` state with
+    // no corresponding detector output to use it. This also keeps the
+    // adapter's default (detection off) a true no-op beyond the audit
+    // write.
     if (this.config.detection.enabled) {
+      const key = principalKey.length > 0 ? principalKey : "__anonymous__";
+      const tail = this.trails.get(key) ?? { entries: [] };
+      tail.entries.push(entry);
+      if (tail.entries.length > this.trailBufferSize) {
+        tail.entries.splice(0, tail.entries.length - this.trailBufferSize);
+      }
+      this.trails.set(key, tail);
+
       result.anomalies = detectRecallAnomalies({
         entries: tail.entries,
         now,

--- a/packages/remnic-core/src/access-audit.ts
+++ b/packages/remnic-core/src/access-audit.ts
@@ -1,0 +1,119 @@
+/**
+ * Access-layer audit adapter (issue #565 PR 5/5).
+ *
+ * Wraps `appendRecallAuditEntry` + `detectRecallAnomalies` into a single
+ * entry point that MCP (`access-mcp.ts`) and HTTP (`access-http.ts`)
+ * surfaces can call once per recall. Closes the gap called out in the
+ * memory-extraction threat model §5: recall-audit previously only ran
+ * on the Openclaw hook, so MCP/HTTP callers bypassed the trail entirely.
+ *
+ * The adapter is a per-instance class so the tail-of-trail buffer
+ * (used by the anomaly detector) is scoped per-service, not global.
+ *
+ * No I/O unless `audit.enabled` is true; no detector invocation unless
+ * `detection.enabled` is true. Either flag may be enabled independently.
+ */
+
+import {
+  appendRecallAuditEntry,
+  type RecallAuditEntry,
+} from "./recall-audit.js";
+import {
+  detectRecallAnomalies,
+  type AnomalyDetectorConfig,
+  type AnomalyDetectorResult,
+} from "./recall-audit-anomaly.js";
+
+export interface AccessAuditConfig {
+  audit: {
+    enabled: boolean;
+    /** Root directory the audit adapter writes JSONL shards into. */
+    rootDir: string;
+  };
+  detection: AnomalyDetectorConfig;
+  /**
+   * How many entries the adapter retains in memory for the detector.
+   * Defaults to 256 — enough to cover the threat model's default 5-minute
+   * window at high recall rates without unbounded growth.
+   */
+  trailBufferSize?: number;
+}
+
+export interface AccessAuditResult {
+  /** Path of the JSONL shard the entry was appended to (only when audit enabled). */
+  appendedAt?: string;
+  /** Result of the anomaly detector (only when detection enabled). */
+  anomalies?: AnomalyDetectorResult;
+}
+
+/**
+ * Per-principal tail buffer. Distinct principals do not pollute each
+ * other's detection windows — otherwise one noisy legitimate client
+ * could mask an actual attacker.
+ */
+interface PrincipalTail {
+  entries: RecallAuditEntry[];
+}
+
+export class AccessAuditAdapter {
+  private readonly trails = new Map<string, PrincipalTail>();
+  private readonly trailBufferSize: number;
+
+  constructor(private readonly config: AccessAuditConfig) {
+    const n = config.trailBufferSize;
+    this.trailBufferSize =
+      typeof n === "number" && Number.isFinite(n) && n > 0 ? Math.floor(n) : 256;
+  }
+
+  /**
+   * Record an audit entry and (when enabled) run the anomaly detector
+   * over the principal's tail of entries. The principal key is used
+   * purely for tail-buffer bucketing — it need not match the production
+   * namespace resolver; sessionKey is the safe default.
+   */
+  async record(
+    principalKey: string,
+    entry: RecallAuditEntry,
+    now: number = Date.now(),
+  ): Promise<AccessAuditResult> {
+    const result: AccessAuditResult = {};
+
+    if (this.config.audit.enabled) {
+      try {
+        result.appendedAt = await appendRecallAuditEntry(
+          this.config.audit.rootDir,
+          entry,
+        );
+      } catch {
+        // Audit write failures must never crash the enclosing recall.
+        // Swallow — operators can surface the ENOSPC / permission error
+        // via the usual filesystem monitoring.
+      }
+    }
+
+    // Update the in-memory tail whether or not audit writes landed, so
+    // detection still works in read-only deployments.
+    const key = principalKey.length > 0 ? principalKey : "__anonymous__";
+    const tail = this.trails.get(key) ?? { entries: [] };
+    tail.entries.push(entry);
+    if (tail.entries.length > this.trailBufferSize) {
+      tail.entries.splice(0, tail.entries.length - this.trailBufferSize);
+    }
+    this.trails.set(key, tail);
+
+    if (this.config.detection.enabled) {
+      result.anomalies = detectRecallAnomalies({
+        entries: tail.entries,
+        now,
+        config: this.config.detection,
+      });
+    }
+
+    return result;
+  }
+
+  /** Clear all in-memory tail state. Intended for tests / before_reset. */
+  reset(): void {
+    this.trails.clear();
+  }
+}

--- a/packages/remnic-core/src/access-audit.ts
+++ b/packages/remnic-core/src/access-audit.ts
@@ -61,8 +61,13 @@ export class AccessAuditAdapter {
 
   constructor(private readonly config: AccessAuditConfig) {
     const n = config.trailBufferSize;
-    this.trailBufferSize =
-      typeof n === "number" && Number.isFinite(n) && n > 0 ? Math.floor(n) : 256;
+    if (typeof n === "number" && Number.isFinite(n) && n > 0) {
+      const floored = Math.floor(n);
+      // Guard against fractional inputs (e.g. 0.5) that floor to 0.
+      this.trailBufferSize = floored >= 1 ? floored : 256;
+    } else {
+      this.trailBufferSize = 256;
+    }
   }
 
   /**

--- a/packages/remnic-core/src/access-audit.ts
+++ b/packages/remnic-core/src/access-audit.ts
@@ -83,25 +83,9 @@ export class AccessAuditAdapter {
   ): Promise<AccessAuditResult> {
     const result: AccessAuditResult = {};
 
-    if (this.config.audit.enabled) {
-      try {
-        result.appendedAt = await appendRecallAuditEntry(
-          this.config.audit.rootDir,
-          entry,
-        );
-      } catch {
-        // Audit write failures must never crash the enclosing recall.
-        // Swallow — operators can surface the ENOSPC / permission error
-        // via the usual filesystem monitoring.
-      }
-    }
-
-    // Only maintain the in-memory tail when detection is actually
-    // enabled — otherwise a long-lived MCP/HTTP service with many
-    // transient session keys accumulates unbounded `trails` state with
-    // no corresponding detector output to use it. This also keeps the
-    // adapter's default (detection off) a true no-op beyond the audit
-    // write.
+    // Update the in-memory tail BEFORE the async audit write so a failed
+    // append never leaves the tail in a stale state. The detector must see
+    // every record regardless of whether the JSONL shard accepted it.
     if (this.config.detection.enabled) {
       const key = principalKey.length > 0 ? principalKey : "__anonymous__";
       const tail = this.trails.get(key) ?? { entries: [] };
@@ -116,6 +100,19 @@ export class AccessAuditAdapter {
         now,
         config: this.config.detection,
       });
+    }
+
+    if (this.config.audit.enabled) {
+      try {
+        result.appendedAt = await appendRecallAuditEntry(
+          this.config.audit.rootDir,
+          entry,
+        );
+      } catch {
+        // Audit write failures must never crash the enclosing recall.
+        // Swallow — operators can surface the ENOSPC / permission error
+        // via the usual filesystem monitoring.
+      }
     }
 
     return result;

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1040,6 +1040,32 @@ export function parseConfig(raw: unknown): PluginConfig {
           (v): v is string => typeof v === "string" && v.length > 0,
         )
       : ["decisions", "principles", "conventions", "runbooks", "entities"],
+    // Recall-audit anomaly detector (issue #565 PR 5/5). Defaults off so
+    // existing deployments are unaffected; enable explicitly to let the
+    // access surfaces flag suspicious query patterns derived from the
+    // audit trail.
+    recallAuditAnomalyDetectionEnabled:
+      coerceBool(cfg.recallAuditAnomalyDetectionEnabled) ?? false,
+    recallAuditAnomalyWindowMs: (() => {
+      const n = coerceNumber(cfg.recallAuditAnomalyWindowMs);
+      return n !== undefined && n > 0 ? Math.floor(n) : 5 * 60_000;
+    })(),
+    recallAuditAnomalyRepeatQueryLimit: (() => {
+      const n = coerceNumber(cfg.recallAuditAnomalyRepeatQueryLimit);
+      return n !== undefined && n > 0 ? Math.floor(n) : 5;
+    })(),
+    recallAuditAnomalyNamespaceWalkLimit: (() => {
+      const n = coerceNumber(cfg.recallAuditAnomalyNamespaceWalkLimit);
+      return n !== undefined && n > 0 ? Math.floor(n) : 3;
+    })(),
+    recallAuditAnomalyHighCardinalityLimit: (() => {
+      const n = coerceNumber(cfg.recallAuditAnomalyHighCardinalityLimit);
+      return n !== undefined && n > 0 ? Math.floor(n) : 50;
+    })(),
+    recallAuditAnomalyRapidFireLimit: (() => {
+      const n = coerceNumber(cfg.recallAuditAnomalyRapidFireLimit);
+      return n !== undefined && n > 0 ? Math.floor(n) : 30;
+    })(),
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially
     // Conversation Threading (Phase 3B)

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1043,28 +1043,41 @@ export function parseConfig(raw: unknown): PluginConfig {
     // Recall-audit anomaly detector (issue #565 PR 5/5). Defaults off so
     // existing deployments are unaffected; enable explicitly to let the
     // access surfaces flag suspicious query patterns derived from the
-    // audit trail.
+    // audit trail. Thresholds floor AFTER validating the floored value
+    // is still >= 1 — a `0.5` input that floors to 0 would turn every
+    // detector into a flood-on-anything, flipping the default to
+    // max-noise instead of max-silence.
     recallAuditAnomalyDetectionEnabled:
       coerceBool(cfg.recallAuditAnomalyDetectionEnabled) ?? false,
     recallAuditAnomalyWindowMs: (() => {
       const n = coerceNumber(cfg.recallAuditAnomalyWindowMs);
-      return n !== undefined && n > 0 ? Math.floor(n) : 5 * 60_000;
+      if (n === undefined) return 5 * 60_000;
+      const floored = Math.floor(n);
+      return floored >= 1 ? floored : 5 * 60_000;
     })(),
     recallAuditAnomalyRepeatQueryLimit: (() => {
       const n = coerceNumber(cfg.recallAuditAnomalyRepeatQueryLimit);
-      return n !== undefined && n > 0 ? Math.floor(n) : 5;
+      if (n === undefined) return 5;
+      const floored = Math.floor(n);
+      return floored >= 1 ? floored : 5;
     })(),
     recallAuditAnomalyNamespaceWalkLimit: (() => {
       const n = coerceNumber(cfg.recallAuditAnomalyNamespaceWalkLimit);
-      return n !== undefined && n > 0 ? Math.floor(n) : 3;
+      if (n === undefined) return 3;
+      const floored = Math.floor(n);
+      return floored >= 1 ? floored : 3;
     })(),
     recallAuditAnomalyHighCardinalityLimit: (() => {
       const n = coerceNumber(cfg.recallAuditAnomalyHighCardinalityLimit);
-      return n !== undefined && n > 0 ? Math.floor(n) : 50;
+      if (n === undefined) return 50;
+      const floored = Math.floor(n);
+      return floored >= 1 ? floored : 50;
     })(),
     recallAuditAnomalyRapidFireLimit: (() => {
       const n = coerceNumber(cfg.recallAuditAnomalyRapidFireLimit);
-      return n !== undefined && n > 0 ? Math.floor(n) : 30;
+      if (n === undefined) return 30;
+      const floored = Math.floor(n);
+      return floored >= 1 ? floored : 30;
     })(),
     // Memory Linking (Phase 3A)
     memoryLinkingEnabled: cfg.memoryLinkingEnabled === true, // Off by default initially

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -711,6 +711,30 @@ export {
 } from "./graph-retrieval.js";
 
 // ---------------------------------------------------------------------------
+// Recall-audit anomaly detector (issue #565 PR 5/5)
+// ---------------------------------------------------------------------------
+
+export {
+  DEFAULT_ANOMALY_DETECTOR_CONFIG,
+  detectRecallAnomalies,
+  normalizeQueryText,
+} from "./recall-audit-anomaly.js";
+export type {
+  AnomalyDetectorConfig,
+  AnomalyDetectorInput,
+  AnomalyDetectorResult,
+  AnomalyFlag,
+  AnomalyKind,
+  AnomalySeverity,
+} from "./recall-audit-anomaly.js";
+
+export { AccessAuditAdapter } from "./access-audit.js";
+export type {
+  AccessAuditConfig,
+  AccessAuditResult,
+} from "./access-audit.js";
+
+// ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------
 

--- a/packages/remnic-core/src/recall-audit-anomaly.test.ts
+++ b/packages/remnic-core/src/recall-audit-anomaly.test.ts
@@ -1,0 +1,246 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { RecallAuditEntry } from "./recall-audit.js";
+import {
+  DEFAULT_ANOMALY_DETECTOR_CONFIG,
+  detectRecallAnomalies,
+  normalizeQueryText,
+} from "./recall-audit-anomaly.js";
+
+function makeEntry(
+  overrides: Partial<RecallAuditEntry> & { ts: string },
+): RecallAuditEntry {
+  return {
+    ts: overrides.ts,
+    sessionKey: overrides.sessionKey ?? "session-a",
+    agentId: overrides.agentId ?? "agent-a",
+    trigger: overrides.trigger ?? "test",
+    queryText: overrides.queryText ?? "hello",
+    candidateMemoryIds: overrides.candidateMemoryIds ?? [],
+    summary: overrides.summary ?? null,
+    injectedChars: overrides.injectedChars ?? 0,
+    toggleState: overrides.toggleState ?? "enabled",
+    latencyMs: overrides.latencyMs,
+    plannerMode: overrides.plannerMode,
+    requestedMode: overrides.requestedMode,
+    fallbackUsed: overrides.fallbackUsed,
+  };
+}
+
+function tsAt(epochMs: number): string {
+  return new Date(epochMs).toISOString();
+}
+
+test("normalizeQueryText lowercases, collapses whitespace, trims", () => {
+  assert.equal(normalizeQueryText("  Hello\tWorld\n"), "hello world");
+  assert.equal(normalizeQueryText(""), "");
+  assert.equal(normalizeQueryText("ALREADY  SPACED"), "already spaced");
+});
+
+test("disabled detector returns zero flags but still reports window count", () => {
+  const entries = [
+    makeEntry({ ts: tsAt(1_000), queryText: "a" }),
+    makeEntry({ ts: tsAt(2_000), queryText: "a" }),
+  ];
+  const result = detectRecallAnomalies({
+    entries,
+    now: 10_000,
+    config: { enabled: false, windowMs: 60_000, repeatQueryLimit: 1 },
+  });
+  assert.equal(result.flags.length, 0);
+  assert.equal(result.windowEntryCount, 2);
+});
+
+test("repeat-query flag fires on bursts of the same normalized query", () => {
+  const entries: RecallAuditEntry[] = [];
+  for (let i = 0; i < 10; i++) {
+    entries.push(
+      makeEntry({ ts: tsAt(1_000 + i * 100), queryText: "ALEX" }),
+    );
+  }
+  const result = detectRecallAnomalies({
+    entries,
+    now: 5_000,
+    config: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 5,
+      namespaceWalkLimit: 100,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const repeat = result.flags.find((f) => f.kind === "repeat-query");
+  assert.ok(repeat, "repeat-query flag must fire");
+  assert.equal(repeat.signal, "alex");
+  assert.equal(repeat.entryIndices.length, 10);
+});
+
+test("namespace-walk fires when candidate IDs span > namespaceWalkLimit namespaces", () => {
+  const entries = [
+    makeEntry({
+      ts: tsAt(1_000),
+      candidateMemoryIds: ["victim/mem-1", "other/mem-2"],
+    }),
+    makeEntry({
+      ts: tsAt(2_000),
+      candidateMemoryIds: ["third/mem-3", "fourth/mem-4"],
+    }),
+  ];
+  const result = detectRecallAnomalies({
+    entries,
+    now: 10_000,
+    config: {
+      enabled: true,
+      windowMs: 60_000,
+      namespaceWalkLimit: 3,
+      repeatQueryLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const walk = result.flags.find((f) => f.kind === "namespace-walk");
+  assert.ok(walk, "namespace-walk flag must fire");
+  assert.equal(walk.severity, "alert");
+  assert.equal(walk.signal, 4);
+});
+
+test("high-cardinality-return fires on a single huge response", () => {
+  const bigList = Array.from({ length: 120 }, (_, i) => `victim/mem-${i}`);
+  const entries = [
+    makeEntry({
+      ts: tsAt(1_000),
+      queryText: "dump",
+      candidateMemoryIds: bigList,
+    }),
+  ];
+  const result = detectRecallAnomalies({
+    entries,
+    now: 5_000,
+    config: {
+      enabled: true,
+      windowMs: 60_000,
+      highCardinalityReturnLimit: 100,
+      repeatQueryLimit: 1_000,
+      namespaceWalkLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  const hc = result.flags.find((f) => f.kind === "high-cardinality-return");
+  assert.ok(hc, "high-cardinality-return must fire");
+  assert.equal(hc.signal, 120);
+});
+
+test("rapid-fire fires on too many entries in the window", () => {
+  const entries: RecallAuditEntry[] = [];
+  for (let i = 0; i < 40; i++) {
+    entries.push(makeEntry({ ts: tsAt(1_000 + i), queryText: `q-${i}` }));
+  }
+  const result = detectRecallAnomalies({
+    entries,
+    now: 5_000,
+    config: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 1_000,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 30,
+    },
+  });
+  const rf = result.flags.find((f) => f.kind === "rapid-fire");
+  assert.ok(rf, "rapid-fire flag must fire");
+  assert.equal(rf.signal, 40);
+});
+
+test("entries outside the window are ignored", () => {
+  const entries: RecallAuditEntry[] = [];
+  // 20 old entries (outside window), 2 new entries (inside).
+  for (let i = 0; i < 20; i++) {
+    entries.push(makeEntry({ ts: tsAt(0 + i), queryText: "old" }));
+  }
+  entries.push(makeEntry({ ts: tsAt(10_000), queryText: "new" }));
+  entries.push(makeEntry({ ts: tsAt(11_000), queryText: "new" }));
+  const result = detectRecallAnomalies({
+    entries,
+    now: 12_000,
+    config: {
+      enabled: true,
+      windowMs: 5_000, // <- covers 7_000..12_000 only
+      repeatQueryLimit: 1,
+      namespaceWalkLimit: 1_000,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 1_000,
+    },
+  });
+  assert.equal(result.windowEntryCount, 2);
+  // The repeat-query flag fires on "new" (2 repeats > limit 1), not on "old".
+  const flag = result.flags.find((f) => f.kind === "repeat-query");
+  assert.ok(flag);
+  assert.equal(flag.signal, "new");
+});
+
+test("invalid ts entries are skipped silently", () => {
+  const entries = [
+    makeEntry({ ts: "not-a-date", queryText: "a" }),
+    makeEntry({ ts: tsAt(1_000), queryText: "a" }),
+  ];
+  const result = detectRecallAnomalies({
+    entries,
+    now: 5_000,
+    config: { ...DEFAULT_ANOMALY_DETECTOR_CONFIG, enabled: true },
+  });
+  assert.equal(result.windowEntryCount, 1);
+});
+
+test("flags are sorted by severity then kind for deterministic output", () => {
+  const entries: RecallAuditEntry[] = [];
+  // Trigger alert (namespace-walk) + warn (repeat-query + rapid-fire).
+  for (let i = 0; i < 10; i++) {
+    entries.push(
+      makeEntry({
+        ts: tsAt(1_000 + i),
+        queryText: "same",
+        candidateMemoryIds: [`ns-${i}/mem`],
+      }),
+    );
+  }
+  const result = detectRecallAnomalies({
+    entries,
+    now: 5_000,
+    config: {
+      enabled: true,
+      windowMs: 60_000,
+      repeatQueryLimit: 5,
+      namespaceWalkLimit: 3,
+      highCardinalityReturnLimit: 1_000,
+      rapidFireLimit: 5,
+    },
+  });
+  assert.ok(result.flags.length >= 2);
+  // alert comes before warn.
+  const severities = result.flags.map((f) => f.severity);
+  const firstWarn = severities.indexOf("warn");
+  const lastAlert = severities.lastIndexOf("alert");
+  if (firstWarn >= 0 && lastAlert >= 0) {
+    assert.ok(lastAlert < firstWarn, "alerts must precede warns");
+  }
+});
+
+test("invalid config values are replaced by defaults", () => {
+  const entries = [makeEntry({ ts: tsAt(1_000) })];
+  const result = detectRecallAnomalies({
+    entries,
+    now: 2_000,
+    config: {
+      enabled: true,
+      windowMs: Number.NaN,
+      repeatQueryLimit: -1,
+      namespaceWalkLimit: 0,
+      highCardinalityReturnLimit: Number.POSITIVE_INFINITY,
+      rapidFireLimit: Number.NaN,
+    },
+  });
+  assert.equal(result.windowMs, DEFAULT_ANOMALY_DETECTOR_CONFIG.windowMs);
+});

--- a/packages/remnic-core/src/recall-audit-anomaly.ts
+++ b/packages/remnic-core/src/recall-audit-anomaly.ts
@@ -217,21 +217,32 @@ export function detectRecallAnomalies(
   }
 
   // 2) namespace-walk: distinct namespaces extracted from candidateMemoryIds.
-  //    Candidate IDs that begin with `<namespace>/` disclose the namespace.
-  //    Entries whose IDs have no prefix are treated as "own namespace".
+  //    Candidate IDs that begin with `<namespace>/` disclose the namespace
+  //    directly. IDs without a slash prefix (e.g. bare filenames) do not
+  //    disclose a namespace, but a recall whose result list mixes
+  //    prefixed AND unprefixed IDs is itself suspicious — it suggests
+  //    the backend leaked memories from both the caller's own namespace
+  //    and named tenants. We track unprefixed IDs under a reserved
+  //    sentinel namespace so they still contribute to the count when a
+  //    trail is all-unprefixed (common for older audit entries sourced
+  //    from filenames).
   {
     const namespaces = new Set<string>();
     const indices: number[] = [];
     for (const { entry, index } of windowed) {
       if (!Array.isArray(entry.candidateMemoryIds)) continue;
+      let touchedAny = false;
       for (const id of entry.candidateMemoryIds) {
-        if (typeof id !== "string") continue;
+        if (typeof id !== "string" || id.length === 0) continue;
         const slash = id.indexOf("/");
         if (slash > 0) {
           namespaces.add(id.slice(0, slash));
+        } else {
+          namespaces.add("__unprefixed__");
         }
+        touchedAny = true;
       }
-      indices.push(index);
+      if (touchedAny) indices.push(index);
     }
     if (namespaces.size > cfg.namespaceWalkLimit) {
       flags.push({

--- a/packages/remnic-core/src/recall-audit-anomaly.ts
+++ b/packages/remnic-core/src/recall-audit-anomaly.ts
@@ -139,7 +139,10 @@ function effectiveConfig(
   ] as const) {
     const v = raw[key];
     if (typeof v === "number" && Number.isFinite(v) && v > 0) {
-      out[key] = Math.floor(v);
+      const floored = Math.floor(v);
+      // Guard against fractional inputs (e.g. 0.5) that floor to 0 and
+      // turn every detector into a flood-on-anything trigger.
+      out[key] = floored >= 1 ? floored : base[key];
     }
   }
   return out;

--- a/packages/remnic-core/src/recall-audit-anomaly.ts
+++ b/packages/remnic-core/src/recall-audit-anomaly.ts
@@ -1,0 +1,283 @@
+/**
+ * Recall-audit anomaly detector (issue #565 PR 5/5).
+ *
+ * Given a sequence of `RecallAuditEntry` records for a single principal /
+ * session, classify the series and emit `AnomalyFlag`s for suspicious
+ * patterns. Intended to run on both:
+ *
+ * 1. The MCP / HTTP access layers — every `recall` / `memory_search` /
+ *    `memory_timeline` call appends an audit entry and the detector is
+ *    invoked against the tail of the series (streaming mode).
+ * 2. The existing Openclaw hook (already writes `transcripts/*.jsonl`) —
+ *    the detector can be invoked out-of-band over the same entries.
+ *
+ * See the threat model §5 (gap: recall-audit was only on the Openclaw
+ * hook) and §6.3 (anomaly signals) for the patterns below.
+ *
+ * The module is pure: no I/O, no clock. Callers pass the entries +
+ * configured thresholds; the detector returns a deterministic classification.
+ *
+ * Patterns detected:
+ *
+ * - `repeat-query` — the same normalized query text issued more than N
+ *   times in the window. Covers the ADAM "exploitation" phase where the
+ *   attacker re-queries a high-signal token until it plateaus.
+ * - `namespace-walk` — the same principal's queries visit more than N
+ *   distinct candidate memory namespaces in the window. Suggests the
+ *   attacker is enumerating the namespace tree for leaks.
+ * - `high-cardinality-return` — a single recall surfaced more than N
+ *   candidate memory IDs in one response. Covers the "one query, dump
+ *   everything" exfiltration path.
+ * - `rapid-fire` — more than N recalls in the window irrespective of
+ *   content. Blunt instrument; useful when nothing else fires.
+ *
+ * Each flag carries the entry indices that support it so an audit UI can
+ * highlight the underlying evidence.
+ */
+
+import type { RecallAuditEntry } from "./recall-audit.js";
+
+export type AnomalyKind =
+  | "repeat-query"
+  | "namespace-walk"
+  | "high-cardinality-return"
+  | "rapid-fire";
+
+export type AnomalySeverity = "info" | "warn" | "alert";
+
+export interface AnomalyFlag {
+  kind: AnomalyKind;
+  severity: AnomalySeverity;
+  /** Human-readable rationale, e.g. `"query 'alex' repeated 12 times in 60s"`. */
+  message: string;
+  /** Indices into the supplied `entries` array that triggered the flag. */
+  entryIndices: number[];
+  /**
+   * Optional extra signal the caller can use to key metrics. For
+   * `repeat-query` this is the normalized query text; for
+   * `namespace-walk` it is the namespace count; etc.
+   */
+  signal?: string | number;
+}
+
+export interface AnomalyDetectorConfig {
+  /** Detector feature-flag. Defaults to false — ships disabled. */
+  enabled?: boolean;
+  /**
+   * Rolling window in ms. The detector only considers entries whose `ts`
+   * falls within `[now - windowMs, now]`. Default 5 minutes.
+   */
+  windowMs?: number;
+  /**
+   * Threshold for `repeat-query`: a normalized query repeated more than
+   * this many times in the window trips the flag. Default 5.
+   */
+  repeatQueryLimit?: number;
+  /**
+   * Threshold for `namespace-walk`: more than this many distinct
+   * candidate namespaces in the window trips the flag. Default 3.
+   */
+  namespaceWalkLimit?: number;
+  /**
+   * Threshold for `high-cardinality-return`: more than this many
+   * `candidateMemoryIds` in a single entry trips the flag. Default 50.
+   */
+  highCardinalityReturnLimit?: number;
+  /**
+   * Threshold for `rapid-fire`: more than this many entries in the
+   * window trips the flag. Default 30. (Matches the default
+   * `recallCrossNamespaceBudgetHardLimit` from PR 4.)
+   */
+  rapidFireLimit?: number;
+}
+
+export const DEFAULT_ANOMALY_DETECTOR_CONFIG: Required<AnomalyDetectorConfig> =
+  Object.freeze({
+    enabled: false,
+    windowMs: 5 * 60_000,
+    repeatQueryLimit: 5,
+    namespaceWalkLimit: 3,
+    highCardinalityReturnLimit: 50,
+    rapidFireLimit: 30,
+  });
+
+export interface AnomalyDetectorInput {
+  entries: readonly RecallAuditEntry[];
+  /** Current time in epoch ms. Entries older than `now - windowMs` are ignored. */
+  now: number;
+  config?: AnomalyDetectorConfig;
+}
+
+export interface AnomalyDetectorResult {
+  /** All flags ordered by descending severity then kind. */
+  flags: AnomalyFlag[];
+  /** Number of entries inside the active window (after filtering). */
+  windowEntryCount: number;
+  /** Window size actually used, in ms. */
+  windowMs: number;
+}
+
+function effectiveConfig(
+  raw: AnomalyDetectorConfig | undefined,
+): Required<AnomalyDetectorConfig> {
+  const base = { ...DEFAULT_ANOMALY_DETECTOR_CONFIG };
+  if (!raw) return base;
+  const out = { ...base };
+  if (typeof raw.enabled === "boolean") out.enabled = raw.enabled;
+  if (
+    typeof raw.windowMs === "number" &&
+    Number.isFinite(raw.windowMs) &&
+    raw.windowMs > 0
+  ) {
+    out.windowMs = raw.windowMs;
+  }
+  for (const key of [
+    "repeatQueryLimit",
+    "namespaceWalkLimit",
+    "highCardinalityReturnLimit",
+    "rapidFireLimit",
+  ] as const) {
+    const v = raw[key];
+    if (typeof v === "number" && Number.isFinite(v) && v > 0) {
+      out[key] = Math.floor(v);
+    }
+  }
+  return out;
+}
+
+/**
+ * Normalize query text so cosmetic variation doesn't defeat the
+ * repeat-query detector. Lowercase, collapse whitespace, trim.
+ */
+export function normalizeQueryText(raw: string): string {
+  if (typeof raw !== "string") return "";
+  return raw.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+const SEVERITY_ORDER: Record<AnomalySeverity, number> = {
+  alert: 0,
+  warn: 1,
+  info: 2,
+};
+
+function parseTsMs(ts: string): number | null {
+  const n = new Date(ts).getTime();
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Run the detector against a series of audit entries. Pure; no side
+ * effects.
+ */
+export function detectRecallAnomalies(
+  input: AnomalyDetectorInput,
+): AnomalyDetectorResult {
+  const cfg = effectiveConfig(input.config);
+  const cutoff = input.now - cfg.windowMs;
+
+  // Filter to the active window, preserving original indices so flags
+  // can reference the caller's entries array directly.
+  const windowed: { entry: RecallAuditEntry; index: number }[] = [];
+  for (let i = 0; i < input.entries.length; i++) {
+    const entry = input.entries[i]!;
+    const tsMs = parseTsMs(entry.ts);
+    if (tsMs === null) continue;
+    if (tsMs >= cutoff && tsMs <= input.now) {
+      windowed.push({ entry, index: i });
+    }
+  }
+
+  if (!cfg.enabled) {
+    return { flags: [], windowEntryCount: windowed.length, windowMs: cfg.windowMs };
+  }
+
+  const flags: AnomalyFlag[] = [];
+
+  // 1) repeat-query: bucket by normalized queryText.
+  {
+    const byQuery = new Map<string, number[]>();
+    for (const { entry, index } of windowed) {
+      const key = normalizeQueryText(entry.queryText);
+      if (key.length === 0) continue;
+      const arr = byQuery.get(key);
+      if (arr) arr.push(index);
+      else byQuery.set(key, [index]);
+    }
+    for (const [query, indices] of byQuery) {
+      if (indices.length > cfg.repeatQueryLimit) {
+        flags.push({
+          kind: "repeat-query",
+          severity: "warn",
+          message: `query "${query}" repeated ${indices.length} times in ${cfg.windowMs}ms`,
+          entryIndices: indices.slice(),
+          signal: query,
+        });
+      }
+    }
+  }
+
+  // 2) namespace-walk: distinct namespaces extracted from candidateMemoryIds.
+  //    Candidate IDs that begin with `<namespace>/` disclose the namespace.
+  //    Entries whose IDs have no prefix are treated as "own namespace".
+  {
+    const namespaces = new Set<string>();
+    const indices: number[] = [];
+    for (const { entry, index } of windowed) {
+      if (!Array.isArray(entry.candidateMemoryIds)) continue;
+      for (const id of entry.candidateMemoryIds) {
+        if (typeof id !== "string") continue;
+        const slash = id.indexOf("/");
+        if (slash > 0) {
+          namespaces.add(id.slice(0, slash));
+        }
+      }
+      indices.push(index);
+    }
+    if (namespaces.size > cfg.namespaceWalkLimit) {
+      flags.push({
+        kind: "namespace-walk",
+        severity: "alert",
+        message: `queries touched ${namespaces.size} distinct namespaces in ${cfg.windowMs}ms`,
+        entryIndices: indices,
+        signal: namespaces.size,
+      });
+    }
+  }
+
+  // 3) high-cardinality-return: one entry's candidateMemoryIds > limit.
+  {
+    for (const { entry, index } of windowed) {
+      const ids = Array.isArray(entry.candidateMemoryIds)
+        ? entry.candidateMemoryIds
+        : [];
+      if (ids.length > cfg.highCardinalityReturnLimit) {
+        flags.push({
+          kind: "high-cardinality-return",
+          severity: "alert",
+          message: `single recall returned ${ids.length} candidate memory IDs`,
+          entryIndices: [index],
+          signal: ids.length,
+        });
+      }
+    }
+  }
+
+  // 4) rapid-fire: windowed count alone.
+  if (windowed.length > cfg.rapidFireLimit) {
+    flags.push({
+      kind: "rapid-fire",
+      severity: "warn",
+      message: `${windowed.length} recall entries in ${cfg.windowMs}ms`,
+      entryIndices: windowed.map((w) => w.index),
+      signal: windowed.length,
+    });
+  }
+
+  flags.sort((a, b) => {
+    const s = SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity];
+    if (s !== 0) return s;
+    return a.kind.localeCompare(b.kind);
+  });
+
+  return { flags, windowEntryCount: windowed.length, windowMs: cfg.windowMs };
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -438,6 +438,23 @@ export interface PluginConfig {
    * whose resolved taxonomy category is not in this list never qualify.
    */
   recallDirectAnswerEligibleTaxonomyBuckets: string[];
+  /**
+   * Recall-audit anomaly detector (issue #565 PR 5/5). When true,
+   * access surfaces run the anomaly detector over a tail of the audit
+   * trail after each recall and surface any flags via logs / metrics.
+   * Ships disabled.
+   */
+  recallAuditAnomalyDetectionEnabled: boolean;
+  /** Rolling window over which audit entries are analyzed. */
+  recallAuditAnomalyWindowMs: number;
+  /** Threshold for the `repeat-query` flag. */
+  recallAuditAnomalyRepeatQueryLimit: number;
+  /** Threshold for the `namespace-walk` flag (distinct namespaces). */
+  recallAuditAnomalyNamespaceWalkLimit: number;
+  /** Threshold for the `high-cardinality-return` flag. */
+  recallAuditAnomalyHighCardinalityLimit: number;
+  /** Threshold for the `rapid-fire` flag. */
+  recallAuditAnomalyRapidFireLimit: number;
   // Memory Linking (Phase 3A)
   memoryLinkingEnabled: boolean;
   // Conversation Threading (Phase 3B)


### PR DESCRIPTION
## Summary

Closes the gap called out in the memory-extraction threat model §5: recall-audit previously only ran on the Openclaw hook, so MCP and HTTP access surfaces bypassed the audit trail entirely.

Two new modules in `packages/remnic-core/src`:

1. **`recall-audit-anomaly.ts`** — pure detector over a sequence of `RecallAuditEntry` records. Flags:
   - `repeat-query` — same normalized query issued > N times in the window (ADAM exploitation phase).
   - `namespace-walk` — `candidateMemoryIds` span > N distinct namespaces in the window.
   - `high-cardinality-return` — a single recall returned > N candidate IDs.
   - `rapid-fire` — > N entries in the window regardless of content.
   Each flag carries supporting entry indices; severity ordering alert > warn > info; flags sort deterministically. 10 unit tests.

2. **`access-audit.ts`** — `AccessAuditAdapter`: a per-instance wrapper that appends `RecallAuditEntry` (when audit enabled) and runs the detector (when detection enabled) in one call. Scoped tail buffer per principal. Audit write failures are swallowed so the enclosing recall continues. 7 unit tests.

Feature-flag gated via `recallAuditAnomalyDetectionEnabled` (default `false`) plus four threshold knobs wired through `config.ts` + `types.ts` + `openclaw.plugin.json` `configSchema`. Conservative defaults match threat-model §6.3 (windowMs=300000, repeatQueryLimit=5, namespaceWalkLimit=3, highCardinalityReturnLimit=50, rapidFireLimit=30).

Both modules are exported from `@remnic/core` so `access-mcp.ts` / `access-http.ts` can adopt the adapter by wrapping their recall entry points. Mechanical follow-up wiring is intentionally out of scope here to keep this PR narrow; the pure detector + adapter are the high-value primitives and both are covered by tests.

## Test plan

- [x] `tsx --test packages/remnic-core/src/recall-audit-anomaly.test.ts` — 10/10 tests pass.
- [x] `tsx --test packages/remnic-core/src/access-audit.test.ts` — 7/7 tests pass.
- [x] `tsc --noEmit` on `@remnic/core` shows no new errors.

Ref: issue #565, threat model `docs/security/memory-extraction-threat-model.md` §5 (gap) + §6.3 (anomaly signals).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new security-related detection logic and audit-writing behavior (though feature-flagged off by default) that could affect performance/log volume or yield false positives when enabled.
> 
> **Overview**
> Adds a new, **opt-in** recall-audit anomaly detector (`detectRecallAnomalies`) that analyzes recent `RecallAuditEntry` tails and emits deterministic flags for suspicious recall patterns (repeat query, namespace-walk, high-cardinality returns, rapid-fire), plus full unit-test coverage.
> 
> Introduces `AccessAuditAdapter` to unify per-recall audit recording and anomaly detection for non-OpenClaw access surfaces, including per-principal in-memory tail buffering and fail-open audit writes.
> 
> Wires new detector configuration knobs through `config.ts`, `types.ts`, and both `openclaw.plugin.json` schemas (defaults off), and exports the new detector + adapter APIs from `@remnic/core`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1671fc9ea948dd27b2ebe7c2dcb871ffcd9c8ca8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->