### PR TITLE
fix(remnic-cli): wire remnic xray command (Codex P2 on #636)

### DIFF
--- a/packages/remnic-cli/package.json
+++ b/packages/remnic-cli/package.json
@@ -27,7 +27,7 @@
     "prebuild": "node ../../scripts/ensure-cli-bench-build-deps.mjs",
     "build": "tsup --config tsup.config.ts && node scripts/copy-bench-assets.mjs",
     "check-types": "tsc --noEmit",
-    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts",
+    "test": "tsx --test src/import-dispatch.test.ts src/import-bundle-detect.test.ts src/optional-importer.test.ts src/bench-args.test.ts src/xray.test.ts",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2957,12 +2957,25 @@ export async function runXrayCommand(
 }
 
 /**
- * `remnic xray <query>` handler.  Bootstraps an orchestrator from the
- * on-disk config the same way `cmdQuery` does, then delegates to
- * `runXrayCommand` so the rendering and flag-parsing paths stay
- * testable without a real memory directory.
+ * `remnic xray <query>` handler.  Validates CLI arguments *before*
+ * booting the orchestrator so invalid invocations (empty query,
+ * unknown --format, bare --budget, etc.) fail fast with the intended
+ * CLI validation error rather than an unrelated initialization error,
+ * and without paying the config-load / QMD-probe / deferred-ready
+ * startup cost (Codex P2 on PR #643 — CLAUDE.md rules 14 + 51 require
+ * explicit, fail-fast validation).
+ *
+ * Once the arg bag is validated, bootstraps the orchestrator the same
+ * way `cmdQuery` does and delegates to `runXrayCommand` for the
+ * recall + render + emit flow.
  */
 async function cmdXray(rest: string[]): Promise<void> {
+  // Parse and validate flags FIRST — `parseXrayCliOptions` throws
+  // listed-options errors for bad input.  Keep this before any IO so
+  // a bad invocation surfaces the right error without touching disk.
+  const { rawQuery, options } = extractXrayRawArgs(rest);
+  const parsed = parseXrayCliOptions(rawQuery, options);
+
   initLogger();
   const configPath = resolveConfigPath();
   const raw = fs.existsSync(configPath)
@@ -2975,14 +2988,19 @@ async function cmdXray(rest: string[]): Promise<void> {
   await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
-  await runXrayCommand(rest, {
-    recallXray: (request) => service.recallXray(request),
-    writeFile: async (filePath, data) => {
-      const { writeFile: fsWriteFile } = await import("node:fs/promises");
-      await fsWriteFile(filePath, data, "utf8");
-    },
-    stdout: (line) => console.log(line),
+  const response = await service.recallXray({
+    query: parsed.query,
+    ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
+    ...(parsed.budget !== undefined ? { budget: parsed.budget } : {}),
   });
+  const snapshot = response.snapshotFound ? response.snapshot ?? null : null;
+  const rendered = renderXray(snapshot, parsed.format);
+  if (parsed.outPath) {
+    const { writeFile: fsWriteFile } = await import("node:fs/promises");
+    await fsWriteFile(expandTildePath(parsed.outPath), rendered, "utf8");
+  } else {
+    console.log(rendered);
+  }
 }
 
 // ── Page-level versioning (issue #371) ─────────────────────────────────────

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2965,16 +2965,22 @@ export async function runXrayCommand(
  * startup cost (Codex P2 on PR #643 — CLAUDE.md rules 14 + 51 require
  * explicit, fail-fast validation).
  *
- * Once the arg bag is validated, bootstraps the orchestrator the same
- * way `cmdQuery` does and delegates to `runXrayCommand` for the
- * recall + render + emit flow.
+ * After the arg bag is validated, bootstraps the orchestrator the
+ * same way `cmdQuery` does and delegates to `runXrayCommand` for the
+ * recall + render + emit flow.  Delegation keeps the production
+ * handler's post-orchestrator path covered by `runXrayCommand`'s
+ * existing unit tests (Cursor Medium on PR #643 — avoid duplicated
+ * code paths that only one surface exercises).
  */
 async function cmdXray(rest: string[]): Promise<void> {
   // Parse and validate flags FIRST — `parseXrayCliOptions` throws
   // listed-options errors for bad input.  Keep this before any IO so
   // a bad invocation surfaces the right error without touching disk.
+  // `runXrayCommand` re-runs the same validators below; re-parsing is
+  // cheap (pure + no IO) and avoids a second "validated flags" shape
+  // that would drift from the raw-argv contract tests already cover.
   const { rawQuery, options } = extractXrayRawArgs(rest);
-  const parsed = parseXrayCliOptions(rawQuery, options);
+  parseXrayCliOptions(rawQuery, options);
 
   initLogger();
   const configPath = resolveConfigPath();
@@ -2988,19 +2994,14 @@ async function cmdXray(rest: string[]): Promise<void> {
   await orchestrator.deferredReady;
   const service = new EngramAccessService(orchestrator);
 
-  const response = await service.recallXray({
-    query: parsed.query,
-    ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
-    ...(parsed.budget !== undefined ? { budget: parsed.budget } : {}),
+  await runXrayCommand(rest, {
+    recallXray: (request) => service.recallXray(request),
+    writeFile: async (filePath, data) => {
+      const { writeFile: fsWriteFile } = await import("node:fs/promises");
+      await fsWriteFile(filePath, data, "utf8");
+    },
+    stdout: (line) => console.log(line),
   });
-  const snapshot = response.snapshotFound ? response.snapshot ?? null : null;
-  const rendered = renderXray(snapshot, parsed.format);
-  if (parsed.outPath) {
-    const { writeFile: fsWriteFile } = await import("node:fs/promises");
-    await fsWriteFile(expandTildePath(parsed.outPath), rendered, "utf8");
-  } else {
-    console.log(rendered);
-  }
 }
 
 // ── Page-level versioning (issue #371) ─────────────────────────────────────

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -7,6 +7,7 @@
  *   init              Create remnic.config.json in the current directory
  *   status            Show server/daemon status
  *   query <text>      Query memories
+ *   xray <query>      Recall with X-ray capture; renders tier + filters + scores
  *   doctor            Run diagnostics
  *   config            Show current config
  *   daemon start      Start background server
@@ -119,6 +120,9 @@ import {
   StorageManager,
   computeProcedureStats,
   formatProcedureStatsText,
+  parseXrayCliOptions,
+  renderXray,
+  expandTildePath,
 } from "@remnic/core";
 // @remnic/export-weclone is an optional install surface (training:export
 // only uses it). Load lazily so the CLI works without it — see
@@ -207,7 +211,8 @@ type CommandName =
   | "openclaw"
   | "extensions"
   | "training:export"
-  | "import";
+  | "import"
+  | "xray";
 
 type DaemonAction = "start" | "stop" | "restart" | "install" | "uninstall" | "status";
 type TokenAction = "generate" | "list" | "revoke";
@@ -2857,6 +2862,127 @@ async function cmdQuery(queryText: string, json: boolean, explain: boolean): Pro
       console.log(`- ${m.content}`);
     }
   }
+}
+
+// ── Recall X-ray (issue #570) ──────────────────────────────────────────────
+
+/**
+ * Extract the `parseXrayCliOptions` option bag from CLI `rest` tokens.
+ *
+ * Splits `rest` into positional query tokens and `--flag value` pairs.
+ * Validates that every value-taking flag (`--format`, `--budget`,
+ * `--namespace`, `--out`) has a following value — CLAUDE.md rule 14
+ * forbids silently defaulting when the flag is bare.
+ *
+ * Exported for test coverage.  Returns the `{rawQuery, options}` pair
+ * that `parseXrayCliOptions` expects; downstream validation (format /
+ * budget enum checks, empty-query rejection) is delegated to
+ * `parseXrayCliOptions` itself so this function stays a thin tokenizer.
+ */
+export function extractXrayRawArgs(rest: string[]): {
+  rawQuery: string;
+  options: Record<string, unknown>;
+} {
+  const VALUE_FLAGS = new Set(["--format", "--budget", "--namespace", "--out"]);
+  const positional: string[] = [];
+  const options: Record<string, unknown> = {};
+
+  for (let i = 0; i < rest.length; i++) {
+    const token = rest[i];
+    if (token.startsWith("--")) {
+      if (!VALUE_FLAGS.has(token)) {
+        throw new Error(
+          `Unknown flag ${JSON.stringify(token)}. Supported flags: --format, --budget, --namespace, --out.`,
+        );
+      }
+      const next = rest[i + 1];
+      if (next === undefined || next.startsWith("--")) {
+        throw new Error(
+          `${token} requires a value. Provide it as \`${token} <value>\`, not as a bare flag.`,
+        );
+      }
+      // Strip leading "--" from flag to produce the camelCase key
+      // parseXrayCliOptions expects (`format`, `budget`, `namespace`,
+      // `out`).
+      const key = token.slice(2);
+      options[key] = next;
+      i++;
+      continue;
+    }
+    positional.push(token);
+  }
+
+  return { rawQuery: positional.join(" "), options };
+}
+
+/**
+ * Thin dependency-injected runner for `remnic xray`.  Parses flags,
+ * invokes the caller-provided recall function, renders the snapshot via
+ * the shared `renderXray` formatter, and emits the result to stdout or a
+ * file.  Extracted from `cmdXray` so tests can exercise the full flow
+ * with a stubbed recall function (CLAUDE.md rule 33 — test mocks must
+ * match production signatures).
+ */
+export async function runXrayCommand(
+  rest: string[],
+  io: {
+    recallXray: (request: {
+      query: string;
+      namespace?: string;
+      budget?: number;
+    }) => Promise<{
+      snapshotFound: boolean;
+      snapshot?: import("@remnic/core").RecallXraySnapshot;
+    }>;
+    writeFile: (filePath: string, data: string) => Promise<void>;
+    stdout: (line: string) => void;
+  },
+): Promise<void> {
+  const { rawQuery, options } = extractXrayRawArgs(rest);
+  // `parseXrayCliOptions` throws listed-options errors for empty query,
+  // unknown --format, malformed --budget (CLAUDE.md rules 14, 51).
+  const parsed = parseXrayCliOptions(rawQuery, options);
+  const response = await io.recallXray({
+    query: parsed.query,
+    ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
+    ...(parsed.budget !== undefined ? { budget: parsed.budget } : {}),
+  });
+  const snapshot = response.snapshotFound ? response.snapshot ?? null : null;
+  const rendered = renderXray(snapshot, parsed.format);
+  if (parsed.outPath) {
+    await io.writeFile(expandTildePath(parsed.outPath), rendered);
+  } else {
+    io.stdout(rendered);
+  }
+}
+
+/**
+ * `remnic xray <query>` handler.  Bootstraps an orchestrator from the
+ * on-disk config the same way `cmdQuery` does, then delegates to
+ * `runXrayCommand` so the rendering and flag-parsing paths stay
+ * testable without a real memory directory.
+ */
+async function cmdXray(rest: string[]): Promise<void> {
+  initLogger();
+  const configPath = resolveConfigPath();
+  const raw = fs.existsSync(configPath)
+    ? JSON.parse(fs.readFileSync(configPath, "utf8"))
+    : {};
+  const remnicCfg = raw.remnic ?? raw.engram ?? raw;
+  const config = parseConfig(remnicCfg);
+  const orchestrator = new Orchestrator(config);
+  await orchestrator.initialize();
+  await orchestrator.deferredReady;
+  const service = new EngramAccessService(orchestrator);
+
+  await runXrayCommand(rest, {
+    recallXray: (request) => service.recallXray(request),
+    writeFile: async (filePath, data) => {
+      const { writeFile: fsWriteFile } = await import("node:fs/promises");
+      await fsWriteFile(filePath, data, "utf8");
+    },
+    stdout: (line) => console.log(line),
+  });
 }
 
 // ── Page-level versioning (issue #371) ─────────────────────────────────────
@@ -6398,6 +6524,15 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
       break;
     }
 
+    case "xray":
+      // `remnic xray "<query>"` — recall with X-ray capture and print
+      // the unified snapshot (issue #570 / PR #636 Codex P2).  The
+      // plugin-runtime path registers the same surface via
+      // `registerCli` in `@remnic/core/cli.ts`; this case wires the
+      // standalone `remnic` binary so documented usage actually works.
+      await cmdXray(rest);
+      break;
+
     case "doctor":
       await cmdDoctor();
       break;
@@ -6812,6 +6947,10 @@ Usage:
   remnic migrate [--rollback] [--json]  Run or undo first-run Engram migration
   remnic status [--json]       Show server status
   remnic query <text> [--json] [--explain] Query memories (use --explain for tier breakdown)
+  remnic xray <query> [--format text|markdown|json] [--budget <chars>] [--namespace <ns>] [--out <path>]
+    Run a recall with X-ray capture and print the unified snapshot
+    (tier + audit + MMR + filters). Part of #570. Defaults to text
+    output on stdout.
 
   remnic doctor                Run diagnostics
   remnic config                Show current config

--- a/packages/remnic-cli/src/xray.test.ts
+++ b/packages/remnic-cli/src/xray.test.ts
@@ -156,6 +156,23 @@ describe("runXrayCommand", () => {
     );
   });
 
+  it("fail-fast: validation errors throw before recallXray is called (Codex P2 on #643)", async () => {
+    const { io, mock } = makeIo(() => ({ snapshotFound: false }));
+    // All four failure modes must short-circuit BEFORE the recall IO
+    // fires, so `cmdXray`'s fail-fast guard (which calls the same
+    // validators ahead of orchestrator bootstrap) is protected by
+    // parity with this test.
+    await assert.rejects(() => runXrayCommand([], io));
+    await assert.rejects(() => runXrayCommand(["q", "--format", "xml"], io));
+    await assert.rejects(() => runXrayCommand(["q", "--budget", "0"], io));
+    await assert.rejects(() => runXrayCommand(["q", "--format"], io));
+    assert.equal(
+      mock.recallCalls.length,
+      0,
+      "recallXray must not be invoked when arg validation fails",
+    );
+  });
+
   it("rejects an unknown --format value", async () => {
     const { io } = makeIo(() => ({ snapshotFound: false }));
     await assert.rejects(

--- a/packages/remnic-cli/src/xray.test.ts
+++ b/packages/remnic-cli/src/xray.test.ts
@@ -1,0 +1,274 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+
+import type { RecallXraySnapshot } from "@remnic/core";
+
+import { extractXrayRawArgs, runXrayCommand } from "./index.js";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function minimalSnapshot(): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "what is my favorite editor?",
+    snapshotId: "11111111-1111-1111-1111-111111111111",
+    capturedAt: 1_700_000_000_000,
+    tierExplain: null,
+    results: [],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+  };
+}
+
+type MockIo = {
+  recallCalls: Array<{ query: string; namespace?: string; budget?: number }>;
+  writeFileCalls: Array<{ filePath: string; data: string }>;
+  stdoutLines: string[];
+};
+
+function makeIo(
+  respond: (
+    request: { query: string; namespace?: string; budget?: number },
+  ) => {
+    snapshotFound: boolean;
+    snapshot?: RecallXraySnapshot;
+  },
+): {
+  io: Parameters<typeof runXrayCommand>[1];
+  mock: MockIo;
+} {
+  const mock: MockIo = {
+    recallCalls: [],
+    writeFileCalls: [],
+    stdoutLines: [],
+  };
+  const io = {
+    recallXray: async (request: {
+      query: string;
+      namespace?: string;
+      budget?: number;
+    }) => {
+      mock.recallCalls.push(request);
+      return respond(request);
+    },
+    writeFile: async (filePath: string, data: string) => {
+      mock.writeFileCalls.push({ filePath, data });
+    },
+    stdout: (line: string) => {
+      mock.stdoutLines.push(line);
+    },
+  };
+  return { io, mock };
+}
+
+// ---------------------------------------------------------------------------
+// extractXrayRawArgs — pure tokenizer
+// ---------------------------------------------------------------------------
+
+describe("extractXrayRawArgs", () => {
+  it("joins positional tokens into a single query string", () => {
+    const parsed = extractXrayRawArgs(["what", "editor", "do", "I", "use"]);
+    assert.equal(parsed.rawQuery, "what editor do I use");
+    assert.deepEqual(parsed.options, {});
+  });
+
+  it("extracts every supported value flag", () => {
+    const parsed = extractXrayRawArgs([
+      "what",
+      "editor",
+      "--format",
+      "markdown",
+      "--budget",
+      "2048",
+      "--namespace",
+      "workspace-a",
+      "--out",
+      "/tmp/out.md",
+    ]);
+    assert.equal(parsed.rawQuery, "what editor");
+    assert.deepEqual(parsed.options, {
+      format: "markdown",
+      budget: "2048",
+      namespace: "workspace-a",
+      out: "/tmp/out.md",
+    });
+  });
+
+  it("preserves positional tokens that appear after flags", () => {
+    const parsed = extractXrayRawArgs([
+      "--format",
+      "json",
+      "what",
+      "editor",
+    ]);
+    assert.equal(parsed.rawQuery, "what editor");
+    assert.deepEqual(parsed.options, { format: "json" });
+  });
+
+  it("rejects unknown flags with a listed-options error (rule 51)", () => {
+    assert.throws(
+      () => extractXrayRawArgs(["q", "--bogus", "v"]),
+      /Unknown flag "--bogus"/,
+    );
+  });
+
+  it("rejects --format with no following value (rule 14)", () => {
+    assert.throws(
+      () => extractXrayRawArgs(["q", "--format"]),
+      /--format requires a value/,
+    );
+  });
+
+  it("rejects --budget when the following token is another --flag (rule 14)", () => {
+    assert.throws(
+      () => extractXrayRawArgs(["q", "--budget", "--format", "json"]),
+      /--budget requires a value/,
+    );
+  });
+
+  it("rejects --namespace with no following value", () => {
+    assert.throws(
+      () => extractXrayRawArgs(["q", "--namespace"]),
+      /--namespace requires a value/,
+    );
+  });
+
+  it("rejects --out with no following value", () => {
+    assert.throws(
+      () => extractXrayRawArgs(["q", "--out"]),
+      /--out requires a value/,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runXrayCommand — full handler with mocked orchestrator
+// ---------------------------------------------------------------------------
+
+describe("runXrayCommand", () => {
+  it("rejects an empty query (rule 51 via parseXrayCliOptions)", async () => {
+    const { io } = makeIo(() => ({ snapshotFound: false }));
+    await assert.rejects(
+      () => runXrayCommand([], io),
+      /xray: <query> is required and must be non-empty/,
+    );
+  });
+
+  it("rejects an unknown --format value", async () => {
+    const { io } = makeIo(() => ({ snapshotFound: false }));
+    await assert.rejects(
+      () => runXrayCommand(["hello", "--format", "xml"], io),
+      /--format expects one of json, text, markdown/,
+    );
+  });
+
+  it("rejects a non-positive --budget value", async () => {
+    const { io } = makeIo(() => ({ snapshotFound: false }));
+    await assert.rejects(
+      () => runXrayCommand(["hello", "--budget", "0"], io),
+      /--budget expects a positive integer/,
+    );
+  });
+
+  it("prints the text renderer output to stdout by default", async () => {
+    const snap = minimalSnapshot();
+    const { io, mock } = makeIo(() => ({
+      snapshotFound: true,
+      snapshot: snap,
+    }));
+    await runXrayCommand(["what", "editor"], io);
+    assert.equal(mock.recallCalls.length, 1);
+    assert.equal(mock.recallCalls[0].query, "what editor");
+    assert.equal(mock.stdoutLines.length, 1);
+    // Golden-style assertion: the rendered text prefix matches the
+    // renderer contract in recall-xray-renderer.ts.
+    assert.ok(mock.stdoutLines[0].startsWith("=== Recall X-ray ==="));
+    assert.ok(mock.stdoutLines[0].includes(`query: ${snap.query}`));
+    assert.equal(mock.writeFileCalls.length, 0);
+  });
+
+  it("renders JSON when --format json is passed", async () => {
+    const snap = minimalSnapshot();
+    const { io, mock } = makeIo(() => ({
+      snapshotFound: true,
+      snapshot: snap,
+    }));
+    await runXrayCommand(["hello", "--format", "json"], io);
+    assert.equal(mock.stdoutLines.length, 1);
+    const parsed = JSON.parse(mock.stdoutLines[0]);
+    assert.equal(parsed.snapshotFound, true);
+    assert.equal(parsed.schemaVersion, "1");
+    assert.equal(parsed.query, snap.query);
+  });
+
+  it("emits the v1 not-found envelope when the service returns no snapshot", async () => {
+    const { io, mock } = makeIo(() => ({ snapshotFound: false }));
+    await runXrayCommand(["hello", "--format", "json"], io);
+    assert.equal(mock.stdoutLines.length, 1);
+    const parsed = JSON.parse(mock.stdoutLines[0]);
+    assert.equal(parsed.snapshotFound, false);
+    assert.equal(parsed.schemaVersion, "1");
+  });
+
+  it("threads --namespace and --budget through to recallXray", async () => {
+    const snap = minimalSnapshot();
+    const { io, mock } = makeIo(() => ({
+      snapshotFound: true,
+      snapshot: snap,
+    }));
+    await runXrayCommand(
+      [
+        "hello",
+        "--namespace",
+        "workspace-a",
+        "--budget",
+        "2048",
+      ],
+      io,
+    );
+    assert.equal(mock.recallCalls.length, 1);
+    assert.equal(mock.recallCalls[0].namespace, "workspace-a");
+    assert.equal(mock.recallCalls[0].budget, 2048);
+  });
+
+  it("writes to --out instead of stdout when the flag is set", async () => {
+    const snap = minimalSnapshot();
+    const { io, mock } = makeIo(() => ({
+      snapshotFound: true,
+      snapshot: snap,
+    }));
+    await runXrayCommand(
+      [
+        "hello",
+        "--format",
+        "markdown",
+        "--out",
+        "/tmp/xray-out.md",
+      ],
+      io,
+    );
+    assert.equal(mock.stdoutLines.length, 0);
+    assert.equal(mock.writeFileCalls.length, 1);
+    assert.equal(mock.writeFileCalls[0].filePath, "/tmp/xray-out.md");
+    // Markdown output uses an H1 header per the renderer contract.
+    assert.ok(mock.writeFileCalls[0].data.startsWith("# Recall X-ray"));
+  });
+
+  it("omits optional fields from the recall request when the flags are absent", async () => {
+    const snap = minimalSnapshot();
+    const { io, mock } = makeIo(() => ({
+      snapshotFound: true,
+      snapshot: snap,
+    }));
+    await runXrayCommand(["hello"], io);
+    assert.equal(mock.recallCalls.length, 1);
+    const request = mock.recallCalls[0];
+    assert.equal(request.query, "hello");
+    // namespace/budget should not be threaded through when absent so
+    // access-service.ts can honor its own defaults.
+    assert.equal("namespace" in request, false);
+    assert.equal("budget" in request, false);
+  });
+});

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -191,6 +191,31 @@ export { EngramAccessService, EngramAccessInputError } from "./access-service.js
 export { EngramAccessHttpServer } from "./access-http.js";
 export { EngramMcpServer } from "./access-mcp.js";
 
+// Recall X-ray CLI helpers (issue #570).  Exported so the standalone
+// `@remnic/cli` binary can wire the `remnic xray` command without
+// reimporting core-internal modules by relative path (CLAUDE.md rule 26).
+export {
+  parseXrayCliOptions,
+  parseXrayBudgetFlag,
+  type ParsedXrayCliOptions,
+} from "./recall-xray-cli.js";
+export {
+  renderXray,
+  renderXrayJson,
+  renderXrayText,
+  renderXrayMarkdown,
+  parseXrayFormat,
+  RECALL_XRAY_FORMATS,
+  type RecallXrayFormat,
+} from "./recall-xray-renderer.js";
+export type {
+  RecallXraySnapshot,
+  RecallXrayResult,
+  RecallXrayScoreDecomposition,
+  RecallXrayServedBy,
+  RecallFilterTrace,
+} from "./recall-xray.js";
+
 // Coding-agent subsystem (issue #569)
 export {
   resolveGitContext,


### PR DESCRIPTION
## Summary

Addresses Codex P2 review on [#636](https://github.com/joshuaswarren/remnic/pull/636#discussion_r_PRRT_kwDORJXyws58ZhK2): README/CHANGELOG documented `remnic xray "<query>"` as a supported invocation but the standalone `@remnic/cli` dispatcher had no `xray` case. Users running `npm install @remnic/cli` and following the README would hit the default-usage fallback.

The implementation already lived in `@remnic/core` and was wired into the plugin-runtime path via `registerCli`, but never exposed in `packages/remnic-cli/src/index.ts`. This PR closes the gap (CLAUDE.md rule 55: documented behavior must have a corresponding implementation and test).

- New `case "xray":` routes to `cmdXray`, which bootstraps the orchestrator the same way `cmdQuery` does and calls `EngramAccessService.recallXray`.
- Pure `extractXrayRawArgs` tokenizer validates every `--format`/`--budget`/`--namespace`/`--out` flag has a following value (CLAUDE.md rule 14) and rejects unknown flags (rule 51).
- `runXrayCommand(rest, io)` is dependency-injected so the full handler is unit-testable without booting a real memory directory.
- `@remnic/core` now exports `parseXrayCliOptions`, `renderXray`, and X-ray types so the CLI imports by package name (CLAUDE.md rule 26), not relative cross-package paths.
- Usage block + top-of-file JSDoc updated.

## Test plan

- [x] `pnpm --filter @remnic/cli exec tsx --test src/xray.test.ts` — 17 tests, 0 failures (8 tokenizer, 9 handler-with-mocked-orchestrator).
- [x] `pnpm --filter @remnic/core check-types` — clean.
- [x] `pnpm --filter @remnic/core build` — clean.
- [x] Full `pnpm --filter @remnic/cli test` — 70/71 pass (1 unrelated failure on main: `optional-importer` install-hint assertion).
- [x] Type errors in `src/index.ts` at lines 728/2092 are pre-existing on main, not introduced here.

## Cross-references

- Codex P2 thread on #636: "Remove unsupported `remnic xray` invocation from README" — addressed by *implementing* the command rather than removing the doc reference, since the core implementation already existed.
- Issue #570 (recall X-ray surface).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CLI command that boots the orchestrator and exercises the recall path; primary risk is regressions in CLI dispatch/arg parsing and unexpected behavior when writing output files.
> 
> **Overview**
> Adds a new `remnic xray <query>` command to the standalone `@remnic/cli` dispatcher, including updated help/usage text and CLI docs.
> 
> Implements a fail-fast argument tokenizer (`extractXrayRawArgs`) and a dependency-injected execution path (`runXrayCommand`) that validates `--format/--budget/--namespace/--out`, calls `EngramAccessService.recallXray`, renders via shared `renderXray`, and optionally writes to `--out`.
> 
> Extends `@remnic/core`’s public exports to expose X-ray CLI parsing/rendering helpers and snapshot types for the CLI, and adds unit tests covering flag parsing, validation short-circuiting, rendering formats, and output routing; `@remnic/cli`’s test suite now includes `xray.test.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d73d4bf54a6d20765b7638b9037f6851646a5cc0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->