### PR TITLE
feat(extraction-judge): training-pair collection shim (issue #562 PR 4/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2376,6 +2376,16 @@
         "default": false,
         "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
       },
+      "collectJudgeTrainingPairs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+      },
+      "judgeTrainingDir": {
+        "type": "string",
+        "default": "",
+        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2334,6 +2334,16 @@
         "default": false,
         "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
       },
+      "collectJudgeTrainingPairs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+      },
+      "judgeTrainingDir": {
+        "type": "string",
+        "default": "",
+        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1553,6 +1553,13 @@ export function parseConfig(raw: unknown): PluginConfig {
     // codebase (CLAUDE.md gotcha 36).
     extractionJudgeTelemetryEnabled:
       coerceBool(cfg.extractionJudgeTelemetryEnabled) === true,
+    // Judge training-pair collection (issue #562 PR 4): opt-in shim for a
+    // future GRPO training pipeline. Rows land under ~/.remnic/judge-
+    // training/<date>.jsonl — NOT in the shared memory directory.
+    // Uses `coerceBool` per CLAUDE.md gotcha 36 for CLI-string parity.
+    collectJudgeTrainingPairs: coerceBool(cfg.collectJudgeTrainingPairs) === true,
+    judgeTrainingDir:
+      typeof cfg.judgeTrainingDir === "string" ? cfg.judgeTrainingDir : "",
     // Inline source attribution (issue #369). Opt-in to preserve
     // backwards compatibility with existing downstream consumers.
     inlineSourceAttributionEnabled: cfg.inlineSourceAttributionEnabled === true,

--- a/packages/remnic-core/src/extraction-judge-training.ts
+++ b/packages/remnic-core/src/extraction-judge-training.ts
@@ -60,9 +60,31 @@ export interface JudgeTrainingOptions {
   directory?: string;
 }
 
+/**
+ * Expand a leading `~` / `~/` / `$HOME/` / `${HOME}/` to the process home
+ * directory. Node's `fs` APIs do not expand `~` themselves (CLAUDE.md
+ * gotcha 17), so every user-facing path input must be funnelled through
+ * this helper before it reaches the filesystem.
+ */
+function expandTilde(p: string): string {
+  const home = homedir();
+  if (p === "~" || p.startsWith("~/") || p.startsWith("~\\")) {
+    return home + p.slice(1);
+  }
+  if (p === "$HOME" || p.startsWith("$HOME/") || p.startsWith("$HOME\\")) {
+    return home + p.slice(5);
+  }
+  if (p === "${HOME}" || p.startsWith("${HOME}/") || p.startsWith("${HOME}\\")) {
+    return home + p.slice(7);
+  }
+  return p;
+}
+
 export function resolveTrainingDir(options: JudgeTrainingOptions): string {
   if (options.directory && options.directory.length > 0) {
-    return options.directory;
+    // Expand `~` / `$HOME` in the override so operators can write the
+    // config as the user sees it (CLAUDE.md gotcha 17).
+    return expandTilde(options.directory);
   }
   return path.join(homedir(), ".remnic", "judge-training");
 }

--- a/packages/remnic-core/src/extraction-judge-training.ts
+++ b/packages/remnic-core/src/extraction-judge-training.ts
@@ -1,0 +1,195 @@
+/**
+ * Extraction Judge Training Data Shim (issue #562, PR 4).
+ *
+ * Opt-in collector for `(candidate_text, verdict_kind, reason,
+ * ground_truth_label?)` tuples. Rows are appended to JSONL files under
+ * `~/.remnic/judge-training/<YYYY-MM-DD>.jsonl` so operators can ship the
+ * data into a future GRPO training pipeline without exfiltrating live
+ * memory content through the regular observation ledger.
+ *
+ * Gating:
+ *   - Off by default. Must be explicitly enabled via
+ *     `collectJudgeTrainingPairs: true` in plugin config.
+ *   - The ground-truth label is always optional — labels are added out-of-
+ *     band once reviewers disambiguate the candidate's fate.
+ *
+ * Privacy: the row carries only what the judge already sees — the
+ * candidate text and its metadata. It does NOT carry session keys,
+ * principal IDs, or any user identifiers. The file lives in the user's
+ * home directory rather than the shared memory directory so it is never
+ * committed, sync'd, or bundled into exports.
+ */
+
+import path from "node:path";
+import { homedir } from "node:os";
+import { appendFile, mkdir, readFile, readdir } from "node:fs/promises";
+import { log } from "./logger.js";
+import type { JudgeVerdictKind } from "./extraction-judge.js";
+
+/**
+ * Persisted training row. Intentionally minimal: just the signal needed
+ * to train a judge replacement policy. Schema version is tagged so future
+ * readers can migrate older rows.
+ */
+export interface JudgeTrainingPair {
+  version: 1;
+  ts: string; // ISO-8601
+  candidateText: string;
+  candidateCategory: string;
+  candidateConfidence?: number;
+  verdictKind: JudgeVerdictKind;
+  reason: string;
+  /**
+   * Number of prior deferrals when the verdict was resolved. `0` for the
+   * first resolution; only set when known (defer pathway).
+   */
+  priorDeferrals?: number;
+  /**
+   * Optional human-applied ground-truth label. Added after the fact by a
+   * reviewer / labelling script; not present on fresh rows.
+   */
+  groundTruthLabel?: JudgeVerdictKind;
+}
+
+export interface JudgeTrainingOptions {
+  enabled: boolean;
+  /**
+   * Override for the output directory. Defaults to
+   * `~/.remnic/judge-training`. Tests pass a temp path here.
+   */
+  directory?: string;
+}
+
+export function resolveTrainingDir(options: JudgeTrainingOptions): string {
+  if (options.directory && options.directory.length > 0) {
+    return options.directory;
+  }
+  return path.join(homedir(), ".remnic", "judge-training");
+}
+
+function dateStamp(iso: string): string {
+  // `YYYY-MM-DD` from an ISO-8601 string. Falls back to today on a parse
+  // failure rather than throwing — the caller already wrote a row and the
+  // timestamp is best-effort.
+  const ms = Date.parse(iso);
+  const d = Number.isFinite(ms) ? new Date(ms) : new Date();
+  const yyyy = d.getUTCFullYear().toString().padStart(4, "0");
+  const mm = (d.getUTCMonth() + 1).toString().padStart(2, "0");
+  const dd = d.getUTCDate().toString().padStart(2, "0");
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export function trainingFilePathFor(
+  directory: string,
+  iso: string,
+): string {
+  return path.join(directory, `${dateStamp(iso)}.jsonl`);
+}
+
+/**
+ * Append a single training row. Fails open — write errors are logged at
+ * debug level and swallowed, same policy as the telemetry emitter.
+ * No-op when `options.enabled` is false.
+ */
+export async function recordJudgeTrainingPair(
+  row: JudgeTrainingPair,
+  options: JudgeTrainingOptions,
+): Promise<void> {
+  if (!options.enabled) return;
+  const dir = resolveTrainingDir(options);
+  const filePath = trainingFilePathFor(dir, row.ts);
+  try {
+    await mkdir(dir, { recursive: true });
+    await appendFile(filePath, `${JSON.stringify(row)}\n`, "utf-8");
+  } catch (err) {
+    log.debug(
+      `extraction-judge-training: append failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+}
+
+/**
+ * Read all training rows from the configured directory. Returns an empty
+ * array when the directory is missing. Malformed lines are skipped and
+ * counted in the returned `malformed` tally.
+ */
+export async function readJudgeTrainingPairs(
+  options: Pick<JudgeTrainingOptions, "directory">,
+): Promise<{ rows: JudgeTrainingPair[]; malformed: number }> {
+  const dir = resolveTrainingDir({ enabled: true, ...options });
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return { rows: [], malformed: 0 };
+    throw err;
+  }
+
+  const rows: JudgeTrainingPair[] = [];
+  let malformed = 0;
+  // Sort so reads are deterministic across platforms.
+  entries.sort();
+  for (const name of entries) {
+    if (!name.endsWith(".jsonl")) continue;
+    const raw = await readFile(path.join(dir, name), "utf-8");
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        malformed += 1;
+        continue;
+      }
+      if (!isValidTrainingPair(parsed)) {
+        malformed += 1;
+        continue;
+      }
+      rows.push(parsed);
+    }
+  }
+  return { rows, malformed };
+}
+
+/**
+ * Structural validator matching the persisted schema. Forward-compat: an
+ * unknown `verdictKind` string is treated as malformed (strict training
+ * signal — we do not want to admit unlabelled gibberish into a trainer).
+ */
+export function isValidTrainingPair(value: unknown): value is JudgeTrainingPair {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const p = value as Record<string, unknown>;
+  if (p.version !== 1) return false;
+  if (typeof p.ts !== "string") return false;
+  if (typeof p.candidateText !== "string") return false;
+  if (typeof p.candidateCategory !== "string") return false;
+  if (
+    p.verdictKind !== "accept" &&
+    p.verdictKind !== "reject" &&
+    p.verdictKind !== "defer"
+  ) {
+    return false;
+  }
+  if (typeof p.reason !== "string") return false;
+  if (
+    p.candidateConfidence !== undefined &&
+    typeof p.candidateConfidence !== "number"
+  ) {
+    return false;
+  }
+  if (p.priorDeferrals !== undefined && typeof p.priorDeferrals !== "number") {
+    return false;
+  }
+  if (
+    p.groundTruthLabel !== undefined &&
+    p.groundTruthLabel !== "accept" &&
+    p.groundTruthLabel !== "reject" &&
+    p.groundTruthLabel !== "defer"
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -33,6 +33,7 @@ import {
   EXTRACTION_JUDGE_VERDICT_CATEGORY,
   recordJudgeVerdict,
 } from "./extraction-judge-telemetry.js";
+import { recordJudgeTrainingPair } from "./extraction-judge-training.js";
 import { buildProcedurePersistBody } from "./procedural/procedure-types.js";
 import { buildProcedureRecallSection } from "./procedural/procedure-recall.js";
 import {
@@ -10849,38 +10850,63 @@ export class Orchestrator {
           });
           candidateToFactIndex.push(fi);
         }
-        // Telemetry callback (issue #562 PR 3). Emits one structured row to
-        // the observation ledger per resolved verdict. Gated on
-        // `extractionJudgeTelemetryEnabled`; the callback is a no-op when
-        // the flag is off. `recordJudgeVerdict` swallows write errors so
-        // telemetry never blocks extraction.
+        // Telemetry + training-pair emit (issue #562 PR 3 + PR 4). The
+        // orchestrator wires two fire-and-forget writers behind a single
+        // callback so `judgeFactDurability` does not need to know about
+        // either ledger. Both handlers are skipped when their flags are
+        // off; the combined callback itself is undefined when both are
+        // disabled so there is zero overhead in the default configuration.
         const judgeTelemetryOpts = {
           enabled: this.config.extractionJudgeTelemetryEnabled === true,
           memoryDir: this.config.memoryDir,
         };
-        const judgeTelemetryHandler = judgeTelemetryOpts.enabled
-          ? (obs: import("./extraction-judge.js").JudgeVerdictObservation) => {
-              const event: import("./extraction-judge-telemetry.js").JudgeVerdictEvent = {
-                version: 1,
-                category: EXTRACTION_JUDGE_VERDICT_CATEGORY,
-                ts: new Date().toISOString(),
-                verdictKind: getVerdictKind(obs.verdict),
-                reason: obs.verdict.reason,
-                deferrals: obs.priorDeferrals,
-                elapsedMs: obs.elapsedMs,
-                candidateCategory: obs.candidate.category,
-                confidence: obs.candidate.confidence,
-                contentHash: obs.contentHash,
-                fromCache: obs.source === "cache",
-                ...(obs.source === "llm-cap-rejected"
-                  ? { deferCapTriggered: true }
-                  : {}),
-              };
-              // Best-effort fire-and-forget: don't await the write, but log
-              // failures at debug via the helper's internal catch.
-              void recordJudgeVerdict(event, judgeTelemetryOpts);
-            }
-          : undefined;
+        const judgeTrainingOpts = {
+          enabled: this.config.collectJudgeTrainingPairs === true,
+          ...(this.config.judgeTrainingDir
+            ? { directory: this.config.judgeTrainingDir }
+            : {}),
+        };
+        const judgeTelemetryHandler =
+          judgeTelemetryOpts.enabled || judgeTrainingOpts.enabled
+            ? (obs: import("./extraction-judge.js").JudgeVerdictObservation) => {
+                const ts = new Date().toISOString();
+                const verdictKind = getVerdictKind(obs.verdict);
+                if (judgeTelemetryOpts.enabled) {
+                  const event: import("./extraction-judge-telemetry.js").JudgeVerdictEvent = {
+                    version: 1,
+                    category: EXTRACTION_JUDGE_VERDICT_CATEGORY,
+                    ts,
+                    verdictKind,
+                    reason: obs.verdict.reason,
+                    deferrals: obs.priorDeferrals,
+                    elapsedMs: obs.elapsedMs,
+                    candidateCategory: obs.candidate.category,
+                    confidence: obs.candidate.confidence,
+                    contentHash: obs.contentHash,
+                    fromCache: obs.source === "cache",
+                    ...(obs.source === "llm-cap-rejected"
+                      ? { deferCapTriggered: true }
+                      : {}),
+                  };
+                  void recordJudgeVerdict(event, judgeTelemetryOpts);
+                }
+                if (judgeTrainingOpts.enabled) {
+                  const pair: import("./extraction-judge-training.js").JudgeTrainingPair = {
+                    version: 1,
+                    ts,
+                    candidateText: obs.candidate.text,
+                    candidateCategory: obs.candidate.category,
+                    ...(typeof obs.candidate.confidence === "number"
+                      ? { candidateConfidence: obs.candidate.confidence }
+                      : {}),
+                    verdictKind,
+                    reason: obs.verdict.reason,
+                    priorDeferrals: obs.priorDeferrals,
+                  };
+                  void recordJudgeTrainingPair(pair, judgeTrainingOpts);
+                }
+              }
+            : undefined;
         const judgeResult = await judgeFactDurability(
           judgeCandidates,
           this.config,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -590,6 +590,21 @@ export interface PluginConfig {
    * metrics for operator dashboards (issue #562, PR 3).
    */
   extractionJudgeTelemetryEnabled: boolean;
+  /**
+   * Collect `(candidate_text, verdict_kind, reason)` tuples into
+   * `~/.remnic/judge-training/<date>.jsonl` for use by a future GRPO
+   * training pipeline (issue #562, PR 4). Off by default. Rows live in
+   * the user's home directory rather than the shared memory directory so
+   * they are not committed, sync'd, or bundled into memory exports.
+   */
+  collectJudgeTrainingPairs: boolean;
+  /**
+   * Override directory for judge training-pair collection. Empty string
+   * means use the default (`~/.remnic/judge-training`). Primarily for
+   * tests and for operators who want the output to land in a specific
+   * location.
+   */
+  judgeTrainingDir: string;
   // Hourly summaries
   hourlySummariesEnabled: boolean;
   daySummaryEnabled: boolean;

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2365,6 +2365,16 @@
         "default": false,
         "description": "Emit structured telemetry rows to state/observation-ledger/extraction-judge-verdicts.jsonl on every judge verdict. Off by default; enable to collect defer-rate and latency metrics for operator dashboards (issue #562)."
       },
+      "collectJudgeTrainingPairs": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt-in collector for (candidate_text, verdict_kind, reason) tuples used to prep a future GRPO training pipeline. Rows land under ~/.remnic/judge-training/<date>.jsonl (NOT in the shared memory directory). Off by default (issue #562)."
+      },
+      "judgeTrainingDir": {
+        "type": "string",
+        "default": "",
+        "description": "Override directory for judge training-pair collection. Empty string uses the default (~/.remnic/judge-training). Only consulted when collectJudgeTrainingPairs is true."
+      },
       "inlineSourceAttributionEnabled": {
         "type": "boolean",
         "default": false,

--- a/tests/extraction-judge-training.test.ts
+++ b/tests/extraction-judge-training.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { mkdtemp, readFile, rm, writeFile, mkdir, readdir } from "node:fs/promises";
 import path from "node:path";
-import { tmpdir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import {
   recordJudgeTrainingPair,
   readJudgeTrainingPairs,
@@ -97,6 +97,31 @@ test("PR 4: resolveTrainingDir defaults to ~/.remnic/judge-training", () => {
   assert.ok(
     p.endsWith(path.join(".remnic", "judge-training")),
     `default path should end with .remnic/judge-training, got ${p}`,
+  );
+});
+
+test("PR 4: resolveTrainingDir expands leading ~ in directory override (CLAUDE.md gotcha 17)", () => {
+  const home = homedir();
+  const expanded = resolveTrainingDir({
+    enabled: true,
+    directory: "~/custom-training-dir",
+  });
+  assert.ok(
+    expanded.startsWith(home + "/"),
+    `~/ should expand to ${home}, got ${expanded}`,
+  );
+  assert.ok(expanded.endsWith("custom-training-dir"));
+});
+
+test("PR 4: resolveTrainingDir expands $HOME prefix in directory override", () => {
+  const home = homedir();
+  const expanded = resolveTrainingDir({
+    enabled: true,
+    directory: "$HOME/custom",
+  });
+  assert.ok(
+    expanded.startsWith(home + "/"),
+    `$HOME/ should expand to ${home}, got ${expanded}`,
   );
 });
 

--- a/tests/extraction-judge-training.test.ts
+++ b/tests/extraction-judge-training.test.ts
@@ -1,0 +1,202 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm, writeFile, mkdir, readdir } from "node:fs/promises";
+import path from "node:path";
+import { tmpdir } from "node:os";
+import {
+  recordJudgeTrainingPair,
+  readJudgeTrainingPairs,
+  resolveTrainingDir,
+  trainingFilePathFor,
+  isValidTrainingPair,
+  type JudgeTrainingPair,
+} from "../packages/remnic-core/src/extraction-judge-training.ts";
+
+async function mkdirTmp(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "judge-training-"));
+}
+
+function basePair(overrides: Partial<JudgeTrainingPair> = {}): JudgeTrainingPair {
+  return {
+    version: 1,
+    ts: "2026-04-10T12:00:00.000Z",
+    candidateText: "Synthetic fact body",
+    candidateCategory: "fact",
+    candidateConfidence: 0.8,
+    verdictKind: "accept",
+    reason: "mock",
+    ...overrides,
+  };
+}
+
+test("PR 4: recordJudgeTrainingPair is a no-op when disabled", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await recordJudgeTrainingPair(basePair(), {
+      enabled: false,
+      directory: dir,
+    });
+    // Nothing should be written.
+    const entries = await readdir(dir);
+    assert.equal(entries.length, 0);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: recordJudgeTrainingPair appends one row per day file", async () => {
+  const dir = await mkdirTmp();
+  try {
+    const opts = { enabled: true, directory: dir };
+    await recordJudgeTrainingPair(
+      basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }),
+      opts,
+    );
+    await recordJudgeTrainingPair(
+      basePair({ ts: "2026-04-10T23:59:59.000Z", verdictKind: "defer" }),
+      opts,
+    );
+    await recordJudgeTrainingPair(
+      basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }),
+      opts,
+    );
+    const files = (await readdir(dir)).sort();
+    assert.deepEqual(files, ["2026-04-10.jsonl", "2026-04-11.jsonl"]);
+    const day1 = await readFile(path.join(dir, "2026-04-10.jsonl"), "utf-8");
+    const day2 = await readFile(path.join(dir, "2026-04-11.jsonl"), "utf-8");
+    assert.equal(day1.trim().split("\n").length, 2);
+    assert.equal(day2.trim().split("\n").length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: recordJudgeTrainingPair fails open on directory errors", async () => {
+  const dir = await mkdirTmp();
+  try {
+    // Place a regular file at the training-dir location so mkdir fails.
+    const sub = path.join(dir, "wedge");
+    await writeFile(sub, "not a directory", "utf-8");
+    // Must not throw; the helper swallows the error.
+    await recordJudgeTrainingPair(basePair(), {
+      enabled: true,
+      directory: sub,
+    });
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: resolveTrainingDir honors explicit directory override", () => {
+  const p = resolveTrainingDir({ enabled: true, directory: "/tmp/foo" });
+  assert.equal(p, "/tmp/foo");
+});
+
+test("PR 4: resolveTrainingDir defaults to ~/.remnic/judge-training", () => {
+  const p = resolveTrainingDir({ enabled: true });
+  assert.ok(
+    p.endsWith(path.join(".remnic", "judge-training")),
+    `default path should end with .remnic/judge-training, got ${p}`,
+  );
+});
+
+test("PR 4: trainingFilePathFor uses UTC date stamp", () => {
+  // 23:59 UTC → YYYY-MM-DD of same UTC day, not local.
+  const p = trainingFilePathFor("/tmp/x", "2026-04-10T23:59:00.000Z");
+  assert.equal(p, path.join("/tmp/x", "2026-04-10.jsonl"));
+});
+
+test("PR 4: readJudgeTrainingPairs returns empty on missing directory", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await rm(dir, { recursive: true, force: true });
+    const result = await readJudgeTrainingPairs({ directory: dir });
+    assert.equal(result.rows.length, 0);
+    assert.equal(result.malformed, 0);
+  } finally {
+    // Already removed.
+  }
+});
+
+test("PR 4: readJudgeTrainingPairs returns rows from all day files sorted", async () => {
+  const dir = await mkdirTmp();
+  try {
+    const opts = { enabled: true, directory: dir };
+    await recordJudgeTrainingPair(
+      basePair({ ts: "2026-04-11T00:00:00.000Z", verdictKind: "reject" }),
+      opts,
+    );
+    await recordJudgeTrainingPair(
+      basePair({ ts: "2026-04-10T00:00:00.000Z", verdictKind: "accept" }),
+      opts,
+    );
+    const result = await readJudgeTrainingPairs({ directory: dir });
+    assert.equal(result.rows.length, 2);
+    // Deterministic ordering: files are sorted lexicographically by name,
+    // which matches chronological order for ISO date stamps.
+    assert.equal(result.rows[0].verdictKind, "accept");
+    assert.equal(result.rows[1].verdictKind, "reject");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: readJudgeTrainingPairs counts malformed rows separately", async () => {
+  const dir = await mkdirTmp();
+  try {
+    await mkdir(dir, { recursive: true });
+    const lines = [
+      JSON.stringify(basePair({ verdictKind: "accept" })),
+      "not-json",
+      JSON.stringify({ version: 1, ts: "now", verdictKind: "bogus" }),
+      JSON.stringify(basePair({ verdictKind: "defer" })),
+    ];
+    await writeFile(
+      path.join(dir, "2026-04-10.jsonl"),
+      lines.join("\n") + "\n",
+      "utf-8",
+    );
+    const result = await readJudgeTrainingPairs({ directory: dir });
+    assert.equal(result.rows.length, 2);
+    assert.equal(result.malformed, 2);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("PR 4: isValidTrainingPair structural validation", () => {
+  assert.equal(isValidTrainingPair(null), false);
+  assert.equal(isValidTrainingPair({}), false);
+  assert.equal(isValidTrainingPair(basePair()), true);
+  assert.equal(
+    isValidTrainingPair(basePair({ verdictKind: "bogus" as any })),
+    false,
+  );
+  assert.equal(
+    isValidTrainingPair(basePair({ groundTruthLabel: "defer" })),
+    true,
+  );
+  assert.equal(
+    isValidTrainingPair(basePair({ groundTruthLabel: "bogus" as any })),
+    false,
+  );
+  assert.equal(isValidTrainingPair({ ...basePair(), version: 99 }), false);
+  assert.equal(
+    isValidTrainingPair({ ...basePair(), candidateConfidence: "hi" }),
+    false,
+  );
+});
+
+test("PR 4: training pair schema preserves ground truth label round-trip", async () => {
+  const dir = await mkdirTmp();
+  try {
+    const opts = { enabled: true, directory: dir };
+    const pair = basePair({ groundTruthLabel: "accept" });
+    await recordJudgeTrainingPair(pair, opts);
+    const result = await readJudgeTrainingPairs({ directory: dir });
+    assert.equal(result.rows.length, 1);
+    assert.equal(result.rows[0].groundTruthLabel, "accept");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

PR 4 of 4 (final) for issue #562 (MemReader-inspired defer action on the extraction judge).

- New module `extraction-judge-training.ts` collects `(candidate_text, verdict_kind, reason, ground_truth_label?)` tuples into `~/.remnic/judge-training/<YYYY-MM-DD>.jsonl`
- Off by default. Gated on new config `collectJudgeTrainingPairs` (uses `coerceBool` for CLI-string parity, per CLAUDE.md gotcha 36). Override directory via `judgeTrainingDir`
- Rows land in the user's home directory (NOT the shared memory directory) so they are never committed, sync'd, or bundled into memory exports
- Strict schema validation via `isValidTrainingPair` — unknown `verdictKind` / `groundTruthLabel` values are rejected so the training signal stays clean
- Orchestrator wires training emission alongside PR 3's telemetry on the same `onVerdict` callback. Both are independently gated; the callback is `undefined` (zero overhead) when both flags are off

This is a **data-collection shim only** — no training code lands. Training the GRPO policy is a follow-up issue once enough data has accumulated.

## Test plan

- [x] `npx tsx --test tests/extraction-judge-training.test.ts` — 11 tests pass
- [x] `npx tsx --test tests/extraction-judge.test.ts tests/extraction-judge-telemetry.test.ts packages/remnic-core/src/buffer-session.test.ts` — 64 prior tests still pass
- [x] `npm run build` — clean
- [x] Privacy: rows carry only candidate text + metadata — no session keys or principal IDs
- [x] UTC date stamping, not local
- [x] Fail-open on directory errors

## Issue #562 summary

- PR 1 (#579): `JudgeVerdictKind = "accept" | "reject" | "defer"` type
- PR 2 (#635): defer-capable prompt + routing (buffer retention, defer cap)
- PR 3 (#641): verdict telemetry to observation ledger + `remnic judge-stats` CLI
- PR 4 (this): opt-in training-pair collection shim

Closes #562.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new disk writes of judge-seen candidate text (privacy/ops implications) and wires a new side-effect into the extraction pipeline, though it is fully opt-in and fail-open.
> 
> **Overview**
> Adds an **opt-in extraction-judge training-pair collector** that appends `(candidateText, verdictKind, reason, …)` rows to per-day JSONL files under `~/.remnic/judge-training` (or `judgeTrainingDir`), separate from the shared memory/observation ledger.
> 
> Introduces new config flags (`collectJudgeTrainingPairs`, `judgeTrainingDir`) across the OpenClaw plugin schemas and Remnic config/types, and updates the orchestrator to emit training rows alongside existing judge telemetry via a single gated callback (no-op/undefined when both are disabled). Includes a new module with strict row validation + tilde/$HOME path expansion and a dedicated test suite for write/read behavior and malformed-line handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab0e019c5b111eb1235527fe8e541b7feace2b91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->