### PR TITLE
docs(readme): add context-substrate positioning section

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Architecture rule: standalone Remnic is first-class. `@remnic/core`, `@remnic/se
 | Default OpenClaw memory doesn't scale | Hybrid search, lifecycle management, namespaces, and governance |
 | Third-party memory services cost money and share your data | Everything stays local — your filesystem, your rules |
 
+## Memory or context substrate? Both.
+
+There's a useful split in the AI-memory space between **memory backends** (extract facts → vector DB → retrieve relevant ones) and **context substrates** (structured human-readable context that accumulates across sessions and compounds over time). Most tools land firmly in one camp. Remnic does both.
+
+**The files are the source of truth.** Every memory is a markdown file with YAML frontmatter on your filesystem. You can `cat`, `grep`, edit, version-control, back up, and reason about your memory with standard tools. The hybrid search index (QMD: BM25 + vector + reranking) is downstream of the files — fully rebuildable from disk, never the source of truth itself.
+
+**The recall stays sharp.** Three retrieval tiers (chunk → section → raw transcript), feature-flagged graph retrieval with Personalized PageRank, memory-worth scoring that filters low-value facts before they reach the LLM, temporal supersession that keeps stale facts out of recall, and Recall X-ray so you can see exactly which tier produced each result and why.
+
+**It compounds.** Background consolidation (the "dreams" surface) merges duplicates, promotes recurring themes, and snapshots page versions on every overwrite. Provenance fields (`derived_from`, `derived_via`) track where every consolidated memory came from. Procedural memory (on by default) captures multi-step runbooks. The longer you use it, the better it gets — and you can always read exactly what it knows.
+
+**Camp 1 asks "what should the AI remember?" Remnic answers that.** **Camp 2 asks "what context should the AI work inside?" Remnic answers that too.**
+
 ## Quick install (OpenClaw)
 
 If you have OpenClaw installed, the fastest path to working Remnic memory is:


### PR DESCRIPTION
## Summary

Adds a new \"Memory or context substrate? Both.\" section between **The Solution** and **Quick install (OpenClaw)** in the README.

The recent ["Two Camps of AI Memory"](https://x.com/) analysis splits the space into memory backends (extract → store → retrieve) and context substrates (files-as-truth, accumulating context). Remnic genuinely sits across both, and the README didn't say so. This PR makes that explicit:

- **Files are the source of truth** — markdown + YAML; QMD index is downstream and fully rebuildable.
- **The recall stays sharp** — three retrieval tiers, graph-tier with Personalized PageRank, memory-worth scoring, Recall X-ray.
- **It compounds** — background consolidation, provenance, procedural memory.

This pairs with 8 newly opened feature requests (#676–#683) that strengthen the substrate side further.

## Test plan

- [x] Markdown lints clean (no broken anchors).
- [x] Section sits cleanly between existing structure (\"The Solution\" → new section → \"Quick install\").
- [ ] Spot-check render on GitHub.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change that adds positioning/feature explanation text without affecting runtime behavior.
> 
> **Overview**
> Adds a new README section, `Memory or context substrate? Both.`, to explicitly position Remnic as both a *memory backend* and a *context substrate*.
> 
> The new copy emphasizes files-as-source-of-truth with a rebuildable hybrid index, describes recall quality mechanisms (multi-tier retrieval, optional graph retrieval, scoring/supersession, Recall X-ray), and highlights compounding via consolidation/provenance/procedural memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4865d0f0e8465fa4a603af1556f2cc1a5525c3e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->