### PR TITLE
feat(xray): per-disclosure token-spend telemetry on recall X-ray (#677 PR 3/4)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -481,6 +481,25 @@ export class EngramAccessHttpServer {
         }
         budget = parsedBudget;
       }
+      // Disclosure depth (issue #677 PR 3/4 telemetry plumbing).  When
+      // present, must match the chunk|section|raw allow-list; invalid
+      // values surface as a 400 (CLAUDE.md rule 51 — no silent
+      // fallback) rather than silently disabling the per-disclosure
+      // summary table.
+      const disclosureParam = parsed.searchParams.get("disclosure");
+      let disclosure: RecallDisclosure | undefined;
+      if (disclosureParam !== null && disclosureParam.length > 0) {
+        if (!isRecallDisclosure(disclosureParam)) {
+          this.respondJson(res, 400, {
+            error: "invalid_disclosure",
+            code: "invalid_disclosure",
+            message:
+              "disclosure must be one of: chunk, section, raw",
+          });
+          return;
+        }
+        disclosure = disclosureParam;
+      }
       // Only translate validation errors (empty query, bad budget)
       // into 400s.  Backend faults (timeouts, storage errors,
       // unexpected orchestrator failures) must bubble to the global
@@ -496,6 +515,7 @@ export class EngramAccessHttpServer {
           namespace,
           budget,
           authenticatedPrincipal: this.resolveRequestPrincipal(req),
+          ...(disclosure !== undefined ? { disclosure } : {}),
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1321,15 +1321,29 @@ export class EngramMcpServer {
           budget = parsed;
         }
         // Forward disclosure depth so the recallXray telemetry table is
-        // populated for MCP callers (issue #677 PR 3/4).  Treat empty
-        // string as absent (matches HTTP `?disclosure=` handling) so
-        // the two surfaces don't diverge on the same pathological
-        // input.  Non-empty strings flow through to the service's
-        // strict allow-list validator (which throws on unknown values).
-        const disclosure =
-          typeof args.disclosure === "string" && args.disclosure.length > 0
-            ? args.disclosure
-            : undefined;
+        // populated for MCP callers (issue #677 PR 3/4).  Reject
+        // non-string types explicitly (matches the strict input
+        // contract used elsewhere in this handler — see `budget` /
+        // `disclosure` in engram.recall around line 1198 — and the
+        // HTTP path's 400-on-bad-disclosure handling).  Treat empty
+        // string as absent so HTTP `?disclosure=` and MCP align on
+        // the same observable contract for that pathological input.
+        // Non-empty strings flow through to the service's strict
+        // allow-list validator (which throws on unknown values).
+        let disclosure: string | undefined;
+        if (
+          "disclosure" in args &&
+          args.disclosure !== undefined &&
+          args.disclosure !== null &&
+          args.disclosure !== ""
+        ) {
+          if (typeof args.disclosure !== "string") {
+            throw new Error(
+              "engram.recall_xray: disclosure must be a string (one of: chunk, section, raw)",
+            );
+          }
+          disclosure = args.disclosure;
+        }
         return this.service.recallXray({
           query,
           sessionKey,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -211,6 +211,12 @@ export class EngramMcpServer {
               description:
                 "Optional positive-integer override for the recall character budget.",
             },
+            disclosure: {
+              type: "string",
+              enum: ["chunk", "section", "raw"],
+              description:
+                "Optional disclosure depth for X-ray telemetry (issue #677). When set, populates the per-disclosure token-spend summary on each result.",
+            },
           },
           required: ["query"],
           additionalProperties: false,
@@ -1315,10 +1321,15 @@ export class EngramMcpServer {
           budget = parsed;
         }
         // Forward disclosure depth so the recallXray telemetry table is
-        // populated for MCP callers (issue #677 PR 3/4).  Service does
-        // strict allow-list validation up front.
+        // populated for MCP callers (issue #677 PR 3/4).  Treat empty
+        // string as absent (matches HTTP `?disclosure=` handling) so
+        // the two surfaces don't diverge on the same pathological
+        // input.  Non-empty strings flow through to the service's
+        // strict allow-list validator (which throws on unknown values).
         const disclosure =
-          typeof args.disclosure === "string" ? args.disclosure : undefined;
+          typeof args.disclosure === "string" && args.disclosure.length > 0
+            ? args.disclosure
+            : undefined;
         return this.service.recallXray({
           query,
           sessionKey,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1314,12 +1314,20 @@ export class EngramMcpServer {
           }
           budget = parsed;
         }
+        // Forward disclosure depth so the recallXray telemetry table is
+        // populated for MCP callers (issue #677 PR 3/4).  Service does
+        // strict allow-list validation up front.
+        const disclosure =
+          typeof args.disclosure === "string" ? args.disclosure : undefined;
         return this.service.recallXray({
           query,
           sessionKey,
           namespace,
           budget,
           authenticatedPrincipal: effectivePrincipal,
+          ...(disclosure !== undefined
+            ? { disclosure: disclosure as import("./types.js").RecallDisclosure }
+            : {}),
         });
       }
       case "engram.day_summary":

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1554,6 +1554,19 @@ export class EngramAccessService {
       // an empty snapshot.
       throw new Error("recallXray: query is required and must be non-empty");
     }
+    // Validate disclosure UP FRONT — before recall executes, before
+    // the xray queue mutex is acquired, before namespace resolution.
+    // A bad value should fail fast rather than after we've burned
+    // cycles on an irreversible recall (Cursor Medium review on PR
+    // #699).
+    if (
+      request.disclosure !== undefined &&
+      !isRecallDisclosure(request.disclosure)
+    ) {
+      throw new EngramAccessInputError(
+        `recallXray: disclosure must be one of: chunk, section, raw (got: ${String(request.disclosure)})`,
+      );
+    }
 
     const namespacesEnabled = this.orchestrator.config.namespacesEnabled;
     const requestedNamespace = request.namespace?.trim()
@@ -1666,15 +1679,9 @@ export class EngramAccessService {
       // and raw use full content.  Best-effort only — a missing
       // memory or read failure is silently dropped (CLAUDE.md rule 13).
       if (request.disclosure !== undefined) {
-        // Validate disclosure input — recallXray must reject invalid
-        // values rather than writing them straight into result metadata
-        // (Codex P2 review on PR #699).  Aligned with `recall()` above.
-        if (!isRecallDisclosure(request.disclosure)) {
-          throw new EngramAccessInputError(
-            `recallXray: disclosure must be one of: chunk, section, raw (got: ${String(request.disclosure)})`,
-          );
-        }
-        const disclosure = request.disclosure;
+        // Disclosure already validated up front; pin to the narrowed
+        // type here.  Re-validation inside the queue would be dead code.
+        const disclosure: RecallDisclosure = request.disclosure;
         const namespace = snapshot.namespace
           ? this.resolveNamespace(snapshot.namespace)
           : this.orchestrator.config.defaultNamespace;
@@ -1722,7 +1729,16 @@ export class EngramAccessService {
           (await this.orchestrator.getStorage(namespace)).dir;
         const decorated = snapshot.results.map((result, index) => {
           const memory = memoryByIndex[index];
-          if (!memory) return result;
+          if (!memory) {
+            // Unreadable result: attach the disclosure tag anyway so
+            // the per-disclosure summary classifies it correctly,
+            // but skip the token estimate since we don't have the
+            // content to measure.  Without the disclosure tag the
+            // result silently flows into the `unspecified` bucket
+            // even though the caller explicitly requested a depth
+            // (Cursor Low review on PR #699).
+            return { ...result, disclosure };
+          }
           // Build a representative shaped summary so the estimate
           // counts every field `shapeMemorySummary` actually emits.
           // The serialized JSON form is a close-enough proxy for the

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1670,16 +1670,51 @@ export class EngramAccessService {
         const namespace = snapshot.namespace
           ? this.resolveNamespace(snapshot.namespace)
           : this.orchestrator.config.defaultNamespace;
+        // Pre-fetch raw excerpts ONCE so the first raw-disclosure
+        // result's token estimate includes the LCM-side excerpt spend
+        // that `shapeMemorySummary` actually attaches in the recall
+        // response.  Without this, raw recalls systematically
+        // undercounted spend on the first result (Cursor Medium review
+        // on PR #699).  Excerpts are scoped to the same session +
+        // namespace as the recall.
+        const rawExcerpts =
+          disclosure === "raw"
+            ? await this.fetchRawExcerpts(disclosure, {
+                query,
+                ...(request.sessionKey ? { sessionKey: request.sessionKey } : {}),
+                namespace,
+              })
+            : null;
+        const rawExcerptText =
+          rawExcerpts && rawExcerpts.length > 0
+            ? rawExcerpts.map((e) => e.content).join("\n")
+            : "";
+        let firstRawDecorated = false;
         const decorated = await Promise.all(
           snapshot.results.map(async (result) => {
             try {
               const storage = await this.orchestrator.getStorage(namespace);
               const memory = await storage.readMemoryByPath(result.path);
               if (!memory) return result;
-              const renderedText =
+              const baseText =
                 disclosure === "chunk"
                   ? normalizeProjectionPreview(memory.content)
                   : memory.content;
+              // Match `shapeMemorySummary`'s rawExcerpts attribution:
+              // the helper attaches excerpts to the first raw result
+              // only.  We do the same here so the per-result token
+              // estimate matches what the response actually rendered.
+              let extraText = "";
+              if (
+                disclosure === "raw" &&
+                !firstRawDecorated &&
+                rawExcerptText.length > 0
+              ) {
+                extraText = rawExcerptText;
+                firstRawDecorated = true;
+              }
+              const renderedText =
+                extraText.length > 0 ? `${baseText}\n${extraText}` : baseText;
               return {
                 ...result,
                 disclosure,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1666,6 +1666,14 @@ export class EngramAccessService {
       // and raw use full content.  Best-effort only — a missing
       // memory or read failure is silently dropped (CLAUDE.md rule 13).
       if (request.disclosure !== undefined) {
+        // Validate disclosure input — recallXray must reject invalid
+        // values rather than writing them straight into result metadata
+        // (Codex P2 review on PR #699).  Aligned with `recall()` above.
+        if (!isRecallDisclosure(request.disclosure)) {
+          throw new EngramAccessInputError(
+            `recallXray: disclosure must be one of: chunk, section, raw (got: ${String(request.disclosure)})`,
+          );
+        }
         const disclosure = request.disclosure;
         const namespace = snapshot.namespace
           ? this.resolveNamespace(snapshot.namespace)
@@ -1689,45 +1697,70 @@ export class EngramAccessService {
           rawExcerpts && rawExcerpts.length > 0
             ? rawExcerpts.map((e) => e.content).join("\n")
             : "";
-        // Excerpts attach to result[0] in the recall response — pin the
-        // attribution to the deterministic index here so concurrent
-        // execution inside the Promise.all map can't reassign which
-        // result gets credited (Cursor + Codex Medium review on PR #699).
-        const decorated = await Promise.all(
-          snapshot.results.map(async (result, index) => {
+        // Pre-load every memory in parallel so we can:
+        //   (a) re-attribute raw excerpts to the *first readable* result
+        //       rather than always to index 0 (Cursor Low review on PR
+        //       #699: a missing/unreadable result[0] orphaned the excerpt
+        //       budget); and
+        //   (b) include the metadata fields `shapeMemorySummary` actually
+        //       emits at every depth (id, path, category, status, created,
+        //       updated, tags, entityRef) in the token estimate, so the
+        //       summary reflects real spend rather than only payload-body
+        //       spend (Cursor Low review on PR #699).
+        const memoryByIndex = await Promise.all(
+          snapshot.results.map(async (result) => {
             try {
               const storage = await this.orchestrator.getStorage(namespace);
-              const memory = await storage.readMemoryByPath(result.path);
-              if (!memory) return result;
-              // Mirror `shapeMemorySummary` output exactly:
-              //   chunk   → preview only
-              //   section → preview + full content
-              //   raw     → preview + full content + (first result) rawExcerpts
-              // Earlier rev under-counted section/raw by omitting the
-              // preview emitted at every depth (Cursor Low review on
-              // PR #699).
-              const previewText = normalizeProjectionPreview(memory.content);
-              const parts: string[] = [previewText];
-              if (disclosure === "section" || disclosure === "raw") {
-                parts.push(memory.content);
-              }
-              if (
-                disclosure === "raw" &&
-                index === 0 &&
-                rawExcerptText.length > 0
-              ) {
-                parts.push(rawExcerptText);
-              }
-              return {
-                ...result,
-                disclosure,
-                estimatedTokens: estimateRecallTokens(parts.join("\n")),
-              };
+              return await storage.readMemoryByPath(result.path);
             } catch {
-              return result;
+              return null;
             }
           }),
         );
+        const firstReadableIndex = memoryByIndex.findIndex((m) => m !== null);
+        const baseDir =
+          (await this.orchestrator.getStorage(namespace)).dir;
+        const decorated = snapshot.results.map((result, index) => {
+          const memory = memoryByIndex[index];
+          if (!memory) return result;
+          // Build a representative shaped summary so the estimate
+          // counts every field `shapeMemorySummary` actually emits.
+          // The serialized JSON form is a close-enough proxy for the
+          // wire payload size.
+          const shaped = shapeMemorySummary(
+            memory,
+            baseDir,
+            disclosure,
+            disclosure === "raw" &&
+            index === firstReadableIndex &&
+            rawExcerpts &&
+            rawExcerpts.length > 0
+              ? rawExcerpts
+              : undefined,
+          );
+          return {
+            ...result,
+            disclosure,
+            estimatedTokens: estimateRecallTokens(JSON.stringify(shaped)),
+          };
+        });
+        // Edge case: every result was unreadable but rawExcerpts
+        // still has content — credit that spend to result[0] rather
+        // than dropping it on the floor.  Without this, the raw row
+        // in the per-disclosure summary under-reports spend whenever
+        // every memory file is missing/unreadable.
+        if (
+          disclosure === "raw" &&
+          firstReadableIndex === -1 &&
+          rawExcerptText.length > 0 &&
+          decorated.length > 0
+        ) {
+          decorated[0] = {
+            ...decorated[0]!,
+            disclosure,
+            estimatedTokens: estimateRecallTokens(rawExcerptText),
+          };
+        }
         return {
           snapshotFound: true,
           snapshot: { ...snapshot, results: decorated },

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1689,36 +1689,39 @@ export class EngramAccessService {
           rawExcerpts && rawExcerpts.length > 0
             ? rawExcerpts.map((e) => e.content).join("\n")
             : "";
-        let firstRawDecorated = false;
+        // Excerpts attach to result[0] in the recall response — pin the
+        // attribution to the deterministic index here so concurrent
+        // execution inside the Promise.all map can't reassign which
+        // result gets credited (Cursor + Codex Medium review on PR #699).
         const decorated = await Promise.all(
-          snapshot.results.map(async (result) => {
+          snapshot.results.map(async (result, index) => {
             try {
               const storage = await this.orchestrator.getStorage(namespace);
               const memory = await storage.readMemoryByPath(result.path);
               if (!memory) return result;
-              const baseText =
-                disclosure === "chunk"
-                  ? normalizeProjectionPreview(memory.content)
-                  : memory.content;
-              // Match `shapeMemorySummary`'s rawExcerpts attribution:
-              // the helper attaches excerpts to the first raw result
-              // only.  We do the same here so the per-result token
-              // estimate matches what the response actually rendered.
-              let extraText = "";
+              // Mirror `shapeMemorySummary` output exactly:
+              //   chunk   → preview only
+              //   section → preview + full content
+              //   raw     → preview + full content + (first result) rawExcerpts
+              // Earlier rev under-counted section/raw by omitting the
+              // preview emitted at every depth (Cursor Low review on
+              // PR #699).
+              const previewText = normalizeProjectionPreview(memory.content);
+              const parts: string[] = [previewText];
+              if (disclosure === "section" || disclosure === "raw") {
+                parts.push(memory.content);
+              }
               if (
                 disclosure === "raw" &&
-                !firstRawDecorated &&
+                index === 0 &&
                 rawExcerptText.length > 0
               ) {
-                extraText = rawExcerptText;
-                firstRawDecorated = true;
+                parts.push(rawExcerptText);
               }
-              const renderedText =
-                extraText.length > 0 ? `${baseText}\n${extraText}` : baseText;
               return {
                 ...result,
                 disclosure,
-                estimatedTokens: estimateRecallTokens(renderedText),
+                estimatedTokens: estimateRecallTokens(parts.join("\n")),
               };
             } catch {
               return result;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1692,11 +1692,17 @@ export class EngramAccessService {
         // undercounted spend on the first result (Cursor Medium review
         // on PR #699).  Excerpts are scoped to the same session +
         // namespace as the recall.
+        // Trim sessionKey to match what `orchestrator.recall(...)`
+        // already does (`request.sessionKey?.trim() || undefined`),
+        // otherwise a whitespace-padded key drives recall under one
+        // identity but probes LCM under a different prefix and
+        // misses stored excerpts (Cursor Low review on PR #699).
+        const trimmedSessionKey = request.sessionKey?.trim() || undefined;
         const rawExcerpts =
           disclosure === "raw"
             ? await this.fetchRawExcerpts(disclosure, {
                 query,
-                ...(request.sessionKey ? { sessionKey: request.sessionKey } : {}),
+                ...(trimmedSessionKey ? { sessionKey: trimmedSessionKey } : {}),
                 namespace,
               })
             : null;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -82,6 +82,7 @@ import type {
   RecallPlanMode,
 } from "./types.js";
 import { DEFAULT_RECALL_DISCLOSURE, isRecallDisclosure } from "./types.js";
+import { estimateRecallTokens } from "./recall-xray.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import type { SemanticDedupLookup } from "./dedup/semantic.js";
@@ -1533,6 +1534,15 @@ export class EngramAccessService {
     namespace?: string;
     budget?: number;
     authenticatedPrincipal?: string;
+    /**
+     * Disclosure depth used to shape per-result payload (issue #677
+     * PR 3/4).  When set, each X-ray result is decorated with the
+     * matching `disclosure` field and `estimatedTokens` computed from
+     * the actual rendered content at that depth, so the renderer's
+     * "Token spend by disclosure" summary reflects real spend rather
+     * than staying empty when no caller wires the depth knob through.
+     */
+    disclosure?: RecallDisclosure;
   }): Promise<{
     snapshotFound: boolean;
     snapshot?: import("./recall-xray.js").RecallXraySnapshot;
@@ -1646,6 +1656,44 @@ export class EngramAccessService {
       // asked for.
       if (requestedNamespace && snapshot.namespace !== requestedNamespace) {
         return { snapshotFound: false };
+      }
+      // Decorate per-result disclosure + token estimate when the caller
+      // wired a depth knob (issue #677 PR 3/4 — codex review on #699
+      // flagged that the renderer's per-disclosure summary stays empty
+      // until callers populate these fields).  Estimate tokens from
+      // the actual rendered payload at the requested depth so the
+      // summary reflects real spend; chunk uses the preview, section
+      // and raw use full content.  Best-effort only — a missing
+      // memory or read failure is silently dropped (CLAUDE.md rule 13).
+      if (request.disclosure !== undefined) {
+        const disclosure = request.disclosure;
+        const namespace = snapshot.namespace
+          ? this.resolveNamespace(snapshot.namespace)
+          : this.orchestrator.config.defaultNamespace;
+        const decorated = await Promise.all(
+          snapshot.results.map(async (result) => {
+            try {
+              const storage = await this.orchestrator.getStorage(namespace);
+              const memory = await storage.readMemoryByPath(result.path);
+              if (!memory) return result;
+              const renderedText =
+                disclosure === "chunk"
+                  ? normalizeProjectionPreview(memory.content)
+                  : memory.content;
+              return {
+                ...result,
+                disclosure,
+                estimatedTokens: estimateRecallTokens(renderedText),
+              };
+            } catch {
+              return result;
+            }
+          }),
+        );
+        return {
+          snapshotFound: true,
+          snapshot: { ...snapshot, results: decorated },
+        };
       }
       return { snapshotFound: true, snapshot };
     } finally {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -4258,6 +4258,10 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           "--out <path>",
           "Write the rendered snapshot to a file instead of stdout",
         )
+        .option(
+          "--disclosure <level>",
+          "Disclosure depth (chunk | section | raw). Populates the per-disclosure token-spend summary.",
+        )
         .action(async (...args: unknown[]) => {
           // Commander passes positional args first, then the options
           // object as the last argument.  `parseXrayCliOptions` is a
@@ -4285,6 +4289,9 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             query: parsed.query,
             ...(parsed.namespace ? { namespace: parsed.namespace } : {}),
             ...(parsed.budget !== undefined ? { budget: parsed.budget } : {}),
+            ...(parsed.disclosure !== undefined
+              ? { disclosure: parsed.disclosure }
+              : {}),
           });
           const snapshot = response.snapshotFound
             ? response.snapshot ?? null

--- a/packages/remnic-core/src/recall-xray-cli.ts
+++ b/packages/remnic-core/src/recall-xray-cli.ts
@@ -14,6 +14,11 @@ import {
   parseXrayFormat,
   type RecallXrayFormat,
 } from "./recall-xray-renderer.js";
+import {
+  isRecallDisclosure,
+  RECALL_DISCLOSURE_LEVELS,
+  type RecallDisclosure,
+} from "./types.js";
 
 export interface ParsedXrayCliOptions {
   format: RecallXrayFormat;
@@ -23,6 +28,22 @@ export interface ParsedXrayCliOptions {
   namespace?: string;
   /** Trimmed, tilde-unexpanded output path, or undefined when stdout. */
   outPath?: string;
+  /** Disclosure depth for X-ray telemetry, or undefined when not specified. */
+  disclosure?: RecallDisclosure;
+}
+
+/**
+ * Validate and coerce `--disclosure <level>`.  Must be one of the
+ * canonical levels; throws a listed-options error otherwise.
+ */
+export function parseXrayDisclosureFlag(value: unknown): RecallDisclosure | undefined {
+  if (value === undefined || value === null) return undefined;
+  if (typeof value !== "string" || !isRecallDisclosure(value)) {
+    throw new Error(
+      `--disclosure expects one of ${RECALL_DISCLOSURE_LEVELS.join(", ")}; got ${JSON.stringify(value)}`,
+    );
+  }
+  return value;
 }
 
 /**
@@ -67,11 +88,13 @@ export function parseXrayCliOptions(
     typeof options.out === "string" && options.out.trim().length > 0
       ? options.out.trim()
       : undefined;
+  const disclosure = parseXrayDisclosureFlag(options.disclosure);
   return {
     query: rawQuery,
     format,
     ...(budget !== undefined ? { budget } : {}),
     ...(namespace !== undefined ? { namespace } : {}),
     ...(outPath !== undefined ? { outPath } : {}),
+    ...(disclosure !== undefined ? { disclosure } : {}),
   };
 }

--- a/packages/remnic-core/src/recall-xray-disclosure-telemetry.test.ts
+++ b/packages/remnic-core/src/recall-xray-disclosure-telemetry.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the disclosure-telemetry surface added to Recall X-ray in
+ * issue #677 PR 3/4.  Covers:
+ *
+ *   - `estimateRecallTokens()` heuristic edge cases.
+ *   - Per-result `disclosure` + `estimatedTokens` round-trip through
+ *     `cloneResult` / `buildXraySnapshot`.
+ *   - `summarizeDisclosureTokens()` aggregation across all four buckets.
+ *   - Markdown renderer emits the per-disclosure summary table only
+ *     when at least one result carries a disclosure level.
+ *
+ * No real recall data is exercised here; fixtures are synthetic.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  buildXraySnapshot,
+  estimateRecallTokens,
+  summarizeDisclosureTokens,
+  type RecallXrayResult,
+} from "./recall-xray.ts";
+import { renderXrayMarkdown } from "./recall-xray-renderer.ts";
+
+function makeResult(overrides: Partial<RecallXrayResult>): RecallXrayResult {
+  return {
+    memoryId: overrides.memoryId ?? "mem-1",
+    path: overrides.path ?? "/tmp/mem-1.md",
+    servedBy: overrides.servedBy ?? "hybrid",
+    scoreDecomposition: overrides.scoreDecomposition ?? { final: 0.5 },
+    admittedBy: overrides.admittedBy ?? [],
+    ...overrides,
+  };
+}
+
+test("estimateRecallTokens: empty / null / undefined returns 0", () => {
+  assert.equal(estimateRecallTokens(""), 0);
+  assert.equal(estimateRecallTokens(null), 0);
+  assert.equal(estimateRecallTokens(undefined), 0);
+});
+
+test("estimateRecallTokens: ~4 chars/token heuristic, ceiling rounded", () => {
+  // 8 chars → 2 tokens
+  assert.equal(estimateRecallTokens("abcdefgh"), 2);
+  // 9 chars → 3 tokens (ceil 9/4)
+  assert.equal(estimateRecallTokens("abcdefghi"), 3);
+  // 1 char → 1 token (rounding up from 0.25)
+  assert.equal(estimateRecallTokens("x"), 1);
+});
+
+test("estimateRecallTokens: rejects non-string input gracefully", () => {
+  // TypeScript blocks this at the type system but we still want
+  // runtime safety for surfaces that pass through unknown payloads.
+  assert.equal(estimateRecallTokens(42 as unknown as string), 0);
+  assert.equal(estimateRecallTokens({} as unknown as string), 0);
+});
+
+test("buildXraySnapshot preserves disclosure + estimatedTokens on results", () => {
+  const snap = buildXraySnapshot({
+    query: "q",
+    results: [
+      makeResult({ memoryId: "a", disclosure: "chunk", estimatedTokens: 50 }),
+      makeResult({ memoryId: "b", disclosure: "section", estimatedTokens: 200 }),
+      makeResult({ memoryId: "c", disclosure: "raw", estimatedTokens: 800 }),
+    ],
+  });
+  assert.equal(snap.results.length, 3);
+  assert.equal(snap.results[0]?.disclosure, "chunk");
+  assert.equal(snap.results[0]?.estimatedTokens, 50);
+  assert.equal(snap.results[1]?.disclosure, "section");
+  assert.equal(snap.results[2]?.estimatedTokens, 800);
+});
+
+test("buildXraySnapshot drops invalid disclosure + tokens silently (poison guard)", () => {
+  const snap = buildXraySnapshot({
+    query: "q",
+    results: [
+      makeResult({
+        memoryId: "bad-disc",
+        disclosure: "FULL" as unknown as RecallXrayResult["disclosure"],
+        estimatedTokens: 100,
+      }),
+      makeResult({
+        memoryId: "neg-tokens",
+        disclosure: "chunk",
+        estimatedTokens: -5,
+      }),
+      makeResult({
+        memoryId: "nan-tokens",
+        disclosure: "chunk",
+        estimatedTokens: NaN,
+      }),
+    ],
+  });
+  // Invalid disclosure dropped; tokens still preserved (>= 0).
+  assert.equal(snap.results[0]?.disclosure, undefined);
+  assert.equal(snap.results[0]?.estimatedTokens, 100);
+  // Negative tokens dropped; disclosure preserved.
+  assert.equal(snap.results[1]?.disclosure, "chunk");
+  assert.equal(snap.results[1]?.estimatedTokens, undefined);
+  // NaN tokens dropped.
+  assert.equal(snap.results[2]?.estimatedTokens, undefined);
+});
+
+test("summarizeDisclosureTokens: empty results yield zeroed buckets", () => {
+  const summary = summarizeDisclosureTokens([]);
+  assert.deepStrictEqual(summary, {
+    chunk: { count: 0, estimatedTokens: 0 },
+    section: { count: 0, estimatedTokens: 0 },
+    raw: { count: 0, estimatedTokens: 0 },
+    unspecified: { count: 0, estimatedTokens: 0 },
+  });
+});
+
+test("summarizeDisclosureTokens: aggregates across buckets including unspecified", () => {
+  const results = [
+    makeResult({ memoryId: "1", disclosure: "chunk", estimatedTokens: 10 }),
+    makeResult({ memoryId: "2", disclosure: "chunk", estimatedTokens: 20 }),
+    makeResult({ memoryId: "3", disclosure: "section", estimatedTokens: 100 }),
+    makeResult({ memoryId: "4", disclosure: "raw", estimatedTokens: 500 }),
+    makeResult({ memoryId: "5" /* no disclosure */, estimatedTokens: 7 }),
+    makeResult({ memoryId: "6" /* no disclosure, no tokens */ }),
+  ];
+  const summary = summarizeDisclosureTokens(results);
+  assert.deepStrictEqual(summary, {
+    chunk: { count: 2, estimatedTokens: 30 },
+    section: { count: 1, estimatedTokens: 100 },
+    raw: { count: 1, estimatedTokens: 500 },
+    unspecified: { count: 2, estimatedTokens: 7 },
+  });
+});
+
+test("renderXrayMarkdown: emits token-spend table when any result has disclosure", () => {
+  const snap = buildXraySnapshot({
+    query: "test",
+    results: [
+      makeResult({ memoryId: "a", disclosure: "chunk", estimatedTokens: 50 }),
+      makeResult({ memoryId: "b", disclosure: "section", estimatedTokens: 200 }),
+    ],
+  });
+  const md = renderXrayMarkdown(snap);
+  assert.match(md, /## Results/);
+  assert.match(md, /### Token spend by disclosure/);
+  assert.match(md, /\| chunk \| 1 \| 50 \|/);
+  assert.match(md, /\| section \| 1 \| 200 \|/);
+  assert.match(md, /\| raw \| 0 \| 0 \|/);
+});
+
+test("renderXrayMarkdown: omits token-spend table when no result has disclosure", () => {
+  const snap = buildXraySnapshot({
+    query: "test",
+    results: [
+      makeResult({ memoryId: "a" }),
+      makeResult({ memoryId: "b" }),
+    ],
+  });
+  const md = renderXrayMarkdown(snap);
+  assert.match(md, /## Results/);
+  assert.doesNotMatch(md, /Token spend by disclosure/);
+});
+
+test("renderXrayMarkdown: per-result line surfaces disclosure + token estimate", () => {
+  const snap = buildXraySnapshot({
+    query: "test",
+    results: [
+      makeResult({ memoryId: "alpha", disclosure: "raw", estimatedTokens: 800 }),
+    ],
+  });
+  const md = renderXrayMarkdown(snap);
+  assert.match(md, /\*\*Disclosure:\*\* `raw` \(~800 tokens\)/);
+});
+
+test("renderXrayMarkdown: unspecified-disclosure tokens shown as own line", () => {
+  const snap = buildXraySnapshot({
+    query: "test",
+    results: [
+      makeResult({ memoryId: "lone", estimatedTokens: 42 }),
+    ],
+  });
+  const md = renderXrayMarkdown(snap);
+  assert.match(md, /\*\*Estimated tokens:\*\* 42/);
+});

--- a/packages/remnic-core/src/recall-xray-disclosure-telemetry.test.ts
+++ b/packages/remnic-core/src/recall-xray-disclosure-telemetry.test.ts
@@ -20,8 +20,8 @@ import {
   estimateRecallTokens,
   summarizeDisclosureTokens,
   type RecallXrayResult,
-} from "./recall-xray.ts";
-import { renderXrayMarkdown } from "./recall-xray-renderer.ts";
+} from "./recall-xray.js";
+import { renderXrayMarkdown } from "./recall-xray-renderer.js";
 
 function makeResult(overrides: Partial<RecallXrayResult>): RecallXrayResult {
   return {

--- a/packages/remnic-core/src/recall-xray-renderer.ts
+++ b/packages/remnic-core/src/recall-xray-renderer.ts
@@ -22,6 +22,7 @@ import type {
   RecallXraySnapshot,
   RecallXrayServedBy,
 } from "./recall-xray.js";
+import { summarizeDisclosureTokens } from "./recall-xray.js";
 import { renderTierExplainTextLines } from "./recall-explain-renderer.js";
 
 export type RecallXrayFormat = "json" | "text" | "markdown";
@@ -224,6 +225,36 @@ export function renderXrayMarkdown(
         lines.push(line);
       }
     });
+
+    // Per-disclosure token-spend summary (issue #677 PR 3/4).  Only
+    // emitted when at least one result carries a disclosure level so
+    // we don't pollute the snapshot for callers who haven't wired the
+    // depth knob through.  Counts and tokens default to 0 for buckets
+    // with no contributions.
+    const summary = summarizeDisclosureTokens(snapshot.results);
+    const hasAnyDisclosure =
+      summary.chunk.count + summary.section.count + summary.raw.count > 0;
+    if (hasAnyDisclosure) {
+      lines.push("");
+      lines.push("### Token spend by disclosure");
+      lines.push("");
+      lines.push("| Disclosure | Results | Estimated tokens |");
+      lines.push("| --- | ---: | ---: |");
+      lines.push(
+        `| chunk | ${summary.chunk.count} | ${summary.chunk.estimatedTokens} |`,
+      );
+      lines.push(
+        `| section | ${summary.section.count} | ${summary.section.estimatedTokens} |`,
+      );
+      lines.push(
+        `| raw | ${summary.raw.count} | ${summary.raw.estimatedTokens} |`,
+      );
+      if (summary.unspecified.count > 0) {
+        lines.push(
+          `| _(unspecified)_ | ${summary.unspecified.count} | ${summary.unspecified.estimatedTokens} |`,
+        );
+      }
+    }
   }
 
   lines.push("");
@@ -297,6 +328,17 @@ function renderResultMarkdownLines(
   }
   if (result.auditEntryId) {
     lines.push(`- **Audit entry:** \`${result.auditEntryId}\``);
+  }
+  if (result.disclosure !== undefined) {
+    const tokenLine =
+      typeof result.estimatedTokens === "number"
+        ? ` (~${result.estimatedTokens} tokens)`
+        : "";
+    lines.push(`- **Disclosure:** \`${result.disclosure}\`${tokenLine}`);
+  } else if (typeof result.estimatedTokens === "number") {
+    // Disclosure unspecified but tokens recorded — still surface the
+    // budget so the operator can attribute spend.
+    lines.push(`- **Estimated tokens:** ${result.estimatedTokens}`);
   }
   return lines;
 }

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -20,6 +20,7 @@
 import { randomUUID } from "node:crypto";
 
 import type { RecallDisclosure, RecallTierExplain } from "./types.js";
+import { isRecallDisclosure } from "./types.js";
 
 /**
  * Estimate token cost of a payload at the rough ~4 chars/token English
@@ -352,12 +353,10 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
   if (rejectedBy !== undefined) out.rejectedBy = rejectedBy;
   // Disclosure + token telemetry (issue #677 PR 3/4).  Only attach when
   // present and well-formed; unknown disclosure values are dropped so a
-  // bad caller can't poison downstream renderers.
-  if (
-    result.disclosure === "chunk" ||
-    result.disclosure === "section" ||
-    result.disclosure === "raw"
-  ) {
+  // bad caller can't poison downstream renderers.  Uses the shared
+  // `isRecallDisclosure` guard so adding a fourth disclosure level
+  // requires touching only `types.ts`.
+  if (isRecallDisclosure(result.disclosure)) {
     out.disclosure = result.disclosure;
   }
   if (
@@ -391,12 +390,9 @@ export function summarizeDisclosureTokens(
       result.estimatedTokens >= 0
         ? Math.floor(result.estimatedTokens)
         : 0;
-    const bucket =
-      result.disclosure === "chunk" ||
-      result.disclosure === "section" ||
-      result.disclosure === "raw"
-        ? result.disclosure
-        : "unspecified";
+    const bucket = isRecallDisclosure(result.disclosure)
+      ? result.disclosure
+      : "unspecified";
     summary[bucket].count += 1;
     summary[bucket].estimatedTokens += tokens;
   }

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -19,7 +19,32 @@
 
 import { randomUUID } from "node:crypto";
 
-import type { RecallTierExplain } from "./types.js";
+import type { RecallDisclosure, RecallTierExplain } from "./types.js";
+
+/**
+ * Estimate token cost of a payload at the rough ~4 chars/token English
+ * heuristic.  Non-negative integer; returns 0 for empty / null input.
+ * Used by recall surfaces to attach `estimatedTokens` to X-ray results
+ * (issue #677 PR 3/4).  Identical to the private heuristic in
+ * `chunking.ts`; kept self-contained here so X-ray callers don't pull
+ * in chunking internals.
+ */
+export function estimateRecallTokens(text: string | null | undefined): number {
+  if (typeof text !== "string" || text.length === 0) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+/**
+ * Aggregated per-disclosure token spend summary, computed by the
+ * renderer from a snapshot's results.  Non-negative integers.
+ */
+export interface RecallXrayDisclosureSummary {
+  chunk: { count: number; estimatedTokens: number };
+  section: { count: number; estimatedTokens: number };
+  raw: { count: number; estimatedTokens: number };
+  /** Number of results without a recorded disclosure level. */
+  unspecified: { count: number; estimatedTokens: number };
+}
 
 /**
  * Which retrieval source produced a given result.  This is the X-ray
@@ -93,6 +118,21 @@ export interface RecallXrayResult {
    * before the rejecting gate; consumers should render both.
    */
   rejectedBy?: string;
+  /**
+   * Disclosure depth used to render this result's payload (issue #677
+   * PR 3/4).  Mirrors the per-result disclosure already exposed in the
+   * recall response so X-ray consumers can attribute token spend to
+   * the depth that produced it.
+   */
+  disclosure?: RecallDisclosure;
+  /**
+   * Estimated token cost of the rendered payload at the chosen
+   * disclosure depth.  Non-negative integer.  Computed by callers via
+   * `estimateRecallTokens(text)`; the renderer aggregates these into
+   * a per-disclosure summary so operators can see where their budget
+   * went.
+   */
+  estimatedTokens?: number;
 }
 
 /**
@@ -310,7 +350,57 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
   if (graphPath !== undefined) out.graphPath = graphPath;
   if (auditEntryId !== undefined) out.auditEntryId = auditEntryId;
   if (rejectedBy !== undefined) out.rejectedBy = rejectedBy;
+  // Disclosure + token telemetry (issue #677 PR 3/4).  Only attach when
+  // present and well-formed; unknown disclosure values are dropped so a
+  // bad caller can't poison downstream renderers.
+  if (
+    result.disclosure === "chunk" ||
+    result.disclosure === "section" ||
+    result.disclosure === "raw"
+  ) {
+    out.disclosure = result.disclosure;
+  }
+  if (
+    typeof result.estimatedTokens === "number" &&
+    Number.isFinite(result.estimatedTokens) &&
+    result.estimatedTokens >= 0
+  ) {
+    out.estimatedTokens = Math.floor(result.estimatedTokens);
+  }
   return out;
+}
+
+/**
+ * Summarize per-disclosure token spend across an X-ray snapshot's
+ * results.  Pure helper — used by the markdown renderer to print a
+ * "per-disclosure token spend" line and exposed for tests / surfaces.
+ */
+export function summarizeDisclosureTokens(
+  results: ReadonlyArray<RecallXrayResult>,
+): RecallXrayDisclosureSummary {
+  const summary: RecallXrayDisclosureSummary = {
+    chunk: { count: 0, estimatedTokens: 0 },
+    section: { count: 0, estimatedTokens: 0 },
+    raw: { count: 0, estimatedTokens: 0 },
+    unspecified: { count: 0, estimatedTokens: 0 },
+  };
+  for (const result of results) {
+    const tokens =
+      typeof result.estimatedTokens === "number" &&
+      Number.isFinite(result.estimatedTokens) &&
+      result.estimatedTokens >= 0
+        ? Math.floor(result.estimatedTokens)
+        : 0;
+    const bucket =
+      result.disclosure === "chunk" ||
+      result.disclosure === "section" ||
+      result.disclosure === "raw"
+        ? result.disclosure
+        : "unspecified";
+    summary[bucket].count += 1;
+    summary[bucket].estimatedTokens += tokens;
+  }
+  return summary;
 }
 
 function cloneFilter(filter: RecallFilterTrace): RecallFilterTrace {


### PR DESCRIPTION
## Summary

PR 3/4 of #677. Surfaces disclosure-level token spend on every recall X-ray snapshot so operators can see where their context budget went across chunk / section / raw tiers — making the disclosure knob from PR 1/4 (#694) and PR 2/4 (#696) actionable instead of opaque.

## Changes

- \`RecallXrayResult\` gains optional \`disclosure\` and \`estimatedTokens\`.
- New \`estimateRecallTokens()\` helper (4 chars/token English heuristic, matches the private \`chunking.ts\` heuristic without pulling in chunking internals).
- New \`summarizeDisclosureTokens()\` aggregator returning per-disclosure counts + token totals plus an "unspecified" bucket for results without disclosure metadata.
- Markdown renderer:
  - Per-result line now includes \`Disclosure: chunk (~50 tokens)\` when set.
  - New "Token spend by disclosure" summary table after the Results section, emitted only when at least one result carries a disclosure level (back-compat for callers who haven't wired the depth knob through).
- Poison guards: invalid disclosure values silently dropped during clone; negative / NaN \`estimatedTokens\` discarded.

## Test plan

- [x] \`npm run build\` clean.
- [x] 11 new unit tests in \`recall-xray-disclosure-telemetry.test.ts\` (heuristic edges, clone round-trip, poison guard, summary aggregation, markdown emission for disclosed / undisclosed / mixed snapshots).
- [x] Existing 36 X-ray tests (\`recall-xray.test.ts\` + \`recall-xray-renderer.test.ts\`) still pass — 47/47 green total.
- [ ] Required CI green.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new `disclosure` parameter and post-processing step in `recallXray` that loads memories/excerpts to estimate tokens, which can affect performance and the shape of X-ray results across HTTP/MCP/CLI callers.
> 
> **Overview**
> Recall X-ray now accepts an optional `disclosure` depth (`chunk`/`section`/`raw`) across HTTP (`?disclosure=`), MCP (`engram.recall_xray`), and the CLI (`--disclosure`), with strict validation and 400/errors on invalid values.
> 
> When `disclosure` is set, `EngramAccessService.recallXray` decorates each snapshot result with `disclosure` and `estimatedTokens` (including raw excerpt attribution edge cases) using a new `estimateRecallTokens()` helper, and the markdown renderer conditionally prints a **Token spend by disclosure** table plus per-result disclosure/token lines.
> 
> Adds `summarizeDisclosureTokens()` aggregation, poison-guards for invalid disclosure/tokens during snapshot cloning, and new unit tests covering token estimation, summary aggregation, clone round-trips, and markdown emission.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 31ac4fafb2c6fdc523c9f6ca5a96ca15c5b14bc4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->