### PR TITLE
feat(bench): write reproducibility manifests

### DIFF
--- a/packages/bench/README.md
+++ b/packages/bench/README.md
@@ -20,6 +20,7 @@ The CLI loads `@remnic/bench` via a computed-specifier dynamic import. If it's n
 
 - **Benchmark runners** for a growing set of memory-oriented evals: `longmemeval`, `locomo`, `memory-arena`, `amemgym`, `ama-bench`, plus a lightweight smoke fixture.
 - **Stored-run management** — every `remnic bench run *` writes a timestamped JSON result under `~/.remnic/bench/results/`; `remnic bench runs list|show|delete` let you browse, inspect, and prune.
+- **Reproducibility manifests** — package-backed runs write `MANIFEST.json` beside the result files, locking result hashes, dataset file hashes, seeds, runtime profiles, command argv with secret values redacted, selected environment keys, git state, QMD collections, and config-file hashes.
 - **Baselines + regression gates** — save a run as a named baseline, compare candidates against it, gate CI on threshold violations.
 - **Result export** — `remnic bench export <run> --format json|csv|html`.
 - **Published feed** — `remnic bench publish --target remnic-ai` builds the tamper-evident integrity manifest consumed by remnic.ai.
@@ -43,6 +44,9 @@ remnic bench run --quick longmemeval
 # Browse stored runs:
 remnic bench runs list
 remnic bench runs show <run-id> --detail
+
+# Inspect the reproducibility lock for the last run set:
+jq . ~/.remnic/bench/results/MANIFEST.json
 
 # Compare two runs:
 remnic bench compare base-run candidate-run
@@ -145,6 +149,7 @@ import {
   listBenchmarks,
   runBenchmark,
   writeBenchmarkResult,
+  writeBenchmarkReproManifest,
   createLightweightAdapter,
   createRemnicAdapter,
   compareResults,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -110,6 +110,19 @@ export type {
 
 export { BENCHMARK_RESULT_SCHEMA } from "./schema.js";
 export {
+  BENCHMARK_REPRO_MANIFEST_FILENAME,
+  BENCHMARK_REPRO_MANIFEST_SCHEMA_VERSION,
+  buildBenchmarkReproManifest,
+  writeBenchmarkReproManifest,
+} from "./repro-manifest.js";
+export type {
+  BuildBenchmarkReproManifestOptions,
+  BenchmarkReproManifest,
+  BenchmarkReproManifestDataset,
+  BenchmarkReproManifestFile,
+  BenchmarkReproManifestResult,
+} from "./repro-manifest.js";
+export {
   BENCHMARK_ARTIFACT_SCHEMA_VERSION,
   buildBenchmarkArtifact,
   buildBenchmarkArtifactFilename,

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, readFile, realpath, symlink, writeFile } from "node:fs/promises";
 import {
   BENCHMARK_REPRO_MANIFEST_FILENAME,
   buildBenchmarkReproManifest,
@@ -59,8 +59,12 @@ function buildResult(): BenchmarkResult {
   };
 }
 
+async function createTempRoot(prefix: string): Promise<string> {
+  return mkdtemp(path.join(await realpath(os.tmpdir()), prefix));
+}
+
 test("buildBenchmarkReproManifest hashes datasets/results and redacts secret argv values", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-"));
+  const root = await createTempRoot("remnic-repro-manifest-");
   const resultsDir = path.join(root, "results");
   const datasetDir = path.join(root, "dataset");
   await mkdir(resultsDir, { recursive: true });
@@ -134,7 +138,7 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
 });
 
 test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-write-"));
+  const root = await createTempRoot("remnic-repro-manifest-write-");
   const resultsDir = path.join(root, "results");
   await mkdir(resultsDir, { recursive: true });
   const resultPath = path.join(resultsDir, "longmemeval.json");
@@ -153,7 +157,7 @@ test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async ()
 });
 
 test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-root-link-"));
+  const root = await createTempRoot("remnic-repro-manifest-root-link-");
   const resultsDir = path.join(root, "results");
   const datasetDir = path.join(root, "dataset");
   const linkedDatasetDir = path.join(root, "linked-dataset");
@@ -175,8 +179,32 @@ test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => 
   assert.equal(manifest.datasets[0]?.sha256, undefined);
 });
 
+test("buildBenchmarkReproManifest rejects symlinked dataset ancestors", async () => {
+  const root = await createTempRoot("remnic-repro-manifest-parent-link-");
+  const resultsDir = path.join(root, "results");
+  const parentDir = path.join(root, "parent");
+  const datasetDir = path.join(parentDir, "dataset");
+  const linkedParentDir = path.join(root, "linked-parent");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "answers.json"), JSON.stringify({ answer: 42 }), "utf8");
+  await symlink(parentDir, linkedParentDir);
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    datasetDirs: { longmemeval: path.join(linkedParentDir, "dataset") },
+  });
+
+  assert.equal(manifest.datasets[0]?.status, "missing");
+  assert.equal(manifest.datasets[0]?.fileCount, 0);
+  assert.equal(manifest.datasets[0]?.sha256, undefined);
+});
+
 test("buildBenchmarkReproManifest preserves explicitly empty result paths", async () => {
-  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-empty-results-"));
+  const root = await createTempRoot("remnic-repro-manifest-empty-results-");
   const resultsDir = path.join(root, "results");
   await mkdir(resultsDir, { recursive: true });
   await writeFile(

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -1,0 +1,139 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from "node:fs/promises";
+import {
+  BENCHMARK_REPRO_MANIFEST_FILENAME,
+  buildBenchmarkReproManifest,
+  writeBenchmarkReproManifest,
+} from "./repro-manifest.ts";
+import type { BenchmarkResult } from "./types.js";
+
+function buildResult(): BenchmarkResult {
+  return {
+    meta: {
+      id: "run-1",
+      benchmark: "longmemeval",
+      benchmarkTier: "published",
+      version: "1.0.0",
+      remnicVersion: "9.3.167",
+      gitSha: "abc1234",
+      timestamp: "2026-04-24T20:00:00.000Z",
+      mode: "full",
+      runCount: 5,
+      seeds: [42, 43, 44, 45, 46],
+    },
+    config: {
+      runtimeProfile: "real",
+      systemProvider: {
+        provider: "openai",
+        model: "gemma4:31b",
+        baseUrl: "https://ollama.com/v1",
+      },
+      judgeProvider: null,
+      adapterMode: "direct",
+      remnicConfig: {
+        qmdCollection: "bench-hot",
+        qmdColdCollection: "bench-cold",
+        conversationIndexQmdCollection: "bench-conversations",
+      },
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [],
+      aggregates: {},
+    },
+    environment: {
+      os: "darwin",
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}
+
+test("buildBenchmarkReproManifest hashes datasets/results and redacts secret argv values", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-"));
+  const resultsDir = path.join(root, "results");
+  const datasetDir = path.join(root, "dataset");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(path.join(datasetDir, "nested"), { recursive: true });
+  await writeFile(path.join(datasetDir, "answers.json"), JSON.stringify({ answer: 42 }), "utf8");
+  await writeFile(path.join(datasetDir, "nested", "notes.txt"), "dataset note\n", "utf8");
+  await symlink("answers.json", path.join(datasetDir, "answers-link.json"));
+
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    runtimeProfiles: ["real"],
+    mode: "full",
+    seed: 42,
+    datasetDirs: { longmemeval: datasetDir },
+    command: {
+      cwd: root,
+      argv: [
+        "bench",
+        "run",
+        "--system-api-key",
+        "secret-value",
+        "--judge-api-key=other-secret",
+      ],
+      env: { OLLAMA_API_KEY: "secret-value", QMD_CONFIG_DIR: "/tmp/qmd" },
+      envKeys: ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"],
+    },
+    qmd: { configDir: "/tmp/qmd" },
+  });
+
+  assert.equal(manifest.run.mode, "full");
+  assert.deepEqual(manifest.run.runtimeProfiles, ["real"]);
+  assert.equal(manifest.run.seed, 42);
+  assert.deepEqual(manifest.command.argv, [
+    "bench",
+    "run",
+    "--system-api-key",
+    "[redacted]",
+    "--judge-api-key=[redacted]",
+  ]);
+  assert.deepEqual(manifest.command.envKeys, ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"]);
+  assert.equal(manifest.datasets[0]?.status, "hashed");
+  assert.equal(manifest.datasets[0]?.fileCount, 3);
+  assert.ok(manifest.datasets[0]?.sha256);
+  assert.equal(manifest.results[0]?.benchmark, "longmemeval");
+  assert.equal(manifest.results[0]?.seeds.length, 5);
+  assert.deepEqual(manifest.qmd?.collections, [
+    "bench-cold",
+    "bench-conversations",
+    "bench-hot",
+  ]);
+  assert.ok(/^[0-9a-f]{64}$/.test(manifest.artifactHash));
+  assert.doesNotMatch(JSON.stringify(manifest), /secret-value|other-secret/);
+});
+
+test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-write-"));
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifestPath = await writeBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+  });
+  assert.equal(manifestPath, path.join(resultsDir, BENCHMARK_REPRO_MANIFEST_FILENAME));
+
+  const manifest = JSON.parse(await readFile(manifestPath, "utf8")) as {
+    results: Array<{ benchmark: string }>;
+  };
+  assert.equal(manifest.results[0]?.benchmark, "longmemeval");
+});

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -88,6 +88,11 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
         "--system-api-key",
         "secret-value",
         "--judge-api-key=other-secret",
