### PR TITLE
feat(core): feature-flagged graph retrieval tier (issue #559 PR 4/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2040,14 +2040,14 @@
         "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
       },
       "recallGraphIterations": {
-        "type": "number",
+        "type": "integer",
         "minimum": 0,
         "maximum": 500,
         "default": 20,
         "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
       },
       "recallGraphTopK": {
-        "type": "number",
+        "type": "integer",
         "minimum": 0,
         "maximum": 10000,
         "default": 50,

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2027,6 +2027,32 @@
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
+      "recallGraphEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
+      },
+      "recallGraphDamping": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.999999999,
+        "default": 0.85,
+        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+      },
+      "recallGraphIterations": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 500,
+        "default": 20,
+        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+      },
+      "recallGraphTopK": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 10000,
+        "default": 50,
+        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
+      },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",
         "minimum": 0,
@@ -4197,6 +4223,25 @@
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallGraphEnabled": {
+      "label": "Graph Retrieval (PPR)",
+      "help": "Run Personalized PageRank on the retrieval graph and merge with QMD via MMR (issue #559)."
+    },
+    "recallGraphDamping": {
+      "label": "Graph Recall Damping",
+      "advanced": true,
+      "placeholder": "0.85"
+    },
+    "recallGraphIterations": {
+      "label": "Graph Recall Iterations",
+      "advanced": true,
+      "placeholder": "20"
+    },
+    "recallGraphTopK": {
+      "label": "Graph Recall Top-K",
+      "advanced": true,
+      "placeholder": "50"
     },
     "recallDirectAnswerTokenOverlapFloor": {
       "label": "Direct-Answer Token Overlap Floor",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -787,7 +787,11 @@
       },
       "binaryLifecycleBackendType": {
         "type": "string",
-        "enum": ["none", "filesystem", "s3"],
+        "enum": [
+          "none",
+          "filesystem",
+          "s3"
+        ],
         "default": "none",
         "description": "Storage backend for binary lifecycle mirror stage."
       },
@@ -1970,12 +1974,42 @@
         "type": "object",
         "description": "Configuration for the nightly contradiction-scan cron (issue #520)",
         "properties": {
-          "enabled": { "type": "boolean", "default": false, "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)" },
-          "similarityFloor": { "type": "number", "default": 0.82, "minimum": 0, "maximum": 1, "description": "Embedding cosine similarity floor for candidate pair generation" },
-          "topicOverlapFloor": { "type": "number", "default": 0.4, "minimum": 0, "maximum": 1, "description": "Minimum topic-token Jaccard overlap for unstructured pairs" },
-          "maxPairsPerRun": { "type": "integer", "default": 500, "minimum": 1, "description": "Cap on candidate pairs evaluated per cron run" },
-          "cooldownDays": { "type": "integer", "default": 14, "minimum": 0, "description": "Cooldown in days. 0 = always re-evaluate." },
-          "autoMergeDuplicates": { "type": "boolean", "default": false, "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)" }
+          "enabled": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable the nightly contradiction scan cron (disabled by default per rule 48)"
+          },
+          "similarityFloor": {
+            "type": "number",
+            "default": 0.82,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Embedding cosine similarity floor for candidate pair generation"
+          },
+          "topicOverlapFloor": {
+            "type": "number",
+            "default": 0.4,
+            "minimum": 0,
+            "maximum": 1,
+            "description": "Minimum topic-token Jaccard overlap for unstructured pairs"
+          },
+          "maxPairsPerRun": {
+            "type": "integer",
+            "default": 500,
+            "minimum": 1,
+            "description": "Cap on candidate pairs evaluated per cron run"
+          },
+          "cooldownDays": {
+            "type": "integer",
+            "default": 14,
+            "minimum": 0,
+            "description": "Cooldown in days. 0 = always re-evaluate."
+          },
+          "autoMergeDuplicates": {
+            "type": "boolean",
+            "default": false,
+            "description": "Auto-flag pairs judged duplicates for dedup (still requires user approval)"
+          }
         }
       },
       "temporalSupersessionEnabled": {
@@ -1992,6 +2026,32 @@
         "type": "boolean",
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
+      },
+      "recallGraphEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
+      },
+      "recallGraphDamping": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.999999999,
+        "default": 0.85,
+        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+      },
+      "recallGraphIterations": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 500,
+        "default": 20,
+        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+      },
+      "recallGraphTopK": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 10000,
+        "default": 50,
+        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
       },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",
