### PR TITLE
security: wire AccessAuditAdapter into recall path (issue #565 slice 7)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1,5 +1,7 @@
 import { stat } from "node:fs/promises";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
+import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
+import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
 import { WorkStorage } from "./work/storage.js";
 import {
   exportWorkBoardMarkdown,
@@ -174,6 +176,7 @@ export interface EngramAccessRecallResponse {
   fallbackUsed: boolean;
   sourcesUsed: string[];
   budgetsApplied?: LastRecallSnapshot["budgetsApplied"];
+  auditAnomalies?: AnomalyDetectorResult;
   latencyMs?: number;
   debug?: {
     snapshot?: LastRecallSnapshot;
@@ -655,9 +658,32 @@ function compareBrowseMemory(
 export class EngramAccessService {
   private readonly idempotency: AccessIdempotencyStore;
   private readonly idempotencyLocks = new Map<string, Promise<void>>();
+  private readonly auditAdapter: AccessAuditAdapter | null;
 
   constructor(private readonly orchestrator: Orchestrator) {
     this.idempotency = new AccessIdempotencyStore(orchestrator.config.memoryDir);
+
+    const auditEnabled = orchestrator.config.recallAuditAnomalyDetectionEnabled === true;
+    const auditLogEnabled = false; // Audit JSONL logging — off until wired to a directory
+    if (auditEnabled || auditLogEnabled) {
+      const auditConfig: AccessAuditConfig = {
+        audit: {
+          enabled: auditLogEnabled,
+          rootDir: orchestrator.config.memoryDir,
+        },
+        detection: {
+          enabled: auditEnabled,
+          windowMs: orchestrator.config.recallAuditAnomalyWindowMs,
+          repeatQueryLimit: orchestrator.config.recallAuditAnomalyRepeatQueryLimit,
+          namespaceWalkLimit: orchestrator.config.recallAuditAnomalyNamespaceWalkLimit,
+          highCardinalityReturnLimit: orchestrator.config.recallAuditAnomalyHighCardinalityLimit,
+          rapidFireLimit: orchestrator.config.recallAuditAnomalyRapidFireLimit,
+        },
+      };
+      this.auditAdapter = new AccessAuditAdapter(auditConfig);
+    } else {
+      this.auditAdapter = null;
+    }
   }
 
   get briefingEnabled(): boolean {
@@ -1082,6 +1108,35 @@ export class EngramAccessService {
       request.sessionKey,
     );
 
+    // Fire-and-forget audit recording. Must never block or crash recall.
+    let auditAnomalies: AccessAuditResult["anomalies"] | undefined;
+    if (this.auditAdapter) {
+      try {
+        const auditEntry = {
+          ts: new Date().toISOString(),
+          sessionKey: request.sessionKey ?? "",
+          agentId: resolvePrincipal(request.sessionKey, this.orchestrator.config),
+          trigger: "access-surface",
+          queryText: query,
+          candidateMemoryIds: snapshot?.memoryIds ?? [],
+          summary: context.slice(0, 200) || null,
+          injectedChars: context.length,
+          toggleState: "enabled" as const,
+          latencyMs: Date.now() - startedAt,
+          plannerMode: snapshot?.plannerMode ?? mode,
+          requestedMode: mode,
+          fallbackUsed: snapshot?.fallbackUsed ?? false,
+        };
+        const auditResult = await this.auditAdapter.record(
+          request.sessionKey ?? "__anonymous__",
+          auditEntry,
+        );
+        auditAnomalies = auditResult.anomalies;
+      } catch {
+        // Audit failures must never crash the recall path.
+      }
+    }
+
     return {
       query,
       sessionKey: request.sessionKey,
@@ -1096,6 +1151,7 @@ export class EngramAccessService {
       fallbackUsed: snapshot?.fallbackUsed ?? false,
       sourcesUsed: snapshot?.sourcesUsed ?? [],
       budgetsApplied: snapshot?.budgetsApplied,
+      auditAnomalies,
       latencyMs: snapshot?.latencyMs ?? (Date.now() - startedAt),
       debug,
     };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1112,10 +1112,14 @@ export class EngramAccessService {
     let auditAnomalies: AccessAuditResult["anomalies"] | undefined;
     if (this.auditAdapter) {
       try {
+        const resolvedAgentId = resolvePrincipal(
+          request.sessionKey,
+          this.orchestrator.config,
+        );
         const auditEntry = {
           ts: new Date().toISOString(),
           sessionKey: request.sessionKey ?? "",
-          agentId: resolvePrincipal(request.sessionKey, this.orchestrator.config),
+          agentId: resolvedAgentId,
           trigger: "access-surface",
           queryText: query,
           candidateMemoryIds: snapshot?.memoryIds ?? [],
@@ -1128,7 +1132,7 @@ export class EngramAccessService {
           fallbackUsed: snapshot?.fallbackUsed ?? false,
         };
         const auditResult = await this.auditAdapter.record(
-          request.sessionKey ?? "__anonymous__",
+          resolvedAgentId || "__anonymous__",
           auditEntry,
         );
         auditAnomalies = auditResult.anomalies;

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -2568,3 +2568,95 @@ test("briefing() accepts absent format (undefined) without error and uses defaul
     "absent format must resolve to the configured default",
   );
 });
+
+test("access service recall records audit entries and detects anomalies when enabled", async () => {
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallAuditAnomalyDetectionEnabled: true,
+      recallAuditAnomalyWindowMs: 60_000,
+      recallAuditAnomalyRepeatQueryLimit: 2,
+      recallAuditAnomalyNamespaceWalkLimit: 3,
+      recallAuditAnomalyHighCardinalityLimit: 50,
+      recallAuditAnomalyRapidFireLimit: 30,
+    },
+    recall: async () => "ctx",
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+  const service = new EngramAccessService(orchestrator as any);
+
+  // First recall — no anomalies expected
+  const res1 = await service.recall({
+    query: "test query",
+    sessionKey: "agent:test:chat",
+  });
+  assert.ok(res1, "first recall should succeed");
+
+  // Repeat the same query to trigger repeat-query anomaly
+  const res2 = await service.recall({
+    query: "test query",
+    sessionKey: "agent:test:chat",
+  });
+  assert.ok(res2, "second recall should succeed");
+
+  // Third repeat should trigger the anomaly detector
+  const res3 = await service.recall({
+    query: "test query",
+    sessionKey: "agent:test:chat",
+  });
+  assert.ok(res3, "third recall should succeed");
+  assert.ok(res3.auditAnomalies, "should have audit anomalies after repeat queries");
+  assert.ok(res3.auditAnomalies!.flags.length > 0, "should have at least one anomaly flag");
+});
+
+test("access service recall has no audit anomalies when detection is disabled", async () => {
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallAuditAnomalyDetectionEnabled: false,
+    },
+    recall: async () => "ctx",
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async () => ({
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+  const service = new EngramAccessService(orchestrator as any);
+
+  const res = await service.recall({
+    query: "test query",
+    sessionKey: "agent:test:chat",
+  });
+  assert.equal(res.auditAnomalies, undefined, "no audit anomalies when disabled");
+});


### PR DESCRIPTION
## Summary
- Wires the existing `AccessAuditAdapter` (from PR #639) into `EngramAccessService.recall()`
- Records audit entries after each successful recall (fire-and-forget, non-blocking)
- Anomaly flags surfaced in response via `auditAnomalies` field
- Audit failures never crash the recall path
- Detection remains **disabled by default** (`recallAuditAnomalyDetectionEnabled: false`, per rule 48)

## Test plan
- [x] `node --import tsx --test tests/access-service.test.ts` — 55/55 pass
- [x] `npx tsc --noEmit --project packages/remnic-core/tsconfig.json` — clean
- [x] New tests: anomaly detection on repeat queries + disabled-by-default

Closes part of #565 (mitigation wiring — slice 7 of N)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core recall path and its public response shape, so regressions could impact all clients even though auditing is gated and failures are intentionally non-blocking.
> 
> **Overview**
> Wires `AccessAuditAdapter` into `EngramAccessService.recall()` behind `recallAuditAnomalyDetectionEnabled`, recording a per-recall audit entry and (when enabled) running the anomaly detector without affecting recall success (errors are swallowed).
> 
> Extends the recall response with optional `auditAnomalies` so access surfaces can observe detector flags, and adds tests covering repeat-query anomaly triggering vs. detection-disabled behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a3938615e4788a198ad301544959cf48eae8c06. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->