+        "--max-tokens",
+        "2048",
+        "--output-token-limit=128",
+        "--auth-token",
+        "auth-secret",
         "next-positional",
       ],
       env: { OLLAMA_API_KEY: "secret-value", QMD_CONFIG_DIR: "/tmp/qmd" },
@@ -106,6 +111,11 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
     "--system-api-key",
     "[redacted]",
     "--judge-api-key=[redacted]",
+    "--max-tokens",
+    "2048",
+    "--output-token-limit=128",
+    "--auth-token",
+    "[redacted]",
     "next-positional",
   ]);
   assert.deepEqual(manifest.command.envKeys, ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"]);
@@ -120,7 +130,7 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
     "bench-hot",
   ]);
   assert.ok(/^[0-9a-f]{64}$/.test(manifest.artifactHash));
-  assert.doesNotMatch(JSON.stringify(manifest), /secret-value|other-secret/);
+  assert.doesNotMatch(JSON.stringify(manifest), /secret-value|other-secret|auth-secret/);
 });
 
 test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async () => {

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -84,9 +84,11 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
       argv: [
         "bench",
         "run",
+        "fixtures/token-benchmark.json",
         "--system-api-key",
         "secret-value",
         "--judge-api-key=other-secret",
+        "next-positional",
       ],
       env: { OLLAMA_API_KEY: "secret-value", QMD_CONFIG_DIR: "/tmp/qmd" },
       envKeys: ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"],
@@ -100,9 +102,11 @@ test("buildBenchmarkReproManifest hashes datasets/results and redacts secret arg
   assert.deepEqual(manifest.command.argv, [
     "bench",
     "run",
+    "fixtures/token-benchmark.json",
     "--system-api-key",
     "[redacted]",
     "--judge-api-key=[redacted]",
+    "next-positional",
   ]);
   assert.deepEqual(manifest.command.envKeys, ["OLLAMA_API_KEY", "QMD_CONFIG_DIR"]);
   assert.equal(manifest.datasets[0]?.status, "hashed");

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -167,7 +167,7 @@ test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => 
   const manifest = await buildBenchmarkReproManifest(resultsDir, {
     resultPaths: [resultPath],
     selectedBenchmarks: ["longmemeval"],
-    datasetDirs: { longmemeval: linkedDatasetDir },
+    datasetDirs: { longmemeval: `${linkedDatasetDir}${path.sep}` },
   });
 
   assert.equal(manifest.datasets[0]?.status, "missing");

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -156,6 +156,35 @@ test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async ()
   assert.equal(manifest.results[0]?.benchmark, "longmemeval");
 });
 
+test("artifact hash ignores volatile host and command metadata", async () => {
+  const firstRoot = await createTempRoot("remnic-repro-manifest-stable-a-");
+  const secondRoot = await createTempRoot("remnic-repro-manifest-stable-b-");
+  const firstResultsDir = path.join(firstRoot, "results");
+  const secondResultsDir = path.join(secondRoot, "results");
+  await mkdir(firstResultsDir, { recursive: true });
+  await mkdir(secondResultsDir, { recursive: true });
+
+  const resultJson = `${JSON.stringify(buildResult(), null, 2)}\n`;
+  const firstResultPath = path.join(firstResultsDir, "longmemeval.json");
+  const secondResultPath = path.join(secondResultsDir, "longmemeval.json");
+  await writeFile(firstResultPath, resultJson, "utf8");
+  await writeFile(secondResultPath, resultJson, "utf8");
+
+  const firstManifest = await buildBenchmarkReproManifest(firstResultsDir, {
+    resultPaths: [firstResultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: { cwd: firstRoot, argv: ["bench", "run", "longmemeval"] },
+  });
+  const secondManifest = await buildBenchmarkReproManifest(secondResultsDir, {
+    resultPaths: [secondResultPath],
+    selectedBenchmarks: ["longmemeval"],
+    command: { cwd: secondRoot, argv: ["bench", "run", "longmemeval"] },
+  });
+
+  assert.notEqual(firstManifest.command.cwd, secondManifest.command.cwd);
+  assert.equal(firstManifest.artifactHash, secondManifest.artifactHash);
+});
+
 test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => {
   const root = await createTempRoot("remnic-repro-manifest-root-link-");
   const resultsDir = path.join(root, "results");

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -174,3 +174,21 @@ test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => 
   assert.equal(manifest.datasets[0]?.fileCount, 0);
   assert.equal(manifest.datasets[0]?.sha256, undefined);
 });
+
+test("buildBenchmarkReproManifest preserves explicitly empty result paths", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-empty-results-"));
+  const resultsDir = path.join(root, "results");
+  await mkdir(resultsDir, { recursive: true });
+  await writeFile(
+    path.join(resultsDir, "longmemeval.json"),
+    `${JSON.stringify(buildResult(), null, 2)}\n`,
+    "utf8",
+  );
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [],
+  });
+
+  assert.deepEqual(manifest.results, []);
+  assert.deepEqual(manifest.run.selectedBenchmarks, []);
+});

