### PR TITLE
fix(plugin-openclaw): probe QMD before reporting backend unavailable

### DIFF
--- a/.changeset/qmd-probe-fallback.md
+++ b/.changeset/qmd-probe-fallback.md
@@ -1,0 +1,10 @@
+---
+"@remnic/plugin-openclaw": patch
+"@joshuaswarren/openclaw-engram": patch
+---
+
+Fix false-negative QMD availability reports from `probeEmbeddingAvailability` and `probeVectorAvailability`.
+
+Both probe surfaces previously consulted only the cached `qmd.isAvailable()` flag, which starts as `false` on a fresh process and only flips to `true` after some other code path has actively probed QMD. On systems where probe checks fired before any read/write traffic (e.g. `openclaw status --all --json` immediately after gateway start), the runtime would report `vector.available: false` and `qmdAvailable: false` even when QMD was fully functional. The probe surfaces now fall back to an actual `qmd.probe()` call before reporting the backend down, so status checks reflect real availability.
+
+Credit: reported and patched by [@earlvanze](https://github.com/earlvanze) — see the 2026-04-24 OpenClaw/Remnic QMD fix bundle for the original analysis. The companion OpenClaw upstream fixes (memory-search config plumbing and config-less allowlist warning suppression) live outside this repo and are tracked separately.

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import { registerLcmTools } from "./lcm/index.js";
 import { estimateTokens as estimateLcmTokens } from "./lcm/archive.js";
 import { registerCli } from "./cli.js";
 import { recordObjectiveStateSnapshotsFromAgentMessages } from "./objective-state-writers.js";
+import { probeQmdAvailability } from "./qmd-availability-probe.js";
 import { EngramAccessService } from "./access-service.js";
 import { EngramAccessHttpServer } from "./access-http.js";
 
@@ -2604,10 +2605,7 @@ const pluginDefinition = {
               },
               async probeEmbeddingAvailability() {
                 if (!remnicUsesQmd) return { ok: true };
-                const qmdAvailable =
-                  typeof (orchestrator as any).qmd?.isAvailable === "function"
-                    ? Boolean((orchestrator as any).qmd.isAvailable())
-                    : false;
+                const qmdAvailable = await probeQmdAvailability(orchestrator as unknown as Parameters<typeof probeQmdAvailability>[0]);
                 if (qmdAvailable) return { ok: true };
                 const qmdDebug =
                   typeof (orchestrator as any).qmd?.debugStatus === "function"
@@ -2620,9 +2618,7 @@ const pluginDefinition = {
               },
               async probeVectorAvailability() {
                 if (!remnicUsesQmd) return false;
-                return typeof (orchestrator as any).qmd?.isAvailable === "function"
-                  ? Boolean((orchestrator as any).qmd.isAvailable())
-                  : false;
+                return probeQmdAvailability(orchestrator as unknown as Parameters<typeof probeQmdAvailability>[0]);
               },
               async close() {},
             },

--- a/src/qmd-availability-probe.ts
+++ b/src/qmd-availability-probe.ts
@@ -1,0 +1,35 @@
+/**
+ * Helper for probing QMD availability from runtime surfaces.
+ *
+ * `orchestrator.qmd.isAvailable()` returns a cached boolean derived from prior
+ * probes. On a fresh process it can be `false` simply because nothing has
+ * exercised the CLI/daemon yet — not because QMD is genuinely unavailable.
+ * Runtime probe surfaces should fall back to an actual `qmd.probe()` before
+ * reporting the backend as down, so consumers like `openclaw status` don't
+ * see false negatives.
+ *
+ * Credit: behavior reported by https://github.com/earlvanze (2026-04-24 patch
+ * bundle) — see fix bundle README for details.
+ */
+export interface QmdProbeTarget {
+  isAvailable?: () => boolean;
+  probe?: () => Promise<boolean>;
+}
+
+export interface QmdProbeHost {
+  qmd?: QmdProbeTarget;
+}
+
+export async function probeQmdAvailability(host: QmdProbeHost): Promise<boolean> {
+  const qmd = host?.qmd;
+  let available =
+    typeof qmd?.isAvailable === "function" ? Boolean(qmd.isAvailable()) : false;
+  if (!available && typeof qmd?.probe === "function") {
+    try {
+      available = Boolean(await qmd.probe());
+    } catch {
+      available = false;
+    }
+  }
+  return available;
+}

--- a/tests/qmd-availability-probe.test.ts
+++ b/tests/qmd-availability-probe.test.ts
@@ -1,0 +1,73 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { probeQmdAvailability } from "../src/qmd-availability-probe.ts";
+
+test("returns true when isAvailable() reports true without calling probe", async () => {
+  let probeCalls = 0;
+  const result = await probeQmdAvailability({
+    qmd: {
+      isAvailable: () => true,
+      probe: async () => {
+        probeCalls += 1;
+        return true;
+      },
+    },
+  });
+  assert.equal(result, true);
+  assert.equal(probeCalls, 0);
+});
+
+test("falls back to probe() when isAvailable() reports false", async () => {
+  let probeCalls = 0;
+  const result = await probeQmdAvailability({
+    qmd: {
+      isAvailable: () => false,
+      probe: async () => {
+        probeCalls += 1;
+        return true;
+      },
+    },
+  });
+  assert.equal(result, true);
+  assert.equal(probeCalls, 1);
+});
+
+test("returns false when both isAvailable() and probe() report false", async () => {
+  const result = await probeQmdAvailability({
+    qmd: {
+      isAvailable: () => false,
+      probe: async () => false,
+    },
+  });
+  assert.equal(result, false);
+});
+
+test("treats probe() rejection as unavailable rather than throwing", async () => {
+  const result = await probeQmdAvailability({
+    qmd: {
+      isAvailable: () => false,
+      probe: async () => {
+        throw new Error("daemon offline");
+      },
+    },
+  });
+  assert.equal(result, false);
+});
+
+test("returns false when qmd is missing entirely", async () => {
+  assert.equal(await probeQmdAvailability({}), false);
+  assert.equal(await probeQmdAvailability({ qmd: undefined }), false);
+});
+
+test("returns false when isAvailable is missing and probe is missing", async () => {
+  assert.equal(await probeQmdAvailability({ qmd: {} }), false);
+});
+
+test("uses probe() when isAvailable is missing", async () => {
+  const result = await probeQmdAvailability({
+    qmd: {
+      probe: async () => true,
+    },
+  });
+  assert.equal(result, true);
+});


### PR DESCRIPTION
## Summary

- `probeEmbeddingAvailability` and `probeVectorAvailability` consulted only the cached `qmd.isAvailable()` flag, which starts as `false` on a fresh process. Status surfaces fired before any read/write traffic (e.g. `openclaw status --all --json` immediately after gateway start) reported `vector.available: false` and `qmdAvailable: false` even when QMD was fully functional.
- Both probes now fall back to an actual `qmd.probe()` when the cached flag is false, so status checks reflect real availability instead of stale cache state.
- Probe logic extracted into a small helper (`src/qmd-availability-probe.ts`) with unit tests covering all branches.

## Credit

Reported and patched by [@earlvanze](https://github.com/earlvanze) in the 2026-04-24 OpenClaw/Remnic QMD fix bundle. This PR ports the equivalent fix to the TypeScript source so it survives rebuilds (the original patch targeted compiled `dist/index.js`).

The bundle also included two upstream patches against `openclaw/openclaw` (`src/agents/memory-search.ts` config plumbing into `getMemoryEmbeddingProvider`, and `src/plugins/loader.ts` allowlist-warning suppression on config-less loads). Those live outside this repo. The visible-impact symptom for Remnic users (false `vector.available: false`) is what this PR fixes.

## Test plan

- [x] Added `tests/qmd-availability-probe.test.ts` with 7 cases (cached-true short-circuits probe, cached-false falls back to probe, probe rejection treated as unavailable, missing methods handled).
- [x] `npm run build` clean.
- [x] `npx tsx --test tests/qmd-availability-probe.test.ts` — 7/7 pass.
- [x] `npm run preflight:quick` — pre-existing failures only (lcm/sqlite/projection — confirmed identical to `main`); no new failures introduced.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: small, isolated change to QMD status probing logic with unit coverage; main behavior change is when/if `qmd.probe()` is invoked during status checks.
> 
> **Overview**
> Fixes false-negative QMD availability reporting by updating `probeEmbeddingAvailability`/`probeVectorAvailability` to fall back from cached `qmd.isAvailable()` to an active `qmd.probe()` before declaring the backend down.
> 
> Extracts the probing logic into `probeQmdAvailability` and adds focused unit tests covering cached-true short-circuiting, probe fallback, missing methods, and probe errors, plus a changeset bump for the affected packages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6213ad17b25c20b7b748610b7c2a5662fcfe373d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->