### PR TITLE
feat(core): wire codingContext from all harnesses via cwd and projectTag

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -389,6 +389,9 @@ export class EngramAccessHttpServer {
         // `resolveRecallDisclosure()` validates the query-param fallback.
         disclosure,
         codingContext,
+        // Forward cwd/projectTag for auto git-context resolution (issue #569).
+        cwd: body.cwd,
+        projectTag: body.projectTag,
       });
       this.respondJson(res, 200, response);
       return;
@@ -529,6 +532,9 @@ export class EngramAccessHttpServer {
         namespace: this.resolveNamespace(req, body.namespace),
         authenticatedPrincipal: this.resolveRequestPrincipal(req),
         skipExtraction: body.skipExtraction === true,
+        // Forward cwd/projectTag for auto git-context resolution (issue #569).
+        cwd: body.cwd,
+        projectTag: body.projectTag,
       });
       this.recordWriteRateLimitHit();
       this.respondJson(res, 202, response);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -113,6 +113,8 @@ export class EngramMcpServer {
             // wires the field end-to-end so clients can already pass it
             // without it being silently dropped.
             disclosure: { type: "string", enum: ["chunk", "section", "raw"] },
+            cwd: { type: "string", description: "Working directory for auto git-context resolution." },
+            projectTag: { type: "string", description: "Project tag for non-git project scoping (e.g. 'blend-supply')." },
           },
           required: ["query"],
           additionalProperties: false,
@@ -133,7 +135,7 @@ export class EngramMcpServer {
       {
         name: "engram.set_coding_context",
         description:
-          "Attach a coding-agent context (project / branch) to a session so recall routes to a project- / branch-scoped namespace (issue #569). For MCP clients that do not ship cwd automatically (Cursor, generic agents, etc.). Also aliased as remnic.set_coding_context. Pass codingContext: null to clear.",
+          "Attach a coding-agent context (project / branch) to a session so recall routes to a project- / branch-scoped namespace (issue #569). For MCP clients that do not ship cwd automatically (Cursor, generic agents, etc.). Also aliased as remnic.set_coding_context. Pass codingContext: null to clear. Alternatively, pass just a projectTag for non-git project scoping (e.g. OpenClaw channels).",
         inputSchema: {
           type: "object",
           properties: {
@@ -156,10 +158,17 @@ export class EngramMcpServer {
                   additionalProperties: false,
                 },
               ],
-              description: "The context to attach, or null to clear.",
+              description: "The context to attach, or null to clear. Omit when using projectTag instead.",
+            },
+            projectTag: {
+              type: "string",
+              description:
+                "Arbitrary project tag for non-git project scoping (e.g. 'blend-supply'). " +
+                "Creates a coding context with projectId 'tag:<projectTag>'. " +
+                "Use instead of codingContext when the session isn't tied to a specific git repo.",
             },
           },
-          required: ["sessionKey", "codingContext"],
+          required: ["sessionKey"],
           additionalProperties: false,
         },
       },
@@ -392,6 +401,8 @@ export class EngramMcpServer {
             },
             namespace: { type: "string" },
             skipExtraction: { type: "boolean" },
+            cwd: { type: "string", description: "Working directory for auto git-context resolution." },
+            projectTag: { type: "string", description: "Project tag for non-git project scoping (e.g. 'blend-supply')." },
           },
           required: ["sessionKey", "messages"],
           additionalProperties: false,
