### PR TITLE
feat(connectors): live-connector framework + cursor state store (#683 PR 1/N)

### DIFF
--- a/docs/live-connectors.md
+++ b/docs/live-connectors.md
@@ -1,0 +1,168 @@
+# Live Connectors
+
+Live connectors are the **continuous** ingest path: they run on a schedule,
+remember where they left off, and pull *new* documents from external services
+(Google Drive, Notion, Gmail, GitHub, …) into the user's memory directory.
+
+This page documents the framework contract that landed in issue #683 PR 1/N.
+Concrete connector implementations ship in PRs 2–5. The maintenance scheduler
+hookup and the `remnic connector …` CLI surface land in later PRs.
+
+## How live connectors differ from importers
+
+Remnic already ships **importers** (`packages/remnic-core/src/importers/`) that
+transform a one-shot export file (ChatGPT export, Claude export, mem0 dump)
+into memories in a single pass. Importers are not stateful — once the file is
+ingested, the importer's job is done.
+
+Live connectors are different in two ways:
+
+1. **Continuous, not one-shot.** A live connector is invoked on a schedule by
+   the maintenance loop. Every invocation is an *incremental* sync that picks
+   up where the previous one stopped.
+2. **Cursor-based.** Each connector persists an opaque cursor (`pageToken`,
+   `historyId`, `since` timestamp, etc.) so the next pass only fetches
+   documents the source considers new.
+
+If you have a single export file in hand, write an **importer**. If you have a
+service you want Remnic to keep watching, write a **live connector**.
+
+## The contract
+
+```ts
+import type {
+  LiveConnector,
+  ConnectorConfig,
+  ConnectorCursor,
+  ConnectorDocument,
+} from "@remnic/core";
+```
+
+Every connector implements:
+
+```ts
+interface LiveConnector {
+  readonly id: string;          // /^[a-z0-9][a-z0-9-]{0,63}$/
+  readonly displayName: string;
+  readonly description?: string;
+
+  validateConfig(raw: unknown): ConnectorConfig;
+  syncIncremental(args: {
+    cursor: ConnectorCursor | null;
+    config: ConnectorConfig;
+    abortSignal?: AbortSignal;
+  }): Promise<{ newDocs: ConnectorDocument[]; nextCursor: ConnectorCursor }>;
+}
+```
+
+Connectors **must** be:
+
+- **Idempotent.** Re-running with the same cursor never duplicates documents.
+  Documents carry `source.externalId` and (optionally) `source.externalRevision`
+  so downstream dedup can de-duplicate by stable upstream identity.
+- **Read-only on the source.** Live connectors never mutate the upstream
+  service: no marking emails read, no editing pages, no archiving.
+- **Cancellable.** Long-running syncs check `abortSignal.aborted` and bail
+  cleanly when the scheduler cancels them.
+- **Privacy-aware.** Connectors never log document content. Counts, ids, and
+  timing are fine; bodies are not.
+
+## Cursor + state persistence
+
+Cursors and per-connector sync metadata live at:
+
+```
+<memoryDir>/state/connectors/<id>.json
+```
+
+Use the public helpers:
+
+```ts
+import {
+  readConnectorState,
+  writeConnectorState,
+  listConnectorStates,
+} from "@remnic/core";
+```
+
+Writes are atomic (temp file + rename) and never destroy the previous good
+state on failure. Files that fail to parse are skipped by `listConnectorStates`
+rather than failing the whole listing — operators inspecting the directory
+can still see the corrupt file by hand.
+
+The state record shape:
+
+```ts
+interface ConnectorState {
+  id: string;
+  cursor: ConnectorCursor | null;
+  lastSyncAt: string | null;
+  lastSyncStatus: "success" | "error" | "never";
+  lastSyncError?: string;          // truncated to 1 KB
+  totalDocsImported: number;
+  updatedAt: string;
+}
+```
+
+`"never"` is intentionally distinct from `"success"` so callers can detect
+"registered but never run" without inspecting timestamps.
+
+## Registry
+
+```ts
+import { LiveConnectorRegistry } from "@remnic/core";
+
+const reg = new LiveConnectorRegistry();
+reg.register(myConnector);
+reg.list();         // sorted by id
+reg.get("drive");
+reg.unregister("drive");
+```
+
+The registry is pure in-memory and one-instance-per-orchestrator. Duplicate
+ids are rejected (rather than silently overwritten) so plugin loading bugs
+fail loudly and a malicious extension cannot shadow a built-in connector.
+
+`unregister()` does **not** touch the on-disk state file. Fully decommission a
+connector by also deleting `<memoryDir>/state/connectors/<id>.json`.
+
+## Privacy posture
+
+The framework is built around three rules:
+
+1. **Read-only scopes.** Each concrete connector documents the minimum OAuth
+   scope it requires. The framework itself never exposes write APIs to
+   upstream services.
+2. **Opt-in per connector.** Connectors are off until a user explicitly
+   configures them. There is no "enable everything" switch.
+3. **Local cursors.** Cursor state lives in the user's memory directory on
+   disk. Nothing is uploaded to a Remnic-controlled service.
+
+Credential storage (OAuth tokens, refresh tokens) is **not** part of this PR
+— that's the design surface for PR 2. Connectors that need credentials will
+read them from the OS keychain or a user-supplied secret store, never from
+the connector state file.
+
+## What's deferred
+
+- **Concrete connectors** — Drive, Notion, Gmail, GitHub (PRs 2–5).
+- **Maintenance scheduler integration** — wiring connectors into the periodic
+  sync loop (separate PR).
+- **CLI surface** — `remnic connector list/status/sync/disable` (PR 6).
+- **OAuth helpers and credential storage** — PR 2 design.
+
+## File map
+
+```
+packages/remnic-core/src/connectors/live/
+├── framework.ts         # LiveConnector interface + ConnectorConfig/Cursor/Document
+├── registry.ts          # LiveConnectorRegistry (pure, in-memory)
+├── state-store.ts       # readConnectorState / writeConnectorState / listConnectorStates
+├── index.ts             # Public barrel
+└── live-connectors.test.ts
+```
+
+The new framework lives under `connectors/live/` because the parent
+`connectors/` directory is already scoped to the existing Codex marketplace
+integration (`codex-marketplace.ts`, `codex-materialize-runner.ts`,
+`codex-materialize.ts`). Keep the namespaces distinct.

--- a/packages/remnic-core/src/connectors/live/framework.ts
+++ b/packages/remnic-core/src/connectors/live/framework.ts
@@ -1,0 +1,164 @@
+/**
+ * @remnic/core — Live Connectors Framework (issue #683 PR 1/N)
+ *
+ * Defines the contract that every "live" connector (Drive, Notion, Gmail,
+ * GitHub, ...) must satisfy. A live connector is **continuous**: it runs on a
+ * schedule, persists a cursor to disk, and ingests *new* documents since the
+ * last sync. This is distinct from one-shot importers in
+ * `packages/remnic-core/src/importers/` which transform an entire export file
+ * in a single pass.
+ *
+ * This module is intentionally pure types + interfaces. No I/O. No schedule
+ * wiring. Concrete connectors (PRs 2–5), the maintenance scheduler hookup
+ * (separate PR), and the CLI surface (PR 6) are deferred.
+ *
+ * Naming caveat: `packages/remnic-core/src/connectors/` is already scoped to
+ * the Codex marketplace integration. The live-connector framework lives under
+ * the `live/` subdirectory to avoid collision. Do not import Codex symbols
+ * from here, and do not import live-connector symbols from the Codex code.
+ */
+
+/**
+ * Free-form connector configuration. Validated by each connector's
+ * `validateConfig` implementation. Stored alongside the cursor in the state
+ * store. MUST be JSON-serializable: no functions, no class instances, no
+ * circular references.
+ *
+ * Connectors MUST NOT persist secrets here — credentials belong in OS keychain
+ * / OAuth token storage (PR 2 design).
+ */
+export type ConnectorConfig = Record<string, unknown>;
+
+/**
+ * Opaque cursor describing "where the last sync left off". Each connector
+ * defines what `kind` and `value` mean (e.g. Drive: `{kind: "pageToken",
+ * value: "..."}`, Gmail: `{kind: "historyId", value: "..."}`). The orchestrator
+ * treats it as opaque and only round-trips it through the state store.
+ *
+ * `updatedAt` is an ISO 8601 timestamp set by the framework when the cursor is
+ * written. It is informational — connectors MUST NOT use it to decide
+ * monotonicity. They own the `value` semantics.
+ */
+export interface ConnectorCursor {
+  /** Connector-defined cursor kind (e.g. `"pageToken"`, `"historyId"`, `"sinceTs"`). */
+  readonly kind: string;
+  /** Connector-defined opaque cursor value. */
+  readonly value: string;
+  /** ISO 8601 timestamp of when this cursor was last written. */
+  readonly updatedAt: string;
+}
+
+/**
+ * Provenance for a connector-ingested document. Required so downstream recall
+ * can attribute facts back to their origin and avoid re-ingesting on the next
+ * incremental pass.
+ */
+export interface ConnectorDocumentSource {
+  /** Stable connector id (matches `LiveConnector.id`). */
+  readonly connector: string;
+  /** Source-system identifier (Drive file id, Notion page id, Gmail msg id, ...). */
+  readonly externalId: string;
+  /** Optional source-system revision/version (etag, page version, history id). */
+  readonly externalRevision?: string;
+  /** Optional canonical URL pointing back at the source document. */
+  readonly externalUrl?: string;
+  /** ISO 8601 timestamp of when the connector fetched this document. */
+  readonly fetchedAt: string;
+}
+
+/**
+ * A single document yielded by an incremental sync. Connectors are responsible
+ * for chunking large source documents themselves if needed; the orchestrator
+ * ingests `content` as a unit.
+ */
+export interface ConnectorDocument {
+  /** Connector-local stable id for this document. SHOULD match `source.externalId`. */
+  readonly id: string;
+  /** Optional human-readable title. */
+  readonly title?: string;
+  /** Body content. Plaintext or Markdown — connectors document their format. */
+  readonly content: string;
+  /** Provenance. Required. */
+  readonly source: ConnectorDocumentSource;
+}
+
+/**
+ * Arguments passed to `syncIncremental`. The framework owns cursor/config
+ * lifecycle; connectors only read these and return the next cursor.
+ */
+export interface SyncIncrementalArgs {
+  /** Last persisted cursor, or `null` on the first ever sync. */
+  readonly cursor: ConnectorCursor | null;
+  /** Validated connector config (already passed through `validateConfig`). */
+  readonly config: ConnectorConfig;
+  /** Optional abort signal. Connectors SHOULD honor it for cooperative cancellation. */
+  readonly abortSignal?: AbortSignal;
+}
+
+/**
+ * Result of a single incremental sync pass.
+ *
+ * `newDocs` MAY be empty (no new documents since the last cursor). `nextCursor`
+ * MUST always be returned — even on no-op syncs the framework persists it so
+ * `updatedAt` reflects the most recent attempt.
+ */
+export interface SyncIncrementalResult {
+  readonly newDocs: ConnectorDocument[];
+  readonly nextCursor: ConnectorCursor;
+}
+
+/**
+ * The contract every live connector implements.
+ *
+ * Connectors MUST be:
+ *   - **Idempotent**: re-running with the same cursor MUST NOT duplicate
+ *     documents. The `source.externalId` + `source.externalRevision` pair is
+ *     used downstream for dedup.
+ *   - **Read-only on the source**: live connectors never mutate the upstream
+ *     system (no marking emails read, no editing Notion pages).
+ *   - **Cancellable**: long-running syncs SHOULD periodically check
+ *     `abortSignal.aborted` and bail cleanly.
+ *   - **Privacy-aware**: connectors MUST NOT log document content. Logging
+ *     metadata (counts, ids, timings) is fine.
+ */
+export interface LiveConnector {
+  /**
+   * Stable connector id. MUST match `CONNECTOR_ID_PATTERN` — lowercase
+   * alphanumeric plus dash, 1–64 chars, must start AND end with alphanumeric
+   * (no leading or trailing dash). The registry enforces this.
+   */
+  readonly id: string;
+  /** Short human-readable name shown in CLI / status output. */
+  readonly displayName: string;
+  /** Optional longer description. */
+  readonly description?: string;
+
+  /**
+   * Validate raw user-supplied config. MUST throw on malformed input — never
+   * silently default. The returned object is what gets persisted and passed
+   * back to `syncIncremental`. Connectors SHOULD strip unknown fields.
+   */
+  validateConfig(raw: unknown): ConnectorConfig;
+
+  /**
+   * Run one incremental sync pass. See `SyncIncrementalArgs` /
+   * `SyncIncrementalResult` for the contract.
+   */
+  syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult>;
+}
+
+/**
+ * Regex enforcing the connector-id naming rule. Exported so connectors and
+ * tests can validate ids consistently with the registry.
+ *
+ * Rule: lowercase alphanumeric + dash, 1..64 chars, must start AND end with
+ * alphanumeric (no leading or trailing dash). Single-char ids are allowed.
+ */
+export const CONNECTOR_ID_PATTERN = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+/**
+ * Returns `true` if `id` is a syntactically valid connector id.
+ */
+export function isValidConnectorId(id: unknown): id is string {
+  return typeof id === "string" && CONNECTOR_ID_PATTERN.test(id);
+}

--- a/packages/remnic-core/src/connectors/live/index.ts
+++ b/packages/remnic-core/src/connectors/live/index.ts
@@ -1,0 +1,36 @@
+/**
+ * @remnic/core — Live Connectors public barrel (issue #683 PR 1/N)
+ *
+ * Re-exports the live-connector framework, registry, and state store. This
+ * is the only path other modules in `@remnic/core` should import from.
+ *
+ * NOTE: These symbols intentionally live under `connectors/live/` to avoid
+ * colliding with the existing Codex marketplace integration in
+ * `connectors/`. Do not flatten this barrel into the parent `connectors/`
+ * index — keep the namespaces distinct.
+ */
+
+export {
+  CONNECTOR_ID_PATTERN,
+  isValidConnectorId,
+  type ConnectorConfig,
+  type ConnectorCursor,
+  type ConnectorDocument,
+  type ConnectorDocumentSource,
+  type LiveConnector,
+  type SyncIncrementalArgs,
+  type SyncIncrementalResult,
+} from "./framework.js";
+
+export {
+  LiveConnectorRegistry,
+  LiveConnectorRegistryError,
+} from "./registry.js";
+
+export {
+  listConnectorStates,
+  readConnectorState,
+  writeConnectorState,
+  type ConnectorState,
+  type ConnectorSyncStatus,
+} from "./state-store.js";

--- a/packages/remnic-core/src/connectors/live/live-connectors.test.ts
+++ b/packages/remnic-core/src/connectors/live/live-connectors.test.ts
@@ -15,6 +15,7 @@ import {
   type ConnectorConfig,
   type ConnectorCursor,
   type ConnectorDocument,
+  type ConnectorSyncStatus,
   type LiveConnector,
   type SyncIncrementalArgs,
   type SyncIncrementalResult,
@@ -399,6 +400,86 @@ test("state store: rejects invalid id at boundary", async (t) => {
       }),
     /invalid connector id/,
   );
+});
+
+test("state store: rejects invalid lastSyncStatus at boundary (PR #724 review)", async (t) => {
+  // P1 review: writeConnectorState must validate lastSyncStatus before
+  // writing — otherwise readConnectorState's shape check rejects the file
+  // and bricks the cursor until manual repair.
+  const memoryDir = makeMemoryDir(t);
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "drive", {
+        id: "drive",
+        cursor: null,
+        lastSyncAt: null,
+        // Bypass TypeScript to exercise the runtime guard the way an
+        // untyped JS caller would.
+        lastSyncStatus: "BOGUS" as unknown as ConnectorSyncStatus,
+        totalDocsImported: 0,
+      } as unknown as Parameters<typeof writeConnectorState>[2]),
+    /lastSyncStatus must be one of/,
+  );
+  // And the file must NOT have been written.
+  const after = await readConnectorState(memoryDir, "drive");
+  assert.equal(after, null);
+});
+
+test("state store: rejects malformed cursor at boundary (PR #724 review)", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "drive", {
+        id: "drive",
+        // Missing `value` and `updatedAt`.
+        cursor: { kind: "pageToken" } as unknown as ConnectorCursor,
+        lastSyncAt: new Date().toISOString(),
+        lastSyncStatus: "success",
+        totalDocsImported: 0,
+      }),
+    /cursor must have string/,
+  );
+});
+
+test("state store: listConnectorStates skips corrupt files but rethrows EACCES (PR #724 review)", async (t) => {
+  // P2 review: only ConnectorStateCorruptionError should be swallowed.
+  // Genuine I/O failures must propagate so the scheduler / CLI sees them.
+  const memoryDir = makeMemoryDir(t);
+  // Write one good file.
+  await writeConnectorState(memoryDir, "good", {
+    id: "good",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  // Drop a corrupt file.
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.writeFileSync(path.join(dir, "corrupt.json"), "{ not valid json");
+  // Listing succeeds, returning only the good record.
+  const states = await listConnectorStates(memoryDir);
+  assert.deepEqual(states.map((s) => s.id), ["good"]);
+
+  // Now make one of the files unreadable (EACCES). On platforms that respect
+  // chmod for the current user (POSIX, when not running as root), this
+  // produces EACCES which must propagate. Skip the assertion when running as
+  // root or on Windows where chmod 0 is a no-op.
+  const isRoot = typeof process.getuid === "function" && process.getuid() === 0;
+  if (process.platform !== "win32" && !isRoot) {
+    const goodPath = path.join(dir, "good.json");
+    fs.chmodSync(goodPath, 0o000);
+    t.after(() => {
+      try {
+        fs.chmodSync(goodPath, 0o600);
+      } catch {
+        // ignore
+      }
+    });
+    await assert.rejects(
+      () => listConnectorStates(memoryDir),
+      (err: NodeJS.ErrnoException) => err.code === "EACCES" || err.code === "EPERM",
+    );
+  }
 });
 
 test("state store: rejects negative totalDocsImported", async (t) => {

--- a/packages/remnic-core/src/connectors/live/live-connectors.test.ts
+++ b/packages/remnic-core/src/connectors/live/live-connectors.test.ts
@@ -1,0 +1,497 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  CONNECTOR_ID_PATTERN,
+  isValidConnectorId,
+  LiveConnectorRegistry,
+  LiveConnectorRegistryError,
+  listConnectorStates,
+  readConnectorState,
+  writeConnectorState,
+  type ConnectorConfig,
+  type ConnectorCursor,
+  type ConnectorDocument,
+  type LiveConnector,
+  type SyncIncrementalArgs,
+  type SyncIncrementalResult,
+} from "./index.js";
+import { _connectorStatePathForTest } from "./state-store.js";
+
+/**
+ * Mock `LiveConnector`. Exists primarily as a compile-time assertion that
+ * the published interface is satisfiable from outside the framework module
+ * — if a future change drops a method or tightens a signature, this stops
+ * compiling.
+ */
+class MockConnector implements LiveConnector {
+  readonly id: string;
+  readonly displayName: string;
+  readonly description?: string;
+  syncCalls = 0;
+
+  constructor(id: string, displayName = `Mock ${id}`) {
+    this.id = id;
+    this.displayName = displayName;
+  }
+
+  validateConfig(raw: unknown): ConnectorConfig {
+    if (typeof raw !== "object" || raw === null) {
+      throw new Error("config must be an object");
+    }
+    return raw as ConnectorConfig;
+  }
+
+  async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
+    this.syncCalls++;
+    const newDocs: ConnectorDocument[] = [
+      {
+        id: `${this.id}-doc-1`,
+        title: "Synthetic doc",
+        content: "synthetic body",
+        source: {
+          connector: this.id,
+          externalId: `${this.id}-ext-1`,
+          fetchedAt: new Date().toISOString(),
+        },
+      },
+    ];
+    const nextCursor: ConnectorCursor = {
+      kind: "counter",
+      value: String((args.cursor?.value ? Number(args.cursor.value) : 0) + 1),
+      updatedAt: new Date().toISOString(),
+    };
+    return { newDocs, nextCursor };
+  }
+}
+
+function makeMemoryDir(t: { after: (fn: () => void) => void }): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-live-connectors-test-"));
+  t.after(() => {
+    try {
+      fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+  return dir;
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// Connector id validation
+// ───────────────────────────────────────────────────────────────────────────
+
+test("isValidConnectorId accepts well-formed ids", () => {
+  for (const id of ["a", "abc", "drive", "g-mail", "github-issues", "0", "abc123-xyz"]) {
+    assert.equal(isValidConnectorId(id), true, `expected ${id} to be valid`);
+  }
+});
+
+test("isValidConnectorId rejects malformed ids", () => {
+  for (const id of [
+    "",
+    "Drive",          // uppercase
+    "-leading-dash",  // must start with alphanumeric
+    "trailing-dash-",
+    "white space",
+    "slash/y",
+    "a".repeat(65),   // > 64
+    null,
+    undefined,
+    42,
+    {},
+  ]) {
+    assert.equal(isValidConnectorId(id as unknown), false, `expected ${String(id)} to be invalid`);
+  }
+});
+
+test("CONNECTOR_ID_PATTERN matches isValidConnectorId", () => {
+  assert.ok(CONNECTOR_ID_PATTERN.test("drive"));
+  assert.ok(!CONNECTOR_ID_PATTERN.test("Drive"));
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// Registry
+// ───────────────────────────────────────────────────────────────────────────
+
+test("registry: register, get, list, unregister, size", () => {
+  const reg = new LiveConnectorRegistry();
+  assert.equal(reg.size(), 0);
+  assert.equal(reg.list().length, 0);
+
+  const a = new MockConnector("alpha");
+  const b = new MockConnector("bravo");
+  reg.register(a);
+  reg.register(b);
+
+  assert.equal(reg.size(), 2);
+  assert.equal(reg.get("alpha"), a);
+  assert.equal(reg.get("bravo"), b);
+  assert.equal(reg.get("missing"), undefined);
+
+  // list() is sorted by id for stable enumeration
+  const ids = reg.list().map((c) => c.id);
+  assert.deepEqual(ids, ["alpha", "bravo"]);
+
+  assert.equal(reg.unregister("alpha"), true);
+  assert.equal(reg.unregister("alpha"), false); // already gone
+  assert.equal(reg.size(), 1);
+  assert.equal(reg.get("alpha"), undefined);
+});
+
+test("registry: rejects duplicate ids", () => {
+  const reg = new LiveConnectorRegistry();
+  reg.register(new MockConnector("dup"));
+  assert.throws(
+    () => reg.register(new MockConnector("dup")),
+    LiveConnectorRegistryError,
+  );
+});
+
+test("registry: rejects invalid ids", () => {
+  const reg = new LiveConnectorRegistry();
+  assert.throws(
+    () => reg.register(new MockConnector("Bad-Caps")),
+    LiveConnectorRegistryError,
+  );
+  assert.throws(
+    () => reg.register(new MockConnector("-leading-dash")),
+    LiveConnectorRegistryError,
+  );
+  assert.throws(
+    () => reg.register(new MockConnector("a".repeat(65))),
+    LiveConnectorRegistryError,
+  );
+});
+
+test("registry: rejects connectors missing required fields", () => {
+  const reg = new LiveConnectorRegistry();
+  // Cast through unknown to bypass TypeScript and exercise the runtime guard.
+  assert.throws(
+    () =>
+      reg.register({
+        id: "bad",
+        displayName: "",
+        validateConfig: () => ({}),
+        syncIncremental: async () => ({
+          newDocs: [],
+          nextCursor: { kind: "x", value: "0", updatedAt: new Date().toISOString() },
+        }),
+      } as unknown as LiveConnector),
+    LiveConnectorRegistryError,
+  );
+
+  assert.throws(
+    () =>
+      reg.register({
+        id: "bad2",
+        displayName: "ok",
+        validateConfig: () => ({}),
+        // missing syncIncremental
+      } as unknown as LiveConnector),
+    LiveConnectorRegistryError,
+  );
+
+  assert.throws(
+    () => reg.register(null as unknown as LiveConnector),
+    LiveConnectorRegistryError,
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// State store: round-trip
+// ───────────────────────────────────────────────────────────────────────────
+
+test("state store: write/read round-trip", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  const cursor: ConnectorCursor = {
+    kind: "pageToken",
+    value: "abc123",
+    updatedAt: new Date().toISOString(),
+  };
+  const written = await writeConnectorState(memoryDir, "drive", {
+    id: "drive",
+    cursor,
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: 17,
+  });
+  assert.equal(written.id, "drive");
+  assert.equal(written.lastSyncStatus, "success");
+  assert.equal(written.totalDocsImported, 17);
+  assert.ok(written.updatedAt, "updatedAt should be stamped");
+
+  const read = await readConnectorState(memoryDir, "drive");
+  assert.ok(read);
+  assert.equal(read!.id, "drive");
+  assert.deepEqual(read!.cursor, cursor);
+  assert.equal(read!.totalDocsImported, 17);
+  assert.equal(read!.lastSyncStatus, "success");
+});
+
+test("state store: ENOENT returns null", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  const result = await readConnectorState(memoryDir, "nonexistent");
+  assert.equal(result, null);
+});
+
+test("state store: file is valid JSON on disk", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await writeConnectorState(memoryDir, "notion", {
+    id: "notion",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  const filePath = _connectorStatePathForTest(memoryDir, "notion");
+  const raw = await fs.promises.readFile(filePath, "utf-8");
+  const parsed = JSON.parse(raw);
+  assert.equal(parsed.id, "notion");
+  assert.equal(parsed.cursor, null);
+  assert.equal(parsed.lastSyncStatus, "never");
+});
+
+test("state store: lives at <memoryDir>/state/connectors/<id>.json", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await writeConnectorState(memoryDir, "github", {
+    id: "github",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  const expected = path.join(memoryDir, "state", "connectors", "github.json");
+  assert.ok(fs.existsSync(expected), `expected state file at ${expected}`);
+});
+
+test("state store: listConnectorStates enumerates and is sorted", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await writeConnectorState(memoryDir, "zeta", {
+    id: "zeta",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  await writeConnectorState(memoryDir, "alpha", {
+    id: "alpha",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  await writeConnectorState(memoryDir, "mike", {
+    id: "mike",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+
+  const states = await listConnectorStates(memoryDir);
+  assert.deepEqual(states.map((s) => s.id), ["alpha", "mike", "zeta"]);
+});
+
+test("state store: listConnectorStates returns [] for missing dir", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  // Don't write anything — directory doesn't exist yet.
+  const states = await listConnectorStates(memoryDir);
+  assert.deepEqual(states, []);
+});
+
+test("state store: listConnectorStates skips non-matching files", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await writeConnectorState(memoryDir, "real", {
+    id: "real",
+    cursor: null,
+    lastSyncAt: null,
+    lastSyncStatus: "never",
+    totalDocsImported: 0,
+  });
+  // Drop in stray files that should be ignored.
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.writeFileSync(path.join(dir, "real.json~"), "backup");
+  fs.writeFileSync(path.join(dir, ".swp"), "swap");
+  fs.writeFileSync(path.join(dir, "Bad-Caps.json"), '{"id":"Bad-Caps"}');
+  fs.writeFileSync(path.join(dir, "corrupt.json"), "{ not valid");
+
+  const states = await listConnectorStates(memoryDir);
+  assert.deepEqual(states.map((s) => s.id), ["real"]);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// State store: cursor monotonicity / overwrite / atomic write
+// ───────────────────────────────────────────────────────────────────────────
+
+test("state store: writing twice with same id overwrites", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await writeConnectorState(memoryDir, "drive", {
+    id: "drive",
+    cursor: { kind: "pageToken", value: "old", updatedAt: new Date().toISOString() },
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: 1,
+  });
+  await writeConnectorState(memoryDir, "drive", {
+    id: "drive",
+    cursor: { kind: "pageToken", value: "new", updatedAt: new Date().toISOString() },
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: 5,
+  });
+  const read = await readConnectorState(memoryDir, "drive");
+  assert.equal(read!.cursor!.value, "new");
+  assert.equal(read!.totalDocsImported, 5);
+});
+
+test("state store: previous good state is preserved when a new write fails", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  // First, persist a known-good state.
+  await writeConnectorState(memoryDir, "drive", {
+    id: "drive",
+    cursor: { kind: "pageToken", value: "good", updatedAt: new Date().toISOString() },
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: 3,
+  });
+  const goodPath = _connectorStatePathForTest(memoryDir, "drive");
+  const goodBody = fs.readFileSync(goodPath, "utf-8");
+  assert.match(goodBody, /"value": "good"/);
+
+  // Now attempt a write with mismatched id — should reject before touching disk.
+  await assert.rejects(
+    writeConnectorState(memoryDir, "drive", {
+      // id does not match argument
+      id: "other",
+      cursor: null,
+      lastSyncAt: null,
+      lastSyncStatus: "never",
+      totalDocsImported: 0,
+    }),
+    /does not match/,
+  );
+
+  // The good file must still be readable and unchanged.
+  assert.equal(fs.readFileSync(goodPath, "utf-8"), goodBody);
+  const read = await readConnectorState(memoryDir, "drive");
+  assert.equal(read!.cursor!.value, "good");
+  assert.equal(read!.totalDocsImported, 3);
+});
+
+test("state store: rejects invalid id at boundary", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "Bad-Caps"),
+    /invalid connector id/,
+  );
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "../escape" as string, {
+        id: "../escape",
+        cursor: null,
+        lastSyncAt: null,
+        lastSyncStatus: "never",
+        totalDocsImported: 0,
+      }),
+    /invalid connector id/,
+  );
+});
+
+test("state store: rejects negative totalDocsImported", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "drive", {
+        id: "drive",
+        cursor: null,
+        lastSyncAt: null,
+        lastSyncStatus: "never",
+        totalDocsImported: -1,
+      }),
+    /non-negative/,
+  );
+});
+
+test("state store: truncates oversized lastSyncError", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  const huge = "x".repeat(5000);
+  const written = await writeConnectorState(memoryDir, "drive", {
+    id: "drive",
+    cursor: null,
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "error",
+    lastSyncError: huge,
+    totalDocsImported: 0,
+  });
+  assert.ok(written.lastSyncError);
+  assert.ok(written.lastSyncError!.length <= 1024);
+});
+
+test("state store: rejects corrupt JSON loudly via readConnectorState", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "drive.json"), "{ not valid json");
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "drive"),
+    /not valid JSON/,
+  );
+});
+
+test("state store: rejects null parsed result", async (t) => {
+  // CLAUDE.md gotcha #18 — JSON.parse('null') returns null.
+  const memoryDir = makeMemoryDir(t);
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(path.join(dir, "drive.json"), "null");
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "drive"),
+    /does not match ConnectorState shape/,
+  );
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// End-to-end registry + state-store smoke test using MockConnector
+// ───────────────────────────────────────────────────────────────────────────
+
+test("end-to-end: registry + state store advance cursor across syncs", async (t) => {
+  const memoryDir = makeMemoryDir(t);
+  const reg = new LiveConnectorRegistry();
+  const mock = new MockConnector("smoke");
+  reg.register(mock);
+
+  // First sync: no cursor yet.
+  let prior = await readConnectorState(memoryDir, "smoke");
+  assert.equal(prior, null);
+
+  const r1 = await mock.syncIncremental({ cursor: null, config: {} });
+  await writeConnectorState(memoryDir, "smoke", {
+    id: "smoke",
+    cursor: r1.nextCursor,
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: r1.newDocs.length,
+  });
+
+  prior = await readConnectorState(memoryDir, "smoke");
+  assert.equal(prior!.cursor!.value, "1");
+
+  // Second sync: prior cursor passed in, advances.
+  const r2 = await mock.syncIncremental({ cursor: prior!.cursor, config: {} });
+  await writeConnectorState(memoryDir, "smoke", {
+    id: "smoke",
+    cursor: r2.nextCursor,
+    lastSyncAt: new Date().toISOString(),
+    lastSyncStatus: "success",
+    totalDocsImported: prior!.totalDocsImported + r2.newDocs.length,
+  });
+
+  const final = await readConnectorState(memoryDir, "smoke");
+  assert.equal(final!.cursor!.value, "2");
+  assert.equal(final!.totalDocsImported, 2);
+  assert.equal(mock.syncCalls, 2);
+});

