### PR TITLE
docs(685): Trace → Observation → Primitive pipeline naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ THEORY.MD
 logs/
 *.tgz
 irc-debug.ts
+.subagents/

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 **Persistent, private memory for AI agents.** Your agents forget everything between sessions — Remnic fixes that.
 
+**The trace is noise. The primitive is the product.** Remnic's job is the pipeline that distills hours of agent conversation into compressed, searchable, durable memory primitives. ([How it works →](docs/trace-to-primitive.md))
+
 Remnic gives AI agents long-term memory that survives across conversations. Decisions, preferences, project context, personal details, past mistakes — everything your agent learns persists and resurfaces exactly when it's needed. All data stays on your machine as plain markdown files. No cloud services, no subscriptions, no sharing your data with third parties.
 
 [![npm version](https://img.shields.io/npm/v/@remnic/cli)](https://www.npmjs.com/package/@remnic/cli)

--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@
 ## Architecture
 
 - [Overview](architecture/overview.md) — System design, components, storage layout
+- [Trace → Observation → Primitive](trace-to-primitive.md) — How Remnic compresses noisy session traces into durable memory primitives (issue #685)
 - [Retrieval Pipeline](architecture/retrieval-pipeline.md) — How recall works end-to-end
 - [Memory Lifecycle](architecture/memory-lifecycle.md) — Write, consolidation, expiry
 - [Graph Reasoning](architecture/graph-reasoning.md) — Opt-in graph traversal, assist, and explainability

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -46,13 +46,13 @@ The trace is the noise. We are not going to keep it.
 
 ### Extraction — distill the trace into observation candidates
 
-When the buffer flushes (smart-flush signals: topic shift, time elapsed, explicit `before_reset`), `extraction.ts` calls the extractor (GPT-5.2 via the OpenAI Responses API). The extractor reads the trace and emits zero or more `ExtractedFact` records, each with a category (decision, preference, fact, principle, …), content, confidence, tags, and an importance score.
+When the buffer flushes (smart-flush signals: topic shift, time elapsed, explicit `before_reset`), `extraction.ts` calls the extractor (GPT-5.2 via the OpenAI Responses API). The extractor reads the trace and emits zero or more `ExtractedFact` records, each with a category (decision, preference, fact, principle, …), content, confidence, and tags. A separate pass (`importance.ts` / `calibration.ts`) then assigns an importance score in `[0, 1]` — importance is computed *after* extraction, not part of the `ExtractedFact` payload itself.
 
-For our session, the extractor might emit:
+For our session, the pipeline might emit (extractor output → after importance scoring):
 
-1. `{ category: "decision", content: "Cut releases every Tuesday", confidence: 0.95, importance: 0.85 }`
-2. `{ category: "fact", content: "Postgres replica lag alarm fires when GC pauses cross 200ms", confidence: 0.9, importance: 0.78 }`
-3. `{ category: "principle", content: "Caching layer should be per-tenant, not global", confidence: 0.85, importance: 0.7 }`
+1. `{ category: "decision", content: "Cut releases every Tuesday", confidence: 0.95 }` → `importance: 0.85`
+2. `{ category: "fact", content: "Postgres replica lag alarm fires when GC pauses cross 200ms", confidence: 0.9 }` → `importance: 0.78`
+3. `{ category: "principle", content: "Caching layer should be per-tenant, not global", confidence: 0.85 }` → `importance: 0.7`
 
 The extraction judge (`extraction-judge.ts`) then post-filters: it asks an LLM whether each candidate is genuinely durable or just transient task chatter. The flaky-test debugging turns produce no observations — they were noise.
 

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -1,0 +1,152 @@
+# Trace → Observation → Primitive
+
+> Issue: [#685 — Name and document the observation pipeline](https://github.com/joshuaswarren/remnic/issues/685).
+>
+> This page is the canonical walkthrough of how Remnic compresses
+> noisy session traces into durable memory primitives. If you only
+> read one piece of Remnic architecture, read this one.
+
+## The one-liner
+
+**The trace is noise. The primitive is the product.**
+
+Remnic's job is the pipeline that converts the former into the latter.
+
+## The three stages
+
+```
+┌────────────┐    extract     ┌──────────────┐  consolidate  ┌────────────┐
+│   Trace    │  ─────────────▶│ Observation  │ ─────────────▶│  Primitive │
+└────────────┘   importance   └──────────────┘    dedup       └────────────┘
+   raw turns       judge          candidate       compound       durable
+                                                                  memory
+```
+
+| Stage | What it is | Where it lives | Lifetime |
+|-------|------------|----------------|----------|
+| **Trace** | Raw conversation turns — every user message, every assistant reply, every tool call. Verbose, noisy, redundant. | `packages/remnic-core/src/buffer.ts` | Until session flush, then discarded. |
+| **Observation** | Post-extraction, importance-scored fact candidate. The trace has been distilled but not yet committed to the corpus. | Emitted by `extraction.ts` / `extraction-judge.ts`; modeled by the public `MemoryObservation` type in `@remnic/core`. | In-flight only; not persisted unless promoted. |
+| **Primitive** | Durable `MemoryFile` on disk: YAML frontmatter + markdown body. Searchable, citable, reinforceable. | `packages/remnic-core/src/storage.ts` writes them under `<memoryDir>/{facts,procedures,reasoning-traces,corrections}/`. | Persistent; subject to lifecycle (consolidation, supersession, retention). |
+
+## Walkthrough: a 4-hour coding session
+
+Concrete example. Anonymized but representative.
+
+### Trace stage — buffer captures raw turns
+
+The user opens a coding session. Over four hours they:
+- Discuss the design of a new caching layer (~40 turns).
+- Debug a flaky integration test (~25 turns, lots of stack traces).
+- Decide on a deployment cadence ("we'll cut releases every Tuesday").
+- Mention in passing that the Postgres replica lag alarm fires when GC pauses cross 200ms.
+
+The buffer (`buffer.ts`) holds all of this — every turn, every tool call, every error. **Roughly 80,000 tokens of raw trace.**
+
+The trace is the noise. We are not going to keep it.
+
+### Extraction — distill the trace into observation candidates
+
+When the buffer flushes (smart-flush signals: topic shift, time elapsed, explicit `before_reset`), `extraction.ts` calls the extractor (GPT-5.2 via the OpenAI Responses API). The extractor reads the trace and emits zero or more `ExtractedFact` records, each with a category (decision, preference, fact, principle, …), content, confidence, tags, and an importance score.
+
+For our session, the extractor might emit:
+
+1. `{ category: "decision", content: "Cut releases every Tuesday", confidence: 0.95, importance: 0.85 }`
+2. `{ category: "fact", content: "Postgres replica lag alarm fires when GC pauses cross 200ms", confidence: 0.9, importance: 0.78 }`
+3. `{ category: "principle", content: "Caching layer should be per-tenant, not global", confidence: 0.85, importance: 0.7 }`
+
+The extraction judge (`extraction-judge.ts`) then post-filters: it asks an LLM whether each candidate is genuinely durable or just transient task chatter. The flaky-test debugging turns produce no observations — they were noise.
+
+Each surviving candidate becomes a `MemoryObservation` (the public type in `@remnic/core`):
+
+```ts
+import type { MemoryObservation } from "@remnic/core";
+
+const observation: MemoryObservation = {
+  id: "obs_018f9a...",
+  sessionId: "sess_2026-04-25_coding",
+  observedAt: "2026-04-25T18:32:11Z",
+  fact: {
+    category: "decision",
+    content: "Cut releases every Tuesday",
+    confidence: 0.95,
+    tags: ["release-cadence", "ops"],
+  },
+  importance: 0.85,
+  judgeAccepted: true,
+};
+```
+
+**At this point: ~80,000 tokens of trace have become 3 observations totaling ~80 tokens.** The compression ratio is the product.
+
+### Consolidation — observations become primitives
+
+Observations are not yet persistent. Before they hit disk, consolidation runs (`semantic-consolidation.ts`, `dedup/`):
+
+- Does the corpus already contain a near-duplicate? → MERGE (`resultingPrimitiveId` points at the merged record).
+- Does the corpus contain a contradicting earlier fact? → SUPERSEDE (the older fact gets `invalid_at` flipped via `temporal-supersession.ts`; the new one is added).
+- Genuinely new? → ADD.
+
+Each accepted observation is written by `storage.ts` as a `MemoryFile` with full YAML frontmatter:
+
+```yaml
+---
+id: mem_018f9a...
+category: decision
+created: 2026-04-25T18:32:11Z
+confidence: 0.95
+confidenceTier: high
+tags: ["release-cadence", "ops"]
+importance: 0.85
+status: active
+---
+
+Cut releases every Tuesday.
+```
+
+That `MemoryFile` is the **primitive**. Three primitives now exist where four hours of conversation used to be.
+
+### Reinforcement — primitives compound over time
+
+`compounding/engine.ts` runs weekly, surfacing primitives that recurred or were referenced and bumping their access counters / heat scores. Stale, never-recalled primitives drift toward the cold tier under the lifecycle policy (issue #686). The retention substrate decides when a primitive is durable enough to keep, when it's cold enough to demote, and — via `remnic forget` — when an operator wants it gone entirely.
+
+## Why this framing matters
+
+Most "AI memory" tools store the trace and call that memory. That's a recording, not memory. Memory is what survives the trace.
+
+Remnic's pipeline produces primitives that are:
+- **Compressed** — observations distill traces by ~1000x.
+- **Searchable** — primitives are first-class records, not buried inside transcripts.
+- **Citable** — every recall response includes `<oai-mem-citation>` blocks pointing back to the source primitive.
+- **Reinforceable** — compounding raises the value of primitives that keep mattering.
+- **Forgettable** — `remnic forget <id>` is the explicit escape hatch.
+
+The trace is noise. The primitive is the product.
+
+## Where this shows up in the API
+
+| Surface | What you'll see |
+|---------|-----------------|
+| `@remnic/core` types | The `MemoryObservation` interface ships in the public types so callers can read post-extraction state without reaching into `extraction.ts`. |
+| `remnic doctor` | Reports observation throughput (observations/hour), judge acceptance rate, and the most recent `observedAt`. |
+| `recall` responses | `<oai-mem-citation>` blocks point at the primitive ids that came out the other end of the pipeline. |
+| `remnic tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
+| `observation-ledger` | A separate concept: this records *lifecycle events* on primitives (supersessions, archive, forget). It is **not** the observation stage of this pipeline — see the naming note below. |
+
+## Naming note: observation vs observation-ledger
+
+`@remnic/core` has two things that share a root word:
+
+| Term | Meaning |
+|------|---------|
+| `MemoryObservation` (this doc, public type) | The post-extraction, pre-storage candidate. The "observation" stage of Trace → Observation → Primitive. |
+| `observation-ledger` (`maintenance/observation-ledger-utils.ts`) | A JSONL log of *lifecycle events* on primitives — status flips, supersessions, archival, forgetting. Nothing to do with extraction. |
+
+The ledger logs what happens to primitives **after** they exist; an observation describes the candidate that **became** a primitive in the first place. We considered renaming the ledger to disambiguate but kept it for backward compatibility — operator tooling and crons reference the existing path. New code should reach for `MemoryObservation` when describing the extraction pipeline and `observation-ledger` only when describing the lifecycle event log.
+
+## References
+
+- agentmemory's `mem::observe` / `mem::compress` framing — the clearest public articulation of "trace is garbage; primitive is the product": <https://github.com/rohitg00/agentmemory>
+- Karpathy's LLM Wiki concept (cited as design lineage by agentmemory).
+- Pipeline modules: `buffer.ts`, `extraction.ts`, `extraction-judge.ts`, `importance.ts`, `calibration.ts`, `semantic-consolidation.ts`, `storage.ts`, `compounding/engine.ts`.
+- Observation-ledger lifecycle events: `packages/remnic-core/src/maintenance/observation-ledger-utils.ts`.
+- Retention substrate ([#686](https://github.com/joshuaswarren/remnic/issues/686)) — what happens to primitives over their year-2 lifetime.

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -78,13 +78,14 @@ const observation: MemoryObservation = {
 
 **At this point: ~80,000 tokens of trace have become 3 observations totaling ~80 tokens.** The compression ratio is the product.
 
-### Consolidation — observations become primitives
+### Persist + consolidate — observations become primitives
 
-Observations are not yet persistent. Before they hit disk, consolidation runs (`semantic-consolidation.ts`, `dedup/`):
+The write path runs in two stages, not the "consolidate before persist" order an earlier draft implied:
 
-- Does the corpus already contain a near-duplicate? → MERGE (`resultingPrimitiveId` points at the merged record).
-- Does the corpus contain a contradicting earlier fact? → SUPERSEDE (the older fact gets `invalid_at` flipped via `temporal-supersession.ts`; the new one is added).
-- Genuinely new? → ADD.
+1. **Persist immediately.** `runExtraction()` calls `persistExtraction(...)` so each accepted observation lands on disk as soon as the extraction judge approves it. Hash-dedup and supersession (`temporal-supersession.ts`) gate the write at this stage; superseded predecessors get `invalid_at` stamped without losing the file.
+2. **Consolidate asynchronously.** `maybeScheduleConsolidation(...)` then schedules a separate consolidation pass (`semantic-consolidation.ts`, `dedup/`) that merges near-duplicates of recently persisted primitives, updates or invalidates older primitives that turn out to be redundant, and leaves genuinely new primitives unchanged. `resultingPrimitiveId` on the original `MemoryObservation` ends up pointing at the merged record after that pass.
+
+A primitive *exists* before consolidation runs — consolidation refines an already-durable corpus rather than gating the write itself.
 
 Each accepted observation is written by `storage.ts` as a `MemoryFile`. Illustrative subset of the keys `serializeFrontmatter` actually emits (the live serializer is the source of truth):
 

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -86,22 +86,27 @@ Observations are not yet persistent. Before they hit disk, consolidation runs (`
 - Does the corpus contain a contradicting earlier fact? → SUPERSEDE (the older fact gets `invalid_at` flipped via `temporal-supersession.ts`; the new one is added).
 - Genuinely new? → ADD.
 
-Each accepted observation is written by `storage.ts` as a `MemoryFile` with full YAML frontmatter:
+Each accepted observation is written by `storage.ts` as a `MemoryFile`. Illustrative subset of the keys `serializeFrontmatter` actually emits (the live serializer is the source of truth):
 
 ```yaml
 ---
 id: mem_018f9a...
 category: decision
 created: 2026-04-25T18:32:11Z
+updated: 2026-04-25T18:32:11Z
+source: extraction
 confidence: 0.95
 confidenceTier: high
 tags: ["release-cadence", "ops"]
-importance: 0.85
+importanceScore: 0.85
+importanceLevel: high
 status: active
 ---
 
 Cut releases every Tuesday.
 ```
+
+Importance is split into `importanceScore` (numeric in `[0, 1]`) and `importanceLevel` (categorical: `trivial` / `low` / `normal` / `high` / `critical`) on disk, and `updated` / `source` are always present alongside `id`, `category`, and `created`. See `serializeFrontmatter` in `packages/remnic-core/src/storage.ts` for the full key set.
 
 That `MemoryFile` is the **primitive**. Three primitives now exist where four hours of conversation used to be.
 
@@ -130,7 +135,7 @@ The trace is noise. The primitive is the product.
 | `remnic doctor` | *(future)* Will report observation throughput, judge acceptance rate, and the most recent `observedAt`. Today these signals live in the separate observation-ledger / judge stats paths; surfacing them in `doctor` is tracked as a follow-up. |
 | `recall` responses | `<oai-mem-citation>` blocks point at the primitive ids that came out the other end of the pipeline. |
 | `remnic tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
-| `observation-ledger` | A separate concept: this records *lifecycle events* on primitives (supersessions, archive, forget). It is **not** the observation stage of this pipeline — see the naming note below. |
+| `observation-ledger` | A separate concept: a JSONL telemetry directory (`state/observation-ledger/`) capturing turn-count aggregates (`maintenance/rebuild-observations.ts`) and judge verdict events (`extraction-judge-telemetry.ts`). Operator-observability data, distinct from the lifecycle-event ledger and from the `MemoryObservation` type — see the naming note below. |
 
 ## Naming note: observation vs observation-ledger
 
@@ -139,9 +144,9 @@ The trace is noise. The primitive is the product.
 | Term | Meaning |
 |------|---------|
 | `MemoryObservation` (this doc, public type) | The post-extraction, pre-storage candidate. The "observation" stage of Trace → Observation → Primitive. |
-| `observation-ledger` (`maintenance/observation-ledger-utils.ts`) | A JSONL log of *lifecycle events* on primitives — status flips, supersessions, archival, forgetting. Nothing to do with extraction. |
+| `observation-ledger` (`state/observation-ledger/` directory) | Telemetry storage for the extraction pipeline itself: turn-count aggregates rebuilt by `maintenance/rebuild-observations.ts` (`rebuilt-observations.jsonl`) and judge verdict events appended by `extraction-judge-telemetry.ts`. Operator-observability data, not lifecycle transitions. Lifecycle events on primitives (supersession, archive, forget) live in `state/memory-lifecycle-ledger/`. |
 
-The ledger logs what happens to primitives **after** they exist; an observation describes the candidate that **became** a primitive in the first place. We considered renaming the ledger to disambiguate but kept it for backward compatibility — operator tooling and crons reference the existing path. New code should reach for `MemoryObservation` when describing the extraction pipeline and `observation-ledger` only when describing the lifecycle event log.
+`MemoryObservation` is the in-flight candidate type; `observation-ledger` is the on-disk telemetry directory describing how that pipeline performed. They share a word but describe different layers — the type is what the pipeline produces, the ledger directory is how it reports on itself. We considered renaming the directory to disambiguate but kept it for backward compatibility (operator tooling and crons reference the existing path). New code should reach for `MemoryObservation` when describing the extraction pipeline and `observation-ledger` only when referring to that telemetry storage.
 
 ## References
 

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -127,7 +127,7 @@ The trace is noise. The primitive is the product.
 | Surface | What you'll see |
 |---------|-----------------|
 | `@remnic/core` types | The `MemoryObservation` interface ships in the public types so callers can read post-extraction state without reaching into `extraction.ts`. |
-| `remnic doctor` | Reports observation throughput (observations/hour), judge acceptance rate, and the most recent `observedAt`. |
+| `remnic doctor` | *(future)* Will report observation throughput, judge acceptance rate, and the most recent `observedAt`. Today these signals live in the separate observation-ledger / judge stats paths; surfacing them in `doctor` is tracked as a follow-up. |
 | `recall` responses | `<oai-mem-citation>` blocks point at the primitive ids that came out the other end of the pipeline. |
 | `remnic tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
 | `observation-ledger` | A separate concept: this records *lifecycle events* on primitives (supersessions, archive, forget). It is **not** the observation stage of this pipeline — see the naming note below. |

--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -144,7 +144,7 @@ The trace is noise. The primitive is the product.
 | Term | Meaning |
 |------|---------|
 | `MemoryObservation` (this doc, public type) | The post-extraction, pre-storage candidate. The "observation" stage of Trace → Observation → Primitive. |
-| `observation-ledger` (`state/observation-ledger/` directory) | Telemetry storage for the extraction pipeline itself: turn-count aggregates rebuilt by `maintenance/rebuild-observations.ts` (`rebuilt-observations.jsonl`) and judge verdict events appended by `extraction-judge-telemetry.ts`. Operator-observability data, not lifecycle transitions. Lifecycle events on primitives (supersession, archive, forget) live in `state/memory-lifecycle-ledger/`. |
+| `observation-ledger` (`state/observation-ledger/` directory) | Telemetry storage for the extraction pipeline itself: turn-count aggregates rebuilt by `maintenance/rebuild-observations.ts` (`rebuilt-observations.jsonl`) and judge verdict events appended by `extraction-judge-telemetry.ts`. Operator-observability data, not lifecycle transitions. Lifecycle events on primitives (supersession, archive, forget) live in `state/memory-lifecycle-ledger.jsonl`. |
 
 `MemoryObservation` is the in-flight candidate type; `observation-ledger` is the on-disk telemetry directory describing how that pipeline performed. They share a word but describe different layers — the type is what the pipeline produces, the ledger directory is how it reports on itself. We considered renaming the directory to disambiguate but kept it for backward compatibility (operator tooling and crons reference the existing path). New code should reach for `MemoryObservation` when describing the extraction pipeline and `observation-ledger` only when referring to that telemetry storage.
 

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -879,6 +879,7 @@ export type {
   PluginConfig,
   GatewayConfig,
   MemoryFile,
+  MemoryObservation,
   MemoryCategory,
   MemoryScope,
   MemoryActionType,

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -880,6 +880,7 @@ export type {
   GatewayConfig,
   MemoryFile,
   MemoryObservation,
+  ExtractedFact,
   MemoryCategory,
   MemoryScope,
   MemoryActionType,

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1878,11 +1878,15 @@ export interface MemoryFile {
  * internals.
  *
  * Naming note: this is intentionally NOT the same as the existing
- * `observation-ledger` (`maintenance/observation-ledger-utils.ts`),
- * which records *lifecycle events* on memory files (status flips,
- * supersessions). The ledger logs primitive transitions; a
- * `MemoryObservation` describes the candidate that became (or didn't
- * become) a primitive in the first place. See
+ * `state/observation-ledger/` directory, which is telemetry storage
+ * for the extraction pipeline (turn-count aggregates rebuilt by
+ * `maintenance/rebuild-observations.ts` and judge verdict events
+ * appended by `extraction-judge-telemetry.ts`). Lifecycle events on
+ * primitives — status flips, supersessions, archival, forget — live
+ * in `state/memory-lifecycle-ledger.jsonl`, written by
+ * `StorageManager`. A `MemoryObservation` describes the in-flight
+ * candidate that became (or didn't become) a primitive; the ledger
+ * directory is how the pipeline reports on itself. See
  * `docs/trace-to-primitive.md` for the full pipeline walkthrough.
  */
 export interface MemoryObservation {

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1859,6 +1859,59 @@ export interface MemoryFile {
   content: string;
 }
 
+/**
+ * Public type representing the **Observation** stage in the
+ * Trace → Observation → Primitive pipeline (issue #685).
+ *
+ * - **Trace**: raw conversation turns captured in `buffer.ts`. Noisy,
+ *   verbose, ephemeral.
+ * - **Observation** (this type): post-extraction, importance-scored
+ *   fact candidate emitted by `extraction.ts` / `extraction-judge.ts`.
+ *   Already distilled — but not yet consolidated against the corpus.
+ * - **Primitive**: the durable `MemoryFile` written by `storage.ts`,
+ *   reinforced over time by `compounding/engine.ts`.
+ *
+ * `MemoryObservation` is the named handle on the intermediate stage
+ * the codebase has always produced but never publicly typed. It lets
+ * callers (telemetry, doctor surfaces, tests, downstream tooling)
+ * inspect the post-extraction shape without reaching into extraction
+ * internals.
+ *
+ * Naming note: this is intentionally NOT the same as the existing
+ * `observation-ledger` (`maintenance/observation-ledger-utils.ts`),
+ * which records *lifecycle events* on memory files (status flips,
+ * supersessions). The ledger logs primitive transitions; a
+ * `MemoryObservation` describes the candidate that became (or didn't
+ * become) a primitive in the first place. See
+ * `docs/trace-to-primitive.md` for the full pipeline walkthrough.
+ */
+export interface MemoryObservation {
+  /** Stable id for this observation, distinct from any primitive id. */
+  id: string;
+  /** Source session id the trace came from. */
+  sessionId?: string;
+  /** ISO timestamp the observation was emitted. */
+  observedAt: string;
+  /** The extracted fact candidate (category, content, confidence, tags, etc.). */
+  fact: ExtractedFact;
+  /** Importance score in [0,1], from `importance.ts`. */
+  importance?: number;
+  /**
+   * Whether the observation passed the extraction judge
+   * (`extraction-judge.ts`). When `false`, the observation was
+   * captured for telemetry but not persisted as a primitive.
+   */
+  judgeAccepted?: boolean;
+  /** Optional reason the judge gave when rejecting. */
+  judgeRejectionReason?: string;
+  /**
+   * Id of the resulting `MemoryFile` primitive once consolidation runs.
+   * Absent until consolidation decides to ADD/MERGE/UPDATE the
+   * observation into the corpus.
+   */
+  resultingPrimitiveId?: string;
+}
+
 /** Ordered step for extracted procedure memories (issue #519). */
 export interface ExtractedProcedureStep {
   order: number;


### PR DESCRIPTION
## Summary

Closes #685 with a single bundled PR (issue suggested 3, this lands the highest-leverage subset tonight). Pure documentation + naming, no behavior changes.

- Adds the public **`MemoryObservation`** type to `@remnic/core` representing the post-extraction, importance-scored, pre-consolidation candidate emitted by `extraction.ts` / `extraction-judge.ts`. Names the stage the codebase has always produced but never exposed.
- Adds **`docs/trace-to-primitive.md`** as the canonical walkthrough: how ~80k tokens of trace become ~80 tokens of observation become durable primitives. Includes the stage table, a concrete 4-hour-coding-session worked example, and explicit naming guidance vs the existing `observation-ledger`.
- Updates the README hero with the canonical one-liner: **"The trace is noise. The primitive is the product."** linked to the new doc.
- Indexes the new page under Architecture in `docs/README.md`.
- Adds `.subagents/` to `.gitignore` (local orchestrator artifacts that should never be committed).

### Naming resolution

The issue flagged a possible collision with the existing `observation-ledger`. Decision: keep both, distinguish in docs. The new public type is `MemoryObservation` (the extraction-pipeline candidate); `observation-ledger` stays as the lifecycle-event log on persisted primitives. The doc's "Naming note" section makes the distinction explicit so contributors don't conflate them.

### Deferred to follow-ups (not blocking #685 close)

- `remnic doctor` / `/status` surface for observation throughput. (Lower-leverage; the type is what unblocks downstream tooling.)

## Test plan

- [x] `npx tsc --noEmit` clean across `@remnic/core`.
- [x] `MemoryObservation` exported from `@remnic/core` index.
- [x] All existing tests still pass (no behavior change).
- [x] Doc cross-references verified against current module paths.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: primarily documentation plus additive type exports in `@remnic/core`, with no changes to runtime logic or persistence behavior.
> 
> **Overview**
> Adds a new architecture doc, `docs/trace-to-primitive.md`, that formalizes the **Trace → Observation → Primitive** framing and clarifies terminology vs the existing `observation-ledger`.
> 
> Updates the main `README.md` and `docs/README.md` to surface and link this pipeline writeup.
> 
> Exposes a new public `MemoryObservation` type (and re-exports `ExtractedFact`) from `@remnic/core` to give downstream tooling a named, supported shape for post-extraction / pre-consolidation observations, and adds `.subagents/` to `.gitignore`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a51cb285e9761ee6781c3e8f832bf4c4272e33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->