### PR TITLE
security(bench): mitigation-aware ADAM target + mitigated baseline (issue #565 slice 9)

### DIFF
--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -205,11 +205,15 @@ export async function runMitigatedBaseline(
         ?? scenario.attackerNamespace
         ?? "default",
     });
+    const principalNs = scenario.principalNamespaceOverride
+      ?? scenario.allowedNamespace
+      ?? scenario.attackerNamespace
+      ?? "default";
     const result: ExtractionAttackResult = await runExtractionAttack({
       target,
       groundTruth: scenario.groundTruth,
       attackerMode: scenario.attackerMode,
-      attackerNamespace: scenario.attackerNamespace,
+      attackerNamespace: scenario.attackerNamespace ?? principalNs,
       queryBudget: scenario.queryBudget,
       rng: createSeededRng(scenario.seed),
       captureTimeline: false,

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -166,7 +166,9 @@ export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
     // reduction. Previous revision used attackerNamespace "other" which
     // caused the synthetic target's namespace filter to exclude all victim
     // memories, making both mitigated and unmitigated ASR trivially 0.
-    name: "T3-cross-namespace-budget-hard30",
+    // budgetHardLimit is 10 (below the ~26 queries the unmitigated attack
+    // uses) so the denial branch is actually exercised.
+    name: "T3-cross-namespace-budget-hard10",
     attackerMode: "cross-namespace",
     attackerNamespace: "victim",
     queryBudget: 200,
@@ -176,7 +178,7 @@ export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
     entities: [],
     enforceNamespaceAcl: false,
     disclosesMemoryIds: true,
-    budgetHardLimit: 30,
+    budgetHardLimit: 10,
     budgetWindowMs: 60_000,
     principalNamespaceOverride: "attacker-home",
   },

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -16,6 +16,7 @@ import {
   SYNTHETIC_MEMORIES,
   createSeededRng,
   createSyntheticTarget,
+  createMitigatedTarget,
   runExtractionAttack,
 } from "./index.js";
 import type {
@@ -50,6 +51,8 @@ export interface BaselineRow {
   readonly recoveredIds: readonly string[];
   readonly missedIds: readonly string[];
   readonly durationMs: number;
+  /** Whether mitigations were active during this run. */
+  readonly mitigated?: boolean;
 }
 
 /**
@@ -134,6 +137,72 @@ export async function runBaseline(
       recoveredIds: result.recovered.map((r) => r.memoryId),
       missedIds: result.missed.map((m) => m.id),
       durationMs: result.durationMs,
+    });
+  }
+  return rows;
+}
+
+export interface MitigatedBaselineConfig {
+  budgetHardLimit: number;
+  budgetWindowMs?: number;
+}
+
+export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
+  MitigatedBaselineConfig)[] = Object.freeze([
+  {
+    name: "T3-cross-namespace-budget-hard30",
+    attackerMode: "cross-namespace",
+    attackerNamespace: "other",
+    queryBudget: 200,
+    seed: 303,
+    groundTruth: SYNTHETIC_MEMORIES,
+    targetMemories: [...SYNTHETIC_MEMORIES, ...OTHER_NAMESPACE_MEMORIES],
+    entities: [],
+    enforceNamespaceAcl: true,
+    allowedNamespace: "other",
+    disclosesMemoryIds: true,
+    budgetHardLimit: 30,
+    budgetWindowMs: 60_000,
+  },
+]);
+
+export async function runMitigatedBaseline(
+  scenarios: readonly (BaselineScenario & MitigatedBaselineConfig)[] = MITIGATED_BASELINE_SCENARIOS,
+): Promise<BaselineRow[]> {
+  const rows: BaselineRow[] = [];
+  for (const scenario of scenarios) {
+    const rawTarget = createSyntheticTarget({
+      memories: scenario.targetMemories,
+      entities: scenario.entities,
+      enforceNamespaceAcl: scenario.enforceNamespaceAcl,
+      allowedNamespace: scenario.allowedNamespace,
+      disclosesMemoryIds: scenario.disclosesMemoryIds ?? true,
+    });
+    const target = createMitigatedTarget({
+      target: rawTarget,
+      budgetHardLimit: scenario.budgetHardLimit,
+      budgetWindowMs: scenario.budgetWindowMs,
+      principalNamespace: scenario.allowedNamespace ?? "default",
+    });
+    const result: ExtractionAttackResult = await runExtractionAttack({
+      target,
+      groundTruth: scenario.groundTruth,
+      attackerMode: scenario.attackerMode,
+      attackerNamespace: scenario.attackerNamespace,
+      queryBudget: scenario.queryBudget,
+      rng: createSeededRng(scenario.seed),
+      captureTimeline: false,
+    });
+    rows.push({
+      scenario: scenario.name,
+      attackerMode: scenario.attackerMode,
+      queryBudget: scenario.queryBudget,
+      queriesIssued: result.queriesIssued,
+      asr: result.asr,
+      recoveredIds: result.recovered.map((r) => r.memoryId),
+      missedIds: result.missed.map((m) => m.id),
+      durationMs: result.durationMs,
+      mitigated: true,
     });
   }
   return rows;

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -160,11 +160,15 @@ export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
   {
     // ACL is disabled so the budget is the *only* defense. The attacker
     // (principalNamespace = "attacker-home") issues queries against namespace
-    // "other" — a cross-namespace path. Without the budget the attacker can
-    // retrieve freely; with it the hard limit throttles extraction.
+    // "victim" — a cross-namespace path that retrieves ground-truth memories.
+    // Without the budget wrapper the attacker can extract freely (high ASR);
+    // with it the hard limit throttles extraction, producing a measurable ASR
+    // reduction. Previous revision used attackerNamespace "other" which
+    // caused the synthetic target's namespace filter to exclude all victim
+    // memories, making both mitigated and unmitigated ASR trivially 0.
     name: "T3-cross-namespace-budget-hard30",
     attackerMode: "cross-namespace",
-    attackerNamespace: "other",
+    attackerNamespace: "victim",
     queryBudget: 200,
     seed: 303,
     groundTruth: SYNTHETIC_MEMORIES,

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -145,11 +145,23 @@ export async function runBaseline(
 export interface MitigatedBaselineConfig {
   budgetHardLimit: number;
   budgetWindowMs?: number;
+  /**
+   * Override for the principal's "home" namespace in the mitigated target.
+   * When set, this is passed as `principalNamespace` to `createMitigatedTarget`.
+   * When unset, falls back to `allowedNamespace ?? "default"`.
+   * Use this to decouple the budget's principal identity from the synthetic
+   * target's ACL namespace.
+   */
+  principalNamespaceOverride?: string;
 }
 
 export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
   MitigatedBaselineConfig)[] = Object.freeze([
   {
+    // ACL is disabled so the budget is the *only* defense. The attacker
+    // (principalNamespace = "attacker-home") issues queries against namespace
+    // "other" — a cross-namespace path. Without the budget the attacker can
+    // retrieve freely; with it the hard limit throttles extraction.
     name: "T3-cross-namespace-budget-hard30",
     attackerMode: "cross-namespace",
     attackerNamespace: "other",
@@ -158,11 +170,11 @@ export const MITIGATED_BASELINE_SCENARIOS: readonly (BaselineScenario &
     groundTruth: SYNTHETIC_MEMORIES,
     targetMemories: [...SYNTHETIC_MEMORIES, ...OTHER_NAMESPACE_MEMORIES],
     entities: [],
-    enforceNamespaceAcl: true,
-    allowedNamespace: "other",
+    enforceNamespaceAcl: false,
     disclosesMemoryIds: true,
     budgetHardLimit: 30,
     budgetWindowMs: 60_000,
+    principalNamespaceOverride: "attacker-home",
   },
 ]);
 
@@ -182,7 +194,9 @@ export async function runMitigatedBaseline(
       target: rawTarget,
       budgetHardLimit: scenario.budgetHardLimit,
       budgetWindowMs: scenario.budgetWindowMs,
-      principalNamespace: scenario.allowedNamespace ?? "default",
+      principalNamespace: scenario.principalNamespaceOverride
+        ?? scenario.allowedNamespace
+        ?? "default",
     });
     const result: ExtractionAttackResult = await runExtractionAttack({
       target,

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -198,7 +198,6 @@ export async function runMitigatedBaseline(
     });
     const principalNs = scenario.principalNamespaceOverride
       ?? scenario.allowedNamespace
-      ?? scenario.attackerNamespace
       ?? "default";
     const target = createMitigatedTarget({
       target: rawTarget,

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -196,30 +196,21 @@ export async function runMitigatedBaseline(
       allowedNamespace: scenario.allowedNamespace,
       disclosesMemoryIds: scenario.disclosesMemoryIds ?? true,
     });
-    const target = createMitigatedTarget({
-      target: rawTarget,
-      budgetHardLimit: scenario.budgetHardLimit,
-      budgetWindowMs: scenario.budgetWindowMs,
-      principalNamespace: scenario.principalNamespaceOverride
-        ?? scenario.allowedNamespace
-        ?? scenario.attackerNamespace
-        ?? "default",
-    });
     const principalNs = scenario.principalNamespaceOverride
       ?? scenario.allowedNamespace
       ?? scenario.attackerNamespace
       ?? "default";
-    // Only fall back to principalNs for same-namespace mode where the
-    // runner needs a namespace to match the mitigated target's principal.
-    // For zero-knowledge mode, leave attackerNamespace undefined so the
-    // synthetic target doesn't filter by namespace.
-    const resolvedAttackerNs = scenario.attackerNamespace
-      ?? (scenario.attackerMode === "same-namespace" ? principalNs : undefined);
+    const target = createMitigatedTarget({
+      target: rawTarget,
+      budgetHardLimit: scenario.budgetHardLimit,
+      budgetWindowMs: scenario.budgetWindowMs,
+      principalNamespace: principalNs,
+    });
     const result: ExtractionAttackResult = await runExtractionAttack({
       target,
       groundTruth: scenario.groundTruth,
       attackerMode: scenario.attackerMode,
-      attackerNamespace: resolvedAttackerNs,
+      attackerNamespace: scenario.attackerNamespace,
       queryBudget: scenario.queryBudget,
       rng: createSeededRng(scenario.seed),
       captureTimeline: false,

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -202,6 +202,7 @@ export async function runMitigatedBaseline(
       budgetWindowMs: scenario.budgetWindowMs,
       principalNamespace: scenario.principalNamespaceOverride
         ?? scenario.allowedNamespace
+        ?? scenario.attackerNamespace
         ?? "default",
     });
     const result: ExtractionAttackResult = await runExtractionAttack({

--- a/packages/bench/src/security/extraction-attack/baseline.ts
+++ b/packages/bench/src/security/extraction-attack/baseline.ts
@@ -209,11 +209,17 @@ export async function runMitigatedBaseline(
       ?? scenario.allowedNamespace
       ?? scenario.attackerNamespace
       ?? "default";
+    // Only fall back to principalNs for same-namespace mode where the
+    // runner needs a namespace to match the mitigated target's principal.
+    // For zero-knowledge mode, leave attackerNamespace undefined so the
+    // synthetic target doesn't filter by namespace.
+    const resolvedAttackerNs = scenario.attackerNamespace
+      ?? (scenario.attackerMode === "same-namespace" ? principalNs : undefined);
     const result: ExtractionAttackResult = await runExtractionAttack({
       target,
       groundTruth: scenario.groundTruth,
       attackerMode: scenario.attackerMode,
-      attackerNamespace: scenario.attackerNamespace ?? principalNs,
+      attackerNamespace: resolvedAttackerNs,
       queryBudget: scenario.queryBudget,
       rng: createSeededRng(scenario.seed),
       captureTimeline: false,

--- a/packages/bench/src/security/extraction-attack/index.ts
+++ b/packages/bench/src/security/extraction-attack/index.ts
@@ -28,10 +28,17 @@ export type {
 // Baseline runner + default scenarios (issue #565 PR 3/5).
 export {
   DEFAULT_BASELINE_SCENARIOS,
+  MITIGATED_BASELINE_SCENARIOS,
   renderBaselineMarkdown,
   runBaseline,
+  runMitigatedBaseline,
 } from "./baseline.js";
 export type {
   BaselineRow,
   BaselineScenario,
+  MitigatedBaselineConfig,
 } from "./baseline.js";
+
+// Mitigation-aware target wrapper (issue #565 slice 9).
+export { createMitigatedTarget } from "./mitigated-target.js";
+export type { MitigatedTargetConfig } from "./mitigated-target.js";

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -75,12 +75,12 @@ test("mitigated T3 ASR is lower than or equal to unmitigated (no-ACL) T3 ASR", a
   const { runBaseline } = await import("./baseline.js");
 
   // Run the mitigated scenario *without* the budget wrapper to get the
-  // unmitigated comparison point. Same fixture: ACL disabled, attacker
-  // namespace "other".
+  // unmitigated comparison point. ACL disabled, attacker queries namespace
+  // "victim" where ground truth lives, so unmitigated ASR is non-trivial.
   const unmitigatedRows = await runBaseline([{
     name: "T3-no-acl-unmitigated",
     attackerMode: "cross-namespace",
-    attackerNamespace: "other",
+    attackerNamespace: "victim",
     queryBudget: 200,
     seed: 303,
     groundTruth: SYNTHETIC_MEMORIES,
@@ -97,8 +97,58 @@ test("mitigated T3 ASR is lower than or equal to unmitigated (no-ACL) T3 ASR", a
   assert.ok(unmitigated, "unmitigated row should exist");
   assert.ok(mitigated, "mitigated row should exist");
 
+  // The unmitigated path should have non-trivial ASR (the attacker can
+  // actually retrieve victim memories when ACL is off and namespace matches).
+  assert.ok(
+    unmitigated.asr > 0,
+    `unmitigated ASR should be > 0 (got ${(unmitigated.asr * 100).toFixed(1)}%) — fixture may be misconfigured`,
+  );
+
   assert.ok(
     mitigated.asr <= unmitigated.asr + 0.01,
     `mitigated ASR (${(mitigated.asr * 100).toFixed(1)}%) should be <= unmitigated ASR (${(unmitigated.asr * 100).toFixed(1)}%)`,
+  );
+});
+
+test("createMitigatedTarget rejects invalid budget parameters", () => {
+  const rawTarget = createSyntheticTarget({
+    memories: SYNTHETIC_MEMORIES,
+    disclosesMemoryIds: true,
+  });
+
+  // NaN budgetHardLimit
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: NaN, principalNamespace: "default" }),
+    /budgetHardLimit must be a non-negative finite integer/,
+  );
+
+  // Negative budgetHardLimit
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: -1, principalNamespace: "default" }),
+    /budgetHardLimit must be a non-negative finite integer/,
+  );
+
+  // Non-integer budgetHardLimit
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 1.5, principalNamespace: "default" }),
+    /budgetHardLimit must be a non-negative finite integer/,
+  );
+
+  // Zero budgetWindowMs
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 5, budgetWindowMs: 0, principalNamespace: "default" }),
+    /budgetWindowMs must be a positive finite number/,
+  );
+
+  // Negative budgetWindowMs
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 5, budgetWindowMs: -100, principalNamespace: "default" }),
+    /budgetWindowMs must be a positive finite number/,
+  );
+
+  // Empty principalNamespace
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 5, principalNamespace: "" }),
+    /principalNamespace must be a non-empty string/,
   );
 });

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createSyntheticTarget,
+  SYNTHETIC_MEMORIES,
+  runExtractionAttack,
+  createSeededRng,
+} from "./index.js";
+import { createMitigatedTarget } from "./mitigated-target.js";
+import { runMitigatedBaseline } from "./baseline.js";
+
+test("createMitigatedTarget returns empty hits when budget is exceeded", async () => {
+  const rawTarget = createSyntheticTarget({
+    memories: SYNTHETIC_MEMORIES,
+    disclosesMemoryIds: true,
+  });
+
+  const mitigated = createMitigatedTarget({
+    target: rawTarget,
+    budgetHardLimit: 3,
+    budgetWindowMs: 60_000,
+    principalNamespace: "default",
+  });
+
+  // Same-namespace queries should not count against the budget.
+  for (let i = 0; i < 5; i++) {
+    const hits = await mitigated.recall("test", { namespace: "default" });
+    assert.ok(Array.isArray(hits), `same-ns query ${i} should return array`);
+  }
+
+  // Cross-namespace queries should exhaust the budget.
+  for (let i = 0; i < 3; i++) {
+    const hits = await mitigated.recall("test", { namespace: "other" });
+    assert.ok(Array.isArray(hits), `cross-ns query ${i} should return array`);
+  }
+
+  // 4th cross-namespace query should be denied (empty hits).
+  const denied = await mitigated.recall("test", { namespace: "other" });
+  assert.equal(denied.length, 0, "should return empty after budget exhausted");
+});
+
+test("createMitigatedTarget does not count undefined namespace against budget", async () => {
+  const rawTarget = createSyntheticTarget({
+    memories: SYNTHETIC_MEMORIES,
+    disclosesMemoryIds: true,
+  });
+
+  const mitigated = createMitigatedTarget({
+    target: rawTarget,
+    budgetHardLimit: 1,
+    budgetWindowMs: 60_000,
+    principalNamespace: "default",
+  });
+
+  // No namespace specified — should not count.
+  for (let i = 0; i < 5; i++) {
+    const hits = await mitigated.recall("test");
+    assert.ok(Array.isArray(hits), `no-ns query ${i} should work`);
+  }
+});
+
+test("runMitigatedBaseline returns mitigated rows", async () => {
+  const rows = await runMitigatedBaseline();
+  assert.ok(rows.length > 0, "should return at least one row");
+  for (const row of rows) {
+    assert.equal(row.mitigated, true);
+    assert.ok(typeof row.asr === "number");
+    assert.ok(row.asr >= 0 && row.asr <= 1);
+  }
+});
+
+test("mitigated T3 ASR is lower than or equal to unmitigated T3 ASR", async () => {
+  const { runBaseline, DEFAULT_BASELINE_SCENARIOS } = await import("./baseline.js");
+
+  const baselineRows = await runBaseline(DEFAULT_BASELINE_SCENARIOS);
+  const mitigatedRows = await runMitigatedBaseline();
+
+  const t3Baseline = baselineRows.find((r) => r.scenario === "T3-cross-namespace-acl-enforced");
+  const t3Mitigated = mitigatedRows.find((r) => r.scenario === "T3-cross-namespace-budget-hard30");
+
+  assert.ok(t3Baseline, "T3 baseline should exist");
+  assert.ok(t3Mitigated, "T3 mitigated should exist");
+
+  assert.ok(
+    t3Mitigated.asr <= t3Baseline.asr + 0.01,
+    `mitigated ASR (${(t3Mitigated.asr * 100).toFixed(1)}%) should be <= baseline ASR (${(t3Baseline.asr * 100).toFixed(1)}%)`,
+  );
+});

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -11,8 +11,15 @@ import { createMitigatedTarget } from "./mitigated-target.js";
 import { runMitigatedBaseline } from "./baseline.js";
 
 test("createMitigatedTarget returns empty hits when budget is exceeded", async () => {
+  // Use namespace-less memories so the synthetic target doesn't filter them
+  // out by namespace. SYNTHETIC_MEMORIES live in namespace "victim" and would
+  // be excluded when querying "other" (Cursor review: vacuous test).
+  const testMemories = [
+    { id: "tm-1", content: "alpha beta gamma", category: "fact", tokens: ["alpha", "beta", "gamma"] },
+    { id: "tm-2", content: "delta epsilon zeta", category: "fact", tokens: ["delta", "epsilon", "zeta"] },
+  ];
   const rawTarget = createSyntheticTarget({
-    memories: SYNTHETIC_MEMORIES,
+    memories: testMemories,
     disclosesMemoryIds: true,
   });
 
@@ -29,14 +36,15 @@ test("createMitigatedTarget returns empty hits when budget is exceeded", async (
     assert.ok(Array.isArray(hits), `same-ns query ${i} should return array`);
   }
 
-  // Cross-namespace queries should exhaust the budget.
+  // Cross-namespace queries should exhaust the budget and still return hits
+  // (the raw target has no namespace filter for these memories).
   for (let i = 0; i < 3; i++) {
-    const hits = await mitigated.recall("test", { namespace: "other" });
+    const hits = await mitigated.recall("alpha", { namespace: "other" });
     assert.ok(Array.isArray(hits), `cross-ns query ${i} should return array`);
   }
 
-  // 4th cross-namespace query should be denied (empty hits).
-  const denied = await mitigated.recall("test", { namespace: "other" });
+  // 4th cross-namespace query should be denied (empty hits from budget).
+  const denied = await mitigated.recall("delta", { namespace: "other" });
   assert.equal(denied.length, 0, "should return empty after budget exhausted");
 });
 

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -48,7 +48,7 @@ test("createMitigatedTarget returns empty hits when budget is exceeded", async (
   assert.equal(denied.length, 0, "should return empty after budget exhausted");
 });
 
-test("createMitigatedTarget does not count undefined namespace against budget", async () => {
+test("createMitigatedTarget treats missing namespace as budget-eligible (fail-closed)", async () => {
   const rawTarget = createSyntheticTarget({
     memories: SYNTHETIC_MEMORIES,
     disclosesMemoryIds: true,
@@ -61,11 +61,13 @@ test("createMitigatedTarget does not count undefined namespace against budget", 
     principalNamespace: "default",
   });
 
-  // No namespace specified — should not count.
-  for (let i = 0; i < 5; i++) {
-    const hits = await mitigated.recall("test");
-    assert.ok(Array.isArray(hits), `no-ns query ${i} should work`);
-  }
+  // No namespace specified — should count against budget (fail-closed).
+  const firstHit = await mitigated.recall("test");
+  assert.ok(Array.isArray(firstHit), "first query should return array");
+
+  // Second query without namespace should be denied — budget exhausted.
+  const denied = await mitigated.recall("test");
+  assert.equal(denied.length, 0, "should return empty after budget exhausted with no namespace");
 });
 
 test("runMitigatedBaseline returns mitigated rows", async () => {

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -11,12 +11,13 @@ import { createMitigatedTarget } from "./mitigated-target.js";
 import { runMitigatedBaseline } from "./baseline.js";
 
 test("createMitigatedTarget returns empty hits when budget is exceeded", async () => {
-  // Use namespace-less memories so the synthetic target doesn't filter them
-  // out by namespace. SYNTHETIC_MEMORIES live in namespace "victim" and would
-  // be excluded when querying "other" (Cursor review: vacuous test).
+  // Memories in namespace "other" so cross-namespace queries retrieve actual
+  // hits. Same-namespace queries (namespace "default") return empty from the
+  // synthetic target's namespace filter, which is fine — the test only needs
+  // to verify budget accounting, not recall result content.
   const testMemories = [
-    { id: "tm-1", content: "alpha beta gamma", category: "fact", tokens: ["alpha", "beta", "gamma"] },
-    { id: "tm-2", content: "delta epsilon zeta", category: "fact", tokens: ["delta", "epsilon", "zeta"] },
+    { id: "tm-1", content: "alpha beta gamma", category: "fact", tokens: ["alpha", "beta", "gamma"], namespace: "other" },
+    { id: "tm-2", content: "delta epsilon zeta", category: "fact", tokens: ["delta", "epsilon", "zeta"], namespace: "other" },
   ];
   const rawTarget = createSyntheticTarget({
     memories: testMemories,
@@ -61,12 +62,14 @@ test("createMitigatedTarget treats missing namespace as budget-eligible (fail-cl
     principalNamespace: "default",
   });
 
-  // No namespace specified — should count against budget (fail-closed).
-  const firstHit = await mitigated.recall("test");
+  // Query with a token that actually exists in SYNTHETIC_MEMORIES so the
+  // first recall returns non-empty hits — proving the raw target works.
+  const firstHit = await mitigated.recall("Alex");
   assert.ok(Array.isArray(firstHit), "first query should return array");
+  assert.ok(firstHit.length > 0, "first query should return at least one hit");
 
   // Second query without namespace should be denied — budget exhausted.
-  const denied = await mitigated.recall("test");
+  const denied = await mitigated.recall("Alex");
   assert.equal(denied.length, 0, "should return empty after budget exhausted with no namespace");
 });
 

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -38,10 +38,11 @@ test("createMitigatedTarget returns empty hits when budget is exceeded", async (
   }
 
   // Cross-namespace queries should exhaust the budget and still return hits
-  // (the raw target has no namespace filter for these memories).
+  // (the raw target returns matches from namespace "other").
   for (let i = 0; i < 3; i++) {
     const hits = await mitigated.recall("alpha", { namespace: "other" });
     assert.ok(Array.isArray(hits), `cross-ns query ${i} should return array`);
+    assert.ok(hits.length > 0, `cross-ns query ${i} should return non-empty hits before budget exhausted`);
   }
 
   // 4th cross-namespace query should be denied (empty hits from budget).

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -132,19 +132,25 @@ test("createMitigatedTarget rejects invalid budget parameters", () => {
   // NaN budgetHardLimit
   assert.throws(
     () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: NaN, principalNamespace: "default" }),
-    /budgetHardLimit must be a non-negative finite integer/,
+    /budgetHardLimit must be a positive integer/,
   );
 
   // Negative budgetHardLimit
   assert.throws(
     () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: -1, principalNamespace: "default" }),
-    /budgetHardLimit must be a non-negative finite integer/,
+    /budgetHardLimit must be a positive integer/,
+  );
+
+  // Zero budgetHardLimit
+  assert.throws(
+    () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 0, principalNamespace: "default" }),
+    /budgetHardLimit must be a positive integer/,
   );
 
   // Non-integer budgetHardLimit
   assert.throws(
     () => createMitigatedTarget({ target: rawTarget, budgetHardLimit: 1.5, principalNamespace: "default" }),
-    /budgetHardLimit must be a non-negative finite integer/,
+    /budgetHardLimit must be a positive integer/,
   );
 
   // Zero budgetWindowMs

--- a/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.test.ts
@@ -70,20 +70,35 @@ test("runMitigatedBaseline returns mitigated rows", async () => {
   }
 });
 
-test("mitigated T3 ASR is lower than or equal to unmitigated T3 ASR", async () => {
-  const { runBaseline, DEFAULT_BASELINE_SCENARIOS } = await import("./baseline.js");
+test("mitigated T3 ASR is lower than or equal to unmitigated (no-ACL) T3 ASR", async () => {
+  const { SYNTHETIC_MEMORIES, OTHER_NAMESPACE_MEMORIES } = await import("./fixture.js");
+  const { runBaseline } = await import("./baseline.js");
 
-  const baselineRows = await runBaseline(DEFAULT_BASELINE_SCENARIOS);
+  // Run the mitigated scenario *without* the budget wrapper to get the
+  // unmitigated comparison point. Same fixture: ACL disabled, attacker
+  // namespace "other".
+  const unmitigatedRows = await runBaseline([{
+    name: "T3-no-acl-unmitigated",
+    attackerMode: "cross-namespace",
+    attackerNamespace: "other",
+    queryBudget: 200,
+    seed: 303,
+    groundTruth: SYNTHETIC_MEMORIES,
+    targetMemories: [...SYNTHETIC_MEMORIES, ...OTHER_NAMESPACE_MEMORIES],
+    entities: [],
+    enforceNamespaceAcl: false,
+    disclosesMemoryIds: true,
+  }]);
   const mitigatedRows = await runMitigatedBaseline();
 
-  const t3Baseline = baselineRows.find((r) => r.scenario === "T3-cross-namespace-acl-enforced");
-  const t3Mitigated = mitigatedRows.find((r) => r.scenario === "T3-cross-namespace-budget-hard30");
+  const unmitigated = unmitigatedRows[0];
+  const mitigated = mitigatedRows[0];
 
-  assert.ok(t3Baseline, "T3 baseline should exist");
-  assert.ok(t3Mitigated, "T3 mitigated should exist");
+  assert.ok(unmitigated, "unmitigated row should exist");
+  assert.ok(mitigated, "mitigated row should exist");
 
   assert.ok(
-    t3Mitigated.asr <= t3Baseline.asr + 0.01,
-    `mitigated ASR (${(t3Mitigated.asr * 100).toFixed(1)}%) should be <= baseline ASR (${(t3Baseline.asr * 100).toFixed(1)}%)`,
+    mitigated.asr <= unmitigated.asr + 0.01,
+    `mitigated ASR (${(mitigated.asr * 100).toFixed(1)}%) should be <= unmitigated ASR (${(unmitigated.asr * 100).toFixed(1)}%)`,
   );
 });

--- a/packages/bench/src/security/extraction-attack/mitigated-target.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.ts
@@ -55,9 +55,9 @@ export function createMitigatedTarget(
 
   // Validate budget parameters to prevent silent enforcement skew from
   // NaN, negative, or non-integer inputs (Codex P2 review feedback).
-  if (!Number.isFinite(budgetHardLimit) || budgetHardLimit < 0 || !Number.isInteger(budgetHardLimit)) {
+  if (!Number.isFinite(budgetHardLimit) || budgetHardLimit < 1 || !Number.isInteger(budgetHardLimit)) {
     throw new Error(
-      `createMitigatedTarget: budgetHardLimit must be a non-negative finite integer, got ${budgetHardLimit}`,
+      `createMitigatedTarget: budgetHardLimit must be a positive integer, got ${budgetHardLimit}`,
     );
   }
   if (!Number.isFinite(budgetWindowMs) || budgetWindowMs <= 0) {

--- a/packages/bench/src/security/extraction-attack/mitigated-target.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.ts
@@ -91,12 +91,15 @@ export function createMitigatedTarget(
       options?: AttackRecallOptions,
     ): Promise<AttackRetrievalHit[]> {
       const queryNs = options?.namespace;
-      const isCrossNamespace =
+      // Fail-closed: queries without an explicit namespace are treated as
+      // cross-namespace (count against the budget), matching the core
+      // CrossNamespaceBudget behavior for missing namespaces.
+      const isSameNamespace =
         typeof queryNs === "string" &&
         queryNs.length > 0 &&
-        queryNs !== principalNamespace;
+        queryNs === principalNamespace;
 
-      if (isCrossNamespace) {
+      if (!isSameNamespace) {
         const allowed = recordAndCheck(Date.now());
         if (!allowed) {
           return [];

--- a/packages/bench/src/security/extraction-attack/mitigated-target.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.ts
@@ -53,6 +53,24 @@ export function createMitigatedTarget(
     principalNamespace,
   } = config;
 
+  // Validate budget parameters to prevent silent enforcement skew from
+  // NaN, negative, or non-integer inputs (Codex P2 review feedback).
+  if (!Number.isFinite(budgetHardLimit) || budgetHardLimit < 0 || !Number.isInteger(budgetHardLimit)) {
+    throw new Error(
+      `createMitigatedTarget: budgetHardLimit must be a non-negative finite integer, got ${budgetHardLimit}`,
+    );
+  }
+  if (!Number.isFinite(budgetWindowMs) || budgetWindowMs <= 0) {
+    throw new Error(
+      `createMitigatedTarget: budgetWindowMs must be a positive finite number, got ${budgetWindowMs}`,
+    );
+  }
+  if (typeof principalNamespace !== "string" || principalNamespace.length === 0) {
+    throw new Error(
+      "createMitigatedTarget: principalNamespace must be a non-empty string",
+    );
+  }
+
   const timestamps: TimestampEntry[] = [];
 
   function recordAndCheck(now: number): boolean {

--- a/packages/bench/src/security/extraction-attack/mitigated-target.ts
+++ b/packages/bench/src/security/extraction-attack/mitigated-target.ts
@@ -1,0 +1,99 @@
+/**
+ * Mitigation-aware target wrapper for the ADAM extraction attack harness.
+ *
+ * Wraps a raw `ExtractionAttackTarget` and enforces:
+ * 1. Cross-namespace query budget (mirrors `CrossNamespaceBudget` from core)
+ * 2. Namespace ACL (carries forward from `createSyntheticTarget`)
+ *
+ * When the budget is exceeded, the wrapper returns empty hits instead of
+ * forwarding the query — simulating the real recall-path denial. This lets
+ * the harness re-measure ASR with mitigations active and compare against
+ * the unmitigated baseline.
+ */
+
+import type { AttackRecallOptions, AttackRetrievalHit, ExtractionAttackTarget } from "./types.js";
+
+export interface MitigatedTargetConfig {
+  /** Inner (unmitigated) target to wrap. */
+  target: ExtractionAttackTarget;
+  /**
+   * Maximum cross-namespace queries per `budgetWindowMs` window.
+   * Queries beyond this limit return empty hits.
+   */
+  budgetHardLimit: number;
+  /**
+   * Rolling window in ms for the budget counter. Defaults to 60_000.
+   */
+  budgetWindowMs?: number;
+  /**
+   * The principal's "home" namespace. Queries targeting a different
+   * namespace count against the budget; same-namespace queries are free.
+   */
+  principalNamespace: string;
+}
+
+interface TimestampEntry {
+  ts: number;
+}
+
+/**
+ * Creates a mitigation-aware wrapper around a raw target.
+ *
+ * The wrapper tracks cross-namespace queries in a sliding window and
+ * returns empty hits when the budget is exceeded. Same-namespace queries
+ * pass through without counting.
+ */
+export function createMitigatedTarget(
+  config: MitigatedTargetConfig,
+): ExtractionAttackTarget {
+  const {
+    target,
+    budgetHardLimit,
+    budgetWindowMs = 60_000,
+    principalNamespace,
+  } = config;
+
+  const timestamps: TimestampEntry[] = [];
+
+  function recordAndCheck(now: number): boolean {
+    const cutoff = now - budgetWindowMs;
+    while (timestamps.length > 0 && timestamps[0].ts < cutoff) {
+      timestamps.shift();
+    }
+    if (timestamps.length >= budgetHardLimit) {
+      return false;
+    }
+    timestamps.push({ ts: now });
+    return true;
+  }
+
+  return {
+    async recall(
+      query: string,
+      options?: AttackRecallOptions,
+    ): Promise<AttackRetrievalHit[]> {
+      const queryNs = options?.namespace;
+      const isCrossNamespace =
+        typeof queryNs === "string" &&
+        queryNs.length > 0 &&
+        queryNs !== principalNamespace;
+
+      if (isCrossNamespace) {
+        const allowed = recordAndCheck(Date.now());
+        if (!allowed) {
+          return [];
+        }
+      }
+
+      return target.recall(query, options);
+    },
+
+    listEntities: target.listEntities
+      ? async () => target.listEntities!()
+      : undefined,
+
+    lastRecallIds: target.lastRecallIds
+      ? async () => target.lastRecallIds!()
+      : undefined,
+  };
+}


### PR DESCRIPTION
## Summary
- Adds `createMitigatedTarget()` — a wrapper around any ADAM target that enforces cross-namespace query budgets
- Adds `runMitigatedBaseline()` + `MITIGATED_BASELINE_SCENARIOS` for re-measuring ASR with mitigations
- Budget is enforced in a sliding window; exceeded queries return empty hits (mirrors real recall denial)
- Tests confirm mitigated T3 ASR <= unmitigated T3 ASR

## Test plan
- [x] `node --import tsx --test packages/bench/src/security/extraction-attack/mitigated-target.test.ts` — 4/4 pass
- [x] Existing harness tests still pass (17/17)
- [x] Key assertion: mitigated ASR <= baseline ASR

Closes part of #565 (mitigation wiring — slice 9 of N)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect the security benchmark harness and baseline scenario configuration, so mistakes could skew mitigation efficacy measurements even though no production read-path code is modified.
> 
> **Overview**
> Adds `createMitigatedTarget()` to wrap an `ExtractionAttackTarget` with a sliding-window *cross-namespace query budget* that returns empty hits once exceeded (and treats missing namespaces as budget-eligible), including parameter validation.
> 
> Extends the benchmark harness with `MITIGATED_BASELINE_SCENARIOS` and `runMitigatedBaseline()` to re-measure ASR with the budget mitigation enabled (tagging results via `BaselineRow.mitigated`), and re-exports these APIs from `index.ts`.
> 
> Introduces `mitigated-target.test.ts` covering budget behavior (same-namespace free, cross-namespace capped, fail-closed), invalid config rejection, and an assertion that mitigated T3 ASR is <= an unmitigated no-ACL comparison run.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d02cafb9313695d00e2fcde3515aeffac0daf24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->