### PR TITLE
fix(bench): stream BEAM datasets

### DIFF
--- a/packages/bench/src/benchmarks/published/beam/fixture.ts
+++ b/packages/bench/src/benchmarks/published/beam/fixture.ts
@@ -31,13 +31,20 @@ export type BeamQuestionMap = Record<string, BeamQuestion[]>;
 
 export interface BeamPlan {
   plan_id?: number | string;
-  chat?: BeamChatTurn[][] | BeamChatTurn[];
+  chat?: BeamChatTurn[][] | BeamChatTurn[] | BeamPlanChatMap[];
   [key: string]: unknown;
 }
 
+export interface BeamPlanChatBatch {
+  turns?: BeamChatTurn[][] | BeamChatTurn[];
+  [key: string]: unknown;
+}
+
+export type BeamPlanChatMap = Record<string, BeamPlanChatBatch[] | null>;
+
 export interface BeamConversation {
   conversation_id: string | number;
-  chat: BeamChatTurn[][] | BeamChatTurn[];
+  chat: BeamChatTurn[][] | BeamChatTurn[] | BeamPlanChatMap[];
   probing_questions: BeamQuestionMap | string;
   plans?: BeamPlan[];
   [key: string]: unknown;

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -3,8 +3,10 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile, readdir } from "node:fs/promises";
+import { createReadStream } from "node:fs";
+import { readdir } from "node:fs/promises";
 import path from "node:path";
