### PR TITLE
fix: unblock import-chatgpt dts build

### DIFF
--- a/packages/import-chatgpt/src/parser.ts
+++ b/packages/import-chatgpt/src/parser.ts
@@ -401,7 +401,7 @@ function followCurrentNodeChain(
       return [];
     }
     visited.add(cursor);
-    const node = mapping[cursor];
+    const node: ChatGPTConversationNode | undefined = mapping[cursor];
     if (!node) {
       // Broken parent link (dangling reference). Don't return a partial
       // tail — it would silently omit the root and leave the caller with


### PR DESCRIPTION
## Summary
- add an explicit `ChatGPTConversationNode | undefined` annotation in `followCurrentNodeChain`
- fix the TypeScript DTS inference failure in `@remnic/import-chatgpt`
- unblock the release workflow so npm publish can proceed again

## Validation
- `pnpm --filter @remnic/core run build && pnpm --filter @remnic/import-chatgpt run build && pnpm --filter @remnic/import-chatgpt test && pnpm -r run build`
- `npm run preflight:quick` (entered full quick-gate test phase without surfacing failures before this hotfix push)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a type-only annotation in `followCurrentNodeChain` to satisfy TypeScript DTS generation, with no intended runtime behavior change.
> 
> **Overview**
> Fixes TypeScript declaration generation for `@remnic/import-chatgpt` by explicitly typing the `mapping[cursor]` lookup in `followCurrentNodeChain` as `ChatGPTConversationNode | undefined`, avoiding problematic inference during DTS emit.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ed8c0a410eaf451b4b7e0304dce1dbe10e149d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->