### PR TITLE
feat(retention): remnic forget <id> CLI for soft-delete (#686 PR 4/6)

### DIFF
--- a/packages/remnic-core/src/briefing.test.ts
+++ b/packages/remnic-core/src/briefing.test.ts
@@ -224,6 +224,7 @@ function makeMemoryWithStatus(
     | "active"
     | "superseded"
     | "archived"
+    | "forgotten"
     | "pending_review"
     | "rejected"
     | "quarantined",
@@ -284,6 +285,15 @@ test("filterMemoriesByWindow: quarantined memory within window is excluded from 
   const active = makeMemoryWithStatus("2026-04-10T11:00:00.000Z", "active");
   const result = filterMemoriesByWindow([quarantined, active], window);
   assert.equal(result.length, 1, "quarantined memory must be excluded from briefing");
+  assert.equal(result[0]!.frontmatter.status, "active");
+});
+
+test("filterMemoriesByWindow: forgotten memory within window is excluded from briefing", () => {
+  const window = makeWindow("2026-04-10T00:00:00.000Z", "2026-04-11T00:00:00.000Z");
+  const forgotten = makeMemoryWithStatus("2026-04-10T10:00:00.000Z", "forgotten");
+  const active = makeMemoryWithStatus("2026-04-10T11:00:00.000Z", "active");
+  const result = filterMemoriesByWindow([forgotten, active], window);
+  assert.equal(result.length, 1, "forgotten memory must be excluded from briefing");
   assert.equal(result[0]!.frontmatter.status, "active");
 });
 

--- a/packages/remnic-core/src/briefing.ts
+++ b/packages/remnic-core/src/briefing.ts
@@ -994,7 +994,8 @@ export function filterMemoriesByWindow(memories: MemoryFile[], window: ParsedBri
       status === "superseded" ||
       status === "archived" ||
       status === "rejected" ||
-      status === "quarantined"
+      status === "quarantined" ||
+      status === "forgotten"
     ) {
       return false;
     }

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3536,6 +3536,60 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         });
 
       cmd
+        .command("forget")
+        .description(
+          "Forget a memory by id (issue #686 PR 4/6). Soft-delete: sets " +
+          "status='forgotten' and stamps forgottenAt; the file stays on " +
+          "disk and the act is reversible by editing the YAML directly. " +
+          "Forgotten memories are excluded from recall, browse, and entity " +
+          "attribution.",
+        )
+        .argument("<id>", "Memory id (frontmatter `id`) to forget")
+        .option(
+          "--reason <text>",
+          "Optional human-readable reason captured in YAML and the lifecycle ledger",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const idArg = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          const reason =
+            typeof options.reason === "string" && options.reason.trim().length > 0
+              ? options.reason.trim()
+              : undefined;
+          const { forgetMemory } = await import("./maintenance/forget.js");
+          try {
+            const result = await forgetMemory(orchestrator.storage, {
+              id: idArg,
+              ...(reason !== undefined ? { reason } : {}),
+            });
+            if (reportHasMachineReadableOutput(options)) {
+              console.log(JSON.stringify(result, null, 2));
+            } else {
+              console.log(`forgot ${result.id}`);
+              console.log(`  path: ${result.path}`);
+              console.log(`  prior status: ${result.priorStatus}`);
+              console.log(`  forgotten at: ${result.forgottenAt}`);
+              if (result.reason.length > 0) {
+                console.log(`  reason: ${result.reason}`);
+              }
+              console.log(
+                "Forgotten memories are excluded from recall + browse. " +
+                "Edit the YAML to restore.",
+              );
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (reportHasMachineReadableOutput(options)) {
+              console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+            } else {
+              console.error(`forget: ${message}`);
+            }
+            process.exitCode = 1;
+          }
+        });
+
+      cmd
         .command("config-review")
         .description("Review Engram config defaults, recommendations, and contradictory settings")
         .option("--json", "Emit machine-readable JSON only")

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -11,6 +11,7 @@ import type {
   MemoryActionEvent,
   MemoryFile,
   MemoryStatus,
+  QmdSearchResult,
   RecallDisclosure,
   TranscriptEntry,
 } from "./types.js";
@@ -1339,6 +1340,26 @@ export async function runVerifiedRecallSearchCliCommand(options: {
     maxResults: Math.max(1, Math.floor(options.maxResults ?? 3)),
     boxRecallDays: options.boxRecallDays,
   });
