### PR TITLE
feat(console): structured engine-state aggregator (#688 PR 1/3)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7321,6 +7321,35 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(`  Queued: ${result.queued}`);
           console.log(`  Cooled down: ${result.cooledDown}`);
         });
+
+      // ── Console subcommand (issue #688 PR 1/3) ──────────────────────────
+      // Structured engine-state aggregator. PR 1/3 ships only the
+      // `--state-only` flag which prints the snapshot as JSON. The
+      // interactive TUI (PR 2/3), HTTP `/console/state`, MCP
+      // `engram.console_state`, and trace replay (PR 3/3) land in
+      // follow-ups.
+      cmd
+        .command("console")
+        .description(
+          "Operator console (issue #688). PR 1/3 ships --state-only, which emits a structured engine-state snapshot as JSON. The interactive TUI lands in PR 2/3.",
+        )
+        .option(
+          "--state-only",
+          "Print a single console-state snapshot as JSON and exit",
+        )
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          if (options.stateOnly !== true) {
+            console.error(
+              "remnic console: interactive TUI not yet available (issue #688 PR 2/3). Pass --state-only to print a JSON snapshot.",
+            );
+            process.exitCode = 1;
+            return;
+          }
+          const { gatherConsoleState } = await import("./console/state.js");
+          const snapshot = await gatherConsoleState(orchestrator);
+          console.log(JSON.stringify(snapshot, null, 2));
+        });
     },
     { commands: ["engram"] },
   );

--- a/packages/remnic-core/src/console/state.test.ts
+++ b/packages/remnic-core/src/console/state.test.ts
@@ -1,0 +1,173 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import {
+  gatherConsoleState,
+  type ConsoleStateOrchestratorLike,
+} from "./state.js";
+
+function makeOrchestrator(
+  overrides: Partial<ConsoleStateOrchestratorLike> = {},
+): ConsoleStateOrchestratorLike {
+  return {
+    config: { memoryDir: "/nonexistent" },
+    buffer: { getTurns: () => [] },
+    qmd: {
+      isAvailable: () => false,
+      isDaemonMode: () => false,
+      debugStatus: () => "stub",
+    },
+    ...overrides,
+  };
+}
+
+test("gatherConsoleState returns a JSON-serializable snapshot", async () => {
+  const snapshot = await gatherConsoleState(
+    makeOrchestrator({
+      buffer: {
+        getTurns: () => [
+          { content: "hello" },
+          { content: "world" },
+        ],
+      },
+    }),
+  );
+
+  // capturedAt is ISO-8601
+  assert.match(snapshot.capturedAt, /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}/);
+
+  // Must round-trip cleanly through JSON
+  const json = JSON.stringify(snapshot);
+  const parsed = JSON.parse(json);
+  assert.equal(typeof parsed, "object");
+  assert.equal(parsed.bufferState.turnsCount, 2);
+  assert.equal(parsed.bufferState.byteCount, "hello".length + "world".length);
+  assert.deepEqual(parsed.errors, []);
+  assert.equal(typeof parsed.daemon.uptimeMs, "number");
+  assert.equal(typeof parsed.daemon.version, "string");
+  assert.equal(parsed.qmdProbe.available, false);
+});
+
+test("one subsystem failure does not crash gatherConsoleState", async () => {
+  const snapshot = await gatherConsoleState(
+    makeOrchestrator({
+      buffer: {
+        getTurns: () => {
+          throw new Error("buffer exploded");
+        },
+      },
+    }),
+  );
+
+  // Buffer section is empty + an entry in errors
+  assert.equal(snapshot.bufferState.turnsCount, 0);
+  assert.equal(snapshot.bufferState.byteCount, 0);
+  assert.ok(
+    snapshot.errors.some((e) => e.includes("bufferState") && e.includes("buffer exploded")),
+    `expected bufferState error, got ${JSON.stringify(snapshot.errors)}`,
+  );
+
+  // Other sections still populated
+  assert.equal(snapshot.qmdProbe.debug, "stub");
+});
+
+test("qmd probe failure is captured without crashing", async () => {
+  const snapshot = await gatherConsoleState(
+    makeOrchestrator({
+      qmd: {
+        isAvailable: () => {
+          throw new Error("qmd boom");
+        },
+      },
+    }),
+  );
+  assert.equal(snapshot.qmdProbe.available, false);
+  assert.ok(snapshot.errors.some((e) => e.includes("qmdProbe")));
+});
+
+test("missing optional accessors fall back to placeholders", async () => {
+  const snapshot = await gatherConsoleState({
+    config: { memoryDir: "/nonexistent" },
+  });
+  assert.equal(snapshot.extractionQueue.depth, 0);
+  assert.deepEqual(snapshot.extractionQueue.recentVerdicts, []);
+  assert.deepEqual(snapshot.dedupRecent, []);
+  assert.equal(snapshot.bufferState.turnsCount, 0);
+  // No errors — these are graceful empty fallbacks, not failures.
+  assert.deepEqual(snapshot.errors, []);
+});
+
+test("optional accessors populate extractionQueue and dedupRecent", async () => {
+  const snapshot = await gatherConsoleState(
+    makeOrchestrator({
+      getConsoleExtractionQueueDepth: () => 3,
+      getConsoleExtractionRecentVerdicts: () => [
+        { ts: "2026-04-25T00:00:00Z", kind: "accept", reason: "ok" },
+        { ts: "2026-04-25T00:01:00Z", kind: "reject" },
+      ],
+      getConsoleDedupRecentDecisions: () => [
+        { ts: "2026-04-25T00:02:00Z", decision: "duplicate", similarity: 0.97 },
+      ],
+    }),
+  );
+  assert.equal(snapshot.extractionQueue.depth, 3);
+  assert.equal(snapshot.extractionQueue.recentVerdicts.length, 2);
+  assert.equal(snapshot.extractionQueue.recentVerdicts[0].reason, "ok");
+  assert.equal(snapshot.dedupRecent.length, 1);
+  assert.equal(snapshot.dedupRecent[0].similarity, 0.97);
+});
+
+test("maintenance ledger tail reads the most recent N rows", async () => {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "remnic-console-state-"));
+  try {
+    const ledgerDir = path.join(baseDir, "state", "observation-ledger");
+    mkdirSync(ledgerDir, { recursive: true });
+    const lines: string[] = [];
+    for (let i = 0; i < 60; i++) {
+      lines.push(
+        JSON.stringify({
+          ts: `2026-04-25T00:${String(i).padStart(2, "0")}:00Z`,
+          category: "EXTRACTION_JUDGE_VERDICT",
+          verdictKind: i % 2 === 0 ? "accept" : "reject",
+          reason: `event-${i}`,
+        }),
+      );
+    }
+    // Add a malformed row to confirm the parser tolerates it.
+    lines.push("not-json");
+    writeFileSync(
+      path.join(ledgerDir, "rebuilt-observations.jsonl"),
+      lines.join("\n") + "\n",
+    );
+
+    const snapshot = await gatherConsoleState({
+      config: { memoryDir: baseDir },
+    });
+    // Capped at 50; oldest-first within the tail window.
+    assert.equal(snapshot.maintenanceLedgerTail.length, 50);
+    assert.ok(
+      snapshot.maintenanceLedgerTail[0].ts <
+        snapshot.maintenanceLedgerTail[49].ts,
+      "tail should be ordered oldest-first",
+    );
+    assert.deepEqual(snapshot.errors, []);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});
+
+test("missing ledger file is not an error", async () => {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "remnic-console-state-"));
+  try {
+    const snapshot = await gatherConsoleState({
+      config: { memoryDir: baseDir },
+    });
+    assert.deepEqual(snapshot.maintenanceLedgerTail, []);
+    assert.deepEqual(snapshot.errors, []);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/console/state.test.ts
+++ b/packages/remnic-core/src/console/state.test.ts
@@ -171,3 +171,54 @@ test("missing ledger file is not an error", async () => {
     rmSync(baseDir, { recursive: true, force: true });
   }
 });
