### PR TITLE
feat(bench): 429 session-quota wait budget and detached runner

### DIFF
--- a/packages/bench/src/providers/retry-fetch.test.ts
+++ b/packages/bench/src/providers/retry-fetch.test.ts
@@ -146,3 +146,45 @@ test("retryFetch does not retry on 3xx redirect", async () => {
     mock.restore();
   }
 });
+
+test("retryFetch retries 429 beyond maxAttempts when max429WaitMs is set", async () => {
+  // Returns 429 for first 5 calls, then 200.
+  const mock = mockFetchSequence([
+    { status: 429 },
+    { status: 429 },
+    { status: 429 },
+    { status: 429 },
+    { status: 429 },
+    { status: 200, body: "finally" },
+  ]);
+  try {
+    const response = await retryFetch(
+      "https://example.com/api",
+      { method: "GET" },
+      // maxAttempts=3 but max429WaitMs=30s allows retries beyond 3 attempts
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 30_000 },
+    );
+    assert.equal(response.status, 200);
+    assert.equal(mock.calls.length, 6);
+  } finally {
+    mock.restore();
+  }
+});
+
+test("retryFetch respects max429WaitMs budget and returns 429 when exhausted", async () => {
+  // Always returns 429 — budget should expire quickly.
+  const mock = mockFetchSequence([{ status: 429 }]);
+  try {
+    // Tiny budget: 10ms. With baseBackoffMs=1, we'll get a few attempts before budget expires.
+    const response = await retryFetch(
+      "https://example.com/api",
+      { method: "GET" },
+      { maxAttempts: 3, baseBackoffMs: 1, timeoutMs: 5000, max429WaitMs: 10 },
+    );
+    assert.equal(response.status, 429);
+    // Should have retried at least once beyond maxAttempts due to budget
+    assert.ok(mock.calls.length >= 3);
+  } finally {
+    mock.restore();
+  }
+});

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -114,7 +114,9 @@ export async function retryFetch(
       const in429Budget = opts.max429WaitMs > 0 &&
         (Date.now() - loopStartMs) < opts.max429WaitMs;
       if (!in429Budget) {
-        if (last429Response) return last429Response;
+        // Only return a saved 429 when the budget feature is active.
+        // With max429WaitMs=0 (default), always break to throw lastError.
+        if (opts.max429WaitMs > 0 && last429Response) return last429Response;
         break;
       }
       // Past maxAttempts but within 429 budget — only continue if we've

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -227,6 +227,7 @@ export async function retryFetch(
       }
       lastError = err instanceof Error ? err : new Error(String(err));
       last429IsStale = true;
+      callerSignal?.removeEventListener("abort", onCallerAbort);
     }
 
     // Backoff before next attempt. Capped at maxAttempts for non-429 errors.

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -171,8 +171,8 @@ export async function retryFetch(
 
         const retryAfter = parseRetryAfterMs(response.headers.get("retry-after"));
         let waitMs =
-          (retryAfter && retryAfter > 0)
-            ? retryAfter
+          retryAfter != null
+            ? Math.max(retryAfter, 100)
             : Math.min(
                 opts.baseBackoffMs * Math.pow(2, attempt - 1),
                 MAX_429_BACKOFF_S * 1000,

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -100,6 +100,7 @@ export async function retryFetch(
   const opts = { ...DEFAULTS, ...options };
   let lastError: Error | null = null;
   let last429Response: Response | null = null;
+  let last429IsStale = false;
   const loopStartMs = Date.now();
 
   for (let attempt = 1; ; attempt++) {
@@ -114,9 +115,10 @@ export async function retryFetch(
       const in429Budget = opts.max429WaitMs > 0 &&
         (Date.now() - loopStartMs) < opts.max429WaitMs;
       if (!in429Budget) {
-        // Only return a saved 429 when the budget feature is active.
+        // Only return a saved 429 when the budget feature is active and
+        // no non-429 failures have occurred since the last 429.
         // With max429WaitMs=0 (default), always break to throw lastError.
-        if (opts.max429WaitMs > 0 && last429Response) return last429Response;
+        if (opts.max429WaitMs > 0 && last429Response && !last429IsStale) return last429Response;
         break;
       }
       // Past maxAttempts but within 429 budget — only continue if we've
@@ -165,6 +167,7 @@ export async function retryFetch(
         // Only cancel the body when we're going to retry.
         await response.body?.cancel();
         last429Response = response;
+        last429IsStale = false;
 
         let waitMs =
           parseRetryAfterMs(response.headers.get("retry-after")) ??
@@ -211,6 +214,7 @@ export async function retryFetch(
       lastError = new Error(
         `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,
       );
+      last429IsStale = true;
     } catch (err) {
       clearTimeout(timeout);
       if (callerSignal?.aborted) {
@@ -222,6 +226,7 @@ export async function retryFetch(
         throw err;
       }
       lastError = err instanceof Error ? err : new Error(String(err));
+      last429IsStale = true;
     }
 
     // Backoff before next attempt. Capped at maxAttempts for non-429 errors.

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -154,11 +154,11 @@ export async function retryFetch(
         const inBudget = opts.max429WaitMs > 0 &&
           (Date.now() - loopStartMs) < opts.max429WaitMs;
         const underMaxAttempts = attempt < opts.maxAttempts;
-        const budgetExhausted = opts.max429WaitMs > 0 && !inBudget;
 
-        // Stop if budget is exhausted (enforces wall-clock limit even under
-        // maxAttempts) or if past maxAttempts with no budget remaining.
-        if (budgetExhausted || (!underMaxAttempts && !inBudget)) {
+        // Stop if past maxAttempts with no budget remaining.
+        // Under maxAttempts, 429s always retry regardless of budget —
+        // the budget only EXTENDS retries beyond maxAttempts.
+        if (!underMaxAttempts && !inBudget) {
           // Return the response with a readable body for the caller.
           callerSignal?.removeEventListener("abort", onCallerAbort);
           return response;

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -169,12 +169,14 @@ export async function retryFetch(
         last429Response = response;
         last429IsStale = false;
 
+        const retryAfter = parseRetryAfterMs(response.headers.get("retry-after"));
         let waitMs =
-          parseRetryAfterMs(response.headers.get("retry-after")) ??
-          Math.min(
-            opts.baseBackoffMs * Math.pow(2, attempt - 1),
-            MAX_429_BACKOFF_S * 1000,
-          );
+          (retryAfter && retryAfter > 0)
+            ? retryAfter
+            : Math.min(
+                opts.baseBackoffMs * Math.pow(2, attempt - 1),
+                MAX_429_BACKOFF_S * 1000,
+              );
 
         // Clamp to remaining 429 budget so we don't overshoot.
         if (opts.max429WaitMs > 0) {

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -9,16 +9,28 @@ export interface RetryFetchOptions {
   maxAttempts?: number;
   baseBackoffMs?: number;
   timeoutMs?: number;
+  /**
+   * Maximum wall-clock time (ms) to keep retrying 429 responses.
+   * When set, 429s are retried with capped exponential backoff
+   * until this budget expires, regardless of maxAttempts.
+   * Useful for session-quota rate limits that take minutes to reset.
+   * Set to 0 or undefined to disable (uses maxAttempts instead).
+   */
+  max429WaitMs?: number;
 }
 
 const DEFAULTS: Required<RetryFetchOptions> = {
   maxAttempts: 3,
   baseBackoffMs: 1000,
   timeoutMs: 120_000,
+  max429WaitMs: 0,
 };
 
 /** Maximum time to wait on a single Retry-After value (seconds). */
 const MAX_RETRY_AFTER_S = 600;
+
+/** Maximum backoff for a single 429 retry when no Retry-After header (seconds). */
+const MAX_429_BACKOFF_S = 120;
 
 async function readBodyPreview(response: Response, maxBytes: number): Promise<string> {
   try {
@@ -68,6 +80,18 @@ export function parseRetryAfterMs(value: string | null): number | undefined {
   return undefined;
 }
 
+function abortAwareSleep(ms: number, signal: AbortSignal | undefined): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) { resolve(); return; }
+    const onAbort = () => { clearTimeout(timer); resolve(); };
+    const timer = setTimeout(() => {
+      signal?.removeEventListener("abort", onAbort);
+      resolve();
+    }, ms);
+    signal?.addEventListener("abort", onAbort, { once: true });
+  });
+}
+
 export async function retryFetch(
   url: string,
   init: RequestInit,
@@ -75,14 +99,26 @@ export async function retryFetch(
 ): Promise<Response> {
   const opts = { ...DEFAULTS, ...options };
   let lastError: Error | null = null;
+  let last429Response: Response | null = null;
+  const loopStartMs = Date.now();
 
-  for (let attempt = 1; attempt <= opts.maxAttempts; attempt++) {
-    if ((init.signal as AbortSignal | undefined)?.aborted) {
+  for (let attempt = 1; ; attempt++) {
+    const callerSignal = init.signal as AbortSignal | undefined;
+    if (callerSignal?.aborted) {
       throw new DOMException("The operation was aborted.", "AbortError");
     }
 
+    // Stop when we've exhausted normal attempts AND have no 429 time budget left.
+    const outOfRegularAttempts = attempt > opts.maxAttempts;
+    const outOf429Budget = opts.max429WaitMs <= 0 ||
+      (Date.now() - loopStartMs) >= opts.max429WaitMs;
+    if (outOfRegularAttempts && outOf429Budget) {
+      // Return the 429 response if we have one, otherwise throw.
+      if (last429Response) return last429Response;
+      break;
+    }
+
     const controller = new AbortController();
-    const callerSignal = init.signal as AbortSignal | undefined;
     const onCallerAbort = () => controller.abort();
     callerSignal?.addEventListener("abort", onCallerAbort, { once: true });
     const timeout = setTimeout(() => controller.abort(), opts.timeoutMs);
@@ -104,25 +140,36 @@ export async function retryFetch(
       }
 
       // 429 Too Many Requests — pause and retry.
-      if (response.status === 429 && attempt < opts.maxAttempts) {
-        // Release the response body without buffering.
+      if (response.status === 429) {
         await response.body?.cancel();
+        last429Response = response;
+
+        const inBudget = opts.max429WaitMs > 0 &&
+          (Date.now() - loopStartMs) < opts.max429WaitMs;
+        const underMaxAttempts = attempt < opts.maxAttempts;
+
+        if (!underMaxAttempts && !inBudget) {
+          callerSignal?.removeEventListener("abort", onCallerAbort);
+          return response;
+        }
+
         const waitMs =
           parseRetryAfterMs(response.headers.get("retry-after")) ??
-          opts.baseBackoffMs * Math.pow(2, attempt - 1);
+          Math.min(
+            opts.baseBackoffMs * Math.pow(2, attempt - 1),
+            MAX_429_BACKOFF_S * 1000,
+          );
+
+        const budgetTag = inBudget
+          ? ` (${Math.round((Date.now() - loopStartMs) / 1000)}s/${Math.round(opts.max429WaitMs / 1000)}s budget)`
+          : "";
+
         console.error(
-          `[rate-limit] 429 received (attempt ${attempt}/${opts.maxAttempts}), ` +
+          `[rate-limit] 429 received (attempt ${attempt}/${opts.maxAttempts})${budgetTag}, ` +
             `pausing ${Math.round(waitMs / 1000)}s before retry…`,
         );
-        await new Promise<void>((resolve) => {
-          if (callerSignal?.aborted) { resolve(); return; }
-          const onSleepAbort = () => { clearTimeout(timer); resolve(); };
-          const timer = setTimeout(() => {
-            callerSignal?.removeEventListener("abort", onSleepAbort);
-            resolve();
-          }, waitMs);
-          callerSignal?.addEventListener("abort", onSleepAbort, { once: true });
-        });
+        await abortAwareSleep(waitMs, callerSignal);
+
         callerSignal?.removeEventListener("abort", onCallerAbort);
         continue;
       }
@@ -133,7 +180,14 @@ export async function retryFetch(
         return response;
       }
 
-      // 5xx — retry with exponential backoff.
+      // 5xx — retry with exponential backoff (bounded by maxAttempts only).
+      if (attempt >= opts.maxAttempts) {
+        callerSignal?.removeEventListener("abort", onCallerAbort);
+        const bodyPreview = await readBodyPreview(response, 512);
+        throw new Error(
+          `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,
+        );
+      }
       const bodyPreview = await readBodyPreview(response, 512);
       lastError = new Error(
         `HTTP ${response.status} ${response.statusText} (attempt ${attempt}/${opts.maxAttempts}): ${bodyPreview}`,

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -150,8 +150,11 @@ export async function retryFetch(
         const inBudget = opts.max429WaitMs > 0 &&
           (Date.now() - loopStartMs) < opts.max429WaitMs;
         const underMaxAttempts = attempt < opts.maxAttempts;
+        const budgetExhausted = opts.max429WaitMs > 0 && !inBudget;
 
-        if (!underMaxAttempts && !inBudget) {
+        // Stop if budget is exhausted (enforces wall-clock limit even under
+        // maxAttempts) or if past maxAttempts with no budget remaining.
+        if (budgetExhausted || (!underMaxAttempts && !inBudget)) {
           // Return the response with a readable body for the caller.
           callerSignal?.removeEventListener("abort", onCallerAbort);
           return response;

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -109,6 +109,8 @@ export async function retryFetch(
     }
 
     // Stop when we've exhausted normal attempts AND have no 429 time budget left.
+    // The 429 budget only extends retries for 429 responses — transient/5xx
+    // errors are always capped by maxAttempts.
     const outOfRegularAttempts = attempt > opts.maxAttempts;
     const outOf429Budget = opts.max429WaitMs <= 0 ||
       (Date.now() - loopStartMs) >= opts.max429WaitMs;
@@ -141,24 +143,32 @@ export async function retryFetch(
 
       // 429 Too Many Requests — pause and retry.
       if (response.status === 429) {
-        await response.body?.cancel();
-        last429Response = response;
-
         const inBudget = opts.max429WaitMs > 0 &&
           (Date.now() - loopStartMs) < opts.max429WaitMs;
         const underMaxAttempts = attempt < opts.maxAttempts;
 
         if (!underMaxAttempts && !inBudget) {
+          // Return the response with a readable body for the caller.
           callerSignal?.removeEventListener("abort", onCallerAbort);
           return response;
         }
 
-        const waitMs =
+        // Only cancel the body when we're going to retry.
+        await response.body?.cancel();
+        last429Response = response;
+
+        let waitMs =
           parseRetryAfterMs(response.headers.get("retry-after")) ??
           Math.min(
             opts.baseBackoffMs * Math.pow(2, attempt - 1),
             MAX_429_BACKOFF_S * 1000,
           );
+
+        // Clamp to remaining 429 budget so we don't overshoot.
+        if (opts.max429WaitMs > 0) {
+          const remaining = opts.max429WaitMs - (Date.now() - loopStartMs);
+          waitMs = Math.min(waitMs, Math.max(remaining, 0));
+        }
 
         const budgetTag = inBudget
           ? ` (${Math.round((Date.now() - loopStartMs) / 1000)}s/${Math.round(opts.max429WaitMs / 1000)}s budget)`
@@ -205,7 +215,7 @@ export async function retryFetch(
       lastError = err instanceof Error ? err : new Error(String(err));
     }
 
-    if (attempt < opts.maxAttempts) {
+    if (attempt < opts.maxAttempts || (opts.max429WaitMs > 0 && (Date.now() - loopStartMs) < opts.max429WaitMs)) {
       const backoffMs = opts.baseBackoffMs * Math.pow(2, attempt - 1);
       await new Promise((resolve) => setTimeout(resolve, backoffMs));
     }

--- a/packages/bench/src/providers/retry-fetch.ts
+++ b/packages/bench/src/providers/retry-fetch.ts
@@ -108,16 +108,20 @@ export async function retryFetch(
       throw new DOMException("The operation was aborted.", "AbortError");
     }
 
-    // Stop when we've exhausted normal attempts AND have no 429 time budget left.
-    // The 429 budget only extends retries for 429 responses — transient/5xx
-    // errors are always capped by maxAttempts.
-    const outOfRegularAttempts = attempt > opts.maxAttempts;
-    const outOf429Budget = opts.max429WaitMs <= 0 ||
-      (Date.now() - loopStartMs) >= opts.max429WaitMs;
-    if (outOfRegularAttempts && outOf429Budget) {
-      // Return the 429 response if we have one, otherwise throw.
-      if (last429Response) return last429Response;
-      break;
+    // Non-429 errors (transient, 5xx) are always capped by maxAttempts.
+    // The 429 budget only extends retries for 429 responses beyond maxAttempts.
+    if (attempt > opts.maxAttempts) {
+      const in429Budget = opts.max429WaitMs > 0 &&
+        (Date.now() - loopStartMs) < opts.max429WaitMs;
+      if (!in429Budget) {
+        if (last429Response) return last429Response;
+        break;
+      }
+      // Past maxAttempts but within 429 budget — only continue if we've
+      // seen a 429. Otherwise transient/5xx errors would loop uncapped.
+      if (!last429Response) {
+        break;
+      }
     }
 
     const controller = new AbortController();
@@ -215,7 +219,8 @@ export async function retryFetch(
       lastError = err instanceof Error ? err : new Error(String(err));
     }
 
-    if (attempt < opts.maxAttempts || (opts.max429WaitMs > 0 && (Date.now() - loopStartMs) < opts.max429WaitMs)) {
+    // Backoff before next attempt. Capped at maxAttempts for non-429 errors.
+    if (attempt < opts.maxAttempts) {
       const backoffMs = opts.baseBackoffMs * Math.pow(2, attempt - 1);
       await new Promise((resolve) => setTimeout(resolve, backoffMs));
     }

--- a/packages/bench/src/providers/types.ts
+++ b/packages/bench/src/providers/types.ts
@@ -32,7 +32,7 @@ export interface ProviderBaseConfig {
   baseUrl?: string;
   apiKey?: string;
   headers?: Record<string, string>;
-  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
+  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
   /** Suppress thinking/reasoning tokens for thinking-capable models (Qwen 3.5, Gemma 4, DeepSeek). */
   disableThinking?: boolean;
 }

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -43,6 +43,7 @@ export interface ResolveBenchRuntimeProfileOptions {
   judgeBaseUrl?: string;
   judgeApiKey?: string;
   requestTimeout?: number;
+  max429WaitMs?: number;
   disableThinking?: boolean;
 }
 
@@ -94,6 +95,7 @@ export async function resolveBenchRuntimeProfile(
       options.requestTimeout,
       options.disableThinking,
       options.systemApiKey,
+      options.max429WaitMs,
     );
   const judgeProvider = resolveProviderConfig(
     "judge",
@@ -103,6 +105,7 @@ export async function resolveBenchRuntimeProfile(
     options.requestTimeout,
     options.disableThinking,
     options.judgeApiKey,
+    options.max429WaitMs,
   );
   const responderFactoryConfig = systemProvider
     ? asProviderFactoryConfig(systemProvider)
@@ -326,6 +329,7 @@ function resolveProviderConfig(
   requestTimeout?: number,
   disableThinking?: boolean,
   apiKey?: string,
+  max429WaitMs?: number,
 ): ProviderConfig | null {
   const hasProvider = typeof provider === "string";
   const hasModel = typeof model === "string" && model.trim().length > 0;
@@ -356,7 +360,12 @@ function resolveProviderConfig(
     model: model.trim(),
     ...(hasBaseUrl ? { baseUrl: baseUrl!.trim() } : {}),
     ...(apiKey ? { apiKey } : {}),
-    ...(requestTimeout != null ? { retryOptions: { timeoutMs: requestTimeout } } : {}),
+    ...(requestTimeout != null || max429WaitMs != null
+      ? { retryOptions: {
+          ...(requestTimeout != null ? { timeoutMs: requestTimeout } : {}),
+          ...(max429WaitMs != null ? { max429WaitMs } : {}),
+        } }
+      : {}),
     ...(disableThinking ? { disableThinking: true } : {}),
   };
 }

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -33,7 +33,7 @@ export interface ProviderConfig {
   model: string;
   baseUrl?: string;
   apiKey?: string;
-  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number };
+  retryOptions?: { maxAttempts?: number; baseBackoffMs?: number; timeoutMs?: number; max429WaitMs?: number };
   disableThinking?: boolean;
 }
 

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -63,6 +63,8 @@ export interface ParsedBenchArgs {
   custom?: string;
   target?: BenchPublishTarget;
   requestTimeout?: number;
+  /** Max wall-clock time (ms) to keep retrying 429 rate-limit responses. */
+  max429WaitMs?: number;
   /** Suppress thinking/reasoning tokens for thinking-capable models (Gemma 4, Qwen 3.5, DeepSeek). */
   disableThinking?: boolean;
   /** `bench published` — specific benchmark to run (longmemeval|locomo). */
@@ -186,7 +188,8 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--out" ||
       arg === "--provider" ||
       arg === "--base-url" ||
-      arg === "--request-timeout"
+      arg === "--request-timeout" ||
+      arg === "--max-429-wait"
     ) {
       index += 1;
       continue;
@@ -304,6 +307,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const output = readBenchOptionValue(args, "--output");
   const targetRaw = readBenchOptionValue(args, "--target");
   const requestTimeoutRaw = readBenchOptionValue(args, "--request-timeout");
+  const max429WaitRaw = readBenchOptionValue(args, "--max-429-wait");
   let runtimeProfile: BenchRuntimeProfile | undefined;
   if (runtimeProfileRaw !== undefined) {
     runtimeProfile = parseBenchRuntimeProfile(
@@ -381,6 +385,21 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     if (requestTimeout > 3600_000) {
       throw new Error(
         "ERROR: --request-timeout must not exceed 3,600,000 ms (1 hour).",
+      );
+    }
+  }
+
+  let max429WaitMs: number | undefined;
+  if (max429WaitRaw !== undefined) {
+    max429WaitMs = Number(max429WaitRaw);
+    if (!Number.isInteger(max429WaitMs) || max429WaitMs < 0) {
+      throw new Error(
+        "ERROR: --max-429-wait must be a non-negative integer (milliseconds).",
+      );
+    }
+    if (max429WaitMs > 86_400_000) {
+      throw new Error(
+        "ERROR: --max-429-wait must not exceed 86,400,000 ms (24 hours).",
       );
     }
   }
@@ -516,6 +535,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
       : undefined,
     publishedDryRun: args.includes("--dry-run"),
     requestTimeout,
+    max429WaitMs,
     disableThinking: args.includes("--disable-thinking"),
   };
 }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -670,6 +670,7 @@ export function buildBenchRuntimeProfileRequest(
     judgeBaseUrl: parsed.judgeBaseUrl,
     judgeApiKey: parsed.judgeApiKey,
     requestTimeout: parsed.requestTimeout,
+    max429WaitMs: parsed.max429WaitMs,
     disableThinking: parsed.disableThinking,
   };
 }

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -87,7 +87,7 @@ cmd_start() {
   # Save flags for reproducibility (redact API keys).
   # Join args onto one line so sed can match flag+value pairs that
   # arrive as separate shell words.
-  printf '%s' "$*" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g' > "$ENV_FILE"
+  printf '%s' "$*" | sed -E 's/(-system-api-key[= ]|-judge-api-key[= ]|-api-key[= ])[^ ]*/\1***REDACTED***/g' > "$ENV_FILE"
   chmod 600 "$ENV_FILE"
 
   # Rotate log if large (>10MB)
@@ -97,7 +97,7 @@ cmd_start() {
 
   # Log flags with API keys redacted
   local redacted_args
-  redacted_args="$(printf '%s' "$*" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g')"
+  redacted_args="$(printf '%s' "$*" | sed -E 's/(-system-api-key[= ]|-judge-api-key[= ]|-api-key[= ])[^ ]*/\1***REDACTED***/g')"
   echo "[$(date -Iseconds)] Starting benchmark: run-bench-cli.mjs run $redacted_args" >> "$LOG_FILE"
 
   # Use setsid to create a new process group so kill -- -$pid
@@ -161,7 +161,14 @@ cmd_status() {
 
   # Process status
   if [[ -n "$pid" ]] && is_alive "$pid"; then
-    echo "process: running (PID $pid)"
+    local cmd
+    cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+    if [[ "$cmd" == *"run-bench-cli"* ]]; then
+      echo "process: running (PID $pid)"
+    else
+      echo "process: stale (PID $pid reused by another process)"
+      pid=""
+    fi
   elif [[ -n "$pid" ]]; then
     echo "process: stopped (PID $pid exited)"
   else

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -104,6 +104,15 @@ cmd_stop() {
     exit 0
   fi
 
+  # Verify the PID still belongs to the bench runner before signaling.
+  local cmd
+  cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+  if [[ "$cmd" != *"run-bench-cli"* ]]; then
+    echo "WARNING: PID $pid no longer belongs to bench runner. Skipping kill."
+    rm -f "$PID_FILE"
+    exit 0
+  fi
+
   echo "Stopping benchmark (PID $pid)..."
   # Kill the process group so child processes are also terminated
   kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -44,6 +44,21 @@ read_pid() {
 }
 
 latest_status_file() {
+  local runner_pid="${1:-}"
+  if [[ -n "$runner_pid" ]] && is_alive "$runner_pid"; then
+    # Find the bench child process PID via pgrep.
+    local child_pid
+    child_pid="$(pgrep -P "$runner_pid" 2>/dev/null | head -1 || true)"
+    # Try status files matching the child PID first, then fall back to newest.
+    if [[ -n "$child_pid" ]]; then
+      local matched
+      matched="$(ls -t "$RESULTS_DIR"/bench-status-*-"$child_pid".json 2>/dev/null | head -1 || true)"
+      if [[ -n "$matched" ]]; then
+        printf '%s' "$matched"
+        return
+      fi
+    fi
+  fi
   ls -t "$RESULTS_DIR"/bench-status-*.json 2>/dev/null | head -1 || true
 }
 
@@ -153,9 +168,9 @@ cmd_status() {
     echo "process: no run"
   fi
 
-  # Parse latest status JSON
+  # Parse latest status JSON (filtered by runner PID when available).
   local status_file
-  status_file="$(latest_status_file)"
+  status_file="$(latest_status_file "$pid")"
 
   if [[ -z "$status_file" ]]; then
     echo "status_file: none"

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -156,13 +156,16 @@ cmd_status() {
   fi
 
   # Extract key fields with portable parsing (no jq dependency).
-  # Patterns tolerate pretty-printed JSON (optional whitespace around colons).
+  # Collapse whitespace first to handle pretty-printed JSON.
+  local collapsed
+  collapsed="$(tr -s ' \n\r\t' ' ' < "$status_file")"
+
   local current_bench completed total benchmarks failed
-  current_bench="$(grep -oE '"currentBenchmark"\s*:\s*"[^"]*"' "$status_file" | head -1 | grep -oE '"[^"]*"$' | tr -d '"')"
-  completed="$(grep -oE '"completed"\s*:\s*[0-9]+' "$status_file" | head -1 | grep -oE '[0-9]+$')"
-  total="$(grep -oE '"total"\s*:\s*[0-9]+' "$status_file" | head -1 | grep -oE '[0-9]+$')"
-  benchmarks="$(grep -oE '"id"\s*:\s*"[^"]*"\s*,\s*"status"\s*:\s*"[^"]*"' "$status_file" | sed -E 's/"id"\s*:\s*"/  /;s/"\s*,\s*"status"\s*:\s*"/ → /;s/"$//' | tail -20)"
-  failed="$(grep -cE '"status"\s*:\s*"failed"' "$status_file" 2>/dev/null || echo 0)"
+  current_bench="$(printf '%s' "$collapsed" | grep -oE '"currentBenchmark"\s*:\s*"[^"]*"' | head -1 | grep -oE '"[^"]*"$' | tr -d '"' || true)"
+  completed="$(printf '%s' "$collapsed" | grep -oE '"completed"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
+  total="$(printf '%s' "$collapsed" | grep -oE '"total"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
+  benchmarks="$(printf '%s' "$collapsed" | grep -oE '"id"\s*:\s*"[^"]*"[^}]*?"status"\s*:\s*"[^"]*"' | sed -E 's/"id"\s*:\s*"/  /;s/".*?"status"\s*:\s*"/ → /;s/"$//' | tail -20 || true)"
+  failed="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"failed"' || echo 0)"
 
   echo "status_file: $(basename "$status_file")"
   if [[ -n "$current_bench" ]]; then
@@ -170,8 +173,8 @@ cmd_status() {
   fi
 
   local bench_complete bench_total
-  bench_complete="$(grep -cE '"status"\s*:\s*"complete"' "$status_file" 2>/dev/null || echo 0)"
-  bench_total="$(grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' "$status_file" 2>/dev/null || echo 0)"
+  bench_complete="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"complete"' || echo 0)"
+  bench_total="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' || echo 0)"
 
   echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
   if [[ -n "$benchmarks" ]]; then

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -147,8 +147,15 @@ cmd_stop() {
   done
 
   if is_alive "$pid"; then
-    echo "Process did not exit, sending SIGKILL to process group..."
-    kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
+    # Re-validate ownership before SIGKILL — PID may have been reused.
+    local sigkill_cmd
+    sigkill_cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+    if [[ "$sigkill_cmd" == *"run-bench-cli"* ]]; then
+      echo "Process did not exit, sending SIGKILL to process group..."
+      kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
+    else
+      echo "PID $pid reassigned during shutdown, skipping SIGKILL."
+    fi
   fi
 
   rm -f "$PID_FILE"

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -43,21 +43,31 @@ read_pid() {
   fi
 }
 
+# Collect all descendant PIDs of a given PID (walks the full process tree).
+descendant_pids() {
+  local parent="$1"
+  local children
+  children="$(pgrep -P "$parent" 2>/dev/null || true)"
+  for child in $children; do
+    printf '%s\n' "$child"
+    descendant_pids "$child"
+  done
+}
+
 latest_status_file() {
   local runner_pid="${1:-}"
   if [[ -n "$runner_pid" ]] && is_alive "$runner_pid"; then
-    # Find the bench child process PID via pgrep.
-    local child_pid
-    child_pid="$(pgrep -P "$runner_pid" 2>/dev/null | head -1 || true)"
-    # Try status files matching the child PID first, then fall back to newest.
-    if [[ -n "$child_pid" ]]; then
+    # Walk the full process tree to find the bench process PID.
+    local all_pids
+    all_pids="$(descendant_pids "$runner_pid")"
+    for pid in $all_pids; do
       local matched
-      matched="$(ls -t "$RESULTS_DIR"/bench-status-*-"$child_pid".json 2>/dev/null | head -1 || true)"
+      matched="$(ls -t "$RESULTS_DIR"/bench-status-*-"$pid".json 2>/dev/null | head -1 || true)"
       if [[ -n "$matched" ]]; then
         printf '%s' "$matched"
         return
       fi
-    fi
+    done
   fi
   ls -t "$RESULTS_DIR"/bench-status-*.json 2>/dev/null | head -1 || true
 }

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -1,0 +1,226 @@
+#!/usr/bin/env bash
+# Session-independent benchmark runner.
+# Runs benchmarks via nohup so they survive terminal/session restarts.
+#
+# Usage:
+#   scripts/bench-runner.sh start [bench flags...]   - launch detached run
+#   scripts/bench-runner.sh status                   - show progress (machine-readable)
+#   scripts/bench-runner.sh stop                     - kill running benchmark
+#   scripts/bench-runner.sh log                      - tail the log file
+#   scripts/bench-runner.sh show                     - print latest status JSON
+#
+# State files:
+#   ~/.remnic/bench/runner.pid   - PID of the bench process
+#   ~/.remnic/bench/runner.log   - combined stdout+stderr
+#   ~/.remnic/bench/runner.env   - saved CLI flags for reproducibility
+#   ~/.remnic/bench/results/bench-status-*.json - progress (written by bench-status.ts)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+BENCH_DIR="$HOME/.remnic/bench"
+RESULTS_DIR="$BENCH_DIR/results"
+PID_FILE="$BENCH_DIR/runner.pid"
+LOG_FILE="$BENCH_DIR/runner.log"
+ENV_FILE="$BENCH_DIR/runner.env"
+RUNNER_SCRIPT="$REPO_ROOT/scripts/run-bench-cli.mjs"
+
+mkdir -p "$BENCH_DIR" "$RESULTS_DIR"
+
+usage() {
+  sed -n '2,/^$/s/^# //p' "$0"
+  exit 1
+}
+
+is_alive() {
+  local pid="$1"
+  kill -0 "$pid" 2>/dev/null
+}
+
+read_pid() {
+  if [[ -f "$PID_FILE" ]]; then
+    cat "$PID_FILE"
+  fi
+}
+
+latest_status_file() {
+  ls -t "$RESULTS_DIR"/bench-status-*.json 2>/dev/null | head -1
+}
+
+cmd_start() {
+  if [[ $# -eq 0 ]]; then
+    echo "ERROR: start requires bench run flags." >&2
+    echo "Usage: scripts/bench-runner.sh start <benchmark> [flags...]" >&2
+    exit 1
+  fi
+
+  local pid
+  pid="$(read_pid)"
+  if [[ -n "$pid" ]] && is_alive "$pid"; then
+    echo "ERROR: benchmark already running (PID $pid). Stop it first." >&2
+    echo "  scripts/bench-runner.sh stop" >&2
+    exit 1
+  fi
+
+  # Save flags for reproducibility (redact API keys)
+  printf '%s\n' "$@" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g' > "$ENV_FILE"
+  chmod 600 "$ENV_FILE"
+
+  # Rotate log if large (>10MB)
+  if [[ -f "$LOG_FILE" ]] && [[ "$(wc -c < "$LOG_FILE")" -gt 10485760 ]]; then
+    mv "$LOG_FILE" "$LOG_FILE.$(date +%Y%m%d%H%M%S)"
+  fi
+
+  # Log flags with API keys redacted
+  local redacted_args
+  redacted_args="$(printf '%s' "$*" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g')"
+  echo "[$(date -Iseconds)] Starting benchmark: run-bench-cli.mjs run $redacted_args" >> "$LOG_FILE"
+
+  nohup node "$RUNNER_SCRIPT" run "$@" >> "$LOG_FILE" 2>&1 &
+  local bg_pid=$!
+  echo "$bg_pid" > "$PID_FILE"
+
+  echo "Benchmark started."
+  echo "  PID:  $bg_pid"
+  echo "  Log:  $LOG_FILE"
+  echo "  Status: scripts/bench-runner.sh status"
+}
+
+cmd_stop() {
+  local pid
+  pid="$(read_pid)"
+  if [[ -z "$pid" ]]; then
+    echo "No PID file found. Nothing to stop."
+    exit 0
+  fi
+
+  if ! is_alive "$pid"; then
+    echo "Process $pid is not running. Cleaning up PID file."
+    rm -f "$PID_FILE"
+    exit 0
+  fi
+
+  echo "Stopping benchmark (PID $pid)..."
+  # Kill the process group so child processes are also terminated
+  kill -- -"$pid" 2>/dev/null || kill "$pid" 2>/dev/null || true
+
+  # Wait up to 10s for graceful shutdown
+  local waited=0
+  while [[ $waited -lt 10 ]] && is_alive "$pid"; do
+    sleep 1
+    waited=$((waited + 1))
+  done
+
+  if is_alive "$pid"; then
+    echo "Process did not exit, sending SIGKILL..."
+    kill -9 "$pid" 2>/dev/null || true
+  fi
+
+  # Kill any orphaned bench processes from previous runs
+  local orphaned
+  orphaned="$(pgrep -f "tsx.*packages/remnic-cli/src/index.ts bench run" 2>/dev/null || true)"
+  if [[ -n "$orphaned" ]]; then
+    echo "Killing orphaned bench processes: $orphaned"
+    echo "$orphaned" | xargs kill 2>/dev/null || true
+  fi
+
+  rm -f "$PID_FILE"
+  echo "Stopped."
+}
+
+cmd_status() {
+  local pid
+  pid="$(read_pid)"
+
+  # Process status
+  if [[ -n "$pid" ]] && is_alive "$pid"; then
+    echo "process: running (PID $pid)"
+  elif [[ -n "$pid" ]]; then
+    echo "process: stopped (PID $pid exited)"
+  else
+    echo "process: no run"
+  fi
+
+  # Parse latest status JSON
+  local status_file
+  status_file="$(latest_status_file)"
+
+  if [[ -z "$status_file" ]]; then
+    echo "status_file: none"
+    if [[ -z "$pid" ]] || ! is_alive "${pid:-}"; then
+      exit 1
+    fi
+    exit 0
+  fi
+
+  # Extract key fields with portable parsing (no jq dependency)
+  local current_bench completed total benchmarks failed
+  current_bench="$(grep -o '"currentBenchmark":"[^"]*"' "$status_file" | head -1 | cut -d'"' -f4)"
+  completed="$(grep -o '"completed":[0-9]*' "$status_file" | head -1 | cut -d: -f2)"
+  total="$(grep -o '"total":[0-9]*' "$status_file" | head -1 | cut -d: -f2)"
+  benchmarks="$(grep -o '"id":"[^"]*","status":"[^"]*"' "$status_file" | sed 's/"id":"/  /;s/","status":"/ → /;s/"$//' | tail -20)"
+  failed="$(grep -c '"status":"failed"' "$status_file" 2>/dev/null || echo 0)"
+
+  echo "status_file: $(basename "$status_file")"
+  if [[ -n "$current_bench" ]]; then
+    echo "current: $current_bench (${completed:-0}${total:+/$total} tasks)"
+  fi
+
+  local bench_complete bench_total
+  bench_complete="$(grep -c '"status":"complete"' "$status_file" 2>/dev/null || echo 0)"
+  bench_total="$(grep -c '"status":"pending"\|"status":"running"\|"status":"complete"\|"status":"failed"' "$status_file" 2>/dev/null || echo 0)"
+
+  echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
+  if [[ -n "$benchmarks" ]]; then
+    echo "$benchmarks"
+  fi
+
+  # Exit codes: 0=running, 2=completed, 1=stopped/no run
+  if [[ -n "$pid" ]] && is_alive "$pid"; then
+    exit 0
+  elif [[ "$bench_complete" -eq "$bench_total" ]] && [[ "$bench_total" -gt 0 ]]; then
+    exit 2
+  else
+    exit 1
+  fi
+}
+
+cmd_log() {
+  if [[ ! -f "$LOG_FILE" ]]; then
+    echo "No log file yet."
+    exit 1
+  fi
+  tail -f "$LOG_FILE"
+}
+
+cmd_show() {
+  local status_file
+  status_file="$(latest_status_file)"
+  if [[ -z "$status_file" ]]; then
+    echo "No status file found."
+    exit 1
+  fi
+  cat "$status_file"
+}
+
+# --- Main dispatch ---
+
+if [[ $# -eq 0 ]]; then
+  usage
+fi
+
+cmd="$1"
+shift
+
+case "$cmd" in
+  start)  cmd_start "$@" ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  log)    cmd_log ;;
+  show)   cmd_show ;;
+  -h|--help) usage ;;
+  *)
+    echo "ERROR: unknown command '$cmd'" >&2
+    usage
+    ;;
+esac

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -44,7 +44,7 @@ read_pid() {
 }
 
 latest_status_file() {
-  ls -t "$RESULTS_DIR"/bench-status-*.json 2>/dev/null | head -1
+  ls -t "$RESULTS_DIR"/bench-status-*.json 2>/dev/null | head -1 || true
 }
 
 cmd_start() {
@@ -62,8 +62,10 @@ cmd_start() {
     exit 1
   fi
 
-  # Save flags for reproducibility (redact API keys)
-  printf '%s\n' "$@" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g' > "$ENV_FILE"
+  # Save flags for reproducibility (redact API keys).
+  # Join args onto one line so sed can match flag+value pairs that
+  # arrive as separate shell words.
+  printf '%s' "$*" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g' > "$ENV_FILE"
   chmod 600 "$ENV_FILE"
 
   # Rotate log if large (>10MB)
@@ -153,13 +155,14 @@ cmd_status() {
     exit 0
   fi
 
-  # Extract key fields with portable parsing (no jq dependency)
+  # Extract key fields with portable parsing (no jq dependency).
+  # Patterns tolerate pretty-printed JSON (optional whitespace around colons).
   local current_bench completed total benchmarks failed
-  current_bench="$(grep -o '"currentBenchmark":"[^"]*"' "$status_file" | head -1 | cut -d'"' -f4)"
-  completed="$(grep -o '"completed":[0-9]*' "$status_file" | head -1 | cut -d: -f2)"
-  total="$(grep -o '"total":[0-9]*' "$status_file" | head -1 | cut -d: -f2)"
-  benchmarks="$(grep -o '"id":"[^"]*","status":"[^"]*"' "$status_file" | sed 's/"id":"/  /;s/","status":"/ → /;s/"$//' | tail -20)"
-  failed="$(grep -c '"status":"failed"' "$status_file" 2>/dev/null || echo 0)"
+  current_bench="$(grep -oE '"currentBenchmark"\s*:\s*"[^"]*"' "$status_file" | head -1 | grep -oE '"[^"]*"$' | tr -d '"')"
+  completed="$(grep -oE '"completed"\s*:\s*[0-9]+' "$status_file" | head -1 | grep -oE '[0-9]+$')"
+  total="$(grep -oE '"total"\s*:\s*[0-9]+' "$status_file" | head -1 | grep -oE '[0-9]+$')"
+  benchmarks="$(grep -oE '"id"\s*:\s*"[^"]*"\s*,\s*"status"\s*:\s*"[^"]*"' "$status_file" | sed -E 's/"id"\s*:\s*"/  /;s/"\s*,\s*"status"\s*:\s*"/ → /;s/"$//' | tail -20)"
+  failed="$(grep -cE '"status"\s*:\s*"failed"' "$status_file" 2>/dev/null || echo 0)"
 
   echo "status_file: $(basename "$status_file")"
   if [[ -n "$current_bench" ]]; then
@@ -167,8 +170,8 @@ cmd_status() {
   fi
 
   local bench_complete bench_total
-  bench_complete="$(grep -c '"status":"complete"' "$status_file" 2>/dev/null || echo 0)"
-  bench_total="$(grep -c '"status":"pending"\|"status":"running"\|"status":"complete"\|"status":"failed"' "$status_file" 2>/dev/null || echo 0)"
+  bench_complete="$(grep -cE '"status"\s*:\s*"complete"' "$status_file" 2>/dev/null || echo 0)"
+  bench_total="$(grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' "$status_file" 2>/dev/null || echo 0)"
 
   echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
   if [[ -n "$benchmarks" ]]; then

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -57,9 +57,16 @@ cmd_start() {
   local pid
   pid="$(read_pid)"
   if [[ -n "$pid" ]] && is_alive "$pid"; then
-    echo "ERROR: benchmark already running (PID $pid). Stop it first." >&2
-    echo "  scripts/bench-runner.sh stop" >&2
-    exit 1
+    # Verify the PID still belongs to the bench runner before blocking.
+    local cmd
+    cmd="$(ps -o command= -p "$pid" 2>/dev/null || true)"
+    if [[ "$cmd" == *"run-bench-cli"* ]]; then
+      echo "ERROR: benchmark already running (PID $pid). Stop it first." >&2
+      echo "  scripts/bench-runner.sh stop" >&2
+      exit 1
+    fi
+    # Stale PID file — clean it up and continue.
+    rm -f "$PID_FILE"
   fi
 
   # Save flags for reproducibility (redact API keys).
@@ -125,8 +132,8 @@ cmd_stop() {
   done
 
   if is_alive "$pid"; then
-    echo "Process did not exit, sending SIGKILL..."
-    kill -9 "$pid" 2>/dev/null || true
+    echo "Process did not exit, sending SIGKILL to process group..."
+    kill -9 -- -"$pid" 2>/dev/null || kill -9 "$pid" 2>/dev/null || true
   fi
 
   rm -f "$PID_FILE"

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -190,7 +190,7 @@ cmd_status() {
   completed="$(printf '%s' "$collapsed" | grep -oE '"completed"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   total="$(printf '%s' "$collapsed" | grep -oE '"total"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   benchmarks="$(printf '%s' "$collapsed" | grep -oE '"id"\s*:\s*"[^"]*"[^}]*?"status"\s*:\s*"[^"]*"' | sed -E 's/"id"\s*:\s*"/  /;s/".*?"status"\s*:\s*"/ → /;s/"$//' | tail -20 || true)"
-  failed="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"failed"' | wc -l | tr -d ' ')"
+  failed="$(printf '%s' "$collapsed" | { grep -oE '"status"\s*:\s*"failed"' || true; } | wc -l | tr -d ' ')"
 
   echo "status_file: $(basename "$status_file")"
   if [[ -n "$current_bench" ]]; then
@@ -198,8 +198,8 @@ cmd_status() {
   fi
 
   local bench_complete bench_total
-  bench_complete="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"complete"' | wc -l | tr -d ' ')"
-  bench_total="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"(pending|running|complete|failed)"' | wc -l | tr -d ' ')"
+  bench_complete="$(printf '%s' "$collapsed" | { grep -oE '"status"\s*:\s*"complete"' || true; } | wc -l | tr -d ' ')"
+  bench_total="$(printf '%s' "$collapsed" | { grep -oE '"status"\s*:\s*"(pending|running|complete|failed)"' || true; } | wc -l | tr -d ' ')"
 
   echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
   if [[ -n "$benchmarks" ]]; then

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -118,14 +118,6 @@ cmd_stop() {
     kill -9 "$pid" 2>/dev/null || true
   fi
 
-  # Kill any orphaned bench processes from previous runs
-  local orphaned
-  orphaned="$(pgrep -f "tsx.*packages/remnic-cli/src/index.ts bench run" 2>/dev/null || true)"
-  if [[ -n "$orphaned" ]]; then
-    echo "Killing orphaned bench processes: $orphaned"
-    echo "$orphaned" | xargs kill 2>/dev/null || true
-  fi
-
   rm -f "$PID_FILE"
   echo "Stopped."
 }

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -165,7 +165,7 @@ cmd_status() {
   completed="$(printf '%s' "$collapsed" | grep -oE '"completed"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   total="$(printf '%s' "$collapsed" | grep -oE '"total"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   benchmarks="$(printf '%s' "$collapsed" | grep -oE '"id"\s*:\s*"[^"]*"[^}]*?"status"\s*:\s*"[^"]*"' | sed -E 's/"id"\s*:\s*"/  /;s/".*?"status"\s*:\s*"/ → /;s/"$//' | tail -20 || true)"
-  failed="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"failed"' || echo 0)"
+  failed="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"failed"' || true)"
 
   echo "status_file: $(basename "$status_file")"
   if [[ -n "$current_bench" ]]; then
@@ -173,8 +173,8 @@ cmd_status() {
   fi
 
   local bench_complete bench_total
-  bench_complete="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"complete"' || echo 0)"
-  bench_total="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' || echo 0)"
+  bench_complete="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"complete"' || true)"
+  bench_total="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' || true)"
 
   echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
   if [[ -n "$benchmarks" ]]; then

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -78,7 +78,9 @@ cmd_start() {
   redacted_args="$(printf '%s' "$*" | sed -E 's/(-system-api-key |-judge-api-key |-api-key )[^ ]*/\1***REDACTED***/g')"
   echo "[$(date -Iseconds)] Starting benchmark: run-bench-cli.mjs run $redacted_args" >> "$LOG_FILE"
 
-  nohup node "$RUNNER_SCRIPT" run "$@" >> "$LOG_FILE" 2>&1 &
+  # Use setsid to create a new process group so kill -- -$pid
+  # reliably terminates the entire benchmark tree.
+  setsid nohup node "$RUNNER_SCRIPT" run "$@" >> "$LOG_FILE" 2>&1 &
   local bg_pid=$!
   echo "$bg_pid" > "$PID_FILE"
 

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -175,7 +175,7 @@ cmd_status() {
   completed="$(printf '%s' "$collapsed" | grep -oE '"completed"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   total="$(printf '%s' "$collapsed" | grep -oE '"total"\s*:\s*[0-9]+' | head -1 | grep -oE '[0-9]+$' || true)"
   benchmarks="$(printf '%s' "$collapsed" | grep -oE '"id"\s*:\s*"[^"]*"[^}]*?"status"\s*:\s*"[^"]*"' | sed -E 's/"id"\s*:\s*"/  /;s/".*?"status"\s*:\s*"/ → /;s/"$//' | tail -20 || true)"
-  failed="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"failed"' || true)"
+  failed="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"failed"' | wc -l | tr -d ' ')"
 
   echo "status_file: $(basename "$status_file")"
   if [[ -n "$current_bench" ]]; then
@@ -183,8 +183,8 @@ cmd_status() {
   fi
 
   local bench_complete bench_total
-  bench_complete="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"complete"' || true)"
-  bench_total="$(printf '%s' "$collapsed" | grep -cE '"status"\s*:\s*"(pending|running|complete|failed)"' || true)"
+  bench_complete="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"complete"' | wc -l | tr -d ' ')"
+  bench_total="$(printf '%s' "$collapsed" | grep -oE '"status"\s*:\s*"(pending|running|complete|failed)"' | wc -l | tr -d ' ')"
 
   echo "benchmarks: ${bench_complete}/${bench_total} complete, ${failed} failed"
   if [[ -n "$benchmarks" ]]; then


### PR DESCRIPTION
## Summary
- Add `--max-429-wait <ms>` CLI flag that keeps retrying 429 responses within a wall-clock budget, even beyond `maxAttempts`
- Capped exponential backoff (max 120s per retry) handles session-quota rate limits like Ollama Cloud's 5-hour reset window
- Add `scripts/bench-runner.sh` for session-independent benchmark execution (start/stop/status/log)

## Test plan
- [x] 12/12 retry-fetch tests pass (2 new tests for max429WaitMs behavior)
- [x] `--max-429-wait` flag validation (non-negative integer, max 24h)
- [x] bench-runner.sh start/stop/status/log subcommands tested
- [ ] Full Ollama Cloud benchmark with `--max-429-wait 18000000`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry behavior for HTTP 429s by allowing retries beyond `maxAttempts` within a wall-clock budget, which could lengthen runs or alter failure modes if misconfigured. Also introduces a new detached runner script that manages background processes and status files, with moderate operational risk on different environments.
> 
> **Overview**
> Adds an optional `max429WaitMs` *wall-clock budget* to `retryFetch` so HTTP `429` responses can keep retrying beyond `maxAttempts` with capped exponential backoff, budget clamping, and abort-aware sleeping; includes new tests covering both budget extension and budget exhaustion behavior.
> 
> Threads the new setting through bench configuration surfaces (provider `retryOptions`, runtime profile resolution) and exposes it as a validated CLI flag `--max-429-wait`.
> 
> Introduces `scripts/bench-runner.sh` to run benchmarks detached (start/stop/status/log/show), persisting PID/log/flag snapshots under `~/.remnic/bench` and parsing the latest `bench-status-*.json` for progress reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a7903c68807cec8cccac01024f3b2523034672a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->