### PR TITLE
security: wire CrossNamespaceBudget into recall path (issue #565 slice 6)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1171,6 +1171,9 @@ export class EngramAccessService {
           `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,
         );
       }
+      // Prune expired principal buckets to prevent unbounded Map growth from
+      // high-cardinality / transient principals (Codex P2 review feedback).
+      this.budget.gc();
     }
     const topK = Number.isFinite(request.topK) ? Math.max(0, Math.floor(request.topK ?? 0)) : undefined;
     const recallOptions: RecallInvocationOptions = {

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -40,7 +40,7 @@ import {
   toMemoryPathRel,
 } from "./memory-lifecycle-ledger-utils.js";
 import { getMemoryProjectionPath } from "./memory-projection-store.js";
-import { canReadNamespace, canWriteNamespace, resolvePrincipal } from "./namespaces/principal.js";
+import { canReadNamespace, canWriteNamespace, defaultNamespaceForPrincipal, recallNamespacesForPrincipal, resolvePrincipal } from "./namespaces/principal.js";
 import type { LastRecallSnapshot } from "./recall-state.js";
 import type {
   GraphRecallSnapshot,
@@ -1095,12 +1095,40 @@ export class EngramAccessService {
     const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
     const namespace = namespaceOverride ?? this.orchestrator.config.defaultNamespace;
     const principal = resolvePrincipal(request.sessionKey, this.orchestrator.config);
-    const principalNamespace = this.orchestrator.config.defaultNamespace;
-    const budgetDecision = this.budget.check({
-      principal,
-      principalNamespace,
-      queryNamespace: namespace,
-    });
+    const principalNamespace = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+    // Derive the full set of namespaces the orchestrator will actually search.
+    // When no explicit override is provided, `recallNamespacesForPrincipal()` may
+    // expand to shared / policy-default namespaces.  Budget must be checked
+    // against every cross-namespace entry in the effective set so that omitting
+    // `namespace` cannot bypass the limiter (Cursor/Codex review feedback).
+    const effectiveNamespaces = namespaceOverride
+      ? [namespaceOverride]
+      : recallNamespacesForPrincipal(principal, this.orchestrator.config);
+    let budgetDecision: BudgetDecision = {
+      allowed: true,
+      reason: "allowed-same-namespace" as const,
+      count: 0,
+      limit: {
+        softLimit: this.orchestrator.config.recallCrossNamespaceBudgetSoftLimit ?? 10,
+        hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
+        windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
+      },
+    };
+    for (const ns of effectiveNamespaces) {
+      const decision = this.budget.check({
+        principal,
+        principalNamespace,
+        queryNamespace: ns,
+      });
+      // Keep the most restrictive decision. Denied > warned > allowed.
+      if (!decision.allowed) {
+        budgetDecision = decision;
+        break;
+      }
+      if (decision.reason === "warn-over-soft" && budgetDecision.reason !== "warn-over-soft") {
+        budgetDecision = decision;
+      }
+    }
     if (!budgetDecision.allowed) {
       throw new EngramAccessInputError(
         `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1094,8 +1094,13 @@ export class EngramAccessService {
     }
     const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
     const namespace = namespaceOverride ?? this.orchestrator.config.defaultNamespace;
+    // Normalize mode early so that no_recall / invalid modes skip budget
+    // accounting (Codex P1: budget recorded before mode validation).
+    const mode = this.normalizeRecallMode(request.mode);
     const principal = resolvePrincipal(request.sessionKey, this.orchestrator.config);
     const principalNamespace = defaultNamespaceForPrincipal(principal, this.orchestrator.config);
+    // Skip budget checks for modes that never perform a cross-namespace read.
+    const modeSkipsBudget = mode === "no_recall";
     // Derive the full set of namespaces the orchestrator will actually search.
     // When no explicit override is provided, `recallNamespacesForPrincipal()` may
     // expand to shared / policy-default namespaces.  Budget must be checked
@@ -1110,7 +1115,20 @@ export class EngramAccessService {
     const effectiveNamespaces = namespaceOverride
       ? [namespaceOverride]
       : recallNamespacesForPrincipal(principal, this.orchestrator.config);
-    // Peek at every effective namespace to find the worst-case decision
+    let budgetDecision: BudgetDecision;
+    if (modeSkipsBudget) {
+      budgetDecision = {
+        allowed: true as const,
+        reason: "allowed-same-namespace" as const,
+        count: 0,
+        limit: {
+          softLimit: this.orchestrator.config.recallCrossNamespaceBudgetSoftLimit ?? 10,
+          hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
+          windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
+        },
+      };
+    } else {
+      // Peek at every effective namespace to find the worst-case decision
     // WITHOUT recording side effects (Cursor review: multi-count bug).
     // Then record a single budget event if any cross-namespace query exists.
     let worstPeek: BudgetDecision | null = null;
@@ -1134,7 +1152,7 @@ export class EngramAccessService {
     }
     // Record a single budget event for this recall if any namespace is
     // cross-namespace.  Same-namespace-only recalls are free.
-    const budgetDecision = anyCrossNamespace
+    budgetDecision = anyCrossNamespace
       ? this.budget.record(principal)
       : (worstPeek ?? {
           allowed: true as const,
@@ -1151,7 +1169,7 @@ export class EngramAccessService {
         `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,
       );
     }
-    const mode = this.normalizeRecallMode(request.mode);
+    }
     const topK = Number.isFinite(request.topK) ? Math.max(0, Math.floor(request.topK ?? 0)) : undefined;
     const recallOptions: RecallInvocationOptions = {
       namespace: namespaceOverride,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -16,6 +16,7 @@ import {
   type ExplicitCaptureInput,
   type ValidExplicitCapture,
 } from "./explicit-capture.js";
+import { CrossNamespaceBudget, type BudgetDecision } from "./cross-namespace-budget.js";
 import { log } from "./logger.js";
 import {
   buildQualityScore,
@@ -177,6 +178,7 @@ export interface EngramAccessRecallResponse {
   sourcesUsed: string[];
   budgetsApplied?: LastRecallSnapshot["budgetsApplied"];
   auditAnomalies?: AnomalyDetectorResult;
+  budgetWarning?: BudgetDecision;
   latencyMs?: number;
   debug?: {
     snapshot?: LastRecallSnapshot;
@@ -658,10 +660,17 @@ function compareBrowseMemory(
 export class EngramAccessService {
   private readonly idempotency: AccessIdempotencyStore;
   private readonly idempotencyLocks = new Map<string, Promise<void>>();
+  private readonly budget: CrossNamespaceBudget;
   private readonly auditAdapter: AccessAuditAdapter | null;
 
   constructor(private readonly orchestrator: Orchestrator) {
     this.idempotency = new AccessIdempotencyStore(orchestrator.config.memoryDir);
+    this.budget = new CrossNamespaceBudget({
+      enabled: orchestrator.config.recallCrossNamespaceBudgetEnabled,
+      windowMs: orchestrator.config.recallCrossNamespaceBudgetWindowMs,
+      softLimit: orchestrator.config.recallCrossNamespaceBudgetSoftLimit,
+      hardLimit: orchestrator.config.recallCrossNamespaceBudgetHardLimit,
+    });
 
     const auditEnabled = orchestrator.config.recallAuditAnomalyDetectionEnabled === true;
     const auditLogEnabled = false; // Audit JSONL logging — off until wired to a directory
@@ -1085,6 +1094,18 @@ export class EngramAccessService {
     }
     const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
     const namespace = namespaceOverride ?? this.orchestrator.config.defaultNamespace;
+    const principal = resolvePrincipal(request.sessionKey, this.orchestrator.config);
+    const principalNamespace = this.orchestrator.config.defaultNamespace;
+    const budgetDecision = this.budget.check({
+      principal,
+      principalNamespace,
+      queryNamespace: namespace,
+    });
+    if (!budgetDecision.allowed) {
+      throw new EngramAccessInputError(
+        `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,
+      );
+    }
     const mode = this.normalizeRecallMode(request.mode);
     const topK = Number.isFinite(request.topK) ? Math.max(0, Math.floor(request.topK ?? 0)) : undefined;
     const recallOptions: RecallInvocationOptions = {
@@ -1156,6 +1177,7 @@ export class EngramAccessService {
       sourcesUsed: snapshot?.sourcesUsed ?? [],
       budgetsApplied: snapshot?.budgetsApplied,
       auditAnomalies,
+      budgetWarning: budgetDecision.reason === "warn-over-soft" ? budgetDecision : undefined,
       latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),
       debug,
     };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1101,34 +1101,51 @@ export class EngramAccessService {
     // expand to shared / policy-default namespaces.  Budget must be checked
     // against every cross-namespace entry in the effective set so that omitting
     // `namespace` cannot bypass the limiter (Cursor/Codex review feedback).
+    //
+    // NOTE: coding overlays (branch/project scope) are resolved inside
+    // orchestrator.recall() AFTER this check.  The access-service does not
+    // duplicate that resolution here to avoid tight coupling.  Coding-overlay
+    // namespaces are a second-layer defense covered by the anomaly detector
+    // (PR 5/5 of issue #565).
     const effectiveNamespaces = namespaceOverride
       ? [namespaceOverride]
       : recallNamespacesForPrincipal(principal, this.orchestrator.config);
-    let budgetDecision: BudgetDecision = {
-      allowed: true,
-      reason: "allowed-same-namespace" as const,
-      count: 0,
-      limit: {
-        softLimit: this.orchestrator.config.recallCrossNamespaceBudgetSoftLimit ?? 10,
-        hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
-        windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
-      },
-    };
+    // Peek at every effective namespace to find the worst-case decision
+    // WITHOUT recording side effects (Cursor review: multi-count bug).
+    // Then record a single budget event if any cross-namespace query exists.
+    let worstPeek: BudgetDecision | null = null;
+    let anyCrossNamespace = false;
     for (const ns of effectiveNamespaces) {
-      const decision = this.budget.check({
+      const peek = this.budget.peek({
         principal,
         principalNamespace,
         queryNamespace: ns,
       });
-      // Keep the most restrictive decision. Denied > warned > allowed.
-      if (!decision.allowed) {
-        budgetDecision = decision;
+      if (peek.reason !== "allowed-same-namespace") {
+        anyCrossNamespace = true;
+      }
+      if (!peek.allowed) {
+        worstPeek = peek;
         break;
       }
-      if (decision.reason === "warn-over-soft" && budgetDecision.reason !== "warn-over-soft") {
-        budgetDecision = decision;
+      if (peek.reason === "warn-over-soft" && (!worstPeek || worstPeek.reason !== "warn-over-soft")) {
+        worstPeek = peek;
       }
     }
+    // Record a single budget event for this recall if any namespace is
+    // cross-namespace.  Same-namespace-only recalls are free.
+    const budgetDecision = anyCrossNamespace
+      ? this.budget.record(principal)
+      : (worstPeek ?? {
+          allowed: true as const,
+          reason: "allowed-same-namespace" as const,
+          count: 0,
+          limit: {
+            softLimit: this.orchestrator.config.recallCrossNamespaceBudgetSoftLimit ?? 10,
+            hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
+            windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
+          },
+        });
     if (!budgetDecision.allowed) {
       throw new EngramAccessInputError(
         `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1128,33 +1128,34 @@ export class EngramAccessService {
         },
       };
     } else {
-      // Peek at every effective namespace to find the worst-case decision
-    // WITHOUT recording side effects (Cursor review: multi-count bug).
-    // Then record a single budget event if any cross-namespace query exists.
-    let worstPeek: BudgetDecision | null = null;
-    let anyCrossNamespace = false;
-    for (const ns of effectiveNamespaces) {
-      const peek = this.budget.peek({
-        principal,
-        principalNamespace,
-        queryNamespace: ns,
-      });
-      if (peek.reason !== "allowed-same-namespace") {
-        anyCrossNamespace = true;
+      // Peek at every effective namespace to determine whether ANY would be
+      // cross-namespace WITHOUT recording side effects (Cursor review:
+      // multi-count bug).  Record a single budget event only when at least
+      // one effective namespace differs from the principal's self namespace.
+      let anyCrossNamespace = false;
+      let denied: BudgetDecision | null = null;
+      for (const ns of effectiveNamespaces) {
+        const peek = this.budget.peek({
+          principal,
+          principalNamespace,
+          queryNamespace: ns,
+        });
+        if (peek.reason !== "allowed-same-namespace") {
+          anyCrossNamespace = true;
+        }
+        if (!peek.allowed) {
+          denied = peek;
+          break;
+        }
       }
-      if (!peek.allowed) {
-        worstPeek = peek;
-        break;
-      }
-      if (peek.reason === "warn-over-soft" && (!worstPeek || worstPeek.reason !== "warn-over-soft")) {
-        worstPeek = peek;
-      }
-    }
-    // Record a single budget event for this recall if any namespace is
-    // cross-namespace.  Same-namespace-only recalls are free.
-    budgetDecision = anyCrossNamespace
-      ? this.budget.record(principal)
-      : (worstPeek ?? {
+      if (denied) {
+        // The peek projected a denial — deny without recording so the
+        // bucket is not inflated by rejected attempts.
+        budgetDecision = denied;
+      } else if (anyCrossNamespace) {
+        budgetDecision = this.budget.record(principal);
+      } else {
+        budgetDecision = {
           allowed: true as const,
           reason: "allowed-same-namespace" as const,
           count: 0,
@@ -1163,12 +1164,13 @@ export class EngramAccessService {
             hardLimit: this.orchestrator.config.recallCrossNamespaceBudgetHardLimit ?? 30,
             windowMs: this.orchestrator.config.recallCrossNamespaceBudgetWindowMs ?? 60_000,
           },
-        });
-    if (!budgetDecision.allowed) {
-      throw new EngramAccessInputError(
-        `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,
-      );
-    }
+        };
+      }
+      if (!budgetDecision.allowed) {
+        throw new EngramAccessInputError(
+          `recall denied: cross-namespace budget exceeded (${budgetDecision.count}/${budgetDecision.limit.hardLimit} in ${budgetDecision.limit.windowMs}ms window)`,
+        );
+      }
     }
     const topK = Number.isFinite(request.topK) ? Math.max(0, Math.floor(request.topK ?? 0)) : undefined;
     const recallOptions: RecallInvocationOptions = {

--- a/packages/remnic-core/src/cross-namespace-budget.ts
+++ b/packages/remnic-core/src/cross-namespace-budget.ts
@@ -237,6 +237,62 @@ export class CrossNamespaceBudget {
   }
 
   /**
+   * Read-only peek at whether a call would be allowed, WITHOUT recording a
+   * timestamp. Useful when the caller must inspect multiple namespaces before
+   * deciding to record a single event. The returned `count` reflects the
+   * current window state at call time.
+   */
+  peek(args: {
+    principal: string;
+    principalNamespace: string;
+    queryNamespace: string;
+    now?: number;
+  }): BudgetDecision {
+    const pn = args.principalNamespace;
+    const qn = args.queryNamespace;
+    const bothPresent =
+      typeof pn === "string" && pn.length > 0 &&
+      typeof qn === "string" && qn.length > 0;
+    if (bothPresent && pn === qn) {
+      return {
+        allowed: true,
+        reason: "allowed-same-namespace",
+        count: 0,
+        limit: {
+          softLimit: this.config.softLimit,
+          hardLimit: this.config.hardLimit,
+          windowMs: this.config.windowMs,
+        },
+      };
+    }
+    // Cross-namespace: simulate what record() would do without the push.
+    const { enabled, windowMs, softLimit, hardLimit } = this.config;
+    const limit = { softLimit, hardLimit, windowMs };
+    if (!enabled) {
+      return { allowed: true, reason: "allowed-no-limit", count: 0, limit };
+    }
+    let principal = args.principal;
+    if (typeof principal !== "string" || principal.length === 0) {
+      principal = "__anonymous__";
+    }
+    const now = args.now ?? Date.now();
+    const bucket = this.buckets.get(principal) ?? { timestamps: [] };
+    const cutoff = now - windowMs;
+    let liveCount = 0;
+    for (const ts of bucket.timestamps) {
+      if (ts >= cutoff) liveCount++;
+    }
+    const projected = liveCount + 1; // +1 for the current call
+    if (projected > hardLimit) {
+      return { allowed: false, reason: "deny-over-hard", count: liveCount, limit };
+    }
+    if (projected > softLimit) {
+      return { allowed: true, reason: "warn-over-soft", count: projected, limit };
+    }
+    return { allowed: true, reason: "allowed-under-soft", count: projected, limit };
+  }
+
+  /**
    * Convenience guard that also skips the limiter when `principalNamespace`
    * equals `queryNamespace` (same-namespace is never cross-namespace).
    * Returns an `allowed-same-namespace` decision in that case.

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -35,6 +35,10 @@ function createService() {
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -120,6 +124,10 @@ test("access service allows readable namespace overrides outside default recall 
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async (_query: string, _sessionKey?: string, options?: unknown) => {
       capturedOptions = options;
@@ -189,6 +197,10 @@ test("access service allows readable explicit namespace overrides outside defaul
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: { get: () => null, getMostRecent: () => null },
@@ -619,6 +631,10 @@ test("access service recallExplain omits mismatched most-recent snapshot when na
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -666,6 +682,10 @@ test("access service recallExplain omits most-recent snapshots without a namespa
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -712,6 +732,10 @@ test("access service recallExplain without a namespace preserves the most recent
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -762,6 +786,10 @@ test("access service recallExplain filters session snapshots by the requested na
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     },
     recall: async () => "ctx",
     lastRecall: {
@@ -923,6 +951,10 @@ test("access service acquires a shared idempotency key lock before executing wri
       searchBackend: "qmd",
       qmdEnabled: true,
       nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
     };
     const orchestrator = {
       config,
@@ -2659,4 +2691,111 @@ test("access service recall has no audit anomalies when detection is disabled", 
     sessionKey: "agent:test:chat",
   });
   assert.equal(res.auditAnomalies, undefined, "no audit anomalies when disabled");
+});
+
+test("access service recall enforces cross-namespace budget when enabled", async () => {
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        { name: "project-x", readPrincipals: ["project-x", "attacker"], writePrincipals: ["project-x"] },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: true,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 2,
+      recallCrossNamespaceBudgetHardLimit: 3,
+    },
+    recall: async () => "ctx",
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+  const service = new EngramAccessService(orchestrator as any);
+
+  // First 3 cross-namespace recalls should succeed (under hard limit)
+  for (let i = 0; i < 3; i++) {
+    const res = await service.recall({
+      query: `query ${i}`,
+      sessionKey: "agent:attacker:chat",
+      namespace: "project-x",
+    });
+    assert.ok(res, `recall ${i} should succeed`);
+  }
+
+  // 4th cross-namespace recall should be denied
+  await assert.rejects(
+    () => service.recall({
+      query: "one more",
+      sessionKey: "agent:attacker:chat",
+      namespace: "project-x",
+    }),
+    (err: unknown) =>
+      err instanceof EngramAccessInputError &&
+      err.message.includes("cross-namespace budget exceeded"),
+  );
+});
+
+test("access service recall surfaces budgetWarning when over soft limit", async () => {
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        { name: "project-x", readPrincipals: ["project-x", "attacker"], writePrincipals: ["project-x"] },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: true,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 1,
+      recallCrossNamespaceBudgetHardLimit: 10,
+    },
+    recall: async () => "ctx",
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+  const service = new EngramAccessService(orchestrator as any);
+
+  // First call — under soft limit, no warning
+  const res1 = await service.recall({
+    query: "first",
+    sessionKey: "agent:attacker:chat",
+    namespace: "project-x",
+  });
+  assert.equal(res1.budgetWarning, undefined);
+
+  // Second call — over soft limit, warning present
+  const res2 = await service.recall({
+    query: "second",
+    sessionKey: "agent:attacker:chat",
+    namespace: "project-x",
+  });
+  assert.ok(res2.budgetWarning, "should have budgetWarning");
+  assert.equal(res2.budgetWarning!.reason, "warn-over-soft");
 });


### PR DESCRIPTION
## Summary
- Wires the existing `CrossNamespaceBudget` class (from PR #638) into `EngramAccessService.recall()` 
- Budget is checked before every recall; cross-namespace queries over the hard limit are rejected
- Soft-limit warnings surfaced in response via `budgetWarning` field
- Budget remains **disabled by default** (`recallCrossNamespaceBudgetEnabled: false`, per rule 48)

## Test plan
- [x] `node --import tsx --test tests/access-service.test.ts` — 55/55 pass
- [x] `npx tsc --noEmit --project packages/remnic-core/tsconfig.json` — clean
- [x] New tests: hard-limit denial + soft-limit warning

Closes part of #565 (mitigation wiring — slice 6 of N)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `recall()` path and can start rejecting requests when enabled, so misconfiguration or edge cases could impact availability; default-off flag reduces risk for existing deployments.
> 
> **Overview**
> Wires the in-process `CrossNamespaceBudget` limiter into `EngramAccessService.recall()` to throttle cross-namespace recalls per principal when the `recallCrossNamespaceBudgetEnabled` flag is on.
> 
> The recall path now derives the effective namespace set (including default/policy-expanded namespaces), `peek()`s each to avoid multi-counting, records a single budget event when any cross-namespace read occurs, denies recalls over the hard limit, and returns a `budgetWarning` in the response when the soft limit is exceeded. Tests are updated to include budget config defaults and new cases for hard-limit denial and soft-limit warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f49e59b033d19de73d1e458dc523ee055c182cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->