### PR TITLE
feat(bench): aged-dataset retention bench harness (#686 PR 2/6)

### DIFF
--- a/docs/benchmarks/retention-aged-dataset.md
+++ b/docs/benchmarks/retention-aged-dataset.md
@@ -1,0 +1,76 @@
+# Aged-Dataset Retention Bench
+
+Issue #686 PR 2/6.
+
+## Goal
+
+Measure structural properties of Remnic's hot/cold tier policy on a synthetic
+1- or 2-year corpus. PR 3/6 will use this bench to tune the production
+defaults (`demotionMinAgeDays`, `demotionValueThreshold`,
+`promotionValueThreshold`) and decide whether to flip
+`lifecyclePolicyEnabled` to `true` by default.
+
+## Design
+
+The bench is **hermetic** — no orchestrator, no QMD, no filesystem. It uses
+`decideTierTransition` from `@remnic/core` so the tier-routing computation
+is identical to production.
+
+### Synthetic corpus
+
+`generateAgedDataset()` produces a deterministic dataset given a seed:
+
+- **`size`** — total memory count.
+- **`horizonDays`** — 365 (1y) for `quick` mode, 730 (2y) for `full` mode.
+- **`topicCount`** — number of distinct topics each memory belongs to.
+- **`paretoAlpha`** — controls topic-frequency skew (1.16 ≈ Zipf's "80/20").
+- **`ageSkew`** — bias toward old (>1) or recent (<1) memories. Default 1.5.
+- **`seed`** — deterministic PRNG seed.
+- **`nowIso`** — anchors "now" so memory ages are reproducible across runs.
+
+Confidence tiers are spread across the four production tiers based on
+topic Pareto rank: hot topics lean explicit/implied, cold-tail topics lean
+inferred/speculative. This mirrors the realistic distribution of facts
+produced by extraction at scale.
+
+### Metrics emitted (per query, one query per topic)
+
+- **`recall_at_5_full`** — recall@5 against the full corpus.
+- **`recall_at_5_hot_only`** — recall@5 against the hot partition (the
+  cold partition is removed using the production tier policy).
+- **`recall_at_5_delta`** — full minus hot-only.
+- **`hot_share`** / **`cold_share`** — fraction of corpus per tier.
+
+Latency per task records `latencyFullMs` (full-corpus rank) and
+`latencyHotMs` (hot-only rank); the relative delta is the proxy for the
+"index size cost" benefit of demoting cold memories out of the live index.
+
+## Acceptance criteria for PR 3 (default-tuning study)
+
+- Aggregate `recall_at_5_delta` ≤ 0.01 (within 1pp).
+- `hot_share` ≤ 0.20 at 2y horizon (≥ 5× hot-index reduction).
+- Aggregate `latencyHotMs / latencyFullMs` ≤ 0.20 (linear in corpus size).
+
+If any of these fail, do **not** flip `lifecyclePolicyEnabled` to `true`
+by default; instead document findings in PR 3 and re-tune.
+
+## Running
+
+```bash
+# Quick mode (200 memories, 1y horizon — fast smoke).
+npx remnic bench run retention-aged-dataset --mode quick
+
+# Full mode (2000 memories, 2y horizon).
+npx remnic bench run retention-aged-dataset --mode full
+```
+
+Results emit JSON conforming to `BENCHMARK_RESULT_SCHEMA` like every
+other bench in `@remnic/bench`.
+
+## Why synthetic
+
+The repo is public and bench fixtures must not contain personal data
+(see `CLAUDE.md`). A real long-tail corpus at this scale is unavailable
+without leaking real conversations. The synthetic generator is
+parameterized so the bench remains useful as the default policy
+evolves.

--- a/docs/benchmarks/retention-aged-dataset.md
+++ b/docs/benchmarks/retention-aged-dataset.md
@@ -58,14 +58,16 @@ by default; instead document findings in PR 3 and re-tune.
 
 ```bash
 # Quick mode (200 memories, 1y horizon — fast smoke).
-npx remnic bench run retention-aged-dataset --mode quick
+remnic bench run --quick retention-aged-dataset
 
-# Full mode (2000 memories, 2y horizon).
-npx remnic bench run retention-aged-dataset --mode full
+# Full mode (2000 memories, 2y horizon — the default when --quick is omitted).
+remnic bench run retention-aged-dataset
 ```
 
-Results emit JSON conforming to `BENCHMARK_RESULT_SCHEMA` like every
-other bench in `@remnic/bench`.
+The CLI surface uses the `--quick` flag (full mode is the default); other
+remnic benchmarks follow the same convention. Results emit JSON
+conforming to `BENCHMARK_RESULT_SCHEMA` like every other bench in
+`@remnic/bench`.
 
 ## Why synthetic
 

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -39,6 +39,13 @@ export interface AgedDatasetGeneratorOptions {
 }
 
 export interface AgedQuery {
+  /**
+   * Unique per-query identifier across the entire fixture. Used as the
+   * task identifier in benchmark results; downstream consumers
+   * (reporters, dedup, storage) key on this so collisions would
+   * silently collapse rows.
+   */
+  id: string;
   /** Synthetic query text (topic-derived keywords). */
   text: string;
   /** ID of the topic this query targets. */
@@ -68,17 +75,32 @@ function mulberry32(seed: number): () => number {
 }
 
 /**
- * Generate a Pareto-distributed integer in [0, n).
+ * Generate a Zipf-distributed integer in [0, n).
  * Higher `alpha` = more skewed toward index 0.
+ *
+ * Uses a Zipf-style discrete distribution: P(rank=k) ∝ (k+1)^-alpha
+ * across k ∈ [0, n-1], sampled by inverse-CDF lookup. This produces a
+ * true long tail across all ranks; the previous Pareto-clamp approach
+ * collapsed high-tail samples onto the last index, creating an
+ * artificial second hotspot. (Codex P1 review on PR #698.)
  */
 function paretoIndex(rng: () => number, n: number, alpha: number): number {
-  // Inverse-CDF sampling on a discrete Pareto-like distribution.
-  const u = rng();
-  // Approximate Pareto: x = (1 - u)^(-1/alpha), normalized to [0, n).
-  const raw = Math.pow(1 - u, -1 / alpha);
-  // Map to [0, n) via floor; clamp.
-  const idx = Math.floor((raw - 1) * (n / 4));
-  return Math.max(0, Math.min(n - 1, idx));
+  if (n <= 1) return 0;
+  // Build a rank-weight array (cached per-call; n is small for our bench).
+  const weights: number[] = new Array(n);
+  let total = 0;
+  for (let k = 0; k < n; k += 1) {
+    const w = Math.pow(k + 1, -alpha);
+    weights[k] = w;
+    total += w;
+  }
+  const u = rng() * total;
+  let cum = 0;
+  for (let k = 0; k < n; k += 1) {
+    cum += weights[k];
+    if (u <= cum) return k;
+  }
+  return n - 1;
 }
 
 /**
@@ -239,6 +261,12 @@ export function generateAgedDataset(
     );
     for (let q = 0; q < topicQueryCount; q += 1) {
       queries.push({
+        // Include the per-topic instance index so duplicates within a
+        // topic stay distinguishable. Other bench runners use unique
+        // taskIds; downstream consumers (reporters, dedup, storage)
+        // key on taskId, so collisions would silently collapse rows.
+        // (Codex review on PR #698.)
+        id: `topic-${topicId}-${q}`,
         text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
         topicId,
         relevantMemoryIds: ids,
@@ -246,7 +274,10 @@ export function generateAgedDataset(
     }
   }
   // Sort by topicId for determinism, with stable ordering within a topic.
-  queries.sort((a, b) => a.topicId - b.topicId);
+  queries.sort((a, b) => {
+    if (a.topicId !== b.topicId) return a.topicId - b.topicId;
+    return a.id.localeCompare(b.id);
+  });
 
   return { options, memories, queries };
 }

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -1,0 +1,236 @@
+/**
+ * Synthetic aged-dataset fixture generator (issue #686 PR 2/6).
+ *
+ * Generates a hermetic corpus of memories spanning a configurable horizon
+ * with Pareto-distributed query frequencies (a few "hot" topics queried
+ * often; long-tail memories rarely queried). The fixture is deterministic
+ * given a seed so bench results are reproducible.
+ *
+ * Why synthetic: the issue's goal is to measure structural properties of
+ * the tier policy (recall@K, p95 latency proxy, hot/cold split) at 1- and
+ * 2-year scale. A real corpus at that scale is unavailable and would risk
+ * leaking personal data into a public-repo bench. The synthetic generator
+ * is parameterized so the bench can be tuned for either horizon.
+ */
+
+import type { MemoryFile } from "@remnic/core";
+
+export interface AgedDatasetGeneratorOptions {
+  /** Total memory count. */
+  size: number;
+  /** Horizon in days. e.g. 365 (1y), 730 (2y). */
+  horizonDays: number;
+  /** Number of distinct topics. Each memory belongs to one topic. */
+  topicCount: number;
+  /**
+   * Pareto shape parameter. Higher → more skewed (fewer hot topics carry
+   * most queries). 1.16 ≈ Zipf with alpha 1, the classic "80/20" curve.
+   */
+  paretoAlpha: number;
+  /**
+   * Age skew. >1 means more old memories than recent (long-tail aged
+   * dataset). =1 means uniform. <1 means more recent memories.
+   */
+  ageSkew: number;
+  /** Deterministic seed. */
+  seed: number;
+  /** ISO timestamp anchoring "now" so bench is reproducible. */
+  nowIso: string;
+}
+
+export interface AgedQuery {
+  /** Synthetic query text (topic-derived keywords). */
+  text: string;
+  /** ID of the topic this query targets. */
+  topicId: number;
+  /** Memory IDs that are relevant ground truth for this query. */
+  relevantMemoryIds: string[];
+}
+
+export interface AgedDatasetFixture {
+  options: AgedDatasetGeneratorOptions;
+  memories: MemoryFile[];
+  queries: AgedQuery[];
+}
+
+/**
+ * Mulberry32 PRNG — small, deterministic, fast.
+ */
+function mulberry32(seed: number): () => number {
+  let s = seed | 0;
+  return () => {
+    s = (s + 0x6d2b79f5) | 0;
+    let t = s;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+/**
+ * Generate a Pareto-distributed integer in [0, n).
+ * Higher `alpha` = more skewed toward index 0.
+ */
+function paretoIndex(rng: () => number, n: number, alpha: number): number {
+  // Inverse-CDF sampling on a discrete Pareto-like distribution.
+  const u = rng();
+  // Approximate Pareto: x = (1 - u)^(-1/alpha), normalized to [0, n).
+  const raw = Math.pow(1 - u, -1 / alpha);
+  // Map to [0, n) via floor; clamp.
+  const idx = Math.floor((raw - 1) * (n / 4));
+  return Math.max(0, Math.min(n - 1, idx));
+}
+
+/**
+ * Skewed age in [0, horizonDays].
+ * skew=1 → uniform, skew>1 → bias toward old, skew<1 → bias toward recent.
+ */
+function skewedAgeDays(rng: () => number, horizon: number, skew: number): number {
+  const u = rng();
+  return Math.floor(Math.pow(u, 1 / skew) * horizon);
+}
+
+const TOPIC_KEYWORDS = [
+  ["alpha", "primary", "core"],
+  ["beta", "secondary", "supporting"],
+  ["gamma", "tertiary", "auxiliary"],
+  ["delta", "change", "diff"],
+  ["epsilon", "tiny", "minor"],
+  ["zeta", "edge", "boundary"],
+  ["eta", "ratio", "measure"],
+  ["theta", "angle", "rotation"],
+  ["iota", "small", "incremental"],
+  ["kappa", "agreement", "consent"],
+  ["lambda", "function", "compute"],
+  ["mu", "average", "mean"],
+  ["nu", "frequency", "cadence"],
+  ["xi", "random", "noise"],
+  ["omicron", "small", "letter"],
+  ["pi", "circle", "ratio"],
+];
+
+function topicWord(topicId: number, slot: number): string {
+  const kws = TOPIC_KEYWORDS[topicId % TOPIC_KEYWORDS.length];
+  return kws[slot % kws.length];
+}
+
+/**
+ * Build a synthetic aged-corpus fixture.
+ */
+export function generateAgedDataset(
+  options: AgedDatasetGeneratorOptions,
+): AgedDatasetFixture {
+  const {
+    size,
+    horizonDays,
+    topicCount,
+    paretoAlpha,
+    ageSkew,
+    seed,
+    nowIso,
+  } = options;
+
+  if (size <= 0 || !Number.isFinite(size)) {
+    throw new Error(`size must be a positive integer, got ${size}`);
+  }
+  if (topicCount <= 0 || !Number.isFinite(topicCount)) {
+    throw new Error(`topicCount must be positive, got ${topicCount}`);
+  }
+  if (horizonDays <= 0 || !Number.isFinite(horizonDays)) {
+    throw new Error(`horizonDays must be positive, got ${horizonDays}`);
+  }
+
+  const rng = mulberry32(seed);
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) {
+    throw new Error(`nowIso must be a valid ISO timestamp, got ${nowIso}`);
+  }
+
+  const memories: MemoryFile[] = [];
+  // Track memories per topic so we can build relevant-id lists for queries.
+  const memoriesByTopic: Map<number, string[]> = new Map();
+
+  for (let i = 0; i < size; i += 1) {
+    const topicId = paretoIndex(rng, topicCount, paretoAlpha);
+    const ageDays = skewedAgeDays(rng, horizonDays, ageSkew);
+    const createdMs = nowMs - ageDays * 24 * 60 * 60 * 1000;
+    // Recent access bias: a few memories are accessed more often, mostly
+    // mirroring the topic Pareto skew (a memory in a hot topic gets more
+    // accesses).
+    const accessCount = Math.max(
+      0,
+      Math.floor(rng() * 16 * Math.pow(2, -topicId / 4)),
+    );
+    const lastAccessedMs =
+      accessCount > 0
+        ? createdMs +
+          Math.floor(rng() * Math.max(1, nowMs - createdMs))
+        : createdMs;
+    const id = `bench-mem-${seed}-${i.toString(16)}`;
+    // Spread confidenceTier across the 4 production tiers so the bench
+    // exercises the full range of demotion eligibility. Hot topics
+    // (low topicId after Pareto sampling) lean toward "explicit" /
+    // "implied"; cold-tail topics lean toward "inferred" / "speculative".
+    // This mirrors the realistic distribution of facts produced by
+    // extraction at scale.
+    const confidenceTier =
+      topicId === 0
+        ? "explicit"
+        : topicId === 1
+          ? "implied"
+          : topicId < topicCount / 2
+            ? "inferred"
+            : "speculative";
+    const baseConfidence =
+      confidenceTier === "explicit"
+        ? 0.9
+        : confidenceTier === "implied"
+          ? 0.75
+          : confidenceTier === "inferred"
+            ? 0.55
+            : 0.3;
+    const memoryFile: MemoryFile = {
+      path: `synthetic/facts/${id}.md`,
+      frontmatter: {
+        id,
+        category: "fact",
+        created: new Date(createdMs).toISOString(),
+        updated: new Date(createdMs).toISOString(),
+        source: "bench",
+        confidence: baseConfidence + (rng() - 0.5) * 0.1,
+        confidenceTier,
+        tags: [topicWord(topicId, 0)],
+        accessCount,
+        lastAccessed: new Date(lastAccessedMs).toISOString(),
+      },
+      content: [
+        topicWord(topicId, 0),
+        topicWord(topicId, 1),
+        topicWord(topicId, 2),
+        `record-${i}`,
+      ].join(" "),
+    };
+    memories.push(memoryFile);
+
+    let perTopic = memoriesByTopic.get(topicId);
+    if (!perTopic) {
+      perTopic = [];
+      memoriesByTopic.set(topicId, perTopic);
+    }
+    perTopic.push(id);
+  }
+
+  // Build queries — one per topic that has at least 1 memory.
+  const queries: AgedQuery[] = [];
+  for (const [topicId, ids] of memoriesByTopic.entries()) {
+    queries.push({
+      text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
+      topicId,
+      relevantMemoryIds: ids,
+    });
+  }
+  // Sort queries by topicId for determinism.
+  queries.sort((a, b) => a.topicId - b.topicId);
+
+  return { options, memories, queries };
+}

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -276,15 +276,36 @@ export function generateAgedDataset(
   );
   // Second pass: trim to MAX_TOTAL_QUERIES if rounding pushed us over.
   // Trim from the largest topics first so we don't drop sparse topics
-  // below the floor of 1. (Codex P2 review on PR #698.)
+  // below the floor of 1. If every topic is already at 1 and we're
+  // STILL over the cap (high-topic fixtures), drop the lowest-frequency
+  // topics entirely rather than emit > MAX_TOTAL_QUERIES queries.
+  // (Codex P2 reviews on PR #698.)
   let runningTotal = rawCounts.reduce((s, n) => s + n, 0);
   while (runningTotal > MAX_TOTAL_QUERIES) {
     let maxIdx = 0;
     for (let i = 1; i < rawCounts.length; i += 1) {
       if (rawCounts[i] > rawCounts[maxIdx]) maxIdx = i;
     }
-    if (rawCounts[maxIdx] <= 1) break; // safety: don't push any topic below 1.
-    rawCounts[maxIdx] -= 1;
+    if (rawCounts[maxIdx] > 1) {
+      rawCounts[maxIdx] -= 1;
+      runningTotal -= 1;
+      continue;
+    }
+    // All topics are at the floor of 1 — drop the smallest-share topics
+    // (the lowest topicId's memory count is largest by Pareto, so the
+    // last-rank topic with the smallest memory count is dropped first).
+    let smallestTopicMemoryCount = Number.POSITIVE_INFINITY;
+    let smallestTopicEntryIdx = -1;
+    for (let i = 0; i < rawCounts.length; i += 1) {
+      if (rawCounts[i] === 0) continue;
+      const topicMemoryCount = topicEntries[i][1].length;
+      if (topicMemoryCount < smallestTopicMemoryCount) {
+        smallestTopicMemoryCount = topicMemoryCount;
+        smallestTopicEntryIdx = i;
+      }
+    }
+    if (smallestTopicEntryIdx === -1) break;
+    rawCounts[smallestTopicEntryIdx] = 0;
     runningTotal -= 1;
   }
 
@@ -292,10 +313,31 @@ export function generateAgedDataset(
   for (let i = 0; i < topicEntries.length; i += 1) {
     const [topicId, ids] = topicEntries[i];
     const topicQueryCount = rawCounts[i];
+    if (topicQueryCount === 0) continue;
     // Choose the K most recently-touched memories as the bounded
-    // relevant set for queries on this topic. This makes recall@K a
-    // meaningful, tier-policy-sensitive metric.
-    const relevantSubset = [...ids].slice(0, RELEVANT_PER_QUERY);
+    // relevant set. The fixture appends to `ids` in generation order,
+    // not recency order, so we must sort by lastAccessed (falling back
+    // to created/updated for memories with no access history) before
+    // slicing. Without this sort, the "relevant" set is arbitrary early
+    // memories, which `rankMemories` (recency-tiebreaker) systematically
+    // misses, depressing recall scores and making the delta metric noisy
+    // about real tier-policy behavior. (Codex P1 review on PR #698.)
+    const memoryLookup = new Map<string, MemoryFile>();
+    for (const memory of memories) {
+      memoryLookup.set(memory.frontmatter.id, memory);
+    }
+    const recencyMs = (id: string): number => {
+      const m = memoryLookup.get(id);
+      if (!m) return 0;
+      return Date.parse(
+        m.frontmatter.lastAccessed
+          ?? m.frontmatter.updated
+          ?? m.frontmatter.created,
+      );
+    };
+    const relevantSubset = [...ids]
+      .sort((a, b) => recencyMs(b) - recencyMs(a))
+      .slice(0, RELEVANT_PER_QUERY);
     for (let q = 0; q < topicQueryCount; q += 1) {
       queries.push({
         // Per-topic instance index keeps duplicates within a topic

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -132,8 +132,18 @@ const TOPIC_KEYWORDS = [
 ];
 
 function topicWord(topicId: number, slot: number): string {
-  const kws = TOPIC_KEYWORDS[topicId % TOPIC_KEYWORDS.length];
-  return kws[slot % kws.length];
+  // Disambiguate distinct topics that wrap past the keyword table's
+  // length so query/content text stays unique even when topicCount
+  // exceeds 16.  (Codex P2 review on PR #698: bare modulo collapsed
+  // topic 0 and topic 16 to identical text, contaminating recall@K
+  // measurement at high topic counts.)  Format: keyword for the first
+  // wrap, keyword + "-N" for subsequent wraps where N is the wrap
+  // generation.
+  const tableLen = TOPIC_KEYWORDS.length;
+  const kws = TOPIC_KEYWORDS[topicId % tableLen];
+  const generation = Math.floor(topicId / tableLen);
+  const base = kws[slot % kws.length];
+  return generation === 0 ? base : `${base}-${generation}`;
 }
 
 /**
@@ -309,6 +319,24 @@ export function generateAgedDataset(
     runningTotal -= 1;
   }
 
+  // Hoist the memory id→file lookup out of the per-topic loop — it's
+  // identical for every topic, so building it once removes O(topics ×
+  // memories) work without changing semantics. (Cursor low-severity
+  // review on PR #698.)
+  const memoryLookup = new Map<string, MemoryFile>();
+  for (const memory of memories) {
+    memoryLookup.set(memory.frontmatter.id, memory);
+  }
+  const recencyMs = (id: string): number => {
+    const m = memoryLookup.get(id);
+    if (!m) return 0;
+    return Date.parse(
+      m.frontmatter.lastAccessed
+        ?? m.frontmatter.updated
+        ?? m.frontmatter.created,
+    );
+  };
+
   const queries: AgedQuery[] = [];
   for (let i = 0; i < topicEntries.length; i += 1) {
     const [topicId, ids] = topicEntries[i];
@@ -322,19 +350,6 @@ export function generateAgedDataset(
     // memories, which `rankMemories` (recency-tiebreaker) systematically
     // misses, depressing recall scores and making the delta metric noisy
     // about real tier-policy behavior. (Codex P1 review on PR #698.)
-    const memoryLookup = new Map<string, MemoryFile>();
-    for (const memory of memories) {
-      memoryLookup.set(memory.frontmatter.id, memory);
-    }
-    const recencyMs = (id: string): number => {
-      const m = memoryLookup.get(id);
-      if (!m) return 0;
-      return Date.parse(
-        m.frontmatter.lastAccessed
-          ?? m.frontmatter.updated
-          ?? m.frontmatter.created,
-      );
-    };
     const relevantSubset = [...ids]
       .sort((a, b) => recencyMs(b) - recencyMs(a))
       .slice(0, RELEVANT_PER_QUERY);

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -178,6 +178,20 @@ export function generateAgedDataset(
   ) {
     throw new Error(`topicCount must be a positive integer, got ${topicCount}`);
   }
+  // paretoAlpha and ageSkew must be finite positive numbers — otherwise
+  // the samplers silently produce degenerate corpora (collapsed topic
+  // distribution or collapsed ages) and the bench reports successful
+  // but useless results (Codex P2 review on PR #698).
+  if (!Number.isFinite(paretoAlpha) || paretoAlpha <= 0) {
+    throw new Error(
+      `paretoAlpha must be a finite positive number, got ${paretoAlpha}`,
+    );
+  }
+  if (!Number.isFinite(ageSkew) || ageSkew <= 0) {
+    throw new Error(
+      `ageSkew must be a finite positive number, got ${ageSkew}`,
+    );
+  }
   if (
     horizonDays <= 0 ||
     !Number.isFinite(horizonDays) ||
@@ -359,8 +373,21 @@ export function generateAgedDataset(
     // memories, which `rankMemories` (recency-tiebreaker) systematically
     // misses, depressing recall scores and making the delta metric noisy
     // about real tier-policy behavior. (Codex P1 review on PR #698.)
+    // Use the SAME tie-break the ranker applies (`id.localeCompare`)
+    // so the labeled relevant set and the ranker's top-K agree on
+    // which memories are "first" when timestamps tie.  Without this
+    // alignment, `accessCount === 0` entries that share `ageDays`
+    // ended up with a relevant set ordered by generation (stable sort
+    // input order) and a ranker output ordered by id, depressing
+    // recall@K through pure tie-break noise.  (Codex Medium review
+    // on PR #698.)  Mirror this exact comparator in
+    // `rankMemories` (runner.ts).
     const relevantSubset = [...ids]
-      .sort((a, b) => recencyMs(b) - recencyMs(a))
+      .sort((a, b) => {
+        const recencyDelta = recencyMs(b) - recencyMs(a);
+        if (recencyDelta !== 0) return recencyDelta;
+        return a.localeCompare(b);
+      })
       .slice(0, RELEVANT_PER_QUERY);
     for (let q = 0; q < topicQueryCount; q += 1) {
       queries.push({

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -252,20 +252,32 @@ export function generateAgedDataset(
   //
   // We cap the multiplier per topic at `MAX_QUERIES_PER_TOPIC` to keep
   // total task count tractable in `quick` mode.
-  const MAX_QUERIES_PER_TOPIC = 8;
+  // Build a Pareto-weighted query workload. Total queries scale with
+  // total memory count so each topic's share of the workload is
+  // proportional to its share of the corpus. With size=2000 and a
+  // Pareto-skewed corpus (topic 0 ≈ 695 memories, topic 15 ≈ 26), this
+  // yields topic 0 ≈ 70 queries and topic 15 ≈ 3 queries — a clean
+  // Pareto-weighted workload. The saturating `min(8, ceil(n/4))` formula
+  // collapsed both extremes onto the cap, losing the Pareto signal.
+  // (Codex P1 review on PR #698.)
+  //
+  // We cap total queries to `MAX_TOTAL_QUERIES` so quick mode stays
+  // tractable. Each topic gets at least 1 query.
+  const MAX_TOTAL_QUERIES = 200;
+  const totalMemoryCount = memories.length;
+  const totalShare = Math.min(MAX_TOTAL_QUERIES, Math.max(1, totalMemoryCount));
   const queries: AgedQuery[] = [];
   for (const [topicId, ids] of memoriesByTopic.entries()) {
-    const topicQueryCount = Math.min(
-      MAX_QUERIES_PER_TOPIC,
-      Math.max(1, Math.ceil(ids.length / 4)),
+    const topicQueryCount = Math.max(
+      1,
+      Math.round((ids.length / Math.max(1, totalMemoryCount)) * totalShare),
     );
     for (let q = 0; q < topicQueryCount; q += 1) {
       queries.push({
-        // Include the per-topic instance index so duplicates within a
-        // topic stay distinguishable. Other bench runners use unique
-        // taskIds; downstream consumers (reporters, dedup, storage)
-        // key on taskId, so collisions would silently collapse rows.
-        // (Codex review on PR #698.)
+        // Per-topic instance index keeps duplicates within a topic
+        // distinguishable. Downstream consumers (reporters, dedup,
+        // storage) key on taskId, so collisions would silently collapse
+        // rows.
         id: `topic-${topicId}-${q}`,
         text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
         topicId,

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -220,16 +220,32 @@ export function generateAgedDataset(
     perTopic.push(id);
   }
 
-  // Build queries — one per topic that has at least 1 memory.
+  // Build queries weighted by topic frequency. Topic memory counts are
+  // already Pareto-distributed (because memories are sampled with
+  // `paretoIndex`), so emitting one query per memory in a topic — rounded
+  // by a freq-floor cap so each topic gets at least one query but hot
+  // topics get proportionally more — yields aggregate scores that reflect
+  // realistic hot-topic-heavy traffic instead of weighting every topic
+  // equally. (Codex review on PR #698.)
+  //
+  // We cap the multiplier per topic at `MAX_QUERIES_PER_TOPIC` to keep
+  // total task count tractable in `quick` mode.
+  const MAX_QUERIES_PER_TOPIC = 8;
   const queries: AgedQuery[] = [];
   for (const [topicId, ids] of memoriesByTopic.entries()) {
-    queries.push({
-      text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
-      topicId,
-      relevantMemoryIds: ids,
-    });
+    const topicQueryCount = Math.min(
+      MAX_QUERIES_PER_TOPIC,
+      Math.max(1, Math.ceil(ids.length / 4)),
+    );
+    for (let q = 0; q < topicQueryCount; q += 1) {
+      queries.push({
+        text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
+        topicId,
+        relevantMemoryIds: ids,
+      });
+    }
   }
-  // Sort queries by topicId for determinism.
+  // Sort by topicId for determinism, with stable ordering within a topic.
   queries.sort((a, b) => a.topicId - b.topicId);
 
   return { options, memories, queries };

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -164,14 +164,26 @@ export function generateAgedDataset(
     nowIso,
   } = options;
 
-  if (size <= 0 || !Number.isFinite(size)) {
+  if (size <= 0 || !Number.isFinite(size) || !Number.isInteger(size)) {
     throw new Error(`size must be a positive integer, got ${size}`);
   }
-  if (topicCount <= 0 || !Number.isFinite(topicCount)) {
-    throw new Error(`topicCount must be positive, got ${topicCount}`);
+  // topicCount must be an integer — `new Array(n)` and the Zipf weight
+  // builder both crash with a `RangeError` on fractional inputs.  Reject
+  // here so callers see a clear validation error rather than a deep
+  // stack trace from `paretoIndex` (Codex P2 review on PR #698).
+  if (
+    topicCount <= 0 ||
+    !Number.isFinite(topicCount) ||
+    !Number.isInteger(topicCount)
+  ) {
+    throw new Error(`topicCount must be a positive integer, got ${topicCount}`);
   }
-  if (horizonDays <= 0 || !Number.isFinite(horizonDays)) {
-    throw new Error(`horizonDays must be positive, got ${horizonDays}`);
+  if (
+    horizonDays <= 0 ||
+    !Number.isFinite(horizonDays) ||
+    !Number.isInteger(horizonDays)
+  ) {
+    throw new Error(`horizonDays must be a positive integer, got ${horizonDays}`);
   }
 
   const rng = mulberry32(seed);
@@ -254,19 +266,14 @@ export function generateAgedDataset(
     perTopic.push(id);
   }
 
-  // Build queries weighted by topic frequency. Topic memory counts are
-  // already Pareto-distributed (because memories are sampled with
-  // `paretoIndex`), so emitting one query per memory in a topic — rounded
-  // by a freq-floor cap so each topic gets at least one query but hot
-  // topics get proportionally more — yields aggregate scores that reflect
-  // realistic hot-topic-heavy traffic instead of weighting every topic
-  // equally. (Codex review on PR #698.)
-  //
-  // We cap the multiplier per topic at `MAX_QUERIES_PER_TOPIC` to keep
-  // total task count tractable in `quick` mode.
-  // Build a Pareto-weighted query workload. Total queries scale with
-  // total memory count so each topic's share of the workload is
-  // proportional to its share of the corpus.
+  // Build a Pareto-weighted query workload.  Topic memory counts are
+  // already Pareto-distributed (memories were sampled via
+  // `paretoIndex`), so emitting one query per memory in a topic —
+  // proportionally trimmed to the global `MAX_TOTAL_QUERIES` cap —
+  // yields aggregate scores that reflect realistic hot-topic-heavy
+  // traffic instead of weighting every topic equally.  Total queries
+  // scale with total memory count so each topic's share of the workload
+  // is proportional to its share of the corpus.
   //
   // Each query carries a *bounded* relevant-memory subset (the K most
   // recently-accessed members of the topic, capped at RELEVANT_PER_QUERY).

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -134,16 +134,18 @@ const TOPIC_KEYWORDS = [
 function topicWord(topicId: number, slot: number): string {
   // Disambiguate distinct topics that wrap past the keyword table's
   // length so query/content text stays unique even when topicCount
-  // exceeds 16.  (Codex P2 review on PR #698: bare modulo collapsed
-  // topic 0 and topic 16 to identical text, contaminating recall@K
-  // measurement at high topic counts.)  Format: keyword for the first
-  // wrap, keyword + "-N" for subsequent wraps where N is the wrap
-  // generation.
+  // exceeds 16.  (Codex P2 + Cursor Medium review on PR #698: a bare
+  // modulo collapsed topic 0 and topic 16 to identical text, and a
+  // hyphenated `keyword-N` suffix was defeated by the ranker's
+  // `[^a-z0-9]` tokenizer which splits the suffix back off.)  Format:
+  // keyword for the first wrap, keyword + Nth-generation digit
+  // CONCATENATED (no hyphen) so the result remains a single token after
+  // tokenization — `alpha`, `alpha1`, `alpha2`, ...
   const tableLen = TOPIC_KEYWORDS.length;
   const kws = TOPIC_KEYWORDS[topicId % tableLen];
   const generation = Math.floor(topicId / tableLen);
   const base = kws[slot % kws.length];
-  return generation === 0 ? base : `${base}-${generation}`;
+  return generation === 0 ? base : `${base}${generation}`;
 }
 
 /**

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts
@@ -254,24 +254,48 @@ export function generateAgedDataset(
   // total task count tractable in `quick` mode.
   // Build a Pareto-weighted query workload. Total queries scale with
   // total memory count so each topic's share of the workload is
-  // proportional to its share of the corpus. With size=2000 and a
-  // Pareto-skewed corpus (topic 0 ≈ 695 memories, topic 15 ≈ 26), this
-  // yields topic 0 ≈ 70 queries and topic 15 ≈ 3 queries — a clean
-  // Pareto-weighted workload. The saturating `min(8, ceil(n/4))` formula
-  // collapsed both extremes onto the cap, losing the Pareto signal.
-  // (Codex P1 review on PR #698.)
+  // proportional to its share of the corpus.
   //
-  // We cap total queries to `MAX_TOTAL_QUERIES` so quick mode stays
-  // tractable. Each topic gets at least 1 query.
+  // Each query carries a *bounded* relevant-memory subset (the K most
+  // recently-accessed members of the topic, capped at RELEVANT_PER_QUERY).
+  // Without this cap, `recall_at_5` is structurally capped at
+  // `5 / size_of_topic` for large topics — recall@5 against a 695-member
+  // topic can never exceed ~0.007, making `recall_at_5_delta` insensitive
+  // to tier-policy changes. Bounding the relevant set lets recall@5 range
+  // freely across [0, 1]. (Cursor Bugbot medium-severity review on PR #698.)
   const MAX_TOTAL_QUERIES = 200;
+  const RELEVANT_PER_QUERY = 5;
   const totalMemoryCount = memories.length;
   const totalShare = Math.min(MAX_TOTAL_QUERIES, Math.max(1, totalMemoryCount));
+  // First pass: compute proportional integer query counts per topic.
+  const topicEntries = [...memoriesByTopic.entries()].sort(
+    (a, b) => a[0] - b[0],
+  );
+  const rawCounts = topicEntries.map(([, ids]) =>
+    Math.max(1, Math.round((ids.length / Math.max(1, totalMemoryCount)) * totalShare)),
+  );
+  // Second pass: trim to MAX_TOTAL_QUERIES if rounding pushed us over.
+  // Trim from the largest topics first so we don't drop sparse topics
+  // below the floor of 1. (Codex P2 review on PR #698.)
+  let runningTotal = rawCounts.reduce((s, n) => s + n, 0);
+  while (runningTotal > MAX_TOTAL_QUERIES) {
+    let maxIdx = 0;
+    for (let i = 1; i < rawCounts.length; i += 1) {
+      if (rawCounts[i] > rawCounts[maxIdx]) maxIdx = i;
+    }
+    if (rawCounts[maxIdx] <= 1) break; // safety: don't push any topic below 1.
+    rawCounts[maxIdx] -= 1;
+    runningTotal -= 1;
+  }
+
   const queries: AgedQuery[] = [];
-  for (const [topicId, ids] of memoriesByTopic.entries()) {
-    const topicQueryCount = Math.max(
-      1,
-      Math.round((ids.length / Math.max(1, totalMemoryCount)) * totalShare),
-    );
+  for (let i = 0; i < topicEntries.length; i += 1) {
+    const [topicId, ids] = topicEntries[i];
+    const topicQueryCount = rawCounts[i];
+    // Choose the K most recently-touched memories as the bounded
+    // relevant set for queries on this topic. This makes recall@K a
+    // meaningful, tier-policy-sensitive metric.
+    const relevantSubset = [...ids].slice(0, RELEVANT_PER_QUERY);
     for (let q = 0; q < topicQueryCount; q += 1) {
       queries.push({
         // Per-topic instance index keeps duplicates within a topic
@@ -281,7 +305,7 @@ export function generateAgedDataset(
         id: `topic-${topicId}-${q}`,
         text: `${topicWord(topicId, 0)} ${topicWord(topicId, 1)}`,
         topicId,
-        relevantMemoryIds: ids,
+        relevantMemoryIds: relevantSubset,
       });
     }
   }

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
@@ -91,3 +91,43 @@ test("aged-dataset bench reports plausible hot/cold split for default policy", a
     `default policy must keep some memories hot; cold_share=${coldShare}`,
   );
 });
+
+test("aged-dataset bench applies options.limit to fixture queries", async () => {
+  const unlimited = await runRetentionAgedDatasetBenchmark(options());
+  const limited = await runRetentionAgedDatasetBenchmark(options({ limit: 1 }));
+  assert.ok(unlimited.results.tasks.length >= 2);
+  assert.equal(limited.results.tasks.length, 1);
+});
+
+test("aged-dataset bench threads options.seed into the generator", async () => {
+  const a = await runRetentionAgedDatasetBenchmark(options({ seed: 1234 }));
+  const b = await runRetentionAgedDatasetBenchmark(options({ seed: 5678 }));
+  // Different seed → different fixture → different first-task topFull.
+  const aTopFull = JSON.parse(a.results.tasks[0].actual).topFull;
+  const bTopFull = JSON.parse(b.results.tasks[0].actual).topFull;
+  assert.notDeepEqual(
+    aTopFull,
+    bTopFull,
+    "different seeds must produce different fixtures",
+  );
+  // And meta.seeds must reflect the seed actually used (not the
+  // hardcoded baseOptions seed).
+  assert.deepEqual(a.meta.seeds, [1234]);
+  assert.deepEqual(b.meta.seeds, [5678]);
+});
+
+test("aged-dataset bench produces non-empty aggregates", async () => {
+  const result = await runRetentionAgedDatasetBenchmark(options());
+  // Aggregate keys should include the per-task score names. If we used
+  // buildTieredAggregates without setting details.tier, this object
+  // would be empty.
+  const keys = Object.keys(result.results.aggregates);
+  assert.ok(
+    keys.includes("recall_at_5_full"),
+    `aggregates must include recall_at_5_full, got: ${keys.join(",")}`,
+  );
+  assert.ok(
+    keys.includes("recall_at_5_hot_only"),
+    `aggregates must include recall_at_5_hot_only, got: ${keys.join(",")}`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
@@ -153,38 +153,33 @@ test("aged-dataset Pareto sampler produces a long-tail distribution (no clamping
     seed: 0xa686,
     nowIso: "2026-04-25T12:00:00.000Z",
   });
-  // Count memories per topic.
-  const counts: number[] = new Array(16).fill(0);
-  for (const m of fixture.memories) {
-    // The topic is encoded by the first tag; recover it from the keyword
-    // list match.
-    const tag = m.frontmatter.tags?.[0] ?? "";
-    // Find which topic this tag maps to: the topic-keyword grid uses
-    // index % 16 for slot 0; we just need *some* indicator. The simplest
-    // reliable check is that the highest-rank topic does not dominate —
-    // if the previous Pareto-clamp bug were back, topic 15 would be a
-    // second hotspot rivaling topic 0.
-    void tag;
-  }
-  // Pull topicId via the queries' relevantMemoryIds → frontmatter id mapping
-  // would be expensive; instead, infer per-topic counts from the queries
-  // that the fixture emits (which use ids grouped by topic).
-  const queryCountsByTopic: number[] = new Array(16).fill(0);
+  // Per-topic memory counts come straight from the queries' relevantMemoryIds
+  // (each query carries the full memory-id list for its topic).
+  const memoriesByTopic: number[] = new Array(16).fill(0);
   for (const q of fixture.queries) {
-    queryCountsByTopic[q.topicId] = q.relevantMemoryIds.length;
+    memoriesByTopic[q.topicId] = q.relevantMemoryIds.length;
   }
-  // Topic 0 (highest-frequency) should have the most memories.
-  // Topic 15 (lowest) should have *strictly* fewer than topic 0.
-  // The previous clamped Pareto would have made topic 15 a second
-  // hotspot — possibly tying or exceeding topic 0.
+  // Topic 0 (highest-frequency) must have more memories than topic 15
+  // (lowest). The previous clamped Pareto would have made topic 15 a
+  // second hotspot rivaling topic 0.
   assert.ok(
-    queryCountsByTopic[0] > queryCountsByTopic[15],
-    `topic 0 must dominate over topic 15: topic0=${queryCountsByTopic[0]} topic15=${queryCountsByTopic[15]}`,
+    memoriesByTopic[0] > memoriesByTopic[15],
+    `topic 0 must dominate over topic 15: topic0=${memoriesByTopic[0]} topic15=${memoriesByTopic[15]}`,
   );
-  // And the distribution should be reasonably monotonic — there shouldn't
-  // be a spike at the last index.
+  // And the last rank must not be a second hotspot.
   assert.ok(
-    queryCountsByTopic[15] <= queryCountsByTopic[0] / 2,
-    `last-rank topic must not be a second hotspot: topic0=${queryCountsByTopic[0]} topic15=${queryCountsByTopic[15]}`,
+    memoriesByTopic[15] <= memoriesByTopic[0] / 2,
+    `last-rank topic must not be a second hotspot: topic0=${memoriesByTopic[0]} topic15=${memoriesByTopic[15]}`,
+  );
+
+  // Query-count distribution must also reflect the Pareto skew (P1 fix):
+  // topic 0 should drive proportionally more queries than topic 15.
+  const queriesByTopic: number[] = new Array(16).fill(0);
+  for (const q of fixture.queries) {
+    queriesByTopic[q.topicId] += 1;
+  }
+  assert.ok(
+    queriesByTopic[0] > queriesByTopic[15],
+    `query workload must Pareto-weight topic 0 above topic 15: topic0=${queriesByTopic[0]} topic15=${queriesByTopic[15]}`,
   );
 });

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
@@ -153,11 +153,17 @@ test("aged-dataset Pareto sampler produces a long-tail distribution (no clamping
     seed: 0xa686,
     nowIso: "2026-04-25T12:00:00.000Z",
   });
-  // Per-topic memory counts come straight from the queries' relevantMemoryIds
-  // (each query carries the full memory-id list for its topic).
+  // Per-topic memory counts come from the memory frontmatter tags
+  // (the first tag is the topic keyword).
+  const TOPIC_KEYWORDS = [
+    "alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta",
+    "iota", "kappa", "lambda", "mu", "nu", "xi", "omicron", "pi",
+  ];
   const memoriesByTopic: number[] = new Array(16).fill(0);
-  for (const q of fixture.queries) {
-    memoriesByTopic[q.topicId] = q.relevantMemoryIds.length;
+  for (const m of fixture.memories) {
+    const tag = m.frontmatter.tags?.[0] ?? "";
+    const idx = TOPIC_KEYWORDS.indexOf(tag);
+    if (idx >= 0) memoriesByTopic[idx] += 1;
   }
   // Topic 0 (highest-frequency) must have more memories than topic 15
   // (lowest). The previous clamped Pareto would have made topic 15 a
@@ -181,5 +187,23 @@ test("aged-dataset Pareto sampler produces a long-tail distribution (no clamping
   assert.ok(
     queriesByTopic[0] > queriesByTopic[15],
     `query workload must Pareto-weight topic 0 above topic 15: topic0=${queriesByTopic[0]} topic15=${queriesByTopic[15]}`,
+  );
+});
+
+test("aged-dataset bench enforces MAX_TOTAL_QUERIES cap", async () => {
+  // The fixture must trim to MAX_TOTAL_QUERIES=200 even when rounding
+  // would otherwise push the total over. (Codex P2 review on PR #698.)
+  const fixture = generateAgedDataset({
+    size: 4000,
+    horizonDays: 365,
+    topicCount: 32,
+    paretoAlpha: 1.16,
+    ageSkew: 1.5,
+    seed: 0xa686,
+    nowIso: "2026-04-25T12:00:00.000Z",
+  });
+  assert.ok(
+    fixture.queries.length <= 200,
+    `MAX_TOTAL_QUERIES cap must be honored; got ${fixture.queries.length} queries`,
   );
 });

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
@@ -131,3 +131,60 @@ test("aged-dataset bench produces non-empty aggregates", async () => {
     `aggregates must include recall_at_5_hot_only, got: ${keys.join(",")}`,
   );
 });
+
+test("aged-dataset bench emits unique taskId per task", async () => {
+  const result = await runRetentionAgedDatasetBenchmark(options());
+  const taskIds = result.results.tasks.map((t) => t.taskId);
+  const unique = new Set(taskIds);
+  assert.equal(
+    taskIds.length,
+    unique.size,
+    `taskIds must be unique; found ${taskIds.length - unique.size} duplicates among ${taskIds.length} tasks`,
+  );
+});
+
+test("aged-dataset Pareto sampler produces a long-tail distribution (no clamping artifact)", () => {
+  const fixture = generateAgedDataset({
+    size: 4000,
+    horizonDays: 365,
+    topicCount: 16,
+    paretoAlpha: 1.16,
+    ageSkew: 1.5,
+    seed: 0xa686,
+    nowIso: "2026-04-25T12:00:00.000Z",
+  });
+  // Count memories per topic.
+  const counts: number[] = new Array(16).fill(0);
+  for (const m of fixture.memories) {
+    // The topic is encoded by the first tag; recover it from the keyword
+    // list match.
+    const tag = m.frontmatter.tags?.[0] ?? "";
+    // Find which topic this tag maps to: the topic-keyword grid uses
+    // index % 16 for slot 0; we just need *some* indicator. The simplest
+    // reliable check is that the highest-rank topic does not dominate —
+    // if the previous Pareto-clamp bug were back, topic 15 would be a
+    // second hotspot rivaling topic 0.
+    void tag;
+  }
+  // Pull topicId via the queries' relevantMemoryIds → frontmatter id mapping
+  // would be expensive; instead, infer per-topic counts from the queries
+  // that the fixture emits (which use ids grouped by topic).
+  const queryCountsByTopic: number[] = new Array(16).fill(0);
+  for (const q of fixture.queries) {
+    queryCountsByTopic[q.topicId] = q.relevantMemoryIds.length;
+  }
+  // Topic 0 (highest-frequency) should have the most memories.
+  // Topic 15 (lowest) should have *strictly* fewer than topic 0.
+  // The previous clamped Pareto would have made topic 15 a second
+  // hotspot — possibly tying or exceeding topic 0.
+  assert.ok(
+    queryCountsByTopic[0] > queryCountsByTopic[15],
+    `topic 0 must dominate over topic 15: topic0=${queryCountsByTopic[0]} topic15=${queryCountsByTopic[15]}`,
+  );
+  // And the distribution should be reasonably monotonic — there shouldn't
+  // be a spike at the last index.
+  assert.ok(
+    queryCountsByTopic[15] <= queryCountsByTopic[0] / 2,
+    `last-rank topic must not be a second hotspot: topic0=${queryCountsByTopic[0]} topic15=${queryCountsByTopic[15]}`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts
@@ -1,0 +1,93 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  runRetentionAgedDatasetBenchmark,
+  retentionAgedDatasetDefinition,
+} from "./runner.js";
+import { generateAgedDataset } from "./fixture.js";
+import type { ResolvedRunBenchmarkOptions } from "../../../types.js";
+
+function options(overrides: Partial<ResolvedRunBenchmarkOptions> = {}): ResolvedRunBenchmarkOptions {
+  return {
+    mode: "quick",
+    benchmark: retentionAgedDatasetDefinition,
+    system: { describe: () => "noop", store: async () => undefined, query: async () => "" },
+    ...overrides,
+  } as ResolvedRunBenchmarkOptions;
+}
+
+test("aged-dataset fixture is deterministic given a seed", () => {
+  const a = generateAgedDataset({
+    size: 50,
+    horizonDays: 365,
+    topicCount: 4,
+    paretoAlpha: 1.16,
+    ageSkew: 1.5,
+    seed: 12345,
+    nowIso: "2026-04-25T12:00:00.000Z",
+  });
+  const b = generateAgedDataset({
+    size: 50,
+    horizonDays: 365,
+    topicCount: 4,
+    paretoAlpha: 1.16,
+    ageSkew: 1.5,
+    seed: 12345,
+    nowIso: "2026-04-25T12:00:00.000Z",
+  });
+  assert.equal(a.memories.length, b.memories.length);
+  assert.equal(a.queries.length, b.queries.length);
+  for (let i = 0; i < a.memories.length; i += 1) {
+    assert.equal(a.memories[i].frontmatter.id, b.memories[i].frontmatter.id);
+    assert.equal(
+      a.memories[i].frontmatter.created,
+      b.memories[i].frontmatter.created,
+    );
+    assert.equal(
+      a.memories[i].frontmatter.accessCount,
+      b.memories[i].frontmatter.accessCount,
+    );
+  }
+});
+
+test("aged-dataset bench runs in quick mode and emits expected metrics", async () => {
+  const result = await runRetentionAgedDatasetBenchmark(options());
+  assert.ok(result.results.tasks.length > 0, "must emit at least one task");
+  for (const task of result.results.tasks) {
+    assert.ok("recall_at_5_full" in task.scores);
+    assert.ok("recall_at_5_hot_only" in task.scores);
+    assert.ok("recall_at_5_delta" in task.scores);
+    assert.ok("hot_share" in task.scores);
+    assert.ok("cold_share" in task.scores);
+    // recall@K is in [0, 1].
+    assert.ok(task.scores.recall_at_5_full >= 0 && task.scores.recall_at_5_full <= 1);
+    assert.ok(task.scores.recall_at_5_hot_only >= 0 && task.scores.recall_at_5_hot_only <= 1);
+    // hot_share + cold_share should sum to 1 (within float epsilon).
+    const sum = task.scores.hot_share + task.scores.cold_share;
+    assert.ok(Math.abs(sum - 1) < 1e-9, `hot+cold share must sum to 1, got ${sum}`);
+  }
+  assert.ok(
+    typeof result.cost.meanQueryLatencyMs === "number",
+    "meanQueryLatencyMs must be a number",
+  );
+});
+
+test("aged-dataset bench reports plausible hot/cold split for default policy", async () => {
+  const result = await runRetentionAgedDatasetBenchmark(options());
+  // The default policy demotes memories ≥14d old with value ≤ 0.35. With
+  // ageSkew=1.5 and a 365d horizon, a meaningful fraction of memories
+  // should land in the cold tier — but not all of them (recently-created
+  // and high-value memories must stay hot). Use loose bounds so this
+  // doesn't false-fail when defaults change in PR 3.
+  const firstTask = result.results.tasks[0];
+  assert.ok(firstTask, "expected at least one task");
+  const coldShare = firstTask.scores.cold_share;
+  assert.ok(
+    coldShare > 0,
+    `default policy must demote some memories at 1y horizon; cold_share=${coldShare}`,
+  );
+  assert.ok(
+    coldShare < 1,
+    `default policy must keep some memories hot; cold_share=${coldShare}`,
+  );
+});

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
@@ -91,27 +91,32 @@ const FULL_OPTIONS: AgedDatasetGeneratorOptions = {
   nowIso: "2026-04-25T12:00:00.000Z",
 };
 
-/**
- * Deterministic ranker — keyword-overlap on `content` + `tags`. Mirrors
- * the simple ranker style used in `retrieval-temporal/runner.ts`.
- */
-function rankMemories(query: string, memories: MemoryFile[]): MemoryFile[] {
-  const tokens = new Set(
-    query
+function tokenize(text: string): Set<string> {
+  return new Set(
+    text
       .toLowerCase()
       .split(/[^a-z0-9]+/)
       .filter(Boolean),
   );
+}
+
+/**
+ * Deterministic ranker — keyword-overlap on `content` + `tags` using
+ * **whole-word token matching**. Substring matching (the previous
+ * approach) caused cross-topic collisions in the fixture vocabulary
+ * (`eta` substring of `beta`, `zeta`, `theta`), perturbing top-K recall
+ * measurements. (Codex review on PR #698.)
+ */
+function rankMemories(query: string, memories: MemoryFile[]): MemoryFile[] {
+  const queryTokens = tokenize(query);
   return [...memories]
     .map((m) => {
-      const haystack = (
-        m.content +
-        " " +
-        (m.frontmatter.tags ?? []).join(" ")
-      ).toLowerCase();
+      const haystackTokens = tokenize(
+        (m.content + " " + (m.frontmatter.tags ?? []).join(" ")),
+      );
       let score = 0;
-      for (const tok of tokens) {
-        if (haystack.includes(tok)) score += 1;
+      for (const tok of queryTokens) {
+        if (haystackTokens.has(tok)) score += 1;
       }
       // Tiebreak: more recent first.
       const recencyMs = Date.parse(

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
@@ -1,0 +1,271 @@
+/**
+ * Aged-dataset retention bench (issue #686 PR 2/6).
+ *
+ * Goal: measure structural properties of the hot/cold tier policy on a
+ * synthetic 1- or 2-year dataset, contrasting `lifecyclePolicyEnabled:
+ * false` (full corpus visible to recall) with `lifecyclePolicyEnabled:
+ * true` (cold memories partitioned away from default recall).
+ *
+ * Metrics emitted per task (one task per query):
+ *   - recall_at_5_full         — recall@5 against the full corpus.
+ *   - recall_at_5_hot_only     — recall@5 against the hot-only corpus
+ *                                (cold partition removed via the same
+ *                                tier policy used in production).
+ *   - recall_at_5_delta        — full minus hot-only (target: ≤ 0.01 in
+ *                                aggregate; PR 3 will tune defaults).
+ *   - hot_share                — fraction of corpus that ended up hot.
+ *   - cold_share               — fraction that ended up cold.
+ *
+ * Latency is measured as the deterministic-ranker time per query as a
+ * proxy for the "scan-and-score" component of recall — the relative
+ * delta between full-corpus and hot-only-corpus rank time is what
+ * matters for index-cost analysis, since the QMD index runtime is
+ * proportional to the corpus the index covers.
+ *
+ * The bench is hermetic: no orchestrator, no QMD, no filesystem. It
+ * relies on `decideTierTransition` from `@remnic/core` so the tier
+ * computation is identical to production behavior.
+ */
+
+import { randomUUID } from "node:crypto";
+import {
+  decideTierTransition,
+  type MemoryFile,
+  type MemoryTier,
+  type TierRoutingPolicy,
+} from "@remnic/core";
+import type {
+  BenchmarkDefinition,
+  BenchmarkResult,
+  ResolvedRunBenchmarkOptions,
+  TaskResult,
+} from "../../../types.js";
+import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+import { buildTieredAggregates } from "../retrieval-shared.js";
+import {
+  generateAgedDataset,
+  type AgedDatasetGeneratorOptions,
+} from "./fixture.js";
+
+export const retentionAgedDatasetDefinition: BenchmarkDefinition = {
+  id: "retention-aged-dataset",
+  title: "Retention Aged Dataset",
+  tier: "remnic",
+  status: "ready",
+  runnerAvailable: true,
+  meta: {
+    name: "retention-aged-dataset",
+    version: "1.0.0",
+    description:
+      "Synthetic aged-corpus benchmark for the hot/cold tier policy at 1- and 2-year scale.",
+    category: "retrieval",
+    citation: "Remnic internal synthetic benchmark for issue #686 PR 2/6",
+  },
+};
+
+/** Default policy values match the production defaults from `config.ts`. */
+const DEFAULT_POLICY: TierRoutingPolicy = {
+  enabled: true,
+  demotionMinAgeDays: 14,
+  demotionValueThreshold: 0.35,
+  promotionValueThreshold: 0.7,
+};
+
+const QUICK_OPTIONS: AgedDatasetGeneratorOptions = {
+  size: 200,
+  horizonDays: 365,
+  topicCount: 8,
+  paretoAlpha: 1.16,
+  ageSkew: 1.5,
+  seed: 0xa686,
+  nowIso: "2026-04-25T12:00:00.000Z",
+};
+
+const FULL_OPTIONS: AgedDatasetGeneratorOptions = {
+  size: 2000,
+  horizonDays: 730,
+  topicCount: 16,
+  paretoAlpha: 1.16,
+  ageSkew: 1.5,
+  seed: 0xa686,
+  nowIso: "2026-04-25T12:00:00.000Z",
+};
+
+/**
+ * Deterministic ranker — keyword-overlap on `content` + `tags`. Mirrors
+ * the simple ranker style used in `retrieval-temporal/runner.ts`.
+ */
+function rankMemories(query: string, memories: MemoryFile[]): MemoryFile[] {
+  const tokens = new Set(
+    query
+      .toLowerCase()
+      .split(/[^a-z0-9]+/)
+      .filter(Boolean),
+  );
+  return [...memories]
+    .map((m) => {
+      const haystack = (
+        m.content +
+        " " +
+        (m.frontmatter.tags ?? []).join(" ")
+      ).toLowerCase();
+      let score = 0;
+      for (const tok of tokens) {
+        if (haystack.includes(tok)) score += 1;
+      }
+      // Tiebreak: more recent first.
+      const recencyMs = Date.parse(
+        m.frontmatter.updated ?? m.frontmatter.created,
+      );
+      return { memory: m, score, recencyMs };
+    })
+    .sort((a, b) => {
+      if (b.score !== a.score) return b.score - a.score;
+      if (b.recencyMs !== a.recencyMs) return b.recencyMs - a.recencyMs;
+      return a.memory.frontmatter.id.localeCompare(b.memory.frontmatter.id);
+    })
+    .map((s) => s.memory);
+}
+
+function recallAtK(
+  ranked: MemoryFile[],
+  relevantIds: Set<string>,
+  k: number,
+): number {
+  if (relevantIds.size === 0) return 1;
+  const topK = ranked.slice(0, k);
+  let hits = 0;
+  for (const m of topK) {
+    if (relevantIds.has(m.frontmatter.id)) hits += 1;
+  }
+  return Math.min(1, hits / Math.min(k, relevantIds.size));
+}
+
+function partitionByTier(
+  memories: MemoryFile[],
+  policy: TierRoutingPolicy,
+  nowIso: string,
+): { hot: MemoryFile[]; cold: MemoryFile[] } {
+  const now = new Date(nowIso);
+  const hot: MemoryFile[] = [];
+  const cold: MemoryFile[] = [];
+  for (const memory of memories) {
+    // Start every memory in `hot` and apply the demotion decision once.
+    // This mirrors production: memories are written to hot and demoted
+    // when the tier-migration cycle sweeps past them.
+    const decision = decideTierTransition(memory, "hot" as MemoryTier, policy, now);
+    if (decision.nextTier === "cold") {
+      cold.push(memory);
+    } else {
+      hot.push(memory);
+    }
+  }
+  return { hot, cold };
+}
+
+export async function runRetentionAgedDatasetBenchmark(
+  options: ResolvedRunBenchmarkOptions,
+): Promise<BenchmarkResult> {
+  const fixtureOptions = options.mode === "quick" ? QUICK_OPTIONS : FULL_OPTIONS;
+  const fixture = generateAgedDataset(fixtureOptions);
+
+  const policyEnabled: TierRoutingPolicy = { ...DEFAULT_POLICY, enabled: true };
+  const { hot: hotMemories, cold: coldMemories } = partitionByTier(
+    fixture.memories,
+    policyEnabled,
+    fixture.options.nowIso,
+  );
+  const hotShare = hotMemories.length / Math.max(1, fixture.memories.length);
+  const coldShare = coldMemories.length / Math.max(1, fixture.memories.length);
+
+  const tasks: TaskResult[] = [];
+  for (const query of fixture.queries) {
+    const relevantIds = new Set(query.relevantMemoryIds);
+
+    const startedFull = performance.now();
+    const fullRanked = rankMemories(query.text, fixture.memories);
+    const latencyFullMs = Math.round(performance.now() - startedFull);
+
+    const startedHot = performance.now();
+    const hotRanked = rankMemories(query.text, hotMemories);
+    const latencyHotMs = Math.round(performance.now() - startedHot);
+
+    const recallFull = recallAtK(fullRanked, relevantIds, 5);
+    const recallHot = recallAtK(hotRanked, relevantIds, 5);
+    const recallDelta = recallFull - recallHot;
+
+    tasks.push({
+      taskId: `topic-${query.topicId}`,
+      question: query.text,
+      expected: JSON.stringify({
+        relevantCount: relevantIds.size,
+      }),
+      actual: JSON.stringify({
+        topFull: fullRanked.slice(0, 5).map((m) => m.frontmatter.id),
+        topHot: hotRanked.slice(0, 5).map((m) => m.frontmatter.id),
+      }),
+      scores: {
+        recall_at_5_full: recallFull,
+        recall_at_5_hot_only: recallHot,
+        recall_at_5_delta: recallDelta,
+        hot_share: hotShare,
+        cold_share: coldShare,
+      },
+      // Use the full-corpus latency as the headline — the comparison to
+      // hotMs is captured in details.
+      latencyMs: latencyFullMs,
+      tokens: { input: 0, output: 0 },
+      details: {
+        topicId: query.topicId,
+        relevantCount: relevantIds.size,
+        latencyFullMs,
+        latencyHotMs,
+        latencyDeltaMs: latencyFullMs - latencyHotMs,
+        hotMemoryCount: hotMemories.length,
+        coldMemoryCount: coldMemories.length,
+        totalMemoryCount: fixture.memories.length,
+      },
+    });
+  }
+
+  const remnicVersion = await getRemnicVersion();
+  const totalLatencyMs = tasks.reduce((sum, t) => sum + t.latencyMs, 0);
+  return {
+    meta: {
+      id: randomUUID(),
+      benchmark: options.benchmark.id,
+      benchmarkTier: options.benchmark.tier,
+      version: options.benchmark.meta.version,
+      remnicVersion,
+      gitSha: getGitSha(),
+      timestamp: new Date().toISOString(),
+      mode: options.mode,
+      runCount: 1,
+      seeds: [options.seed ?? fixture.options.seed],
+    },
+    config: {
+      systemProvider: options.systemProvider ?? null,
+      judgeProvider: options.judgeProvider ?? null,
+      adapterMode: options.adapterMode ?? "synthetic",
+      remnicConfig: options.remnicConfig ?? {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs,
+      meanQueryLatencyMs:
+        tasks.length > 0 ? totalLatencyMs / tasks.length : 0,
+    },
+    results: {
+      tasks,
+      aggregates: buildTieredAggregates(tasks),
+    },
+    environment: {
+      os: process.platform,
+      nodeVersion: process.version,
+      hardware: process.arch,
+    },
+  };
+}

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
@@ -118,9 +118,17 @@ function rankMemories(query: string, memories: MemoryFile[]): MemoryFile[] {
       for (const tok of queryTokens) {
         if (haystackTokens.has(tok)) score += 1;
       }
-      // Tiebreak: more recent first.
+      // Tiebreak: more recent first, mirroring the fixture's
+      // `relevantMemoryIds` recency selection.  The fixture sorts by
+      // `lastAccessed ?? updated ?? created` (fixture.ts), so we MUST
+      // use the same fallback chain here — using only `updated ?? created`
+      // (the prior version) misalignned with the labeled relevant set
+      // when memories had a `lastAccessed` distinct from `updated`,
+      // artificially deflating recall@K.  (Codex P1 review on PR #698.)
       const recencyMs = Date.parse(
-        m.frontmatter.updated ?? m.frontmatter.created,
+        m.frontmatter.lastAccessed
+          ?? m.frontmatter.updated
+          ?? m.frontmatter.created,
       );
       return { memory: m, score, recencyMs };
     })

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
@@ -41,7 +41,7 @@ import type {
   TaskResult,
 } from "../../../types.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
-import { buildTieredAggregates } from "../retrieval-shared.js";
+import { aggregateTaskScores } from "../../../scorer.js";
 import {
   generateAgedDataset,
   type AgedDatasetGeneratorOptions,
@@ -138,7 +138,10 @@ function recallAtK(
   for (const m of topK) {
     if (relevantIds.has(m.frontmatter.id)) hits += 1;
   }
-  return Math.min(1, hits / Math.min(k, relevantIds.size));
+  // Recall@K = (relevant items in top K) / (total relevant items).
+  // Using min(k, relevantIds.size) as the denominator turns this into
+  // precision@K. (Cursor Bugbot review on PR #698.)
+  return hits / relevantIds.size;
 }
 
 function partitionByTier(
@@ -166,7 +169,16 @@ function partitionByTier(
 export async function runRetentionAgedDatasetBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
-  const fixtureOptions = options.mode === "quick" ? QUICK_OPTIONS : FULL_OPTIONS;
+  const baseOptions =
+    options.mode === "quick" ? QUICK_OPTIONS : FULL_OPTIONS;
+  // Thread `options.seed` into the generator so result metadata's reported
+  // seed actually drives the corpus. (Cursor Bugbot review on PR #698.)
+  const seed =
+    typeof options.seed === "number" ? options.seed : baseOptions.seed;
+  const fixtureOptions: AgedDatasetGeneratorOptions = {
+    ...baseOptions,
+    seed,
+  };
   const fixture = generateAgedDataset(fixtureOptions);
 
   const policyEnabled: TierRoutingPolicy = { ...DEFAULT_POLICY, enabled: true };
@@ -178,8 +190,16 @@ export async function runRetentionAgedDatasetBenchmark(
   const hotShare = hotMemories.length / Math.max(1, fixture.memories.length);
   const coldShare = coldMemories.length / Math.max(1, fixture.memories.length);
 
+  // Honor `options.limit` so quick / limited bench runs don't fan out across
+  // every fixture topic. Other remnic runners apply this same shape.
+  // (Codex review on PR #698.)
+  const queries =
+    typeof options.limit === "number" && options.limit > 0
+      ? fixture.queries.slice(0, options.limit)
+      : fixture.queries;
+
   const tasks: TaskResult[] = [];
-  for (const query of fixture.queries) {
+  for (const query of queries) {
     const relevantIds = new Set(query.relevantMemoryIds);
 
     const startedFull = performance.now();
@@ -241,7 +261,9 @@ export async function runRetentionAgedDatasetBenchmark(
       timestamp: new Date().toISOString(),
       mode: options.mode,
       runCount: 1,
-      seeds: [options.seed ?? fixture.options.seed],
+      // `seed` is the actual seed used to generate `fixture` (resolved
+      // from options.seed if provided, otherwise from baseOptions).
+      seeds: [seed],
     },
     config: {
       systemProvider: options.systemProvider ?? null,
@@ -260,7 +282,11 @@ export async function runRetentionAgedDatasetBenchmark(
     },
     results: {
       tasks,
-      aggregates: buildTieredAggregates(tasks),
+      // Use plain `aggregateTaskScores` rather than `buildTieredAggregates`:
+      // this bench has no clean/dirty pairing semantics. The latter requires
+      // each task to set `details.tier === "clean" | "dirty"` and produces
+      // empty aggregates otherwise. (Cursor Bugbot review on PR #698.)
+      aggregates: aggregateTaskScores(tasks.map((t) => t.scores)),
     },
     environment: {
       os: process.platform,

--- a/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
+++ b/packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts
@@ -220,7 +220,7 @@ export async function runRetentionAgedDatasetBenchmark(
     const recallDelta = recallFull - recallHot;
 
     tasks.push({
-      taskId: `topic-${query.topicId}`,
+      taskId: query.id,
       question: query.text,
       expected: JSON.stringify({
         relevantCount: relevantIds.size,

--- a/packages/bench/src/registry.ts
+++ b/packages/bench/src/registry.ts
@@ -131,6 +131,10 @@ import {
   contradictionDetectionDefinition,
   runContradictionDetectionBenchmark,
 } from "./benchmarks/remnic/contradiction-detection/runner.js";
+import {
+  retentionAgedDatasetDefinition,
+  runRetentionAgedDatasetBenchmark,
+} from "./benchmarks/remnic/retention-aged-dataset/runner.js";
 
 interface RegisteredBenchmark extends BenchmarkDefinition {
   run?: (options: ResolvedRunBenchmarkOptions) => Promise<BenchmarkResult>;
@@ -264,6 +268,10 @@ const REGISTERED_BENCHMARKS: RegisteredBenchmark[] = [
   {
     ...contradictionDetectionDefinition,
     run: runContradictionDetectionBenchmark,
+  },
+  {
+    ...retentionAgedDatasetDefinition,
+    run: runRetentionAgedDatasetBenchmark,
   },
 ];
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -147,6 +147,18 @@ export {
 } from "./direct-answer.js";
 
 // ---------------------------------------------------------------------------
+// Hot/cold tier routing (issue #686)
+// ---------------------------------------------------------------------------
+
+export {
+  computeTierValueScore,
+  decideTierTransition,
+  type MemoryTier,
+  type TierRoutingPolicy,
+  type TierTransitionDecision,
+} from "./tier-routing.js";
+
+// ---------------------------------------------------------------------------
 // Reasoning-trace retrieval boost (issue #564)
 // ---------------------------------------------------------------------------
 

--- a/tests/bench-registry.test.ts
+++ b/tests/bench-registry.test.ts
@@ -44,6 +44,7 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "assistant-synthesis",
       "buffer-surprise-trigger",
       "contradiction-detection",
+      "retention-aged-dataset",
     ],
   );
   assert.deepEqual(
@@ -81,11 +82,12 @@ test("listBenchmarks exposes the published and remnic benchmark catalog from @re
       "remnic",
       "remnic",
       "remnic",
+      "remnic",
     ],
   );
   assert.equal(
     benchmarks.filter((benchmark) => benchmark.runnerAvailable).map((benchmark) => benchmark.id).join(","),
-    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection",
+    "ama-bench,memory-arena,amemgym,longmemeval,locomo,beam,personamem,membench,memoryagentbench,taxonomy-accuracy,extraction-judge-calibration,enrichment-fidelity,entity-consolidation,page-versioning,retrieval-personalization,retrieval-temporal,retrieval-direct-answer,retrieval-graph,retrieval-reasoning-trace,coding-recall,procedural-recall,ingestion-entity-recall,ingestion-schema-completeness,ingestion-backlink-f1,ingestion-setup-friction,ingestion-citation-accuracy,assistant-morning-brief,assistant-meeting-prep,assistant-next-best-action,assistant-synthesis,buffer-surprise-trigger,contradiction-detection,retention-aged-dataset",
   );
   // The synthetic ingestion adapter wires all built-in ingestion benchmarks.
   assert.equal(getBenchmark("ingestion-schema-completeness")?.runnerAvailable, true);


### PR DESCRIPTION
## Summary

Adds a new `@remnic/bench` benchmark — `retention-aged-dataset` — that measures structural properties of Remnic's hot/cold tier policy on a synthetic 1- or 2-year corpus.

PR 3/6 will use this bench to tune the production defaults (`demotionMinAgeDays`, `demotionValueThreshold`, `promotionValueThreshold`) and decide whether to flip `lifecyclePolicyEnabled` to `true` by default.

## What the bench measures

Per query (one query per synthetic topic):

- `recall_at_5_full` — recall@5 against the full corpus.
- `recall_at_5_hot_only` — recall@5 against the hot partition (cold partition removed via the production `decideTierTransition` policy).
- `recall_at_5_delta` — full minus hot-only (target: ≤ 0.01).
- `hot_share` / `cold_share` — fraction of corpus per tier.

Per-task latency captures `latencyFullMs` and `latencyHotMs` as a proxy for the index-cost benefit of demoting cold memories out of the live index.

## Design

- **Hermetic.** No orchestrator, no QMD, no filesystem. The bench imports `decideTierTransition` from `@remnic/core` so tier computation is identical to production.
- **Deterministic.** Mulberry32-seeded PRNG; same seed → same fixture.
- **Configurable Pareto + age skew.** Topic frequencies follow a Pareto distribution (1.16 ≈ Zipf's "80/20"); ageSkew biases the corpus toward old memories for a realistic long-tail aged dataset.
- **Spread confidenceTier.** Hot topics lean explicit/implied, cold-tail topics lean inferred/speculative, so the corpus exercises the demotion path.

## Files

- `packages/bench/src/benchmarks/remnic/retention-aged-dataset/fixture.ts` — synthetic corpus + query generator.
- `packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.ts` — bench runner.
- `packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts` — 3 unit tests.
- `packages/bench/src/registry.ts` — registers the new bench.
- `packages/remnic-core/src/index.ts` — exports `computeTierValueScore`, `decideTierTransition`, `MemoryTier`, `TierRoutingPolicy`, `TierTransitionDecision`.
- `tests/bench-registry.test.ts` — catalog test updated.
- `docs/benchmarks/retention-aged-dataset.md` — design doc + acceptance criteria for PR 3.

## Test plan

- [x] `npm run build` clean.
- [x] `npx tsx --test packages/bench/src/benchmarks/remnic/retention-aged-dataset/runner.test.ts` — 3/3 pass.
- [x] `npx tsx --test tests/bench-registry.test.ts` — 24/24 pass (catalog updated).
- [x] `npm run preflight:quick` — fail count 47 → 46 vs `main` baseline (no new failures; the dropped failure is unrelated test-numbering noise).
- [ ] CI green
- [ ] AI reviewers green

Implements PR 2/6 of #686.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new runnable benchmark plus a new public re-export surface in `@remnic/core`, which can impact downstream consumers and benchmark registry expectations but does not change production tier-routing behavior.
> 
> **Overview**
> Adds a new hermetic `retention-aged-dataset` benchmark that generates a deterministic, Pareto/age-skewed synthetic corpus and measures hot/cold tier-policy impact via `recall_at_5_full`, `recall_at_5_hot_only`, `recall_at_5_delta`, and hot/cold share, including per-query latency comparisons.
> 
> Registers the new benchmark in `@remnic/bench` (registry + catalog test), adds unit tests for determinism/limits/metrics, and documents the benchmark goals + PR3 acceptance criteria. Also re-exports tier-routing APIs (`computeTierValueScore`, `decideTierTransition`, related types) from `@remnic/core`’s public `index.ts` so the bench can call the production decision logic.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea30a5496309e064ba358671ef99e0a5cb30314. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->