### PR TITLE
feat(core): add scope classification to extraction pipeline

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2428,6 +2428,11 @@
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
+      "extractionScopeClassificationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
+      },
       "extractionJudgeEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2428,6 +2428,11 @@
         "default": "low",
         "description": "Minimum locally-scored importance level required to persist an extracted fact. Facts below this level are dropped before write and counted toward the importance_gated metric. Default \"low\" drops only trivial turn-level chatter (greetings, single-word replies); raise to \"normal\" or higher for a stricter gate."
       },
+      "extractionScopeClassificationEnabled": {
+        "type": "boolean",
+        "default": true,
+        "description": "When enabled, the extraction prompt instructs the LLM to classify each fact as 'project' (codebase-specific) or 'global' (cross-project knowledge). Global-scoped facts are promoted to the shared namespace so they are visible across all projects. Disable to restore pre-scope-classification behavior where all facts go to the session namespace."
+      },
       "extractionJudgeEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1643,6 +1643,11 @@ export function parseConfig(raw: unknown): PluginConfig {
       }
       return "low";
     })(),
+    // Extraction scope classification. When enabled, the extraction prompt
+    // asks the LLM to classify each fact as "project" or "global". Global
+    // facts are promoted to the shared namespace. Default true (rule 30 gate).
+    extractionScopeClassificationEnabled:
+      coerceBool(cfg.extractionScopeClassificationEnabled) !== false,
     // Extraction judge (issue #376). Opt-in LLM-as-judge fact-worthiness gate.
     extractionJudgeEnabled: cfg.extractionJudgeEnabled === true,
     extractionJudgeModel:

--- a/packages/remnic-core/src/extraction.ts
+++ b/packages/remnic-core/src/extraction.ts
@@ -215,6 +215,8 @@ export class ExtractionEngine {
             entityRef: typeof f?.entityRef === "string" ? f.entityRef : undefined,
             promptedByQuestion:
               typeof f?.promptedByQuestion === "string" ? f.promptedByQuestion : undefined,
+            scope:
+              f?.scope === "global" || f?.scope === "project" ? f.scope : undefined,
             structuredAttributes:
               f?.structuredAttributes && typeof f.structuredAttributes === "object" && !Array.isArray(f.structuredAttributes)
                 ? Object.fromEntries(
@@ -1222,7 +1224,8 @@ These are durable insights - capture them:
 - CRITICAL: Use canonical hyphenated entity names (e.g., "jane-doe" not "janedoe")
 - CRITICAL: NEVER extract the same fact twice - check for duplicates before adding to facts array
 - CRITICAL: NEVER extract cron job schedules, automation configurations, or system monitoring details (these are operational noise)
-- If uncertain about relevance, prefer NOT extracting
+- If uncertain about relevance, prefer NOT extracting${this.config.extractionScopeClassificationEnabled ? `
+- For each fact, set "scope" to "global" (cross-project knowledge: framework bugs, library behavior, user preferences, tool configs, general patterns) or "project" (codebase-specific: file paths, env configs, deployment details, project workarounds). When in doubt, prefer "project".` : ""}
 
 === Structured Attributes ===
 When a fact contains measurable, categorical, or precisely valued data, add a "structuredAttributes" object with key-value string pairs. This captures exact values for precise retrieval later.
@@ -1242,7 +1245,7 @@ Also generate:
 
 Output JSON:
 {
-  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "procedure", "content": "When you cut a hotfix release, follow the checklist", "importance": 8, "confidence": 0.9, "procedureSteps": [{"order": 1, "intent": "Branch from main and cherry-pick the fix"}, {"order": 2, "intent": "Run CI and tag the release"}]}, {"category": "reasoning_trace", "content": "How I debugged the staging latency spike", "importance": 7, "confidence": 0.9, "reasoningTrace": {"steps": [{"order": 1, "description": "Checked CPU/memory dashboards — both were flat"}, {"order": 2, "description": "Ran a traceroute and saw retries against the cache tier"}, {"order": 3, "description": "Tailed cache-tier logs and spotted eviction storms"}], "finalAnswer": "Root cause was an undersized eviction policy on the session cache", "observedOutcome": "Increased cache size, p95 returned to baseline within 10 minutes"}}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9}],
+  "facts": [{"category": "decision", "content": "Chose PostgreSQL over MongoDB for the user service", "importance": 8, "confidence": 0.9, "scope": "project", "structuredAttributes": {"chosen": "PostgreSQL", "rejected": "MongoDB"}}, {"category": "procedure", "content": "When you cut a hotfix release, follow the checklist", "importance": 8, "confidence": 0.9, "scope": "project", "procedureSteps": [{"order": 1, "intent": "Branch from main and cherry-pick the fix"}, {"order": 2, "intent": "Run CI and tag the release"}]}, {"category": "reasoning_trace", "content": "How I debugged the staging latency spike", "importance": 7, "confidence": 0.9, "scope": "project", "reasoningTrace": {"steps": [{"order": 1, "description": "Checked CPU/memory dashboards — both were flat"}, {"order": 2, "description": "Ran a traceroute and saw retries against the cache tier"}, {"order": 3, "description": "Tailed cache-tier logs and spotted eviction storms"}], "finalAnswer": "Root cause was an undersized eviction policy on the session cache", "observedOutcome": "Increased cache size, p95 returned to baseline within 10 minutes"}}, {"category": "commitment", "content": "Must ship v2.0 API by end of March", "importance": 10, "confidence": 1.0, "scope": "project", "structuredAttributes": {"deadline": "end of March", "deliverable": "v2.0 API"}}, {"category": "fact", "content": "The store backend uses Redis for session caching", "importance": 6, "confidence": 0.95, "scope": "project", "entityRef": "project-acme-store"}, {"category": "principle", "content": "Always run migrations in a transaction to avoid partial schema updates", "importance": 8, "confidence": 0.9, "scope": "global"}],
   "entities": [{"name": "person-jane-doe", "type": "person", "facts": ["Works at Acme Corp", "Prefers Python over JavaScript"], "structuredSections": [{"key": "beliefs", "title": "Beliefs", "facts": ["Python is a better fit than JavaScript for backend work."]}]}, {"name": "project-acme-store", "type": "project", "facts": ["Built with Next.js", "Deployed on Vercel"]}],
   "profileUpdates": ["User prefers dark mode in all editors"],
   "questions": [{"question": "Which cloud provider hosts the staging environment?", "context": "Came up during deployment discussion", "priority": 0.5}],
