### PR TITLE
feat(server): add /remnic/ui route for admin console

### DIFF
--- a/admin-console/public/index.html
+++ b/admin-console/public/index.html
@@ -465,6 +465,6 @@
         <div class="mono-box"><pre id="maintenanceJson">Maintenance summary will appear here.</pre></div>
       </section>
     </main>
-    <script src="/engram/ui/app.js"></script>
+    <script src="app.js"></script>
   </body>
 </html>

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1016,11 +1016,12 @@ export class EngramAccessHttpServer {
     pathname: string,
   ): Promise<boolean> {
     if (req.method !== "GET") return false;
-    if (pathname === "/engram/ui" || pathname === "/engram/ui/") {
+    if (pathname === "/remnic/ui" || pathname === "/remnic/ui/"
+      || pathname === "/engram/ui" || pathname === "/engram/ui/") {
       await this.respondStatic(res, path.join(this.adminConsolePublicDir, "index.html"), "text/html; charset=utf-8");
       return true;
     }
-    if (pathname === "/engram/ui/app.js") {
+    if (pathname === "/remnic/ui/app.js" || pathname === "/engram/ui/app.js") {
       await this.respondStatic(res, path.join(this.adminConsolePublicDir, "app.js"), "application/javascript; charset=utf-8");
       return true;
     }

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1016,8 +1016,13 @@ export class EngramAccessHttpServer {
     pathname: string,
   ): Promise<boolean> {
     if (req.method !== "GET") return false;
-    if (pathname === "/remnic/ui" || pathname === "/remnic/ui/"
-      || pathname === "/engram/ui" || pathname === "/engram/ui/") {
+    if (pathname === "/remnic/ui" || pathname === "/engram/ui") {
+      res.statusCode = 301;
+      res.setHeader("location", pathname + "/");
+      res.end();
+      return true;
+    }
+    if (pathname === "/remnic/ui/" || pathname === "/engram/ui/") {
       await this.respondStatic(res, path.join(this.adminConsolePublicDir, "index.html"), "text/html; charset=utf-8");
       return true;
     }


### PR DESCRIPTION
## Summary

- Add `/remnic/ui` and `/remnic/ui/app.js` as the primary admin console routes
- Keep `/engram/ui` and `/engram/ui/app.js` for backwards compatibility
- Change `index.html` script tag from absolute `/engram/ui/app.js` to relative `app.js` so the console works from either route prefix

## Test plan

- [x] `npx tsx --test tests/access-http*.test.ts` — 21/21 pass
- [x] `npm run build` — clean
- [ ] Verify `http://<host>:<port>/remnic/ui` serves the admin console
- [ ] Verify `http://<host>:<port>/engram/ui` still works (compat)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to static admin-console routing and a script path tweak, with backwards-compatible `/engram/ui` support retained. Main risk is accidental redirect/static path misconfiguration causing the console to fail to load.
> 
> **Overview**
> Serves the admin console under **new primary routes** `GET /remnic/ui/` and `GET /remnic/ui/app.js`, while keeping `GET /engram/ui/` and `GET /engram/ui/app.js` working for backwards compatibility.
> 
> Adds a 301 redirect from `/remnic/ui` (and `/engram/ui`) to the trailing-slash variant, and updates `admin-console/public/index.html` to load `app.js` via a relative path so the UI works under either prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5849278f5e0e2a605ca1b5ecca8121975a9b6a2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->