### PR TITLE
feat(core): plumb recall disclosure depth (chunk/section/raw) — #677 PR 1/4

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -344,6 +344,12 @@ export class EngramAccessHttpServer {
         topK: body.topK,
         mode: body.mode as RecallPlanMode | "auto" | undefined,
         includeDebug: body.includeDebug === true,
+        // Forward the validated disclosure depth to the service layer
+        // (issue #677).  The zod schema accepts/rejects values; the
+        // service applies the chunk default when undefined.  Without
+        // this forwarding, callers passing `disclosure: "raw"` would
+        // silently get `chunk` back.
+        disclosure: body.disclosure,
         codingContext,
       });
       this.respondJson(res, 200, response);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -3,7 +3,7 @@ import { readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { EngramAccessInputError, type EngramAccessService, type EngramAccessRecallResponse } from "./access-service.js";
 import { readEnvVar } from "./runtime/env.js";
-import type { RecallPlanMode } from "./types.js";
+import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
 import { buildCitationGuidance, type CitationMetadata } from "./citations.js";
 
@@ -108,6 +108,11 @@ export class EngramMcpServer {
             topK: { type: "number" },
             mode: { type: "string", enum: ["auto", "no_recall", "minimal", "full", "graph_mode"] },
             includeDebug: { type: "boolean" },
+            // Recall disclosure depth (issue #677).  Default `chunk` when
+            // omitted.  Section/raw payload shaping ships in PR 2; this PR
+            // wires the field end-to-end so clients can already pass it
+            // without it being silently dropped.
+            disclosure: { type: "string", enum: ["chunk", "section", "raw"] },
           },
           required: ["query"],
           additionalProperties: false,
@@ -1172,6 +1177,15 @@ export class EngramMcpServer {
   private async callTool(name: string, args: Record<string, unknown>, effectivePrincipal?: string, mcpSessionId?: string): Promise<unknown> {
     switch (toLegacyToolName(name)) {
       case "engram.recall": {
+        // Forward `disclosure` only when the caller actually supplied it,
+        // so the service layer's default-application path stays the
+        // single source of truth.  Pass it through as a raw string when
+        // present; the service rejects unknown values via the shared
+        // `isRecallDisclosure` guard (CLAUDE.md rule 51).
+        const disclosure =
+          typeof args.disclosure === "string"
+            ? (args.disclosure as RecallDisclosure)
+            : undefined;
         const response = await this.service.recall({
           query: typeof args.query === "string" ? args.query : "",
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
@@ -1179,6 +1193,7 @@ export class EngramMcpServer {
           topK: typeof args.topK === "number" && Number.isFinite(args.topK) ? args.topK : undefined,
           mode: typeof args.mode === "string" ? args.mode as RecallPlanMode | "auto" : undefined,
           includeDebug: args.includeDebug === true,
+          disclosure,
         });
 
         if (this.shouldEmitCitations(mcpSessionId)) {

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1179,13 +1179,24 @@ export class EngramMcpServer {
       case "engram.recall": {
         // Forward `disclosure` only when the caller actually supplied it,
         // so the service layer's default-application path stays the
-        // single source of truth.  Pass it through as a raw string when
-        // present; the service rejects unknown values via the shared
-        // `isRecallDisclosure` guard (CLAUDE.md rule 51).
-        const disclosure =
-          typeof args.disclosure === "string"
-            ? (args.disclosure as RecallDisclosure)
-            : undefined;
+        // single source of truth.  We must distinguish "absent" from
+        // "present-but-wrong-type": absence forwards as `undefined`
+        // (service applies the chunk default), while a present-but-
+        // non-string value (e.g. `1`, `true`) is rejected here as a
+        // structured input error instead of silently being coerced to
+        // `undefined`.  CLAUDE.md rule 51: never silently default on
+        // malformed input.  String values are forwarded as-is; the
+        // service's `isRecallDisclosure` guard rejects unknown enum
+        // strings (e.g. `"verbose"`) with the same error class.
+        let disclosure: RecallDisclosure | undefined;
+        if ("disclosure" in args && args.disclosure !== undefined && args.disclosure !== null) {
+          if (typeof args.disclosure !== "string") {
+            throw new EngramAccessInputError(
+              "disclosure must be a string (one of: chunk, section, raw)",
+            );
+          }
+          disclosure = args.disclosure as RecallDisclosure;
+        }
         const response = await this.service.recall({
           query: typeof args.query === "string" ? args.query : "",
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -54,6 +54,15 @@ export const codingContextSchema = z
   })
   .nullable();
 
+/**
+ * Recall disclosure depth (issue #677).  Mirrors the `RecallDisclosure`
+ * type in `types.ts` — keep these in sync.  Default-application happens
+ * inside `EngramAccessService.recall()`; the schema only accepts/rejects.
+ * Invalid values throw a structured 400 instead of silently defaulting,
+ * per CLAUDE.md rule 51.
+ */
+export const recallDisclosureSchema = z.enum(["chunk", "section", "raw"]);
+
 export const recallRequestSchema = z.object({
   query: z.string().min(1, "query is required"),
   sessionKey: sessionKeySchema,
@@ -61,6 +70,7 @@ export const recallRequestSchema = z.object({
   topK: z.number().int().min(0).max(200).optional(),
   mode: z.enum(["auto", "no_recall", "minimal", "full", "graph_mode"]).optional(),
   includeDebug: z.boolean().optional(),
+  disclosure: recallDisclosureSchema.optional(),
   codingContext: codingContextSchema.optional(),
 });
 

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -78,8 +78,10 @@ import type {
   MemoryLifecycleEvent,
   MemoryStatus,
   PluginConfig,
+  RecallDisclosure,
   RecallPlanMode,
 } from "./types.js";
+import { DEFAULT_RECALL_DISCLOSURE, isRecallDisclosure } from "./types.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import type { SemanticDedupLookup } from "./dedup/semantic.js";
@@ -133,6 +135,14 @@ export interface EngramAccessRecallRequest {
   mode?: RecallPlanMode | "auto";
   includeDebug?: boolean;
   /**
+   * Recall disclosure depth (issue #677).  Selects how much content each
+   * result returns: `"chunk"` (default), `"section"`, or `"raw"`.  Omitting
+   * this field is equivalent to passing `"chunk"` and preserves pre-#677
+   * behavior.  Surfaces (CLI / HTTP / MCP) and per-level token telemetry
+   * are wired in subsequent PRs of #677.
+   */
+  disclosure?: RecallDisclosure;
+  /**
    * Coding-agent context (issue #569). When a connector resolves a git
    * context for the session's cwd, it passes it here and the access service
    * attaches it to the orchestrator before recall so project- / branch-
@@ -176,6 +186,14 @@ export interface EngramAccessRecallResponse {
   plannerMode?: RecallPlanMode;
   fallbackUsed: boolean;
   sourcesUsed: string[];
+  /**
+   * Disclosure depth applied to this recall (issue #677).  Reflects the
+   * caller-requested level after defaulting; useful for surfaces that want
+   * to render a "served at depth X" hint without re-deriving it.  PR 1 of
+   * #677 wires this end-to-end for plumbing only — section/raw payload
+   * shaping ships in later PRs.
+   */
+  disclosure: RecallDisclosure;
   budgetsApplied?: LastRecallSnapshot["budgetsApplied"];
   auditAnomalies?: AnomalyDetectorResult;
   budgetWarning?: BudgetDecision;
@@ -247,6 +265,14 @@ export interface EngramAccessMemorySummary {
   tags: string[];
   entityRef?: string;
   preview: string;
+  /**
+   * Disclosure depth at which this result was served (issue #677).  Set by
+   * recall paths; omitted on non-recall surfaces (e.g. memory browse) where
+   * the concept does not apply.  PR 1 of #677 always reports the
+   * request-level disclosure on recall results; per-result divergence is
+   * reserved for the auto-escalation policy that ships in PR 4/4.
+   */
+  disclosure?: RecallDisclosure;
 }
 
 export interface EngramAccessMemoryBrowseRequest {
@@ -792,7 +818,10 @@ export class EngramAccessService {
       : undefined;
   }
 
-  private async serializeRecallResults(snapshot: LastRecallSnapshot | null): Promise<EngramAccessMemorySummary[]> {
+  private async serializeRecallResults(
+    snapshot: LastRecallSnapshot | null,
+    disclosure: RecallDisclosure,
+  ): Promise<EngramAccessMemorySummary[]> {
     if (!snapshot) return [];
     const namespace = snapshot.namespace ? this.resolveNamespace(snapshot.namespace) : this.orchestrator.config.defaultNamespace;
     const storage = await this.orchestrator.getStorage(namespace);
@@ -805,7 +834,7 @@ export class EngramAccessService {
       const memory = await storage.readMemoryByPath(memoryPath);
       if (!memory) continue;
       seen.add(memoryPath);
-      results.push(this.serializeMemorySummary(memory, storageDir));
+      results.push(this.serializeMemorySummary(memory, storageDir, disclosure));
     }
 
     if (results.length > 0) return results;
@@ -814,7 +843,7 @@ export class EngramAccessService {
       const memory = await storage.getMemoryById(memoryId);
       if (!memory || seen.has(memory.path)) continue;
       seen.add(memory.path);
-      results.push(this.serializeMemorySummary(memory, storageDir));
+      results.push(this.serializeMemorySummary(memory, storageDir, disclosure));
     }
     return results;
   }
@@ -1084,6 +1113,20 @@ export class EngramAccessService {
     if (query.length === 0) {
       throw new EngramAccessInputError("query is required");
     }
+    // Disclosure depth (issue #677).  Default to `"chunk"` when omitted so
+    // pre-#677 callers see unchanged behavior.  Reject explicitly invalid
+    // string values per CLAUDE.md rule 51 (do not silently fall back).
+    const disclosure: RecallDisclosure = (() => {
+      if (request.disclosure === undefined || request.disclosure === null) {
+        return DEFAULT_RECALL_DISCLOSURE;
+      }
+      if (!isRecallDisclosure(request.disclosure)) {
+        throw new EngramAccessInputError(
+          `disclosure must be one of: chunk, section, raw (got: ${String(request.disclosure)})`,
+        );
+      }
+      return request.disclosure;
+    })();
     // Attach any coding context shipped with the recall request BEFORE
     // namespace resolution so the overlay applies to this recall (issue #569).
     if (request.codingContext !== undefined && request.sessionKey) {
@@ -1189,7 +1232,7 @@ export class EngramAccessService {
     const effectiveNamespace = snapshot?.namespace
       ? this.resolveNamespace(snapshot.namespace)
       : namespace;
-    const results = await this.serializeRecallResults(snapshot);
+    const results = await this.serializeRecallResults(snapshot, disclosure);
     const debug = await this.buildRecallDebug(
       snapshot,
       effectiveNamespace,
@@ -1243,6 +1286,7 @@ export class EngramAccessService {
       plannerMode: snapshot?.plannerMode ?? mode,
       fallbackUsed: snapshot?.fallbackUsed ?? false,
       sourcesUsed: snapshot?.sourcesUsed ?? [],
+      disclosure,
       budgetsApplied: snapshot?.budgetsApplied,
       auditAnomalies,
       budgetWarning: budgetDecision.reason === "warn-over-soft" ? budgetDecision : undefined,
@@ -2292,7 +2336,11 @@ export class EngramAccessService {
     };
   }
 
-  private serializeMemorySummary(memory: MemoryFile, baseDir: string): EngramAccessMemorySummary {
+  private serializeMemorySummary(
+    memory: MemoryFile,
+    baseDir: string,
+    disclosure?: RecallDisclosure,
+  ): EngramAccessMemorySummary {
     return {
       id: memory.frontmatter.id,
       path: memory.path,
@@ -2303,6 +2351,11 @@ export class EngramAccessService {
       tags: normalizeProjectionTags(memory.frontmatter.tags),
       entityRef: memory.frontmatter.entityRef,
       preview: normalizeProjectionPreview(memory.content),
+      // PR 1/4 of issue #677: recall paths pass an explicit disclosure;
+      // non-recall paths (browse / fallback) leave it undefined.  Section/
+      // raw payload shaping ships in PR 2; per-result divergence ships in
+      // PR 4 (auto-escalation).
+      ...(disclosure !== undefined ? { disclosure } : {}),
     };
   }
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -883,4 +883,12 @@ export type {
   BriefingResult,
   CalendarEvent,
   CalendarSource,
+  RecallDisclosure,
+} from "./types.js";
+
+// Recall disclosure depth (issue #677).
+export {
+  DEFAULT_RECALL_DISCLOSURE,
+  RECALL_DISCLOSURE_LEVELS,
+  isRecallDisclosure,
 } from "./types.js";

--- a/packages/remnic-core/src/recall-disclosure.test.ts
+++ b/packages/remnic-core/src/recall-disclosure.test.ts
@@ -7,11 +7,13 @@
  *  - The `isRecallDisclosure()` type guard.
  *  - The zod `recallRequestSchema` accept/reject behavior for the new
  *    `disclosure` field.
+ *  - The MCP `engram.recall` handler forwards `disclosure` to the service
+ *    layer instead of silently dropping it (regression for the
+ *    cursor[bot] / codex review feedback on PR #694).
  *
- * Surface-level tests (CLI / HTTP / MCP) live with their respective surface
- * suites and ship in PR 2/4.  Auto-escalation tests ship in PR 4/4.
- *
- * All fixtures are synthetic — no real user data.
+ * Full surface integration tests (HTTP path, CLI flag) ship with their
+ * respective surface work in PR 2/4.  Auto-escalation tests ship in
+ * PR 4/4.  All fixtures are synthetic — no real user data.
  */
 
 import assert from "node:assert/strict";
@@ -23,6 +25,8 @@ import {
   isRecallDisclosure,
 } from "./types.js";
 import { recallRequestSchema, validateRequest } from "./access-schema.js";
+import { EngramMcpServer } from "./access-mcp.js";
+import type { EngramAccessRecallRequest, EngramAccessService } from "./access-service.js";
 
 test("RECALL_DISCLOSURE_LEVELS is ordered chunk -> section -> raw", () => {
   // Order matters for future escalation policy comparisons (PR 4/4).  The
@@ -84,4 +88,84 @@ test("validateRequest('recall') surfaces disclosure validation errors with struc
     const fields = outcome.error.details.map((d) => d.field);
     assert.ok(fields.includes("disclosure"), `expected disclosure field error, got ${JSON.stringify(fields)}`);
   }
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// MCP handler must forward `disclosure` to the service layer.
+//
+// Regression coverage for the review feedback on PR #694: schema-level
+// validation alone is not enough — the handler must actually pass the
+// validated field through, otherwise callers see a silent default.
+// ──────────────────────────────────────────────────────────────────────────
+
+function makeMcpRecallSpyService(): {
+  service: EngramAccessService;
+  calls: EngramAccessRecallRequest[];
+} {
+  const calls: EngramAccessRecallRequest[] = [];
+  const service = {
+    briefingEnabled: false,
+    recall: (req: EngramAccessRecallRequest) => {
+      calls.push(req);
+      return Promise.resolve({
+        query: req.query,
+        sessionKey: req.sessionKey,
+        namespace: "default",
+        context: "",
+        count: 0,
+        memoryIds: [],
+        results: [],
+        fallbackUsed: false,
+        sourcesUsed: [],
+        disclosure: req.disclosure ?? DEFAULT_RECALL_DISCLOSURE,
+      });
+    },
+  } as unknown as EngramAccessService;
+  return { service, calls };
+}
+
+test("MCP engram.recall handler forwards explicit `disclosure` to the service", async () => {
+  const { service, calls } = makeMcpRecallSpyService();
+  const server = new EngramMcpServer(service);
+  await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "engram.recall",
+      arguments: { query: "hello", disclosure: "raw" },
+    },
+  });
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0]?.disclosure, "raw");
+});
+
+test("MCP engram.recall handler omits `disclosure` when caller does not supply it", async () => {
+  // The service layer owns default-application; the handler should pass
+  // `undefined` (not `"chunk"`) when the caller did not provide a value
+  // so the single source of truth stays in `EngramAccessService.recall()`.
+  const { service, calls } = makeMcpRecallSpyService();
+  const server = new EngramMcpServer(service);
+  await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "engram.recall", arguments: { query: "hello" } },
+  });
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0]?.disclosure, undefined);
+});
+
+test("MCP engram.recall inputSchema advertises the `disclosure` enum", () => {
+  // MCP clients with strict validation reject unknown fields; the
+  // tool-list schema must declare `disclosure` so legitimate clients
+  // can use it.
+  const { service } = makeMcpRecallSpyService();
+  const server = new EngramMcpServer(service);
+  const tools = (server as unknown as { tools: Array<{ name: string; inputSchema: { properties?: Record<string, unknown> } }> }).tools;
+  const recallTool = tools.find((t) => t.name === "engram.recall");
+  assert.ok(recallTool, "engram.recall tool should be registered");
+  const props = recallTool?.inputSchema?.properties as Record<string, { type?: string; enum?: string[] }> | undefined;
+  assert.ok(props && "disclosure" in props, "engram.recall inputSchema must declare 'disclosure'");
+  assert.deepStrictEqual(props?.disclosure?.enum, ["chunk", "section", "raw"]);
 });

--- a/packages/remnic-core/src/recall-disclosure.test.ts
+++ b/packages/remnic-core/src/recall-disclosure.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Tests for the recall disclosure-depth plumbing introduced in PR 1/4 of
+ * issue #677.  Covers:
+ *
+ *  - Type-level constants (`DEFAULT_RECALL_DISCLOSURE`,
+ *    `RECALL_DISCLOSURE_LEVELS`).
+ *  - The `isRecallDisclosure()` type guard.
+ *  - The zod `recallRequestSchema` accept/reject behavior for the new
+ *    `disclosure` field.
+ *
+ * Surface-level tests (CLI / HTTP / MCP) live with their respective surface
+ * suites and ship in PR 2/4.  Auto-escalation tests ship in PR 4/4.
+ *
+ * All fixtures are synthetic — no real user data.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_RECALL_DISCLOSURE,
+  RECALL_DISCLOSURE_LEVELS,
+  isRecallDisclosure,
+} from "./types.js";
+import { recallRequestSchema, validateRequest } from "./access-schema.js";
+
+test("RECALL_DISCLOSURE_LEVELS is ordered chunk -> section -> raw", () => {
+  // Order matters for future escalation policy comparisons (PR 4/4).  The
+  // ladder must be stable; freezing here so a refactor that flips order is
+  // caught immediately.
+  assert.deepStrictEqual(
+    [...RECALL_DISCLOSURE_LEVELS],
+    ["chunk", "section", "raw"],
+  );
+});
+
+test("DEFAULT_RECALL_DISCLOSURE is 'chunk' (preserves pre-#677 behavior)", () => {
+  assert.strictEqual(DEFAULT_RECALL_DISCLOSURE, "chunk");
+});
+
+test("isRecallDisclosure() accepts the three valid levels", () => {
+  for (const level of RECALL_DISCLOSURE_LEVELS) {
+    assert.strictEqual(isRecallDisclosure(level), true, `level=${level}`);
+  }
+});
+
+test("isRecallDisclosure() rejects unknown strings, casing variants, and non-strings", () => {
+  for (const bad of ["", "Chunk", "CHUNK", "section ", "full", "raw_excerpt", "tier"]) {
+    assert.strictEqual(isRecallDisclosure(bad), false, `bad=${JSON.stringify(bad)}`);
+  }
+  for (const bad of [null, undefined, 0, 1, true, false, {}, []]) {
+    assert.strictEqual(isRecallDisclosure(bad as unknown), false);
+  }
+});
+
+test("recallRequestSchema: omitting disclosure is valid (default applied at service layer)", () => {
+  const result = recallRequestSchema.safeParse({ query: "hello" });
+  assert.strictEqual(result.success, true);
+  if (result.success) {
+    assert.strictEqual(result.data.disclosure, undefined);
+  }
+});
+
+test("recallRequestSchema: each documented disclosure level is accepted", () => {
+  for (const level of RECALL_DISCLOSURE_LEVELS) {
+    const result = recallRequestSchema.safeParse({ query: "hello", disclosure: level });
+    assert.strictEqual(result.success, true, `level=${level}`);
+    if (result.success) {
+      assert.strictEqual(result.data.disclosure, level);
+    }
+  }
+});
+
+test("recallRequestSchema: invalid disclosure is rejected with field-level error", () => {
+  const result = recallRequestSchema.safeParse({ query: "hello", disclosure: "full" });
+  assert.strictEqual(result.success, false);
+});
+
+test("validateRequest('recall') surfaces disclosure validation errors with structured detail", () => {
+  const outcome = validateRequest("recall", { query: "hello", disclosure: "verbose" });
+  assert.strictEqual(outcome.success, false);
+  if (!outcome.success) {
+    assert.strictEqual(outcome.error.code, "validation_error");
+    const fields = outcome.error.details.map((d) => d.field);
+    assert.ok(fields.includes("disclosure"), `expected disclosure field error, got ${JSON.stringify(fields)}`);
+  }
+});

--- a/packages/remnic-core/src/recall-disclosure.test.ts
+++ b/packages/remnic-core/src/recall-disclosure.test.ts
@@ -156,6 +156,49 @@ test("MCP engram.recall handler omits `disclosure` when caller does not supply i
   assert.strictEqual(calls[0]?.disclosure, undefined);
 });
 
+test("MCP engram.recall rejects non-string disclosure with a structured error", async () => {
+  // Codex review on PR #694: a number (e.g. `1`) used to be coerced to
+  // `undefined`, masking malformed input and silently applying the
+  // chunk default.  The handler now distinguishes "absent" from
+  // "present-but-wrong-type" and throws a structured error for the
+  // latter.  The MCP transport surfaces tool errors as `isError: true`.
+  const { service, calls } = makeMcpRecallSpyService();
+  const server = new EngramMcpServer(service);
+  const response = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "engram.recall",
+      arguments: { query: "hello", disclosure: 1 as unknown as string },
+    },
+  });
+  assert.strictEqual(calls.length, 0, "service.recall must not be called for invalid input");
+  const result = (response as { result?: { isError?: boolean; content?: Array<{ text?: string }> } } | undefined)?.result;
+  assert.strictEqual(result?.isError, true);
+  const text = result?.content?.[0]?.text ?? "";
+  assert.match(text, /disclosure must be a string/i);
+});
+
+test("MCP engram.recall treats explicit `null` disclosure as absent (service applies default)", async () => {
+  // JSON-RPC clients sometimes serialize an unset field as `null`.
+  // Treat `null` like absence so the service-layer default path runs
+  // — matches `EngramAccessService.recall()`'s own null-tolerance.
+  const { service, calls } = makeMcpRecallSpyService();
+  const server = new EngramMcpServer(service);
+  await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "engram.recall",
+      arguments: { query: "hello", disclosure: null as unknown as string },
+    },
+  });
+  assert.strictEqual(calls.length, 1);
+  assert.strictEqual(calls[0]?.disclosure, undefined);
+});
+
 test("MCP engram.recall inputSchema advertises the `disclosure` enum", () => {
   // MCP clients with strict validation reject unknown fields; the
   // tool-list schema must declare `disclosure` so legitimate clients

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -67,6 +67,52 @@ export interface RecallTierExplain {
   sourceAnchors?: Array<{ path: string; lineRange?: [number, number] }>;
 }
 
+/**
+ * Recall disclosure depth (issue #677).  Selects how much content each
+ * recall result returns:
+ *
+ * - `"chunk"`   — semantic chunk excerpt (cheapest; default).
+ * - `"section"` — full markdown section / memory body (current pre-#677 behavior).
+ * - `"raw"`     — raw transcript / archive excerpts from `lcm/` when present.
+ *
+ * Disclosure is **orthogonal** to the retrieval-tier ladder
+ * (`RetrievalTier` / `RETRIEVAL_TIERS`).  The tier ladder controls *which
+ * pipeline stage served a result*; disclosure controls *how deep into the
+ * underlying memory the result reaches*.  A request can mix any retrieval
+ * tier with any disclosure depth.
+ *
+ * Default is `"chunk"` when the caller omits the field; this preserves the
+ * existing recall behavior because callers that did not request a disclosure
+ * level continue to receive the same chunk-shaped previews they always had.
+ * Surfaces (CLI / HTTP / MCP) and downstream telemetry are wired in later
+ * PRs of #677.
+ */
+export type RecallDisclosure = "chunk" | "section" | "raw";
+
+/**
+ * Ordered list of disclosure levels, cheapest to most expensive.  Used for
+ * validation, escalation policy comparisons, and future telemetry rollups.
+ * Treat this as the single source of truth — do not hard-code disclosure
+ * strings elsewhere.
+ */
+export const RECALL_DISCLOSURE_LEVELS: readonly RecallDisclosure[] = [
+  "chunk",
+  "section",
+  "raw",
+] as const;
+
+/**
+ * Default disclosure level when a caller omits `disclosure`.  Set to `chunk`
+ * so callers that did not opt in to deeper disclosure see the same
+ * preview-shaped behavior as before #677.
+ */
+export const DEFAULT_RECALL_DISCLOSURE: RecallDisclosure = "chunk";
+
+export function isRecallDisclosure(value: unknown): value is RecallDisclosure {
+  return typeof value === "string"
+    && (RECALL_DISCLOSURE_LEVELS as readonly string[]).includes(value);
+}
+
 export interface RecallSectionConfig {
   id: string;
   enabled?: boolean;


### PR DESCRIPTION
Implements PR 1/4 of #677 — three-tier progressive disclosure on recall.

## Summary

Adds a `disclosure` field to the recall request/response surface so callers can ask for chunk-, section-, or raw-level depth on recall without colliding with the existing retrieval-tier ladder.

### Naming (settled here per the issue body)

- `RETRIEVAL_TIERS` in `retrieval-tiers.ts` already names the **pipeline-stage ladder** (`exact-cache`, `fuzzy-cache`, `direct-answer`, `hybrid`, `rerank-graph`, `agentic`).
- `MemoryTier = "hot" | "cold"` in `tier-routing.ts` already names the **storage tier**.
- This concept — chunk → section → raw — is therefore named **disclosure**, orthogonal to either tier dimension.

## Scope (plumbing only)

- `RecallDisclosure = "chunk" | "section" | "raw"` plus `RECALL_DISCLOSURE_LEVELS`, `DEFAULT_RECALL_DISCLOSURE = "chunk"`, and `isRecallDisclosure()` guard in `types.ts`.
- `EngramAccessRecallRequest.disclosure?` (optional input).
- `EngramAccessRecallResponse.disclosure` (always reflects the request-level value after defaulting).
- `EngramAccessMemorySummary.disclosure?` (set on recall paths only; left undefined on browse-style paths).
- Zod `recallDisclosureSchema` and accept-only-known-values validation in `access-schema.ts` (CLAUDE.md rule 51 — invalid values throw 400, no silent fallback).
- Default-application + invalid-value rejection in `EngramAccessService.recall()`.
- Re-exports from `@remnic/core` index.

## Behavior preservation

Callers that omit `disclosure` get exactly the previous behavior — `chunk` is just an explicit name for "what we already returned." Section/raw payload shaping ships in PR 2 (CLI + HTTP + MCP exposure); per-disclosure token telemetry ships in PR 3 via Recall X-ray (#570); auto-escalation policy ships in PR 4 (manual default).

## Test plan

- [x] `npm run build` clean.
- [x] `npx tsc -p packages/remnic-core/tsconfig.json --noEmit` clean.
- [x] New `packages/remnic-core/src/recall-disclosure.test.ts` (8 tests) — ladder ordering, default value, type guard accept/reject, schema accept/reject, structured-error path. All pass.
- [x] `npm run preflight:quick` — 46 pre-existing failures on origin/main are unrelated to this change (LCM sqlite native build, projection-store, observe-engine timing tests). No new failures introduced.

## References

- Parent issue: #677
- Adjacent surfaces: #570 (Recall X-ray, target for PR 3 telemetry), #518 (retrieval-tier ladder we are explicitly NOT renaming).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `disclosure` field to recall requests/responses and enforces validation/defaulting, which changes the typed public API and could impact downstream consumers expecting the previous response shape or looser input handling.
> 
> **Overview**
> Adds end-to-end plumbing for a new recall *disclosure depth* option (`chunk`/`section`/`raw`) across schemas, HTTP (`POST /engram/v1/recall`), and MCP (`engram.recall`), including advertising the enum in the MCP tool schema.
> 
> `EngramAccessService.recall()` now defaults missing/`null` `disclosure` to `chunk` and rejects invalid values, and recall responses/results include the applied disclosure (`EngramAccessRecallResponse.disclosure`, optional `EngramAccessMemorySummary.disclosure`). New constants/type guard (`DEFAULT_RECALL_DISCLOSURE`, `RECALL_DISCLOSURE_LEVELS`, `isRecallDisclosure`) are added/re-exported, with tests covering validation and MCP forwarding/regression behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b1c2dacce02d31dc16222f376e271d34426301c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->