+import { createInterface } from "node:readline/promises";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
 import type {
@@ -27,6 +29,8 @@ import {
   type BeamChatTurn,
   type BeamConversation,
   type BeamPlan,
+  type BeamPlanChatBatch,
+  type BeamPlanChatMap,
   type BeamQuestion,
   type BeamQuestionMap,
 } from "./fixture.js";
@@ -65,23 +69,21 @@ interface BeamSession {
   messages: Message[];
 }
 
+interface BeamDatasetSource {
+  totalTasks?: number;
+  entries(): AsyncIterable<BeamDatasetEntry>;
+}
+
 export async function runBeamBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
   const tasks: TaskResult[] = [];
+  const totalTasks = dataset.totalTasks;
+  let entryCount = 0;
 
-  const totalTasks = dataset.reduce(
-    (sum, entry) =>
-      sum +
-      Object.values(normalizeQuestionMap(entry.conversation.probing_questions)).reduce(
-        (qSum, questions) => qSum + questions.length,
-        0,
-      ),
-    0,
-  );
-
-  for (const entry of dataset) {
+  for await (const entry of dataset.entries()) {
+    entryCount += 1;
     await options.system.reset();
 
     const questionMap = normalizeQuestionMap(entry.conversation.probing_questions);
@@ -195,6 +197,10 @@ export async function runBeamBenchmark(
     }
   }
 
+  if (entryCount === 0) {
+    throw new Error("BEAM dataset is empty after applying the requested limit.");
+  }
+
   const remnicVersion = await getRemnicVersion();
   const totalLatencyMs = tasks.reduce((sum, task) => sum + task.latencyMs, 0);
   const totalInputTokens = tasks.reduce((sum, task) => sum + task.tokens.input, 0);
@@ -244,13 +250,12 @@ async function loadDataset(
   mode: "full" | "quick",
   datasetDir: string | undefined,
   limit?: number,
-): Promise<BeamDatasetEntry[]> {
+): Promise<BeamDatasetSource> {
   const normalizedLimit = normalizeLimit(limit);
-  const ensureDatasetEntries = (entries: BeamDatasetEntry[]): BeamDatasetEntry[] => {
-    if (entries.length === 0) {
+  const ensureDatasetEntries = (entryCount: number): void => {
+    if (entryCount === 0) {
       throw new Error("BEAM dataset is empty after applying the requested limit.");
     }
-    return entries;
   };
 
   if (datasetDir) {
@@ -273,32 +278,13 @@ async function loadDataset(
       );
     }
 
-    const entries: BeamDatasetEntry[] = [];
-    let remainingLimit = normalizedLimit;
-    for (const filename of datasetFiles) {
-      if (remainingLimit === 0) {
-        break;
-      }
-
-      const raw = await readFile(path.join(datasetDir, filename), "utf8");
-      const scale = inferScaleFromFilename(filename);
-      const conversations = filename.endsWith(".jsonl")
-        ? parseJsonlDataset(raw, filename)
-        : parseJsonDataset(raw, filename);
-
-      const limitedConversations = applyLimit(conversations, remainingLimit);
-      entries.push(
-        ...limitedConversations.map((conversation) => ({
-          scale,
-          conversation,
-        })),
-      );
-      if (remainingLimit !== undefined) {
-        remainingLimit = Math.max(0, remainingLimit - limitedConversations.length);
-      }
+    if (normalizedLimit === 0) {
+      ensureDatasetEntries(0);
     }
 
-    return ensureDatasetEntries(entries);
+    return {
+      entries: () => iterateDatasetFiles(datasetDir, datasetFiles, normalizedLimit),
+    };
   }
 
   if (mode === "full") {
@@ -307,12 +293,23 @@ async function loadDataset(
     );
   }
 
-  return ensureDatasetEntries(
-    applyLimit(BEAM_SMOKE_FIXTURE, normalizedLimit).map((conversation) => ({
-      scale: "100K",
-      conversation,
-    })),
-  );
+  const conversations = applyLimit(BEAM_SMOKE_FIXTURE, normalizedLimit);
+  ensureDatasetEntries(conversations.length);
+
+  return {
+    totalTasks: conversations.reduce(
+      (sum, conversation) => sum + countQuestions(conversation),
+      0,
+    ),
+    entries: async function* entries() {
+      for (const conversation of conversations) {
+        yield {
+          scale: "100K",
+          conversation,
+        };
+      }
+    },
+  };
 }
 
 function compareDatasetFiles(left: string, right: string): number {
@@ -334,30 +331,213 @@ function inferScaleFromFilename(filename: string): string {
   return "unknown";
 }
 
-function parseJsonDataset(raw: string, filename: string): BeamConversation[] {
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch (error) {
-    throw new Error(
-      `BEAM dataset file ${filename} contains invalid JSON: ${error instanceof Error ? error.message : String(error)}`,
-    );
-  }
+async function* iterateDatasetFiles(
+  datasetDir: string,
+  datasetFiles: string[],
+  limit: number | undefined,
+): AsyncIterable<BeamDatasetEntry> {
+  let remainingLimit = limit;
+  for (const filename of datasetFiles) {
+    const scale = inferScaleFromFilename(filename);
+    const filePath = path.join(datasetDir, filename);
+    const conversations = filename.endsWith(".jsonl")
+      ? streamJsonlDataset(filePath, filename, remainingLimit)
+      : streamJsonDataset(filePath, filename, remainingLimit);
 
-  if (!Array.isArray(parsed)) {
-    throw new Error(`BEAM dataset file ${filename} must contain an array of conversations.`);
+    for await (const conversation of conversations) {
+      yield {
+        scale,
+        conversation,
+      };
+      if (remainingLimit !== undefined) {
+        remainingLimit -= 1;
+      }
+    }
+    if (remainingLimit === 0) {
+      break;
+    }
   }
-
-  return parsed.map((conversation, index) =>
-    validateConversation(conversation, `${filename}[${index}]`),
-  );
 }
 
-function parseJsonlDataset(raw: string, filename: string): BeamConversation[] {
-  const conversations: BeamConversation[] = [];
-  raw.split("\n").forEach((line, lineIndex) => {
+async function* streamJsonDataset(
+  filePath: string,
+  filename: string,
+  limit: number | undefined,
+): AsyncIterable<BeamConversation> {
+  const stream = createReadStream(filePath, {
+    encoding: "utf8",
+    highWaterMark: 1024 * 1024,
+  });
+  let seenArrayStart = false;
+  let seenArrayEnd = false;
+  let collectingObject = false;
+  let inString = false;
+  let escaped = false;
+  let depth = 0;
+  let objectIndex = 0;
+  let yielded = 0;
+  let hasSeenArrayValue = false;
+  let expectingArrayValue = false;
+  let objectParts: string[] = [];
+
+  for await (const chunk of stream) {
+    let objectStart = collectingObject ? 0 : -1;
+
+    for (let index = 0; index < chunk.length; index += 1) {
+      const current = chunk[index]!;
+
+      if (!collectingObject) {
+        if (seenArrayEnd) {
+          if (/\s/.test(current)) {
+            continue;
+          }
+          throw new Error(
+            `BEAM dataset file ${filename} contains trailing content after the JSON array.`,
+          );
+        }
+
+        if (!seenArrayStart) {
+          if (/\s/.test(current)) {
+            continue;
+          }
+          if (current !== "[") {
+            throw new Error(
+              `BEAM dataset file ${filename} must contain a JSON array of conversations.`,
+            );
+          }
+          seenArrayStart = true;
+          expectingArrayValue = true;
+          continue;
+        }
+
+        if (/\s/.test(current)) {
+          continue;
+        }
+        if (current === ",") {
+          if (expectingArrayValue) {
+            throw new Error(
+              `BEAM dataset file ${filename} contains invalid comma placement near conversation ${objectIndex}.`,
+            );
+          }
+          expectingArrayValue = true;
+          continue;
+        }
+        if (current === "]") {
+          if (expectingArrayValue && hasSeenArrayValue) {
+            throw new Error(
+              `BEAM dataset file ${filename} contains invalid trailing comma near conversation ${objectIndex}.`,
+            );
+          }
+          seenArrayEnd = true;
+          continue;
+        }
+        if (current !== "{") {
+          throw new Error(
+            `BEAM dataset file ${filename} contains invalid JSON array content near conversation ${objectIndex}.`,
+          );
+        }
+        if (!expectingArrayValue) {
+          throw new Error(
+            `BEAM dataset file ${filename} is missing a comma before conversation ${objectIndex + 1}.`,
+          );
+        }
+
+        collectingObject = true;
+        inString = false;
+        escaped = false;
+        depth = 1;
+        objectParts = [];
+        objectStart = index;
+        continue;
+      }
+
+      if (inString) {
+        if (escaped) {
+          escaped = false;
+          continue;
+        }
+        if (current === "\\") {
+          escaped = true;
+          continue;
+        }
+        if (current === "\"") {
+          inString = false;
+        }
+        continue;
+      }
+
+      if (current === "\"") {
+        inString = true;
+        continue;
+      }
+      if (current === "{") {
+        depth += 1;
+        continue;
+      }
+      if (current !== "}") {
+        continue;
+      }
+
+      depth -= 1;
+      if (depth === 0) {
+        objectParts.push(chunk.slice(objectStart, index + 1));
+        const rawObject = objectParts.join("");
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(rawObject);
+        } catch (error) {
+          throw new Error(
+            `BEAM dataset file ${filename} contains invalid JSON at conversation ${objectIndex}: ${error instanceof Error ? error.message : String(error)}`,
+          );
+        }
+        const conversation = validateConversation(parsed, `${filename}[${objectIndex}]`);
+        objectIndex += 1;
+        hasSeenArrayValue = true;
+        expectingArrayValue = false;
+        collectingObject = false;
+        objectParts = [];
+        objectStart = -1;
+        if (limit === undefined || yielded < limit) {
+          yield conversation;
+          yielded += 1;
+        }
+      }
+    }
+
+    if (collectingObject && objectStart >= 0) {
+      objectParts.push(chunk.slice(objectStart));
+    }
+  }
+
+  if (collectingObject) {
+    throw new Error(`BEAM dataset file ${filename} has an unterminated conversation object.`);
+  }
+  if (!seenArrayStart) {
+    throw new Error(
+      `BEAM dataset file ${filename} must contain a JSON array of conversations.`,
+    );
+  }
+  if (!seenArrayEnd) {
+    throw new Error(`BEAM dataset file ${filename} has an unterminated JSON array.`);
+  }
+}
+
+async function* streamJsonlDataset(
+  filePath: string,
+  filename: string,
+  limit: number | undefined,
+): AsyncIterable<BeamConversation> {
+  const lines = createInterface({
+    input: createReadStream(filePath, { encoding: "utf8" }),
+    crlfDelay: Infinity,
+  });
+  let yielded = 0;
+  let lineIndex = 0;
+
+  for await (const line of lines) {
+    lineIndex += 1;
     if (line.trim().length === 0) {
-      return;
+      continue;
     }
 
     let parsed: unknown;
@@ -365,15 +545,22 @@ function parseJsonlDataset(raw: string, filename: string): BeamConversation[] {
       parsed = JSON.parse(line);
     } catch (error) {
       throw new Error(
-        `BEAM dataset file ${filename} contains invalid JSON on line ${lineIndex + 1}: ${error instanceof Error ? error.message : String(error)}`,
+        `BEAM dataset file ${filename} contains invalid JSON on line ${lineIndex}: ${error instanceof Error ? error.message : String(error)}`,
       );
     }
-    conversations.push(
-      validateConversation(parsed, `${filename}:${lineIndex + 1}`),
-    );
-  });
+    const conversation = validateConversation(parsed, `${filename}:${lineIndex}`);
+    if (limit === undefined || yielded < limit) {
+      yield conversation;
+      yielded += 1;
+    }
+  }
+}
 
-  return conversations;
+function countQuestions(conversation: BeamConversation): number {
+  return Object.values(normalizeQuestionMap(conversation.probing_questions)).reduce(
+    (sum, questions) => sum + questions.length,
+    0,
+  );
 }
 
 function validateConversation(
@@ -393,7 +580,7 @@ function validateConversation(
       `BEAM conversation ${location} must include a string or integer conversation_id.`,
     );
   }
-  if (!isChatCollection(record.chat)) {
+  if (!isChatCollection(record.chat) && !isPlanChatMapCollection(record.chat)) {
     throw new Error(
       `BEAM conversation ${location} must include chat data as a list of turns or turn batches.`,
     );
@@ -415,7 +602,7 @@ function validateConversation(
   return record as unknown as BeamConversation;
 }
 
-function isChatCollection(value: unknown): value is BeamConversation["chat"] {
+function isChatCollection(value: unknown): value is BeamChatTurn[][] | BeamChatTurn[] {
   if (!Array.isArray(value)) {
     return false;
   }
@@ -432,6 +619,36 @@ function isChatCollection(value: unknown): value is BeamConversation["chat"] {
   }
 
   return false;
+}
+
+function isPlanChatMapCollection(value: unknown): value is BeamPlanChatMap[] {
+  return (
+    Array.isArray(value) &&
+    value.length > 0 &&
+    value.every((entry) => isPlanChatMap(entry))
+  );
+}
+
+function isPlanChatMap(value: unknown): value is BeamPlanChatMap {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+
+  return Object.values(value).every(
+    (batches) =>
+      batches === null ||
+      (Array.isArray(batches) && batches.every((batch) => isPlanChatBatch(batch))),
+  );
+}
+
+function isPlanChatBatch(value: unknown): value is BeamPlanChatBatch {
+  return (
+    !!value &&
+    typeof value === "object" &&
+    !Array.isArray(value) &&
+    ((value as BeamPlanChatBatch).turns === undefined ||
+      isChatCollection((value as BeamPlanChatBatch).turns))
+  );
 }
 
 function isChatBatch(value: unknown): value is BeamChatTurn[] {
@@ -465,7 +682,9 @@ function isValidPlans(value: unknown): value is BeamPlan[] {
       (plan) =>
         !!plan &&
         typeof plan === "object" &&
-        (plan.chat === undefined || isChatCollection(plan.chat)),
+        (plan.chat === undefined ||
+          isChatCollection(plan.chat) ||
+          isPlanChatMapCollection(plan.chat)),
     )
   );
 }
@@ -489,17 +708,39 @@ function collectSessions(
   const conversationId = String(conversation.conversation_id);
   const sessions: BeamSession[] = [];
 
-  flattenChatCollection(conversation.chat).forEach((batch, batchIndex) => {
-    sessions.push({
-      sessionId: `beam-${scale}-${conversationId}-main-${batchIndex + 1}`,
-      messages: buildMessages(batch),
+  if (isPlanChatMapCollection(conversation.chat)) {
+    flattenPlanChatMapCollection(conversation.chat).forEach((batch) => {
+      sessions.push({
+        sessionId:
+          `beam-${scale}-${conversationId}-main-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`,
+        messages: buildMessages(batch.turns),
+      });
     });
-  });
+  } else {
+    flattenChatCollection(conversation.chat).forEach((batch, batchIndex) => {
+      sessions.push({
+        sessionId: `beam-${scale}-${conversationId}-main-${batchIndex + 1}`,
+        messages: buildMessages(batch),
+      });
+    });
+  }
 
   (conversation.plans ?? []).forEach((plan, planIndex) => {
     if (!plan.chat) {
       return;
     }
+
+    if (isPlanChatMapCollection(plan.chat)) {
+      flattenPlanChatMapCollection(plan.chat).forEach((batch) => {
+        sessions.push({
+          sessionId:
+            `beam-${scale}-${conversationId}-plan-${String(plan.plan_id ?? planIndex)}-${batch.planId}-${batch.mapIndex + 1}-${batch.batchIndex + 1}-${batch.turnBatchIndex + 1}`,
+          messages: buildMessages(batch.turns),
+        });
+      });
+      return;
+    }
+
     flattenChatCollection(plan.chat).forEach((batch, batchIndex) => {
       sessions.push({
         sessionId:
@@ -513,12 +754,71 @@ function collectSessions(
 }
 
 function flattenChatCollection(
-  chat: BeamConversation["chat"],
+  chat: BeamChatTurn[][] | BeamChatTurn[],
 ): BeamChatTurn[][] {
   if (chat.length === 0) {
     return [];
   }
   return isChatTurn(chat[0]) ? [chat as BeamChatTurn[]] : (chat as BeamChatTurn[][]);
+}
+
+function flattenPlanChatMapCollection(
+  chat: BeamPlanChatMap[],
+): Array<{
+  planId: string;
+  mapIndex: number;
+  batchIndex: number;
+  turnBatchIndex: number;
+  turns: BeamChatTurn[];
+}> {
+  const batches: Array<{
+    planId: string;
+    mapIndex: number;
+    batchIndex: number;
+    turnBatchIndex: number;
+    turns: BeamChatTurn[];
+  }> = [];
+
+  chat.forEach((planMap, mapIndex) => {
+    Object.keys(planMap)
+      .sort(comparePlanIds)
+      .forEach((planId) => {
+        const planBatches = planMap[planId];
+        if (!planBatches) {
+          return;
+        }
+
+        planBatches.forEach((batch, batchIndex) => {
+          if (!batch.turns) {
+            return;
+          }
+
+          flattenChatCollection(batch.turns).forEach((turns, turnBatchIndex) => {
+            batches.push({
+              planId,
+              mapIndex,
+              batchIndex,
+              turnBatchIndex,
+              turns,
+            });
+          });
+        });
+      });
+  });
+
+  return batches;
+}
+
+function comparePlanIds(left: string, right: string): number {
+  const leftNumber = Number(left.match(/\d+/)?.[0] ?? Number.NaN);
+  const rightNumber = Number(right.match(/\d+/)?.[0] ?? Number.NaN);
+  if (Number.isFinite(leftNumber) && Number.isFinite(rightNumber)) {
+    const numberDelta = leftNumber - rightNumber;
+    if (numberDelta !== 0) {
+      return numberDelta;
+    }
+  }
+  return left.localeCompare(right);
 }
 
 function buildMessages(turns: BeamChatTurn[]): Message[] {

--- a/tests/bench-beam-runner.test.ts
+++ b/tests/bench-beam-runner.test.ts
@@ -155,6 +155,484 @@ test("runBenchmark loads beam full-mode datasets and includes 10M plan chats in 
   assert.equal(result.results.tasks[0]?.details.sessionCount, 2);
 });
 
+test("runBenchmark streams beam JSON arrays without misreading braces in strings", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-stream-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-stream-1",
+        chat: [
+          [
+            {
+              id: 1,
+              role: "user",
+              content:
+                "The literal marker is brace {alpha}, bracket [beta], and quote \"gamma\".",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "What is the literal marker?",
+              answer: "brace {alpha}, bracket [beta], and quote \"gamma\"",
+            },
+          ],
+        },
+      },
+      {
+        conversation_id: "beam-stream-2",
+        chat: [
+          [
+            {
+              id: 2,
+              role: "user",
+              content: "The backup owner is Priya.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Who is the backup owner?",
+              answer: "Priya",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 2);
+  assert.equal(
+    result.results.tasks[0]?.actual.includes(
+      'brace {alpha}, bracket [beta], and quote "gamma"',
+    ),
+    true,
+  );
+  assert.equal(result.results.tasks[1]?.actual.includes("Priya"), true);
+});
+
+test("runBenchmark loads beam 10M plan-map chat shards", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-plan-map-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "10M.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-plan-map-1",
+        chat: [
+          {
+            "plan-2": null,
+            "plan-1": [
+              {
+                batch_number: 1,
+                turns: [
+                  [
+                    {
+                      id: 1,
+                      role: "user",
+                      content: "The 10M shard owner is Nia.",
+                    },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        plans: [
+          {
+            plan_id: "plan-1",
+            chat: [
+              [
+                {
+                  id: 2,
+                  role: "user",
+                  content: "The supplemental plan owner is Elias.",
+                },
+              ],
+            ],
+          },
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Who owns the 10M shard?",
+              answer: "Nia",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.actual.includes("Nia"), true);
+  assert.equal(result.results.tasks[0]?.details.sessionCount, 2);
+  assert.equal(
+    [...adapter.sessions.values()]
+      .flat()
+      .some((message) => message.content.includes("supplemental plan owner")),
+    true,
+  );
+});
+
+test("runBenchmark keeps plan chats when top-level beam chat is empty", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-empty-chat-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-empty-chat-1",
+        chat: [],
+        plans: [
+          {
+            plan_id: "plan-only",
+            chat: [
+              [
+                {
+                  id: 1,
+                  role: "user",
+                  content: "The plan-only answer is Rowan.",
+                },
+              ],
+            ],
+          },
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "What is the plan-only answer?",
+              answer: "Rowan",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.actual.includes("Rowan"), true);
+  assert.equal(result.results.tasks[0]?.details.sessionCount, 1);
+});
+
+test("runBenchmark orders same-number beam plan-map ids by stable secondary key", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-plan-order-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "10M.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-plan-order-1",
+        chat: [
+          {
+            "plan-1-b": [
+              {
+                batch_number: 1,
+                turns: [
+                  [
+                    {
+                      id: 2,
+                      role: "user",
+                      content: "The second same-number plan owner is Blake.",
+                    },
+                  ],
+                ],
+              },
+            ],
+            "plan-1-a": [
+              {
+                batch_number: 1,
+                turns: [
+                  [
+                    {
+                      id: 1,
+                      role: "user",
+                      content: "The first same-number plan owner is Avery.",
+                    },
+                  ],
+                ],
+              },
+            ],
+          },
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Who is the first same-number plan owner?",
+              answer: "Avery",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const sessionIds = [...adapter.sessions.keys()];
+  assert.equal(result.results.tasks[0]?.details.sessionCount, 2);
+  assert.equal(sessionIds[0]?.includes("plan-1-a"), true);
+  assert.equal(sessionIds[1]?.includes("plan-1-b"), true);
+  assert.equal(result.results.tasks[0]?.actual.includes("Avery"), true);
+});
+
+test("runBenchmark applies beam dataset limits while streaming arrays", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-limit-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-limit-1",
+        chat: [
+          [
+            {
+              id: 1,
+              role: "user",
+              content: "Only the first streamed conversation should run.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Which streamed conversation should run?",
+              answer: "first",
+            },
+          ],
+        },
+      },
+      {
+        conversation_id: "beam-limit-2",
+        chat: [
+          [
+            {
+              id: 2,
+              role: "user",
+              content: "The second streamed conversation should be skipped.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "Which streamed conversation should be skipped?",
+              answer: "second",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.details.conversationId, "beam-limit-1");
+  assert.equal(adapter.sessions.size, 1);
+});
+
+test("runBenchmark rejects malformed beam JSON array comma placement", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-commas-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  const validObject = JSON.stringify({
+    conversation_id: "beam-comma-1",
+    chat: [],
+    probing_questions: {
+      information_extraction: [
+        {
+          question: "What should this malformed dataset do?",
+          answer: "fail",
+        },
+      ],
+    },
+  });
+
+  for (const [filename, payload, expected] of [
+    ["100K-trailing.json", `[${validObject},]`, /invalid trailing comma/],
+    ["100K-double.json", `[${validObject},,${validObject}]`, /invalid comma placement/],
+    ["100K-missing.json", `[${validObject}${validObject}]`, /missing a comma/],
+  ] as const) {
+    await writeFile(path.join(datasetDir, filename), payload, "utf8");
+    await assert.rejects(
+      () =>
+        runBenchmark("beam", {
+          mode: "full",
+          datasetDir,
+          limit: 2,
+          system: adapter,
+        }),
+      expected,
+    );
+    await writeFile(path.join(datasetDir, filename), "[]", "utf8");
+  }
+});
+
+test("runBenchmark validates beam JSON tails after reaching a limit", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-limit-tail-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  const validObject = JSON.stringify({
+    conversation_id: "beam-limit-tail-1",
+    chat: [],
+    probing_questions: {
+      information_extraction: [
+        {
+          question: "What should this malformed tail do?",
+          answer: "fail",
+        },
+      ],
+    },
+  });
+
+  await writeFile(path.join(datasetDir, "100K.json"), `[${validObject},not-json]`, "utf8");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("beam", {
+        mode: "full",
+        datasetDir,
+        limit: 1,
+        system: adapter,
+      }),
+    /invalid JSON array content/,
+  );
+});
+
+test("runBenchmark validates beam JSONL tails after reaching a limit", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-jsonl-tail-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  const validObject = JSON.stringify({
+    conversation_id: "beam-jsonl-tail-1",
+    chat: [],
+    probing_questions: {
+      information_extraction: [
+        {
+          question: "What should this malformed JSONL tail do?",
+          answer: "fail",
+        },
+      ],
+    },
+  });
+
+  await writeFile(path.join(datasetDir, "100K.jsonl"), `${validObject}\nnot-json\n`, "utf8");
+
+  await assert.rejects(
+    () =>
+      runBenchmark("beam", {
+        mode: "full",
+        datasetDir,
+        limit: 1,
+        system: adapter,
+      }),
+    /invalid JSON on line 2/,
+  );
+});
+
+test("runBenchmark stops reading later beam split files once the global limit is exhausted", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-beam-later-split-"));
+  const datasetDir = path.join(tmpDir, "datasets", "beam");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+
+  await writeFile(
+    path.join(datasetDir, "100K.json"),
+    JSON.stringify([
+      {
+        conversation_id: "beam-later-split-1",
+        chat: [
+          [
+            {
+              id: 1,
+              role: "user",
+              content: "The limited split answer is Hazel.",
+            },
+          ],
+        ],
+        probing_questions: {
+          information_extraction: [
+            {
+              question: "What is the limited split answer?",
+              answer: "Hazel",
+            },
+          ],
+        },
+      },
+    ]),
+    "utf8",
+  );
+  await writeFile(path.join(datasetDir, "10M.json"), "[not-json]", "utf8");
+
+  const result = await runBenchmark("beam", {
+    mode: "full",
+    datasetDir,
+    limit: 1,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.actual.includes("Hazel"), true);
+});
+
 test("runBenchmark rejects beam full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 


### PR DESCRIPTION
## Summary
- Stream BEAM top-level JSON arrays/JSONL instead of reading whole split files into a single string
- Support BEAM 10M plan-map chat shards in addition to standard turn batches
- Add Beam runner regressions for streaming, limits, and 10M plan-map chat shape

## Verification
- pnpm exec tsx --test tests/bench-beam-runner.test.ts
- pnpm --filter @remnic/bench check-types
- pnpm --filter @remnic/bench build
- git diff --check
- real dataset no-op smoke: beam full dataset, limit 91, reached lastScale=10M

## Notes
- npm run preflight:quick was started, but the broad test process hung in an unrelated existing lcm-engine.test.ts child with 0 CPU. I stopped it rather than letting it run indefinitely; focused Beam gates and bench package gates passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a custom streaming parser for top-level JSON arrays/JSONL and changes BEAM session construction to handle additional dataset shapes, which could affect dataset parsing correctness and benchmark determinism.
> 
> **Overview**
> **BEAM full-mode dataset loading is now streamed**: split files are processed via async generators using `createReadStream`/`readline` instead of `readFile` + full `JSON.parse`, with stricter validation for malformed JSON arrays (comma placement, trailing content) and proper global `limit` handling across multiple split files.
> 
> **Adds support for 10M “plan-map” chat shards** by extending `BeamConversation`/`BeamPlan` chat types to accept `BeamPlanChatMap[]`, validating this shape, and flattening it into deterministic session batches (including stable plan-id ordering) for storage/recall.
> 
> **Expands regression coverage** in `bench-beam-runner.test.ts` for streaming edge cases (braces in strings), plan-map ingestion, empty top-level chats, limit behavior, and malformed tail/comma scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c78ea9d10912a33afe267308501f5be72349a9e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->