### PR TITLE
feat(core): recall global fallback for project-scoped sessions

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -363,6 +363,11 @@
             "type": "boolean",
             "default": false,
             "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
+          },
+          "globalFallback": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
           }
         }
       },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -363,6 +363,11 @@
             "type": "boolean",
             "default": false,
             "description": "When true, memory also overlays the current branch (project:<id>/branch:<name>). Opt-in — most development wants cross-branch recall. Wired in PR 3 of #569."
+          },
+          "globalFallback": {
+            "type": "boolean",
+            "default": true,
+            "description": "When true (default), project-scoped sessions include the root/default namespace in read fallbacks so globally useful memories remain visible. Set to false for strict project isolation."
           }
         }
       },

--- a/packages/remnic-cli/src/index.ts
+++ b/packages/remnic-cli/src/index.ts
@@ -4306,7 +4306,8 @@ async function cmdDoctor(): Promise<void> {
       }>;
       describeCodingScope?: (
         ctx: unknown,
-        config: { projectScope: boolean; branchScope: boolean },
+        config: { projectScope: boolean; branchScope: boolean; globalFallback: boolean },
+        defaultNamespace?: string,
       ) => {
         scope: "none" | "project" | "branch";
         effectiveNamespace: string | null;
@@ -4344,12 +4345,21 @@ async function cmdDoctor(): Promise<void> {
           typeof pluginCodingMode.branchScope === "boolean"
             ? pluginCodingMode.branchScope
             : false;
+        const globalFallbackCfg =
+          typeof pluginCodingMode.globalFallback === "boolean"
+            ? pluginCodingMode.globalFallback
+            : true;
+        const defaultNamespaceCfg =
+          typeof pluginRemnic.defaultNamespace === "string" && pluginRemnic.defaultNamespace.length > 0
+            ? pluginRemnic.defaultNamespace
+            : "default";
         let effective = `project-…`;
         if (typeof core.describeCodingScope === "function") {
           const desc = core.describeCodingScope(gitCtx, {
             projectScope: projectScopeCfg,
             branchScope: branchScopeCfg,
-          });
+            globalFallback: globalFallbackCfg,
+          }, defaultNamespaceCfg as string);
           effective = desc.effectiveNamespace ?? "(no overlay)";
         }
         parts.push(`projectScope=${projectScopeCfg}`);

--- a/packages/remnic-core/src/coding/coding-branch-scope.test.ts
+++ b/packages/remnic-core/src/coding/coding-branch-scope.test.ts
@@ -45,6 +45,7 @@ function makeOrchestrator(codingMode: Partial<CodingModeConfig> = {}): Orchestra
     codingMode: {
       projectScope: true,
       branchScope: true,
+      globalFallback: true,
       ...codingMode,
     },
   } as unknown as PluginConfig;
@@ -71,10 +72,11 @@ test("codingMode.branchScope=false → no branch layering even when a branch is 
   assert.ok(overlay);
   // Namespace is the project scope only; no `branch:` segment.
   assert.equal(overlay!.namespace, "project-origin-aaaa");
-  assert.deepEqual(overlay!.readFallbacks, [], "no fallbacks when branch scope is off");
+  // globalFallback is true by default, so the root namespace appears in fallbacks.
+  assert.deepEqual(overlay!.readFallbacks, ["default"], "global fallback present when branchScope is off");
 });
 
