### PR TITLE
fix(bench): score PersonaMem with MCQ accuracy

### DIFF
--- a/packages/bench/src/benchmarks/published/personamem/fixture.ts
+++ b/packages/bench/src/benchmarks/published/personamem/fixture.ts
@@ -12,6 +12,7 @@ export interface PersonaMemSample {
   personaId: string;
   userQuery: string;
   correctAnswer: string;
+  incorrectAnswers?: string[];
   chatHistory: PersonaMemChatHistory;
   topicQuery?: string;
   preference?: string;

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -2,7 +2,7 @@
  * PersonaMem-v2 runner migrated into @remnic/bench for phase 1.
  */
 
-import { randomUUID } from "node:crypto";
+import { createHash, randomUUID } from "node:crypto";
 import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
@@ -39,6 +39,7 @@ interface RawPersonaMemRow {
   chat_history_128k_link?: string;
   user_query: string;
   correct_answer: string;
+  incorrect_answers?: string;
   topic_query?: string;
   preference?: string;
   topic_preference?: string;
@@ -105,8 +106,19 @@ export async function runPersonaMemBenchmark(
         10,
         sessionId,
       );
+      const mcq =
+        sample.incorrectAnswers && sample.incorrectAnswers.length > 0
+          ? buildMcqPrompt(sample, options.seed ?? 0)
+          : undefined;
+      const evaluationQuestion = mcq
+        ? [
+            appendPersonaMemRecallInstruction(sample.userQuery),
+            "",
+            mcq.instruction,
+          ].join("\n")
+        : sample.userQuery;
       const answered = await answerBenchmarkQuestion({
-        question: sample.userQuery,
+        question: evaluationQuestion,
         recalledText,
         responder: options.system.responder,
       });
@@ -122,6 +134,10 @@ export async function runPersonaMemBenchmark(
         contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
         search_hits: searchResults.length,
       };
+      if (mcq) {
+        const predictedOption = extractMcqFinalAnswer(answered.finalAnswer);
+        scores.mcq_accuracy = predictedOption === mcq.correctOption ? 1 : 0;
+      }
       if (judgeResult.score >= 0) {
         scores.llm_judge = judgeResult.score;
       }
@@ -147,9 +163,17 @@ export async function runPersonaMemBenchmark(
           who: sample.who,
           updated: sample.updated,
           prevPref: sample.prevPref,
+          incorrectAnswers: sample.incorrectAnswers,
           chatHistoryMessageCount: sample.chatHistory.chat_history.length,
           chatHistory32kLink: sample.chatHistory32kLink,
           chatHistory128kLink: sample.chatHistory128kLink,
+          evaluationMode: mcq ? "mcq" : "open_ended",
+          evaluationQuestion,
+          mcqOptions: mcq?.options,
+          correctMcqOption: mcq?.correctOption,
+          predictedMcqOption: mcq
+            ? extractMcqFinalAnswer(answered.finalAnswer)
+            : undefined,
           recalledLength: recalledText.length,
           answeredLength: answered.finalAnswer.length,
           recalledText,
@@ -315,6 +339,7 @@ async function hydrateSample(
     personaId: row.persona_id,
     userQuery,
     correctAnswer: row.correct_answer,
+    incorrectAnswers: parseIncorrectAnswers(row.incorrect_answers),
     topicQuery: row.topic_query,
     preference: row.preference,
     topicPreference: row.topic_preference,
@@ -373,6 +398,7 @@ function parseCsvRows(
         chat_history_128k_link: valueAt("chat_history_128k_link") || undefined,
         user_query: valueAt("user_query"),
         correct_answer: valueAt("correct_answer"),
+        incorrect_answers: valueAt("incorrect_answers") || undefined,
         topic_query: valueAt("topic_query") || undefined,
         preference: valueAt("preference") || undefined,
         topic_preference: valueAt("topic_preference") || undefined,
@@ -543,6 +569,135 @@ function readQuotedValue(
       return { value, end: index + 1 };
     }
     value += char;
+  }
+
+  return undefined;
+}
+
+function parseIncorrectAnswers(raw: string | undefined): string[] | undefined {
+  if (!raw || raw.trim().length === 0) {
+    return undefined;
+  }
+
+  const trimmed = raw.trim();
+  try {
+    const parsed = JSON.parse(trimmed) as unknown;
+    if (Array.isArray(parsed)) {
+      return parsed.map((value) => String(value)).filter((value) => value.trim().length > 0);
+    }
+  } catch {
+    // Fall through to the Python-literal parser below.
+  }
+
+  return parseLooseStringList(trimmed);
+}
+
+function parseLooseStringList(raw: string): string[] | undefined {
+  const values: string[] = [];
+  let index = 0;
+
+  while (index < raw.length) {
+    const char = raw[index]!;
+    if (char !== "'" && char !== "\"") {
+      index += 1;
+      continue;
+    }
+
+    const parsed = readQuotedValue(raw, index);
+    if (!parsed) {
+      return undefined;
+    }
+    if (parsed.value.trim().length > 0) {
+      values.push(parsed.value);
+    }
+    index = parsed.end;
+  }
+
+  return values.length > 0 ? values : undefined;
+}
+
+interface PersonaMemMcqPrompt {
+  instruction: string;
+  options: Record<string, string>;
+  correctOption: string;
+}
+
+function buildMcqPrompt(
+  sample: PersonaMemSample,
+  seed: number,
+): PersonaMemMcqPrompt {
+  const options = deterministicShuffle(
+    [sample.correctAnswer, ...(sample.incorrectAnswers ?? [])],
+    `${seed}:${sample.personaId}:${sample.userQuery}`,
+  );
+  const mappedOptions: Record<string, string> = {};
+  const optionLines = options.map((option, index) => {
+    const letter = String.fromCharCode(65 + index);
+    mappedOptions[letter] = option;
+    return `${letter}. ${option}`;
+  });
+  const correctOption = Object.entries(mappedOptions).find(
+    ([, value]) => value === sample.correctAnswer,
+  )?.[0];
+
+  if (!correctOption) {
+    throw new Error(
+      `PersonaMem-v2 could not map correct answer for persona ${sample.personaId}.`,
+    );
+  }
+
+  return {
+    instruction: [
+      "Please choose the best answer from the following options:",
+      "",
+      ...optionLines,
+      "",
+      "Think step by step about which answer best fits the user's query and conversation context.",
+      "Provide your reasoning first, then give your final answer as 'Final Answer: [Letter]'",
+    ].join("\n"),
+    options: mappedOptions,
+    correctOption,
+  };
+}
+
+function deterministicShuffle(values: string[], seedMaterial: string): string[] {
+  return values
+    .map((value, index) => ({
+      value,
+      key: createHash("sha256")
+        .update(`${seedMaterial}:${index}:${value}`)
+        .digest("hex"),
+      index,
+    }))
+    .sort((left, right) => {
+      const byKey = left.key.localeCompare(right.key);
+      return byKey === 0 ? left.index - right.index : byKey;
+    })
+    .map((entry) => entry.value);
+}
+
+function appendPersonaMemRecallInstruction(userQuery: string): string {
+  return `${userQuery} Please recall my related preferences from our conversation history to give personalized responses.`;
+}
+
+function extractMcqFinalAnswer(response: string): string | undefined {
+  const patterns = [
+    /\$\\boxed\{([A-Z])\}\$/i,
+    /\\boxed\{([A-Z])\}/i,
+    /final answer:\s*([A-Z])/i,
+    /answer:\s*([A-Z])/i,
+    /final answer is\s*\$?\\boxed\{([A-Z])\}\$?/i,
+    /final answer is\s*([A-Z])/i,
+    /the answer is\s*\$?\\boxed\{([A-Z])\}\$?/i,
+    /the answer is\s*([A-Z])/i,
+    /\b([A-Z])\.\s*$/i,
+  ];
+
+  for (const pattern of patterns) {
+    const match = response.match(pattern);
+    if (match?.[1]) {
+      return match[1].toUpperCase();
+    }
   }
 
   return undefined;

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -134,9 +134,11 @@ export async function runPersonaMemBenchmark(
         contains_answer: containsAnswer(answered.finalAnswer, sample.correctAnswer),
         search_hits: searchResults.length,
       };
+      const predictedMcqOption = mcq
+        ? extractMcqFinalAnswer(answered.finalAnswer)
+        : undefined;
       if (mcq) {
-        const predictedOption = extractMcqFinalAnswer(answered.finalAnswer);
-        scores.mcq_accuracy = predictedOption === mcq.correctOption ? 1 : 0;
+        scores.mcq_accuracy = predictedMcqOption === mcq.correctOption ? 1 : 0;
       }
       if (judgeResult.score >= 0) {
         scores.llm_judge = judgeResult.score;
@@ -171,9 +173,7 @@ export async function runPersonaMemBenchmark(
           evaluationQuestion,
           mcqOptions: mcq?.options,
           correctMcqOption: mcq?.correctOption,
-          predictedMcqOption: mcq
-            ? extractMcqFinalAnswer(answered.finalAnswer)
-            : undefined,
+          predictedMcqOption,
           recalledLength: recalledText.length,
           answeredLength: answered.finalAnswer.length,
           recalledText,
@@ -685,11 +685,11 @@ function extractMcqFinalAnswer(response: string): string | undefined {
     /\$\\boxed\{([A-Z])\}\$/i,
     /\\boxed\{([A-Z])\}/i,
     /final answer:\s*([A-Z])/i,
-    /answer:\s*([A-Z])/i,
     /final answer is\s*\$?\\boxed\{([A-Z])\}\$?/i,
     /final answer is\s*([A-Z])/i,
     /the answer is\s*\$?\\boxed\{([A-Z])\}\$?/i,
     /the answer is\s*([A-Z])/i,
+    /answer:\s*([A-Z])\b/i,
     /\b([A-Z])\.\s*$/i,
   ];
 

--- a/tests/bench-personamem-runner.test.ts
+++ b/tests/bench-personamem-runner.test.ts
@@ -263,6 +263,71 @@ test("runBenchmark scores personamem with official-style MCQ accuracy when distr
   assert.match(promptSeen, /Final Answer: \[Letter\]/);
 });
 
+test("runBenchmark prefers explicit final MCQ answers over broad answer labels", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-mcq-final-priority-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  const adapter = new FakeMemoryAdapter({
+    async respond() {
+      return {
+        text: "My answer: After checking the memory, my final answer is B.",
+        tokens: { input: 10, output: 10 },
+        latencyMs: 3,
+        model: "fake-responder",
+      };
+    },
+  });
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      chat_history: [
+        {
+          role: "user",
+          content: "I like to journal every morning with a mug of Earl Grey tea.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "user_query",
+        "correct_answer",
+        "incorrect_answers",
+      ],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{'role': 'user', 'content': 'Which tea do I usually drink while journaling?'}",
+        "Earl Grey",
+        JSON.stringify(["peppermint", "zebra"]),
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    seed: 0,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.details?.correctMcqOption, "B");
+  assert.equal(task.details?.predictedMcqOption, "B");
+  assert.equal(task.scores.mcq_accuracy, 1);
+});
+
 test("runBenchmark rejects personamem full mode without datasetDir", async () => {
   const adapter = new FakeMemoryAdapter();
 

--- a/tests/bench-personamem-runner.test.ts
+++ b/tests/bench-personamem-runner.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchResponder,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -12,6 +13,8 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+
+  constructor(readonly responder?: BenchResponder) {}
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -179,6 +182,85 @@ test("runBenchmark executes personamem in full mode from an explicit dataset roo
     result.results.tasks[0]?.actual.includes("Earl Grey"),
     true,
   );
+});
+
+test("runBenchmark scores personamem with official-style MCQ accuracy when distractors are present", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-personamem-mcq-"));
+  const datasetDir = path.join(tmpDir, "datasets", "personamem");
+  const benchmarkDir = path.join(datasetDir, "benchmark", "text");
+  const chatHistoryDir = path.join(datasetDir, "data", "chat_history_32k");
+  let promptSeen = "";
+  const adapter = new FakeMemoryAdapter({
+    async respond(question, recalledText) {
+      promptSeen = question;
+      assert.match(question, /Please choose the best answer/);
+      assert.match(question, /Please recall my related preferences/);
+      assert.match(recalledText, /Earl Grey/);
+      return {
+        text: "The history points to the tea option.\n\nFinal Answer: A",
+        tokens: { input: 10, output: 8 },
+        latencyMs: 3,
+        model: "fake-responder",
+      };
+    },
+  });
+  await mkdir(benchmarkDir, { recursive: true });
+  await mkdir(chatHistoryDir, { recursive: true });
+
+  await writeFile(
+    path.join(chatHistoryDir, "persona-1.json"),
+    JSON.stringify({
+      metadata: { persona_id: "persona-1" },
+      chat_history: [
+        {
+          role: "user",
+          content: "I like to journal every morning with a mug of Earl Grey tea.",
+        },
+      ],
+    }),
+    "utf8",
+  );
+
+  await writeFile(
+    path.join(benchmarkDir, "benchmark.csv"),
+    toCsv(
+      [
+        "persona_id",
+        "chat_history_32k_link",
+        "user_query",
+        "correct_answer",
+        "incorrect_answers",
+      ],
+      [
+        "persona-1",
+        "data/chat_history_32k/persona-1.json",
+        "{'role': 'user', 'content': 'Which tea do I usually drink while journaling?'}",
+        "Earl Grey",
+        JSON.stringify(["coffee", "peppermint"]),
+      ],
+    ),
+    "utf8",
+  );
+
+  const result = await runBenchmark("personamem", {
+    mode: "full",
+    datasetDir,
+    seed: 0,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.scores.mcq_accuracy, 1);
+  assert.equal(result.results.aggregates.mcq_accuracy?.mean, 1);
+  assert.equal(task.details?.evaluationMode, "mcq");
+  assert.equal(task.details?.correctMcqOption, "A");
+  assert.equal(task.details?.predictedMcqOption, "A");
+  assert.deepEqual(task.details?.mcqOptions, {
+    A: "Earl Grey",
+    B: "coffee",
+    C: "peppermint",
+  });
+  assert.match(promptSeen, /Final Answer: \[Letter\]/);
 });
 
 test("runBenchmark rejects personamem full mode without datasetDir", async () => {


### PR DESCRIPTION
## Summary
- add PersonaMem-v2 MCQ prompting/scoring when the benchmark provides incorrect_answers
- emit mcq_accuracy plus option mapping/predicted/correct letter details for leaderboard-style comparison
- keep existing open-ended F1/contains/judge diagnostics for backwards continuity

## Test Plan
- pnpm exec tsx --test tests/bench-personamem-runner.test.ts
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/bench check-types
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes PersonaMem benchmark evaluation prompts and scoring by introducing an MCQ mode when `incorrect_answers` are present, which can materially affect reported metrics and task details. Risk is moderate since it’s limited to benchmarking logic but impacts leaderboard comparability and downstream consumers of results.
> 
> **Overview**
> PersonaMem-v2 now supports an *MCQ evaluation mode* when the dataset provides `incorrect_answers`, generating a deterministic option list, prompting the responder to return a letter, and scoring `mcq_accuracy` alongside existing `f1`/`contains_answer`/judge metrics.
> 
> The runner also records MCQ-specific per-task details (prompt used, option mapping, correct/predicted letter, and whether the task was evaluated as `mcq` vs `open_ended`) and adds parsing for `incorrect_answers` from CSV (JSON array or loose quoted-list formats). New tests validate the MCQ prompt/scoring behavior and answer-extraction precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2e31fec24958988519ddadf2dd026cd2350d99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->