### PR TITLE
fix: bump openclaw engram shim for latest releases

### DIFF
--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.6",
+  "version": "9.3.7",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.6");
+  assert.equal(pkg.version, "9.3.7");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- bump `@joshuaswarren/openclaw-engram` from `9.3.6` to `9.3.7`
- force a republish so shim users pick up the latest published Remnic/OpenClaw surfaces

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm --filter @joshuaswarren/openclaw-engram run build`
- `npm run preflight:quick` (passed type/config/review-pattern stages and entered the broad repo test sweep)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this is a version bump for a compatibility shim with a matching test update and no functional/runtime logic changes.
> 
> **Overview**
> Bumps `@joshuaswarren/openclaw-engram` from `9.3.6` to `9.3.7` to trigger a republish of the Engram compatibility shim.
> 
> Updates the package manifest test to assert the new version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 335b6534e1a9330957e256c65e8d63233e91d1d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->