--- a/packages/remnic-core/src/connectors/live/live-connectors.test.ts
+++ b/packages/remnic-core/src/connectors/live/live-connectors.test.ts
@@ -493,7 +493,118 @@ test("state store: rejects negative totalDocsImported", async (t) => {
         lastSyncStatus: "never",
         totalDocsImported: -1,
       }),
-    /non-negative/,
+    /non-negative integer/,
+  );
+});
+
+test("state store: rejects fractional totalDocsImported (PR #724 review)", async (t) => {
+  // P2 review: cumulative doc count must be an integer; fractional values
+  // would propagate through later increments and corrupt metrics.
+  const memoryDir = makeMemoryDir(t);
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "drive", {
+        id: "drive",
+        cursor: null,
+        lastSyncAt: null,
+        lastSyncStatus: "never",
+        totalDocsImported: 3.7,
+      }),
+    /non-negative integer/,
+  );
+  // And the read-shape check must reject a hand-crafted file with a float.
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    path.join(dir, "drive.json"),
+    JSON.stringify({
+      id: "drive",
+      cursor: null,
+      lastSyncAt: null,
+      lastSyncStatus: "never",
+      totalDocsImported: 3.7,
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "drive"),
+    /does not match ConnectorState shape/,
+  );
+});
+
+test("state store: refuses symlinked state file (PR #724 review)", async (t) => {
+  // P1 review: a symlink at <memoryDir>/state/connectors/<id>.json must be
+  // refused, not silently followed. Otherwise readConnectorState consumes
+  // arbitrary outside JSON and writeConnectorState overwrites an arbitrary
+  // outside file.
+  if (process.platform === "win32") return; // symlink semantics differ on Windows
+  const memoryDir = makeMemoryDir(t);
+  // Set up a parallel target file outside the memory root.
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-live-outside-"));
+  t.after(() => {
+    try {
+      fs.rmSync(outside, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+  const outsideFile = path.join(outside, "evil.json");
+  fs.writeFileSync(
+    outsideFile,
+    JSON.stringify({
+      id: "drive",
+      cursor: null,
+      lastSyncAt: null,
+      lastSyncStatus: "never",
+      totalDocsImported: 999,
+      updatedAt: new Date().toISOString(),
+    }),
+  );
+  // Plant the symlink where the connector state would live.
+  const dir = path.join(memoryDir, "state", "connectors");
+  fs.mkdirSync(dir, { recursive: true });
+  const linkPath = path.join(dir, "drive.json");
+  fs.symlinkSync(outsideFile, linkPath);
+
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "drive"),
+    /symlink/,
+  );
+  await assert.rejects(
+    () =>
+      writeConnectorState(memoryDir, "drive", {
+        id: "drive",
+        cursor: null,
+        lastSyncAt: null,
+        lastSyncStatus: "never",
+        totalDocsImported: 0,
+      }),
+    /symlink/,
+  );
+});
+
+test("state store: refuses symlinked state directory (PR #724 review)", async (t) => {
+  if (process.platform === "win32") return;
+  const memoryDir = makeMemoryDir(t);
+  const outside = fs.mkdtempSync(path.join(os.tmpdir(), "remnic-live-outside-dir-"));
+  t.after(() => {
+    try {
+      fs.rmSync(outside, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+  // Plant a symlink at <memoryDir>/state/connectors -> outside dir.
+  fs.mkdirSync(path.join(memoryDir, "state"), { recursive: true });
+  fs.symlinkSync(outside, path.join(memoryDir, "state", "connectors"));
+
+  await assert.rejects(
+    () => listConnectorStates(memoryDir),
+    /symlink/,
+  );
+  await assert.rejects(
+    () => readConnectorState(memoryDir, "drive"),
+    /symlink/,
   );
 });
 

--- a/packages/remnic-core/src/connectors/live/registry.ts
+++ b/packages/remnic-core/src/connectors/live/registry.ts
@@ -1,0 +1,103 @@
+/**
+ * @remnic/core — Live Connectors Registry (issue #683 PR 1/N)
+ *
+ * Pure in-memory registry. No I/O. Concrete connectors register themselves at
+ * orchestrator boot (later PRs); the maintenance scheduler asks the registry
+ * for the active set when running due syncs.
+ */
+
+import { isValidConnectorId, type LiveConnector } from "./framework.js";
+
+/**
+ * Thrown when registering a duplicate id or an id that fails validation.
+ *
+ * Distinct error class so callers can distinguish framework-level mistakes
+ * (which are programmer errors) from connector-runtime failures.
+ */
+export class LiveConnectorRegistryError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "LiveConnectorRegistryError";
+  }
+}
+
+/**
+ * In-memory registry of live connectors. One instance per orchestrator. Not
+ * safe for cross-process sharing — wire each process to its own registry.
+ */
+export class LiveConnectorRegistry {
+  private readonly connectors = new Map<string, LiveConnector>();
+
+  /**
+   * Register a connector. Throws `LiveConnectorRegistryError` if the id is
+   * malformed or already registered.
+   *
+   * Re-registration is rejected (rather than silently overwriting) because
+   * silent overwrites mask plugin loading bugs in development and could let
+   * a malicious extension shadow a built-in connector.
+   */
+  register(connector: LiveConnector): void {
+    if (!connector || typeof connector !== "object") {
+      throw new LiveConnectorRegistryError(
+        "register(): connector must be a non-null object",
+      );
+    }
+    if (!isValidConnectorId(connector.id)) {
+      throw new LiveConnectorRegistryError(
+        `register(): invalid connector id ${JSON.stringify(connector.id)} — must match /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/`,
+      );
+    }
+    if (this.connectors.has(connector.id)) {
+      throw new LiveConnectorRegistryError(
+        `register(): connector id ${JSON.stringify(connector.id)} is already registered`,
+      );
+    }
+    if (typeof connector.displayName !== "string" || connector.displayName.length === 0) {
+      throw new LiveConnectorRegistryError(
+        `register(): connector ${connector.id} missing displayName`,
+      );
+    }
+    if (typeof connector.validateConfig !== "function") {
+      throw new LiveConnectorRegistryError(
+        `register(): connector ${connector.id} missing validateConfig()`,
+      );
+    }
+    if (typeof connector.syncIncremental !== "function") {
+      throw new LiveConnectorRegistryError(
+        `register(): connector ${connector.id} missing syncIncremental()`,
+      );
+    }
+    this.connectors.set(connector.id, connector);
+  }
+
+  /**
+   * Look up a connector by id. Returns `undefined` if not registered.
+   */
+  get(id: string): LiveConnector | undefined {
+    return this.connectors.get(id);
+  }
+
+  /**
+   * Return all registered connectors, sorted by id for stable enumeration.
+   */
+  list(): LiveConnector[] {
+    return Array.from(this.connectors.values()).sort((a, b) => a.id.localeCompare(b.id));
+  }
+
+  /**
+   * Remove a connector. Returns `true` if a connector was removed, `false`
+   * otherwise. The cursor / state file on disk is **not** touched — callers
+   * who want to fully decommission a connector must also delete its state
+   * file via the `state-store` module.
+   */
+  unregister(id: string): boolean {
+    return this.connectors.delete(id);
+  }
+
+  /**
+   * Number of registered connectors. Cheap; safe to call frequently.
+   */
+  size(): number {
+    return this.connectors.size;
+  }
+}

--- a/packages/remnic-core/src/connectors/live/state-store.ts
+++ b/packages/remnic-core/src/connectors/live/state-store.ts
@@ -67,6 +67,24 @@ export interface ConnectorState {
 const STATE_DIR_NAME = "state";
 const CONNECTORS_DIR_NAME = "connectors";
 const MAX_ERROR_LENGTH = 1024;
+const VALID_SYNC_STATUSES: ReadonlySet<ConnectorSyncStatus> = new Set([
+  "success",
+  "error",
+  "never",
+]);
+
+/**
+ * Internal error thrown when a state file's JSON is unparseable or its shape
+ * doesn't match `ConnectorState`. Used by `listConnectorStates` to distinguish
+ * "skip this corrupt file" cases from genuine I/O failures (`EACCES`, `EIO`)
+ * that the caller must see.
+ */
+class ConnectorStateCorruptionError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ConnectorStateCorruptionError";
+  }
+}
 
 /**
  * Resolve `<memoryDir>/state/connectors/`, expanding `~` per CLAUDE.md #17.
@@ -140,17 +158,17 @@ export async function readConnectorState(
   try {
     parsed = JSON.parse(raw);
   } catch (err) {
-    throw new Error(
+    throw new ConnectorStateCorruptionError(
       `connector state at ${filePath} is not valid JSON: ${(err as Error).message}`,
     );
   }
   if (!isConnectorStateShape(parsed)) {
-    throw new Error(
+    throw new ConnectorStateCorruptionError(
       `connector state at ${filePath} does not match ConnectorState shape`,
     );
   }
   if (parsed.id !== id) {
-    throw new Error(
+    throw new ConnectorStateCorruptionError(
       `connector state at ${filePath} has mismatched id ${JSON.stringify(parsed.id)}; expected ${JSON.stringify(id)}`,
     );
   }
@@ -178,6 +196,34 @@ export async function writeConnectorState(
     throw new Error(
       `writeConnectorState(): state.id ${JSON.stringify(state.id)} does not match id argument ${JSON.stringify(id)}`,
     );
+  }
+  // Full boundary validation. Persisting an out-of-shape record would brick
+  // the connector's cursor file: subsequent `readConnectorState` calls would
+  // throw `ConnectorStateCorruptionError` until manual repair. JS callers
+  // bypassing TS types must be rejected here, not later. (PR #724 review.)
+  if (!VALID_SYNC_STATUSES.has(state.lastSyncStatus as ConnectorSyncStatus)) {
+    throw new Error(
+      `writeConnectorState(): lastSyncStatus must be one of ${[...VALID_SYNC_STATUSES].join(", ")}, got ${JSON.stringify(state.lastSyncStatus)}`,
+    );
+  }
+  if (state.lastSyncAt !== null && typeof state.lastSyncAt !== "string") {
+    throw new Error(
+      `writeConnectorState(): lastSyncAt must be a string or null, got ${typeof state.lastSyncAt}`,
+    );
+  }
+  if (state.cursor !== null) {
+    if (typeof state.cursor !== "object") {
+      throw new Error(`writeConnectorState(): cursor must be an object or null`);
+    }
+    if (
+      typeof state.cursor.kind !== "string" ||
+      typeof state.cursor.value !== "string" ||
+      typeof state.cursor.updatedAt !== "string"
+    ) {
+      throw new Error(
+        `writeConnectorState(): cursor must have string kind, value, and updatedAt`,
+      );
+    }
   }
   if (!Number.isFinite(state.totalDocsImported) || state.totalDocsImported < 0) {
     throw new Error(
@@ -230,9 +276,15 @@ export async function writeConnectorState(
  *
  * Files that do not match the `<id>.json` naming rule are skipped — this
  * keeps stray editor backups (`.json~`, `.swp`) from breaking enumeration.
- * Files whose contents fail validation are also skipped, with the caller
- * receiving the successfully parsed subset; this preserves availability
- * when one connector's state is corrupted.
+ *
+ * Corruption (unparseable JSON, shape mismatch, id mismatch) is also
+ * skipped so one bad file doesn't take down the listing. Operators
+ * inspecting `state/connectors/` can still see the offending file by hand.
+ *
+ * **Genuine I/O failures (`EACCES`, `EIO`, etc.) are NOT swallowed** —
+ * silently returning an incomplete state set would make active connectors
+ * appear missing and trigger duplicate ingestion on the next scheduler tick.
+ * (PR #724 review.)
  */
 export async function listConnectorStates(memoryDir: string): Promise<ConnectorState[]> {
   const dir = resolveConnectorsDir(memoryDir);
@@ -251,10 +303,14 @@ export async function listConnectorStates(memoryDir: string): Promise<ConnectorS
     try {
       const state = await readConnectorState(memoryDir, id);
       if (state !== null) out.push(state);
-    } catch {
-      // Skip corrupted state files rather than failing the whole listing.
-      // Operators inspecting `state/connectors/` will still see the file.
-      continue;
+    } catch (err) {
+      if (err instanceof ConnectorStateCorruptionError) {
+        // Skip corrupt files; preserve availability of the rest.
+        continue;
+      }
+      // Anything else (EACCES, EIO, ENOTDIR, ...) is a real operational
+      // failure. Fail loudly so the scheduler / CLI can surface it.
+      throw err;
     }
   }
   out.sort((a, b) => a.id.localeCompare(b.id));

--- a/packages/remnic-core/src/connectors/live/state-store.ts
+++ b/packages/remnic-core/src/connectors/live/state-store.ts
@@ -122,7 +122,10 @@ function isConnectorStateShape(value: unknown): value is ConnectorState {
   if (typeof v.id !== "string") return false;
   if (typeof v.lastSyncStatus !== "string") return false;
   if (!["success", "error", "never"].includes(v.lastSyncStatus)) return false;
-  if (typeof v.totalDocsImported !== "number" || !Number.isFinite(v.totalDocsImported)) return false;
+  // totalDocsImported is a cumulative count — fractional values would corrupt
+  // metrics on later increments. Mirror the boundary check in writeConnectorState.
+  if (typeof v.totalDocsImported !== "number" || !Number.isInteger(v.totalDocsImported)) return false;
+  if (v.totalDocsImported < 0) return false;
   if (typeof v.updatedAt !== "string") return false;
   if (v.lastSyncAt !== null && typeof v.lastSyncAt !== "string") return false;
   if (v.cursor !== null) {
@@ -137,16 +140,72 @@ function isConnectorStateShape(value: unknown): value is ConnectorState {
 }
 
 /**
+ * Reject any path component along `<memoryDir>/state/connectors/<id>.json`
+ * that is a symlink. Without this guard, a symlink in any of those
+ * components would let `fs.readFile` escape the memory root and consume an
+ * arbitrary outside file as cursor state — silently poisoning sync state and
+ * violating the project-wide rule against symlink traversal.
+ *
+ * `lstat` is used (not `stat`) so we observe the link itself rather than its
+ * target. Missing components are tolerated — the caller's `readFile` /
+ * `mkdir` will surface ENOENT in its normal way.
+ *
+ * (PR #724 review.)
+ */
+async function assertNoSymlinkOnPath(memoryDir: string, filePath: string): Promise<void> {
+  const expandedRoot = expandTildePath(memoryDir);
+  // Normalize so `..` segments can't bypass the prefix check below.
+  const root = path.resolve(expandedRoot);
+  const target = path.resolve(filePath);
+  const rel = path.relative(root, target);
+  // path.relative() yields a "../..." prefix when target escapes root.
+  if (rel.startsWith("..") || path.isAbsolute(rel)) {
+    throw new Error(
+      `connector state path ${target} escapes memory root ${root}`,
+    );
+  }
+  // Walk every component from root to target (inclusive) and lstat each.
+  const segments = rel.length === 0 ? [] : rel.split(path.sep);
+  let current = root;
+  const componentsToCheck = [current];
+  for (const seg of segments) {
+    current = path.join(current, seg);
+    componentsToCheck.push(current);
+  }
+  for (const component of componentsToCheck) {
+    let stat: import("node:fs").Stats;
+    try {
+      stat = await fs.lstat(component);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        // Not yet created — that's fine; caller's readFile/mkdir handles it.
+        continue;
+      }
+      throw err;
+    }
+    if (stat.isSymbolicLink()) {
+      throw new Error(
+        `connector state path component ${component} is a symlink; refusing to follow`,
+      );
+    }
+  }
+}
+
+/**
  * Read the persisted state for a single connector.
  *
  * Returns `null` if the file does not exist (ENOENT). Throws on any other
  * I/O error or on shape mismatch — operators should see corruption loudly.
+ *
+ * Rejects symlinks anywhere on the path so a planted symlink can't redirect
+ * reads outside the memory root. (PR #724 review.)
  */
 export async function readConnectorState(
   memoryDir: string,
   id: string,
 ): Promise<ConnectorState | null> {
   const filePath = resolveConnectorStatePath(memoryDir, id);
+  await assertNoSymlinkOnPath(memoryDir, filePath);
   let raw: string;
   try {
     raw = await fs.readFile(filePath, "utf-8");
@@ -225,9 +284,13 @@ export async function writeConnectorState(
       );
     }
   }
-  if (!Number.isFinite(state.totalDocsImported) || state.totalDocsImported < 0) {
+  if (
+    typeof state.totalDocsImported !== "number" ||
+    !Number.isInteger(state.totalDocsImported) ||
+    state.totalDocsImported < 0
+  ) {
     throw new Error(
-      `writeConnectorState(): totalDocsImported must be a non-negative finite number`,
+      `writeConnectorState(): totalDocsImported must be a non-negative integer`,
     );
   }
   if (state.lastSyncError !== undefined && typeof state.lastSyncError !== "string") {
@@ -249,8 +312,11 @@ export async function writeConnectorState(
   };
 
   const dir = resolveConnectorsDir(memoryDir);
-  await fs.mkdir(dir, { recursive: true });
   const targetPath = path.join(dir, `${id}.json`);
+  // Reject planted symlinks before mkdir/write so a redirected target can't
+  // overwrite an arbitrary file outside the memory root. (PR #724 review.)
+  await assertNoSymlinkOnPath(memoryDir, targetPath);
+  await fs.mkdir(dir, { recursive: true });
   const tmpPath = `${targetPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 
   const body = `${JSON.stringify(finalState, null, 2)}\n`;
@@ -288,6 +354,10 @@ export async function writeConnectorState(
  */
 export async function listConnectorStates(memoryDir: string): Promise<ConnectorState[]> {
   const dir = resolveConnectorsDir(memoryDir);
+  // Refuse to enumerate through a symlinked state directory — a planted
+  // symlink at <memoryDir>/state or <memoryDir>/state/connectors would
+  // otherwise let reads escape the memory root. (PR #724 review.)
+  await assertNoSymlinkOnPath(memoryDir, dir);
   let entries: string[];
   try {
     entries = await fs.readdir(dir);

--- a/packages/remnic-core/src/connectors/live/state-store.ts
+++ b/packages/remnic-core/src/connectors/live/state-store.ts
@@ -1,0 +1,273 @@
+/**
+ * @remnic/core — Live Connectors State Store (issue #683 PR 1/N)
+ *
+ * Persists per-connector cursor + sync metadata to
+ *   `<memoryDir>/state/connectors/<id>.json`
+ *
+ * Reasons this lives next to memory data, not in user config:
+ *   - cursors are *operational* state that should travel with the memory
+ *     directory when a user moves it across machines;
+ *   - it keeps memory + ingest provenance co-located so tooling that backs up
+ *     the memory directory captures cursor state too.
+ *
+ * Atomic-write contract (CLAUDE.md gotcha #54):
+ *   - We NEVER `rmSync(target)` before `renameSync(tmp, target)`.
+ *   - Writes go to a sibling tmp file and `rename()` swaps it in.
+ *   - On error, the tmp file is best-effort cleaned up; the previous good
+ *     state file is left untouched.
+ *
+ * Privacy: cursors are opaque connector-defined strings. We do not log them
+ * and do not surface them through user-visible APIs. Document content NEVER
+ * touches this module.
+ */
+
+import { promises as fs } from "node:fs";
+import path from "node:path";
+
+import { expandTildePath } from "../../utils/path.js";
+
+import {
+  isValidConnectorId,
+  type ConnectorCursor,
+} from "./framework.js";
+
+/**
+ * Status of the most recent sync attempt for a connector.
+ *
+ * `"never"` is distinct from `"success"` so callers can detect
+ * "registered but never run" without inspecting timestamps. Per CLAUDE.md
+ * gotcha #34, we deliberately distinguish empty/unknown from failure states.
+ */
+export type ConnectorSyncStatus = "success" | "error" | "never";
+
+/**
+ * Persisted per-connector state.
+ *
+ * Stored as pretty-printed JSON for human inspection — the file is small
+ * (one record per connector) and operators may need to debug stuck cursors
+ * by hand.
+ */
+export interface ConnectorState {
+  /** Connector id. Matches the filename stem. */
+  readonly id: string;
+  /** Last persisted cursor, or `null` if the connector has never synced. */
+  readonly cursor: ConnectorCursor | null;
+  /** ISO 8601 timestamp of the last completed sync attempt, or `null`. */
+  readonly lastSyncAt: string | null;
+  /** Status of the last completed sync attempt. */
+  readonly lastSyncStatus: ConnectorSyncStatus;
+  /** Optional error message from the last failed sync. Truncated to 1 KB. */
+  readonly lastSyncError?: string;
+  /** Cumulative count of documents successfully imported across all syncs. */
+  readonly totalDocsImported: number;
+  /** ISO 8601 timestamp of when this state record was last written. */
+  readonly updatedAt: string;
+}
+
+const STATE_DIR_NAME = "state";
+const CONNECTORS_DIR_NAME = "connectors";
+const MAX_ERROR_LENGTH = 1024;
+
+/**
+ * Resolve `<memoryDir>/state/connectors/`, expanding `~` per CLAUDE.md #17.
+ */
+function resolveConnectorsDir(memoryDir: string): string {
+  if (typeof memoryDir !== "string" || memoryDir.length === 0) {
+    throw new TypeError("memoryDir must be a non-empty string");
+  }
+  return path.join(expandTildePath(memoryDir), STATE_DIR_NAME, CONNECTORS_DIR_NAME);
+}
+
+/**
+ * Resolve the state file path for a single connector. Throws on invalid id
+ * to prevent path traversal via crafted ids.
+ */
+function resolveConnectorStatePath(memoryDir: string, id: string): string {
+  if (!isValidConnectorId(id)) {
+    throw new TypeError(
+      `invalid connector id ${JSON.stringify(id)} — must match /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/`,
+    );
+  }
+  return path.join(resolveConnectorsDir(memoryDir), `${id}.json`);
+}
+
+/**
+ * Type guard for parsed state records. Validates the on-disk shape so a
+ * corrupted/edited file produces a clear error rather than crashing later.
+ *
+ * Per CLAUDE.md gotcha #18, JSON.parse('null') yields `null` which would
+ * pass a naive truthy check. We explicitly require an object.
+ */
+function isConnectorStateShape(value: unknown): value is ConnectorState {
+  if (typeof value !== "object" || value === null) return false;
+  const v = value as Record<string, unknown>;
+  if (typeof v.id !== "string") return false;
+  if (typeof v.lastSyncStatus !== "string") return false;
+  if (!["success", "error", "never"].includes(v.lastSyncStatus)) return false;
+  if (typeof v.totalDocsImported !== "number" || !Number.isFinite(v.totalDocsImported)) return false;
+  if (typeof v.updatedAt !== "string") return false;
+  if (v.lastSyncAt !== null && typeof v.lastSyncAt !== "string") return false;
+  if (v.cursor !== null) {
+    if (typeof v.cursor !== "object" || v.cursor === null) return false;
+    const c = v.cursor as Record<string, unknown>;
+    if (typeof c.kind !== "string" || typeof c.value !== "string" || typeof c.updatedAt !== "string") {
+      return false;
+    }
+  }
+  if (v.lastSyncError !== undefined && typeof v.lastSyncError !== "string") return false;
+  return true;
+}
+
+/**
+ * Read the persisted state for a single connector.
+ *
+ * Returns `null` if the file does not exist (ENOENT). Throws on any other
+ * I/O error or on shape mismatch — operators should see corruption loudly.
+ */
+export async function readConnectorState(
+  memoryDir: string,
+  id: string,
+): Promise<ConnectorState | null> {
+  const filePath = resolveConnectorStatePath(memoryDir, id);
+  let raw: string;
+  try {
+    raw = await fs.readFile(filePath, "utf-8");
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
+    throw err;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    throw new Error(
+      `connector state at ${filePath} is not valid JSON: ${(err as Error).message}`,
+    );
+  }
+  if (!isConnectorStateShape(parsed)) {
+    throw new Error(
+      `connector state at ${filePath} does not match ConnectorState shape`,
+    );
+  }
+  if (parsed.id !== id) {
+    throw new Error(
+      `connector state at ${filePath} has mismatched id ${JSON.stringify(parsed.id)}; expected ${JSON.stringify(id)}`,
+    );
+  }
+  return parsed;
+}
+
+/**
+ * Write state atomically: create-tmp + rename. Never destroys the previous
+ * file before the new one is in place — see CLAUDE.md gotcha #54.
+ *
+ * We accept `Omit<ConnectorState, "updatedAt">` and stamp `updatedAt`
+ * ourselves so callers can't accidentally persist a stale timestamp.
+ */
+export async function writeConnectorState(
+  memoryDir: string,
+  id: string,
+  state: Omit<ConnectorState, "updatedAt">,
+): Promise<ConnectorState> {
+  if (!isValidConnectorId(id)) {
+    throw new TypeError(
+      `invalid connector id ${JSON.stringify(id)} — must match /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/`,
+    );
+  }
+  if (state.id !== id) {
+    throw new Error(
+      `writeConnectorState(): state.id ${JSON.stringify(state.id)} does not match id argument ${JSON.stringify(id)}`,
+    );
+  }
+  if (!Number.isFinite(state.totalDocsImported) || state.totalDocsImported < 0) {
+    throw new Error(
+      `writeConnectorState(): totalDocsImported must be a non-negative finite number`,
+    );
+  }
+  if (state.lastSyncError !== undefined && typeof state.lastSyncError !== "string") {
+    throw new Error(`writeConnectorState(): lastSyncError must be a string when provided`);
+  }
+  const truncatedError =
+    state.lastSyncError !== undefined && state.lastSyncError.length > MAX_ERROR_LENGTH
+      ? state.lastSyncError.slice(0, MAX_ERROR_LENGTH)
+      : state.lastSyncError;
+
+  const finalState: ConnectorState = {
+    id: state.id,
+    cursor: state.cursor,
+    lastSyncAt: state.lastSyncAt,
+    lastSyncStatus: state.lastSyncStatus,
+    ...(truncatedError !== undefined ? { lastSyncError: truncatedError } : {}),
+    totalDocsImported: state.totalDocsImported,
+    updatedAt: new Date().toISOString(),
+  };
+
+  const dir = resolveConnectorsDir(memoryDir);
+  await fs.mkdir(dir, { recursive: true });
+  const targetPath = path.join(dir, `${id}.json`);
+  const tmpPath = `${targetPath}.tmp-${process.pid}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+  const body = `${JSON.stringify(finalState, null, 2)}\n`;
+  try {
+    await fs.writeFile(tmpPath, body, { encoding: "utf-8", mode: 0o600 });
+    await fs.rename(tmpPath, targetPath);
+  } catch (err) {
+    // Best-effort cleanup of the tmp file. Never touch `targetPath` — the
+    // previous good state must remain readable on failure.
+    try {
+      await fs.unlink(tmpPath);
+    } catch {
+      // ignore
+    }
+    throw err;
+  }
+  return finalState;
+}
+
+/**
+ * Enumerate every persisted connector state. Returns an empty array when
+ * the directory does not exist yet (clean install, no syncs ever run).
+ *
+ * Files that do not match the `<id>.json` naming rule are skipped — this
+ * keeps stray editor backups (`.json~`, `.swp`) from breaking enumeration.
+ * Files whose contents fail validation are also skipped, with the caller
+ * receiving the successfully parsed subset; this preserves availability
+ * when one connector's state is corrupted.
+ */
+export async function listConnectorStates(memoryDir: string): Promise<ConnectorState[]> {
+  const dir = resolveConnectorsDir(memoryDir);
+  let entries: string[];
+  try {
+    entries = await fs.readdir(dir);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw err;
+  }
+  const out: ConnectorState[] = [];
+  for (const entry of entries) {
+    if (!entry.endsWith(".json")) continue;
+    const id = entry.slice(0, -".json".length);
+    if (!isValidConnectorId(id)) continue;
+    try {
+      const state = await readConnectorState(memoryDir, id);
+      if (state !== null) out.push(state);
+    } catch {
+      // Skip corrupted state files rather than failing the whole listing.
+      // Operators inspecting `state/connectors/` will still see the file.
+      continue;
+    }
+  }
+  out.sort((a, b) => a.id.localeCompare(b.id));
+  return out;
+}
+
+/**
+ * Test-only helper: resolve where a given connector's state lives. Exported
+ * so tests can assert the on-disk layout without duplicating the path math.
+ * Not part of the stable public API.
+ *
+ * @internal
+ */
+export function _connectorStatePathForTest(memoryDir: string, id: string): string {
+  return resolveConnectorStatePath(memoryDir, id);
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -558,6 +558,36 @@ export {
 export { coerceInstallExtension } from "./connectors/coerce.js";
 
 // ---------------------------------------------------------------------------
+// Live Connectors framework (#683 PR 1/N)
+// ---------------------------------------------------------------------------
+//
+// Pure framework — interface, registry, and cursor state store. Concrete
+// connectors (Drive, Notion, Gmail, GitHub) ship in PRs 2–5; the maintenance
+// scheduler hookup and CLI surface land in later PRs.
+//
+// NOTE: lives under `connectors/live/` to avoid colliding with the existing
+// Codex marketplace integration above. Do not flatten.
+
+export {
+  CONNECTOR_ID_PATTERN,
+  isValidConnectorId,
+  LiveConnectorRegistry,
+  LiveConnectorRegistryError,
+  listConnectorStates,
+  readConnectorState,
+  writeConnectorState,
+  type ConnectorConfig,
+  type ConnectorCursor,
+  type ConnectorDocument,
+  type ConnectorDocumentSource,
+  type ConnectorState,
+  type ConnectorSyncStatus,
+  type LiveConnector,
+  type SyncIncrementalArgs,
+  type SyncIncrementalResult,
+} from "./connectors/live/index.js";
+
+// ---------------------------------------------------------------------------
 // Spaces + Collaboration
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Lands #683 PR 1/N — the **live-connector framework**. Pure contract + cursor persistence. No actual connector (those are PRs 2–5). No scheduler integration. No CLI surface.

- New module `packages/remnic-core/src/connectors/live/`
  - `framework.ts` — `LiveConnector` interface, `ConnectorConfig`, `ConnectorCursor`, `ConnectorDocument`, `CONNECTOR_ID_PATTERN`.
  - `registry.ts` — pure `LiveConnectorRegistry` (register / get / list / unregister); duplicate-id and invalid-id rejected.
  - `state-store.ts` — JSONL-backed cursor + state at `<memoryDir>/state/connectors/<id>.json`. Atomic writes (temp + rename); never destroys previous good state on failure (CLAUDE.md gotcha #54).
  - `index.ts` — public barrel; re-exported from `@remnic/core`.
- Lives under `connectors/live/` to avoid colliding with the existing Codex marketplace integration in `connectors/`.
- Adds `docs/live-connectors.md` covering the contract, the importer-vs-live-connector distinction, and the privacy posture (read-only scopes, opt-in, local cursors).

### Deferred (explicitly out of scope)
- Concrete connectors (Drive, Notion, Gmail, GitHub) — PRs 2–5.
- Maintenance scheduler integration — separate PR.
- CLI surface (`remnic connector list/status/sync/disable`) — PR 6.
- OAuth helpers / credential storage — PR 2 design.

## Test plan

- [x] 22 new tests in `live-connectors.test.ts` — all pass.
  - id validation accepts well-formed ids, rejects uppercase / whitespace / leading or trailing dash / >64 chars / non-string.
  - Registry: register / get / list (sorted) / unregister / size; duplicate id rejected; invalid id rejected; missing required fields rejected.
  - State store: write / read round-trip; ENOENT returns null; on-disk file is valid JSON; layout is `<memoryDir>/state/connectors/<id>.json`; `listConnectorStates` enumerates and is sorted; missing dir returns `[]`; non-matching files (`.json~`, `.swp`, mixed-case ids, corrupt JSON) skipped; overwrite preserves the new value; previous good state preserved when a new write fails its boundary check; invalid id rejected at boundary; negative `totalDocsImported` rejected; oversized `lastSyncError` truncated to 1 KB; corrupt JSON rejected loudly; `null` parse-result rejected (CLAUDE.md gotcha #18).
  - End-to-end smoke: registry + state store advance cursor across two syncs using a `MockConnector`.
- [x] `npx tsc --noEmit` clean for `@remnic/core`.
- [x] `npm run build` clean for `@remnic/core`.
- [x] Pre-existing failing tests in `npm run preflight:quick` are unrelated to this change (no test under `connectors/live/` is in the failure list).
- [x] Privacy scan: no personal data, secrets, or user identifiers in the diff.

Closes #683 (PR 1/N — framework only; subsequent PRs ship concrete connectors and surfaces).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it introduces new on-disk state handling (atomic writes, validation, symlink defenses) and expands the public `@remnic/core` API surface; bugs here could affect connector cursor persistence and incremental ingest correctness.
> 
> **Overview**
> Adds an initial **live connector framework** to `@remnic/core`, defining the `LiveConnector` contract (config, cursor, and document shapes) plus connector-id validation.
> 
> Introduces a pure in-memory `LiveConnectorRegistry` with runtime guards that reject invalid/duplicate connector ids, and a filesystem-backed state store that persists per-connector cursor + sync metadata under `<memoryDir>/state/connectors/<id>.json` with atomic temp+rename writes, strict boundary/shape validation, and symlink/path-escape protections.
> 
> Exports the new live-connector APIs from the package root, adds extensive unit tests for registry/state-store behavior and edge cases, and documents the new contract and privacy posture in `docs/live-connectors.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 071247ddc4a6a31a2684b079340ca67a4e7a2225. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->