### PR TITLE
feat(bench): --request-timeout flag + agent-readable status file

### DIFF
--- a/packages/bench/src/providers/local-llm.test.ts
+++ b/packages/bench/src/providers/local-llm.test.ts
@@ -179,3 +179,70 @@ test("local-llm provider forwards Authorization header when apiKey is set", asyn
     globalThis.fetch = originalFetch;
   }
 });
+
+test("local-llm provider sends chat_template_kwargs when disableThinking is true", async () => {
+  let capturedBody: string | null = null;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = init?.body as string;
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "google/gemma-4-26b-a4b",
+      baseUrl: "http://127.0.0.1:1234/v1",
+      disableThinking: true,
+    });
+
+    await provider.complete("hello");
+    const parsed = JSON.parse(capturedBody!);
+    assert.deepEqual(parsed.chat_template_kwargs, { enable_thinking: false });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("local-llm provider does not send chat_template_kwargs when disableThinking is omitted", async () => {
+  let capturedBody: string | null = null;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = init?.body as string;
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createLocalLlmProvider({
+      provider: "local-llm",
+      model: "some-model",
+      baseUrl: "http://127.0.0.1:1234/v1",
+    });
+
+    await provider.complete("hello");
+    const parsed = JSON.parse(capturedBody!);
+    assert.equal(parsed.chat_template_kwargs, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});

--- a/packages/bench/src/providers/local-llm.test.ts
+++ b/packages/bench/src/providers/local-llm.test.ts
@@ -94,7 +94,7 @@ test("local-llm provider surfaces non-2xx errors with base-url + model in the me
 
     await assert.rejects(
       provider.complete("hello"),
-      /local-llm completion failed: 503 Service Unavailable — model not loaded \(base-url=http:\/\/127\.0\.0\.1:9876\/v1, model=my-local-model\)/,
+      /local-llm completion failed:.*503.*model not loaded.*base-url=http:\/\/127\.0\.0\.1:9876\/v1, model=my-local-model/,
     );
   } finally {
     globalThis.fetch = originalFetch;

--- a/packages/bench/src/providers/local-llm.test.ts
+++ b/packages/bench/src/providers/local-llm.test.ts
@@ -90,6 +90,7 @@ test("local-llm provider surfaces non-2xx errors with base-url + model in the me
       provider: "local-llm",
       model: "my-local-model",
       baseUrl: "http://127.0.0.1:9876/v1",
+      retryOptions: { maxAttempts: 1, baseBackoffMs: 0 },
     });
 
     await assert.rejects(

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -111,6 +111,9 @@ class LocalLlmProvider implements LlmProvider {
             ],
             temperature: opts.temperature,
             max_tokens: opts.maxTokens,
+            ...(this.config.disableThinking
+              ? { chat_template_kwargs: { enable_thinking: false } }
+              : {}),
           }),
         },
         this.config.retryOptions,

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -36,6 +36,7 @@ import type {
   LocalLlmProviderConfig,
   TokenUsage,
 } from "./types.js";
