### PR TITLE
fix(bench): align MemBench with official MCQ protocol

### DIFF
--- a/packages/bench/src/benchmarks/published/membench/fixture.ts
+++ b/packages/bench/src/benchmarks/published/membench/fixture.ts
@@ -12,6 +12,7 @@ export interface MemBenchCase {
   correctChoice?: "A" | "B" | "C" | "D";
   questionTime?: string;
   targetStepIds?: number[];
+  targetStepCoordinates?: number[][];
 }
 
 export const MEMBENCH_SMOKE_FIXTURE: MemBenchCase[] = [

--- a/packages/bench/src/benchmarks/published/membench/fixture.ts
+++ b/packages/bench/src/benchmarks/published/membench/fixture.ts
@@ -8,6 +8,10 @@ export interface MemBenchCase {
   turns: Message[];
   question: string;
   answer: string;
+  choices?: Record<"A" | "B" | "C" | "D", string>;
+  correctChoice?: "A" | "B" | "C" | "D";
+  questionTime?: string;
+  targetStepIds?: number[];
 }
 
 export const MEMBENCH_SMOKE_FIXTURE: MemBenchCase[] = [

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -1108,8 +1108,7 @@ function aggregateMemBenchOfficialBreakdowns(
           [errorMetricName]: task.scores.membench_accuracy < 0 ? 1 : 0,
         }));
       return [...accuracyScores, ...errorScores];
-    })
-    .flat();
+    });
 
   return aggregateTaskScores(breakdownScores);
 }
