### PR TITLE
refactor(procedural): extract reinforcement-core primitives (#687 PR 1/4)

### DIFF
--- a/packages/remnic-core/src/procedural/procedure-miner.ts
+++ b/packages/remnic-core/src/procedural/procedure-miner.ts
@@ -10,6 +10,7 @@ import {
   filterTrajectoriesByLookbackDays,
 } from "../causal-trajectory.js";
 import { buildProcedurePersistBody, normalizeProcedureSteps, type ProcedureStep } from "./procedure-types.js";
+import { clusterByKey } from "./reinforcement-core.js";
 import { log } from "../logger.js";
 
 /** Must match truncation on `procedure_cluster` structured attribute (dedupe + storage). */
@@ -102,13 +103,7 @@ export async function runProcedureMining(options: {
   });
   const recent = filterTrajectoriesByLookbackDays(trajectories, cfg.lookbackDays);
 
-  const clusters = new Map<string, CausalTrajectoryRecord[]>();
-  for (const t of recent) {
-    const key = clusterKey(t);
-    const arr = clusters.get(key) ?? [];
-    arr.push(t);
-    clusters.set(key, arr);
-  }
+  const clusters = clusterByKey(recent, clusterKey);
 
   let clustersProcessed = 0;
   let proceduresWritten = 0;

--- a/packages/remnic-core/src/procedural/reinforcement-core.test.ts
+++ b/packages/remnic-core/src/procedural/reinforcement-core.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { clusterByKey, summarizeCluster } from "./reinforcement-core.js";
+
+interface Sample {
+  id: string;
+  group: string;
+  ts: string;
+}
+
+test("clusterByKey returns empty map for empty input", () => {
+  const out = clusterByKey<Sample>([], (s) => s.group);
+  assert.equal(out.size, 0);
+});
+
+test("clusterByKey returns a single cluster when all items share a key", () => {
+  const items: Sample[] = [
+    { id: "a", group: "g1", ts: "2026-04-01T00:00:00Z" },
+    { id: "b", group: "g1", ts: "2026-04-02T00:00:00Z" },
+    { id: "c", group: "g1", ts: "2026-04-03T00:00:00Z" },
+  ];
+  const out = clusterByKey(items, (s) => s.group);
+  assert.equal(out.size, 1);
+  const cluster = out.get("g1");
+  assert.ok(cluster);
+  assert.equal(cluster.length, 3);
+  // Preserves input order
+  assert.deepEqual(
+    cluster.map((s) => s.id),
+    ["a", "b", "c"],
+  );
+});
+
+test("clusterByKey splits items into multiple clusters by key", () => {
+  const items: Sample[] = [
+    { id: "a", group: "g1", ts: "2026-04-01T00:00:00Z" },
+    { id: "b", group: "g2", ts: "2026-04-02T00:00:00Z" },
+    { id: "c", group: "g1", ts: "2026-04-03T00:00:00Z" },
+    { id: "d", group: "g3", ts: "2026-04-04T00:00:00Z" },
+    { id: "e", group: "g2", ts: "2026-04-05T00:00:00Z" },
+  ];
+  const out = clusterByKey(items, (s) => s.group);
+  assert.equal(out.size, 3);
+  assert.deepEqual(out.get("g1")?.map((s) => s.id), ["a", "c"]);
+  assert.deepEqual(out.get("g2")?.map((s) => s.id), ["b", "e"]);
+  assert.deepEqual(out.get("g3")?.map((s) => s.id), ["d"]);
+  // First-seen insertion order
+  assert.deepEqual(Array.from(out.keys()), ["g1", "g2", "g3"]);
+});
+
+test("clusterByKey throws TypeError when keyFn returns a non-string", () => {
+  const items = [{ id: "a" }];
+  assert.throws(
+    () => clusterByKey(items, () => undefined as unknown as string),
+    (err: Error) => err instanceof TypeError && /must return a string/.test(err.message),
+  );
+  assert.throws(
+    () => clusterByKey(items, () => null as unknown as string),
+    (err: Error) => err instanceof TypeError && /null/.test(err.message),
+  );
+  assert.throws(
+    () => clusterByKey(items, () => 42 as unknown as string),
+    (err: Error) => err instanceof TypeError && /number/.test(err.message),
+  );
+});
+
+test("summarizeCluster throws RangeError on empty cluster", () => {
+  assert.throws(
+    () => summarizeCluster<Sample>([], (s) => s.ts),
+    (err: Error) => err instanceof RangeError,
+  );
+});
+
+test("summarizeCluster computes count and firstSeen/lastSeen for single-item cluster", () => {
+  const items: Sample[] = [{ id: "a", group: "g", ts: "2026-04-01T00:00:00Z" }];
+  const out = summarizeCluster(items, (s) => s.ts);
+  assert.equal(out.count, 1);
+  assert.equal(out.firstSeen, "2026-04-01T00:00:00Z");
+  assert.equal(out.lastSeen, "2026-04-01T00:00:00Z");
+});
+
+test("summarizeCluster finds min/max regardless of input order", () => {
+  const items: Sample[] = [
+    { id: "b", group: "g", ts: "2026-04-15T00:00:00Z" },
+    { id: "a", group: "g", ts: "2026-04-01T00:00:00Z" },
+    { id: "c", group: "g", ts: "2026-04-30T00:00:00Z" },
+    { id: "d", group: "g", ts: "2026-04-10T00:00:00Z" },
+  ];
+  const out = summarizeCluster(items, (s) => s.ts);
+  assert.equal(out.count, 4);
+  assert.equal(out.firstSeen, "2026-04-01T00:00:00Z");
+  assert.equal(out.lastSeen, "2026-04-30T00:00:00Z");
+});
+
+test("summarizeCluster handles all-equal timestamps", () => {
+  const ts = "2026-04-25T12:00:00Z";
+  const items: Sample[] = [
+    { id: "a", group: "g", ts },
+    { id: "b", group: "g", ts },
+    { id: "c", group: "g", ts },
+  ];
+  const out = summarizeCluster(items, (s) => s.ts);
+  assert.equal(out.count, 3);
+  assert.equal(out.firstSeen, ts);
+  assert.equal(out.lastSeen, ts);
+});
+
+test("summarizeCluster works with non-ISO string keys via localeCompare", () => {
+  // Simple lexicographic ordering — extractTimestamp can return any string.
+  const items = [{ k: "b" }, { k: "a" }, { k: "c" }];
+  const out = summarizeCluster(items, (s) => s.k);
+  assert.equal(out.firstSeen, "a");
+  assert.equal(out.lastSeen, "c");
+});
+
+test("clusterByKey + summarizeCluster compose for end-to-end summarization", () => {
+  const items: Sample[] = [
+    { id: "a", group: "g1", ts: "2026-04-01T00:00:00Z" },
+    { id: "b", group: "g2", ts: "2026-04-02T00:00:00Z" },
+    { id: "c", group: "g1", ts: "2026-04-10T00:00:00Z" },
+    { id: "d", group: "g1", ts: "2026-04-05T00:00:00Z" },
+  ];
+  const clusters = clusterByKey(items, (s) => s.group);
+  const g1 = summarizeCluster(clusters.get("g1") ?? [], (s) => s.ts);
+  assert.equal(g1.count, 3);
+  assert.equal(g1.firstSeen, "2026-04-01T00:00:00Z");
+  assert.equal(g1.lastSeen, "2026-04-10T00:00:00Z");
+  const g2 = summarizeCluster(clusters.get("g2") ?? [], (s) => s.ts);
+  assert.equal(g2.count, 1);
+  assert.equal(g2.firstSeen, g2.lastSeen);
+});

--- a/packages/remnic-core/src/procedural/reinforcement-core.ts
+++ b/packages/remnic-core/src/procedural/reinforcement-core.ts
@@ -1,0 +1,73 @@
+/**
+ * Generic reinforcement-core primitives extracted from `procedure-miner.ts`
+ * (issue #687 PR 1/4). Procedure-specific scoring (success rate, step
+ * normalization) intentionally stays in the miner — this module only
+ * exposes category-agnostic clustering and cluster summarization helpers
+ * so future PRs can run reinforcement across non-procedural categories.
+ *
+ * Pure refactor — no behavior change.
+ */
+
+/**
+ * Group `items` into clusters keyed by `keyFn(item)`.
+ *
+ * - Preserves the original input order within each cluster's array.
+ * - The returned `Map` insertion order matches first-seen key order, so
+ *   downstream iteration is deterministic for a given input.
+ * - Throws `TypeError` if `keyFn` returns a non-string (e.g. `undefined`,
+ *   `null`, or a number). Callers must produce a stable string key.
+ */
+export function clusterByKey<T>(items: readonly T[], keyFn: (item: T) => string): Map<string, T[]> {
+  const clusters = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyFn(item);
+    if (typeof key !== "string") {
+      throw new TypeError(
+        `clusterByKey: keyFn must return a string, got ${key === null ? "null" : typeof key}`,
+      );
+    }
+    const existing = clusters.get(key);
+    if (existing) {
+      existing.push(item);
+    } else {
+      clusters.set(key, [item]);
+    }
+  }
+  return clusters;
+}
+
+export interface ClusterSummary {
+  /** Number of items in the cluster. */
+  count: number;
+  /** Earliest timestamp seen in the cluster (string min via `localeCompare`). */
+  firstSeen: string;
+  /** Latest timestamp seen in the cluster (string max via `localeCompare`). */
+  lastSeen: string;
+}
+
+/**
+ * Summarize a cluster by counting items and tracking earliest/latest
+ * timestamps. Timestamp comparison uses `String#localeCompare`, which is
+ * correct for ISO-8601 strings (lexicographic order matches chronological
+ * order).
+ *
+ * - Throws `RangeError` on empty clusters — `firstSeen`/`lastSeen` are not
+ *   meaningful without at least one item.
+ * - When all timestamps are equal, `firstSeen === lastSeen`.
+ */
+export function summarizeCluster<T>(
+  cluster: readonly T[],
+  extractTimestamp: (item: T) => string,
+): ClusterSummary {
+  if (cluster.length === 0) {
+    throw new RangeError("summarizeCluster: cluster must contain at least one item");
+  }
+  let firstSeen = extractTimestamp(cluster[0]);
+  let lastSeen = firstSeen;
+  for (let i = 1; i < cluster.length; i += 1) {
+    const ts = extractTimestamp(cluster[i]);
+    if (ts.localeCompare(firstSeen) < 0) firstSeen = ts;
+    if (ts.localeCompare(lastSeen) > 0) lastSeen = ts;
+  }
+  return { count: cluster.length, firstSeen, lastSeen };
+}