+
+test("maintenance ledger merges judge-verdicts + rebuilt-observations and picks globally most-recent rows", async () => {
+  const baseDir = mkdtempSync(path.join(tmpdir(), "console-state-merge-"));
+  try {
+    const ledgerDir = path.join(baseDir, "state", "observation-ledger");
+    mkdirSync(ledgerDir, { recursive: true });
+    // Verdicts file: ts-ordered append log with two events.
+    writeFileSync(
+      path.join(ledgerDir, "extraction-judge-verdicts.jsonl"),
+      [
+        JSON.stringify({ ts: "2026-04-25T10:00:00Z", verdictKind: "accept" }),
+        JSON.stringify({ ts: "2026-04-25T11:00:00Z", verdictKind: "reject" }),
+      ].join("\n") + "\n",
+    );
+    // Rebuilt-observations file: sorted by sessionKey/hour, NOT
+    // recency. Includes a row from a lexicographically-late session
+    // that's actually the OLDEST event, and a row from a
+    // lexicographically-early session that's the MOST-RECENT.
+    writeFileSync(
+      path.join(ledgerDir, "rebuilt-observations.jsonl"),
+      [
+        JSON.stringify({
+          sessionKey: "aardvark",
+          hour: "2026-04-25T12:00:00Z",
+          turnCount: 5,
+          rebuiltAt: "2026-04-25T12:30:00Z",
+        }),
+        JSON.stringify({
+          sessionKey: "zebra",
+          hour: "2026-04-25T08:00:00Z",
+          turnCount: 3,
+          rebuiltAt: "2026-04-25T08:30:00Z",
+        }),
+      ].join("\n") + "\n",
+    );
+    const snapshot = await gatherConsoleState(
+      makeOrchestrator({ config: { memoryDir: baseDir } }),
+    );
+    // Most-recent ts is the aardvark row at hour=2026-04-25T12:00:00Z.
+    // The byte-tail-only approach would have picked the zebra row
+    // because it sits last in the file. Streaming top-N visits every
+    // row and keeps the truly-most-recent.
+    const tail = snapshot.maintenanceLedgerTail;
+    assert.ok(tail.length >= 3);
+    const last = tail[tail.length - 1];
+    assert.equal(last.ts, "2026-04-25T12:00:00Z");
+    assert.deepEqual(snapshot.errors, []);
+  } finally {
+    rmSync(baseDir, { recursive: true, force: true });
+  }
+});

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -1,0 +1,384 @@
+/**
+ * Structured engine-state aggregator for the operator console (issue #688).
+ *
+ * This module is the data layer for the upcoming console TUI / HTTP /
+ * MCP surfaces. It collects a point-in-time snapshot of the engine's
+ * runtime state — buffer contents, extraction queue depth, recent
+ * dedup decisions, the tail of the maintenance/observation ledger,
+ * QMD probe status, and daemon metadata — into a single
+ * JSON-serializable shape.
+ *
+ * Design contract:
+ *   - Each subsystem read is wrapped in try/catch so one failure
+ *     never crashes the whole snapshot. Failed reads return null /
+ *     empty values and append a string to `errors`.
+ *   - The output MUST be JSON-serializable so the CLI / HTTP / MCP
+ *     surfaces can pipe it directly through `JSON.stringify`.
+ *   - Read-only: this module never mutates orchestrator state.
+ *
+ * PR 1/3 of issue #688 wires only the data layer + a CLI flag. The
+ * TUI (PR 2/3), HTTP `/console/state`, MCP `engram.console_state`,
+ * SSE live updates, and trace replay (PR 3/3) land separately.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+/**
+ * Public state read off the orchestrator. We intentionally type this
+ * as a permissive duck-typed shape rather than importing the concrete
+ * `Orchestrator` class — the aggregator must tolerate missing fields
+ * (e.g. tests that pass a stub) without throwing. Each accessor is
+ * defensively read at call time.
+ */
+export interface ConsoleStateOrchestratorLike {
+  config?: {
+    memoryDir?: string;
+  };
+  buffer?: {
+    getTurns?: (bufferKey?: string) => Array<{ content?: string }>;
+  };
+  qmd?: {
+    debugStatus?: () => string;
+    isAvailable?: () => boolean;
+    isDaemonMode?: () => boolean;
+  };
+  /**
+   * Optional console-specific read surface added by future slices.
+   * The aggregator falls back to placeholders when these are absent
+   * so PR 1/3 ships without coupling to private orchestrator state.
+   */
+  getConsoleExtractionQueueDepth?: () => number;
+  getConsoleExtractionRecentVerdicts?: () => ReadonlyArray<ConsoleExtractionVerdict>;
+  getConsoleDedupRecentDecisions?: () => ReadonlyArray<ConsoleDedupDecision>;
+  /**
+   * Process / daemon metadata. Hosts that run remnic as a long-lived
+   * daemon (gateway, MCP server) can override these; otherwise the
+   * aggregator falls back to `process.uptime()` and the package
+   * version read from disk.
+   */
+  getConsoleDaemonInfo?: () => ConsoleDaemonInfo;
+}
+
+export interface ConsoleBufferState {
+  /** Number of turns currently held in the default buffer slot. */
+  turnsCount: number;
+  /** Approximate byte size of buffered content (UTF-8). */
+  byteCount: number;
+}
+
+export interface ConsoleExtractionVerdict {
+  /** ISO-8601 timestamp the verdict was recorded. */
+  ts: string;
+  /** Verdict kind — typically "accept" | "reject" | "defer". */
+  kind: string;
+  /** Optional short reason from the judge or fallback. */
+  reason?: string;
+}
+
+export interface ConsoleExtractionQueueState {
+  /** Number of pending extraction tasks queued in the orchestrator. */
+  depth: number;
+  /** Most recent judge verdicts, newest last. Capped at 25 entries. */
+  recentVerdicts: ConsoleExtractionVerdict[];
+}
+
+export interface ConsoleDedupDecision {
+  /** ISO-8601 timestamp the decision was recorded. */
+  ts: string;
+  /** Outcome of the dedup check — "duplicate" | "novel" | etc. */
+  decision: string;
+  /** Optional content fingerprint (first 16 chars of a hash). */
+  fingerprint?: string;
+  /** Optional similarity score that drove the decision. */
+  similarity?: number;
+}
+
+export interface ConsoleMaintenanceLedgerEvent {
+  /** ISO-8601 timestamp from the ledger row. */
+  ts: string;
+  /** Event category (e.g. "EXTRACTION_JUDGE_VERDICT"). */
+  category: string;
+  /** Compact one-line summary. */
+  summary: string;
+}
+
+export interface ConsoleQmdProbeState {
+  /** Whether QMD is reachable via CLI or daemon. */
+  available: boolean;
+  /** Whether the daemon transport is in use. */
+  daemonMode: boolean;
+  /** Raw debug-status string from `qmd.debugStatus()`. */
+  debug: string;
+}
+
+export interface ConsoleDaemonInfo {
+  /** Process uptime in milliseconds. */
+  uptimeMs: number;
+  /** Package / daemon version (best-effort). */
+  version: string;
+}
+
+export interface ConsoleStateSnapshot {
+  /** ISO-8601 capture timestamp. */
+  capturedAt: string;
+  bufferState: ConsoleBufferState;
+  extractionQueue: ConsoleExtractionQueueState;
+  dedupRecent: ConsoleDedupDecision[];
+  maintenanceLedgerTail: ConsoleMaintenanceLedgerEvent[];
+  qmdProbe: ConsoleQmdProbeState;
+  daemon: ConsoleDaemonInfo;
+  /**
+   * Subsystem read errors. One entry per failed reader keyed by
+   * subsystem name (e.g. `"bufferState: ..."`). An empty array means
+   * every section was read cleanly.
+   */
+  errors: string[];
+}
+
+const MAX_LEDGER_TAIL = 50;
+const MAX_VERDICT_TAIL = 25;
+const MAX_DEDUP_TAIL = 10;
+
+/**
+ * Gather a `ConsoleStateSnapshot` from the orchestrator. Each
+ * subsystem read is independent; a thrown error in one reader is
+ * captured in `errors` and the corresponding section is filled with
+ * empty / placeholder values.
+ */
+export async function gatherConsoleState(
+  orchestrator: ConsoleStateOrchestratorLike,
+): Promise<ConsoleStateSnapshot> {
+  const errors: string[] = [];
+  const capturedAt = new Date().toISOString();
+
+  const bufferState = readBufferState(orchestrator, errors);
+  const extractionQueue = readExtractionQueue(orchestrator, errors);
+  const dedupRecent = readDedupRecent(orchestrator, errors);
+  const maintenanceLedgerTail = await readMaintenanceLedgerTail(
+    orchestrator,
+    errors,
+  );
+  const qmdProbe = readQmdProbe(orchestrator, errors);
+  const daemon = readDaemonInfo(orchestrator, errors);
+
+  return {
+    capturedAt,
+    bufferState,
+    extractionQueue,
+    dedupRecent,
+    maintenanceLedgerTail,
+    qmdProbe,
+    daemon,
+    errors,
+  };
+}
+
+function readBufferState(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): ConsoleBufferState {
+  try {
+    const getTurns = orchestrator.buffer?.getTurns;
+    if (typeof getTurns !== "function") {
+      return { turnsCount: 0, byteCount: 0 };
+    }
+    const turns = getTurns.call(orchestrator.buffer) ?? [];
+    let byteCount = 0;
+    for (const turn of turns) {
+      const content = typeof turn?.content === "string" ? turn.content : "";
+      byteCount += Buffer.byteLength(content, "utf8");
+    }
+    return { turnsCount: turns.length, byteCount };
+  } catch (err) {
+    errors.push(`bufferState: ${describeError(err)}`);
+    return { turnsCount: 0, byteCount: 0 };
+  }
+}
+
+function readExtractionQueue(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): ConsoleExtractionQueueState {
+  try {
+    const depth =
+      typeof orchestrator.getConsoleExtractionQueueDepth === "function"
+        ? orchestrator.getConsoleExtractionQueueDepth()
+        : 0;
+    const verdicts =
+      typeof orchestrator.getConsoleExtractionRecentVerdicts === "function"
+        ? orchestrator.getConsoleExtractionRecentVerdicts()
+        : [];
+    const recentVerdicts = (verdicts ?? [])
+      .slice(-MAX_VERDICT_TAIL)
+      .map((v) => ({
+        ts: typeof v?.ts === "string" ? v.ts : "",
+        kind: typeof v?.kind === "string" ? v.kind : "unknown",
+        ...(typeof v?.reason === "string" ? { reason: v.reason } : {}),
+      }));
+    return { depth: Number.isFinite(depth) ? depth : 0, recentVerdicts };
+  } catch (err) {
+    errors.push(`extractionQueue: ${describeError(err)}`);
+    return { depth: 0, recentVerdicts: [] };
+  }
+}
+
+function readDedupRecent(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): ConsoleDedupDecision[] {
+  try {
+    const getter = orchestrator.getConsoleDedupRecentDecisions;
+    if (typeof getter !== "function") return [];
+    const raw = getter() ?? [];
+    return raw.slice(-MAX_DEDUP_TAIL).map((d) => ({
+      ts: typeof d?.ts === "string" ? d.ts : "",
+      decision: typeof d?.decision === "string" ? d.decision : "unknown",
+      ...(typeof d?.fingerprint === "string"
+        ? { fingerprint: d.fingerprint }
+        : {}),
+      ...(typeof d?.similarity === "number" && Number.isFinite(d.similarity)
+        ? { similarity: d.similarity }
+        : {}),
+    }));
+  } catch (err) {
+    errors.push(`dedupRecent: ${describeError(err)}`);
+    return [];
+  }
+}
+
+async function readMaintenanceLedgerTail(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): Promise<ConsoleMaintenanceLedgerEvent[]> {
+  try {
+    const memoryDir = orchestrator.config?.memoryDir;
+    if (!memoryDir || typeof memoryDir !== "string") return [];
+    // Standard observation-ledger location used by extraction judge,
+    // turn-count, and other categories. Keep this in sync with
+    // `state/observation-ledger/` paths in extraction-judge-telemetry.ts
+    // and maintenance/observation-ledger-utils.ts.
+    const ledgerPath = path.join(
+      memoryDir,
+      "state",
+      "observation-ledger",
+      "rebuilt-observations.jsonl",
+    );
+    let raw: string;
+    try {
+      raw = await fs.readFile(ledgerPath, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === "ENOENT") return [];
+      throw err;
+    }
+    const events: ConsoleMaintenanceLedgerEvent[] = [];
+    const lines = raw.split("\n");
+    // Iterate from the tail to bound work for large ledgers.
+    for (let i = lines.length - 1; i >= 0 && events.length < MAX_LEDGER_TAIL; i--) {
+      const line = lines[i]?.trim();
+      if (!line) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(line);
+      } catch {
+        continue;
+      }
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        continue;
+      }
+      const p = parsed as Record<string, unknown>;
+      const ts = typeof p.ts === "string" ? p.ts : "";
+      const category = typeof p.category === "string" ? p.category : "unknown";
+      const summary = summarizeLedgerEvent(p);
+      events.push({ ts, category, summary });
+    }
+    // Reverse so the caller sees oldest-first within the tail window.
+    return events.reverse();
+  } catch (err) {
+    errors.push(`maintenanceLedgerTail: ${describeError(err)}`);
+    return [];
+  }
+}
+
+function summarizeLedgerEvent(p: Record<string, unknown>): string {
+  const parts: string[] = [];
+  if (typeof p.verdictKind === "string") parts.push(`verdict=${p.verdictKind}`);
+  if (typeof p.reason === "string" && p.reason.length > 0) {
+    const trimmed = p.reason.length > 80 ? `${p.reason.slice(0, 80)}…` : p.reason;
+    parts.push(`reason=${trimmed}`);
+  }
+  if (typeof p.candidateCategory === "string") {
+    parts.push(`cat=${p.candidateCategory}`);
+  }
+  if (parts.length === 0) {
+    return typeof p.category === "string" ? p.category : "event";
+  }
+  return parts.join(" ");
+}
+
+function readQmdProbe(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): ConsoleQmdProbeState {
+  try {
+    const qmd = orchestrator.qmd;
+    if (!qmd) {
+      return { available: false, daemonMode: false, debug: "qmd unavailable" };
+    }
+    const available =
+      typeof qmd.isAvailable === "function" ? qmd.isAvailable() : false;
+    const daemonMode =
+      typeof qmd.isDaemonMode === "function" ? qmd.isDaemonMode() : false;
+    const debug =
+      typeof qmd.debugStatus === "function" ? qmd.debugStatus() : "";
+    return { available, daemonMode, debug };
+  } catch (err) {
+    errors.push(`qmdProbe: ${describeError(err)}`);
+    return { available: false, daemonMode: false, debug: "" };
+  }
+}
+
+function readDaemonInfo(
+  orchestrator: ConsoleStateOrchestratorLike,
+  errors: string[],
+): ConsoleDaemonInfo {
+  try {
+    if (typeof orchestrator.getConsoleDaemonInfo === "function") {
+      const info = orchestrator.getConsoleDaemonInfo();
+      return {
+        uptimeMs: Number.isFinite(info?.uptimeMs) ? info.uptimeMs : 0,
+        version: typeof info?.version === "string" ? info.version : "unknown",
+      };
+    }
+    // Fallback: process uptime + best-effort package version. This is
+    // only meaningful when the orchestrator runs in the same process
+    // as the CLI (which is the case for `remnic console --state-only`).
+    const uptimeMs = Math.round((process.uptime?.() ?? 0) * 1000);
+    return { uptimeMs, version: resolvePackageVersion() };
+  } catch (err) {
+    errors.push(`daemon: ${describeError(err)}`);
+    return { uptimeMs: 0, version: "unknown" };
+  }
+}
+
+function resolvePackageVersion(): string {
+  // Best-effort, sync, never throws. We avoid importing package.json
+  // statically because tsup bundles into a single file at runtime.
+  try {
+    const env = process.env?.REMNIC_VERSION;
+    if (typeof env === "string" && env.length > 0) return env;
+  } catch {
+    // ignore
+  }
+  return "unknown";
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try {
+    return String(err);
+  } catch {
+    return "unknown error";
+  }
+}

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -318,8 +318,32 @@ async function readMaintenanceLedgerTail(
         continue;
       }
       const p = parsed as Record<string, unknown>;
