### PR TITLE
fix: unblock core npm releases

### DIFF
--- a/.github/workflows/release-and-publish.yml
+++ b/.github/workflows/release-and-publish.yml
@@ -385,12 +385,31 @@ jobs:
             fi
             pkg_name="$(node -p "require('./$pkg_json').name")"
             pkg_version="$(node -p "require('./$pkg_json').version")"
+            pkg_exists="false"
+            if npm view "${pkg_name}" version >/dev/null 2>&1; then
+              pkg_exists="true"
+            fi
             if npm view "${pkg_name}@${pkg_version}" version >/dev/null 2>&1; then
               echo "::notice::${pkg_name}@${pkg_version} already published; skipping."
               continue
             fi
             echo "Publishing ${pkg_name}@${pkg_version} from ${pkg_dir}..."
-            (cd "$pkg_dir" && pnpm publish --access public --provenance --no-git-checks)
+            publish_log="$(mktemp)"
+            if (cd "$pkg_dir" && pnpm publish --access public --provenance --no-git-checks) >"$publish_log" 2>&1; then
+              cat "$publish_log"
+              rm -f "$publish_log"
+              continue
+            else
+              publish_status=$?
+              cat "$publish_log"
+              if [ "$pkg_exists" != "true" ] && grep -q "npm error code E404" "$publish_log"; then
+                echo "::warning::${pkg_name}@${pkg_version} is not provisioned for first-time npm publish from this automation yet; skipping so existing package updates can still ship."
+                rm -f "$publish_log"
+                continue
+              fi
+              rm -f "$publish_log"
+              exit $publish_status
+            fi
           done
 
       - name: Push release commits to main

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `@remnic/core` to `1.1.1` so the merged core fix can actually publish
- let the workspace publish loop continue when a first-time package fails with npm `E404` because npm-side provisioning is missing
- keep hard failures for already-provisioned packages so real publish regressions still stop the release

## Validation
- `bash -n` on the workflow publish-step shell
- `pnpm install --frozen-lockfile && pnpm --filter @remnic/core run build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the release automation’s publish failure behavior, potentially masking real publish issues if the E404 matching is too broad; otherwise it’s confined to CI and a patch version bump.
> 
> **Overview**
> Unblocks npm releases by bumping `@remnic/core` from `1.1.0` to `1.1.1`.
> 
> Updates the release workflow’s workspace publish loop to capture `pnpm publish` output and **skip (rather than fail the whole release)** when a package that doesn’t yet exist on npm hits a first-time publish provisioning error (`npm error code E404`), while still failing on other publish errors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3cccc038a10705a13bb7b82d99d8564b908d6ef1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->