### PR TITLE
docs: add issue #565 security config to README + config reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -933,6 +933,8 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 | `procedural.enabled` | `true` | **Procedural memory (issue #519):** master gate for procedure extraction, task-init recall injection, and trajectory mining. Default-on since issue #567 PR 4/5; set nested `procedural: { "enabled": false }` to opt out (see [Procedural memory](docs/procedural-memory.md)). |
 | `codingMode.projectScope` | `true` | **Coding agent mode (issue #569):** auto-scope memory to the git project (stable origin-URL hash, falls back to root path). Set to `false` to disable project-based namespace isolation. See [Coding agent mode](docs/coding-agent.md). |
 | `codingMode.branchScope` | `false` | **Coding agent mode (issue #569):** additionally scope writes to the current git branch; reads fall back to the project-level namespace so project memories stay visible from any branch while branch writes don't leak. Enable for per-branch experimentation. |
+| `recallCrossNamespaceBudgetEnabled` | `false` | **Cross-namespace budget (issue #565):** per-principal sliding-window rate limiter. Throttles principals issuing bursts of cross-namespace recalls; soft limit emits a warning, hard limit denies the query. See [Threat model](docs/security/memory-extraction-threat-model.md). |
+| `recallAuditAnomalyDetectionEnabled` | `false` | **Recall audit anomaly detection (issue #565):** flag suspicious query patterns (repeat queries, namespace walks, high-cardinality entity probes, rapid-fire). Anomalies are surfaced in recall responses. See [Threat model](docs/security/memory-extraction-threat-model.md). |
 
 **[See the full config reference for all 60+ settings](docs/config-reference.md)** including search backend configuration, namespace policies, Memory OS features, governance, evaluation harness, trust zones, causal trajectories, and more.
 
@@ -976,6 +978,8 @@ All settings live in `openclaw.json` under `plugins.entries.openclaw-engram.conf
 - [Coding agent mode](docs/coding-agent.md) — Auto-scope memory to git project / branch, review-context recall, `set_coding_context` MCP tool (issue #569)
 - [Recall X-ray](docs/xray.md) — `remnic xray` CLI, HTTP endpoint, MCP tool for per-result retrieval attribution (issue #570)
 - [Memory importers](docs/importers.md) — Bring memory from ChatGPT, Claude, Gemini, and mem0 (issue #568)
+- [Memory Extraction Threat Model](docs/security/memory-extraction-threat-model.md) — ADAM attack analysis, attacker tiers, and mitigation wiring (issue #565)
+- [ADAM Baseline 2026-04](docs/security/adam-baseline-2026-04.md) — Reproducible ASR measurements per attacker tier
 
 ## Contributing
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -982,6 +982,35 @@ Stored as `category: procedure` markdown under `memoryDir/procedures/`. Narrativ
 | Setting | Default | Description |
 |---------|---------|-------------|
 | `memoryExtensionsEnabled` | `true` | Enable third-party memory extension discovery |
+
+## Cross-namespace Query Budget (issue #565)
+
+Per-principal sliding-window rate limiter for cross-namespace recall queries.
+When enabled, principals issuing bursts of recalls against namespaces other than
+their own are throttled: soft limit emits a warning, hard limit denies the query.
+See [Threat model](security/memory-extraction-threat-model.md).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `recallCrossNamespaceBudgetEnabled` | `false` | Enable per-principal cross-namespace recall budget |
+| `recallCrossNamespaceBudgetWindowMs` | `60000` | Sliding window duration in milliseconds |
+| `recallCrossNamespaceBudgetSoftLimit` | `10` | Queries per window that trigger a warning (still allowed) |
+| `recallCrossNamespaceBudgetHardLimit` | `30` | Queries per window that trigger a denial |
+
+## Recall Audit Anomaly Detection (issue #565)
+
+Anomaly detection on the recall audit trail. Flags suspicious query patterns
+(repeat queries, namespace walks, high-cardinality entity probes, rapid-fire)
+in recall responses. See [Threat model](security/memory-extraction-threat-model.md).
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `recallAuditAnomalyDetectionEnabled` | `false` | Enable anomaly detection on recall audit trail |
+| `recallAuditAnomalyWindowMs` | `300000` | Sliding window for anomaly detectors (5 min) |
+| `recallAuditAnomalyRepeatQueryLimit` | `5` | Max identical queries before repeat-query flag |
+| `recallAuditAnomalyNamespaceWalkLimit` | `3` | Max distinct namespaces before namespace-walk flag |
+| `recallAuditAnomalyHighCardinalityLimit` | `50` | Max distinct queries before high-cardinality flag |
+| `recallAuditAnomalyRapidFireLimit` | `30` | Max queries in window before rapid-fire flag |
 | `memoryExtensionsRoot` | `""` | Override memory extensions root directory |
 
 

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -1009,7 +1009,7 @@ in recall responses. See [Threat model](security/memory-extraction-threat-model.
 | `recallAuditAnomalyWindowMs` | `300000` | Sliding window for anomaly detectors (5 min) |
 | `recallAuditAnomalyRepeatQueryLimit` | `5` | Max identical queries before repeat-query flag |
 | `recallAuditAnomalyNamespaceWalkLimit` | `3` | Max distinct namespaces before namespace-walk flag |
-| `recallAuditAnomalyHighCardinalityLimit` | `50` | Max distinct queries before high-cardinality flag |
+| `recallAuditAnomalyHighCardinalityLimit` | `50` | Max candidate memory IDs in a single recall response before high-cardinality flag |
 | `recallAuditAnomalyRapidFireLimit` | `30` | Max queries in window before rapid-fire flag |
 | `memoryExtensionsRoot` | `""` | Override memory extensions root directory |
 


### PR DESCRIPTION
## Summary
- Add CrossNamespaceBudget and AccessAuditAdapter entries to README Configuration table
- Add full config reference sections for all 10 new security settings
- Link threat model and ADAM baseline docs from README Documentation section

## Test plan
- [x] `grep -c "recallCrossNamespaceBudgetEnabled" README.md docs/config-reference.md` — 1 in each
- [x] `grep -c "recallAuditAnomalyDetectionEnabled" README.md docs/config-reference.md` — 1 in each
- [x] `grep "memory-extraction-threat-model" README.md` — 3 matches (config + docs section)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only updates that don’t change runtime behavior; primary risk is mis-documenting defaults or setting semantics.
> 
> **Overview**
> Documents the new issue #565 recall security controls by adding `recallCrossNamespaceBudgetEnabled` and `recallAuditAnomalyDetectionEnabled` to the README’s configuration table, plus links to the threat model and ADAM baseline docs.
> 
> Expands `docs/config-reference.md` with full sections for the cross-namespace recall rate limiter and recall-audit anomaly detection, including all associated tuning knobs (windows and soft/hard thresholds/limits).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 911d50dead40e1ed2a5940de12d207ca9a61ef30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->