@@ -1259,7 +1258,7 @@ function parseTargetStepRefs(
         const mapped = coordinateIndex?.get(coordinateKey(numeric));
         if (mapped !== undefined) {
           candidates.add(mapped);
-        } else if (!options.treatSingleArrayAsCoordinate) {
+        } else if (!options.treatSingleArrayAsCoordinate || options.fallbackArrayTupleToIds) {
           candidates.add(numeric[0]!);
         }
       }

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -656,10 +656,13 @@ function appendTrajectoryTurn(
   speakerRoles: Map<string, Message["role"]>,
   nextSpeakerIndex: () => number,
 ): boolean {
-  const rememberCoordinate = () => {
-    coordinateIndex.set(coordinateKey(coordinate), turns.length);
-    if (coordinate.length === 1) {
-      coordinateIndex.set(coordinateKey([0, coordinate[0]!]), turns.length);
+  const rememberCoordinate = (
+    targetCoordinate: number[] = coordinate,
+    turnIndex = turns.length,
+  ) => {
+    coordinateIndex.set(coordinateKey(targetCoordinate), turnIndex);
+    if (targetCoordinate.length === 1) {
+      coordinateIndex.set(coordinateKey([0, targetCoordinate[0]!]), turnIndex);
     }
   };
 
@@ -691,11 +694,14 @@ function appendTrajectoryTurn(
   const userText = firstString(turn.user, turn.user_message);
   const assistantText = firstString(turn.agent, turn.assistant, turn.assistant_message);
   if (userText || assistantText) {
-    rememberCoordinate();
     if (userText) {
+      rememberCoordinate();
       turns.push({ role: "user", content: userText });
     }
     if (assistantText) {
+      rememberCoordinate(
+        userText ? pairedAssistantCoordinate(coordinate) : coordinate,
+      );
       turns.push({ role: "assistant", content: assistantText });
     }
     return true;
@@ -1136,6 +1142,15 @@ function parseTargetStepRefs(
 
 function coordinateKey(coordinate: number[]): string {
   return coordinate.join(":");
+}
+
+function pairedAssistantCoordinate(coordinate: number[]): number[] {
+  if (coordinate.length === 1) {
+    return [1, coordinate[0]!];
+  }
+
+  const [turnIndex, ...rest] = coordinate;
+  return [(turnIndex ?? 0) + 1, ...rest];
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -815,13 +815,13 @@ function normalizeQaPairs(
 function resolveTargetRefSource(
   item: Record<string, unknown>,
 ): { value: unknown; kind: "ids" | "coordinates" } | undefined {
-  if (hasUsableTargetRef(item.target_step_id)) {
+  if (hasUsableTargetIdRef(item.target_step_id)) {
     return { value: item.target_step_id, kind: "ids" };
   }
-  if (hasUsableTargetRef(item.target_step_ids)) {
+  if (hasUsableTargetIdRef(item.target_step_ids)) {
     return { value: item.target_step_ids, kind: "ids" };
   }
-  if (hasUsableTargetRef(item.targetStepIds)) {
+  if (hasUsableTargetIdRef(item.targetStepIds)) {
     return { value: item.targetStepIds, kind: "ids" };
   }
   if (hasUsableTargetRef(item.target_step_coordinates)) {
@@ -846,6 +846,13 @@ function hasUsableTargetRef(value: unknown): boolean {
   return value !== undefined
     && value !== null
     && (!Array.isArray(value) || value.length > 0);
+}
+
+function hasUsableTargetIdRef(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.some(hasUsableTargetIdRef);
+  }
+  return normalizeTargetRefPart(value) !== undefined;
 }
 
 function resolveCaseId(
@@ -1034,7 +1041,12 @@ async function scoreRecallAt10(
       sessionId,
     );
     const relevant = new Set(testCase.targetStepIds);
-    return results.some((result) => relevant.has(result.turnIndex)) ? 1 : 0;
+    const retrieved = new Set(
+      results
+        .map((result) => result.turnIndex)
+        .filter((turnIndex) => relevant.has(turnIndex)),
+    );
+    return retrieved.size / relevant.size;
   } catch {
     return -1;
   }
@@ -1178,18 +1190,19 @@ function parseTargetStepRefs(
       : [value];
   const coordinates = rawValues
     .filter(Array.isArray)
-    .map((items) => items.filter((item): item is number =>
-      typeof item === "number" && Number.isInteger(item) && item >= 0,
-    ))
+    .map((items) => items
+      .map(normalizeTargetRefPart)
+      .filter((item): item is number => item !== undefined))
     .filter((items) => items.length > 0);
   const candidates = new Set<number>();
   for (const item of rawValues) {
-    if (typeof item === "number" && Number.isInteger(item) && item >= 0) {
-      candidates.add(item);
+    const scalar = normalizeTargetRefPart(item);
+    if (scalar !== undefined) {
+      candidates.add(scalar);
     } else if (Array.isArray(item)) {
-      const numeric = item.filter((part): part is number =>
-        typeof part === "number" && Number.isInteger(part) && part >= 0,
-      );
+      const numeric = item
+        .map(normalizeTargetRefPart)
+        .filter((part): part is number => part !== undefined);
       if (numeric.length >= 2) {
         const mapped = coordinateIndex?.get(coordinateKey(numeric));
         if (mapped !== undefined) {
@@ -1213,10 +1226,19 @@ function parseTargetStepRefs(
   };
 }
 
+function normalizeTargetRefPart(value: unknown): number | undefined {
+  if (typeof value === "number" && Number.isInteger(value) && value >= 0) {
+    return value;
+  }
+  if (typeof value === "string" && /^\d+$/.test(value.trim())) {
+    return Number(value.trim());
+  }
+  return undefined;
+}
+
 function isCoordinateTuple(value: unknown[]): boolean {
-  return value.length > 0 && value.every((item) =>
-    typeof item === "number" && Number.isInteger(item) && item >= 0,
-  );
+  return value.length > 0
+    && value.every((item) => normalizeTargetRefPart(item) !== undefined);
 }
 
 function coordinateKey(coordinate: number[]): string {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -1220,6 +1220,10 @@ function parseTargetStepRefs(
   targetStepIds?: number[];
   targetStepCoordinates?: number[][];
 } {
+  if (options.treatSingleArrayAsCoordinate && value !== undefined && !Array.isArray(value)) {
+    return {};
+  }
+
   const rawValues = Array.isArray(value)
     ? options.treatSingleArrayAsCoordinate
       ? isCoordinateTuple(value) || !value.every(Array.isArray)

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -872,7 +872,7 @@ function hasUsableTargetRef(value: unknown): boolean {
 
 function hasUsableTargetIdRef(value: unknown): boolean {
   if (Array.isArray(value)) {
-    return value.some(hasUsableTargetIdRef);
+    return value.length > 0 && value.every(hasUsableTargetIdRef);
   }
   return normalizeTargetRefPart(value) !== undefined;
 }

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -20,11 +20,24 @@ import type {
 import {
   aggregateTaskScores,
   containsAnswer,
+  exactMatch,
   f1Score,
   llmJudgeScoreDetailed,
   timed,
 } from "../../../scorer.js";
 import { getGitSha, getRemnicVersion } from "../../../reporter.js";
+
+type MemBenchChoice = "A" | "B" | "C" | "D";
+
+interface MemBenchQuestionAnswer {
+  id?: string;
+  question: string;
+  answer: string;
+  choices?: Record<MemBenchChoice, string>;
+  correctChoice?: MemBenchChoice;
+  questionTime?: string;
+  targetStepIds?: number[];
+}
 
 const DATASET_FILENAMES = [
   "membench.json",
@@ -86,31 +99,47 @@ export async function runMemBenchBenchmark(
       const { result: recalledText, durationMs } = await timed(async () =>
         options.system.recall(sessionId, testCase.question),
       );
+      const answerQuestion = buildQuestionPrompt(testCase);
       const answered = await answerBenchmarkQuestion({
-        question: testCase.question,
+        question: answerQuestion,
         recalledText,
         responder: options.system.responder,
       });
+      const predictedChoice = testCase.choices
+        ? extractChoice(answered.finalAnswer)
+        : undefined;
+      const actualAnswer = predictedChoice && testCase.choices
+        ? testCase.choices[predictedChoice]
+        : answered.finalAnswer;
       const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,
         testCase.question,
-        answered.finalAnswer,
+        actualAnswer,
         testCase.answer,
       );
 
       const scores: Record<string, number> = {
-        f1: f1Score(answered.finalAnswer, testCase.answer),
-        contains_answer: containsAnswer(answered.finalAnswer, testCase.answer),
+        f1: f1Score(actualAnswer, testCase.answer),
+        contains_answer: containsAnswer(actualAnswer, testCase.answer),
       };
+      if (testCase.correctChoice) {
+        scores.membench_accuracy = predictedChoice === testCase.correctChoice ? 1 : 0;
+      } else {
+        scores.membench_accuracy = exactMatch(actualAnswer, testCase.answer);
+      }
       if (judgeResult.score >= 0) {
         scores.llm_judge = judgeResult.score;
+      }
+      const recallScore = await scoreRecallAt10(options.system, sessionId, testCase);
+      if (recallScore !== undefined) {
+        scores.membench_recall_at_10 = recallScore;
       }
 
       tasks.push({
         taskId: testCase.id,
         question: testCase.question,
-        expected: testCase.answer,
-        actual: answered.finalAnswer,
+        expected: testCase.correctChoice ?? testCase.answer,
+        actual: predictedChoice ?? answered.finalAnswer,
         scores,
         latencyMs: durationMs + answered.latencyMs + judgeResult.latencyMs,
         tokens: {
@@ -124,6 +153,14 @@ export async function runMemBenchBenchmark(
           turnCount: testCase.turns.length,
           recalledLength: recalledText.length,
           answeredLength: answered.finalAnswer.length,
+          officialProtocol: testCase.choices ? "multiple_choice_accuracy" : "exact_answer_accuracy",
+          choices: testCase.choices,
+          correctChoice: testCase.correctChoice,
+          correctAnswer: testCase.answer,
+          predictedChoice,
+          predictedAnswer: actualAnswer,
+          questionTime: testCase.questionTime,
+          targetStepIds: testCase.targetStepIds,
           recalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
@@ -183,7 +220,10 @@ export async function runMemBenchBenchmark(
     },
     results: {
       tasks,
-      aggregates: aggregateTaskScores(tasks.map((task) => task.scores)),
+      aggregates: {
+        ...aggregateTaskScores(tasks.map((task) => task.scores)),
+        ...aggregateMemBenchOfficialBreakdowns(tasks),
+      },
     },
     environment: {
       os: process.platform,
@@ -317,8 +357,12 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     level,
     turns,
     question,
-    answer,
-  } = entry;
+      answer,
+      choices,
+      correctChoice,
+      questionTime,
+      targetStepIds,
+    } = entry;
 
   if (typeof id !== "string" || id.length === 0) {
     throw new Error(`MemBench case ${location} must include a non-empty id string.`);
@@ -352,6 +396,12 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     throw new Error(`MemBench case ${location} must include a non-empty turns array.`);
   }
 
+  const parsedChoices = parseChoices(choices, location);
+  const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
+  const parsedAnswer = parsedChoices && parsedCorrectChoice
+    ? parsedChoices[parsedCorrectChoice]
+    : answer;
+
   return {
     id,
     memoryType,
@@ -359,7 +409,11 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     level,
     turns: turns.map((turn, index) => parseTurn(turn, `${location}.turns[${index}]`)),
     question,
-    answer,
+    answer: parsedAnswer,
+    choices: parsedChoices,
+    correctChoice: parsedCorrectChoice,
+    questionTime: typeof questionTime === "string" ? questionTime : undefined,
+    targetStepIds: parseTargetStepIds(targetStepIds),
   };
 }
 
@@ -469,6 +523,10 @@ function normalizeFlatCase(
       turns: record.turns,
       question: record.question,
       answer: record.answer,
+      choices: record.choices,
+      correctChoice: record.correctChoice ?? record.correct_choice,
+      questionTime: record.questionTime ?? record.question_time ?? record.time,
+      targetStepIds: record.targetStepIds ?? record.target_step_ids ?? record.target_step_id,
     },
     location,
   );
@@ -479,8 +537,13 @@ function normalizeTrajectoryQaRecord(
   hints: MemBenchHints,
   location: string,
 ): MemBenchCase[] {
-  const trajectory = record.trajectory;
-  const qa = record.qa ?? record.qas ?? record.qa_pairs ?? record.question_answers;
+  const trajectory = record.trajectory ?? record.message_list ?? record.messages;
+  const rawQa = record.qa ?? record.QA ?? record.qas ?? record.qa_pairs ?? record.question_answers;
+  const qa = Array.isArray(rawQa)
+    ? rawQa
+    : isPlainObject(rawQa)
+      ? [rawQa]
+      : undefined;
 
   if (!Array.isArray(trajectory) || !Array.isArray(qa) || qa.length === 0) {
     return [];
@@ -506,6 +569,10 @@ function normalizeTrajectoryQaRecord(
         turns,
         question: pair.question,
         answer: pair.answer,
+        choices: pair.choices,
+        correctChoice: pair.correctChoice,
+        questionTime: pair.questionTime,
+        targetStepIds: pair.targetStepIds,
       },
       `${location}.qa[${index}]`,
     ),
@@ -526,6 +593,11 @@ function normalizeTrajectoryTurns(
 
   for (let index = 0; index < trajectory.length; index += 1) {
     const turn = trajectory[index];
+    if (typeof turn === "string" && turn.trim().length > 0) {
+      turns.push({ role: "user", content: turn });
+      continue;
+    }
+
     if (!isPlainObject(turn)) {
       return null;
     }
@@ -541,7 +613,20 @@ function normalizeTrajectoryTurns(
       ? turn.text
       : typeof turn.content === "string"
         ? turn.content
-        : undefined;
+        : typeof turn.message === "string"
+          ? turn.message
+          : undefined;
+    const userText = firstString(turn.user, turn.user_message);
+    const assistantText = firstString(turn.agent, turn.assistant, turn.assistant_message);
+    if (userText || assistantText) {
+      if (userText) {
+        turns.push({ role: "user", content: userText });
+      }
+      if (assistantText) {
+        turns.push({ role: "assistant", content: assistantText });
+      }
+      continue;
+    }
     if (!speaker || !text) {
       return null;
     }
@@ -570,8 +655,8 @@ function parseDirectMessageTurn(turn: Record<string, unknown>): Message | null {
 function normalizeQaPairs(
   qa: unknown[],
   location: string,
-): Array<{ id?: string; question: string; answer: string }> {
-  const pairs: Array<{ id?: string; question: string; answer: string }> = [];
+): MemBenchQuestionAnswer[] {
+  const pairs: MemBenchQuestionAnswer[] = [];
 
   for (let index = 0; index < qa.length; index += 1) {
     const item = qa[index];
@@ -580,13 +665,40 @@ function normalizeQaPairs(
     }
 
     const question = firstString(item.question, item.query, item.prompt);
-    const answer = firstString(item.answer, item.expected, item.gold, item.reference);
+    const choices = parseChoices(item.choices ?? item.options, `${location}[${index}].choices`);
+    const rawAnswer = firstString(
+      item.answer,
+      item.expected,
+      item.gold,
+      item.reference,
+      item.label,
+      item.correct_choice,
+    );
+    const correctChoice = parseCorrectChoice(
+      item.correctChoice ?? item.correct_choice,
+      rawAnswer,
+      choices,
+      `${location}[${index}]`,
+    );
+    const answer = choices && correctChoice
+      ? choices[correctChoice]
+      : rawAnswer;
     if (!question || !answer) {
       continue;
     }
 
     const id = firstString(item.id, item.qid, item.question_id);
-    pairs.push({ id: id ?? undefined, question, answer });
+    pairs.push({
+      id: id ?? undefined,
+      question,
+      answer,
+      choices: choices ?? undefined,
+      correctChoice: correctChoice ?? undefined,
+      questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
+      targetStepIds: parseTargetStepIds(
+        item.target_step_id ?? item.target_step_ids ?? item.targetStepIds,
+      ),
+    });
   }
 
   return pairs;
@@ -707,6 +819,202 @@ function parseTurn(turn: unknown, location: string): Message {
   }
 
   return { role, content };
+}
+
+function buildQuestionPrompt(testCase: MemBenchCase): string {
+  if (!testCase.choices) {
+    return testCase.question;
+  }
+
+  const scenarioInstruction = testCase.scenario === "observation"
+    ? "Please answer the following question based on past memories of the user's messages."
+    : "Please answer the following question based on past memories of your conversation with the user.";
+  const timePrefix = testCase.questionTime
+    ? `(current time is ${testCase.questionTime}) `
+    : "";
+
+  return [
+    scenarioInstruction,
+    `Question: ${timePrefix}${testCase.question}`,
+    "Choices:",
+    `A. ${testCase.choices.A}`,
+    `B. ${testCase.choices.B}`,
+    `C. ${testCase.choices.C}`,
+    `D. ${testCase.choices.D}`,
+    "Please output the correct option for the question, only one corresponding letter, without any other messages.",
+    "Example: D",
+  ].join("\n");
+}
+
+function extractChoice(answer: string): MemBenchChoice | undefined {
+  const trimmed = answer.trim().toUpperCase();
+  if (/^[ABCD]$/.test(trimmed)) {
+    return trimmed as MemBenchChoice;
+  }
+
+  const jsonChoice = trimmed.match(/"CHOICE"\s*:\s*"([ABCD])"/);
+  if (jsonChoice?.[1]) {
+    return jsonChoice[1] as MemBenchChoice;
+  }
+
+  const firstOption = trimmed.match(/\b([ABCD])\b/);
+  return firstOption?.[1] as MemBenchChoice | undefined;
+}
+
+async function scoreRecallAt10(
+  system: ResolvedRunBenchmarkOptions["system"],
+  sessionId: string,
+  testCase: MemBenchCase,
+): Promise<number | undefined> {
+  if (!testCase.targetStepIds || testCase.targetStepIds.length === 0) {
+    return undefined;
+  }
+
+  try {
+    const results = await system.search(
+      testCase.questionTime
+        ? `${testCase.question} (${testCase.questionTime})`
+        : testCase.question,
+      10,
+      sessionId,
+    );
+    const relevant = new Set(testCase.targetStepIds);
+    return results.some((result) => relevant.has(result.turnIndex)) ? 1 : 0;
+  } catch {
+    return undefined;
+  }
+}
+
+function aggregateMemBenchOfficialBreakdowns(
+  tasks: TaskResult[],
+): ReturnType<typeof aggregateTaskScores> {
+  const metrics: Array<[string, (task: TaskResult) => boolean]> = [
+    ["membench_accuracy_factual_participant", (task) =>
+      task.details?.memoryType === "factual" && task.details?.scenario === "participant"],
+    ["membench_accuracy_factual_observation", (task) =>
+      task.details?.memoryType === "factual" && task.details?.scenario === "observation"],
+    ["membench_accuracy_reflective_participant", (task) =>
+      task.details?.memoryType === "reflective" && task.details?.scenario === "participant"],
+    ["membench_accuracy_reflective_observation", (task) =>
+      task.details?.memoryType === "reflective" && task.details?.scenario === "observation"],
+  ];
+  const breakdownScores = metrics
+    .map(([metricName, predicate]) =>
+      tasks
+        .filter(predicate)
+        .map((task) => ({ [metricName]: task.scores.membench_accuracy }))
+        .filter((score) => typeof Object.values(score)[0] === "number"),
+    )
+    .flat();
+
+  return aggregateTaskScores(breakdownScores);
+}
+
+function parseChoices(
+  choices: unknown,
+  location: string,
+): Record<MemBenchChoice, string> | undefined {
+  if (Array.isArray(choices)) {
+    const parsedArray = choices.map((choice) => firstString(choice));
+    if (parsedArray.length === 0) {
+      return undefined;
+    }
+    if (parsedArray.length !== 4 || parsedArray.some((choice) => !choice)) {
+      throw new Error(
+        `MemBench choices ${location} must include exactly four non-empty options when provided as an array.`,
+      );
+    }
+    return {
+      A: parsedArray[0]!,
+      B: parsedArray[1]!,
+      C: parsedArray[2]!,
+      D: parsedArray[3]!,
+    };
+  }
+
+  if (!isPlainObject(choices)) {
+    return undefined;
+  }
+
+  const parsed = {
+    A: firstString(choices.A, choices.a),
+    B: firstString(choices.B, choices.b),
+    C: firstString(choices.C, choices.c),
+    D: firstString(choices.D, choices.d),
+  };
+
+  if (!parsed.A && !parsed.B && !parsed.C && !parsed.D) {
+    return undefined;
+  }
+  if (!parsed.A || !parsed.B || !parsed.C || !parsed.D) {
+    throw new Error(
+      `MemBench choices ${location} must include non-empty A, B, C, and D options.`,
+    );
+  }
+
+  return parsed as Record<MemBenchChoice, string>;
+}
+
+function parseCorrectChoice(
+  directChoice: unknown,
+  answer: unknown,
+  choices: Record<MemBenchChoice, string> | undefined,
+  location: string,
+): MemBenchChoice | undefined {
+  const normalizedDirect = normalizeChoice(directChoice);
+  if (normalizedDirect) {
+    return normalizedDirect;
+  }
+
+  const normalizedAnswer = normalizeChoice(answer);
+  if (normalizedAnswer) {
+    return normalizedAnswer;
+  }
+
+  if (!choices) {
+    return undefined;
+  }
+
+  const answerText = firstString(answer);
+  if (!answerText) {
+    throw new Error(
+      `MemBench case ${location} includes choices but no answer or correct choice.`,
+    );
+  }
+
+  const matchingChoices = (Object.entries(choices) as Array<[MemBenchChoice, string]>)
+    .filter(([, value]) => normalizeComparable(value) === normalizeComparable(answerText))
+    .map(([choice]) => choice);
+  if (matchingChoices.length === 1) {
+    return matchingChoices[0];
+  }
+
+  throw new Error(
+    `MemBench case ${location} includes choices but answer does not identify exactly one option.`,
+  );
+}
+
+function normalizeChoice(value: unknown): MemBenchChoice | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toUpperCase();
+  return /^[ABCD]$/.test(normalized) ? normalized as MemBenchChoice : undefined;
+}
+
+function normalizeComparable(value: string): string {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function parseTargetStepIds(value: unknown): number[] | undefined {
+  const rawValues = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const parsed = rawValues
+    .map((item) => Array.isArray(item) ? item[0] : item)
+    .map((item) => typeof item === "number" && Number.isInteger(item) && item >= 0
+      ? item
+      : undefined)
+    .filter((item): item is number => item !== undefined);
+  return parsed.length > 0 ? parsed : undefined;
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -429,7 +429,7 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
   const parsedChoices = parseChoices(choices, location);
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
   const flatCoordinateIndex = buildFlatCoordinateIndex(turns.length);
-  const idRefs = parseTargetStepRefs(targetStepIds);
+  const idRefs = parseTargetStepRefs(targetStepIds, flatCoordinateIndex);
   const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, flatCoordinateIndex, {
     treatSingleArrayAsCoordinate: true,
   });

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -419,16 +419,15 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     throw new Error(`MemBench case ${location} must include a non-empty question string.`);
   }
 
-  if (typeof answer !== "string" || answer.length === 0) {
-    throw new Error(`MemBench case ${location} must include a non-empty answer string.`);
-  }
-
   if (!Array.isArray(turns) || turns.length === 0) {
     throw new Error(`MemBench case ${location} must include a non-empty turns array.`);
   }
 
   const parsedChoices = parseChoices(choices, location);
-  const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
+  const rawAnswer = typeof answer === "string" && answer.length > 0
+    ? answer
+    : undefined;
+  const parsedCorrectChoice = parseCorrectChoice(correctChoice, rawAnswer, parsedChoices, location);
   const flatCoordinateIndex = buildFlatCoordinateIndex(turns.length);
   const idRefs = parseTargetStepRefs(targetStepIds, flatCoordinateIndex);
   const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, flatCoordinateIndex, {
@@ -440,7 +439,10 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
   };
   const parsedAnswer = parsedChoices && parsedCorrectChoice
     ? parsedChoices[parsedCorrectChoice]
-    : answer;
+    : rawAnswer;
+  if (!parsedAnswer) {
+    throw new Error(`MemBench case ${location} must include a non-empty answer string or choices with a correct choice.`);
+  }
 
   return {
     id,
@@ -551,7 +553,10 @@ function normalizeFlatCase(
   hints: MemBenchHints,
   location: string,
 ): MemBenchCase | null {
-  if (!("turns" in record) || !("question" in record) || !("answer" in record)) {
+  const hasAnswer = "answer" in record;
+  const hasChoiceAnswer = ("choices" in record || "options" in record)
+    && ("correctChoice" in record || "correct_choice" in record);
+  if (!("turns" in record) || !("question" in record) || (!hasAnswer && !hasChoiceAnswer)) {
     return null;
   }
 
@@ -564,7 +569,7 @@ function normalizeFlatCase(
       turns: record.turns,
       question: record.question,
       answer: record.answer,
-      choices: record.choices,
+      choices: record.choices ?? record.options,
       correctChoice: record.correctChoice ?? record.correct_choice,
       questionTime: record.questionTime ?? record.question_time ?? record.time,
       targetStepIds: record.targetStepIds ?? record.target_step_ids ?? record.target_step_id,
@@ -807,6 +812,7 @@ function normalizeQaPairs(
       ...parseTargetStepRefs(targetRefSource?.value, coordinateIndex, {
         treatSingleArrayAsCoordinate: targetRefSource?.kind === "coordinates"
           || targetRefSource?.treatSingleArrayAsCoordinate === true,
+        fallbackArrayTupleToIds: targetRefSource?.fallbackArrayTupleToIds === true,
       }),
     });
   }
@@ -820,12 +826,14 @@ function resolveTargetRefSource(
   value: unknown;
   kind: "ids" | "coordinates";
   treatSingleArrayAsCoordinate?: boolean;
+  fallbackArrayTupleToIds?: boolean;
 } | undefined {
   if (hasUsableTargetIdRef(item.target_step_id)) {
     return {
       value: item.target_step_id,
       kind: "ids",
       treatSingleArrayAsCoordinate: Array.isArray(item.target_step_id),
+      fallbackArrayTupleToIds: true,
     };
   }
   if (hasUsableTargetIdRef(item.target_step_ids)) {
@@ -1190,7 +1198,10 @@ function normalizeComparable(value: string): string {
 function parseTargetStepRefs(
   value: unknown,
   coordinateIndex?: Map<string, number>,
-  options: { treatSingleArrayAsCoordinate?: boolean } = {},
+  options: {
+    treatSingleArrayAsCoordinate?: boolean;
+    fallbackArrayTupleToIds?: boolean;
+  } = {},
 ): {
   targetStepIds?: number[];
   targetStepCoordinates?: number[][];
@@ -1221,6 +1232,8 @@ function parseTargetStepRefs(
         const mapped = coordinateIndex?.get(coordinateKey(numeric));
         if (mapped !== undefined) {
           candidates.add(mapped);
+        } else if (options.fallbackArrayTupleToIds) {
+          numeric.forEach((part) => candidates.add(part));
         }
       } else if (numeric.length === 1) {
         const mapped = coordinateIndex?.get(coordinateKey(numeric));

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -1040,14 +1040,11 @@ function parseTargetStepRefs(value: unknown): {
       const numeric = item.filter((part): part is number =>
         typeof part === "number" && Number.isInteger(part) && part >= 0,
       );
-      for (const part of numeric) {
-        candidates.add(part);
-      }
       if (numeric.length >= 2) {
         const [first, second] = numeric;
-        candidates.add(first + second);
-        candidates.add(first * 2 + second);
-        candidates.add(second * 2 + first);
+        candidates.add(second * 3 + first);
+      } else if (numeric.length === 1) {
+        candidates.add(numeric[0]!);
       }
     }
   }

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -194,7 +194,20 @@ export async function runMemBenchBenchmark(
         scores,
         latencyMs: 0,
         tokens: { input: 0, output: 0 },
-        details: { error: message },
+        details: {
+          error: message,
+          memoryType: testCase.memoryType,
+          scenario: testCase.scenario,
+          level: testCase.level,
+          turnCount: testCase.turns.length,
+          officialProtocol: testCase.choices ? "multiple_choice_accuracy" : "exact_answer_accuracy",
+          choices: testCase.choices,
+          correctChoice: testCase.correctChoice,
+          correctAnswer: testCase.answer,
+          questionTime: testCase.questionTime,
+          targetStepIds: testCase.targetStepIds,
+          targetStepCoordinates: testCase.targetStepCoordinates,
+        },
       });
     }
 
@@ -415,8 +428,9 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
 
   const parsedChoices = parseChoices(choices, location);
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
+  const flatCoordinateIndex = buildFlatCoordinateIndex(turns.length);
   const idRefs = parseTargetStepRefs(targetStepIds);
-  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, undefined, {
+  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, flatCoordinateIndex, {
     treatSingleArrayAsCoordinate: true,
   });
   const targetRefs = {
@@ -1204,6 +1218,15 @@ function isCoordinateTuple(value: unknown[]): boolean {
 
 function coordinateKey(coordinate: number[]): string {
   return coordinate.join(":");
+}
+
+function buildFlatCoordinateIndex(turnCount: number): Map<string, number> {
+  const index = new Map<string, number>();
+  for (let turnIndex = 0; turnIndex < turnCount; turnIndex += 1) {
+    index.set(coordinateKey([turnIndex]), turnIndex);
+    index.set(coordinateKey([0, turnIndex]), turnIndex);
+  }
+  return index;
 }
 
 function pairedTurnCoordinate(coordinate: number[], sideIndex: 0 | 1): number[] {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -40,6 +40,11 @@ interface MemBenchQuestionAnswer {
   targetStepCoordinates?: number[][];
 }
 
+interface NormalizedMemBenchTurns {
+  turns: Message[];
+  coordinateIndex: Map<string, number>;
+}
+
 const DATASET_FILENAMES = [
   "membench.json",
   "membench.jsonl",
@@ -106,7 +111,7 @@ export async function runMemBenchBenchmark(
         recalledText,
         responder: options.system.responder,
       });
-      const predictedChoice = testCase.choices
+      const predictedChoice = testCase.choices && options.system.responder
         ? extractChoice(answered.finalAnswer)
         : undefined;
       const actualAnswer = predictedChoice && testCase.choices
@@ -554,12 +559,12 @@ function normalizeTrajectoryQaRecord(
     return [];
   }
 
-  const turns = normalizeTrajectoryTurns(trajectory, `${location}.trajectory`);
-  if (!turns) {
+  const normalizedTurns = normalizeTrajectoryTurns(trajectory, `${location}.trajectory`);
+  if (!normalizedTurns) {
     return [];
   }
 
-  const qaPairs = normalizeQaPairs(qa, `${location}.qa`);
+  const qaPairs = normalizeQaPairs(qa, `${location}.qa`, normalizedTurns.coordinateIndex);
   if (qaPairs.length === 0) {
     return [];
   }
@@ -571,14 +576,14 @@ function normalizeTrajectoryQaRecord(
         memoryType: resolveMemoryType(record.memoryType, hints),
         scenario: resolveScenario(record.scenario, hints),
         level: resolveLevel(record.level, hints),
-        turns,
+        turns: normalizedTurns.turns,
         question: pair.question,
         answer: pair.answer,
-      choices: pair.choices,
-      correctChoice: pair.correctChoice,
-      questionTime: pair.questionTime,
-      targetStepIds: pair.targetStepIds,
-      targetStepCoordinates: pair.targetStepCoordinates,
+        choices: pair.choices,
+        correctChoice: pair.correctChoice,
+        questionTime: pair.questionTime,
+        targetStepIds: pair.targetStepIds,
+        targetStepCoordinates: pair.targetStepCoordinates,
       },
       `${location}.qa[${index}]`,
     ),
@@ -588,7 +593,7 @@ function normalizeTrajectoryQaRecord(
 function normalizeTrajectoryTurns(
   trajectory: unknown[],
   location: string,
-): Message[] | null {
+): NormalizedMemBenchTurns | null {
   if (trajectory.length === 0) {
     return null;
   }
@@ -596,58 +601,110 @@ function normalizeTrajectoryTurns(
   const speakerRoles = new Map<string, Message["role"]>();
   let distinctSpeakers = 0;
   const turns: Message[] = [];
+  const coordinateIndex = new Map<string, number>();
 
   for (let index = 0; index < trajectory.length; index += 1) {
     const turn = trajectory[index];
-    if (typeof turn === "string" && turn.trim().length > 0) {
-      turns.push({ role: "user", content: turn });
-      continue;
-    }
-
-    if (!isPlainObject(turn)) {
-      return null;
-    }
-
-    const directMessage = parseDirectMessageTurn(turn);
-    if (directMessage) {
-      turns.push(directMessage);
-      continue;
-    }
-
-    const speaker = typeof turn.speaker === "string" ? turn.speaker : undefined;
-    const text = typeof turn.text === "string"
-      ? turn.text
-      : typeof turn.content === "string"
-        ? turn.content
-        : typeof turn.message === "string"
-          ? turn.message
-          : undefined;
-    const userText = firstString(turn.user, turn.user_message);
-    const assistantText = firstString(turn.agent, turn.assistant, turn.assistant_message);
-    if (userText || assistantText) {
-      if (userText) {
-        turns.push({ role: "user", content: userText });
-      }
-      if (assistantText) {
-        turns.push({ role: "assistant", content: assistantText });
+    if (Array.isArray(turn)) {
+      for (let nestedIndex = 0; nestedIndex < turn.length; nestedIndex += 1) {
+        if (!appendTrajectoryTurn(
+          turn[nestedIndex],
+          `${location}[${index}][${nestedIndex}]`,
+          [nestedIndex, index],
+          turns,
+          coordinateIndex,
+          speakerRoles,
+          () => distinctSpeakers++,
+        )) {
+          return null;
+        }
       }
       continue;
     }
-    if (!speaker || !text) {
+
+    if (!appendTrajectoryTurn(
+      turn,
+      `${location}[${index}]`,
+      [index],
+      turns,
+      coordinateIndex,
+      speakerRoles,
+      () => distinctSpeakers++,
+    )) {
       return null;
     }
-
-    let role = speakerRoles.get(speaker);
-    if (!role) {
-      role = distinctSpeakers === 0 ? "user" : "assistant";
-      speakerRoles.set(speaker, role);
-      distinctSpeakers += 1;
-    }
-
-    turns.push({ role, content: text });
   }
 
-  return turns.length > 0 ? turns : null;
+  return turns.length > 0 ? { turns, coordinateIndex } : null;
+}
+
+function appendTrajectoryTurn(
+  turn: unknown,
+  _location: string,
+  coordinate: number[],
+  turns: Message[],
+  coordinateIndex: Map<string, number>,
+  speakerRoles: Map<string, Message["role"]>,
+  nextSpeakerIndex: () => number,
+): boolean {
+  const rememberCoordinate = () => {
+    coordinateIndex.set(coordinateKey(coordinate), turns.length);
+    if (coordinate.length === 1) {
+      coordinateIndex.set(coordinateKey([coordinate[0]!, 0]), turns.length);
+    }
+  };
+
+  if (typeof turn === "string" && turn.trim().length > 0) {
+    rememberCoordinate();
+    turns.push({ role: "user", content: turn });
+    return true;
+  }
+
+  if (!isPlainObject(turn)) {
+    return false;
+  }
+
+  const directMessage = parseDirectMessageTurn(turn);
+  if (directMessage) {
+    rememberCoordinate();
+    turns.push(directMessage);
+    return true;
+  }
+
+  const speaker = typeof turn.speaker === "string" ? turn.speaker : undefined;
+  const text = typeof turn.text === "string"
+    ? turn.text
+    : typeof turn.content === "string"
+      ? turn.content
+      : typeof turn.message === "string"
+        ? turn.message
+        : undefined;
+  const userText = firstString(turn.user, turn.user_message);
+  const assistantText = firstString(turn.agent, turn.assistant, turn.assistant_message);
+  if (userText || assistantText) {
+    rememberCoordinate();
+    turns.push({
+      role: "assistant",
+      content: [
+        userText ? `'user': ${userText}` : undefined,
+        assistantText ? `'agent': ${assistantText}` : undefined,
+      ].filter(Boolean).join("; "),
+    });
+    return true;
+  }
+  if (!speaker || !text) {
+    return false;
+  }
+
+  let role = speakerRoles.get(speaker);
+  if (!role) {
+    role = nextSpeakerIndex() === 0 ? "user" : "assistant";
+    speakerRoles.set(speaker, role);
+  }
+
+  rememberCoordinate();
+  turns.push({ role, content: text });
+  return true;
 }
 
 function parseDirectMessageTurn(turn: Record<string, unknown>): Message | null {
@@ -661,6 +718,7 @@ function parseDirectMessageTurn(turn: Record<string, unknown>): Message | null {
 function normalizeQaPairs(
   qa: unknown[],
   location: string,
+  coordinateIndex?: Map<string, number>,
 ): MemBenchQuestionAnswer[] {
   const pairs: MemBenchQuestionAnswer[] = [];
 
@@ -703,6 +761,7 @@ function normalizeQaPairs(
       questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
       ...parseTargetStepRefs(
         item.target_step_id ?? item.target_step_ids ?? item.targetStepIds,
+        coordinateIndex,
       ),
     });
   }
@@ -1021,7 +1080,10 @@ function normalizeComparable(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-function parseTargetStepRefs(value: unknown): {
+function parseTargetStepRefs(
+  value: unknown,
+  coordinateIndex?: Map<string, number>,
+): {
   targetStepIds?: number[];
   targetStepCoordinates?: number[][];
 } {
@@ -1041,8 +1103,13 @@ function parseTargetStepRefs(value: unknown): {
         typeof part === "number" && Number.isInteger(part) && part >= 0,
       );
       if (numeric.length >= 2) {
-        const [first, second] = numeric;
-        candidates.add(second * 3 + first);
+        const mapped = coordinateIndex?.get(coordinateKey(numeric));
+        if (mapped !== undefined) {
+          candidates.add(mapped);
+        } else {
+          const [first, second] = numeric;
+          candidates.add(second * 3 + first);
+        }
       } else if (numeric.length === 1) {
         candidates.add(numeric[0]!);
       }
@@ -1054,6 +1121,10 @@ function parseTargetStepRefs(value: unknown): {
     targetStepIds: ids.length > 0 ? ids : undefined,
     targetStepCoordinates: coordinates.length > 0 ? coordinates : undefined,
   };
+}
+
+function coordinateKey(coordinate: number[]): string {
+  return coordinate.join(":");
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -406,7 +406,12 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
 
   const parsedChoices = parseChoices(choices, location);
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
-  const targetRefs = parseTargetStepRefs(targetStepCoordinates ?? targetStepIds);
+  const idRefs = parseTargetStepRefs(targetStepIds);
+  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates);
+  const targetRefs = {
+    targetStepIds: idRefs.targetStepIds ?? coordinateRefs.targetStepIds,
+    targetStepCoordinates: coordinateRefs.targetStepCoordinates ?? idRefs.targetStepCoordinates,
+  };
   const parsedAnswer = parsedChoices && parsedCorrectChoice
     ? parsedChoices[parsedCorrectChoice]
     : answer;
@@ -922,11 +927,13 @@ function extractChoice(answer: string): MemBenchChoice | undefined {
     return jsonChoice[1] as MemBenchChoice;
   }
 
-  const finalAnswer = trimmed.match(
-    /(?:FINAL\s+ANSWER|ANSWER|CHOICE|OPTION)\s*(?:IS|:|-)?\s*([ABCD])\b/,
-  );
-  if (finalAnswer?.[1]) {
-    return finalAnswer[1] as MemBenchChoice;
+  const answerMarkers = [
+    ...trimmed.matchAll(
+      /(?:FINAL\s+ANSWER|ANSWER|CHOICE|OPTION)\s*(?:IS|:|-)?\s*([ABCD])\b/g,
+    ),
+  ].map((match) => match[1] as MemBenchChoice);
+  if (answerMarkers.length > 0) {
+    return answerMarkers.at(-1);
   }
 
   const optionTokens = [...trimmed.matchAll(/\b([ABCD])\b/g)].map(

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -542,6 +542,10 @@ function normalizeFlatCase(
       correctChoice: record.correctChoice ?? record.correct_choice,
       questionTime: record.questionTime ?? record.question_time ?? record.time,
       targetStepIds: record.targetStepIds ?? record.target_step_ids ?? record.target_step_id,
+      targetStepCoordinates:
+        record.targetStepCoordinates
+        ?? record.target_step_coordinates
+        ?? record.target_step_coordinate,
     },
     location,
   );
@@ -765,7 +769,11 @@ function normalizeQaPairs(
       correctChoice: correctChoice ?? undefined,
       questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
       ...parseTargetStepRefs(
-        item.target_step_id ?? item.target_step_ids ?? item.targetStepIds,
+        item.target_step_id
+        ?? item.target_step_ids
+        ?? item.targetStepIds
+        ?? item.target_step_coordinates
+        ?? item.targetStepCoordinates,
         coordinateIndex,
       ),
     });

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -804,7 +804,8 @@ function normalizeQaPairs(
       correctChoice: correctChoice ?? undefined,
       questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
       ...parseTargetStepRefs(targetRefSource?.value, coordinateIndex, {
-        treatSingleArrayAsCoordinate: targetRefSource?.kind === "coordinates",
+        treatSingleArrayAsCoordinate: targetRefSource?.kind === "coordinates"
+          || targetRefSource?.treatSingleArrayAsCoordinate === true,
       }),
     });
   }
@@ -814,9 +815,17 @@ function normalizeQaPairs(
 
 function resolveTargetRefSource(
   item: Record<string, unknown>,
-): { value: unknown; kind: "ids" | "coordinates" } | undefined {
+): {
+  value: unknown;
+  kind: "ids" | "coordinates";
+  treatSingleArrayAsCoordinate?: boolean;
+} | undefined {
   if (hasUsableTargetIdRef(item.target_step_id)) {
-    return { value: item.target_step_id, kind: "ids" };
+    return {
+      value: item.target_step_id,
+      kind: "ids",
+      treatSingleArrayAsCoordinate: Array.isArray(item.target_step_id),
+    };
   }
   if (hasUsableTargetIdRef(item.target_step_ids)) {
     return { value: item.target_step_ids, kind: "ids" };

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -393,6 +393,7 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     questionTime,
     targetStepIds,
     targetStepCoordinates,
+    skipFlatCoordinateFallback,
   } = entry;
 
   if (typeof id !== "string" || id.length === 0) {
@@ -430,9 +431,11 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, rawAnswer, parsedChoices, location);
   const flatCoordinateIndex = buildFlatCoordinateIndex(turns.length);
   const idRefs = parseTargetStepRefs(targetStepIds, flatCoordinateIndex);
-  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, flatCoordinateIndex, {
-    treatSingleArrayAsCoordinate: true,
-  });
+  const coordinateRefs = parseTargetStepRefs(
+    targetStepCoordinates,
+    skipFlatCoordinateFallback === true ? undefined : flatCoordinateIndex,
+    { treatSingleArrayAsCoordinate: true },
+  );
   const targetRefs = {
     targetStepIds: idRefs.targetStepIds ?? coordinateRefs.targetStepIds,
     targetStepCoordinates: coordinateRefs.targetStepCoordinates ?? idRefs.targetStepCoordinates,
@@ -624,6 +627,7 @@ function normalizeTrajectoryQaRecord(
         questionTime: pair.questionTime,
         targetStepIds: pair.targetStepIds,
         targetStepCoordinates: pair.targetStepCoordinates,
+        skipFlatCoordinateFallback: true,
       },
       `${location}.qa[${index}]`,
     ),
@@ -1088,12 +1092,23 @@ function aggregateMemBenchOfficialBreakdowns(
       task.details?.memoryType === "reflective" && task.details?.scenario === "observation"],
   ];
   const breakdownScores = metrics
-    .map(([metricName, predicate]) =>
-      tasks
-        .filter(predicate)
-        .map((task) => ({ [metricName]: task.scores.membench_accuracy }))
-        .filter((score) => typeof Object.values(score)[0] === "number"),
-    )
+    .flatMap(([metricName, predicate]) => {
+      const categoryTasks = tasks.filter(predicate);
+      const accuracyScores = categoryTasks
+        .map((task) => task.scores.membench_accuracy)
+        .filter((score): score is number => typeof score === "number" && score >= 0)
+        .map((score) => ({ [metricName]: score }));
+      const errorMetricName = metricName.replace(
+        "membench_accuracy_",
+        "membench_error_rate_",
+      );
+      const errorScores = categoryTasks
+        .filter((task) => typeof task.scores.membench_accuracy === "number")
+        .map((task) => ({
+          [errorMetricName]: task.scores.membench_accuracy < 0 ? 1 : 0,
+        }));
+      return [...accuracyScores, ...errorScores];
+    })
     .flat();
 
   return aggregateTaskScores(breakdownScores);

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -1222,27 +1222,32 @@ function parseTargetStepRefs(
   targetStepCoordinates?: number[][];
 } {
   const rawValues = Array.isArray(value)
-    ? options.treatSingleArrayAsCoordinate && isCoordinateTuple(value)
-      ? [value]
+    ? options.treatSingleArrayAsCoordinate
+      ? isCoordinateTuple(value) || !value.every(Array.isArray)
+        ? [value]
+        : value
       : value
     : value === undefined
       ? []
       : [value];
   const coordinates = rawValues
     .filter(Array.isArray)
-    .map((items) => items
-      .map(normalizeTargetRefPart)
-      .filter((item): item is number => item !== undefined))
-    .filter((items) => items.length > 0);
+    .map(parseCoordinateTuple)
+    .filter((items): items is number[] => items !== undefined);
   const candidates = new Set<number>();
   for (const item of rawValues) {
     const scalar = normalizeTargetRefPart(item);
     if (scalar !== undefined) {
       candidates.add(scalar);
     } else if (Array.isArray(item)) {
-      const numeric = item
-        .map(normalizeTargetRefPart)
-        .filter((part): part is number => part !== undefined);
+      const numeric = options.treatSingleArrayAsCoordinate
+        ? parseCoordinateTuple(item)
+        : item
+          .map(normalizeTargetRefPart)
+          .filter((part): part is number => part !== undefined);
+      if (!numeric) {
+        continue;
+      }
       if (numeric.length >= 2) {
         const mapped = coordinateIndex?.get(coordinateKey(numeric));
         if (mapped !== undefined) {
@@ -1279,8 +1284,15 @@ function normalizeTargetRefPart(value: unknown): number | undefined {
 }
 
 function isCoordinateTuple(value: unknown[]): boolean {
-  return value.length > 0
-    && value.every((item) => normalizeTargetRefPart(item) !== undefined);
+  return parseCoordinateTuple(value) !== undefined;
+}
+
+function parseCoordinateTuple(value: unknown[]): number[] | undefined {
+  const parsed = value.map(normalizeTargetRefPart);
+  if (parsed.length === 0 || parsed.some((item) => item === undefined)) {
+    return undefined;
+  }
+  return parsed as number[];
 }
 
 function coordinateKey(coordinate: number[]): string {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -177,12 +177,21 @@ export async function runMemBenchBenchmark(
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       console.error(`  [WARN] membench task ${testCase.id} failed: ${message}`);
+      const scores: Record<string, number> = {
+        f1: -1,
+        contains_answer: -1,
+        llm_judge: -1,
+        membench_accuracy: -1,
+      };
+      if (testCase.targetStepIds && testCase.targetStepIds.length > 0) {
+        scores.membench_recall_at_10 = -1;
+      }
       tasks.push({
         taskId: testCase.id,
         question: testCase.question,
-        expected: testCase.answer,
+        expected: testCase.correctChoice ?? testCase.answer,
         actual: `(error: ${message})`,
-        scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
+        scores,
         latencyMs: 0,
         tokens: { input: 0, output: 0 },
         details: { error: message },

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -37,6 +37,7 @@ interface MemBenchQuestionAnswer {
   correctChoice?: MemBenchChoice;
   questionTime?: string;
   targetStepIds?: number[];
+  targetStepCoordinates?: number[][];
 }
 
 const DATASET_FILENAMES = [
@@ -161,6 +162,7 @@ export async function runMemBenchBenchmark(
           predictedAnswer: actualAnswer,
           questionTime: testCase.questionTime,
           targetStepIds: testCase.targetStepIds,
+          targetStepCoordinates: testCase.targetStepCoordinates,
           recalledText,
           answeredText: answered.finalAnswer,
           responderModel: answered.model,
@@ -358,11 +360,12 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     turns,
     question,
       answer,
-      choices,
-      correctChoice,
-      questionTime,
-      targetStepIds,
-    } = entry;
+    choices,
+    correctChoice,
+    questionTime,
+    targetStepIds,
+    targetStepCoordinates,
+  } = entry;
 
   if (typeof id !== "string" || id.length === 0) {
     throw new Error(`MemBench case ${location} must include a non-empty id string.`);
@@ -398,6 +401,7 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
 
   const parsedChoices = parseChoices(choices, location);
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
+  const targetRefs = parseTargetStepRefs(targetStepCoordinates ?? targetStepIds);
   const parsedAnswer = parsedChoices && parsedCorrectChoice
     ? parsedChoices[parsedCorrectChoice]
     : answer;
@@ -413,7 +417,8 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
     choices: parsedChoices,
     correctChoice: parsedCorrectChoice,
     questionTime: typeof questionTime === "string" ? questionTime : undefined,
-    targetStepIds: parseTargetStepIds(targetStepIds),
+    targetStepIds: targetRefs.targetStepIds,
+    targetStepCoordinates: targetRefs.targetStepCoordinates,
   };
 }
 
@@ -569,10 +574,11 @@ function normalizeTrajectoryQaRecord(
         turns,
         question: pair.question,
         answer: pair.answer,
-        choices: pair.choices,
-        correctChoice: pair.correctChoice,
-        questionTime: pair.questionTime,
-        targetStepIds: pair.targetStepIds,
+      choices: pair.choices,
+      correctChoice: pair.correctChoice,
+      questionTime: pair.questionTime,
+      targetStepIds: pair.targetStepIds,
+      targetStepCoordinates: pair.targetStepCoordinates,
       },
       `${location}.qa[${index}]`,
     ),
@@ -695,7 +701,7 @@ function normalizeQaPairs(
       choices: choices ?? undefined,
       correctChoice: correctChoice ?? undefined,
       questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
-      targetStepIds: parseTargetStepIds(
+      ...parseTargetStepRefs(
         item.target_step_id ?? item.target_step_ids ?? item.targetStepIds,
       ),
     });
@@ -1015,15 +1021,42 @@ function normalizeComparable(value: string): string {
   return value.trim().toLowerCase().replace(/\s+/g, " ");
 }
 
-function parseTargetStepIds(value: unknown): number[] | undefined {
+function parseTargetStepRefs(value: unknown): {
+  targetStepIds?: number[];
+  targetStepCoordinates?: number[][];
+} {
   const rawValues = Array.isArray(value) ? value : value === undefined ? [] : [value];
-  const parsed = rawValues
-    .map((item) => Array.isArray(item) ? item[0] : item)
-    .map((item) => typeof item === "number" && Number.isInteger(item) && item >= 0
-      ? item
-      : undefined)
-    .filter((item): item is number => item !== undefined);
-  return parsed.length > 0 ? parsed : undefined;
+  const coordinates = rawValues
+    .filter(Array.isArray)
+    .map((items) => items.filter((item): item is number =>
+      typeof item === "number" && Number.isInteger(item) && item >= 0,
+    ))
+    .filter((items) => items.length > 0);
+  const candidates = new Set<number>();
+  for (const item of rawValues) {
+    if (typeof item === "number" && Number.isInteger(item) && item >= 0) {
+      candidates.add(item);
+    } else if (Array.isArray(item)) {
+      const numeric = item.filter((part): part is number =>
+        typeof part === "number" && Number.isInteger(part) && part >= 0,
+      );
+      for (const part of numeric) {
+        candidates.add(part);
+      }
+      if (numeric.length >= 2) {
+        const [first, second] = numeric;
+        candidates.add(first + second);
+        candidates.add(first * 2 + second);
+        candidates.add(second * 2 + first);
+      }
+    }
+  }
+
+  const ids = [...candidates].sort((left, right) => left - right);
+  return {
+    targetStepIds: ids.length > 0 ? ids : undefined,
+    targetStepCoordinates: coordinates.length > 0 ? coordinates : undefined,
+  };
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -407,7 +407,9 @@ function parseCase(entry: unknown, location: string): MemBenchCase {
   const parsedChoices = parseChoices(choices, location);
   const parsedCorrectChoice = parseCorrectChoice(correctChoice, answer, parsedChoices, location);
   const idRefs = parseTargetStepRefs(targetStepIds);
-  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates);
+  const coordinateRefs = parseTargetStepRefs(targetStepCoordinates, undefined, {
+    treatSingleArrayAsCoordinate: true,
+  });
   const targetRefs = {
     targetStepIds: idRefs.targetStepIds ?? coordinateRefs.targetStepIds,
     targetStepCoordinates: coordinateRefs.targetStepCoordinates ?? idRefs.targetStepCoordinates,
@@ -696,11 +698,12 @@ function appendTrajectoryTurn(
   if (userText || assistantText) {
     if (userText) {
       rememberCoordinate();
+      rememberCoordinate(pairedTurnCoordinate(coordinate, 0));
       turns.push({ role: "user", content: userText });
     }
     if (assistantText) {
       rememberCoordinate(
-        userText ? pairedAssistantCoordinate(coordinate) : coordinate,
+        userText ? pairedTurnCoordinate(coordinate, 1) : coordinate,
       );
       turns.push({ role: "assistant", content: assistantText });
     }
@@ -766,6 +769,7 @@ function normalizeQaPairs(
     }
 
     const id = firstString(item.id, item.qid, item.question_id);
+    const targetRefSource = resolveTargetRefSource(item);
     pairs.push({
       id: id ?? undefined,
       question,
@@ -773,18 +777,40 @@ function normalizeQaPairs(
       choices: choices ?? undefined,
       correctChoice: correctChoice ?? undefined,
       questionTime: firstString(item.time, item.question_time, item.questionTime) ?? undefined,
-      ...parseTargetStepRefs(
-        item.target_step_id
-        ?? item.target_step_ids
-        ?? item.targetStepIds
-        ?? item.target_step_coordinates
-        ?? item.targetStepCoordinates,
-        coordinateIndex,
-      ),
+      ...parseTargetStepRefs(targetRefSource?.value, coordinateIndex, {
+        treatSingleArrayAsCoordinate: targetRefSource?.kind === "coordinates",
+      }),
     });
   }
 
   return pairs;
+}
+
+function resolveTargetRefSource(
+  item: Record<string, unknown>,
+): { value: unknown; kind: "ids" | "coordinates" } | undefined {
+  if (item.target_step_id !== undefined) {
+    return { value: item.target_step_id, kind: "ids" };
+  }
+  if (item.target_step_ids !== undefined) {
+    return { value: item.target_step_ids, kind: "ids" };
+  }
+  if (item.targetStepIds !== undefined) {
+    return { value: item.targetStepIds, kind: "ids" };
+  }
+  if (item.target_step_coordinates !== undefined) {
+    return { value: item.target_step_coordinates, kind: "coordinates" };
+  }
+  if (item.targetStepCoordinates !== undefined) {
+    return { value: item.targetStepCoordinates, kind: "coordinates" };
+  }
+  if (item.target_step_coordinate !== undefined) {
+    return { value: item.target_step_coordinate, kind: "coordinates" };
+  }
+  if (item.targetStepCoordinate !== undefined) {
+    return { value: item.targetStepCoordinate, kind: "coordinates" };
+  }
+  return undefined;
 }
 
 function resolveCaseId(
@@ -1103,11 +1129,18 @@ function normalizeComparable(value: string): string {
 function parseTargetStepRefs(
   value: unknown,
   coordinateIndex?: Map<string, number>,
+  options: { treatSingleArrayAsCoordinate?: boolean } = {},
 ): {
   targetStepIds?: number[];
   targetStepCoordinates?: number[][];
 } {
-  const rawValues = Array.isArray(value) ? value : value === undefined ? [] : [value];
+  const rawValues = Array.isArray(value)
+    ? options.treatSingleArrayAsCoordinate && isCoordinateTuple(value)
+      ? [value]
+      : value
+    : value === undefined
+      ? []
+      : [value];
   const coordinates = rawValues
     .filter(Array.isArray)
     .map((items) => items.filter((item): item is number =>
@@ -1128,7 +1161,12 @@ function parseTargetStepRefs(
           candidates.add(mapped);
         }
       } else if (numeric.length === 1) {
-        candidates.add(numeric[0]!);
+        const mapped = coordinateIndex?.get(coordinateKey(numeric));
+        if (mapped !== undefined) {
+          candidates.add(mapped);
+        } else if (!options.treatSingleArrayAsCoordinate) {
+          candidates.add(numeric[0]!);
+        }
       }
     }
   }
@@ -1140,17 +1178,18 @@ function parseTargetStepRefs(
   };
 }
 
+function isCoordinateTuple(value: unknown[]): boolean {
+  return value.length > 0 && value.every((item) =>
+    typeof item === "number" && Number.isInteger(item) && item >= 0,
+  );
+}
+
 function coordinateKey(coordinate: number[]): string {
   return coordinate.join(":");
 }
 
-function pairedAssistantCoordinate(coordinate: number[]): number[] {
-  if (coordinate.length === 1) {
-    return [1, coordinate[0]!];
-  }
-
-  const [turnIndex, ...rest] = coordinate;
-  return [(turnIndex ?? 0) + 1, ...rest];
+function pairedTurnCoordinate(coordinate: number[], sideIndex: 0 | 1): number[] {
+  return [...coordinate, sideIndex];
 }
 
 function normalizeLimit(limit: number | undefined): number | undefined {

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -664,7 +664,10 @@ function appendTrajectoryTurn(
   ) => {
     coordinateIndex.set(coordinateKey(targetCoordinate), turnIndex);
     if (targetCoordinate.length === 1) {
-      coordinateIndex.set(coordinateKey([0, targetCoordinate[0]!]), turnIndex);
+      const flatAliasKey = coordinateKey([0, targetCoordinate[0]!]);
+      if (!coordinateIndex.has(flatAliasKey)) {
+        coordinateIndex.set(flatAliasKey, turnIndex);
+      }
     }
   };
 

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -857,8 +857,17 @@ function extractChoice(answer: string): MemBenchChoice | undefined {
     return jsonChoice[1] as MemBenchChoice;
   }
 
-  const firstOption = trimmed.match(/\b([ABCD])\b/);
-  return firstOption?.[1] as MemBenchChoice | undefined;
+  const finalAnswer = trimmed.match(
+    /(?:FINAL\s+ANSWER|ANSWER|CHOICE|OPTION)\s*(?:IS|:|-)?\s*([ABCD])\b/,
+  );
+  if (finalAnswer?.[1]) {
+    return finalAnswer[1] as MemBenchChoice;
+  }
+
+  const optionTokens = [...trimmed.matchAll(/\b([ABCD])\b/g)].map(
+    (match) => match[1] as MemBenchChoice,
+  );
+  return optionTokens.at(-1);
 }
 
 async function scoreRecallAt10(
@@ -881,7 +890,7 @@ async function scoreRecallAt10(
     const relevant = new Set(testCase.targetStepIds);
     return results.some((result) => relevant.has(result.turnIndex)) ? 1 : 0;
   } catch {
-    return undefined;
+    return -1;
   }
 }
 
@@ -961,6 +970,10 @@ function parseCorrectChoice(
   choices: Record<MemBenchChoice, string> | undefined,
   location: string,
 ): MemBenchChoice | undefined {
+  if (!choices) {
+    return undefined;
+  }
+
   const normalizedDirect = normalizeChoice(directChoice);
   if (normalizedDirect) {
     return normalizedDirect;
@@ -969,10 +982,6 @@ function parseCorrectChoice(
   const normalizedAnswer = normalizeChoice(answer);
   if (normalizedAnswer) {
     return normalizedAnswer;
-  }
-
-  if (!choices) {
-    return undefined;
   }
 
   const answerText = firstString(answer);

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -102,8 +102,9 @@ export async function runMemBenchBenchmark(
         console.error(`  [WARN] membench drain failed for ${testCase.id}: ${drainErr instanceof Error ? drainErr.message : String(drainErr)}`);
       }
 
+      const recallQuery = buildRecallQuery(testCase);
       const { result: recalledText, durationMs } = await timed(async () =>
-        options.system.recall(sessionId, testCase.question),
+        options.system.recall(sessionId, recallQuery),
       );
       const answerQuestion = buildQuestionPrompt(testCase);
       const answered = await answerBenchmarkQuestion({
@@ -1006,6 +1007,12 @@ function buildQuestionPrompt(testCase: MemBenchCase): string {
   ].join("\n");
 }
 
+function buildRecallQuery(testCase: MemBenchCase): string {
+  return testCase.questionTime
+    ? `${testCase.question} (${testCase.questionTime})`
+    : testCase.question;
+}
+
 function extractChoice(answer: string): MemBenchChoice | undefined {
   const trimmed = answer.trim().toUpperCase();
   if (/^[ABCD]$/.test(trimmed)) {
@@ -1043,9 +1050,7 @@ async function scoreRecallAt10(
 
   try {
     const results = await system.search(
-      testCase.questionTime
-        ? `${testCase.question} (${testCase.questionTime})`
-        : testCase.question,
+      buildRecallQuery(testCase),
       10,
       sessionId,
     );

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -659,7 +659,7 @@ function appendTrajectoryTurn(
   const rememberCoordinate = () => {
     coordinateIndex.set(coordinateKey(coordinate), turns.length);
     if (coordinate.length === 1) {
-      coordinateIndex.set(coordinateKey([coordinate[0]!, 0]), turns.length);
+      coordinateIndex.set(coordinateKey([0, coordinate[0]!]), turns.length);
     }
   };
 
@@ -692,13 +692,12 @@ function appendTrajectoryTurn(
   const assistantText = firstString(turn.agent, turn.assistant, turn.assistant_message);
   if (userText || assistantText) {
     rememberCoordinate();
-    turns.push({
-      role: "assistant",
-      content: [
-        userText ? `'user': ${userText}` : undefined,
-        assistantText ? `'agent': ${assistantText}` : undefined,
-      ].filter(Boolean).join("; "),
-    });
+    if (userText) {
+      turns.push({ role: "user", content: userText });
+    }
+    if (assistantText) {
+      turns.push({ role: "assistant", content: assistantText });
+    }
     return true;
   }
   if (!speaker || !text) {
@@ -1121,9 +1120,6 @@ function parseTargetStepRefs(
         const mapped = coordinateIndex?.get(coordinateKey(numeric));
         if (mapped !== undefined) {
           candidates.add(mapped);
-        } else {
-          const [first, second] = numeric;
-          candidates.add(second * 3 + first);
         }
       } else if (numeric.length === 1) {
         candidates.add(numeric[0]!);

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -621,7 +621,7 @@ function normalizeTrajectoryTurns(
         if (!appendTrajectoryTurn(
           turn[nestedIndex],
           `${location}[${index}][${nestedIndex}]`,
-          [nestedIndex, index],
+          [index, nestedIndex],
           turns,
           coordinateIndex,
           speakerRoles,
@@ -789,28 +789,34 @@ function normalizeQaPairs(
 function resolveTargetRefSource(
   item: Record<string, unknown>,
 ): { value: unknown; kind: "ids" | "coordinates" } | undefined {
-  if (item.target_step_id !== undefined) {
+  if (hasUsableTargetRef(item.target_step_id)) {
     return { value: item.target_step_id, kind: "ids" };
   }
-  if (item.target_step_ids !== undefined) {
+  if (hasUsableTargetRef(item.target_step_ids)) {
     return { value: item.target_step_ids, kind: "ids" };
   }
-  if (item.targetStepIds !== undefined) {
+  if (hasUsableTargetRef(item.targetStepIds)) {
     return { value: item.targetStepIds, kind: "ids" };
   }
-  if (item.target_step_coordinates !== undefined) {
+  if (hasUsableTargetRef(item.target_step_coordinates)) {
     return { value: item.target_step_coordinates, kind: "coordinates" };
   }
-  if (item.targetStepCoordinates !== undefined) {
+  if (hasUsableTargetRef(item.targetStepCoordinates)) {
     return { value: item.targetStepCoordinates, kind: "coordinates" };
   }
-  if (item.target_step_coordinate !== undefined) {
+  if (hasUsableTargetRef(item.target_step_coordinate)) {
     return { value: item.target_step_coordinate, kind: "coordinates" };
   }
-  if (item.targetStepCoordinate !== undefined) {
+  if (hasUsableTargetRef(item.targetStepCoordinate)) {
     return { value: item.targetStepCoordinate, kind: "coordinates" };
   }
   return undefined;
+}
+
+function hasUsableTargetRef(value: unknown): boolean {
+  return value !== undefined
+    && value !== null
+    && (!Array.isArray(value) || value.length > 0);
 }
 
 function resolveCaseId(

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -840,6 +840,9 @@ function resolveTargetRefSource(
 }
 
 function hasUsableTargetRef(value: unknown): boolean {
+  if (typeof value === "string") {
+    return value.trim().length > 0;
+  }
   return value !== undefined
     && value !== null
     && (!Array.isArray(value) || value.length > 0);

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -233,6 +233,12 @@ function createOfficialPairedCoordinateDataset() {
               answer: "B",
               target_step_id: [0, 1],
             },
+            {
+              question: "Which target ids should remain scalar ids?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_id: [3, 7],
+            },
           ],
         },
       ],
@@ -279,6 +285,32 @@ function createLetterAnswerNonChoiceDataset() {
       ],
       question: "What single-letter code did I give?",
       answer: "A",
+    },
+  ];
+}
+
+function createFlatChoiceOnlyDataset() {
+  return [
+    {
+      id: "flat-choice-only",
+      memoryType: "factual",
+      scenario: "observation",
+      level: "low_level",
+      turns: [
+        {
+          role: "user",
+          content: "Avery now lives in Porto near the river walk.",
+        },
+      ],
+      question: "Where does Avery live?",
+      choices: {
+        A: "Lisbon",
+        B: "Porto",
+        C: "Madrid",
+        D: "Seville",
+      },
+      correctChoice: "B",
+      targetStepIds: [0],
     },
   ];
 }
@@ -511,7 +543,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 3);
+  assert.equal(result.results.tasks.length, 4);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -521,6 +553,40 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.deepEqual(result.results.tasks[2]?.details?.targetStepCoordinates, [[0, 1]]);
   assert.deepEqual(result.results.tasks[2]?.details?.targetStepIds, [2]);
   assert.equal(result.results.tasks[2]?.scores.membench_recall_at_10, 0);
+  assert.deepEqual(result.results.tasks[3]?.details?.targetStepIds, [3, 7]);
+});
+
+test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-flat-choice-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "B",
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "membench.json"),
+    JSON.stringify(createFlatChoiceOnlyDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "B");
+  assert.equal(task.details?.correctAnswer, "Porto");
+  assert.equal(task.scores.membench_accuracy, 1);
 });
 
 test("runBenchmark keeps flat aliases from overwriting nested MemBench coordinates", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -155,7 +155,7 @@ function createOfficialChoiceDataset() {
               D: "Seville",
             },
             answer: "B",
-            target_step_id: [0],
+            target_step_id: "0",
           },
         },
       ],
@@ -223,6 +223,7 @@ function createOfficialPairedCoordinateDataset() {
               question: "Which item did I choose second?",
               choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
               answer: "B",
+              target_step_id: "not-a-number",
               target_step_coordinates: [[0, 0, 1], [0, 1]],
             },
           ],
@@ -371,6 +372,15 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-mcq-"));
   const datasetDir = path.join(tmpDir, "datasets", "membench");
   const adapter = new FakeMemoryAdapter();
+  adapter.search = async (_query, _limit, sessionId) => [
+    {
+      turnIndex: 0,
+      role: "user",
+      snippet: "Avery moved to Porto last year to be closer to the river walk.",
+      sessionId,
+      score: 1,
+    },
+  ];
   adapter.responder = {
     async respond() {
       return {
@@ -454,6 +464,15 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-paired-coords-"));
   const datasetDir = path.join(tmpDir, "datasets", "membench");
   const adapter = new FakeMemoryAdapter();
+  adapter.search = async (_query, _limit, sessionId) => [
+    {
+      turnIndex: 1,
+      role: "assistant",
+      snippet: "The blue mug choice is saved.",
+      sessionId,
+      score: 1,
+    },
+  ];
   adapter.responder = {
     async respond() {
       return {
@@ -480,8 +499,10 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.equal(result.results.tasks.length, 2);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
+  assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [0, 1]]);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepIds, [1, 2]);
+  assert.equal(result.results.tasks[1]?.scores.membench_recall_at_10, 0.5);
 });
 
 test("runBenchmark keeps flat aliases from overwriting nested MemBench coordinates", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -186,7 +186,7 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_coordinates: [[0, 1], [0, 1, 1]],
+            target_step_coordinates: [[1, 0], [1, 0, 1]],
           },
         },
       ],
@@ -216,13 +216,14 @@ function createOfficialPairedCoordinateDataset() {
               question: "Which item did the assistant acknowledge first?",
               choices: ["red pen", "blue mug", "black bag", "white lamp"],
               answer: "B",
+              target_step_id: [],
               target_step_coordinate: [0, 0, 1],
             },
             {
               question: "Which item did I choose second?",
               choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
               answer: "B",
-              target_step_coordinates: [[0, 0, 1], [1, 0]],
+              target_step_coordinates: [[0, 0, 1], [0, 1]],
             },
           ],
         },
@@ -415,7 +416,7 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 4);
-  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1], [0, 1, 1]]);
+  assert.deepEqual(task.details?.targetStepCoordinates, [[1, 0], [1, 0, 1]]);
   assert.deepEqual(task.details?.targetStepIds, [2, 3]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
@@ -454,7 +455,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.equal(result.results.tasks.length, 2);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
-  assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [1, 0]]);
+  assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [0, 1]]);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepIds, [1, 2]);
 });
 

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -185,6 +185,25 @@ function createOfficialParticipantDataset() {
   };
 }
 
+function createLetterAnswerNonChoiceDataset() {
+  return [
+    {
+      id: "letter-answer-no-choices",
+      memoryType: "factual",
+      scenario: "participant",
+      level: "surface",
+      turns: [
+        {
+          role: "user",
+          content: "A",
+        },
+      ],
+      question: "What single-letter code did I give?",
+      answer: "A",
+    },
+  ];
+}
+
 test("runBenchmark executes membench in quick mode through the phase-1 package API", async () => {
   const adapter = new FakeMemoryAdapter();
 
@@ -282,7 +301,7 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
   adapter.responder = {
     async respond() {
       return {
-        text: '{"choice":"B"}',
+        text: "A is plausible, but the final answer is B.",
         tokens: { input: 3, output: 1 },
         latencyMs: 2,
         model: "fake-choice-model",
@@ -354,6 +373,65 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,
     1,
   );
+});
+
+test("runBenchmark surfaces MemBench recall@10 search failures", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-search-error-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.search = async () => {
+    throw new Error("search offline");
+  };
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "B",
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataLowLevel.json"),
+    JSON.stringify(createOfficialChoiceDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, -1);
+  assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
+});
+
+test("runBenchmark treats bare letter answers as exact-answer cases when choices are absent", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-letter-answer-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "membench.json"),
+    JSON.stringify(createLetterAnswerNonChoiceDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "A");
+  assert.equal(task.actual, "A");
+  assert.equal(task.details?.correctChoice, undefined);
+  assert.equal(task.details?.officialProtocol, "exact_answer_accuracy");
+  assert.equal(task.scores.membench_accuracy, 1);
 });
 
 test("runBenchmark rejects membench full mode without datasetDir", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -168,10 +168,16 @@ function createOfficialParticipantDataset() {
       FirstAgentDataHighLevel: [
         {
           message_list: [
-            {
-              user: "I loved Alien (1979), especially the practical tension.",
-              agent: "Alien (1979) fits your taste for tense sci-fi.",
-            },
+            [
+              {
+                user: "I liked Toy Story when we discussed lighter animation.",
+                agent: "Toy Story is a lighter animation preference.",
+              },
+              {
+                user: "I loved Alien (1979), especially the practical tension.",
+                agent: "Alien (1979) fits your taste for tense sci-fi.",
+              },
+            ],
           ],
           QA: {
             question: "Which movie preference should the assistant remember?",
@@ -409,6 +415,29 @@ test("runBenchmark surfaces MemBench recall@10 search failures", async () => {
 
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, -1);
   assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
+});
+
+test("runBenchmark does not infer MCQ choices from recalled text without a responder", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-no-responder-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataLowLevel.json"),
+    JSON.stringify(createOfficialChoiceDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "B");
+  assert.notEqual(task.actual, "B");
+  assert.equal(task.scores.membench_accuracy, 0);
 });
 
 test("runBenchmark treats bare letter answers as exact-answer cases when choices are absent", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -245,6 +245,12 @@ function createOfficialPairedCoordinateDataset() {
               answer: "B",
               target_step_coordinate: [0, 99],
             },
+            {
+              question: "Which malformed coordinate should fail closed?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_coordinate: [0, null],
+            },
           ],
         },
       ],
@@ -549,7 +555,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 5);
+  assert.equal(result.results.tasks.length, 6);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -563,6 +569,9 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.deepEqual(result.results.tasks[4]?.details?.targetStepCoordinates, [[0, 99]]);
   assert.equal(result.results.tasks[4]?.details?.targetStepIds, undefined);
   assert.equal(result.results.tasks[4]?.scores.membench_recall_at_10, undefined);
+  assert.equal(result.results.tasks[5]?.details?.targetStepCoordinates, undefined);
+  assert.equal(result.results.tasks[5]?.details?.targetStepIds, undefined);
+  assert.equal(result.results.tasks[5]?.scores.membench_recall_at_10, undefined);
 });
 
 test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -177,7 +177,7 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_id: [[0, 0]],
+            target_step_id: [[1, 0]],
           },
         },
       ],
@@ -368,6 +368,8 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 2);
+  assert.deepEqual(task.details?.targetStepCoordinates, [[1, 0]]);
+  assert.deepEqual(task.details?.targetStepIds, [0, 1, 2]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -173,6 +173,8 @@ function createOfficialParticipantDataset() {
                 user: "I liked Toy Story when we discussed lighter animation.",
                 agent: "Toy Story is a lighter animation preference.",
               },
+            ],
+            [
               {
                 user: "I loved Alien (1979), especially the practical tension.",
                 agent: "Alien (1979) fits your taste for tense sci-fi.",
@@ -183,7 +185,7 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_id: [[1, 0]],
+            target_step_id: [[0, 1]],
           },
         },
       ],
@@ -307,7 +309,7 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
   adapter.responder = {
     async respond() {
       return {
-        text: "A is plausible, but the final answer is B.",
+        text: "Option A is plausible, but the final answer is B.",
         tokens: { input: 3, output: 1 },
         latencyMs: 2,
         model: "fake-choice-model",
@@ -374,7 +376,7 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 2);
-  assert.deepEqual(task.details?.targetStepCoordinates, [[1, 0]]);
+  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1]]);
   assert.deepEqual(task.details?.targetStepIds, [1]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -377,9 +377,9 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.actual, "B");
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
-  assert.equal(task.details?.turnCount, 2);
+  assert.equal(task.details?.turnCount, 4);
   assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1]]);
-  assert.deepEqual(task.details?.targetStepIds, [1]);
+  assert.deepEqual(task.details?.targetStepIds, [2]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -186,8 +186,45 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_coordinates: [[0, 1], [1, 1]],
+            target_step_coordinates: [[0, 1], [0, 1, 1]],
           },
+        },
+      ],
+    },
+  };
+}
+
+function createOfficialPairedCoordinateDataset() {
+  return {
+    factual: {
+      FirstAgentDataLowLevel: [
+        {
+          message_list: [
+            [
+              {
+                user: "I chose the blue mug for my desk.",
+                agent: "The blue mug choice is saved.",
+              },
+              {
+                user: "I chose the green notebook for travel.",
+                agent: "The green notebook choice is saved.",
+              },
+            ],
+          ],
+          QA: [
+            {
+              question: "Which item did the assistant acknowledge first?",
+              choices: ["red pen", "blue mug", "black bag", "white lamp"],
+              answer: "B",
+              target_step_coordinate: [0, 0, 1],
+            },
+            {
+              question: "Which item did I choose second?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_coordinates: [[0, 0, 1], [1, 0]],
+            },
+          ],
         },
       ],
     },
@@ -378,13 +415,47 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 4);
-  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1], [1, 1]]);
+  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1], [0, 1, 1]]);
   assert.deepEqual(task.details?.targetStepIds, [2, 3]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,
     1,
   );
+});
+
+test("runBenchmark maps singular and paired MemBench coordinate tuples without collisions", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-paired-coords-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "B",
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "FirstAgentDataLowLevel.json"),
+    JSON.stringify(createOfficialPairedCoordinateDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 2);
+  assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
+  assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
+  assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [1, 0]]);
+  assert.deepEqual(result.results.tasks[1]?.details?.targetStepIds, [1, 2]);
 });
 
 test("runBenchmark surfaces MemBench recall@10 search failures", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -549,6 +549,34 @@ test("runBenchmark surfaces MemBench recall@10 search failures", async () => {
   assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
 });
 
+test("runBenchmark includes official MemBench failure sentinels on task errors", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-task-error-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.recall = async () => {
+    throw new Error("recall offline");
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataLowLevel.json"),
+    JSON.stringify(createOfficialChoiceDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "B");
+  assert.equal(task.scores.membench_accuracy, -1);
+  assert.equal(task.scores.membench_recall_at_10, -1);
+  assert.equal(result.results.aggregates.membench_accuracy?.mean, -1);
+  assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
+});
+
 test("runBenchmark does not infer MCQ choices from recalled text without a responder", async () => {
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-no-responder-"));
   const datasetDir = path.join(tmpDir, "datasets", "membench");

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -232,6 +232,30 @@ function createOfficialPairedCoordinateDataset() {
   };
 }
 
+function createMixedFlatNestedCoordinateDataset() {
+  return {
+    factual: {
+      ThirdAgentDataLowLevel: [
+        {
+          message_list: [
+            [
+              "Avery booked the first train to Porto.",
+              "Avery booked the second train to Lisbon.",
+            ],
+            "Avery later reserved a ferry to Seville.",
+          ],
+          QA: {
+            question: "Which second train did Avery book?",
+            choices: ["Madrid", "Lisbon", "Porto", "Seville"],
+            answer: "B",
+            target_step_coordinate: [0, 1],
+          },
+        },
+      ],
+    },
+  };
+}
+
 function createLetterAnswerNonChoiceDataset() {
   return [
     {
@@ -457,6 +481,38 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [0, 1]]);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepIds, [1, 2]);
+});
+
+test("runBenchmark keeps flat aliases from overwriting nested MemBench coordinates", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-mixed-coords-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "B",
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataLowLevel.json"),
+    JSON.stringify(createMixedFlatNestedCoordinateDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1]]);
+  assert.deepEqual(task.details?.targetStepIds, [1]);
 });
 
 test("runBenchmark surfaces MemBench recall@10 search failures", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -264,6 +264,12 @@ function createOfficialPairedCoordinateDataset() {
               target_step_id: [0, null],
               target_step_coordinates: [[0, 0, 1]],
             },
+            {
+              question: "Which scalar coordinate should fail closed?",
+              choices: ["red pen", "blue mug", "black bag", "white lamp"],
+              answer: "B",
+              target_step_coordinate: "0",
+            },
           ],
         },
       ],
@@ -568,7 +574,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 8);
+  assert.equal(result.results.tasks.length, 9);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -588,6 +594,8 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.equal(result.results.tasks[6]?.scores.membench_recall_at_10, undefined);
   assert.deepEqual(result.results.tasks[7]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[7]?.details?.targetStepIds, [1]);
+  assert.equal(result.results.tasks[8]?.details?.targetStepCoordinates, undefined);
+  assert.equal(result.results.tasks[8]?.details?.targetStepIds, undefined);
 });
 
 test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -216,7 +216,7 @@ function createOfficialPairedCoordinateDataset() {
               question: "Which item did the assistant acknowledge first?",
               choices: ["red pen", "blue mug", "black bag", "white lamp"],
               answer: "B",
-              target_step_id: [],
+              target_step_id: " ",
               target_step_coordinate: [0, 0, 1],
             },
             {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -240,6 +240,12 @@ function createOfficialPairedCoordinateDataset() {
               target_step_id: [3, 7],
             },
             {
+              question: "Which one-item target id array should remain scalar?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_id: [3],
+            },
+            {
               question: "Which invalid coordinate should not be remapped?",
               choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
               answer: "B",
@@ -555,7 +561,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 6);
+  assert.equal(result.results.tasks.length, 7);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -566,12 +572,13 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.deepEqual(result.results.tasks[2]?.details?.targetStepIds, [2]);
   assert.equal(result.results.tasks[2]?.scores.membench_recall_at_10, 0);
   assert.deepEqual(result.results.tasks[3]?.details?.targetStepIds, [3, 7]);
-  assert.deepEqual(result.results.tasks[4]?.details?.targetStepCoordinates, [[0, 99]]);
-  assert.equal(result.results.tasks[4]?.details?.targetStepIds, undefined);
-  assert.equal(result.results.tasks[4]?.scores.membench_recall_at_10, undefined);
-  assert.equal(result.results.tasks[5]?.details?.targetStepCoordinates, undefined);
+  assert.deepEqual(result.results.tasks[4]?.details?.targetStepIds, [3]);
+  assert.deepEqual(result.results.tasks[5]?.details?.targetStepCoordinates, [[0, 99]]);
   assert.equal(result.results.tasks[5]?.details?.targetStepIds, undefined);
   assert.equal(result.results.tasks[5]?.scores.membench_recall_at_10, undefined);
+  assert.equal(result.results.tasks[6]?.details?.targetStepCoordinates, undefined);
+  assert.equal(result.results.tasks[6]?.details?.targetStepIds, undefined);
+  assert.equal(result.results.tasks[6]?.scores.membench_recall_at_10, undefined);
 });
 
 test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -257,6 +257,13 @@ function createOfficialPairedCoordinateDataset() {
               answer: "B",
               target_step_coordinate: [0, null],
             },
+            {
+              question: "Which partial id array should use coordinates?",
+              choices: ["red pen", "blue mug", "black bag", "white lamp"],
+              answer: "B",
+              target_step_id: [0, null],
+              target_step_coordinates: [[0, 0, 1]],
+            },
           ],
         },
       ],
@@ -561,7 +568,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 7);
+  assert.equal(result.results.tasks.length, 8);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -579,6 +586,8 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.equal(result.results.tasks[6]?.details?.targetStepCoordinates, undefined);
   assert.equal(result.results.tasks[6]?.details?.targetStepIds, undefined);
   assert.equal(result.results.tasks[6]?.scores.membench_recall_at_10, undefined);
+  assert.deepEqual(result.results.tasks[7]?.details?.targetStepCoordinates, [[0, 0, 1]]);
+  assert.deepEqual(result.results.tasks[7]?.details?.targetStepIds, [1]);
 });
 
 test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -227,6 +227,12 @@ function createOfficialPairedCoordinateDataset() {
               target_step_id: "not-a-number",
               target_step_coordinates: [[0, 0, 1], [0, 1]],
             },
+            {
+              question: "Which item did I choose second when using tuple ids?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_id: [0, 1],
+            },
           ],
         },
       ],
@@ -497,13 +503,16 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 2);
+  assert.equal(result.results.tasks.length, 3);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepCoordinates, [[0, 0, 1], [0, 1]]);
   assert.deepEqual(result.results.tasks[1]?.details?.targetStepIds, [1, 2]);
   assert.equal(result.results.tasks[1]?.scores.membench_recall_at_10, 0.5);
+  assert.deepEqual(result.results.tasks[2]?.details?.targetStepCoordinates, [[0, 1]]);
+  assert.deepEqual(result.results.tasks[2]?.details?.targetStepIds, [2]);
+  assert.equal(result.results.tasks[2]?.scores.membench_recall_at_10, 0);
 });
 
 test("runBenchmark keeps flat aliases from overwriting nested MemBench coordinates", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -369,7 +369,7 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 2);
   assert.deepEqual(task.details?.targetStepCoordinates, [[1, 0]]);