-test("codingMode.branchScope=true → namespace gains a branch segment and a project readFallback", () => {
+test("codingMode.branchScope=true → namespace gains a branch segment and a project + root readFallback", () => {
   const orch = makeOrchestrator({ branchScope: true });
   orch.setCodingContextForSession("session-A", contextFor("origin:aaaa", "feat/x"));
   const overlay = orch.applyCodingRecallOverlay("session-A");
@@ -83,14 +85,15 @@ test("codingMode.branchScope=true → namespace gains a branch segment and a pro
   // disambiguating hash is appended to keep it distinct from a literal
   // `feat-x` branch on the same project.
   assert.match(overlay!.namespace, /^project-origin-aaaa-branch-feat-x-[0-9a-f]{8}$/);
-  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa"]);
+  // globalFallback is true by default, so both project and root appear.
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa", "default"]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
 // Detached HEAD — no branch segment
 // ──────────────────────────────────────────────────────────────────────────
 
-test("branchScope=true + detached HEAD (branch=null) → collapses to project scope", () => {
+test("branchScope=true + detached HEAD (branch=null) → collapses to project scope with global fallback", () => {
   const orch = makeOrchestrator({ branchScope: true });
   const ctx: CodingContext = {
     projectId: "origin:bbbb",
@@ -102,7 +105,8 @@ test("branchScope=true + detached HEAD (branch=null) → collapses to project sc
   const overlay = orch.applyCodingRecallOverlay("session-A");
   assert.ok(overlay);
   assert.equal(overlay!.namespace, "project-origin-bbbb");
-  assert.deepEqual(overlay!.readFallbacks, []);
+  // Detached HEAD collapses to project scope; global fallback still included.
+  assert.deepEqual(overlay!.readFallbacks, ["default"]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -173,6 +177,10 @@ test("branchScope=true: project-level memories remain visible via readFallbacks"
     overlay!.readFallbacks.includes("project-origin-eeee"),
     "project-level memories must remain visible from any branch",
   );
+  assert.ok(
+    overlay!.readFallbacks.includes("default"),
+    "global/root memories must remain visible from any branch (globalFallback)",
+  );
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -213,7 +221,7 @@ test("projectScope=false defeats branchScope=true (master gate — CLAUDE.md #30
 // ──────────────────────────────────────────────────────────────────────────
 
 test("describeCodingScope: no context → scope=none, reason=no-context", () => {
-  const desc = describeCodingScope(null, { projectScope: true, branchScope: false });
+  const desc = describeCodingScope(null, { projectScope: true, branchScope: false, globalFallback: true });
   assert.equal(desc.scope, "none");
   assert.equal(desc.disabledReason, "no-context");
   assert.equal(desc.effectiveNamespace, null);
@@ -221,7 +229,7 @@ test("describeCodingScope: no context → scope=none, reason=no-context", () => 
 
 test("describeCodingScope: projectScope=false → scope=none, reason=disabled", () => {
   const ctx = contextFor("origin:hhhh", "main");
-  const desc = describeCodingScope(ctx, { projectScope: false, branchScope: false });
+  const desc = describeCodingScope(ctx, { projectScope: false, branchScope: false, globalFallback: true });
   assert.equal(desc.scope, "none");
   assert.equal(desc.disabledReason, "disabled");
   // Raw context fields are still surfaced so operators can see what would
@@ -230,25 +238,34 @@ test("describeCodingScope: projectScope=false → scope=none, reason=disabled", 
   assert.equal(desc.branch, "main");
 });
 
-test("describeCodingScope: project scope active → scope=project, namespace populated", () => {
+test("describeCodingScope: project scope active → scope=project, namespace populated, global fallback included", () => {
   const ctx = contextFor("origin:iiii", "main");
-  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false });
+  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false, globalFallback: true }, "default");
+  assert.equal(desc.scope, "project");
+  assert.equal(desc.effectiveNamespace, "project-origin-iiii");
+  assert.deepEqual(desc.readFallbacks, ["default"]);
+  assert.equal(desc.disabledReason, null);
+});
+
+test("describeCodingScope: project scope active, globalFallback=false → no root in fallbacks", () => {
+  const ctx = contextFor("origin:iiii", "main");
+  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false, globalFallback: false }, "default");
   assert.equal(desc.scope, "project");
   assert.equal(desc.effectiveNamespace, "project-origin-iiii");
   assert.deepEqual(desc.readFallbacks, []);
   assert.equal(desc.disabledReason, null);
 });
 
-test("describeCodingScope: branch scope active → scope=branch, fallbacks include project", () => {
+test("describeCodingScope: branch scope active → scope=branch, fallbacks include project and root", () => {
   const ctx = contextFor("origin:jjjj", "feat/x");
-  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: true });
+  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: true, globalFallback: true }, "default");
   assert.equal(desc.scope, "branch");
   // Lossy-sanitization hash appended for `/` in `feat/x`.
   assert.match(
     desc.effectiveNamespace ?? "",
     /^project-origin-jjjj-branch-feat-x-[0-9a-f]{8}$/,
   );
-  assert.deepEqual(desc.readFallbacks, ["project-origin-jjjj"]);
+  assert.deepEqual(desc.readFallbacks, ["project-origin-jjjj", "default"]);
 });
 
 test("describeCodingScope: empty projectId → scope=none, reason=empty-project", () => {
@@ -258,7 +275,7 @@ test("describeCodingScope: empty projectId → scope=none, reason=empty-project"
     rootPath: "/work/proj",
     defaultBranch: "main",
   };
-  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false });
+  const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false, globalFallback: true });
   assert.equal(desc.scope, "none");
   assert.equal(desc.disabledReason, "empty-project");
 });

--- a/packages/remnic-core/src/coding/coding-branch-scope.test.ts
+++ b/packages/remnic-core/src/coding/coding-branch-scope.test.ts
@@ -73,7 +73,7 @@ test("codingMode.branchScope=false → no branch layering even when a branch is 
   // Namespace is the project scope only; no `branch:` segment.
   assert.equal(overlay!.namespace, "project-origin-aaaa");
   // globalFallback is true by default, so the root namespace appears in fallbacks.
-  assert.deepEqual(overlay!.readFallbacks, ["default"], "global fallback present when branchScope is off");
+  assert.deepEqual(overlay!.readFallbacks, [""], "global fallback present when branchScope is off");
 });
 
 test("codingMode.branchScope=true → namespace gains a branch segment and a project + root readFallback", () => {
@@ -86,7 +86,7 @@ test("codingMode.branchScope=true → namespace gains a branch segment and a pro
   // `feat-x` branch on the same project.
   assert.match(overlay!.namespace, /^project-origin-aaaa-branch-feat-x-[0-9a-f]{8}$/);
   // globalFallback is true by default, so both project and root appear.
-  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa", "default"]);
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa", ""]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -106,7 +106,7 @@ test("branchScope=true + detached HEAD (branch=null) → collapses to project sc
   assert.ok(overlay);
   assert.equal(overlay!.namespace, "project-origin-bbbb");
   // Detached HEAD collapses to project scope; global fallback still included.
-  assert.deepEqual(overlay!.readFallbacks, ["default"]);
+  assert.deepEqual(overlay!.readFallbacks, [""]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
@@ -178,8 +178,8 @@ test("branchScope=true: project-level memories remain visible via readFallbacks"
     "project-level memories must remain visible from any branch",
   );
   assert.ok(
-    overlay!.readFallbacks.includes("default"),
-    "global/root memories must remain visible from any branch (globalFallback)",
+    overlay!.readFallbacks.includes(""),
+    "global/root memories must remain visible from any branch (empty sentinel for combineNamespaces)",
   );
 });
 
@@ -243,7 +243,7 @@ test("describeCodingScope: project scope active → scope=project, namespace pop
   const desc = describeCodingScope(ctx, { projectScope: true, branchScope: false, globalFallback: true }, "default");
   assert.equal(desc.scope, "project");
   assert.equal(desc.effectiveNamespace, "project-origin-iiii");
-  assert.deepEqual(desc.readFallbacks, ["default"]);
+  assert.deepEqual(desc.readFallbacks, [""]);
   assert.equal(desc.disabledReason, null);
 });
 
@@ -265,7 +265,7 @@ test("describeCodingScope: branch scope active → scope=branch, fallbacks inclu
     desc.effectiveNamespace ?? "",
     /^project-origin-jjjj-branch-feat-x-[0-9a-f]{8}$/,
   );
-  assert.deepEqual(desc.readFallbacks, ["project-origin-jjjj", "default"]);
+  assert.deepEqual(desc.readFallbacks, ["project-origin-jjjj", ""]);
 });
 
 test("describeCodingScope: empty projectId → scope=none, reason=empty-project", () => {

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -11,6 +11,7 @@ import test from "node:test";
 
 import {
   branchNamespaceName,
+  combineNamespaces,
   projectNamespaceName,
   resolveCodingNamespaceOverlay,
 } from "./coding-namespace.js";
@@ -199,12 +200,11 @@ test("resolveCodingNamespaceOverlay: empty projectId → null (defensive)", () =
 // resolveCodingNamespaceOverlay — project scope
 // ──────────────────────────────────────────────────────────────────────────
 
-test("resolveCodingNamespaceOverlay: projectScope=true, no defaultNamespace → project overlay, no fallbacks", () => {
-  // When defaultNamespace is omitted, no root fallback is appended (backward compat).
+test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=true (default) → includes empty sentinel", () => {
   const overlay = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:deadbeef" }), mode());
   assert.deepEqual(overlay, {
     namespace: "project-origin-deadbeef",
-    readFallbacks: [],
+    readFallbacks: [""],
     scope: "project",
   });
 });
@@ -217,9 +217,24 @@ test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=true + d
   );
   assert.deepEqual(overlay, {
     namespace: "project-origin-deadbeef",
-    readFallbacks: ["default"],
+    readFallbacks: [""],
     scope: "project",
   });
+});
+
+test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=true → empty-string sentinel combines to principal self", () => {
+  // Verifies the fix for the P1 double-combination bug: "" as fallback
+  // causes combineNamespaces(principal, "") to return the principal's own
+  // namespace, not "principal-default" which would miss global memories.
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:deadbeef" }),
+    mode({ globalFallback: true }),
+    "default",
+  );
+  assert.equal(overlay!.readFallbacks.length, 1);
+  assert.equal(overlay!.readFallbacks[0], "");
+  assert.equal(combineNamespaces("alice", ""), "alice");
+  assert.equal(combineNamespaces("default", ""), "default");
 });
 
 test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=false → no root in fallbacks", () => {
@@ -235,7 +250,7 @@ test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=false �
   });
 });
 
