### PR TITLE
chore(admin-console): rename Engram → Remnic + token migration (#691 PR 1/5)

### DIFF
--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -1,4 +1,25 @@
-const tokenKey = "engram.adminConsole.token";
+const tokenKey = "remnic.adminConsole.token";
+const legacyTokenKey = "engram.adminConsole.token";
+
+// One-time migration: copy any pre-existing token from the legacy
+// `engram.adminConsole.token` key over to the new `remnic.*` key so
+// existing operators are not logged out by the rename. Runs once on
+// load; the legacy key is removed only after the new key is written.
+function migrateLegacyToken() {
+  try {
+    const storage = window.sessionStorage;
+    if (!storage) return;
+    const current = storage.getItem(tokenKey);
+    if (current) return;
+    const legacy = storage.getItem(legacyTokenKey);
+    if (!legacy) return;
+    storage.setItem(tokenKey, legacy);
+    storage.removeItem(legacyTokenKey);
+  } catch {
+    // sessionStorage can throw in private/sandboxed contexts; ignore.
+  }
+}
+migrateLegacyToken();
 const browserState = {
   sort: "updated_desc",
   limit: 25,
@@ -584,8 +605,8 @@ async function promoteTrustZone(recordId, targetZone, dryRun) {
       recordId,
       targetZone,
       promotionReason: dryRun
-        ? `Previewed in Engram admin console for ${recordId}.`
-        : `Promoted in Engram admin console for ${recordId}.`,
+        ? `Previewed in Remnic admin console for ${recordId}.`
+        : `Promoted in Remnic admin console for ${recordId}.`,
       dryRun,
     }),
   });
@@ -639,7 +660,7 @@ async function connectAndBootstrap() {
   setStatus("authStatus", "Connecting...", "default");
   try {
     await fetchJson("/engram/v1/health");
-    setStatus("authStatus", "Connected to Engram access API.", "ok");
+    setStatus("authStatus", "Connected to Remnic access API.", "ok");
     await Promise.allSettled([
       loadMemoryBrowser(true),
       loadTrustZones(true),

--- a/admin-console/public/index.html
+++ b/admin-console/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Engram Admin Console</title>
+    <title>Remnic Admin Console</title>
     <style>
       :root {
         color-scheme: light;
@@ -243,7 +243,7 @@
   <body>
     <main>
       <header>
-        <h1>Engram Admin Console</h1>
+        <h1>Remnic Admin Console</h1>
         <div class="subtitle">
           Local operator surface for recall inspection, quality review, memory browsing, and maintenance status.
           The UI shell is static; every data fetch and operator action still goes through the loopback bearer-token API.
@@ -253,7 +253,7 @@
       <section class="card auth-bar">
         <label>
           Bearer Token
-          <input id="tokenInput" type="password" placeholder="Paste the Engram access token" autocomplete="off" />
+          <input id="tokenInput" type="password" placeholder="Paste the Remnic access token" autocomplete="off" />
         </label>
         <div class="status" id="authStatus">Waiting for token.</div>
         <div class="toolbar">

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -573,7 +573,7 @@ test("access HTTP server serves admin console shell without auth and rejects inv
     const uiRes = await fetch(`${base}/engram/ui/`);
     assert.equal(uiRes.status, 200);
     const html = await uiRes.text();
-    assert.match(html, /Engram Admin Console/);
+    assert.match(html, /Remnic Admin Console/);
     assert.match(html, /Quality Dashboard/);
     assert.match(html, /Trust Zones/);
 
@@ -695,7 +695,7 @@ test("access HTTP server resolves the admin console shell independently of cwd",
     const uiRes = await fetch(`${base}/engram/ui/`);
     assert.equal(uiRes.status, 200);
     const html = await uiRes.text();
-    assert.match(html, /Engram Admin Console/);
+    assert.match(html, /Remnic Admin Console/);
   } finally {
     await server.stop();
     process.chdir(originalCwd);


### PR DESCRIPTION
## Summary

First slice of issue #691. Pure rename + token-key migration — no behavior change, no new endpoints, no new dependencies. Defers the Memory Graph pane to PRs 2-5/5.

- **`admin-console/public/index.html`** — rename user-facing strings (`<title>`, `<h1>`, token-input placeholder) from "Engram Admin Console" to "Remnic Admin Console". Internal API paths (`/engram/v1/...`), CSS classes, and element IDs are intentionally left alone; they are tracked separately as part of the access-API rename.
- **`admin-console/public/app.js`** — bump `tokenKey` from `engram.adminConsole.token` to `remnic.adminConsole.token`. Add a one-time `migrateLegacyToken()` helper that runs on script load: if the new key is empty AND the legacy key holds a value, copy it over and remove the legacy entry. Wrapped in try/catch so sandboxed contexts that throw on `sessionStorage` access fail gracefully instead of breaking bootstrap. Two operator-facing audit/status strings ("Connected to Engram access API.", trust-zone `promotionReason`) also renamed.
- **`tests/access-http.test.ts`** — assertions updated to match the new "Remnic Admin Console" title (two call sites).

Note: the existing code uses `sessionStorage`, not `localStorage` as the issue brief described. The migration runs over the actual storage backend used by the app.

## Test plan

- [x] `npx tsc --noEmit -p packages/remnic-core` — clean
- [x] `node --check admin-console/public/app.js` — parses
- [x] `node scripts/copy-admin-console.mjs` — `dist/admin-console/public/` reflects the new strings
- [x] `npx tsx --test tests/access-http.test.ts` — 21/21 pass
- [ ] Manual: load admin console with a stale `engram.adminConsole.token` in `sessionStorage`; confirm operator stays connected and the legacy key is removed after first load

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk rename-only UI/text updates plus a small `sessionStorage` key migration; main risk is accidentally breaking persisted auth if the migration or key name is wrong.
> 
> **Overview**
> **Renames the admin console UI branding from “Engram” to “Remnic”** (page title/header, token placeholder, and operator-facing status/audit strings), while leaving API paths unchanged.
> 
> **Updates bearer-token persistence** by changing the `sessionStorage` key to `remnic.adminConsole.token` and adding a one-time migration that copies any existing token from the legacy `engram.adminConsole.token` key before deleting it.
> 
> **Adjusts HTTP server UI tests** to assert the new “Remnic Admin Console” text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d7abd42e239fbebbd56688cde2f7068ff4956732. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->