### PR TITLE
fix(server): wire adminConsolePublicDir through config and improve default resolution

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -46,9 +46,14 @@ export interface EngramAccessHttpServerStatus {
 }
 
 function resolveDefaultAdminConsolePublicDir(): string {
+  const thisDir = path.dirname(fileURLToPath(import.meta.url));
   const candidates = [
-    fileURLToPath(new URL("../admin-console/public", import.meta.url)),
-    fileURLToPath(new URL("./admin-console/public", import.meta.url)),
+    // Standard: admin-console sibling to src/ (development layout)
+    path.resolve(thisDir, "../admin-console/public"),
+    // Bundled: admin-console inside dist/ alongside the bundle
+    path.resolve(thisDir, "./admin-console/public"),
+    // Package root: walk up from dist/ to the package root
+    path.resolve(thisDir, "../../admin-console/public"),
   ];
   return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0];
 }

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -27,6 +27,7 @@ export interface ServerConfig {
     principal?: string;
     maxBodyBytes?: number;
     adminConsoleEnabled?: boolean;
+    adminConsolePublicDir?: string;
   };
 }
 
@@ -163,6 +164,7 @@ export async function startServer(options?: {
     principal: serverConfig.principal,
     maxBodyBytes: serverConfig.maxBodyBytes,
     adminConsoleEnabled: serverConfig.adminConsoleEnabled ?? false,
+    adminConsolePublicDir: serverConfig.adminConsolePublicDir,
     citationsEnabled: config.citationsEnabled,
     citationsAutoDetect: config.citationsAutoDetect,
   });

--- a/packages/remnic-server/src/index.ts
+++ b/packages/remnic-server/src/index.ts
@@ -14,7 +14,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { parseConfig, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, type PluginConfig } from "@remnic/core";
+import { parseConfig, Orchestrator, EngramAccessService, EngramAccessHttpServer, initLogger, log, getAllValidTokens, getAllValidTokensCached, expandTildePath, type PluginConfig } from "@remnic/core";
 
 // ── Config loading ──────────────────────────────────────────────────────────
 
@@ -164,7 +164,9 @@ export async function startServer(options?: {
     principal: serverConfig.principal,
     maxBodyBytes: serverConfig.maxBodyBytes,
     adminConsoleEnabled: serverConfig.adminConsoleEnabled ?? false,
-    adminConsolePublicDir: serverConfig.adminConsolePublicDir,
+    adminConsolePublicDir: serverConfig.adminConsolePublicDir
+      ? path.resolve(expandTildePath(serverConfig.adminConsolePublicDir))
+      : undefined,
     citationsEnabled: config.citationsEnabled,
     citationsAutoDetect: config.citationsAutoDetect,
   });


### PR DESCRIPTION
## Summary

- **Improved default admin console path resolution** — added a third candidate (`../../admin-console/public` relative to the bundle) so the `/engram/ui` route works when `@remnic/core` is bundled by a host (e.g. OpenClaw gateway where `import.meta.url` points to the bundle output, not the original package directory).
- **Wired `server.adminConsolePublicDir`** through `ServerConfig` in `@remnic/server` so operators can set an explicit path in their config file as a fallback when automatic resolution fails.

## Problem

The admin console at `/engram/ui` returned 404 in bundled contexts because `resolveDefaultAdminConsolePublicDir()` only tried two `import.meta.url`-relative paths:
1. `../admin-console/public` (development: sibling to `src/`)
2. `./admin-console/public` (dist: same directory as the bundle)

When a host bundler (like OpenClaw's gateway) bundles the plugin into a single file, `import.meta.url` points to the gateway's output directory — neither candidate matches the actual `admin-console/public` location inside the npm package.

## Fix

1. **Third resolution candidate**: `../../admin-console/public` walks up from `dist/` to the package root, covering the common `node_modules/@remnic/core/dist/` → `node_modules/@remnic/core/admin-console/public` layout.
2. **Config override**: `server.adminConsolePublicDir` in the config file provides an explicit escape hatch when none of the automatic candidates work (e.g. deeply nested or non-standard layouts).

## Test plan

- [x] `npx tsx --test tests/access-http*.test.ts` — 21/21 pass
- [x] `npx tsx --test tests/dashboard-server.test.ts` — 5/5 pass
- [x] `npm run build` — clean across all packages
- [ ] Verify `/engram/ui` returns HTML (not 404) when served from `@remnic/server` with `adminConsolePublicDir` set in config
- [ ] Verify `/engram/ui` returns HTML when `@remnic/core` is imported from `node_modules` without explicit config

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only affect how the admin console static directory is located/configured and should not impact core API behavior beyond `/engram/ui` asset serving when enabled.
> 
> **Overview**
> Fixes admin console UI serving in more deployment layouts by expanding `@remnic/core`’s default `admin-console/public` resolution to include a package-root-relative fallback (`../../admin-console/public`) instead of only `import.meta.url`-adjacent paths.
> 
> Adds `server.adminConsolePublicDir` support in `@remnic/server` configuration and passes it through to `EngramAccessHttpServer`, normalizing it with `expandTildePath` + `path.resolve` so operators can explicitly point `/engram/ui` at the correct static assets when auto-detection fails.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6a3680141b574f6453d5f19c703d86920b304f9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->