-test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → still project scope only", () => {
+test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → project scope + global fallback", () => {
   const overlay = resolveCodingNamespaceOverlay(
     ctx({ projectId: "origin:aaaa0000", branch: null }),
     mode({ branchScope: true }),
@@ -243,14 +258,14 @@ test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → still
   assert.ok(overlay);
   assert.equal(overlay!.scope, "project");
   assert.equal(overlay!.namespace, "project-origin-aaaa0000");
-  assert.deepEqual(overlay!.readFallbacks, []);
+  assert.deepEqual(overlay!.readFallbacks, [""]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────
 // resolveCodingNamespaceOverlay — branch scope (PR 3 preview, but logic is here)
 // ──────────────────────────────────────────────────────────────────────────
 
-test("resolveCodingNamespaceOverlay: branchScope=true + branch set, no defaultNamespace → project fallback only", () => {
+test("resolveCodingNamespaceOverlay: branchScope=true + branch set + globalFallback=true → project + root fallbacks", () => {
   const overlay = resolveCodingNamespaceOverlay(
     ctx({ projectId: "origin:aaaa0000", branch: "feat/x" }),
     mode({ branchScope: true }),
@@ -261,8 +276,8 @@ test("resolveCodingNamespaceOverlay: branchScope=true + branch set, no defaultNa
     overlay!.namespace,
     /^project-origin-aaaa0000-branch-feat-x-[0-9a-f]{8}$/,
   );
-  // No defaultNamespace passed → only project fallback.
-  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000"]);
+  // globalFallback defaults to true → project + empty sentinel for global.
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000", ""]);
 });
 
 test("resolveCodingNamespaceOverlay: branchScope=true + globalFallback=true + defaultNamespace → project and root fallbacks", () => {
@@ -277,7 +292,7 @@ test("resolveCodingNamespaceOverlay: branchScope=true + globalFallback=true + de
     overlay!.namespace,
     /^project-origin-aaaa0000-branch-feat-x-[0-9a-f]{8}$/,
   );
-  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000", "generalist"]);
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000", ""]);
 });
 
 test("resolveCodingNamespaceOverlay: branchScope=true + globalFallback=false → only project fallback", () => {
@@ -301,22 +316,24 @@ test("resolveCodingNamespaceOverlay: branchScope=false → no branch layering ev
 // resolveCodingNamespaceOverlay — globalFallback edge cases
 // ──────────────────────────────────────────────────────────────────────────
 
-test("resolveCodingNamespaceOverlay: globalFallback=true + empty defaultNamespace → no root fallback", () => {
+test("resolveCodingNamespaceOverlay: globalFallback=true + empty defaultNamespace → still includes empty sentinel", () => {
+  // The sentinel "" tells combineNamespaces to return the principal base
+  // unchanged, regardless of what defaultNamespace is configured.
   const overlay = resolveCodingNamespaceOverlay(
     ctx({ projectId: "origin:deadbeef" }),
     mode({ globalFallback: true }),
     "   ",
   );
-  assert.deepEqual(overlay!.readFallbacks, []);
+  assert.deepEqual(overlay!.readFallbacks, [""]);
 });
 
-test("resolveCodingNamespaceOverlay: globalFallback=true + custom defaultNamespace → custom name in fallbacks", () => {
+test("resolveCodingNamespaceOverlay: globalFallback=true + custom defaultNamespace → empty sentinel (not the name)", () => {
   const overlay = resolveCodingNamespaceOverlay(
     ctx({ projectId: "origin:deadbeef" }),
     mode({ globalFallback: true }),
     "generalist",
   );
-  assert.deepEqual(overlay!.readFallbacks, ["generalist"]);
+  assert.deepEqual(overlay!.readFallbacks, [""]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/coding-namespace.test.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.test.ts
@@ -31,6 +31,7 @@ function mode(overrides: Partial<CodingModeConfig> = {}): CodingModeConfig {
   return {
     projectScope: true,
     branchScope: false,
+    globalFallback: true,
     ...overrides,
   };
 }
@@ -198,8 +199,35 @@ test("resolveCodingNamespaceOverlay: empty projectId → null (defensive)", () =
 // resolveCodingNamespaceOverlay — project scope
 // ──────────────────────────────────────────────────────────────────────────
 
-test("resolveCodingNamespaceOverlay: projectScope=true → project overlay, no fallbacks", () => {
+test("resolveCodingNamespaceOverlay: projectScope=true, no defaultNamespace → project overlay, no fallbacks", () => {
+  // When defaultNamespace is omitted, no root fallback is appended (backward compat).
   const overlay = resolveCodingNamespaceOverlay(ctx({ projectId: "origin:deadbeef" }), mode());
+  assert.deepEqual(overlay, {
+    namespace: "project-origin-deadbeef",
+    readFallbacks: [],
+    scope: "project",
+  });
+});
+
+test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=true + defaultNamespace → root in fallbacks", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:deadbeef" }),
+    mode({ globalFallback: true }),
+    "default",
+  );
+  assert.deepEqual(overlay, {
+    namespace: "project-origin-deadbeef",
+    readFallbacks: ["default"],
+    scope: "project",
+  });
+});
+
+test("resolveCodingNamespaceOverlay: projectScope=true + globalFallback=false → no root in fallbacks", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:deadbeef" }),
+    mode({ globalFallback: false }),
+    "default",
+  );
   assert.deepEqual(overlay, {
     namespace: "project-origin-deadbeef",
     readFallbacks: [],
@@ -222,20 +250,43 @@ test("resolveCodingNamespaceOverlay: branchScope=true with branch=null → still
 // resolveCodingNamespaceOverlay — branch scope (PR 3 preview, but logic is here)
 // ──────────────────────────────────────────────────────────────────────────
 
-test("resolveCodingNamespaceOverlay: branchScope=true + branch set → branch overlay with project fallback", () => {
+test("resolveCodingNamespaceOverlay: branchScope=true + branch set, no defaultNamespace → project fallback only", () => {
   const overlay = resolveCodingNamespaceOverlay(
     ctx({ projectId: "origin:aaaa0000", branch: "feat/x" }),
     mode({ branchScope: true }),
   );
   assert.ok(overlay);
   assert.equal(overlay!.scope, "branch");
-  // `feat/x` is lossy under sanitization (`/` → `-`), so the branch
-  // namespace includes a deterministic hash suffix to keep it distinct
-  // from a literal `feat-x` branch on the same project.
   assert.match(
     overlay!.namespace,
     /^project-origin-aaaa0000-branch-feat-x-[0-9a-f]{8}$/,
   );
+  // No defaultNamespace passed → only project fallback.
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000"]);
+});
+
+test("resolveCodingNamespaceOverlay: branchScope=true + globalFallback=true + defaultNamespace → project and root fallbacks", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:aaaa0000", branch: "feat/x" }),
+    mode({ branchScope: true, globalFallback: true }),
+    "generalist",
+  );
+  assert.ok(overlay);
+  assert.equal(overlay!.scope, "branch");
+  assert.match(
+    overlay!.namespace,
+    /^project-origin-aaaa0000-branch-feat-x-[0-9a-f]{8}$/,
+  );
+  assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000", "generalist"]);
+});
+
+test("resolveCodingNamespaceOverlay: branchScope=true + globalFallback=false → only project fallback", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:aaaa0000", branch: "feat/x" }),
+    mode({ branchScope: true, globalFallback: false }),
+    "generalist",
+  );
+  assert.ok(overlay);
   assert.deepEqual(overlay!.readFallbacks, ["project-origin-aaaa0000"]);
 });
 
@@ -244,6 +295,28 @@ test("resolveCodingNamespaceOverlay: branchScope=false → no branch layering ev
   assert.ok(overlay);
   assert.equal(overlay!.scope, "project");
   assert.ok(!overlay!.namespace.includes("branch:"));
+});
+
+// ──────────────────────────────────────────────────────────────────────────
+// resolveCodingNamespaceOverlay — globalFallback edge cases
+// ──────────────────────────────────────────────────────────────────────────
+
+test("resolveCodingNamespaceOverlay: globalFallback=true + empty defaultNamespace → no root fallback", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:deadbeef" }),
+    mode({ globalFallback: true }),
+    "   ",
+  );
+  assert.deepEqual(overlay!.readFallbacks, []);
+});
+
+test("resolveCodingNamespaceOverlay: globalFallback=true + custom defaultNamespace → custom name in fallbacks", () => {
+  const overlay = resolveCodingNamespaceOverlay(
+    ctx({ projectId: "origin:deadbeef" }),
+    mode({ globalFallback: true }),
+    "generalist",
+  );
+  assert.deepEqual(overlay!.readFallbacks, ["generalist"]);
 });
 
 // ──────────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -255,9 +255,10 @@ export function branchNamespaceName(projectId: string, branch: string): string {
  *
  * @param codingContext — git context from the connector
  * @param config — coding mode flags (projectScope, branchScope, globalFallback)
- * @param defaultNamespace — the root/global namespace name (e.g. `"default"`)
- *   used as a read fallback when `globalFallback` is true. When omitted or
- *   empty, no root fallback is appended (preserves pre-globalFallback behavior).
+ * @param defaultNamespace — retained for call-site compatibility; no longer
+ *   used. The global fallback is expressed as an empty-string sentinel in
+ *   `readFallbacks`, which `combineNamespaces(principal, "")` resolves to the
+ *   principal's own namespace at the call site.
  */
 export function resolveCodingNamespaceOverlay(
   codingContext: CodingContext | null | undefined,
@@ -278,12 +279,17 @@ export function resolveCodingNamespaceOverlay(
 
   const projectNs = projectNamespaceName(projectId);
 
-  // Root/global namespace fallback: when `globalFallback` is true and a
-  // non-empty `defaultNamespace` was supplied, include the root namespace in
-  // readFallbacks so cross-project knowledge remains visible. CLAUDE.md #30:
-  // the gate is `globalFallback` — set to false for strict project isolation.
-  const rootNs = typeof defaultNamespace === "string" ? defaultNamespace.trim() : "";
-  const includeRoot = config.globalFallback === true && rootNs.length > 0;
+  // Root/global namespace fallback: when `globalFallback` is true, include
+  // the principal's self namespace in readFallbacks so cross-project knowledge
+  // remains visible. CLAUDE.md #30: the gate is `globalFallback` — set to
+  // false for strict project isolation.
+  //
+  // The fallback value is "" (empty string), NOT the defaultNamespace name.
+  // The orchestrator passes each fallback through combineNamespaces(principal, fallback),
+  // and combineNamespaces(base, "") returns base unchanged — yielding the
+  // principal's own namespace. Using the actual namespace name (e.g., "default")
+  // would produce "default-default" after combination, missing the target.
+  const includeRoot = config.globalFallback === true;
 
   // Branch-scope layering (PR 3):
   //   - only when config.branchScope is explicitly true
@@ -296,7 +302,7 @@ export function resolveCodingNamespaceOverlay(
   if (config.branchScope && typeof codingContext.branch === "string" && codingContext.branch.length > 0) {
     const branchNs = branchNamespaceName(projectId, codingContext.branch);
     const fallbacks = [projectNs];
-    if (includeRoot) fallbacks.push(rootNs);
+    if (includeRoot) fallbacks.push("");
     return {
       namespace: branchNs,
       readFallbacks: fallbacks,
@@ -306,7 +312,7 @@ export function resolveCodingNamespaceOverlay(
 
   return {
     namespace: projectNs,
-    readFallbacks: includeRoot ? [rootNs] : [],
+    readFallbacks: includeRoot ? [""] : [],
     scope: "project",
   };
 }

--- a/packages/remnic-core/src/coding/coding-namespace.ts
+++ b/packages/remnic-core/src/coding/coding-namespace.ts
@@ -252,10 +252,17 @@ export function branchNamespaceName(projectId: string, branch: string): string {
  * existing `defaultNamespaceForPrincipal(...)` result unchanged. This keeps
  * CLAUDE.md #30 (escape hatch): setting `codingMode.projectScope: false`
  * exactly restores pre-#569 behaviour at every call site.
+ *
+ * @param codingContext — git context from the connector
+ * @param config — coding mode flags (projectScope, branchScope, globalFallback)
+ * @param defaultNamespace — the root/global namespace name (e.g. `"default"`)
+ *   used as a read fallback when `globalFallback` is true. When omitted or
+ *   empty, no root fallback is appended (preserves pre-globalFallback behavior).
  */
 export function resolveCodingNamespaceOverlay(
   codingContext: CodingContext | null | undefined,
-  config: Pick<CodingModeConfig, "projectScope" | "branchScope">,
+  config: Pick<CodingModeConfig, "projectScope" | "branchScope" | "globalFallback">,
+  defaultNamespace?: string,
 ): CodingNamespaceOverlay | null {
   // No context supplied (session isn't in a git repo, or connector didn't
   // attach one) → no overlay.
@@ -271,24 +278,35 @@ export function resolveCodingNamespaceOverlay(
 
   const projectNs = projectNamespaceName(projectId);
 
+  // Root/global namespace fallback: when `globalFallback` is true and a
+  // non-empty `defaultNamespace` was supplied, include the root namespace in
+  // readFallbacks so cross-project knowledge remains visible. CLAUDE.md #30:
+  // the gate is `globalFallback` — set to false for strict project isolation.
+  const rootNs = typeof defaultNamespace === "string" ? defaultNamespace.trim() : "";
+  const includeRoot = config.globalFallback === true && rootNs.length > 0;
+
   // Branch-scope layering (PR 3):
   //   - only when config.branchScope is explicitly true
   //   - only when we actually have a branch (null in detached HEAD)
   //   - project namespace becomes a read fallback so project-level memories
   //     remain visible from any branch (deliberate asymmetry — branch writes
   //     don't leak up, but project reads leak down).
+  //   - when globalFallback is on, the root namespace is also appended so
+  //     globally useful memories surface in every branch.
   if (config.branchScope && typeof codingContext.branch === "string" && codingContext.branch.length > 0) {
     const branchNs = branchNamespaceName(projectId, codingContext.branch);
+    const fallbacks = [projectNs];
+    if (includeRoot) fallbacks.push(rootNs);
     return {
       namespace: branchNs,
-      readFallbacks: [projectNs],
+      readFallbacks: fallbacks,
       scope: "branch",
     };
   }
 
   return {
     namespace: projectNs,
-    readFallbacks: [],
+    readFallbacks: includeRoot ? [rootNs] : [],
     scope: "project",
   };
 }
@@ -326,7 +344,8 @@ export interface CodingScopeDescription {
  */
 export function describeCodingScope(
   codingContext: CodingContext | null | undefined,
-  config: Pick<CodingModeConfig, "projectScope" | "branchScope">,
+  config: Pick<CodingModeConfig, "projectScope" | "branchScope" | "globalFallback">,
+  defaultNamespace?: string,
 ): CodingScopeDescription {
   const projectId = codingContext?.projectId ?? null;
   const branch = codingContext?.branch ?? null;
@@ -363,7 +382,7 @@ export function describeCodingScope(
     };
   }
 
-  const overlay = resolveCodingNamespaceOverlay(codingContext, config);
+  const overlay = resolveCodingNamespaceOverlay(codingContext, config, defaultNamespace);
   // Unreachable in practice given the guards above, but keep the return
   // shape consistent if the resolver grows new null branches later.
   if (!overlay) {

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -566,9 +566,13 @@ export function parseConfig(raw: unknown): PluginConfig {
   // `coerceBool` treats "false"/"0"/"no"/"off" as false (CLAUDE.md #36).
   const codingProjectScopeRaw = coerceBool(rawCodingMode.projectScope);
   const codingBranchScopeRaw = coerceBool(rawCodingMode.branchScope);
+  const codingGlobalFallbackRaw = coerceBool(rawCodingMode.globalFallback);
   const codingMode: CodingModeConfig = {
     projectScope: codingProjectScopeRaw === undefined ? true : codingProjectScopeRaw,
     branchScope: codingBranchScopeRaw === true,
+    // Default true — project-scoped sessions include the root namespace in
+    // read fallbacks so globally useful memories remain visible. CLAUDE.md #30.
+    globalFallback: codingGlobalFallbackRaw === undefined ? true : codingGlobalFallbackRaw,
   };
 
   const memoryDir =

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -1485,15 +1485,14 @@ export class Orchestrator {
   applyCodingNamespaceOverlay(sessionKey: string | undefined, baseNamespace: string): string {
     if (!this.config.namespacesEnabled) return baseNamespace;
     const codingContext = this.getCodingContextForSession(sessionKey);
-    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
+    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode, this.config.defaultNamespace);
     if (!overlay) return baseNamespace;
     return combineNamespaces(baseNamespace, overlay.namespace);
   }
 
   /**
    * Read-side overlay: returns the list of namespaces a session should read
-   * from, including any read fallbacks (branch → project asymmetry lands in
-   * PR 3; PR 2 returns an empty fallbacks list).
+   * from, including any read fallbacks (branch → project, global root).
    *
    * Returns `null` when:
    *   - `namespacesEnabled` is false (overlay would create false isolation)
@@ -1510,7 +1509,7 @@ export class Orchestrator {
   applyCodingRecallOverlay(sessionKey: string | undefined): { namespace: string; readFallbacks: string[] } | null {
     if (!this.config.namespacesEnabled) return null;
     const codingContext = this.getCodingContextForSession(sessionKey);
-    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode);
+    const overlay = resolveCodingNamespaceOverlay(codingContext, this.config.codingMode, this.config.defaultNamespace);
     if (!overlay) return null;
     return { namespace: overlay.namespace, readFallbacks: overlay.readFallbacks };
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -272,6 +272,17 @@ export interface CodingModeConfig {
    * issue #569; declared here so the schema ships in one slice.)
    */
   branchScope: boolean;
+  /**
+   * When true (default), project-scoped and branch-scoped sessions include
+   * the root/default namespace in their read fallbacks so globally useful
+   * memories remain visible from any project. When false, project-scoped
+   * sessions only see their own namespace (strict isolation).
+   *
+   * CLAUDE.md #30: configuration gate for the recall fan-out to the root
+   * namespace. Does not affect writes — those always go to the project
+   * namespace only.
+   */
+  globalFallback: boolean;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Project-scoped sessions now include the root/default namespace in their `readFallbacks`, so globally useful memories (e.g. cross-project knowledge) surface during recall without requiring the user to switch namespaces.
- Branch-scoped sessions include both the project namespace and the root namespace in fallbacks.
- New `codingMode.globalFallback` config gate (default `true`) controls this behavior per CLAUDE.md rule 30. Set to `false` for strict project isolation.
- Writes are unaffected -- they still go to the project namespace only (rule 42 preserved).

## Changes

| File | What |
|------|------|
| `packages/remnic-core/src/types.ts` | Add `globalFallback: boolean` to `CodingModeConfig` |
| `packages/remnic-core/src/config.ts` | Parse `codingMode.globalFallback` with `coerceBool`, default `true` |
| `packages/remnic-core/src/coding/coding-namespace.ts` | Accept `defaultNamespace` param; append root to `readFallbacks` when `globalFallback` is on |
| `packages/remnic-core/src/orchestrator.ts` | Pass `config.defaultNamespace` to overlay resolver on both write and recall paths |
| `packages/remnic-cli/src/index.ts` | Wire `globalFallback` + `defaultNamespace` through `remnic doctor` surface |
| `openclaw.plugin.json` + source | Add `globalFallback` to `codingMode` config schema |
| Test files | 43 tests covering all fallback combinations, edge cases, and diagnostic surface |

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/coding/coding-namespace.test.ts` -- 28 pass
- [x] `npx tsx --test packages/remnic-core/src/coding/coding-branch-scope.test.ts` -- 15 pass
- [x] `npm run build` -- success
- [ ] CI passes
- [ ] Verify `globalFallback: false` strictly isolates project namespace (no root in fallbacks)
- [ ] Verify `globalFallback: true` (default) includes root in fallbacks for both project and branch scopes

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall namespace fan-out for project/branch-scoped sessions (default-on), which can alter what memories are surfaced and has privacy/isolation implications if operators relied on strict per-project recall.
> 
> **Overview**
> **Project/branch-scoped recall now falls back to the root namespace by default.** `resolveCodingNamespaceOverlay` appends an empty-string sentinel to `readFallbacks` when new `codingMode.globalFallback` is enabled (default `true`), so callers combine it to the principal’s own namespace and globally useful memories remain visible.
> 
> Adds the `codingMode.globalFallback` config flag end-to-end (types, config parsing, OpenClaw plugin schema), wires `defaultNamespace`/`globalFallback` into `remnic doctor` diagnostics, and updates/extends core tests to assert the new fallback behavior for both project and branch scopes (writes remain project/branch-scoped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ffeac397146c17d234e4e8f750fef2bb7bcba64. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->