-  assert.deepEqual(task.details?.targetStepIds, [0, 1, 2]);
+  assert.deepEqual(task.details?.targetStepIds, [1]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -105,6 +105,7 @@ function createDatasetCases() {
       ],
       question: "Which city did I move to last spring?",
       answer: "Lisbon",
+      targetStepCoordinates: [[0, 0]],
     },
   ];
 }
@@ -185,7 +186,7 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_id: [[0, 1]],
+            target_step_coordinates: [[0, 1]],
           },
         },
       ],
@@ -253,6 +254,7 @@ test("runBenchmark executes membench in full mode from an explicit dataset file"
   assert.equal(result.results.tasks.length, 1);
   assert.equal(result.results.tasks[0]?.expected, "Lisbon");
   assert.equal(result.results.tasks[0]?.details.scenario, "participant");
+  assert.deepEqual(result.results.tasks[0]?.details.targetStepCoordinates, [[0, 0]]);
 });
 
 test("runBenchmark accepts upstream MemBench export filenames in full mode", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -317,6 +317,7 @@ test("runBenchmark executes membench in full mode from an explicit dataset file"
   assert.equal(result.results.tasks[0]?.expected, "Lisbon");
   assert.equal(result.results.tasks[0]?.details.scenario, "participant");
   assert.deepEqual(result.results.tasks[0]?.details.targetStepCoordinates, [[0, 0]]);
+  assert.deepEqual(result.results.tasks[0]?.details.targetStepIds, [0]);
 });
 
 test("runBenchmark accepts upstream MemBench export filenames in full mode", async () => {
@@ -573,8 +574,14 @@ test("runBenchmark includes official MemBench failure sentinels on task errors",
   assert.equal(task.expected, "B");
   assert.equal(task.scores.membench_accuracy, -1);
   assert.equal(task.scores.membench_recall_at_10, -1);
+  assert.equal(task.details?.memoryType, "factual");
+  assert.equal(task.details?.scenario, "observation");
   assert.equal(result.results.aggregates.membench_accuracy?.mean, -1);
   assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
+  assert.equal(
+    result.results.aggregates.membench_accuracy_factual_observation?.mean,
+    -1,
+  );
 });
 
 test("runBenchmark does not infer MCQ choices from recalled text without a responder", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -105,6 +105,7 @@ function createDatasetCases() {
       ],
       question: "Which city did I move to last spring?",
       answer: "Lisbon",
+      targetStepIds: [[0, 0]],
       targetStepCoordinates: [[0, 0]],
     },
   ];

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -239,6 +239,12 @@ function createOfficialPairedCoordinateDataset() {
               answer: "B",
               target_step_id: [3, 7],
             },
