### PR TITLE
chore(release): publish OpenClaw security fixes

### DIFF
--- a/.github/workflows/ai-review-gate.yml
+++ b/.github/workflows/ai-review-gate.yml
@@ -10,6 +10,7 @@ on:
 
 permissions:
   contents: read
+  checks: read
   issues: read
   pull-requests: read
 
@@ -78,6 +79,16 @@ jobs:
               per_page: 100,
             });
 
+            const headSha = context.payload.pull_request?.head?.sha;
+            const checkRuns = headSha
+              ? await github.paginate(github.rest.checks.listForRef, {
+                  owner,
+                  repo,
+                  ref: headSha,
+                  per_page: 100,
+                })
+              : [];
+
             const latestByUser = new Map();
             for (const review of reviews) {
               const login = review.user?.login?.toLowerCase();
@@ -88,6 +99,14 @@ jobs:
               const login = comment.user?.login?.toLowerCase();
               if (!login) continue;
               if (!latestByUser.has(login)) latestByUser.set(login, "COMMENTED");
+            }
+            for (const checkRun of checkRuns) {
+              if (!["success", "failure", "neutral"].includes(checkRun.conclusion)) continue;
+              for (const appName of [checkRun.app?.slug, checkRun.app?.name]) {
+                const login = appName?.toLowerCase();
+                if (!login) continue;
+                if (!latestByUser.has(login)) latestByUser.set(login, "CHECK_RUN");
+              }
             }
 
             const present = [];

--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/core",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Framework-agnostic Remnic memory engine — orchestrator, storage, extraction, search, trust zones",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2027,6 +2027,32 @@
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
+      "recallGraphEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, recall builds a retrieval graph from memory frontmatter and runs Personalized PageRank, merging the result with QMD via MMR (issue #559 PR 4). Default false — ships off pending the retrieval-graph bench in PR 5."
+      },
+      "recallGraphDamping": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 0.999999999,
+        "default": 0.85,
+        "description": "PPR damping factor used by the graph retrieval tier (issue #559)."
+      },
+      "recallGraphIterations": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 500,
+        "default": 20,
+        "description": "Maximum power-iteration rounds for PPR. Higher values trade latency for convergence."
+      },
+      "recallGraphTopK": {
+        "type": "integer",
+        "minimum": 0,
+        "maximum": 10000,
+        "default": 50,
+        "description": "Maximum memories returned by the graph retrieval tier before the MMR diversifier runs."
+      },
       "recallDirectAnswerTokenOverlapFloor": {
         "type": "number",
         "minimum": 0,
@@ -2061,6 +2087,75 @@
           "entities"
         ],
         "description": "Taxonomy category IDs eligible for direct-answer routing."
+      },
+      "recallCrossNamespaceBudgetEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Cross-namespace query-budget limiter (issue #565). When true, a principal that issues a burst of recalls against namespaces other than their own is throttled once its per-window count crosses the hard limit. Ships disabled."
+      },
+      "recallCrossNamespaceBudgetWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 60000,
+        "description": "Rolling window in ms over which cross-namespace reads are counted for the per-principal budget."
+      },
+      "recallCrossNamespaceBudgetSoftLimit": {
+        "type": "number",
+        "minimum": 0,
+        "default": 10,
+        "description": "Soft threshold for the cross-namespace budget: calls past this count are flagged but still allowed."
+      },
+      "recallCrossNamespaceBudgetHardLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Hard threshold for the cross-namespace budget: calls past this count are denied until the window advances."
+      },
+      "recallAuditAnomalyDetectionEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "When true, access surfaces (MCP, HTTP) run the anomaly detector over a tail of the audit trail after each recall and surface flags via logs/metrics. Ships disabled — enable explicitly."
+      },
+      "recallAuditAnomalyWindowMs": {
+        "type": "number",
+        "minimum": 1,
+        "default": 300000,
+        "description": "Rolling window (ms) over which audit entries are analyzed by the anomaly detector. Default 5 minutes."
+      },
+      "recallAuditAnomalyRepeatQueryLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 5,
+        "description": "Threshold for the repeat-query anomaly flag: number of identical queries within the window before flagging."
+      },
+      "recallAuditAnomalyNamespaceWalkLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 3,
+        "description": "Threshold for the namespace-walk anomaly flag: number of distinct namespaces queried within the window before flagging."
+      },
+      "recallAuditAnomalyHighCardinalityLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 50,
+        "description": "Threshold for the high-cardinality-return anomaly flag: number of distinct results returned within the window before flagging."
+      },
+      "recallAuditAnomalyRapidFireLimit": {
+        "type": "number",
+        "minimum": 1,
+        "default": 30,
+        "description": "Threshold for the rapid-fire anomaly flag: number of recall requests within the window before flagging."
+      },
+      "recallMemoryWorthFilterEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When true, recall multiplies candidate scores by the Memory Worth factor (mw_success / mw_fail counters, see issue #560). Memories with a history of failed sessions sink; neutral/uninstrumented memories are untouched. PR 5 bench: +0.60 precision@5 vs baseline on all 50 seeded cases. Operators can opt out with false."
+      },
+      "recallMemoryWorthHalfLifeMs": {
+        "type": "number",
+        "minimum": 0,
+        "default": 0,
+        "description": "Half-life (ms) for Memory Worth decay. Positive values exponentially decay older outcomes toward the neutral prior; 0 disables decay."
       },
       "memoryLinkingEnabled": {
         "type": "boolean",
@@ -2788,6 +2883,11 @@
         "type": "number",
         "default": 100,
         "description": "Max memories to consolidate per run to limit LLM cost."
+      },
+      "operatorAwareConsolidationEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
       "creationMemoryEnabled": {
         "type": "boolean",
@@ -3567,6 +3667,11 @@
         "minimum": 0,
         "description": "Number of top candidates per section to run MMR over. Candidates past this remain in original order."
       },
+      "recallReasoningTraceBoostEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Boost stored reasoning_trace memories in recall results when the incoming query reads like a problem-solving ask (e.g. 'how do I...', 'step by step', 'walk me through...'). Default false - opt in after benchmarking (issue #564)."
+      },
       "recallPipeline": {
         "type": "array",
         "description": "Ordered recall sections with per-section budgets and feature knobs.",
@@ -4182,6 +4287,25 @@
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
     },
+    "recallGraphEnabled": {
+      "label": "Graph Retrieval (PPR)",
+      "help": "Run Personalized PageRank on the retrieval graph and merge with QMD via MMR (issue #559)."
+    },
+    "recallGraphDamping": {
+      "label": "Graph Recall Damping",
+      "advanced": true,
+      "placeholder": "0.85"
+    },
+    "recallGraphIterations": {
+      "label": "Graph Recall Iterations",
+      "advanced": true,
+      "placeholder": "20"
+    },
+    "recallGraphTopK": {
+      "label": "Graph Recall Top-K",
+      "advanced": true,
+      "placeholder": "50"
+    },
     "recallDirectAnswerTokenOverlapFloor": {
       "label": "Direct-Answer Token Overlap Floor",
       "advanced": true,
@@ -4562,6 +4686,11 @@
       "advanced": true,
       "help": "Max memories to consolidate per run to limit LLM cost."
     },
+    "operatorAwareConsolidationEnabled": {
+      "label": "Operator-Aware Consolidation Prompt",
+      "advanced": true,
+      "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+    },
     "creationMemoryEnabled": {
       "label": "Creation Memory",
       "advanced": true,
@@ -4872,6 +5001,11 @@
       "advanced": true,
       "placeholder": "40",
       "help": "Number of top candidates per section over which MMR is applied"
+    },
+    "recallReasoningTraceBoostEnabled": {
+      "label": "Boost Reasoning Traces on Problem-Solving Queries",
+      "advanced": true,
+      "help": "Promote stored reasoning_trace memories to the top of recall results when the incoming query reads like a problem-solving ask. Default off; enable after benchmarking (issue #564)."
     }
   }
 }

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.7",
+  "version": "9.3.8",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.7");
+  assert.equal(pkg.version, "9.3.8");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary
- bump @remnic/core to 1.1.2 so the merged OpenClaw dangerous-scan hardening is published
- bump @remnic/plugin-openclaw to 1.0.9 for the OpenClaw adapter package
- bump @joshuaswarren/openclaw-engram to 9.3.8 and sync its legacy OpenClaw manifest from the canonical adapter manifest
- update the AI review gate to count completed AI reviewer check runs, matching scripts/pre-merge-check.sh behavior for Cursor/Kilo check-run-only reviews

## Verification
- npm run check-types
- pnpm exec tsx --test tests/openclaw-plugin-dangerous-scan.test.ts tests/codex-memory-extension-install.test.ts tests/briefing-save.test.ts tests/memory-extension-publisher.test.ts tests/remnic-migration.test.ts
- pnpm exec tsx --test tests/shim-openclaw-engram-package.test.ts
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/plugin-openclaw build
- pnpm --filter @joshuaswarren/openclaw-engram build
- npm pack --dry-run --json --workspace packages/plugin-openclaw
- node -e "const fs=require('fs'); const YAML=require('yaml'); YAML.parse(fs.readFileSync('.github/workflows/ai-review-gate.yml','utf8')); console.log('yaml ok')"

## Release intent
The merge-triggered v9.3.166 workflow skipped these workspace packages because their previous versions were already published. These bumps create new npm versions for the PR #668 fix set.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates GitHub Actions gating logic and ships new package/plugin manifest versions; the workflow change could unexpectedly pass/fail PRs depending on check-run naming/conclusions.
> 
> **Overview**
> Publishes a new release set by bumping workspace package versions: `@remnic/core` to `1.1.2`, `@remnic/plugin-openclaw` to `1.0.9`, and the legacy shim `@joshuaswarren/openclaw-engram` to `9.3.8` (with its version assertion updated in tests).
> 
> Expands the OpenClaw Engram shim `openclaw.plugin.json` with additional recall/consolidation feature flags and tuning knobs (graph retrieval, cross-namespace budgets, audit anomaly detection, memory-worth filtering, operator-aware consolidation, reasoning-trace boosting) plus corresponding UI hint entries.
> 
> Updates the `AI Review Gate` workflow to also treat completed check runs (via `checks.listForRef`) as AI reviewer activity, and grants the workflow `checks: read` permission to support that.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7b76280a3003f77ef6b7bf278144a1d3ce6f243. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->