### PR TITLE
feat(bench): add --resume and --retry-failed for interrupted runs

### DIFF
--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -193,11 +193,12 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--provider" ||
       arg === "--base-url" ||
       arg === "--request-timeout" ||
-      arg === "--max-429-wait" ||
-      arg === "--resume" ||
-      arg === "--retry-failed"
+      arg === "--max-429-wait"
     ) {
       index += 1;
+      continue;
+    }
+    if (arg === "--resume" || arg === "--retry-failed") {
       continue;
     }
     if (!arg.startsWith("-")) {

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -77,6 +77,10 @@ export interface ParsedBenchArgs {
   publishedOut?: string;
   /** `bench published` — dry-run: validate + load but do NOT call the model. */
   publishedDryRun?: boolean;
+  /** Skip benchmarks that completed successfully in the previous run. */
+  resume?: boolean;
+  /** Only re-run benchmarks that failed in the previous run. */
+  retryFailed?: boolean;
 }
 
 export type PublishedBenchmarkName = "longmemeval" | "locomo";
@@ -189,7 +193,9 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--provider" ||
       arg === "--base-url" ||
       arg === "--request-timeout" ||
-      arg === "--max-429-wait"
+      arg === "--max-429-wait" ||
+      arg === "--resume" ||
+      arg === "--retry-failed"
     ) {
       index += 1;
       continue;
@@ -493,6 +499,16 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
     );
   }
+
+  const resume = args.includes("--resume");
+  const retryFailed = args.includes("--retry-failed");
+  if (resume && retryFailed) {
+    throw new Error(
+      "ERROR: --resume and --retry-failed are mutually exclusive. " +
+        "Use --resume to skip completed benchmarks, or --retry-failed to only re-run failed ones.",
+    );
+  }
+
   return {
     action,
     benchmarks,
@@ -537,5 +553,7 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     requestTimeout,
     max429WaitMs,
     disableThinking: args.includes("--disable-thinking"),
+    resume,
+    retryFailed,
   };
 }

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -11,7 +11,7 @@
  * partially-written JSON.
  */
 
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, rename, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 export interface BenchmarkStatusEntry {
@@ -41,6 +41,38 @@ export function createBenchStatusPath(
   return path.join(resultsDir, `bench-status-${startedAtMs}-${pid}.json`);
 }
 
+const BENCH_STATUS_FILENAME = /^bench-status-\d+-\d+\.json$/;
+
+/**
+ * Find the most recent bench-status file in the results directory.
+ * Returns `null` when no valid status file exists.
+ */
+export async function findLatestBenchStatusFile(
+  resultsDir: string,
+): Promise<string | null> {
+  let entries: string[];
+  try {
+    entries = await readdir(resultsDir);
+  } catch {
+    return null;
+  }
+
+  const candidates = entries
+    .filter((name) => BENCH_STATUS_FILENAME.test(name))
+    .sort()
+    .reverse();
+
+  for (const name of candidates) {
+    const filePath = path.join(resultsDir, name);
+    const status = await readBenchStatus(filePath);
+    if (status) {
+      return filePath;
+    }
+  }
+
+  return null;
+}
+
 async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
   await mkdir(path.dirname(filePath), { recursive: true });
   const tmp = `${filePath}.${Date.now()}-${Math.random().toString(36).slice(2)}.tmp`;
@@ -48,7 +80,7 @@ async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
   await rename(tmp, filePath);
 }
 
