### PR TITLE
feat(extraction-judge): verdict telemetry (issue #562 PR 3/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2371,6 +2371,11 @@
         "minimum": 1,
         "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
       },
+      "extractionJudgeTelemetryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2329,6 +2329,11 @@
         "minimum": 1,
         "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
       },
+      "extractionJudgeTelemetryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3404,6 +3404,83 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         });
 
       cmd
+        .command("judge-stats")
+        .description(
+          "Show extraction-judge verdict stats from the observation ledger",
+        )
+        .option("--since <iso>", "Start timestamp (inclusive, ISO-8601)")
+        .option("--until <iso>", "End timestamp (exclusive, ISO-8601)")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const sinceRaw =
+            typeof options.since === "string" ? options.since : undefined;
+          const untilRaw =
+            typeof options.until === "string" ? options.until : undefined;
+          const sinceMs = sinceRaw ? Date.parse(sinceRaw) : undefined;
+          const untilMs = untilRaw ? Date.parse(untilRaw) : undefined;
+          if (sinceRaw && !Number.isFinite(sinceMs)) {
+            throw new Error(
+              `Invalid --since value: ${sinceRaw}. Use ISO-8601, e.g. 2026-04-01T00:00:00Z`,
+            );
+          }
+          if (untilRaw && !Number.isFinite(untilMs)) {
+            throw new Error(
+              `Invalid --until value: ${untilRaw}. Use ISO-8601, e.g. 2026-04-15T00:00:00Z`,
+            );
+          }
+          const { readJudgeVerdictStats } = await import(
+            "./extraction-judge-telemetry.js"
+          );
+          const stats = await readJudgeVerdictStats(
+            orchestrator.config.memoryDir,
+            {
+              ...(typeof sinceMs === "number" && Number.isFinite(sinceMs)
+                ? { sinceMs }
+                : {}),
+              ...(typeof untilMs === "number" && Number.isFinite(untilMs)
+                ? { untilMs }
+                : {}),
+            },
+          );
+          if (options.json === true) {
+            console.log(JSON.stringify(stats, null, 2));
+            return;
+          }
+          console.log("=== Extraction Judge Verdict Stats ===\n");
+          console.log(`Total verdicts: ${stats.total}`);
+          if (stats.total === 0) {
+            if (!orchestrator.config.extractionJudgeTelemetryEnabled) {
+              console.log(
+                "\nNote: extractionJudgeTelemetryEnabled is OFF. Enable it in plugin config to collect verdict telemetry.",
+              );
+            }
+            return;
+          }
+          console.log(
+            `  accept: ${stats.accept} (${((stats.accept / stats.total) * 100).toFixed(1)}%)`,
+          );
+          console.log(
+            `  reject: ${stats.reject} (${((stats.reject / stats.total) * 100).toFixed(1)}%)`,
+          );
+          console.log(
+            `  defer:  ${stats.defer} (${(stats.deferRate * 100).toFixed(1)}%)`,
+          );
+          if (stats.deferCapTriggered > 0) {
+            console.log(
+              `    of which ${stats.deferCapTriggered} cap-rejected (defer → reject)`,
+            );
+          }
+          console.log(`  mean elapsed: ${stats.meanElapsedMs.toFixed(1)} ms`);
+          if (stats.firstTs && stats.lastTs) {
+            console.log(`  window: ${stats.firstTs} … ${stats.lastTs}`);
+          }
+          if (stats.malformed > 0) {
+            console.log(`  malformed rows skipped: ${stats.malformed}`);
+          }
+        });
+
+      cmd
         .command("setup")
         .description("Validate config, scaffold directories, and print first-run next steps")
         .option("--install-capture-instructions", "Create workspace MEMORY.md when explicit capture is enabled and missing")

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1543,6 +1543,10 @@ export function parseConfig(raw: unknown): PluginConfig {
       cfg.extractionJudgeMaxDeferrals >= 1
         ? Math.floor(cfg.extractionJudgeMaxDeferrals)
         : 2,
+    // Judge telemetry (issue #562 PR 3): opt-in structured emit to the
+    // observation ledger for defer-rate / latency metrics.
+    extractionJudgeTelemetryEnabled:
+      cfg.extractionJudgeTelemetryEnabled === true,
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1545,8 +1545,11 @@ export function parseConfig(raw: unknown): PluginConfig {
         : 2,
     // Judge telemetry (issue #562 PR 3): opt-in structured emit to the
     // observation ledger for defer-rate / latency metrics.
+    // Uses `coerceBool` so CLI-style string inputs (`"true"`, `"false"`,
+    // `"1"`, `"0"`) are accepted consistently with the rest of the
+    // codebase (CLAUDE.md gotcha 36).
     extractionJudgeTelemetryEnabled:
-      cfg.extractionJudgeTelemetryEnabled === true,
+      coerceBool(cfg.extractionJudgeTelemetryEnabled) === true,
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/extraction-judge-telemetry.ts
+++ b/packages/remnic-core/src/extraction-judge-telemetry.ts
@@ -1,0 +1,234 @@
+/**
+ * Extraction Judge Telemetry (issue #562, PR 3).
+ *
+ * Appends one structured event per judge verdict to the observation ledger
+ * under a dedicated JSONL file. The ledger is the same directory used by
+ * the turn-count observation writer
+ * (`state/observation-ledger/rebuilt-observations.jsonl`) but judge events
+ * live in their own file so aggregation stays cheap and schemas do not
+ * collide.
+ *
+ * Emit path is best-effort and fail-open: a telemetry write must never
+ * block an extraction run.
+ */
+
+import path from "node:path";
+import { appendFile, mkdir, readFile } from "node:fs/promises";
+import { log } from "./logger.js";
+import type { JudgeVerdictKind } from "./extraction-judge.js";
+
+/**
+ * Observation-ledger category for judge verdict events. Callers that
+ * aggregate across event kinds can filter on this constant.
+ */
+export const EXTRACTION_JUDGE_VERDICT_CATEGORY = "EXTRACTION_JUDGE_VERDICT";
+
+/**
+ * Structured event written for every judge verdict (including verdicts
+ * served from cache). The `version` field lets future readers upgrade the
+ * schema without breaking older rows.
+ */
+export interface JudgeVerdictEvent {
+  version: 1;
+  category: typeof EXTRACTION_JUDGE_VERDICT_CATEGORY;
+  ts: string; // ISO-8601
+  verdictKind: JudgeVerdictKind;
+  /** Short free-text reason from the judge / deterministic fallback. */
+  reason: string;
+  /**
+   * How many times this candidate's content hash had already been deferred
+   * before this verdict. 0 for the first defer, 1 for the second, etc.
+   * Not applicable for non-defer kinds — emitted as 0.
+   */
+  deferrals: number;
+  /**
+   * Milliseconds between batch start and batch return (the whole
+   * `judgeFactDurability` call, shared across all verdicts in a single
+   * batch).
+   */
+  elapsedMs: number;
+  /** Candidate metadata for coarse filtering. */
+  candidateCategory: string;
+  confidence?: number;
+  /** SHA-256 of the (text\0category) pair, same as the verdict-cache key. */
+  contentHash: string;
+  /** Whether the verdict came from the in-memory verdict cache. */
+  fromCache: boolean;
+  /**
+   * True when the judge forcibly converted a defer to reject because the
+   * defer cap was reached. Only set on cap-triggered rejects.
+   */
+  deferCapTriggered?: boolean;
+}
+
+/**
+ * Options to control emit behavior. `enabled` gates all writes; when
+ * false, `recordJudgeVerdict` is a no-op so callers can unconditionally
+ * invoke it.
+ */
+export interface JudgeTelemetryOptions {
+  enabled: boolean;
+  memoryDir: string;
+}
+
+export function judgeTelemetryPath(memoryDir: string): string {
+  return path.join(
+    memoryDir,
+    "state",
+    "observation-ledger",
+    "extraction-judge-verdicts.jsonl",
+  );
+}
+
+/**
+ * Append a single verdict event as a JSONL row. Fails open — if the write
+ * cannot be completed (directory missing, permissions, disk full), the
+ * error is logged at debug level and swallowed so extraction never fails
+ * because of telemetry.
+ */
+export async function recordJudgeVerdict(
+  event: JudgeVerdictEvent,
+  options: JudgeTelemetryOptions,
+): Promise<void> {
+  if (!options.enabled) return;
+  const filePath = judgeTelemetryPath(options.memoryDir);
+  try {
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await appendFile(filePath, `${JSON.stringify(event)}\n`, "utf-8");
+  } catch (err) {
+    log.debug(
+      `extraction-judge-telemetry: append failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Aggregate statistics over the verdict ledger, optionally restricted to a
+ * time window. Returns zero-count stats when the ledger is missing or
+ * empty — callers do not need to special-case a cold install.
+ */
+export interface JudgeVerdictStats {
+  total: number;
+  accept: number;
+  reject: number;
+  defer: number;
+  deferCapTriggered: number;
+  /** Mean elapsed milliseconds across all events in the window. */
+  meanElapsedMs: number;
+  /** Defer rate as `defer / total`, in `[0, 1]`. `0` when total is 0. */
+  deferRate: number;
+  /** First and last event timestamps observed in the window. */
+  firstTs?: string;
+  lastTs?: string;
+  /** Number of rows skipped because they were malformed or wrong shape. */
+  malformed: number;
+}
+
+/**
+ * Read and aggregate events from the verdict ledger.
+ *
+ * `sinceMs` / `untilMs` bound by `ts` parse — events with unparseable
+ * timestamps are counted toward `malformed`. The upper bound is exclusive
+ * (`ts < untilMs`), per CLAUDE.md gotcha 35.
+ */
+export async function readJudgeVerdictStats(
+  memoryDir: string,
+  opts: { sinceMs?: number; untilMs?: number } = {},
+): Promise<JudgeVerdictStats> {
+  const filePath = judgeTelemetryPath(memoryDir);
+  let raw: string;
+  try {
+    raw = await readFile(filePath, "utf-8");
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      return {
+        total: 0,
+        accept: 0,
+        reject: 0,
+        defer: 0,
+        deferCapTriggered: 0,
+        meanElapsedMs: 0,
+        deferRate: 0,
+        malformed: 0,
+      };
+    }
+    throw err;
+  }
+
+  let total = 0;
+  let accept = 0;
+  let reject = 0;
+  let defer = 0;
+  let deferCapTriggered = 0;
+  let elapsedSum = 0;
+  let malformed = 0;
+  let firstTs: string | undefined;
+  let lastTs: string | undefined;
+
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(line);
+    } catch {
+      malformed += 1;
+      continue;
+    }
+    if (
+      typeof parsed !== "object" ||
+      parsed === null ||
+      Array.isArray(parsed)
+    ) {
+      malformed += 1;
+      continue;
+    }
+    const p = parsed as Record<string, unknown>;
+    if (p.category !== EXTRACTION_JUDGE_VERDICT_CATEGORY) {
+      malformed += 1;
+      continue;
+    }
+    const ts = typeof p.ts === "string" ? p.ts : null;
+    if (ts === null) {
+      malformed += 1;
+      continue;
+    }
+    const tsMs = Date.parse(ts);
+    if (!Number.isFinite(tsMs)) {
+      malformed += 1;
+      continue;
+    }
+    if (typeof opts.sinceMs === "number" && tsMs < opts.sinceMs) continue;
+    if (typeof opts.untilMs === "number" && tsMs >= opts.untilMs) continue;
+
+    const kind = p.verdictKind;
+    if (kind === "accept") accept += 1;
+    else if (kind === "reject") reject += 1;
+    else if (kind === "defer") defer += 1;
+    else {
+      malformed += 1;
+      continue;
+    }
+
+    if (p.deferCapTriggered === true) deferCapTriggered += 1;
+    if (typeof p.elapsedMs === "number" && Number.isFinite(p.elapsedMs)) {
+      elapsedSum += p.elapsedMs;
+    }
+    total += 1;
+    if (firstTs === undefined || ts < firstTs) firstTs = ts;
+    if (lastTs === undefined || ts > lastTs) lastTs = ts;
+  }
+
+  return {
+    total,
+    accept,
+    reject,
+    defer,
+    deferCapTriggered,
+    meanElapsedMs: total > 0 ? elapsedSum / total : 0,
+    deferRate: total > 0 ? defer / total : 0,
+    firstTs,
+    lastTs,
+    malformed,
+  };
+}

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -376,8 +376,24 @@ export async function judgeFactDurability(
   const deferCountMap = deferCounts ?? defaultDeferCounts;
   const deferCap = resolveDeferCap(config);
 
-  const emit = (observation: JudgeVerdictObservation): void => {
+  // Lazy emit (Codex P2): when `onVerdict` is undefined (default path —
+  // telemetry off), payload construction is skipped entirely. Callers
+  // pass a factory instead of a pre-built observation so the `sha256`
+  // `contentHash` and surrounding object allocation only run when a
+  // subscriber is present. For large batches with telemetry off this
+  // removes per-verdict overhead that would otherwise fire on every
+  // auto-approved / cache / fail-open path.
+  const emit = (build: () => JudgeVerdictObservation): void => {
     if (!onVerdict) return;
+    let observation: JudgeVerdictObservation;
+    try {
+      observation = build();
+    } catch (err) {
+      log.debug(
+        `extraction-judge: onVerdict builder threw (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+      return;
+    }
     try {
       onVerdict(observation);
     } catch (err) {
@@ -412,14 +428,14 @@ export async function judgeFactDurability(
         reason: `Auto-approved: ${c.category} category bypasses judge`,
       };
       verdicts.set(i, v);
-      emit({
+      emit(() => ({
         verdict: v,
         candidate: c,
         contentHash: cacheKey(c.text, c.category),
         source: "auto-approve",
         priorDeferrals: 0,
         elapsedMs: Date.now() - startMs,
-      });
+      }));
       continue;
     }
 
@@ -430,14 +446,14 @@ export async function judgeFactDurability(
         reason: "Auto-approved: critical importance",
       };
       verdicts.set(i, v);
-      emit({
+      emit(() => ({
         verdict: v,
         candidate: c,
         contentHash: cacheKey(c.text, c.category),
         source: "auto-approve",
         priorDeferrals: 0,
         elapsedMs: Date.now() - startMs,
-      });
+      }));
       continue;
     }
 
@@ -447,14 +463,14 @@ export async function judgeFactDurability(
     if (cachedVerdict) {
       verdicts.set(i, cachedVerdict);
       cached++;
-      emit({
+      emit(() => ({
         verdict: cachedVerdict,
         candidate: c,
         contentHash: key,
         source: "cache",
         priorDeferrals: deferCountMap.get(key) ?? 0,
         elapsedMs: Date.now() - startMs,
-      });
+      }));
       continue;
     }
 
@@ -559,14 +575,14 @@ export async function judgeFactDurability(
           if (getVerdictKind(verdict) !== "defer") {
             verdictCache.set(key, verdict);
           }
-          emit({
+          emit(() => ({
             verdict,
             candidate: c,
             contentHash: key,
             source,
             priorDeferrals: priorDefers,
             elapsedMs: Date.now() - startMs,
-          });
+          }));
         }
         // Evict oldest entries if cache exceeds max size
         enforceMaxCacheSize(verdictCache);
@@ -587,13 +603,19 @@ export async function judgeFactDurability(
           reason: "Approved by default (judge unavailable or parse error)",
         };
         verdicts.set(idx, v);
-        emit({
-          verdict: v,
-          candidate: c,
-          contentHash: cacheKey(c.text, c.category),
-          source: "fail-open",
-          priorDeferrals: deferCountMap.get(cacheKey(c.text, c.category)) ?? 0,
-          elapsedMs: Date.now() - startMs,
+        emit(() => {
+          // Compute the content hash once and reuse for both the event
+          // payload and the defer-counter lookup so we do not pay for
+          // sha256 twice on this cold path.
+          const hash = cacheKey(c.text, c.category);
+          return {
+            verdict: v,
+            candidate: c,
+            contentHash: hash,
+            source: "fail-open",
+            priorDeferrals: deferCountMap.get(hash) ?? 0,
+            elapsedMs: Date.now() - startMs,
+          };
         });
       }
     }

--- a/packages/remnic-core/src/extraction-judge.ts
+++ b/packages/remnic-core/src/extraction-judge.ts
@@ -179,6 +179,33 @@ export interface JudgeBatchResult {
   deferredCappedToReject: number;
 }
 
+/**
+ * Per-verdict observation emitted by `judgeFactDurability` when an
+ * `onVerdict` callback is supplied (issue #562, PR 3). Used to wire the
+ * observation ledger / telemetry stream without coupling the judge module
+ * directly to filesystem I/O. One event is emitted for every resolved
+ * verdict, including auto-approved and cache-hit paths.
+ */
+export interface JudgeVerdictObservation {
+  verdict: JudgeVerdict;
+  /** The original `JudgeCandidate` passed in (same reference). */
+  candidate: JudgeCandidate;
+  /** SHA-256 of `text\0category`, same key the cache/deferCounter use. */
+  contentHash: string;
+  /** Verdict resolution path. Useful for debugging + dashboards. */
+  source: "auto-approve" | "cache" | "llm" | "llm-cap-rejected" | "fail-open";
+  /**
+   * How many times this candidate had already been deferred before this
+   * verdict resolved. 0 when the candidate had never been deferred.
+   */
+  priorDeferrals: number;
+  /**
+   * Milliseconds from batch start to now. Shared across verdicts emitted in
+   * the same batch.
+   */
+  elapsedMs: number;
+}
+
 // ---------------------------------------------------------------------------
 // Prompt (embedded; mirrors prompts/extraction_judge.prompt.md)
 // ---------------------------------------------------------------------------
@@ -334,6 +361,7 @@ export async function judgeFactDurability(
   fallbackLlm: FallbackLlmClient | null,
   cache?: Map<string, JudgeVerdict>,
   deferCounts?: Map<string, number>,
+  onVerdict?: (observation: JudgeVerdictObservation) => void,
 ): Promise<JudgeBatchResult> {
   const startMs = Date.now();
   const verdicts = new Map<number, JudgeVerdict>();
@@ -347,6 +375,18 @@ export async function judgeFactDurability(
   const verdictCache = cache ?? defaultVerdictCache;
   const deferCountMap = deferCounts ?? defaultDeferCounts;
   const deferCap = resolveDeferCap(config);
+
+  const emit = (observation: JudgeVerdictObservation): void => {
+    if (!onVerdict) return;
+    try {
+      onVerdict(observation);
+    } catch (err) {
+      // Fail-open: telemetry errors must never block extraction.
+      log.debug(
+        `extraction-judge: onVerdict callback threw (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  };
 
   if (candidates.length === 0) {
     return {
@@ -367,18 +407,36 @@ export async function judgeFactDurability(
 
     // Auto-approve safety categories
     if (AUTO_APPROVE_CATEGORIES.has(c.category)) {
-      verdicts.set(i, {
+      const v: JudgeVerdict = {
         durable: true,
         reason: `Auto-approved: ${c.category} category bypasses judge`,
+      };
+      verdicts.set(i, v);
+      emit({
+        verdict: v,
+        candidate: c,
+        contentHash: cacheKey(c.text, c.category),
+        source: "auto-approve",
+        priorDeferrals: 0,
+        elapsedMs: Date.now() - startMs,
       });
       continue;
     }
 
     // Auto-approve critical importance
     if (c.importanceLevel === "critical") {
-      verdicts.set(i, {
+      const v: JudgeVerdict = {
         durable: true,
         reason: "Auto-approved: critical importance",
+      };
+      verdicts.set(i, v);
+      emit({
+        verdict: v,
+        candidate: c,
+        contentHash: cacheKey(c.text, c.category),
+        source: "auto-approve",
+        priorDeferrals: 0,
+        elapsedMs: Date.now() - startMs,
       });
       continue;
     }
@@ -389,6 +447,14 @@ export async function judgeFactDurability(
     if (cachedVerdict) {
       verdicts.set(i, cachedVerdict);
       cached++;
+      emit({
+        verdict: cachedVerdict,
+        candidate: c,
+        contentHash: key,
+        source: "cache",
+        priorDeferrals: deferCountMap.get(key) ?? 0,
+        elapsedMs: Date.now() - startMs,
+      });
       continue;
     }
 
@@ -440,18 +506,20 @@ export async function judgeFactDurability(
           const c = candidates[idx];
           const key = cacheKey(c.text, c.category);
           let verdict = rawVerdict;
+          let source: JudgeVerdictObservation["source"] = "llm";
+          const priorDefers = deferCountMap.get(key) ?? 0;
 
           // Defer cap (issue #562, PR 2). A candidate that has already been
           // deferred `deferCap` times is forcibly rejected so a pathological
           // LLM response cannot produce an infinite defer loop.
           if (getVerdictKind(verdict) === "defer") {
-            const priorDefers = deferCountMap.get(key) ?? 0;
             if (priorDefers >= deferCap) {
               verdict = {
                 durable: false,
                 reason: `Defer cap reached (${deferCap} prior defers); rejecting`,
                 kind: "reject",
               };
+              source = "llm-cap-rejected";
               // Only clear + count the cap conversion once per batch for
               // this key — duplicates in the same response all resolve to
               // reject but should not inflate the cap-rejection counter.
@@ -491,6 +559,14 @@ export async function judgeFactDurability(
           if (getVerdictKind(verdict) !== "defer") {
             verdictCache.set(key, verdict);
           }
+          emit({
+            verdict,
+            candidate: c,
+            contentHash: key,
+            source,
+            priorDeferrals: priorDefers,
+            elapsedMs: Date.now() - startMs,
+          });
         }
         // Evict oldest entries if cache exceeds max size
         enforceMaxCacheSize(verdictCache);
@@ -505,9 +581,19 @@ export async function judgeFactDurability(
     // Fill in any missing verdicts from this batch (fail-open: approve)
     for (const idx of batchIndices) {
       if (!verdicts.has(idx)) {
-        verdicts.set(idx, {
+        const c = candidates[idx];
+        const v: JudgeVerdict = {
           durable: true,
           reason: "Approved by default (judge unavailable or parse error)",
+        };
+        verdicts.set(idx, v);
+        emit({
+          verdict: v,
+          candidate: c,
+          contentHash: cacheKey(c.text, c.category),
+          source: "fail-open",
+          priorDeferrals: deferCountMap.get(cacheKey(c.text, c.category)) ?? 0,
+          elapsedMs: Date.now() - startMs,
         });
       }
     }

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -29,6 +29,10 @@ import {
   type JudgeCandidate,
   type JudgeVerdict,
 } from "./extraction-judge.js";
+import {
+  EXTRACTION_JUDGE_VERDICT_CATEGORY,
+  recordJudgeVerdict,
+} from "./extraction-judge-telemetry.js";
 import { buildProcedurePersistBody } from "./procedural/procedure-types.js";
 import { buildProcedureRecallSection } from "./procedural/procedure-recall.js";
 import {
@@ -10845,6 +10849,38 @@ export class Orchestrator {
           });
           candidateToFactIndex.push(fi);
         }
+        // Telemetry callback (issue #562 PR 3). Emits one structured row to
+        // the observation ledger per resolved verdict. Gated on
+        // `extractionJudgeTelemetryEnabled`; the callback is a no-op when
+        // the flag is off. `recordJudgeVerdict` swallows write errors so
+        // telemetry never blocks extraction.
+        const judgeTelemetryOpts = {
+          enabled: this.config.extractionJudgeTelemetryEnabled === true,
+          memoryDir: this.config.memoryDir,
+        };
+        const judgeTelemetryHandler = judgeTelemetryOpts.enabled
+          ? (obs: import("./extraction-judge.js").JudgeVerdictObservation) => {
+              const event: import("./extraction-judge-telemetry.js").JudgeVerdictEvent = {
+                version: 1,
+                category: EXTRACTION_JUDGE_VERDICT_CATEGORY,
+                ts: new Date().toISOString(),
+                verdictKind: getVerdictKind(obs.verdict),
+                reason: obs.verdict.reason,
+                deferrals: obs.priorDeferrals,
+                elapsedMs: obs.elapsedMs,
+                candidateCategory: obs.candidate.category,
+                confidence: obs.candidate.confidence,
+                contentHash: obs.contentHash,
+                fromCache: obs.source === "cache",
+                ...(obs.source === "llm-cap-rejected"
+                  ? { deferCapTriggered: true }
+                  : {}),
+              };
+              // Best-effort fire-and-forget: don't await the write, but log
+              // failures at debug via the helper's internal catch.
+              void recordJudgeVerdict(event, judgeTelemetryOpts);
+            }
+          : undefined;
         const judgeResult = await judgeFactDurability(
           judgeCandidates,
           this.config,
@@ -10852,6 +10888,7 @@ export class Orchestrator {
           new FallbackLlmClient(this.config.gatewayConfig),
           this.judgeVerdictCache,
           this.judgeDeferCounts,
+          judgeTelemetryHandler,
         );
         // Remap candidate-indexed verdicts to original fact indexes
         judgeVerdictsByFactIndex = new Map();

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -583,6 +583,13 @@ export interface PluginConfig {
    * Defaults to 2 (issue #562, PR 2).
    */
   extractionJudgeMaxDeferrals: number;
+  /**
+   * Emit structured telemetry rows to
+   * `state/observation-ledger/extraction-judge-verdicts.jsonl` on every
+   * judge verdict. Off by default; enable to collect defer-rate / latency
+   * metrics for operator dashboards (issue #562, PR 3).
+   */
+  extractionJudgeTelemetryEnabled: boolean;
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2360,6 +2360,11 @@
         "minimum": 1,
         "description": "Maximum number of times the same candidate text may be deferred by the extraction judge before the verdict is forcibly converted to 'reject'. Prevents pathological LLM responses from looping forever on ambiguous facts (issue #562)."
       },
+      "extractionJudgeTelemetryEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/tests/extraction-judge-telemetry.test.ts
+++ b/tests/extraction-judge-telemetry.test.ts
@@ -1,0 +1,378 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import {
+  recordJudgeVerdict,
+  readJudgeVerdictStats,
+  judgeTelemetryPath,
+  EXTRACTION_JUDGE_VERDICT_CATEGORY,
+  type JudgeVerdictEvent,
+} from "../packages/remnic-core/src/extraction-judge-telemetry.ts";
+import {
+  judgeFactDurability,
+  clearVerdictCache,
+  type JudgeCandidate,
+  type JudgeVerdictObservation,
+} from "../packages/remnic-core/src/extraction-judge.ts";
+import { parseConfig } from "../packages/remnic-core/src/config.ts";
+
+async function mkdirTmp(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "judge-telemetry-"));
+}
+
+function baseEvent(overrides: Partial<JudgeVerdictEvent> = {}): JudgeVerdictEvent {
+  return {
+    version: 1,
+    category: EXTRACTION_JUDGE_VERDICT_CATEGORY,
+    ts: "2026-04-10T12:00:00.000Z",
+    verdictKind: "accept",
+    reason: "mock",
+    deferrals: 0,
+    elapsedMs: 12.5,
+    candidateCategory: "fact",
+    confidence: 0.8,
+    contentHash: "hash-" + Math.random().toString(16).slice(2),
+    fromCache: false,
+    ...overrides,
+  };
+}
+
+test("PR 3: recordJudgeVerdict is a no-op when disabled", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await recordJudgeVerdict(baseEvent(), { enabled: false, memoryDir: dir });
+    // Nothing should be written.
+    await assert.rejects(
+      readFile(judgeTelemetryPath(dir), "utf-8"),
+      /ENOENT/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: recordJudgeVerdict appends one JSONL row per call", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "accept", reason: "a" }),
+      { enabled: true, memoryDir: dir },
+    );
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "defer", reason: "b", deferrals: 1 }),
+      { enabled: true, memoryDir: dir },
+    );
+    const raw = await readFile(judgeTelemetryPath(dir), "utf-8");
+    const lines = raw.trim().split("\n");
+    assert.equal(lines.length, 2);
+    const first = JSON.parse(lines[0]);
+    const second = JSON.parse(lines[1]);
+    assert.equal(first.category, EXTRACTION_JUDGE_VERDICT_CATEGORY);
+    assert.equal(first.verdictKind, "accept");
+    assert.equal(second.verdictKind, "defer");
+    assert.equal(second.deferrals, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: recordJudgeVerdict fails open on directory errors", async () => {
+  // Point at a path whose parent cannot be created: a file existing where a
+  // directory is expected.
+  const dir = await mkdirTmp();
+  try {
+    // Place a regular file where recordJudgeVerdict wants to mkdir — mkdir
+    // { recursive: true } would normally be idempotent; here the *parent*
+    // of the parent is a file, so mkdir throws ENOTDIR, which the helper
+    // must swallow.
+    const blocker = path.join(dir, "state");
+    await writeFile(blocker, "not a directory", "utf-8");
+    // Must not throw.
+    await recordJudgeVerdict(baseEvent(), { enabled: true, memoryDir: dir });
+    // And the ledger file was not created (since the write failed silently).
+    await assert.rejects(
+      readFile(judgeTelemetryPath(dir), "utf-8"),
+      /ENOENT|ENOTDIR/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: readJudgeVerdictStats returns zeros on empty/missing ledger", async () => {
+  const dir = await mkdirTmp();
+  try {
+    const stats = await readJudgeVerdictStats(dir);
+    assert.equal(stats.total, 0);
+    assert.equal(stats.accept, 0);
+    assert.equal(stats.reject, 0);
+    assert.equal(stats.defer, 0);
+    assert.equal(stats.deferRate, 0);
+    assert.equal(stats.meanElapsedMs, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: readJudgeVerdictStats aggregates kinds + defer rate + mean elapsed", async () => {
+  const dir = await mkdirTmp();
+  try {
+    const opts = { enabled: true, memoryDir: dir };
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "accept", elapsedMs: 10 }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "accept", elapsedMs: 20 }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "reject", elapsedMs: 30 }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ verdictKind: "defer", elapsedMs: 40, deferrals: 1 }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({
+        verdictKind: "reject",
+        elapsedMs: 50,
+        deferCapTriggered: true,
+      }),
+      opts,
+    );
+
+    const stats = await readJudgeVerdictStats(dir);
+    assert.equal(stats.total, 5);
+    assert.equal(stats.accept, 2);
+    assert.equal(stats.reject, 2);
+    assert.equal(stats.defer, 1);
+    assert.equal(stats.deferCapTriggered, 1);
+    assert.equal(stats.deferRate, 1 / 5);
+    assert.equal(stats.meanElapsedMs, (10 + 20 + 30 + 40 + 50) / 5);
+    assert.ok(stats.firstTs);
+    assert.ok(stats.lastTs);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: readJudgeVerdictStats respects inclusive sinceMs and exclusive untilMs", async () => {
+  // CLAUDE.md gotcha 35: time-range filters must use exclusive upper bounds.
+  const dir = await mkdirTmp();
+  try {
+    const opts = { enabled: true, memoryDir: dir };
+    await recordJudgeVerdict(
+      baseEvent({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ ts: "2026-04-10T06:00:00.000Z", verdictKind: "reject" }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ ts: "2026-04-10T12:00:00.000Z", verdictKind: "defer" }),
+      opts,
+    );
+    await recordJudgeVerdict(
+      baseEvent({ ts: "2026-04-10T18:00:00.000Z", verdictKind: "accept" }),
+      opts,
+    );
+
+    // Window [06:00, 12:00) must include the 06:00 reject and exclude the
+    // 12:00 defer.
+    const stats = await readJudgeVerdictStats(dir, {
+      sinceMs: Date.parse("2026-04-10T06:00:00.000Z"),
+      untilMs: Date.parse("2026-04-10T12:00:00.000Z"),
+    });
+    assert.equal(stats.total, 1);
+    assert.equal(stats.reject, 1);
+    assert.equal(stats.accept, 0);
+    assert.equal(stats.defer, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: readJudgeVerdictStats counts malformed rows toward malformed, not totals", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await mkdir(path.dirname(judgeTelemetryPath(dir)), { recursive: true });
+    const rows = [
+      JSON.stringify(baseEvent({ verdictKind: "accept" })),
+      "not-json",
+      JSON.stringify({ category: "something-else", ts: "2026-04-10T00:00:00Z" }),
+      JSON.stringify(
+        baseEvent({ verdictKind: "bogus" as unknown as "accept" }),
+      ),
+      JSON.stringify(baseEvent({ verdictKind: "defer" })),
+      "", // blank line — ignored, not counted as malformed
+    ];
+    await writeFile(
+      judgeTelemetryPath(dir),
+      rows.join("\n") + "\n",
+      "utf-8",
+    );
+    const stats = await readJudgeVerdictStats(dir);
+    assert.equal(stats.total, 2, "Only the two valid rows count toward total");
+    assert.equal(stats.malformed, 3);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 3: judge emits onVerdict for every resolved verdict (auto-approve, cache, LLM)", async () => {
+  clearVerdictCache();
+  const observations: JudgeVerdictObservation[] = [];
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: "accept",
+            durable: true,
+            reason: "llm-accept",
+          })),
+        ),
+      };
+    },
+  };
+
+  const cache = new Map();
+  const candidates: JudgeCandidate[] = [
+    { text: "correction fact", category: "correction", confidence: 0.9 },
+    { text: "critical preference", category: "fact", confidence: 0.9, importanceLevel: "critical" },
+    { text: "llm-routed fact body", category: "fact", confidence: 0.7, importanceLevel: "normal" },
+  ];
+
+  const cfg = parseConfig({
+    memoryDir: ".tmp/x",
+    workspaceDir: ".tmp/y",
+    openaiApiKey: "test",
+    extractionJudgeEnabled: true,
+    extractionJudgeBatchSize: 20,
+  });
+
+  // First pass: auto-approve + auto-approve + llm
+  const r1 = await judgeFactDurability(
+    candidates,
+    cfg,
+    mockLocalLlm as any,
+    null,
+    cache,
+    new Map(),
+    (obs) => observations.push(obs),
+  );
+  assert.equal(r1.verdicts.size, 3);
+  assert.equal(observations.length, 3);
+  const sources1 = observations.map((o) => o.source).sort();
+  assert.deepEqual(sources1, ["auto-approve", "auto-approve", "llm"]);
+
+  // Second pass: the LLM-routed candidate is now cached.
+  observations.length = 0;
+  const r2 = await judgeFactDurability(
+    [candidates[2]],
+    cfg,
+    mockLocalLlm as any,
+    null,
+    cache,
+    new Map(),
+    (obs) => observations.push(obs),
+  );
+  assert.equal(r2.verdicts.size, 1);
+  assert.equal(observations.length, 1);
+  assert.equal(observations[0].source, "cache");
+});
+
+test("PR 3: judge emits llm-cap-rejected source when defer cap converts to reject", async () => {
+  clearVerdictCache();
+  const observations: JudgeVerdictObservation[] = [];
+  const mockLocalLlm = {
+    chatCompletion: async (_msgs: any) => {
+      const items = JSON.parse(_msgs[1].content) as Array<{ index: number }>;
+      return {
+        content: JSON.stringify(
+          items.map((it) => ({
+            index: it.index,
+            kind: "defer",
+            durable: false,
+            reason: "defer-always",
+          })),
+        ),
+      };
+    },
+  };
+  const cache = new Map();
+  const defers = new Map<string, number>();
+  const candidates: JudgeCandidate[] = [
+    {
+      text: "repeatedly ambiguous fact",
+      category: "fact",
+      confidence: 0.5,
+      importanceLevel: "normal",
+    },
+  ];
+  const cfg = parseConfig({
+    memoryDir: ".tmp/x",
+    workspaceDir: ".tmp/y",
+    openaiApiKey: "test",
+    extractionJudgeEnabled: true,
+    extractionJudgeMaxDeferrals: 1,
+  });
+
+  await judgeFactDurability(
+    candidates,
+    cfg,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+    (obs) => observations.push(obs),
+  );
+  // Second pass: defer count is at cap (1), so this one converts to reject.
+  await judgeFactDurability(
+    candidates,
+    cfg,
+    mockLocalLlm as any,
+    null,
+    cache,
+    defers,
+    (obs) => observations.push(obs),
+  );
+  const sources = observations.map((o) => o.source);
+  assert.deepEqual(sources, ["llm", "llm-cap-rejected"]);
+  assert.equal(observations[0].verdict.kind, "defer");
+  assert.equal(observations[1].verdict.kind, "reject");
+});
+
+test("PR 3: judge's onVerdict callback failure does not break extraction", async () => {
+  clearVerdictCache();
+  const candidates: JudgeCandidate[] = [
+    { text: "correction", category: "correction", confidence: 0.9 },
+  ];
+  const cfg = parseConfig({
+    memoryDir: ".tmp/x",
+    workspaceDir: ".tmp/y",
+    openaiApiKey: "test",
+    extractionJudgeEnabled: true,
+  });
+  const r = await judgeFactDurability(
+    candidates,
+    cfg,
+    null,
+    null,
+    new Map(),
+    new Map(),
+    () => {
+      throw new Error("telemetry boom");
+    },
+  );
+  // Extraction result should still be intact.
+  assert.equal(r.verdicts.size, 1);
+  assert.equal(r.verdicts.get(0)?.durable, true);
+});


### PR DESCRIPTION
## Summary

PR 3 of 4 for issue #562 (MemReader-inspired defer action on the extraction judge).

- New module `extraction-judge-telemetry.ts` emits one structured event per judge verdict to `state/observation-ledger/extraction-judge-verdicts.jsonl` under category `EXTRACTION_JUDGE_VERDICT`
- `judgeFactDurability` gains an optional `onVerdict` callback; orchestrator wires it through `recordJudgeVerdict`. Zero overhead when the flag is off (handler is `undefined`)
- Events fire for every resolved verdict path: `auto-approve`, `cache`, `llm`, `llm-cap-rejected`, `fail-open`
- `readJudgeVerdictStats(memoryDir, { sinceMs, untilMs })` aggregates by kind with half-open interval semantics per CLAUDE.md gotcha 35
- New CLI: `remnic judge-stats [--since ISO] [--until ISO] [--json]` — rejects invalid date inputs instead of silently defaulting
- New config `extractionJudgeTelemetryEnabled` (default false) wired in three plugin manifests
- Append is fail-open: filesystem errors are logged at debug level; telemetry never blocks extraction
- Callback exception is isolated: a buggy handler cannot fail extraction

## Test plan

- [x] `npx tsx --test tests/extraction-judge-telemetry.test.ts` — 10 tests pass
- [x] `npx tsx --test tests/extraction-judge.test.ts packages/remnic-core/src/buffer-session.test.ts` — 54 prior tests still pass
- [x] `npm run build` — clean
- [x] Half-open interval semantics verified with exact-boundary timestamps
- [x] Malformed rows counted toward `malformed`, not totals
- [x] `llm-cap-rejected` source emitted when defer cap converts to reject

## Follow-ups

- PR 4 — opt-in JSONL training-pair collection shim for future GRPO prep

Closes part of #562.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new file-based telemetry writes and adds an `onVerdict` callback into `judgeFactDurability` plus orchestrator wiring; while fail-open and gated, it touches the extraction-judge execution path and could affect performance or logging behavior when enabled.
> 
> **Overview**
> Adds **opt-in extraction-judge verdict telemetry**: when `extractionJudgeTelemetryEnabled` is true, each resolved verdict emits a structured JSONL row to `state/observation-ledger/extraction-judge-verdicts.jsonl`, including source path (auto-approve/cache/LLM/fail-open) plus defer-cap conversions.
> 
> Introduces `remnic judge-stats` to aggregate this ledger (with `--since/--until` time window and `--json` output), and wires the new config flag through plugin schemas and config parsing. Includes a new telemetry module with fail-open append + stats aggregation, and tests covering emit behavior, malformed rows, time-window semantics, and callback isolation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 58e98b97b978d94741e91787d32032bdebd4d925. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->