### PR TITLE
feat(bench): add AMA-Bench recommended judge protocol

### DIFF
--- a/packages/bench/package.json
+++ b/packages/bench/package.json
@@ -32,6 +32,7 @@
     "provenance": true
   },
   "scripts": {
+    "prebuild": "node ../../scripts/ensure-bench-build-deps.mjs",
     "build": "tsup --config tsup.config.ts",
     "check-types": "tsc --noEmit",
     "prepublishOnly": "npm run build"

--- a/packages/bench/src/benchmark.ts
+++ b/packages/bench/src/benchmark.ts
@@ -33,7 +33,7 @@ import type {
 } from "./types.js";
 
 export { listBenchmarks, getBenchmark } from "./registry.js";
-export { writeBenchmarkResult } from "./reporter.js";
+export { redactBenchmarkResultSecrets, writeBenchmarkResult } from "./reporter.js";
 
 const DEFAULT_BASELINE_PATH = path.join(process.cwd(), "benchmarks", "baseline.json");
 const DEFAULT_REPORT_PATH = path.join(process.cwd(), "benchmarks", "report.json");

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
@@ -95,3 +95,74 @@ test("AMA-Bench normalizes sparse null trajectory fields from the official datas
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("AMA-Bench records recommended and cross-judge protocol metrics", async () => {
+  const result = await runAmaBenchBenchmark({
+    benchmark: amaBenchDefinition,
+    mode: "quick",
+    amaBenchJudgeProtocol: "recommended",
+    amaBenchCrossJudgeProvider: {
+      provider: "ollama",
+      model: "qwen3:32b",
+    },
+    amaBenchCrossJudge: {
+      async score() {
+        return 0;
+      },
+      async scoreWithMetrics() {
+        return {
+          score: 0,
+          tokens: { input: 1, output: 1 },
+          latencyMs: 2,
+          model: "cross-qwen3-32b",
+        };
+      },
+    },
+    system: {
+      async store() {},
+      async recall() {
+        return "Spanish";
+      },
+      async search() {
+        return [];
+      },
+      async reset() {},
+      async getStats() {
+        return {
+          totalMessages: 4,
+          totalSummaryNodes: 0,
+          maxDepth: 0,
+        };
+      },
+      async destroy() {},
+      judge: {
+        async score() {
+          return 1;
+        },
+        async scoreWithMetrics() {
+          return {
+            score: 1,
+            tokens: { input: 1, output: 1 },
+            latencyMs: 2,
+            model: "primary-qwen3-32b",
+          };
+        },
+      },
+    },
+  });
+
+  const first = result.results.tasks[0]!;
+  assert.equal(first.scores.ama_bench_recommended_accuracy, 1);
+  assert.equal(first.scores.ama_bench_cross_accuracy, 0);
+  assert.equal(first.scores.ama_bench_cross_agreement, 0);
+  assert.equal(first.details?.amaBenchJudgeProtocol, "recommended");
+  assert.equal(first.details?.amaBenchCrossJudgeModel, "cross-qwen3-32b");
+  assert.equal(
+    result.config.benchmarkOptions?.amaBenchJudgeProtocol,
+    "recommended",
+  );
+  assert.deepEqual(result.config.benchmarkOptions?.amaBenchCrossJudgeProvider, {
+    provider: "ollama",
+    model: "qwen3:32b",
+  });
+});

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
@@ -155,6 +155,9 @@ test("AMA-Bench records recommended and cross-judge protocol metrics", async () 
   assert.equal(first.scores.ama_bench_recommended_accuracy, 1);
   assert.equal(first.scores.ama_bench_cross_accuracy, 0);
   assert.equal(first.scores.ama_bench_cross_agreement, 0);
+  assert.equal(first.latencyMs >= 4, true);
+  assert.equal(first.tokens.input >= 2, true);
+  assert.equal(first.tokens.output >= 2, true);
   assert.equal(first.details?.amaBenchJudgeProtocol, "recommended");
   assert.equal(first.details?.amaBenchCrossJudgeModel, "cross-qwen3-32b");
   assert.equal(
@@ -165,4 +168,60 @@ test("AMA-Bench records recommended and cross-judge protocol metrics", async () 
     provider: "ollama",
     model: "qwen3:32b",
   });
+});
+
+test("AMA-Bench omits cross-judge agreement for scalar primary protocol", async () => {
+  const result = await runAmaBenchBenchmark({
+    benchmark: amaBenchDefinition,
+    mode: "quick",
+    amaBenchJudgeProtocol: "default",
+    amaBenchCrossJudge: {
+      async score() {
+        return 1;
+      },
+      async scoreWithMetrics() {
+        return {
+          score: 1,
+          tokens: { input: 1, output: 1 },
+          latencyMs: 2,
+          model: "cross-qwen3-32b",
+        };
+      },
+    },
+    system: {
+      async store() {},
+      async recall() {
+        return "Spanish";
+      },
+      async search() {
+        return [];
+      },
+      async reset() {},
+      async getStats() {
+        return {
+          totalMessages: 4,
+          totalSummaryNodes: 0,
+          maxDepth: 0,
+        };
+      },
+      async destroy() {},
+      judge: {
+        async score() {
+          return 0.7;
+        },
+        async scoreWithMetrics() {
+          return {
+            score: 0.7,
+            tokens: { input: 1, output: 1 },
+            latencyMs: 2,
+            model: "primary-scalar",
+          };
+        },
+      },
+    },
+  });
+
+  const first = result.results.tasks[0]!;
+  assert.equal(first.scores.ama_bench_cross_accuracy, 1);
+  assert.equal("ama_bench_cross_agreement" in first.scores, false);
 });

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -95,6 +95,13 @@ export async function runAmaBenchBenchmark(
               qa.answer,
             )
           : undefined;
+        const crossJudgeLatencyMs = crossJudgeResult?.latencyMs ?? 0;
+        const crossJudgeTokens = crossJudgeResult?.tokens ?? {
+          input: 0,
+          output: 0,
+        };
+        const isRecommendedPrimaryProtocol =
+          options.amaBenchJudgeProtocol === "recommended";
 
         const scores: Record<string, number> = {
           f1: f1Score(answered.finalAnswer, qa.answer),
@@ -102,13 +109,13 @@ export async function runAmaBenchBenchmark(
         };
         if (judgeResult.score >= 0) {
           scores.llm_judge = judgeResult.score;
-          if (options.amaBenchJudgeProtocol === "recommended") {
+          if (isRecommendedPrimaryProtocol) {
             scores.ama_bench_recommended_accuracy = judgeResult.score;
           }
         }
         if (crossJudgeResult?.score != null && crossJudgeResult.score >= 0) {
           scores.ama_bench_cross_accuracy = crossJudgeResult.score;
-          if (judgeResult.score >= 0) {
+          if (isRecommendedPrimaryProtocol && judgeResult.score >= 0) {
             scores.ama_bench_cross_agreement =
               judgeResult.score === crossJudgeResult.score ? 1 : 0;
           }
@@ -120,10 +127,20 @@ export async function runAmaBenchBenchmark(
           expected: qa.answer,
           actual: answered.finalAnswer,
           scores,
-          latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
+          latencyMs:
+            durationMs +
+            answered.latencyMs +
+            judgeResult.latencyMs +
+            crossJudgeLatencyMs,
           tokens: {
-            input: answered.tokens.input + judgeResult.tokens.input,
-            output: answered.tokens.output + judgeResult.tokens.output,
+            input:
+              answered.tokens.input +
+              judgeResult.tokens.input +
+              crossJudgeTokens.input,
+            output:
+              answered.tokens.output +
+              judgeResult.tokens.output +
+              crossJudgeTokens.output,
           },
           details: {
             qaType: qa.type,

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -87,6 +87,14 @@ export async function runAmaBenchBenchmark(
           answered.finalAnswer,
           qa.answer,
         );
+        const crossJudgeResult = options.amaBenchCrossJudge
+          ? await llmJudgeScoreDetailed(
+              options.amaBenchCrossJudge,
+              qa.question,
+              answered.finalAnswer,
+              qa.answer,
+            )
+          : undefined;
 
         const scores: Record<string, number> = {
           f1: f1Score(answered.finalAnswer, qa.answer),
@@ -94,6 +102,16 @@ export async function runAmaBenchBenchmark(
         };
         if (judgeResult.score >= 0) {
           scores.llm_judge = judgeResult.score;
+          if (options.amaBenchJudgeProtocol === "recommended") {
+            scores.ama_bench_recommended_accuracy = judgeResult.score;
+          }
+        }
+        if (crossJudgeResult?.score != null && crossJudgeResult.score >= 0) {
+          scores.ama_bench_cross_accuracy = crossJudgeResult.score;
+          if (judgeResult.score >= 0) {
+            scores.ama_bench_cross_agreement =
+              judgeResult.score === crossJudgeResult.score ? 1 : 0;
+          }
         }
 
         tasks.push({
@@ -121,6 +139,14 @@ export async function runAmaBenchBenchmark(
             answeredText: answered.finalAnswer,
             responderModel: answered.model,
             judgeModel: judgeResult.model,
+            amaBenchJudgeProtocol: options.amaBenchJudgeProtocol ?? "default",
+            ...(crossJudgeResult
+              ? {
+                  amaBenchCrossJudgeModel: crossJudgeResult.model,
+                  amaBenchCrossJudgeScore: crossJudgeResult.score,
+                  amaBenchCrossJudgeLatencyMs: crossJudgeResult.latencyMs,
+                }
+              : {}),
           },
         });
       } catch (err) {
@@ -165,6 +191,10 @@ export async function runAmaBenchBenchmark(
       judgeProvider: options.judgeProvider ?? null,
       adapterMode: options.adapterMode ?? "direct",
       remnicConfig: options.remnicConfig ?? {},
+      benchmarkOptions: {
+        amaBenchJudgeProtocol: options.amaBenchJudgeProtocol ?? "default",
+        amaBenchCrossJudgeProvider: options.amaBenchCrossJudgeProvider ?? null,
+      },
     },
     cost: {
       totalTokens: totalInputTokens + totalOutputTokens,

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -152,6 +152,7 @@ export {
 } from "./answering.js";
 export {
   createGatewayResponder,
+  createProviderBackedAmaBenchRecommendedJudge,
   createProviderBackedJudge,
   createProviderBackedResponder,
   createProviderBackedStructuredJudge,
@@ -175,6 +176,7 @@ export {
   runBenchmark,
   listBenchmarks,
   getBenchmark,
+  redactBenchmarkResultSecrets,
   writeBenchmarkResult,
   loadBaseline,
   saveBaseline,

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { redactBenchmarkResultSecrets, writeBenchmarkResult } from "./reporter.ts";
+import type { BenchmarkResult } from "./types.js";
+
+function buildResult(): BenchmarkResult {
+  return {
+    meta: {
+      id: "result-1",
+      benchmark: "ama-bench",
+      benchmarkTier: "published",
+      version: "1.0.0",
+      remnicVersion: "9.3.169",
+      gitSha: "deadbeef",
+      timestamp: "2026-04-25T02:52:05.982Z",
+      mode: "full",
+      runCount: 1,
+      seeds: [0],
+    },
+    config: {
+      runtimeProfile: "real",
+      systemProvider: {
+        provider: "ollama",
+        model: "gemma4:31b-cloud",
+        baseUrl: "https://ollama.com/api",
+        apiKey: "system-secret-key",
+      },
+      judgeProvider: {
+        provider: "ollama",
+        model: "gemma4:31b-cloud",
+        baseUrl: "https://ollama.com/api",
+        apiKey: "judge-secret-key",
+      },
+      adapterMode: "direct",
+      remnicConfig: {
+        nested: {
+          authToken: "nested-token",
+        },
+      },
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [],
+      aggregates: {},
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+    },
+  };
+}
+
+test("redactBenchmarkResultSecrets redacts provider and nested secret fields", () => {
+  const redacted = redactBenchmarkResultSecrets(buildResult());
+
+  assert.equal(redacted.config.systemProvider?.apiKey, "[REDACTED]");
+  assert.equal(redacted.config.judgeProvider?.apiKey, "[REDACTED]");
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { authToken?: string }).authToken,
+    "[REDACTED]",
+  );
+  assert.equal(redacted.config.systemProvider?.provider, "ollama");
+  assert.equal(redacted.config.systemProvider?.model, "gemma4:31b-cloud");
+});
+
+test("writeBenchmarkResult does not persist secret values", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    const filePath = await writeBenchmarkResult(buildResult(), dir);
+    const raw = await readFile(filePath, "utf8");
+
+    assert.doesNotMatch(raw, /system-secret-key|judge-secret-key|nested-token/);
+    assert.match(raw, /"apiKey": "\[REDACTED\]"/);
+    assert.match(raw, /"provider": "ollama"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -39,6 +39,14 @@ function buildResult(): BenchmarkResult {
       remnicConfig: {
         nested: {
           authToken: "nested-token",
+          bearerToken: "bearer-token",
+          privateKey: "private-key",
+          sessionToken: "session-token",
+          authorization: "Bearer auth-header",
+          token: "plain-token",
+          secretary: "office-role",
+          passwordless: true,
+          credentialingOrg: "board",
         },
       },
     },
@@ -70,6 +78,39 @@ test("redactBenchmarkResultSecrets redacts provider and nested secret fields", (
     (redacted.config.remnicConfig.nested as { authToken?: string }).authToken,
     "[REDACTED]",
   );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { bearerToken?: string }).bearerToken,
+    "[REDACTED]",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { privateKey?: string }).privateKey,
+    "[REDACTED]",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { sessionToken?: string }).sessionToken,
+    "[REDACTED]",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { authorization?: string }).authorization,
+    "[REDACTED]",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { token?: string }).token,
+    "[REDACTED]",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { secretary?: string }).secretary,
+    "office-role",
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { passwordless?: boolean }).passwordless,
+    true,
+  );
+  assert.equal(
+    (redacted.config.remnicConfig.nested as { credentialingOrg?: string })
+      .credentialingOrg,
+    "board",
+  );
   assert.equal(redacted.config.systemProvider?.provider, "ollama");
   assert.equal(redacted.config.systemProvider?.model, "gemma4:31b-cloud");
 });
@@ -80,9 +121,14 @@ test("writeBenchmarkResult does not persist secret values", async () => {
     const filePath = await writeBenchmarkResult(buildResult(), dir);
     const raw = await readFile(filePath, "utf8");
 
-    assert.doesNotMatch(raw, /system-secret-key|judge-secret-key|nested-token/);
+    assert.doesNotMatch(
+      raw,
+      /system-secret-key|judge-secret-key|nested-token|bearer-token|private-key|session-token|auth-header|plain-token/,
+    );
     assert.match(raw, /"apiKey": "\[REDACTED\]"/);
     assert.match(raw, /"provider": "ollama"/);
+    assert.match(raw, /"secretary": "office-role"/);
+    assert.match(raw, /"credentialingOrg": "board"/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -8,9 +8,35 @@ import path from "node:path";
 import type { LegacyBenchmarkResult } from "./adapters/types.js";
 import type { BenchmarkResult } from "./types.js";
 
+const REDACTED_SECRET = "[REDACTED]";
+const SECRET_KEY_PATTERN =
+  /(?:api[-_]?key|auth[-_]?token|access[-_]?token|refresh[-_]?token|secret|password|credential)/i;
+
 function sanitizeFilenameSegment(value: string): string {
   const sanitized = value.trim().replace(/[^a-zA-Z0-9._-]/g, "_");
   return sanitized.length > 0 ? sanitized : "unknown";
+}
+
+export function redactBenchmarkResultSecrets<T>(value: T): T {
+  return redactSecrets(value) as T;
+}
+
+function redactSecrets(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactSecrets(item));
+  }
+
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = SECRET_KEY_PATTERN.test(key)
+      ? REDACTED_SECRET
+      : redactSecrets(nestedValue);
+  }
+  return redacted;
 }
 
 export async function writeBenchmarkResult(
@@ -26,7 +52,7 @@ export async function writeBenchmarkResult(
     `${result.meta.benchmark}-v${safeRemnicVersion}-${timestamp}.json`,
   );
 
-  await writeFile(filePath, JSON.stringify(result, null, 2) + "\n");
+  await writeFile(filePath, JSON.stringify(redactBenchmarkResultSecrets(result), null, 2) + "\n");
   return filePath;
 }
 

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -6,11 +6,10 @@ import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { LegacyBenchmarkResult } from "./adapters/types.js";
+import { isSecretKey } from "./security/secret-keys.js";
 import type { BenchmarkResult } from "./types.js";
 
 const REDACTED_SECRET = "[REDACTED]";
-const SECRET_KEY_PATTERN =
-  /(?:api[-_]?key|auth[-_]?token|access[-_]?token|refresh[-_]?token|secret|password|credential)/i;
 
 function sanitizeFilenameSegment(value: string): string {
   const sanitized = value.trim().replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -32,7 +31,7 @@ function redactSecrets(value: unknown): unknown {
 
   const redacted: Record<string, unknown> = {};
   for (const [key, nestedValue] of Object.entries(value)) {
-    redacted[key] = SECRET_KEY_PATTERN.test(key)
+    redacted[key] = isSecretKey(key)
       ? REDACTED_SECRET
       : redactSecrets(nestedValue);
   }

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -202,6 +202,15 @@ test("AMA-Bench recommended judge parses incorrect before correct", async () => 
   assert.equal(await judge.score("q", "predicted", "expected"), 0);
 });
 
+test("AMA-Bench recommended judge scans multiple JSON objects for score", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider('Reasoning object: {"note":"ignore"}\nFinal: {"score":1,"reason":"same fact"}'),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 1);
+});
+
 test("AMA-Bench recommended judge treats negated positive labels as incorrect", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -202,6 +202,22 @@ test("AMA-Bench recommended judge parses incorrect before correct", async () => 
   assert.equal(await judge.score("q", "predicted", "expected"), 0);
 });
 
+test("AMA-Bench recommended judge treats negated positive labels as incorrect", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("The answer is not correct."),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0);
+
+  const passJudge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("This does not pass."),
+  );
+
+  assert.equal(await passJudge.score("q", "predicted", "expected"), 0);
+});
+
 test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {
   const judge = createProviderBackedJudge(
     { provider: "openai", model: "gpt-5.4-mini" },

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -225,6 +225,13 @@ test("AMA-Bench recommended judge treats negated positive labels as incorrect", 
   );
 
   assert.equal(await passJudge.score("q", "predicted", "expected"), 0);
+
+  const adjectiveJudge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("This is not a correct answer."),
+  );
+
+  assert.equal(await adjectiveJudge.score("q", "predicted", "expected"), 0);
 });
 
 test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -211,6 +211,33 @@ test("AMA-Bench recommended judge scans multiple JSON objects for score", async 
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
 });
 
