### PR TITLE
fix(bench): land missed PR 675 scoring hardening

### DIFF
--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -427,20 +427,43 @@ function removeFirstChoiceAnswerText(
   choiceText: string,
   choiceAnswer: string,
 ): string {
-  const trimmedChoiceAnswer = choiceAnswer.trim();
-  if (trimmedChoiceAnswer.length === 0) {
+  const choiceTextTokens = choiceMatchTokenSpans(choiceText);
+  const choiceAnswerTokens = choiceMatchTokenSpans(choiceAnswer);
+  if (
+    choiceTextTokens.length === 0
+    || choiceAnswerTokens.length === 0
+    || choiceAnswerTokens.length > choiceTextTokens.length
+  ) {
     return choiceText;
   }
-  const matchIndex = choiceText
-    .toLowerCase()
-    .indexOf(trimmedChoiceAnswer.toLowerCase());
-  if (matchIndex === -1) {
-    return choiceText;
+
+  for (let index = 0; index <= choiceTextTokens.length - choiceAnswerTokens.length; index += 1) {
+    const matches = choiceAnswerTokens.every(
+      (token, offset) => choiceTextTokens[index + offset]!.token === token.token,
+    );
+    if (!matches) {
+      continue;
+    }
+
+    const start = choiceTextTokens[index]!.start;
+    const end = choiceTextTokens[index + choiceAnswerTokens.length - 1]!.end;
+    return [
+      choiceText.slice(0, start),
+      choiceText.slice(end),
+    ].join(" ");
   }
-  return [
-    choiceText.slice(0, matchIndex),
-    choiceText.slice(matchIndex + trimmedChoiceAnswer.length),
-  ].join(" ");
+
+  return choiceText;
+}
+
+function choiceMatchTokenSpans(
+  value: string,
+): Array<{ token: string; start: number; end: number }> {
+  return [...value.matchAll(/\w+/g)].map((match) => ({
+    token: match[0].toLowerCase(),
+    start: match.index ?? 0,
+    end: (match.index ?? 0) + match[0].length,
+  }));
 }
 
 function containsNormalizedPhrase(haystack: string, needle: string): boolean {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -286,6 +286,14 @@ function parseAMemGymChoice(
       return undefined;
     }
     if (
+      mentionsConflictingOptionNumber(
+        plainTextOption.choiceText,
+        plainTextOption.selectedNumber,
+      )
+    ) {
+      return undefined;
+    }
+    if (
       plainOptionTextMatchesChoice(plainTextOption.choiceText, choice.answer)
     ) {
       return { index, choice };

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -465,11 +465,6 @@ function mentionsConflictingOptionNumber(
       return true;
     }
   }
-  for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
-      return true;
-    }
-  }
   for (const match of trimmed.matchAll(
     /\b(\d+)\s+(?:(?:might|may|could|would|should)\s+be\s+|is\s+(?:also\s+)?|also\s+)?(?:right|correct|valid|the\s+(?:answer|option|choice))\b/gi,
   )) {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -269,7 +269,8 @@ function parseAMemGymChoice(
   qa: AMemGymQA,
 ): { index: number; choice: AMemGymQA["answer_choices"][number] } | undefined {
   const trimmed = rawAnswer.trim();
-  const selectedNumber = parseAMemGymOptionNumber(trimmed);
+  const optionCount = qa.answer_choices.length;
+  const selectedNumber = parseAMemGymOptionNumber(trimmed, optionCount);
   if (selectedNumber !== undefined) {
     const index = selectedNumber - 1;
     const choice = qa.answer_choices[index];
@@ -315,6 +316,7 @@ function parseAMemGymChoice(
     const hasConflictingOptionNumber = mentionsConflictingOptionNumber(
       removeFirstChoiceAnswerText(plainTextOption.choiceText, choice.answer),
       plainTextOption.selectedNumber,
+      optionCount,
     );
     if (
       !hasConflictingOptionNumber
@@ -511,13 +513,16 @@ function leadingNumericToken(value: string): string | undefined {
   return value.match(/^(\d+)\b/)?.[1];
 }
 
-function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
+function parseAMemGymOptionNumber(
+  trimmedAnswer: string,
+  optionCount: number,
+): number | undefined {
   const bareNumber = trimmedAnswer.match(
     /^\(?#?\s*(\d+)\s*(?:\)(?!\s+\S))?(?<tail>\s*(?:\)\s+\S.*|\([^)]*\).*|because.*|[,.;:\-](?!\s*#?\d).*)?)$/i,
   );
   if (bareNumber) {
     const selectedNumber = Number.parseInt(bareNumber[1]!, 10);
-    if (mentionsConflictingOptionNumber(bareNumber.groups?.tail ?? "", selectedNumber)) {
+    if (mentionsConflictingOptionNumber(bareNumber.groups?.tail ?? "", selectedNumber, optionCount)) {
       return undefined;
     }
     return selectedNumber;
@@ -528,7 +533,7 @@ function parseAMemGymOptionNumber(trimmedAnswer: string): number | undefined {
   );
   if (labeledNumber) {
     const selectedNumber = Number.parseInt(labeledNumber[1]!, 10);
-    if (mentionsConflictingOptionNumber(labeledNumber.groups?.tail ?? "", selectedNumber)) {
+    if (mentionsConflictingOptionNumber(labeledNumber.groups?.tail ?? "", selectedNumber, optionCount)) {
       return undefined;
     }
     return selectedNumber;
@@ -546,29 +551,30 @@ function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
 function mentionsConflictingOptionNumber(
   value: string,
   selectedNumber: number,
+  optionCount: number,
 ): boolean {
   const trimmed = value.trim();
   for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+    if (isConflictingOptionRef(match[1]!, selectedNumber, optionCount)) {
       return true;
     }
   }
   for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+    if (isConflictingOptionRef(match[1]!, selectedNumber, optionCount)) {
       return true;
     }
   }
   for (const match of trimmed.matchAll(
     /\b(\d+)\s+(?:(?:might|may|could|would|should)\s+be\s+|is\s+(?:also\s+)?|also\s+)?(?:right|correct|valid|the\s+(?:answer|option|choice))\b/gi,
   )) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+    if (isConflictingOptionRef(match[1]!, selectedNumber, optionCount)) {
       return true;
     }
   }
   for (const match of trimmed.matchAll(
     /\b(?:or|maybe|possibly|probably|perhaps|alternatively)\s+#?\s*(\d+)\b/gi,
   )) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+    if (isConflictingOptionRef(match[1]!, selectedNumber, optionCount)) {
       return true;
     }
   }
@@ -578,7 +584,18 @@ function mentionsConflictingOptionNumber(
   );
   const ambiguousNumber = punctuationNumber?.[1] ?? punctuationNumber?.[2];
   return ambiguousNumber !== undefined
-    && Number.parseInt(ambiguousNumber, 10) !== selectedNumber;
+    && isConflictingOptionRef(ambiguousNumber, selectedNumber, optionCount);
+}
+
+function isConflictingOptionRef(
+  rawNumber: string,
+  selectedNumber: number,
+  optionCount: number,
+): boolean {
+  const optionNumber = Number.parseInt(rawNumber, 10);
+  return optionNumber >= 1
+    && optionNumber <= optionCount
+    && optionNumber !== selectedNumber;
 }
 
 function normalizeForChoiceMatch(value: string): string {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -293,17 +293,12 @@ function parseAMemGymChoice(
         plainTextOption.choiceText,
         choice.answer,
       )
-      || plainOptionTextSafelyExtendsChoice(
-        plainTextOption.choiceText,
-        choice.answer,
-      )
     ) {
       return { index, choice };
     }
     const hasConflictingOptionNumber = mentionsConflictingOptionNumber(
-      plainTextOption.choiceText,
+      removeFirstChoiceAnswerText(plainTextOption.choiceText, choice.answer),
       plainTextOption.selectedNumber,
-      { allowBareHashOption: false },
     );
     if (
       !hasConflictingOptionNumber
@@ -428,30 +423,24 @@ function plainOptionTextExactlyMatchesChoice(
     && normalizedChoiceText === normalizedChoiceAnswer;
 }
 
-function plainOptionTextSafelyExtendsChoice(
+function removeFirstChoiceAnswerText(
   choiceText: string,
   choiceAnswer: string,
-): boolean {
-  const normalizedChoiceAnswer = normalizeForChoiceMatch(choiceAnswer);
-  return choiceHasNumericAlternative(normalizedChoiceAnswer)
-    && startsWithNormalizedPhrase(
-      normalizeForChoiceMatch(choiceText),
-      normalizedChoiceAnswer,
-    );
-}
-
-function choiceHasNumericAlternative(normalizedChoiceAnswer: string): boolean {
-  return /\b\d+\s+(?:or|to)\s+\d+\b/.test(normalizedChoiceAnswer)
-    || /\bor\s+\d+\b/.test(normalizedChoiceAnswer);
-}
-
-function startsWithNormalizedPhrase(haystack: string, needle: string): boolean {
-  const haystackTokens = haystack.split(" ").filter((token) => token.length > 0);
-  const needleTokens = needle.split(" ").filter((token) => token.length > 0);
-  if (needleTokens.length === 0 || needleTokens.length > haystackTokens.length) {
-    return false;
+): string {
+  const trimmedChoiceAnswer = choiceAnswer.trim();
+  if (trimmedChoiceAnswer.length === 0) {
+    return choiceText;
   }
-  return needleTokens.every((token, index) => haystackTokens[index] === token);
+  const matchIndex = choiceText
+    .toLowerCase()
+    .indexOf(trimmedChoiceAnswer.toLowerCase());
+  if (matchIndex === -1) {
+    return choiceText;
+  }
+  return [
+    choiceText.slice(0, matchIndex),
+    choiceText.slice(matchIndex + trimmedChoiceAnswer.length),
+  ].join(" ");
 }
 
 function containsNormalizedPhrase(haystack: string, needle: string): boolean {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -288,6 +288,14 @@ function parseAMemGymChoice(
     if (!choice) {
       return undefined;
     }
+    if (
+      plainOptionTextExactlyMatchesChoice(
+        plainTextOption.choiceText,
+        choice.answer,
+      )
+    ) {
+      return { index, choice };
+    }
     const hasConflictingOptionNumber = mentionsConflictingOptionNumber(
       plainTextOption.choiceText,
       plainTextOption.selectedNumber,
@@ -403,6 +411,17 @@ function plainOptionTextMatchesChoice(
       normalizedChoiceText === normalizedChoiceAnswer
       || containsNormalizedPhrase(normalizedChoiceText, normalizedChoiceAnswer)
     );
+}
+
+function plainOptionTextExactlyMatchesChoice(
+  choiceText: string,
+  choiceAnswer: string,
+): boolean {
+  const normalizedChoiceText = normalizeForChoiceMatch(choiceText);
+  const normalizedChoiceAnswer = normalizeForChoiceMatch(choiceAnswer);
+  return normalizedChoiceText.length > 0
+    && normalizedChoiceAnswer.length > 0
+    && normalizedChoiceText === normalizedChoiceAnswer;
 }
 
 function containsNormalizedPhrase(haystack: string, needle: string): boolean {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -281,6 +281,22 @@ function parseAMemGymChoice(
   let fallbackAnswer = rawAnswer;
   let forceTextFallback = false;
   let blockTextFallbackSelection = false;
+  const normalizedTrimmedAnswer = normalizeForChoiceMatch(trimmed);
+  const exactTrimmedMatches = qa.answer_choices
+    .map((choice, index) => ({
+      index,
+      choice,
+      normalized: normalizeForChoiceMatch(choice.answer),
+    }))
+    .filter(
+      (candidate) =>
+        candidate.normalized.length > 0
+        && normalizedTrimmedAnswer === candidate.normalized,
+    );
+  if (exactTrimmedMatches.length === 1) {
+    const exactMatch = exactTrimmedMatches[0]!;
+    return { index: exactMatch.index, choice: exactMatch.choice };
+  }
   const plainTextOption = parseAMemGymPlainTextOptionNumber(trimmed);
   if (plainTextOption !== undefined) {
     const index = plainTextOption.selectedNumber - 1;
@@ -530,7 +546,6 @@ function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
 function mentionsConflictingOptionNumber(
   value: string,
   selectedNumber: number,
-  options: { allowBareHashOption?: boolean } = {},
 ): boolean {
   const trimmed = value.trim();
   for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
@@ -538,11 +553,9 @@ function mentionsConflictingOptionNumber(
       return true;
     }
   }
-  if (options.allowBareHashOption !== false) {
-    for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
-      if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
-        return true;
-      }
+  for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
     }
   }
   for (const match of trimmed.matchAll(

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -293,6 +293,10 @@ function parseAMemGymChoice(
         plainTextOption.choiceText,
         choice.answer,
       )
+      || plainOptionTextSafelyExtendsChoice(
+        plainTextOption.choiceText,
+        choice.answer,
+      )
     ) {
       return { index, choice };
     }
@@ -422,6 +426,32 @@ function plainOptionTextExactlyMatchesChoice(
   return normalizedChoiceText.length > 0
     && normalizedChoiceAnswer.length > 0
     && normalizedChoiceText === normalizedChoiceAnswer;
+}
+
+function plainOptionTextSafelyExtendsChoice(
+  choiceText: string,
+  choiceAnswer: string,
+): boolean {
+  const normalizedChoiceAnswer = normalizeForChoiceMatch(choiceAnswer);
+  return choiceHasNumericAlternative(normalizedChoiceAnswer)
+    && startsWithNormalizedPhrase(
+      normalizeForChoiceMatch(choiceText),
+      normalizedChoiceAnswer,
+    );
+}
+
+function choiceHasNumericAlternative(normalizedChoiceAnswer: string): boolean {
+  return /\b\d+\s+(?:or|to)\s+\d+\b/.test(normalizedChoiceAnswer)
+    || /\bor\s+\d+\b/.test(normalizedChoiceAnswer);
+}
+
+function startsWithNormalizedPhrase(haystack: string, needle: string): boolean {
+  const haystackTokens = haystack.split(" ").filter((token) => token.length > 0);
+  const needleTokens = needle.split(" ").filter((token) => token.length > 0);
+  if (needleTokens.length === 0 || needleTokens.length > haystackTokens.length) {
+    return false;
+  }
+  return needleTokens.every((token, index) => haystackTokens[index] === token);
 }
 
 function containsNormalizedPhrase(haystack: string, needle: string): boolean {

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -291,6 +291,7 @@ function parseAMemGymChoice(
     const hasConflictingOptionNumber = mentionsConflictingOptionNumber(
       plainTextOption.choiceText,
       plainTextOption.selectedNumber,
+      { allowBareHashOption: false },
     );
     if (
       !hasConflictingOptionNumber
@@ -468,6 +469,7 @@ function looksLikeChoiceNumberAttempt(trimmedAnswer: string): boolean {
 function mentionsConflictingOptionNumber(
   value: string,
   selectedNumber: number,
+  options: { allowBareHashOption?: boolean } = {},
 ): boolean {
   const trimmed = value.trim();
   for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
@@ -475,11 +477,11 @@ function mentionsConflictingOptionNumber(
       return true;
     }
   }
-  for (const match of trimmed.matchAll(
-    /#\s*(\d+)\b(?=[^#]*(?:might|may|could|would|should|right|correct|valid|answer|option|choice)\b)/gi,
-  )) {
-    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
-      return true;
+  if (options.allowBareHashOption !== false) {
+    for (const match of trimmed.matchAll(/#\s*(\d+)\b/gi)) {
+      if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+        return true;
+      }
     }
   }
   for (const match of trimmed.matchAll(

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -278,6 +278,9 @@ function parseAMemGymChoice(
     }
     return undefined;
   }
+  let fallbackAnswer = rawAnswer;
+  let forceTextFallback = false;
+  let blockTextFallbackSelection = false;
   const plainTextOption = parseAMemGymPlainTextOptionNumber(trimmed);
   if (plainTextOption !== undefined) {
     const index = plainTextOption.selectedNumber - 1;
@@ -285,27 +288,31 @@ function parseAMemGymChoice(
     if (!choice) {
       return undefined;
     }
+    const hasConflictingOptionNumber = mentionsConflictingOptionNumber(
+      plainTextOption.choiceText,
+      plainTextOption.selectedNumber,
+    );
     if (
-      mentionsConflictingOptionNumber(
-        plainTextOption.choiceText,
-        plainTextOption.selectedNumber,
-      )
-    ) {
-      return undefined;
-    }
-    if (
+      !hasConflictingOptionNumber
+      &&
       plainOptionTextMatchesChoice(plainTextOption.choiceText, choice.answer)
     ) {
       return { index, choice };
     }
+    if (hasConflictingOptionNumber) {
+      fallbackAnswer = plainTextOption.choiceText;
+      forceTextFallback = true;
+      blockTextFallbackSelection = true;
+    }
   }
-  const normalizedAnswer = normalizeForChoiceMatch(rawAnswer);
+  const normalizedAnswer = normalizeForChoiceMatch(fallbackAnswer);
   const normalizedChoices = qa.answer_choices.map((choice, index) => ({
     index,
     choice,
     normalized: normalizeForChoiceMatch(choice.answer),
   }));
-  const numericChoiceNumberAttempt = looksLikeChoiceNumberAttempt(trimmed);
+  const numericChoiceNumberAttempt = !forceTextFallback
+    && looksLikeChoiceNumberAttempt(trimmed);
   const numericAttemptPrefix = leadingNumericToken(normalizedAnswer);
 
   const exactMatches = normalizedChoices.filter(
@@ -316,8 +323,11 @@ function parseAMemGymChoice(
   if (exactMatches.length === 1) {
     const exactMatch = exactMatches[0]!;
     if (
-      !numericChoiceNumberAttempt
-      || numericPrefixesAgree(numericAttemptPrefix, exactMatch.normalized)
+      !blockTextFallbackSelection
+      && (
+        !numericChoiceNumberAttempt
+        || numericPrefixesAgree(numericAttemptPrefix, exactMatch.normalized)
+      )
     ) {
       return { index: exactMatch.index, choice: exactMatch.choice };
     }
@@ -349,7 +359,7 @@ function parseAMemGymChoice(
   const uniqueMatch = bestSubstringMatches.length === 1
     ? bestSubstringMatches[0]
     : undefined;
-  return uniqueMatch
+  return uniqueMatch && !blockTextFallbackSelection
     ? { index: uniqueMatch.index, choice: uniqueMatch.choice }
     : undefined;
 }
@@ -461,6 +471,13 @@ function mentionsConflictingOptionNumber(
 ): boolean {
   const trimmed = value.trim();
   for (const match of trimmed.matchAll(/\b(?:option|choice|answer)\s*#?\s*(\d+)\b/gi)) {
+    if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
+      return true;
+    }
+  }
+  for (const match of trimmed.matchAll(
+    /#\s*(\d+)\b(?=[^#]*(?:might|may|could|would|should|right|correct|valid|answer|option|choice)\b)/gi,
+  )) {
     if (Number.parseInt(match[1]!, 10) !== selectedNumber) {
       return true;
     }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -894,12 +894,12 @@ function findLastDayContext(
       tokens,
       index - 1,
     );
-    if (previousStandaloneDayContext !== undefined) {
-      return previousStandaloneDayContext;
-    }
     const standaloneDayContext = buildStandalonePlanDayContext(tokens, index);
     if (standaloneDayContext !== undefined) {
       return standaloneDayContext;
+    }
+    if (previousStandaloneDayContext !== undefined) {
+      return previousStandaloneDayContext;
     }
     const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
       tokens,
@@ -958,13 +958,17 @@ function buildStandalonePlanDayContext(
     tokens,
     index,
   );
+  const pairedExplicitDayContext =
+    precedingExplicitDayContext?.endIndex === index - 1
+      ? precedingExplicitDayContext
+      : undefined;
   return {
-    startIndex: precedingExplicitDayContext?.startIndex ?? index,
+    startIndex: pairedExplicitDayContext?.startIndex ?? index,
     dayTokens: [standaloneDayToken],
     alternateDayTokens:
-      precedingExplicitDayContext === undefined
+      pairedExplicitDayContext === undefined
         ? undefined
-        : [precedingExplicitDayContext.dayTokens],
+        : [pairedExplicitDayContext.dayTokens],
   };
 }
 
@@ -1021,7 +1025,7 @@ function extractTrailingPlanDayContext(
 function extractPrecedingExplicitPlanDayContext(
   tokens: string[],
   beforeIndex: number,
-): { startIndex: number; dayTokens: string[] } | undefined {
+): { startIndex: number; endIndex: number; dayTokens: string[] } | undefined {
   const searchStart = Math.max(0, beforeIndex - 4);
   for (let index = beforeIndex - 2; index >= searchStart; index -= 1) {
     if (
@@ -1032,6 +1036,7 @@ function extractPrecedingExplicitPlanDayContext(
       if (dayToken !== undefined) {
         return {
           startIndex: index,
+          endIndex: index + 1,
           dayTokens: [dayToken],
         };
       }

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -890,6 +890,13 @@ function findLastDayContext(
         dayTokens: [compactDayToken],
       };
     }
+    const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
+      tokens,
+      index,
+    );
+    if (precedingExplicitDayContext !== undefined) {
+      return precedingExplicitDayContext;
+    }
     const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index]!);
     if (standaloneDayToken !== undefined) {
       return {
@@ -967,6 +974,28 @@ function extractTrailingPlanDayContext(
     startIndex: dayTokenIndex - 1,
     dayTokens: [previousToken, normalizePlanDayToken(tokens[dayTokenIndex]!)],
   };
+}
+
+function extractPrecedingExplicitPlanDayContext(
+  tokens: string[],
+  beforeIndex: number,
+): { startIndex: number; dayTokens: string[] } | undefined {
+  const searchStart = Math.max(0, beforeIndex - 4);
+  for (let index = beforeIndex - 2; index >= searchStart; index -= 1) {
+    if (
+      (tokens[index] === "day" || tokens[index] === "days")
+      && tokens[index + 1]
+    ) {
+      const dayToken = normalizeExplicitPlanDayToken(tokens[index + 1]!);
+      if (dayToken !== undefined) {
+        return {
+          startIndex: index,
+          dayTokens: [dayToken],
+        };
+      }
+    }
+  }
+  return undefined;
 }
 
 function normalizeExplicitPlanDayToken(token: string): string | undefined {

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -883,21 +883,6 @@ function findLastDayContext(
   beforeIndex: number,
 ): PlanDayContext | undefined {
   for (let index = beforeIndex - 1; index >= 0; index -= 1) {
-    const previousStandaloneDayToken = normalizeStandalonePlanDayToken(tokens[index - 1] ?? "");
-    if (previousStandaloneDayToken !== undefined) {
-      const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
-        tokens,
-        index - 1,
-      );
-      return {
-        startIndex: precedingExplicitDayContext?.startIndex ?? index - 1,
-        dayTokens: [previousStandaloneDayToken],
-        alternateDayTokens:
-          precedingExplicitDayContext === undefined
-            ? undefined
-            : [precedingExplicitDayContext.dayTokens],
-      };
-    }
     const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
     if (compactDayToken !== undefined) {
       return {
@@ -905,12 +890,16 @@ function findLastDayContext(
         dayTokens: [compactDayToken],
       };
     }
-    const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index]!);
-    if (standaloneDayToken !== undefined) {
-      return {
-        startIndex: index,
-        dayTokens: [standaloneDayToken],
-      };
+    const previousStandaloneDayContext = buildStandalonePlanDayContext(
+      tokens,
+      index - 1,
+    );
+    if (previousStandaloneDayContext !== undefined) {
+      return previousStandaloneDayContext;
+    }
+    const standaloneDayContext = buildStandalonePlanDayContext(tokens, index);
+    if (standaloneDayContext !== undefined) {
+      return standaloneDayContext;
     }
     const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
       tokens,
@@ -955,6 +944,28 @@ function dayContextMatches(
     || (context.alternateDayTokens ?? []).some((tokens) =>
       tokensEqual(tokens, expectedDayTokens),
     );
+}
+
+function buildStandalonePlanDayContext(
+  tokens: string[],
+  index: number,
+): PlanDayContext | undefined {
+  const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index] ?? "");
+  if (standaloneDayToken === undefined) {
+    return undefined;
+  }
+  const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
+    tokens,
+    index,
+  );
+  return {
+    startIndex: precedingExplicitDayContext?.startIndex ?? index,
+    dayTokens: [standaloneDayToken],
+    alternateDayTokens:
+      precedingExplicitDayContext === undefined
+        ? undefined
+        : [precedingExplicitDayContext.dayTokens],
+  };
 }
 
 function findNearestPlanFieldLabel(

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -858,7 +858,7 @@ function findPlanFieldTokenWindow(
       : undefined;
     if (
       expectedField.dayTokens.length > 0
-      && (dayContext === undefined || !tokensEqual(dayContext.dayTokens, expectedField.dayTokens))
+      && (dayContext === undefined || !dayContextMatches(dayContext, expectedField.dayTokens))
     ) {
       continue;
     }
@@ -881,13 +881,35 @@ function findPlanFieldTokenWindow(
 function findLastDayContext(
   tokens: string[],
   beforeIndex: number,
-): { startIndex: number; dayTokens: string[] } | undefined {
+): PlanDayContext | undefined {
   for (let index = beforeIndex - 1; index >= 0; index -= 1) {
+    const previousStandaloneDayToken = normalizeStandalonePlanDayToken(tokens[index - 1] ?? "");
+    if (previousStandaloneDayToken !== undefined) {
+      const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
+        tokens,
+        index - 1,
+      );
+      return {
+        startIndex: precedingExplicitDayContext?.startIndex ?? index - 1,
+        dayTokens: [previousStandaloneDayToken],
+        alternateDayTokens:
+          precedingExplicitDayContext === undefined
+            ? undefined
+            : [precedingExplicitDayContext.dayTokens],
+      };
+    }
     const compactDayToken = extractCompactPlanDayToken(tokens[index]!);
     if (compactDayToken !== undefined) {
       return {
         startIndex: index,
         dayTokens: [compactDayToken],
+      };
+    }
+    const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index]!);
+    if (standaloneDayToken !== undefined) {
+      return {
+        startIndex: index,
+        dayTokens: [standaloneDayToken],
       };
     }
     const precedingExplicitDayContext = extractPrecedingExplicitPlanDayContext(
@@ -896,13 +918,6 @@ function findLastDayContext(
     );
     if (precedingExplicitDayContext !== undefined) {
       return precedingExplicitDayContext;
-    }
-    const standaloneDayToken = normalizeStandalonePlanDayToken(tokens[index]!);
-    if (standaloneDayToken !== undefined) {
-      return {
-        startIndex: index,
-        dayTokens: [standaloneDayToken],
-      };
     }
     const trailingDayContext = extractTrailingPlanDayContext(tokens, index);
     if (trailingDayContext !== undefined) {
@@ -924,6 +939,22 @@ function findLastDayContext(
     }
   }
   return undefined;
+}
+
+interface PlanDayContext {
+  startIndex: number;
+  dayTokens: string[];
+  alternateDayTokens?: string[][];
+}
+
+function dayContextMatches(
+  context: PlanDayContext,
+  expectedDayTokens: string[],
+): boolean {
+  return tokensEqual(context.dayTokens, expectedDayTokens)
+    || (context.alternateDayTokens ?? []).some((tokens) =>
+      tokensEqual(tokens, expectedDayTokens),
+    );
 }
 
 function findNearestPlanFieldLabel(

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -567,6 +567,39 @@ test("runBenchmark accepts numeric alternatives inside exact amemgym option text
   assert.equal(task.details?.scoredAnswer, "1 or 2 years");
 });
 
+test("runBenchmark accepts numeric-leading exact amemgym text answers", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-numeric-leading-exact-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.duration = { type: "string" };
+  profile[0]!.periods[0]!.state.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.updates.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.duration = "1 or 2 years";
+  profile[0]!.qas[0]!.required_info = ["duration"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["1 or 2 years"], answer: "1 or 2 years" },
+    { state: ["3 years"], answer: "3 years" },
+  ];
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 or 2 years"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "1 or 2 years");
+});
+
 test("runBenchmark accepts numeric alternatives inside extended amemgym option text", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-extended-or-number-choice-text-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -671,6 +671,29 @@ test("runBenchmark rejects amemgym option-number rationales with bare conflictin
   assert.equal(task.details?.scoredAnswer, "1 because 2 might be right.");
 });
 
+test("runBenchmark rejects amemgym option-number rationales with hash conflicting choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hash-conflicting-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 because #2 might also be right."));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 because #2 might also be right.");
+});
+
 test("runBenchmark rejects amemgym option-number rationales with hedged conflicting choices", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hedged-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -603,6 +603,75 @@ test("runBenchmark accepts numeric alternatives inside extended amemgym option t
   assert.equal(task.details?.scoredAnswer, "1 or 2 years");
 });
 
+test("runBenchmark accepts numeric alternatives inside qualified amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-qualified-or-number-choice-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.duration = { type: "string" };
+  profile[0]!.periods[0]!.state.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.updates.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.duration = "1 or 2 years";
+  profile[0]!.qas[0]!.required_info = ["duration"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["1 or 2 years"], answer: "1 or 2 years" },
+    { state: ["3 years"], answer: "3 years" },
+  ];
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("1 about 1 or 2 years depending on visa"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 about 1 or 2 years depending on visa");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "1 or 2 years");
+});
+
+test("runBenchmark rejects hash conflicts outside matching amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hash-choice-with-conflict-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.route = { type: "string" };
+  profile[0]!.periods[0]!.state.route = "Route #66";
+  profile[0]!.periods[0]!.updates.route = "Route #66";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.route = "Route #66";
+  profile[0]!.qas[0]!.required_info = ["route"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["Route #66"], answer: "Route #66" },
+    { state: ["Route #20"], answer: "Route #20" },
+  ];
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 Route #66 because #2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 Route #66 because #2");
+});
+
 test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -533,6 +533,40 @@ test("runBenchmark accepts hash numerals inside amemgym option text", async () =
   assert.equal(task.details?.scoredAnswer, "Route #66");
 });
 
+test("runBenchmark accepts numeric alternatives inside exact amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-or-number-choice-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.duration = { type: "string" };
+  profile[0]!.periods[0]!.state.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.updates.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.duration = "1 or 2 years";
+  profile[0]!.qas[0]!.required_info = ["duration"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["1 or 2 years"], answer: "1 or 2 years" },
+    { state: ["3 years"], answer: "3 years" },
+  ];
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 1 or 2 years"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 1 or 2 years");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "1 or 2 years");
+});
+
 test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -672,6 +672,41 @@ test("runBenchmark rejects hash conflicts outside matching amemgym option text",
   assert.equal(task.details?.scoredAnswer, "1 Route #66 because #2");
 });
 
+test("runBenchmark accepts punctuation variants of hash-bearing amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hash-punctuation-variant-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.route = { type: "string" };
+  profile[0]!.periods[0]!.state.route = "Route #66 eastbound";
+  profile[0]!.periods[0]!.updates.route = "Route #66 eastbound";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.route = "Route #66 eastbound";
+  profile[0]!.qas[0]!.required_info = ["route"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["Route #66 eastbound"], answer: "Route #66 eastbound" },
+    { state: ["Route #20 westbound"], answer: "Route #20 westbound" },
+  ];
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("1 Route#66 eastbound quickly"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Route #66 eastbound");
+});
+
 test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -763,6 +763,31 @@ test("runBenchmark rejects plain amemgym option text that mentions another optio
   assert.equal(task.details?.scoredAnswer, "1 Seattle or 2 Dallas");
 });
 
+test("runBenchmark accepts plain amemgym option text with unrelated numerals", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-choice-unrelated-number-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("1 Seattle, 20 minutes away"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Seattle");
+});
+
 test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -694,6 +694,29 @@ test("runBenchmark rejects amemgym option-number rationales with hash conflictin
   assert.equal(task.details?.scoredAnswer, "1 because #2 might also be right.");
 });
 
+test("runBenchmark rejects amemgym option-number rationales with bare hash choices", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-hash-conflicting-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 because #2"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 because #2");
+});
+
 test("runBenchmark rejects amemgym option-number rationales with hedged conflicting choices", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hedged-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -499,6 +499,40 @@ test("runBenchmark accepts labeled option numbers followed by plain amemgym text
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark accepts hash numerals inside amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-hash-choice-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.route = { type: "string" };
+  profile[0]!.periods[0]!.state.route = "Route #66";
+  profile[0]!.periods[0]!.updates.route = "Route #66";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.route = "Route #66";
+  profile[0]!.qas[0]!.required_info = ["route"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["Route #66"], answer: "Route #66" },
+    { state: ["Route #20"], answer: "Route #20" },
+  ];
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 Route #66"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 Route #66");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "Route #66");
+});
+
 test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -567,6 +567,42 @@ test("runBenchmark accepts numeric alternatives inside exact amemgym option text
   assert.equal(task.details?.scoredAnswer, "1 or 2 years");
 });
 
+test("runBenchmark accepts numeric alternatives inside extended amemgym option text", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-extended-or-number-choice-text-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const profile = createDatasetProfile();
+  profile[0]!.state_schema.duration = { type: "string" };
+  profile[0]!.periods[0]!.state.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.updates.duration = "1 or 2 years";
+  profile[0]!.periods[0]!.sessions[0]!.exposed_states.duration = "1 or 2 years";
+  profile[0]!.qas[0]!.required_info = ["duration"];
+  profile[0]!.qas[0]!.answer_choices = [
+    { state: ["1 or 2 years"], answer: "1 or 2 years" },
+    { state: ["3 years"], answer: "3 years" },
+  ];
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("1 1 or 2 years depending on visa timing"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(profile),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.actual, "1 1 or 2 years depending on visa timing");
+  assert.equal(task.scores.qa_accuracy, 1);
+  assert.equal(task.details?.selectedChoiceIndex, 1);
+  assert.equal(task.details?.scoredAnswer, "1 or 2 years");
+});
+
 test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-amemgym-runner.test.ts
+++ b/tests/bench-amemgym-runner.test.ts
@@ -499,6 +499,29 @@ test("runBenchmark accepts labeled option numbers followed by plain amemgym text
   assert.equal(task.details?.scoredAnswer, "Seattle");
 });
 
+test("runBenchmark rejects plain amemgym option text that mentions another option", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-plain-conflicting-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "amemgym");
+  const adapter = new FakeMemoryAdapter(new FixedResponder("1 Seattle or 2 Dallas"));
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "data.json"),
+    JSON.stringify(createDatasetProfile()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("amemgym", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.qa_accuracy, 0);
+  assert.equal(task.details?.selectedChoiceIndex, null);
+  assert.equal(task.details?.scoredAnswer, "1 Seattle or 2 Dallas");
+});
+
 test("runBenchmark accepts bare amemgym option-number answers with rationale", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-amemgym-bare-rationale-"));
   const datasetDir = path.join(tmpDir, "datasets", "amemgym");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -842,6 +842,45 @@ test("runBenchmark ignores prose day words when locating memory-arena day contex
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark prefers nearest weekday memory-arena context over earlier numbered day", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-weekday-nearest-context-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 2 Monday Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my Monday shared itinerary."],
+      answers: [[
+        {
+          days: "Monday",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark normalizes string day labels for memory-arena plan fields", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-string-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -881,6 +881,45 @@ test("runBenchmark normalizes string day labels for memory-arena plan fields", a
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark prefers explicit memory-arena day markers over weekday labels", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-day-marker-weekday-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 2 Monday Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my second-day shared itinerary."],
+      answers: [[
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark matches weekday memory-arena plan day headers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-weekday-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -959,6 +959,45 @@ test("runBenchmark prefers explicit memory-arena day markers over weekday labels
   assert.equal(task.scores.soft_process_score, 1);
 });
 
+test("runBenchmark prefers compact numeric memory-arena day markers over prior weekdays", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-compact-day-weekday-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Monday Day2 Dinner: Coco Bambu, Dallas"),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my second-day shared itinerary."],
+      answers: [[
+        {
+          days: 2,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark matches weekday memory-arena plan day headers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-weekday-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");

--- a/tests/bench-memory-arena-runner.test.ts
+++ b/tests/bench-memory-arena-runner.test.ts
@@ -1076,6 +1076,84 @@ test("runBenchmark rejects memory-arena fields under a nearer wrong weekday head
   assert.equal(task.scores.soft_process_score, 0);
 });
 
+test("runBenchmark does not reuse unrelated numbered days as weekday alternates", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-unrelated-day-alternate-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Day 1 Lunch: Sushi Place. Tuesday Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my day-one shared itinerary."],
+      answers: [[
+        {
+          days: 1,
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 0);
+  assert.equal(task.scores.soft_process_score, 0);
+});
+
+test("runBenchmark uses the nearest standalone memory-arena weekday", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-nearest-weekday-"));
+  const datasetDir = path.join(tmpDir, "datasets", "memory-arena");
+  const adapter = new FakeMemoryAdapter(
+    new FixedResponder("Monday Tuesday Dinner: Coco Bambu, Dallas."),
+  );
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "group_travel_planner.jsonl"),
+    `${JSON.stringify({
+      id: 1,
+      questions: ["I am Eric. Generate my Tuesday shared itinerary."],
+      answers: [[
+        {
+          days: "Tuesday",
+          current_city: "-",
+          transportation: "-",
+          breakfast: "-",
+          attraction: "-",
+          lunch: "-",
+          dinner: "Coco Bambu, Dallas",
+          accommodation: "-",
+        },
+      ]],
+    })}\n`,
+    "utf8",
+  );
+
+  const result = await runBenchmark("memory-arena", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.plan_field_recall, 1);
+  assert.equal(task.scores.soft_process_score, 1);
+});
+
 test("runBenchmark matches word-based memory-arena plan day headers", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-memory-arena-word-day-"));
   const datasetDir = path.join(tmpDir, "datasets", "memory-arena");


### PR DESCRIPTION
## Summary
- lands the post-merge PR 675 scoring hardening commit that was pushed after PR 675 was squash-merged
- rejects ambiguous AMemGym option strings and prefers explicit MemoryArena day markers over incidental page/day tokens
- keeps the change scoped to the AMemGym/MemoryArena harness and focused regression tests

## Test Plan
- pnpm exec tsx --test tests/bench-amemgym-runner.test.ts tests/bench-memory-arena-runner.test.ts
- git diff --check HEAD~1..HEAD

## Benchmark Impact
- current full Ollama run already completed AMemGym/MemoryArena before this fix, so those artifacts remain diagnostic rather than leaderboard-ready
- future reruns will include this parser/scoring hardening

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes benchmark scoring/parsing logic, which can shift reported metrics and may introduce edge-case misclassification, but the changes are scoped to benchmark harness code and covered by new regression tests.
> 
> **Overview**
> **AMemGym scoring is tightened to avoid ambiguous choice selection.** The runner now validates option-number references against the actual choice count, supports exact text matches before fallback substring matching, and blocks text fallback when the answer text mentions other in-range options (including `#2`-style refs) unless the option text itself exactly matches.
> 
> **MemoryArena plan-field scoring now prefers the right day context more reliably.** Day-context extraction was extended to treat standalone weekdays as optionally paired with nearby explicit day markers and to prefer explicit `Day N`/`DayN` markers over incidental weekday tokens, improving field matching in mixed day/weekday outputs.
> 
> Adds focused regression tests covering hash/numeric option text and conflicting-option cases for AMemGym, plus additional MemoryArena tests around weekday vs explicit day-marker precedence and nearest-context selection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef29c92ce55286edd137b2d65d78a580bef90180. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->