### PR DESCRIPTION
## Summary

Pure refactor — no behavior change. Sets up follow-up PRs to run reinforcement across non-procedural categories.

- Extracts generic clustering + cluster-summarization out of `procedure-miner.ts` into a new category-agnostic module `packages/remnic-core/src/procedural/reinforcement-core.ts`.
- Procedure-specific scoring (success rate, step normalization) intentionally stays in the miner.
- New unit tests (10) cover empty/single/multi clusters, ordering, equal timestamps, and non-string `keyFn` output.

## Surface

- `clusterByKey<T>(items, keyFn): Map<string, T[]>` — pure clustering helper. Throws `TypeError` if `keyFn` returns a non-string.
- `summarizeCluster<T>(cluster, extractTimestamp): { count, firstSeen, lastSeen }` — count + min/max timestamps via `localeCompare` (correct for ISO-8601). Throws `RangeError` on empty clusters.

## Follow-ups (separate PRs)

- PR 2/4: `pattern-reinforcement` maintenance job + `reinforcement_count` / `last_reinforced_at` frontmatter.
- PR 3/4: recall integration.
- PR 4/4: CLI surface + docs.

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/procedural/*.test.ts` — 10 new tests pass.
- [x] `npx tsx --test tests/procedure-miner.test.ts tests/procedure-stats.test.ts tests/storage-procedure-write.test.ts tests/procedure-recall.test.ts` — 12 existing procedure tests still pass.
- [x] `npx tsc --noEmit -p packages/remnic-core/tsconfig.json` — clean.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk refactor: procedure mining now calls a shared helper for clustering, with behavior locked down by new unit tests; no changes to scoring or persistence logic.
> 
> **Overview**
> Extracts generic reinforcement helpers into new `reinforcement-core.ts`, including `clusterByKey` (deterministic Map-based grouping with input-order preservation and type-checking) and `summarizeCluster` (count + min/max timestamp strings).
> 
> Updates `procedure-miner.ts` to use `clusterByKey` instead of inline clustering logic, and adds unit tests covering clustering behavior, ordering guarantees, and error cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19eae663bf4bd993654620f497598bfbf4fb70c8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->