### PR TITLE
fix: bump openclaw plugin for core 1.1.1

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- bump `@remnic/plugin-openclaw` from `1.0.7` to `1.0.8`
- force a republish so OpenClaw users pick up the shipped `@remnic/core@1.1.1` fix

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @remnic/plugin-openclaw run build`
- `npm run preflight:quick` (entered the repo quick gate and passed type/config checks before broad monorepo tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: metadata-only change (`package.json` version bump) with no code or dependency logic modifications.
> 
> **Overview**
> Bumps `@remnic/plugin-openclaw` from **1.0.7** to **1.0.8** in `package.json` to force a republish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 032bcc30520a4512dad7a79ad180de0ea2f5b0aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->