### PR TITLE
feat(retention): remnic tier list + tier explain CLI (#686 PR 5/6)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3586,7 +3586,11 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             if (reportHasMachineReadableOutput(options)) {
               console.log(JSON.stringify({ ok: false, error: message }, null, 2));
             } else {
-              console.error(`tier explain: ${message}`);
+              console.error(
+                message.startsWith("tier explain:")
+                  ? message
+                  : `tier explain: ${message}`,
+              );
             }
             process.exitCode = 1;
           }

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -3535,6 +3535,63 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           if (!reportHasMachineReadableOutput(options)) console.log("OK");
         });
 
+      // Tier visibility (issue #686 PR 5/6) — operator-facing read-only
+      // surfaces for inspecting hot↔cold tier distribution and
+      // explaining why a single memory ended up where it did.
+      const tierCmd = cmd
+        .command("tier")
+        .description(
+          "Tier-distribution visibility (issue #686). `tier list` summarizes hot/cold counts and per-status breakdown; `tier explain <id>` shows the value-score components and tier-transition decision for a single memory.",
+        );
+      tierCmd
+        .command("list")
+        .description("Summarize tier distribution across all memories")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const { summarizeTiers, formatTierSummaryText } = await import(
+            "./maintenance/tier-stats.js"
+          );
+          const summary = await summarizeTiers(orchestrator.storage);
+          if (reportHasMachineReadableOutput(options)) {
+            console.log(JSON.stringify(summary, null, 2));
+          } else {
+            console.log(formatTierSummaryText(summary));
+          }
+        });
+      tierCmd
+        .command("explain")
+        .description("Explain the tier-transition decision for a single memory")
+        .argument("<id>", "Memory id to explain")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const idArg = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          const { explainTierForMemory, formatTierExplainText } = await import(
+            "./maintenance/tier-stats.js"
+          );
+          try {
+            const explain = await explainTierForMemory(
+              orchestrator.storage,
+              idArg,
+              orchestrator.config,
+            );
+            if (reportHasMachineReadableOutput(options)) {
+              console.log(JSON.stringify(explain, null, 2));
+            } else {
+              console.log(formatTierExplainText(explain));
+            }
+          } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            if (reportHasMachineReadableOutput(options)) {
+              console.log(JSON.stringify({ ok: false, error: message }, null, 2));
+            } else {
+              console.error(`tier explain: ${message}`);
+            }
+            process.exitCode = 1;
+          }
+        });
+
       cmd
         .command("config-review")
         .description("Review Engram config defaults, recommendations, and contradictory settings")

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -6,13 +6,14 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  explainTierForMemory,
   formatTierExplainText,
   formatTierSummaryText,
   summarizeTiers,
   type TierExplainResult,
   type TierSummary,
 } from "./tier-stats.js";
-import type { MemoryFile, MemoryFrontmatter } from "../types.js";
+import type { MemoryFile, MemoryFrontmatter, PluginConfig } from "../types.js";
 
 function makeMemory(
   overrides: Partial<MemoryFrontmatter>,
@@ -32,21 +33,44 @@ function makeMemory(
   };
 }
 