@@ -1205,6 +1216,8 @@ export class EngramMcpServer {
           mode: typeof args.mode === "string" ? args.mode as RecallPlanMode | "auto" : undefined,
           includeDebug: args.includeDebug === true,
           disclosure,
+          cwd: typeof args.cwd === "string" ? args.cwd : undefined,
+          projectTag: typeof args.projectTag === "string" ? args.projectTag : undefined,
         });
 
         if (this.shouldEmitCitations(mcpSessionId)) {
@@ -1230,6 +1243,30 @@ export class EngramMcpServer {
         // Validation lives in EngramAccessService.setCodingContext; any
         // EngramAccessInputError surfaces as a structured tool-call error.
         const sessionKey = typeof args.sessionKey === "string" ? args.sessionKey : "";
+        // Support projectTag as an alternative to full codingContext.
+        // When projectTag is provided and codingContext is absent, create
+        // a tag-based context (issue #569 wiring).
+        const hasProjectTag = typeof args.projectTag === "string" && args.projectTag.trim().length > 0;
+        const hasCodingContext = "codingContext" in args;
+        if (!hasCodingContext && hasProjectTag) {
+          const tag = (args.projectTag as string).trim();
+          this.service.setCodingContext({
+            sessionKey,
+            codingContext: {
+              projectId: `tag:${tag}`,
+              branch: null,
+              rootPath: `tag:${tag}`,
+              defaultBranch: null,
+            },
+          });
+          return { ok: true };
+        }
+        // Require at least one of codingContext or projectTag (CLAUDE.md #51).
+        if (!hasCodingContext && !hasProjectTag) {
+          throw new EngramAccessInputError(
+            "set_coding_context requires either codingContext or projectTag",
+          );
+        }
         const rawCtx = args.codingContext;
         let codingContext: {
           projectId: string;
@@ -1419,6 +1456,8 @@ export class EngramMcpServer {
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
           authenticatedPrincipal: effectivePrincipal,
           skipExtraction: args.skipExtraction === true,
+          cwd: typeof args.cwd === "string" ? args.cwd : undefined,
+          projectTag: typeof args.projectTag === "string" ? args.projectTag : undefined,
         });
       case "engram.lcm_search":
         return this.service.lcmSearch({

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1208,6 +1208,14 @@ export class EngramMcpServer {
           }
           disclosure = args.disclosure as RecallDisclosure;
         }
+        // Reject non-string cwd/projectTag (CLAUDE.md #51) — these control
+        // namespace routing so silent coercion to undefined would mix memories.
+        if ("cwd" in args && args.cwd !== undefined && args.cwd !== null && typeof args.cwd !== "string") {
+          throw new EngramAccessInputError("cwd must be a string");
+        }
+        if ("projectTag" in args && args.projectTag !== undefined && args.projectTag !== null && typeof args.projectTag !== "string") {
+          throw new EngramAccessInputError("projectTag must be a string");
+        }
         const response = await this.service.recall({
           query: typeof args.query === "string" ? args.query : "",
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
@@ -1449,7 +1457,15 @@ export class EngramMcpServer {
           typeof args.namespace === "string" ? args.namespace : undefined,
           effectivePrincipal,
         );
-      case "engram.observe":
+      case "engram.observe": {
+        // Reject non-string cwd/projectTag (CLAUDE.md #51) — these control
+        // namespace routing so silent coercion to undefined would mix memories.
+        if ("cwd" in args && args.cwd !== undefined && args.cwd !== null && typeof args.cwd !== "string") {
+          throw new EngramAccessInputError("cwd must be a string");
+        }
+        if ("projectTag" in args && args.projectTag !== undefined && args.projectTag !== null && typeof args.projectTag !== "string") {
+          throw new EngramAccessInputError("projectTag must be a string");
+        }
         return this.service.observe({
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : "",
           messages: Array.isArray(args.messages) ? args.messages : [],
@@ -1459,6 +1475,7 @@ export class EngramMcpServer {
           cwd: typeof args.cwd === "string" ? args.cwd : undefined,
           projectTag: typeof args.projectTag === "string" ? args.projectTag : undefined,
         });
+      }
       case "engram.lcm_search":
         return this.service.lcmSearch({
           query: typeof args.query === "string" ? args.query : "",

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -72,6 +72,13 @@ export const recallRequestSchema = z.object({
   includeDebug: z.boolean().optional(),
   disclosure: recallDisclosureSchema.optional(),
   codingContext: codingContextSchema.optional(),
+  /** Working directory for auto git-context resolution (issue #569). */
+  cwd: z.string().trim().min(1, "cwd must be non-empty when provided").max(2048).optional(),
+  /**
+   * Arbitrary project tag for non-git-based project scoping (issue #569).
+   * Creates a coding context with `projectId: "tag:<projectTag>"`.
+   */
+  projectTag: z.string().trim().min(1, "projectTag must be non-empty when provided").max(256).optional(),
 });
 
 export const recallExplainRequestSchema = z.object({
@@ -103,6 +110,13 @@ export const observeRequestSchema = z.object({
   messages: z.array(messageSchema).min(1, "messages must be a non-empty array"),
   namespace: namespaceSchema,
   skipExtraction: z.boolean().optional(),
+  /** Working directory for auto git-context resolution (issue #569). */
+  cwd: z.string().trim().min(1, "cwd must be non-empty when provided").max(2048).optional(),
+  /**
+   * Arbitrary project tag for non-git-based project scoping (issue #569).
+   * Creates a coding context with `projectId: "tag:<projectTag>"`.
+   */
+  projectTag: z.string().trim().min(1, "projectTag must be non-empty when provided").max(256).optional(),
 });
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2,6 +2,7 @@ import { stat } from "node:fs/promises";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
+import { resolveGitContext } from "./coding/git-context.js";
 import { WorkStorage } from "./work/storage.js";
 import {
   exportWorkBoardMarkdown,
@@ -156,6 +157,23 @@ export interface EngramAccessRecallRequest {
     rootPath: string;
     defaultBranch: string | null;
   } | null;
+  /**
+   * Working directory of the calling agent session. When provided and no
+   * `codingContext` is already attached to the session, the service resolves
+   * git context from this path and attaches it automatically. This enables
+   * Claude Code hooks (and any connector that knows its cwd) to get
+   * project-scoped memory without explicitly constructing a `codingContext`.
+   */
+  cwd?: string;
+  /**
+   * Arbitrary project tag for non-git-based project scoping. When provided,
+   * creates a `CodingContext` with `projectId: "tag:<projectTag>"`.
+   * Useful for OpenClaw sessions where the whole workspace is one git repo
+   * but different conversations correspond to different client projects.
+   * Takes precedence over `cwd`-based git resolution but NOT over an
+   * explicit `codingContext`.
+   */
+  projectTag?: string;
 }
 
 /**
@@ -550,6 +568,18 @@ export interface EngramAccessObserveRequest {
   namespace?: string;
   authenticatedPrincipal?: string;
   skipExtraction?: boolean;
+  /**
+   * Working directory of the calling agent session (issue #569 wiring).
+   * When provided and no `codingContext` is attached for this session,
+   * resolves git context from the path and attaches it so writes route to
+   * the correct project namespace.
+   */
+  cwd?: string;
+  /**
+   * Arbitrary project tag for non-git-based project scoping (issue #569).
+   * Creates a `CodingContext` with `projectId: "tag:<projectTag>"`.
+   */
+  projectTag?: string;
 }
 
 export interface EngramAccessObserveResponse {
@@ -1254,6 +1284,63 @@ export class EngramAccessService {
     });
   }
 
+  /**
+   * Auto-resolve and attach a coding context for a session when one is not
+   * already present. Resolves from `projectTag` (highest priority after
+   * explicit `codingContext`), then from `cwd` via git detection.
+   *
+   * This is a no-op when:
+   *   - `sessionKey` is missing
+   *   - the session already has a coding context attached
+   *   - codingMode.projectScope is disabled (CLAUDE.md #30)
+   *   - neither `cwd` nor `projectTag` is provided
+   *
+   * Never throws — git resolution failures are silently ignored because not
+   * being in a repo is a normal runtime state.
+   */
+  private async maybeAttachCodingContext(
+    sessionKey: string | undefined,
+    options: { cwd?: string; projectTag?: string },
+  ): Promise<void> {
+    if (!sessionKey) return;
+    // Respect the configuration gate (CLAUDE.md #30).
+    if (!this.orchestrator.config.codingMode?.projectScope) return;
+    // Don't overwrite an already-attached context.
+    if (this.orchestrator.getCodingContextForSession(sessionKey)) return;
+    // projectTag takes priority over cwd.
+    if (typeof options.projectTag === "string" && options.projectTag.trim().length > 0) {
+      const tag = options.projectTag.trim();
+      this.orchestrator.setCodingContextForSession(sessionKey, {
+        projectId: `tag:${tag}`,
+        branch: null,
+        rootPath: `tag:${tag}`,
+        defaultBranch: null,
+      });
+      return;
+    }
+    // cwd → git resolution
+    if (typeof options.cwd === "string" && options.cwd.trim().length > 0) {
+      try {
+        const gitCtx = await resolveGitContext(options.cwd);
+        if (gitCtx) {
+          this.setCodingContext({
+            sessionKey,
+            codingContext: {
+              projectId: gitCtx.projectId,
+              branch: gitCtx.branch,
+              rootPath: gitCtx.rootPath,
+              defaultBranch: gitCtx.defaultBranch,
+            },
+          });
+        }
+      } catch {
+        // Silently ignore git resolution failures — not being in a repo
+        // is normal. resolveGitContext itself never throws, but the
+        // setCodingContext validation might reject edge-case rootPaths.
+      }
+    }
+  }
+
   async recall(request: EngramAccessRecallRequest): Promise<EngramAccessRecallResponse> {
     const query = request.query.trim();
     if (query.length === 0) {
@@ -1279,6 +1366,16 @@ export class EngramAccessService {
       this.setCodingContext({
         sessionKey: request.sessionKey,
         codingContext: request.codingContext,
+      });
+    }
+    // Auto-resolve coding context from cwd/projectTag when no explicit
+    // codingContext was supplied (issue #569 wiring). This allows Claude
+    // Code hooks and OpenClaw connectors to get project-scoped memory
+    // transparently.
+    if (request.codingContext === undefined && request.sessionKey) {
+      await this.maybeAttachCodingContext(request.sessionKey, {
+        cwd: request.cwd,
+        projectTag: request.projectTag,
       });
     }
     const namespaceOverride = this.resolveRecallNamespace(request.namespace, request.sessionKey);
@@ -2509,6 +2606,14 @@ export class EngramAccessService {
         throw new EngramAccessInputError(`invalid message role: ${msg.role} (expected 'user' or 'assistant')`);
       }
     }
+
+    // Auto-resolve coding context from cwd/projectTag so observe writes
+    // route to the correct project namespace (rule 42: same namespace layer
+    // as recall).
+    await this.maybeAttachCodingContext(request.sessionKey, {
+      cwd: request.cwd,
+      projectTag: request.projectTag,
+    });
 
     const namespace = this.resolveWritableNamespace(
       request.namespace,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -2607,6 +2607,15 @@ export class EngramAccessService {
       }
     }
 
+    // Validate namespace authorization BEFORE attaching coding context so
+    // a failed auth check doesn't leave orphaned context on the session
+    // (Codex review P2).
+    const namespace = this.resolveWritableNamespace(
+      request.namespace,
+      request.sessionKey,
+      request.authenticatedPrincipal,
+    );
+
     // Auto-resolve coding context from cwd/projectTag so observe writes
     // route to the correct project namespace (rule 42: same namespace layer
     // as recall).
@@ -2614,12 +2623,6 @@ export class EngramAccessService {
       cwd: request.cwd,
       projectTag: request.projectTag,
     });
-
-    const namespace = this.resolveWritableNamespace(
-      request.namespace,
-      request.sessionKey,
-      request.authenticatedPrincipal,
-    );
 
     // Prefix sessionKey with namespace for LCM archival so turns are namespace-scoped.
     // This ensures multi-tenant isolation in the LCM archive.

--- a/packages/remnic-core/src/coding/wire-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/wire-coding-context.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for coding context auto-resolution wiring (issue #569).
+ *
+ * Validates that:
+ *   - `cwd` in recall/observe triggers git-context resolution and attaches
+ *     a CodingContext to the session
+ *   - `projectTag` creates a tag-based CodingContext
+ *   - explicit `codingContext` takes precedence over `cwd` and `projectTag`
+ *   - the MCP `set_coding_context` tool accepts `projectTag` as an
+ *     alternative to full `codingContext`
+ *   - zod schemas accept `cwd` and `projectTag` fields
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EngramMcpServer } from "../access-mcp.js";
+import { EngramAccessInputError, EngramAccessService } from "../access-service.js";
+import type { CodingContext } from "../types.js";
+import { validateRequest } from "../access-schema.js";
+
+// ──────────────────────────────────────────────────────────────────────────
+// Schema validation tests
+// ──────────────────────────────────────────────────────────────────────────
+
+test("recall schema accepts cwd field", () => {
+  const result = validateRequest("recall", {
+    query: "test query",
+    sessionKey: "sess-1",
+    cwd: "/home/user/project",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.cwd, "/home/user/project");
+  }
+});
+
+test("recall schema accepts projectTag field", () => {
+  const result = validateRequest("recall", {
+    query: "test query",
+    sessionKey: "sess-1",
+    projectTag: "blend-supply",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.projectTag, "blend-supply");
+  }
+});
+
+test("recall schema accepts both cwd and projectTag", () => {
+  const result = validateRequest("recall", {
+    query: "test query",
+    sessionKey: "sess-1",
+    cwd: "/home/user/project",
+    projectTag: "blend-supply",
+  });
+  assert.equal(result.success, true);
+});
+
+test("recall schema rejects empty cwd", () => {
+  const result = validateRequest("recall", {
+    query: "test query",
+    cwd: "",
+  });
+  assert.equal(result.success, false);
+});
+
+test("recall schema rejects empty projectTag", () => {
+  const result = validateRequest("recall", {
+    query: "test query",
+    projectTag: "",
+  });
+  assert.equal(result.success, false);
+});
+
+test("observe schema accepts cwd field", () => {
+  const result = validateRequest("observe", {
+    sessionKey: "sess-1",
+    messages: [{ role: "user", content: "hello" }],
+    cwd: "/home/user/project",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.cwd, "/home/user/project");
+  }
+});
+
+test("observe schema accepts projectTag field", () => {
+  const result = validateRequest("observe", {
+    sessionKey: "sess-1",
+    messages: [{ role: "user", content: "hello" }],
+    projectTag: "worthington-direct",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.projectTag, "worthington-direct");
+  }
+});
+
+test("observe schema rejects empty cwd", () => {
+  const result = validateRequest("observe", {
+    sessionKey: "sess-1",
+    messages: [{ role: "user", content: "hello" }],
+    cwd: "",
+  });
+  assert.equal(result.success, false);
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// MCP set_coding_context with projectTag
+// ──────────────────────────────────────────────────────────────────────────
+
+function makeMcp(): {
+  mcp: EngramMcpServer;
+  calls: Array<{ sessionKey: string; ctx: CodingContext | null }>;
+} {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const service = {
+    setCodingContext(request: { sessionKey: string; codingContext: CodingContext | null }) {
+      if (!request.sessionKey || request.sessionKey.trim().length === 0) {
+        throw new EngramAccessInputError("sessionKey is required for setCodingContext");
+      }
+      if (request.codingContext && !request.codingContext.projectId) {
+        throw new EngramAccessInputError("codingContext.projectId must be a non-empty string");
+      }
+      calls.push({ sessionKey: request.sessionKey, ctx: request.codingContext });
+    },
+  } as unknown as EngramAccessService;
+  const mcp = new EngramMcpServer(service);
+  return { mcp, calls };
+}
+
+async function call(mcp: EngramMcpServer, name: string, args: Record<string, unknown>): Promise<unknown> {
+  const anyMcp = mcp as unknown as {
+    callTool(n: string, a: Record<string, unknown>): Promise<unknown>;
+  };
+  return anyMcp.callTool(name, args);
+}
+
+test("set_coding_context with projectTag creates tag-based context", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    projectTag: "blend-supply",
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx?.projectId, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.branch, null);
+  assert.equal(calls[0]!.ctx?.rootPath, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.defaultBranch, null);
+});
+
+test("set_coding_context with codingContext takes precedence over projectTag", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: {
+      projectId: "origin:abcd1234",
+      branch: "main",
+      rootPath: "/work/proj",
+      defaultBranch: "main",
+    },
+    projectTag: "blend-supply",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx?.projectId, "origin:abcd1234");
+});
+
+test("set_coding_context without codingContext or projectTag rejects", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.set_coding_context", {
+      sessionKey: "session-A",
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError,
+  );
+});
+
+test("set_coding_context with codingContext=null clears (even with projectTag present)", async () => {
+  const { mcp, calls } = makeMcp();
+  await call(mcp, "engram.set_coding_context", {
+    sessionKey: "session-A",
+    codingContext: null,
+    projectTag: "blend-supply",
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx, null);
+});
+
+test("set_coding_context projectTag via canonical alias remnic.*", async () => {
+  const { mcp, calls } = makeMcp();
+  const result = await call(mcp, "remnic.set_coding_context", {
+    sessionKey: "session-B",
+    projectTag: "worthington-direct",
+  });
+  assert.deepEqual(result, { ok: true });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx?.projectId, "tag:worthington-direct");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// MCP recall tool lists cwd and projectTag properties
+// ──────────────────────────────────────────────────────────────────────────
+
+test("engram.recall tool schema includes cwd and projectTag", () => {
+  const { mcp } = makeMcp();
+  const tools = (mcp as unknown as { tools: Array<{ name: string; inputSchema: Record<string, unknown> }> }).tools;
+  const recallTool = tools.find((t) => t.name === "engram.recall");
+  assert.ok(recallTool, "engram.recall tool should exist");
+  const props = (recallTool!.inputSchema as { properties: Record<string, unknown> }).properties;
+  assert.ok("cwd" in props, "engram.recall should have cwd property");
+  assert.ok("projectTag" in props, "engram.recall should have projectTag property");
+});
+
+test("engram.observe tool schema includes cwd and projectTag", () => {
+  const { mcp } = makeMcp();
+  const tools = (mcp as unknown as { tools: Array<{ name: string; inputSchema: Record<string, unknown> }> }).tools;
+  const observeTool = tools.find((t) => t.name === "engram.observe");
+  assert.ok(observeTool, "engram.observe tool should exist");
+  const props = (observeTool!.inputSchema as { properties: Record<string, unknown> }).properties;
+  assert.ok("cwd" in props, "engram.observe should have cwd property");
+  assert.ok("projectTag" in props, "engram.observe should have projectTag property");
+});
+
+test("engram.set_coding_context tool schema includes projectTag", () => {
+  const { mcp } = makeMcp();
+  const tools = (mcp as unknown as { tools: Array<{ name: string; inputSchema: Record<string, unknown> }> }).tools;
+  const tool = tools.find((t) => t.name === "engram.set_coding_context");
+  assert.ok(tool, "engram.set_coding_context tool should exist");
+  const props = (tool!.inputSchema as { properties: Record<string, unknown> }).properties;
+  assert.ok("projectTag" in props, "engram.set_coding_context should have projectTag property");
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// maybeAttachCodingContext via service integration
+// ──────────────────────────────────────────────────────────────────────────
+
+test("maybeAttachCodingContext: projectTag attaches tag-based context", async () => {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+    getCodingContextForSession(_sessionKey: string) {
+      return null;
+    },
+    config: {
+      codingMode: { projectScope: true, branchScope: false },
+      defaultNamespace: "default",
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+
+  // Call the private method directly via cast
+  const maybeAttach = (service as unknown as {
+    maybeAttachCodingContext(
+      sessionKey: string | undefined,
+      options: { cwd?: string; projectTag?: string },
+    ): Promise<void>;
+  }).maybeAttachCodingContext.bind(service);
+
+  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]!.ctx?.projectId, "tag:blend-supply");
+  assert.equal(calls[0]!.ctx?.rootPath, "tag:blend-supply");
+});
+
+test("maybeAttachCodingContext: skips when session already has context", async () => {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+    getCodingContextForSession(_sessionKey: string) {
+      return { projectId: "existing", branch: null, rootPath: "/x", defaultBranch: null };
+    },
+    config: {
+      codingMode: { projectScope: true, branchScope: false },
+      defaultNamespace: "default",
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+
+  const maybeAttach = (service as unknown as {
+    maybeAttachCodingContext(
+      sessionKey: string | undefined,
+      options: { cwd?: string; projectTag?: string },
+    ): Promise<void>;
+  }).maybeAttachCodingContext.bind(service);
+
+  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  assert.equal(calls.length, 0, "should not overwrite existing context");
+});
+
+test("maybeAttachCodingContext: skips when projectScope disabled", async () => {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+    getCodingContextForSession(_sessionKey: string) {
+      return null;
+    },
+    config: {
+      codingMode: { projectScope: false, branchScope: false },
+      defaultNamespace: "default",
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+
+  const maybeAttach = (service as unknown as {
+    maybeAttachCodingContext(
+      sessionKey: string | undefined,
+      options: { cwd?: string; projectTag?: string },
+    ): Promise<void>;
+  }).maybeAttachCodingContext.bind(service);
+
+  await maybeAttach("session-X", { projectTag: "blend-supply" });
+  assert.equal(calls.length, 0, "should not attach when projectScope is disabled");
+});
+
+test("maybeAttachCodingContext: skips when no sessionKey", async () => {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+    getCodingContextForSession(_sessionKey: string) {
+      return null;
+    },
+    config: {
+      codingMode: { projectScope: true, branchScope: false },
+      defaultNamespace: "default",
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+
+  const maybeAttach = (service as unknown as {
+    maybeAttachCodingContext(
+      sessionKey: string | undefined,
+      options: { cwd?: string; projectTag?: string },
+    ): Promise<void>;
+  }).maybeAttachCodingContext.bind(service);
+
+  await maybeAttach(undefined, { projectTag: "blend-supply" });
+  assert.equal(calls.length, 0, "should not attach without sessionKey");
+});
+
+test("maybeAttachCodingContext: skips when neither cwd nor projectTag provided", async () => {
+  const calls: Array<{ sessionKey: string; ctx: CodingContext | null }> = [];
+  const stubOrchestrator = {
+    setCodingContextForSession(sessionKey: string, ctx: CodingContext | null) {
+      calls.push({ sessionKey, ctx });
+    },
+    getCodingContextForSession(_sessionKey: string) {
+      return null;
+    },
+    config: {
+      codingMode: { projectScope: true, branchScope: false },
+      defaultNamespace: "default",
+    },
+  };
+  const service = Object.create(EngramAccessService.prototype) as EngramAccessService;
+  (service as unknown as { orchestrator: typeof stubOrchestrator }).orchestrator = stubOrchestrator;
+
+  const maybeAttach = (service as unknown as {
+    maybeAttachCodingContext(
+      sessionKey: string | undefined,
+      options: { cwd?: string; projectTag?: string },
+    ): Promise<void>;
+  }).maybeAttachCodingContext.bind(service);
+
+  await maybeAttach("session-X", {});
+  assert.equal(calls.length, 0, "should not attach without cwd or projectTag");
+});

--- a/packages/remnic-core/src/coding/wire-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/wire-coding-context.test.ts
@@ -17,14 +17,14 @@ import test from "node:test";
 import { EngramMcpServer } from "../access-mcp.js";
 import { EngramAccessInputError, EngramAccessService } from "../access-service.js";
 import type { CodingContext } from "../types.js";
-import { validateRequest } from "../access-schema.js";
+import { validateRequest, type RecallRequest, type ObserveRequest } from "../access-schema.js";
 
 // ──────────────────────────────────────────────────────────────────────────
 // Schema validation tests
 // ──────────────────────────────────────────────────────────────────────────
 
 test("recall schema accepts cwd field", () => {
-  const result = validateRequest("recall", {
+  const result = validateRequest<RecallRequest>("recall", {
     query: "test query",
     sessionKey: "sess-1",
     cwd: "/home/user/project",
@@ -36,7 +36,7 @@ test("recall schema accepts cwd field", () => {
 });
 
 test("recall schema accepts projectTag field", () => {
-  const result = validateRequest("recall", {
+  const result = validateRequest<RecallRequest>("recall", {
     query: "test query",
     sessionKey: "sess-1",
     projectTag: "blend-supply",
@@ -74,7 +74,7 @@ test("recall schema rejects empty projectTag", () => {
 });
 
 test("observe schema accepts cwd field", () => {
-  const result = validateRequest("observe", {
+  const result = validateRequest<ObserveRequest>("observe", {
     sessionKey: "sess-1",
     messages: [{ role: "user", content: "hello" }],
     cwd: "/home/user/project",
@@ -86,7 +86,7 @@ test("observe schema accepts cwd field", () => {
 });
 
 test("observe schema accepts projectTag field", () => {
-  const result = validateRequest("observe", {
+  const result = validateRequest<ObserveRequest>("observe", {
     sessionKey: "sess-1",
     messages: [{ role: "user", content: "hello" }],
     projectTag: "worthington-direct",

--- a/packages/remnic-core/src/coding/wire-coding-context.test.ts
+++ b/packages/remnic-core/src/coding/wire-coding-context.test.ts
@@ -378,3 +378,47 @@ test("maybeAttachCodingContext: skips when neither cwd nor projectTag provided",
   await maybeAttach("session-X", {});
   assert.equal(calls.length, 0, "should not attach without cwd or projectTag");
 });
+
+// ──────────────────────────────────────────────────────────────────────────
+// P1: Non-string cwd/projectTag must be rejected in MCP (CLAUDE.md #51)
+// ──────────────────────────────────────────────────────────────────────────
+
+test("MCP recall rejects non-string cwd (e.g. number)", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.recall", { query: "test", cwd: 123 }),
+    (err: unknown) => err instanceof EngramAccessInputError && /cwd/i.test((err as Error).message),
+  );
+});
+
+test("MCP recall rejects non-string projectTag (e.g. boolean)", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.recall", { query: "test", projectTag: false }),
+    (err: unknown) => err instanceof EngramAccessInputError && /projectTag/i.test((err as Error).message),
+  );
+});
+
+test("MCP observe rejects non-string cwd", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.observe", {
+      sessionKey: "s",
+      messages: [{ role: "user", content: "hi" }],
+      cwd: 42,
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError && /cwd/i.test((err as Error).message),
+  );
+});
+
+test("MCP observe rejects non-string projectTag", async () => {
+  const { mcp } = makeMcp();
+  await assert.rejects(
+    call(mcp, "engram.observe", {
+      sessionKey: "s",
+      messages: [{ role: "user", content: "hi" }],
+      projectTag: true,
+    }),
+    (err: unknown) => err instanceof EngramAccessInputError && /projectTag/i.test((err as Error).message),
+  );
+});


### PR DESCRIPTION
## Summary

- Add `cwd` and `projectTag` fields to recall and observe request interfaces, HTTP schemas (zod), and MCP tool definitions so all agent harnesses can get project-scoped memory namespaces automatically
- `cwd` triggers server-side `resolveGitContext()` to detect the git project and branch from the working directory
- `projectTag` creates a tag-based `CodingContext` (`projectId: "tag:<tag>"`) for non-git project scoping (e.g., OpenClaw channels mapped to client projects)
- Update MCP `set_coding_context` tool to accept `projectTag` as a simpler alternative to full `codingContext` objects
- Add `maybeAttachCodingContext()` private helper in `EngramAccessService` that respects `codingMode.projectScope` config gate (CLAUDE.md #30), avoids overwriting existing contexts, and resolves from `projectTag` (priority) or `cwd`
- Both recall and observe paths use the same resolution (CLAUDE.md rule 42: read/write through same namespace layer)

## Test plan

- [x] 21 new tests in `wire-coding-context.test.ts` covering:
  - Zod schema accepts/rejects `cwd` and `projectTag` for recall and observe
  - MCP `set_coding_context` with `projectTag` creates tag-based context
  - MCP `set_coding_context` with `codingContext` takes precedence over `projectTag`
  - MCP `set_coding_context` rejects when neither field is provided
  - Tool schemas advertise `cwd` and `projectTag` properties
  - `maybeAttachCodingContext` attaches tag-based context from `projectTag`
  - `maybeAttachCodingContext` skips when session already has context
  - `maybeAttachCodingContext` skips when `projectScope` is disabled
  - `maybeAttachCodingContext` skips when no `sessionKey`
  - `maybeAttachCodingContext` skips when neither `cwd` nor `projectTag` provided
- [x] All 40 existing coding-context tests pass (no regressions)
- [x] All 57 access-service tests pass
- [x] All 30 access-http + observe tests pass
- [x] `npm run build` succeeds

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `recall` and `observe` choose project-scoped namespaces by auto-attaching session coding context from `cwd`/`projectTag`, which could mis-scope reads/writes if inputs are wrong or git detection behaves unexpectedly. Risk is mitigated by strict validation, config gating, and added tests.
> 
> **Overview**
> Adds optional `cwd` and `projectTag` inputs to `recall` and `observe` across HTTP (`access-http.ts`), zod schemas (`access-schema.ts`), and MCP tool schemas/handlers (`access-mcp.ts`) so clients can get project-scoped namespace routing without manually constructing `codingContext`.
> 
> Implements `EngramAccessService.maybeAttachCodingContext()` to auto-resolve and attach context (preferring `projectTag`, else `cwd`→`resolveGitContext()`), ensures `observe` authorizes the namespace *before* attaching context, and expands `engram.set_coding_context` to accept `projectTag` as an alternative. Adds a comprehensive new test suite (`wire-coding-context.test.ts`) covering schema acceptance/rejection and MCP/service behavior, including rejecting non-string `cwd`/`projectTag` to avoid silent misrouting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac53efad5c866d34c6f7830ce1da8111ec35250. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->