+test("AMA-Bench recommended judge prefers the last scored JSON object", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider('Draft: {"score":0,"reason":"scratch"}\nFinal: {"score":1,"reason":"same fact"}'),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 1);
+});
+
+test("AMA-Bench recommended judge parses nested JSON score objects", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider('{"analysis":{"note":"nested braces are valid"},"score":1}'),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 1);
+});
+
+test("AMA-Bench recommended judge does not treat benign no-phrases as negative", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("No issues found; the answer is correct."),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 1);
+});
+
 test("AMA-Bench recommended judge treats negated positive labels as incorrect", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -238,6 +238,22 @@ test("AMA-Bench recommended judge does not treat benign no-phrases as negative",
   assert.equal(await judge.score("q", "predicted", "expected"), 1);
 });
 
+test("AMA-Bench recommended judge treats negated negative labels as correct", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("This is not incorrect."),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 1);
+
+  const failJudge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("It doesn't fail."),
+  );
+
+  assert.equal(await failJudge.score("q", "predicted", "expected"), 1);
+});
+
 test("AMA-Bench recommended judge treats negated positive labels as incorrect", async () => {
   const judge = createProviderBackedAmaBenchRecommendedJudge(
     { provider: "openai", model: "qwen3-32b" },

--- a/packages/bench/src/responders.test.ts
+++ b/packages/bench/src/responders.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   createGatewayResponder,
+  createProviderBackedAmaBenchRecommendedJudge,
   createProviderBackedJudge,
   createProviderBackedResponder,
   createResponderFromProvider,
@@ -179,6 +180,26 @@ test("provider-backed judge parses fraction and percent score formats", async ()
     createFakeProvider("Score: 8 out of 10"),
   );
   assert.equal(await outOfJudge.score("q", "predicted", "expected"), 0.8);
+});
+
+test("AMA-Bench recommended judge uses binary JSON scoring", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider('{"score":1,"reason":"same fact"}'),
+  );
+
+  const result = await judge.scoreWithMetrics?.("q", "predicted", "expected");
+  assert.equal(result?.score, 1);
+  assert.equal(result?.model, "test-model");
+});
+
+test("AMA-Bench recommended judge parses incorrect before correct", async () => {
+  const judge = createProviderBackedAmaBenchRecommendedJudge(
+    { provider: "openai", model: "qwen3-32b" },
+    createFakeProvider("incorrect"),
+  );
+
+  assert.equal(await judge.score("q", "predicted", "expected"), 0);
 });
 
 test("provider-backed judge ignores date-like fractions and uses the trailing score", async () => {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -314,8 +314,8 @@ function parseScalarJudgeScore(raw: string): number {
 
 function parseAmaBenchBinaryJudgeScore(raw: string): number {
   const trimmed = raw.trim();
-  const jsonMatch = trimmed.match(/\{[\s\S]*\}/);
-  if (jsonMatch) {
+  const jsonMatches = trimmed.matchAll(/\{[\s\S]*?\}/g);
+  for (const jsonMatch of jsonMatches) {
     try {
       const parsed = JSON.parse(jsonMatch[0]) as { score?: unknown };
       if (parsed.score === 0 || parsed.score === 1) {
@@ -325,7 +325,7 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
         return Number(parsed.score);
       }
     } catch {
-      // Fall through to permissive parsing below.
+      // Keep scanning for a later score object.
     }
   }
 

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -314,10 +314,10 @@ function parseScalarJudgeScore(raw: string): number {
 
 function parseAmaBenchBinaryJudgeScore(raw: string): number {
   const trimmed = raw.trim();
-  const jsonMatches = trimmed.matchAll(/\{[\s\S]*?\}/g);
-  for (const jsonMatch of jsonMatches) {
+  const jsonCandidates = extractJsonObjects(trimmed);
+  for (const jsonCandidate of jsonCandidates.reverse()) {
     try {
-      const parsed = JSON.parse(jsonMatch[0]) as { score?: unknown };
+      const parsed = JSON.parse(jsonCandidate) as { score?: unknown };
       if (parsed.score === 0 || parsed.score === 1) {
         return parsed.score;
       }
@@ -339,7 +339,10 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
   if (scalar >= 0) {
     return 0;
   }
-  if (/\b(incorrect|no|false|fail)\b/i.test(trimmed)) {
+  if (/^\s*no[.!]?\s*$/i.test(trimmed)) {
+    return 0;
+  }
+  if (/\b(incorrect|false|fail(?:ed|s)?)\b/i.test(trimmed)) {
     return 0;
   }
   if (
@@ -353,6 +356,52 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
     return 1;
   }
   return -1;
+}
+
+function extractJsonObjects(raw: string): string[] {
+  const objects: string[] = [];
+  let start = -1;
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let index = 0; index < raw.length; index += 1) {
+    const char = raw[index];
+    if (start < 0) {
+      if (char === "{") {
+        start = index;
+        depth = 1;
+        inString = false;
+        escaped = false;
+      }
+      continue;
+    }
+
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (char === "\\") {
+        escaped = true;
+      } else if (char === "\"") {
+        inString = false;
+      }
+      continue;
+    }
+
+    if (char === "\"") {
+      inString = true;
+    } else if (char === "{") {
+      depth += 1;
+    } else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) {
+        objects.push(raw.slice(start, index + 1));
+        start = -1;
+      }
+    }
+  }
+
+  return objects;
 }
 
 function isPlausibleScoreFraction(

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -342,6 +342,13 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
   if (/^\s*no[.!]?\s*$/i.test(trimmed)) {
     return 0;
   }
+  if (
+    /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\b(?:\s+\w+){0,3}\s+(?:incorrect|false|fail(?:ed|s|ing)?)\b/i.test(
+      trimmed,
+    )
+  ) {
+    return 1;
+  }
   if (/\b(incorrect|false|fail(?:ed|s)?)\b/i.test(trimmed)) {
     return 0;
   }

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -343,7 +343,7 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
     return 0;
   }
   if (
-    /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\s+(?:correct|true|pass(?:ed|es)?|a\s+match|the\s+same)\b/i.test(
+    /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\b(?:\s+\w+){0,3}\s+(?:correct|true|pass(?:ed|es|ing)?|match(?:es|ed|ing)?|same)\b/i.test(
       trimmed,
     )
   ) {

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -342,6 +342,13 @@ function parseAmaBenchBinaryJudgeScore(raw: string): number {
   if (/\b(incorrect|no|false|fail)\b/i.test(trimmed)) {
     return 0;
   }
+  if (
+    /\b(?:not|never|isn'?t|wasn'?t|doesn'?t|didn'?t|cannot|can'?t)\s+(?:correct|true|pass(?:ed|es)?|a\s+match|the\s+same)\b/i.test(
+      trimmed,
+    )
+  ) {
+    return 0;
+  }
   if (/\b(correct|yes|true|pass)\b/i.test(trimmed)) {
     return 1;
   }

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -28,6 +28,15 @@ const DEFAULT_JUDGE_SYSTEM_PROMPT = [
   "Use 1.00 for a fully correct answer, 0.00 for a fully incorrect answer, and fractional values for partial matches.",
 ].join(" ");
 
+const AMA_BENCH_RECOMMENDED_JUDGE_SYSTEM_PROMPT = [
+  "You are evaluating an AMA-Bench long-horizon memory question.",
+  "Decide whether the predicted answer correctly answers the question using the reference answer as ground truth.",
+  "Award 1 only when the predicted answer contains the same essential information as the reference answer.",
+  "Award 0 when the answer is wrong, missing, contradictory, or only vaguely related.",
+  "Ignore harmless wording differences, formatting differences, and extra explanation that does not change the answer.",
+  'Return only JSON: {"score":0 or 1,"reason":"short reason"}.',
+].join(" ");
+
 const SCORE_CUE_REGEX = /\b(score|rated|rating|grade|graded|result|overall|final)\b/;
 
 export interface GatewayResponderOptions {
@@ -123,6 +132,54 @@ export function createProviderBackedJudge(
   return createJudgeFromProvider(providerInstance ?? createProvider(config));
 }
 
+function createAmaBenchRecommendedJudgeFromProvider(provider: LlmProvider): BenchJudge {
+  async function scoreWithMetrics(
+    question: string,
+    predicted: string,
+    expected: string,
+  ): Promise<BenchJudgeResult> {
+    const completion = await provider.complete(
+      [
+        `QUESTION: ${question}`,
+        "",
+        `REFERENCE_ANSWER: ${expected}`,
+        "",
+        `PREDICTED_ANSWER: ${predicted}`,
+        "",
+        "Judge the predicted answer under the AMA-Bench binary accuracy protocol.",
+      ].join("\n"),
+      {
+        systemPrompt: AMA_BENCH_RECOMMENDED_JUDGE_SYSTEM_PROMPT,
+        temperature: 0,
+      },
+    );
+
+    return {
+      score: parseAmaBenchBinaryJudgeScore(completion.text),
+      tokens: completion.tokens,
+      latencyMs: completion.latencyMs,
+      model: completion.model,
+    };
+  }
+
+  return {
+    async score(question: string, predicted: string, expected: string): Promise<number> {
+      return (await scoreWithMetrics(question, predicted, expected)).score;
+    },
+    scoreWithMetrics,
+  };
+}
+
+export function createProviderBackedAmaBenchRecommendedJudge(
+  config: ProviderFactoryConfig,
+  providerInstance?: LlmProvider,
+): BenchJudge {
+  validateProviderConfig(config, "AMA-Bench recommended judge");
+  return createAmaBenchRecommendedJudgeFromProvider(
+    providerInstance ?? createProvider(config),
+  );
+}
+
 export function createStructuredJudgeFromProvider(
   provider: LlmProvider,
 ): StructuredJudge {
@@ -204,7 +261,7 @@ export function createGatewayResponder(
 
 function validateProviderConfig(
   config: ProviderFactoryConfig,
-  kind: "responder" | "judge",
+  kind: "responder" | "judge" | "AMA-Bench recommended judge",
 ): void {
   if (typeof config.model !== "string" || config.model.trim().length === 0) {
     throw new Error(`provider-backed ${kind} requires a non-empty model`);
@@ -252,6 +309,42 @@ function parseScalarJudgeScore(raw: string): number {
     }
   }
 
+  return -1;
+}
+
+function parseAmaBenchBinaryJudgeScore(raw: string): number {
+  const trimmed = raw.trim();
+  const jsonMatch = trimmed.match(/\{[\s\S]*\}/);
+  if (jsonMatch) {
+    try {
+      const parsed = JSON.parse(jsonMatch[0]) as { score?: unknown };
+      if (parsed.score === 0 || parsed.score === 1) {
+        return parsed.score;
+      }
+      if (parsed.score === "0" || parsed.score === "1") {
+        return Number(parsed.score);
+      }
+    } catch {
+      // Fall through to permissive parsing below.
+    }
+  }
+
+  const scalar = parseScalarJudgeScore(trimmed);
+  if (scalar === 0 || scalar === 1) {
+    return scalar;
+  }
+  if (scalar > 0.5) {
+    return 1;
+  }
+  if (scalar >= 0) {
+    return 0;
+  }
+  if (/\b(incorrect|no|false|fail)\b/i.test(trimmed)) {
+    return 0;
+  }
+  if (/\b(correct|yes|true|pass)\b/i.test(trimmed)) {
+    return 1;
+  }
   return -1;
 }
 

--- a/packages/bench/src/runtime-profiles.ts
+++ b/packages/bench/src/runtime-profiles.ts
@@ -24,6 +24,7 @@ import {
 } from "./responders.js";
 import type { ProviderFactoryConfig } from "./providers/types.js";
 import { createProvider } from "./providers/factory.js";
+import { isSecretKey } from "./security/secret-keys.js";
 import type { BenchRuntimeProfile, BuiltInProvider, ProviderConfig } from "./types.js";
 export type BenchModelSource = "plugin" | "gateway";
 
@@ -60,24 +61,6 @@ export interface ResolvedBenchRuntimeProfile {
   systemProvider: ProviderConfig | null;
   judgeProvider: ProviderConfig | null;
 }
-
-const EXACT_SECRET_KEYS = new Set([
-  "authorization",
-  "password",
-  "secret",
-  "token",
-] as const);
-
-const SECRET_KEY_SEGMENT_SUFFIXES = new Set([
-  "apikey",
-  "authtoken",
-  "accesstoken",
-  "refreshtoken",
-  "bearertoken",
-  "clientsecret",
-  "secretkey",
-  "privatekey",
-] as const);
 
 const REDACTED_CONFIG_VALUE = "[redacted]";
 
@@ -443,48 +426,6 @@ function sanitizePersistedValue(value: unknown): unknown {
     next[key] = sanitizePersistedValue(entry);
   }
   return next;
-}
-
-function isSecretKey(key: string): boolean {
-  const segments = key
-    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
-    .split(/[^a-z0-9]+/i)
-    .map((segment) => segment.trim().toLowerCase())
-    .filter(Boolean);
-
-  if (segments.length === 0) {
-    return false;
-  }
-
-  const normalized = segments.join("");
-  if (EXACT_SECRET_KEYS.has(normalized as (typeof EXACT_SECRET_KEYS extends Set<infer T> ? T : never))) {
-    return true;
-  }
-
-  if (
-    SECRET_KEY_SEGMENT_SUFFIXES.has(
-      normalized as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never),
-    )
-  ) {
-    return true;
-  }
-
-  const lastSegment = segments.at(-1);
-  if (
-    lastSegment &&
-    EXACT_SECRET_KEYS.has(lastSegment as (typeof EXACT_SECRET_KEYS extends Set<infer T> ? T : never))
-  ) {
-    return true;
-  }
-
-  for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
-    const candidate = segments.slice(-width).join("");
-    if (SECRET_KEY_SEGMENT_SUFFIXES.has(candidate as (typeof SECRET_KEY_SEGMENT_SUFFIXES extends Set<infer T> ? T : never))) {
-      return true;
-    }
-  }
-
-  return false;
 }
 
 function isPlainObject(value: unknown): value is Record<string, unknown> {

--- a/packages/bench/src/security/secret-keys.ts
+++ b/packages/bench/src/security/secret-keys.ts
@@ -1,0 +1,52 @@
+const EXACT_SECRET_KEYS: ReadonlySet<string> = new Set([
+  "authorization",
+  "password",
+  "secret",
+  "token",
+] as const);
+
+const SECRET_KEY_SEGMENT_SUFFIXES: ReadonlySet<string> = new Set([
+  "apikey",
+  "authtoken",
+  "accesstoken",
+  "refreshtoken",
+  "bearertoken",
+  "clientsecret",
+  "secretkey",
+  "privatekey",
+] as const);
+
+export function isSecretKey(key: string): boolean {
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^a-z0-9]+/i)
+    .map((segment) => segment.trim().toLowerCase())
+    .filter(Boolean);
+
+  if (segments.length === 0) {
+    return false;
+  }
+
+  const normalized = segments.join("");
+  if (EXACT_SECRET_KEYS.has(normalized)) {
+    return true;
+  }
+
+  if (SECRET_KEY_SEGMENT_SUFFIXES.has(normalized)) {
+    return true;
+  }
+
+  const lastSegment = segments.at(-1);
+  if (lastSegment && EXACT_SECRET_KEYS.has(lastSegment)) {
+    return true;
+  }
+
+  for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
+    const candidate = segments.slice(-width).join("");
+    if (SECRET_KEY_SEGMENT_SUFFIXES.has(candidate)) {
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/packages/bench/src/types.ts
+++ b/packages/bench/src/types.ts
@@ -12,6 +12,7 @@ export type BenchmarkTier = "published" | "remnic" | "custom";
 export type BenchmarkStatus = "ready" | "planned";
 export type BenchmarkCategory = "agentic" | "retrieval" | "conversational" | "ingestion";
 export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
+export type AmaBenchJudgeProtocol = "default" | "recommended";
 /**
  * Built-in LLM providers supported by the bench harness.
  *
@@ -151,6 +152,7 @@ export interface BenchmarkResult {
     judgeProvider: ProviderConfig | null;
     adapterMode: string;
     remnicConfig: Record<string, unknown>;
+    benchmarkOptions?: Record<string, unknown>;
   };
   cost: {
     totalTokens: number;
@@ -210,6 +212,9 @@ export interface RunBenchmarkOptions {
   systemProvider?: ProviderConfig | null;
   judgeProvider?: ProviderConfig | null;
   remnicConfig?: Record<string, unknown>;
+  amaBenchJudgeProtocol?: AmaBenchJudgeProtocol;
+  amaBenchCrossJudge?: import("./adapters/types.js").BenchJudge;
+  amaBenchCrossJudgeProvider?: ProviderConfig | null;
 }
 
 export interface ResolvedRunBenchmarkOptions extends RunBenchmarkOptions {

--- a/packages/remnic-cli/src/bench-args.test.ts
+++ b/packages/remnic-cli/src/bench-args.test.ts
@@ -154,6 +154,53 @@ test("parseBenchArgs accepts --provider shorthand", () => {
   assert.equal(parsed.systemBaseUrl, "https://api.openai.com");
 });
 
+test("parseBenchArgs accepts AMA-Bench recommended judge and cross-judge flags", () => {
+  const parsed = parseBenchArgs([
+    "run",
+    "ama-bench",
+    "--judge-provider",
+    "ollama",
+    "--judge-model",
+    "qwen3:32b",
+    "--judge-base-url",
+    "https://ollama.com/api",
+    "--ama-bench-judge-protocol",
+    "recommended",
+    "--ama-bench-cross-judge-model",
+    "gemma4:31b-cloud",
+  ]);
+
+  assert.equal(parsed.amaBenchJudgeProtocol, "recommended");
+  assert.equal(parsed.amaBenchCrossJudgeModel, "gemma4:31b-cloud");
+  assert.equal(parsed.amaBenchCrossJudgeProvider, undefined);
+});
+
+test("parseBenchArgs rejects unknown AMA-Bench judge protocol", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--ama-bench-judge-protocol",
+        "paperish",
+      ]),
+    /--ama-bench-judge-protocol must be "default" or "recommended"/,
+  );
+});
+
+test("parseBenchArgs requires cross-judge model when cross-judge provider is configured", () => {
+  assert.throws(
+    () =>
+      parseBenchArgs([
+        "run",
+        "ama-bench",
+        "--ama-bench-cross-judge-provider",
+        "ollama",
+      ]),
+    /--ama-bench-cross-judge-model is required/,
+  );
+});
+
 test("parseBenchArgs rejects unknown --provider", () => {
   assert.throws(
     () =>

--- a/packages/remnic-cli/src/bench-args.ts
+++ b/packages/remnic-cli/src/bench-args.ts
@@ -27,6 +27,7 @@ export type BenchPublishTarget = "remnic-ai";
 export type BenchRuntimeProfile = "baseline" | "real" | "openclaw-chain";
 export type BenchModelSource = "plugin" | "gateway";
 export type BenchRunAction = "list" | "show" | "delete";
+export type AmaBenchJudgeProtocol = "default" | "recommended";
 
 export interface ParsedBenchArgs {
   action: BenchAction;
@@ -67,6 +68,12 @@ export interface ParsedBenchArgs {
   max429WaitMs?: number;
   /** Suppress thinking/reasoning tokens for thinking-capable models (Gemma 4, Qwen 3.5, DeepSeek). */
   disableThinking?: boolean;
+  /** AMA-Bench-specific judge protocol. `recommended` uses binary accuracy scoring. */
+  amaBenchJudgeProtocol?: AmaBenchJudgeProtocol;
+  amaBenchCrossJudgeProvider?: BuiltInProvider;
+  amaBenchCrossJudgeModel?: string;
+  amaBenchCrossJudgeBaseUrl?: string;
+  amaBenchCrossJudgeApiKey?: string;
   /** `bench published` — specific benchmark to run (longmemeval|locomo). */
   publishedName?: PublishedBenchmarkName;
   /** `bench published` — seed forwarded into the harness context. */
@@ -193,7 +200,12 @@ export function collectBenchmarks(argv: string[]): string[] {
       arg === "--provider" ||
       arg === "--base-url" ||
       arg === "--request-timeout" ||
-      arg === "--max-429-wait"
+      arg === "--max-429-wait" ||
+      arg === "--ama-bench-judge-protocol" ||
+      arg === "--ama-bench-cross-judge-provider" ||
+      arg === "--ama-bench-cross-judge-model" ||
+      arg === "--ama-bench-cross-judge-base-url" ||
+      arg === "--ama-bench-cross-judge-api-key"
     ) {
       index += 1;
       continue;
@@ -315,6 +327,11 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   const targetRaw = readBenchOptionValue(args, "--target");
   const requestTimeoutRaw = readBenchOptionValue(args, "--request-timeout");
   const max429WaitRaw = readBenchOptionValue(args, "--max-429-wait");
+  const amaBenchJudgeProtocolRaw = readBenchOptionValue(args, "--ama-bench-judge-protocol");
+  const amaBenchCrossJudgeProviderRaw = readBenchOptionValue(args, "--ama-bench-cross-judge-provider");
+  const amaBenchCrossJudgeModel = readBenchOptionValue(args, "--ama-bench-cross-judge-model");
+  const amaBenchCrossJudgeBaseUrl = readBenchOptionValue(args, "--ama-bench-cross-judge-base-url");
+  const amaBenchCrossJudgeApiKey = readBenchOptionValue(args, "--ama-bench-cross-judge-api-key");
   let runtimeProfile: BenchRuntimeProfile | undefined;
   if (runtimeProfileRaw !== undefined) {
     runtimeProfile = parseBenchRuntimeProfile(
@@ -355,6 +372,27 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
   let judgeProvider: BuiltInProvider | undefined;
   if (judgeProviderRaw !== undefined) {
     judgeProvider = parseBenchProvider(judgeProviderRaw, "--judge-provider");
+  }
+
+  let amaBenchJudgeProtocol: AmaBenchJudgeProtocol | undefined;
+  if (amaBenchJudgeProtocolRaw !== undefined) {
+    if (
+      amaBenchJudgeProtocolRaw !== "default" &&
+      amaBenchJudgeProtocolRaw !== "recommended"
+    ) {
+      throw new Error(
+        'ERROR: --ama-bench-judge-protocol must be "default" or "recommended".',
+      );
+    }
+    amaBenchJudgeProtocol = amaBenchJudgeProtocolRaw;
+  }
+
+  let amaBenchCrossJudgeProvider: BuiltInProvider | undefined;
+  if (amaBenchCrossJudgeProviderRaw !== undefined) {
+    amaBenchCrossJudgeProvider = parseBenchProvider(
+      amaBenchCrossJudgeProviderRaw,
+      "--ama-bench-cross-judge-provider",
+    );
   }
 
   let threshold: number | undefined;
@@ -500,6 +538,25 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
         "vLLM (http://localhost:8000/v1), LM Studio (http://localhost:1234/v1).",
     );
   }
+  if (
+    amaBenchCrossJudgeProvider === "local-llm" &&
+    !(amaBenchCrossJudgeBaseUrl ?? judgeBaseUrl)
+  ) {
+    throw new Error(
+      "ERROR: --ama-bench-cross-judge-provider local-llm requires " +
+        "--ama-bench-cross-judge-base-url (or --judge-base-url).",
+    );
+  }
+  if (
+    (amaBenchCrossJudgeProvider !== undefined ||
+      amaBenchCrossJudgeBaseUrl !== undefined ||
+      amaBenchCrossJudgeApiKey !== undefined) &&
+    amaBenchCrossJudgeModel === undefined
+  ) {
+    throw new Error(
+      "ERROR: --ama-bench-cross-judge-model is required when configuring an AMA-Bench cross judge.",
+    );
+  }
 
   const resume = args.includes("--resume");
   const retryFailed = args.includes("--retry-failed");
@@ -554,6 +611,11 @@ export function parseBenchArgs(argv: string[]): ParsedBenchArgs {
     requestTimeout,
     max429WaitMs,
     disableThinking: args.includes("--disable-thinking"),
+    amaBenchJudgeProtocol,
+    amaBenchCrossJudgeProvider,
+    amaBenchCrossJudgeModel,
+    amaBenchCrossJudgeBaseUrl,
+    amaBenchCrossJudgeApiKey,
     resume,
     retryFailed,
   };

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -2318,9 +2318,7 @@ function resolveAmaBenchCrossJudgeProvider(
   const canInheritPrimaryTransport =
     parsed.amaBenchCrossJudgeProvider === undefined ||
     parsed.amaBenchCrossJudgeProvider === primaryJudgeProvider?.provider;
-  const inheritedBaseUrl = canInheritPrimaryTransport
-    ? primaryJudgeProvider?.baseUrl
-    : undefined;
+  const inheritedBaseUrl = primaryJudgeProvider?.baseUrl;
   const inheritedApiKey = canInheritPrimaryTransport
     ? primaryJudgeProvider?.apiKey
     : undefined;

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -841,6 +841,7 @@ async function runBenchViaFallback(
     parsed.amaBenchCrossJudgeProvider !== undefined ||
     parsed.amaBenchCrossJudgeModel !== undefined ||
     parsed.amaBenchCrossJudgeBaseUrl !== undefined ||
+    parsed.amaBenchCrossJudgeApiKey !== undefined ||
     parsed.disableThinking === true ||
     parsed.requestTimeout !== undefined
   ) {
@@ -2314,20 +2315,29 @@ function resolveAmaBenchCrossJudgeProvider(
         "or an existing --judge-provider.",
     );
   }
+  const canInheritPrimaryTransport =
+    parsed.amaBenchCrossJudgeProvider === undefined ||
+    parsed.amaBenchCrossJudgeProvider === primaryJudgeProvider?.provider;
+  const inheritedBaseUrl = canInheritPrimaryTransport
+    ? primaryJudgeProvider?.baseUrl
+    : undefined;
+  const inheritedApiKey = canInheritPrimaryTransport
+    ? primaryJudgeProvider?.apiKey
+    : undefined;
 
   return {
     provider,
     model: parsed.amaBenchCrossJudgeModel,
-    ...(parsed.amaBenchCrossJudgeBaseUrl ?? primaryJudgeProvider?.baseUrl
-      ? { baseUrl: parsed.amaBenchCrossJudgeBaseUrl ?? primaryJudgeProvider?.baseUrl }
+    ...(parsed.amaBenchCrossJudgeBaseUrl ?? inheritedBaseUrl
+      ? { baseUrl: parsed.amaBenchCrossJudgeBaseUrl ?? inheritedBaseUrl }
       : {}),
-    ...(parsed.amaBenchCrossJudgeApiKey ?? primaryJudgeProvider?.apiKey
-      ? { apiKey: parsed.amaBenchCrossJudgeApiKey ?? primaryJudgeProvider?.apiKey }
+    ...(parsed.amaBenchCrossJudgeApiKey ?? inheritedApiKey
+      ? { apiKey: parsed.amaBenchCrossJudgeApiKey ?? inheritedApiKey }
       : {}),
-    ...(primaryJudgeProvider?.retryOptions
+    ...(canInheritPrimaryTransport && primaryJudgeProvider?.retryOptions
       ? { retryOptions: primaryJudgeProvider.retryOptions }
       : {}),
-    ...(primaryJudgeProvider?.disableThinking
+    ...(canInheritPrimaryTransport && primaryJudgeProvider?.disableThinking
       ? { disableThinking: primaryJudgeProvider.disableThinking }
       : {}),
   };

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -294,6 +294,20 @@ export const BENCHMARK_CATALOG: BenchCatalogEntry[] = [
 
 const BENCHMARK_IDS = new Set(BENCHMARK_CATALOG.map((entry) => entry.id));
 
+type PackageBenchProviderConfig = {
+  provider: string;
+  model: string;
+  baseUrl?: string;
+  apiKey?: string;
+  retryOptions?: {
+    maxAttempts?: number;
+    baseBackoffMs?: number;
+    timeoutMs?: number;
+    max429WaitMs?: number;
+  };
+  disableThinking?: boolean;
+};
+
 type PackageBenchModule = {
   getBenchmark?: (id: string) => {
     runnerAvailable?: boolean;
@@ -310,17 +324,12 @@ type PackageBenchModule = {
     seed?: number;
     adapterMode?: string;
     runtimeProfile?: BenchRuntimeProfile | null;
-    systemProvider?: {
-      provider: string;
-      model: string;
-      baseUrl?: string;
-    } | null;
-    judgeProvider?: {
-      provider: string;
-      model: string;
-      baseUrl?: string;
-    } | null;
+    systemProvider?: PackageBenchProviderConfig | null;
+    judgeProvider?: PackageBenchProviderConfig | null;
     remnicConfig?: Record<string, unknown>;
+    amaBenchJudgeProtocol?: "default" | "recommended";
+    amaBenchCrossJudge?: unknown;
+    amaBenchCrossJudgeProvider?: PackageBenchProviderConfig | null;
     system: {
       destroy(): Promise<void>;
     };
@@ -330,18 +339,11 @@ type PackageBenchModule = {
     meta: { benchmark: string; mode: string };
     config: {
       runtimeProfile?: BenchRuntimeProfile | null;
-      systemProvider?: {
-        provider: string;
-        model: string;
-        baseUrl?: string;
-      } | null;
-      judgeProvider?: {
-        provider: string;
-        model: string;
-        baseUrl?: string;
-      } | null;
+      systemProvider?: PackageBenchProviderConfig | null;
+      judgeProvider?: PackageBenchProviderConfig | null;
       adapterMode: string;
       remnicConfig: Record<string, unknown>;
+      benchmarkOptions?: Record<string, unknown>;
     };
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
@@ -407,6 +409,10 @@ type PackageBenchModule = {
     results: { tasks: Array<unknown>; aggregates: Record<string, { mean: number }> };
     cost: { meanQueryLatencyMs: number };
   }, outputDir: string) => Promise<string>;
+  redactBenchmarkResultSecrets?: <T>(result: T) => T;
+  createProviderBackedAmaBenchRecommendedJudge?: (
+    config: PackageBenchProviderConfig,
+  ) => unknown;
   writeBenchmarkReproManifest?: (resultsDir: string, options?: {
     resultPaths?: string[];
     selectedBenchmarks?: string[];
@@ -509,6 +515,14 @@ interface BenchProviderConfig {
   provider: string;
   model: string;
   baseUrl?: string;
+  apiKey?: string;
+  retryOptions?: {
+    maxAttempts?: number;
+    baseBackoffMs?: number;
+    timeoutMs?: number;
+    max429WaitMs?: number;
+  };
+  disableThinking?: boolean;
 }
 
 interface ResolveBenchRuntimeProfileOptions {
@@ -526,6 +540,11 @@ interface ResolveBenchRuntimeProfileOptions {
   judgeModel?: string;
   judgeBaseUrl?: string;
   judgeApiKey?: string;
+  amaBenchJudgeProtocol?: "default" | "recommended";
+  amaBenchCrossJudgeProvider?: string;
+  amaBenchCrossJudgeModel?: string;
+  amaBenchCrossJudgeBaseUrl?: string;
+  amaBenchCrossJudgeApiKey?: string;
   requestTimeout?: number;
   max429WaitMs?: number;
   disableThinking?: boolean;
@@ -626,6 +645,14 @@ Options:
                            Use a direct provider-backed judge
   --judge-model <model>    Model name for the judge provider
   --judge-base-url <url>   Base URL for the judge provider
+  --ama-bench-judge-protocol <default|recommended>
+                           For ama-bench, use the recommended binary LLM-judge protocol
+  --ama-bench-cross-judge-model <model>
+                           For ama-bench, add a second recommended-protocol judge for agreement checks
+  --ama-bench-cross-judge-provider <provider>
+                           Provider for the ama-bench cross judge (defaults to --judge-provider)
+  --ama-bench-cross-judge-base-url <url>
+                           Base URL for the ama-bench cross judge (defaults to --judge-base-url)
   --custom <path>          Run a YAML-defined custom benchmark file
   --results-dir <path>     Override the stored benchmark results directory
   --baselines-dir <path>   Override the named baseline directory
@@ -649,6 +676,7 @@ Examples:
   remnic bench run longmemeval --dataset-dir ~/datasets/longmemeval
   remnic bench run longmemeval --runtime-profile real --remnic-config ~/.config/remnic/config.json
   remnic bench run longmemeval --runtime-profile real --system-provider openai --system-model gpt-5.4-mini
+  remnic bench run ama-bench --runtime-profile real --system-provider ollama --system-model gemma4:31b-cloud --judge-provider ollama --judge-model qwen3:32b --ama-bench-judge-protocol recommended
   remnic bench run longmemeval --runtime-profile openclaw-chain --openclaw-config ~/.openclaw/openclaw.json --gateway-agent-id memory-primary
   remnic bench run longmemeval --matrix baseline,real,openclaw-chain
   remnic bench compare base-run candidate-run
@@ -809,6 +837,10 @@ async function runBenchViaFallback(
     parsed.judgeProvider !== undefined ||
     parsed.judgeModel !== undefined ||
     parsed.judgeBaseUrl !== undefined ||
+    parsed.amaBenchJudgeProtocol !== undefined ||
+    parsed.amaBenchCrossJudgeProvider !== undefined ||
+    parsed.amaBenchCrossJudgeModel !== undefined ||
+    parsed.amaBenchCrossJudgeBaseUrl !== undefined ||
     parsed.disableThinking === true ||
     parsed.requestTimeout !== undefined
   ) {
@@ -2116,7 +2148,18 @@ async function runBenchViaPackage(
   let system: Awaited<ReturnType<PackageBenchExecutionPlan["createAdapter"]>> | undefined;
 
   try {
-    system = await plan.createAdapter(plan.runtime.adapterOptions);
+    const amaBenchProtocol = buildAmaBenchProtocolOptions(
+      benchModule,
+      parsed,
+      benchmarkId,
+      plan.runtime,
+    );
+    system = await plan.createAdapter({
+      ...plan.runtime.adapterOptions,
+      ...(amaBenchProtocol.primaryJudge
+        ? { judge: amaBenchProtocol.primaryJudge }
+        : {}),
+    });
     // `publishedLimit` (from `bench published --limit N`) takes
     // precedence over the implicit quick-mode limit of 1.
     const effectiveLimit =
@@ -2138,6 +2181,15 @@ async function runBenchViaPackage(
       systemProvider: plan.runtime.systemProvider,
       judgeProvider: plan.runtime.judgeProvider,
       remnicConfig: plan.runtime.effectiveRemnicConfig,
+      ...(amaBenchProtocol.judgeProtocol
+        ? { amaBenchJudgeProtocol: amaBenchProtocol.judgeProtocol }
+        : {}),
+      ...(amaBenchProtocol.crossJudge
+        ? { amaBenchCrossJudge: amaBenchProtocol.crossJudge }
+        : {}),
+      ...(amaBenchProtocol.crossJudgeProvider
+        ? { amaBenchCrossJudgeProvider: amaBenchProtocol.crossJudgeProvider }
+        : {}),
       system,
       onTaskComplete: (task, completed, total) => {
         partialTasks.push(task as import("@remnic/bench").TaskResult);
@@ -2160,7 +2212,7 @@ async function runBenchViaPackage(
     result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
-      console.log(JSON.stringify(result, null, 2));
+      console.log(JSON.stringify(benchModule.redactBenchmarkResultSecrets?.(result) ?? result, null, 2));
     } else {
       printBenchPackageSummary(result, writtenPath);
     }
@@ -2188,6 +2240,97 @@ async function runBenchViaPackage(
   } finally {
     await system?.destroy();
   }
+}
+
+function buildAmaBenchProtocolOptions(
+  benchModule: PackageBenchModule,
+  parsed: ParsedBenchArgs,
+  benchmarkId: string,
+  runtime: ResolvedBenchRuntimeProfile,
+): {
+  judgeProtocol?: "default" | "recommended";
+  primaryJudge?: unknown;
+  crossJudge?: unknown;
+  crossJudgeProvider?: PackageBenchProviderConfig | null;
+} {
+  if (benchmarkId !== "ama-bench") {
+    return {};
+  }
+
+  const judgeProtocol = parsed.amaBenchJudgeProtocol;
+  const primaryJudge = judgeProtocol === "recommended"
+    ? createAmaBenchRecommendedJudge(
+        benchModule,
+        runtime.judgeProvider,
+        "--ama-bench-judge-protocol recommended requires --judge-provider and --judge-model.",
+      )
+    : undefined;
+
+  const crossJudgeProvider = resolveAmaBenchCrossJudgeProvider(parsed, runtime.judgeProvider);
+  const crossJudge = crossJudgeProvider
+    ? createAmaBenchRecommendedJudge(
+        benchModule,
+        crossJudgeProvider,
+        "--ama-bench-cross-judge-model requires @remnic/bench to expose the AMA-Bench recommended judge.",
+      )
+    : undefined;
+
+  return {
+    judgeProtocol,
+    primaryJudge,
+    crossJudge,
+    crossJudgeProvider,
+  };
+}
+
+function createAmaBenchRecommendedJudge(
+  benchModule: PackageBenchModule,
+  provider: PackageBenchProviderConfig | null | undefined,
+  missingMessage: string,
+): unknown {
+  if (!provider) {
+    throw new Error(missingMessage);
+  }
+  if (!benchModule.createProviderBackedAmaBenchRecommendedJudge) {
+    throw new Error(
+      "Installed @remnic/bench runtime does not expose createProviderBackedAmaBenchRecommendedJudge().",
+    );
+  }
+  return benchModule.createProviderBackedAmaBenchRecommendedJudge(provider);
+}
+
+function resolveAmaBenchCrossJudgeProvider(
+  parsed: ParsedBenchArgs,
+  primaryJudgeProvider: PackageBenchProviderConfig | null,
+): PackageBenchProviderConfig | null {
+  if (!parsed.amaBenchCrossJudgeModel) {
+    return null;
+  }
+
+  const provider = parsed.amaBenchCrossJudgeProvider ?? primaryJudgeProvider?.provider;
+  if (!provider) {
+    throw new Error(
+      "--ama-bench-cross-judge-model requires --ama-bench-cross-judge-provider " +
+        "or an existing --judge-provider.",
+    );
+  }
+
+  return {
+    provider,
+    model: parsed.amaBenchCrossJudgeModel,
+    ...(parsed.amaBenchCrossJudgeBaseUrl ?? primaryJudgeProvider?.baseUrl
+      ? { baseUrl: parsed.amaBenchCrossJudgeBaseUrl ?? primaryJudgeProvider?.baseUrl }
+      : {}),
+    ...(parsed.amaBenchCrossJudgeApiKey ?? primaryJudgeProvider?.apiKey
+      ? { apiKey: parsed.amaBenchCrossJudgeApiKey ?? primaryJudgeProvider?.apiKey }
+      : {}),
+    ...(primaryJudgeProvider?.retryOptions
+      ? { retryOptions: primaryJudgeProvider.retryOptions }
+      : {}),
+    ...(primaryJudgeProvider?.disableThinking
+      ? { disableThinking: primaryJudgeProvider.disableThinking }
+      : {}),
+  };
 }
 
 function buildPartialBenchmarkResult(
@@ -2284,7 +2427,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       writtenPaths.push(writtenPath);
       if (parsed.json) {
-        console.log(JSON.stringify(result, null, 2));
+        console.log(JSON.stringify(benchModule.redactBenchmarkResultSecrets?.(result) ?? result, null, 2));
       } else {
         printBenchPackageSummary(result, writtenPath);
       }

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -736,6 +736,82 @@ export function buildBenchRuntimeProfileRequest(
   };
 }
 
+const BENCH_STDOUT_REDACTED_SECRET = "[REDACTED]";
+const BENCH_STDOUT_EXACT_SECRET_KEYS: ReadonlySet<string> = new Set([
+  "authorization",
+  "password",
+  "secret",
+  "token",
+]);
+const BENCH_STDOUT_SECRET_KEY_SUFFIXES: ReadonlySet<string> = new Set([
+  "apikey",
+  "authtoken",
+  "accesstoken",
+  "refreshtoken",
+  "bearertoken",
+  "clientsecret",
+  "secretkey",
+  "privatekey",
+]);
+
+function redactBenchResultForStdout<T>(
+  benchModule: PackageBenchModule,
+  result: T,
+): T {
+  return benchModule.redactBenchmarkResultSecrets?.(result) ??
+    (redactBenchSecretsFallback(result) as T);
+}
+
+function redactBenchSecretsFallback(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => redactBenchSecretsFallback(item));
+  }
+  if (!value || typeof value !== "object") {
+    return value;
+  }
+
+  const redacted: Record<string, unknown> = {};
+  for (const [key, nestedValue] of Object.entries(value)) {
+    redacted[key] = isBenchSecretKey(key)
+      ? BENCH_STDOUT_REDACTED_SECRET
+      : redactBenchSecretsFallback(nestedValue);
+  }
+  return redacted;
+}
+
+function isBenchSecretKey(key: string): boolean {
+  const segments = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .split(/[^a-z0-9]+/i)
+    .map((segment) => segment.trim().toLowerCase())
+    .filter(Boolean);
+  if (segments.length === 0) {
+    return false;
+  }
+
+  const normalized = segments.join("");
+  if (
+    BENCH_STDOUT_EXACT_SECRET_KEYS.has(normalized) ||
+    BENCH_STDOUT_SECRET_KEY_SUFFIXES.has(normalized)
+  ) {
+    return true;
+  }
+
+  const lastSegment = segments.at(-1);
+  if (lastSegment && BENCH_STDOUT_EXACT_SECRET_KEYS.has(lastSegment)) {
+    return true;
+  }
+
+  for (let width = 2; width <= Math.min(3, segments.length); width += 1) {
+    const candidate = segments.slice(-width).join("");
+    if (BENCH_STDOUT_SECRET_KEY_SUFFIXES.has(candidate)) {
+      return true;
+    }
+  }
+
+  return false;
+}
+
 function coerceBenchCategory(
   benchmarkId: string,
   category: string | undefined,
@@ -2213,7 +2289,7 @@ async function runBenchViaPackage(
     result.config.remnicConfig = plan.runtime.remnicConfig;
     const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
     if (parsed.json) {
-      console.log(JSON.stringify(benchModule.redactBenchmarkResultSecrets?.(result) ?? result, null, 2));
+      console.log(JSON.stringify(redactBenchResultForStdout(benchModule, result), null, 2));
     } else {
       printBenchPackageSummary(result, writtenPath);
     }
@@ -2435,7 +2511,7 @@ async function runCustomBenchViaPackage(parsed: ParsedBenchArgs): Promise<boolea
       const writtenPath = await benchModule.writeBenchmarkResult(result, outputDir);
       writtenPaths.push(writtenPath);
       if (parsed.json) {
-        console.log(JSON.stringify(benchModule.redactBenchmarkResultSecrets?.(result) ?? result, null, 2));
+        console.log(JSON.stringify(redactBenchResultForStdout(benchModule, result), null, 2));
       } else {
         printBenchPackageSummary(result, writtenPath);
       }

--- a/packages/remnic-core/src/surfaces/dreams.test.ts
+++ b/packages/remnic-core/src/surfaces/dreams.test.ts
@@ -335,6 +335,23 @@ test("dreams surface watch catches callback failures instead of leaking unhandle
   const surface = createDreamsSurface();
   const warnings: unknown[][] = [];
   const originalWarn = console.warn;
+  await writeFile(
+    dreamsPath,
+    [
+      "# Dream Diary",
+      "",
+      "<!-- openclaw:dreaming:diary:start -->",
+      "---",
+      "",
+      "*2026-04-12T14:00:00Z — Initial entry*",
+      "",
+      "Create the watched file before arming the watcher.",
+      "",
+      "<!-- openclaw:dreaming:diary:end -->",
+      "",
+    ].join("\n"),
+    "utf8",
+  );
   const stop = surface.watch(dreamsPath, () => {
     throw new Error("boom");
   });
@@ -344,6 +361,7 @@ test("dreams surface watch catches callback failures instead of leaking unhandle
   };
 
   try {
+    await new Promise((resolve) => setTimeout(resolve, 50));
     await writeFile(
       dreamsPath,
       [
@@ -367,6 +385,10 @@ test("dreams surface watch catches callback failures instead of leaking unhandle
     stop();
   }
 
-  assert.equal(warnings.length, 1);
-  assert.match(String(warnings[0]?.[0] ?? ""), /dreams surface watch update failed/);
+  assert.equal(warnings.length >= 1, true);
+  assert.equal(
+    warnings.some((args) =>
+      /dreams surface watch update failed/.test(String(args[0] ?? ""))),
+    true,
+  );
 });

--- a/scripts/ensure-bench-build-deps.mjs
+++ b/scripts/ensure-bench-build-deps.mjs
@@ -1,0 +1,36 @@
+import fs from "node:fs";
+import path from "node:path";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
+
+function run(args) {
+  const result = spawnSync(pnpmCmd, args, {
+    cwd: repoRoot,
+    stdio: "inherit",
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw result.error;
+  }
+
+  if (typeof result.status === "number" && result.status !== 0) {
+    process.exit(result.status);
+  }
+}
+
+function ensurePackageBuild(pkgName, distPath) {
+  if (fs.existsSync(distPath)) {
+    return;
+  }
+
+  run(["--filter", pkgName, "build"]);
+}
+
+ensurePackageBuild(
+  "@remnic/core",
+  path.join(repoRoot, "packages", "remnic-core", "dist", "index.js"),
+);


### PR DESCRIPTION
## Summary
- add an AMA-Bench recommended binary LLM-judge protocol and optional cross-judge agreement metrics
- add CLI flags for AMA-Bench judge protocol and cross-judge provider/model configuration
- redact secret-like fields from benchmark result artifacts and JSON output
- restore declaration-generation path by confirming core and bench declaration builds work after generated d.ts files are present

## Usage
After the current full run completes, launch an AMA-only follow-up without --disable-thinking, for example:

```bash
remnic bench run ama-bench \
  --runtime-profile real \
  --remnic-config <isolated-full-feature-config.json> \
  --system-provider ollama \
  --system-model gemma4:31b-cloud \
  --system-base-url https://ollama.com/api \
  --system-api-key "" \
  --judge-provider ollama \
  --judge-model qwen3:32b \
  --judge-base-url https://ollama.com/api \
  --judge-api-key "" \
  --ama-bench-judge-protocol recommended
```

If Ollama Cloud does not expose qwen3:32b for the account, the same protocol can be pointed at another explicit judge model/provider, or use a separate cross judge via `--ama-bench-cross-judge-model`.

## Verification
- `pnpm exec tsx --test packages/bench/src/responders.test.ts`
- `pnpm exec tsx --test packages/bench/src/benchmarks/published/ama-bench/runner.test.ts`
- `pnpm exec tsx --test packages/remnic-cli/src/bench-args.test.ts packages/bench/src/reporter.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `pnpm --filter @remnic/cli check-types`
- `npm run preflight:quick`

Note: `preflight:quick` passes with existing warning scans about legacy Engram references and other repo-wide review-pattern warnings; no test failures.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new AMA-Bench scoring paths (binary recommended protocol plus optional cross-judge agreement) and threads new CLI flags/config into result artifacts, which could change benchmark outputs and latency/token accounting. Also changes how benchmark results are persisted/printed by redacting secret-like fields, so mistakes could hide needed config or miss sensitive keys.
> 
> **Overview**
> **AMA-Bench now supports the paper’s *recommended* binary LLM-judge protocol** via `amaBenchJudgeProtocol`, including a new provider-backed judge factory (`createProviderBackedAmaBenchRecommendedJudge`) with robust JSON/heuristic parsing for 0/1 outputs.
> 
> **Optional AMA-Bench cross-judge support** was added: the runner can invoke a second judge, aggregate its latency/tokens, and emit `ama_bench_cross_accuracy` plus `ama_bench_cross_agreement` (agreement only when the primary protocol is `recommended`), while persisting these settings under `result.config.benchmarkOptions`.
> 
> **Benchmark result outputs are now secret-redacted by default**: `writeBenchmarkResult` writes a redacted JSON artifact, the bench package exports `redactBenchmarkResultSecrets`, and the CLI redacts JSON stdout (using the bench module helper when available, with a fallback implementation). The bench build also gains a `prebuild` step to ensure `@remnic/core` is built when needed, and tests were added/updated to cover the new protocol, CLI flags/validation, and secret redaction behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7bb3fefc312c1faeb9d3378940d68d519e2caa23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->