+            {
+              question: "Which invalid coordinate should not be remapped?",
+              choices: ["blue mug", "green notebook", "yellow folder", "silver watch"],
+              answer: "B",
+              target_step_coordinate: [0, 99],
+            },
           ],
         },
       ],
@@ -543,7 +549,7 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
     system: adapter,
   });
 
-  assert.equal(result.results.tasks.length, 4);
+  assert.equal(result.results.tasks.length, 5);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepCoordinates, [[0, 0, 1]]);
   assert.deepEqual(result.results.tasks[0]?.details?.targetStepIds, [1]);
   assert.equal(result.results.tasks[0]?.scores.membench_recall_at_10, 1);
@@ -554,6 +560,9 @@ test("runBenchmark maps singular and paired MemBench coordinate tuples without c
   assert.deepEqual(result.results.tasks[2]?.details?.targetStepIds, [2]);
   assert.equal(result.results.tasks[2]?.scores.membench_recall_at_10, 0);
   assert.deepEqual(result.results.tasks[3]?.details?.targetStepIds, [3, 7]);
+  assert.deepEqual(result.results.tasks[4]?.details?.targetStepCoordinates, [[0, 99]]);
+  assert.equal(result.results.tasks[4]?.details?.targetStepIds, undefined);
+  assert.equal(result.results.tasks[4]?.scores.membench_recall_at_10, undefined);
 });
 
 test("runBenchmark accepts flat MCQ cases with choices and correctChoice only", async () => {
@@ -684,8 +693,12 @@ test("runBenchmark includes official MemBench failure sentinels on task errors",
   assert.equal(result.results.aggregates.membench_accuracy?.mean, -1);
   assert.equal(result.results.aggregates.membench_recall_at_10?.mean, -1);
   assert.equal(
-    result.results.aggregates.membench_accuracy_factual_observation?.mean,
-    -1,
+    result.results.aggregates.membench_accuracy_factual_observation,
+    undefined,
+  );
+  assert.equal(
+    result.results.aggregates.membench_error_rate_factual_observation?.mean,
+    1,
   );
 });
 

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
+  BenchResponder,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -12,6 +13,7 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  responder?: BenchResponder;
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
     const existing = this.sessions.get(sessionId) ?? [];
@@ -34,9 +36,14 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
       : [...this.sessions.entries()];
 
     const results: SearchResult[] = [];
+    const queryTerms = query.toLowerCase().split(/\W+/).filter((term) => term.length > 3);
     for (const [currentSessionId, messages] of haystack) {
       messages.forEach((message, index) => {
-        if (message.content.toLowerCase().includes(query.toLowerCase())) {
+        const content = message.content.toLowerCase();
+        if (
+          content.includes(query.toLowerCase())
+          || queryTerms.some((term) => content.includes(term))
+        ) {
           results.push({
             turnIndex: index,
             role: message.role,
@@ -124,6 +131,57 @@ function createNestedPublishedDataset() {
         ],
       },
     ],
+  };
+}
+
+function createOfficialChoiceDataset() {
+  return {
+    factual: {
+      ThirdAgentDataLowLevel: [
+        {
+          message_list: [
+            "Avery moved to Porto last year to be closer to the river walk.",
+            "Avery now lives in Porto near the river walk.",
+          ],
+          QA: {
+            id: "official-mcq-1",
+            question: "Which city did Avery move to last year?",
+            time: "2026-04-01",
+            choices: {
+              A: "Lisbon",
+              B: "Porto",
+              C: "Madrid",
+              D: "Seville",
+            },
+            answer: "B",
+            target_step_id: [0],
+          },
+        },
+      ],
+    },
+  };
+}
+
+function createOfficialParticipantDataset() {
+  return {
+    preference: {
+      FirstAgentDataHighLevel: [
+        {
+          message_list: [
+            {
+              user: "I loved Alien (1979), especially the practical tension.",
+              agent: "Alien (1979) fits your taste for tense sci-fi.",
+            },
+          ],
+          QA: {
+            question: "Which movie preference should the assistant remember?",
+            choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
+            answer: "Alien (1979)",
+            target_step_id: [[0, 0]],
+          },
+        },
+      ],
+    },
   };
 }
 
@@ -215,6 +273,87 @@ test("runBenchmark normalizes nested published MemBench trajectory and qa struct
   assert.equal(result.results.tasks[0]?.question, "Which city did Avery move to last year?");
   assert.equal(result.results.tasks[0]?.details.memoryType, "reflective");
   assert.equal(result.results.tasks[0]?.details.scenario, "observation");
+});
+
+test("runBenchmark scores official MemBench multiple-choice accuracy and recall", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-mcq-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: '{"choice":"B"}',
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "ThirdAgentDataLowLevel.json"),
+    JSON.stringify(createOfficialChoiceDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "B");
+  assert.equal(task.actual, "B");
+  assert.equal(task.scores.membench_accuracy, 1);
+  assert.equal(task.scores.membench_recall_at_10, 1);
+  assert.equal(task.details?.correctAnswer, "Porto");
+  assert.equal(task.details?.officialProtocol, "multiple_choice_accuracy");
+  assert.equal(result.results.aggregates.membench_accuracy?.mean, 1);
+  assert.equal(
+    result.results.aggregates.membench_accuracy_factual_observation?.mean,
+    1,
+  );
+});
+
+test("runBenchmark accepts official first-agent message_list and QA records", async () => {
+  const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-first-agent-"));
+  const datasetDir = path.join(tmpDir, "datasets", "membench");
+  const adapter = new FakeMemoryAdapter();
+  adapter.responder = {
+    async respond() {
+      return {
+        text: "B",
+        tokens: { input: 3, output: 1 },
+        latencyMs: 2,
+        model: "fake-choice-model",
+      };
+    },
+  };
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "FirstAgentDataHighLevel.json"),
+    JSON.stringify(createOfficialParticipantDataset()),
+    "utf8",
+  );
+
+  const result = await runBenchmark("membench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const task = result.results.tasks[0]!;
+  assert.equal(task.expected, "B");
+  assert.equal(task.actual, "B");
+  assert.equal(task.details?.memoryType, "reflective");
+  assert.equal(task.details?.scenario, "participant");
+  assert.equal(task.details?.turnCount, 2);
+  assert.equal(task.scores.membench_accuracy, 1);
+  assert.equal(
+    result.results.aggregates.membench_accuracy_reflective_participant?.mean,
+    1,
+  );
 });
 
 test("runBenchmark rejects membench full mode without datasetDir", async () => {

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -379,6 +379,13 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
   const tmpDir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-membench-mcq-"));
   const datasetDir = path.join(tmpDir, "datasets", "membench");
   const adapter = new FakeMemoryAdapter();
+  let recallQuery = "";
+  adapter.recall = async (sessionId, query) => {
+    recallQuery = query;
+    return (adapter.sessions.get(sessionId) ?? [])
+      .map((message) => message.content)
+      .join("\n");
+  };
   adapter.search = async (_query, _limit, sessionId) => [
     {
       turnIndex: 0,
@@ -416,6 +423,7 @@ test("runBenchmark scores official MemBench multiple-choice accuracy and recall"
   assert.equal(task.actual, "B");
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(task.scores.membench_recall_at_10, 1);
+  assert.match(recallQuery, /2026-04-01/);
   assert.equal(task.details?.correctAnswer, "Porto");
   assert.equal(task.details?.officialProtocol, "multiple_choice_accuracy");
   assert.equal(result.results.aggregates.membench_accuracy?.mean, 1);

--- a/tests/bench-membench-runner.test.ts
+++ b/tests/bench-membench-runner.test.ts
@@ -186,7 +186,7 @@ function createOfficialParticipantDataset() {
             question: "Which movie preference should the assistant remember?",
             choices: ["Toy Story", "Alien (1979)", "Heat", "Jaws"],
             answer: "Alien (1979)",
-            target_step_coordinates: [[0, 1]],
+            target_step_coordinates: [[0, 1], [1, 1]],
           },
         },
       ],
@@ -378,8 +378,8 @@ test("runBenchmark accepts official first-agent message_list and QA records", as
   assert.equal(task.details?.memoryType, "reflective");
   assert.equal(task.details?.scenario, "participant");
   assert.equal(task.details?.turnCount, 4);
-  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1]]);
-  assert.deepEqual(task.details?.targetStepIds, [2]);
+  assert.deepEqual(task.details?.targetStepCoordinates, [[0, 1], [1, 1]]);
+  assert.deepEqual(task.details?.targetStepIds, [2, 3]);
   assert.equal(task.scores.membench_accuracy, 1);
   assert.equal(
     result.results.aggregates.membench_accuracy_reflective_participant?.mean,


### PR DESCRIPTION
## Summary
- preserve MemBench official choices, correct letters, question time, and target evidence ids
- score `membench_accuracy` with official multiple-choice answers when choices are present
- parse official `message_list`/`QA` files for first-agent and third-agent datasets, plus existing normalized formats
- emit category-specific MemBench accuracy aggregates for factual/reflective participation/observation comparisons

## Test Plan
- `pnpm exec tsx --test tests/bench-membench-runner.test.ts`
- `pnpm --filter @remnic/core build`
- `pnpm --filter @remnic/bench check-types`
- `git diff --check`

## Notes
- `npm run preflight:quick` was started after the focused checks. It reported an existing unrelated failure in `direct adapter recall expands search hits with adjacent stored results`, then launched the broad test glob and was interrupted after several minutes of no output.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates MemBench dataset normalization and scoring logic (including new recall@10 and MCQ handling), which can change reported benchmark results and relies on parsing varied upstream dataset shapes.
> 
> **Overview**
> MemBench now supports the official multiple-choice protocol by carrying `choices`, `correctChoice`, `questionTime`, and target-evidence references through parsing and into task `details`.
> 
> When choices are present, the runner prompts for a single-letter answer, extracts the predicted option, scores `membench_accuracy` against the correct letter, and records the mapped answer text for other metrics/judging; it also adds `membench_recall_at_10` via `system.search` against the provided target step ids.
> 
> Dataset ingestion is expanded to accept official `message_list` + `QA` formats (including nested/paired message coordinates) and to emit new aggregate breakdowns for MemBench accuracy and error rate across factual/reflective × participant/observation categories. Extensive new tests cover MCQ scoring, coordinate/id remapping edge cases, and failure sentinels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 90c302e10ff1a59e7cd185f54569d96712321c6a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->