### PR TITLE
feat(doctor): add security mitigation status check (issue #565 slice 8)

### DIFF
--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1450,8 +1450,8 @@ function summarizeSecurityMitigations(
   return {
     key: "security_mitigations",
     status: "ok",
-    summary: `Memory-extraction mitigations active: ${budgetEnabled ? "budget" : ""}${budgetEnabled && anomalyEnabled ? ", " : ""}${anomalyEnabled ? "anomaly detection" : ""}.`,
-    details,
+    summary: `Memory-extraction mitigation config enabled: ${budgetEnabled ? "budget" : ""}${budgetEnabled && anomalyEnabled ? ", " : ""}${anomalyEnabled ? "anomaly detection" : ""}.`,
+    details: { ...details, configOnly: true },
   };
 }
 

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1206,6 +1206,11 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // false-missing warnings.
   checks.push(await summarizeConsolidationProvenance(new StorageManager(config.memoryDir), config));
 
+  // Security mitigation status (issue #565).
+  // Reports whether the cross-namespace budget and anomaly detection
+  // mitigations are enabled and surfaces config values for operator review.
+  checks.push(summarizeSecurityMitigations(config));
+
   const summary = checks.reduce(
     (acc, check) => {
       acc[check.status] += 1;
@@ -1387,6 +1392,69 @@ export async function summarizeBufferSurpriseDistribution(
  * Exported so unit tests can exercise the summarization without booting a
  * full orchestrator.
  */
+
+function summarizeSecurityMitigations(
+  config: Pick<
+    PluginConfig,
+    | "recallCrossNamespaceBudgetEnabled"
+    | "recallCrossNamespaceBudgetWindowMs"
+    | "recallCrossNamespaceBudgetSoftLimit"
+    | "recallCrossNamespaceBudgetHardLimit"
+    | "recallAuditAnomalyDetectionEnabled"
+    | "recallAuditAnomalyWindowMs"
+    | "recallAuditAnomalyRepeatQueryLimit"
+    | "recallAuditAnomalyNamespaceWalkLimit"
+    | "recallAuditAnomalyHighCardinalityLimit"
+    | "recallAuditAnomalyRapidFireLimit"
+  >,
+): OperatorDoctorCheck {
+  const budgetEnabled = config.recallCrossNamespaceBudgetEnabled === true;
+  const anomalyEnabled = config.recallAuditAnomalyDetectionEnabled === true;
+
+  if (!budgetEnabled && !anomalyEnabled) {
+    return {
+      key: "security_mitigations",
+      status: "warn",
+      summary: "Memory-extraction mitigations are disabled (cross-namespace budget and anomaly detection off).",
+      remediation: "Enable recallCrossNamespaceBudgetEnabled and/or recallAuditAnomalyDetectionEnabled for production deployments. See docs/security/memory-extraction-threat-model.md.",
+      details: {
+        budgetEnabled: false,
+        anomalyDetectionEnabled: false,
+      },
+    };
+  }
+
+  const details: Record<string, unknown> = {
+    budgetEnabled,
+    anomalyDetectionEnabled: anomalyEnabled,
+  };
+
+  if (budgetEnabled) {
+    details.budgetConfig = {
+      windowMs: config.recallCrossNamespaceBudgetWindowMs,
+      softLimit: config.recallCrossNamespaceBudgetSoftLimit,
+      hardLimit: config.recallCrossNamespaceBudgetHardLimit,
+    };
+  }
+
+  if (anomalyEnabled) {
+    details.anomalyConfig = {
+      windowMs: config.recallAuditAnomalyWindowMs,
+      repeatQueryLimit: config.recallAuditAnomalyRepeatQueryLimit,
+      namespaceWalkLimit: config.recallAuditAnomalyNamespaceWalkLimit,
+      highCardinalityLimit: config.recallAuditAnomalyHighCardinalityLimit,
+      rapidFireLimit: config.recallAuditAnomalyRapidFireLimit,
+    };
+  }
+
+  return {
+    key: "security_mitigations",
+    status: "ok",
+    summary: `Memory-extraction mitigations active: ${budgetEnabled ? "budget" : ""}${budgetEnabled && anomalyEnabled ? ", " : ""}${anomalyEnabled ? "anomaly detection" : ""}.`,
+    details,
+  };
+}
+
 export async function summarizeConsolidationProvenance(
   storage: StorageManager,
   config: Pick<PluginConfig, "memoryDir"> & { versioningSidecarDir?: string },

--- a/tests/operator-toolkit.test.ts
+++ b/tests/operator-toolkit.test.ts
@@ -693,10 +693,11 @@ test("operator doctor reports ok when security mitigations are enabled", async (
   const sec = report.checks.find((c) => c.key === "security_mitigations");
   assert.ok(sec, "security_mitigations check should exist");
   assert.equal(sec.status, "ok");
-  assert.match(sec.summary, /active/);
+  assert.match(sec.summary, /config enabled/);
   const details = sec.details as Record<string, unknown>;
   assert.equal(details.budgetEnabled, true);
   assert.equal(details.anomalyDetectionEnabled, true);
+  assert.equal(details.configOnly, true, "should indicate this is config-only, not enforcement");
   assert.ok(details.budgetConfig, "should include budget config");
   assert.ok(details.anomalyConfig, "should include anomaly config");
 });

--- a/tests/operator-toolkit.test.ts
+++ b/tests/operator-toolkit.test.ts
@@ -667,3 +667,36 @@ test("operator repair aggregates dry-run session repair and graph guidance", asy
   const after = await readFile(transcriptPath, "utf-8");
   assert.match(after, /not-json/);
 });
+
+test("operator doctor warns when security mitigations are disabled", async () => {
+  const fixture = await makeFixture();
+  const report = await runOperatorDoctor({
+    configPath: fixture.configPath,
+    orchestrator: fixture.orchestrator,
+  });
+  const sec = report.checks.find((c) => c.key === "security_mitigations");
+  assert.ok(sec, "security_mitigations check should exist");
+  assert.equal(sec.status, "warn");
+  assert.match(sec.summary, /disabled/);
+  assert.ok(sec.remediation, "should have remediation guidance");
+});
+
+test("operator doctor reports ok when security mitigations are enabled", async () => {
+  const fixture = await makeFixture({
+    recallCrossNamespaceBudgetEnabled: true,
+    recallAuditAnomalyDetectionEnabled: true,
+  });
+  const report = await runOperatorDoctor({
+    configPath: fixture.configPath,
+    orchestrator: fixture.orchestrator,
+  });
+  const sec = report.checks.find((c) => c.key === "security_mitigations");
+  assert.ok(sec, "security_mitigations check should exist");
+  assert.equal(sec.status, "ok");
+  assert.match(sec.summary, /active/);
+  const details = sec.details as Record<string, unknown>;
+  assert.equal(details.budgetEnabled, true);
+  assert.equal(details.anomalyDetectionEnabled, true);
+  assert.ok(details.budgetConfig, "should include budget config");
+  assert.ok(details.anomalyConfig, "should include anomaly config");
+});


### PR DESCRIPTION
## Summary
- Adds `security_mitigations` check to `remnic doctor` output
- Warns when both cross-namespace budget and anomaly detection are disabled (the default)
- Reports active config values when mitigations are enabled
- Guides operators to the threat model docs for configuration

## Test plan
- [x] `node --import tsx --test tests/operator-toolkit.test.ts` — 22/22 pass
- [x] `npx tsc --noEmit` — clean
- [x] New tests: disabled-warning and enabled-ok scenarios

Closes part of #565 (mitigation wiring — slice 8 of N)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Adds an informational doctor-report check and tests only; no enforcement behavior or runtime security logic is changed.
> 
> **Overview**
> `remnic doctor` now includes a new `security_mitigations` check that **warns** when both cross-namespace recall budgeting and audit anomaly detection are disabled, and otherwise reports **ok** while surfacing the active config values (window/limits) for operator review, including remediation guidance linking to the threat-model doc.
> 
> Adds unit coverage for both the disabled (warn + remediation) and enabled (ok + details payload) scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508db8effc208b783fdc7159f6e73256a8dfde78. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->