@@ -1336,7 +1339,7 @@ ${truncatedConversation}`;
             this.buildExtractionInstructions(existingEntities) +
             `\n\nRespond with valid JSON matching this schema:
 {
-  "facts": [{"category": "decision", "content": "Chose React over Vue for the dashboard rewrite", "importance": 8, "confidence": 0.9, "tags": ["frontend"], "structuredAttributes": {"chosen": "React", "rejected": "Vue"}}, {"category": "fact", "content": "The API gateway uses rate limiting at 1000 req/min", "importance": 6, "confidence": 0.95, "tags": ["infra"], "entityRef": "project-dashboard", "structuredAttributes": {"rate_limit": "1000 req/min"}}, {"category": "reasoning_trace", "content": "How I chose the dashboard rewrite framework", "confidence": 0.9, "tags": ["frontend"], "reasoningTrace": {"steps": [{"order": 1, "description": "Listed constraints: SSR needed, team mostly JS"}, {"order": 2, "description": "Ran a spike in Vue 3 — worked, but ecosystem felt thin for our needs"}, {"order": 3, "description": "Ran the same spike in React — integrated faster with Next.js"}], "finalAnswer": "Picked React with Next.js for SSR + ecosystem fit"}}],
+  "facts": [{"category": "decision", "content": "Chose React over Vue for the dashboard rewrite", "importance": 8, "confidence": 0.9, "tags": ["frontend"], "scope": "project", "structuredAttributes": {"chosen": "React", "rejected": "Vue"}}, {"category": "fact", "content": "The API gateway uses rate limiting at 1000 req/min", "importance": 6, "confidence": 0.95, "tags": ["infra"], "scope": "project", "entityRef": "project-dashboard", "structuredAttributes": {"rate_limit": "1000 req/min"}}, {"category": "reasoning_trace", "content": "How I chose the dashboard rewrite framework", "confidence": 0.9, "tags": ["frontend"], "scope": "project", "reasoningTrace": {"steps": [{"order": 1, "description": "Listed constraints: SSR needed, team mostly JS"}, {"order": 2, "description": "Ran a spike in Vue 3 — worked, but ecosystem felt thin for our needs"}, {"order": 3, "description": "Ran the same spike in React — integrated faster with Next.js"}], "finalAnswer": "Picked React with Next.js for SSR + ecosystem fit"}}],
   "entities": [{"name": "person-sarah-chen", "type": "person", "facts": ["Leads the backend team", "Joined from Google in 2024"], "structuredSections": [{"key": "beliefs", "title": "Beliefs", "facts": ["Small teams should own whole systems."]}]}, {"name": "project-dashboard", "type": "project", "facts": ["React-based admin panel", "Deployed on AWS ECS"]}],
   "profileUpdates": ["User prefers TypeScript over plain JavaScript"],
   "questions": [{"question": "What database does the analytics service use?", "context": "Came up during discussion of migration plan", "priority": 0.5}],
@@ -1475,7 +1478,20 @@ Rules:
   * Implied (0.70-0.94): Strong contextual inference — user consistently does X, clear from conversation flow
   * Inferred (0.40-0.69): Pattern recognition — reasonable guess from limited evidence
   * Speculative (0.00-0.39): Tentative hypothesis — weak signal, needs future confirmation. Speculative memories auto-expire after 30 days if not confirmed.
-- For commitments: include any deadline or timeframe mentioned
+- For commitments: include any deadline or timeframe mentioned${this.config.extractionScopeClassificationEnabled ? `
+
+Scope classification:
+For each fact, set "scope" to one of:
+- "global" — knowledge that applies across projects: core framework/library bugs, API behavior patterns, user preferences (editor, language, style), tool configurations, general coding patterns, infrastructure knowledge, technology facts not tied to one codebase
+- "project" — knowledge specific to one codebase: file paths, environment configs, deployment details, project-specific workarounds, team/stakeholder info tied to one project, repo-specific conventions
+When in doubt, prefer "project" — it is safer to keep knowledge scoped narrowly.
+Examples:
+  "Magento 2.4.8 has a race condition in checkout" → "global"
+  "User prefers dark mode in all editors" → "global"
+  "The staging server is at staging.acme.com" → "project"
+  "The deploy script lives at scripts/deploy.sh" → "project"
+  "PostgreSQL 15 requires the uuid-ossp extension for gen_random_uuid()" → "global"
+  "The acme-store repo uses a custom Webpack config for SSR" → "project"` : ""}
 
 Entity creation rules (STRICT):
 - Only create entities for DURABLE things: real people, companies, products, tools, ongoing projects

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -868,6 +868,7 @@ export type {
   GatewayConfig,
   MemoryFile,
   MemoryCategory,
+  MemoryScope,
   MemoryActionType,
   MemoryActionEligibilityContext,
   MemoryActionEligibilitySource,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -11058,6 +11058,35 @@ export class Orchestrator {
         }
       }
 
+      // Scope-based namespace routing: when scope classification is enabled
+      // and the LLM tagged this fact as "global", route it to the shared
+      // namespace so cross-project knowledge is visible everywhere. Only
+      // applies when namespaces are enabled and the fact was not already
+      // routed to a specific namespace by a routing rule (routing rules
+      // take precedence). Rule 30: gated by extractionScopeClassificationEnabled.
+      if (
+        this.config.extractionScopeClassificationEnabled &&
+        this.config.namespacesEnabled &&
+        fact.scope === "global" &&
+        !routedRuleId
+      ) {
+        const currentNs = this.namespaceFromStorageDir(targetStorage.dir);
+        if (currentNs !== this.config.sharedNamespace) {
+          try {
+            targetStorage = await this.storageRouter.storageFor(
+              this.config.sharedNamespace,
+            );
+            log.debug(
+              `scope-routing: fact "${fact.content.slice(0, 60)}…" routed to shared namespace (scope=global)`,
+            );
+          } catch (scopeRouteErr) {
+            log.warn(
+              `scope-routing: failed to resolve shared namespace storage; writing to session namespace (fail-open): ${scopeRouteErr}`,
+            );
+          }
+        }
+      }
+
       // Procedures: fingerprint the full serialized body (title + steps), not
       // the title alone, so distinct step lists are not collapsed (issue #519).
       const canonicalContentForHash =

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -11036,6 +11036,7 @@ export class Orchestrator {
       let writeCategory = fact.category;
       let targetStorage = storage;
       let routedRuleId: string | undefined;
+      let routedNamespaceExplicit = false;
       if (routeRules.length > 0) {
         try {
           const routeText = `${fact.category} ${fact.tags.join(" ")} ${fact.content}`;
@@ -11046,6 +11047,7 @@ export class Orchestrator {
               writeCategory = selected.target.category;
             }
             if (selected.target.namespace) {
+              routedNamespaceExplicit = true;
               targetStorage = await this.storageRouter.storageFor(
                 selected.target.namespace,
               );
@@ -11063,12 +11065,14 @@ export class Orchestrator {
       // namespace so cross-project knowledge is visible everywhere. Only
       // applies when namespaces are enabled and the fact was not already
       // routed to a specific namespace by a routing rule (routing rules
-      // take precedence). Rule 30: gated by extractionScopeClassificationEnabled.
+      // that set an explicit namespace take precedence; category-only rules
+      // do not block scope routing). Rule 30: gated by
+      // extractionScopeClassificationEnabled.
       if (
         this.config.extractionScopeClassificationEnabled &&
         this.config.namespacesEnabled &&
         fact.scope === "global" &&
-        !routedRuleId
+        !routedNamespaceExplicit
       ) {
         const currentNs = this.namespaceFromStorageDir(targetStorage.dir);
         if (currentNs !== this.config.sharedNamespace) {

--- a/packages/remnic-core/src/schemas.ts
+++ b/packages/remnic-core/src/schemas.ts
@@ -86,6 +86,13 @@ export const ExtractedFactSchema = z.object({
     .optional()
     .nullable()
     .describe("Optional proactive follow-up question that surfaced this fact."),
+  scope: z
+    .enum(["project", "global"])
+    .optional()
+    .nullable()
+    .describe(
+      'Scope classification: "global" for cross-project knowledge (framework bugs, library behavior, API patterns, user preferences, tool configs, general coding patterns); "project" for project-specific knowledge (file paths, env configs, deployment details, project workarounds). Defaults to "project" when a coding context is active.',
+    ),
   structuredAttributes: z
     .record(z.string(), z.string())
     .optional()

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -12,6 +12,20 @@ export type IdentityInjectionMode = "recovery_only" | "minimal" | "full";
 export type CaptureMode = "implicit" | "explicit" | "hybrid";
 export type MemoryOsPresetName = "conservative" | "balanced" | "research-max" | "local-llm-heavy";
 export type ExtractionPassSource = "base" | "proactive";
+/**
+ * Scope classification for extracted facts (issue #XXX).
+ *
+ * - `"project"` — knowledge specific to one codebase: file paths, environment
+ *   configs, deployment details, project-specific workarounds, team/stakeholder
+ *   info tied to one project.
+ * - `"global"` — knowledge that applies across projects: core framework bugs,
+ *   library behavior, API patterns, user preferences, tool configurations,
+ *   general coding patterns, infrastructure knowledge.
+ *
+ * Default is `"project"` when a coding context is active, `"global"` when no
+ * coding context is present.
+ */
+export type MemoryScope = "project" | "global";
 export type SlotMismatchMode = "error" | "warn" | "silent";
 export type CodexCompactionFlushMode = "signal" | "heuristic" | "auto";
 export type DreamingNarrativePromptStyle = "reflective" | "diary" | "analytical";
@@ -663,6 +677,14 @@ export interface PluginConfig {
   heartbeat: HeartbeatConfig;
   slotBehavior: SlotBehaviorConfig;
   codexCompat: CodexCompatConfig;
+  /**
+   * When true (default), the extraction prompt instructs the LLM to classify
+   * each fact as `"project"` or `"global"` scope. Global-scoped facts are
+   * promoted to the shared namespace so they are visible across all projects.
+   * When false, all facts go to whatever namespace the session is in (pre-
+   * scope-classification behavior). Rule 30: configuration gate.
+   */
+  extractionScopeClassificationEnabled: boolean;
   // Extraction judge (issue #376)
   /** Enable the LLM-as-judge fact-worthiness gate on extracted facts. Default false (opt-in). */
   extractionJudgeEnabled: boolean;
@@ -1803,6 +1825,13 @@ export interface ExtractedFact {
   entityRef?: string;
   source?: ExtractionPassSource;
   promptedByQuestion?: string;
+  /**
+   * Whether this fact is project-scoped or globally applicable.
+   * When `extractionScopeClassificationEnabled` is true, the extraction LLM
+   * classifies each fact. Default is `"project"` when a coding context is
+   * active, `"global"` when no coding context is present.
+   */
+  scope?: MemoryScope;
   /** Structured key-value attributes extracted from the content (e.g., product attributes, dates, quantities). */
   structuredAttributes?: Record<string, string>;
   /** When category is `procedure`, ordered steps with intents (persisted under procedures/). */

--- a/tests/extraction-scope-classification.test.ts
+++ b/tests/extraction-scope-classification.test.ts
@@ -1,0 +1,145 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { parseConfig } from "../src/config.js";
+import { ExtractedFactSchema, ExtractionResultSchema } from "../src/schemas.js";
+
+// ---------------------------------------------------------------------------
+// Config parsing
+// ---------------------------------------------------------------------------
+
+test("parseConfig: extractionScopeClassificationEnabled defaults to true", () => {
+  const cfg = parseConfig({ openaiApiKey: "sk-test" });
+  assert.equal(cfg.extractionScopeClassificationEnabled, true);
+});
+
+test("parseConfig: extractionScopeClassificationEnabled can be explicitly disabled", () => {
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    extractionScopeClassificationEnabled: false,
+  });
+  assert.equal(cfg.extractionScopeClassificationEnabled, false);
+});
+
+test("parseConfig: extractionScopeClassificationEnabled coerces string 'false' to false", () => {
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    extractionScopeClassificationEnabled: "false" as any,
+  });
+  assert.equal(cfg.extractionScopeClassificationEnabled, false);
+});
+
+test("parseConfig: extractionScopeClassificationEnabled coerces string 'true' to true", () => {
+  const cfg = parseConfig({
+    openaiApiKey: "sk-test",
+    extractionScopeClassificationEnabled: "true" as any,
+  });
+  assert.equal(cfg.extractionScopeClassificationEnabled, true);
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation: scope field on ExtractedFactSchema
+// ---------------------------------------------------------------------------
+
+test("ExtractedFactSchema: accepts scope='global'", () => {
+  const result = ExtractedFactSchema.safeParse({
+    category: "fact",
+    content: "PostgreSQL 15 requires uuid-ossp for gen_random_uuid()",
+    confidence: 0.95,
+    tags: ["database"],
+    scope: "global",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.scope, "global");
+  }
+});
+
+test("ExtractedFactSchema: accepts scope='project'", () => {
+  const result = ExtractedFactSchema.safeParse({
+    category: "fact",
+    content: "The deploy script is at scripts/deploy.sh",
+    confidence: 0.9,
+    tags: ["deployment"],
+    scope: "project",
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.scope, "project");
+  }
+});
+
+test("ExtractedFactSchema: accepts scope=null (optional nullable)", () => {
+  const result = ExtractedFactSchema.safeParse({
+    category: "fact",
+    content: "Some fact",
+    confidence: 0.8,
+    tags: [],
+    scope: null,
+  });
+  assert.equal(result.success, true);
+});
+
+test("ExtractedFactSchema: accepts omitted scope (optional)", () => {
+  const result = ExtractedFactSchema.safeParse({
+    category: "fact",
+    content: "Some fact",
+    confidence: 0.8,
+    tags: [],
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.scope, undefined);
+  }
+});
+
+test("ExtractedFactSchema: rejects invalid scope value", () => {
+  const result = ExtractedFactSchema.safeParse({
+    category: "fact",
+    content: "Some fact",
+    confidence: 0.8,
+    tags: [],
+    scope: "workspace",
+  });
+  assert.equal(result.success, false);
+});
+
+// ---------------------------------------------------------------------------
+// Full ExtractionResultSchema with scope
+// ---------------------------------------------------------------------------
+
+test("ExtractionResultSchema: parses extraction result with mixed scopes", () => {
+  const result = ExtractionResultSchema.safeParse({
+    facts: [
+      {
+        category: "fact",
+        content: "Magento 2.4.8 has a race condition in checkout",
+        confidence: 0.95,
+        tags: ["magento", "bug"],
+        scope: "global",
+      },
+      {
+        category: "fact",
+        content: "The staging DB is at staging-db.internal",
+        confidence: 0.9,
+        tags: ["infrastructure"],
+        scope: "project",
+      },
+      {
+        category: "preference",
+        content: "User prefers dark mode in all editors",
+        confidence: 1.0,
+        tags: ["preference"],
+        scope: "global",
+      },
+    ],
+    profileUpdates: [],
+    entities: [],
+    questions: [],
+  });
+  assert.equal(result.success, true);
+  if (result.success) {
+    assert.equal(result.data.facts[0].scope, "global");
+    assert.equal(result.data.facts[1].scope, "project");
+    assert.equal(result.data.facts[2].scope, "global");
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a `scope` field (`"project"` | `"global"`) to extracted facts so the extraction LLM classifies whether knowledge is project-specific or globally applicable
- Global-scoped facts (framework bugs, library behavior, user preferences, tool configs, general patterns) are routed to the shared namespace so they are visible across all projects
- Project-scoped facts (file paths, env configs, deployment details, project workarounds) stay in the session namespace as before
- Gated by `extractionScopeClassificationEnabled` (default `true`; set to `false` to restore pre-classification behavior per CLAUDE.md rule 30)

## Changes

| File | What |
|------|------|
| `types.ts` | Add `MemoryScope` type and `scope` field to `ExtractedFact`; add `extractionScopeClassificationEnabled` to `PluginConfig` |
| `schemas.ts` | Add `scope` enum field to `ExtractedFactSchema` (optional nullable) |
| `config.ts` | Parse `extractionScopeClassificationEnabled` with `coerceBool` (handles string `"false"` per CLAUDE.md #36) |
| `extraction.ts` | Add scope classification guidance to all three extraction paths (local LLM, direct client, gateway); normalize `scope` in `normalizeExtractionResultPayload` |
| `orchestrator.ts` | Route `scope: "global"` facts to shared namespace in `persistExtraction` (routing rules take precedence; fail-open on errors) |
| `index.ts` | Export `MemoryScope` type |
| `openclaw.plugin.json` | Add `extractionScopeClassificationEnabled` to config schema |
| `tests/extraction-scope-classification.test.ts` | 10 tests for config parsing, schema validation, and mixed scopes |

## Test plan

- [x] `npm run build` succeeds
- [x] 10 new tests pass (`npx tsx --test tests/extraction-scope-classification.test.ts`)
- [x] 75 existing extraction tests pass unchanged
- [x] Config tests pass
- [ ] CI checks green
- [ ] AI reviewer feedback addressed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the extraction output contract and adds automatic namespace promotion for `scope: "global"`, which can alter where memories are persisted and potentially affect cross-project data isolation if misclassified. The behavior is gated and fail-open, but touches core extraction/persistence paths.
> 
> **Overview**
> Adds an optional `scope` (`"project"` | `"global"`) to extracted facts, including schema/type exports and prompt guidance so the extraction LLM can classify each fact’s intended sharing level.
> 
> Introduces `extractionScopeClassificationEnabled` (default `true`) and, when enabled with namespaces, routes `scope: "global"` facts to the shared namespace unless an explicit routing rule already chose a namespace; config schemas are updated accordingly and new tests cover config coercion and schema acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 85a262e6c8e56878db56fdf7e250cd4a08d9372c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->