### PR TITLE
feat(bench): re-enable LCM with episode-level draining

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -318,12 +318,15 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       async drain(): Promise<void> {
         const DRAIN_TIMEOUT_MS = 5 * 60_000;
         const engine = getEngine();
-        await Promise.race([
-          engine.waitForObserveQueueIdle(),
-          new Promise<void>((_, reject) =>
-            setTimeout(() => reject(new Error("drain() timed out after 5 minutes")), DRAIN_TIMEOUT_MS),
-          ),
-        ]);
+        let timer: ReturnType<typeof setTimeout> | undefined;
+        const timeout = new Promise<void>((_, reject) => {
+          timer = setTimeout(() => reject(new Error("drain() timed out after 5 minutes")), DRAIN_TIMEOUT_MS);
+        });
+        try {
+          await Promise.race([engine.waitForObserveQueueIdle(), timeout]);
+        } finally {
+          clearTimeout(timer);
+        }
       },
 
       async getStats(sessionId?: string): Promise<MemoryStats> {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -315,6 +315,13 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         await rebuild();
       },
 
+      async drain(): Promise<void> {
+        const engine = state.orchestrator.lcmEngine;
+        if (engine && typeof (engine as any).waitForObserveQueueIdle === "function") {
+          await (engine as any).waitForObserveQueueIdle();
+        }
+      },
+
       async getStats(sessionId?: string): Promise<MemoryStats> {
         return getEngine().getStats(sessionId);
       },

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -318,12 +318,22 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       async drain(): Promise<void> {
         const DRAIN_TIMEOUT_MS = 5 * 60_000;
         const engine = getEngine();
+        const abortController = new AbortController();
         let timer: ReturnType<typeof setTimeout> | undefined;
         const timeout = new Promise<void>((_, reject) => {
-          timer = setTimeout(() => reject(new Error("drain() timed out after 5 minutes")), DRAIN_TIMEOUT_MS);
+          timer = setTimeout(() => {
+            abortController.abort();
+            reject(new Error("drain() timed out after 5 minutes"));
+          }, DRAIN_TIMEOUT_MS);
         });
         try {
-          await Promise.race([engine.waitForObserveQueueIdle(), timeout]);
+          await Promise.race([
+            engine.waitForObserveQueueIdle().catch((err: unknown) => {
+              if (abortController.signal.aborted) return;
+              throw err;
+            }),
+            timeout,
+          ]);
         } finally {
           clearTimeout(timer);
         }

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -316,10 +316,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       },
 
       async drain(): Promise<void> {
-        const engine = state.orchestrator.lcmEngine;
-        if (engine && typeof (engine as any).waitForObserveQueueIdle === "function") {
-          await (engine as any).waitForObserveQueueIdle();
-        }
+        await getEngine().waitForObserveQueueIdle();
       },
 
       async getStats(sessionId?: string): Promise<MemoryStats> {

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -316,7 +316,14 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
       },
 
       async drain(): Promise<void> {
-        await getEngine().waitForObserveQueueIdle();
+        const DRAIN_TIMEOUT_MS = 5 * 60_000;
+        const engine = getEngine();
+        await Promise.race([
+          engine.waitForObserveQueueIdle(),
+          new Promise<void>((_, reject) =>
+            setTimeout(() => reject(new Error("drain() timed out after 5 minutes")), DRAIN_TIMEOUT_MS),
+          ),
+        ]);
       },
 
       async getStats(sessionId?: string): Promise<MemoryStats> {

--- a/packages/bench/src/adapters/types.ts
+++ b/packages/bench/src/adapters/types.ts
@@ -60,6 +60,8 @@ export interface BenchMemoryAdapter {
   search(query: string, limit: number, sessionId?: string): Promise<SearchResult[]>;
   reset(sessionId?: string): Promise<void>;
   getStats(sessionId?: string): Promise<MemoryStats>;
+  /** Wait for background summarization (e.g. LCM) to finish after store(). */
+  drain?(): Promise<void>;
   destroy(): Promise<void>;
   responder?: BenchResponder;
   judge?: BenchJudge;

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -65,6 +65,8 @@ export async function runAmaBenchBenchmark(
       await options.system.store(sessionId, messages.slice(index, index + 50));
     }
 
+    await options.system.drain?.();
+
     for (const qa of episode.qa_pairs) {
       try {
         const { result: recalledText, durationMs } = await timed(async () =>

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -65,7 +65,11 @@ export async function runAmaBenchBenchmark(
       await options.system.store(sessionId, messages.slice(index, index + 50));
     }
 
-    await options.system.drain?.();
+    try {
+      await options.system.drain?.();
+    } catch (drainErr) {
+      console.error(`  [WARN] ama-bench drain failed for episode ${episode.episode_id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    }
 
     for (const qa of episode.qa_pairs) {
       try {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -94,6 +94,8 @@ export async function runAMemGymBenchmark(
       }
     }
 
+    await options.system.drain?.();
+
     for (
       let questionIndex = 0;
       questionIndex < profile.qas.length;

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -94,7 +94,11 @@ export async function runAMemGymBenchmark(
       }
     }
 
-    await options.system.drain?.();
+    try {
+      await options.system.drain?.();
+    } catch (drainErr) {
+      console.error(`  [WARN] amemgym drain failed for profile ${profile.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    }
 
     for (
       let questionIndex = 0;

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -96,6 +96,8 @@ export async function runBeamBenchmark(
       }
     }
 
+    await options.system.drain?.();
+
     let taskIndex = 0;
     for (const [ability, questions] of Object.entries(questionMap)) {
       for (const probe of questions) {

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -96,7 +96,11 @@ export async function runBeamBenchmark(
       }
     }
 
-    await options.system.drain?.();
+    try {
+      await options.system.drain?.();
+    } catch (drainErr) {
+      console.error(`  [WARN] beam drain failed for ${entry.conversation.conversation_id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    }
 
     let taskIndex = 0;
     for (const [ability, questions] of Object.entries(questionMap)) {

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -180,7 +180,11 @@ export async function runPublishedHarness(
         await ctx.options.system.store(session.sessionId, session.messages);
       }
     }
-    await ctx.options.system.drain?.();
+    try {
+      await ctx.options.system.drain?.();
+    } catch (drainErr) {
+      console.error(`  [WARN] harness drain failed for plan: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    }
     const planIndex = tasks.length;
     for (const trial of plan.trials) {
       const trialId = trial.taskId ?? trial.question.slice(0, 60);

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -180,6 +180,7 @@ export async function runPublishedHarness(
         await ctx.options.system.store(session.sessionId, session.messages);
       }
     }
+    await ctx.options.system.drain?.();
     const planIndex = tasks.length;
     for (const trial of plan.trials) {
       const trialId = trial.taskId ?? trial.question.slice(0, 60);

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -77,6 +77,8 @@ export async function runMemBenchBenchmark(
         await options.system.store(sessionId, testCase.turns);
       }
 
+      await options.system.drain?.();
+
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, testCase.question),
       );

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -77,7 +77,11 @@ export async function runMemBenchBenchmark(
         await options.system.store(sessionId, testCase.turns);
       }
 
-      await options.system.drain?.();
+      try {
+        await options.system.drain?.();
+      } catch (drainErr) {
+        console.error(`  [WARN] membench drain failed for ${testCase.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+      }
 
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, testCase.question),

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -87,7 +87,11 @@ export async function runMemoryArenaBenchmark(
             },
           ]);
 
-          await options.system.drain?.();
+          try {
+            await options.system.drain?.();
+          } catch (drainErr) {
+            console.error(`  [WARN] memory-arena drain failed for ${taskResultId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+          }
 
           const { result: recalledText, durationMs } = await timed(async () =>
             options.system.recall(sessionId, question),

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -87,6 +87,8 @@ export async function runMemoryArenaBenchmark(
             },
           ]);
 
+          await options.system.drain?.();
+
           const { result: recalledText, durationMs } = await timed(async () =>
             options.system.recall(sessionId, question),
           );
@@ -142,6 +144,7 @@ export async function runMemoryArenaBenchmark(
                 content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
               },
             ]);
+            await options.system.drain?.();
           } catch (storeErr) {
             console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`);
           }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -144,9 +144,14 @@ export async function runMemoryArenaBenchmark(
                 content: `Answer for subtask ${questionIndex + 1}: ${expected}`,
               },
             ]);
-            await options.system.drain?.();
           } catch (storeErr) {
             console.error(`  [WARN] memory-arena store failed for ${taskResultId}: ${storeErr instanceof Error ? storeErr.message : String(storeErr)}`);
+          }
+
+          try {
+            await options.system.drain?.();
+          } catch (drainErr) {
+            console.error(`  [WARN] memory-arena drain failed for ${taskResultId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
           }
         } catch (err) {
           const message = err instanceof Error ? err.message : String(err);

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -116,7 +116,11 @@ export async function runMemoryAgentBenchBenchmark(
     await options.system.reset();
 
     const sessionIds = await storeBenchmarkContext(options, item, itemIndex);
-    await options.system.drain?.();
+    try {
+      await options.system.drain?.();
+    } catch (drainErr) {
+      console.error(`  [WARN] memoryagentbench drain failed for sample ${item.metadata.source}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+    }
     for (let questionIndex = 0; questionIndex < item.questions.length; questionIndex += 1) {
       const question = item.questions[questionIndex]!;
       const answerVariants = item.answers[questionIndex];

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -116,6 +116,7 @@ export async function runMemoryAgentBenchBenchmark(
     await options.system.reset();
 
     const sessionIds = await storeBenchmarkContext(options, item, itemIndex);
+    await options.system.drain?.();
     for (let questionIndex = 0; questionIndex < item.questions.length; questionIndex += 1) {
       const question = item.questions[questionIndex]!;
       const answerVariants = item.answers[questionIndex];

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -91,7 +91,11 @@ export async function runPersonaMemBenchmark(
         await options.system.store(sessionId, messages);
       }
 
-      await options.system.drain?.();
+      try {
+        await options.system.drain?.();
+      } catch (drainErr) {
+        console.error(`  [WARN] personamem drain failed for ${taskId}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+      }
 
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, sample.userQuery),

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -91,6 +91,8 @@ export async function runPersonaMemBenchmark(
         await options.system.store(sessionId, messages);
       }
 
+      await options.system.drain?.();
+
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, sample.userQuery),
       );


### PR DESCRIPTION
## Summary

- Re-enables LCM summarization in the bench adapter (reverting the no-op path from the previous run)
- Adds `drain?(): Promise<void>` to `BenchMemoryAdapter` interface
- Implements `drain()` using `waitForObserveQueueIdle()` to serialize LCM work with QA on single-slot local models
- Adds `await adapter.drain?.()` between store and recall phases in all 8 published benchmark runners + shared harness

## Why

The previous benchmark run disabled LCM entirely to avoid contention with LM Studio's single inference slot. This produced meaningless scores (no memory was being tested). The episode-level drain approach lets LCM summarize after each store phase completes, then blocks until summarization finishes before starting QA — serializing the two without contention.

## Files changed

- `packages/bench/src/adapters/types.ts` — add `drain?()` to interface
- `packages/bench/src/adapters/remnic-adapter.ts` — re-enable LCM, implement `drain()`
- `packages/bench/src/benchmarks/published/harness.ts` — drain after ingest, before trials
- `packages/bench/src/benchmarks/published/ama-bench/runner.ts` — drain between store and QA
- `packages/bench/src/benchmarks/published/amemgym/runner.ts` — same
- `packages/bench/src/benchmarks/published/membench/runner.ts` — same
- `packages/bench/src/benchmarks/published/memoryagentbench/runner.ts` — same
- `packages/bench/src/benchmarks/published/personamem/runner.ts` — same
- `packages/bench/src/benchmarks/published/beam/runner.ts` — same
- `packages/bench/src/benchmarks/published/memory-arena/runner.ts` — drain after each store (two per question)

## Test plan

- [x] All 192 bench package tests pass
- [x] `pnpm run build --filter @remnic/bench` succeeds
- [ ] Full benchmark run in progress against Gemma 4 26B via LM Studio (PID 42441)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark execution ordering by inserting a blocking `drain()` phase between ingestion and QA, which can affect results and runtime and may introduce new timeout/failure modes in long runs. The logic is contained to bench adapters/runners and does not impact production request paths.
> 
> **Overview**
> Re-introduces an ingestion-to-QA synchronization point in `@remnic/bench` by adding an optional `BenchMemoryAdapter.drain()` hook and calling it after `store()` ingestion phases across the published benchmark runners and shared `harness`.
> 
> Implements `drain()` in the Remnic adapter via `lcmEngine.waitForObserveQueueIdle()` with a **5-minute timeout** and adds best-effort warning logs so benchmarks proceed even if draining fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4825db95a37c78c65d01696243060bd36d43c555. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->