-function makeStorageStub(memories: MemoryFile[]) {
+function makeStorageStub(
+  memories: MemoryFile[],
+  coldMemories: MemoryFile[] = [],
+) {
   return {
     readAllMemories: async () => memories,
+    readAllColdMemories: async () => coldMemories,
   };
+}
+
+function makeConfigStub(
+  overrides: Partial<PluginConfig> = {},
+): PluginConfig {
+  return {
+    qmdTierMigrationEnabled: true,
+    qmdTierDemotionMinAgeDays: 14,
+    qmdTierDemotionValueThreshold: 0.35,
+    qmdTierPromotionValueThreshold: 0.7,
+    lifecyclePolicyEnabled: false,
+    lifecycleStaleDecayThreshold: 0,
+    lifecyclePromoteHeatThreshold: 0,
+    ...overrides,
+  } as unknown as PluginConfig;
 }
 
 test("summarizeTiers: counts tiers, statuses, and categories", async () => {
   const memories = [
     makeMemory({ id: "a", status: "active", category: "preference" }),
     makeMemory({ id: "b", status: "active", category: "decision" }),
-    makeMemory({ id: "c", status: "archived", category: "preference" }, "/tmp/mem/cold/c.md"),
     makeMemory({ id: "d", status: "forgotten" as MemoryFrontmatter["status"], category: "fact" }),
+  ];
+  const coldMemories = [
+    makeMemory({ id: "c", status: "archived", category: "preference" }, "/tmp/mem/cold/c.md"),
     makeMemory({ id: "e" }, "/tmp/mem/cold/e.md"),
   ];
-  const summary = await summarizeTiers(makeStorageStub(memories) as never);
+  const summary = await summarizeTiers(
+    makeStorageStub(memories, coldMemories) as never,
+  );
   assert.equal(summary.total, 5);
   assert.equal(summary.byTier.hot, 3);
   assert.equal(summary.byTier.cold, 2);
@@ -75,6 +99,60 @@ test("summarizeTiers: defaults missing status to active", async () => {
     makeStorageStub([makeMemory({ id: "a" })]) as never,
   );
   assert.equal(summary.byStatus.active, 1);
+});
+
+test("explainTierForMemory: finds cold memories and reports importance score", async () => {
+  const coldMemory = makeMemory(
+    {
+      id: "cold-a",
+      status: "active",
+      confidence: 0.8,
+      accessCount: 2,
+      importance: {
+        score: 0.91,
+        level: "high",
+        reasons: ["operator marked important"],
+        keywords: ["operator"],
+      },
+    },
+    "/tmp/mem/cold/facts/cold-a.md",
+  );
+
+  const explain = await explainTierForMemory(
+    makeStorageStub([], [coldMemory]) as never,
+    "cold-a",
+    makeConfigStub(),
+  );
+
+  assert.equal(explain.id, "cold-a");
+  assert.equal(explain.currentTier, "cold");
+  assert.equal(explain.signals.importance, 0.91);
+});
+
+test("explainTierForMemory: uses qmd tier migration policy for decisions", async () => {
+  const memory = makeMemory({
+    id: "hot-low-value",
+    confidence: 0,
+    updated: "2020-01-01T00:00:00.000Z",
+  });
+
+  const explain = await explainTierForMemory(
+    makeStorageStub([memory]) as never,
+    "hot-low-value",
+    makeConfigStub({
+      qmdTierMigrationEnabled: true,
+      qmdTierDemotionMinAgeDays: 0,
+      qmdTierDemotionValueThreshold: 1,
+      qmdTierPromotionValueThreshold: 1,
+      lifecyclePolicyEnabled: false,
+      lifecycleStaleDecayThreshold: 0,
+      lifecyclePromoteHeatThreshold: 0,
+    }),
+  );
+
+  assert.equal(explain.decision.nextTier, "cold");
+  assert.equal(explain.decision.changed, true);
+  assert.equal(explain.decision.reason, "value_below_demotion_threshold");
 });
 
 test("formatTierSummaryText: renders headings and counts", () => {

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -107,6 +107,17 @@ test("summarizeTiers: defaults missing status to active", async () => {
   assert.equal(summary.byStatus.active, 1);
 });
 
+test("summarizeTiers: treats hot scan memories as hot even under cold-named roots", async () => {
+  const summary = await summarizeTiers(
+    makeStorageStub([
+      makeMemory({ id: "hot-cold-root" }, "/tmp/cold/remnic/facts/hot.md"),
+    ]) as never,
+  );
+
+  assert.equal(summary.byTier.hot, 1);
+  assert.equal(summary.byTier.cold, 0);
+});
+
 test("explainTierForMemory: finds cold memories and reports importance score", async () => {
   const coldMemory = makeMemory(
     {
@@ -159,6 +170,22 @@ test("explainTierForMemory: uses qmd tier migration policy for decisions", async
   assert.equal(explain.decision.nextTier, "cold");
   assert.equal(explain.decision.changed, true);
   assert.equal(explain.decision.reason, "value_below_demotion_threshold");
+});
+
+test("explainTierForMemory: uses source scan tier instead of path substring", async () => {
+  const memory = makeMemory(
+    { id: "hot-cold-root" },
+    "/tmp/cold/remnic/facts/hot.md",
+  );
+
+  const explain = await explainTierForMemory(
+    makeStorageStub([memory]) as never,
+    "hot-cold-root",
+    makeConfigStub(),
+  );
+
+  assert.equal(explain.currentTier, "hot");
+  assert.equal(explain.decision.currentTier, "hot");
 });
 
 test("explainTierForMemory: applies utility runtime tier deltas", async () => {

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -146,6 +146,19 @@ test("explainTierForMemory: finds cold memories and reports importance score", a
   assert.equal(explain.signals.importance, 0.91);
 });
 
+test("explainTierForMemory: reports scoring importance and feedback inputs", async () => {
+  const memory = makeMemory({ id: "default-value-inputs" });
+
+  const explain = await explainTierForMemory(
+    makeStorageStub([memory]) as never,
+    "default-value-inputs",
+    makeConfigStub(),
+  );
+
+  assert.equal(explain.signals.importance, 0.5);
+  assert.equal(explain.signals.feedback, 0.5);
+});
+
 test("explainTierForMemory: uses qmd tier migration policy for decisions", async () => {
   const memory = makeMemory({
     id: "hot-low-value",
@@ -321,7 +334,7 @@ test("formatTierExplainText: renders score, decision, and signals", () => {
       created: "2026-01-01T00:00:00.000Z",
       updated: "2026-04-19T00:00:00.000Z",
       importance: 0.5,
-      feedback: "user_confirmed",
+      feedback: 0.5,
     },
   };
   const text = formatTierExplainText(explain);
@@ -333,7 +346,7 @@ test("formatTierExplainText: renders score, decision, and signals", () => {
   assert.match(text, /lastAccessed: 2026-04-20/);
 });
 
-test("formatTierExplainText: shows '(never)' / '(unset)' for missing signals", () => {
+test("formatTierExplainText: shows '(never)' and scoring defaults for missing signals", () => {
   const explain: TierExplainResult = {
     id: "bare",
     path: "/tmp/mem/bare.md",
@@ -354,12 +367,12 @@ test("formatTierExplainText: shows '(never)' / '(unset)' for missing signals", (
       lastAccessed: null,
       created: "",
       updated: "",
-      importance: null,
-      feedback: null,
+      importance: 0.5,
+      feedback: 0.5,
     },
   };
   const text = formatTierExplainText(explain);
   assert.match(text, /lastAccessed: \(never\)/);
-  assert.match(text, /importance: {3}\(unset\)/);
-  assert.match(text, /feedback: {5}\(unset\)/);
+  assert.match(text, /importance: {3}0\.5/);
+  assert.match(text, /feedback: {5}0\.5/);
 });

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -188,6 +188,22 @@ test("explainTierForMemory: uses source scan tier instead of path substring", as
   assert.equal(explain.decision.currentTier, "hot");
 });
 
+test("explainTierForMemory: reports scoring confidence input", async () => {
+  const memory = makeMemory({
+    id: "explicit-confidence",
+    confidence: 0.2,
+    confidenceTier: "explicit",
+  });
+
+  const explain = await explainTierForMemory(
+    makeStorageStub([memory]) as never,
+    "explicit-confidence",
+    makeConfigStub(),
+  );
+
+  assert.equal(explain.signals.confidence, 1);
+});
+
 test("explainTierForMemory: applies utility runtime tier deltas", async () => {
   const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-tier-stats-"));
   try {

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -3,6 +3,9 @@
  */
 
 import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
 import test from "node:test";
 
 import {
@@ -47,10 +50,13 @@ function makeConfigStub(
   overrides: Partial<PluginConfig> = {},
 ): PluginConfig {
   return {
+    memoryDir: "/tmp/remnic-tier-stats-test",
     qmdTierMigrationEnabled: true,
     qmdTierDemotionMinAgeDays: 14,
     qmdTierDemotionValueThreshold: 0.35,
     qmdTierPromotionValueThreshold: 0.7,
+    memoryUtilityLearningEnabled: false,
+    promotionByOutcomeEnabled: false,
     lifecyclePolicyEnabled: false,
     lifecycleStaleDecayThreshold: 0,
     lifecyclePromoteHeatThreshold: 0,
@@ -153,6 +159,70 @@ test("explainTierForMemory: uses qmd tier migration policy for decisions", async
   assert.equal(explain.decision.nextTier, "cold");
   assert.equal(explain.decision.changed, true);
   assert.equal(explain.decision.reason, "value_below_demotion_threshold");
+});
+
+test("explainTierForMemory: applies utility runtime tier deltas", async () => {
+  const memoryDir = await mkdtemp(path.join(tmpdir(), "remnic-tier-stats-"));
+  try {
+    const stateDir = path.join(memoryDir, "state", "utility-telemetry");
+    const snapshot = {
+      version: 1,
+      updatedAt: "2026-04-25T00:00:00.000Z",
+      windowDays: 14,
+      minEventCount: 3,
+      maxWeightMagnitude: 0.35,
+      weights: [
+        {
+          target: "promotion",
+          decision: "demote",
+          eventCount: 10,
+          learnedWeight: 0.35,
+          averageUtilityScore: 0.35,
+          confidence: 0.9,
+          outcomeCounts: { helpful: 10 },
+          updatedAt: "2026-04-25T00:00:00.000Z",
+        },
+      ],
+    };
+    await mkdir(stateDir, { recursive: true });
+    await writeFile(
+      path.join(stateDir, "learning-state.json"),
+      `${JSON.stringify(snapshot, null, 2)}\n`,
+      "utf8",
+    );
+    const memory = makeMemory({
+      id: "runtime-borderline",
+      category: "fact",
+      confidence: 0,
+      updated: "2020-01-01T00:00:00.000Z",
+      importance: {
+        score: 0,
+        level: "low",
+        reasons: [],
+        keywords: [],
+      },
+    });
+
+    const explain = await explainTierForMemory(
+      makeStorageStub([memory]) as never,
+      "runtime-borderline",
+      makeConfigStub({
+        memoryDir,
+        memoryUtilityLearningEnabled: true,
+        promotionByOutcomeEnabled: true,
+        qmdTierMigrationEnabled: true,
+        qmdTierDemotionMinAgeDays: 0,
+        qmdTierDemotionValueThreshold: 0.04,
+        qmdTierPromotionValueThreshold: 1,
+      }),
+    );
+
+    assert.equal(explain.decision.nextTier, "cold");
+    assert.equal(explain.decision.changed, true);
+    assert.equal(explain.decision.reason, "value_below_demotion_threshold");
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
 });
 
 test("formatTierSummaryText: renders headings and counts", () => {

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -1,0 +1,160 @@
+/**
+ * Unit tests for tier-stats helpers (issue #686 PR 5/6).
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  formatTierExplainText,
+  formatTierSummaryText,
+  summarizeTiers,
+  type TierExplainResult,
+  type TierSummary,
+} from "./tier-stats.js";
+import type { MemoryFile, MemoryFrontmatter } from "../types.js";
+
+function makeMemory(
+  overrides: Partial<MemoryFrontmatter>,
+  pathOverride?: string,
+): MemoryFile {
+  return {
+    path: pathOverride ?? `/tmp/mem/${overrides.id ?? "mem"}.md`,
+    content: "synthetic",
+    frontmatter: {
+      id: overrides.id ?? "mem",
+      category: "preference",
+      created: "2026-01-01T00:00:00.000Z",
+      updated: "2026-01-01T00:00:00.000Z",
+      source: "test",
+      ...overrides,
+    } as MemoryFrontmatter,
+  };
+}
+
+function makeStorageStub(memories: MemoryFile[]) {
+  return {
+    readAllMemories: async () => memories,
+  };
+}
+
+test("summarizeTiers: counts tiers, statuses, and categories", async () => {
+  const memories = [
+    makeMemory({ id: "a", status: "active", category: "preference" }),
+    makeMemory({ id: "b", status: "active", category: "decision" }),
+    makeMemory({ id: "c", status: "archived", category: "preference" }, "/tmp/mem/cold/c.md"),
+    makeMemory({ id: "d", status: "forgotten" as MemoryFrontmatter["status"], category: "fact" }),
+    makeMemory({ id: "e" }, "/tmp/mem/cold/e.md"),
+  ];
+  const summary = await summarizeTiers(makeStorageStub(memories) as never);
+  assert.equal(summary.total, 5);
+  assert.equal(summary.byTier.hot, 3);
+  assert.equal(summary.byTier.cold, 2);
+  // 3 active: a, b, e (e has no explicit status → defaults to active).
+  assert.equal(summary.byStatus.active, 3);
+  assert.equal(summary.byStatus.archived, 1);
+  assert.equal(summary.byStatus.forgotten, 1);
+  assert.equal(summary.forgottenCount, 1);
+  // 3 preference: a, c, e (e inherits the makeMemory default).
+  assert.equal(summary.byCategory.preference, 3);
+  assert.equal(summary.byCategory.decision, 1);
+  assert.equal(summary.byCategory.fact, 1);
+});
+
+test("summarizeTiers: handles empty store", async () => {
+  const summary = await summarizeTiers(makeStorageStub([]) as never);
+  assert.equal(summary.total, 0);
+  assert.equal(summary.byTier.hot, 0);
+  assert.equal(summary.byTier.cold, 0);
+  assert.deepEqual(summary.byStatus, {});
+  assert.equal(summary.forgottenCount, 0);
+});
+
+test("summarizeTiers: defaults missing status to active", async () => {
+  const summary = await summarizeTiers(
+    makeStorageStub([makeMemory({ id: "a" })]) as never,
+  );
+  assert.equal(summary.byStatus.active, 1);
+});
+
+test("formatTierSummaryText: renders headings and counts", () => {
+  const summary: TierSummary = {
+    total: 5,
+    byTier: { hot: 3, cold: 2 },
+    byStatus: { active: 4, archived: 1 },
+    forgottenCount: 0,
+    byCategory: { preference: 3, decision: 2 },
+  };
+  const text = formatTierSummaryText(summary);
+  assert.match(text, /Memory Tier Distribution/);
+  assert.match(text, /Total memories: 5/);
+  assert.match(text, /hot: {2}3/);
+  assert.match(text, /cold: 2/);
+  assert.match(text, /active: 4/);
+  assert.match(text, /preference: 3/);
+});
+
+test("formatTierExplainText: renders score, decision, and signals", () => {
+  const explain: TierExplainResult = {
+    id: "alpha",
+    path: "/tmp/mem/alpha.md",
+    currentTier: "hot",
+    status: "active",
+    category: "preference",
+    valueScore: 0.123456,
+    decision: {
+      currentTier: "hot",
+      nextTier: "hot",
+      valueScore: 0.123456,
+      changed: false,
+      reason: "demotion_min_age_not_met",
+    },
+    signals: {
+      confidence: 0.7,
+      accessCount: 4,
+      lastAccessed: "2026-04-20T00:00:00.000Z",
+      created: "2026-01-01T00:00:00.000Z",
+      updated: "2026-04-19T00:00:00.000Z",
+      importance: 0.5,
+      feedback: "user_confirmed",
+    },
+  };
+  const text = formatTierExplainText(explain);
+  assert.match(text, /alpha/);
+  assert.match(text, /value score: {3}0\.123/);
+  assert.match(text, /next tier: hot/);
+  assert.match(text, /demotion_min_age_not_met/);
+  assert.match(text, /confidence: {3}0\.7/);
+  assert.match(text, /lastAccessed: 2026-04-20/);
+});
+
+test("formatTierExplainText: shows '(never)' / '(unset)' for missing signals", () => {
+  const explain: TierExplainResult = {
+    id: "bare",
+    path: "/tmp/mem/bare.md",
+    currentTier: "hot",
+    status: "active",
+    category: "fact",
+    valueScore: 0,
+    decision: {
+      currentTier: "hot",
+      nextTier: "hot",
+      valueScore: 0,
+      changed: false,
+      reason: "tier_migration_disabled",
+    },
+    signals: {
+      confidence: 0,
+      accessCount: 0,
+      lastAccessed: null,
+      created: "",
+      updated: "",
+      importance: null,
+      feedback: null,
+    },
+  };
+  const text = formatTierExplainText(explain);
+  assert.match(text, /lastAccessed: \(never\)/);
+  assert.match(text, /importance: {3}\(unset\)/);
+  assert.match(text, /feedback: {5}\(unset\)/);
+});

--- a/packages/remnic-core/src/maintenance/tier-stats.test.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.test.ts
@@ -269,6 +269,20 @@ test("formatTierSummaryText: renders headings and counts", () => {
   assert.match(text, /preference: 3/);
 });
 
+test("formatTierSummaryText: sorts equal-count rows by key", () => {
+  const summary: TierSummary = {
+    total: 4,
+    byTier: { hot: 4, cold: 0 },
+    byStatus: { pending_review: 1, active: 1, archived: 2 },
+    forgottenCount: 0,
+    byCategory: { zebra: 1, decision: 2, alpha: 1 },
+  };
+
+  const text = formatTierSummaryText(summary);
+  assert.match(text, /archived: 2[\s\S]*active: 1[\s\S]*pending_review: 1/);
+  assert.match(text, /decision: 2[\s\S]*alpha: 1[\s\S]*zebra: 1/);
+});
+
 test("formatTierExplainText: renders score, decision, and signals", () => {
   const explain: TierExplainResult = {
     id: "alpha",

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -66,10 +66,29 @@ function inferTier(memory: MemoryFile): MemoryTier {
     : "hot";
 }
 
+async function readTierVisibleMemories(
+  storage: StorageManager,
+): Promise<MemoryFile[]> {
+  const [hotMemories, coldMemories] = await Promise.all([
+    storage.readAllMemories(),
+    storage.readAllColdMemories(),
+  ]);
+  return [...hotMemories, ...coldMemories];
+}
+
+function tierRoutingPolicyFromConfig(config: PluginConfig): TierRoutingPolicy {
+  return {
+    enabled: config.qmdTierMigrationEnabled,
+    demotionMinAgeDays: config.qmdTierDemotionMinAgeDays,
+    demotionValueThreshold: config.qmdTierDemotionValueThreshold,
+    promotionValueThreshold: config.qmdTierPromotionValueThreshold,
+  };
+}
+
 export async function summarizeTiers(
   storage: StorageManager,
 ): Promise<TierSummary> {
-  const all = await storage.readAllMemories();
+  const all = await readTierVisibleMemories(storage);
   const summary: TierSummary = {
     total: all.length,
     byTier: { hot: 0, cold: 0 },
@@ -100,22 +119,18 @@ export async function explainTierForMemory(
   if (trimmed.length === 0) {
     throw new Error("tier explain: memory id is required and must be non-empty");
   }
-  const all = await storage.readAllMemories();
+  const all = await readTierVisibleMemories(storage);
   const memory = all.find((m) => m.frontmatter.id === trimmed);
   if (!memory) {
     throw new Error(`tier explain: memory not found: ${trimmed}`);
   }
   const now = new Date();
   const valueScore = computeTierValueScore(memory, now);
-  const policy: TierRoutingPolicy = {
-    enabled: config.lifecyclePolicyEnabled,
-    demotionMinAgeDays: 14,
-    demotionValueThreshold: config.lifecycleStaleDecayThreshold,
-    promotionValueThreshold: config.lifecyclePromoteHeatThreshold,
-  };
+  const policy = tierRoutingPolicyFromConfig(config);
   const currentTier = inferTier(memory);
   const decision = decideTierTransition(memory, currentTier, policy, now);
   const fm = memory.frontmatter as unknown as Record<string, unknown>;
+  const importanceScore = memory.frontmatter.importance?.score;
   return {
     id: trimmed,
     path: memory.path,
@@ -134,7 +149,9 @@ export async function explainTierForMemory(
       created: typeof fm.created === "string" ? (fm.created as string) : "",
       updated: typeof fm.updated === "string" ? (fm.updated as string) : "",
       importance:
-        typeof fm.importance === "number" ? (fm.importance as number) : null,
+        typeof importanceScore === "number" && Number.isFinite(importanceScore)
+          ? importanceScore
+          : null,
       feedback:
         typeof fm.verificationState === "string"
           ? (fm.verificationState as string)

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -183,7 +183,7 @@ export function formatTierSummaryText(summary: TierSummary): string {
   lines.push("");
   lines.push("Status:");
   const statusEntries = Object.entries(summary.byStatus).sort(
-    (a, b) => b[1] - a[1],
+    (a, b) => b[1] - a[1] || a[0].localeCompare(b[0]),
   );
   for (const [status, count] of statusEntries) {
     lines.push(`  ${status}: ${count}`);
@@ -191,7 +191,7 @@ export function formatTierSummaryText(summary: TierSummary): string {
   lines.push("");
   lines.push("Top categories:");
   const categoryEntries = Object.entries(summary.byCategory)
-    .sort((a, b) => b[1] - a[1])
+    .sort((a, b) => b[1] - a[1] || a[0].localeCompare(b[0]))
     .slice(0, 8);
   for (const [cat, count] of categoryEntries) {
     lines.push(`  ${cat}: ${count}`);

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -55,8 +55,8 @@ export interface TierExplainResult {
     lastAccessed: string | null;
     created: string;
     updated: string;
-    importance: number | null;
-    feedback: string | null;
+    importance: number;
+    feedback: number;
   };
 }
 
@@ -140,7 +140,6 @@ export async function explainTierForMemory(
   const policy = await tierRoutingPolicyFromConfig(config);
   const decision = decideTierTransition(memory, currentTier, policy, now);
   const fm = memory.frontmatter as unknown as Record<string, unknown>;
-  const importanceScore = memory.frontmatter.importance?.score;
   return {
     id: trimmed,
     path: memory.path,
@@ -157,14 +156,8 @@ export async function explainTierForMemory(
         typeof fm.lastAccessed === "string" ? (fm.lastAccessed as string) : null,
       created: typeof fm.created === "string" ? (fm.created as string) : "",
       updated: typeof fm.updated === "string" ? (fm.updated as string) : "",
-      importance:
-        typeof importanceScore === "number" && Number.isFinite(importanceScore)
-          ? importanceScore
-          : null,
-      feedback:
-        typeof fm.verificationState === "string"
-          ? (fm.verificationState as string)
-          : null,
+      importance: valueInputs.importance,
+      feedback: valueInputs.feedback,
     },
   };
 }
@@ -223,7 +216,7 @@ export function formatTierExplainText(explain: TierExplainResult): string {
   lines.push(`  lastAccessed: ${explain.signals.lastAccessed ?? "(never)"}`);
   lines.push(`  created:      ${explain.signals.created}`);
   lines.push(`  updated:      ${explain.signals.updated}`);
-  lines.push(`  importance:   ${explain.signals.importance ?? "(unset)"}`);
-  lines.push(`  feedback:     ${explain.signals.feedback ?? "(unset)"}`);
+  lines.push(`  importance:   ${explain.signals.importance}`);
+  lines.push(`  feedback:     ${explain.signals.feedback}`);
   return lines.join("\n");
 }

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -24,6 +24,10 @@ import {
   type TierRoutingPolicy,
   type TierTransitionDecision,
 } from "../tier-routing.js";
+import {
+  applyUtilityPromotionRuntimePolicy,
+  loadUtilityRuntimeValues,
+} from "../utility-runtime.js";
 
 export interface TierSummary {
   /** Total memories scanned (all tiers, all statuses). */
@@ -76,13 +80,21 @@ async function readTierVisibleMemories(
   return [...hotMemories, ...coldMemories];
 }
 
-function tierRoutingPolicyFromConfig(config: PluginConfig): TierRoutingPolicy {
-  return {
+async function tierRoutingPolicyFromConfig(
+  config: PluginConfig,
+): Promise<TierRoutingPolicy> {
+  const basePolicy: TierRoutingPolicy = {
     enabled: config.qmdTierMigrationEnabled,
     demotionMinAgeDays: config.qmdTierDemotionMinAgeDays,
     demotionValueThreshold: config.qmdTierDemotionValueThreshold,
     promotionValueThreshold: config.qmdTierPromotionValueThreshold,
   };
+  const runtime = await loadUtilityRuntimeValues({
+    memoryDir: config.memoryDir,
+    memoryUtilityLearningEnabled: config.memoryUtilityLearningEnabled,
+    promotionByOutcomeEnabled: config.promotionByOutcomeEnabled,
+  });
+  return applyUtilityPromotionRuntimePolicy(basePolicy, runtime);
 }
 
 export async function summarizeTiers(
@@ -126,7 +138,7 @@ export async function explainTierForMemory(
   }
   const now = new Date();
   const valueScore = computeTierValueScore(memory, now);
-  const policy = tierRoutingPolicyFromConfig(config);
+  const policy = await tierRoutingPolicyFromConfig(config);
   const currentTier = inferTier(memory);
   const decision = decideTierTransition(memory, currentTier, policy, now);
   const fm = memory.frontmatter as unknown as Record<string, unknown>;

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -1,0 +1,203 @@
+/**
+ * Operator-facing tier visibility (issue #686 PR 5/6).
+ *
+ * Two read-only surfaces:
+ *
+ *   - `summarizeTiers(storage)` — count memories by tier (hot vs cold)
+ *     plus per-status breakdown so operators can see at a glance
+ *     whether the lifecycle policy has actually demoted anything.
+ *   - `explainTierForMemory(storage, id)` — show the value-score
+ *     components and tier-transition decision for a single memory
+ *     so an operator can reason about why a memory ended up where
+ *     it did.
+ *
+ * Pure inspection — neither surface mutates anything.  The CLI wires
+ * them as `remnic tier list` and `remnic tier explain <id>`.
+ */
+
+import type { StorageManager } from "../storage.js";
+import type { MemoryFile, PluginConfig } from "../types.js";
+import {
+  computeTierValueScore,
+  decideTierTransition,
+  type MemoryTier,
+  type TierRoutingPolicy,
+  type TierTransitionDecision,
+} from "../tier-routing.js";
+
+export interface TierSummary {
+  /** Total memories scanned (all tiers, all statuses). */
+  total: number;
+  byTier: Record<MemoryTier, number>;
+  byStatus: Record<string, number>;
+  /** Memories with `status === "forgotten"` (issue #686 PR 4/6). */
+  forgottenCount: number;
+  /** Top contributors to the forgotten / archived buckets, by category. */
+  byCategory: Record<string, number>;
+}
+
+export interface TierExplainResult {
+  id: string;
+  path: string;
+  currentTier: MemoryTier;
+  status: string;
+  category: string;
+  valueScore: number;
+  decision: TierTransitionDecision;
+  signals: {
+    confidence: number;
+    accessCount: number;
+    lastAccessed: string | null;
+    created: string;
+    updated: string;
+    importance: number | null;
+    feedback: string | null;
+  };
+}
+
+/**
+ * Determine the on-disk tier of a memory by scanning its path for the
+ * `cold/` segment that `tier-migration.ts` writes.  Mirrors the same
+ * detection that `temporal-supersession.ts` uses around line 283.
+ */
+function inferTier(memory: MemoryFile): MemoryTier {
+  return memory.path.includes("/cold/") || memory.path.includes("\\cold\\")
+    ? "cold"
+    : "hot";
+}
+
+export async function summarizeTiers(
+  storage: StorageManager,
+): Promise<TierSummary> {
+  const all = await storage.readAllMemories();
+  const summary: TierSummary = {
+    total: all.length,
+    byTier: { hot: 0, cold: 0 },
+    byStatus: {},
+    forgottenCount: 0,
+    byCategory: {},
+  };
+  for (const m of all) {
+    const tier = inferTier(m);
+    summary.byTier[tier] += 1;
+    const status: string = m.frontmatter.status ?? "active";
+    summary.byStatus[status] = (summary.byStatus[status] ?? 0) + 1;
+    // Compare via the widened `string` type so this module compiles
+    // both before and after PR 4/6 lands `"forgotten"` in MemoryStatus.
+    if (status === "forgotten") summary.forgottenCount += 1;
+    const cat = m.frontmatter.category ?? "(uncategorized)";
+    summary.byCategory[cat] = (summary.byCategory[cat] ?? 0) + 1;
+  }
+  return summary;
+}
+
+export async function explainTierForMemory(
+  storage: StorageManager,
+  id: string,
+  config: PluginConfig,
+): Promise<TierExplainResult> {
+  const trimmed = typeof id === "string" ? id.trim() : "";
+  if (trimmed.length === 0) {
+    throw new Error("tier explain: memory id is required and must be non-empty");
+  }
+  const all = await storage.readAllMemories();
+  const memory = all.find((m) => m.frontmatter.id === trimmed);
+  if (!memory) {
+    throw new Error(`tier explain: memory not found: ${trimmed}`);
+  }
+  const now = new Date();
+  const valueScore = computeTierValueScore(memory, now);
+  const policy: TierRoutingPolicy = {
+    enabled: config.lifecyclePolicyEnabled,
+    demotionMinAgeDays: 14,
+    demotionValueThreshold: config.lifecycleStaleDecayThreshold,
+    promotionValueThreshold: config.lifecyclePromoteHeatThreshold,
+  };
+  const currentTier = inferTier(memory);
+  const decision = decideTierTransition(memory, currentTier, policy, now);
+  const fm = memory.frontmatter as unknown as Record<string, unknown>;
+  return {
+    id: trimmed,
+    path: memory.path,
+    currentTier,
+    status: typeof fm.status === "string" ? (fm.status as string) : "active",
+    category: typeof fm.category === "string" ? (fm.category as string) : "",
+    valueScore,
+    decision,
+    signals: {
+      confidence:
+        typeof fm.confidence === "number" ? (fm.confidence as number) : 0,
+      accessCount:
+        typeof fm.accessCount === "number" ? (fm.accessCount as number) : 0,
+      lastAccessed:
+        typeof fm.lastAccessed === "string" ? (fm.lastAccessed as string) : null,
+      created: typeof fm.created === "string" ? (fm.created as string) : "",
+      updated: typeof fm.updated === "string" ? (fm.updated as string) : "",
+      importance:
+        typeof fm.importance === "number" ? (fm.importance as number) : null,
+      feedback:
+        typeof fm.verificationState === "string"
+          ? (fm.verificationState as string)
+          : null,
+    },
+  };
+}
+
+/**
+ * Render a TierSummary as plain text for `remnic tier list` text mode.
+ * Pure formatter — exposed so future surfaces (HTTP, MCP) can reuse.
+ */
+export function formatTierSummaryText(summary: TierSummary): string {
+  const lines: string[] = [];
+  lines.push("=== Memory Tier Distribution ===");
+  lines.push(`Total memories: ${summary.total}`);
+  lines.push("");
+  lines.push("Tier:");
+  lines.push(`  hot:  ${summary.byTier.hot}`);
+  lines.push(`  cold: ${summary.byTier.cold}`);
+  lines.push("");
+  lines.push("Status:");
+  const statusEntries = Object.entries(summary.byStatus).sort(
+    (a, b) => b[1] - a[1],
+  );
+  for (const [status, count] of statusEntries) {
+    lines.push(`  ${status}: ${count}`);
+  }
+  lines.push("");
+  lines.push("Top categories:");
+  const categoryEntries = Object.entries(summary.byCategory)
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 8);
+  for (const [cat, count] of categoryEntries) {
+    lines.push(`  ${cat}: ${count}`);
+  }
+  return lines.join("\n");
+}
+
+/**
+ * Render a TierExplainResult as plain text for `remnic tier explain`.
+ */
+export function formatTierExplainText(explain: TierExplainResult): string {
+  const lines: string[] = [];
+  lines.push(`=== Tier Explain: ${explain.id} ===`);
+  lines.push(`path:          ${explain.path}`);
+  lines.push(`current tier:  ${explain.currentTier}`);
+  lines.push(`status:        ${explain.status}`);
+  lines.push(`category:      ${explain.category}`);
+  lines.push(`value score:   ${explain.valueScore.toFixed(3)}`);
+  lines.push("");
+  lines.push("Tier-transition decision:");
+  lines.push(`  next tier: ${explain.decision.nextTier}`);
+  lines.push(`  changed:   ${explain.decision.changed}`);
+  lines.push(`  reason:    ${explain.decision.reason}`);
+  lines.push("");
+  lines.push("Signals:");
+  lines.push(`  confidence:   ${explain.signals.confidence}`);
+  lines.push(`  accessCount:  ${explain.signals.accessCount}`);
+  lines.push(`  lastAccessed: ${explain.signals.lastAccessed ?? "(never)"}`);
+  lines.push(`  created:      ${explain.signals.created}`);
+  lines.push(`  updated:      ${explain.signals.updated}`);
+  lines.push(`  importance:   ${explain.signals.importance ?? "(unset)"}`);
+  lines.push(`  feedback:     ${explain.signals.feedback ?? "(unset)"}`);
+  return lines.join("\n");
+}

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -59,25 +59,22 @@ export interface TierExplainResult {
   };
 }
 
-/**
- * Determine the on-disk tier of a memory by scanning its path for the
- * `cold/` segment that `tier-migration.ts` writes.  Mirrors the same
- * detection that `temporal-supersession.ts` uses around line 283.
- */
-function inferTier(memory: MemoryFile): MemoryTier {
-  return memory.path.includes("/cold/") || memory.path.includes("\\cold\\")
-    ? "cold"
-    : "hot";
+interface TierVisibleMemory {
+  memory: MemoryFile;
+  tier: MemoryTier;
 }
 
 async function readTierVisibleMemories(
   storage: StorageManager,
-): Promise<MemoryFile[]> {
+): Promise<TierVisibleMemory[]> {
   const [hotMemories, coldMemories] = await Promise.all([
     storage.readAllMemories(),
     storage.readAllColdMemories(),
   ]);
-  return [...hotMemories, ...coldMemories];
+  return [
+    ...hotMemories.map((memory) => ({ memory, tier: "hot" as const })),
+    ...coldMemories.map((memory) => ({ memory, tier: "cold" as const })),
+  ];
 }
 
 async function tierRoutingPolicyFromConfig(
@@ -108,8 +105,7 @@ export async function summarizeTiers(
     forgottenCount: 0,
     byCategory: {},
   };
-  for (const m of all) {
-    const tier = inferTier(m);
+  for (const { memory: m, tier } of all) {
     summary.byTier[tier] += 1;
     const status: string = m.frontmatter.status ?? "active";
     summary.byStatus[status] = (summary.byStatus[status] ?? 0) + 1;
@@ -132,14 +128,14 @@ export async function explainTierForMemory(
     throw new Error("tier explain: memory id is required and must be non-empty");
   }
   const all = await readTierVisibleMemories(storage);
-  const memory = all.find((m) => m.frontmatter.id === trimmed);
-  if (!memory) {
+  const entry = all.find(({ memory: m }) => m.frontmatter.id === trimmed);
+  if (!entry) {
     throw new Error(`tier explain: memory not found: ${trimmed}`);
   }
+  const { memory, tier: currentTier } = entry;
   const now = new Date();
   const valueScore = computeTierValueScore(memory, now);
   const policy = await tierRoutingPolicyFromConfig(config);
-  const currentTier = inferTier(memory);
   const decision = decideTierTransition(memory, currentTier, policy, now);
   const fm = memory.frontmatter as unknown as Record<string, unknown>;
   const importanceScore = memory.frontmatter.importance?.score;

--- a/packages/remnic-core/src/maintenance/tier-stats.ts
+++ b/packages/remnic-core/src/maintenance/tier-stats.ts
@@ -17,6 +17,7 @@
 
 import type { StorageManager } from "../storage.js";
 import type { MemoryFile, PluginConfig } from "../types.js";
+import { computeLifecycleValueInputs } from "../lifecycle.js";
 import {
   computeTierValueScore,
   decideTierTransition,
@@ -134,6 +135,7 @@ export async function explainTierForMemory(
   }
   const { memory, tier: currentTier } = entry;
   const now = new Date();
+  const valueInputs = computeLifecycleValueInputs(memory, now);
   const valueScore = computeTierValueScore(memory, now);
   const policy = await tierRoutingPolicyFromConfig(config);
   const decision = decideTierTransition(memory, currentTier, policy, now);
@@ -148,8 +150,7 @@ export async function explainTierForMemory(
     valueScore,
     decision,
     signals: {
-      confidence:
-        typeof fm.confidence === "number" ? (fm.confidence as number) : 0,
+      confidence: valueInputs.confidence,
       accessCount:
         typeof fm.accessCount === "number" ? (fm.accessCount as number) : 0,
       lastAccessed:


### PR DESCRIPTION
Implements PR 5/6 of #686. Operator-facing read-only visibility into tier-distribution state and per-memory tier-transition decisions.

- `remnic tier list` — total / hot / cold / per-status / per-category breakdown.
- `remnic tier explain <id>` — value score, transition decision, underlying signals.
- Pure helpers `summarizeTiers` + `explainTierForMemory` + formatters in maintenance/tier-stats.ts.
- 6 unit tests cover summary aggregation and both formatters.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds read-only CLI commands and helper functions/tests without changing migration or persistence behavior; primary risk is minor output/format or performance impact when scanning all memories.
> 
> **Overview**
> Adds operator-facing, **read-only tier visibility** via a new `remnic tier` command.
> 
> `tier list` scans hot + cold memories and outputs a summary (total, hot/cold counts, per-status counts, top categories) in text or `--json` mode. `tier explain <id>` reports a single memory’s current tier, computed value score, tier-transition decision (using current routing policy plus utility runtime adjustments), and the underlying scoring signals.
> 
> Includes a new `maintenance/tier-stats.ts` helper module with text formatters and comprehensive unit tests for aggregation, formatting, and explain behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e40b3005b2cbf9e982f49fc1eaa09471f847b0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->