-      const ts = typeof p.ts === "string" ? p.ts : "";
-      const category = typeof p.category === "string" ? p.category : "unknown";
+      // Codex P2: the canonical writers (`rebuildObservations` and
+      // `migrateObservations`) emit rows shaped like
+      // `{sessionKey, hour, turnCount, userTurns, assistantTurns,
+      // rebuiltAt}`, NOT `{ts, category}`. Map fields accordingly:
+      // `ts` derives from `hour` (or `rebuiltAt`), `category` falls
+      // back to a stable "observation" tag for canonical rows. Judge-
+      // verdict rows that DO have `ts`/`verdictKind` from
+      // `extraction-judge-telemetry.ts` are still picked up via the
+      // existing field-shape detection so both sources render in the
+      // tail.
+      const ts =
+        typeof p.ts === "string" && p.ts.length > 0
+          ? p.ts
+          : typeof p.hour === "string" && p.hour.length > 0
+            ? p.hour
+            : typeof p.rebuiltAt === "string" && p.rebuiltAt.length > 0
+              ? p.rebuiltAt
+              : "";
+      const category =
+        typeof p.category === "string" && p.category.length > 0
+          ? p.category
+          : typeof p.verdictKind === "string"
+            ? "judge-verdict"
+            : typeof p.turnCount === "number"
+              ? "observation"
+              : "unknown";
       const summary = summarizeLedgerEvent(p);
       events.push({ ts, category, summary });
     }
