### PR TITLE
feat(console): operator console TUI (#688 PR 2/3)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7322,16 +7322,18 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(`  Cooled down: ${result.cooledDown}`);
         });
 
-      // ── Console subcommand (issue #688 PR 1/3) ──────────────────────────
-      // Structured engine-state aggregator. PR 1/3 ships only the
-      // `--state-only` flag which prints the snapshot as JSON. The
-      // interactive TUI (PR 2/3), HTTP `/console/state`, MCP
-      // `engram.console_state`, and trace replay (PR 3/3) land in
-      // follow-ups.
+      // ── Console subcommand (issue #688) ─────────────────────────────────
+      // PR 1/3 (#721) shipped the structured engine-state aggregator
+      // and the `--state-only` flag (one-shot JSON snapshot). PR 2/3
+      // wires the interactive TUI: invoking `remnic console` with no
+      // flags starts a clear+repaint refresh loop. Trace replay
+      // (`--trace <session-id>`) lands in PR 3/3 along with the HTTP
+      // `/console/state` endpoint and the MCP `engram.console_state`
+      // tool.
       cmd
         .command("console")
         .description(
-          "Operator console (issue #688). PR 1/3 ships --state-only, which emits a structured engine-state snapshot as JSON. The interactive TUI lands in PR 2/3.",
+          "Operator console (issue #688). With no flags: launches the interactive TUI. With --state-only: prints a single JSON snapshot and exits.",
         )
         .option(
           "--state-only",
@@ -7339,16 +7341,15 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         )
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
-          if (options.stateOnly !== true) {
-            console.error(
-              "remnic console: interactive TUI not yet available (issue #688 PR 2/3). Pass --state-only to print a JSON snapshot.",
-            );
-            process.exitCode = 1;
+          if (options.stateOnly === true) {
+            const { gatherConsoleState } = await import("./console/state.js");
+            const snapshot = await gatherConsoleState(orchestrator);
+            console.log(JSON.stringify(snapshot, null, 2));
             return;
           }
-          const { gatherConsoleState } = await import("./console/state.js");
-          const snapshot = await gatherConsoleState(orchestrator);
-          console.log(JSON.stringify(snapshot, null, 2));
+          const { runConsoleTui } = await import("./console/tui.js");
+          const handle = runConsoleTui(orchestrator);
+          await handle.done;
         });
     },
     { commands: ["engram"] },