+}
+
+export function isNormalRetrievalVisibleMemory(memory: MemoryFile): boolean {
+  return memory.frontmatter.status !== "forgotten";
+}
+
+export async function filterNormalMemorySearchResults(
+  results: QmdSearchResult[],
+  storage: {
+    readMemoryByPath(path: string): Promise<MemoryFile | null>;
+  },
+): Promise<QmdSearchResult[]> {
+  const filtered: QmdSearchResult[] = [];
+  for (const result of results) {
+    if (!result.path) continue;
+    const memory = await storage.readMemoryByPath(result.path);
+    if (!memory || !isNormalRetrievalVisibleMemory(memory)) continue;
+    filtered.push(result);
+  }
+  return filtered;
 }
 
 export async function runSemanticRulePromoteCliCommand(options: {
@@ -6261,10 +6282,14 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           await orchestrator.qmd.probe();
 
           if (orchestrator.qmd.isAvailable()) {
-            const results = await orchestrator.qmd.search(
+            const rawResults = await orchestrator.qmd.search(
               query,
               undefined,
               maxResults,
+            );
+            const results = await filterNormalMemorySearchResults(
+              rawResults,
+              orchestrator.storage,
             );
             if (results.length === 0) {
               console.log(`No results for: "${query}"`);
@@ -6286,8 +6311,9 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             const lowerQuery = query.toLowerCase();
             const matches = memories.filter(
               (m) =>
-                m.content.toLowerCase().includes(lowerQuery) ||
-                m.frontmatter.tags.some((t) => t.includes(lowerQuery)),
+                isNormalRetrievalVisibleMemory(m) &&
+                (m.content.toLowerCase().includes(lowerQuery) ||
+                  m.frontmatter.tags.some((t) => t.includes(lowerQuery))),
             );
             const qmdStatus = orchestrator.qmd.debugStatus();
             if (matches.length === 0) {

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -6,7 +6,6 @@ import { log } from "../logger.js";
 import { sanitizeMemoryContent } from "../sanitize.js";
 import { StorageManager } from "../storage.js";
 import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
-import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
 import { parseContinuityIncident, parseContinuityImprovementLoops } from "../identity-continuity.js";
 
@@ -666,7 +665,8 @@ export class CompoundingEngine {
     const storage = opts.storage ?? new StorageManager(this.config.memoryDir);
     const existing = (await storage.readAllMemories()).find((memory) =>
       memory.frontmatter.category === candidate.category &&
-      isActiveMemoryStatus(memory.frontmatter.status) &&
+      memory.frontmatter.status !== "archived" &&
+      memory.frontmatter.status !== "forgotten" &&
       canonicalPromotionContentKey(memory.content) === canonicalPromotionContentKey(persistedContent)
     );
     if (existing) {

--- a/packages/remnic-core/src/compounding/engine.ts
+++ b/packages/remnic-core/src/compounding/engine.ts
@@ -6,6 +6,7 @@ import { log } from "../logger.js";
 import { sanitizeMemoryContent } from "../sanitize.js";
 import { StorageManager } from "../storage.js";
 import type { ContinuityIncidentRecord, PluginConfig } from "../types.js";
+import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 import { SharedFeedbackEntrySchema, type SharedFeedbackEntry } from "../shared-context/manager.js";
 import { parseContinuityIncident, parseContinuityImprovementLoops } from "../identity-continuity.js";
 
@@ -665,7 +666,7 @@ export class CompoundingEngine {
     const storage = opts.storage ?? new StorageManager(this.config.memoryDir);
     const existing = (await storage.readAllMemories()).find((memory) =>
       memory.frontmatter.category === candidate.category &&
-      memory.frontmatter.status !== "archived" &&
+      isActiveMemoryStatus(memory.frontmatter.status) &&
       canonicalPromotionContentKey(memory.content) === canonicalPromotionContentKey(persistedContent)
     );
     if (existing) {

--- a/packages/remnic-core/src/maintenance/forget.test.ts
+++ b/packages/remnic-core/src/maintenance/forget.test.ts
@@ -87,8 +87,12 @@ test("forgetMemory: marks active memory as forgotten with timestamp + reason", a
   });
 });
 
-test("forgetMemory: omits forgottenReason when reason is empty", async () => {
-  const mem = makeMemory({ id: "beta", status: "active" });
+test("forgetMemory: clears forgottenReason when reason is empty", async () => {
+  const mem = makeMemory({
+    id: "beta",
+    status: "active",
+    forgottenReason: "stale restored reason",
+  });
   const { stub, writes } = makeStorageStub([mem]);
   const result = await forgetMemory(stub, {
     id: "beta",
@@ -96,6 +100,10 @@ test("forgetMemory: omits forgottenReason when reason is empty", async () => {
     now: () => new Date("2026-04-25T12:00:00Z"),
   });
   assert.equal(result.reason, "");
+  assert.ok(
+    Object.hasOwn(writes[0]?.patch ?? {}, "forgottenReason"),
+    "patch must explicitly clear stale merged frontmatter",
+  );
   assert.equal(writes[0]?.patch.forgottenReason, undefined);
 });
 

--- a/packages/remnic-core/src/maintenance/forget.test.ts
+++ b/packages/remnic-core/src/maintenance/forget.test.ts
@@ -1,0 +1,134 @@
+/**
+ * Unit tests for `forgetMemory` (issue #686 PR 4/6).
+ *
+ * Pure helper-level coverage — uses a minimal in-memory storage stub
+ * so the test focuses on the forget pipeline (find by id → write
+ * frontmatter → return result) without booting an orchestrator.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  forgetMemory,
+  ForgetMemoryAlreadyForgottenError,
+  ForgetMemoryNotFoundError,
+} from "./forget.js";
+import type { MemoryFile, MemoryFrontmatter } from "../types.js";
+
+interface StubWriteCall {
+  memoryId: string;
+  patch: Partial<MemoryFrontmatter>;
+}
+
+function makeMemory(overrides: Partial<MemoryFrontmatter> = {}): MemoryFile {
+  return {
+    path: `/tmp/mem/${overrides.id ?? "mem-1"}.md`,
+    content: "synthetic body",
+    frontmatter: {
+      id: "mem-1",
+      category: "preference",
+      created: "2026-01-01T00:00:00.000Z",
+      updated: "2026-01-01T00:00:00.000Z",
+      source: "test",
+      ...overrides,
+    } as MemoryFrontmatter,
+  };
+}
+
+function makeStorageStub(memories: MemoryFile[]) {
+  const writes: StubWriteCall[] = [];
+  const stub = {
+    readAllMemories: async () => memories,
+    writeMemoryFrontmatter: async (memory: MemoryFile, patch: Partial<MemoryFrontmatter>) => {
+      writes.push({ memoryId: memory.frontmatter.id, patch });
+      return true;
+    },
+  };
+  return { stub, writes };
+}
+
+test("forgetMemory: marks active memory as forgotten with timestamp + reason", async () => {
+  const mem = makeMemory({ id: "alpha", status: "active" });
+  const { stub, writes } = makeStorageStub([mem]);
+  const result = await forgetMemory(stub as never, {
+    id: "alpha",
+    reason: "stale preference",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(result.id, "alpha");
+  assert.equal(result.path, "/tmp/mem/alpha.md");
+  assert.equal(result.priorStatus, "active");
+  assert.equal(result.forgottenAt, "2026-04-25T12:00:00.000Z");
+  assert.equal(result.reason, "stale preference");
+  assert.equal(writes.length, 1);
+  assert.equal(writes[0]?.memoryId, "alpha");
+  assert.equal(writes[0]?.patch.status, "forgotten");
+  assert.equal(writes[0]?.patch.forgottenAt, "2026-04-25T12:00:00.000Z");
+  assert.equal(writes[0]?.patch.forgottenReason, "stale preference");
+  assert.equal(writes[0]?.patch.updated, "2026-04-25T12:00:00.000Z");
+});
+
+test("forgetMemory: omits forgottenReason when reason is empty", async () => {
+  const mem = makeMemory({ id: "beta", status: "active" });
+  const { stub, writes } = makeStorageStub([mem]);
+  const result = await forgetMemory(stub as never, {
+    id: "beta",
+    reason: "   ",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(result.reason, "");
+  assert.equal(writes[0]?.patch.forgottenReason, undefined);
+});
+
+test("forgetMemory: throws ForgetMemoryNotFoundError on unknown id", async () => {
+  const { stub } = makeStorageStub([makeMemory({ id: "gamma" })]);
+  await assert.rejects(
+    forgetMemory(stub as never, { id: "no-such-id" }),
+    (err: unknown) => err instanceof ForgetMemoryNotFoundError,
+  );
+});
+
+test("forgetMemory: throws ForgetMemoryAlreadyForgottenError on already-forgotten", async () => {
+  const mem = makeMemory({
+    id: "delta",
+    status: "forgotten",
+    forgottenAt: "2026-04-20T00:00:00.000Z",
+  });
+  const { stub } = makeStorageStub([mem]);
+  await assert.rejects(
+    forgetMemory(stub as never, { id: "delta" }),
+    (err: unknown) =>
+      err instanceof ForgetMemoryAlreadyForgottenError &&
+      err.message.includes("2026-04-20T00:00:00.000Z"),
+  );
+});
+
+test("forgetMemory: rejects empty/whitespace id", async () => {
+  const { stub } = makeStorageStub([makeMemory({ id: "epsilon" })]);
+  await assert.rejects(forgetMemory(stub as never, { id: "" }), /required/);
+  await assert.rejects(forgetMemory(stub as never, { id: "   " }), /required/);
+});
+
+test("forgetMemory: trims whitespace from id and reason", async () => {
+  const mem = makeMemory({ id: "zeta", status: "active" });
+  const { stub, writes } = makeStorageStub([mem]);
+  const result = await forgetMemory(stub as never, {
+    id: "  zeta  ",
+    reason: "  bad data  ",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(result.id, "zeta");
+  assert.equal(result.reason, "bad data");
+  assert.equal(writes[0]?.patch.forgottenReason, "bad data");
+});
+
+test("forgetMemory: preserves prior non-active status in result", async () => {
+  const mem = makeMemory({ id: "eta", status: "archived" });
+  const { stub } = makeStorageStub([mem]);
+  const result = await forgetMemory(stub as never, {
+    id: "eta",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(result.priorStatus, "archived");
+});

--- a/packages/remnic-core/src/maintenance/forget.test.ts
+++ b/packages/remnic-core/src/maintenance/forget.test.ts
@@ -7,7 +7,10 @@
  */
 
 import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
 import test from "node:test";
+import { mkdtemp, rm } from "node:fs/promises";
 
 import {
   forgetMemory,
@@ -15,10 +18,12 @@ import {
   ForgetMemoryNotFoundError,
 } from "./forget.js";
 import type { MemoryFile, MemoryFrontmatter } from "../types.js";
+import { StorageManager, type MemoryLifecycleEventWriteOptions } from "../storage.js";
 
 interface StubWriteCall {
   memoryId: string;
   patch: Partial<MemoryFrontmatter>;
+  lifecycle?: MemoryLifecycleEventWriteOptions;
 }
 
 function makeMemory(overrides: Partial<MemoryFrontmatter> = {}): MemoryFile {
@@ -36,22 +41,31 @@ function makeMemory(overrides: Partial<MemoryFrontmatter> = {}): MemoryFile {
   };
 }
 
-function makeStorageStub(memories: MemoryFile[]) {
+function makeStorageStub(
+  memories: MemoryFile[],
+  tiers: { archived?: MemoryFile[]; cold?: MemoryFile[] } = {},
+) {
   const writes: StubWriteCall[] = [];
   const stub = {
     readAllMemories: async () => memories,
-    writeMemoryFrontmatter: async (memory: MemoryFile, patch: Partial<MemoryFrontmatter>) => {
-      writes.push({ memoryId: memory.frontmatter.id, patch });
+    readArchivedMemories: async () => tiers.archived ?? [],
+    readAllColdMemories: async () => tiers.cold ?? [],
+    writeMemoryFrontmatter: async (
+      memory: MemoryFile,
+      patch: Partial<MemoryFrontmatter>,
+      lifecycle?: MemoryLifecycleEventWriteOptions,
+    ) => {
+      writes.push({ memoryId: memory.frontmatter.id, patch, lifecycle });
       return true;
     },
   };
-  return { stub, writes };
+  return { stub: stub as unknown as StorageManager, writes };
 }
 
 test("forgetMemory: marks active memory as forgotten with timestamp + reason", async () => {
   const mem = makeMemory({ id: "alpha", status: "active" });
   const { stub, writes } = makeStorageStub([mem]);
-  const result = await forgetMemory(stub as never, {
+  const result = await forgetMemory(stub, {
     id: "alpha",
     reason: "stale preference",
     now: () => new Date("2026-04-25T12:00:00Z"),
@@ -67,12 +81,16 @@ test("forgetMemory: marks active memory as forgotten with timestamp + reason", a
   assert.equal(writes[0]?.patch.forgottenAt, "2026-04-25T12:00:00.000Z");
   assert.equal(writes[0]?.patch.forgottenReason, "stale preference");
   assert.equal(writes[0]?.patch.updated, "2026-04-25T12:00:00.000Z");
+  assert.deepEqual(writes[0]?.lifecycle, {
+    actor: "remnic-forget",
+    reasonCode: "operator_forget",
+  });
 });
 
 test("forgetMemory: omits forgottenReason when reason is empty", async () => {
   const mem = makeMemory({ id: "beta", status: "active" });
   const { stub, writes } = makeStorageStub([mem]);
-  const result = await forgetMemory(stub as never, {
+  const result = await forgetMemory(stub, {
     id: "beta",
     reason: "   ",
     now: () => new Date("2026-04-25T12:00:00Z"),
@@ -84,7 +102,7 @@ test("forgetMemory: omits forgottenReason when reason is empty", async () => {
 test("forgetMemory: throws ForgetMemoryNotFoundError on unknown id", async () => {
   const { stub } = makeStorageStub([makeMemory({ id: "gamma" })]);
   await assert.rejects(
-    forgetMemory(stub as never, { id: "no-such-id" }),
+    forgetMemory(stub, { id: "no-such-id" }),
     (err: unknown) => err instanceof ForgetMemoryNotFoundError,
   );
 });
@@ -97,7 +115,7 @@ test("forgetMemory: throws ForgetMemoryAlreadyForgottenError on already-forgotte
   });
   const { stub } = makeStorageStub([mem]);
   await assert.rejects(
-    forgetMemory(stub as never, { id: "delta" }),
+    forgetMemory(stub, { id: "delta" }),
     (err: unknown) =>
       err instanceof ForgetMemoryAlreadyForgottenError &&
       err.message.includes("2026-04-20T00:00:00.000Z"),
@@ -106,14 +124,14 @@ test("forgetMemory: throws ForgetMemoryAlreadyForgottenError on already-forgotte
 
 test("forgetMemory: rejects empty/whitespace id", async () => {
   const { stub } = makeStorageStub([makeMemory({ id: "epsilon" })]);
-  await assert.rejects(forgetMemory(stub as never, { id: "" }), /required/);
-  await assert.rejects(forgetMemory(stub as never, { id: "   " }), /required/);
+  await assert.rejects(forgetMemory(stub, { id: "" }), /required/);
+  await assert.rejects(forgetMemory(stub, { id: "   " }), /required/);
 });
 
 test("forgetMemory: trims whitespace from id and reason", async () => {
   const mem = makeMemory({ id: "zeta", status: "active" });
   const { stub, writes } = makeStorageStub([mem]);
-  const result = await forgetMemory(stub as never, {
+  const result = await forgetMemory(stub, {
     id: "  zeta  ",
     reason: "  bad data  ",
     now: () => new Date("2026-04-25T12:00:00Z"),
@@ -126,9 +144,55 @@ test("forgetMemory: trims whitespace from id and reason", async () => {
 test("forgetMemory: preserves prior non-active status in result", async () => {
   const mem = makeMemory({ id: "eta", status: "archived" });
   const { stub } = makeStorageStub([mem]);
-  const result = await forgetMemory(stub as never, {
+  const result = await forgetMemory(stub, {
     id: "eta",
     now: () => new Date("2026-04-25T12:00:00Z"),
   });
   assert.equal(result.priorStatus, "archived");
+});
+
+test("forgetMemory: resolves archived and cold tier memories by id", async () => {
+  const archived = makeMemory({ id: "theta", status: "archived" });
+  const cold = makeMemory({ id: "iota", status: "active" });
+  const archivedStub = makeStorageStub([], { archived: [archived] });
+  const archivedResult = await forgetMemory(archivedStub.stub, {
+    id: "theta",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(archivedResult.id, "theta");
+  assert.equal(archivedStub.writes[0]?.memoryId, "theta");
+
+  const coldStub = makeStorageStub([], { cold: [cold] });
+  const coldResult = await forgetMemory(coldStub.stub, {
+    id: "iota",
+    now: () => new Date("2026-04-25T12:00:00Z"),
+  });
+  assert.equal(coldResult.id, "iota");
+  assert.equal(coldStub.writes[0]?.memoryId, "iota");
+});
+
+test("forgetMemory: forgotten metadata survives storage round-trip", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-forget-roundtrip-"));
+  try {
+    const storage = new StorageManager(dir);
+    await storage.ensureDirectories();
+    const id = await storage.writeMemory("fact", "Synthetic fact to forget.", {
+      source: "test",
+      tags: ["roundtrip"],
+    });
+
+    await forgetMemory(storage, {
+      id,
+      reason: "contains stale: quoted \"value\"",
+      now: () => new Date("2026-04-25T12:00:00Z"),
+    });
+
+    const reloaded = (await storage.readAllMemories()).find((memory) => memory.frontmatter.id === id);
+    assert.ok(reloaded, "forgotten memory should still exist during retention window");
+    assert.equal(reloaded!.frontmatter.status, "forgotten");
+    assert.equal(reloaded!.frontmatter.forgottenAt, "2026-04-25T12:00:00.000Z");
+    assert.equal(reloaded!.frontmatter.forgottenReason, "contains stale: quoted \"value\"");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
 });

--- a/packages/remnic-core/src/maintenance/forget.ts
+++ b/packages/remnic-core/src/maintenance/forget.ts
@@ -1,0 +1,122 @@
+/**
+ * Operator-facing memory forgetting (issue #686 PR 4/6).
+ *
+ * `remnic forget <id>` marks a memory as forgotten — a soft-delete that:
+ *
+ *   1. Sets `status: "forgotten"`, `forgottenAt`, optional
+ *      `forgottenReason` in YAML frontmatter via the existing
+ *      `storage.writeMemoryFrontmatter` path (which logs the change
+ *      to the lifecycle ledger and invalidates caches).
+ *   2. Returns a structured result describing what changed so the
+ *      CLI and downstream telemetry can render it.
+ *
+ * Memories with `status === "forgotten"` are excluded from recall,
+ * browse, and entity attribution by the existing status filters
+ * (storage.ts and access-service.ts already drop everything that
+ * isn't `active` from default reads).  A future maintenance cron
+ * will hard-delete forgotten memories after a configurable retention
+ * window (default 90 days) — for this PR the file stays on disk and
+ * the act is reversible by editing the YAML directly.
+ *
+ * This module ships the pure helper; the CLI wires it in `cli.ts` as
+ * a new `remnic forget` subcommand.
+ */
+
+import type { StorageManager } from "../storage.js";
+import type { MemoryFile } from "../types.js";
+
+export interface ForgetMemoryRequest {
+  /** Memory id (frontmatter `id`) to forget. */
+  id: string;
+  /** Optional human-readable reason. */
+  reason?: string;
+  /** Override the timestamp written to `forgottenAt`. Defaults to `new Date().toISOString()`. */
+  now?: () => Date;
+}
+
+export interface ForgetMemoryResult {
+  /** Memory id that was forgotten. */
+  id: string;
+  /** Filesystem path of the forgotten memory. */
+  path: string;
+  /** Prior status before the forget call, for audit. */
+  priorStatus: string;
+  /** Timestamp written to `forgottenAt`. */
+  forgottenAt: string;
+  /** Reason captured (or empty string if none). */
+  reason: string;
+}
+
+export class ForgetMemoryNotFoundError extends Error {
+  readonly code = "memory_not_found" as const;
+  constructor(id: string) {
+    super(`memory not found: ${id}`);
+    this.name = "ForgetMemoryNotFoundError";
+  }
+}
+
+export class ForgetMemoryAlreadyForgottenError extends Error {
+  readonly code = "already_forgotten" as const;
+  constructor(id: string, forgottenAt: string) {
+    super(`memory ${id} was already forgotten at ${forgottenAt}`);
+    this.name = "ForgetMemoryAlreadyForgottenError";
+  }
+}
+
+/**
+ * Mark a memory as forgotten.  Pure orchestration over storage —
+ * caller supplies the storage instance and the request.  Status
+ * filters elsewhere in the codebase already exclude
+ * `status: "forgotten"` from default reads (memory-cache,
+ * access-service browse, retrieval) because they enumerate the
+ * `active` allow-list rather than excluding individual non-active
+ * statuses (CLAUDE.md rule 53).
+ */
+export async function forgetMemory(
+  storage: StorageManager,
+  request: ForgetMemoryRequest,
+): Promise<ForgetMemoryResult> {
+  const id = typeof request.id === "string" ? request.id.trim() : "";
+  if (id.length === 0) {
+    throw new Error("forget: memory id is required and must be non-empty");
+  }
+  const memory = await findMemoryById(storage, id);
+  if (!memory) {
+    throw new ForgetMemoryNotFoundError(id);
+  }
+  if (memory.frontmatter.status === "forgotten") {
+    throw new ForgetMemoryAlreadyForgottenError(
+      id,
+      memory.frontmatter.forgottenAt ?? "(unknown)",
+    );
+  }
+  const priorStatus =
+    typeof memory.frontmatter.status === "string" ? memory.frontmatter.status : "active";
+  const now = (request.now ?? (() => new Date()))();
+  const forgottenAt = now.toISOString();
+  const reason = typeof request.reason === "string" ? request.reason.trim() : "";
+  await storage.writeMemoryFrontmatter(memory, {
+    status: "forgotten",
+    forgottenAt,
+    ...(reason.length > 0 ? { forgottenReason: reason } : {}),
+    updated: forgottenAt,
+  }, {
+    actor: "remnic-forget",
+    reasonCode: "operator_forget",
+  });
+  return {
+    id,
+    path: memory.path,
+    priorStatus,
+    forgottenAt,
+    reason,
+  };
+}
+
+async function findMemoryById(
+  storage: StorageManager,
+  id: string,
+): Promise<MemoryFile | null> {
+  const all = await storage.readAllMemories();
+  return all.find((m) => m.frontmatter.id === id) ?? null;
+}

--- a/packages/remnic-core/src/maintenance/forget.ts
+++ b/packages/remnic-core/src/maintenance/forget.ts
@@ -11,12 +11,11 @@
  *      CLI and downstream telemetry can render it.
  *
  * Memories with `status === "forgotten"` are excluded from recall,
- * browse, and entity attribution by the existing status filters
- * (storage.ts and access-service.ts already drop everything that
- * isn't `active` from default reads).  A future maintenance cron
- * will hard-delete forgotten memories after a configurable retention
- * window (default 90 days) — for this PR the file stays on disk and
- * the act is reversible by editing the YAML directly.
+ * browse, and entity attribution by the status filters that serve
+ * active user context.  A future maintenance cron will hard-delete
+ * forgotten memories after a configurable retention window (default
+ * 90 days) — for this PR the file stays on disk and the act is
+ * reversible by editing the YAML directly.
  *
  * This module ships the pure helper; the CLI wires it in `cli.ts` as
  * a new `remnic forget` subcommand.
@@ -66,11 +65,8 @@ export class ForgetMemoryAlreadyForgottenError extends Error {
 /**
  * Mark a memory as forgotten.  Pure orchestration over storage —
  * caller supplies the storage instance and the request.  Status
- * filters elsewhere in the codebase already exclude
- * `status: "forgotten"` from default reads (memory-cache,
- * access-service browse, retrieval) because they enumerate the
- * `active` allow-list rather than excluding individual non-active
- * statuses (CLAUDE.md rule 53).
+ * filters elsewhere in the codebase exclude `status: "forgotten"`
+ * from recall/browse surfaces before they serve active user context.
  */
 export async function forgetMemory(
   storage: StorageManager,
@@ -117,6 +113,14 @@ async function findMemoryById(
   storage: StorageManager,
   id: string,
 ): Promise<MemoryFile | null> {
-  const all = await storage.readAllMemories();
-  return all.find((m) => m.frontmatter.id === id) ?? null;
+  const hot = await storage.readAllMemories();
+  const hotMatch = hot.find((m) => m.frontmatter.id === id);
+  if (hotMatch) return hotMatch;
+
+  const archived = await storage.readArchivedMemories();
+  const archivedMatch = archived.find((m) => m.frontmatter.id === id);
+  if (archivedMatch) return archivedMatch;
+
+  const cold = await storage.readAllColdMemories();
+  return cold.find((m) => m.frontmatter.id === id) ?? null;
 }

--- a/packages/remnic-core/src/maintenance/forget.ts
+++ b/packages/remnic-core/src/maintenance/forget.ts
@@ -94,7 +94,7 @@ export async function forgetMemory(
   await storage.writeMemoryFrontmatter(memory, {
     status: "forgotten",
     forgottenAt,
-    ...(reason.length > 0 ? { forgottenReason: reason } : {}),
+    forgottenReason: reason.length > 0 ? reason : undefined,
     updated: forgottenAt,
   }, {
     actor: "remnic-forget",

--- a/packages/remnic-core/src/memory-cache.ts
+++ b/packages/remnic-core/src/memory-cache.ts
@@ -1,4 +1,5 @@
 import type { EntityFile, MemoryFile } from "./types.js";
+import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 interface CacheEntry {
   memories: Map<string, MemoryFile>; // keyed by file path
@@ -102,7 +103,7 @@ export function getCachedEpisodeMap(baseDir: string, currentVersion: number): Ma
 export function setCachedEpisodeMap(baseDir: string, memories: MemoryFile[], version: number): Map<string, MemoryFile> {
   const map = new Map<string, MemoryFile>();
   for (const m of memories) {
-    if (m.frontmatter.status === "archived") continue;
+    if (!isActiveMemoryStatus(m.frontmatter.status)) continue;
     if (m.frontmatter.memoryKind !== "episode") continue;
     map.set(m.frontmatter.id, m);
   }
@@ -123,8 +124,9 @@ export function setCachedRuleMemories(baseDir: string, memories: MemoryFile[], v
   const byId = new Map<string, MemoryFile>();
   const all: MemoryFile[] = [];
   for (const m of memories) {
+    if (!isActiveMemoryStatus(m.frontmatter.status)) continue;
     byId.set(m.frontmatter.id, m);
-    if (m.frontmatter.category === "rule" && m.frontmatter.status !== "archived") {
+    if (m.frontmatter.category === "rule") {
       all.push(m);
     }
   }

--- a/packages/remnic-core/src/memory-cache.ts
+++ b/packages/remnic-core/src/memory-cache.ts
@@ -1,5 +1,4 @@
 import type { EntityFile, MemoryFile } from "./types.js";
-import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 interface CacheEntry {
   memories: Map<string, MemoryFile>; // keyed by file path
@@ -103,7 +102,7 @@ export function getCachedEpisodeMap(baseDir: string, currentVersion: number): Ma
 export function setCachedEpisodeMap(baseDir: string, memories: MemoryFile[], version: number): Map<string, MemoryFile> {
   const map = new Map<string, MemoryFile>();
   for (const m of memories) {
-    if (!isActiveMemoryStatus(m.frontmatter.status)) continue;
+    if (m.frontmatter.status === "archived" || m.frontmatter.status === "forgotten") continue;
     if (m.frontmatter.memoryKind !== "episode") continue;
     map.set(m.frontmatter.id, m);
   }
@@ -124,9 +123,12 @@ export function setCachedRuleMemories(baseDir: string, memories: MemoryFile[], v
   const byId = new Map<string, MemoryFile>();
   const all: MemoryFile[] = [];
   for (const m of memories) {
-    if (!isActiveMemoryStatus(m.frontmatter.status)) continue;
     byId.set(m.frontmatter.id, m);
-    if (m.frontmatter.category === "rule") {
+    if (
+      m.frontmatter.category === "rule" &&
+      m.frontmatter.status !== "archived" &&
+      m.frontmatter.status !== "forgotten"
+    ) {
       all.push(m);
     }
   }

--- a/packages/remnic-core/src/memory-lifecycle-ledger-utils.ts
+++ b/packages/remnic-core/src/memory-lifecycle-ledger-utils.ts
@@ -45,6 +45,10 @@ export function inferMemoryStatus(
   return fallbackStatus;
 }
 
+export function isActiveMemoryStatus(status: MemoryStatus | string | undefined): boolean {
+  return status === undefined || status === "active";
+}
+
 export function summarizeMemoryLifecycleState(memory: MemoryFile): MemoryLifecycleStateSummary {
   return {
     category: memory.frontmatter.category,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -174,6 +174,7 @@ import {
   resolveLifecycleState,
   type LifecycleSignals,
 } from "./lifecycle.js";
+import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 import {
   indexMemoriesBatch,
   clearIndexes,
@@ -12110,10 +12111,8 @@ export class Orchestrator {
 
       // Bootstrap: index only active (non-archived, non-superseded) memories.
       // Incremental: index only the newly persisted IDs.
-      const isActive = (m: { frontmatter: { status?: string } }) =>
-        !m.frontmatter.status || m.frontmatter.status === "active";
       const pool = needsFullRebuild
-        ? allMemories.filter(isActive)
+        ? allMemories.filter((m) => isActiveMemoryStatus(m.frontmatter.status))
         : (() => {
             const idSet = new Set(persistedIds);
             return allMemories.filter((m) => idSet.has(m.frontmatter.id));
@@ -12499,8 +12498,7 @@ export class Orchestrator {
         const tmtEntries = allMemories
           .filter(
             (m) =>
-              m.frontmatter.status !== "superseded" &&
-              m.frontmatter.status !== "archived",
+              isActiveMemoryStatus(m.frontmatter.status),
           )
           .map((m) => ({
             path: m.path,
@@ -13005,7 +13003,7 @@ export class Orchestrator {
     const actionPriors = await this.buildLifecycleActionPriors();
 
     for (const memory of allMemories) {
-      if (memory.frontmatter.status === "superseded") {
+      if (!isActiveMemoryStatus(memory.frontmatter.status)) {
         continue;
       }
       evaluatedCount += 1;
@@ -13181,7 +13179,7 @@ export class Orchestrator {
   ): Promise<void> {
     // Only active memories count toward the threshold
     const activeMemories = allMemories.filter(
-      (m) => !m.frontmatter.status || m.frontmatter.status === "active",
+      (m) => isActiveMemoryStatus(m.frontmatter.status),
     );
 
     if (activeMemories.length < this.config.summarizationTriggerCount) {
@@ -13276,7 +13274,7 @@ export class Orchestrator {
   ): Promise<void> {
     // Only extract from active memories
     const activeMemories = allMemories.filter(
-      (m) => !m.frontmatter.status || m.frontmatter.status === "active",
+      (m) => isActiveMemoryStatus(m.frontmatter.status),
     );
 
     if (activeMemories.length === 0) return;
@@ -14823,8 +14821,8 @@ export class Orchestrator {
       const existingMemory = await resultStorage.getMemoryById(memoryId);
       if (!existingMemory) continue;
 
-      // Skip already superseded memories
-      if (existingMemory.frontmatter.status === "superseded") continue;
+      // Skip memories outside the active corpus.
+      if (!isActiveMemoryStatus(existingMemory.frontmatter.status)) continue;
 
       // Verify contradiction with LLM
       const verification = await this.extraction.verifyContradiction(
@@ -14922,7 +14920,7 @@ export class Orchestrator {
       const resultStorage =
         await this.storageRouter.storageFor(resultNamespace);
       const memory = await resultStorage.getMemoryById(memoryId);
-      if (memory && memory.frontmatter.status !== "superseded") {
+      if (memory && isActiveMemoryStatus(memory.frontmatter.status)) {
         candidates.push({
           id: memory.frontmatter.id,
           content: memory.content,

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -14560,6 +14560,7 @@ export class Orchestrator {
     let lifecycleFilteredCount = 0;
     let temporalSupersededFilteredCount = 0;
     let dedicatedSurfaceFilteredCount = 0;
+    let forgottenFilteredCount = 0;
     const boosted: QmdSearchResult[] = [];
     const recencyWeight = this.effectiveRecencyWeight();
     for (const r of results) {
@@ -14567,6 +14568,11 @@ export class Orchestrator {
       let score = r.score;
 
       if (memory) {
+        if (memory.frontmatter.status === "forgotten") {
+          forgottenFilteredCount += 1;
+          continue;
+        }
+
         if (
           options?.allowLifecycleFiltered !== true &&
           shouldFilterLifecycleRecallCandidate(memory.frontmatter, {
@@ -14734,6 +14740,11 @@ export class Orchestrator {
     if (dedicatedSurfaceFilteredCount > 0) {
       log.debug(
         `dedicated surface filter removed ${dedicatedSurfaceFilteredCount} dream/procedural candidates from generic recall`,
+      );
+    }
+    if (forgottenFilteredCount > 0) {
+      log.debug(
+        `forgotten status filter removed ${forgottenFilteredCount} candidates from recall`,
       );
     }
 

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -12498,7 +12498,9 @@ export class Orchestrator {
         const tmtEntries = allMemories
           .filter(
             (m) =>
-              isActiveMemoryStatus(m.frontmatter.status),
+              m.frontmatter.status !== "superseded" &&
+              m.frontmatter.status !== "archived" &&
+              m.frontmatter.status !== "forgotten",
           )
           .map((m) => ({
             path: m.path,
@@ -13003,7 +13005,10 @@ export class Orchestrator {
     const actionPriors = await this.buildLifecycleActionPriors();
 
     for (const memory of allMemories) {
-      if (!isActiveMemoryStatus(memory.frontmatter.status)) {
+      if (
+        memory.frontmatter.status === "superseded" ||
+        memory.frontmatter.status === "forgotten"
+      ) {
         continue;
       }
       evaluatedCount += 1;
@@ -14821,8 +14826,14 @@ export class Orchestrator {
       const existingMemory = await resultStorage.getMemoryById(memoryId);
       if (!existingMemory) continue;
 
-      // Skip memories outside the active corpus.
-      if (!isActiveMemoryStatus(existingMemory.frontmatter.status)) continue;
+      // Skip memories already resolved or explicitly forgotten. Other
+      // non-active statuses remain valid contradiction candidates.
+      if (
+        existingMemory.frontmatter.status === "superseded" ||
+        existingMemory.frontmatter.status === "forgotten"
+      ) {
+        continue;
+      }
 
       // Verify contradiction with LLM
       const verification = await this.extraction.verifyContradiction(
@@ -14920,7 +14931,11 @@ export class Orchestrator {
       const resultStorage =
         await this.storageRouter.storageFor(resultNamespace);
       const memory = await resultStorage.getMemoryById(memoryId);
-      if (memory && isActiveMemoryStatus(memory.frontmatter.status)) {
+      if (
+        memory &&
+        memory.frontmatter.status !== "superseded" &&
+        memory.frontmatter.status !== "forgotten"
+      ) {
         candidates.push({
           id: memory.frontmatter.id,
           content: memory.content,

--- a/packages/remnic-core/src/procedural/procedure-recall.ts
+++ b/packages/remnic-core/src/procedural/procedure-recall.ts
@@ -5,6 +5,7 @@
 import type { MemoryFile, PluginConfig } from "../types.js";
 import type { StorageManager } from "../storage.js";
 import { inferIntentFromText, intentCompatibilityScore, isTaskInitiationIntent } from "../intent.js";
+import { isActiveMemoryStatus } from "../memory-lifecycle-ledger-utils.js";
 
 function tokenOverlapScore(prompt: string, memoryText: string): number {
   const norm = (s: string) =>
@@ -71,11 +72,7 @@ export async function buildProcedureRecallSection(
     .filter(
       (m) =>
         m.frontmatter.category === "procedure" &&
-        m.frontmatter.status !== "pending_review" &&
-        m.frontmatter.status !== "rejected" &&
-        m.frontmatter.status !== "quarantined" &&
-        m.frontmatter.status !== "superseded" &&
-        m.frontmatter.status !== "archived",
+        isActiveMemoryStatus(m.frontmatter.status),
     )
     .map((m) => ({ m, score: scoreProcedureForPrompt(m, trimmed, queryIntent) }))
     .filter((x) => x.score > 0.04)

--- a/packages/remnic-core/src/semantic-rule-promotion.ts
+++ b/packages/remnic-core/src/semantic-rule-promotion.ts
@@ -1,5 +1,6 @@
 import { StorageManager } from "./storage.js";
 import type { MemoryFile, MemoryLink } from "./types.js";
+import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export interface SemanticRulePromotionCandidate {
   id: string;
@@ -103,7 +104,7 @@ export async function promoteSemanticRuleFromMemory(options: {
     });
     return report;
   }
-  if (sourceMemory.frontmatter.status === "archived" || sourceMemory.frontmatter.memoryKind !== "episode") {
+  if (!isActiveMemoryStatus(sourceMemory.frontmatter.status) || sourceMemory.frontmatter.memoryKind !== "episode") {
     report.skipped.push({
       sourceMemoryId: options.sourceMemoryId,
       reason: "source-memory-not-episode",
@@ -124,7 +125,7 @@ export async function promoteSemanticRuleFromMemory(options: {
   const existingRule = (await storage.readAllMemories()).find(
     (memory) =>
       memory.frontmatter.category === "rule" &&
-      memory.frontmatter.status !== "archived" &&
+      isActiveMemoryStatus(memory.frontmatter.status) &&
       canonicalizeRuleKey(memory.content) === ruleKey,
   );
   if (existingRule) {

--- a/packages/remnic-core/src/semantic-rule-promotion.ts
+++ b/packages/remnic-core/src/semantic-rule-promotion.ts
@@ -1,6 +1,5 @@
 import { StorageManager } from "./storage.js";
 import type { MemoryFile, MemoryLink } from "./types.js";
-import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export interface SemanticRulePromotionCandidate {
   id: string;
@@ -104,7 +103,11 @@ export async function promoteSemanticRuleFromMemory(options: {
     });
     return report;
   }
-  if (!isActiveMemoryStatus(sourceMemory.frontmatter.status) || sourceMemory.frontmatter.memoryKind !== "episode") {
+  if (
+    sourceMemory.frontmatter.status === "archived" ||
+    sourceMemory.frontmatter.status === "forgotten" ||
+    sourceMemory.frontmatter.memoryKind !== "episode"
+  ) {
     report.skipped.push({
       sourceMemoryId: options.sourceMemoryId,
       reason: "source-memory-not-episode",
@@ -125,7 +128,8 @@ export async function promoteSemanticRuleFromMemory(options: {
   const existingRule = (await storage.readAllMemories()).find(
     (memory) =>
       memory.frontmatter.category === "rule" &&
-      isActiveMemoryStatus(memory.frontmatter.status) &&
+      memory.frontmatter.status !== "archived" &&
+      memory.frontmatter.status !== "forgotten" &&
       canonicalizeRuleKey(memory.content) === ruleKey,
   );
   if (existingRule) {

--- a/packages/remnic-core/src/semantic-rule-promotion.ts
+++ b/packages/remnic-core/src/semantic-rule-promotion.ts
@@ -16,6 +16,7 @@ export interface SemanticRulePromotionSkip {
   reason:
     | "disabled"
     | "source-memory-missing"
+    | "source-memory-forgotten"
     | "source-memory-not-episode"
     | "no-explicit-rule"
     | "duplicate-rule";
@@ -103,9 +104,15 @@ export async function promoteSemanticRuleFromMemory(options: {
     });
     return report;
   }
+  if (sourceMemory.frontmatter.status === "forgotten") {
+    report.skipped.push({
+      sourceMemoryId: options.sourceMemoryId,
+      reason: "source-memory-forgotten",
+    });
+    return report;
+  }
   if (
     sourceMemory.frontmatter.status === "archived" ||
-    sourceMemory.frontmatter.status === "forgotten" ||
     sourceMemory.frontmatter.memoryKind !== "episode"
   ) {
     report.skipped.push({

--- a/packages/remnic-core/src/semantic-rule-verifier.ts
+++ b/packages/remnic-core/src/semantic-rule-verifier.ts
@@ -2,7 +2,6 @@ import { getCachedRuleMemories, setCachedRuleMemories } from "./memory-cache.js"
 import { StorageManager } from "./storage.js";
 import type { MemoryFile } from "./types.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
-import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export type SemanticRuleVerificationStatus =
   | "verified"
@@ -38,7 +37,12 @@ function verificationConfidenceMultiplier(status: SemanticRuleVerificationStatus
 
 function resolveVerificationStatus(sourceMemory: MemoryFile | undefined): SemanticRuleVerificationStatus {
   if (!sourceMemory) return "source-memory-missing";
-  if (!isActiveMemoryStatus(sourceMemory.frontmatter.status)) return "source-memory-archived";
+  if (
+    sourceMemory.frontmatter.status === "archived" ||
+    sourceMemory.frontmatter.status === "forgotten"
+  ) {
+    return "source-memory-archived";
+  }
   if (sourceMemory.frontmatter.memoryKind !== "episode") return "source-memory-not-episode";
   return "verified";
 }
@@ -116,7 +120,7 @@ export async function searchVerifiedSemanticRules(options: {
   const minEffectiveConfidence = options.minEffectiveConfidence ?? DEFAULT_MIN_EFFECTIVE_CONFIDENCE;
 
   const candidates: VerifiedSemanticRuleResult[] = [];
-  // ruleMemories is pre-filtered to active category=rule memories.
+  // ruleMemories is pre-filtered to category=rule and recall-hidden statuses.
   for (const memory of ruleMemories) {
     if (memory.frontmatter.source !== "semantic-rule-promotion") continue;
     const sourceMemoryId = memory.frontmatter.sourceMemoryId;

--- a/packages/remnic-core/src/semantic-rule-verifier.ts
+++ b/packages/remnic-core/src/semantic-rule-verifier.ts
@@ -2,6 +2,7 @@ import { getCachedRuleMemories, setCachedRuleMemories } from "./memory-cache.js"
 import { StorageManager } from "./storage.js";
 import type { MemoryFile } from "./types.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
+import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export type SemanticRuleVerificationStatus =
   | "verified"
@@ -37,7 +38,7 @@ function verificationConfidenceMultiplier(status: SemanticRuleVerificationStatus
 
 function resolveVerificationStatus(sourceMemory: MemoryFile | undefined): SemanticRuleVerificationStatus {
   if (!sourceMemory) return "source-memory-missing";
-  if (sourceMemory.frontmatter.status === "archived") return "source-memory-archived";
+  if (!isActiveMemoryStatus(sourceMemory.frontmatter.status)) return "source-memory-archived";
   if (sourceMemory.frontmatter.memoryKind !== "episode") return "source-memory-not-episode";
   return "verified";
 }
@@ -115,7 +116,7 @@ export async function searchVerifiedSemanticRules(options: {
   const minEffectiveConfidence = options.minEffectiveConfidence ?? DEFAULT_MIN_EFFECTIVE_CONFIDENCE;
 
   const candidates: VerifiedSemanticRuleResult[] = [];
-  // ruleMemories is pre-filtered to category=rule, status!=archived
+  // ruleMemories is pre-filtered to active category=rule memories.
   for (const memory of ruleMemories) {
     if (memory.frontmatter.source !== "semantic-rule-promotion") continue;
     const sourceMemoryId = memory.frontmatter.sourceMemoryId;

--- a/packages/remnic-core/src/semantic-rule-verifier.ts
+++ b/packages/remnic-core/src/semantic-rule-verifier.ts
@@ -7,6 +7,7 @@ export type SemanticRuleVerificationStatus =
   | "verified"
   | "source-memory-missing"
   | "source-memory-archived"
+  | "source-memory-forgotten"
   | "source-memory-not-episode";
 
 export interface VerifiedSemanticRuleResult {
@@ -28,6 +29,8 @@ function verificationConfidenceMultiplier(status: SemanticRuleVerificationStatus
       return 0.45;
     case "source-memory-archived":
       return 0.4;
+    case "source-memory-forgotten":
+      return 0.3;
     case "source-memory-missing":
       return 0.35;
     default:
@@ -37,12 +40,10 @@ function verificationConfidenceMultiplier(status: SemanticRuleVerificationStatus
 
 function resolveVerificationStatus(sourceMemory: MemoryFile | undefined): SemanticRuleVerificationStatus {
   if (!sourceMemory) return "source-memory-missing";
-  if (
-    sourceMemory.frontmatter.status === "archived" ||
-    sourceMemory.frontmatter.status === "forgotten"
-  ) {
+  if (sourceMemory.frontmatter.status === "archived") {
     return "source-memory-archived";
   }
+  if (sourceMemory.frontmatter.status === "forgotten") return "source-memory-forgotten";
   if (sourceMemory.frontmatter.memoryKind !== "episode") return "source-memory-not-episode";
   return "verified";
 }

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -191,6 +191,8 @@ function serializeFrontmatter(fm: MemoryFrontmatter): string {
   if (fm.supersededBy) lines.push(`supersededBy: ${fm.supersededBy}`);
   if (fm.supersededAt) lines.push(`supersededAt: ${fm.supersededAt}`);
   if (fm.archivedAt) lines.push(`archivedAt: ${fm.archivedAt}`);
+  if (fm.forgottenAt) lines.push(`forgottenAt: ${fm.forgottenAt}`);
+  if (fm.forgottenReason) lines.push(`forgottenReason: ${JSON.stringify(fm.forgottenReason)}`);
   // Lifecycle policy fields
   if (fm.lifecycleState) lines.push(`lifecycleState: ${fm.lifecycleState}`);
   if (fm.verificationState) lines.push(`verificationState: ${fm.verificationState}`);
@@ -331,6 +333,21 @@ function parseLinkReasonValue(rawValue: string): string {
   } catch {
     return legacyValue;
   }
+}
+
+function parseFrontmatterStringValue(rawValue: string | undefined): string | undefined {
+  if (rawValue === undefined) return undefined;
+  const trimmed = rawValue.trim();
+  if (trimmed.length === 0) return undefined;
+  if (trimmed.startsWith('"') && trimmed.endsWith('"')) {
+    try {
+      const parsed = JSON.parse(trimmed) as unknown;
+      return typeof parsed === "string" ? parsed : trimmed;
+    } catch {
+      return trimmed.slice(1, -1).replace(/\\"/g, '"');
+    }
+  }
+  return trimmed;
 }
 
 /**
@@ -624,6 +641,8 @@ function parseFrontmatter(
       supersededBy: fm.supersededBy || undefined,
       supersededAt: fm.supersededAt || undefined,
       archivedAt: fm.archivedAt || undefined,
+      forgottenAt: fm.forgottenAt || undefined,
+      forgottenReason: parseFrontmatterStringValue(fm.forgottenReason),
       lifecycleState: (fm.lifecycleState as LifecycleState) || undefined,
       verificationState: (fm.verificationState as VerificationState) || undefined,
       policyClass: (fm.policyClass as PolicyClass) || undefined,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1698,7 +1698,7 @@ export interface MemoryFrontmatter {
   expiresAt?: string;
   /** IDs of parent memories this was derived from (lineage tracking) */
   lineage?: string[];
-  /** Memory status: active (default), pending_review, rejected, quarantined, superseded, or archived */
+  /** Memory status: active (default), pending_review, rejected, quarantined, superseded, archived, or forgotten */
   status?: MemoryStatus;
   /** ID of memory that superseded this one */
   supersededBy?: string;

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1648,7 +1648,22 @@ export interface BufferSurpriseEvent {
 }
 
 /** Memory status for lifecycle management */
-export type MemoryStatus = "active" | "pending_review" | "rejected" | "quarantined" | "superseded" | "archived";
+export type MemoryStatus =
+  | "active"
+  | "pending_review"
+  | "rejected"
+  | "quarantined"
+  | "superseded"
+  | "archived"
+  /**
+   * Operator explicitly forgot the memory (issue #686 PR 4/6).  Soft
+   * delete: the file stays on disk and a page-version snapshot is kept
+   * so the act is reversible during a configurable retention window
+   * (default 90 days), but the memory is excluded from recall, browse,
+   * and entity attribution.  After the retention window passes, a
+   * future maintenance cron will hard-delete forgotten memories.
+   */
+  | "forgotten";
 export type LifecycleState = "candidate" | "validated" | "active" | "stale" | "archived";
 export type VerificationState = "unverified" | "user_confirmed" | "system_inferred" | "disputed";
 export type PolicyClass = "ephemeral" | "durable" | "protected";
@@ -1691,6 +1706,16 @@ export interface MemoryFrontmatter {
   supersededAt?: string;
   /** Timestamp when archived */
   archivedAt?: string;
+  /**
+   * Timestamp when the operator explicitly forgot this memory
+   * (issue #686 PR 4/6).  Set by `remnic forget <id>`.  Memories with
+   * `status === "forgotten"` are excluded from recall, browse, and
+   * entity attribution; the file remains on disk until the retention
+   * window passes.
+   */
+  forgottenAt?: string;
+  /** Optional human-readable reason captured by `remnic forget --reason`. */
+  forgottenReason?: string;
   /** Policy-driven lifecycle state used for retrieval eligibility/ranking. */
   lifecycleState?: LifecycleState;
   /** Verification provenance used by lifecycle policy. */

--- a/packages/remnic-core/src/verified-recall.ts
+++ b/packages/remnic-core/src/verified-recall.ts
@@ -3,7 +3,6 @@ import { getCachedEpisodeMap, setCachedEpisodeMap } from "./memory-cache.js";
 import { StorageManager } from "./storage.js";
 import type { MemoryFile } from "./types.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
-import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export interface VerifiedEpisodeResult {
   box: BoxFrontmatter;
@@ -75,7 +74,7 @@ function resolveVerifiedEpisodeMemoriesFromMap(
     try {
       const memory = memoryById.get(memoryId);
       if (!memory) continue;
-      if (!isActiveMemoryStatus(memory.frontmatter.status)) continue;
+      if (memory.frontmatter.status === "archived" || memory.frontmatter.status === "forgotten") continue;
       if (memory.frontmatter.memoryKind !== "episode") continue;
       verified.push(memory);
     } catch {

--- a/packages/remnic-core/src/verified-recall.ts
+++ b/packages/remnic-core/src/verified-recall.ts
@@ -3,6 +3,7 @@ import { getCachedEpisodeMap, setCachedEpisodeMap } from "./memory-cache.js";
 import { StorageManager } from "./storage.js";
 import type { MemoryFile } from "./types.js";
 import { countRecallTokenOverlap, normalizeRecallTokens } from "./recall-tokenization.js";
+import { isActiveMemoryStatus } from "./memory-lifecycle-ledger-utils.js";
 
 export interface VerifiedEpisodeResult {
   box: BoxFrontmatter;
@@ -74,7 +75,7 @@ function resolveVerifiedEpisodeMemoriesFromMap(
     try {
       const memory = memoryById.get(memoryId);
       if (!memory) continue;
-      if (memory.frontmatter.status === "archived") continue;
+      if (!isActiveMemoryStatus(memory.frontmatter.status)) continue;
       if (memory.frontmatter.memoryKind !== "episode") continue;
       verified.push(memory);
     } catch {

--- a/tests/cli-memory-search.test.ts
+++ b/tests/cli-memory-search.test.ts
@@ -1,0 +1,76 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  filterNormalMemorySearchResults,
+  isNormalRetrievalVisibleMemory,
+} from "../src/cli.js";
+import type { MemoryFile, MemoryFrontmatter, QmdSearchResult } from "../src/types.js";
+
+function makeMemory(
+  id: string,
+  overrides: Partial<MemoryFrontmatter> = {},
+): MemoryFile {
+  return {
+    path: `/tmp/memory/facts/${id}.md`,
+    content: `${id} content`,
+    frontmatter: {
+      id,
+      category: "fact",
+      created: "2026-02-01T00:00:00.000Z",
+      updated: "2026-02-01T00:00:00.000Z",
+      source: "test",
+      confidence: 0.9,
+      confidenceTier: "explicit",
+      tags: [],
+      ...overrides,
+    } as MemoryFrontmatter,
+  };
+}
+
+function makeSearchResult(id: string): QmdSearchResult {
+  return {
+    path: `/tmp/memory/facts/${id}.md`,
+    docid: id,
+    snippet: `${id} snippet`,
+    score: 0.9,
+  };
+}
+
+test("normal memory search filtering drops forgotten and stale missing QMD hits", async () => {
+  const memories = new Map<string, MemoryFile>([
+    ["/tmp/memory/facts/active.md", makeMemory("active", { status: "active" })],
+    [
+      "/tmp/memory/facts/forgotten.md",
+      makeMemory("forgotten", {
+        status: "forgotten",
+        forgottenAt: "2026-04-25T12:00:00.000Z",
+      }),
+    ],
+  ]);
+
+  const filtered = await filterNormalMemorySearchResults(
+    [
+      makeSearchResult("forgotten"),
+      makeSearchResult("missing"),
+      makeSearchResult("active"),
+    ],
+    {
+      readMemoryByPath: async (path) => memories.get(path) ?? null,
+    },
+  );
+
+  assert.deepEqual(filtered.map((result) => result.docid), ["active"]);
+});
+
+test("normal retrieval visibility treats only forgotten status as hidden", () => {
+  assert.equal(
+    isNormalRetrievalVisibleMemory(makeMemory("forgotten", { status: "forgotten" })),
+    false,
+  );
+  assert.equal(
+    isNormalRetrievalVisibleMemory(makeMemory("archived", { status: "archived" })),
+    true,
+  );
+  assert.equal(isNormalRetrievalVisibleMemory(makeMemory("active")), true);
+});

--- a/tests/compounding-promotion.test.ts
+++ b/tests/compounding-promotion.test.ts
@@ -195,6 +195,7 @@ test("compounding promotion persists durable guidance and dedupes repeated promo
   assert.equal(memory!.frontmatter.category, "principle");
   assert.equal(memory!.frontmatter.source, "compounding-promotion");
   assert.match(memory!.content, /Always include explicit confidence rationale\./);
+  await storage.writeMemoryFrontmatter(memory!, { status: "superseded" });
 
   const duplicate = await engine.promoteCandidate({ weekId: "2026-W09", candidateId: candidate!.id });
   assert.equal(duplicate.promoted.length, 0);

--- a/tests/orchestrator-lifecycle-policy.test.ts
+++ b/tests/orchestrator-lifecycle-policy.test.ts
@@ -47,6 +47,10 @@ test("runConsolidation applies lifecycle policy metadata and writes metrics", as
       lastAccessed: "2010-01-01T00:00:00.000Z",
       confidenceTier: "speculative",
     });
+    await storage.updateMemoryFrontmatter(ids[3], {
+      status: "archived",
+      archivedAt: "2026-04-25T00:00:00.000Z",
+    });
     await storage.updateMemoryFrontmatter(ids[4], {
       status: "superseded",
     });
@@ -71,6 +75,7 @@ test("runConsolidation applies lifecycle policy metadata and writes metrics", as
     assert.equal(metrics.memoriesEvaluated, evaluated.length);
     assert.equal(typeof metrics.memoriesUpdated, "number");
     assert.equal(typeof metrics.countsByLifecycleState, "object");
+    assert.equal(metrics.countsByLifecycleState.archived >= 1, true);
     assert.equal(typeof metrics.staleRatio, "number");
     assert.equal(typeof metrics.disputedRatio, "number");
   } finally {

--- a/tests/orchestrator-utility-runtime.test.ts
+++ b/tests/orchestrator-utility-runtime.test.ts
@@ -159,6 +159,86 @@ test("boostSearchResults excludes dream and procedural memories from generic rec
   }
 });
 
+test("boostSearchResults excludes forgotten memories even when returned by stale search indexes", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-forgotten-recall-filter-memory-"));
+  const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "engram-forgotten-recall-filter-workspace-"));
+  try {
+    const config = parseConfig({
+      openaiApiKey: "sk-test",
+      memoryDir,
+      workspaceDir,
+      qmdEnabled: false,
+      recencyWeight: 0,
+      boostAccessCount: false,
+      feedbackEnabled: false,
+      negativeExamplesEnabled: false,
+      intentRoutingEnabled: false,
+      queryAwareIndexingEnabled: false,
+      lifecyclePolicyEnabled: false,
+      lifecycleFilterStaleEnabled: false,
+    });
+    const orchestrator = new Orchestrator(config) as any;
+    const memories = new Map<string, any>([
+      [
+        "/tmp/memory/facts/forgotten.md",
+        {
+          path: "/tmp/memory/facts/forgotten.md",
+          content: "Forgotten memory",
+          frontmatter: {
+            id: "forgotten",
+            category: "fact",
+            created: "2026-02-01T00:00:00.000Z",
+            updated: "2026-04-25T12:00:00.000Z",
+            source: "test",
+            confidence: 0.9,
+            confidenceTier: "explicit",
+            tags: [],
+            status: "forgotten",
+            forgottenAt: "2026-04-25T12:00:00.000Z",
+          },
+        },
+      ],
+      [
+        "/tmp/memory/facts/active.md",
+        {
+          path: "/tmp/memory/facts/active.md",
+          content: "Active memory",
+          frontmatter: {
+            id: "active",
+            category: "fact",
+            created: "2026-02-01T00:00:00.000Z",
+            updated: "2026-02-01T00:00:00.000Z",
+            source: "test",
+            confidence: 0.9,
+            confidenceTier: "explicit",
+            tags: [],
+            status: "active",
+          },
+        },
+      ],
+    ]);
+    orchestrator.storage = {
+      readMemoryByPath: async (path: string) => memories.get(path) ?? null,
+    };
+
+    const output = await orchestrator.boostSearchResults(
+      [
+        { path: "/tmp/memory/facts/forgotten.md", score: 0.9, docid: "forgotten", snippet: "forgotten" },
+        { path: "/tmp/memory/facts/active.md", score: 0.8, docid: "active", snippet: "active" },
+      ],
+      [],
+      undefined,
+      undefined,
+      { allowLifecycleFiltered: true, allowDedicatedSurface: true },
+    );
+
+    assert.deepEqual(output.map((entry: { docid: string }) => entry.docid), ["active"]);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+    await rm(workspaceDir, { recursive: true, force: true });
+  }
+});
+
 test("boostSearchResults can opt dedicated surfaces back into explicit recall flows", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "engram-dedicated-surface-opt-in-memory-"));
   const workspaceDir = await mkdtemp(path.join(os.tmpdir(), "engram-dedicated-surface-opt-in-workspace-"));

--- a/tests/semantic-rule-promotion.test.ts
+++ b/tests/semantic-rule-promotion.test.ts
@@ -189,6 +189,9 @@ test("promoteSemanticRuleFromMemory dedupes against existing rule memories with 
       memoryKind: "note",
     },
   );
+  const existingRule = await storage.getMemoryById(existingRuleId);
+  assert.ok(existingRule);
+  await storage.writeMemoryFrontmatter(existingRule, { status: "superseded" });
 
   const sourceEpisodeId = await storage.writeMemory(
     "fact",

--- a/tests/semantic-rule-promotion.test.ts
+++ b/tests/semantic-rule-promotion.test.ts
@@ -136,6 +136,35 @@ test("promoteSemanticRuleFromMemory skips non-episodic memories and duplicate pr
   assert.equal(second.skipped[0]?.reason, "duplicate-rule");
 });
 
+test("promoteSemanticRuleFromMemory reports forgotten episode sources distinctly", async () => {
+  const { memoryDir, storage } = await createStore();
+  const sourceEpisodeId = await storage.writeMemory(
+    "fact",
+    "IF a memory has been forgotten THEN keep it out of promoted rules.",
+    {
+      source: "test",
+      tags: ["retention"],
+      confidence: 0.87,
+      memoryKind: "episode",
+    },
+  );
+  const sourceMemory = await storage.getMemoryById(sourceEpisodeId);
+  assert.ok(sourceMemory);
+  await storage.writeMemoryFrontmatter(sourceMemory, {
+    status: "forgotten",
+    forgottenAt: "2026-04-25T12:00:00.000Z",
+  });
+
+  const report = await promoteSemanticRuleFromMemory({
+    memoryDir,
+    enabled: true,
+    sourceMemoryId: sourceEpisodeId,
+  });
+
+  assert.equal(report.promoted.length, 0);
+  assert.equal(report.skipped[0]?.reason, "source-memory-forgotten");
+});
+
 test("promoteSemanticRuleFromMemory strips trailing punctuation from THEN outcomes before duplicate checks", async () => {
   const { memoryDir, storage } = await createStore();
   const firstEpisodeId = await storage.writeMemory(

--- a/tests/semantic-rule-verifier.test.ts
+++ b/tests/semantic-rule-verifier.test.ts
@@ -64,7 +64,7 @@ test("searchVerifiedSemanticRules returns promoted rules whose source episode st
 
 test("searchVerifiedSemanticRules downgrades archived-source rules below the default recall threshold", async () => {
   const { memoryDir, storage } = await createSemanticRuleHarness();
-  const { sourceMemoryId } = await seedPromotedRule(memoryDir, storage);
+  const { ruleMemoryId, sourceMemoryId } = await seedPromotedRule(memoryDir, storage);
   const sourceMemory = await storage.getMemoryById(sourceMemoryId);
   assert.ok(sourceMemory);
   await storage.writeMemoryFrontmatter(sourceMemory, {
@@ -79,6 +79,17 @@ test("searchVerifiedSemanticRules downgrades archived-source rules below the def
   });
 
   assert.deepEqual(results, []);
+
+  const diagnosticResults = await searchVerifiedSemanticRules({
+    memoryDir,
+    query: "What rule says to wait for Cursor before merging?",
+    maxResults: 3,
+    minEffectiveConfidence: 0.1,
+  });
+  assert.equal(diagnosticResults.length, 1);
+  assert.equal(diagnosticResults[0]?.rule.frontmatter.id, ruleMemoryId);
+  assert.equal(diagnosticResults[0]?.verificationStatus, "source-memory-archived");
+  assert.equal(diagnosticResults[0]?.sourceMemoryId, sourceMemoryId);
 });
 
 test("semantic-rule-verify CLI command honors the verification feature flag", async () => {

--- a/tests/semantic-rule-verifier.test.ts
+++ b/tests/semantic-rule-verifier.test.ts
@@ -92,6 +92,37 @@ test("searchVerifiedSemanticRules downgrades archived-source rules below the def
   assert.equal(diagnosticResults[0]?.sourceMemoryId, sourceMemoryId);
 });
 
+test("searchVerifiedSemanticRules reports forgotten-source rules distinctly from archived sources", async () => {
+  const { memoryDir, storage } = await createSemanticRuleHarness();
+  const { ruleMemoryId, sourceMemoryId } = await seedPromotedRule(memoryDir, storage);
+  const sourceMemory = await storage.getMemoryById(sourceMemoryId);
+  assert.ok(sourceMemory);
+  await storage.writeMemoryFrontmatter(sourceMemory, {
+    status: "forgotten",
+    forgottenAt: "2026-03-09T00:00:00.000Z",
+    forgottenReason: "operator removed stale source",
+  });
+
+  const results = await searchVerifiedSemanticRules({
+    memoryDir,
+    query: "What rule says to wait for Cursor before merging?",
+    maxResults: 3,
+  });
+
+  assert.deepEqual(results, []);
+
+  const diagnosticResults = await searchVerifiedSemanticRules({
+    memoryDir,
+    query: "What rule says to wait for Cursor before merging?",
+    maxResults: 3,
+    minEffectiveConfidence: 0.1,
+  });
+  assert.equal(diagnosticResults.length, 1);
+  assert.equal(diagnosticResults[0]?.rule.frontmatter.id, ruleMemoryId);
+  assert.equal(diagnosticResults[0]?.verificationStatus, "source-memory-forgotten");
+  assert.equal(diagnosticResults[0]?.sourceMemoryId, sourceMemoryId);
+});
+
 test("semantic-rule-verify CLI command honors the verification feature flag", async () => {
   const { memoryDir, storage } = await createSemanticRuleHarness();
   const { ruleMemoryId } = await seedPromotedRule(memoryDir, storage);


### PR DESCRIPTION
Implements PR 4/6 of #686. Adds the operator-facing forget surface that closes the year-2 retention story.

- New `remnic forget <id> [--reason <text>]` CLI subcommand.
- New `MemoryStatus: "forgotten"` + `forgottenAt` + `forgottenReason` frontmatter.
- Soft-delete: file stays on disk, act is reversible. Excluded from recall/browse/entity attribution by existing allow-list filters. Lifecycle ledger logs the change.
- Bulk `remnic purge` with retention window deferred to a follow-up maintenance cron.
- 7 unit tests cover the full decision tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new lifecycle status that is now filtered out across multiple retrieval/indexing paths (briefing, recall boost, search, caches, promotion engines), so mistakes could hide or surface memories unexpectedly. Scope is moderate but touches core retrieval behavior and storage frontmatter parsing/writing.
> 
> **Overview**
> Adds operator-facing soft-delete via new `MemoryStatus` value `"forgotten"` plus `forgottenAt`/`forgottenReason` frontmatter fields, persisted through `storage.ts` read/write paths.
> 
> Introduces a new `remnic forget <id> [--reason]` CLI command backed by `maintenance/forget.ts`, and updates retrieval surfaces to *exclude forgotten memories* from briefings, recall boosting, verified recall episode resolution, normal CLI search (QMD + fallback), procedure recall, lifecycle evaluation, TMT rebuild, and rule/episode promotion and verification.
> 
> Adds targeted tests covering the forget pipeline, search filtering, recall filtering, semantic-rule behavior, and briefing window filtering for `forgotten`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 24abcb44bbea21193afed7cefb69f0d8cd42c33c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->