### PR TITLE
Fix AMemGym and MemoryArena scoring protocols

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -278,16 +278,13 @@ function parseAMemGymChoice(
     }
     return undefined;
   }
-  if (looksLikeChoiceNumberAttempt(trimmed)) {
-    return undefined;
-  }
-
   const normalizedAnswer = normalizeForChoiceMatch(rawAnswer);
   const normalizedChoices = qa.answer_choices.map((choice, index) => ({
     index,
     choice,
     normalized: normalizeForChoiceMatch(choice.answer),
   }));
+  const numericChoiceNumberAttempt = looksLikeChoiceNumberAttempt(trimmed);
 
   const exactMatches = normalizedChoices.filter(
     (candidate) =>
@@ -296,7 +293,9 @@ function parseAMemGymChoice(
   );
   if (exactMatches.length === 1) {
     const exactMatch = exactMatches[0]!;
-    return { index: exactMatch.index, choice: exactMatch.choice };
+    if (!numericChoiceNumberAttempt || startsWithNumericToken(exactMatch.normalized)) {
+      return { index: exactMatch.index, choice: exactMatch.choice };
+    }
   }
 
   let bestSubstringLength = -1;
@@ -309,6 +308,7 @@ function parseAMemGymChoice(
     const candidate = normalizedChoices[index]!;
     if (
       candidate.normalized.length > 0
+      && (!numericChoiceNumberAttempt || startsWithNumericToken(candidate.normalized))
       && containsNormalizedPhrase(normalizedAnswer, candidate.normalized)
     ) {
       if (candidate.normalized.length > bestSubstringLength) {
@@ -343,6 +343,10 @@ function containsNormalizedPhrase(haystack: string, needle: string): boolean {
   return false;
 }
 
+function startsWithNumericToken(value: string): boolean {
+  return /^\d+\b/.test(value);
+}
+
 function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   const bareNumber = trimmedAnswer.match(
     /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
@@ -375,7 +379,7 @@ function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
 function mentionsAdditionalOptionNumber(value: string): boolean {
   const trimmed = value.trim();
   return /\b(?:option|choice|answer)\s*#?\d+\b/i.test(trimmed)
-    || (/^[,.;:\-]/.test(trimmed) && /\b#?\d+\b/.test(trimmed));
+    || /^[,.;:\-]\s*(?:#?\d+\b|(?:or|maybe|possibly|probably|perhaps|alternatively)\s+#?\d+\b)/i.test(trimmed);
 }
 
 function normalizeForChoiceMatch(value: string): string {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -40,15 +40,24 @@ const DATASET_FILENAMES = [
  * We pick the one matching the user's final state.
  */
 function findBestAnswer(qa: AMemGymQA, finalState: Record<string, string>): string {
+  const choice = findBestAnswerChoice(qa, finalState);
+  return choice?.choice.answer ?? qa.answer_choices[0]?.answer ?? "";
+}
+
+function findBestAnswerChoice(
+  qa: AMemGymQA,
+  finalState: Record<string, string>,
+): { index: number; choice: AMemGymQA["answer_choices"][number] } | undefined {
   for (const choice of qa.answer_choices) {
+    const index = qa.answer_choices.indexOf(choice);
     const requiredStates = choice.state;
     const matchValues = qa.required_info.map((key) => finalState[key]);
     if (requiredStates.length === matchValues.length &&
       requiredStates.every((s, i) => s === matchValues[i])) {
-      return choice.answer;
+      return { index, choice };
     }
   }
-  return qa.answer_choices[0]?.answer ?? "";
+  return undefined;
 }
 
 export const amemGymDefinition: BenchmarkDefinition = {
@@ -107,26 +116,34 @@ export async function runAMemGymBenchmark(
     ) {
       const qa = profile.qas[questionIndex]!;
       const taskResultId = `${profile.id}-q${questionIndex}`;
-      const expectedAnswer = findBestAnswer(qa, finalState);
+      const expectedChoice = findBestAnswerChoice(qa, finalState);
+      const expectedAnswer = expectedChoice?.choice.answer ?? findBestAnswer(qa, finalState);
+      const benchmarkQuestion = formatAMemGymQuestion(qa);
 
       try {
         const { result: recallText, durationMs } = await timed(async () => {
           return options.system.recall(sessionId, qa.query);
         });
         const answered = await answerBenchmarkQuestion({
-          question: qa.query,
+          question: benchmarkQuestion,
           recalledText: recallText,
           responder: options.system.responder,
         });
+        const selectedChoice = parseAMemGymChoice(answered.finalAnswer, qa);
+        const answerForScoring = selectedChoice?.choice.answer ?? answered.finalAnswer;
 
         const scores: Record<string, number> = {
-          f1: f1Score(answered.finalAnswer, expectedAnswer),
-          contains_answer: containsAnswer(answered.finalAnswer, expectedAnswer),
+          f1: f1Score(answerForScoring, expectedAnswer),
+          contains_answer: containsAnswer(answerForScoring, expectedAnswer),
+          qa_accuracy:
+            selectedChoice && expectedChoice && selectedChoice.index === expectedChoice.index
+              ? 1
+              : 0,
         };
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,
           qa.query,
-          answered.finalAnswer,
+          answerForScoring,
           expectedAnswer,
         );
         if (judgeResult.score >= 0) {
@@ -135,7 +152,7 @@ export async function runAMemGymBenchmark(
 
         tasks.push({
           taskId: taskResultId,
-          question: qa.query,
+          question: benchmarkQuestion,
           expected: expectedAnswer,
           actual: answered.finalAnswer,
           scores,
@@ -148,8 +165,15 @@ export async function runAMemGymBenchmark(
             profileId: profile.id,
             profileName: profile.user_profile.name,
             questionIndex,
+            originalQuery: qa.query,
             periodCount: profile.periods.length,
             requiredInfo: qa.required_info,
+            expectedChoiceIndex:
+              expectedChoice === undefined ? null : expectedChoice.index + 1,
+            selectedChoiceIndex:
+              selectedChoice === undefined ? null : selectedChoice.index + 1,
+            selectedAnswer:
+              selectedChoice === undefined ? null : selectedChoice.choice.answer,
             recalledLength: recallText.length,
             answeredLength: answered.finalAnswer.length,
             recalledText: recallText,
@@ -226,6 +250,61 @@ export async function runAMemGymBenchmark(
       hardware: process.arch,
     },
   };
+}
+
+function formatAMemGymQuestion(qa: AMemGymQA): string {
+  const choices = qa.answer_choices
+    .map((choice, index) => `${index + 1}. ${choice.answer}`)
+    .join("\n");
+
+  return [
+    qa.query,
+    "",
+    "Choose the single best answer using the user's current remembered state.",
+    "Return only the option number and no explanation.",
+    "",
+    "Answer choices:",
+    choices,
+  ].join("\n");
+}
+
+function parseAMemGymChoice(
+  rawAnswer: string,
+  qa: AMemGymQA,
+): { index: number; choice: AMemGymQA["answer_choices"][number] } | undefined {
+  const trimmed = rawAnswer.trim();
+  const leadingNumber = trimmed.match(/^(?:option|choice|answer)?\s*#?\s*(\d+)\b/i);
+  if (leadingNumber) {
+    const index = Number.parseInt(leadingNumber[1]!, 10) - 1;
+    const choice = qa.answer_choices[index];
+    if (choice) {
+      return { index, choice };
+    }
+  }
+
+  const normalizedAnswer = normalizeForChoiceMatch(rawAnswer);
+  for (let index = 0; index < qa.answer_choices.length; index += 1) {
+    const choice = qa.answer_choices[index]!;
+    const normalizedChoice = normalizeForChoiceMatch(choice.answer);
+    if (
+      normalizedChoice.length > 0
+      && (normalizedAnswer === normalizedChoice
+        || normalizedAnswer.includes(normalizedChoice))
+    ) {
+      return { index, choice };
+    }
+  }
+
+  return undefined;
+}
+
+function normalizeForChoiceMatch(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 async function loadDataset(

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -39,17 +39,12 @@ const DATASET_FILENAMES = [
  * The QA has answer_choices, each tied to specific state values.
  * We pick the one matching the user's final state.
  */
-function findBestAnswer(qa: AMemGymQA, finalState: Record<string, string>): string {
-  const choice = findBestAnswerChoice(qa, finalState);
-  return choice?.choice.answer ?? qa.answer_choices[0]?.answer ?? "";
-}
-
-function findBestAnswerChoice(
+function findExpectedAnswerChoice(
   qa: AMemGymQA,
   finalState: Record<string, string>,
 ): { index: number; choice: AMemGymQA["answer_choices"][number] } | undefined {
-  for (const choice of qa.answer_choices) {
-    const index = qa.answer_choices.indexOf(choice);
+  for (let index = 0; index < qa.answer_choices.length; index += 1) {
+    const choice = qa.answer_choices[index]!;
     const requiredStates = choice.state;
     const matchValues = qa.required_info.map((key) => finalState[key]);
     if (requiredStates.length === matchValues.length &&
@@ -116,8 +111,8 @@ export async function runAMemGymBenchmark(
     ) {
       const qa = profile.qas[questionIndex]!;
       const taskResultId = `${profile.id}-q${questionIndex}`;
-      const expectedChoice = findBestAnswerChoice(qa, finalState);
-      const expectedAnswer = expectedChoice?.choice.answer ?? findBestAnswer(qa, finalState);
+      const expectedChoice = findExpectedAnswerChoice(qa, finalState);
+      const expectedAnswer = expectedChoice?.choice.answer ?? qa.answer_choices[0]?.answer ?? "";
       const benchmarkQuestion = formatAMemGymQuestion(qa);
 
       try {
@@ -174,6 +169,7 @@ export async function runAMemGymBenchmark(
               selectedChoice === undefined ? null : selectedChoice.index + 1,
             selectedAnswer:
               selectedChoice === undefined ? null : selectedChoice.choice.answer,
+            scoredAnswer: answerForScoring,
             recalledLength: recallText.length,
             answeredLength: answered.finalAnswer.length,
             recalledText: recallText,
@@ -187,10 +183,10 @@ export async function runAMemGymBenchmark(
         console.error(`  [WARN] amemgym task ${taskResultId} failed: ${message}`);
         tasks.push({
           taskId: taskResultId,
-          question: qa.query,
+          question: benchmarkQuestion,
           expected: expectedAnswer,
           actual: `(error: ${message})`,
-          scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+          scores: { f1: -1, contains_answer: -1, qa_accuracy: -1, llm_judge: -1 },
           latencyMs: 0,
           tokens: { input: 0, output: 0 },
           details: { error: message },
@@ -273,29 +269,113 @@ function parseAMemGymChoice(
   qa: AMemGymQA,
 ): { index: number; choice: AMemGymQA["answer_choices"][number] } | undefined {
   const trimmed = rawAnswer.trim();
-  const leadingNumber = trimmed.match(/^(?:option|choice|answer)?\s*#?\s*(\d+)\b/i);
-  if (leadingNumber) {
-    const index = Number.parseInt(leadingNumber[1]!, 10) - 1;
+  const selectedNumber = parseAMemGymOptionNumber(trimmed);
+  if (selectedNumber !== undefined) {
+    const index = selectedNumber - 1;
     const choice = qa.answer_choices[index];
     if (choice) {
       return { index, choice };
     }
+    return undefined;
+  }
+  if (looksLikeChoiceNumberAttempt(trimmed)) {
+    return undefined;
   }
 
   const normalizedAnswer = normalizeForChoiceMatch(rawAnswer);
+  const normalizedChoices = qa.answer_choices.map((choice, index) => ({
+    index,
+    choice,
+    normalized: normalizeForChoiceMatch(choice.answer),
+  }));
+
+  const exactMatches = normalizedChoices.filter(
+    (candidate) =>
+      candidate.normalized.length > 0
+      && normalizedAnswer === candidate.normalized,
+  );
+  if (exactMatches.length === 1) {
+    const exactMatch = exactMatches[0]!;
+    return { index: exactMatch.index, choice: exactMatch.choice };
+  }
+
+  let bestSubstringLength = -1;
+  let bestSubstringMatches: Array<{
+    index: number;
+    choice: AMemGymQA["answer_choices"][number];
+    normalized: string;
+  }> = [];
   for (let index = 0; index < qa.answer_choices.length; index += 1) {
-    const choice = qa.answer_choices[index]!;
-    const normalizedChoice = normalizeForChoiceMatch(choice.answer);
+    const candidate = normalizedChoices[index]!;
     if (
-      normalizedChoice.length > 0
-      && (normalizedAnswer === normalizedChoice
-        || normalizedAnswer.includes(normalizedChoice))
+      candidate.normalized.length > 0
+      && containsNormalizedPhrase(normalizedAnswer, candidate.normalized)
     ) {
-      return { index, choice };
+      if (candidate.normalized.length > bestSubstringLength) {
+        bestSubstringLength = candidate.normalized.length;
+        bestSubstringMatches = [candidate];
+      } else if (candidate.normalized.length === bestSubstringLength) {
+        bestSubstringMatches.push(candidate);
+      }
     }
   }
 
-  return undefined;
+  const uniqueMatch = bestSubstringMatches.length === 1
+    ? bestSubstringMatches[0]
+    : undefined;
+  return uniqueMatch
+    ? { index: uniqueMatch.index, choice: uniqueMatch.choice }
+    : undefined;
+}
+
+function containsNormalizedPhrase(haystack: string, needle: string): boolean {
+  const haystackTokens = haystack.split(" ").filter((token) => token.length > 0);
+  const needleTokens = needle.split(" ").filter((token) => token.length > 0);
+  if (needleTokens.length === 0 || needleTokens.length > haystackTokens.length) {
+    return false;
+  }
+
+  for (let index = 0; index <= haystackTokens.length - needleTokens.length; index += 1) {
+    if (needleTokens.every((token, offset) => haystackTokens[index + offset] === token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
+  const bareNumber = trimmedAnswer.match(
+    /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+  );
+  if (bareNumber) {
+    if (mentionsAdditionalOptionNumber(bareNumber.groups?.tail ?? "")) {
+      return undefined;
+    }
+    return Number.parseInt(bareNumber[1]!, 10);
+  }
+
+  const labeledNumber = trimmedAnswer.match(
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+  );
+  if (labeledNumber && mentionsAdditionalOptionNumber(labeledNumber.groups?.tail ?? "")) {
+    return undefined;
+  }
+  return labeledNumber
+    ? Number.parseInt(labeledNumber[1]!, 10)
+    : undefined;
+}
+
+function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
+  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*\(?#?\s*\d+/i.test(trimmedAnswer)) {
+    return true;
+  }
+  return /^\(?#?\s*\d+\s*\)?\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)/i.test(trimmedAnswer);
+}
+
+function mentionsAdditionalOptionNumber(value: string): boolean {
+  const trimmed = value.trim();
+  return /\b(?:option|choice|answer)\s*#?\d+\b/i.test(trimmed)
+    || (/^[,.;:\-]/.test(trimmed) && /\b#?\d+\b/.test(trimmed));
 }
 
 function normalizeForChoiceMatch(value: string): string {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -282,9 +282,11 @@ function parseAMemGymChoice(
   if (plainTextOption !== undefined) {
     const index = plainTextOption.selectedNumber - 1;
     const choice = qa.answer_choices[index];
+    if (!choice) {
+      return undefined;
+    }
     if (
-      choice
-      && plainOptionTextMatchesChoice(plainTextOption.choiceText, choice.answer)
+      plainOptionTextMatchesChoice(plainTextOption.choiceText, choice.answer)
     ) {
       return { index, choice };
     }

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -364,7 +364,7 @@ function leadingNumericToken(value: string): string | undefined {
 
 function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   const bareNumber = trimmedAnswer.match(
-    /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:\([^)]*\)|because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^\(?#?\s*(\d+)\s*(?:\)(?!\s+\S))?(?<tail>\s*(?:\)\s+\S.*|\([^)]*\).*|because.*|[,.;:\-](?!\s*#?\d).*)?)$/i,
   );
   if (bareNumber) {
     const selectedNumber = Number.parseInt(bareNumber[1]!, 10);
@@ -375,7 +375,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:\([^)]*\)|because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*(?:\)(?!\s+\S))?(?<tail>\s*(?:\)\s+\S.*|\([^)]*\).*|because.*|[,.;:\-](?!\s*#?\d).*)?)$/i,
   );
   if (labeledNumber) {
     const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);
@@ -411,6 +411,13 @@ function mentionsConflictingOptionNumber(
   }
   for (const match of trimmed.matchAll(
     /\b(\d+)\s+(?:(?:might|may|could|would|should)\s+be\s+|is\s+(?:also\s+)?|also\s+)?(?:right|correct|valid|the\s+(?:answer|option|choice))\b/gi,
+  )) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
+    }
+  }
+  for (const match of trimmed.matchAll(
+    /\b(?:or|maybe|possibly|probably|perhaps|alternatively)\s+#?\s*(\d+)\b/gi,
   )) {
     if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
       return true;

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -352,21 +352,24 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
     /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
   if (bareNumber) {
-    if (mentionsAdditionalOptionNumber(bareNumber.groups?.tail ?? "")) {
+    const selectedNumber = Number.parseInt(bareNumber[1]!, 10);
+    if (mentionsConflictingOptionNumber(bareNumber.groups?.tail ?? "", selectedNumber)) {
       return undefined;
     }
-    return Number.parseInt(bareNumber[1]!, 10);
+    return selectedNumber;
   }
 
   const labeledNumber = trimmedAnswer.match(
     /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?:(?:the\s+)?(?:option|choice|answer)\s*)?(?::|#)?\s*\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
-  if (labeledNumber && mentionsAdditionalOptionNumber(labeledNumber.groups?.tail ?? "")) {
-    return undefined;
+  if (labeledNumber) {
+    const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);
+    if (mentionsConflictingOptionNumber(labeledNumber.groups?.tail ?? "", selectedNumber)) {
+      return undefined;
+    }
+    return selectedNumber;
   }
-  return labeledNumber
-    ? Number.parseInt(labeledNumber[1]!, 10)
-    : undefined;
+  return undefined;
 }
 
 function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
@@ -376,10 +379,23 @@ function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
   return /^\(?#?\s*\d+\s*\)?\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)/i.test(trimmedAnswer);
 }
 
-function mentionsAdditionalOptionNumber(value: string): boolean {
+function mentionsConflictingOptionNumber(
+  value: string,
+  selectedNumber: number,
+): boolean {
   const trimmed = value.trim();
-  return /\b(?:option|choice|answer)\s*#?\d+\b/i.test(trimmed)
-    || /^[,.;:\-]\s*(?:#?\d+\b|(?:or|maybe|possibly|probably|perhaps|alternatively)\s+#?\d+\b)/i.test(trimmed);
+  for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
+    }
+  }
+
+  const punctuationNumber = trimmed.match(
+    /^[,.;:\-]\s*(?:#?(\d+)\b|(?:or|maybe|possibly|probably|perhaps|alternatively)\s+#?(\d+)\b)/i,
+  );
+  const ambiguousNumber = punctuationNumber?.[1] ?? punctuationNumber?.[2];
+  return ambiguousNumber !== undefined
+    && Number.parseInt(ambiguousNumber, 10) !== selectedNumber;
 }
 
 function normalizeForChoiceMatch(value: string): string {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -359,7 +359,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?:(?:the\s+)?(?:option|choice|answer)\s*)?(?::|#)?\s*\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
   if (labeledNumber && mentionsAdditionalOptionNumber(labeledNumber.groups?.tail ?? "")) {
     return undefined;
@@ -370,7 +370,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
 }
 
 function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
-  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*\(?#?\s*\d+/i.test(trimmedAnswer)) {
+  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?:(?:the\s+)?(?:option|choice|answer)\s*)?(?::|#)?\s*\(?#?\s*\d+/i.test(trimmedAnswer)) {
     return true;
   }
   return /^\(?#?\s*\d+\s*\)?\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)/i.test(trimmedAnswer);

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -278,6 +278,17 @@ function parseAMemGymChoice(
     }
     return undefined;
   }
+  const plainTextOption = parseAMemGymPlainTextOptionNumber(trimmed);
+  if (plainTextOption !== undefined) {
+    const index = plainTextOption.selectedNumber - 1;
+    const choice = qa.answer_choices[index];
+    if (
+      choice
+      && plainOptionTextMatchesChoice(plainTextOption.choiceText, choice.answer)
+    ) {
+      return { index, choice };
+    }
+  }
   const normalizedAnswer = normalizeForChoiceMatch(rawAnswer);
   const normalizedChoices = qa.answer_choices.map((choice, index) => ({
     index,
@@ -331,6 +342,46 @@ function parseAMemGymChoice(
   return uniqueMatch
     ? { index: uniqueMatch.index, choice: uniqueMatch.choice }
     : undefined;
+}
+
+function parseAMemGymPlainTextOptionNumber(
+  trimmedAnswer: string,
+): { selectedNumber: number; choiceText: string } | undefined {
+  const bareNumber = trimmedAnswer.match(
+    /^\(?#?\s*(\d+)\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)(?<choiceText>\S.*)$/i,
+  );
+  if (bareNumber) {
+    return {
+      selectedNumber: Number.parseInt(bareNumber[1]!, 10),
+      choiceText: bareNumber.groups!.choiceText!,
+    };
+  }
+
+  const labeledNumber = trimmedAnswer.match(
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s+(?<choiceText>\S.*)$/i,
+  );
+  if (labeledNumber) {
+    return {
+      selectedNumber: Number.parseInt(labeledNumber[1]!, 10),
+      choiceText: labeledNumber.groups!.choiceText!,
+    };
+  }
+
+  return undefined;
+}
+
+function plainOptionTextMatchesChoice(
+  choiceText: string,
+  choiceAnswer: string,
+): boolean {
+  const normalizedChoiceText = normalizeForChoiceMatch(choiceText);
+  const normalizedChoiceAnswer = normalizeForChoiceMatch(choiceAnswer);
+  return normalizedChoiceText.length > 0
+    && normalizedChoiceAnswer.length > 0
+    && (
+      normalizedChoiceText === normalizedChoiceAnswer
+      || containsNormalizedPhrase(normalizedChoiceText, normalizedChoiceAnswer)
+    );
 }
 
 function containsNormalizedPhrase(haystack: string, needle: string): boolean {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -358,7 +358,7 @@ function parseAMemGymPlainTextOptionNumber(
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s+(?<choiceText>\S.*)$/i,
+    /^(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s+(?<choiceText>\S.*)$/i,
   );
   if (labeledNumber) {
     return {
@@ -426,7 +426,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*(?:\)(?!\s+\S))?(?<tail>\s*(?:\)\s+\S.*|\([^)]*\).*|because.*|[,.;:\-](?!\s*#?\d).*)?)$/i,
+    /^(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*(?:\)(?!\s+\S))?(?<tail>\s*(?:\)\s+\S.*|\([^)]*\).*|because.*|[,.;:\-](?!\s*#?\d).*)?)$/i,
   );
   if (labeledNumber) {
     const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);
@@ -439,7 +439,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
 }
 
 function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
-  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*\d+/i.test(trimmedAnswer)) {
+  if (/^(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:(?:correct|final|right)\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*\d+/i.test(trimmedAnswer)) {
     return true;
   }
   return /^\(?#?\s*\d+\s*\)?\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)/i.test(trimmedAnswer);

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -285,6 +285,7 @@ function parseAMemGymChoice(
     normalized: normalizeForChoiceMatch(choice.answer),
   }));
   const numericChoiceNumberAttempt = looksLikeChoiceNumberAttempt(trimmed);
+  const numericAttemptPrefix = leadingNumericToken(normalizedAnswer);
 
   const exactMatches = normalizedChoices.filter(
     (candidate) =>
@@ -293,7 +294,10 @@ function parseAMemGymChoice(
   );
   if (exactMatches.length === 1) {
     const exactMatch = exactMatches[0]!;
-    if (!numericChoiceNumberAttempt || startsWithNumericToken(exactMatch.normalized)) {
+    if (
+      !numericChoiceNumberAttempt
+      || numericPrefixesAgree(numericAttemptPrefix, exactMatch.normalized)
+    ) {
       return { index: exactMatch.index, choice: exactMatch.choice };
     }
   }
@@ -308,7 +312,8 @@ function parseAMemGymChoice(
     const candidate = normalizedChoices[index]!;
     if (
       candidate.normalized.length > 0
-      && (!numericChoiceNumberAttempt || startsWithNumericToken(candidate.normalized))
+      && (!numericChoiceNumberAttempt
+        || numericPrefixesAgree(numericAttemptPrefix, candidate.normalized))
       && containsNormalizedPhrase(normalizedAnswer, candidate.normalized)
     ) {
       if (candidate.normalized.length > bestSubstringLength) {
@@ -343,8 +348,18 @@ function containsNormalizedPhrase(haystack: string, needle: string): boolean {
   return false;
 }
 
-function startsWithNumericToken(value: string): boolean {
-  return /^\d+\b/.test(value);
+function numericPrefixesAgree(
+  answerPrefix: string | undefined,
+  choiceText: string,
+): boolean {
+  const choicePrefix = leadingNumericToken(choiceText);
+  return answerPrefix !== undefined
+    && choicePrefix !== undefined
+    && answerPrefix === choicePrefix;
+}
+
+function leadingNumericToken(value: string): string | undefined {
+  return value.match(/^(\d+)\b/)?.[1];
 }
 
 function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -375,7 +375,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?:(?:the\s+)?(?:option|choice|answer)\s*)?(?::|#)?\s*\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
   if (labeledNumber) {
     const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);
@@ -388,7 +388,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
 }
 
 function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
-  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?:(?:the\s+)?(?:option|choice|answer)\s*)?(?::|#)?\s*\(?#?\s*\d+/i.test(trimmedAnswer)) {
+  if (/^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*\d+/i.test(trimmedAnswer)) {
     return true;
   }
   return /^\(?#?\s*\d+\s*\)?\s+(?!weeks?\b|days?\b|months?\b|years?\b|hours?\b|minutes?\b)/i.test(trimmedAnswer);
@@ -400,6 +400,18 @@ function mentionsConflictingOptionNumber(
 ): boolean {
   const trimmed = value.trim();
   for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
+    }
+  }
+  for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
+    }
+  }
+  for (const match of trimmed.matchAll(
+    /\b(\d+)\s+(?:(?:might|may|could|would|should)\s+be\s+|is\s+(?:also\s+)?|also\s+)?(?:right|correct|valid|the\s+(?:answer|option|choice))\b/gi,
+  )) {
     if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
       return true;
     }

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -364,7 +364,7 @@ function leadingNumericToken(value: string): string | undefined {
 
 function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   const bareNumber = trimmedAnswer.match(
-    /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:\([^)]*\)|because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
   if (bareNumber) {
     const selectedNumber = Number.parseInt(bareNumber[1]!, 10);
@@ -375,7 +375,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   }
 
   const labeledNumber = trimmedAnswer.match(
-    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:because|[,.;:\-](?!\s*#?\d)).*)?$/i,
+    /^(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*(?:(?:the\s+)?(?:option|choice|answer)\s*(?:is\s*)?(?::|#)?\s*)?\(?#?\s*(\d+)\s*\)?(?<tail>\s*(?:\([^)]*\)|because|[,.;:\-](?!\s*#?\d)).*)?$/i,
   );
   if (labeledNumber) {
     const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);

--- a/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
@@ -14,7 +14,15 @@ export interface ArenaTask {
   questions: string[];
   answers: ArenaExpectedAnswer[];
   backgrounds?: string | string[];
+  base_person?: ArenaBasePerson;
   category: string;
+}
+
+export interface ArenaBasePerson {
+  name?: string;
+  query?: string;
+  daily_plans?: ArenaExpectedAnswer;
+  [key: string]: unknown;
 }
 
 export interface DomainData {

--- a/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/fixture.ts
@@ -21,7 +21,7 @@ export interface ArenaTask {
 export interface ArenaBasePerson {
   name?: string;
   query?: string;
-  daily_plans?: ArenaExpectedAnswer;
+  daily_plans?: ArenaExpectedAnswer | null;
   [key: string]: unknown;
 }
 

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -434,7 +434,7 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
     );
   }
   if (
-    record.base_person !== undefined
+    record.base_person != null
     && !isValidBasePerson(record.base_person)
   ) {
     throw new Error(
@@ -450,7 +450,7 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
     ...(record.backgrounds === undefined
       ? {}
       : { backgrounds: record.backgrounds as string | string[] }),
-    ...(record.base_person === undefined
+    ...(record.base_person == null
       ? {}
       : { base_person: record.base_person as ArenaBasePerson }),
   };
@@ -907,18 +907,6 @@ function normalizePlanDayToken(token: string): string {
 function tokensEqual(left: string[], right: string[]): boolean {
   return left.length === right.length
     && left.every((token, index) => token === right[index]);
-}
-
-function containsTokenSequence(tokens: string[], sequence: string[]): boolean {
-  if (sequence.length === 0 || sequence.length > tokens.length) {
-    return false;
-  }
-  for (let index = 0; index <= tokens.length - sequence.length; index += 1) {
-    if (sequence.every((token, offset) => tokens[index + offset] === token)) {
-      return true;
-    }
-  }
-  return false;
 }
 
 function tokenizePlanText(value: string): string[] {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -862,9 +862,13 @@ function findLastDayContext(
       && (tokens[index] === "day" || tokens[index] === "days")
       && tokens[index + 1]
     ) {
+      const dayToken = normalizeExplicitPlanDayToken(tokens[index + 1]!);
+      if (dayToken === undefined) {
+        continue;
+      }
       return {
         startIndex: index,
-        dayTokens: [normalizePlanDayToken(tokens[index + 1]!)],
+        dayTokens: [dayToken],
       };
     }
   }
@@ -895,6 +899,12 @@ function extractCompactPlanDayToken(token: string): string | undefined {
   return match?.[1] === undefined
     ? undefined
     : normalizePlanDayToken(match[1]);
+}
+
+function normalizeExplicitPlanDayToken(token: string): string | undefined {
+  return /^\d+$/.test(token)
+    ? normalizePlanDayToken(token)
+    : undefined;
 }
 
 function normalizePlanDayToken(token: string): string {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -727,6 +727,30 @@ const WEEKDAY_PLAN_DAY_TOKENS = new Set([
   "saturday",
   "sunday",
 ]);
+const WORD_PLAN_DAY_TOKENS = new Set([
+  ...WEEKDAY_PLAN_DAY_TOKENS,
+  "zero",
+  "one",
+  "two",
+  "three",
+  "four",
+  "five",
+  "six",
+  "seven",
+  "eight",
+  "nine",
+  "ten",
+  "first",
+  "second",
+  "third",
+  "fourth",
+  "fifth",
+  "sixth",
+  "seventh",
+  "eighth",
+  "ninth",
+  "tenth",
+]);
 
 function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectation[] {
   const planItems = Array.isArray(answer) ? answer : [answer];
@@ -860,6 +884,15 @@ function findLastDayContext(
   expectedDayTokens: string[],
 ): { startIndex: number; dayTokens: string[] } | undefined {
   for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    const expectedSequence = matchExpectedDayTokensEndingAt(
+      tokens,
+      index,
+      expectedDayTokens,
+    );
+    if (expectedSequence !== undefined) {
+      return expectedSequence;
+    }
+
     const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
     if (compactDayToken !== undefined) {
       return {
@@ -867,25 +900,23 @@ function findLastDayContext(
         dayTokens: [compactDayToken],
       };
     }
-    const standaloneDayToken = normalizeStandalonePlanDayToken(
-      tokens[index]!,
-      expectedDayTokens,
-    );
+    const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index]!);
     if (standaloneDayToken !== undefined) {
       return {
         startIndex: index,
         dayTokens: [standaloneDayToken],
       };
     }
+    const trailingDayContext = extractTrailingPlanDayContext(tokens, index);
+    if (trailingDayContext !== undefined) {
+      return trailingDayContext;
+    }
     if (
       index <= beforeIndex - 2
       && (tokens[index] === "day" || tokens[index] === "days")
       && tokens[index + 1]
     ) {
-      const dayToken = normalizeExplicitPlanDayToken(
-        tokens[index + 1]!,
-        expectedDayTokens,
-      );
+      const dayToken = normalizeExplicitPlanDayToken(tokens[index + 1]!);
       if (dayToken === undefined) {
         continue;
       }
@@ -924,30 +955,53 @@ function extractCompactPlanDayToken(token: string): string | undefined {
     : normalizePlanDayToken(match[1]);
 }
 
-function normalizeStandalonePlanDayToken(
-  token: string,
+function matchExpectedDayTokensEndingAt(
+  tokens: string[],
+  endIndex: number,
   expectedDayTokens: string[],
-): string | undefined {
-  return matchesSingleExpectedDayToken(token, expectedDayTokens)
-    && WEEKDAY_PLAN_DAY_TOKENS.has(token)
+): { startIndex: number; dayTokens: string[] } | undefined {
+  if (expectedDayTokens.length === 0) {
+    return undefined;
+  }
+  const startIndex = endIndex - expectedDayTokens.length + 1;
+  if (startIndex < 0) {
+    return undefined;
+  }
+  return expectedDayTokens.every(
+    (token, offset) => tokens[startIndex + offset] === token,
+  )
+    ? { startIndex, dayTokens: expectedDayTokens }
+    : undefined;
+}
+
+function normalizeStandalonePlanDayToken(token: string): string | undefined {
+  return WEEKDAY_PLAN_DAY_TOKENS.has(token)
     ? token
     : undefined;
 }
 
-function matchesSingleExpectedDayToken(
-  token: string,
-  expectedDayTokens: string[],
-): boolean {
-  return expectedDayTokens.length === 1 && expectedDayTokens[0] === token;
+function extractTrailingPlanDayContext(
+  tokens: string[],
+  dayTokenIndex: number,
+): { startIndex: number; dayTokens: string[] } | undefined {
+  const previousToken = tokens[dayTokenIndex - 1];
+  if (
+    previousToken === undefined
+    || (tokens[dayTokenIndex] !== "day" && tokens[dayTokenIndex] !== "days")
+    || !WORD_PLAN_DAY_TOKENS.has(previousToken)
+  ) {
+    return undefined;
+  }
+  return {
+    startIndex: dayTokenIndex - 1,
+    dayTokens: [previousToken, normalizePlanDayToken(tokens[dayTokenIndex]!)],
+  };
 }
 
-function normalizeExplicitPlanDayToken(
-  token: string,
-  expectedDayTokens: string[],
-): string | undefined {
+function normalizeExplicitPlanDayToken(token: string): string | undefined {
   const normalizedToken = normalizePlanDayToken(token);
   return /^\d+$/.test(token)
-    || matchesSingleExpectedDayToken(normalizedToken, expectedDayTokens)
+    || WORD_PLAN_DAY_TOKENS.has(normalizedToken)
     ? normalizedToken
     : undefined;
 }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -718,6 +718,15 @@ const PLAN_FIELD_KEYS = [
 const PLAN_FIELD_LABEL_TOKEN_SEQUENCES = PLAN_FIELD_KEYS
   .map((key) => tokenizePlanText(key.replace(/_/g, " ")))
   .sort((a, b) => b.length - a.length);
+const WEEKDAY_PLAN_DAY_TOKENS = new Set([
+  "monday",
+  "tuesday",
+  "wednesday",
+  "thursday",
+  "friday",
+  "saturday",
+  "sunday",
+]);
 
 function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectation[] {
   const planItems = Array.isArray(answer) ? answer : [answer];
@@ -821,7 +830,7 @@ function findPlanFieldTokenWindow(
     }
 
     const dayContext = expectedField.dayTokens.length > 0
-      ? findLastDayContext(predictedTokens, index)
+      ? findLastDayContext(predictedTokens, index, expectedField.dayTokens)
       : undefined;
     if (
       expectedField.dayTokens.length > 0
@@ -848,6 +857,7 @@ function findPlanFieldTokenWindow(
 function findLastDayContext(
   tokens: string[],
   beforeIndex: number,
+  expectedDayTokens: string[],
 ): { startIndex: number; dayTokens: string[] } | undefined {
   for (let index = beforeIndex - 1; index >= 0; index -= 1) {
     const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
@@ -857,12 +867,25 @@ function findLastDayContext(
         dayTokens: [compactDayToken],
       };
     }
+    const standaloneDayToken = normalizeStandalonePlanDayToken(
+      tokens[index]!,
+      expectedDayTokens,
+    );
+    if (standaloneDayToken !== undefined) {
+      return {
+        startIndex: index,
+        dayTokens: [standaloneDayToken],
+      };
+    }
     if (
       index <= beforeIndex - 2
       && (tokens[index] === "day" || tokens[index] === "days")
       && tokens[index + 1]
     ) {
-      const dayToken = normalizeExplicitPlanDayToken(tokens[index + 1]!);
+      const dayToken = normalizeExplicitPlanDayToken(
+        tokens[index + 1]!,
+        expectedDayTokens,
+      );
       if (dayToken === undefined) {
         continue;
       }
@@ -901,9 +924,25 @@ function extractCompactPlanDayToken(token: string): string | undefined {
     : normalizePlanDayToken(match[1]);
 }
 
-function normalizeExplicitPlanDayToken(token: string): string | undefined {
+function normalizeStandalonePlanDayToken(
+  token: string,
+  expectedDayTokens: string[],
+): string | undefined {
+  return expectedDayTokens.length === 1
+    && expectedDayTokens[0] === token
+    && WEEKDAY_PLAN_DAY_TOKENS.has(token)
+    ? token
+    : undefined;
+}
+
+function normalizeExplicitPlanDayToken(
+  token: string,
+  expectedDayTokens: string[],
+): string | undefined {
+  const normalizedToken = normalizePlanDayToken(token);
   return /^\d+$/.test(token)
-    ? normalizePlanDayToken(token)
+    || normalizeStandalonePlanDayToken(normalizedToken, expectedDayTokens) !== undefined
+    ? normalizedToken
     : undefined;
 }
 

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -747,7 +747,10 @@ function normalizePlanDayLabel(value: string | number): string {
   const tokens = tokenizePlanText(String(value));
   const dayIndex = tokens.findIndex((token) => token === "day" || token === "days");
   if (dayIndex !== -1 && tokens[dayIndex + 1]) {
-    return tokens[dayIndex + 1]!;
+    return normalizePlanDayToken(tokens[dayIndex + 1]!);
+  }
+  if (tokens.length === 1) {
+    return extractCompactPlanDayToken(tokens[0]!) ?? normalizePlanDayToken(tokens[0]!);
   }
   return tokens.join(" ");
 }
@@ -831,12 +834,6 @@ function findPlanFieldTokenWindow(
     ) {
       continue;
     }
-    if (
-      expectedField.dayTokens.length > 0
-      && !containsTokenSequence(context, expectedField.dayTokens)
-    ) {
-      continue;
-    }
     return index;
   }
   return -1;
@@ -846,15 +843,40 @@ function findLastDayContext(
   tokens: string[],
   beforeIndex: number,
 ): { startIndex: number; dayTokens: string[] } | undefined {
-  for (let index = beforeIndex - 2; index >= 0; index -= 1) {
-    if ((tokens[index] === "day" || tokens[index] === "days") && tokens[index + 1]) {
+  for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
+    if (compactDayToken !== undefined) {
       return {
         startIndex: index,
-        dayTokens: [tokens[index + 1]!],
+        dayTokens: [compactDayToken],
+      };
+    }
+    if (
+      index <= beforeIndex - 2
+      && (tokens[index] === "day" || tokens[index] === "days")
+      && tokens[index + 1]
+    ) {
+      return {
+        startIndex: index,
+        dayTokens: [normalizePlanDayToken(tokens[index + 1]!)],
       };
     }
   }
   return undefined;
+}
+
+function extractCompactPlanDayToken(token: string): string | undefined {
+  const match = /^days?(\d+)$/.exec(token);
+  return match?.[1] === undefined
+    ? undefined
+    : normalizePlanDayToken(match[1]);
+}
+
+function normalizePlanDayToken(token: string): string {
+  if (/^\d+$/.test(token)) {
+    return String(Number(token));
+  }
+  return token;
 }
 
 function tokensEqual(left: string[], right: string[]): boolean {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -854,7 +854,7 @@ function findPlanFieldTokenWindow(
     }
 
     const dayContext = expectedField.dayTokens.length > 0
-      ? findLastDayContext(predictedTokens, index, expectedField.dayTokens)
+      ? findLastDayContext(predictedTokens, index)
       : undefined;
     if (
       expectedField.dayTokens.length > 0
@@ -881,18 +881,8 @@ function findPlanFieldTokenWindow(
 function findLastDayContext(
   tokens: string[],
   beforeIndex: number,
-  expectedDayTokens: string[],
 ): { startIndex: number; dayTokens: string[] } | undefined {
   for (let index = beforeIndex - 1; index >= 0; index -= 1) {
-    const expectedSequence = matchExpectedDayTokensEndingAt(
-      tokens,
-      index,
-      expectedDayTokens,
-    );
-    if (expectedSequence !== undefined) {
-      return expectedSequence;
-    }
-
     const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
     if (compactDayToken !== undefined) {
       return {
@@ -953,25 +943,6 @@ function extractCompactPlanDayToken(token: string): string | undefined {
   return match?.[1] === undefined
     ? undefined
     : normalizePlanDayToken(match[1]);
-}
-
-function matchExpectedDayTokensEndingAt(
-  tokens: string[],
-  endIndex: number,
-  expectedDayTokens: string[],
-): { startIndex: number; dayTokens: string[] } | undefined {
-  if (expectedDayTokens.length === 0) {
-    return undefined;
-  }
-  const startIndex = endIndex - expectedDayTokens.length + 1;
-  if (startIndex < 0) {
-    return undefined;
-  }
-  return expectedDayTokens.every(
-    (token, offset) => tokens[startIndex + offset] === token,
-  )
-    ? { startIndex, dayTokens: expectedDayTokens }
-    : undefined;
 }
 
 function normalizeStandalonePlanDayToken(token: string): string | undefined {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -8,6 +8,7 @@ import path from "node:path";
 import {
   MEMORY_ARENA_SMOKE_FIXTURE,
   type ArenaAnswer,
+  type ArenaBasePerson,
   type ArenaExpectedAnswer,
   type ArenaTask,
   type DomainData,
@@ -62,6 +63,7 @@ export async function runMemoryArenaBenchmark(
       await options.system.reset();
 
       const sessionId = `arena-${domain}-${task.id}`;
+      await storeInitialTaskState(options, sessionId, task);
       for (
         let questionIndex = 0;
         questionIndex < task.questions.length;
@@ -104,11 +106,21 @@ export async function runMemoryArenaBenchmark(
           const { result: recalledText, durationMs } = await timed(async () =>
             options.system.recall(sessionId, question),
           );
-          const answered = await answerBenchmarkQuestion({
+          const benchmarkQuestion = formatMemoryArenaQuestion(
+            domain,
             question,
+            expectedAnswer,
+          );
+          const answered = await answerBenchmarkQuestion({
+            question: benchmarkQuestion,
             recalledText,
             responder: options.system.responder,
           });
+          const domainScores = scoreMemoryArenaDomainAnswer(
+            domain,
+            answered.finalAnswer,
+            expectedAnswer,
+          );
           const judgeResult = await llmJudgeScoreDetailed(
             options.system.judge,
             question,
@@ -119,6 +131,7 @@ export async function runMemoryArenaBenchmark(
           const scores: Record<string, number> = {
             f1: f1Score(answered.finalAnswer, expected),
             contains_answer: containsAnswer(answered.finalAnswer, expected),
+            ...domainScores,
           };
           if (judgeResult.score >= 0) {
             scores.llm_judge = judgeResult.score;
@@ -145,6 +158,7 @@ export async function runMemoryArenaBenchmark(
               taskId: task.id,
               subtaskIndex: questionIndex,
               category: task.category,
+              promptQuestion: benchmarkQuestion,
               recalledLength: recalledText.length,
               answeredLength: answered.finalAnswer.length,
               recalledText,
@@ -398,6 +412,14 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
       `${location} backgrounds must be a string or an array of strings when provided.`,
     );
   }
+  if (
+    record.base_person !== undefined
+    && !isValidBasePerson(record.base_person)
+  ) {
+    throw new Error(
+      `${location} base_person must be an object when provided.`,
+    );
+  }
 
   return {
     id: record.id as number,
@@ -407,6 +429,9 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
     ...(record.backgrounds === undefined
       ? {}
       : { backgrounds: record.backgrounds as string | string[] }),
+    ...(record.base_person === undefined
+      ? {}
+      : { base_person: record.base_person as ArenaBasePerson }),
   };
 }
 
@@ -487,6 +512,12 @@ function isValidBackgrounds(backgrounds: unknown): backgrounds is string | strin
       && backgrounds.every((entry) => typeof entry === "string"));
 }
 
+function isValidBasePerson(basePerson: unknown): basePerson is ArenaBasePerson {
+  return Boolean(basePerson)
+    && typeof basePerson === "object"
+    && !Array.isArray(basePerson);
+}
+
 function scoredSubtaskCount(task: ArenaTask): number {
   return task.questions.filter((_, index) => shouldScoreSubtask(task, index)).length;
 }
@@ -513,6 +544,146 @@ function backgroundForSubtask(
       : undefined;
   }
   return undefined;
+}
+
+async function storeInitialTaskState(
+  options: ResolvedRunBenchmarkOptions,
+  sessionId: string,
+  task: ArenaTask,
+): Promise<void> {
+  if (!task.base_person) {
+    return;
+  }
+
+  const basePerson = task.base_person;
+  const name = typeof basePerson.name === "string" ? basePerson.name : "base traveler";
+  const query = typeof basePerson.query === "string" ? basePerson.query : "";
+  const plan = basePerson.daily_plans === undefined
+    ? ""
+    : answerToString(basePerson.daily_plans);
+
+  await options.system.store(sessionId, [
+    {
+      role: "user",
+      content: query.trim().length > 0
+        ? query
+        : `MemoryArena initial state for ${name}.`,
+    },
+    {
+      role: "assistant",
+      content: [
+        `MemoryArena initial finalized plan for ${name}.`,
+        query.trim().length > 0 ? `Base traveler request: ${query}` : "",
+        plan.trim().length > 0 ? `Environment result: ${plan}` : "",
+      ].filter((part) => part.length > 0).join("\n"),
+    },
+  ]);
+
+  try {
+    await options.system.drain?.();
+  } catch (drainErr) {
+    console.error(`  [WARN] memory-arena drain failed after initial task state: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
+  }
+}
+
+function formatMemoryArenaQuestion(
+  domain: string,
+  question: string,
+  expectedAnswer: ArenaExpectedAnswer,
+): string {
+  if (domain !== "group_travel_planner") {
+    return question;
+  }
+
+  const expectedDayCount = Array.isArray(expectedAnswer)
+    ? expectedAnswer.filter((entry) => isValidArenaAnswerObject(entry)).length
+    : 0;
+
+  return [
+    "You are a travel planner assistant in the MemoryArena Group Travel Planning task.",
+    "Use the supplied memory context containing the base traveler plan and previous travelers' finalized plans.",
+    "Generate the complete finalized plan for the current traveler, not just a short answer to one constraint.",
+    "Preserve the exact known flight, restaurant, attraction, and accommodation names from memory when they are required by JOIN or comparison constraints.",
+    expectedDayCount > 0
+      ? `Return ${expectedDayCount} day sections.`
+      : "Return all required day sections.",
+    "",
+    "Final output format:",
+    "=== Traveler Plan ===",
+    "Day 1:",
+    "Current City: ...",
+    "Transportation: ...",
+    "Breakfast: ...",
+    "Attraction: ...",
+    "Lunch: ...",
+    "Dinner: ...",
+    "Accommodation: ...",
+    "",
+    "Current traveler request:",
+    question,
+  ].join("\n");
+}
+
+function scoreMemoryArenaDomainAnswer(
+  domain: string,
+  predicted: string,
+  expectedAnswer: ArenaExpectedAnswer,
+): Record<string, number> {
+  if (domain !== "group_travel_planner") {
+    return {};
+  }
+
+  const expectedFields = extractPlanFieldValues(expectedAnswer);
+  if (expectedFields.length === 0) {
+    return {};
+  }
+
+  const normalizedPredicted = normalizePlanText(predicted);
+  const hits = expectedFields.filter((value) =>
+    normalizedPredicted.includes(normalizePlanText(value)),
+  ).length;
+
+  return {
+    soft_process_score: hits / expectedFields.length,
+    plan_field_recall: hits / expectedFields.length,
+  };
+}
+
+function extractPlanFieldValues(answer: ArenaExpectedAnswer): string[] {
+  if (!Array.isArray(answer)) {
+    return [];
+  }
+
+  const fields: string[] = [];
+  for (const item of answer) {
+    if (!isValidArenaAnswerObject(item)) {
+      continue;
+    }
+    for (const key of [
+      "current_city",
+      "transportation",
+      "breakfast",
+      "attraction",
+      "lunch",
+      "dinner",
+      "accommodation",
+    ]) {
+      const value = item[key];
+      if (typeof value === "string" && value.trim().length > 0 && value.trim() !== "-") {
+        fields.push(value);
+      }
+    }
+  }
+  return fields;
+}
+
+function normalizePlanText(value: string): string {
+  return value
+    .trim()
+    .toLowerCase()
+    .replace(/[^\w\s]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
 }
 
 async function storeCompletedSubtask(

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -63,7 +63,19 @@ export async function runMemoryArenaBenchmark(
       await options.system.reset();
 
       const sessionId = `arena-${domain}-${task.id}`;
-      await storeInitialTaskState(options, sessionId, task);
+      let initialSeedError: string | undefined;
+      if (isGroupTravelPlannerCategory(task.category)) {
+        try {
+          await storeInitialTaskState(options, sessionId, task);
+        } catch (seedErr) {
+          initialSeedError = seedErr instanceof Error
+            ? seedErr.message
+            : String(seedErr);
+          console.error(
+            `  [WARN] memory-arena initial task state failed for ${domain}:${task.id}: ${initialSeedError}`,
+          );
+        }
+      }
       for (
         let questionIndex = 0;
         questionIndex < task.questions.length;
@@ -107,7 +119,7 @@ export async function runMemoryArenaBenchmark(
             options.system.recall(sessionId, question),
           );
           const benchmarkQuestion = formatMemoryArenaQuestion(
-            domain,
+            task.category,
             question,
             expectedAnswer,
           );
@@ -117,7 +129,7 @@ export async function runMemoryArenaBenchmark(
             responder: options.system.responder,
           });
           const domainScores = scoreMemoryArenaDomainAnswer(
-            domain,
+            task.category,
             answered.finalAnswer,
             expectedAnswer,
           );
@@ -159,6 +171,9 @@ export async function runMemoryArenaBenchmark(
               subtaskIndex: questionIndex,
               category: task.category,
               promptQuestion: benchmarkQuestion,
+              ...(initialSeedError === undefined
+                ? {}
+                : { initialSeedError }),
               recalledLength: recalledText.length,
               answeredLength: answered.finalAnswer.length,
               recalledText,
@@ -194,6 +209,7 @@ export async function runMemoryArenaBenchmark(
               f1: -1,
               contains_answer: -1,
               llm_judge: -1,
+              ...failureMemoryArenaDomainScores(task.category, expectedAnswer),
               process_score: 0,
               ...(questionIndex === task.questions.length - 1
                 ? { task_success_rate: 0 }
@@ -201,7 +217,12 @@ export async function runMemoryArenaBenchmark(
             },
             latencyMs: 0,
             tokens: { input: 0, output: 0 },
-            details: { error: message },
+            details: {
+              error: message,
+              ...(initialSeedError === undefined
+                ? {}
+                : { initialSeedError }),
+            },
           });
         }
 
@@ -417,7 +438,7 @@ function parseTask(line: string, filename: string, lineNumber: number): ArenaTas
     && !isValidBasePerson(record.base_person)
   ) {
     throw new Error(
-      `${location} base_person must be an object when provided.`,
+      `${location} base_person must be an object with a valid daily_plans value when provided.`,
     );
   }
 
@@ -513,9 +534,15 @@ function isValidBackgrounds(backgrounds: unknown): backgrounds is string | strin
 }
 
 function isValidBasePerson(basePerson: unknown): basePerson is ArenaBasePerson {
-  return Boolean(basePerson)
-    && typeof basePerson === "object"
-    && !Array.isArray(basePerson);
+  if (!basePerson || typeof basePerson !== "object" || Array.isArray(basePerson)) {
+    return false;
+  }
+
+  const record = basePerson as Record<string, unknown>;
+  return !("daily_plans" in record)
+    || record.daily_plans === undefined
+    || record.daily_plans === null
+    || isValidExpectedAnswer(record.daily_plans);
 }
 
 function scoredSubtaskCount(task: ArenaTask): number {
@@ -558,9 +585,12 @@ async function storeInitialTaskState(
   const basePerson = task.base_person;
   const name = typeof basePerson.name === "string" ? basePerson.name : "base traveler";
   const query = typeof basePerson.query === "string" ? basePerson.query : "";
-  const plan = basePerson.daily_plans === undefined
+  const plan = basePerson.daily_plans == null
     ? ""
     : answerToString(basePerson.daily_plans);
+  if (query.trim().length === 0 && plan.trim().length === 0) {
+    return;
+  }
 
   await options.system.store(sessionId, [
     {
@@ -587,26 +617,20 @@ async function storeInitialTaskState(
 }
 
 function formatMemoryArenaQuestion(
-  domain: string,
+  category: string,
   question: string,
   expectedAnswer: ArenaExpectedAnswer,
 ): string {
-  if (domain !== "group_travel_planner") {
+  if (!shouldUseGroupTravelPlanProtocol(category, expectedAnswer)) {
     return question;
   }
-
-  const expectedDayCount = Array.isArray(expectedAnswer)
-    ? expectedAnswer.filter((entry) => isValidArenaAnswerObject(entry)).length
-    : 0;
 
   return [
     "You are a travel planner assistant in the MemoryArena Group Travel Planning task.",
     "Use the supplied memory context containing the base traveler plan and previous travelers' finalized plans.",
     "Generate the complete finalized plan for the current traveler, not just a short answer to one constraint.",
     "Preserve the exact known flight, restaurant, attraction, and accommodation names from memory when they are required by JOIN or comparison constraints.",
-    expectedDayCount > 0
-      ? `Return ${expectedDayCount} day sections.`
-      : "Return all required day sections.",
+    "Return all required day sections from the current traveler request and memory context.",
     "",
     "Final output format:",
     "=== Traveler Plan ===",
@@ -625,11 +649,11 @@ function formatMemoryArenaQuestion(
 }
 
 function scoreMemoryArenaDomainAnswer(
-  domain: string,
+  category: string,
   predicted: string,
   expectedAnswer: ArenaExpectedAnswer,
 ): Record<string, number> {
-  if (domain !== "group_travel_planner") {
+  if (!isGroupTravelPlannerCategory(category)) {
     return {};
   }
 
@@ -638,27 +662,59 @@ function scoreMemoryArenaDomainAnswer(
     return {};
   }
 
-  const normalizedPredicted = normalizePlanText(predicted);
-  const hits = expectedFields.filter((value) =>
-    normalizedPredicted.includes(normalizePlanText(value)),
-  ).length;
+  const hits = countNonOverlappingPlanFieldHits(predicted, expectedFields);
+  const planFieldRecall = hits / expectedFields.length;
 
   return {
-    soft_process_score: hits / expectedFields.length,
-    plan_field_recall: hits / expectedFields.length,
+    soft_process_score: hits === expectedFields.length ? 1 : 0,
+    plan_field_recall: planFieldRecall,
   };
 }
 
-function extractPlanFieldValues(answer: ArenaExpectedAnswer): string[] {
-  if (!Array.isArray(answer)) {
-    return [];
+function failureMemoryArenaDomainScores(
+  category: string,
+  expectedAnswer: ArenaExpectedAnswer,
+): Record<string, number> {
+  if (
+    !isGroupTravelPlannerCategory(category)
+    || extractPlanFieldValues(expectedAnswer).length === 0
+  ) {
+    return {};
   }
+  return {
+    plan_field_recall: 0,
+    soft_process_score: 0,
+  };
+}
 
-  const fields: string[] = [];
-  for (const item of answer) {
+function isGroupTravelPlannerCategory(category: string): boolean {
+  return category.trim().toLowerCase() === "group_travel_planner";
+}
+
+function shouldUseGroupTravelPlanProtocol(
+  category: string,
+  expectedAnswer: ArenaExpectedAnswer,
+): boolean {
+  return isGroupTravelPlannerCategory(category)
+    && extractPlanFieldValues(expectedAnswer).length > 0;
+}
+
+interface PlanFieldExpectation {
+  value: string;
+  fieldKey: string;
+  day?: string;
+}
+
+function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectation[] {
+  const planItems = Array.isArray(answer) ? answer : [answer];
+  const fields: PlanFieldExpectation[] = [];
+  for (const item of planItems) {
     if (!isValidArenaAnswerObject(item)) {
       continue;
     }
+    const day = typeof item.days === "string" || typeof item.days === "number"
+      ? normalizePlanDayLabel(item.days)
+      : undefined;
     for (const key of [
       "current_city",
       "transportation",
@@ -670,7 +726,7 @@ function extractPlanFieldValues(answer: ArenaExpectedAnswer): string[] {
     ]) {
       const value = item[key];
       if (typeof value === "string" && value.trim().length > 0 && value.trim() !== "-") {
-        fields.push(value);
+        fields.push({ value: value.trim(), fieldKey: key, day });
       }
     }
   }
@@ -681,9 +737,147 @@ function normalizePlanText(value: string): string {
   return value
     .trim()
     .toLowerCase()
+    .replace(/_/g, " ")
     .replace(/[^\w\s]/g, " ")
     .replace(/\s+/g, " ")
     .trim();
+}
+
+function normalizePlanDayLabel(value: string | number): string {
+  const tokens = tokenizePlanText(String(value));
+  const dayIndex = tokens.findIndex((token) => token === "day" || token === "days");
+  if (dayIndex !== -1 && tokens[dayIndex + 1]) {
+    return tokens[dayIndex + 1]!;
+  }
+  return tokens.join(" ");
+}
+
+function countNonOverlappingPlanFieldHits(
+  predicted: string,
+  expectedFields: PlanFieldExpectation[],
+): number {
+  const predictedTokens = tokenizePlanText(predicted);
+  const expectedTokenFields = expectedFields
+    .map((field, index) => ({
+      index,
+      tokens: tokenizePlanText(field.value),
+      fieldTokens: tokenizePlanText(field.fieldKey.replace(/_/g, " ")),
+      dayTokens: field.day === undefined ? [] : tokenizePlanText(field.day),
+    }))
+    .filter((field) => field.tokens.length > 0)
+    .sort((a, b) =>
+      b.tokens.length - a.tokens.length
+      || a.index - b.index,
+    );
+
+  const usedTokens = Array.from({ length: predictedTokens.length }, () => false);
+  let count = 0;
+  for (const expectedField of expectedTokenFields) {
+    const matchIndex = findPlanFieldTokenWindow(
+      predictedTokens,
+      expectedField,
+      usedTokens,
+    );
+    if (matchIndex !== -1) {
+      count += 1;
+      for (
+        let tokenIndex = matchIndex;
+        tokenIndex < matchIndex + expectedField.tokens.length;
+        tokenIndex += 1
+      ) {
+        usedTokens[tokenIndex] = true;
+      }
+    }
+  }
+  return count;
+}
+
+function findPlanFieldTokenWindow(
+  predictedTokens: string[],
+  expectedField: {
+    tokens: string[];
+    fieldTokens: string[];
+    dayTokens: string[];
+  },
+  usedTokens: boolean[],
+): number {
+  for (let index = 0; index <= predictedTokens.length - expectedField.tokens.length; index += 1) {
+    const valueMatches = expectedField.tokens.every(
+      (token, offset) =>
+        !usedTokens[index + offset]
+        && predictedTokens[index + offset] === token,
+    );
+    if (!valueMatches) {
+      continue;
+    }
+
+    const dayContext = expectedField.dayTokens.length > 0
+      ? findLastDayContext(predictedTokens, index)
+      : undefined;
+    if (
+      expectedField.dayTokens.length > 0
+      && (dayContext === undefined || !tokensEqual(dayContext.dayTokens, expectedField.dayTokens))
+    ) {
+      continue;
+    }
+
+    const context = predictedTokens.slice(
+      dayContext?.startIndex ?? Math.max(0, index - 32),
+      index,
+    );
+    if (
+      expectedField.fieldTokens.length > 0
+      && !containsTokenSequence(context, expectedField.fieldTokens)
+    ) {
+      continue;
+    }
+    if (
+      expectedField.dayTokens.length > 0
+      && !containsTokenSequence(context, expectedField.dayTokens)
+    ) {
+      continue;
+    }
+    return index;
+  }
+  return -1;
+}
+
+function findLastDayContext(
+  tokens: string[],
+  beforeIndex: number,
+): { startIndex: number; dayTokens: string[] } | undefined {
+  for (let index = beforeIndex - 2; index >= 0; index -= 1) {
+    if ((tokens[index] === "day" || tokens[index] === "days") && tokens[index + 1]) {
+      return {
+        startIndex: index,
+        dayTokens: [tokens[index + 1]!],
+      };
+    }
+  }
+  return undefined;
+}
+
+function tokensEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length
+    && left.every((token, index) => token === right[index]);
+}
+
+function containsTokenSequence(tokens: string[], sequence: string[]): boolean {
+  if (sequence.length === 0 || sequence.length > tokens.length) {
+    return false;
+  }
+  for (let index = 0; index <= tokens.length - sequence.length; index += 1) {
+    if (sequence.every((token, offset) => tokens[index + offset] === token)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function tokenizePlanText(value: string): string[] {
+  return normalizePlanText(value)
+    .split(" ")
+    .filter((token) => token.length > 0);
 }
 
 async function storeCompletedSubtask(
@@ -715,6 +909,9 @@ async function storeCompletedSubtask(
 }
 
 function scoreSubtaskSuccess(scores: Record<string, number>): number {
+  if (typeof scores.soft_process_score === "number") {
+    return scores.soft_process_score >= 1 ? 1 : 0;
+  }
   if (typeof scores.llm_judge === "number") {
     return scores.llm_judge >= 0.5 ? 1 : 0;
   }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -928,11 +928,17 @@ function normalizeStandalonePlanDayToken(
   token: string,
   expectedDayTokens: string[],
 ): string | undefined {
-  return expectedDayTokens.length === 1
-    && expectedDayTokens[0] === token
+  return matchesSingleExpectedDayToken(token, expectedDayTokens)
     && WEEKDAY_PLAN_DAY_TOKENS.has(token)
     ? token
     : undefined;
+}
+
+function matchesSingleExpectedDayToken(
+  token: string,
+  expectedDayTokens: string[],
+): boolean {
+  return expectedDayTokens.length === 1 && expectedDayTokens[0] === token;
 }
 
 function normalizeExplicitPlanDayToken(
@@ -941,7 +947,7 @@ function normalizeExplicitPlanDayToken(
 ): string | undefined {
   const normalizedToken = normalizePlanDayToken(token);
   return /^\d+$/.test(token)
-    || normalizeStandalonePlanDayToken(normalizedToken, expectedDayTokens) !== undefined
+    || matchesSingleExpectedDayToken(normalizedToken, expectedDayTokens)
     ? normalizedToken
     : undefined;
 }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -705,6 +705,20 @@ interface PlanFieldExpectation {
   day?: string;
 }
 
+const PLAN_FIELD_KEYS = [
+  "current_city",
+  "transportation",
+  "breakfast",
+  "attraction",
+  "lunch",
+  "dinner",
+  "accommodation",
+] as const;
+
+const PLAN_FIELD_LABEL_TOKEN_SEQUENCES = PLAN_FIELD_KEYS
+  .map((key) => tokenizePlanText(key.replace(/_/g, " ")))
+  .sort((a, b) => b.length - a.length);
+
 function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectation[] {
   const planItems = Array.isArray(answer) ? answer : [answer];
   const fields: PlanFieldExpectation[] = [];
@@ -715,15 +729,7 @@ function extractPlanFieldValues(answer: ArenaExpectedAnswer): PlanFieldExpectati
     const day = typeof item.days === "string" || typeof item.days === "number"
       ? normalizePlanDayLabel(item.days)
       : undefined;
-    for (const key of [
-      "current_city",
-      "transportation",
-      "breakfast",
-      "attraction",
-      "lunch",
-      "dinner",
-      "accommodation",
-    ]) {
+    for (const key of PLAN_FIELD_KEYS) {
       const value = item[key];
       if (typeof value === "string" && value.trim().length > 0 && value.trim() !== "-") {
         fields.push({ value: value.trim(), fieldKey: key, day });
@@ -824,13 +830,13 @@ function findPlanFieldTokenWindow(
       continue;
     }
 
-    const context = predictedTokens.slice(
-      dayContext?.startIndex ?? Math.max(0, index - 32),
-      index,
-    );
+    const contextStart = dayContext?.startIndex ?? Math.max(0, index - 32);
     if (
       expectedField.fieldTokens.length > 0
-      && !containsTokenSequence(context, expectedField.fieldTokens)
+      && !tokensEqual(
+        findNearestPlanFieldLabel(predictedTokens, contextStart, index) ?? [],
+        expectedField.fieldTokens,
+      )
     ) {
       continue;
     }
@@ -860,6 +866,25 @@ function findLastDayContext(
         startIndex: index,
         dayTokens: [normalizePlanDayToken(tokens[index + 1]!)],
       };
+    }
+  }
+  return undefined;
+}
+
+function findNearestPlanFieldLabel(
+  tokens: string[],
+  startIndex: number,
+  beforeIndex: number,
+): string[] | undefined {
+  for (let endIndex = beforeIndex - 1; endIndex >= startIndex; endIndex -= 1) {
+    for (const labelTokens of PLAN_FIELD_LABEL_TOKEN_SEQUENCES) {
+      const labelStart = endIndex - labelTokens.length + 1;
+      if (labelStart < startIndex) {
+        continue;
+      }
+      if (labelTokens.every((token, offset) => tokens[labelStart + offset] === token)) {
+        return labelTokens;
+      }
     }
   }
   return undefined;
@@ -931,11 +956,11 @@ async function storeCompletedSubtask(
 }
 
 function scoreSubtaskSuccess(scores: Record<string, number>): number {
-  if (typeof scores.soft_process_score === "number") {
-    return scores.soft_process_score >= 1 ? 1 : 0;
-  }
   if (typeof scores.llm_judge === "number") {
     return scores.llm_judge >= 0.5 ? 1 : 0;
+  }
+  if (typeof scores.soft_process_score === "number") {
+    return scores.soft_process_score >= 1 ? 1 : 0;
   }
   if (scores.contains_answer === 1) {
     return 1;

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -332,6 +332,54 @@ test("runBenchmark accepts parenthesized amemgym option-number answers", async (
   assert.equal(task.details?.selectedChoiceIndex, 1);
 });
 
+test("runBenchmark accepts option numbers followed by parenthesized amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-parenthetical-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 (Seattle)"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 (Seattle)");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark accepts labeled option numbers followed by parenthesized amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-choice-parenthetical-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Option 1 (Seattle)"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "Option 1 (Seattle)");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -428,6 +428,54 @@ test("runBenchmark accepts labeled option numbers with closing-paren amemgym tex
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts option numbers followed by plain amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-plain-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 Seattle");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark accepts labeled option numbers followed by plain amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-choice-plain-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Option 1 Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "Option 1 Seattle");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -286,6 +286,29 @@ test("runBenchmark accepts amemgym answers labeled as answer is option", async (
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts colon-labeled amemgym option-number answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-colon-option-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: option 1"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts parenthesized amemgym option-number answers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-parenthesized-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");
@@ -399,6 +422,29 @@ test("runBenchmark rejects amemgym option-number rationales that mention a confl
   assert.equal(task.scores.qa_accuracy, 0);
   assert.equal(task.details?.selectedChoiceIndex, null);
   assert.equal(task.details?.scoredAnswer, "Answer: 1 because option 2 is Denver.");
+});
+
+test("runBenchmark rejects amemgym option-number rationales with bare conflicting choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-conflicting-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 because 2 might be right."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 because 2 might be right.");
 });
 
 test("runBenchmark accepts comma-led amemgym option-number rationales with non-option numbers", async () => {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -355,6 +355,52 @@ test("runBenchmark accepts amemgym option-number rationales with non-option numb
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts amemgym option-number rationales that restate the same option", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-same-option-rationale-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1 because option 1 is Seattle."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark rejects amemgym option-number rationales that mention a conflicting option", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-conflicting-option-rationale-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1 because option 2 is Denver."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "Answer: 1 because option 2 is Denver.");
+});
+
 test("runBenchmark accepts comma-led amemgym option-number rationales with non-option numbers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-comma-rationale-number-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -380,6 +380,54 @@ test("runBenchmark accepts labeled option numbers followed by parenthesized amem
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts option numbers with closing-paren amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-closing-paren-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1) Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1) Seattle");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark accepts labeled option numbers with closing-paren amemgym text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-choice-closing-paren-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Option 1) Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "Option 1) Seattle");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");
@@ -493,6 +541,29 @@ test("runBenchmark rejects amemgym option-number rationales with bare conflictin
   assert.equal(task.scores.qa_accuracy, 0);
   assert.equal(task.details?.selectedChoiceIndex, null);
   assert.equal(task.details?.scoredAnswer, "1 because 2 might be right.");
+});
+
+test("runBenchmark rejects amemgym option-number rationales with hedged conflicting choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hedged-conflicting-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1 because maybe 2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "Answer: 1 because maybe 2");
 });
 
 test("runBenchmark accepts comma-led amemgym option-number rationales with non-option numbers", async () => {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -625,6 +625,39 @@ test("runBenchmark matches numeric-prefixed amemgym text answer choices", async 
   assert.equal(task.details?.scoredAnswer, "2 bedrooms");
 });
 
+test("runBenchmark rejects conflicting numeric prefixes before amemgym text fallback", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-conflicting-numeric-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 3 bedrooms"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "3 bedrooms";
+  dataset[0]!.periods[0]!.updates.city = "3 bedrooms";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "3 bedrooms";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["2 bedrooms"], answer: "2 bedrooms" },
+    { state: ["3 bedrooms"], answer: "3 bedrooms" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "3 bedrooms");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 3 bedrooms");
+});
+
 test("runBenchmark uses token boundaries for amemgym text choice fallback", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-boundary-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -332,6 +332,29 @@ test("runBenchmark accepts amemgym option-number rationales with non-option numb
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts comma-led amemgym option-number rationales with non-option numbers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-comma-rationale-number-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1, because 2 weeks ago I moved to Seattle."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts labeled amemgym text answers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-text-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");
@@ -498,6 +521,39 @@ test("runBenchmark blocks text fallback for labeled numeric-prefixed amemgym con
   assert.equal(task.scores.qa_accuracy, 0);
   assert.equal(task.details?.selectedChoiceIndex, null);
   assert.equal(task.details?.scoredAnswer, "option 2 Seattle");
+});
+
+test("runBenchmark matches numeric-prefixed amemgym text answer choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-numeric-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("2 bedrooms"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "2 bedrooms";
+  dataset[0]!.periods[0]!.updates.city = "2 bedrooms";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "2 bedrooms";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["2 bedrooms"], answer: "2 bedrooms" },
+    { state: ["3 bedrooms"], answer: "3 bedrooms" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "2 bedrooms");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "2 bedrooms");
 });
 
 test("runBenchmark uses token boundaries for amemgym text choice fallback", async () => {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchResponder,
+  BenchResponse,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -12,6 +14,11 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  responder?: BenchResponder;
+
+  constructor(responder?: BenchResponder) {
+    this.responder = responder;
+  }
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -73,6 +80,19 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
   }
 
   async destroy(): Promise<void> {}
+}
+
+class FixedResponder implements BenchResponder {
+  constructor(private readonly text: string) {}
+
+  async respond(): Promise<BenchResponse> {
+    return {
+      text: this.text,
+      tokens: { input: 0, output: 0 },
+      latencyMs: 0,
+      model: "fixed",
+    };
+  }
 }
 
 function createDatasetProfile() {
@@ -161,6 +181,33 @@ test("runBenchmark executes amemgym in full mode from an explicit dataset file",
 
   assert.equal(result.results.tasks.length, 1);
   assert.equal(result.results.tasks[0]?.expected, "Seattle");
+});
+
+test("runBenchmark scores amemgym using the benchmark multiple-choice protocol", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(task.question, /Answer choices:/);
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.scores.contains_answer, 1);
+  assert.equal(task.details?.expectedChoiceIndex, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.selectedAnswer, "Seattle");
+  assert.equal(typeof result.results.aggregates.qa_accuracy?.mean, "number");
 });
 
 test("runBenchmark rejects amemgym full mode without datasetDir", async () => {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -95,6 +95,12 @@ class FixedResponder implements BenchResponder {
   }
 }
 
+class FailingRecallAdapter extends FakeMemoryAdapter {
+  async recall(): Promise<string> {
+    throw new Error("forced recall failure");
+  }
+}
+
 function createDatasetProfile() {
   return [
     {
@@ -202,12 +208,474 @@ test("runBenchmark scores amemgym using the benchmark multiple-choice protocol",
 
   const task = result.results.tasks[0]!;
   assert.match(task.question, /Answer choices:/);
+  assert.equal(task.actual, "1");
   assert.equal(task.scores.qa_accuracy, 1);
   assert.equal(task.scores.contains_answer, 1);
   assert.equal(task.details?.expectedChoiceIndex, 1);
   assert.equal(task.details?.selectedChoiceIndex, 1);
   assert.equal(task.details?.selectedAnswer, "Seattle");
+  assert.equal(task.details?.scoredAnswer, "Seattle");
   assert.equal(typeof result.results.aggregates.qa_accuracy?.mean, "number");
+});
+
+test("runBenchmark accepts labeled amemgym option-number answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: (1) because Seattle is current."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+});
+
+test("runBenchmark accepts amemgym answers labeled with is and a colon", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-is-colon-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer is: 1"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark accepts parenthesized amemgym option-number answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-parenthesized-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("(1)"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "(1)");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+});
+
+test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 because Seattle is current."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 because Seattle is current.");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+});
+
+test("runBenchmark accepts amemgym option-number rationales with non-option numbers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-rationale-number-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1 because 2 weeks ago I moved to Seattle."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark accepts labeled amemgym text answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
+test("runBenchmark does not parse leading prose numbers as amemgym choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-prose-number-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("2 weeks ago I moved to Seattle."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.selectedAnswer, "Seattle");
+});
+
+test("runBenchmark rejects ambiguous labeled amemgym option-number answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-ambiguous-labeled-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Answer: 1 or 2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "Answer: 1 or 2");
+});
+
+test("runBenchmark rejects ambiguous bare amemgym option-number answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-ambiguous-bare-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1, maybe 2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1, maybe 2");
+});
+
+test("runBenchmark rejects out-of-range amemgym option numbers before text fallback", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-out-of-range-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("3"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["Seattle"], answer: "3" },
+    { state: ["Dallas"], answer: "4" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "3");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "3");
+});
+
+test("runBenchmark blocks text fallback for numeric-prefixed amemgym contradictions", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-number-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("2 Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "2 Seattle");
+});
+
+test("runBenchmark blocks text fallback for labeled numeric-prefixed amemgym contradictions", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-labeled-number-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("option 2 Seattle"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "option 2 Seattle");
+});
+
+test("runBenchmark uses token boundaries for amemgym text choice fallback", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-choice-boundary-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Dallas"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "LA";
+  dataset[0]!.periods[0]!.updates.city = "LA";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "LA";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["LA"], answer: "LA" },
+    { state: ["SF"], answer: "SF" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "LA");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+});
+
+test("runBenchmark leaves ambiguous amemgym text choice fallbacks unselected", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-ambiguous-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Paris or Tokyo"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "Paris";
+  dataset[0]!.periods[0]!.updates.city = "Paris";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "Paris";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["Paris"], answer: "Paris" },
+    { state: ["Tokyo"], answer: "Tokyo" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "Paris");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+});
+
+test("runBenchmark leaves duplicate exact amemgym answer text unselected", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-duplicate-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Seattle"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["Denver"], answer: "Seattle" },
+    { state: ["Seattle"], answer: "Seattle" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "Seattle");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+});
+
+test("runBenchmark matches exact amemgym choices before substring fallbacks", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-overlap-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Seattle Washington"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "Seattle Washington";
+  dataset[0]!.periods[0]!.updates.city = "Seattle Washington";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "Seattle Washington";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["Seattle"], answer: "Seattle" },
+    { state: ["Seattle Washington"], answer: "Seattle Washington" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "Seattle Washington");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.expectedChoiceIndex, 2);
+  assert.equal(task.details?.selectedChoiceIndex, 2);
+});
+
+test("runBenchmark scores amemgym qa_accuracy against the first-choice fallback", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-fallback-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "Portland";
+  dataset[0]!.periods[0]!.updates.city = "Portland";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "Portland";
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "Seattle");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.expectedChoiceIndex, null);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+});
+
+test("runBenchmark includes qa_accuracy in amemgym failure rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-failure-score-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FailingRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(task.question, /Answer choices:/);
+  assert.equal(task.scores.qa_accuracy, -1);
+  assert.equal(result.results.aggregates.qa_accuracy?.mean, -1);
 });
 
 test("runBenchmark rejects amemgym full mode without datasetDir", async () => {

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -286,6 +286,29 @@ test("runBenchmark accepts amemgym answers labeled as answer is option", async (
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts amemgym answers labeled as correct answer is option", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-correct-answer-option-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("The correct answer is option 1"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts colon-labeled amemgym option-number answers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-colon-option-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -263,6 +263,29 @@ test("runBenchmark accepts amemgym answers labeled with is and a colon", async (
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts amemgym answers labeled as answer is option", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-answer-option-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("The answer is option 1"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts parenthesized amemgym option-number answers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-parenthesized-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -782,6 +782,39 @@ test("runBenchmark rejects out-of-range amemgym option numbers before text fallb
   assert.equal(task.details?.scoredAnswer, "3");
 });
 
+test("runBenchmark rejects out-of-range plain-text amemgym option numbers before text fallback", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-out-of-range-plain-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("3 3 bedrooms"));
+  const dataset = createDatasetProfile();
+  dataset[0]!.periods[0]!.state.city = "3 bedrooms";
+  dataset[0]!.periods[0]!.updates.city = "3 bedrooms";
+  dataset[0]!.periods[0]!.sessions[0]!.exposed_states.city = "3 bedrooms";
+  dataset[0]!.qas[0]!.answer_choices = [
+    { state: ["3 bedrooms"], answer: "3 bedrooms" },
+    { state: ["4 bedrooms"], answer: "4 bedrooms" },
+  ];
+
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(dataset),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "3 bedrooms");
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "3 3 bedrooms");
+});
+
 test("runBenchmark blocks text fallback for numeric-prefixed amemgym contradictions", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-number-text-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -5,6 +5,8 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchResponder,
+  BenchResponse,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -12,6 +14,11 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  responder?: BenchResponder;
+
+  constructor(responder?: BenchResponder) {
+    this.responder = responder;
+  }
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -75,6 +82,43 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
   async destroy(): Promise<void> {}
 }
 
+class FixedResponder implements BenchResponder {
+  constructor(private readonly text: string) {}
+
+  async respond(): Promise<BenchResponse> {
+    return {
+      text: this.text,
+      tokens: { input: 0, output: 0 },
+      latencyMs: 0,
+      model: "fixed",
+    };
+  }
+}
+
+class FailingFirstStoreAdapter extends FakeMemoryAdapter {
+  private shouldFailStore = true;
+
+  async store(sessionId: string, messages: Message[]): Promise<void> {
+    if (this.shouldFailStore) {
+      this.shouldFailStore = false;
+      throw new Error("forced seed store failure");
+    }
+    await super.store(sessionId, messages);
+  }
+}
+
+class FailingRecallAdapter extends FakeMemoryAdapter {
+  async recall(): Promise<string> {
+    throw new Error("forced recall failure");
+  }
+}
+
+class FailingSeedAndRecallAdapter extends FailingFirstStoreAdapter {
+  async recall(): Promise<string> {
+    throw new Error("forced recall failure");
+  }
+}
+
 test("runBenchmark executes memory-arena in quick mode through the phase-1 package API", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -131,7 +175,7 @@ test("runBenchmark preserves array-form memory-arena answers in full mode datase
     path.join(datasetDir, "group_travel_planner.jsonl"),
     `${JSON.stringify({
       id: 1,
-      category: "group_travel_planner",
+      category: " Group_Travel_Planner ",
       questions: ["Which museum stop should we keep in the itinerary?"],
       answers: [[{ name: "Art Institute" }, { day: "Saturday" }]],
     })}\n`,
@@ -203,6 +247,657 @@ test("runBenchmark seeds memory-arena group travel with the base traveler plan",
   assert.match(String(task.details?.promptQuestion), /complete finalized plan/);
   assert.equal(task.scores.plan_field_recall, 1);
   assert.equal(task.scores.soft_process_score, 1);
+  assert.equal(task.scores.process_score, 1);
+  assert.equal(task.scores.task_success_rate, 1);
+});
+
+test("runBenchmark treats null memory-arena base traveler plans as absent", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-null-base-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Which dinner should I share with Jennifer?"],
+      answers: ["Coco Bambu, Dallas"],
+      base_person: {
+        name: "Jennifer",
+        query: "I am Jennifer. Plan my trip.",
+        daily_plans: null,
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(task.actual, /initial finalized plan for Jennifer/);
+  assert.match(task.actual, /Base traveler request: I am Jennifer/);
+  assert.doesNotMatch(task.actual, /Environment result:/);
+});
+
+test("runBenchmark keeps memory-arena base traveler seed failures task-local", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-seed-failure-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FailingFirstStoreAdapter(new FixedResponder("Coco Bambu, Dallas"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Which dinner should I share with Jennifer?"],
+      answers: ["Coco Bambu, Dallas"],
+      base_person: {
+        name: "Jennifer",
+        query: "I am Jennifer. Plan my trip.",
+        daily_plans: [{ dinner: "Coco Bambu, Dallas" }],
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "Coco Bambu, Dallas");
+  assert.match(String(task.details?.initialSeedError), /forced seed store failure/);
+});
+
+test("runBenchmark ignores base traveler seeds outside group-travel tasks", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-non-group-base-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("trail mix"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+      base_person: {
+        name: "Jennifer",
+        query: "I am Jennifer. Plan my trip.",
+        daily_plans: [{ dinner: "Coco Bambu, Dallas" }],
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.actual, "trail mix");
+  assert.equal(
+    [...adapter.sessions.values()].some((messages) =>
+      messages.some((message) => /initial finalized plan/.test(message.content)),
+    ),
+    false,
+  );
+});
+
+test("runBenchmark applies group-travel protocol using the task category", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-category-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Transportation: Flight Number: F1\nDay 1 Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "custom_domain.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "group_travel_planner",
+      questions: ["I am Eric. Generate my complete shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "Flight Number: F1",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(String(task.details?.promptQuestion), /complete finalized plan/);
+  assert.doesNotMatch(String(task.details?.promptQuestion), /Return 1 day sections/);
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark keeps memory-arena partial plan recall separate from process completion", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-partial-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Transportation: Flight Number: F1"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my complete shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "Flight Number: F1",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0.5);
+  assert.equal(task.scores.soft_process_score, 0);
+  assert.equal(task.scores.process_score, 0);
+  assert.equal(task.scores.task_success_rate, 0);
+});
+
+test("runBenchmark does not double-count overlapping memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-overlap-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Transportation: Flight Number: F1, from Austin to Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my complete shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "from Austin to Dallas",
+          transportation: "Flight Number: F1, from Austin to Dallas",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0.5);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
+test("runBenchmark uses boundary-aware matching for memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-boundary-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Flight Number: F10"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my complete shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "Flight Number: F1",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
+test("runBenchmark includes group-travel metrics in memory-arena failure rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-failure-metrics-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FailingRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my complete shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "Flight Number: F1",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+  assert.equal(result.results.aggregates.plan_field_recall?.mean, 0);
+  assert.equal(result.results.aggregates.soft_process_score?.mean, 0);
+});
+
+test("runBenchmark omits group-travel plan metrics in failure rows without plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-failure-no-plan-metrics-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FailingRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Which dinner should I choose?"],
+      answers: ["Coco Bambu, Dallas"],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal("plan_field_recall" in task.scores, false);
+  assert.equal("soft_process_score" in task.scores, false);
+  assert.equal(result.results.aggregates.plan_field_recall, undefined);
+  assert.equal(result.results.aggregates.soft_process_score, undefined);
+});
+
+test("runBenchmark counts repeated memory-arena plan fields with multiplicity", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-repeated-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Accommodation: Central Stay, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my two-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "Central Stay, Dallas",
+        },
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "Central Stay, Dallas",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0.5);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
+test("runBenchmark counts adjacent repeated memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-adjacent-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder(
+      "Day 1 Accommodation: Central Stay, Dallas Day 2 Accommodation: Central Stay, Dallas",
+    ),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my two-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "Central Stay, Dallas",
+        },
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "Central Stay, Dallas",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark rejects swapped-day memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-swapped-days-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Dinner: Sushi Place. Day 2 Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my two-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Sushi Place",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
+test("runBenchmark normalizes string day labels for memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my one-day shared itinerary."],
+      answers: [[
+        {
+          days: "Day 1",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark scores object-form memory-arena group-travel plans by field", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-object-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 dinner is Coco Bambu, Dallas. Accommodation is Central Stay, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my one-day shared itinerary."],
+      answers: [
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "Central Stay, Dallas",
+        },
+      ],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark leaves string-answer memory-arena group-travel prompts unrewritten", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-plan-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Coco Bambu, Dallas"));
+  const question = "What dinner should Eric keep?";
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: [question],
+      answers: ["Coco Bambu, Dallas"],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.details?.promptQuestion, question);
+  assert.equal(task.scores.plan_field_recall, undefined);
+  assert.equal(task.scores.soft_process_score, undefined);
+  assert.equal(task.scores.contains_answer, 1);
+});
+
+test("runBenchmark skips empty memory-arena base-person seed data", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-empty-base-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("Coco Bambu, Dallas"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["What dinner should Eric keep?"],
+      answers: ["Coco Bambu, Dallas"],
+      base_person: {
+        name: "Jennifer",
+        query: "",
+        daily_plans: null,
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const storedText = [...adapter.sessions.values()]
+    .flat()
+    .map((message) => message.content)
+    .join("\n");
+  assert.equal(storedText.includes("MemoryArena initial state"), false);
+  assert.equal(storedText.includes("MemoryArena initial finalized plan"), false);
+});
+
+test("runBenchmark keeps memory-arena initial seed errors in failure rows", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-seed-failure-details-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FailingSeedAndRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["What dinner should Eric keep?"],
+      answers: ["Coco Bambu, Dallas"],
+      base_person: {
+        name: "Jennifer",
+        query: "Jennifer wants a one-day Dallas plan.",
+        daily_plans: {
+          days: 1,
+          dinner: "Coco Bambu, Dallas",
+        },
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.details?.error, "forced recall failure");
+  assert.equal(task.details?.initialSeedError, "forced seed store failure");
 });
 
 test("runBenchmark applies the memory-arena limit across the full benchmark, not once per domain file", async () => {
@@ -434,6 +1129,36 @@ test("runBenchmark rejects memory-arena answer objects with non-array attributes
         system: adapter,
       }),
     /must include an answers array of strings, objects, or arrays of those values/,
+  );
+});
+
+test("runBenchmark rejects invalid memory-arena base traveler plans while parsing", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-bad-base-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["What dinner should we keep?"],
+      answers: ["Coco Bambu, Dallas"],
+      base_person: {
+        name: "Jennifer",
+        daily_plans: 42,
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  await assert.rejects(
+    () =>
+      runBenchmark("memory-arena", {
+        mode: "full",
+        datasetDir,
+        system: adapter,
+      }),
+    /base_person must be an object with a valid daily_plans value/,
   );
 });
 

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -881,6 +881,45 @@ test("runBenchmark normalizes string day labels for memory-arena plan fields", a
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark matches weekday memory-arena plan day headers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-weekday-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Monday\nDinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my Monday shared itinerary."],
+      answers: [[
+        {
+          days: "Monday",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark parses compact day headers for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-compact-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -803,6 +803,45 @@ test("runBenchmark rejects same-day memory-arena plan fields under the wrong nea
   assert.equal(task.scores.soft_process_score, 0);
 });
 
+test("runBenchmark ignores prose day words when locating memory-arena day context", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-prose-day-context-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Dinner: after a mid-day activity, Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my one-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark normalizes string day labels for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -920,6 +920,45 @@ test("runBenchmark matches weekday memory-arena plan day headers", async () => {
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark rejects memory-arena fields under a nearer wrong weekday header", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-wrong-weekday-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Monday Dinner: Sushi Place. Tuesday Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my Monday shared itinerary."],
+      answers: [[
+        {
+          days: "Monday",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
 test("runBenchmark matches word-based memory-arena plan day headers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-word-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
@@ -935,6 +974,45 @@ test("runBenchmark matches word-based memory-arena plan day headers", async () =
       answers: [[
         {
           days: "Day One",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark matches multi-token memory-arena plan day headers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-multi-token-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("First Day Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my first-day shared itinerary."],
+      answers: [[
+        {
+          days: "First Day",
           current_city: "-",
           transportation: "-",
           breakfast: "-",

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -920,6 +920,45 @@ test("runBenchmark matches weekday memory-arena plan day headers", async () => {
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark matches word-based memory-arena plan day headers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-word-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day One Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my day-one shared itinerary."],
+      answers: [[
+        {
+          days: "Day One",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark parses compact day headers for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-compact-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -1037,6 +1037,45 @@ test("runBenchmark matches multi-token memory-arena plan day headers", async () 
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark rejects incidental memory-arena day words without explicit headers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-incidental-day-word-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("One traveler prefers seafood. Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my day-one shared itinerary."],
+      answers: [[
+        {
+          days: "Day One",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
 test("runBenchmark parses compact day headers for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-compact-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -150,6 +150,61 @@ test("runBenchmark preserves array-form memory-arena answers in full mode datase
   );
 });
 
+test("runBenchmark seeds memory-arena group travel with the base traveler plan", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-base-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. I want to join Jennifer for dinner."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "from Austin to Dallas",
+          transportation: "Flight Number: F1, from Austin to Dallas",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "Central Stay, Dallas",
+        },
+      ]],
+      base_person: {
+        name: "Jennifer",
+        query: "I am Jennifer. Plan my trip.",
+        daily_plans: [
+          {
+            days: 1,
+            current_city: "from Austin to Dallas",
+            transportation: "Flight Number: F1, from Austin to Dallas",
+            breakfast: "-",
+            attraction: "-",
+            lunch: "-",
+            dinner: "Coco Bambu, Dallas",
+            accommodation: "Central Stay, Dallas",
+          },
+        ],
+      },
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.match(task.actual, /initial finalized plan for Jennifer/);
+  assert.match(String(task.details?.promptQuestion), /complete finalized plan/);
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark applies the memory-arena limit across the full benchmark, not once per domain file", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-global-limit-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchJudge,
   BenchResponder,
   BenchResponse,
   Message,
@@ -15,9 +16,11 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
   responder?: BenchResponder;
+  judge?: BenchJudge;
 
-  constructor(responder?: BenchResponder) {
+  constructor(responder?: BenchResponder, judge?: BenchJudge) {
     this.responder = responder;
+    this.judge = judge;
   }
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
@@ -92,6 +95,14 @@ class FixedResponder implements BenchResponder {
       latencyMs: 0,
       model: "fixed",
     };
+  }
+}
+
+class FixedJudge implements BenchJudge {
+  constructor(private readonly scoreValue: number) {}
+
+  async score(): Promise<number> {
+    return this.scoreValue;
   }
 }
 
@@ -725,6 +736,45 @@ test("runBenchmark rejects swapped-day memory-arena plan fields", async () => {
   assert.equal(task.scores.soft_process_score, 0);
 });
 
+test("runBenchmark rejects same-day memory-arena plan fields under the wrong nearest label", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-swapped-fields-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Lunch: Sushi Place. Day 1 Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my one-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "Coco Bambu, Dallas",
+          dinner: "Sushi Place",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
 test("runBenchmark normalizes string day labels for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
@@ -811,6 +861,49 @@ test("runBenchmark parses compact day headers for memory-arena plan fields", asy
   const task = result.results.tasks[0]!;
   assert.equal(task.scores.plan_field_recall, 1);
   assert.equal(task.scores.soft_process_score, 1);
+});
+
+test("runBenchmark lets a positive memory-arena judge score pass despite soft plan diagnostics", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-judge-pass-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("The plan should include Coco Bambu, Dallas."),
+    new FixedJudge(1),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my one-day shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+  assert.equal(task.scores.llm_judge, 1);
+  assert.equal(task.scores.process_score, 1);
+  assert.equal(task.scores.task_success_rate, 1);
 });
 
 test("runBenchmark scores object-form memory-arena group-travel plans by field", async () => {

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -764,6 +764,55 @@ test("runBenchmark normalizes string day labels for memory-arena plan fields", a
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark parses compact day headers for memory-arena plan fields", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-compact-day-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day1 Dinner: Coco Bambu, Dallas\nDay02 Accommodation: Central Stay, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my two-day shared itinerary."],
+      answers: [[
+        {
+          days: "Day01",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "-",
+          accommodation: "Central Stay, Dallas",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark scores object-form memory-arena group-travel plans by field", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-object-plan-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -294,6 +294,34 @@ test("runBenchmark treats null memory-arena base traveler plans as absent", asyn
   assert.doesNotMatch(task.actual, /Environment result:/);
 });
 
+test("runBenchmark treats null memory-arena base_person as absent metadata", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-null-base-person-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("trail mix"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "bundled_shopping.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      category: "bundled_shopping",
+      questions: ["Which snack did we agree to buy?"],
+      answers: ["trail mix"],
+      base_person: null,
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "trail mix");
+  assert.equal(task.scores.contains_answer, 1);
+});
+
 test("runBenchmark keeps memory-arena base traveler seed failures task-local", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-seed-failure-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");


### PR DESCRIPTION
## Summary
- run AMemGym through its state-dependent multiple-choice answer protocol and record parsed `qa_accuracy`
- seed MemoryArena group-travel runs with the base traveler plan before subtasks
- prompt group-travel responders for complete finalized itineraries and add soft plan-field diagnostics

## Verification
- `pnpm exec tsx --test tests/bench-amemgym-runner.test.ts tests/bench-memory-arena-runner.test.ts`
- `pnpm --filter @remnic/bench check-types`
- `pnpm --filter @remnic/bench build`
- `npm run preflight:quick` started cleanly and the first full test pass reported 4795 pass / 0 fail / 7 skip, but I stopped it because the quick preflight script expands each targeted test into the full workspace test suite repeatedly in this checkout.

## Notes
The live Ollama full benchmark process imported the previous registry at startup, so these changes should apply to a subsequent rerun of AMemGym/MemoryArena rather than mutating the in-flight run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark prompting and scoring for AMemGym and MemoryArena, which will materially alter reported metrics and may affect comparability with prior runs. Risk is moderate due to new parsing/heuristic scoring logic and additional dataset schema handling.
> 
> **Overview**
> **AMemGym now runs as a strict multiple-choice benchmark.** Questions are rewritten to include numbered answer choices, model outputs are parsed back into a selected option (with robust handling for labeled/rationale/ambiguous outputs), and scoring uses the chosen option text.
> 
> Adds `qa_accuracy` (and richer task `details` like expected/selected choice indices and `scoredAnswer`) while keeping `f1`/`contains_answer`/LLM judge aligned to the parsed choice. Extensive new tests cover parsing edge cases and failure-row scoring.
> 
> **MemoryArena group travel planning now seeds and scores itinerary structure.** Datasets can include an optional `base_person` (validated on parse), group-travel tasks are pre-seeded with the base traveler plan, prompts are rewritten to request a full finalized itinerary, and new diagnostics (`plan_field_recall`, `soft_process_score`) are computed via boundary-aware field/day matching and incorporated into `process_score` fallback behavior; tests cover seeding, metrics, and error handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d7d865aff19fb9992d68c13848fb2ab9537450b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->