### PR TITLE
docs: index recently shipped feature guides in docs/README

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -34,6 +34,10 @@
 ## Feature Guides
 
 - [Advanced Retrieval](advanced-retrieval.md) — Reranking, query expansion, feedback loop
+- [Recall X-ray](xray.md) — Per-result retrieval attribution: which tier served each memory and why (issue #570)
+- [Temporal Recall](temporal-recall.md) — `valid_at` / `invalid_at` fact lifecycle and `as_of` recall filter (issue #680)
+- [Tags](tags.md) — Free-form tag filter on recall and propose; tags vs taxonomy (issue #689)
+- [Live Connectors](live-connectors.md) — Continuous-sync framework for external sources (issue #683)
 - [Context Retention](context-retention.md) — Transcript indexing, hourly summaries
 - [Namespaces](namespaces.md) — Multi-agent memory isolation (v3.0)
 - [Shared Context](shared-context.md) — Cross-agent shared intelligence (v4.0)


### PR DESCRIPTION
## Summary

Audit follow-up: four feature guides shipped under `docs/` but were never added to `docs/README.md` (the docs landing index):

- `docs/temporal-recall.md` — issue #680 (`valid_at`/`invalid_at` lifecycle + `as_of` filter)
- `docs/tags.md` — issue #689 (free-form tag filter on recall)
- `docs/live-connectors.md` — issue #683 (live-connector framework)
- `docs/xray.md` — issue #570 (Recall X-ray)

This PR adds them under the **Feature Guides** section. Pure index entries — no content changes, no code changes.

## Test plan

- [x] Files referenced exist on \`main\`.
- [x] \`npx tsc --noEmit\` from \`packages/remnic-core\` clean (docs-only diff).
- [x] No personal data, secrets, or memory content in the diff.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk docs-only change that adds links to existing guides; no code or behavior changes.
> 
> **Overview**
> Updates `docs/README.md` to include four recently shipped feature guides under **Feature Guides**: `xray.md`, `temporal-recall.md`, `tags.md`, and `live-connectors.md` (with short descriptions and issue references).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03fbf113d8a033cbd5ef732ce3abdbdf13c5df50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->