--- a/packages/remnic-core/src/console/tui.test.ts
+++ b/packages/remnic-core/src/console/tui.test.ts
@@ -1,0 +1,207 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { Writable } from "node:stream";
+
+import {
+  renderFrame,
+  runConsoleTui,
+  stripAnsi,
+} from "./tui.js";
+import {
+  type ConsoleStateOrchestratorLike,
+  type ConsoleStateSnapshot,
+} from "./state.js";
+
+/**
+ * Test stream that accumulates writes into a buffer string. Used in
+ * place of `process.stdout` so we can assert what the TUI rendered.
+ */
+class CaptureStream extends Writable {
+  public chunks: string[] = [];
+  override _write(
+    chunk: unknown,
+    _enc: BufferEncoding,
+    cb: (err?: Error | null) => void,
+  ): void {
+    this.chunks.push(typeof chunk === "string" ? chunk : String(chunk));
+    cb();
+  }
+  text(): string {
+    return this.chunks.join("");
+  }
+  textPlain(): string {
+    return stripAnsi(this.text());
+  }
+}
+
+function makeOrchestrator(
+  overrides: Partial<ConsoleStateOrchestratorLike> = {},
+): ConsoleStateOrchestratorLike {
+  return {
+    config: { memoryDir: "/nonexistent" },
+    buffer: { getTurns: () => [] },
+    qmd: {
+      isAvailable: () => true,
+      isDaemonMode: () => true,
+      debugStatus: () => "stub",
+    },
+    ...overrides,
+  };
+}
+
+function makeSnapshot(
+  overrides: Partial<ConsoleStateSnapshot> = {},
+): ConsoleStateSnapshot {
+  return {
+    capturedAt: "2025-01-01T00:00:00.000Z",
+    bufferState: { turnsCount: 0, byteCount: 0 },
+    extractionQueue: { depth: 0, recentVerdicts: [] },
+    dedupRecent: [],
+    maintenanceLedgerTail: [],
+    qmdProbe: { available: true, daemonMode: true, debug: "" },
+    daemon: { uptimeMs: 0, version: "test" },
+    errors: [],
+    ...overrides,
+  };
+}
+
+test("renderFrame produces text containing each panel header", () => {
+  const frame = renderFrame({
+    snapshot: makeSnapshot({
+      bufferState: { turnsCount: 3, byteCount: 42 },
+      extractionQueue: {
+        depth: 5,
+        recentVerdicts: [
+          { ts: "2025-01-01T00:00:00.000Z", kind: "accept" },
+          { ts: "2025-01-01T00:00:01.000Z", kind: "accept" },
+          { ts: "2025-01-01T00:00:02.000Z", kind: "reject" },
+        ],
+      },
+      dedupRecent: [
+        {
+          ts: "2025-01-01T00:00:00.000Z",
+          decision: "admit",
+          fingerprint: "abc123",
+        },
+      ],
+      maintenanceLedgerTail: [
+        {
+          ts: "2025-01-01T00:00:00.000Z",
+          category: "judge-verdict",
+          summary: "verdict=accept",
+        },
+      ],
+    }),
+    renderError: null,
+    now: () => Date.parse("2025-01-01T00:00:10.000Z"),
+  });
+
+  const plain = stripAnsi(frame);
+  assert.match(plain, /remnic console/);
+  assert.match(plain, /Buffer\b/);
+  assert.match(plain, /turns=3 bytes=42/);
+  assert.match(plain, /Extraction\b/);
+  assert.match(plain, /queue=5/);
+  assert.match(plain, /accept\(2\)\/reject\(1\)/);
+  assert.match(plain, /Dedup\b/);
+  assert.match(plain, /hash=abc123/);
+  assert.match(plain, /decision=admit/);
+  assert.match(plain, /Maintenance\b/);
+  assert.match(plain, /judge-verdict/);
+  assert.match(plain, /QMD\b/);
+  assert.match(plain, /probe=ok/);
+});
+
+test("renderFrame surfaces a refresh error in the Error panel without losing layout", () => {
+  const frame = renderFrame({
+    snapshot: null,
+    renderError: "boom",
+    now: () => Date.parse("2025-01-01T00:00:00.000Z"),
+  });
+  const plain = stripAnsi(frame);
+  assert.match(plain, /Error/);
+  assert.match(plain, /refresh failed: boom/);
+  // Layout headers are still present so operators see the structure.
+  assert.match(plain, /Buffer\b/);
+  assert.match(plain, /Extraction\b/);
+  assert.match(plain, /Dedup\b/);
+  assert.match(plain, /Maintenance\b/);
+  assert.match(plain, /QMD\b/);
+});
+
+test("runConsoleTui repaints once on start and survives a snapshot failure", async () => {
+  const stream = new CaptureStream();
+  let calls = 0;
+  // Mock orchestrator: first call succeeds (via gatherConsoleState's
+  // defensive readers), second call throws when the buffer accessor
+  // is invoked. The loop must NOT crash.
+  const orchestrator: ConsoleStateOrchestratorLike = {
+    config: { memoryDir: "/nonexistent" },
+    qmd: {
+      isAvailable: () => true,
+      isDaemonMode: () => false,
+      debugStatus: () => "stub",
+    },
+    buffer: {
+      getTurns: () => {
+        calls += 1;
+        if (calls >= 2) {
+          throw new Error("simulated read failure");
+        }
+        return [{ content: "hi" }];
+      },
+    },
+  };
+
+  const handle = runConsoleTui(orchestrator, {
+    refreshIntervalMs: 50,
+    output: stream,
+    installSigintHandler: false,
+    now: () => Date.parse("2025-01-01T00:00:00.000Z"),
+  });
+
+  // Wait long enough for at least two ticks (initial paint + one
+  // interval-driven tick that exercises the failure path).
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  handle.stop();
+  await handle.done;
+
+  // Loop did not crash and we got at least one frame.
+  const text = stream.textPlain();
+  assert.match(text, /remnic console/);
+  assert.match(text, /Buffer\b/);
+  // Error from the failing buffer reader is captured by gatherConsoleState's
+  // try/catch and surfaced via the snapshot's `errors` array → Errors panel.
+  // It is NOT a renderError (which only fires for gatherConsoleState
+  // throwing outright). We assert the loop reached the second tick.
+  assert.ok(calls >= 2, `expected >= 2 buffer reads, got ${calls}`);
+});
+
+test("stop() clears the interval and resolves done", async () => {
+  const stream = new CaptureStream();
+  const orchestrator = makeOrchestrator();
+  const handle = runConsoleTui(orchestrator, {
+    refreshIntervalMs: 30,
+    output: stream,
+    installSigintHandler: false,
+  });
+
+  // Let it paint at least once.
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const beforeStop = stream.chunks.length;
+  handle.stop();
+  await handle.done;
+
+  // Wait past several would-be intervals and confirm no further paints.
+  await new Promise((resolve) => setTimeout(resolve, 150));
+  const afterStop = stream.chunks.length;
+  // A single trailing write (cursor restore) is allowed but no paints
+  // beyond that should happen.
+  assert.ok(
+    afterStop - beforeStop <= 1,
+    `expected interval to stop, saw ${afterStop - beforeStop} extra writes`,
+  );
+
+  // done() resolved (we already awaited it). Calling stop again is a no-op.
+  handle.stop();
+});

