### PR TITLE
feat(peers): peer registry schema + storage primitives (#679 PR 1/5)

### DIFF
--- a/docs/peers.md
+++ b/docs/peers.md
@@ -1,0 +1,107 @@
+# Peers
+
+Issue [#679](https://github.com/joshuaswarren/remnic/issues/679) introduces a
+**peer registry**: a generalization of Remnic's singular
+identity-anchor model into a multi-peer schema. Every party that interacts
+with a Remnic store — the operator themself, other humans, other agents,
+and non-conversational integrations — can be represented as a `Peer` with
+an evolving cognitive profile.
+
+This page describes the **PR 1/5** schema slice. Async profile updates,
+recall integration, and CLI/HTTP/MCP surfaces ship in later PRs.
+
+## Concepts
+
+A **peer** is a stable, opaque identity. Each peer has three on-disk
+kernel files under `peers/{peer-id}/`:
+
+| File | Purpose | Update cadence | Owner |
+|------|---------|----------------|-------|
+| `identity.md` | Slow-changing facts: `id`, `kind`, `displayName`, timestamps, free-form notes. | Manual / rare. | Operator. |
+| `profile.md` | Evolving cognitive profile derived from session signals. JSON payload inside a fenced block, with per-field provenance. | Background reasoner (PR 2/5). | Reasoner. |
+| `interactions.log.md` | Append-only signal log the reasoner reads. | Per turn / per signal. | Append-only. |
+
+### Peer kinds
+
+`Peer.kind` is one of:
+
+- `self` — the current Remnic operator. Replaces the singular
+  identity-anchor; PR 5/5 migrates existing identity-anchor data into
+  `peers/self/identity.md`.
+- `human` — another human collaborator distinct from `self`.
+- `agent` — another AI agent (e.g. Claude Code, Codex, Hermes).
+- `integration` — a non-conversational integration that produces signals
+  but does not act on its own (cron, webhook, importer).
+
+### Peer ids
+
+`Peer.id` must match `^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$`,
+1–64 characters, with no leading/trailing/consecutive separators. The
+storage layer validates this on every read and write — `..`, paths with
+`/`, and other traversal-ish strings are rejected before any filesystem
+operation.
+
+## Distinguishing peers from `IDENTITY.md`
+
+The pre-existing `IDENTITY.md` / identity-anchor model represents one
+party — the operator. The peer registry is the multi-party
+generalization:
+
+- `IDENTITY.md` (today) → `peers/self/identity.md` after PR 5/5 migration.
+- The `engram_identity_anchor_*` MCP tools continue to work unchanged
+  during the migration window (PR 4/5 introduces deprecated aliases).
+- `peers/self/profile.md` is the new home for the kind of evolving
+  per-operator profile that the compounding engine maintains today;
+  the reasoner in PR 2/5 will own writes there.
+
+If you are reading this in PR 1/5: nothing has migrated yet. The peer
+registry is purely additive on disk. No code path reads or writes peer
+files outside of explicit calls to the new helpers in
+`packages/remnic-core/src/peers/`.
+
+## Privacy posture
+
+- **Local-only by default.** Peer kernel files are stored under the
+  same `memoryDir` tree as the rest of Remnic. They are not synced or
+  exported anywhere automatically.
+- **No personality inference.** The eventual reasoner (PR 2/5) only
+  derives profile fields from observable signals — explicit
+  preferences, communication-style cues, recurring concerns, decision
+  patterns. Sentiment-based or affective inference is a non-goal.
+- **Provenance everywhere.** Every profile field carries a list of
+  `PeerProfileFieldProvenance` entries pointing back to the originating
+  session/signal. Users can audit exactly why a profile claim exists.
+- **Forget is destructive.** PR 5/5 will ship `remnic peer forget` —
+  immediate file delete + archive purge + reasoner state cleanup for
+  one peer.
+- **Capsule export gating.** Capsule export (issue #676) controls
+  whether peer data travels off-machine; peer profiles are not
+  included in any capsule unless explicitly opted in.
+
+## What ships in PR 1/5
+
+Schema and storage primitives only:
+
+- `Peer`, `PeerKind`, `PeerProfile`, `PeerProfileFieldProvenance`,
+  `PeerInteractionLogEntry` types.
+- `readPeer`, `writePeer`, `listPeers`, `readPeerProfile`,
+  `writePeerProfile`, `appendInteractionLog`, `readInteractionLogRaw`,
+  `assertValidPeerId` helpers.
+- `PEER_ID_PATTERN`, `PEER_ID_MAX_LENGTH`, `PEERS_DIR_NAME` constants.
+
+Public exports live on `@remnic/core`. Nothing in the orchestrator,
+recall pipeline, extraction pipeline, or any access surface
+(CLI/HTTP/MCP) consumes the peer registry yet — that wiring lands in
+later PRs.
+
+## What is deferred
+
+- **PR 2/5** — async profile reasoner inside the Dreams REM phase.
+  Disabled by default behind `peer.profileReasoner.enabled: false`.
+- **PR 3/5** — recall integration: optional `peer` field on recall
+  requests, profile excerpt injection, X-ray annotation.
+- **PR 4/5** — CLI (`remnic peer list / show / set / forget`), HTTP
+  endpoints under `/peers`, MCP tools `engram.peer_*`. Existing
+  identity-anchor tools become deprecated aliases for `peers/self/`.
+- **PR 5/5** — migration of existing identity-anchor data into
+  `peers/self/`, plus the destructive `remnic peer forget` flow.

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -907,3 +907,28 @@ export {
   RECALL_DISCLOSURE_LEVELS,
   isRecallDisclosure,
 } from "./types.js";
+
+// ---------------------------------------------------------------------------
+// Peer registry (issue #679 PR 1/5)
+// ---------------------------------------------------------------------------
+
+export type {
+  Peer,
+  PeerKind,
+  PeerProfile,
+  PeerProfileFieldProvenance,
+  PeerInteractionLogEntry,
+} from "./peers/index.js";
+export {
+  PEER_ID_PATTERN,
+  PEER_ID_MAX_LENGTH,
+  PEERS_DIR_NAME,
+  assertValidPeerId,
+  readPeer,
+  writePeer,
+  listPeers,
+  appendInteractionLog,
+  readInteractionLogRaw,
+  readPeerProfile,
+  writePeerProfile,
+} from "./peers/index.js";

--- a/packages/remnic-core/src/peers/index.ts
+++ b/packages/remnic-core/src/peers/index.ts
@@ -1,0 +1,30 @@
+/**
+ * Peer registry — public barrel.
+ *
+ * Issue #679 PR 1/5 — schema + storage primitives only. The async profile
+ * reasoner (PR 2/5), recall injection (PR 3/5), CLI/HTTP/MCP surfaces
+ * (PR 4/5), and migration of existing identity-anchor data (PR 5) are
+ * deferred.
+ */
+
+export type {
+  Peer,
+  PeerKind,
+  PeerProfile,
+  PeerProfileFieldProvenance,
+  PeerInteractionLogEntry,
+} from "./types.js";
+
+export { PEER_ID_PATTERN, PEER_ID_MAX_LENGTH } from "./types.js";
+
+export {
+  PEERS_DIR_NAME,
+  assertValidPeerId,
+  readPeer,
+  writePeer,
+  listPeers,
+  appendInteractionLog,
+  readInteractionLogRaw,
+  readPeerProfile,
+  writePeerProfile,
+} from "./storage.js";

--- a/packages/remnic-core/src/peers/peers.test.ts
+++ b/packages/remnic-core/src/peers/peers.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Peer registry tests — issue #679 PR 1/5.
+ *
+ * Covers schema + storage primitives only. No reasoner, recall, or CLI
+ * coverage in this PR. All fixtures are synthetic.
+ */
+
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  appendInteractionLog,
+  assertValidPeerId,
+  listPeers,
+  PEER_ID_PATTERN,
+  readInteractionLogRaw,
+  readPeer,
+  readPeerProfile,
+  writePeer,
+  writePeerProfile,
+  type Peer,
+  type PeerInteractionLogEntry,
+  type PeerProfile,
+} from "./index.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Fixtures
+// ──────────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "peers-test-"));
+}
+
+function samplePeer(overrides: Partial<Peer> = {}): Peer {
+  return {
+    id: "self",
+    kind: "self",
+    displayName: "Operator",
+    createdAt: "2026-04-25T00:00:00.000Z",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+    notes: "Initial identity kernel.",
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Round-trip
+// ──────────────────────────────────────────────────────────────────────
+
+test("writePeer + readPeer round-trips identity", async () => {
+  const dir = await makeTempDir();
+  const peer = samplePeer({ id: "agent.codex", kind: "agent", displayName: "Codex" });
+  await writePeer(dir, peer);
+  const loaded = await readPeer(dir, "agent.codex");
+  assert.ok(loaded);
+  assert.equal(loaded.id, "agent.codex");
+  assert.equal(loaded.kind, "agent");
+  assert.equal(loaded.displayName, "Codex");
+  assert.equal(loaded.createdAt, peer.createdAt);
+  assert.equal(loaded.updatedAt, peer.updatedAt);
+  assert.equal(loaded.notes, "Initial identity kernel.");
+});
+
+test("readPeer round-trips peers with quote/backslash characters in displayName", async () => {
+  const dir = await makeTempDir();
+  const peer = samplePeer({
+    id: "human.alex",
+    kind: "human",
+    displayName: 'Alex "the architect" \\ collaborator',
+  });
+  await writePeer(dir, peer);
+  const loaded = await readPeer(dir, "human.alex");
+  assert.ok(loaded);
+  assert.equal(loaded.displayName, 'Alex "the architect" \\ collaborator');
+});
+
+test("readPeer returns null for a non-existent peer", async () => {
+  const dir = await makeTempDir();
+  const loaded = await readPeer(dir, "ghost");
+  assert.equal(loaded, null);
+});
+
+test("readPeer returns null when the peers root does not exist", async () => {
+  const dir = await makeTempDir();
+  // makeTempDir creates the dir but no peers/ subtree.
+  const loaded = await readPeer(dir, "self");
+  assert.equal(loaded, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// listPeers
+// ──────────────────────────────────────────────────────────────────────
+
+test("listPeers enumerates multiple peers in deterministic order", async () => {
+  const dir = await makeTempDir();
+  const peers = [
+    samplePeer({ id: "self", kind: "self", displayName: "Operator" }),
+    samplePeer({ id: "agent.codex", kind: "agent", displayName: "Codex" }),
+    samplePeer({ id: "human.alex", kind: "human", displayName: "Alex" }),
+  ];
+  for (const p of peers) {
+    await writePeer(dir, p);
+  }
+  const listed = await listPeers(dir);
+  assert.equal(listed.length, 3);
+  // Listing is sorted by id.
+  assert.deepEqual(
+    listed.map((p) => p.id),
+    ["agent.codex", "human.alex", "self"],
+  );
+  for (const p of listed) {
+    const ref = peers.find((q) => q.id === p.id);
+    assert.ok(ref);
+    assert.equal(p.kind, ref.kind);
+    assert.equal(p.displayName, ref.displayName);
+  }
+});
+
+test("listPeers returns [] when peers root does not exist", async () => {
+  const dir = await makeTempDir();
+  const listed = await listPeers(dir);
+  assert.deepEqual(listed, []);
+});
+
+test("listPeers skips directory entries with invalid peer ids", async () => {
+  const dir = await makeTempDir();
+  await writePeer(dir, samplePeer({ id: "ok", displayName: "OK" }));
+  // Create stray directory with an illegal name — should be ignored.
+  await fs.mkdir(path.join(dir, "peers", "..hidden"), { recursive: true });
+  await fs.mkdir(path.join(dir, "peers", "has space"), { recursive: true });
+  const listed = await listPeers(dir);
+  assert.deepEqual(
+    listed.map((p) => p.id),
+    ["ok"],
+  );
+});
+
+test("listPeers skips directories that lack identity.md", async () => {
+  const dir = await makeTempDir();
+  await writePeer(dir, samplePeer({ id: "ok", displayName: "OK" }));
+  await fs.mkdir(path.join(dir, "peers", "empty"), { recursive: true });
+  const listed = await listPeers(dir);
+  assert.deepEqual(
+    listed.map((p) => p.id),
+    ["ok"],
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Validation
+// ──────────────────────────────────────────────────────────────────────
+
+test("PEER_ID_PATTERN accepts canonical ids", () => {
+  for (const id of [
+    "self",
+    "agent.codex",
+    "human.alex",
+    "a",
+    "A1",
+    "x-y_z.0",
+    "kebab-case-id",
+    "snake_case_id",
+  ]) {
+    assert.ok(PEER_ID_PATTERN.test(id), `expected ${id} to match`);
+  }
+});
+
+test("assertValidPeerId rejects invalid ids", () => {
+  const bad = [
+    "", // empty
+    " ", // space
+    "has space", // contains space
+    "-leading", // leading dash
+    "trailing-", // trailing dash
+    ".dot", // leading dot
+    "dot.", // trailing dot
+    "double..dot", // consecutive dots
+    "double--dash", // consecutive dashes
+    "weird/slash", // path separator
+    "..", // traversal
+    "a".repeat(65), // too long (limit is 64)
+  ];
+  for (const id of bad) {
+    assert.throws(
+      () => assertValidPeerId(id),
+      (err: Error) => err instanceof Error,
+      `expected ${JSON.stringify(id)} to be rejected`,
+    );
+  }
+});
+
+test("assertValidPeerId rejects non-string input", () => {
+  for (const v of [null, undefined, 42, {}, []]) {
+    assert.throws(() => assertValidPeerId(v as unknown));
+  }
+});
+
+test("writePeer rejects invalid kind", async () => {
+  const dir = await makeTempDir();
+  await assert.rejects(
+    writePeer(dir, samplePeer({ kind: "robot" as never })),
+    /peer kind must be one of/,
+  );
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Interaction log — monotonic append
+// ──────────────────────────────────────────────────────────────────────
+
+test("appendInteractionLog appends entries in order", async () => {
+  const dir = await makeTempDir();
+  const peerId = "agent.codex";
+  await writePeer(dir, samplePeer({ id: peerId, kind: "agent", displayName: "Codex" }));
+  const entries: PeerInteractionLogEntry[] = [
+    {
+      timestamp: "2026-04-25T00:00:01.000Z",
+      kind: "message",
+      summary: "first turn",
+      sessionId: "s-1",
+    },
+    {
+      timestamp: "2026-04-25T00:00:02.000Z",
+      kind: "tool_call",
+      summary: "second turn — used recall",
+      sessionId: "s-1",
+    },
+    {
+      timestamp: "2026-04-25T00:00:03.000Z",
+      kind: "preference_set",
+      summary: "third turn — set preference",
+    },
+  ];
+  for (const e of entries) {
+    await appendInteractionLog(dir, peerId, e);
+  }
+  const raw = await readInteractionLogRaw(dir, peerId);
+  const lines = raw.trim().split("\n");
+  assert.equal(lines.length, 3);
+  // Entries appear in append order — verify by timestamp prefix.
+  assert.ok(lines[0].includes("[2026-04-25T00:00:01.000Z]"));
+  assert.ok(lines[0].includes("(message)"));
+  assert.ok(lines[0].includes("first turn"));
+  assert.ok(lines[1].includes("[2026-04-25T00:00:02.000Z]"));
+  assert.ok(lines[1].includes("second turn"));
+  assert.ok(lines[2].includes("[2026-04-25T00:00:03.000Z]"));
+  assert.ok(lines[2].includes("third turn"));
+});
+
+test("appendInteractionLog escapes embedded newlines so each entry stays one line", async () => {
+  const dir = await makeTempDir();
+  const peerId = "human.alex";
+  await appendInteractionLog(dir, peerId, {
+    timestamp: "2026-04-25T00:00:00.000Z",
+    kind: "message",
+    summary: "line one\nline two\nline three",
+  });
+  const raw = await readInteractionLogRaw(dir, peerId);
+  assert.equal(raw.split("\n").filter((l) => l.length > 0).length, 1);
+});
+
+test("appendInteractionLog creates peer directory on demand", async () => {
+  const dir = await makeTempDir();
+  // No prior writePeer — the log helper should still work.
+  await appendInteractionLog(dir, "self", {
+    timestamp: "2026-04-25T00:00:00.000Z",
+    kind: "message",
+    summary: "no identity yet",
+  });
+  const raw = await readInteractionLogRaw(dir, "self");
+  assert.ok(raw.includes("no identity yet"));
+});
+
+test("readInteractionLogRaw returns empty string when log does not exist", async () => {
+  const dir = await makeTempDir();
+  const raw = await readInteractionLogRaw(dir, "self");
+  assert.equal(raw, "");
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Profile read/write (schema scaffold)
+// ──────────────────────────────────────────────────────────────────────
+
+test("writePeerProfile + readPeerProfile round-trips fields and provenance", async () => {
+  const dir = await makeTempDir();
+  const profile: PeerProfile = {
+    peerId: "agent.codex",
+    updatedAt: "2026-04-25T01:00:00.000Z",
+    fields: {
+      communication_style: "Terse, prefers code blocks.",
+      recurring_concerns: "Test coverage on retrieval paths.",
+    },
+    provenance: {
+      communication_style: [
+        {
+          observedAt: "2026-04-25T00:30:00.000Z",
+          signal: "explicit_preference",
+          sourceSessionId: "s-1",
+          note: "User said 'keep it short'",
+        },
+      ],
+      recurring_concerns: [
+        {
+          observedAt: "2026-04-25T00:45:00.000Z",
+          signal: "decision_pattern",
+        },
+      ],
+    },
+  };
+  await writePeerProfile(dir, profile);
+  const loaded = await readPeerProfile(dir, "agent.codex");
+  assert.ok(loaded);
+  assert.equal(loaded.peerId, "agent.codex");
+  assert.equal(loaded.updatedAt, profile.updatedAt);
+  assert.deepEqual(loaded.fields, profile.fields);
+  assert.equal(loaded.provenance.communication_style.length, 1);
+  assert.equal(loaded.provenance.communication_style[0].signal, "explicit_preference");
+  assert.equal(loaded.provenance.communication_style[0].note, "User said 'keep it short'");
+  assert.equal(loaded.provenance.recurring_concerns[0].signal, "decision_pattern");
+});
+
+test("readPeerProfile returns null when profile does not exist", async () => {
+  const dir = await makeTempDir();
+  await writePeer(dir, samplePeer({ id: "self" }));
+  const loaded = await readPeerProfile(dir, "self");
+  assert.equal(loaded, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// On-disk shape — confirms the YAML+markdown contract
+// ──────────────────────────────────────────────────────────────────────
+
+test("identity.md is YAML frontmatter + markdown body", async () => {
+  const dir = await makeTempDir();
+  const peer = samplePeer({ id: "self", notes: "Operator notes." });
+  await writePeer(dir, peer);
+  const file = path.join(dir, "peers", "self", "identity.md");
+  const raw = await fs.readFile(file, "utf8");
+  // Frontmatter open + close, then a body section.
+  assert.ok(raw.startsWith("---\n"));
+  const lines = raw.split("\n");
+  const closeIndex = lines.indexOf("---", 1);
+  assert.ok(closeIndex > 0, "expected closing --- delimiter");
+  const fmBlock = lines.slice(1, closeIndex).join("\n");
+  assert.ok(fmBlock.includes("id:"));
+  assert.ok(fmBlock.includes("kind:"));
+  assert.ok(fmBlock.includes("displayName:"));
+  assert.ok(fmBlock.includes("createdAt:"));
+  assert.ok(fmBlock.includes("updatedAt:"));
+  const body = lines.slice(closeIndex + 1).join("\n");
+  assert.ok(body.includes("Operator notes."));
+});

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -639,9 +639,13 @@ export async function appendInteractionLog(
   // are both rejected explicitly: the previous behavior silently
   // dropped them during formatting, which reinterprets invalid input
   // instead of failing fast like other validators in this module.
+  // Codex P2 round 12: trim() before the empty check matches what
+  // sanitizeLogField does at format time. Whitespace-only sessionId
+  // would otherwise pass validation and produce a `session=` token
+  // with an empty value that breaks downstream log parsers.
   if (entry.sessionId !== undefined) {
-    if (typeof entry.sessionId !== "string" || entry.sessionId === "") {
-      throw new Error("interaction entry sessionId must be a non-empty string when provided");
+    if (typeof entry.sessionId !== "string" || entry.sessionId.trim() === "") {
+      throw new Error("interaction entry sessionId must be a non-whitespace string when provided");
     }
   }
   await assertPeersRootNotSymlink(memoryDir);

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -453,6 +453,14 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   if (typeof peer.updatedAt !== "string" || peer.updatedAt === "") {
     throw new Error("peer.updatedAt must be a non-empty ISO-8601 string");
   }
+  // Codex P2 round 8: reject non-string `peer.notes`. Without this,
+  // an untyped JS caller passing an object/number would silently
+  // coerce to "[object Object]"/"42" via lines.push(notes ?? "")
+  // and corrupt user-authored identity content. Notes are optional;
+  // omit by passing undefined (NOT null).
+  if (peer.notes !== undefined && typeof peer.notes !== "string") {
+    throw new Error("peer.notes must be a string when provided");
+  }
   // Codex P2 + cursor M: validate the peers root BEFORE mkdir so a
   // symlinked `peers/` root can't get its target mutated by the
   // recursive mkdir even though the post-check would later throw.
@@ -575,15 +583,13 @@ export async function appendInteractionLog(
   if (typeof entry.summary !== "string") {
     throw new Error("interaction entry must have a string summary");
   }
-  // Codex P2 round 6: optional sessionId must still be a string when
-  // present, otherwise formatLogEntry → sanitizeLogField throws an
-  // opaque TypeError after directory setup. Validate at the API
-  // boundary so the error is clear and fires before any I/O.
-  if (
-    entry.sessionId !== undefined &&
-    entry.sessionId !== null &&
-    typeof entry.sessionId !== "string"
-  ) {
+  // Codex P2 round 6: optional sessionId must be a string OR
+  // strictly `undefined` (omitted). Round 8 follow-up: `null` was
+  // previously treated as acceptable but silently dropped during
+  // formatting; reject it explicitly so the boundary fails fast on
+  // any non-string input, matching the "fail fast" pattern of the
+  // other validators in this module.
+  if (entry.sessionId !== undefined && typeof entry.sessionId !== "string") {
     throw new Error("interaction entry sessionId must be a string when provided");
   }
   await assertPeersRootNotSymlink(memoryDir);

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -434,6 +434,12 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
  * `identity.md` are also skipped.
  */
 export async function listPeers(memoryDir: string): Promise<Peer[]> {
+  // Codex P1 (round 2): `fs.readdir(root)` follows a symlinked
+  // peers root, so without checking first, listing on a malicious
+  // `peers → /tmp/outside` symlink would enumerate out-of-scope
+  // contents and feed them to readPeer. Reject the symlinked root
+  // BEFORE the readdir.
+  await assertPeersRootNotSymlink(memoryDir);
   const root = peersRoot(memoryDir);
   let entries: string[];
   try {
@@ -630,13 +636,30 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
     const list: PeerProfileFieldProvenance[] = [];
     for (const item of v) {
       if (
-        typeof item === "object" &&
-        item !== null &&
-        typeof (item as PeerProfileFieldProvenance).observedAt === "string" &&
-        typeof (item as PeerProfileFieldProvenance).signal === "string"
+        typeof item !== "object" ||
+        item === null ||
+        Array.isArray(item)
       ) {
-        list.push(item as PeerProfileFieldProvenance);
+        continue;
       }
+      const r = item as unknown as Record<string, unknown>;
+      if (typeof r.observedAt !== "string" || typeof r.signal !== "string") {
+        continue;
+      }
+      // Codex P2: previously the optional fields were never type-
+      // checked, so a hand-edited `{sourceSessionId: 123}` survived
+      // and corrupted the PeerProfileFieldProvenance contract for
+      // downstream consumers. Build a clean record with only
+      // string-typed optional fields included.
+      const clean: PeerProfileFieldProvenance = {
+        observedAt: r.observedAt,
+        signal: r.signal,
+        ...(typeof r.sourceSessionId === "string"
+          ? { sourceSessionId: r.sourceSessionId }
+          : {}),
+        ...(typeof r.note === "string" ? { note: r.note } : {}),
+      };
+      list.push(clean);
     }
     provenance[k] = list;
   }

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -107,36 +107,13 @@ function peerDir(memoryDir: string, peerId: string): string {
 }
 
 /**
- * Codex P1 on PR #723: `peerDir` only enforces a lexical
- * `path.relative` check, so a symlinked peer directory like
- * `peers/self → /tmp/outside` would slip through. Any I/O site that
- * touches a peer directory must call this guard, which:
- *   1. Rejects the path entirely if it (or any direct ancestor up to
- *      `peers/`) is a symlink.
- *   2. Verifies that the realpath of the candidate (and its parent
- *      `peers/` root) keeps the candidate strictly under the
- *      realpath of the peers root.
- *
- * Returns silently when the path either does not exist yet (write
- * path will create it under a real-directory chain) or is a real
- * directory inside the peers root. Throws otherwise.
+ * Reject the peers root if it is itself a symlink. Called BEFORE any
+ * `fs.mkdir`, so a `peers → /tmp/outside` symlink can't get its
+ * target mutated by a recursive mkdir before subsequent checks fire
+ * (codex P2 + cursor M on PR #723).
  */
-async function assertPeerDirNotEscaped(memoryDir: string, peerId: string): Promise<void> {
-  const candidate = peerDir(memoryDir, peerId);
+async function assertPeersRootNotSymlink(memoryDir: string): Promise<void> {
   const root = peersRoot(memoryDir);
-  // 1. lstat on the candidate itself. If it's a symlink, refuse.
-  let candidateStat: import("node:fs").Stats | null = null;
-  try {
-    candidateStat = await fs.lstat(candidate);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-  }
-  if (candidateStat && candidateStat.isSymbolicLink()) {
-    throw new Error(`peer directory "${peerId}" is a symlink and is rejected`);
-  }
-  // 2. lstat on the peers root. If the root itself is a symlink, the
-  // realpath check below would compare against the symlink target,
-  // letting an attacker bypass the boundary. Refuse.
   let rootStat: import("node:fs").Stats | null = null;
   try {
     rootStat = await fs.lstat(root);
@@ -146,9 +123,53 @@ async function assertPeerDirNotEscaped(memoryDir: string, peerId: string): Promi
   if (rootStat && rootStat.isSymbolicLink()) {
     throw new Error(`peers root "${root}" is a symlink and is rejected`);
   }
-  // 3. Real-path containment check. Only meaningful if the candidate
-  // exists (writes that create the directory will catch escape via
-  // step 1; reads that hit ENOENT are no-ops anyway).
+}
+
+/**
+ * Reject any path that exists and is a symlink. Used to gate every
+ * file-level I/O so a malicious `peers/<id>/identity.md → /etc/passwd`
+ * can't redirect a read or a write to an arbitrary file (codex P1 #2
+ * on PR #723). Returns silently when the path does not exist (writes
+ * create files under directories that have already been validated).
+ */
+async function assertPathNotSymlink(p: string): Promise<void> {
+  let stat: import("node:fs").Stats | null = null;
+  try {
+    stat = await fs.lstat(p);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+    return;
+  }
+  if (stat.isSymbolicLink()) {
+    throw new Error(`path "${p}" is a symlink and is rejected`);
+  }
+}
+
+/**
+ * Codex P1 on PR #723: `peerDir` only enforces a lexical
+ * `path.relative` check, so a symlinked peer directory like
+ * `peers/self → /tmp/outside` would slip through. Run this guard
+ * AFTER the peer directory has been (or is known to) exist, so we
+ * can lstat it and realpath-check containment. For first-time writes,
+ * call `assertPeersRootNotSymlink` BEFORE `fs.mkdir` and this AFTER.
+ */
+async function assertPeerDirNotEscaped(memoryDir: string, peerId: string): Promise<void> {
+  const candidate = peerDir(memoryDir, peerId);
+  const root = peersRoot(memoryDir);
+  // 1. The peers root must not be a symlink (defensive — writers
+  // already checked this before mkdir, but reads must still verify).
+  await assertPeersRootNotSymlink(memoryDir);
+  // 2. lstat on the candidate itself. If it's a symlink, refuse.
+  let candidateStat: import("node:fs").Stats | null = null;
+  try {
+    candidateStat = await fs.lstat(candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  if (candidateStat && candidateStat.isSymbolicLink()) {
+    throw new Error(`peer directory "${peerId}" is a symlink and is rejected`);
+  }
+  // 3. Real-path containment. Only meaningful if the candidate exists.
   if (candidateStat) {
     const realRoot = await fs.realpath(root);
     const realCandidate = await fs.realpath(candidate);
@@ -321,6 +342,10 @@ export async function readPeer(
   assertValidPeerId(peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = identityPath(memoryDir, peerId);
+  // Codex P1 #2: even with the directory validated, a symlinked
+  // identity.md inside a real peer dir would let us read arbitrary
+  // out-of-scope files. Reject symlinks at the file level too.
+  await assertPathNotSymlink(file);
   let raw: string;
   try {
     raw = await fs.readFile(file, "utf8");
@@ -386,10 +411,18 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   if (typeof peer.updatedAt !== "string" || peer.updatedAt === "") {
     throw new Error("peer.updatedAt must be a non-empty ISO-8601 string");
   }
+  // Codex P2 + cursor M: validate the peers root BEFORE mkdir so a
+  // symlinked `peers/` root can't get its target mutated by the
+  // recursive mkdir even though the post-check would later throw.
+  await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, peer.id);
   await fs.mkdir(dir, { recursive: true });
   await assertPeerDirNotEscaped(memoryDir, peer.id);
-  await fs.writeFile(identityPath(memoryDir, peer.id), emitPeerIdentity(peer), "utf8");
+  const file = identityPath(memoryDir, peer.id);
+  // Codex P1 #2: reject if identity.md exists as a symlink so we
+  // don't follow it on overwrite.
+  await assertPathNotSymlink(file);
+  await fs.writeFile(file, emitPeerIdentity(peer), "utf8");
 }
 
 /**
@@ -495,10 +528,12 @@ export async function appendInteractionLog(
   if (typeof entry.summary !== "string") {
     throw new Error("interaction entry must have a string summary");
   }
+  await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, peerId);
   await fs.mkdir(dir, { recursive: true });
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
+  await assertPathNotSymlink(file);
   const line = formatLogEntry(entry) + "\n";
   // `appendFile` creates the file if it does not exist. POSIX guarantees
   // writes < PIPE_BUF are atomic; entries on this path are well under
@@ -622,6 +657,7 @@ export async function readPeerProfile(
   assertValidPeerId(peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = profilePath(memoryDir, peerId);
+  await assertPathNotSymlink(file);
   let raw: string;
   try {
     raw = await fs.readFile(file, "utf8");
@@ -645,10 +681,13 @@ export async function writePeerProfile(
   if (typeof profile.updatedAt !== "string" || profile.updatedAt === "") {
     throw new Error("profile.updatedAt must be a non-empty ISO-8601 string");
   }
+  await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, profile.peerId);
   await fs.mkdir(dir, { recursive: true });
   await assertPeerDirNotEscaped(memoryDir, profile.peerId);
-  await fs.writeFile(profilePath(memoryDir, profile.peerId), emitPeerProfile(profile), "utf8");
+  const file = profilePath(memoryDir, profile.peerId);
+  await assertPathNotSymlink(file);
+  await fs.writeFile(file, emitPeerProfile(profile), "utf8");
 }
 
 /**
@@ -665,6 +704,7 @@ export async function readInteractionLogRaw(
   assertValidPeerId(peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
+  await assertPathNotSymlink(file);
   try {
     return await fs.readFile(file, "utf8");
   } catch (err) {

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -1,0 +1,550 @@
+/**
+ * Peer registry storage primitives — issue #679 PR 1/5.
+ *
+ * Pure file-I/O helpers for the per-peer kernel files:
+ *
+ *   peers/{peer-id}/identity.md       — slow, human-edited identity facts
+ *   peers/{peer-id}/profile.md        — evolving profile (reasoner-owned)
+ *   peers/{peer-id}/interactions.log.md — append-only signal log
+ *
+ * No reasoner logic, no recall integration, no migration of existing
+ * identity-anchor data — those land in PR 2/5 — 5/5.
+ *
+ * Path safety: `peerId` is validated against PEER_ID_PATTERN before any
+ * filesystem operation. Reading a non-existent peer returns null (does not
+ * throw). Reading malformed files throws — callers can catch and recover.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import {
+  PEER_ID_MAX_LENGTH,
+  PEER_ID_PATTERN,
+  type Peer,
+  type PeerInteractionLogEntry,
+  type PeerKind,
+  type PeerProfile,
+  type PeerProfileFieldProvenance,
+} from "./types.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Validation
+// ──────────────────────────────────────────────────────────────────────
+
+const ALLOWED_KINDS: ReadonlySet<PeerKind> = new Set<PeerKind>([
+  "self",
+  "human",
+  "agent",
+  "integration",
+]);
+
+/**
+ * Validate a peer id. Throws `Error` with a descriptive message on failure.
+ * Exported so callers can pre-check user input before constructing a Peer.
+ */
+export function assertValidPeerId(peerId: unknown): asserts peerId is string {
+  if (typeof peerId !== "string") {
+    throw new Error("peerId must be a string");
+  }
+  if (peerId.length === 0) {
+    throw new Error("peerId must not be empty");
+  }
+  if (peerId.length > PEER_ID_MAX_LENGTH) {
+    throw new Error(`peerId must be ≤ ${PEER_ID_MAX_LENGTH} characters`);
+  }
+  if (!PEER_ID_PATTERN.test(peerId)) {
+    throw new Error(
+      `peerId "${peerId}" is invalid — must match ${PEER_ID_PATTERN}`,
+    );
+  }
+  // Defence-in-depth: reject consecutive dots/dashes/underscores. The
+  // regex already prevents leading/trailing separators, but explicit
+  // adjacency checks document intent and survive future regex refactors.
+  if (/[.\-_]{2,}/.test(peerId)) {
+    throw new Error(
+      `peerId "${peerId}" is invalid — must not contain consecutive separators`,
+    );
+  }
+}
+
+function assertValidKind(kind: unknown): asserts kind is PeerKind {
+  if (typeof kind !== "string" || !ALLOWED_KINDS.has(kind as PeerKind)) {
+    throw new Error(
+      `peer kind must be one of ${Array.from(ALLOWED_KINDS).join(", ")}`,
+    );
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Path helpers
+// ──────────────────────────────────────────────────────────────────────
+
+/** Root directory holding the peer registry, relative to memoryDir. */
+export const PEERS_DIR_NAME = "peers";
+
+function peersRoot(memoryDir: string): string {
+  return path.join(memoryDir, PEERS_DIR_NAME);
+}
+
+function peerDir(memoryDir: string, peerId: string): string {
+  // Guard against path traversal on top of regex validation. After
+  // assertValidPeerId, peerId cannot contain `/`, `..`, or NUL — but we
+  // re-check defensively here.
+  assertValidPeerId(peerId);
+  const candidate = path.join(peersRoot(memoryDir), peerId);
+  const root = peersRoot(memoryDir);
+  // Ensure resolved path stays within peersRoot.
+  const relative = path.relative(root, candidate);
+  if (relative.startsWith("..") || path.isAbsolute(relative)) {
+    throw new Error(`peerId "${peerId}" resolves outside peers root`);
+  }
+  return candidate;
+}
+
+function identityPath(memoryDir: string, peerId: string): string {
+  return path.join(peerDir(memoryDir, peerId), "identity.md");
+}
+
+function profilePath(memoryDir: string, peerId: string): string {
+  return path.join(peerDir(memoryDir, peerId), "profile.md");
+}
+
+function interactionsPath(memoryDir: string, peerId: string): string {
+  return path.join(peerDir(memoryDir, peerId), "interactions.log.md");
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Minimal YAML helpers (peer files only)
+// ──────────────────────────────────────────────────────────────────────
+//
+// We deliberately do not depend on the codebase's primary YAML parser
+// (`storage.ts`) because the peer schema is small and structured. We emit
+// a strict, predictable subset:
+//
+//   ---
+//   id: my-peer
+//   kind: agent
+//   displayName: "Codex"
+//   createdAt: 2026-04-25T00:00:00.000Z
+//   updatedAt: 2026-04-25T00:00:00.000Z
+//   ---
+//   {free-form markdown notes}
+//
+// String values are always double-quoted with `\\` and `\"` escapes. ISO
+// timestamps and the kind enum are emitted bare. This keeps round-trip
+// behaviour deterministic and easy to validate.
+
+function escapeYamlString(value: string): string {
+  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+}
+
+function unescapeYamlString(quoted: string): string {
+  // Caller has already verified `quoted` starts and ends with a double quote.
+  const body = quoted.slice(1, -1);
+  let out = "";
+  for (let i = 0; i < body.length; i++) {
+    const ch = body[i];
+    if (ch === "\\" && i + 1 < body.length) {
+      const next = body[i + 1];
+      if (next === "\\" || next === '"') {
+        out += next;
+        i++;
+        continue;
+      }
+    }
+    out += ch;
+  }
+  return out;
+}
+
+interface ParsedFrontmatter {
+  fields: Record<string, string>;
+  body: string;
+}
+
+function parsePeerFrontmatter(raw: string): ParsedFrontmatter {
+  // Frontmatter must begin with a `---` line. We tolerate a leading BOM
+  // and trailing newlines but otherwise require a strict, line-oriented
+  // YAML subset of `key: value` pairs.
+  const text = raw.replace(/^﻿/, "");
+  if (!text.startsWith("---")) {
+    throw new Error("peer file is missing YAML frontmatter delimiter");
+  }
+  // Split on the first occurrence of `\n---` after the leading `---`.
+  const after = text.slice(3);
+  const close = after.indexOf("\n---");
+  if (close === -1) {
+    throw new Error("peer file frontmatter is not terminated");
+  }
+  const fmBlock = after.slice(0, close).replace(/^\n/, "");
+  const body = after.slice(close + 4).replace(/^\n/, "");
+  const fields: Record<string, string> = {};
+  for (const lineRaw of fmBlock.split("\n")) {
+    const line = lineRaw.trim();
+    if (line === "" || line.startsWith("#")) continue;
+    const colon = line.indexOf(":");
+    if (colon === -1) {
+      throw new Error(`peer frontmatter line is malformed: ${line}`);
+    }
+    const key = line.slice(0, colon).trim();
+    const valueRaw = line.slice(colon + 1).trim();
+    if (key === "") {
+      throw new Error(`peer frontmatter has empty key: ${line}`);
+    }
+    let value: string;
+    if (valueRaw.startsWith('"') && valueRaw.endsWith('"') && valueRaw.length >= 2) {
+      value = unescapeYamlString(valueRaw);
+    } else {
+      value = valueRaw;
+    }
+    fields[key] = value;
+  }
+  return { fields, body };
+}
+
+function emitPeerIdentity(peer: Peer): string {
+  const lines: string[] = ["---"];
+  lines.push(`id: ${escapeYamlString(peer.id)}`);
+  lines.push(`kind: ${peer.kind}`);
+  lines.push(`displayName: ${escapeYamlString(peer.displayName)}`);
+  lines.push(`createdAt: ${peer.createdAt}`);
+  lines.push(`updatedAt: ${peer.updatedAt}`);
+  lines.push("---");
+  lines.push("");
+  lines.push(peer.notes ?? "");
+  // Trailing newline for POSIX friendliness.
+  return lines.join("\n").replace(/\n+$/, "\n") + "\n";
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Public storage API
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Read a peer's identity kernel.
+ *
+ * Returns `null` (does not throw) when the peer directory or identity
+ * file does not exist. Throws on filesystem errors other than ENOENT and
+ * on malformed files.
+ */
+export async function readPeer(
+  memoryDir: string,
+  peerId: string,
+): Promise<Peer | null> {
+  assertValidPeerId(peerId);
+  const file = identityPath(memoryDir, peerId);
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+  const { fields, body } = parsePeerFrontmatter(raw);
+  const id = fields.id ?? peerId;
+  if (id !== peerId) {
+    throw new Error(
+      `peer identity file mismatch — expected id "${peerId}", file claims "${id}"`,
+    );
+  }
+  const kind = fields.kind;
+  assertValidKind(kind);
+  const displayName = fields.displayName ?? "";
+  const createdAt = fields.createdAt ?? "";
+  const updatedAt = fields.updatedAt ?? createdAt;
+  if (createdAt === "") {
+    throw new Error(`peer "${peerId}" is missing createdAt`);
+  }
+  // Strip leading blank lines (frontmatter close inserts one) and any
+  // trailing whitespace. Internal whitespace is preserved verbatim.
+  const trimmedBody = body.replace(/^\s+/, "").replace(/\s+$/, "");
+  return {
+    id: peerId,
+    kind,
+    displayName,
+    createdAt,
+    updatedAt,
+    notes: trimmedBody === "" ? undefined : trimmedBody,
+  };
+}
+
+/**
+ * Write (create or overwrite) a peer's identity kernel.
+ *
+ * Creates `peers/{id}/` if it does not exist. Does not touch the peer's
+ * profile or interaction log. Atomic-write semantics are deferred to
+ * later PRs — for the schema slice we simply write the file.
+ */
+export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
+  assertValidPeerId(peer.id);
+  assertValidKind(peer.kind);
+  if (typeof peer.displayName !== "string") {
+    throw new Error("peer.displayName must be a string");
+  }
+  if (typeof peer.createdAt !== "string" || peer.createdAt === "") {
+    throw new Error("peer.createdAt must be a non-empty ISO-8601 string");
+  }
+  if (typeof peer.updatedAt !== "string" || peer.updatedAt === "") {
+    throw new Error("peer.updatedAt must be a non-empty ISO-8601 string");
+  }
+  const dir = peerDir(memoryDir, peer.id);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(identityPath(memoryDir, peer.id), emitPeerIdentity(peer), "utf8");
+}
+
+/**
+ * Enumerate all peers under `memoryDir/peers/`.
+ *
+ * Returns an empty array if the peers root does not exist. Subdirectories
+ * whose name fails `PEER_ID_PATTERN` are skipped (defensive: the user
+ * may have hand-edited the directory). Directories that exist but lack
+ * `identity.md` are also skipped.
+ */
+export async function listPeers(memoryDir: string): Promise<Peer[]> {
+  const root = peersRoot(memoryDir);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(root);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return [];
+    }
+    throw err;
+  }
+  const peers: Peer[] = [];
+  // Sort for deterministic ordering — callers that need a different
+  // sort order can re-sort the result.
+  entries.sort();
+  for (const name of entries) {
+    if (!PEER_ID_PATTERN.test(name) || name.length > PEER_ID_MAX_LENGTH) {
+      continue;
+    }
+    let stat;
+    try {
+      stat = await fs.stat(path.join(root, name));
+    } catch {
+      continue;
+    }
+    if (!stat.isDirectory()) continue;
+    let peer: Peer | null = null;
+    try {
+      peer = await readPeer(memoryDir, name);
+    } catch {
+      // Skip malformed peer directories rather than failing the whole list.
+      continue;
+    }
+    if (peer !== null) {
+      peers.push(peer);
+    }
+  }
+  return peers;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Interaction log (append-only)
+// ──────────────────────────────────────────────────────────────────────
+
+function formatLogEntry(entry: PeerInteractionLogEntry): string {
+  // One line per entry. We use a leading bullet so the file remains
+  // readable as ordinary markdown. Order: timestamp, kind, optional
+  // session id, summary. Newlines in the summary are escaped to keep
+  // each entry on a single line — preserves monotonic append semantics.
+  const safeSummary = entry.summary.replace(/\r?\n/g, " ");
+  const session = entry.sessionId ? ` session=${entry.sessionId}` : "";
+  return `- [${entry.timestamp}] (${entry.kind})${session} ${safeSummary}`;
+}
+
+/**
+ * Append one entry to a peer's interaction log.
+ *
+ * Creates `peers/{id}/` and `interactions.log.md` if needed. The file is
+ * append-only by contract — this helper never rewrites prior entries.
+ * Returns the absolute path of the log file (useful for tests).
+ */
+export async function appendInteractionLog(
+  memoryDir: string,
+  peerId: string,
+  entry: PeerInteractionLogEntry,
+): Promise<string> {
+  assertValidPeerId(peerId);
+  if (typeof entry.timestamp !== "string" || entry.timestamp === "") {
+    throw new Error("interaction entry must have a non-empty timestamp");
+  }
+  if (typeof entry.kind !== "string" || entry.kind === "") {
+    throw new Error("interaction entry must have a non-empty kind");
+  }
+  if (typeof entry.summary !== "string") {
+    throw new Error("interaction entry must have a string summary");
+  }
+  const dir = peerDir(memoryDir, peerId);
+  await fs.mkdir(dir, { recursive: true });
+  const file = interactionsPath(memoryDir, peerId);
+  const line = formatLogEntry(entry) + "\n";
+  // `appendFile` creates the file if it does not exist. POSIX guarantees
+  // writes < PIPE_BUF are atomic; entries on this path are well under
+  // that bound. Ordering across concurrent writers is the caller's
+  // responsibility for now — the reasoner runs serially in PR 2/5.
+  await fs.appendFile(file, line, "utf8");
+  return file;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Profile read/write (schema scaffold; reasoner ships in PR 2/5)
+// ──────────────────────────────────────────────────────────────────────
+
+interface ProfileFile {
+  updatedAt: string;
+  fields: Record<string, string>;
+  provenance: Record<string, PeerProfileFieldProvenance[]>;
+}
+
+function emitPeerProfile(profile: PeerProfile): string {
+  // Profiles use a JSON-in-fenced-code-block payload inside a markdown
+  // file so they remain human-readable. The frontmatter holds the
+  // updatedAt stamp; the body holds the full structured payload.
+  const payload: ProfileFile = {
+    updatedAt: profile.updatedAt,
+    fields: { ...profile.fields },
+    provenance: Object.fromEntries(
+      Object.entries(profile.provenance).map(([k, v]) => [k, [...v]]),
+    ),
+  };
+  const json = JSON.stringify(payload, null, 2);
+  return [
+    "---",
+    `peerId: ${escapeYamlString(profile.peerId)}`,
+    `updatedAt: ${profile.updatedAt}`,
+    "---",
+    "",
+    "<!-- peer profile — managed by the async reasoner. Manual edits will be overwritten. -->",
+    "",
+    "```json",
+    json,
+    "```",
+    "",
+  ].join("\n");
+}
+
+function parsePeerProfile(raw: string, peerId: string): PeerProfile {
+  const { fields: fm, body } = parsePeerFrontmatter(raw);
+  if (fm.peerId !== undefined && fm.peerId !== peerId) {
+    throw new Error(
+      `peer profile mismatch — expected "${peerId}", file claims "${fm.peerId}"`,
+    );
+  }
+  const fenceMatch = body.match(/```json\s*\n([\s\S]*?)\n```/);
+  if (!fenceMatch) {
+    throw new Error(`peer profile for "${peerId}" is missing JSON payload`);
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(fenceMatch[1]);
+  } catch (err) {
+    throw new Error(
+      `peer profile for "${peerId}" has invalid JSON: ${(err as Error).message}`,
+    );
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    throw new Error(`peer profile for "${peerId}" is not an object`);
+  }
+  const payload = parsed as Partial<ProfileFile>;
+  const updatedAt = payload.updatedAt ?? fm.updatedAt ?? "";
+  if (updatedAt === "") {
+    throw new Error(`peer profile for "${peerId}" is missing updatedAt`);
+  }
+  const fieldsObj =
+    typeof payload.fields === "object" && payload.fields !== null ? payload.fields : {};
+  const provenanceObj =
+    typeof payload.provenance === "object" && payload.provenance !== null
+      ? payload.provenance
+      : {};
+  // Coerce values defensively. We never trust the on-disk shape.
+  const fields: Record<string, string> = {};
+  for (const [k, v] of Object.entries(fieldsObj)) {
+    if (typeof v === "string") fields[k] = v;
+  }
+  const provenance: Record<string, PeerProfileFieldProvenance[]> = {};
+  for (const [k, v] of Object.entries(provenanceObj)) {
+    if (!Array.isArray(v)) continue;
+    const list: PeerProfileFieldProvenance[] = [];
+    for (const item of v) {
+      if (
+        typeof item === "object" &&
+        item !== null &&
+        typeof (item as PeerProfileFieldProvenance).observedAt === "string" &&
+        typeof (item as PeerProfileFieldProvenance).signal === "string"
+      ) {
+        list.push(item as PeerProfileFieldProvenance);
+      }
+    }
+    provenance[k] = list;
+  }
+  return { peerId, updatedAt, fields, provenance };
+}
+
+/**
+ * Read a peer's profile. Returns null if the profile file does not exist.
+ *
+ * The PR-1 surface only ships the structured read/write so the reasoner
+ * (PR 2/5) and recall integration (PR 3/5) have a stable target. We do
+ * not yet expose any field-update helpers.
+ */
+export async function readPeerProfile(
+  memoryDir: string,
+  peerId: string,
+): Promise<PeerProfile | null> {
+  assertValidPeerId(peerId);
+  const file = profilePath(memoryDir, peerId);
+  let raw: string;
+  try {
+    raw = await fs.readFile(file, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw err;
+  }
+  return parsePeerProfile(raw, peerId);
+}
+
+/**
+ * Write (create or overwrite) a peer's profile.
+ */
+export async function writePeerProfile(
+  memoryDir: string,
+  profile: PeerProfile,
+): Promise<void> {
+  assertValidPeerId(profile.peerId);
+  if (typeof profile.updatedAt !== "string" || profile.updatedAt === "") {
+    throw new Error("profile.updatedAt must be a non-empty ISO-8601 string");
+  }
+  const dir = peerDir(memoryDir, profile.peerId);
+  await fs.mkdir(dir, { recursive: true });
+  await fs.writeFile(profilePath(memoryDir, profile.peerId), emitPeerProfile(profile), "utf8");
+}
+
+/**
+ * Read the raw interaction log for a peer.
+ *
+ * Returns the empty string if the log does not yet exist. Callers parse
+ * the log themselves — this PR does not ship structured log parsing.
+ * Exposed primarily so tests can verify monotonic append semantics.
+ */
+export async function readInteractionLogRaw(
+  memoryDir: string,
+  peerId: string,
+): Promise<string> {
+  assertValidPeerId(peerId);
+  const file = interactionsPath(memoryDir, peerId);
+  try {
+    return await fs.readFile(file, "utf8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return "";
+    }
+    throw err;
+  }
+}

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -684,20 +684,20 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
       ? payload.provenance
       : {};
   // Coerce values defensively. We never trust the on-disk shape.
-  // Codex P1: use null-prototype objects so an attacker-controlled
-  // JSON key like "__proto__" cannot mutate Object.prototype when we
-  // assign into the maps. Same defense applied to fields and
-  // provenance. Reject the dangerous keys outright as well — they
-  // should never appear in legitimate peer data.
+  // Codex P1: skip prototype-pollution keys explicitly. We don't use
+  // null-prototype objects in the returned shape because callers
+  // (tests, downstream consumers) expect plain objects with normal
+  // semantics — the assertion `assert.deepEqual` differentiates by
+  // prototype. The skip-list is the load-bearing defense; iteration
+  // via Object.entries() of attacker-controlled JSON objects is safe
+  // as long as we never assign through dangerous keys.
   const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
-  const fields: Record<string, string> = Object.create(null) as Record<string, string>;
+  const fields: Record<string, string> = {};
   for (const [k, v] of Object.entries(fieldsObj)) {
     if (DANGEROUS_KEYS.has(k)) continue;
     if (typeof v === "string") fields[k] = v;
   }
-  const provenance: Record<string, PeerProfileFieldProvenance[]> = Object.create(
-    null,
-  ) as Record<string, PeerProfileFieldProvenance[]>;
+  const provenance: Record<string, PeerProfileFieldProvenance[]> = {};
   for (const [k, v] of Object.entries(provenanceObj)) {
     if (DANGEROUS_KEYS.has(k)) continue;
     if (!Array.isArray(v)) continue;

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -607,11 +607,15 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
   // operates on the original inode regardless of subsequent path-
   // based mutations.
   const root = peersRoot(memoryDir);
-  // Cursor M round 14: use the held directory handle's readdir so
-  // we read entries from the original-inode directory we opened
-  // with O_NOFOLLOW. A path-based fs.readdir(root) would re-resolve
-  // the path and could traverse a swapped-in symlink. dh.readdir()
-  // operates on the open file descriptor and is immune to that race.
+  // Cursor M round 14: Node's FileHandle has no `readdir` method
+  // (only `fs.readdir(path)` is exposed), so we can't read directly
+  // from the handle. Instead anchor the original-inode by opening
+  // the dir with O_NOFOLLOW, fstat it, then do path-based readdir
+  // and confirm the path's lstat AFTER matches the held inode. If
+  // it diverges, a swap happened — abort. This is a fence around
+  // the readdir, not the kernel-level guarantee a true `fdreaddir`
+  // would give, but it closes the path-traversal race without
+  // requiring native bindings.
   let entries: string[];
   let dh: import("node:fs/promises").FileHandle | null = null;
   try {
@@ -619,7 +623,16 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
       root,
       fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
     );
-    entries = await dh.readdir();
+    const fstatBefore = await dh.stat();
+    entries = await fs.readdir(root);
+    const lstatAfter = await fs.lstat(root);
+    if (
+      fstatBefore.ino !== lstatAfter.ino ||
+      fstatBefore.dev !== lstatAfter.dev ||
+      lstatAfter.isSymbolicLink()
+    ) {
+      throw new Error(`peers root "${root}" was swapped during readdir`);
+    }
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return [];

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -398,10 +398,20 @@ export async function readPeer(
   assertValidKind(kind);
   const displayName = fields.displayName ?? "";
   const createdAt = fields.createdAt ?? "";
-  const updatedAt = fields.updatedAt ?? createdAt;
   if (createdAt === "") {
     throw new Error(`peer "${peerId}" is missing createdAt`);
   }
+  // Codex P2: nullish-coalescing alone treated `updatedAt: ""` as a
+  // valid empty timestamp, contradicting writePeer's non-empty
+  // validation and the module's "malformed files throw" contract.
+  // Treat empty string as missing and fall back to createdAt; throw
+  // only when the field is malformed in some other way (caught by
+  // the typeof check).
+  const rawUpdatedAt = fields.updatedAt;
+  const updatedAt =
+    typeof rawUpdatedAt === "string" && rawUpdatedAt.length > 0
+      ? rawUpdatedAt
+      : createdAt;
   // Codex P2 + CodeQL: previously used `body.replace(/^\s+/, "")`
   // which stripped ALL leading whitespace — including indentation in
   // notes. The `\s+` patterns also flagged as polynomial-regex risk

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -161,6 +161,21 @@ export function assertValidPeerId(peerId: unknown): asserts peerId is string {
   }
 }
 
+/**
+ * Strict plain-object check. Rejects arrays, null, Maps, Sets, class
+ * instances, and anything else with a non-Object/null prototype.
+ * Codex P2 round 13: writePeerProfile previously treated any
+ * non-null non-array object as plain; inputs like `new Map()` would
+ * pass and serialize to `{}` losing all data.
+ */
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
 function assertValidKind(kind: unknown): asserts kind is PeerKind {
   if (typeof kind !== "string" || !ALLOWED_KINDS.has(kind as PeerKind)) {
     throw new Error(
@@ -219,12 +234,64 @@ async function assertPeersRootNotSymlink(memoryDir: string): Promise<void> {
 }
 
 /**
+ * Codex P1 round 13: atomic mkdir of the peer directory under a
+ * verified peers root. Opens the peers root with O_DIRECTORY|
+ * O_NOFOLLOW first (creating it if missing under the same flags) so
+ * a root-symlink swap can't redirect the subsequent mkdir to its
+ * target. The dir handle is held across the mkdir, then we lstat
+ * the candidate and reject if it's a symlink.
+ */
+async function mkdirPeerDirAtomic(memoryDir: string, peerId: string): Promise<void> {
+  const root = peersRoot(memoryDir);
+  // Ensure the root exists as a real directory, not a symlink. Use
+  // mkdir + lstat: if mkdir succeeds (or EEXIST), lstat must report
+  // a directory and not a symlink.
+  await fs.mkdir(memoryDir, { recursive: true });
+  try {
+    await fs.mkdir(root);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
+  }
+  const rootLstat = await fs.lstat(root);
+  if (rootLstat.isSymbolicLink()) {
+    throw new Error(`peers root "${root}" is a symlink and is rejected`);
+  }
+  if (!rootLstat.isDirectory()) {
+    throw new Error(`peers root "${root}" exists but is not a directory`);
+  }
+  // Open the root with O_DIRECTORY|O_NOFOLLOW to anchor the inode.
+  // Hold the handle across the peer-dir mkdir so a root swap
+  // mid-operation is detected via fstat-vs-lstat compare afterward.
+  const rootHandle = await fs.open(
+    root,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const candidate = peerDir(memoryDir, peerId);
+    await fs.mkdir(candidate, { recursive: true });
+    // Verify root inode unchanged across the mkdir.
+    const fstatRoot = await rootHandle.stat();
+    const lstatRoot = await fs.lstat(root);
+    if (fstatRoot.ino !== lstatRoot.ino || fstatRoot.dev !== lstatRoot.dev) {
+      throw new Error(`peers root "${root}" was swapped during mkdir`);
+    }
+    // Reject symlinked peer dir.
+    const peerLstat = await fs.lstat(candidate);
+    if (peerLstat.isSymbolicLink()) {
+      throw new Error(`peer directory "${peerId}" is a symlink and is rejected`);
+    }
+  } finally {
+    await rootHandle.close();
+  }
+}
+
+/**
  * Codex P1 on PR #723: `peerDir` only enforces a lexical
  * `path.relative` check, so a symlinked peer directory like
  * `peers/self → /tmp/outside` would slip through. Run this guard
  * AFTER the peer directory has been (or is known to) exist, so we
  * can lstat it and realpath-check containment. For first-time writes,
- * call `assertPeersRootNotSymlink` BEFORE `fs.mkdir` and this AFTER.
+ * call `mkdirPeerDirAtomic` BEFORE this; for reads, this alone.
  */
 async function assertPeerDirNotEscaped(memoryDir: string, peerId: string): Promise<void> {
   const candidate = peerDir(memoryDir, peerId);
@@ -507,12 +574,14 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   if (peer.notes !== undefined && typeof peer.notes !== "string") {
     throw new Error("peer.notes must be a string when provided");
   }
-  // Codex P2 + cursor M: validate the peers root BEFORE mkdir so a
-  // symlinked `peers/` root can't get its target mutated by the
-  // recursive mkdir even though the post-check would later throw.
-  await assertPeersRootNotSymlink(memoryDir);
-  const dir = peerDir(memoryDir, peer.id);
-  await fs.mkdir(dir, { recursive: true });
+  // Codex P1 round 13: atomic root validation. Open the peers root
+  // (or its parent if peers doesn't exist yet) with O_DIRECTORY|
+  // O_NOFOLLOW BEFORE the mkdir. This holds a kernel handle on the
+  // original-inode root, so a swap between the symlink check and
+  // the mkdir can't redirect mkdir to a symlink-target. We then
+  // mkdir, lstat the result against the held handle, and only
+  // proceed if they match.
+  await mkdirPeerDirAtomic(memoryDir, peer.id);
   await assertPeerDirNotEscaped(memoryDir, peer.id);
   const file = identityPath(memoryDir, peer.id);
   // Codex P1 #2: reject if identity.md exists as a symlink so we
@@ -529,21 +598,31 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
  * `identity.md` are also skipped.
  */
 export async function listPeers(memoryDir: string): Promise<Peer[]> {
-  // Codex P1 (round 2): `fs.readdir(root)` follows a symlinked
-  // peers root, so without checking first, listing on a malicious
-  // `peers → /tmp/outside` symlink would enumerate out-of-scope
-  // contents and feed them to readPeer. Reject the symlinked root
-  // BEFORE the readdir.
-  await assertPeersRootNotSymlink(memoryDir);
+  // Codex P2 round 13: atomic readdir against the root. Open the
+  // peers directory with O_DIRECTORY|O_NOFOLLOW first so we hold the
+  // original-inode handle, then readdir from that handle. A
+  // root-symlink swap between assertPeersRootNotSymlink and a path-
+  // based readdir is no longer possible — the kernel rejects the
+  // open if the path resolves to a symlink, and the dirHandle.read()
+  // operates on the original inode regardless of subsequent path-
+  // based mutations.
   const root = peersRoot(memoryDir);
   let entries: string[];
+  let dh: import("node:fs/promises").FileHandle | null = null;
   try {
-    entries = await fs.readdir(root);
+    dh = await fs.open(
+      root,
+      fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+    );
+    const dir = await fs.readdir(root);
+    entries = dir;
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return [];
     }
     throw err;
+  } finally {
+    if (dh) await dh.close();
   }
   const peers: Peer[] = [];
   // Sort for deterministic ordering — callers that need a different
@@ -560,16 +639,28 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
       // would otherwise let listPeers (and the readPeer that
       // follows) traverse outside the peers root.
       stat = await fs.lstat(path.join(root, name));
-    } catch {
-      continue;
+    } catch (err) {
+      // Codex P2 round 13: don't swallow non-ENOENT errors.
+      // Permission-denied / EACCES / EIO need to surface so the
+      // operator sees a real I/O problem rather than a silently
+      // truncated peer list.
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw err;
     }
     // Skip symlinks entirely — only real directories are peers.
     if (!stat.isDirectory() || stat.isSymbolicLink()) continue;
     let peer: Peer | null = null;
     try {
       peer = await readPeer(memoryDir, name);
-    } catch {
-      // Skip malformed peer directories rather than failing the whole list.
+    } catch (err) {
+      // Codex P2 round 13: only skip schema/parse failures (those
+      // are caught and re-thrown as plain Error). Re-throw real I/O
+      // errors (EACCES, EIO, EBUSY, etc.) so the operator sees them.
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code && code !== "ENOENT") {
+        throw err;
+      }
+      // Schema/parse failures fall through and skip the entry.
       continue;
     }
     if (peer !== null) {
@@ -648,9 +739,7 @@ export async function appendInteractionLog(
       throw new Error("interaction entry sessionId must be a non-whitespace string when provided");
     }
   }
-  await assertPeersRootNotSymlink(memoryDir);
-  const dir = peerDir(memoryDir, peerId);
-  await fs.mkdir(dir, { recursive: true });
+  await mkdirPeerDirAtomic(memoryDir, peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
   const line = formatLogEntry(entry) + "\n";
@@ -858,7 +947,7 @@ export async function writePeerProfile(
   // provenance entries — readPeerProfile silently scrubs them on
   // the way back, so data is lost without an error. Fail fast at
   // the boundary instead.
-  if (typeof profile.fields !== "object" || profile.fields === null || Array.isArray(profile.fields)) {
+  if (!isPlainObject(profile.fields)) {
     throw new Error("profile.fields must be a plain object");
   }
   // Codex P2 round 11: parsePeerProfile drops "__proto__" /
@@ -876,11 +965,7 @@ export async function writePeerProfile(
       throw new Error(`profile.fields["${key}"] must be a string`);
     }
   }
-  if (
-    typeof profile.provenance !== "object" ||
-    profile.provenance === null ||
-    Array.isArray(profile.provenance)
-  ) {
+  if (!isPlainObject(profile.provenance)) {
     throw new Error("profile.provenance must be a plain object");
   }
   for (const [key, list] of Object.entries(profile.provenance)) {
@@ -917,9 +1002,7 @@ export async function writePeerProfile(
       }
     }
   }
-  await assertPeersRootNotSymlink(memoryDir);
-  const dir = peerDir(memoryDir, profile.peerId);
-  await fs.mkdir(dir, { recursive: true });
+  await mkdirPeerDirAtomic(memoryDir, profile.peerId);
   await assertPeerDirNotEscaped(memoryDir, profile.peerId);
   const file = profilePath(memoryDir, profile.peerId);
   await writeFileNoFollow(file, emitPeerProfile(profile));

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -857,7 +857,17 @@ export async function writePeerProfile(
   if (typeof profile.fields !== "object" || profile.fields === null || Array.isArray(profile.fields)) {
     throw new Error("profile.fields must be a plain object");
   }
+  // Codex P2 round 11: parsePeerProfile drops "__proto__" /
+  // "constructor" / "prototype" keys on read. Without symmetric
+  // rejection on write, those keys silently disappear during
+  // round-trip — failing the contract that what writes succeeds
+  // also reads back. Reject at the boundary so JS callers learn
+  // immediately that those keys aren't allowed.
+  const RESERVED_KEYS: ReadonlySet<string> = new Set(["__proto__", "constructor", "prototype"]);
   for (const [key, value] of Object.entries(profile.fields)) {
+    if (RESERVED_KEYS.has(key)) {
+      throw new Error(`profile.fields key "${key}" is reserved and cannot be persisted`);
+    }
     if (typeof value !== "string") {
       throw new Error(`profile.fields["${key}"] must be a string`);
     }
@@ -870,6 +880,9 @@ export async function writePeerProfile(
     throw new Error("profile.provenance must be a plain object");
   }
   for (const [key, list] of Object.entries(profile.provenance)) {
+    if (RESERVED_KEYS.has(key)) {
+      throw new Error(`profile.provenance key "${key}" is reserved and cannot be persisted`);
+    }
     if (!Array.isArray(list)) {
       throw new Error(`profile.provenance["${key}"] must be an array`);
     }

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -136,7 +136,16 @@ function interactionsPath(memoryDir: string, peerId: string): string {
 // behaviour deterministic and easy to validate.
 
 function escapeYamlString(value: string): string {
-  return `"${value.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`;
+  // Cursor Medium: must escape newlines / carriage returns / tabs so a
+  // value like `displayName: "first\nsecond"` doesn't blow up the
+  // line-oriented parsePeerFrontmatter. Backslash → `\\`, double-quote
+  // → `\"`, newline → `\n`, carriage return → `\r`, tab → `\t`.
+  return `"${value
+    .replace(/\\/g, "\\\\")
+    .replace(/"/g, '\\"')
+    .replace(/\n/g, "\\n")
+    .replace(/\r/g, "\\r")
+    .replace(/\t/g, "\\t")}"`;
 }
 
 function unescapeYamlString(quoted: string): string {
@@ -149,6 +158,21 @@ function unescapeYamlString(quoted: string): string {
       const next = body[i + 1];
       if (next === "\\" || next === '"') {
         out += next;
+        i++;
+        continue;
+      }
+      if (next === "n") {
+        out += "\n";
+        i++;
+        continue;
+      }
+      if (next === "r") {
+        out += "\r";
+        i++;
+        continue;
+      }
+      if (next === "t") {
+        out += "\t";
         i++;
         continue;
       }
@@ -258,9 +282,18 @@ export async function readPeer(
   if (createdAt === "") {
     throw new Error(`peer "${peerId}" is missing createdAt`);
   }
-  // Strip leading blank lines (frontmatter close inserts one) and any
-  // trailing whitespace. Internal whitespace is preserved verbatim.
-  const trimmedBody = body.replace(/^\s+/, "").replace(/\s+$/, "");
+  // Codex P2 + CodeQL: previously used `body.replace(/^\s+/, "")`
+  // which stripped ALL leading whitespace — including indentation in
+  // notes. The `\s+` patterns also flagged as polynomial-regex risk
+  // (CodeQL alert #74) because they can backtrack on adversarial
+  // inputs. Strip exactly one leading separator newline and one
+  // trailing newline — internal AND user-authored leading
+  // indentation are preserved verbatim, and the regex is bounded.
+  let trimmedBody = body;
+  if (trimmedBody.startsWith("\r\n")) trimmedBody = trimmedBody.slice(2);
+  else if (trimmedBody.startsWith("\n")) trimmedBody = trimmedBody.slice(1);
+  if (trimmedBody.endsWith("\r\n")) trimmedBody = trimmedBody.slice(0, -2);
+  else if (trimmedBody.endsWith("\n")) trimmedBody = trimmedBody.slice(0, -1);
   return {
     id: peerId,
     kind,
@@ -324,11 +357,16 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
     }
     let stat;
     try {
-      stat = await fs.stat(path.join(root, name));
+      // Codex P1: use `lstat` so we don't follow symlinks. A
+      // `peers/<valid-id>` symlink pointing at an arbitrary directory
+      // would otherwise let listPeers (and the readPeer that
+      // follows) traverse outside the peers root.
+      stat = await fs.lstat(path.join(root, name));
     } catch {
       continue;
     }
-    if (!stat.isDirectory()) continue;
+    // Skip symlinks entirely — only real directories are peers.
+    if (!stat.isDirectory() || stat.isSymbolicLink()) continue;
     let peer: Peer | null = null;
     try {
       peer = await readPeer(memoryDir, name);
@@ -347,14 +385,28 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
 // Interaction log (append-only)
 // ──────────────────────────────────────────────────────────────────────
 
+function sanitizeLogField(value: string): string {
+  // Cursor Medium: every interaction-log field — not just summary —
+  // must collapse newlines so a malicious or buggy `timestamp` /
+  // `kind` / `sessionId` value can't break the one-line-per-entry
+  // invariant the append-only log relies on. Replace CR/LF/Tab with
+  // a single space; trim leading/trailing whitespace.
+  return value.replace(/[\r\n\t]+/g, " ").trim();
+}
+
 function formatLogEntry(entry: PeerInteractionLogEntry): string {
   // One line per entry. We use a leading bullet so the file remains
   // readable as ordinary markdown. Order: timestamp, kind, optional
-  // session id, summary. Newlines in the summary are escaped to keep
-  // each entry on a single line — preserves monotonic append semantics.
-  const safeSummary = entry.summary.replace(/\r?\n/g, " ");
-  const session = entry.sessionId ? ` session=${entry.sessionId}` : "";
-  return `- [${entry.timestamp}] (${entry.kind})${session} ${safeSummary}`;
+  // session id, summary. ALL fields are passed through `sanitizeLogField`
+  // so a stray newline anywhere can't shatter the append-only invariant
+  // (cursor Medium on PR #723).
+  const ts = sanitizeLogField(entry.timestamp);
+  const kind = sanitizeLogField(entry.kind);
+  const summary = sanitizeLogField(entry.summary);
+  const session = entry.sessionId
+    ? ` session=${sanitizeLogField(entry.sessionId)}`
+    : "";
+  return `- [${ts}] (${kind})${session} ${summary}`;
 }
 
 /**

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -29,8 +29,10 @@ async function openNoFollow(file: string, flags: number): Promise<import("node:f
   return fs.open(file, flags | fsConstants.O_NOFOLLOW);
 }
 
-/** Read a file, refusing to follow symlinks at the kernel level. */
+/** Read a file, refusing to follow symlinks at the kernel level
+ * AND verifying parent-dir inode stability (codex P1 round 9). */
 async function readFileNoFollow(file: string): Promise<string> {
+  await assertParentDirInodeStable(file);
   const fh = await openNoFollow(file, fsConstants.O_RDONLY);
   try {
     return await fh.readFile("utf8");
@@ -39,8 +41,50 @@ async function readFileNoFollow(file: string): Promise<string> {
   }
 }
 
-/** Overwrite a file, refusing to follow symlinks at the kernel level. */
+/**
+ * Codex P1 round 9: O_NOFOLLOW only protects the FINAL path
+ * component, so a parent-directory swap mid-flight (peers/<id>
+ * unlinked + replaced with a symlink between assertPeerDirNotEscaped
+ * and the open) could still write outside memoryDir. Without
+ * `openat` (Node has no stable JS binding for it), the best
+ * pure-Node mitigation is to:
+ *   1. Open the parent directory with O_DIRECTORY | O_NOFOLLOW so
+ *      WE hold the original-inode handle.
+ *   2. fstat the parent handle and compare its (dev, inode) against
+ *      lstat of the parent path. If they diverge, a swap happened
+ *      between mkdir and now — abort.
+ *   3. Then do the symlink-rejecting open of the file.
+ * This narrows the race window to the few microseconds between the
+ * fstat/lstat compare and the open. Fully closing the race needs
+ * `openat`, which is tracked as a follow-up.
+ */
+async function assertParentDirInodeStable(filePath: string): Promise<void> {
+  const parent = path.dirname(filePath);
+  const dh = await fs.open(
+    parent,
+    fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
+  );
+  try {
+    const fstatInfo = await dh.stat();
+    const lstatInfo = await fs.lstat(parent);
+    if (fstatInfo.ino !== lstatInfo.ino || fstatInfo.dev !== lstatInfo.dev) {
+      throw new Error(
+        `parent directory "${parent}" was swapped between checks (inode mismatch)`,
+      );
+    }
+    if (lstatInfo.isSymbolicLink()) {
+      throw new Error(`parent directory "${parent}" is a symlink and is rejected`);
+    }
+  } finally {
+    await dh.close();
+  }
+}
+
+/** Overwrite a file, refusing to follow symlinks at the kernel level
+ * AND verifying the parent directory inode is stable across the open
+ * (codex P1 round 9). */
 async function writeFileNoFollow(file: string, data: string): Promise<void> {
+  await assertParentDirInodeStable(file);
   const fh = await openNoFollow(
     file,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC,
@@ -52,8 +96,10 @@ async function writeFileNoFollow(file: string, data: string): Promise<void> {
   }
 }
 
-/** Append to a file, refusing to follow symlinks at the kernel level. */
+/** Append to a file, refusing to follow symlinks AND verifying parent
+ * inode stability (codex P1 round 9). */
 async function appendFileNoFollow(file: string, data: string): Promise<void> {
+  await assertParentDirInodeStable(file);
   const fh = await openNoFollow(
     file,
     fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND,
@@ -810,11 +856,18 @@ export async function writePeerProfile(
       if (typeof r.signal !== "string" || r.signal === "") {
         throw new Error(`profile.provenance["${key}"][${i}].signal must be a non-empty string`);
       }
-      if (r.sourceSessionId !== undefined && typeof r.sourceSessionId !== "string") {
-        throw new Error(`profile.provenance["${key}"][${i}].sourceSessionId must be a string when provided`);
+      // Cursor M round 9: empty optional strings would round-trip lose
+      // (parsePeerProfile drops them on read). Reject at the boundary
+      // for consistency with other validators in this module.
+      if (r.sourceSessionId !== undefined) {
+        if (typeof r.sourceSessionId !== "string" || r.sourceSessionId === "") {
+          throw new Error(`profile.provenance["${key}"][${i}].sourceSessionId must be a non-empty string when provided`);
+        }
       }
-      if (r.note !== undefined && typeof r.note !== "string") {
-        throw new Error(`profile.provenance["${key}"][${i}].note must be a string when provided`);
+      if (r.note !== undefined) {
+        if (typeof r.note !== "string" || r.note === "") {
+          throw new Error(`profile.provenance["${key}"][${i}].note must be a non-empty string when provided`);
+        }
       }
     }
   }

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -607,6 +607,11 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
   // operates on the original inode regardless of subsequent path-
   // based mutations.
   const root = peersRoot(memoryDir);
+  // Cursor M round 14: use the held directory handle's readdir so
+  // we read entries from the original-inode directory we opened
+  // with O_NOFOLLOW. A path-based fs.readdir(root) would re-resolve
+  // the path and could traverse a swapped-in symlink. dh.readdir()
+  // operates on the open file descriptor and is immune to that race.
   let entries: string[];
   let dh: import("node:fs/promises").FileHandle | null = null;
   try {
@@ -614,8 +619,7 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
       root,
       fsConstants.O_RDONLY | fsConstants.O_DIRECTORY | fsConstants.O_NOFOLLOW,
     );
-    const dir = await fs.readdir(root);
-    entries = dir;
+    entries = await dh.readdir();
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return [];
@@ -653,13 +657,27 @@ export async function listPeers(memoryDir: string): Promise<Peer[]> {
     try {
       peer = await readPeer(memoryDir, name);
     } catch (err) {
-      // Codex P2 round 13: only skip schema/parse failures (those
-      // are caught and re-thrown as plain Error). Re-throw real I/O
-      // errors (EACCES, EIO, EBUSY, etc.) so the operator sees them.
+      // Cursor M round 14: classifying by `.code` alone treated
+      // security-check failures (assertPeerDirNotEscaped /
+      // assertParentDirInodeStable / "is a symlink and is rejected"
+      // / "inode mismatch") as parse failures and silently skipped
+      // them. Those messages are critical signals — an attacker
+      // attempted to redirect a read outside the peers root. Match
+      // by message prefix to detect them and propagate.
       const code = (err as NodeJS.ErrnoException).code;
-      if (code && code !== "ENOENT") {
-        throw err;
-      }
+      const message = err instanceof Error ? err.message : String(err);
+      const isSecurityFailure =
+        message.startsWith("peers root") ||
+        message.startsWith("peer directory") ||
+        message.startsWith("parent directory") ||
+        message.startsWith("path ") /* "path \"...\" is a symlink" */ ||
+        message.includes("escapes the peers root") ||
+        message.includes("inode mismatch") ||
+        message.includes("is a symlink and is rejected") ||
+        message.includes("was swapped");
+      if (isSecurityFailure) throw err;
+      // Real I/O errors (EACCES, EIO, EBUSY, etc.) propagate too.
+      if (code && code !== "ENOENT") throw err;
       // Schema/parse failures fall through and skip the entry.
       continue;
     }

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -583,14 +583,15 @@ export async function appendInteractionLog(
   if (typeof entry.summary !== "string") {
     throw new Error("interaction entry must have a string summary");
   }
-  // Codex P2 round 6: optional sessionId must be a string OR
-  // strictly `undefined` (omitted). Round 8 follow-up: `null` was
-  // previously treated as acceptable but silently dropped during
-  // formatting; reject it explicitly so the boundary fails fast on
-  // any non-string input, matching the "fail fast" pattern of the
-  // other validators in this module.
-  if (entry.sessionId !== undefined && typeof entry.sessionId !== "string") {
-    throw new Error("interaction entry sessionId must be a string when provided");
+  // Codex P2 round 6/8/9: optional sessionId must be a non-empty
+  // string OR strictly `undefined` (omitted). null and empty string
+  // are both rejected explicitly: the previous behavior silently
+  // dropped them during formatting, which reinterprets invalid input
+  // instead of failing fast like other validators in this module.
+  if (entry.sessionId !== undefined) {
+    if (typeof entry.sessionId !== "string" || entry.sessionId === "") {
+      throw new Error("interaction entry sessionId must be a non-empty string when provided");
+    }
   }
   await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, peerId);
@@ -683,12 +684,22 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
       ? payload.provenance
       : {};
   // Coerce values defensively. We never trust the on-disk shape.
-  const fields: Record<string, string> = {};
+  // Codex P1: use null-prototype objects so an attacker-controlled
+  // JSON key like "__proto__" cannot mutate Object.prototype when we
+  // assign into the maps. Same defense applied to fields and
+  // provenance. Reject the dangerous keys outright as well — they
+  // should never appear in legitimate peer data.
+  const DANGEROUS_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+  const fields: Record<string, string> = Object.create(null) as Record<string, string>;
   for (const [k, v] of Object.entries(fieldsObj)) {
+    if (DANGEROUS_KEYS.has(k)) continue;
     if (typeof v === "string") fields[k] = v;
   }
-  const provenance: Record<string, PeerProfileFieldProvenance[]> = {};
+  const provenance: Record<string, PeerProfileFieldProvenance[]> = Object.create(
+    null,
+  ) as Record<string, PeerProfileFieldProvenance[]>;
   for (const [k, v] of Object.entries(provenanceObj)) {
+    if (DANGEROUS_KEYS.has(k)) continue;
     if (!Array.isArray(v)) continue;
     const list: PeerProfileFieldProvenance[] = [];
     for (const item of v) {
@@ -700,21 +711,23 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
         continue;
       }
       const r = item as unknown as Record<string, unknown>;
-      if (typeof r.observedAt !== "string" || typeof r.signal !== "string") {
-        continue;
-      }
-      // Codex P2: previously the optional fields were never type-
-      // checked, so a hand-edited `{sourceSessionId: 123}` survived
-      // and corrupted the PeerProfileFieldProvenance contract for
-      // downstream consumers. Build a clean record with only
-      // string-typed optional fields included.
+      // Codex P2 round 9: empty observedAt/signal strings should be
+      // treated as malformed, not valid. Drop the entry.
+      if (typeof r.observedAt !== "string" || r.observedAt === "") continue;
+      if (typeof r.signal !== "string" || r.signal === "") continue;
+      // Codex P2 round 6: previously the optional fields were never
+      // type-checked, so a hand-edited `{sourceSessionId: 123}`
+      // survived and corrupted the PeerProfileFieldProvenance contract.
+      // Build a clean record with only string-typed optional fields.
       const clean: PeerProfileFieldProvenance = {
         observedAt: r.observedAt,
         signal: r.signal,
-        ...(typeof r.sourceSessionId === "string"
+        ...(typeof r.sourceSessionId === "string" && r.sourceSessionId.length > 0
           ? { sourceSessionId: r.sourceSessionId }
           : {}),
-        ...(typeof r.note === "string" ? { note: r.note } : {}),
+        ...(typeof r.note === "string" && r.note.length > 0
+          ? { note: r.note }
+          : {}),
       };
       list.push(clean);
     }

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -94,12 +94,69 @@ function peerDir(memoryDir: string, peerId: string): string {
   assertValidPeerId(peerId);
   const candidate = path.join(peersRoot(memoryDir), peerId);
   const root = peersRoot(memoryDir);
-  // Ensure resolved path stays within peersRoot.
+  // Ensure resolved path stays within peersRoot. Note: this is a
+  // lexical check only — a symlinked peer directory can still escape.
+  // I/O sites must additionally call `assertPeerDirNotEscaped` (below)
+  // before reading or writing, which uses lstat to reject symlinks
+  // and realpath to confirm physical containment (codex P1 #723).
   const relative = path.relative(root, candidate);
   if (relative.startsWith("..") || path.isAbsolute(relative)) {
     throw new Error(`peerId "${peerId}" resolves outside peers root`);
   }
   return candidate;
+}
+
+/**
+ * Codex P1 on PR #723: `peerDir` only enforces a lexical
+ * `path.relative` check, so a symlinked peer directory like
+ * `peers/self → /tmp/outside` would slip through. Any I/O site that
+ * touches a peer directory must call this guard, which:
+ *   1. Rejects the path entirely if it (or any direct ancestor up to
+ *      `peers/`) is a symlink.
+ *   2. Verifies that the realpath of the candidate (and its parent
+ *      `peers/` root) keeps the candidate strictly under the
+ *      realpath of the peers root.
+ *
+ * Returns silently when the path either does not exist yet (write
+ * path will create it under a real-directory chain) or is a real
+ * directory inside the peers root. Throws otherwise.
+ */
+async function assertPeerDirNotEscaped(memoryDir: string, peerId: string): Promise<void> {
+  const candidate = peerDir(memoryDir, peerId);
+  const root = peersRoot(memoryDir);
+  // 1. lstat on the candidate itself. If it's a symlink, refuse.
+  let candidateStat: import("node:fs").Stats | null = null;
+  try {
+    candidateStat = await fs.lstat(candidate);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  if (candidateStat && candidateStat.isSymbolicLink()) {
+    throw new Error(`peer directory "${peerId}" is a symlink and is rejected`);
+  }
+  // 2. lstat on the peers root. If the root itself is a symlink, the
+  // realpath check below would compare against the symlink target,
+  // letting an attacker bypass the boundary. Refuse.
+  let rootStat: import("node:fs").Stats | null = null;
+  try {
+    rootStat = await fs.lstat(root);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
+  }
+  if (rootStat && rootStat.isSymbolicLink()) {
+    throw new Error(`peers root "${root}" is a symlink and is rejected`);
+  }
+  // 3. Real-path containment check. Only meaningful if the candidate
+  // exists (writes that create the directory will catch escape via
+  // step 1; reads that hit ENOENT are no-ops anyway).
+  if (candidateStat) {
+    const realRoot = await fs.realpath(root);
+    const realCandidate = await fs.realpath(candidate);
+    const rel = path.relative(realRoot, realCandidate);
+    if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) {
+      throw new Error(`peer directory "${peerId}" escapes the peers root`);
+    }
+  }
 }
 
 function identityPath(memoryDir: string, peerId: string): string {
@@ -262,6 +319,7 @@ export async function readPeer(
   peerId: string,
 ): Promise<Peer | null> {
   assertValidPeerId(peerId);
+  await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = identityPath(memoryDir, peerId);
   let raw: string;
   try {
@@ -330,6 +388,7 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   }
   const dir = peerDir(memoryDir, peer.id);
   await fs.mkdir(dir, { recursive: true });
+  await assertPeerDirNotEscaped(memoryDir, peer.id);
   await fs.writeFile(identityPath(memoryDir, peer.id), emitPeerIdentity(peer), "utf8");
 }
 
@@ -438,6 +497,7 @@ export async function appendInteractionLog(
   }
   const dir = peerDir(memoryDir, peerId);
   await fs.mkdir(dir, { recursive: true });
+  await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
   const line = formatLogEntry(entry) + "\n";
   // `appendFile` creates the file if it does not exist. POSIX guarantees
@@ -508,8 +568,14 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
     throw new Error(`peer profile for "${peerId}" is not an object`);
   }
   const payload = parsed as Partial<ProfileFile>;
-  const updatedAt = payload.updatedAt ?? fm.updatedAt ?? "";
-  if (updatedAt === "") {
+  // Codex P2: only accept string updatedAt values. A malformed payload
+  // like `{ "updatedAt": 123 }` would previously short-circuit through
+  // `payload.updatedAt ?? fm.updatedAt ?? ""` and produce a `PeerProfile`
+  // whose updatedAt is a number — corrupting any downstream code that
+  // assumes the contract.
+  const payloadUpdatedAt = typeof payload.updatedAt === "string" ? payload.updatedAt : undefined;
+  const updatedAt = payloadUpdatedAt ?? fm.updatedAt ?? "";
+  if (typeof updatedAt !== "string" || updatedAt === "") {
     throw new Error(`peer profile for "${peerId}" is missing updatedAt`);
   }
   const fieldsObj =
@@ -554,6 +620,7 @@ export async function readPeerProfile(
   peerId: string,
 ): Promise<PeerProfile | null> {
   assertValidPeerId(peerId);
+  await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = profilePath(memoryDir, peerId);
   let raw: string;
   try {
@@ -580,6 +647,7 @@ export async function writePeerProfile(
   }
   const dir = peerDir(memoryDir, profile.peerId);
   await fs.mkdir(dir, { recursive: true });
+  await assertPeerDirNotEscaped(memoryDir, profile.peerId);
   await fs.writeFile(profilePath(memoryDir, profile.peerId), emitPeerProfile(profile), "utf8");
 }
 
@@ -595,6 +663,7 @@ export async function readInteractionLogRaw(
   peerId: string,
 ): Promise<string> {
   assertValidPeerId(peerId);
+  await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
   try {
     return await fs.readFile(file, "utf8");

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -321,7 +321,13 @@ function emitPeerIdentity(peer: Peer): string {
   lines.push("");
   lines.push(peer.notes ?? "");
   // Trailing newline for POSIX friendliness.
-  return lines.join("\n").replace(/\n+$/, "\n") + "\n";
+  // CodeQL: the previous `replace(/\n+$/, "\n")` flagged as
+  // polynomial-regex risk because `\n+` can backtrack on long
+  // trailing-newline runs. Strip trailing newlines with a bounded
+  // loop instead — O(N) over the trailing-newline count, no regex.
+  let out = lines.join("\n");
+  while (out.endsWith("\n")) out = out.slice(0, -1);
+  return out + "\n";
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -620,11 +620,16 @@ export async function appendInteractionLog(
   entry: PeerInteractionLogEntry,
 ): Promise<string> {
   assertValidPeerId(peerId);
-  if (typeof entry.timestamp !== "string" || entry.timestamp === "") {
-    throw new Error("interaction entry must have a non-empty timestamp");
+  // Codex P2 round 10: trim() before the empty check matches what
+  // sanitizeLogField does at format time. A whitespace-only
+  // `timestamp` or `kind` would previously pass validation and then
+  // be normalized to "" later, producing an entry like `- [] ()`
+  // that breaks downstream parsers.
+  if (typeof entry.timestamp !== "string" || entry.timestamp.trim() === "") {
+    throw new Error("interaction entry must have a non-whitespace timestamp");
   }
-  if (typeof entry.kind !== "string" || entry.kind === "") {
-    throw new Error("interaction entry must have a non-empty kind");
+  if (typeof entry.kind !== "string" || entry.kind.trim() === "") {
+    throw new Error("interaction entry must have a non-whitespace kind");
   }
   if (typeof entry.summary !== "string") {
     throw new Error("interaction entry must have a string summary");
@@ -723,12 +728,36 @@ function parsePeerProfile(raw: string, peerId: string): PeerProfile {
   if (typeof updatedAt !== "string" || updatedAt === "") {
     throw new Error(`peer profile for "${peerId}" is missing updatedAt`);
   }
-  const fieldsObj =
-    typeof payload.fields === "object" && payload.fields !== null ? payload.fields : {};
-  const provenanceObj =
-    typeof payload.provenance === "object" && payload.provenance !== null
-      ? payload.provenance
-      : {};
+  // Codex P2 round 10: a malformed `fields: "wat"` or
+  // `provenance: 42` previously coerced to {} and silently dropped
+  // the section. That contradicts the "malformed files throw"
+  // contract — the file IS malformed, not just empty. Reject loudly.
+  // `undefined` is still tolerated (an older profile file might omit
+  // the section entirely).
+  let fieldsObj: object;
+  if (payload.fields === undefined) {
+    fieldsObj = {};
+  } else if (
+    typeof payload.fields === "object" &&
+    payload.fields !== null &&
+    !Array.isArray(payload.fields)
+  ) {
+    fieldsObj = payload.fields;
+  } else {
+    throw new Error(`peer profile for "${peerId}" has malformed fields section`);
+  }
+  let provenanceObj: object;
+  if (payload.provenance === undefined) {
+    provenanceObj = {};
+  } else if (
+    typeof payload.provenance === "object" &&
+    payload.provenance !== null &&
+    !Array.isArray(payload.provenance)
+  ) {
+    provenanceObj = payload.provenance;
+  } else {
+    throw new Error(`peer profile for "${peerId}" has malformed provenance section`);
+  }
   // Coerce values defensively. We never trust the on-disk shape.
   // Codex P1: skip prototype-pollution keys explicitly. We don't use
   // null-prototype objects in the returned shape because callers

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -565,6 +565,17 @@ export async function appendInteractionLog(
   if (typeof entry.summary !== "string") {
     throw new Error("interaction entry must have a string summary");
   }
+  // Codex P2 round 6: optional sessionId must still be a string when
+  // present, otherwise formatLogEntry → sanitizeLogField throws an
+  // opaque TypeError after directory setup. Validate at the API
+  // boundary so the error is clear and fires before any I/O.
+  if (
+    entry.sessionId !== undefined &&
+    entry.sessionId !== null &&
+    typeof entry.sessionId !== "string"
+  ) {
+    throw new Error("interaction entry sessionId must be a string when provided");
+  }
   await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, peerId);
   await fs.mkdir(dir, { recursive: true });
@@ -732,6 +743,51 @@ export async function writePeerProfile(
   assertValidPeerId(profile.peerId);
   if (typeof profile.updatedAt !== "string" || profile.updatedAt === "") {
     throw new Error("profile.updatedAt must be a non-empty ISO-8601 string");
+  }
+  // Codex P2 round 6: validate the nested payload shape on write so
+  // round-trip semantics are preserved. Without this, untyped JS
+  // callers can persist non-string field values or malformed
+  // provenance entries — readPeerProfile silently scrubs them on
+  // the way back, so data is lost without an error. Fail fast at
+  // the boundary instead.
+  if (typeof profile.fields !== "object" || profile.fields === null || Array.isArray(profile.fields)) {
+    throw new Error("profile.fields must be a plain object");
+  }
+  for (const [key, value] of Object.entries(profile.fields)) {
+    if (typeof value !== "string") {
+      throw new Error(`profile.fields["${key}"] must be a string`);
+    }
+  }
+  if (
+    typeof profile.provenance !== "object" ||
+    profile.provenance === null ||
+    Array.isArray(profile.provenance)
+  ) {
+    throw new Error("profile.provenance must be a plain object");
+  }
+  for (const [key, list] of Object.entries(profile.provenance)) {
+    if (!Array.isArray(list)) {
+      throw new Error(`profile.provenance["${key}"] must be an array`);
+    }
+    for (let i = 0; i < list.length; i++) {
+      const item = list[i] as unknown;
+      if (typeof item !== "object" || item === null || Array.isArray(item)) {
+        throw new Error(`profile.provenance["${key}"][${i}] must be an object`);
+      }
+      const r = item as Record<string, unknown>;
+      if (typeof r.observedAt !== "string" || r.observedAt === "") {
+        throw new Error(`profile.provenance["${key}"][${i}].observedAt must be a non-empty string`);
+      }
+      if (typeof r.signal !== "string" || r.signal === "") {
+        throw new Error(`profile.provenance["${key}"][${i}].signal must be a non-empty string`);
+      }
+      if (r.sourceSessionId !== undefined && typeof r.sourceSessionId !== "string") {
+        throw new Error(`profile.provenance["${key}"][${i}].sourceSessionId must be a string when provided`);
+      }
+      if (r.note !== undefined && typeof r.note !== "string") {
+        throw new Error(`profile.provenance["${key}"][${i}].note must be a string when provided`);
+      }
+    }
   }
   await assertPeersRootNotSymlink(memoryDir);
   const dir = peerDir(memoryDir, profile.peerId);

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -232,8 +232,13 @@ function emitPeerIdentity(peer: Peer): string {
   lines.push(`id: ${escapeYamlString(peer.id)}`);
   lines.push(`kind: ${peer.kind}`);
   lines.push(`displayName: ${escapeYamlString(peer.displayName)}`);
-  lines.push(`createdAt: ${peer.createdAt}`);
-  lines.push(`updatedAt: ${peer.updatedAt}`);
+  // Cursor M: emit timestamps as quoted YAML strings — bare emission
+  // would let a `createdAt` value containing a newline inject extra
+  // frontmatter fields when round-tripped through `parsePeerFrontmatter`.
+  // (`writePeer` validates these are non-empty strings, but the type
+  // doesn't constrain content.)
+  lines.push(`createdAt: ${escapeYamlString(peer.createdAt)}`);
+  lines.push(`updatedAt: ${escapeYamlString(peer.updatedAt)}`);
   lines.push("---");
   lines.push("");
   lines.push(peer.notes ?? "");
@@ -468,7 +473,7 @@ function emitPeerProfile(profile: PeerProfile): string {
   return [
     "---",
     `peerId: ${escapeYamlString(profile.peerId)}`,
-    `updatedAt: ${profile.updatedAt}`,
+    `updatedAt: ${escapeYamlString(profile.updatedAt)}`,
     "---",
     "",
     "<!-- peer profile — managed by the async reasoner. Manual edits will be overwritten. -->",

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -15,8 +15,55 @@
  * throw). Reading malformed files throws — callers can catch and recover.
  */
 
-import { promises as fs } from "node:fs";
+import { promises as fs, constants as fsConstants } from "node:fs";
 import path from "node:path";
+
+/**
+ * Atomic, symlink-rejecting open: returns a file handle whose
+ * underlying open(2) call carried `O_NOFOLLOW`, so the kernel itself
+ * refuses to follow a symlink at the target path. Closes the
+ * check-then-use TOCTOU race that a separate `assertPathNotSymlink`
+ * + `fs.writeFile` pattern leaves open (codex P1 round 5 on PR #723).
+ */
+async function openNoFollow(file: string, flags: number): Promise<import("node:fs/promises").FileHandle> {
+  return fs.open(file, flags | fsConstants.O_NOFOLLOW);
+}
+
+/** Read a file, refusing to follow symlinks at the kernel level. */
+async function readFileNoFollow(file: string): Promise<string> {
+  const fh = await openNoFollow(file, fsConstants.O_RDONLY);
+  try {
+    return await fh.readFile("utf8");
+  } finally {
+    await fh.close();
+  }
+}
+
+/** Overwrite a file, refusing to follow symlinks at the kernel level. */
+async function writeFileNoFollow(file: string, data: string): Promise<void> {
+  const fh = await openNoFollow(
+    file,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_TRUNC,
+  );
+  try {
+    await fh.writeFile(data, "utf8");
+  } finally {
+    await fh.close();
+  }
+}
+
+/** Append to a file, refusing to follow symlinks at the kernel level. */
+async function appendFileNoFollow(file: string, data: string): Promise<void> {
+  const fh = await openNoFollow(
+    file,
+    fsConstants.O_WRONLY | fsConstants.O_CREAT | fsConstants.O_APPEND,
+  );
+  try {
+    await fh.writeFile(data, "utf8");
+  } finally {
+    await fh.close();
+  }
+}
 
 import {
   PEER_ID_MAX_LENGTH,
@@ -122,26 +169,6 @@ async function assertPeersRootNotSymlink(memoryDir: string): Promise<void> {
   }
   if (rootStat && rootStat.isSymbolicLink()) {
     throw new Error(`peers root "${root}" is a symlink and is rejected`);
-  }
-}
-
-/**
- * Reject any path that exists and is a symlink. Used to gate every
- * file-level I/O so a malicious `peers/<id>/identity.md → /etc/passwd`
- * can't redirect a read or a write to an arbitrary file (codex P1 #2
- * on PR #723). Returns silently when the path does not exist (writes
- * create files under directories that have already been validated).
- */
-async function assertPathNotSymlink(p: string): Promise<void> {
-  let stat: import("node:fs").Stats | null = null;
-  try {
-    stat = await fs.lstat(p);
-  } catch (err) {
-    if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
-    return;
-  }
-  if (stat.isSymbolicLink()) {
-    throw new Error(`path "${p}" is a symlink and is rejected`);
   }
 }
 
@@ -351,10 +378,9 @@ export async function readPeer(
   // Codex P1 #2: even with the directory validated, a symlinked
   // identity.md inside a real peer dir would let us read arbitrary
   // out-of-scope files. Reject symlinks at the file level too.
-  await assertPathNotSymlink(file);
   let raw: string;
   try {
-    raw = await fs.readFile(file, "utf8");
+    raw = await readFileNoFollow(file);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
@@ -427,8 +453,7 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
   const file = identityPath(memoryDir, peer.id);
   // Codex P1 #2: reject if identity.md exists as a symlink so we
   // don't follow it on overwrite.
-  await assertPathNotSymlink(file);
-  await fs.writeFile(file, emitPeerIdentity(peer), "utf8");
+  await writeFileNoFollow(file, emitPeerIdentity(peer));
 }
 
 /**
@@ -545,13 +570,12 @@ export async function appendInteractionLog(
   await fs.mkdir(dir, { recursive: true });
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
-  await assertPathNotSymlink(file);
   const line = formatLogEntry(entry) + "\n";
   // `appendFile` creates the file if it does not exist. POSIX guarantees
   // writes < PIPE_BUF are atomic; entries on this path are well under
   // that bound. Ordering across concurrent writers is the caller's
   // responsibility for now — the reasoner runs serially in PR 2/5.
-  await fs.appendFile(file, line, "utf8");
+  await appendFileNoFollow(file, line);
   return file;
 }
 
@@ -686,10 +710,9 @@ export async function readPeerProfile(
   assertValidPeerId(peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = profilePath(memoryDir, peerId);
-  await assertPathNotSymlink(file);
   let raw: string;
   try {
-    raw = await fs.readFile(file, "utf8");
+    raw = await readFileNoFollow(file);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return null;
@@ -715,8 +738,7 @@ export async function writePeerProfile(
   await fs.mkdir(dir, { recursive: true });
   await assertPeerDirNotEscaped(memoryDir, profile.peerId);
   const file = profilePath(memoryDir, profile.peerId);
-  await assertPathNotSymlink(file);
-  await fs.writeFile(file, emitPeerProfile(profile), "utf8");
+  await writeFileNoFollow(file, emitPeerProfile(profile));
 }
 
 /**
@@ -733,9 +755,8 @@ export async function readInteractionLogRaw(
   assertValidPeerId(peerId);
   await assertPeerDirNotEscaped(memoryDir, peerId);
   const file = interactionsPath(memoryDir, peerId);
-  await assertPathNotSymlink(file);
   try {
-    return await fs.readFile(file, "utf8");
+    return await readFileNoFollow(file);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       return "";

--- a/packages/remnic-core/src/peers/types.ts
+++ b/packages/remnic-core/src/peers/types.ts
@@ -114,9 +114,18 @@ export interface PeerInteractionLogEntry {
  *   - First and last character must be `[A-Za-z0-9]`
  *   - Interior may contain `.`, `_`, `-` in addition to alphanumerics
  *   - No leading or trailing dot/dash/underscore
- *   - No consecutive dots or dashes (enforced separately for clarity)
+ *   - No consecutive separators (`..`, `--`, `__`, `.-`, etc.)
+ *
+ * Cursor Medium: previously the regex allowed `a..b` even though the
+ * docs claimed otherwise — a separate JS-side check enforced the rule
+ * but the standalone PATTERN was wrong for any external consumer
+ * relying on it. Tighten the regex itself so PEER_ID_PATTERN is the
+ * single source of truth: an alphanumeric, optionally followed by
+ * groups of (one separator + one-or-more alphanumerics), with the
+ * final group ending on an alphanumeric. Negative lookahead-free so
+ * it works in any JS engine.
  */
-export const PEER_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+export const PEER_ID_PATTERN = /^[A-Za-z0-9](?:[._-]?[A-Za-z0-9]+)*$/;
 
 /** Maximum length for `Peer.id`. */
 export const PEER_ID_MAX_LENGTH = 64;

--- a/packages/remnic-core/src/peers/types.ts
+++ b/packages/remnic-core/src/peers/types.ts
@@ -125,7 +125,14 @@ export interface PeerInteractionLogEntry {
  * final group ending on an alphanumeric. Negative lookahead-free so
  * it works in any JS engine.
  */
-export const PEER_ID_PATTERN = /^[A-Za-z0-9](?:[._-]?[A-Za-z0-9]+)*$/;
+// CodeQL alert #75: the previous form `^[A-Za-z0-9](?:[._-]?[A-Za-z0-9]+)*$`
+// was ambiguous on alphanumeric runs because `[._-]?` could match
+// empty, letting each iteration consume 1+ alphanumerics in many
+// overlapping ways — exponential backtracking on adversarial inputs.
+// Tighten so the optional group REQUIRES a separator before each
+// subsequent alphanumeric run; no overlapping match paths, linear
+// time on any input.
+export const PEER_ID_PATTERN = /^[A-Za-z0-9]+(?:[._-][A-Za-z0-9]+)*$/;
 
 /** Maximum length for `Peer.id`. */
 export const PEER_ID_MAX_LENGTH = 64;

--- a/packages/remnic-core/src/peers/types.ts
+++ b/packages/remnic-core/src/peers/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Peer registry types — issue #679 PR 1/5.
+ *
+ * Generalizes the singular identity-anchor model to a multi-peer registry.
+ * Every party Remnic interacts with — humans, agents, integrations, and
+ * "self" — is represented as a `Peer` with an evolving cognitive profile.
+ *
+ * This module defines pure types only. Storage primitives live in
+ * `./storage.ts`. Reasoner integration, recall injection, CLI/HTTP/MCP
+ * surfaces, and migration of existing identity-anchor data ship in later
+ * PRs (2/5 — 5/5).
+ */
+
+/**
+ * Kind of peer.
+ *
+ * - `self`     — the current Remnic operator (replaces singular identity-anchor).
+ * - `human`    — another human collaborator distinct from self.
+ * - `agent`    — another AI agent (Claude Code, Codex, Hermes, etc.).
+ * - `integration` — non-conversational integration (cron, webhook, importer).
+ */
+export type PeerKind = "self" | "human" | "agent" | "integration";
+
+/**
+ * Stable, slow-changing facts about a peer.
+ *
+ * `id` matches `^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$`, 1-64 chars,
+ * with no leading/trailing/consecutive dots or dashes. Stored on disk under
+ * `peers/{id}/identity.md` as YAML frontmatter + markdown body.
+ */
+export interface Peer {
+  /** Stable, opaque identifier. See PEER_ID_PATTERN. */
+  readonly id: string;
+  /** Kind of peer. Drives default profile schema and recall posture. */
+  readonly kind: PeerKind;
+  /** Human-readable display name. Distinct from `id`; mutable. */
+  readonly displayName: string;
+  /** ISO-8601 timestamp of first registration. */
+  readonly createdAt: string;
+  /** ISO-8601 timestamp of most recent update to identity. */
+  readonly updatedAt: string;
+  /** Optional free-form markdown body for the identity kernel. */
+  readonly notes?: string;
+}
+
+/**
+ * Evolving cognitive profile for a peer.
+ *
+ * Updated by the async profile reasoner (PR 2/5) from observable session
+ * signals. Every field carries provenance back to its originating session
+ * and signal. This PR only defines the shape — population is deferred.
+ */
+export interface PeerProfile {
+  /** Peer this profile belongs to. */
+  readonly peerId: string;
+  /** ISO-8601 timestamp of most recent profile mutation. */
+  readonly updatedAt: string;
+  /**
+   * Arbitrary key/value profile fields. Values are markdown strings.
+   * Keys are stable section identifiers (e.g. `communication_style`,
+   * `recurring_concerns`). The reasoner is responsible for choosing
+   * keys; this PR does not constrain them beyond requiring strings.
+   */
+  readonly fields: Record<string, string>;
+  /**
+   * Per-field provenance. Maps field key → list of provenance entries.
+   * A field may have multiple sources (the reasoner accumulates evidence
+   * across sessions before promoting a field).
+   */
+  readonly provenance: Record<string, ReadonlyArray<PeerProfileFieldProvenance>>;
+}
+
+/**
+ * Provenance for a single profile-field mutation.
+ *
+ * Reasoner output (PR 2/5) attaches one of these every time it touches a
+ * field, so the user can audit exactly why a profile claim exists.
+ */
+export interface PeerProfileFieldProvenance {
+  /** ISO-8601 timestamp the field was set/updated by this signal. */
+  readonly observedAt: string;
+  /** Originating session id (or other source identifier). */
+  readonly sourceSessionId?: string;
+  /** Short label for the signal type (e.g. "explicit_preference"). */
+  readonly signal: string;
+  /** Optional free-form note explaining the inference. */
+  readonly note?: string;
+}
+
+/**
+ * One row of the append-only interaction log for a peer.
+ *
+ * Stored on disk under `peers/{id}/interactions.log.md` as a sequence of
+ * markdown bullet entries with a leading ISO-8601 timestamp. Append-only
+ * by contract — the reasoner reads this log to derive profile updates.
+ */
+export interface PeerInteractionLogEntry {
+  /** ISO-8601 timestamp the interaction occurred. */
+  readonly timestamp: string;
+  /** Originating session id, if any. */
+  readonly sessionId?: string;
+  /** Short kind label (e.g. "message", "tool_call", "preference_set"). */
+  readonly kind: string;
+  /** Free-form markdown summary of the interaction. */
+  readonly summary: string;
+}
+
+/**
+ * Regex enforced on `Peer.id`. Exported so callers can mirror validation
+ * before constructing a `Peer`.
+ *
+ * Rules:
+ *   - 1-64 characters total
+ *   - First and last character must be `[A-Za-z0-9]`
+ *   - Interior may contain `.`, `_`, `-` in addition to alphanumerics
+ *   - No leading or trailing dot/dash/underscore
+ *   - No consecutive dots or dashes (enforced separately for clarity)
+ */
+export const PEER_ID_PATTERN = /^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$/;
+
+/** Maximum length for `Peer.id`. */
+export const PEER_ID_MAX_LENGTH = 64;


### PR DESCRIPTION
## Summary

First slice of [#679](https://github.com/joshuaswarren/remnic/issues/679) — generalize the singular identity-anchor model to a multi-peer registry. **Schema + storage primitives only.**

- New `packages/remnic-core/src/peers/` module with `Peer`, `PeerKind`, `PeerProfile`, `PeerProfileFieldProvenance`, `PeerInteractionLogEntry` types and `readPeer` / `writePeer` / `listPeers` / `appendInteractionLog` / `readPeerProfile` / `writePeerProfile` helpers.
- Strict `peer-id` validation against `^[A-Za-z0-9](?:[A-Za-z0-9._-]*[A-Za-z0-9])?$`, max 64 chars, no consecutive separators, plus a defensive path-traversal check.
- On-disk shape: `peers/{id}/identity.md` (YAML frontmatter + markdown body), `peers/{id}/profile.md` (frontmatter + JSON-in-fenced-block payload), `peers/{id}/interactions.log.md` (append-only, one bullet per entry, embedded newlines escaped).
- Public exports re-exported from `@remnic/core`.
- New `docs/peers.md` covering concept, kinds, privacy posture, and what is deferred.

## Bundled vs deferred

**In this PR:**
- Types, storage primitives, validation, public exports, docs.
- 19 tests in `packages/remnic-core/src/peers/peers.test.ts` covering round-trip, listing, invalid-id rejection, monotonic append, null-on-missing, profile serialization, and on-disk YAML+markdown shape.

**Deferred to later PRs in the #679 series:**
- PR 2/5 — async profile reasoner inside Dreams REM, behind `peer.profileReasoner.enabled: false`.
- PR 3/5 — recall integration: optional `peer` field on recall requests, profile excerpt injection, X-ray annotation.
- PR 4/5 — CLI (`remnic peer list / show / set / forget`), HTTP `/peers`, MCP `engram.peer_*`, plus deprecated identity-anchor aliases.
- PR 5/5 — migration of existing identity-anchor data into `peers/self/` and destructive `remnic peer forget` flow.

No orchestrator, recall, extraction, or access-surface code consumes the peer registry yet — the module is purely additive on disk and in the export surface.

## Test plan

- [x] `npx tsc --noEmit` clean from `packages/remnic-core/`
- [x] `npx tsx --test src/peers/peers.test.ts` — 19/19 pass
- [ ] AI reviewer pass on the schema choices (peer-id regex, profile JSON-in-fence shape, interaction-log line format)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new filesystem read/write/append APIs and parsing/serialization for peer data under `memoryDir`, including symlink/race-hardening and input validation; mistakes could impact data integrity or path-safety despite being additive and not yet wired into runtime flows.
> 
> **Overview**
> Introduces an initial **peer registry** as a new, additive on-disk schema under `peers/{peerId}/` with three kernel files: `identity.md` (YAML frontmatter + markdown notes), `profile.md` (frontmatter + JSON-in-fenced-block), and `interactions.log.md` (append-only markdown bullets).
> 
> Adds a new `@remnic/core` public module (`src/peers/`) exporting the peer types plus storage primitives (`readPeer`/`writePeer`/`listPeers`, `readPeerProfile`/`writePeerProfile`, `appendInteractionLog`/`readInteractionLogRaw`, and `assertValidPeerId`), with strict `peerId` validation and path/symlink-safety guards.
> 
> Adds comprehensive unit tests for round-trips, listing behavior, validation failures, interaction-log append semantics, and profile serialization, plus new `docs/peers.md` documenting the PR 1/5 scope and deferred follow-ups.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3381d99f87d529737c87df7de1bdf96e673a0c37. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->