### PR TITLE
feat(retention): flip lifecyclePolicyEnabled default to true (#686 PR 3/6)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -3321,8 +3321,8 @@
       },
       "lifecyclePolicyEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "Enable lifecycle scoring/promotions during consolidation (v8.3)."
+        "default": true,
+        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
       },
       "lifecycleFilterStaleEnabled": {
         "type": "boolean",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -3318,8 +3318,8 @@
       },
       "lifecyclePolicyEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "Enable lifecycle scoring/promotions during consolidation (v8.3)."
+        "default": true,
+        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
       },
       "lifecycleFilterStaleEnabled": {
         "type": "boolean",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -44,6 +44,30 @@ const DEFAULT_WORKSPACE_DIR = path.join(
   "workspace",
 );
 
+// Coerce common string/number representations of a boolean to a real boolean.
+// Returns `undefined` when the value cannot be interpreted, so callers can
+// fall back to their own default. Guards against the "string `false` is
+// truthy" footgun (CLAUDE.md gotcha #36) when config values arrive from
+// CLI/env/JSON sources where booleans are sometimes string-typed.
+function coerceBooleanLike(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") {
+    if (value === 1) return true;
+    if (value === 0) return false;
+    return undefined;
+  }
+  if (typeof value === "string") {
+    const normalized = value.trim().toLowerCase();
+    if (normalized === "true" || normalized === "1" || normalized === "yes" || normalized === "on") {
+      return true;
+    }
+    if (normalized === "false" || normalized === "0" || normalized === "no" || normalized === "off") {
+      return false;
+    }
+  }
+  return undefined;
+}
+
 function resolveEnvVars(value: string): string {
   const resolved = value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, envVar: string) => {
     const envValue = readEnvVar(envVar);
@@ -2033,11 +2057,11 @@ export function parseConfig(raw: unknown): PluginConfig {
     // an opt-in flag the typical operator never reaches.  Operators
     // who need pre-#686 behavior (no automatic hot↔cold migration,
     // no recall-time stale filtering) can set
-    // `lifecyclePolicyEnabled: false` explicitly.
-    lifecyclePolicyEnabled:
-      typeof cfg.lifecyclePolicyEnabled === "boolean"
-        ? cfg.lifecyclePolicyEnabled
-        : true,
+    // `lifecyclePolicyEnabled: false` explicitly. Coerce string/number
+    // boolean-likes (e.g. CLI `--config lifecyclePolicyEnabled=false`)
+    // before applying the default — otherwise an explicit false-ish
+    // input falls through and silently re-enables the policy.
+    lifecyclePolicyEnabled: coerceBooleanLike(cfg.lifecyclePolicyEnabled) ?? true,
     lifecycleFilterStaleEnabled: cfg.lifecycleFilterStaleEnabled === true,
     lifecyclePromoteHeatThreshold:
       typeof cfg.lifecyclePromoteHeatThreshold === "number"
@@ -2062,11 +2086,9 @@ export function parseConfig(raw: unknown): PluginConfig {
     // metrics even though the policy is enabled by default since
     // #686 PR 3/6.
     lifecycleMetricsEnabled:
-      typeof cfg.lifecycleMetricsEnabled === "boolean"
-        ? cfg.lifecycleMetricsEnabled
-        : typeof cfg.lifecyclePolicyEnabled === "boolean"
-          ? cfg.lifecyclePolicyEnabled
-          : true,
+      coerceBooleanLike(cfg.lifecycleMetricsEnabled) ??
+      coerceBooleanLike(cfg.lifecyclePolicyEnabled) ??
+      true,
     // v8.3 proactive + policy learning (default off)
     proactiveExtractionEnabled: cfg.proactiveExtractionEnabled === true,
     contextCompressionActionsEnabled: cfg.contextCompressionActionsEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2025,8 +2025,19 @@ export function parseConfig(raw: unknown): PluginConfig {
     factArchivalProtectedCategories: Array.isArray(cfg.factArchivalProtectedCategories)
       ? (cfg.factArchivalProtectedCategories as any[]).filter((c) => typeof c === "string")
       : ["commitment", "preference", "decision", "principle", "procedure"],
-    // v8.3 lifecycle policy engine (default off)
-    lifecyclePolicyEnabled: cfg.lifecyclePolicyEnabled === true,
+    // Lifecycle policy engine (issue #686 PR 3/6 — flipped default to
+    // `true`).  Tier infrastructure (`tier-routing.ts`,
+    // `tier-migration.ts`, separate cold QMD collection) has shipped
+    // for several releases.  Default-on lets the year-2 retention
+    // story land for every install instead of staying gated behind
+    // an opt-in flag the typical operator never reaches.  Operators
+    // who need pre-#686 behavior (no automatic hot↔cold migration,
+    // no recall-time stale filtering) can set
+    // `lifecyclePolicyEnabled: false` explicitly.
+    lifecyclePolicyEnabled:
+      typeof cfg.lifecyclePolicyEnabled === "boolean"
+        ? cfg.lifecyclePolicyEnabled
+        : true,
     lifecycleFilterStaleEnabled: cfg.lifecycleFilterStaleEnabled === true,
     lifecyclePromoteHeatThreshold:
       typeof cfg.lifecyclePromoteHeatThreshold === "number"
@@ -2046,10 +2057,16 @@ export function parseConfig(raw: unknown): PluginConfig {
             typeof c === "string" && VALID_MEMORY_CATEGORIES.has(c),
         )
       : ["decision", "principle", "commitment", "preference", "procedure"],
+    // Mirror the *resolved* lifecyclePolicyEnabled default (not the
+    // raw input) — otherwise omitting both flags returns `false` for
+    // metrics even though the policy is enabled by default since
+    // #686 PR 3/6.
     lifecycleMetricsEnabled:
       typeof cfg.lifecycleMetricsEnabled === "boolean"
         ? cfg.lifecycleMetricsEnabled
-        : cfg.lifecyclePolicyEnabled === true,
+        : typeof cfg.lifecyclePolicyEnabled === "boolean"
+          ? cfg.lifecyclePolicyEnabled
+          : true,
     // v8.3 proactive + policy learning (default off)
     proactiveExtractionEnabled: cfg.proactiveExtractionEnabled === true,
     contextCompressionActionsEnabled: cfg.contextCompressionActionsEnabled === true,

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -3308,8 +3308,8 @@
       },
       "lifecyclePolicyEnabled": {
         "type": "boolean",
-        "default": false,
-        "description": "Enable lifecycle scoring/promotions during consolidation (v8.3)."
+        "default": true,
+        "description": "Enable the lifecycle policy engine (hot↔cold tier migration, value scoring, decay). Default true since #686 PR 3/6 — flipping enables the year-2 retention story by default. Set to false to opt out."
       },
       "lifecycleFilterStaleEnabled": {
         "type": "boolean",

--- a/tests/config-lifecycle-policy.test.ts
+++ b/tests/config-lifecycle-policy.test.ts
@@ -2,14 +2,26 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { parseConfig } from "../src/config.js";
 
-test("parseConfig sets lifecycle policy defaults with policy disabled", () => {
+test("parseConfig sets lifecycle policy defaults with policy enabled (#686 PR 3/6)", () => {
+  // Default flipped to true since #686 PR 3/6 — the year-2 retention
+  // story (hot↔cold tier migration) ships on by default for every
+  // install rather than gated behind an opt-in flag.
   const cfg = parseConfig({ openaiApiKey: "sk-test" });
-  assert.equal(cfg.lifecyclePolicyEnabled, false);
+  assert.equal(cfg.lifecyclePolicyEnabled, true);
   assert.equal(cfg.lifecycleFilterStaleEnabled, false);
   assert.equal(cfg.lifecyclePromoteHeatThreshold, 0.55);
   assert.equal(cfg.lifecycleStaleDecayThreshold, 0.65);
   assert.equal(cfg.lifecycleArchiveDecayThreshold, 0.85);
   assert.deepEqual(cfg.lifecycleProtectedCategories, ["decision", "principle", "commitment", "preference", "procedure"]);
+  // lifecycleMetricsEnabled mirrors lifecyclePolicyEnabled when not
+  // explicitly set, so the flip carries through here.
+  assert.equal(cfg.lifecycleMetricsEnabled, true);
+});
+
+test("parseConfig honors explicit lifecyclePolicyEnabled: false opt-out", () => {
+  const cfg = parseConfig({ openaiApiKey: "sk-test", lifecyclePolicyEnabled: false });
+  assert.equal(cfg.lifecyclePolicyEnabled, false);
+  // lifecycleMetricsEnabled mirrors when not explicitly set.
   assert.equal(cfg.lifecycleMetricsEnabled, false);
 });
 

--- a/tests/config-lifecycle-policy.test.ts
+++ b/tests/config-lifecycle-policy.test.ts
@@ -25,6 +25,24 @@ test("parseConfig honors explicit lifecyclePolicyEnabled: false opt-out", () => 
   assert.equal(cfg.lifecycleMetricsEnabled, false);
 });
 
+test("parseConfig coerces boolean-like strings for lifecyclePolicyEnabled", () => {
+  // CLAUDE.md gotcha #36: string `"false"` is truthy in JS, so the
+  // strict `typeof === "boolean"` check would silently re-enable the
+  // policy when operators pass `--config lifecyclePolicyEnabled=false`.
+  for (const falsey of ["false", "0", "no", "off", "False", " FALSE ", 0]) {
+    const cfg = parseConfig({ openaiApiKey: "sk-test", lifecyclePolicyEnabled: falsey });
+    assert.equal(cfg.lifecyclePolicyEnabled, false, `expected ${JSON.stringify(falsey)} → false`);
+    assert.equal(cfg.lifecycleMetricsEnabled, false, `metrics should mirror coerced false for ${JSON.stringify(falsey)}`);
+  }
+  for (const truthy of ["true", "1", "yes", "on", "True", 1]) {
+    const cfg = parseConfig({ openaiApiKey: "sk-test", lifecyclePolicyEnabled: truthy });
+    assert.equal(cfg.lifecyclePolicyEnabled, true, `expected ${JSON.stringify(truthy)} → true`);
+  }
+  // Uninterpretable values fall through to the default (`true`).
+  const cfg = parseConfig({ openaiApiKey: "sk-test", lifecyclePolicyEnabled: "maybe" });
+  assert.equal(cfg.lifecyclePolicyEnabled, true);
+});
+
 test("parseConfig supports explicit lifecycle policy settings", () => {
   const cfg = parseConfig({
     openaiApiKey: "sk-test",


### PR DESCRIPTION
Implements PR 3/6 of #686. Flips the lifecyclePolicyEnabled default to true so the year-2 retention story (hot↔cold tier migration) ships on by default instead of being gated behind an opt-in flag. PR 1/6 (#693) verified the recall path excludes cold by default; PR 2/6 (#698) shipped the aged-dataset bench harness. lifecycleMetricsEnabled fallback also fixed to mirror the resolved default. Explicit false opt-out still honored. 3/3 tests pass.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes a default config flag from off→on, which can alter retention behavior (hot↔cold migration/decay) for existing installs that rely on defaults. Risk is mitigated by explicit opt-out support and added coercion/tests to avoid misinterpreting `false` passed via CLI/env/JSON.
> 
> **Overview**
> Flips `lifecyclePolicyEnabled` to default **on** across the OpenClaw plugin schemas, enabling the lifecycle policy engine by default while still allowing an explicit `false` opt-out.
> 
> Updates `parseConfig` to default `lifecyclePolicyEnabled` (and its `lifecycleMetricsEnabled` fallback) to `true`, and adds boolean-like coercion so string/number inputs like `"false"` or `0` correctly disable the policy.
> 
> Extends config tests to cover the new default, explicit opt-out, and boolean-like coercion cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e1dc11882b919655b348b8c7df3893a6ddbd4279. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->