+import { retryFetch } from "./retry-fetch.js";
 
 interface ChatCompletionResponse {
   model?: string;
@@ -93,21 +94,33 @@ class LocalLlmProvider implements LlmProvider {
     opts: CompletionOpts = {},
   ): Promise<CompletionResult> {
     const startedAt = performance.now();
-    const response = await fetch(this.urlFor("chat/completions"), {
-      method: "POST",
-      headers: this.headers(opts.headers),
-      body: JSON.stringify({
-        model: this.config.model,
-        messages: [
-          ...(opts.systemPrompt
-            ? [{ role: "system", content: opts.systemPrompt }]
-            : []),
-          { role: "user", content: prompt },
-        ],
-        temperature: opts.temperature,
-        max_tokens: opts.maxTokens,
-      }),
-    });
+    let response: Response;
+    try {
+      response = await retryFetch(
+        this.urlFor("chat/completions"),
+        {
+          method: "POST",
+          headers: this.headers(opts.headers),
+          body: JSON.stringify({
+            model: this.config.model,
+            messages: [
+              ...(opts.systemPrompt
+                ? [{ role: "system", content: opts.systemPrompt }]
+                : []),
+              { role: "user", content: prompt },
+            ],
+            temperature: opts.temperature,
+            max_tokens: opts.maxTokens,
+          }),
+        },
+        this.config.retryOptions,
+      );
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      throw new Error(
+        `local-llm completion failed: ${msg} (base-url=${this.config.baseUrl}, model=${this.config.model})`,
+      );
+    }
 
     if (!response.ok) {
       const errorBody = await readErrorBody(response);
@@ -135,10 +148,14 @@ class LocalLlmProvider implements LlmProvider {
   }
 
   async discover(): Promise<DiscoveredModel[]> {
-    const response = await fetch(this.urlFor("models"), {
-      method: "GET",
-      headers: this.headers(),
-    });
+    const response = await retryFetch(
+      this.urlFor("models"),
+      {
+        method: "GET",
+        headers: this.headers(),
+      },
+      this.config.retryOptions,
+    );
 
     if (!response.ok) {
       throw new Error(

--- a/packages/bench/src/providers/local-llm.ts
+++ b/packages/bench/src/providers/local-llm.ts
@@ -151,14 +151,21 @@ class LocalLlmProvider implements LlmProvider {
   }
 
   async discover(): Promise<DiscoveredModel[]> {
-    const response = await retryFetch(
-      this.urlFor("models"),
-      {
-        method: "GET",
-        headers: this.headers(),
-      },
-      this.config.retryOptions,
-    );
+    let response: Response;
+    try {
+      response = await retryFetch(
+        this.urlFor("models"),
+        {
+          method: "GET",
+          headers: this.headers(),
+        },
+        this.config.retryOptions,
+      );
+    } catch (err) {
+      throw new Error(
+        `local-llm model discovery failed: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
 
     if (!response.ok) {
       throw new Error(

--- a/packages/bench/src/providers/openai-compatible.test.ts
+++ b/packages/bench/src/providers/openai-compatible.test.ts
@@ -2,21 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createOpenAiCompatibleProvider } from "./openai-compatible.ts";
 
-function mockFetchSuccess() {
-  return async () =>
-    new Response(
-      JSON.stringify({
-        choices: [{ message: { content: "ok" } }],
-        usage: { prompt_tokens: 1, completion_tokens: 1 },
-        model: "test",
-      }),
-      {
-        status: 200,
-        headers: { "content-type": "application/json" },
-      },
-    );
-}
-
 test("OpenAI-compatible provider adds an LM Studio context hint for context window errors", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>

--- a/packages/bench/src/providers/openai-compatible.test.ts
+++ b/packages/bench/src/providers/openai-compatible.test.ts
@@ -2,6 +2,21 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import { createOpenAiCompatibleProvider } from "./openai-compatible.ts";
 
+function mockFetchSuccess() {
+  return async () =>
+    new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+}
+
 test("OpenAI-compatible provider adds an LM Studio context hint for context window errors", async () => {
   const originalFetch = globalThis.fetch;
   globalThis.fetch = async () =>
@@ -53,6 +68,107 @@ test("OpenAI-compatible provider leaves unrelated errors unchanged", async () =>
       provider.complete("hello"),
       /OpenAI-compatible completion failed: 401 Unauthorized — unauthorized$/,
     );
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenAI-compatible provider sends chat_template_kwargs when disableThinking is true and baseUrl is LM Studio", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody: string | null = null;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = init?.body as string;
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createOpenAiCompatibleProvider({
+      provider: "openai",
+      model: "google/gemma-4-26b-a4b",
+      baseUrl: "http://127.0.0.1:1234/v1",
+      disableThinking: true,
+    });
+
+    await provider.complete("hello");
+    const parsed = JSON.parse(capturedBody!);
+    assert.deepEqual(parsed.chat_template_kwargs, { enable_thinking: false });
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenAI-compatible provider does not send chat_template_kwargs when disableThinking is false", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody: string | null = null;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = init?.body as string;
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createOpenAiCompatibleProvider({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      baseUrl: "http://127.0.0.1:1234/v1",
+    });
+
+    await provider.complete("hello");
+    const parsed = JSON.parse(capturedBody!);
+    assert.equal(parsed.chat_template_kwargs, undefined);
+  } finally {
+    globalThis.fetch = originalFetch;
+  }
+});
+
+test("OpenAI-compatible provider does not send chat_template_kwargs for non-LM Studio URLs even with disableThinking", async () => {
+  const originalFetch = globalThis.fetch;
+  let capturedBody: string | null = null;
+  globalThis.fetch = async (_url, init) => {
+    capturedBody = init?.body as string;
+    return new Response(
+      JSON.stringify({
+        choices: [{ message: { content: "ok" } }],
+        usage: { prompt_tokens: 1, completion_tokens: 1 },
+        model: "test",
+      }),
+      {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      },
+    );
+  };
+
+  try {
+    const provider = createOpenAiCompatibleProvider({
+      provider: "openai",
+      model: "gpt-4.1-mini",
+      disableThinking: true,
+      // No baseUrl — defaults to api.openai.com, which is not LM Studio
+    });
+
+    await provider.complete("hello");
+    const parsed = JSON.parse(capturedBody!);
+    assert.equal(parsed.chat_template_kwargs, undefined);
   } finally {
     globalThis.fetch = originalFetch;
   }

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -76,6 +76,10 @@ class OpenAiCompatibleProvider implements LlmProvider {
           ],
           temperature: opts.temperature,
           max_tokens: opts.maxTokens,
+          ...(this.config.disableThinking &&
+          isThinkingCompatibleBackend(this.config.baseUrl)
+            ? { chat_template_kwargs: { enable_thinking: false } }
+            : {}),
         }),
       },
       this.config.retryOptions,
@@ -216,7 +220,7 @@ function isContextWindowError(errorBody: string): boolean {
   );
 }
 
-function isLmStudioBaseUrl(baseUrl?: string): boolean {
+export function isLmStudioBaseUrl(baseUrl?: string): boolean {
   if (!baseUrl) {
     return false;
   }
@@ -230,6 +234,26 @@ function isLmStudioBaseUrl(baseUrl?: string): boolean {
   } catch {
     return false;
   }
+}
+
+function isVllmBaseUrl(baseUrl?: string): boolean {
+  if (!baseUrl) {
+    return false;
+  }
+
+  try {
+    const url = new URL(baseUrl);
+    return (
+      (url.hostname === "127.0.0.1" || url.hostname === "localhost") &&
+      url.port === "8000"
+    );
+  } catch {
+    return false;
+  }
+}
+
+function isThinkingCompatibleBackend(baseUrl?: string): boolean {
+  return isLmStudioBaseUrl(baseUrl) || isVllmBaseUrl(baseUrl);
 }
 
 function readMessageText(payload: ChatCompletionResponse): string {

--- a/packages/bench/src/providers/openai-compatible.ts
+++ b/packages/bench/src/providers/openai-compatible.ts
@@ -245,7 +245,8 @@ function isVllmBaseUrl(baseUrl?: string): boolean {
     const url = new URL(baseUrl);
     return (
       (url.hostname === "127.0.0.1" || url.hostname === "localhost") &&
-      url.port === "8000"
+      url.port === "8000" &&
+      url.pathname.startsWith("/v1")
     );
   } catch {
     return false;

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -33,6 +33,8 @@ export interface ProviderBaseConfig {
   apiKey?: string;
   headers?: Record<string, string>;
   retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
+  /** Suppress thinking/reasoning tokens for thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek). */
+  disableThinking?: boolean;
 }
 
 export interface OpenAiCompatibleProviderConfig extends ProviderBaseConfig {

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -40,6 +40,7 @@ export interface ResolveBenchRuntimeProfileOptions {
   judgeProvider?: BuiltInProvider;
   judgeModel?: string;
   judgeBaseUrl?: string;
+  requestTimeout?: number;
 }
 
 export interface ResolvedBenchRuntimeProfile {
@@ -87,12 +88,14 @@ export async function resolveBenchRuntimeProfile(
       options.systemProvider,
       options.systemModel,
       options.systemBaseUrl,
+      options.requestTimeout,
     );
   const judgeProvider = resolveProviderConfig(
     "judge",
     options.judgeProvider,
     options.judgeModel,
     options.judgeBaseUrl,
+    options.requestTimeout,
   );
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
@@ -313,6 +316,7 @@ function resolveProviderConfig(
   provider: BuiltInProvider | undefined,
   model: string | undefined,
   baseUrl: string | undefined,
+  requestTimeout?: number,
 ): ProviderConfig | null {
   const hasProvider = typeof provider === "string";
   const hasModel = typeof model === "string" && model.trim().length > 0;
@@ -342,6 +346,7 @@ function resolveProviderConfig(
     provider,
     model: model.trim(),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
+    ...(requestTimeout ? { retryOptions: { timeoutMs: requestTimeout } } : {}),
   };
 }
 
@@ -378,6 +383,7 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     provider: config.provider,
     model: config.model,
     ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
+    ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
   } as ProviderFactoryConfig;
 }
 

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -41,6 +41,7 @@ export interface ResolveBenchRuntimeProfileOptions {
   judgeModel?: string;
   judgeBaseUrl?: string;
   requestTimeout?: number;
+  disableThinking?: boolean;
 }
 
 export interface ResolvedBenchRuntimeProfile {
@@ -89,6 +90,7 @@ export async function resolveBenchRuntimeProfile(
       options.systemModel,
       options.systemBaseUrl,
       options.requestTimeout,
+      options.disableThinking,
     );
   const judgeProvider = resolveProviderConfig(
     "judge",
@@ -96,6 +98,7 @@ export async function resolveBenchRuntimeProfile(
     options.judgeModel,
     options.judgeBaseUrl,
     options.requestTimeout,
+    options.disableThinking,
   );
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
@@ -317,6 +320,7 @@ function resolveProviderConfig(
   model: string | undefined,
   baseUrl: string | undefined,
   requestTimeout?: number,
+  disableThinking?: boolean,
 ): ProviderConfig | null {
   const hasProvider = typeof provider === "string";
   const hasModel = typeof model === "string" && model.trim().length > 0;
@@ -347,6 +351,7 @@ function resolveProviderConfig(
     model: model.trim(),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
     ...(requestTimeout ? { retryOptions: { timeoutMs: requestTimeout } } : {}),
+    ...(disableThinking ? { disableThinking: true } : {}),
   };
 }
 
@@ -384,6 +389,7 @@ function asProviderFactoryConfig(config: ProviderConfig): ProviderFactoryConfig 
     model: config.model,
     ...(config.baseUrl ? { baseUrl: config.baseUrl } : {}),
     ...(config.retryOptions ? { retryOptions: config.retryOptions } : {}),
+    ...(config.disableThinking ? { disableThinking: config.disableThinking } : {}),
   } as ProviderFactoryConfig;
 }
 

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -350,7 +350,7 @@ function resolveProviderConfig(
     provider,
     model: model.trim(),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
-    ...(requestTimeout ? { retryOptions: { timeoutMs: requestTimeout } } : {}),
+    ...(requestTimeout != null ? { retryOptions: { timeoutMs: requestTimeout } } : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
   };
 }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -32,6 +32,7 @@ export interface ProviderConfig {
   provider: BuiltInProvider;
   model: string;
   baseUrl?: string;
+  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
 }
 
 export interface TaskTokenUsage {

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -33,6 +33,7 @@ export interface ProviderConfig {
   model: string;
   baseUrl?: string;
   retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
+  disableThinking?: boolean;
 }
 
 export interface TaskTokenUsage {

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -61,6 +61,8 @@ export interface ParsedBenchArgs {
   custom?: string;
   target?: BenchPublishTarget;
   requestTimeout?: number;
+  /** Suppress thinking/reasoning tokens for thinking-capable models (Gemma 4, Qwen 3.5, DeepSeek). */
+  disableThinking?: boolean;
   /** `bench published` — specific benchmark to run (longmemeval|locomo). */
   publishedName?: PublishedBenchmarkName;
   /** `bench published` — seed forwarded into the harness context. */
@@ -501,5 +503,6 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       : undefined,
     publishedDryRun: args.includes("--dry-run"),
     requestTimeout,
+    disableThinking: args.includes("--disable-thinking"),
   };
 }

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -372,6 +372,11 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         "ERROR: --request-timeout must be a positive integer (milliseconds).",
       );
     }
+    if (requestTimeout > 3600_000) {
+      throw new Error(
+        "ERROR: --request-timeout must not exceed 3,600,000 ms (1 hour).",
+      );
+    }
   }
 
   // `bench published` flags. Parsed unconditionally so `--name`, `--model`,

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -60,6 +60,7 @@ export interface ParsedBenchArgs {
   output?: string;
   custom?: string;
   target?: BenchPublishTarget;
+  requestTimeout?: number;
   /** `bench published` — specific benchmark to run (longmemeval|locomo). */
   publishedName?: PublishedBenchmarkName;
   /** `bench published` — seed forwarded into the harness context. */
@@ -178,7 +179,8 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--seed" ||
       arg === "--out" ||
       arg === "--provider" ||
-      arg === "--base-url"
+      arg === "--base-url" ||
+      arg === "--request-timeout"
     ) {
       index += 1;
       continue;
@@ -293,6 +295,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const formatRaw = readBenchOptionValue(args, "--format");
   const output = readBenchOptionValue(args, "--output");
   const targetRaw = readBenchOptionValue(args, "--target");
+  const requestTimeoutRaw = readBenchOptionValue(args, "--request-timeout");
   let runtimeProfile: BenchRuntimeProfile | undefined;
   if (runtimeProfileRaw !== undefined) {
     runtimeProfile = parseBenchRuntimeProfile(
@@ -357,6 +360,16 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       throw new Error('ERROR: --target must be "remnic-ai".');
     }
     target = targetRaw;
+  }
+
+  let requestTimeout: number | undefined;
+  if (requestTimeoutRaw !== undefined) {
+    requestTimeout = Number(requestTimeoutRaw);
+    if (!Number.isInteger(requestTimeout) || requestTimeout <= 0) {
+      throw new Error(
+        "ERROR: --request-timeout must be a positive integer (milliseconds).",
+      );
+    }
   }
 
   // `bench published` flags. Parsed unconditionally so `--name`, `--model`,
@@ -487,5 +500,6 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       ? path.resolve(expandTilde(publishedOutRaw))
       : undefined,
     publishedDryRun: args.includes("--dry-run"),
+    requestTimeout,
   };
 }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -43,7 +43,9 @@ async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
 async function readStatusFile(filePath: string): Promise<BenchStatus | null> {
   try {
     const raw = await readFile(filePath, "utf-8");
-    return JSON.parse(raw) as BenchStatus;
+    const parsed = JSON.parse(raw);
+    if (typeof parsed !== "object" || parsed === null) return null;
+    return parsed as BenchStatus;
   } catch {
     return null;
   }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -154,7 +154,7 @@ export function updateTaskProgress(
 ): Promise<void> {
   return serializedWrite(filePath, (status) => {
     status.updatedAt = new Date().toISOString();
-    status.currentTaskProgress = { completed, ...(total ? { total } : {}) };
+    status.currentTaskProgress = { completed, ...(total != null ? { total } : {}) };
     return status;
   });
 }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -5,11 +5,13 @@
  * (or humans) can poll to track benchmark progress without relying on
  * Node.js stdout (which is invisible when piped/nohup'd).
  *
- * All writes use atomic temp-file + rename so readers never see
+ * All writes are serialized through a per-file queue so that concurrent
+ * task-progress updates never race with benchmark completion/failure writes.
+ * Each write uses atomic temp-file + rename so readers never see
  * partially-written JSON.
  */
 
-import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export interface BenchmarkStatusEntry {
@@ -47,6 +49,34 @@ async function readStatusFile(filePath: string): Promise<BenchStatus | null> {
   }
 }
 
+// Per-file serialized write queue to prevent concurrent writes from racing.
+const writeQueues = new Map<string, Promise<void>>();
+
+function serializedWrite(
+  filePath: string,
+  fn: (status: BenchStatus) => BenchStatus | null,
+): Promise<void> {
+  const prev = writeQueues.get(filePath) ?? Promise.resolve();
+  const next = prev.then(async () => {
+    const current = await readStatusFile(filePath);
+    if (!current) return;
+    const updated = fn(current);
+    if (updated) {
+      await atomicWriteJSON(filePath, updated);
+    }
+  }).catch(() => {
+    // Swallow I/O errors so status file failures never crash the benchmark loop.
+  });
+  writeQueues.set(filePath, next);
+  // Prune completed entries to avoid unbounded map growth.
+  void next.finally(() => {
+    if (writeQueues.get(filePath) === next) {
+      writeQueues.delete(filePath);
+    }
+  });
+  return next;
+}
+
 export async function initBenchStatus(
   filePath: string,
   benchmarks: string[],
@@ -63,89 +93,79 @@ export async function initBenchStatus(
   await atomicWriteJSON(filePath, status);
 }
 
-export async function updateBenchmarkStarted(
+export function updateBenchmarkStarted(
   filePath: string,
   benchmarkId: string,
 ): Promise<void> {
-  const status = await readStatusFile(filePath);
-  if (!status) return;
-  status.updatedAt = new Date().toISOString();
-  status.currentBenchmark = benchmarkId;
-  status.currentTaskProgress = { completed: 0 };
-  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
-  if (entry) {
-    entry.status = "running";
-    entry.startedAt = new Date().toISOString();
-  }
-  await atomicWriteJSON(filePath, status);
+  return serializedWrite(filePath, (status) => {
+    status.updatedAt = new Date().toISOString();
+    status.currentBenchmark = benchmarkId;
+    status.currentTaskProgress = { completed: 0 };
+    const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+    if (entry) {
+      entry.status = "running";
+      entry.startedAt = new Date().toISOString();
+    }
+    return status;
+  });
 }
 
-export async function updateBenchmarkCompleted(
+export function updateBenchmarkCompleted(
   filePath: string,
   benchmarkId: string,
   resultPath: string,
 ): Promise<void> {
-  const status = await readStatusFile(filePath);
-  if (!status) return;
-  status.updatedAt = new Date().toISOString();
-  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
-  if (entry) {
-    entry.status = "complete";
-    entry.completedAt = new Date().toISOString();
-    entry.resultPath = resultPath;
-  }
-  status.completedResults.push(resultPath);
-  delete status.currentTaskProgress;
-  await atomicWriteJSON(filePath, status);
+  return serializedWrite(filePath, (status) => {
+    status.updatedAt = new Date().toISOString();
+    const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+    if (entry) {
+      entry.status = "complete";
+      entry.completedAt = new Date().toISOString();
+      entry.resultPath = resultPath;
+    }
+    status.completedResults.push(resultPath);
+    delete status.currentTaskProgress;
+    return status;
+  });
 }
 
-export async function updateBenchmarkFailed(
+export function updateBenchmarkFailed(
   filePath: string,
   benchmarkId: string,
   error: string,
 ): Promise<void> {
-  const status = await readStatusFile(filePath);
-  if (!status) return;
-  status.updatedAt = new Date().toISOString();
-  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
-  if (entry) {
-    entry.status = "failed";
-    entry.completedAt = new Date().toISOString();
-    entry.error = error;
-  }
-  delete status.currentTaskProgress;
-  await atomicWriteJSON(filePath, status);
+  return serializedWrite(filePath, (status) => {
+    status.updatedAt = new Date().toISOString();
+    const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+    if (entry) {
+      entry.status = "failed";
+      entry.completedAt = new Date().toISOString();
+      entry.error = error;
+    }
+    delete status.currentTaskProgress;
+    return status;
+  });
 }
 
-export async function updateTaskProgress(
+export function updateTaskProgress(
   filePath: string,
   completed: number,
   total?: number,
 ): Promise<void> {
-  const status = await readStatusFile(filePath);
-  if (!status) return;
-  status.updatedAt = new Date().toISOString();
-  status.currentTaskProgress = { completed, ...(total ? { total } : {}) };
-  await atomicWriteJSON(filePath, status);
+  return serializedWrite(filePath, (status) => {
+    status.updatedAt = new Date().toISOString();
+    status.currentTaskProgress = { completed, ...(total ? { total } : {}) };
+    return status;
+  });
 }
 
-export async function finalizeBenchStatus(
+export function finalizeBenchStatus(
   filePath: string,
 ): Promise<void> {
-  const status = await readStatusFile(filePath);
-  if (!status) return;
-  status.updatedAt = new Date().toISOString();
-  delete status.currentBenchmark;
-  delete status.currentTaskProgress;
-  await atomicWriteJSON(filePath, status);
-}
-
-export async function removeBenchStatus(
-  filePath: string,
-): Promise<void> {
-  try {
-    await unlink(filePath);
-  } catch {
-    // already gone is fine
-  }
+  return serializedWrite(filePath, (status) => {
+    status.updatedAt = new Date().toISOString();
+    delete status.currentBenchmark;
+    delete status.currentTaskProgress;
+    return status;
+  });
 }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -127,6 +127,7 @@ export function updateBenchmarkCompleted(
     }
     status.completedResults.push(resultPath);
     delete status.currentTaskProgress;
+    delete status.currentBenchmark;
     return status;
   });
 }
@@ -145,6 +146,7 @@ export function updateBenchmarkFailed(
       entry.error = error;
     }
     delete status.currentTaskProgress;
+    delete status.currentBenchmark;
     return status;
   });
 }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -1,0 +1,151 @@
+/**
+ * Agent-readable benchmark status file.
+ *
+ * Writes a `bench-status.json` to the results directory that AI agents
+ * (or humans) can poll to track benchmark progress without relying on
+ * Node.js stdout (which is invisible when piped/nohup'd).
+ *
+ * All writes use atomic temp-file + rename so readers never see
+ * partially-written JSON.
+ */
+
+import { mkdir, readFile, rename, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+export interface BenchmarkStatusEntry {
+  id: string;
+  status: "pending" | "running" | "complete" | "failed";
+  startedAt?: string;
+  completedAt?: string;
+  resultPath?: string;
+  error?: string;
+}
+
+export interface BenchStatus {
+  pid: number;
+  startedAt: string;
+  updatedAt: string;
+  currentBenchmark?: string;
+  currentTaskProgress?: { completed: number; total?: number };
+  benchmarks: BenchmarkStatusEntry[];
+  completedResults: string[];
+}
+
+async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tmp = `${filePath}.tmp`;
+  await writeFile(tmp, JSON.stringify(data, null, 2) + "\n");
+  await rename(tmp, filePath);
+}
+
+async function readStatusFile(filePath: string): Promise<BenchStatus | null> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    return JSON.parse(raw) as BenchStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function initBenchStatus(
+  filePath: string,
+  benchmarks: string[],
+  pid: number,
+): Promise<void> {
+  const now = new Date().toISOString();
+  const status: BenchStatus = {
+    pid,
+    startedAt: now,
+    updatedAt: now,
+    benchmarks: benchmarks.map((id) => ({ id, status: "pending" as const })),
+    completedResults: [],
+  };
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function updateBenchmarkStarted(
+  filePath: string,
+  benchmarkId: string,
+): Promise<void> {
+  const status = await readStatusFile(filePath);
+  if (!status) return;
+  status.updatedAt = new Date().toISOString();
+  status.currentBenchmark = benchmarkId;
+  status.currentTaskProgress = { completed: 0 };
+  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+  if (entry) {
+    entry.status = "running";
+    entry.startedAt = new Date().toISOString();
+  }
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function updateBenchmarkCompleted(
+  filePath: string,
+  benchmarkId: string,
+  resultPath: string,
+): Promise<void> {
+  const status = await readStatusFile(filePath);
+  if (!status) return;
+  status.updatedAt = new Date().toISOString();
+  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+  if (entry) {
+    entry.status = "complete";
+    entry.completedAt = new Date().toISOString();
+    entry.resultPath = resultPath;
+  }
+  status.completedResults.push(resultPath);
+  delete status.currentTaskProgress;
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function updateBenchmarkFailed(
+  filePath: string,
+  benchmarkId: string,
+  error: string,
+): Promise<void> {
+  const status = await readStatusFile(filePath);
+  if (!status) return;
+  status.updatedAt = new Date().toISOString();
+  const entry = status.benchmarks.find((b) => b.id === benchmarkId);
+  if (entry) {
+    entry.status = "failed";
+    entry.completedAt = new Date().toISOString();
+    entry.error = error;
+  }
+  delete status.currentTaskProgress;
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function updateTaskProgress(
+  filePath: string,
+  completed: number,
+  total?: number,
+): Promise<void> {
+  const status = await readStatusFile(filePath);
+  if (!status) return;
+  status.updatedAt = new Date().toISOString();
+  status.currentTaskProgress = { completed, ...(total ? { total } : {}) };
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function finalizeBenchStatus(
+  filePath: string,
+): Promise<void> {
+  const status = await readStatusFile(filePath);
+  if (!status) return;
+  status.updatedAt = new Date().toISOString();
+  delete status.currentBenchmark;
+  delete status.currentTaskProgress;
+  await atomicWriteJSON(filePath, status);
+}
+
+export async function removeBenchStatus(
+  filePath: string,
+): Promise<void> {
+  try {
+    await unlink(filePath);
+  } catch {
+    // already gone is fine
+  }
+}

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -33,7 +33,7 @@ export interface BenchStatus {
 
 async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
-  const tmp = `${filePath}.tmp`;
+  const tmp = `${filePath}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
   await writeFile(tmp, JSON.stringify(data, null, 2) + "\n");
   await rename(tmp, filePath);
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4748,10 +4748,20 @@ async function cmdBench(rest: string[]): Promise<void> {
             try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath ?? ""); } catch { /* non-fatal */ }
           } else {
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
-            // Fallback runner writes to evals/results (not
-            // resolveBenchOutputDir()), so we cannot reliably determine the
-            // result path.  Mark complete without a resultPath.
-            try { await updateBenchmarkCompleted(benchStatusPath, statusId, ""); } catch { /* non-fatal */ }
+            // Fallback runner writes to evals/results with a timestamped
+            // filename. Scan for the most recent match by mtime.
+            let fallbackResultPath = "";
+            try {
+              const fallbackDir = path.join(path.dirname(EVAL_RUNNER_PATH), "results");
+              const files = fs.readdirSync(fallbackDir)
+                .filter((f) => f.startsWith(benchmarkId) && f.endsWith(".json"))
+                .map((f) => ({ name: f, mtime: fs.statSync(path.join(fallbackDir, f)).mtimeMs }))
+                .sort((a, b) => b.mtime - a.mtime);
+              if (files.length > 0) {
+                fallbackResultPath = path.join(fallbackDir, files[0].name);
+              }
+            } catch { /* scan failure is non-fatal */ }
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath); } catch { /* non-fatal */ }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4725,7 +4725,7 @@ async function cmdBench(rest: string[]): Promise<void> {
         runtimeProfiles.map((profile) => `${benchmarkId} [${profile}]`),
       )
     : selectedBenchmarks;
-  await initBenchStatus(benchStatusPath, statusEntryIds, process.pid);
+  try { await initBenchStatus(benchStatusPath, statusEntryIds, process.pid); } catch { /* non-fatal */ }
   try {
     for (const benchmarkId of selectedBenchmarks) {
       for (const runtimeProfile of runtimeProfiles) {
@@ -4743,16 +4743,21 @@ async function cmdBench(rest: string[]): Promise<void> {
           if (handledByPackage.ok && handledByPackage.writtenPath) {
             try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath); } catch { /* non-fatal */ }
           } else if (!handledByPackage.ok) {
-            // Fallback runner doesn't return a writtenPath — look for the
-            // result file in the default output directory after completion.
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
-            // Mark fallback runs complete using the default output dir path
-            // (fallback always writes to resolveBenchOutputDir).
-            const fallbackResultPath = path.join(
-              resolveBenchOutputDir(),
-              `${benchmarkId}-result.json`,
-            );
-            try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath); } catch { /* non-fatal */ }
+            // Scan for the real result file — fallback writes a timestamped
+            // filename (${name}-v${version}-${ts}.json) so we glob for the
+            // latest match rather than fabricating a path.
+            let fallbackResultPath: string | undefined;
+            try {
+              const fallbackDir = resolveBenchOutputDir();
+              const files = fs.readdirSync(fallbackDir)
+                .filter((f) => f.startsWith(benchmarkId) && f.endsWith(".json"))
+                .sort();
+              if (files.length > 0) {
+                fallbackResultPath = path.join(fallbackDir, files[files.length - 1]);
+              }
+            } catch { /* scan failure is non-fatal */ }
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath ?? ""); } catch { /* non-fatal */ }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -153,7 +153,6 @@ import {
   updateBenchmarkFailed,
   updateTaskProgress as updateBenchStatusTaskProgress,
   finalizeBenchStatus,
-  removeBenchStatus,
 } from "./bench-status.js";
 import {
   cleanupRollbackDirectoryBestEffort,
@@ -2030,6 +2029,7 @@ async function runBenchViaPackage(
   parsed: ParsedBenchArgs,
   benchmarkId: string,
   runtimeProfile: BenchRuntimeProfile,
+  benchStatusPath?: string,
 ): Promise<{ ok: boolean; writtenPath?: string }> {
   const loaded = await tryLoadBenchModule();
   if (!loaded) return { ok: false };
@@ -2096,11 +2096,13 @@ async function runBenchViaPackage(
       system,
       onTaskComplete: (task, completed, total) => {
         partialTasks.push(task);
-        updateBenchStatusTaskProgress(
-          path.join(outputDir, "bench-status.json"),
-          completed,
-          total ?? undefined,
-        ).catch(() => {});
+        if (benchStatusPath) {
+          updateBenchStatusTaskProgress(
+            benchStatusPath,
+            completed,
+            total ?? undefined,
+          ).catch(() => {});
+        }
         if (completed % 50 === 0 || completed === total) {
           const elapsed = Math.round((Date.now() - benchStartTime) / 1000);
           const remaining = total && elapsed > 0 ? Math.round((total - completed) / (completed / elapsed)) : "?";
@@ -4716,28 +4718,47 @@ async function cmdBench(rest: string[]): Promise<void> {
     parsed.resultsDir ?? resolveBenchOutputDir(),
     "bench-status.json",
   );
-  await initBenchStatus(benchStatusPath, selectedBenchmarks, process.pid);
+  // When running a matrix (multiple profiles), create profile-specific status
+  // entries so that a failed profile doesn't get overwritten by a later success.
+  const statusEntryIds = runtimeProfiles.length > 1
+    ? selectedBenchmarks.flatMap((benchmarkId) =>
+        runtimeProfiles.map((profile) => `${benchmarkId} [${profile}]`),
+      )
+    : selectedBenchmarks;
+  await initBenchStatus(benchStatusPath, statusEntryIds, process.pid);
   try {
     for (const benchmarkId of selectedBenchmarks) {
       for (const runtimeProfile of runtimeProfiles) {
-        await updateBenchmarkStarted(benchStatusPath, benchmarkId);
+        const statusId = runtimeProfiles.length > 1
+          ? `${benchmarkId} [${runtimeProfile}]`
+          : benchmarkId;
+        await updateBenchmarkStarted(benchStatusPath, statusId);
         try {
           const handledByPackage = await runBenchViaPackage(
             parsed,
             benchmarkId,
             runtimeProfile,
+            benchStatusPath,
           );
-          if (!handledByPackage.ok) {
+          if (handledByPackage.ok && handledByPackage.writtenPath) {
+            await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath);
+          } else if (!handledByPackage.ok) {
+            // Fallback runner doesn't return a writtenPath — look for the
+            // result file in the default output directory after completion.
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
-          }
-          if (handledByPackage.writtenPath) {
-            await updateBenchmarkCompleted(benchStatusPath, benchmarkId, handledByPackage.writtenPath);
+            // Mark fallback runs complete using the default output dir path
+            // (fallback always writes to resolveBenchOutputDir).
+            const fallbackResultPath = path.join(
+              resolveBenchOutputDir(),
+              `${benchmarkId}-result.json`,
+            );
+            await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
           failures.add(benchmarkId);
-          await updateBenchmarkFailed(benchStatusPath, benchmarkId, message);
+          await updateBenchmarkFailed(benchStatusPath, statusId, message);
         }
       }
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4722,11 +4722,13 @@ async function cmdBench(rest: string[]): Promise<void> {
   );
   // When running a matrix (multiple profiles), create profile-specific status
   // entries so that a failed profile doesn't get overwritten by a later success.
-  const statusEntryIds = runtimeProfiles.length > 1
-    ? selectedBenchmarks.flatMap((benchmarkId) =>
-        runtimeProfiles.map((profile) => `${benchmarkId} [${profile}]`),
-      )
-    : selectedBenchmarks;
+  const statusEntryIds = [...new Set(
+    runtimeProfiles.length > 1
+      ? selectedBenchmarks.flatMap((benchmarkId) =>
+          runtimeProfiles.map((profile) => `${benchmarkId} [${profile}]`),
+        )
+      : selectedBenchmarks,
+  )];
   try { await initBenchStatus(benchStatusPath, statusEntryIds, process.pid); } catch { /* non-fatal */ }
   try {
     for (const benchmarkId of selectedBenchmarks) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -776,7 +776,7 @@ async function runBenchViaFallback(
     parsed.judgeProvider !== undefined ||
     parsed.judgeModel !== undefined ||
     parsed.judgeBaseUrl !== undefined ||
-    parsed.disableThinking !== undefined ||
+    parsed.disableThinking === true ||
     parsed.requestTimeout !== undefined
   ) {
     throw new Error(

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4732,7 +4732,7 @@ async function cmdBench(rest: string[]): Promise<void> {
         const statusId = runtimeProfiles.length > 1
           ? `${benchmarkId} [${runtimeProfile}]`
           : benchmarkId;
-        await updateBenchmarkStarted(benchStatusPath, statusId);
+        try { await updateBenchmarkStarted(benchStatusPath, statusId); } catch { /* non-fatal */ }
         try {
           const handledByPackage = await runBenchViaPackage(
             parsed,
@@ -4741,7 +4741,7 @@ async function cmdBench(rest: string[]): Promise<void> {
             benchStatusPath,
           );
           if (handledByPackage.ok && handledByPackage.writtenPath) {
-            await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath);
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath); } catch { /* non-fatal */ }
           } else if (!handledByPackage.ok) {
             // Fallback runner doesn't return a writtenPath — look for the
             // result file in the default output directory after completion.
@@ -4752,18 +4752,18 @@ async function cmdBench(rest: string[]): Promise<void> {
               resolveBenchOutputDir(),
               `${benchmarkId}-result.json`,
             );
-            await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath);
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath); } catch { /* non-fatal */ }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);
           console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
           failures.add(benchmarkId);
-          await updateBenchmarkFailed(benchStatusPath, statusId, message);
+          try { await updateBenchmarkFailed(benchStatusPath, statusId, message); } catch { /* non-fatal */ }
         }
       }
     }
   } finally {
-    await finalizeBenchStatus(benchStatusPath);
+    try { await finalizeBenchStatus(benchStatusPath); } catch { /* non-fatal */ }
   }
   if (failures.size > 0) {
     console.error(`\nFailed benchmarks: ${[...failures].join(", ")}`);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -775,10 +775,12 @@ async function runBenchViaFallback(
     parsed.systemBaseUrl !== undefined ||
     parsed.judgeProvider !== undefined ||
     parsed.judgeModel !== undefined ||
-    parsed.judgeBaseUrl !== undefined
+    parsed.judgeBaseUrl !== undefined ||
+    parsed.disableThinking !== undefined ||
+    parsed.requestTimeout !== undefined
   ) {
     throw new Error(
-      "Fallback benchmark runner does not support provider-backed or gateway runtime flags. Build/install @remnic/bench to use those options.",
+      "Fallback benchmark runner does not support provider-backed, gateway, or thinking/timeout flags. Build/install @remnic/bench to use those options.",
     );
   }
   if (!fs.existsSync(EVAL_RUNNER_PATH)) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -147,6 +147,15 @@ import {
   parseBenchArgs,
 } from "./bench-args.js";
 import {
+  initBenchStatus,
+  updateBenchmarkStarted,
+  updateBenchmarkCompleted,
+  updateBenchmarkFailed,
+  updateTaskProgress as updateBenchStatusTaskProgress,
+  finalizeBenchStatus,
+  removeBenchStatus,
+} from "./bench-status.js";
+import {
   cleanupRollbackDirectoryBestEffort,
   createOpenclawUpgradeRollbackFailure,
   runBestEffortGatewayRestart,
@@ -659,6 +668,7 @@ export function buildBenchRuntimeProfileRequest(
     judgeProvider: parsed.judgeProvider,
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,
+    requestTimeout: parsed.requestTimeout,
   };
 }
 
@@ -2085,6 +2095,11 @@ async function runBenchViaPackage(
       system,
       onTaskComplete: (task, completed, total) => {
         partialTasks.push(task);
+        updateBenchStatusTaskProgress(
+          path.join(outputDir, "bench-status.json"),
+          completed,
+          total ?? undefined,
+        ).catch(() => {});
         if (completed % 50 === 0 || completed === total) {
           const elapsed = Math.round((Date.now() - benchStartTime) / 1000);
           const remaining = total && elapsed > 0 ? Math.round((total - completed) / (completed / elapsed)) : "?";
@@ -4696,23 +4711,37 @@ async function cmdBench(rest: string[]): Promise<void> {
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
   const failures = new Set<string>();
-  for (const benchmarkId of selectedBenchmarks) {
-    for (const runtimeProfile of runtimeProfiles) {
-      try {
-        const handledByPackage = await runBenchViaPackage(
-          parsed,
-          benchmarkId,
-          runtimeProfile,
-        );
-        if (!handledByPackage.ok) {
-          await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
+  const benchStatusPath = path.join(
+    parsed.resultsDir ?? resolveBenchOutputDir(),
+    "bench-status.json",
+  );
+  await initBenchStatus(benchStatusPath, selectedBenchmarks, process.pid);
+  try {
+    for (const benchmarkId of selectedBenchmarks) {
+      for (const runtimeProfile of runtimeProfiles) {
+        await updateBenchmarkStarted(benchStatusPath, benchmarkId);
+        try {
+          const handledByPackage = await runBenchViaPackage(
+            parsed,
+            benchmarkId,
+            runtimeProfile,
+          );
+          if (!handledByPackage.ok) {
+            await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
+          }
+          if (handledByPackage.writtenPath) {
+            await updateBenchmarkCompleted(benchStatusPath, benchmarkId, handledByPackage.writtenPath);
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
+          failures.add(benchmarkId);
+          await updateBenchmarkFailed(benchStatusPath, benchmarkId, message);
         }
-      } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        console.error(`  [ERROR] benchmark "${benchmarkId}" failed: ${message}`);
-        failures.add(benchmarkId);
       }
     }
+  } finally {
+    await finalizeBenchStatus(benchStatusPath);
   }
   if (failures.size > 0) {
     console.error(`\nFailed benchmarks: ${[...failures].join(", ")}`);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4746,15 +4746,16 @@ async function cmdBench(rest: string[]): Promise<void> {
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
             // Scan for the real result file — fallback writes a timestamped
             // filename (${name}-v${version}-${ts}.json) so we glob for the
-            // latest match rather than fabricating a path.
+            // latest match by mtime rather than fabricating a path.
             let fallbackResultPath: string | undefined;
             try {
               const fallbackDir = resolveBenchOutputDir();
               const files = fs.readdirSync(fallbackDir)
                 .filter((f) => f.startsWith(benchmarkId) && f.endsWith(".json"))
-                .sort();
+                .map((f) => ({ name: f, mtime: fs.statSync(path.join(fallbackDir, f)).mtimeMs }))
+                .sort((a, b) => b.mtime - a.mtime);
               if (files.length > 0) {
-                fallbackResultPath = path.join(fallbackDir, files[files.length - 1]);
+                fallbackResultPath = path.join(fallbackDir, files[0].name);
               }
             } catch { /* scan failure is non-fatal */ }
             try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath ?? ""); } catch { /* non-fatal */ }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4740,9 +4740,9 @@ async function cmdBench(rest: string[]): Promise<void> {
             runtimeProfile,
             benchStatusPath,
           );
-          if (handledByPackage.ok && handledByPackage.writtenPath) {
-            try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath); } catch { /* non-fatal */ }
-          } else if (!handledByPackage.ok) {
+          if (handledByPackage.ok) {
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath ?? ""); } catch { /* non-fatal */ }
+          } else {
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
             // Fallback runner writes to evals/results (not
             // resolveBenchOutputDir()), so we cannot reliably determine the

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4744,21 +4744,10 @@ async function cmdBench(rest: string[]): Promise<void> {
             try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath); } catch { /* non-fatal */ }
           } else if (!handledByPackage.ok) {
             await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
-            // Scan for the real result file — fallback writes a timestamped
-            // filename (${name}-v${version}-${ts}.json) so we glob for the
-            // latest match by mtime rather than fabricating a path.
-            let fallbackResultPath: string | undefined;
-            try {
-              const fallbackDir = resolveBenchOutputDir();
-              const files = fs.readdirSync(fallbackDir)
-                .filter((f) => f.startsWith(benchmarkId) && f.endsWith(".json"))
-                .map((f) => ({ name: f, mtime: fs.statSync(path.join(fallbackDir, f)).mtimeMs }))
-                .sort((a, b) => b.mtime - a.mtime);
-              if (files.length > 0) {
-                fallbackResultPath = path.join(fallbackDir, files[0].name);
-              }
-            } catch { /* scan failure is non-fatal */ }
-            try { await updateBenchmarkCompleted(benchStatusPath, statusId, fallbackResultPath ?? ""); } catch { /* non-fatal */ }
+            // Fallback runner writes to evals/results (not
+            // resolveBenchOutputDir()), so we cannot reliably determine the
+            // result path.  Mark complete without a resultPath.
+            try { await updateBenchmarkCompleted(benchStatusPath, statusId, ""); } catch { /* non-fatal */ }
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -669,6 +669,7 @@ export function buildBenchRuntimeProfileRequest(
     judgeModel: parsed.judgeModel,
     judgeBaseUrl: parsed.judgeBaseUrl,
     requestTimeout: parsed.requestTimeout,
+    disableThinking: parsed.disableThinking,
   };
 }
 


### PR DESCRIPTION
## Summary

- **`--request-timeout <ms>` CLI flag** — flows from CLI through `ParsedBenchArgs` → `ResolveBenchRuntimeProfileOptions` → `ProviderConfig.retryOptions` → `retryFetch()`. Applied to both system and judge providers. Fixes the root cause of two failed Gemma 26B benchmark runs where 120s default timeout was too short for local inference on Apple Silicon MPS.
- **Switch `local-llm` provider to `retryFetch()`** — was the only provider still using bare `fetch()`, meaning no retries, no timeout, no access to `retryOptions`. Now consistent with openai-compatible, anthropic, and ollama providers.
- **Agent-readable `bench-status.json`** — written atomically to the results directory after every task completion and benchmark transition. Contains: PID, current benchmark, per-task progress (completed/total), per-benchmark status (pending/running/complete/failed), and completed result paths. Solves Node.js stdout buffering that made progress invisible to AI agents monitoring background runs.

## Context

Two `bench run --all` runs against Gemma 26B via LM Studio failed completely — all 28 published benchmarks errored with `fetch failed` after 3 retries × 120s timeout. The 120s per-request timeout was not configurable from the CLI. Additionally, AI agents monitoring the runs had zero filesystem visibility — no structured status, just proxy signals like temp directory rotations.

## Files changed

| File | Change |
|------|--------|
| `packages/remnic-cli/src/bench-args.ts` | Add `--request-timeout` flag parsing + validation |
| `packages/remnic-cli/src/index.ts` | Wire timeout to runtime profiles, add bench-status calls to benchmark loop |
| `packages/remnic-cli/src/bench-status.ts` | **New** — atomic status file read/write helpers |
| `packages/bench/src/types.ts` | Add `retryOptions` to `ProviderConfig` |
| `packages/bench/src/runtime-profiles.ts` | Wire `requestTimeout` → `retryOptions` through provider resolution |
| `packages/bench/src/providers/local-llm.ts` | Switch from bare `fetch()` to `retryFetch()` |
| `packages/bench/src/providers/local-llm.test.ts` | Update error message regex for retryFetch-wrapped errors |

## Test plan

- [x] `pnpm run build` — clean build, no type errors
- [x] `packages/bench/src/providers/local-llm.test.ts` — 7/7 pass (updated regex for retryFetch error wrapping)
- [x] `packages/remnic-cli/src/bench-args.test.ts` — 12/12 pass
- [x] `packages/bench/src/runtime-profiles.test.ts` — 8/8 pass
- [x] Core bench tests (scorer, answering, responders, published-artifact, integrity, harness, custom runner) — 80/80 pass
- [ ] Manual: `bench run ama-bench --quick --request-timeout 600000 --system-provider openai --system-base-url http://127.0.0.1:1234/v1 --system-model google/gemma-4-26b-a4b` — verify status file appears and timeout is applied
- [ ] Manual: Run in background, `cat ~/.remnic/bench/results/bench-status.json` from another terminal — verify live progress updates

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes CLI-to-provider wiring (timeouts/retry options) and modifies request payloads/error handling for `local-llm` and OpenAI-compatible backends, which can affect benchmark execution behavior and compatibility with local servers.
> 
> **Overview**
> Adds a new `--request-timeout` CLI option and wires it through runtime profile resolution into provider `retryOptions.timeoutMs`, applying to both system and judge model requests.
> 
> Introduces an agent-readable, atomically-written `bench-status.json` in the results directory and updates the bench run loop to record benchmark start/complete/failure plus per-task progress (including profile-qualified entries when running a matrix).
> 
> Updates `local-llm` to use `retryFetch` (with wrapped error messaging) and adds `disableThinking` support across provider configs; `local-llm` always sends `chat_template_kwargs.enable_thinking=false` when set, while `openai-compatible` only sends it for LM Studio/vLLM-like base URLs, with new tests covering both behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e12af15891955c908c3c5d5104a6f7905ee44aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->