--- a/packages/bench/src/repro-manifest.test.ts
+++ b/packages/bench/src/repro-manifest.test.ts
@@ -141,3 +141,26 @@ test("writeBenchmarkReproManifest writes MANIFEST.json beside results", async ()
   };
   assert.equal(manifest.results[0]?.benchmark, "longmemeval");
 });
+
+test("buildBenchmarkReproManifest rejects symlinked dataset roots", async () => {
+  const root = await mkdtemp(path.join(os.tmpdir(), "remnic-repro-manifest-root-link-"));
+  const resultsDir = path.join(root, "results");
+  const datasetDir = path.join(root, "dataset");
+  const linkedDatasetDir = path.join(root, "linked-dataset");
+  await mkdir(resultsDir, { recursive: true });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(path.join(datasetDir, "answers.json"), JSON.stringify({ answer: 42 }), "utf8");
+  await symlink(datasetDir, linkedDatasetDir);
+  const resultPath = path.join(resultsDir, "longmemeval.json");
+  await writeFile(resultPath, `${JSON.stringify(buildResult(), null, 2)}\n`, "utf8");
+
+  const manifest = await buildBenchmarkReproManifest(resultsDir, {
+    resultPaths: [resultPath],
+    selectedBenchmarks: ["longmemeval"],
+    datasetDirs: { longmemeval: linkedDatasetDir },
+  });
+
+  assert.equal(manifest.datasets[0]?.status, "missing");
+  assert.equal(manifest.datasets[0]?.fileCount, 0);
+  assert.equal(manifest.datasets[0]?.sha256, undefined);
+});

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -218,6 +218,33 @@ function buildGitInfo(cwd: string): BenchmarkReproManifest["git"] {
   };
 }
 