@@ -333,6 +357,7 @@ async function readMaintenanceLedgerTail(
 
 function summarizeLedgerEvent(p: Record<string, unknown>): string {
   const parts: string[] = [];
+  // Judge-verdict rows.
   if (typeof p.verdictKind === "string") parts.push(`verdict=${p.verdictKind}`);
   if (typeof p.reason === "string" && p.reason.length > 0) {
     const trimmed = p.reason.length > 80 ? `${p.reason.slice(0, 80)}…` : p.reason;
@@ -340,6 +365,19 @@ function summarizeLedgerEvent(p: Record<string, unknown>): string {
   }
   if (typeof p.candidateCategory === "string") {
     parts.push(`cat=${p.candidateCategory}`);
+  }
+  // Canonical rebuilt-observations rows (codex P2).
+  if (typeof p.sessionKey === "string" && p.sessionKey.length > 0) {
+    parts.push(`session=${p.sessionKey}`);
+  }
+  if (typeof p.turnCount === "number" && Number.isFinite(p.turnCount)) {
+    parts.push(`turns=${p.turnCount}`);
+  }
+  if (typeof p.userTurns === "number" && Number.isFinite(p.userTurns)) {
+    parts.push(`u=${p.userTurns}`);
+  }
+  if (typeof p.assistantTurns === "number" && Number.isFinite(p.assistantTurns)) {
+    parts.push(`a=${p.assistantTurns}`);
   }
   if (parts.length === 0) {
     return typeof p.category === "string" ? p.category : "event";

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -228,9 +228,14 @@ function readDedupRecent(
   errors: string[],
 ): ConsoleDedupDecision[] {
   try {
-    const getter = orchestrator.getConsoleDedupRecentDecisions;
-    if (typeof getter !== "function") return [];
-    const raw = getter() ?? [];
+    // Cursor Medium: call directly on `orchestrator` to preserve the
+    // `this` binding. Extracting the method into a local and invoking
+    // it bare loses `this`, so a non-arrow implementation that
+    // references `this` would fail at runtime. Mirrors how
+    // `readExtractionQueue` and `readMaintenanceLedgerTail` invoke
+    // their orchestrator methods.
+    if (typeof orchestrator.getConsoleDedupRecentDecisions !== "function") return [];
+    const raw = orchestrator.getConsoleDedupRecentDecisions() ?? [];
     return raw.slice(-MAX_DEDUP_TAIL).map((d) => ({
       ts: typeof d?.ts === "string" ? d.ts : "",
       decision: typeof d?.decision === "string" ? d.decision : "unknown",

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -269,9 +269,34 @@ async function readMaintenanceLedgerTail(
       "observation-ledger",
       "rebuilt-observations.jsonl",
     );
+    // Codex P2: read only the tail rather than the full file so
+    // `gatherConsoleState()` doesn't scale with ledger size. JSONL
+    // rows are bounded in practice; capping at 256 KiB still returns
+    // far more than `MAX_LEDGER_TAIL=50` rows in any realistic case
+    // and protects the console surface from a multi-GB observation
+    // ledger.
+    const TAIL_BYTES = 256 * 1024;
     let raw: string;
     try {
-      raw = await fs.readFile(ledgerPath, "utf-8");
+      const stat = await fs.stat(ledgerPath);
+      const fileSize = stat.size;
+      if (fileSize <= TAIL_BYTES) {
+        raw = await fs.readFile(ledgerPath, "utf-8");
+      } else {
+        const fh = await fs.open(ledgerPath, "r");
+        try {
+          const offset = fileSize - TAIL_BYTES;
+          const buf = Buffer.alloc(TAIL_BYTES);
+          await fh.read(buf, 0, TAIL_BYTES, offset);
+          // Drop everything before the first newline so we don't try
+          // to parse a partial JSON row at the start of the window.
+          const slice = buf.toString("utf-8");
+          const firstNewline = slice.indexOf("\n");
+          raw = firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
+        } finally {
+          await fh.close();
+        }
+      }
     } catch (err) {
       const code = (err as NodeJS.ErrnoException).code;
       if (code === "ENOENT") return [];

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -252,6 +252,38 @@ function readDedupRecent(
   }
 }
 
+/**
+ * Read the tail of a JSONL file capped at TAIL_BYTES so we never load
+ * gigabytes into memory just to surface the most recent rows.
+ */
+async function readJsonlTail(
+  ledgerPath: string,
+  tailBytes: number,
+): Promise<string | null> {
+  try {
+    const stat = await fs.stat(ledgerPath);
+    const fileSize = stat.size;
+    if (fileSize <= tailBytes) {
+      return await fs.readFile(ledgerPath, "utf-8");
+    }
+    const fh = await fs.open(ledgerPath, "r");
+    try {
+      const offset = fileSize - tailBytes;
+      const buf = Buffer.alloc(tailBytes);
+      await fh.read(buf, 0, tailBytes, offset);
+      const slice = buf.toString("utf-8");
+      const firstNewline = slice.indexOf("\n");
+      return firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
+    } finally {
+      await fh.close();
+    }
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return null;
+    throw err;
+  }
+}
+
 async function readMaintenanceLedgerTail(
   orchestrator: ConsoleStateOrchestratorLike,
   errors: string[],
@@ -259,65 +291,46 @@ async function readMaintenanceLedgerTail(
   try {
     const memoryDir = orchestrator.config?.memoryDir;
     if (!memoryDir || typeof memoryDir !== "string") return [];
-    // Standard observation-ledger location used by extraction judge,
-    // turn-count, and other categories. Keep this in sync with
-    // `state/observation-ledger/` paths in extraction-judge-telemetry.ts
-    // and maintenance/observation-ledger-utils.ts.
-    const ledgerPath = path.join(
-      memoryDir,
-      "state",
-      "observation-ledger",
-      "rebuilt-observations.jsonl",
-    );
-    // Codex P2: read only the tail rather than the full file so
-    // `gatherConsoleState()` doesn't scale with ledger size. JSONL
-    // rows are bounded in practice; capping at 256 KiB still returns
-    // far more than `MAX_LEDGER_TAIL=50` rows in any realistic case
-    // and protects the console surface from a multi-GB observation
-    // ledger.
+    const ledgerDir = path.join(memoryDir, "state", "observation-ledger");
+    // Codex P2 (round 2): read BOTH canonical ledger files and merge
+    // them. `extraction-judge-verdicts.jsonl` is the live verdict
+    // append-log written by extraction-judge-telemetry.ts;
+    // `rebuilt-observations.jsonl` is the periodic aggregate from
+    // maintenance/rebuild-observations.ts. Without the verdicts file,
+    // the snapshot misses recent judge events when no rebuild has
+    // run. Sort the merged set by `ts` descending afterward so the
+    // tail reflects global recency, not the on-disk row order
+    // (rebuilt rows are sorted by sessionKey/hour, not recency —
+    // codex P2 round 2).
     const TAIL_BYTES = 256 * 1024;
-    let raw: string;
-    try {
-      const stat = await fs.stat(ledgerPath);
-      const fileSize = stat.size;
-      if (fileSize <= TAIL_BYTES) {
-        raw = await fs.readFile(ledgerPath, "utf-8");
-      } else {
-        const fh = await fs.open(ledgerPath, "r");
-        try {
-          const offset = fileSize - TAIL_BYTES;
-          const buf = Buffer.alloc(TAIL_BYTES);
-          await fh.read(buf, 0, TAIL_BYTES, offset);
-          // Drop everything before the first newline so we don't try
-          // to parse a partial JSON row at the start of the window.
-          const slice = buf.toString("utf-8");
-          const firstNewline = slice.indexOf("\n");
-          raw = firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
-        } finally {
-          await fh.close();
-        }
-      }
-    } catch (err) {
-      const code = (err as NodeJS.ErrnoException).code;
-      if (code === "ENOENT") return [];
-      throw err;
-    }
+    const verdictsRaw = await readJsonlTail(
+      path.join(ledgerDir, "extraction-judge-verdicts.jsonl"),
+      TAIL_BYTES,
+    );
+    const rebuiltRaw = await readJsonlTail(
+      path.join(ledgerDir, "rebuilt-observations.jsonl"),
+      TAIL_BYTES,
+    );
+    if (verdictsRaw === null && rebuiltRaw === null) return [];
     const events: ConsoleMaintenanceLedgerEvent[] = [];
-    const lines = raw.split("\n");
-    // Iterate from the tail to bound work for large ledgers.
-    for (let i = lines.length - 1; i >= 0 && events.length < MAX_LEDGER_TAIL; i--) {
-      const line = lines[i]?.trim();
-      if (!line) continue;
-      let parsed: unknown;
-      try {
-        parsed = JSON.parse(line);
-      } catch {
-        continue;
-      }
-      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-        continue;
-      }
-      const p = parsed as Record<string, unknown>;
+    const sources: Array<{ raw: string }> = [];
+    if (verdictsRaw !== null) sources.push({ raw: verdictsRaw });
+    if (rebuiltRaw !== null) sources.push({ raw: rebuiltRaw });
+    for (const { raw } of sources) {
+      const lines = raw.split("\n");
+      for (const line of lines) {
+        const trimmed = line.trim();
+        if (!trimmed) continue;
+        let parsed: unknown;
+        try {
+          parsed = JSON.parse(trimmed);
+        } catch {
+          continue;
+        }
+        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+          continue;
+        }
+        const p = parsed as Record<string, unknown>;
       // Codex P2: the canonical writers (`rebuildObservations` and
       // `migrateObservations`) emit rows shaped like
       // `{sessionKey, hour, turnCount, userTurns, assistantTurns,
@@ -345,10 +358,27 @@ async function readMaintenanceLedgerTail(
               ? "observation"
               : "unknown";
       const summary = summarizeLedgerEvent(p);
-      events.push({ ts, category, summary });
+        events.push({ ts, category, summary });
+      }
     }
+    // Codex P2 round 2: rebuilt-observations rows are written sorted
+    // by sessionKey then hour, NOT by global recency. Sort the merged
+    // set by `ts` descending and take the most recent MAX_LEDGER_TAIL
+    // so the snapshot reflects what just happened, regardless of
+    // on-disk row order. Rows with no parseable `ts` sort last.
+    events.sort((a, b) => {
+      const aMs = a.ts ? Date.parse(a.ts) : NaN;
+      const bMs = b.ts ? Date.parse(b.ts) : NaN;
+      const aOk = Number.isFinite(aMs);
+      const bOk = Number.isFinite(bMs);
+      if (aOk && bOk) return bMs - aMs;
+      if (aOk) return -1;
+      if (bOk) return 1;
+      return 0;
+    });
+    const tail = events.slice(0, MAX_LEDGER_TAIL);
     // Reverse so the caller sees oldest-first within the tail window.
-    return events.reverse();
+    return tail.reverse();
   } catch (err) {
     errors.push(`maintenanceLedgerTail: ${describeError(err)}`);
     return [];

--- a/packages/remnic-core/src/console/state.ts
+++ b/packages/remnic-core/src/console/state.ts
@@ -21,7 +21,8 @@
  * SSE live updates, and trace replay (PR 3/3) land separately.
  */
 
-import { promises as fs } from "node:fs";
+import { promises as fs, createReadStream } from "node:fs";
+import { createInterface } from "node:readline";
 import path from "node:path";
 
 /**
@@ -253,35 +254,115 @@ function readDedupRecent(
 }
 
 /**
- * Read the tail of a JSONL file capped at TAIL_BYTES so we never load
- * gigabytes into memory just to surface the most recent rows.
+ * Stream a JSONL file line-by-line, parse each row, project it into a
+ * console event, and keep only the `topN` most-recent items by `ts`
+ * (descending). Memory is bounded at O(2 * topN) regardless of file
+ * size — we sort-and-truncate whenever the working buffer grows past
+ * `2 * topN`. This satisfies BOTH:
+ *
+ *   1. "Don't load the whole file into memory" — streaming + bounded
+ *      buffer means a multi-GB ledger never blows up RAM.
+ *   2. "Don't miss recent rows just because the file isn't sorted by
+ *      recency" — `rebuilt-observations.jsonl` is written sorted by
+ *      `(sessionKey, hour)`, NOT by global ts, so a byte-tail-only
+ *      read silently dropped recent-but-lexicographically-earlier
+ *      sessions. Streaming top-N visits every row and keeps the
+ *      globally-most-recent ones.
+ *
+ * Returns an array sorted oldest-first within the top-N window. Rows
+ * with no parseable `ts` are dropped (they would otherwise compare
+ * undefined under any sort).
  */
-async function readJsonlTail(
+async function streamLedgerTopN<T extends { ts: string }>(
   ledgerPath: string,
-  tailBytes: number,
-): Promise<string | null> {
+  topN: number,
+  project: (parsed: Record<string, unknown>) => T | null,
+): Promise<T[]> {
+  let stream: ReturnType<typeof createReadStream>;
   try {
-    const stat = await fs.stat(ledgerPath);
-    const fileSize = stat.size;
-    if (fileSize <= tailBytes) {
-      return await fs.readFile(ledgerPath, "utf-8");
-    }
-    const fh = await fs.open(ledgerPath, "r");
-    try {
-      const offset = fileSize - tailBytes;
-      const buf = Buffer.alloc(tailBytes);
-      await fh.read(buf, 0, tailBytes, offset);
-      const slice = buf.toString("utf-8");
-      const firstNewline = slice.indexOf("\n");
-      return firstNewline >= 0 ? slice.slice(firstNewline + 1) : slice;
-    } finally {
-      await fh.close();
-    }
+    // `fs.access`-style probe so we can quietly return `[]` for
+    // ENOENT without hitting the readline error path.
+    await fs.stat(ledgerPath);
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code === "ENOENT") return null;
+    if (code === "ENOENT") return [];
     throw err;
   }
+  try {
+    stream = createReadStream(ledgerPath, { encoding: "utf-8" });
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return [];
+    throw err;
+  }
+  const rl = createInterface({ input: stream, crlfDelay: Infinity });
+  const cap = Math.max(1, topN) * 2;
+  const buf: T[] = [];
+  const truncate = () => {
+    // Sort descending by ts, keep top-N, drop the rest.
+    buf.sort((a, b) => {
+      const aMs = Date.parse(a.ts);
+      const bMs = Date.parse(b.ts);
+      if (Number.isFinite(aMs) && Number.isFinite(bMs)) return bMs - aMs;
+      if (Number.isFinite(aMs)) return -1;
+      if (Number.isFinite(bMs)) return 1;
+      return 0;
+    });
+    if (buf.length > topN) buf.length = topN;
+  };
+  try {
+    for await (const line of rl) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(trimmed);
+      } catch {
+        continue;
+      }
+      if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+        continue;
+      }
+      const event = project(parsed as Record<string, unknown>);
+      if (event === null) continue;
+      // Drop rows we couldn't even date-stamp — they can't be sorted
+      // meaningfully against the rest of the corpus.
+      if (!event.ts || !Number.isFinite(Date.parse(event.ts))) continue;
+      buf.push(event);
+      if (buf.length >= cap) truncate();
+    }
+  } finally {
+    rl.close();
+    stream.close();
+  }
+  truncate();
+  return buf.reverse(); // oldest-first within the top-N window
+}
+
+function projectLedgerRow(p: Record<string, unknown>): ConsoleMaintenanceLedgerEvent | null {
+  // The two canonical writers produce different row shapes:
+  //   - extraction-judge-telemetry: `{ts, verdictKind, reason, candidateCategory, ...}`
+  //   - rebuild-observations / migrate-observations:
+  //     `{sessionKey, hour, turnCount, userTurns, assistantTurns, rebuiltAt}`
+  // Map both into the canonical {ts, category, summary} shape.
+  const ts =
+    typeof p.ts === "string" && p.ts.length > 0
+      ? p.ts
+      : typeof p.hour === "string" && p.hour.length > 0
+        ? p.hour
+        : typeof p.rebuiltAt === "string" && p.rebuiltAt.length > 0
+          ? p.rebuiltAt
+          : "";
+  const category =
+    typeof p.category === "string" && p.category.length > 0
+      ? p.category
+      : typeof p.verdictKind === "string"
+        ? "judge-verdict"
+        : typeof p.turnCount === "number"
+          ? "observation"
+          : "unknown";
+  const summary = summarizeLedgerEvent(p);
+  return { ts, category, summary };
 }
 
 async function readMaintenanceLedgerTail(
@@ -292,88 +373,39 @@ async function readMaintenanceLedgerTail(
     const memoryDir = orchestrator.config?.memoryDir;
     if (!memoryDir || typeof memoryDir !== "string") return [];
     const ledgerDir = path.join(memoryDir, "state", "observation-ledger");
-    // Codex P2 (round 2): read BOTH canonical ledger files and merge
-    // them. `extraction-judge-verdicts.jsonl` is the live verdict
-    // append-log written by extraction-judge-telemetry.ts;
-    // `rebuilt-observations.jsonl` is the periodic aggregate from
-    // maintenance/rebuild-observations.ts. Without the verdicts file,
-    // the snapshot misses recent judge events when no rebuild has
-    // run. Sort the merged set by `ts` descending afterward so the
-    // tail reflects global recency, not the on-disk row order
-    // (rebuilt rows are sorted by sessionKey/hour, not recency —
-    // codex P2 round 2).
-    const TAIL_BYTES = 256 * 1024;
-    const verdictsRaw = await readJsonlTail(
+    // Codex review converged on two competing constraints:
+    //   1. Don't load the whole file into memory (multi-GB ledgers
+    //      would OOM the console surface).
+    //   2. Don't miss recent rows just because the file isn't sorted
+    //      by recency (`rebuilt-observations.jsonl` is sorted by
+    //      sessionKey/hour, so byte-tail reads silently drop recent
+    //      lexicographically-earlier sessions).
+    // The right answer is a streaming bounded top-N: visit every row,
+    // but keep only the MAX_LEDGER_TAIL most-recent in memory at any
+    // time. Memory stays O(MAX_LEDGER_TAIL); recency ordering is
+    // globally correct.
+    const verdictsTopN = await streamLedgerTopN(
       path.join(ledgerDir, "extraction-judge-verdicts.jsonl"),
-      TAIL_BYTES,
+      MAX_LEDGER_TAIL,
+      projectLedgerRow,
     );
-    const rebuiltRaw = await readJsonlTail(
+    const rebuiltTopN = await streamLedgerTopN(
       path.join(ledgerDir, "rebuilt-observations.jsonl"),
-      TAIL_BYTES,
+      MAX_LEDGER_TAIL,
+      projectLedgerRow,
     );
-    if (verdictsRaw === null && rebuiltRaw === null) return [];
-    const events: ConsoleMaintenanceLedgerEvent[] = [];
-    const sources: Array<{ raw: string }> = [];
-    if (verdictsRaw !== null) sources.push({ raw: verdictsRaw });
-    if (rebuiltRaw !== null) sources.push({ raw: rebuiltRaw });
-    for (const { raw } of sources) {
-      const lines = raw.split("\n");
-      for (const line of lines) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        let parsed: unknown;
-        try {
-          parsed = JSON.parse(trimmed);
-        } catch {
-          continue;
-        }
-        if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
-          continue;
-        }
-        const p = parsed as Record<string, unknown>;
-      // Codex P2: the canonical writers (`rebuildObservations` and
-      // `migrateObservations`) emit rows shaped like
-      // `{sessionKey, hour, turnCount, userTurns, assistantTurns,
-      // rebuiltAt}`, NOT `{ts, category}`. Map fields accordingly:
-      // `ts` derives from `hour` (or `rebuiltAt`), `category` falls
-      // back to a stable "observation" tag for canonical rows. Judge-
-      // verdict rows that DO have `ts`/`verdictKind` from
-      // `extraction-judge-telemetry.ts` are still picked up via the
-      // existing field-shape detection so both sources render in the
-      // tail.
-      const ts =
-        typeof p.ts === "string" && p.ts.length > 0
-          ? p.ts
-          : typeof p.hour === "string" && p.hour.length > 0
-            ? p.hour
-            : typeof p.rebuiltAt === "string" && p.rebuiltAt.length > 0
-              ? p.rebuiltAt
-              : "";
-      const category =
-        typeof p.category === "string" && p.category.length > 0
-          ? p.category
-          : typeof p.verdictKind === "string"
-            ? "judge-verdict"
-            : typeof p.turnCount === "number"
-              ? "observation"
-              : "unknown";
-      const summary = summarizeLedgerEvent(p);
-        events.push({ ts, category, summary });
-      }
-    }
-    // Codex P2 round 2: rebuilt-observations rows are written sorted
-    // by sessionKey then hour, NOT by global recency. Sort the merged
-    // set by `ts` descending and take the most recent MAX_LEDGER_TAIL
-    // so the snapshot reflects what just happened, regardless of
-    // on-disk row order. Rows with no parseable `ts` sort last.
+    // Merge the two source top-N windows and select the global
+    // top-N. Both inputs already arrive oldest-first within their
+    // respective windows; sort the merged set descending by ts and
+    // take the most-recent MAX_LEDGER_TAIL.
+    const events: ConsoleMaintenanceLedgerEvent[] = [...verdictsTopN, ...rebuiltTopN];
+    if (events.length === 0) return [];
     events.sort((a, b) => {
-      const aMs = a.ts ? Date.parse(a.ts) : NaN;
-      const bMs = b.ts ? Date.parse(b.ts) : NaN;
-      const aOk = Number.isFinite(aMs);
-      const bOk = Number.isFinite(bMs);
-      if (aOk && bOk) return bMs - aMs;
-      if (aOk) return -1;
-      if (bOk) return 1;
+      const aMs = Date.parse(a.ts);
+      const bMs = Date.parse(b.ts);
+      if (Number.isFinite(aMs) && Number.isFinite(bMs)) return bMs - aMs;
+      if (Number.isFinite(aMs)) return -1;
+      if (Number.isFinite(bMs)) return 1;
       return 0;
     });
     const tail = events.slice(0, MAX_LEDGER_TAIL);


### PR DESCRIPTION
## Summary

Issue #688 PR 1/3 — ships **only the data layer + a CLI flag** for the upcoming operator console. No TUI, no HTTP, no MCP wiring, no SSE — those land in PR 2/3 and PR 3/3.

- New `console/state.ts` module exporting `gatherConsoleState()` and the `ConsoleStateSnapshot` interface covering `bufferState`, `extractionQueue`, `dedupRecent`, `maintenanceLedgerTail`, `qmdProbe`, `daemon`, and `capturedAt`.
- Each subsystem read is independently wrapped in try/catch so one failure cannot crash the whole snapshot — failed sections fall back to empty values and append a string to `errors`.
- Output is JSON-serializable so future HTTP / MCP / TUI surfaces can pipe it directly through `JSON.stringify`.
- New CLI subcommand `remnic engram console --state-only` prints the snapshot as JSON and exits. Without `--state-only` it prints a "TUI not yet available" hint and exits non-zero.
- Aggregator uses a permissive `ConsoleStateOrchestratorLike` duck type so future slices can wire in live extraction-queue / dedup / daemon data via optional accessors without churning the contract.

## Tests

`packages/remnic-core/src/console/state.test.ts` — 7 cases covering JSON-serializability, single-subsystem failure isolation, QMD failure isolation, missing-accessor placeholders, optional-accessor population, ledger-tail bounding with malformed-row tolerance, and missing-ledger graceful return.

## Test plan

- [x] tsc clean from packages/remnic-core
- [x] state.test.ts — 7/7 pass
- [x] npm run build succeeds
- [x] preflight:quick — 46 pre-existing failures verified identical on main; zero new failures introduced

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CLI subcommand and a new state-aggregation layer that reads runtime state and streams JSONL ledger files from disk; while read-only, the new filesystem/JSON parsing paths could affect operator workflows and performance on large ledgers.
> 
> **Overview**
> Adds an initial operator-console data layer via new `console/state.ts`, exposing `gatherConsoleState()` to collect a **JSON-serializable** engine snapshot (buffer stats, optional extraction/dedup tails, maintenance-ledger tail, QMD probe info, and daemon metadata) while isolating subsystem failures into an `errors` array.
> 
> Wires a new `remnic engram console --state-only` CLI path that prints the snapshot as pretty JSON and exits, and returns a non-zero status with a message when invoked without `--state-only`.
> 
> Includes `state.test.ts` coverage for JSON round-tripping, per-subsystem failure isolation, optional-accessor fallbacks, and bounded streaming of recent JSONL ledger events (including malformed rows and missing files).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a5f17268e7e59cc94e8b1a13ba633788634818b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->