@@ -2016,8 +2076,16 @@
       },
       "recallDirectAnswerEligibleTaxonomyBuckets": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["decisions", "principles", "conventions", "runbooks", "entities"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "decisions",
+          "principles",
+          "conventions",
+          "runbooks",
+          "entities"
+        ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
       },
       "recallMemoryWorthFilterEnabled": {
@@ -4155,6 +4223,25 @@
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallGraphEnabled": {
+      "label": "Graph Retrieval (PPR)",
+      "help": "Run Personalized PageRank on the retrieval graph and merge with QMD via MMR (issue #559)."
+    },
+    "recallGraphDamping": {
+      "label": "Graph Recall Damping",
+      "advanced": true,
+      "placeholder": "0.85"
+    },
+    "recallGraphIterations": {
+      "label": "Graph Recall Iterations",
+      "advanced": true,
+      "placeholder": "20"
+    },
+    "recallGraphTopK": {
+      "label": "Graph Recall Top-K",
+      "advanced": true,
+      "placeholder": "50"
     },
     "recallDirectAnswerTokenOverlapFloor": {
       "label": "Direct-Answer Token Overlap Floor",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2040,14 +2040,14 @@
         "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
       },
       "recallGraphIterations": {
-        "type": "number",
+        "type": "integer",
         "minimum": 0,
         "maximum": 500,
         "default": 20,
         "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
       },
       "recallGraphTopK": {
-        "type": "number",
+        "type": "integer",
         "minimum": 0,
         "maximum": 10000,
         "default": 50,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1052,6 +1052,26 @@ export function parseConfig(raw: unknown): PluginConfig {
     // recallDirectAnswerEnabled=false.
     recallDirectAnswerEnabled:
       coerceBool(cfg.recallDirectAnswerEnabled) ?? true,
+    // Graph-based retrieval tier (issue #559 PR 4).  Default `false` —
+    // the tier ships off pending the `retrieval-graph` bench in PR 5.
+    recallGraphEnabled:
+      coerceBool(cfg.recallGraphEnabled) ?? false,
+    recallGraphDamping: (() => {
+      const n = coerceNumber(cfg.recallGraphDamping);
+      return n !== undefined && n >= 0 && n < 1 ? n : 0.85;
+    })(),
+    recallGraphIterations: (() => {
+      const n = coerceNumber(cfg.recallGraphIterations);
+      return n !== undefined && Number.isFinite(n) && n >= 0 && n <= 500
+        ? Math.floor(n)
+        : 20;
+    })(),
+    recallGraphTopK: (() => {
+      const n = coerceNumber(cfg.recallGraphTopK);
+      return n !== undefined && Number.isFinite(n) && n >= 0 && n <= 10000
+        ? Math.floor(n)
+        : 50;
+    })(),
     recallDirectAnswerTokenOverlapFloor: (() => {
       const n = coerceNumber(cfg.recallDirectAnswerTokenOverlapFloor);
       return n !== undefined && n >= 0 && n <= 1 ? n : 0.55;

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1060,17 +1060,41 @@ export function parseConfig(raw: unknown): PluginConfig {
       const n = coerceNumber(cfg.recallGraphDamping);
       return n !== undefined && n >= 0 && n < 1 ? n : 0.85;
     })(),
+    // Fractional integer values (e.g. `0.5`) are REJECTED rather than
+    // silently floored to zero — CLAUDE.md rule 51 ("Reject invalid
+    // user input instead of silently defaulting"). Users who set a
+    // fractional iteration cap almost certainly meant an integer and
+    // quietly flooring their value to 0 turns off the tier without
+    // warning.
     recallGraphIterations: (() => {
+      if (cfg.recallGraphIterations === undefined) return 20;
       const n = coerceNumber(cfg.recallGraphIterations);
-      return n !== undefined && Number.isFinite(n) && n >= 0 && n <= 500
-        ? Math.floor(n)
-        : 20;
+      if (n === undefined || !Number.isFinite(n) || n < 0 || n > 500) {
+        throw new Error(
+          `recallGraphIterations must be an integer in [0, 500] (got ${JSON.stringify(cfg.recallGraphIterations)}).`,
+        );
+      }
+      if (!Number.isInteger(n)) {
+        throw new Error(
+          `recallGraphIterations must be an integer (got fractional value ${n}).`,
+        );
+      }
+      return n;
     })(),
     recallGraphTopK: (() => {
+      if (cfg.recallGraphTopK === undefined) return 50;
       const n = coerceNumber(cfg.recallGraphTopK);
-      return n !== undefined && Number.isFinite(n) && n >= 0 && n <= 10000
-        ? Math.floor(n)
-        : 50;
+      if (n === undefined || !Number.isFinite(n) || n < 0 || n > 10000) {
+        throw new Error(
+          `recallGraphTopK must be an integer in [0, 10000] (got ${JSON.stringify(cfg.recallGraphTopK)}).`,
+        );
+      }
+      if (!Number.isInteger(n)) {
+        throw new Error(
+          `recallGraphTopK must be an integer (got fractional value ${n}).`,
+        );
+      }
+      return n;
     })(),
     recallDirectAnswerTokenOverlapFloor: (() => {
       const n = coerceNumber(cfg.recallDirectAnswerTokenOverlapFloor);

--- a/packages/remnic-core/src/graph-recall.test.ts
+++ b/packages/remnic-core/src/graph-recall.test.ts
@@ -1,0 +1,164 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  type GraphRecallConfig,
+  type GraphRecallOptions,
+  runGraphRecall,
+} from "./graph-recall.js";
+import type { MemoryEdgeSource } from "./graph-retrieval.js";
+
+const DEFAULT_CONFIG: GraphRecallConfig = {
+  recallGraphEnabled: true,
+  recallGraphDamping: 0.85,
+  recallGraphIterations: 20,
+  recallGraphTopK: 50,
+};
+
+function disabledConfig(): GraphRecallConfig {
+  return { ...DEFAULT_CONFIG, recallGraphEnabled: false };
+}
+
+function sampleMemories(): MemoryEdgeSource[] {
+  return [
+    { id: "m1", entityRef: "person:Jane" },
+    { id: "m2", entityRef: "person:Jane" },
+    { id: "m3", lineage: ["m1"], entityRefs: ["person:Jane", "org:Acme"] },
+    { id: "m4", supersedes: "m3" },
+    { id: "m5", entityRef: "org:Acme" },
+  ];
+}
+
+test("runGraphRecall short-circuits when recallGraphEnabled=false", () => {
+  const run = runGraphRecall(disabledConfig(), {
+    memories: sampleMemories(),
+    seedIds: ["m1"],
+  });
+  assert.equal(run.ran, false);
+  assert.equal(run.reason, "disabled");
+  assert.equal(run.results.length, 0);
+  assert.equal(run.graph, null);
+});
+
+test("runGraphRecall short-circuits when recallGraphTopK<=0", () => {
+  for (const topK of [0, -1]) {
+    const cfg: GraphRecallConfig = { ...DEFAULT_CONFIG, recallGraphTopK: topK };
+    const run = runGraphRecall(cfg, {
+      memories: sampleMemories(),
+      seedIds: ["m1"],
+    });
+    assert.equal(run.ran, false);
+    assert.equal(run.reason, "topk-zero");
+    assert.equal(run.results.length, 0);
+    assert.equal(run.graph, null);
+  }
+});
+
+test("runGraphRecall short-circuits when memory pool is empty", () => {
+  const run = runGraphRecall(DEFAULT_CONFIG, {
+    memories: [],
+    seedIds: ["m1"],
+  });
+  assert.equal(run.ran, false);
+  assert.equal(run.reason, "empty-input");
+});
+
+test("runGraphRecall returns memory-typed results only", () => {
+  const run = runGraphRecall(DEFAULT_CONFIG, {
+    memories: sampleMemories(),
+    seedIds: ["m1"],
+  });
+  assert.equal(run.ran, true);
+  assert.equal(run.reason, "ran");
+  assert.ok(run.graph !== null);
+  for (const r of run.results) {
+    assert.equal(run.graph!.nodes.get(r.id)?.type, "memory");
+  }
+  assert.ok(run.results.length > 0);
+  assert.equal(run.results[0]?.id, "m1");
+});
+
+test("runGraphRecall respects recallGraphTopK after projection", () => {
+  const chain: MemoryEdgeSource[] = [
+    { id: "m1" },
+    { id: "m2", supersedes: "m1" },
+    { id: "m3", supersedes: "m2" },
+    { id: "m4", supersedes: "m3" },
+  ];
+  const cfg: GraphRecallConfig = { ...DEFAULT_CONFIG, recallGraphTopK: 2 };
+  const run = runGraphRecall(cfg, {
+    memories: chain,
+    seedIds: ["m4"],
+  });
+  assert.equal(run.ran, true);
+  assert.equal(run.results.length, 2);
+});
+
+test("runGraphRecall threads damping + iteration cap through to PPR", () => {
+  const cfg: GraphRecallConfig = {
+    ...DEFAULT_CONFIG,
+    recallGraphDamping: 0.5,
+    recallGraphIterations: 5,
+  };
+  const run = runGraphRecall(cfg, {
+    memories: sampleMemories(),
+    seedIds: ["m1"],
+  });
+  assert.ok(run.iterations <= 5, `expected <= 5 iterations, got ${run.iterations}`);
+});
+
+test("runGraphRecall uniform-fallback when seed ids are empty", () => {
+  const run = runGraphRecall(DEFAULT_CONFIG, {
+    memories: sampleMemories(),
+    seedIds: [],
+  });
+  assert.equal(run.ran, true);
+  assert.ok(run.results.length > 0);
+  for (const r of run.results) {
+    assert.equal(run.graph!.nodes.get(r.id)?.type, "memory");
+  }
+});
+
+test("runGraphRecall accepts seedWeights and biases ranking accordingly", () => {
+  const weightedM1 = runGraphRecall(DEFAULT_CONFIG, {
+    memories: sampleMemories(),
+    seedIds: ["m1", "m2"],
+    seedWeights: { m1: 0.9, m2: 0.1 },
+  });
+  const weightedM2 = runGraphRecall(DEFAULT_CONFIG, {
+    memories: sampleMemories(),
+    seedIds: ["m1", "m2"],
+    seedWeights: { m1: 0.1, m2: 0.9 },
+  });
+
+  const m1_scoreA = weightedM1.results.find((r) => r.id === "m1")?.score ?? 0;
+  const m2_scoreA = weightedM1.results.find((r) => r.id === "m2")?.score ?? 0;
+  const m1_scoreB = weightedM2.results.find((r) => r.id === "m1")?.score ?? 0;
+  const m2_scoreB = weightedM2.results.find((r) => r.id === "m2")?.score ?? 0;
+
+  assert.ok(m1_scoreA > m1_scoreB, "m1 should rank higher when weighted on m1");
+  assert.ok(m2_scoreB > m2_scoreA, "m2 should rank higher when weighted on m2");
+});
+
+test("runGraphRecall is deterministic", () => {
+  const memories = sampleMemories();
+  const seedIds = ["m1"];
+  const r1 = runGraphRecall(DEFAULT_CONFIG, { memories, seedIds });
+  const r2 = runGraphRecall(DEFAULT_CONFIG, { memories, seedIds });
+  assert.deepEqual(r1.results, r2.results);
+});
+
+test("runGraphRecall default-off: disabled config with defaults does nothing", () => {
+  const defaults: GraphRecallConfig = {
+    recallGraphEnabled: false,
+    recallGraphDamping: 0.85,
+    recallGraphIterations: 20,
+    recallGraphTopK: 50,
+  };
+  const run = runGraphRecall(defaults, {
+    memories: sampleMemories(),
+    seedIds: ["m1"],
+  });
+  assert.equal(run.ran, false);
+  assert.equal(run.reason, "disabled");
+});

--- a/packages/remnic-core/src/graph-recall.ts
+++ b/packages/remnic-core/src/graph-recall.ts
@@ -121,7 +121,14 @@ export function runGraphRecall(
     };
   }
 
-  const topK = typeof config.recallGraphTopK === "number" ? config.recallGraphTopK : 50;
+  // `isFinite` guard on `topK` mirrors the checks on `damping` and
+  // `iterations` below. Without it a `NaN` topK would pass the typeof
+  // check, then `NaN <= 0` is false (bypassing the short-circuit) and
+  // the downstream `memoryResults.length >= topK` never triggers.
+  const topK =
+    typeof config.recallGraphTopK === "number" && Number.isFinite(config.recallGraphTopK)
+      ? config.recallGraphTopK
+      : 50;
   if (topK <= 0) {
     return {
       ran: false,

--- a/packages/remnic-core/src/graph-recall.ts
+++ b/packages/remnic-core/src/graph-recall.ts
@@ -1,0 +1,182 @@
+/**
+ * Graph-based retrieval integration (issue #559 PR 4 of 5).
+ *
+ * Pure helper that composes `extractGraphEdges` (PR 2) and `queryGraph`
+ * (PR 3) into a single retrieval surface. Operators opt in via the
+ * `recallGraphEnabled` config flag; until the `retrieval-graph` bench in
+ * PR 5 justifies flipping the default, this tier ships disabled.
+ *
+ * Kept as a pure function so the orchestrator can call it with whatever
+ * candidate pool it has (hot cache, recent window, QMD first-pass, etc.)
+ * without forcing a specific storage contract on this module.
+ */
+
+import {
+  DEFAULT_PPR_DAMPING,
+  DEFAULT_PPR_ITERATIONS,
+  type MemoryEdgeSource,
+  type RemnicGraph,
+  buildGraphFromMemories,
+  queryGraph,
+} from "./graph-retrieval.js";
+
+/**
+ * Subset of `PluginConfig` that governs the graph retrieval tier. Kept
+ * as a local interface so this module does not pull in the full
+ * `PluginConfig` import — `orchestrator.ts` can pass the fields directly.
+ */
+export interface GraphRecallConfig {
+  /** Master enable flag. When false, `runGraphRecall` is a no-op. */
+  recallGraphEnabled: boolean;
+  /** PPR damping factor (default 0.85). */
+  recallGraphDamping: number;
+  /** PPR power-iteration cap (default 20). */
+  recallGraphIterations: number;
+  /**
+   * Max memories the graph tier returns. `0` disables the tier's
+   * contribution without touching `recallGraphEnabled`.
+   */
+  recallGraphTopK: number;
+}
+
+/** Per-invocation options for `runGraphRecall`. */
+export interface GraphRecallOptions {
+  /**
+   * Candidate memories to build the graph from. Typically the caller's
+   * recall candidate pool (hot cache + QMD first-pass). The extractor
+   * reads only the fields declared on `MemoryEdgeSource` — callers can
+   * safely pass richer memory objects.
+   */
+  memories: readonly MemoryEdgeSource[];
+  /**
+   * Seed memory / entity ids produced by the query-to-graph matcher.
+   * Typically the ids of the top QMD hits plus any entity-exact matches.
+   * If empty, PPR falls back to a uniform distribution over graph nodes.
+   */
+  seedIds: readonly string[];
+  /**
+   * Optional per-seed weights. When provided, PPR starts from the
+   * weighted distribution instead of uniform-over-seeds.
+   */
+  seedWeights?: ReadonlyMap<string, number> | Readonly<Record<string, number>>;
+}
+
+/** A single result from the graph tier. */
+export interface GraphRecallResult {
+  /** Memory id (the `to` of the highest-scoring `memory`-typed node). */
+  id: string;
+  /** PPR score in [0, 1]. Higher is better. */
+  score: number;
+}
+
+/** The full shape returned by `runGraphRecall`. */
+export interface GraphRecallRun {
+  /**
+   * Whether the graph tier actually ran. `false` when `recallGraphEnabled`
+   * is `false` or `recallGraphTopK <= 0` — in both cases `results` is `[]`
+   * and `reason` indicates which gate short-circuited.
+   */
+  ran: boolean;
+  /**
+   * Memory-typed ranked results. Entity / agent nodes are filtered out
+   * because the orchestrator merges this list with memory-typed QMD
+   * results via MMR.
+   */
+  results: GraphRecallResult[];
+  /** The graph that was built (or `null` if the tier did not run). */
+  graph: RemnicGraph | null;
+  /** Debugging tag for tier-explain surfaces. */
+  reason: "ran" | "disabled" | "topk-zero" | "empty-input";
+  /** Number of power-iteration rounds that executed. */
+  iterations: number;
+  /** Whether PPR's L1 delta fell below tolerance before the iter cap. */
+  converged: boolean;
+}
+
+/**
+ * Pure graph retrieval run.
+ *
+ * 1. Short-circuits to `{ ran: false }` when the feature flag is off,
+ *    `topK <= 0`, or the memory pool is empty. No graph is built, no
+ *    PPR runs — this preserves the zero-cost guarantee for
+ *    `recallGraphEnabled: false` (the default).
+ * 2. Otherwise builds the retrieval graph from the candidate pool via
+ *    `buildGraphFromMemories` (PR 2 extractor).
+ * 3. Runs Personalized PageRank via `queryGraph` (PR 3).
+ * 4. Projects ranked nodes to memory-typed ids only — entity and agent
+ *    nodes never appear in the recall result set.
+ */
+export function runGraphRecall(
+  config: GraphRecallConfig,
+  options: GraphRecallOptions,
+): GraphRecallRun {
+  if (!config.recallGraphEnabled) {
+    return {
+      ran: false,
+      results: [],
+      graph: null,
+      reason: "disabled",
+      iterations: 0,
+      converged: true,
+    };
+  }
+
+  const topK = typeof config.recallGraphTopK === "number" ? config.recallGraphTopK : 50;
+  if (topK <= 0) {
+    return {
+      ran: false,
+      results: [],
+      graph: null,
+      reason: "topk-zero",
+      iterations: 0,
+      converged: true,
+    };
+  }
+
+  if (options.memories.length === 0) {
+    return {
+      ran: false,
+      results: [],
+      graph: null,
+      reason: "empty-input",
+      iterations: 0,
+      converged: true,
+    };
+  }
+
+  const graph = buildGraphFromMemories(options.memories);
+
+  const damping =
+    typeof config.recallGraphDamping === "number" && Number.isFinite(config.recallGraphDamping)
+      ? config.recallGraphDamping
+      : DEFAULT_PPR_DAMPING;
+  const iterations =
+    typeof config.recallGraphIterations === "number" && Number.isFinite(config.recallGraphIterations)
+      ? config.recallGraphIterations
+      : DEFAULT_PPR_ITERATIONS;
+
+  // PPR runs without a topK so we can post-filter non-memory nodes without
+  // the trim dropping memory-typed results. We apply topK after projection.
+  const ppr = queryGraph(graph, options.seedIds, {
+    damping,
+    iterations,
+    seedWeights: options.seedWeights,
+  });
+
+  const memoryResults: GraphRecallResult[] = [];
+  for (const node of ppr.rankedNodes) {
+    const graphNode = graph.nodes.get(node.id);
+    if (!graphNode || graphNode.type !== "memory") continue;
+    memoryResults.push({ id: node.id, score: node.score });
+    if (memoryResults.length >= topK) break;
+  }
+
+  return {
+    ran: true,
+    results: memoryResults,
+    graph,
+    reason: "ran",
+    iterations: ppr.iterations,
+    converged: ppr.converged,
+  };
+}

--- a/packages/remnic-core/src/graph-retrieval.ts
+++ b/packages/remnic-core/src/graph-retrieval.ts
@@ -229,9 +229,18 @@ function buildSeedVector(
 
   const explicitWeights = normalizeSeedWeights(options.seedWeights);
   if (explicitWeights.size > 0) {
+    // Restrict weight keys to the declared seed set (or, if empty, to
+    // graph nodes). Documented contract in `QueryGraphOptions.seedWeights`:
+    // keys must appear in `seedIds` — unrelated / stale weight entries
+    // must not silently override the requested personalization.
+    const allowedKeys =
+      seedIds.length > 0
+        ? new Set(seedIds.filter((id) => typeof id === "string"))
+        : null;
     let total = 0;
     for (const [id, w] of explicitWeights) {
       if (!graph.nodes.has(id)) continue;
+      if (allowedKeys !== null && !allowedKeys.has(id)) continue;
       seed.set(id, (seed.get(id) ?? 0) + w);
       total += w;
     }

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -778,6 +778,14 @@ export {
   type ExtractGraphEdgesOptions,
 } from "./graph-retrieval.js";
 
+export {
+  runGraphRecall,
+  type GraphRecallConfig,
+  type GraphRecallOptions,
+  type GraphRecallResult,
+  type GraphRecallRun,
+} from "./graph-recall.js";
+
 // ---------------------------------------------------------------------------
 // Public types
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -460,6 +460,22 @@ export interface PluginConfig {
    */
   recallDirectAnswerEnabled: boolean;
   /**
+   * Graph-based retrieval tier via Personalized PageRank (issue #559 PR 4).
+   * When true, recall builds a retrieval graph from memory frontmatter
+   * and runs PPR, merging the result with QMD via MMR.  Default false —
+   * ships off pending the retrieval-graph bench in PR 5.
+   */
+  recallGraphEnabled: boolean;
+  /** PPR damping factor used when `recallGraphEnabled` is true. */
+  recallGraphDamping: number;
+  /** PPR power-iteration cap used when `recallGraphEnabled` is true. */
+  recallGraphIterations: number;
+  /**
+   * Max memories returned by the graph tier before MMR.  Set to 0 to
+   * disable the graph tier's contribution without flipping the flag.
+   */
+  recallGraphTopK: number;
+  /**
    * Minimum token-overlap ratio (query tokens ∩ memory tokens / query tokens)
    * required for direct-answer eligibility.  Set to 0 to disable the gate.
    */


### PR DESCRIPTION
## Summary

Fourth slice of issue #559 (graph-based retrieval with PPR). Adds a pure graph-recall helper that composes `extractGraphEdges` (PR 2 / #622) and `queryGraph` (PR 3 / #629) into a single retrieval surface, gated by a `recallGraphEnabled: false` config flag.

**Default off.** The flag stays disabled until the `retrieval-graph` bench in PR 5 justifies flipping it.

> [!NOTE]
> This branch is stacked on top of PRs #622 + #629. GitHub shows a combined diff until those land. The PR-4-only changes are `graph-recall.ts`, `graph-recall.test.ts`, the four new config fields, and the plugin manifest / schema entries.

## New module: `graph-recall.ts`

`runGraphRecall(config, options)` — pure function. Given:
- `config` (subset of `PluginConfig`): `recallGraphEnabled`, `recallGraphDamping`, `recallGraphIterations`, `recallGraphTopK`.
- `options`: `{ memories, seedIds, seedWeights? }`.

Returns `{ ran, results, graph, reason, iterations, converged }`:
- `ran: false` when the flag is off / `topK <= 0` / memory pool empty. `reason` is `"disabled" | "topk-zero" | "empty-input"`.
- `ran: true` runs the full pipeline: build graph → PPR → project to memory-typed nodes → top-K trim. Entity / agent nodes never leak into the result list.

Zero-cost guarantee when `recallGraphEnabled: false`: default users pay no CPU for graph construction, PPR, or even the `buildGraphFromMemories` call.

## Config additions

- `recallGraphEnabled` (boolean, default `false`).
- `recallGraphDamping` (number, default `0.85`, range `[0, 1)`).
- `recallGraphIterations` (number, default `20`, range `[0, 500]`).
- `recallGraphTopK` (number, default `50`, range `[0, 10000]`).

Wired in `types.ts`, `config.ts`, and `openclaw.plugin.json` (both `configSchema` and `configUI`).

`npm run check-config-contract` passes: `PluginConfig=548, parseConfig.return=548, schema=547`.

## Order-independence hardening in extractGraphEdges

Addresses a post-merge Codex P2 flagged on PR #622. With `includeDanglingEdges: true`, processing `{supersedes: "shared"}` before `{entityRef: "shared"}` previously produced different output than the reverse order. Pre-scan now collects all entity / agent references before the relationship pass so the memory-target guard rejects entity-claimed ids regardless of iteration order.

(Same fix was also pushed to PR #622 — kept here so this branch builds on top without conflicts.)

## Test plan

- `npx tsx --test packages/remnic-core/src/graph-retrieval.test.ts packages/remnic-core/src/graph-recall.test.ts` — 63 tests, all pass.
- 10 new `graph-recall` tests cover: short-circuit paths, memory-only projection, `topK` trimming after projection, damping / iterations threaded through to PPR, uniform fallback for empty seeds, `seedWeights` biasing, determinism, and the default-off config.
- `npm run check-config-contract` — passes.
- `npm run preflight:quick` — passes.

## Behavior change: none

No existing code path is rewired. Callers opt in by setting `recallGraphEnabled: true` and invoking `runGraphRecall`. Orchestrator wiring into the primary recall pipeline is deferred to PR 5 alongside the bench harness.

## Out of scope

- **PR 5 — Benchmark + default flip.** `retrieval-graph` bench fixture on LongMemEval or a synthetic multi-hop fixture; flip default if graph-on wins or ties.

Refs #559.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Feature is gated off by default, but new config parsing can now throw on previously-accepted invalid numeric values and the new retrieval helper/exports may impact downstream consumers relying on stable APIs.
> 
> **Overview**
> Adds a new, **default-off** graph retrieval tier surfaced as a pure helper `runGraphRecall` that builds a retrieval graph from candidate memories, runs Personalized PageRank, and returns memory-only ranked results with explicit short-circuit reasons.
> 
> Wires new graph-recall configuration (`recallGraphEnabled`, `recallGraphDamping`, `recallGraphIterations`, `recallGraphTopK`) through `types.ts`, `config.ts` (including stricter integer-range validation that throws on fractional/invalid iteration/topK), and the plugin schema/UI manifests. Also hardens `graph-retrieval` seed personalization by ignoring `seedWeights` keys not present in the declared `seedIds`, and adds a dedicated `graph-recall.test.ts` suite plus public exports in `index.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc2b9596c9ddd9290edc792be2a187eb1e32884c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->