+function buildArtifactHashIdentity(manifest: Omit<BenchmarkReproManifest, "artifactHash">): unknown {
+  return {
+    schemaVersion: manifest.schemaVersion,
+    run: manifest.run,
+    git: {
+      commit: manifest.git.commit,
+      shortCommit: manifest.git.shortCommit,
+    },
+    command: {
+      argv: manifest.command.argv,
+      envKeys: manifest.command.envKeys,
+    },
+    environment: {
+      platform: manifest.environment.platform,
+      arch: manifest.environment.arch,
+      nodeVersion: manifest.environment.nodeVersion,
+      ...(manifest.environment.packageManager
+        ? { packageManager: manifest.environment.packageManager }
+        : {}),
+    },
+    ...(manifest.qmd ? { qmd: manifest.qmd } : {}),
+    configFiles: manifest.configFiles,
+    datasets: manifest.datasets,
+    results: manifest.results,
+  };
+}
+
 async function scanDatasetFiles(root: string): Promise<BenchmarkReproManifestFile[]> {
   const files: BenchmarkReproManifestFile[] = [];
 
@@ -493,7 +520,7 @@ export async function buildBenchmarkReproManifest(
 
   return {
     ...manifestWithoutHash,
-    artifactHash: sha256String(stableStringify(manifestWithoutHash)),
+    artifactHash: sha256String(stableStringify(buildArtifactHashIdentity(manifestWithoutHash))),
   };
 }
 

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -126,7 +126,7 @@ const SECRET_ARG_FLAGS = new Set([
   "--auth-token",
 ]);
 
-const SECRET_KEY_PATTERN = /(?:api[_-]?key|token|secret|password|authorization)/i;
+const SECRET_KEY_PATTERN = /(^|[-_])(?:api[-_]?key|secret|password|authorization|credential|access[-_]?token|auth[-_]?token|refresh[-_]?token|id[-_]?token|token)$/i;
 
 function sha256String(value: string): string {
   return createHash("sha256").update(value).digest("hex");
@@ -317,8 +317,8 @@ async function buildDatasetManifest(
 async function buildResultManifest(
   resultsDir: string,
   resultPath: string,
+  result: BenchmarkResult,
 ): Promise<BenchmarkReproManifestResult> {
-  const result = await loadBenchmarkResult(resultPath);
   const fileStats = await stat(resultPath);
   return {
     path: path.relative(resultsDir, resultPath).split(path.sep).join("/"),
@@ -416,7 +416,9 @@ export async function buildBenchmarkReproManifest(
   const resultPaths = await resolveResultPaths(resolvedResultsDir, options.resultPaths);
   const loadedResults = await Promise.all(resultPaths.map((resultPath) => loadBenchmarkResult(resultPath)));
   const resultEntries = await Promise.all(
-    resultPaths.map((resultPath) => buildResultManifest(resolvedResultsDir, resultPath)),
+    resultPaths.map((resultPath, index) =>
+      buildResultManifest(resolvedResultsDir, resultPath, loadedResults[index]!),
+    ),
   );
   const selectedBenchmarks = options.selectedBenchmarks ??
     [...new Set(loadedResults.map((result) => result.meta.benchmark))].sort();

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -160,8 +160,12 @@ function sanitizeArgv(argv: string[]): string[] {
   const sanitized: string[] = [];
   for (let index = 0; index < argv.length; index += 1) {
     const arg = argv[index]!;
+    const isOptionFlag = arg.startsWith("-");
     const [flagName] = arg.split("=", 1);
-    if (SECRET_ARG_FLAGS.has(flagName) || SECRET_KEY_PATTERN.test(flagName)) {
+    if (
+      isOptionFlag &&
+      (SECRET_ARG_FLAGS.has(flagName) || SECRET_KEY_PATTERN.test(flagName))
+    ) {
       if (arg.includes("=")) {
         sanitized.push(`${flagName}=[redacted]`);
       } else {

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -1,0 +1,477 @@
+import { execFileSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { createReadStream } from "node:fs";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readlink,
+  realpath,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import type { BenchmarkMode, BenchmarkResult } from "./types.js";
+import { loadBenchmarkResult, listBenchmarkResults } from "./results-store.js";
+
+export const BENCHMARK_REPRO_MANIFEST_FILENAME = "MANIFEST.json";
+export const BENCHMARK_REPRO_MANIFEST_SCHEMA_VERSION = 1;
+
+export interface BenchmarkReproManifestFile {
+  path: string;
+  kind: "file" | "symlink";
+  sizeBytes: number;
+  sha256: string;
+  target?: string;
+}
+
+export interface BenchmarkReproManifestDataset {
+  benchmark: string;
+  status: "not-provided" | "missing" | "hashed";
+  path?: string;
+  realpath?: string;
+  fileCount: number;
+  totalBytes: number;
+  sha256?: string;
+  files: BenchmarkReproManifestFile[];
+}
+
+export interface BenchmarkReproManifestResult {
+  path: string;
+  sha256: string;
+  sizeBytes: number;
+  resultId: string;
+  benchmark: string;
+  mode: BenchmarkMode;
+  gitSha: string;
+  runCount: number;
+  seeds: number[];
+  taskCount: number;
+  configHash: string;
+}
+
+export interface BenchmarkReproManifest {
+  schemaVersion: number;
+  generatedAt: string;
+  run: {
+    mode?: BenchmarkMode;
+    selectedBenchmarks: string[];
+    runtimeProfiles: string[];
+    limit?: number;
+    seed?: number;
+  };
+  git: {
+    commit: string;
+    shortCommit: string;
+    dirty: boolean;
+    dirtyEntryCount: number;
+  };
+  command: {
+    cwd: string;
+    argv: string[];
+    envKeys: string[];
+  };
+  environment: {
+    platform: NodeJS.Platform;
+    arch: string;
+    nodeVersion: string;
+    hostname: string;
+    packageManager?: string;
+  };
+  qmd?: {
+    configDir?: string;
+    cacheDir?: string;
+    collections: string[];
+  };
+  configFiles: Array<{
+    label: string;
+    path: string;
+    sha256?: string;
+    sizeBytes?: number;
+    missing?: boolean;
+  }>;
+  datasets: BenchmarkReproManifestDataset[];
+  results: BenchmarkReproManifestResult[];
+  artifactHash: string;
+}
+
+export interface BuildBenchmarkReproManifestOptions {
+  resultPaths?: string[];
+  selectedBenchmarks?: string[];
+  runtimeProfiles?: string[];
+  mode?: BenchmarkMode;
+  limit?: number;
+  seed?: number;
+  datasetDirs?: Record<string, string | undefined>;
+  command?: {
+    cwd?: string;
+    argv?: string[];
+    env?: NodeJS.ProcessEnv;
+    envKeys?: string[];
+  };
+  configFiles?: Array<{ label: string; path?: string }>;
+  qmd?: {
+    configDir?: string;
+    cacheDir?: string;
+    collections?: string[];
+  };
+}
+
+const SECRET_ARG_FLAGS = new Set([
+  "--api-key",
+  "--system-api-key",
+  "--judge-api-key",
+  "--token",
+  "--auth-token",
+]);
+
+const SECRET_KEY_PATTERN = /(?:api[_-]?key|token|secret|password|authorization)/i;
+
+function sha256String(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+async function sha256File(filePath: string): Promise<string> {
+  const hash = createHash("sha256");
+  await new Promise<void>((resolve, reject) => {
+    const stream = createReadStream(filePath);
+    stream.on("data", (chunk) => hash.update(chunk));
+    stream.on("error", reject);
+    stream.on("end", resolve);
+  });
+  return hash.digest("hex");
+}
+
+function stableStringify(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map((entry) => stableStringify(entry)).join(",")}]`;
+  }
+  if (value && typeof value === "object") {
+    return `{${Object.keys(value as Record<string, unknown>)
+      .sort()
+      .map((key) => `${JSON.stringify(key)}:${stableStringify((value as Record<string, unknown>)[key])}`)
+      .join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "undefined";
+}
+
+function sanitizeArgv(argv: string[]): string[] {
+  const sanitized: string[] = [];
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]!;
+    const [flagName] = arg.split("=", 1);
+    if (SECRET_ARG_FLAGS.has(flagName) || SECRET_KEY_PATTERN.test(flagName)) {
+      if (arg.includes("=")) {
+        sanitized.push(`${flagName}=[redacted]`);
+      } else {
+        sanitized.push(arg);
+        if (index + 1 < argv.length) {
+          sanitized.push("[redacted]");
+          index += 1;
+        }
+      }
+      continue;
+    }
+    sanitized.push(arg);
+  }
+  return sanitized;
+}
+
+function sanitizeEnvKeys(
+  env: NodeJS.ProcessEnv | undefined,
+  explicitKeys: string[] | undefined,
+): string[] {
+  const sourceKeys = explicitKeys ?? Object.keys(env ?? {});
+  return [...new Set(sourceKeys)]
+    .filter((key) => typeof key === "string" && key.length > 0)
+    .sort((left, right) => left.localeCompare(right));
+}
+
+function gitOutput(args: string[], cwd: string): string {
+  try {
+    return execFileSync("git", args, {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "";
+  }
+}
+
+function buildGitInfo(cwd: string): BenchmarkReproManifest["git"] {
+  const commit = gitOutput(["rev-parse", "HEAD"], cwd) || "unknown";
+  const shortCommit = gitOutput(["rev-parse", "--short", "HEAD"], cwd) || "unknown";
+  const dirtyEntries = gitOutput(["status", "--porcelain", "--untracked-files=all"], cwd)
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0);
+  return {
+    commit,
+    shortCommit,
+    dirty: dirtyEntries.length > 0,
+    dirtyEntryCount: dirtyEntries.length,
+  };
+}
+
+async function scanDatasetFiles(root: string): Promise<BenchmarkReproManifestFile[]> {
+  const files: BenchmarkReproManifestFile[] = [];
+
+  const walk = async (directory: string): Promise<void> => {
+    const entries = await readdir(directory, { withFileTypes: true });
+    entries.sort((left, right) => left.name.localeCompare(right.name));
+
+    for (const entry of entries) {
+      const entryPath = path.join(directory, entry.name);
+      const entryStat = await lstat(entryPath);
+      const relativePath = path.relative(root, entryPath).split(path.sep).join("/");
+      if (entryStat.isSymbolicLink()) {
+        const target = await readlink(entryPath);
+        files.push({
+          path: relativePath,
+          kind: "symlink",
+          sizeBytes: Buffer.byteLength(target, "utf8"),
+          sha256: sha256String(target),
+          target,
+        });
+        continue;
+      }
+      if (entryStat.isDirectory()) {
+        await walk(entryPath);
+        continue;
+      }
+      if (entryStat.isFile()) {
+        files.push({
+          path: relativePath,
+          kind: "file",
+          sizeBytes: entryStat.size,
+          sha256: await sha256File(entryPath),
+        });
+      }
+    }
+  };
+
+  await walk(root);
+  return files.sort((left, right) => left.path.localeCompare(right.path));
+}
+
+async function buildDatasetManifest(
+  benchmark: string,
+  datasetDir: string | undefined,
+): Promise<BenchmarkReproManifestDataset> {
+  if (!datasetDir) {
+    return {
+      benchmark,
+      status: "not-provided",
+      fileCount: 0,
+      totalBytes: 0,
+      files: [],
+    };
+  }
+
+  let datasetStat;
+  try {
+    datasetStat = await stat(datasetDir);
+  } catch {
+    return {
+      benchmark,
+      status: "missing",
+      path: datasetDir,
+      fileCount: 0,
+      totalBytes: 0,
+      files: [],
+    };
+  }
+
+  if (!datasetStat.isDirectory()) {
+    return {
+      benchmark,
+      status: "missing",
+      path: datasetDir,
+      fileCount: 0,
+      totalBytes: 0,
+      files: [],
+    };
+  }
+
+  const realDatasetDir = await realpath(datasetDir);
+  const files = await scanDatasetFiles(realDatasetDir);
+  const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
+  const digest = sha256String(stableStringify(files));
+  return {
+    benchmark,
+    status: "hashed",
+    path: datasetDir,
+    realpath: realDatasetDir,
+    fileCount: files.length,
+    totalBytes,
+    sha256: digest,
+    files,
+  };
+}
+
+async function buildResultManifest(
+  resultsDir: string,
+  resultPath: string,
+): Promise<BenchmarkReproManifestResult> {
+  const result = await loadBenchmarkResult(resultPath);
+  const fileStats = await stat(resultPath);
+  return {
+    path: path.relative(resultsDir, resultPath).split(path.sep).join("/"),
+    sha256: await sha256File(resultPath),
+    sizeBytes: fileStats.size,
+    resultId: result.meta.id,
+    benchmark: result.meta.benchmark,
+    mode: result.meta.mode,
+    gitSha: result.meta.gitSha,
+    runCount: result.meta.runCount,
+    seeds: [...result.meta.seeds],
+    taskCount: result.results.tasks.length,
+    configHash: sha256String(stableStringify(result.config)),
+  };
+}
+
+async function resolveResultPaths(
+  resultsDir: string,
+  explicitPaths: string[] | undefined,
+): Promise<string[]> {
+  if (explicitPaths && explicitPaths.length > 0) {
+    return [...new Set(explicitPaths.map((entry) => path.resolve(entry)))]
+      .sort((left, right) => left.localeCompare(right));
+  }
+  const summaries = await listBenchmarkResults(resultsDir);
+  return summaries.map((summary) => path.resolve(summary.path));
+}
+
+async function buildConfigFileEntries(
+  configFiles: BuildBenchmarkReproManifestOptions["configFiles"] = [],
+): Promise<BenchmarkReproManifest["configFiles"]> {
+  const entries: BenchmarkReproManifest["configFiles"] = [];
+  for (const configFile of configFiles) {
+    if (!configFile.path) {
+      continue;
+    }
+    try {
+      const fileStats = await stat(configFile.path);
+      if (!fileStats.isFile()) {
+        entries.push({ label: configFile.label, path: configFile.path, missing: true });
+        continue;
+      }
+      entries.push({
+        label: configFile.label,
+        path: configFile.path,
+        sizeBytes: fileStats.size,
+        sha256: await sha256File(configFile.path),
+      });
+    } catch {
+      entries.push({ label: configFile.label, path: configFile.path, missing: true });
+    }
+  }
+  return entries;
+}
+
+function collectQmdCollections(
+  explicitCollections: string[] | undefined,
+  results: BenchmarkResult[],
+): string[] {
+  const collections = new Set(explicitCollections ?? []);
+  for (const result of results) {
+    const config = result.config.remnicConfig ?? {};
+    for (const key of [
+      "qmdCollection",
+      "qmdColdCollection",
+      "conversationIndexQmdCollection",
+    ]) {
+      const value = config[key];
+      if (typeof value === "string" && value.trim().length > 0) {
+        collections.add(value);
+      }
+    }
+  }
+  return [...collections].sort((left, right) => left.localeCompare(right));
+}
+
+function resolvePackageManager(cwd: string): string | undefined {
+  try {
+    return execFileSync("pnpm", ["--version"], {
+      cwd,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+export async function buildBenchmarkReproManifest(
+  resultsDir: string,
+  options: BuildBenchmarkReproManifestOptions = {},
+): Promise<BenchmarkReproManifest> {
+  const resolvedResultsDir = path.resolve(resultsDir);
+  const cwd = options.command?.cwd ?? process.cwd();
+  const resultPaths = await resolveResultPaths(resolvedResultsDir, options.resultPaths);
+  const loadedResults = await Promise.all(resultPaths.map((resultPath) => loadBenchmarkResult(resultPath)));
+  const resultEntries = await Promise.all(
+    resultPaths.map((resultPath) => buildResultManifest(resolvedResultsDir, resultPath)),
+  );
+  const selectedBenchmarks = options.selectedBenchmarks ??
+    [...new Set(loadedResults.map((result) => result.meta.benchmark))].sort();
+  const datasetDirs = options.datasetDirs ?? {};
+  const datasets = await Promise.all(
+    selectedBenchmarks.map((benchmark) => buildDatasetManifest(benchmark, datasetDirs[benchmark])),
+  );
+  const qmdCollections = collectQmdCollections(options.qmd?.collections, loadedResults);
+  const pnpmVersion = resolvePackageManager(cwd);
+  const manifestWithoutHash = {
+    schemaVersion: BENCHMARK_REPRO_MANIFEST_SCHEMA_VERSION,
+    generatedAt: new Date().toISOString(),
+    run: {
+      ...(options.mode ? { mode: options.mode } : {}),
+      selectedBenchmarks,
+      runtimeProfiles: options.runtimeProfiles ?? [],
+      ...(options.limit !== undefined ? { limit: options.limit } : {}),
+      ...(options.seed !== undefined ? { seed: options.seed } : {}),
+    },
+    git: buildGitInfo(cwd),
+    command: {
+      cwd,
+      argv: sanitizeArgv(options.command?.argv ?? process.argv.slice(2)),
+      envKeys: sanitizeEnvKeys(options.command?.env, options.command?.envKeys),
+    },
+    environment: {
+      platform: process.platform,
+      arch: process.arch,
+      nodeVersion: process.version,
+      hostname: os.hostname(),
+      ...(pnpmVersion ? { packageManager: `pnpm@${pnpmVersion}` } : {}),
+    },
+    ...(options.qmd || qmdCollections.length > 0
+      ? {
+          qmd: {
+            ...(options.qmd?.configDir ? { configDir: options.qmd.configDir } : {}),
+            ...(options.qmd?.cacheDir ? { cacheDir: options.qmd.cacheDir } : {}),
+            collections: qmdCollections,
+          },
+        }
+      : {}),
+    configFiles: await buildConfigFileEntries(options.configFiles),
+    datasets,
+    results: resultEntries.sort((left, right) => left.path.localeCompare(right.path)),
+  };
+
+  return {
+    ...manifestWithoutHash,
+    artifactHash: sha256String(stableStringify(manifestWithoutHash)),
+  };
+}
+
+export async function writeBenchmarkReproManifest(
+  resultsDir: string,
+  options: BuildBenchmarkReproManifestOptions = {},
+): Promise<string> {
+  await mkdir(resultsDir, { recursive: true });
+  const manifest = await buildBenchmarkReproManifest(resultsDir, options);
+  const manifestPath = path.join(resultsDir, BENCHMARK_REPRO_MANIFEST_FILENAME);
+  await writeFile(manifestPath, `${JSON.stringify(manifest, null, 2)}\n`);
+  return manifestPath;
+}

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -275,7 +275,7 @@ async function buildDatasetManifest(
 
   let datasetStat;
   try {
-    datasetStat = await stat(datasetDir);
+    datasetStat = await lstat(datasetDir);
   } catch {
     return {
       benchmark,
@@ -287,7 +287,7 @@ async function buildDatasetManifest(
     };
   }
 
-  if (!datasetStat.isDirectory()) {
+  if (!datasetStat.isDirectory() || datasetStat.isSymbolicLink()) {
     return {
       benchmark,
       status: "missing",

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -340,7 +340,7 @@ async function resolveResultPaths(
   resultsDir: string,
   explicitPaths: string[] | undefined,
 ): Promise<string[]> {
-  if (explicitPaths && explicitPaths.length > 0) {
+  if (explicitPaths !== undefined) {
     return [...new Set(explicitPaths.map((entry) => path.resolve(entry)))]
       .sort((left, right) => left.localeCompare(right));
   }

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -273,9 +273,10 @@ async function buildDatasetManifest(
     };
   }
 
+  const datasetRoot = path.resolve(datasetDir);
   let datasetStat;
   try {
-    datasetStat = await lstat(datasetDir);
+    datasetStat = await lstat(datasetRoot);
   } catch {
     return {
       benchmark,
@@ -298,7 +299,7 @@ async function buildDatasetManifest(
     };
   }
 
-  const realDatasetDir = await realpath(datasetDir);
+  const realDatasetDir = await realpath(datasetRoot);
   const files = await scanDatasetFiles(realDatasetDir);
   const totalBytes = files.reduce((sum, file) => sum + file.sizeBytes, 0);
   const digest = sha256String(stableStringify(files));

--- a/packages/bench/src/repro-manifest.ts
+++ b/packages/bench/src/repro-manifest.ts
@@ -259,6 +259,33 @@ async function scanDatasetFiles(root: string): Promise<BenchmarkReproManifestFil
   return files.sort((left, right) => left.path.localeCompare(right.path));
 }
 
+async function lstatPathWithoutSymlinkComponents(
+  targetPath: string,
+): Promise<Awaited<ReturnType<typeof lstat>> | undefined> {
+  const parsed = path.parse(targetPath);
+  const relativePath = path.relative(parsed.root, targetPath);
+  const parts = relativePath.length > 0 ? relativePath.split(path.sep) : [];
+  let currentPath = parsed.root;
+  let currentStat: Awaited<ReturnType<typeof lstat>> | undefined;
+
+  try {
+    if (parts.length === 0) {
+      currentStat = await lstat(currentPath);
+    }
+    for (const part of parts) {
+      currentPath = path.join(currentPath, part);
+      currentStat = await lstat(currentPath);
+      if (currentStat.isSymbolicLink()) {
+        return undefined;
+      }
+    }
+  } catch {
+    return undefined;
+  }
+
+  return currentStat;
+}
+
 async function buildDatasetManifest(
   benchmark: string,
   datasetDir: string | undefined,
@@ -274,10 +301,8 @@ async function buildDatasetManifest(
   }
 
   const datasetRoot = path.resolve(datasetDir);
-  let datasetStat;
-  try {
-    datasetStat = await lstat(datasetRoot);
-  } catch {
+  const datasetStat = await lstatPathWithoutSymlinkComponents(datasetRoot);
+  if (!datasetStat) {
     return {
       benchmark,
       status: "missing",
@@ -288,7 +313,7 @@ async function buildDatasetManifest(
     };
   }
 
-  if (!datasetStat.isDirectory() || datasetStat.isSymbolicLink()) {
+  if (!datasetStat.isDirectory()) {
     return {
       benchmark,
       status: "missing",

--- a/packages/remnic-cli/README.md
+++ b/packages/remnic-cli/README.md
@@ -85,6 +85,12 @@ full runs need a real benchmark dataset. In a repo checkout the CLI will use
 `evals/datasets/<benchmark>` automatically; in packaged installs pass
 `--dataset-dir <path>` explicitly.
 
+Package-backed benchmark runs also write `MANIFEST.json` in the results
+directory. The manifest records result artifact hashes, dataset file hashes,
+fixed seeds, runtime profile/model configuration, git state, QMD collection
+names, selected benchmark environment keys, and config-file hashes. Secret
+argument values are redacted.
+
 `remnic bench datasets download` currently manages the published benchmark
 datasets for `ama-bench`, `memory-arena`, `amemgym`, `longmemeval`, `locomo`,
 `beam`, `personamem`, `membench`, and `memoryagentbench`. Internal Remnic

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2347,31 +2347,36 @@ async function writeBenchReproManifestForPackageRun(args: {
   const resultsDir = args.parsed.resultsDir ?? resolveBenchOutputDir();
   const effectiveLimit =
     args.parsed.publishedLimit ?? (args.parsed.quick ? 1 : undefined);
-  const manifestPath = await benchModule.writeBenchmarkReproManifest(resultsDir, {
-    resultPaths: args.resultPaths,
-    selectedBenchmarks: args.benchmarkIds,
-    runtimeProfiles: args.runtimeProfiles,
-    mode: args.parsed.quick ? "quick" : "full",
-    ...(effectiveLimit !== undefined ? { limit: effectiveLimit } : {}),
-    ...(args.parsed.publishedSeed !== undefined ? { seed: args.parsed.publishedSeed } : {}),
-    datasetDirs: resolveBenchReproDatasetDirs(args.parsed, args.benchmarkIds),
-    command: {
-      cwd: process.cwd(),
-      argv: process.argv.slice(2),
-      env: process.env,
-      envKeys: resolveBenchReproEnvKeys(),
-    },
-    configFiles: [
-      { label: "remnic", path: args.parsed.remnicConfigPath },
-      { label: "openclaw", path: args.parsed.openclawConfigPath },
-    ],
-    qmd: {
-      ...(process.env.QMD_CONFIG_DIR ? { configDir: process.env.QMD_CONFIG_DIR } : {}),
-      ...(process.env.XDG_CACHE_HOME ? { cacheDir: process.env.XDG_CACHE_HOME } : {}),
-    },
-  });
-  if (!args.parsed.json) {
-    console.log(`Reproducibility manifest: ${manifestPath}`);
+  try {
+    const manifestPath = await benchModule.writeBenchmarkReproManifest(resultsDir, {
+      resultPaths: args.resultPaths,
+      selectedBenchmarks: args.benchmarkIds,
+      runtimeProfiles: args.runtimeProfiles,
+      mode: args.parsed.quick ? "quick" : "full",
+      ...(effectiveLimit !== undefined ? { limit: effectiveLimit } : {}),
+      ...(args.parsed.publishedSeed !== undefined ? { seed: args.parsed.publishedSeed } : {}),
+      datasetDirs: resolveBenchReproDatasetDirs(args.parsed, args.benchmarkIds),
+      command: {
+        cwd: process.cwd(),
+        argv: process.argv.slice(2),
+        env: process.env,
+        envKeys: resolveBenchReproEnvKeys(),
+      },
+      configFiles: [
+        { label: "remnic", path: args.parsed.remnicConfigPath },
+        { label: "openclaw", path: args.parsed.openclawConfigPath },
+      ],
+      qmd: {
+        ...(process.env.QMD_CONFIG_DIR ? { configDir: process.env.QMD_CONFIG_DIR } : {}),
+        ...(process.env.XDG_CACHE_HOME ? { cacheDir: process.env.XDG_CACHE_HOME } : {}),
+      },
+    });
+    if (!args.parsed.json) {
+      console.log(`Reproducibility manifest: ${manifestPath}`);
+    }
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    console.warn(`WARNING: failed to write reproducibility manifest: ${message}`);
   }
 }
 

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -406,6 +406,27 @@ type PackageBenchModule = {
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   }, outputDir: string) => Promise<string>;
+  writeBenchmarkReproManifest?: (resultsDir: string, options?: {
+    resultPaths?: string[];
+    selectedBenchmarks?: string[];
+    runtimeProfiles?: string[];
+    mode?: "full" | "quick";
+    limit?: number;
+    seed?: number;
+    datasetDirs?: Record<string, string | undefined>;
+    command?: {
+      cwd?: string;
+      argv?: string[];
+      env?: NodeJS.ProcessEnv;
+      envKeys?: string[];
+    };
+    configFiles?: Array<{ label: string; path?: string }>;
+    qmd?: {
+      configDir?: string;
+      cacheDir?: string;
+      collections?: string[];
+    };
+  }) => Promise<string>;
   getRemnicVersion?: () => Promise<string>;
   createLightweightAdapter?: (options?: {
     configOverrides?: Record<string, unknown>;
@@ -1964,6 +1985,12 @@ async function runBenchPublished(parsed: ParsedBenchArgs): Promise<void> {
       writtenPaths.push(result.writtenPath);
     }
   }
+  await writeBenchReproManifestForPackageRun({
+    parsed,
+    benchmarkIds: [benchmarkId],
+    runtimeProfiles,
+    resultPaths: writtenPaths,
+  });
 
   // When `--out` is supplied, copy the result artifact we just wrote
   // into the directory under a canonical leaderboard filename. We
@@ -2076,7 +2103,7 @@ async function runBenchViaPackage(
     return { ok: false };
   }
 
-  const outputDir = resolveBenchOutputDir();
+  const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
   const datasetDir = resolveBenchDatasetDir(
     benchmarkId,
     parsed.quick,
@@ -2231,7 +2258,8 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
     return false;
   }
 
-  const outputDir = resolveBenchOutputDir();
+  const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const writtenPaths: string[] = [];
   for (const plan of plans) {
     const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
@@ -2249,6 +2277,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
       });
       result.config.remnicConfig = plan.runtime.remnicConfig;
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
+      writtenPaths.push(writtenPath);
       if (parsed.json) {
         console.log(JSON.stringify(result, null, 2));
       } else {
@@ -2259,7 +2288,91 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
     }
   }
 
+  await writeBenchReproManifestForPackageRun({
+    parsed,
+    benchmarkIds: parsed.custom ? [path.basename(parsed.custom)] : [],
+    runtimeProfiles,
+    resultPaths: writtenPaths,
+  });
+
   return true;
+}
+
+const BENCH_REPRO_ENV_KEYS = [
+  "ANTHROPIC_API_KEY",
+  "LITELLM_API_KEY",
+  "OLLAMA_API_KEY",
+  "OPENAI_API_KEY",
+  "QMD_CONFIG_DIR",
+  "REMNIC_BENCH_DATASET_ROOT",
+  "REMNIC_BENCH_IDS",
+  "REMNIC_BENCH_LIMIT",
+  "REMNIC_BENCH_MODE",
+  "REMNIC_BENCH_PHASE_TIMEOUT_MS",
+  "REMNIC_BENCH_REQUEST_TIMEOUT_MS",
+  "XDG_CACHE_HOME",
+] as const;
+
+function resolveBenchReproEnvKeys(): string[] {
+  return BENCH_REPRO_ENV_KEYS.filter((key) => process.env[key] !== undefined);
+}
+
+function resolveBenchReproDatasetDirs(
+  parsed: ParsedBenchArgs,
+  benchmarkIds: string[],
+): Record<string, string | undefined> {
+  return Object.fromEntries(
+    benchmarkIds.map((benchmarkId) => [
+      benchmarkId,
+      resolveBenchDatasetDir(benchmarkId, parsed.quick, parsed.datasetDir),
+    ]),
+  );
+}
+
+async function writeBenchReproManifestForPackageRun(args: {
+  parsed: ParsedBenchArgs;
+  benchmarkIds: string[];
+  runtimeProfiles: BenchRuntimeProfile[];
+  resultPaths: string[];
+}): Promise<void> {
+  if (args.resultPaths.length === 0) {
+    return;
+  }
+  const loaded = await tryLoadBenchModule();
+  const benchModule = loaded as unknown as PackageBenchModule | undefined;
+  if (!benchModule?.writeBenchmarkReproManifest) {
+    return;
+  }
+
+  const resultsDir = args.parsed.resultsDir ?? resolveBenchOutputDir();
+  const effectiveLimit =
+    args.parsed.publishedLimit ?? (args.parsed.quick ? 1 : undefined);
+  const manifestPath = await benchModule.writeBenchmarkReproManifest(resultsDir, {
+    resultPaths: args.resultPaths,
+    selectedBenchmarks: args.benchmarkIds,
+    runtimeProfiles: args.runtimeProfiles,
+    mode: args.parsed.quick ? "quick" : "full",
+    ...(effectiveLimit !== undefined ? { limit: effectiveLimit } : {}),
+    ...(args.parsed.publishedSeed !== undefined ? { seed: args.parsed.publishedSeed } : {}),
+    datasetDirs: resolveBenchReproDatasetDirs(args.parsed, args.benchmarkIds),
+    command: {
+      cwd: process.cwd(),
+      argv: process.argv.slice(2),
+      env: process.env,
+      envKeys: resolveBenchReproEnvKeys(),
+    },
+    configFiles: [
+      { label: "remnic", path: args.parsed.remnicConfigPath },
+      { label: "openclaw", path: args.parsed.openclawConfigPath },
+    ],
+    qmd: {
+      ...(process.env.QMD_CONFIG_DIR ? { configDir: process.env.QMD_CONFIG_DIR } : {}),
+      ...(process.env.XDG_CACHE_HOME ? { cacheDir: process.env.XDG_CACHE_HOME } : {}),
+    },
+  });
+  if (!args.parsed.json) {
+    console.log(`Reproducibility manifest: ${manifestPath}`);
+  }
 }
 
 // ── Config helpers ───────────────────────────────────────────────────────────
@@ -4984,6 +5097,7 @@ async function cmdBench(rest: string[]): Promise<void> {
       : selectedBenchmarks,
   )];
   try { await initBenchStatus(benchStatusPath, statusEntryIds, process.pid); } catch { /* non-fatal */ }
+  const writtenPaths: string[] = [];
   try {
     for (const benchmarkId of selectedBenchmarks) {
       for (const runtimeProfile of runtimeProfiles) {
@@ -4999,6 +5113,9 @@ async function cmdBench(rest: string[]): Promise<void> {
             benchStatusPath,
           );
           if (handledByPackage.ok) {
+            if (handledByPackage.writtenPath) {
+              writtenPaths.push(handledByPackage.writtenPath);
+            }
             try { await updateBenchmarkCompleted(benchStatusPath, statusId, handledByPackage.writtenPath ?? ""); } catch { /* non-fatal */ }
           } else {
             const fallbackResultPath = await runBenchViaFallback(parsed, benchmarkId, runtimeProfile);
@@ -5015,6 +5132,12 @@ async function cmdBench(rest: string[]): Promise<void> {
   } finally {
     try { await finalizeBenchStatus(benchStatusPath); } catch { /* non-fatal */ }
   }
+  await writeBenchReproManifestForPackageRun({
+    parsed,
+    benchmarkIds: selectedBenchmarks,
+    runtimeProfiles,
+    resultPaths: writtenPaths,
+  });
   if (failures.size > 0) {
     console.error(`\nFailed benchmarks: ${[...failures].join(", ")}`);
     if (failures.size === selectedBenchmarks.length) {

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -350,6 +350,7 @@ type PackageBenchModule = {
     mode?: "full" | "quick";
     outputDir?: string;
     limit?: number;
+    seed?: number;
     adapterMode?: string;
     runtimeProfile?: BenchRuntimeProfile | null;
     systemProvider?: {
@@ -2259,6 +2260,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
   }
 
   const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
+  const effectiveLimit = parsed.publishedLimit ?? (parsed.quick ? 1 : undefined);
   const writtenPaths: string[] = [];
   const customBenchmarkIds: string[] = [];
   for (const plan of plans) {
@@ -2268,7 +2270,8 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
       const result = await benchModule.runCustomBenchmarkFile(parsed.custom!, {
         mode: parsed.quick ? "quick" : "full",
         outputDir,
-        limit: parsed.quick ? 1 : undefined,
+        ...(effectiveLimit !== undefined ? { limit: effectiveLimit } : {}),
+        ...(parsed.publishedSeed !== undefined ? { seed: parsed.publishedSeed } : {}),
         adapterMode: plan.adapterMode,
         runtimeProfile: plan.runtime.profile,
         systemProvider: plan.runtime.systemProvider,

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2260,6 +2260,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
 
   const outputDir = parsed.resultsDir ?? resolveBenchOutputDir();
   const writtenPaths: string[] = [];
+  const customBenchmarkIds: string[] = [];
   for (const plan of plans) {
     const system = await plan.createAdapter(plan.runtime.adapterOptions);
 
@@ -2276,6 +2277,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
         system,
       });
       result.config.remnicConfig = plan.runtime.remnicConfig;
+      customBenchmarkIds.push(result.meta.benchmark);
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       writtenPaths.push(writtenPath);
       if (parsed.json) {
@@ -2290,7 +2292,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
 
   await writeBenchReproManifestForPackageRun({
     parsed,
-    benchmarkIds: parsed.custom ? [path.basename(parsed.custom)] : [],
+    benchmarkIds: [...new Set(customBenchmarkIds)],
     runtimeProfiles,
     resultPaths: writtenPaths,
   });

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -153,6 +153,7 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /result\.config\.remnicConfig = plan\.runtime\.remnicConfig;/);
   assert.match(source, /writeBenchReproManifestForPackageRun/);
   assert.match(source, /writeBenchmarkReproManifest/);
+  assert.match(source, /WARNING: failed to write reproducibility manifest/);
 });
 
 test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -144,6 +144,9 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
   assert.match(source, /if \(parsed\.custom\) \{/);
   assert.match(source, /const outputDir = parsed\.resultsDir \?\? resolveBenchOutputDir\(\);/);
+  assert.match(source, /const effectiveLimit = parsed\.publishedLimit \?\? \(parsed\.quick \? 1 : undefined\);/);
+  assert.match(source, /\.\.\.\(effectiveLimit !== undefined \? \{ limit: effectiveLimit \} : \{\}\),/);
+  assert.match(source, /\.\.\.\(parsed\.publishedSeed !== undefined \? \{ seed: parsed\.publishedSeed \} : \{\}\),/);
   assert.match(source, /const customBenchmarkIds: string\[\] = \[\];/);
   assert.match(source, /customBenchmarkIds\.push\(result\.meta\.benchmark\);/);
   assert.match(source, /benchmarkIds: \[\.\.\.new Set\(customBenchmarkIds\)\]/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -144,6 +144,9 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
   assert.match(source, /if \(parsed\.custom\) \{/);
   assert.match(source, /const outputDir = parsed\.resultsDir \?\? resolveBenchOutputDir\(\);/);
+  assert.match(source, /const customBenchmarkIds: string\[\] = \[\];/);
+  assert.match(source, /customBenchmarkIds\.push\(result\.meta\.benchmark\);/);
+  assert.match(source, /benchmarkIds: \[\.\.\.new Set\(customBenchmarkIds\)\]/);
   assert.match(source, /const datasetDir = resolveBenchDatasetDir\(/);
   assert.doesNotMatch(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const runtime = await resolvePackageBenchRuntime\(/);

--- a/tests/remnic-cli-bench-surface.test.ts
+++ b/tests/remnic-cli-bench-surface.test.ts
@@ -143,7 +143,7 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(parserSource, /custom: customRaw \? path\.resolve\(expandTilde\(customRaw\)\) : undefined/);
   assert.match(source, /resolveBenchDatasetDir\(\s*benchmarkId,\s*parsed\.quick,\s*parsed\.datasetDir/s);
   assert.match(source, /if \(parsed\.custom\) \{/);
-  assert.match(source, /const outputDir = resolveBenchOutputDir\(\);/);
+  assert.match(source, /const outputDir = parsed\.resultsDir \?\? resolveBenchOutputDir\(\);/);
   assert.match(source, /const datasetDir = resolveBenchDatasetDir\(/);
   assert.doesNotMatch(source, /full benchmark runs for "\$\{benchmarkId\}" require dataset files/);
   assert.match(source, /const runtime = await resolvePackageBenchRuntime\(/);
@@ -151,6 +151,8 @@ test("bench CLI validates and resolves explicit dataset overrides for full packa
   assert.match(source, /const system = await plan\.createAdapter\(plan\.runtime\.adapterOptions\);/);
   assert.match(source, /remnicConfig: plan\.runtime\.effectiveRemnicConfig,/);
   assert.match(source, /result\.config\.remnicConfig = plan\.runtime\.remnicConfig;/);
+  assert.match(source, /writeBenchReproManifestForPackageRun/);
+  assert.match(source, /writeBenchmarkReproManifest/);
 });
 
 test("parseBenchArgs supports custom benchmark files without counting them as benchmark ids", async () => {


### PR DESCRIPTION
## Summary
- add `MANIFEST.json` generation for package-backed benchmark results
- record result hashes, dataset tree hashes, selected benchmarks, runtime profiles, seed/limit/mode, git commit/dirty state, redacted argv/env key names, QMD collections, and config-file hashes
- wire manifest writing through `remnic bench run`, `remnic bench published`, and custom package benchmark runs
- document the manifest and add tests for hashing/redaction plus CLI wiring

## Verification
- `pnpm --filter @remnic/bench run check-types`
- `pnpm --filter @remnic/cli run check-types`
- `pnpm exec tsx --test packages/bench/src/repro-manifest.test.ts tests/remnic-cli-bench-surface.test.ts packages/remnic-cli/src/bench-args.test.ts`
- `npm run check-types && npm run check-config-contract && bash scripts/check-review-patterns.sh && pnpm exec tsx --test tests/register-multi-registry.test.ts tests/intent.test.ts tests/runtime-input-guards.test.ts tests/artifact-recall-limit.test.ts tests/artifact-status-snapshot.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts packages/bench/src/repro-manifest.test.ts tests/remnic-cli-bench-surface.test.ts packages/remnic-cli/src/bench-args.test.ts`

## Note
`npm run preflight:quick` was attempted, but the repo script currently routes `npm test -- <file>` through the broad package test globs and drifted into unrelated `packages/remnic-core/src/lcm-engine.test.ts`, where it sat idle. I stopped that hung process and ran the equivalent gate components directly as listed above.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it adds new filesystem-writing and hashing logic (including git/argv/env capture and redaction) and wires it into multiple `remnic bench` run paths, which could affect benchmark CLI output/directories and performance.
> 
> **Overview**
> Package-backed benchmark runs now emit a reproducibility `MANIFEST.json` alongside result artifacts, capturing **stable hashes** for result files and dataset trees plus run parameters (benchmarks/profiles/mode/limit/seed), git state, selected env key names, QMD collections, and config-file hashes with **secret argv values redacted**.
> 
> `@remnic/bench` exports `buildBenchmarkReproManifest`/`writeBenchmarkReproManifest` and adds coverage for hashing stability, redaction, and symlinked dataset rejection. The CLI wires manifest writing into `remnic bench run`, `bench published`, and custom benchmark runs, and updates docs/tests to reflect the new manifest behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7502bae9601e68702c41c53957a28c54527396a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->