### PR TITLE
docs(security): update threat model with mitigation wiring status (issue #565)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
-
 ### Added
 
 - **Security mitigation wiring** (issue #565). CrossNamespaceBudget and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,13 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 ### Added
 
-- **Security mitigation wiring** (issue #565). CrossNamespaceBudget and
-  AccessAuditAdapter wired into the access-service recall path. Both ship
-  disabled by default (`recallCrossNamespaceBudgetEnabled`,
-  `recallAuditAnomalyDetectionEnabled`). `remnic doctor` warns when
-  mitigations are off. Mitigation-aware ADAM bench target added.
+- **Security mitigation wiring docs** (issue #565). Threat-model §10
+  documents the wiring status of PRs #649–#652. `AccessAuditAdapter`
+  recall-path wiring (#650) and `remnic doctor` security-mitigation check
+  (#651) are merged. `CrossNamespaceBudget` recall-path wiring (#649)
+  and mitigation-aware ADAM baseline (#652) are still open. Both
+  mitigations ship disabled by default (`recallCrossNamespaceBudgetEnabled`,
+  `recallAuditAnomalyDetectionEnabled`).
 
 - **Contradiction-detection bench scenario** (issue #647). Synthetic
   benchmark at `packages/bench/src/benchmarks/remnic/contradiction-detection/`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 
+- **Security mitigation wiring** (issue #565). CrossNamespaceBudget and
+  AccessAuditAdapter wired into the access-service recall path. Both ship
+  disabled by default (`recallCrossNamespaceBudgetEnabled`,
+  `recallAuditAnomalyDetectionEnabled`). `remnic doctor` warns when
+  mitigations are off. Mitigation-aware ADAM bench target added.
+
 - **Contradiction-detection bench scenario** (issue #647). Synthetic
   benchmark at `packages/bench/src/benchmarks/remnic/contradiction-detection/`
   with 4 fixture classes (true-contradiction, near-paraphrase,

--- a/docs/security/memory-extraction-threat-model.md
+++ b/docs/security/memory-extraction-threat-model.md
@@ -358,10 +358,10 @@ The mitigated baseline (PR #652, still open as of this writing) re-runs
 the T3 scenario with a cross-namespace budget of 30 queries per 60-second
 window:
 
-| Scenario | Budget | ASR |
-|---|---:|---:|
-| T3 unmitigated (baseline) | 200 | 0.0% (ACL enforced) |
-| T3 mitigated (budget=30) | 200 | 0.0% (ACL + budget) |
+| Scenario | Queries | Budget limit | ASR |
+|---|---:|---:|---|
+| T3 unmitigated (baseline) | 200 | none | 0.0% (ACL enforced) |
+| T3 mitigated (budget=30/60s) | 200 | 30/60s | 0.0% (ACL + budget) |
 
 The T3 ASR was already 0.0% in the baseline because the synthetic
 target enforces namespace ACLs. The budget mitigation provides defense

--- a/docs/security/memory-extraction-threat-model.md
+++ b/docs/security/memory-extraction-threat-model.md
@@ -331,24 +331,32 @@ PRs #638 and #639 introduced the `CrossNamespaceBudget` and
 `AccessAuditAdapter` classes, but they were not wired into the actual
 recall paths. PRs #649–#652 close this gap:
 
-| PR | Slice | Change |
-|---|---|---|
-| #649 | 6 | Wire `CrossNamespaceBudget` into `EngramAccessService.recall()` |
-| #650 | 7 | Wire `AccessAuditAdapter` into `EngramAccessService.recall()` |
-| #651 | 8 | Add `security_mitigations` check to `remnic doctor` |
-| #652 | 9 | Mitigation-aware ADAM target + mitigated baseline |
+| PR | Slice | Change | Status |
+|---|---|---|---|
+| #649 | 6 | Wire `CrossNamespaceBudget` into `EngramAccessService.recall()` | **Open** |
+| #650 | 7 | Wire `AccessAuditAdapter` into `EngramAccessService.recall()` | **Merged** |
+| #651 | 8 | Add `security_mitigations` check to `remnic doctor` | **Merged** |
+| #652 | 9 | Mitigation-aware ADAM target + mitigated baseline | **Open** |
+
+As of this writing, slices 7 and 8 (PRs #650, #651) are merged to
+`main`. Slices 6 and 9 (PRs #649, #652) are still open. Once #649
+lands, `CrossNamespaceBudget` will be invoked inside
+`EngramAccessService.recall()` alongside the already-wired
+`AccessAuditAdapter`.
 
 Both mitigations ship **disabled by default** (rule 48):
 - `recallCrossNamespaceBudgetEnabled: false`
 - `recallAuditAnomalyDetectionEnabled: false`
 
 Operators enable them explicitly in config. The `remnic doctor` command
-warns when both are disabled.
+(wired in PR #651 via `summarizeSecurityMitigations` in
+`operator-toolkit.ts`) warns when both are disabled.
 
-### Mitigated baseline ASR
+### Mitigated baseline ASR (PR #652, pending merge)
 
-The mitigated baseline (PR #652) re-runs the T3 scenario with a
-cross-namespace budget of 30 queries per 60-second window:
+The mitigated baseline (PR #652, still open as of this writing) re-runs
+the T3 scenario with a cross-namespace budget of 30 queries per 60-second
+window:
 
 | Scenario | Budget | ASR |
 |---|---:|---:|

--- a/docs/security/memory-extraction-threat-model.md
+++ b/docs/security/memory-extraction-threat-model.md
@@ -325,7 +325,42 @@ Secondary metrics:
   concern and will be tracked separately if/when it materializes in the
   harness.
 
-## 10. References
+## 10. Mitigation wiring status (PRs #649–#652)
+
+PRs #638 and #639 introduced the `CrossNamespaceBudget` and
+`AccessAuditAdapter` classes, but they were not wired into the actual
+recall paths. PRs #649–#652 close this gap:
+
+| PR | Slice | Change |
+|---|---|---|
+| #649 | 6 | Wire `CrossNamespaceBudget` into `EngramAccessService.recall()` |
+| #650 | 7 | Wire `AccessAuditAdapter` into `EngramAccessService.recall()` |
+| #651 | 8 | Add `security_mitigations` check to `remnic doctor` |
+| #652 | 9 | Mitigation-aware ADAM target + mitigated baseline |
+
+Both mitigations ship **disabled by default** (rule 48):
+- `recallCrossNamespaceBudgetEnabled: false`
+- `recallAuditAnomalyDetectionEnabled: false`
+
+Operators enable them explicitly in config. The `remnic doctor` command
+warns when both are disabled.
+
+### Mitigated baseline ASR
+
+The mitigated baseline (PR #652) re-runs the T3 scenario with a
+cross-namespace budget of 30 queries per 60-second window:
+
+| Scenario | Budget | ASR |
+|---|---:|---:|
+| T3 unmitigated (baseline) | 200 | 0.0% (ACL enforced) |
+| T3 mitigated (budget=30) | 200 | 0.0% (ACL + budget) |
+
+The T3 ASR was already 0.0% in the baseline because the synthetic
+target enforces namespace ACLs. The budget mitigation provides defense
+in depth — it would throttle a regression that accidentally disabled
+the ACL check.
+
+## 11. References
 
 - Issue #565 (this work).
 - ADAM — *Adaptive Data Extraction Attack*, arXiv:2604.09747 (Apr 2026).


### PR DESCRIPTION
## Summary
- Updates `docs/security/memory-extraction-threat-model.md` with new §10: mitigation wiring status
- Documents PRs #649–#652 (budget wiring, audit wiring, doctor check, mitigated baseline)
- Adds mitigated baseline ASR numbers
- CHANGELOG entry for the mitigation wiring work

Closes #565

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates (threat model + changelog) with no runtime, security-enforcement, or data-path changes.
> 
> **Overview**
> Updates security documentation to **explicitly track mitigation wiring progress** for issue #565 by adding a new threat-model section summarizing PRs #649–#652 (what’s wired vs still open), default-disabled config flags, and a note about `remnic doctor` warnings.
> 
> Adds a matching `CHANGELOG.md` entry pointing reviewers/operators to the new threat-model §10 and the current merge status of the recall-path audit/budget mitigations and the pending mitigated-baseline work.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21d7f54733ee2e45b57c01b9cfadc22427591c73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->