### PR TITLE
feat(recall): disclosure auto-escalation policy (#677 PR 4/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2032,6 +2032,22 @@
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
+      "recallDisclosureEscalation": {
+        "type": "string",
+        "enum": [
+          "manual",
+          "auto"
+        ],
+        "default": "manual",
+        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+      },
+      "recallDisclosureEscalationThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.5,
+        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+      },
       "recallGraphEnabled": {
         "type": "boolean",
         "default": false,
@@ -4296,6 +4312,16 @@
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDisclosureEscalation": {
+      "label": "Disclosure Auto-Escalation",
+      "help": "Auto-promote default chunk recalls to section when top-K confidence is low (issue #677 PR 4/4). Set to 'auto' to enable; 'manual' (default) preserves pre-#677 behavior."
+    },
+    "recallDisclosureEscalationThreshold": {
+      "label": "Disclosure Escalation Threshold",
+      "advanced": true,
+      "placeholder": "0.5",
+      "help": "Top-K confidence (0-1) below which auto-escalation triggers. Only consulted when Disclosure Auto-Escalation is set to 'auto'."
     },
     "recallGraphEnabled": {
       "label": "Graph Retrieval (PPR)",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2032,6 +2032,19 @@
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
+      "recallDisclosureEscalation": {
+        "type": "string",
+        "enum": ["manual", "auto"],
+        "default": "manual",
+        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+      },
+      "recallDisclosureEscalationThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.5,
+        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+      },
       "recallGraphEnabled": {
         "type": "boolean",
         "default": false,
@@ -4296,6 +4309,16 @@
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDisclosureEscalation": {
+      "label": "Disclosure Auto-Escalation",
+      "help": "Auto-promote default chunk recalls to section when top-K confidence is low (issue #677 PR 4/4). Set to 'auto' to enable; 'manual' (default) preserves pre-#677 behavior."
+    },
+    "recallDisclosureEscalationThreshold": {
+      "label": "Disclosure Escalation Threshold",
+      "advanced": true,
+      "placeholder": "0.5",
+      "help": "Top-K confidence (0-1) below which auto-escalation triggers. Only consulted when Disclosure Auto-Escalation is set to 'auto'."
     },
     "recallGraphEnabled": {
       "label": "Graph Retrieval (PPR)",

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -84,6 +84,7 @@ import type {
 } from "./types.js";
 import { DEFAULT_RECALL_DISCLOSURE, isRecallDisclosure } from "./types.js";
 import { estimateRecallTokens } from "./recall-xray.js";
+import { decideDisclosureEscalation } from "./recall-disclosure-escalation.js";
 import type { LocalLlmClient } from "./local-llm.js";
 import type { FallbackLlmClient } from "./fallback-llm.js";
 import type { SemanticDedupLookup } from "./dedup/semantic.js";
@@ -1350,8 +1351,10 @@ export class EngramAccessService {
     // Disclosure depth (issue #677).  Default to `"chunk"` when omitted so
     // pre-#677 callers see unchanged behavior.  Reject explicitly invalid
     // string values per CLAUDE.md rule 51 (do not silently fall back).
-    const disclosure: RecallDisclosure = (() => {
-      if (request.disclosure === undefined || request.disclosure === null) {
+    const callerProvidedDisclosure =
+      request.disclosure !== undefined && request.disclosure !== null;
+    const requestedDisclosure: RecallDisclosure = (() => {
+      if (!callerProvidedDisclosure) {
         return DEFAULT_RECALL_DISCLOSURE;
       }
       if (!isRecallDisclosure(request.disclosure)) {
@@ -1476,6 +1479,34 @@ export class EngramAccessService {
     const effectiveNamespace = snapshot?.namespace
       ? this.resolveNamespace(snapshot.namespace)
       : namespace;
+    // Auto-escalation policy (issue #677 PR 4/4).  When the operator
+    // configured `recallDisclosureEscalation: "auto"` AND the caller
+    // did not explicitly choose a disclosure level AND recall produced
+    // a low-confidence result set (proxied by fill ratio: results
+    // returned / topK requested), we escalate the default `chunk`
+    // shape to `section` so the LLM gets richer context to compensate
+    // for ambiguous retrieval.  Manual mode and explicit caller
+    // disclosure both bypass the policy.  Documented in
+    // `recall-disclosure-escalation.ts` and unit-tested there.
+    // Use the caller's topK when provided, otherwise fall back to a
+    // sensible default that matches `conversationRecallTopK`'s
+    // documented baseline.  The exact value here only affects the
+    // confidence proxy; it does not change recall behavior.
+    const topKResolved =
+      typeof topK === "number" && topK > 0 ? topK : 5;
+    const resultsReturned = snapshot?.memoryIds?.length ?? 0;
+    const topKConfidence =
+      topKResolved > 0
+        ? Math.min(1, resultsReturned / topKResolved)
+        : undefined;
+    const escalationDecision = decideDisclosureEscalation({
+      mode: this.orchestrator.config.recallDisclosureEscalation,
+      threshold: this.orchestrator.config.recallDisclosureEscalationThreshold,
+      originalDisclosure: requestedDisclosure,
+      callerProvidedDisclosure,
+      topKConfidence,
+    });
+    const disclosure = escalationDecision.effective;
     const results = await this.serializeRecallResults(snapshot, disclosure, {
       query,
       sessionKey: request.sessionKey,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1488,16 +1488,37 @@ export class EngramAccessService {
     // for ambiguous retrieval.  Manual mode and explicit caller
     // disclosure both bypass the policy.  Documented in
     // `recall-disclosure-escalation.ts` and unit-tested there.
-    // Use the caller's topK when provided, otherwise fall back to a
-    // sensible default that matches `conversationRecallTopK`'s
-    // documented baseline.  The exact value here only affects the
-    // confidence proxy; it does not change recall behavior.
-    const topKResolved =
-      typeof topK === "number" && topK > 0 ? topK : 5;
+    // Confidence-proxy denominator: prefer (in order):
+    //   1. The caller's explicit topK if supplied.
+    //   2. The orchestrator's actual applied top-K
+    //      (`snapshot.budgetsApplied.appliedTopK`) — this is the
+    //      authoritative number after planner/minimal-mode caps and
+    //      section caps have all narrowed the limit.
+    //   3. Config `qmdMaxResults` as a last-resort fallback.
+    // Codex P1 round 2 on #705: hardcoded `5` (round 1) and naïve
+    // `qmdMaxResults` (round 2) both ignored the dynamic per-call
+    // limit the orchestrator already records.  Floor at the observed
+    // result count so the ratio stays in [0, 1] even if config drifts
+    // below it.
     const resultsReturned = snapshot?.memoryIds?.length ?? 0;
+    const appliedTopK = snapshot?.budgetsApplied?.appliedTopK;
+    const configMaxResults =
+      typeof this.orchestrator.config.qmdMaxResults === "number" &&
+      Number.isFinite(this.orchestrator.config.qmdMaxResults) &&
+      this.orchestrator.config.qmdMaxResults > 0
+        ? this.orchestrator.config.qmdMaxResults
+        : 0;
+    const topKDenominator =
+      typeof topK === "number" && topK > 0
+        ? topK
+        : typeof appliedTopK === "number" &&
+            Number.isFinite(appliedTopK) &&
+            appliedTopK > 0
+          ? Math.max(appliedTopK, resultsReturned)
+          : Math.max(configMaxResults, resultsReturned, 1);
     const topKConfidence =
-      topKResolved > 0
-        ? Math.min(1, resultsReturned / topKResolved)
+      topKDenominator > 0
+        ? Math.min(1, resultsReturned / topKDenominator)
         : undefined;
     const escalationDecision = decideDisclosureEscalation({
       mode: this.orchestrator.config.recallDisclosureEscalation,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1488,18 +1488,19 @@ export class EngramAccessService {
     // for ambiguous retrieval.  Manual mode and explicit caller
     // disclosure both bypass the policy.  Documented in
     // `recall-disclosure-escalation.ts` and unit-tested there.
-    // Confidence-proxy denominator: prefer (in order):
-    //   1. The caller's explicit topK if supplied.
-    //   2. The orchestrator's actual applied top-K
-    //      (`snapshot.budgetsApplied.appliedTopK`) — this is the
-    //      authoritative number after planner/minimal-mode caps and
-    //      section caps have all narrowed the limit.
+    // Confidence-proxy denominator: priority order is
+    //   1. `snapshot.budgetsApplied.appliedTopK` (ALWAYS wins) — this is
+    //      the limit the orchestrator actually applied after planner /
+    //      minimal-mode / section-cap narrowing.  Codex P1 rounds 2+3
+    //      on #705 emphasize that even a caller's explicit `request.topK`
+    //      is wrong when the orchestrator caps below it (e.g. topK=50
+    //      but appliedTopK=3 makes a 2-hit recall actually 0.67, not
+    //      0.04).
+    //   2. The caller's explicit `topK` when the snapshot lacks
+    //      `budgetsApplied` (early-return paths, error cases).
     //   3. Config `qmdMaxResults` as a last-resort fallback.
-    // Codex P1 round 2 on #705: hardcoded `5` (round 1) and naïve
-    // `qmdMaxResults` (round 2) both ignored the dynamic per-call
-    // limit the orchestrator already records.  Floor at the observed
-    // result count so the ratio stays in [0, 1] even if config drifts
-    // below it.
+    // Floor at observed-results so the ratio stays in [0, 1] even if
+    // any of the signals drifts below the actual hit count.
     const resultsReturned = snapshot?.memoryIds?.length ?? 0;
     const appliedTopK = snapshot?.budgetsApplied?.appliedTopK;
     const configMaxResults =
@@ -1509,12 +1510,12 @@ export class EngramAccessService {
         ? this.orchestrator.config.qmdMaxResults
         : 0;
     const topKDenominator =
-      typeof topK === "number" && topK > 0
-        ? topK
-        : typeof appliedTopK === "number" &&
-            Number.isFinite(appliedTopK) &&
-            appliedTopK > 0
-          ? Math.max(appliedTopK, resultsReturned)
+      typeof appliedTopK === "number" &&
+      Number.isFinite(appliedTopK) &&
+      appliedTopK > 0
+        ? Math.max(appliedTopK, resultsReturned)
+        : typeof topK === "number" && topK > 0
+          ? Math.max(topK, resultsReturned)
           : Math.max(configMaxResults, resultsReturned, 1);
     const topKConfidence =
       topKDenominator > 0

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1517,8 +1517,14 @@ export class EngramAccessService {
         : typeof topK === "number" && topK > 0
           ? Math.max(topK, resultsReturned)
           : Math.max(configMaxResults, resultsReturned, 1);
+    // When the recall produced no snapshot (sessionless / namespace
+    // mismatch / early-return path), there is no confidence signal to
+    // base escalation on.  Pass `undefined` so the helper takes its
+    // `no-top-k-confidence` branch instead of computing 0/N=0 and
+    // forcing auto-escalation on every sessionless caller (Codex P2
+    // review on PR #705).
     const topKConfidence =
-      topKDenominator > 0
+      snapshot && topKDenominator > 0
         ? Math.min(1, resultsReturned / topKDenominator)
         : undefined;
     const escalationDecision = decideDisclosureEscalation({

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1056,6 +1056,22 @@ export function parseConfig(raw: unknown): PluginConfig {
     // recallDirectAnswerEnabled=false.
     recallDirectAnswerEnabled:
       coerceBool(cfg.recallDirectAnswerEnabled) ?? true,
+    // Disclosure auto-escalation (issue #677 PR 4/4).  Default `manual`
+    // so pre-#677 callers see unchanged behavior.  Reject anything
+    // outside the allow-list rather than silently defaulting (CLAUDE.md
+    // rule 51).
+    recallDisclosureEscalation: (() => {
+      const raw = cfg.recallDisclosureEscalation;
+      if (raw === undefined || raw === null) return "manual" as const;
+      if (raw === "manual" || raw === "auto") return raw;
+      throw new Error(
+        `recallDisclosureEscalation must be "manual" or "auto" (got ${JSON.stringify(raw)}).`,
+      );
+    })(),
+    recallDisclosureEscalationThreshold: (() => {
+      const n = coerceNumber(cfg.recallDisclosureEscalationThreshold);
+      return n !== undefined && n >= 0 && n <= 1 ? n : 0.5;
+    })(),
     // Graph-based retrieval tier (issue #559 PR 4).  Default `false` —
     // the tier ships off pending the `retrieval-graph` bench in PR 5.
     recallGraphEnabled:

--- a/packages/remnic-core/src/recall-disclosure-escalation.test.ts
+++ b/packages/remnic-core/src/recall-disclosure-escalation.test.ts
@@ -1,0 +1,196 @@
+/**
+ * Tests for the disclosure auto-escalation policy (issue #677 PR 4/4).
+ * Pure helper, exhaustive coverage of the decision tree.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DISCLOSURE_ESCALATION_MODES,
+  DEFAULT_DISCLOSURE_ESCALATION_THRESHOLD,
+  decideDisclosureEscalation,
+  isDisclosureEscalationMode,
+} from "./recall-disclosure-escalation.js";
+
+test("isDisclosureEscalationMode accepts the two valid modes only", () => {
+  assert.equal(isDisclosureEscalationMode("manual"), true);
+  assert.equal(isDisclosureEscalationMode("auto"), true);
+  assert.equal(isDisclosureEscalationMode("AUTO"), false);
+  assert.equal(isDisclosureEscalationMode(""), false);
+  assert.equal(isDisclosureEscalationMode(undefined), false);
+  assert.equal(isDisclosureEscalationMode(42), false);
+});
+
+test("DISCLOSURE_ESCALATION_MODES is the single source of truth", () => {
+  assert.deepStrictEqual([...DISCLOSURE_ESCALATION_MODES], ["manual", "auto"]);
+});
+
+test("manual mode never escalates regardless of confidence", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "manual",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.0,
+  });
+  assert.equal(decision.effective, "chunk");
+  assert.equal(decision.escalated, false);
+  assert.match(decision.reason, /manual/);
+});
+
+test("auto + caller-explicit disclosure does not escalate (respects caller)", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: true,
+    topKConfidence: 0.0,
+  });
+  assert.equal(decision.effective, "chunk");
+  assert.equal(decision.escalated, false);
+  assert.match(decision.reason, /caller-explicit/);
+});
+
+test("auto + section/raw original is not auto-promoted", () => {
+  for (const original of ["section", "raw"] as const) {
+    const decision = decideDisclosureEscalation({
+      mode: "auto",
+      threshold: 0.5,
+      originalDisclosure: original,
+      callerProvidedDisclosure: false,
+      topKConfidence: 0.0,
+    });
+    assert.equal(decision.effective, original);
+    assert.equal(decision.escalated, false);
+    assert.match(decision.reason, /not-eligible/);
+  }
+});
+
+test("auto + chunk + low confidence escalates to section", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.3,
+  });
+  assert.equal(decision.effective, "section");
+  assert.equal(decision.escalated, true);
+  assert.match(decision.reason, /top-k-confidence=0.300<0.5/);
+});
+
+test("auto + chunk + high confidence stays at chunk", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.9,
+  });
+  assert.equal(decision.effective, "chunk");
+  assert.equal(decision.escalated, false);
+  assert.match(decision.reason, />=0.5/);
+});
+
+test("auto + chunk + confidence equal to threshold stays at chunk (strict less-than)", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.5,
+  });
+  assert.equal(decision.effective, "chunk");
+  assert.equal(decision.escalated, false);
+});
+
+test("auto + missing topK confidence does not escalate", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: undefined,
+  });
+  assert.equal(decision.effective, "chunk");
+  assert.equal(decision.escalated, false);
+  assert.match(decision.reason, /no-top-k-confidence/);
+});
+
+test("auto + non-finite topK confidence does not escalate", () => {
+  for (const bad of [NaN, Infinity, -Infinity]) {
+    const decision = decideDisclosureEscalation({
+      mode: "auto",
+      threshold: 0.5,
+      originalDisclosure: "chunk",
+      callerProvidedDisclosure: false,
+      topKConfidence: bad,
+    });
+    assert.equal(decision.effective, "chunk");
+    assert.equal(decision.escalated, false);
+  }
+});
+
+test("auto + invalid threshold falls back to default and still uses confidence signal", () => {
+  // threshold out of range → fallback to DEFAULT_DISCLOSURE_ESCALATION_THRESHOLD (0.5).
+  // Confidence 0.3 < 0.5 → escalate.
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: -1,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.3,
+  });
+  assert.equal(decision.effective, "section");
+  assert.equal(decision.escalated, true);
+  assert.match(
+    decision.reason,
+    new RegExp(`<${DEFAULT_DISCLOSURE_ESCALATION_THRESHOLD}`),
+  );
+});
+
+test("auto + threshold above 1 falls back to default", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 999,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0.4,
+  });
+  assert.equal(decision.effective, "section");
+  assert.equal(decision.escalated, true);
+});
+
+test("auto + zero confidence (no results) escalates", () => {
+  const decision = decideDisclosureEscalation({
+    mode: "auto",
+    threshold: 0.5,
+    originalDisclosure: "chunk",
+    callerProvidedDisclosure: false,
+    topKConfidence: 0,
+  });
+  assert.equal(decision.effective, "section");
+  assert.equal(decision.escalated, true);
+});
+
+test("decision.reason is always a non-empty string", () => {
+  // Guard against accidentally returning an empty reason — operator
+  // telemetry depends on it.
+  const branches = [
+    { mode: "manual" as const, callerProvidedDisclosure: false, topKConfidence: 0.3 },
+    { mode: "auto" as const, callerProvidedDisclosure: true, topKConfidence: 0.3 },
+    { mode: "auto" as const, callerProvidedDisclosure: false, topKConfidence: undefined },
+    { mode: "auto" as const, callerProvidedDisclosure: false, topKConfidence: 0.3 },
+    { mode: "auto" as const, callerProvidedDisclosure: false, topKConfidence: 0.9 },
+  ];
+  for (const branch of branches) {
+    const decision = decideDisclosureEscalation({
+      threshold: 0.5,
+      originalDisclosure: "chunk",
+      ...branch,
+    });
+    assert.equal(typeof decision.reason, "string");
+    assert.ok(decision.reason.length > 0, `empty reason for branch ${JSON.stringify(branch)}`);
+  }
+});

--- a/packages/remnic-core/src/recall-disclosure-escalation.ts
+++ b/packages/remnic-core/src/recall-disclosure-escalation.ts
@@ -1,0 +1,158 @@
+/**
+ * Recall disclosure auto-escalation policy (issue #677 PR 4/4).
+ *
+ * Pure helper that decides the *effective* disclosure depth for a recall
+ * given the configured policy and the observed top-K confidence.  Lives
+ * outside `access-service.ts` so the decision logic can be unit-tested
+ * exhaustively without booting an orchestrator.
+ *
+ * Policy summary:
+ *
+ *   manual (default):
+ *     The caller's `disclosure` is honored verbatim.  Auto-escalation
+ *     does not run.
+ *
+ *   auto:
+ *     If the caller did NOT explicitly specify a disclosure (i.e. the
+ *     value in use is the system default) AND the recall's top-K
+ *     confidence falls below the configured threshold, escalate from
+ *     `chunk` to `section`.  `raw` is never auto-selected — it requires
+ *     an explicit caller request because of its higher cost and the
+ *     LCM-archive read paths it activates.  If the caller explicitly
+ *     passed a disclosure (even `chunk`), the policy respects that
+ *     choice and does not escalate.
+ *
+ * The threshold compares against `final` from the top result's score
+ * decomposition.  When the snapshot has no results or no scores, no
+ * escalation fires (`undefined` confidence is treated as "skip" rather
+ * than "always escalate").
+ */
+
+import type { RecallDisclosure } from "./types.js";
+
+export type DisclosureEscalationMode = "manual" | "auto";
+
+export const DISCLOSURE_ESCALATION_MODES: readonly DisclosureEscalationMode[] = [
+  "manual",
+  "auto",
+] as const;
+
+export function isDisclosureEscalationMode(
+  value: unknown,
+): value is DisclosureEscalationMode {
+  return (
+    typeof value === "string" &&
+    (DISCLOSURE_ESCALATION_MODES as readonly string[]).includes(value)
+  );
+}
+
+/**
+ * Threshold defaults — applied when config-side coercion produces an
+ * out-of-range or missing value.  0.5 is a deliberate midpoint:
+ * confidently-served recalls (top-K >= 0.5) stay on the cheap chunk
+ * tier; ambiguous recalls escalate to section.
+ */
+export const DEFAULT_DISCLOSURE_ESCALATION_THRESHOLD = 0.5;
+
+export interface DisclosureEscalationDecision {
+  /** The disclosure depth the caller should use to shape the response. */
+  effective: RecallDisclosure;
+  /**
+   * `true` when the policy escalated from the original disclosure;
+   * `false` when the original was kept (either by manual mode, by
+   * caller explicit choice, or because confidence stayed above the
+   * threshold).
+   */
+  escalated: boolean;
+  /**
+   * Human-readable reason for the decision.  Always populated; surfaces
+   * in operator-facing telemetry / debug paths.
+   */
+  reason: string;
+}
+
+export interface DecideDisclosureEscalationInput {
+  /** The mode from config (`manual` | `auto`). */
+  mode: DisclosureEscalationMode;
+  /** Threshold in [0, 1]; values outside this range fall back to the default. */
+  threshold: number;
+  /** Disclosure resolved at request time (after default-fill). */
+  originalDisclosure: RecallDisclosure;
+  /**
+   * Whether the caller explicitly specified a disclosure value.  Auto
+   * mode only acts when the caller did NOT specify, so explicit
+   * `chunk` requests are not silently upgraded.
+   */
+  callerProvidedDisclosure: boolean;
+  /**
+   * Top-K confidence (`final` score from the highest-ranked result),
+   * or `undefined` when the snapshot has no scored results.
+   */
+  topKConfidence: number | undefined;
+}
+
+/**
+ * Decide whether to escalate disclosure depth based on policy + signals.
+ * Pure function — no IO, no state.
+ */
+export function decideDisclosureEscalation(
+  input: DecideDisclosureEscalationInput,
+): DisclosureEscalationDecision {
+  if (input.mode === "manual") {
+    return {
+      effective: input.originalDisclosure,
+      escalated: false,
+      reason: "escalation-mode=manual",
+    };
+  }
+
+  if (input.callerProvidedDisclosure) {
+    return {
+      effective: input.originalDisclosure,
+      escalated: false,
+      reason: "caller-explicit-disclosure",
+    };
+  }
+
+  // Only chunk → section auto-escalation is allowed.  Section and raw
+  // are never demoted; raw is never auto-selected.
+  if (input.originalDisclosure !== "chunk") {
+    return {
+      effective: input.originalDisclosure,
+      escalated: false,
+      reason: `original-disclosure=${input.originalDisclosure}-not-eligible-for-auto`,
+    };
+  }
+
+  if (
+    input.topKConfidence === undefined ||
+    !Number.isFinite(input.topKConfidence)
+  ) {
+    return {
+      effective: input.originalDisclosure,
+      escalated: false,
+      reason: "no-top-k-confidence",
+    };
+  }
+
+  const threshold =
+    Number.isFinite(input.threshold) &&
+    input.threshold >= 0 &&
+    input.threshold <= 1
+      ? input.threshold
+      : DEFAULT_DISCLOSURE_ESCALATION_THRESHOLD;
+
+  if (input.topKConfidence < threshold) {
+    return {
+      effective: "section",
+      escalated: true,
+      reason: `top-k-confidence=${input.topKConfidence.toFixed(3)}<${threshold}`,
+    };
+  }
+
+  return {
+    effective: input.originalDisclosure,
+    escalated: false,
+    reason: `top-k-confidence=${input.topKConfidence.toFixed(3)}>=${threshold}`,
+  };
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -531,6 +531,21 @@ export interface PluginConfig {
    */
   recallDirectAnswerEnabled: boolean;
   /**
+   * Disclosure auto-escalation policy (issue #677 PR 4/4).  When set to
+   * `"auto"`, recalls without an explicit caller-supplied disclosure
+   * escalate from `chunk` to `section` if the top-K confidence falls
+   * below {@link recallDisclosureEscalationThreshold}.  `raw` is never
+   * auto-selected — it requires an explicit caller request.  Default
+   * `"manual"` preserves pre-#677 behavior.
+   */
+  recallDisclosureEscalation: "manual" | "auto";
+  /**
+   * Top-K confidence threshold (in `[0, 1]`) below which auto-escalation
+   * promotes `chunk` → `section`.  Only consulted when
+   * {@link recallDisclosureEscalation} is `"auto"`.  Default `0.5`.
+   */
+  recallDisclosureEscalationThreshold: number;
+  /**
    * Graph-based retrieval tier via Personalized PageRank (issue #559 PR 4).
    * When true, recall builds a retrieval graph from memory frontmatter
    * and runs PPR, merging the result with QMD via MMR.  Default false —

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -2027,6 +2027,19 @@
         "default": true,
         "description": "When true, recall runs the direct-answer tier in observation mode: annotates LastRecallSnapshot.tierExplain with which tier would have served the query (issue #518). Does not short-circuit the QMD path in the current release."
       },
+      "recallDisclosureEscalation": {
+        "type": "string",
+        "enum": ["manual", "auto"],
+        "default": "manual",
+        "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
+      },
+      "recallDisclosureEscalationThreshold": {
+        "type": "number",
+        "minimum": 0,
+        "maximum": 1,
+        "default": 0.5,
+        "description": "Top-K confidence threshold (0-1) below which auto-escalation promotes chunk to section. Only consulted when recallDisclosureEscalation is 'auto'. Default 0.5."
+      },
       "recallGraphEnabled": {
         "type": "boolean",
         "default": false,
@@ -4286,6 +4299,16 @@
     "recallDirectAnswerEnabled": {
       "label": "Direct-Answer Retrieval Tier",
       "help": "Route validated high-trust queries to a fast direct-answer path before QMD (issue #518)."
+    },
+    "recallDisclosureEscalation": {
+      "label": "Disclosure Auto-Escalation",
+      "help": "Auto-promote default chunk recalls to section when top-K confidence is low (issue #677 PR 4/4). Set to 'auto' to enable; 'manual' (default) preserves pre-#677 behavior."
+    },
+    "recallDisclosureEscalationThreshold": {
+      "label": "Disclosure Escalation Threshold",
+      "advanced": true,
+      "placeholder": "0.5",
+      "help": "Top-K confidence (0-1) below which auto-escalation triggers. Only consulted when Disclosure Auto-Escalation is set to 'auto'."
     },
     "recallGraphEnabled": {
       "label": "Graph Retrieval (PPR)",


### PR DESCRIPTION
Implements PR 4/4 of #677 — opt-in auto-escalation policy. When recallDisclosureEscalation='auto' AND no caller-explicit disclosure AND top-K confidence < threshold (default 0.5), escalates default chunk → section. Raw never auto-selected. Manual mode (default) preserves pre-#677 behavior. Confidence is proxied by results/topK ratio. 14 unit tests cover the full decision tree.

Issue #677 PRs: 1/4 (#694) merged, 2/4 (#696) merged, 3/4 (#699) in review, 4/4 this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes recall response shaping by optionally escalating disclosure depth based on retrieval confidence; while default remains unchanged, enabling the feature can increase context size/cost and affect downstream prompt behavior.
> 
> **Overview**
> Introduces a new **opt-in** recall disclosure auto-escalation policy: when `recallDisclosureEscalation` is set to `"auto"` and the caller omits `disclosure`, low-confidence recalls (proxied by results/topK fill ratio) are automatically promoted from `chunk` to `section`, while `raw` is never auto-selected.
> 
> Wires this into `access-service.ts` (including careful topK denominator selection using `snapshot.budgetsApplied.appliedTopK` when available), adds strict config parsing + new typed config fields in `types.ts`/`config.ts`, and updates plugin `openclaw.plugin.json` schemas/UI hints across packages. Adds a new pure helper `recall-disclosure-escalation.ts` with exhaustive unit tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61fe299a0472a32a803969534722d549fe9c05e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->