-async function readStatusFile(filePath: string): Promise<BenchStatus | null> {
+export async function readBenchStatus(filePath: string): Promise<BenchStatus | null> {
   try {
     const raw = await readFile(filePath, "utf-8");
     const parsed = JSON.parse(raw);
@@ -68,7 +100,7 @@ function serializedWrite(
 ): Promise<void> {
   const prev = writeQueues.get(filePath) ?? Promise.resolve();
   const next = prev.then(async () => {
-    const current = await readStatusFile(filePath);
+    const current = await readBenchStatus(filePath);
     if (!current) return;
     const updated = fn(current);
     if (updated) {

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -42,6 +42,7 @@ export function createBenchStatusPath(
 }
 
 const BENCH_STATUS_FILENAME = /^bench-status-\d+-\d+\.json$/;
+const VALID_BENCH_ENTRY_STATUSES = new Set(["pending", "running", "complete", "failed"]);
 
 /**
  * Find the most recent bench-status file in the results directory.
@@ -94,7 +95,12 @@ export async function readBenchStatus(filePath: string): Promise<BenchStatus | n
       if (typeof entry !== "object" || entry === null) return null;
       const e = entry as Record<string, unknown>;
       if (typeof e.id !== "string") return null;
-      if (typeof e.status !== "string") return null;
+      if (
+        typeof e.status !== "string" ||
+        !VALID_BENCH_ENTRY_STATUSES.has(e.status)
+      ) {
+        return null;
+      }
     }
     return parsed as BenchStatus;
   } catch {

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -89,6 +89,13 @@ export async function readBenchStatus(filePath: string): Promise<BenchStatus | n
     if (!Array.isArray(obj.benchmarks)) return null;
     if (typeof obj.pid !== "number") return null;
     if (typeof obj.startedAt !== "string") return null;
+    // Validate each benchmark entry has required fields.
+    for (const entry of obj.benchmarks as unknown[]) {
+      if (typeof entry !== "object" || entry === null) return null;
+      const e = entry as Record<string, unknown>;
+      if (typeof e.id !== "string") return null;
+      if (typeof e.status !== "string") return null;
+    }
     return parsed as BenchStatus;
   } catch {
     return null;

--- a/packages/remnic-cli/src/bench-status.ts
+++ b/packages/remnic-cli/src/bench-status.ts
@@ -83,8 +83,12 @@ async function atomicWriteJSON(filePath: string, data: unknown): Promise<void> {
 export async function readBenchStatus(filePath: string): Promise<BenchStatus | null> {
   try {
     const raw = await readFile(filePath, "utf-8");
-    const parsed = JSON.parse(raw);
+    const parsed: unknown = JSON.parse(raw);
     if (typeof parsed !== "object" || parsed === null) return null;
+    const obj = parsed as Record<string, unknown>;
+    if (!Array.isArray(obj.benchmarks)) return null;
+    if (typeof obj.pid !== "number") return null;
+    if (typeof obj.startedAt !== "string") return null;
     return parsed as BenchStatus;
   } catch {
     return null;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4912,14 +4912,17 @@ async function cmdBench(rest: string[]): Promise<void> {
         const s = statusEntryMap.get(id);
         if (s) statuses.push(s);
       }
-      // Cross-profile: when current run profiles don't cover all previous
-      // entries, also check bare IDs and bracket-suffixed IDs.
+      // Bare ID from a previous single-profile run (needed for
+      // single→matrix and matrix→single transitions).
       const bareStatus = statusEntryMap.get(benchmarkId);
       if (bareStatus && !statuses.includes(bareStatus)) {
         statuses.push(bareStatus);
       }
-      for (const [entryId, entryStatus] of statusEntryMap) {
-        if (entryId.startsWith(`${benchmarkId} [`) && !statuses.includes(entryStatus)) {
+      // Bracket-suffixed entries ONLY for profiles in the current run.
+      // This avoids contamination from profiles not being re-run.
+      for (const p of runtimeProfiles) {
+        const entryStatus = statusEntryMap.get(`${benchmarkId} [${p}]`);
+        if (entryStatus && !statuses.includes(entryStatus)) {
           statuses.push(entryStatus);
         }
       }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4917,11 +4917,15 @@ async function cmdBench(rest: string[]): Promise<void> {
           : [benchmarkId];
         return profileEntries.some((id) => statusEntryMap.get(id) === "failed");
       });
-      console.log(`  Retrying: ${selectedBenchmarks.length} of ${before} failed benchmarks`);
+      console.log(`  Retrying: ${selectedBenchmarks.length} of ${before} selected benchmarks had failures`);
     }
 
     if (selectedBenchmarks.length === 0) {
-      console.log("Nothing to re-run — all selected benchmarks completed successfully.");
+      if (parsed.retryFailed) {
+        console.log("Nothing to re-run — no selected benchmarks had failures.");
+      } else {
+        console.log("Nothing to re-run — all selected benchmarks completed successfully.");
+      }
       process.exit(0);
     }
   }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4951,7 +4951,9 @@ async function cmdBench(rest: string[]): Promise<void> {
       if (parsed.retryFailed) {
         console.log("Nothing to re-run — no selected benchmarks had failures.");
       } else {
-        console.log("Nothing to re-run — all selected benchmarks completed successfully.");
+        console.log(
+          "Nothing to re-run — all selected benchmarks completed successfully in the previous run.",
+        );
       }
       process.exit(0);
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4900,23 +4900,27 @@ async function cmdBench(rest: string[]): Promise<void> {
     const statusEntryMap = new Map(prevStatus.benchmarks.map((b) => [b.id, b.status]));
 
     // Helper: collect all status entries relevant to a benchmark ID across
-    // profile variations. Handles both current-matrix → previous-single and
-    // current-single → previous-matrix (where entries have ` [profile]` suffix).
+    // profile variations. Handles all four combinations of current/previous
+    // single vs matrix runs.
     const relevantStatuses = (benchmarkId: string): string[] => {
       const profileEntries = runtimeProfiles.length > 1
         ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
         : [benchmarkId];
       const statuses: string[] = [];
+      // Direct match: current profile entries against previous status entries.
       for (const id of profileEntries) {
         const s = statusEntryMap.get(id);
         if (s) statuses.push(s);
       }
-      // Also check previous matrix entries when current run is single-profile.
-      if (runtimeProfiles.length <= 1) {
-        for (const [entryId, entryStatus] of statusEntryMap) {
-          if (entryId.startsWith(`${benchmarkId} [`) && !statuses.includes(entryStatus)) {
-            statuses.push(entryStatus);
-          }
+      // Cross-profile: when current run profiles don't cover all previous
+      // entries, also check bare IDs and bracket-suffixed IDs.
+      const bareStatus = statusEntryMap.get(benchmarkId);
+      if (bareStatus && !statuses.includes(bareStatus)) {
+        statuses.push(bareStatus);
+      }
+      for (const [entryId, entryStatus] of statusEntryMap) {
+        if (entryId.startsWith(`${benchmarkId} [`) && !statuses.includes(entryStatus)) {
+          statuses.push(entryStatus);
         }
       }
       return statuses;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -158,6 +158,8 @@ import {
   updateBenchmarkFailed,
   updateTaskProgress as updateBenchStatusTaskProgress,
   finalizeBenchStatus,
+  findLatestBenchStatusFile,
+  readBenchStatus,
 } from "./bench-status.js";
 import {
   buildBenchRunnerArgs,
@@ -4848,7 +4850,7 @@ async function cmdBench(rest: string[]): Promise<void> {
     return;
   }
 
-  const selectedBenchmarks = parsed.all
+  let selectedBenchmarks = parsed.all
     ? await resolveAllBenchmarks()
     : parsed.benchmarks;
   if (selectedBenchmarks.length === 0) {
@@ -4860,6 +4862,61 @@ async function cmdBench(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
+  const runtimeProfiles = resolveBenchRunProfiles(parsed);
+
+  // --resume / --retry-failed: filter against previous run status
+  if (parsed.resume || parsed.retryFailed) {
+    const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
+    const latestStatusPath = await findLatestBenchStatusFile(resultsDir);
+    if (!latestStatusPath) {
+      console.error(
+        parsed.resume
+          ? "ERROR: --resume requires a previous bench-status file. Run a benchmark first."
+          : "ERROR: --retry-failed requires a previous bench-status file. Run a benchmark first.",
+      );
+      process.exit(1);
+    }
+    const prevStatus = await readBenchStatus(latestStatusPath);
+    if (!prevStatus) {
+      console.error("ERROR: could not parse previous bench-status file.");
+      process.exit(1);
+    }
+
+    const completeCount = prevStatus.benchmarks.filter((b) => b.status === "complete").length;
+    const failedCount = prevStatus.benchmarks.filter((b) => b.status === "failed").length;
+    console.log(`Resuming from: ${path.basename(latestStatusPath)}`);
+    console.log(`  Previous run: ${prevStatus.startedAt}`);
+    console.log(`  Benchmarks: ${prevStatus.benchmarks.length} total, ${completeCount} complete, ${failedCount} failed`);
+
+    const statusEntryMap = new Map(prevStatus.benchmarks.map((b) => [b.id, b.status]));
+    const before = selectedBenchmarks.length;
+
+    if (parsed.resume) {
+      // Skip completed benchmarks; re-run pending/running/failed.
+      selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
+        const profileEntries = runtimeProfiles.length > 1
+          ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
+          : [benchmarkId];
+        return !profileEntries.every((id) => statusEntryMap.get(id) === "complete");
+      });
+      console.log(`  Resuming: ${selectedBenchmarks.length} of ${before} benchmarks to re-run`);
+    } else {
+      // --retry-failed: only re-run failed benchmarks.
+      selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
+        const profileEntries = runtimeProfiles.length > 1
+          ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
+          : [benchmarkId];
+        return profileEntries.some((id) => statusEntryMap.get(id) === "failed");
+      });
+      console.log(`  Retrying: ${selectedBenchmarks.length} of ${before} failed benchmarks`);
+    }
+
+    if (selectedBenchmarks.length === 0) {
+      console.log("Nothing to re-run — all selected benchmarks completed successfully.");
+      process.exit(0);
+    }
+  }
+
   const knownBenchmarkIds = await resolveKnownBenchmarkIds();
   const unknown = selectedBenchmarks.filter((benchmarkId) => !knownBenchmarkIds.has(benchmarkId));
   if (unknown.length > 0) {
@@ -4867,7 +4924,6 @@ async function cmdBench(rest: string[]): Promise<void> {
     process.exit(1);
   }
 
-  const runtimeProfiles = resolveBenchRunProfiles(parsed);
   const failures = new Set<string>();
   const benchStatusPath = createBenchStatusPath(
     parsed.resultsDir ?? resolveBenchOutputDir(),

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4898,24 +4898,47 @@ async function cmdBench(rest: string[]): Promise<void> {
     console.log(`  Benchmarks: ${prevStatus.benchmarks.length} total, ${completeCount} complete, ${failedCount} failed`);
 
     const statusEntryMap = new Map(prevStatus.benchmarks.map((b) => [b.id, b.status]));
+
+    // Helper: collect all status entries relevant to a benchmark ID across
+    // profile variations. Handles both current-matrix → previous-single and
+    // current-single → previous-matrix (where entries have ` [profile]` suffix).
+    const relevantStatuses = (benchmarkId: string): string[] => {
+      const profileEntries = runtimeProfiles.length > 1
+        ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
+        : [benchmarkId];
+      const statuses: string[] = [];
+      for (const id of profileEntries) {
+        const s = statusEntryMap.get(id);
+        if (s) statuses.push(s);
+      }
+      // Also check previous matrix entries when current run is single-profile.
+      if (runtimeProfiles.length <= 1) {
+        for (const [entryId, entryStatus] of statusEntryMap) {
+          if (entryId.startsWith(`${benchmarkId} [`) && !statuses.includes(entryStatus)) {
+            statuses.push(entryStatus);
+          }
+        }
+      }
+      return statuses;
+    };
+
     const before = selectedBenchmarks.length;
 
     if (parsed.resume) {
-      // Skip completed benchmarks; re-run pending/running/failed.
+      // Skip benchmarks where ALL entries completed; re-run if any entry is
+      // pending, running, or failed. Benchmarks absent from previous status
+      // are treated as new and always re-run.
       selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
-        const profileEntries = runtimeProfiles.length > 1
-          ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
-          : [benchmarkId];
-        return !profileEntries.every((id) => statusEntryMap.get(id) === "complete");
+        const statuses = relevantStatuses(benchmarkId);
+        if (statuses.length === 0) return true; // not in previous run
+        return !statuses.every((s) => s === "complete");
       });
       console.log(`  Resuming: ${selectedBenchmarks.length} of ${before} benchmarks to re-run`);
     } else {
-      // --retry-failed: only re-run failed benchmarks.
+      // --retry-failed: only re-run benchmarks that had failures.
       selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
-        const profileEntries = runtimeProfiles.length > 1
-          ? runtimeProfiles.map((p) => `${benchmarkId} [${p}]`)
-          : [benchmarkId];
-        return profileEntries.some((id) => statusEntryMap.get(id) === "failed");
+        const statuses = relevantStatuses(benchmarkId);
+        return statuses.some((s) => s === "failed");
       });
       console.log(`  Retrying: ${selectedBenchmarks.length} of ${before} selected benchmarks had failures`);
     }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4864,6 +4864,15 @@ async function cmdBench(rest: string[]): Promise<void> {
 
   const runtimeProfiles = resolveBenchRunProfiles(parsed);
 
+  // Validate benchmark IDs before resume/retry-failed filtering so unknown
+  // names are caught early instead of being silently dropped by the filter.
+  const knownBenchmarkIds = await resolveKnownBenchmarkIds();
+  const unknown = selectedBenchmarks.filter((benchmarkId) => !knownBenchmarkIds.has(benchmarkId));
+  if (unknown.length > 0) {
+    console.error(`ERROR: unknown benchmark(s): ${unknown.join(", ")}. Use 'remnic bench list' to see available.`);
+    process.exit(1);
+  }
+
   // --resume / --retry-failed: filter against previous run status
   if (parsed.resume || parsed.retryFailed) {
     const resultsDir = parsed.resultsDir ?? resolveBenchOutputDir();
@@ -4915,13 +4924,6 @@ async function cmdBench(rest: string[]): Promise<void> {
       console.log("Nothing to re-run — all selected benchmarks completed successfully.");
       process.exit(0);
     }
-  }
-
-  const knownBenchmarkIds = await resolveKnownBenchmarkIds();
-  const unknown = selectedBenchmarks.filter((benchmarkId) => !knownBenchmarkIds.has(benchmarkId));
-  if (unknown.length > 0) {
-    console.error(`ERROR: unknown benchmark(s): ${unknown.join(", ")}. Use 'remnic bench list' to see available.`);
-    process.exit(1);
   }
 
   const failures = new Set<string>();

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4929,12 +4929,19 @@ async function cmdBench(rest: string[]): Promise<void> {
     const before = selectedBenchmarks.length;
 
     if (parsed.resume) {
-      // Skip benchmarks where ALL entries completed; re-run if any entry is
-      // pending, running, or failed. Benchmarks absent from previous status
-      // are treated as new and always re-run.
+      // Skip benchmarks where ALL expected profile entries completed; re-run
+      // if any entry is pending, running, failed, or absent (new profile).
       selectedBenchmarks = selectedBenchmarks.filter((benchmarkId) => {
         const statuses = relevantStatuses(benchmarkId);
         if (statuses.length === 0) return true; // not in previous run
+        // When running multiple profiles, check that each expected profile
+        // entry exists in the previous status. Missing profiles mean the
+        // benchmark hasn't been run for that profile yet.
+        if (runtimeProfiles.length > 1) {
+          for (const p of runtimeProfiles) {
+            if (!statusEntryMap.has(`${benchmarkId} [${p}]`)) return true;
+          }
+        }
         return !statuses.every((s) => s === "complete");
       });
       console.log(`  Resuming: ${selectedBenchmarks.length} of ${before} benchmarks to re-run`);

--- a/scripts/bench-runner.sh
+++ b/scripts/bench-runner.sh
@@ -9,6 +9,10 @@
 #   scripts/bench-runner.sh log                      - tail the log file
 #   scripts/bench-runner.sh show                     - print latest status JSON
 #
+# Resume / retry flags (passed to run-bench-cli.mjs):
+#   --resume          - skip benchmarks that completed successfully
+#   --retry-failed    - only re-run benchmarks that failed
+#
 # State files:
 #   ~/.remnic/bench/runner.pid   - PID of the bench process
 #   ~/.remnic/bench/runner.log   - combined stdout+stderr

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -110,7 +110,7 @@ test("--all selection resolves to runnable package benchmarks when package metad
     source,
     /packageBenchmarks\s*\n\s*\.filter\(\s*\(entry\) =>\s*entry\.runnerAvailable\s*&&\s*entry\.meta\?\.category !== "ingestion"/s,
   );
-  assert.match(source, /const selectedBenchmarks = parsed\.all\s+\? await resolveAllBenchmarks\(\)/s);
+  assert.match(source, /let selectedBenchmarks = parsed\.all\s+\? await resolveAllBenchmarks\(\)/s);
   assert.match(source, /async function resolveKnownBenchmarkIds\(\): Promise<Set<string>>/);
   assert.match(source, /const knownBenchmarkIds = await resolveKnownBenchmarkIds\(\);/);
   assert.match(source, /selectedBenchmarks\.filter\(\(benchmarkId\) => !knownBenchmarkIds\.has\(benchmarkId\)\)/);


### PR DESCRIPTION
## Summary

- **`--resume`**: Reads the latest bench-status file and skips benchmarks that completed successfully, re-running any pending/running/failed entries. Useful when a benchmark run was interrupted (session overflow, killed process, rate limits).
- **`--retry-failed`**: Only re-runs benchmarks that failed in the previous run. Useful after transient failures like 429 rate limits have cleared.
- Both flags are mutually exclusive and require a previous bench-status file.
- Matrix-aware: checks all profile-specific status entries before deciding to skip a benchmark.

## Files changed

- `packages/remnic-cli/src/bench-args.ts` — New `resume`/`retryFailed` fields + mutual exclusion validation
- `packages/remnic-cli/src/bench-status.ts` — Export `readBenchStatus` and new `findLatestBenchStatusFile()`
- `packages/remnic-cli/src/index.ts` — Filter `selectedBenchmarks` before the run loop based on previous status
- `scripts/bench-runner.sh` — Usage docs for new flags

## Test plan

- [ ] Run a benchmark, then `--resume` confirms completed ones are skipped
- [ ] Run a benchmark that fails, then `--retry-failed` only re-runs the failed ones
- [ ] `--resume --retry-failed` together produces an error
- [ ] `--resume` with no previous status file produces an error
- [ ] All previously completed + nothing-to-rerun exits cleanly with message
- [ ] Matrix runs (`--matrix baseline,real`) correctly skip/retry per-profile

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark selection logic to conditionally skip/re-run work based on prior `bench-status` files; bugs here could cause benchmarks to be incorrectly omitted or re-executed, especially across matrix profile runs.
> 
> **Overview**
> Adds `--resume` and `--retry-failed` to the bench CLI to continue from the latest `bench-status-*.json` run, either **skipping previously completed** benchmarks or **re-running only failures** (mutually exclusive).
> 
> Exports and hardens status-file reading (`readBenchStatus`) and adds `findLatestBenchStatusFile()` to locate the most recent valid status file, then `index.ts` filters `selectedBenchmarks` (matrix-aware, with early unknown-benchmark validation) and exits cleanly when there’s nothing to re-run. Documentation/tests are updated to reflect the new flags.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2362e82cfd81b1da64491550342b20e4f2498668. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->