### PR TITLE
chore(release): bump plugin-openclaw 1.0.10 + shim 9.3.9 for QMD probe fix

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",

--- a/packages/shim-openclaw-engram/package.json
+++ b/packages/shim-openclaw-engram/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@joshuaswarren/openclaw-engram",
-  "version": "9.3.8",
+  "version": "9.3.9",
   "description": "Deprecated compatibility shim for Engram installs. Re-exports @remnic/plugin-openclaw and forwards engram-access to @remnic/core.",
   "type": "module",
   "main": "dist/index.js",

--- a/tests/shim-openclaw-engram-package.test.ts
+++ b/tests/shim-openclaw-engram-package.test.ts
@@ -13,7 +13,7 @@ test("Phase C shim package keeps a workspace-linked source manifest", async () =
   const dependencies = pkg.dependencies as Record<string, string>;
 
   assert.equal(pkg.name, "@joshuaswarren/openclaw-engram");
-  assert.equal(pkg.version, "9.3.8");
+  assert.equal(pkg.version, "9.3.9");
   assert.equal(bin["engram-access"], "./bin/engram-access.js");
   assert.equal(exportsMap["."].import, "./dist/index.js");
   assert.equal(exportsMap["./access-cli"].import, "./dist/access-cli.js");


### PR DESCRIPTION
## Summary

Follow-up to #672 ([@earlvanze](https://github.com/earlvanze) credit). The QMD availability probe fix lives in the root `src/index.ts`, which is re-exported by `@remnic/plugin-openclaw` and the `@joshuaswarren/openclaw-engram` shim.

The release-and-publish workflow only republishes workspace packages whose `package.json` version differs from what's already on npm. Without this bump, the fix exists on `main` and in the v9.3.170 tag but never reaches npm consumers.

## Changes

- `@remnic/plugin-openclaw` 1.0.9 → 1.0.10
- `@joshuaswarren/openclaw-engram` 9.3.8 → 9.3.9

## Test plan

- [x] `pnpm install --lockfile-only` clean.
- [x] No source changes — pure version bump.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk since this is a pure package version bump plus a matching test update; no runtime/source logic changes.
> 
> **Overview**
> Bumps `@remnic/plugin-openclaw` from `1.0.9` → `1.0.10` and the deprecated `@joshuaswarren/openclaw-engram` shim from `9.3.8` → `9.3.9` to force a republish.
> 
> Updates `tests/shim-openclaw-engram-package.test.ts` to assert the new shim version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dd04e5beb8883fdf7e570ac5b4e1a43d2ce1104b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->