--- a/packages/remnic-core/src/console/tui.test.ts
+++ b/packages/remnic-core/src/console/tui.test.ts
@@ -177,6 +177,60 @@ test("runConsoleTui repaints once on start and survives a snapshot failure", asy
   assert.ok(calls >= 2, `expected >= 2 buffer reads, got ${calls}`);
 });
 
+test("renderFrame produces panel lines aligned with header/footer borders", () => {
+  // Cursor Medium regression: panel lines were 71 chars while
+  // header/footer were 72, misaligning the right-hand ║ column.
+  const frame = renderFrame({
+    snapshot: makeSnapshot(),
+    renderError: null,
+    now: () => Date.parse("2025-01-01T00:00:00.000Z"),
+  });
+  const lines = frame.split("\n").filter((l) => l.length > 0);
+  // First line is the header, last is the footer; everything between
+  // is a panel line. All must be the same visual width.
+  const widths = new Set(lines.map((l) => [...l].length));
+  assert.equal(
+    widths.size,
+    1,
+    `expected uniform line widths, saw ${[...widths].sort().join(", ")}`,
+  );
+});
+
+test("runConsoleTui survives a renderer-side exception without freezing", async () => {
+  // Cursor Low regression: if the render path threw after `inFlight`
+  // was set to true, the latch was never released and every
+  // subsequent tick silently bailed via `if (inFlight) return`. The
+  // try/finally fix should keep the loop ticking even if `now()`
+  // returns NaN (which makes `new Date(NaN).toISOString()` throw).
+  const stream = new CaptureStream();
+  const orchestrator = makeOrchestrator();
+  let nowCalls = 0;
+  const handle = runConsoleTui(orchestrator, {
+    refreshIntervalMs: 30,
+    output: stream,
+    installSigintHandler: false,
+    now: () => {
+      nowCalls += 1;
+      // First two calls poison the renderer; subsequent ticks recover.
+      if (nowCalls <= 2) return Number.NaN;
+      return Date.parse("2025-01-01T00:00:00.000Z");
+    },
+  });
+
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  handle.stop();
+  await handle.done;
+
+  // The loop kept ticking through the poisoned renders.
+  assert.ok(
+    nowCalls >= 3,
+    `expected loop to keep ticking past renderer failure, saw ${nowCalls} now() calls`,
+  );
+  // And eventually emitted a healthy frame.
+  const text = stream.textPlain();
+  assert.match(text, /remnic console/);
+});
+
 test("stop() clears the interval and resolves done", async () => {
   const stream = new CaptureStream();
   const orchestrator = makeOrchestrator();

--- a/packages/remnic-core/src/console/tui.ts
+++ b/packages/remnic-core/src/console/tui.ts
@@ -1,0 +1,335 @@
+/**
+ * Operator console TUI for issue #688 (PR 2/3).
+ *
+ * Renders a five-panel one-screen layout that periodically polls
+ * `gatherConsoleState` and repaints the terminal. Deliberately uses
+ * the minimal-deps "clear + repaint" approach (no curses / blessed /
+ * ink) — we just emit ANSI control sequences directly to the output
+ * stream. This keeps the surface portable and dependency-free.
+ *
+ * PR 1/3 (#721) shipped `gatherConsoleState` plus the CLI's
+ * `--state-only` flag (one-shot JSON snapshot). PR 2/3 wires the
+ * interactive surface. Trace replay (`--trace <session-id>`) is
+ * deferred to PR 3/3.
+ *
+ * Design contract:
+ *   - Read-only: never mutates orchestrator state.
+ *   - Resilient: a thrown error in one refresh cycle must NOT crash
+ *     the loop. Errors are surfaced inside the rendered frame.
+ *   - Cleanly stoppable: `runConsoleTui` returns a `stop()` that
+ *     clears the interval, restores the cursor, and resolves the
+ *     pending exit promise. SIGINT triggers the same cleanup.
+ *   - No external deps: only ANSI control sequences.
+ */
+
+import type { Writable } from "node:stream";
+
+import {
+  gatherConsoleState,
+  type ConsoleStateOrchestratorLike,
+  type ConsoleStateSnapshot,
+} from "./state.js";
+
+/** ANSI: clear screen + move cursor to home (top-left). */
+const ANSI_CLEAR_HOME = "\x1b[2J\x1b[H";
+/** ANSI: hide / show the cursor (we hide during the loop, restore on exit). */
+const ANSI_HIDE_CURSOR = "\x1b[?25l";
+const ANSI_SHOW_CURSOR = "\x1b[?25h";
+
+/** Total inner width of the rendered frame (between the box borders). */
+const FRAME_INNER_WIDTH = 70;
+
+/** Default refresh interval in milliseconds. Chosen to match the spec. */
+const DEFAULT_REFRESH_INTERVAL_MS = 2000;
+
+export interface RunConsoleTuiOptions {
+  /** Polling interval in milliseconds. Defaults to 2000ms. */
+  refreshIntervalMs?: number;
+  /** Output stream. Defaults to `process.stdout`. */
+  output?: Writable;
+  /**
+   * Optional clock injection — primarily for tests so the rendered
+   * timestamp is deterministic. Defaults to `Date.now`.
+   */
+  now?: () => number;
+  /**
+   * If true, install a SIGINT handler that calls `stop()` and resolves
+   * the returned promise. Defaults to true. Tests typically pass false.
+   */
+  installSigintHandler?: boolean;
+}
+
+export interface RunConsoleTuiHandle {
+  /** Stop the refresh loop, restore the cursor, and resolve `done`. */
+  stop: () => void;
+  /** Resolves once `stop()` has been invoked and cleanup ran. */
+  done: Promise<void>;
+}
+
+/**
+ * Start the operator console TUI. Returns immediately with a handle
+ * exposing `stop()` and a `done` promise that resolves once the loop
+ * has been torn down. The caller can `await handle.done` to block
+ * until the user (or a SIGINT) exits.
+ */
+export function runConsoleTui(
+  orchestrator: ConsoleStateOrchestratorLike,
+  options: RunConsoleTuiOptions = {},
+): RunConsoleTuiHandle {
+  const refreshIntervalMs = Math.max(
+    50,
+    options.refreshIntervalMs ?? DEFAULT_REFRESH_INTERVAL_MS,
+  );
+  const output: Writable = options.output ?? process.stdout;
+  const now = options.now ?? (() => Date.now());
+  const installSigintHandler = options.installSigintHandler ?? true;
+
+  let stopped = false;
+  let inFlight = false;
+  let resolveDone!: () => void;
+  const done = new Promise<void>((resolve) => {
+    resolveDone = resolve;
+  });
+
+  // Hide the cursor while the loop runs so the repaint doesn't flicker.
+  safeWrite(output, ANSI_HIDE_CURSOR);
+
+  const tick = async () => {
+    if (stopped || inFlight) return;
+    inFlight = true;
+    let snapshot: ConsoleStateSnapshot | null = null;
+    let renderError: string | null = null;
+    try {
+      snapshot = await gatherConsoleState(orchestrator);
+    } catch (err) {
+      renderError = describeError(err);
+    }
+    if (stopped) {
+      inFlight = false;
+      return;
+    }
+    const frame = renderFrame({ snapshot, renderError, now });
+    safeWrite(output, ANSI_CLEAR_HOME);
+    safeWrite(output, frame);
+    inFlight = false;
+  };
+
+  // Kick off an immediate first paint, then schedule the interval.
+  void tick();
+  const handle = setInterval(() => {
+    void tick();
+  }, refreshIntervalMs);
+  // Don't keep the event loop alive solely on the interval. Hosts that
+  // want the process to stay up should `await handle.done`.
+  if (typeof handle.unref === "function") handle.unref();
+
+  const sigintHandler = () => {
+    stop();
+  };
+  if (installSigintHandler) {
+    process.on("SIGINT", sigintHandler);
+  }
+
+  const stop = () => {
+    if (stopped) return;
+    stopped = true;
+    clearInterval(handle);
+    if (installSigintHandler) {
+      try {
+        process.removeListener("SIGINT", sigintHandler);
+      } catch {
+        // ignore
+      }
+    }
+    safeWrite(output, ANSI_SHOW_CURSOR);
+    resolveDone();
+  };
+
+  return { stop, done };
+}
+
+interface RenderFrameInput {
+  snapshot: ConsoleStateSnapshot | null;
+  renderError: string | null;
+  now: () => number;
+}
+
+/**
+ * Build the full rendered frame as a single string. Pure — exposed
+ * for testing.
+ */
+export function renderFrame(input: RenderFrameInput): string {
+  const ts = new Date(input.now()).toISOString();
+  const lines: string[] = [];
+  lines.push(renderHeader(ts));
+  for (const panel of renderPanels(input)) {
+    lines.push(panel);
+  }
+  lines.push(renderFooter());
+  return lines.join("\n") + "\n";
+}
+
+function renderHeader(ts: string): string {
+  // ╔═ remnic console ════════════════════════════════ <ts> ═╗
+  const title = " remnic console ";
+  const trailing = ` ${ts} `;
+  // 2 corner chars + title + ts + filler. Filler at minimum 1 char.
+  const fillerLen = Math.max(
+    1,
+    FRAME_INNER_WIDTH - title.length - trailing.length,
+  );
+  const filler = "═".repeat(fillerLen);
+  return `╔${title}${filler}${trailing}╗`;
+}
+
+function renderFooter(): string {
+  return `╚${"═".repeat(FRAME_INNER_WIDTH)}╝`;
+}
+
+function renderPanels(input: RenderFrameInput): string[] {
+  const lines: string[] = [];
+  const snap = input.snapshot;
+
+  if (input.renderError !== null) {
+    lines.push(panelLine("Error", `refresh failed: ${input.renderError}`));
+    // Even on error we still print the section headers so the layout
+    // stays stable for the operator and tests can locate them.
+    lines.push(panelLine("Buffer", "(unavailable)"));
+    lines.push(panelLine("Extraction", "(unavailable)"));
+    lines.push(panelLine("Dedup", "(unavailable)"));
+    lines.push(panelLine("Maintenance", "(unavailable)"));
+    lines.push(panelLine("QMD", "(unavailable)"));
+    return lines;
+  }
+
+  // Buffer panel.
+  if (snap) {
+    lines.push(
+      panelLine(
+        "Buffer",
+        `turns=${snap.bufferState.turnsCount} bytes=${snap.bufferState.byteCount}`,
+      ),
+    );
+
+    // Extraction panel.
+    const verdicts = snap.extractionQueue.recentVerdicts;
+    const accepts = verdicts.filter((v) => v.kind === "accept").length;
+    const rejects = verdicts.filter((v) => v.kind === "reject").length;
+    lines.push(
+      panelLine(
+        "Extraction",
+        `queue=${snap.extractionQueue.depth}  recent verdicts: accept(${accepts})/reject(${rejects})`,
+      ),
+    );
+
+    // Dedup panel.
+    const dedupSummary = formatDedupSummary(snap.dedupRecent, input.now);
+    lines.push(panelLine("Dedup", dedupSummary));
+
+    // Maintenance panel.
+    const maintSummary = formatMaintenanceTail(snap.maintenanceLedgerTail);
+    lines.push(panelLine("Maintenance", maintSummary));
+
+    // QMD panel.
+    lines.push(panelLine("QMD", formatQmdSummary(snap)));
+  }
+
+  // Surface aggregator-level read errors (e.g. ledger I/O failures)
+  // without crashing the loop. These are not fatal — the snapshot is
+  // still partially usable.
+  if (snap && snap.errors.length > 0) {
+    const head = snap.errors[0];
+    lines.push(panelLine("Errors", head ?? ""));
+  }
+
+  return lines;
+}
+
+function formatDedupSummary(
+  decisions: ConsoleStateSnapshot["dedupRecent"],
+  now: () => number,
+): string {
+  if (decisions.length === 0) return "no recent decisions";
+  const last = decisions[decisions.length - 1];
+  if (!last) return "no recent decisions";
+  const ageMs = ageMsFromIso(last.ts, now);
+  const ageStr = ageMs === null ? "T-?" : `T-${Math.round(ageMs / 1000)}s`;
+  const fp = last.fingerprint ? `hash=${last.fingerprint}` : "hash=?";
+  return `recent: ${fp} decision=${last.decision} (${ageStr})`;
+}
+
+function formatMaintenanceTail(
+  events: ConsoleStateSnapshot["maintenanceLedgerTail"],
+): string {
+  if (events.length === 0) return "no events";
+  const last = events[events.length - 1];
+  if (!last) return "no events";
+  // Show count + most-recent event line.
+  return `n=${events.length}  last: ${last.category} ${truncate(last.summary, 40)}`;
+}
+
+function formatQmdSummary(snap: ConsoleStateSnapshot): string {
+  const probe = snap.qmdProbe.available ? "ok" : "down";
+  const uptimeH = snap.daemon.uptimeMs / 3_600_000;
+  const uptimeStr = uptimeH < 1
+    ? `${Math.round(snap.daemon.uptimeMs / 1000)}s`
+    : `${uptimeH.toFixed(1)}h`;
+  const mode = snap.qmdProbe.daemonMode ? "daemon" : "cli";
+  return `probe=${probe}  mode=${mode}  uptime=${uptimeStr}`;
+}
+
+function panelLine(label: string, value: string): string {
+  // ║ <label padded to 13> <value padded to inner-width-15> ║
+  const labelCol = padRight(label, 13);
+  const remaining = FRAME_INNER_WIDTH - 1 - labelCol.length - 1;
+  // -1 for leading space, -1 for trailing space. We deliberately keep
+  // the layout simple — overflow is truncated rather than wrapped.
+  const valueCol = padRight(truncate(value, remaining), remaining);
+  return `║ ${labelCol}${valueCol}║`;
+}
+
+function padRight(s: string, width: number): string {
+  if (s.length >= width) return s;
+  return s + " ".repeat(width - s.length);
+}
+
+function truncate(s: string, max: number): string {
+  if (max <= 0) return "";
+  if (s.length <= max) return s;
+  if (max <= 1) return s.slice(0, max);
+  return s.slice(0, max - 1) + "…";
+}
+
+function ageMsFromIso(iso: string, now: () => number): number | null {
+  const ms = Date.parse(iso);
+  if (!Number.isFinite(ms)) return null;
+  const delta = now() - ms;
+  return delta < 0 ? 0 : delta;
+}
+
+function safeWrite(output: Writable, chunk: string): void {
+  try {
+    output.write(chunk);
+  } catch {
+    // Writing to a closed / broken stream is non-fatal for the TUI;
+    // the next tick will retry.
+  }
+}
+
+function describeError(err: unknown): string {
+  if (err instanceof Error) return err.message;
+  try {
+    return String(err);
+  } catch {
+    return "unknown error";
+  }
+}
+
+/**
+ * Strip ANSI escape sequences from a string. Exposed for tests so the
+ * rendered frame can be asserted against plain text.
+ */
+export function stripAnsi(s: string): string {
+  // eslint-disable-next-line no-control-regex
+  return s.replace(/\x1b\[[0-9;?]*[A-Za-z]/g, "");
+}

--- a/packages/remnic-core/src/console/tui.ts
+++ b/packages/remnic-core/src/console/tui.ts
@@ -97,31 +97,51 @@ export function runConsoleTui(
   const tick = async () => {
     if (stopped || inFlight) return;
     inFlight = true;
-    let snapshot: ConsoleStateSnapshot | null = null;
-    let renderError: string | null = null;
+    // Cursor Low: wrap the entire body in try/finally so a thrown
+    // `renderFrame` (or any other unexpected sync failure after the
+    // gatherConsoleState try/catch) still releases the `inFlight`
+    // latch. Without this guard, a single render-time exception
+    // permanently freezes the loop because every subsequent tick
+    // hits `if (inFlight) return`. Honors the file's design contract
+    // ("a thrown error in one refresh cycle must NOT crash the loop").
     try {
-      snapshot = await gatherConsoleState(orchestrator);
-    } catch (err) {
-      renderError = describeError(err);
-    }
-    if (stopped) {
+      let snapshot: ConsoleStateSnapshot | null = null;
+      let renderError: string | null = null;
+      try {
+        snapshot = await gatherConsoleState(orchestrator);
+      } catch (err) {
+        renderError = describeError(err);
+      }
+      if (stopped) return;
+      let frame: string;
+      try {
+        frame = renderFrame({ snapshot, renderError, now });
+      } catch (err) {
+        // If the renderer itself throws (e.g. an invalid clock
+        // injection produced `NaN`), fall back to a minimal error
+        // frame instead of letting the exception escape and reject
+        // the void-floated promise (which would also be unhandled).
+        frame = `remnic console: render failed: ${describeError(err)}\n`;
+      }
+      safeWrite(output, ANSI_CLEAR_HOME);
+      safeWrite(output, frame);
+    } finally {
       inFlight = false;
-      return;
     }
-    const frame = renderFrame({ snapshot, renderError, now });
-    safeWrite(output, ANSI_CLEAR_HOME);
-    safeWrite(output, frame);
-    inFlight = false;
   };
 
   // Kick off an immediate first paint, then schedule the interval.
-  void tick();
+  // Codex P1: do NOT call `handle.unref()`. The CLI path keeps the
+  // process alive by `await`-ing `handle.done`, but a pending promise
+  // alone is not enough to keep Node.js running — the interval timer
+  // is the only ref'd handle that holds the event loop open between
+  // ticks. Unref'ing it caused `remnic console` to render once and
+  // exit immediately. Tests that don't want the process held open
+  // can call `handle.stop()` directly when they're done.
+  void runTickSafely(tick);
   const handle = setInterval(() => {
-    void tick();
+    void runTickSafely(tick);
   }, refreshIntervalMs);
-  // Don't keep the event loop alive solely on the interval. Hosts that
-  // want the process to stay up should `await handle.done`.
-  if (typeof handle.unref === "function") handle.unref();
 
   const sigintHandler = () => {
     stop();
@@ -279,13 +299,17 @@ function formatQmdSummary(snap: ConsoleStateSnapshot): string {
 }
 
 function panelLine(label: string, value: string): string {
-  // ║ <label padded to 13> <value padded to inner-width-15> ║
-  const labelCol = padRight(label, 13);
-  const remaining = FRAME_INNER_WIDTH - 1 - labelCol.length - 1;
-  // -1 for leading space, -1 for trailing space. We deliberately keep
-  // the layout simple — overflow is truncated rather than wrapped.
+  // Layout: ║<space><label padded to LABEL_WIDTH><value padded to fill><space>║
+  // Cursor Medium: the closing ║ must be preceded by a trailing space
+  // so the rendered line width matches the header/footer borders.
+  // Without it, every panel line was 71 chars while the borders were
+  // 72, misaligning the right-hand box edge.
+  const LABEL_WIDTH = 13;
+  const labelCol = padRight(label, LABEL_WIDTH);
+  // Two spaces (leading + trailing) inside the box, consuming 2 cols.
+  const remaining = FRAME_INNER_WIDTH - LABEL_WIDTH - 2;
   const valueCol = padRight(truncate(value, remaining), remaining);
-  return `║ ${labelCol}${valueCol}║`;
+  return `║ ${labelCol}${valueCol} ║`;
 }
 
 function padRight(s: string, width: number): string {
@@ -305,6 +329,22 @@ function ageMsFromIso(iso: string, now: () => number): number | null {
   if (!Number.isFinite(ms)) return null;
   const delta = now() - ms;
   return delta < 0 ? 0 : delta;
+}
+
+/**
+ * Run an async tick function and swallow any rejection so the floated
+ * `void runTickSafely(tick)` call never produces an unhandled-rejection
+ * crash (which Node ≥15 escalates to a process exit). The tick body
+ * itself already wraps everything in try/finally, but this is the
+ * outermost belt-and-suspenders guard.
+ */
+async function runTickSafely(tick: () => Promise<void>): Promise<void> {
+  try {
+    await tick();
+  } catch {
+    // Any error has already been (or will be) surfaced inside the
+    // rendered frame; never let it escape the timer callback.
+  }
 }
 
 function safeWrite(output: Writable, chunk: string): void {


### PR DESCRIPTION
## Summary

- Implements the `remnic console` interactive terminal UI on top of the `gatherConsoleState` aggregator shipped in PR 1/3 (#721).
- New module `packages/remnic-core/src/console/tui.ts` exporting `runConsoleTui(orchestrator, options)` — minimal-deps clear+repaint loop using ANSI escape codes, no curses / blessed / ink.
- Five-panel one-screen layout: Buffer / Extraction / Dedup / Maintenance / QMD. Layout stays stable even when a refresh fails (errors surface inline). SIGINT triggers clean teardown that restores the cursor.
- CLI `console` subcommand now launches the TUI when invoked with no flags. `--state-only` keeps PR 1/3 one-shot JSON snapshot behavior.

Trace replay (`--trace <session-id>`), HTTP `/console/state`, and MCP `engram.console_state` remain deferred to PR 3/3 per issue #688.

## Test plan

- [x] `tui.test.ts` — render produces ANSI-stripped text containing each panel header
- [x] `tui.test.ts` — render surfaces a refresh error in the Error panel without losing layout
- [x] `tui.test.ts` — `runConsoleTui` repaints once on start and survives a snapshot failure on tick 2 without crashing the loop
- [x] `tui.test.ts` — `stop()` clears the interval, restores the cursor, and resolves `done`
- [x] `npx tsc --noEmit` clean
- [x] `npm run build` (tsup) clean
- [x] `npx tsx --test src/console/*.test.ts` → 12/12 pass (4 new + 8 from PR 1/3)
- [x] `bash scripts/pr-preflight.sh quick` — no console-related regressions; pre-existing failures (sqlite / projection store / lcm) are orthogonal to this slice

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds an interactive terminal refresh loop to the `remnic console` CLI path, which changes runtime behavior and introduces timer/signal handling that could affect process lifecycle and output in different environments.
> 
> **Overview**
> `remnic console` now defaults to an interactive, ANSI clear-and-repaint TUI and reserves `--state-only` for printing a single JSON snapshot and exiting.
> 
> Introduces `console/tui.ts` to poll `gatherConsoleState` on an interval, render a fixed multi-panel frame, surface refresh/render errors inside the UI, and support clean shutdown via `stop()`/SIGINT cursor restore. Adds a focused `tui.test.ts` suite covering rendering, alignment, error resilience, and teardown semantics.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efe5a44fcfa4e5425eb95f4f050ec5671b4661b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->