### PR TITLE
feat(graph): graph-edge-decay maintenance job (#681 PR 2/3)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1804,6 +1804,44 @@
         "default": 7,
         "description": "Number of top competing nodes considered for lateral inhibition"
       },
+      "graphEdgeDecayEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
+      },
+      "graphEdgeDecayCadenceMs": {
+        "type": "number",
+        "default": 604800000,
+        "minimum": 60000,
+        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
+      },
+      "graphEdgeDecayWindowMs": {
+        "type": "number",
+        "default": 7776000000,
+        "minimum": 60000,
+        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
+      },
+      "graphEdgeDecayPerWindow": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Per-window confidence drop applied during decay. Default 0.1."
+      },
+      "graphEdgeDecayFloor": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Floor confidence will not decay below. Default 0.1."
+      },
+      "graphEdgeDecayVisibilityThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
+      },
       "temporalMemoryTreeEnabled": {
         "type": "boolean",
         "default": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1804,6 +1804,44 @@
         "default": 7,
         "description": "Number of top competing nodes considered for lateral inhibition"
       },
+      "graphEdgeDecayEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). Opt-in."
+      },
+      "graphEdgeDecayCadenceMs": {
+        "type": "number",
+        "default": 604800000,
+        "minimum": 60000,
+        "description": "Cadence in milliseconds for the graph-edge decay cron. Default 7 days. Sub-day cadences map to a daily cron expression."
+      },
+      "graphEdgeDecayWindowMs": {
+        "type": "number",
+        "default": 7776000000,
+        "minimum": 60000,
+        "description": "Decay window in milliseconds passed to decayEdgeConfidence. Default 90 days."
+      },
+      "graphEdgeDecayPerWindow": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Per-window confidence drop applied during decay. Default 0.1."
+      },
+      "graphEdgeDecayFloor": {
+        "type": "number",
+        "default": 0.1,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Floor confidence will not decay below. Default 0.1."
+      },
+      "graphEdgeDecayVisibilityThreshold": {
+        "type": "number",
+        "default": 0.2,
+        "minimum": 0,
+        "maximum": 1,
+        "description": "Confidence threshold used by the decay telemetry counter for low-visibility edges. Default 0.2."
+      },
       "temporalMemoryTreeEnabled": {
         "type": "boolean",
         "default": false,
@@ -2034,7 +2072,10 @@
       },
       "recallDisclosureEscalation": {
         "type": "string",
-        "enum": ["manual", "auto"],
+        "enum": [
+          "manual",
+          "auto"
+        ],
         "default": "manual",
         "description": "Disclosure auto-escalation policy (issue #677 PR 4/4). When 'auto', recalls without an explicit caller-supplied disclosure escalate from chunk to section if the top-K confidence falls below recallDisclosureEscalationThreshold. 'raw' is never auto-selected. Default 'manual' preserves pre-#677 behavior."
       },

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -953,6 +953,18 @@ export class EngramMcpServer {
           additionalProperties: false,
         },
       },
+      {
+        name: "engram.graph_edge_decay_run",
+        description:
+          "Run the graph-edge-confidence decay maintenance pass (issue #681 PR 2/3). Respects graphEdgeDecayEnabled; writes a structured telemetry record to state/graph-edge-decay-status.json.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            dryRun: { type: "boolean" },
+          },
+          additionalProperties: false,
+        },
+      },
     ].flatMap((tool) => withToolAliases(tool));
   }
 
@@ -1855,6 +1867,31 @@ export class EngramMcpServer {
           fallbackLlm: this.service.fallbackLlmRef,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      }
+      case "engram.graph_edge_decay_run":
+      case "remnic.graph_edge_decay_run": {
+        // Issue #681 PR 2/3 — gated by config; tool always callable, but
+        // the job is a no-op when disabled (and the response indicates it).
+        const cfg = this.service.configRef;
+        if (!cfg.graphEdgeDecayEnabled) {
+          return {
+            ranAt: new Date().toISOString(),
+            disabled: true,
+            reason: "graphEdgeDecayEnabled is false",
+          };
+        }
+        const { runGraphEdgeDecayMaintenance } = await import(
+          "./maintenance/graph-edge-decay.js"
+        );
+        const dryRun = args.dryRun === true;
+        const telemetry = await runGraphEdgeDecayMaintenance(this.service.memoryDir, {
+          windowMs: cfg.graphEdgeDecayWindowMs,
+          perWindow: cfg.graphEdgeDecayPerWindow,
+          floor: cfg.graphEdgeDecayFloor,
+          visibilityThreshold: cfg.graphEdgeDecayVisibilityThreshold,
+          dryRun,
+        });
+        return telemetry;
       }
       default:
         throw new Error(`unknown tool: ${name}`);

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1880,18 +1880,27 @@ export class EngramMcpServer {
             reason: "graphEdgeDecayEnabled is false",
           };
         }
-        const { runGraphEdgeDecayMaintenance } = await import(
+        const { runGraphEdgeDecayMaintenanceAcrossNamespaces } = await import(
           "./maintenance/graph-edge-decay.js"
         );
         const dryRun = args.dryRun === true;
-        const telemetry = await runGraphEdgeDecayMaintenance(this.service.memoryDir, {
-          windowMs: cfg.graphEdgeDecayWindowMs,
-          perWindow: cfg.graphEdgeDecayPerWindow,
-          floor: cfg.graphEdgeDecayFloor,
-          visibilityThreshold: cfg.graphEdgeDecayVisibilityThreshold,
-          dryRun,
-        });
-        return telemetry;
+        // Codex P2 / gotcha #42: enumerate every namespace storage root
+        // so non-default namespaces (memoryDir/namespaces/<ns>) also get
+        // confidence decay applied. Returns a list of per-namespace
+        // results — each with telemetry or an error string.
+        const results = await runGraphEdgeDecayMaintenanceAcrossNamespaces(
+          this.service.memoryDir,
+          {
+            windowMs: cfg.graphEdgeDecayWindowMs,
+            perWindow: cfg.graphEdgeDecayPerWindow,
+            floor: cfg.graphEdgeDecayFloor,
+            visibilityThreshold: cfg.graphEdgeDecayVisibilityThreshold,
+            dryRun,
+            namespacesEnabled: cfg.namespacesEnabled === true,
+            defaultNamespace: cfg.defaultNamespace,
+          },
+        );
+        return { results };
       }
       default:
         throw new Error(`unknown tool: ${name}`);

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2330,6 +2330,30 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.graphLateralInhibitionTopM === "number"
         ? Math.max(0, Math.round(cfg.graphLateralInhibitionTopM))
         : 7,
+    // Issue #681 PR 2/3 — graph-edge confidence decay maintenance.
+    // Boolean coerced via shared helper (gotcha #36: string "false" is truthy).
+    graphEdgeDecayEnabled: coerceBooleanLike(cfg.graphEdgeDecayEnabled) ?? false,
+    graphEdgeDecayCadenceMs:
+      typeof cfg.graphEdgeDecayCadenceMs === "number" && Number.isFinite(cfg.graphEdgeDecayCadenceMs)
+        ? Math.max(60_000, Math.floor(cfg.graphEdgeDecayCadenceMs))
+        : 7 * 24 * 60 * 60 * 1000,
+    graphEdgeDecayWindowMs:
+      typeof cfg.graphEdgeDecayWindowMs === "number" && Number.isFinite(cfg.graphEdgeDecayWindowMs)
+        ? Math.max(60_000, Math.floor(cfg.graphEdgeDecayWindowMs))
+        : 90 * 24 * 60 * 60 * 1000,
+    graphEdgeDecayPerWindow:
+      typeof cfg.graphEdgeDecayPerWindow === "number" && Number.isFinite(cfg.graphEdgeDecayPerWindow)
+        ? Math.max(0, Math.min(1, cfg.graphEdgeDecayPerWindow))
+        : 0.1,
+    graphEdgeDecayFloor:
+      typeof cfg.graphEdgeDecayFloor === "number" && Number.isFinite(cfg.graphEdgeDecayFloor)
+        ? Math.max(0, Math.min(1, cfg.graphEdgeDecayFloor))
+        : 0.1,
+    graphEdgeDecayVisibilityThreshold:
+      typeof cfg.graphEdgeDecayVisibilityThreshold === "number" &&
+      Number.isFinite(cfg.graphEdgeDecayVisibilityThreshold)
+        ? Math.max(0, Math.min(1, cfg.graphEdgeDecayVisibilityThreshold))
+        : 0.2,
     // v8.2: Temporal Memory Tree
     temporalMemoryTreeEnabled: cfg.temporalMemoryTreeEnabled === true,
     tmtHourlyMinMemories:

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -66,33 +66,102 @@ export async function ensureGraphsDir(memoryDir: string): Promise<void> {
   await mkdir(graphsDir(memoryDir), { recursive: true });
 }
 
+// ---------------------------------------------------------------------------
+// Per-graph-file write lock (gotcha #40 promise-chain pattern).
+//
+// Both the append path (`appendEdge`) and the rewrite path used by the
+// decay maintenance job must serialize on the same lock keyed by the
+// JSONL file path. Without this, an extraction can append a new edge
+// between the decay job's read-snapshot and rewrite, silently dropping
+// the appended edge during active traffic (issue #729 / Codex P1).
+// ---------------------------------------------------------------------------
+const graphWriteLocks = new Map<string, Promise<void>>();
+
+/**
+ * Run `fn` while holding the write lock for the given graph JSONL file.
+ *
+ * The lock is keyed by absolute file path so concurrent writes to
+ * different graph types proceed independently. The chain recovers from
+ * rejection (gotcha #40) so a single I/O failure does not poison all
+ * future writers, but the original error is still surfaced to the
+ * caller of `withGraphWriteLock`.
+ */
+export function withGraphWriteLock<T>(filePath: string, fn: () => Promise<T>): Promise<T> {
+  const prev = graphWriteLocks.get(filePath) ?? Promise.resolve();
+  const next = prev.then(fn, fn);
+  graphWriteLocks.set(
+    filePath,
+    next.then(
+      () => undefined,
+      () => undefined,
+    ),
+  );
+  return next;
+}
+
 export async function appendEdge(memoryDir: string, edge: GraphEdge): Promise<void> {
   await ensureGraphsDir(memoryDir);
+  const filePath = graphFilePath(memoryDir, edge.type);
   const line = JSON.stringify(edge) + "\n";
-  await appendFile(graphFilePath(memoryDir, edge.type), line, "utf8");
+  await withGraphWriteLock(filePath, async () => {
+    await appendFile(filePath, line, "utf8");
+  });
+}
+
+function isNodeError(err: unknown): err is NodeJS.ErrnoException {
+  return typeof err === "object" && err !== null && "code" in err;
+}
+
+function parseEdgesJsonl(raw: string): GraphEdge[] {
+  const edges: GraphEdge[] = [];
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    try {
+      edges.push(JSON.parse(trimmed) as GraphEdge);
+    } catch {
+      // skip corrupt lines — fail-open for partial JSONL recovery
+    }
+  }
+  return edges;
 }
 
 /**
  * Read all edges of a given type from the JSONL file.
- * Returns [] if the file doesn't exist or is corrupt (fail-open).
+ * Returns [] if the file doesn't exist or any read error occurs (fail-open).
+ *
+ * Production traversal callers (recall/PageRank) depend on this fail-open
+ * posture so a temporarily missing or unreadable graph file never blocks
+ * a recall. Maintenance jobs that need to distinguish ENOENT from real
+ * I/O failures must use {@link readEdgesStrict} instead.
  */
 export async function readEdges(memoryDir: string, type: GraphType): Promise<GraphEdge[]> {
   const filePath = graphFilePath(memoryDir, type);
   try {
     const raw = await readFile(filePath, "utf8");
-    const edges: GraphEdge[] = [];
-    for (const line of raw.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        edges.push(JSON.parse(trimmed) as GraphEdge);
-      } catch {
-        // skip corrupt lines
-      }
-    }
-    return edges;
+    return parseEdgesJsonl(raw);
   } catch {
     return [];
+  }
+}
+
+/**
+ * Same as {@link readEdges} but only swallows `ENOENT`; all other read
+ * errors (`EACCES`, `EIO`, …) are propagated. Used by the graph-edge
+ * decay maintenance job so I/O outages surface as a failed run instead
+ * of being silently reported as "no edges to decay" (issue #729 /
+ * Codex P1, line 120).
+ */
+export async function readEdgesStrict(memoryDir: string, type: GraphType): Promise<GraphEdge[]> {
+  const filePath = graphFilePath(memoryDir, type);
+  try {
+    const raw = await readFile(filePath, "utf8");
+    return parseEdgesJsonl(raw);
+  } catch (err) {
+    if (isNodeError(err) && err.code === "ENOENT") {
+      return [];
+    }
+    throw err;
   }
 }
 

--- a/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
+++ b/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
@@ -8,16 +8,18 @@ import path from "node:path";
 import test from "node:test";
 import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 
-import { graphFilePath, graphsDir, type GraphEdge } from "../graph.js";
+import { appendEdge, graphFilePath, graphsDir, type GraphEdge } from "../graph.js";
 import {
   DEFAULT_DECAY_FLOOR,
   DEFAULT_DECAY_PER_WINDOW,
   DEFAULT_DECAY_WINDOW_MS,
 } from "../graph-edge-reinforcement.js";
 import {
+  discoverGraphNamespaceRoots,
   graphEdgeDecayStatusPath,
   readGraphEdgeDecayStatus,
   runGraphEdgeDecayMaintenance,
+  runGraphEdgeDecayMaintenanceAcrossNamespaces,
 } from "./graph-edge-decay.js";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -262,6 +264,145 @@ test("disabled flag is honored by the parsed config (default = false)", async ()
   assert.equal(parseConfig({ graphEdgeDecayEnabled: "off" }).graphEdgeDecayEnabled, false);
   assert.equal(parseConfig({ graphEdgeDecayEnabled: true }).graphEdgeDecayEnabled, true);
   assert.equal(parseConfig({ graphEdgeDecayEnabled: "true" }).graphEdgeDecayEnabled, true);
+});
+
+test("concurrent appendEdge calls during a decay run preserve every appended edge", async () => {
+  // Issue #729 / Codex P1, line 224: the decay rewrite must hold the
+  // same write lock as `appendEdge` so an ingestion that lands between
+  // the read-snapshot and the rewrite is not silently dropped.
+  await withTempDir(async (memoryDir) => {
+    // Seed an existing edge that the decay run will scan.
+    await seedEdges(memoryDir, [midDecayEdge()]);
+
+    const concurrentAppends = 25;
+    const decayPromise = runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+    });
+
+    // Fire many concurrent appends while the decay rewrite is in flight.
+    // Without the per-file lock, some of these would be lost when the
+    // decay job's snapshot replaces the file.
+    const appendPromises: Promise<void>[] = [];
+    for (let i = 0; i < concurrentAppends; i += 1) {
+      appendPromises.push(
+        appendEdge(memoryDir, {
+          from: `facts/2026-04-22/append-${i}.md`,
+          to: `facts/2026-04-22/target.md`,
+          type: "entity",
+          weight: 1,
+          label: `concurrent-append-${i}`,
+          ts: "2026-04-22T00:00:00.000Z",
+          confidence: 1,
+          lastReinforcedAt: "2026-04-22T00:00:00.000Z",
+        }),
+      );
+    }
+
+    await Promise.all([decayPromise, ...appendPromises]);
+
+    const final = await readEdgesFile(memoryDir);
+    const appendedLabels = new Set(
+      final
+        .map((e) => e.label)
+        .filter((l) => typeof l === "string" && l.startsWith("concurrent-append-")),
+    );
+    assert.equal(
+      appendedLabels.size,
+      concurrentAppends,
+      `expected ${concurrentAppends} concurrent-append-* edges to survive, found ${appendedLabels.size}`,
+    );
+    // The pre-seeded edge must still be present too.
+    const preserved = final.some((e) => e.label === "mid-label");
+    assert.ok(preserved, "expected pre-seeded mid-decay edge to remain after concurrent run");
+  });
+});
+
+test("read failures other than ENOENT surface as a thrown error", async () => {
+  // Issue #729 / Codex P1, line 120: the decay job must distinguish
+  // ENOENT (no edges yet) from real I/O outages so operators see a
+  // failed run rather than silent zero-count "success" telemetry.
+  await withTempDir(async (memoryDir) => {
+    await mkdir(graphsDir(memoryDir), { recursive: true });
+    const filePath = graphFilePath(memoryDir, "entity");
+    // Replace the file location with a directory so readFile gets EISDIR
+    // (a non-ENOENT error path that previously was silently swallowed).
+    await mkdir(filePath, { recursive: true });
+
+    await assert.rejects(
+      runGraphEdgeDecayMaintenance(memoryDir, { now: "2026-04-25T00:00:00.000Z" }),
+      (err: unknown) => {
+        if (!(err instanceof Error)) return false;
+        const code = (err as NodeJS.ErrnoException).code;
+        return code !== "ENOENT";
+      },
+    );
+  });
+});
+
+test("namespace discovery enumerates default + every safe subdir under namespaces/", async () => {
+  // Codex P2 / gotcha #42: the multi-root runner must reach every
+  // namespace storage root, not just `memoryDir`.
+  await withTempDir(async (memoryDir) => {
+    await mkdir(path.join(memoryDir, "namespaces", "team-alpha"), { recursive: true });
+    await mkdir(path.join(memoryDir, "namespaces", "team-beta"), { recursive: true });
+
+    const enabled = await discoverGraphNamespaceRoots(memoryDir, {
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+    });
+    const enabledNames = new Set(enabled.map((r) => r.namespace));
+    assert.ok(enabledNames.has("default"));
+    assert.ok(enabledNames.has("team-alpha"));
+    assert.ok(enabledNames.has("team-beta"));
+    const alphaRoot = enabled.find((r) => r.namespace === "team-alpha")?.storageRoot;
+    assert.equal(alphaRoot, path.join(memoryDir, "namespaces", "team-alpha"));
+
+    // namespacesEnabled=false returns only the default root.
+    const disabled = await discoverGraphNamespaceRoots(memoryDir, {
+      namespacesEnabled: false,
+      defaultNamespace: "default",
+    });
+    assert.equal(disabled.length, 1);
+    assert.equal(disabled[0].namespace, "default");
+    assert.equal(disabled[0].storageRoot, memoryDir);
+  });
+});
+
+test("multi-root decay runs against every namespace storage root", async () => {
+  // Issue #729 / Codex P2: the MCP handler previously only ran decay
+  // against memoryDir, leaving non-default namespace graphs un-decayed.
+  await withTempDir(async (memoryDir) => {
+    // Seed default namespace at memoryDir.
+    await seedEdges(memoryDir, [midDecayEdge({ label: "default-ns-edge" })]);
+    // Seed a team-alpha namespace under memoryDir/namespaces/team-alpha.
+    const alphaRoot = path.join(memoryDir, "namespaces", "team-alpha");
+    await mkdir(graphsDir(alphaRoot), { recursive: true });
+    await writeFile(
+      graphFilePath(alphaRoot, "entity"),
+      JSON.stringify(midDecayEdge({ label: "alpha-ns-edge" })) + "\n",
+      "utf-8",
+    );
+
+    const results = await runGraphEdgeDecayMaintenanceAcrossNamespaces(memoryDir, {
+      namespacesEnabled: true,
+      defaultNamespace: "default",
+      now: "2026-04-25T00:00:00.000Z",
+    });
+
+    const byNamespace = new Map(results.map((r) => [r.namespace, r]));
+    assert.ok(byNamespace.has("default"), "default namespace must be in results");
+    assert.ok(byNamespace.has("team-alpha"), "team-alpha namespace must be in results");
+
+    const defaultResult = byNamespace.get("default")!;
+    const alphaResult = byNamespace.get("team-alpha")!;
+    assert.ok(defaultResult.telemetry, "default namespace must have telemetry");
+    assert.ok(alphaResult.telemetry, "team-alpha namespace must have telemetry");
+    assert.equal(defaultResult.telemetry!.edgesTotal, 1);
+    assert.equal(alphaResult.telemetry!.edgesTotal, 1);
+    // Both seeded mid-decay edges should have actually been decayed.
+    assert.equal(defaultResult.telemetry!.edgesDecayed, 1);
+    assert.equal(alphaResult.telemetry!.edgesDecayed, 1);
+  });
 });
 
 // Suppress unused-import warning for `DAY_MS` when `node --test` strips it.

--- a/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
+++ b/packages/remnic-core/src/maintenance/graph-edge-decay.test.ts
@@ -1,0 +1,268 @@
+/**
+ * Unit tests for `runGraphEdgeDecayMaintenance` (issue #681 PR 2/3).
+ */
+
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+
+import { graphFilePath, graphsDir, type GraphEdge } from "../graph.js";
+import {
+  DEFAULT_DECAY_FLOOR,
+  DEFAULT_DECAY_PER_WINDOW,
+  DEFAULT_DECAY_WINDOW_MS,
+} from "../graph-edge-reinforcement.js";
+import {
+  graphEdgeDecayStatusPath,
+  readGraphEdgeDecayStatus,
+  runGraphEdgeDecayMaintenance,
+} from "./graph-edge-decay.js";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function freshEdge(overrides: Partial<GraphEdge> = {}): GraphEdge {
+  return {
+    from: "facts/2026-04-01/a.md",
+    to: "facts/2026-04-01/b.md",
+    type: "entity",
+    weight: 1,
+    label: "fresh-label",
+    ts: "2026-04-20T00:00:00.000Z",
+    confidence: 1,
+    lastReinforcedAt: "2026-04-20T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function midDecayEdge(overrides: Partial<GraphEdge> = {}): GraphEdge {
+  // ~150 days old (one window past the 90-day grace), confidence 0.6.
+  return {
+    from: "facts/2025-11-01/c.md",
+    to: "facts/2025-11-01/d.md",
+    type: "entity",
+    weight: 1,
+    label: "mid-label",
+    ts: "2025-11-01T00:00:00.000Z",
+    confidence: 0.6,
+    lastReinforcedAt: "2025-11-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function staleEdge(overrides: Partial<GraphEdge> = {}): GraphEdge {
+  // ~700 days old, already at the floor — should not move below the floor.
+  return {
+    from: "facts/2024-05-01/e.md",
+    to: "facts/2024-05-01/f.md",
+    type: "entity",
+    weight: 1,
+    label: "stale-label",
+    ts: "2024-05-01T00:00:00.000Z",
+    confidence: 0.1,
+    lastReinforcedAt: "2024-05-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+async function seedEdges(memoryDir: string, edges: GraphEdge[]): Promise<void> {
+  const filePath = graphFilePath(memoryDir, "entity");
+  await mkdir(graphsDir(memoryDir), { recursive: true });
+  const body = edges.map((e) => JSON.stringify(e)).join("\n") + (edges.length > 0 ? "\n" : "");
+  await writeFile(filePath, body, "utf-8");
+}
+
+async function readEdgesFile(memoryDir: string): Promise<GraphEdge[]> {
+  const filePath = graphFilePath(memoryDir, "entity");
+  const raw = await readFile(filePath, "utf-8");
+  return raw
+    .split("\n")
+    .map((l) => l.trim())
+    .filter((l) => l.length > 0)
+    .map((l) => JSON.parse(l) as GraphEdge);
+}
+
+async function withTempDir(fn: (dir: string) => Promise<void>): Promise<void> {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-graph-decay-test-"));
+  try {
+    await fn(dir);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test("runs end-to-end on a fixture graph with fresh, mid-decay, stale edges", async () => {
+  await withTempDir(async (memoryDir) => {
+    await seedEdges(memoryDir, [freshEdge(), midDecayEdge(), staleEdge()]);
+
+    // "now" = 2026-04-25, ~175 days past stale anchor, ~175 days past mid anchor,
+    // 5 days past the fresh anchor (well within grace).
+    const telemetry = await runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+    });
+
+    assert.equal(telemetry.edgesTotal, 3);
+    // Fresh: no decay. Mid: drops from 0.6. Stale: already at floor, no decay.
+    assert.equal(telemetry.edgesDecayed, 1);
+    // visibilityThreshold default 0.2 — only the stale edge (0.1) is below.
+    assert.equal(telemetry.edgesBelowVisibilityThreshold, 1);
+    assert.equal(telemetry.topDecayedEntities[0]?.label, "mid-label");
+    assert.ok(telemetry.topDecayedEntities[0]?.totalDrop > 0);
+
+    const written = await readEdgesFile(memoryDir);
+    const fresh = written.find((e) => e.label === "fresh-label");
+    const mid = written.find((e) => e.label === "mid-label");
+    const stale = written.find((e) => e.label === "stale-label");
+    assert.ok(fresh && mid && stale);
+    assert.equal(fresh.confidence, 1, "fresh edge confidence preserved");
+    assert.ok(mid.confidence !== undefined && mid.confidence < 0.6, "mid edge decayed");
+    assert.equal(stale.confidence, 0.1, "stale edge stays at floor");
+    // Fresh edge anchor preserved (no decay path advanced it).
+    assert.equal(fresh.lastReinforcedAt, "2026-04-20T00:00:00.000Z");
+  });
+});
+
+test("idempotent re-run produces no further decay (anchors advance correctly)", async () => {
+  await withTempDir(async (memoryDir) => {
+    await seedEdges(memoryDir, [midDecayEdge()]);
+    const now = "2026-04-25T00:00:00.000Z";
+
+    const first = await runGraphEdgeDecayMaintenance(memoryDir, { now });
+    const after1 = (await readEdgesFile(memoryDir))[0];
+    assert.equal(first.edgesDecayed, 1);
+
+    const second = await runGraphEdgeDecayMaintenance(memoryDir, { now });
+    const after2 = (await readEdgesFile(memoryDir))[0];
+
+    // Second pass must not decay further: the anchor advanced past the
+    // first pass's window, putting the edge back inside its grace window.
+    assert.equal(second.edgesDecayed, 0);
+    assert.equal(after2.confidence, after1.confidence, "confidence stable on re-run");
+    assert.equal(
+      after2.lastReinforcedAt,
+      after1.lastReinforcedAt,
+      "lastReinforcedAt anchor stable on re-run",
+    );
+  });
+});
+
+test("dry-run computes telemetry without rewriting graph files or status", async () => {
+  await withTempDir(async (memoryDir) => {
+    await seedEdges(memoryDir, [midDecayEdge()]);
+    const before = await readEdgesFile(memoryDir);
+    const beforeBytes = JSON.stringify(before);
+
+    const telemetry = await runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+      dryRun: true,
+    });
+
+    assert.equal(telemetry.edgesDecayed, 1);
+    const after = await readEdgesFile(memoryDir);
+    assert.equal(JSON.stringify(after), beforeBytes, "graph file untouched in dry-run");
+    const status = await readGraphEdgeDecayStatus(memoryDir);
+    assert.equal(status, null, "status file not written in dry-run");
+  });
+});
+
+test("telemetry record has the expected shape and is persisted", async () => {
+  await withTempDir(async (memoryDir) => {
+    await seedEdges(memoryDir, [
+      freshEdge({ label: "alpha" }),
+      midDecayEdge({ label: "beta" }),
+      midDecayEdge({
+        label: "gamma",
+        from: "facts/x/y.md",
+        to: "facts/x/z.md",
+      }),
+    ]);
+
+    const telemetry = await runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+    });
+
+    assert.ok(typeof telemetry.ranAt === "string" && telemetry.ranAt.length > 0);
+    assert.ok(Number.isFinite(telemetry.durationMs) && telemetry.durationMs >= 0);
+    assert.equal(telemetry.windowMs, DEFAULT_DECAY_WINDOW_MS);
+    assert.equal(telemetry.perWindow, DEFAULT_DECAY_PER_WINDOW);
+    assert.equal(telemetry.floor, DEFAULT_DECAY_FLOOR);
+    assert.ok(Array.isArray(telemetry.perType));
+    const types = telemetry.perType.map((p) => p.type).sort();
+    assert.deepEqual(types, ["causal", "entity", "time"]);
+    // Top decayed entities listed in descending totalDrop order, max 5,
+    // labels deterministic.
+    assert.ok(telemetry.topDecayedEntities.length <= 5);
+    for (let i = 1; i < telemetry.topDecayedEntities.length; i += 1) {
+      const prev = telemetry.topDecayedEntities[i - 1];
+      const cur = telemetry.topDecayedEntities[i];
+      assert.ok(prev.totalDrop >= cur.totalDrop);
+    }
+
+    // Persisted to the status file.
+    const status = await readGraphEdgeDecayStatus(memoryDir);
+    assert.ok(status, "status file exists");
+    assert.equal(status?.edgesTotal, telemetry.edgesTotal);
+    assert.equal(status?.edgesDecayed, telemetry.edgesDecayed);
+
+    // Status path is under <memoryDir>/state/.
+    const expectedPath = path.join(memoryDir, "state", "graph-edge-decay-status.json");
+    assert.equal(graphEdgeDecayStatusPath(memoryDir), expectedPath);
+  });
+});
+
+test("custom visibility threshold is honored", async () => {
+  await withTempDir(async (memoryDir) => {
+    await seedEdges(memoryDir, [
+      midDecayEdge({ label: "x", confidence: 0.45, lastReinforcedAt: "2026-04-20T00:00:00.000Z" }),
+    ]);
+
+    // Edge confidence 0.45, age 5 days < 90-day grace — no decay, but it sits
+    // below threshold 0.5 so the "below visibility" counter must include it.
+    const telemetry = await runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+      visibilityThreshold: 0.5,
+    });
+
+    assert.equal(telemetry.edgesDecayed, 0);
+    assert.equal(telemetry.edgesBelowVisibilityThreshold, 1);
+    assert.equal(telemetry.visibilityThreshold, 0.5);
+  });
+});
+
+test("missing graph files are treated as empty (fail-open)", async () => {
+  await withTempDir(async (memoryDir) => {
+    // Do not seed any edges — directory is empty.
+    const telemetry = await runGraphEdgeDecayMaintenance(memoryDir, {
+      now: "2026-04-25T00:00:00.000Z",
+    });
+    assert.equal(telemetry.edgesTotal, 0);
+    assert.equal(telemetry.edgesDecayed, 0);
+    assert.equal(telemetry.edgesBelowVisibilityThreshold, 0);
+    assert.deepEqual(telemetry.topDecayedEntities, []);
+  });
+});
+
+test("disabled flag is honored by the parsed config (default = false)", async () => {
+  // Verifies that the public Config defaults the flag to disabled, so the
+  // call sites that gate the cron / MCP tool on `cfg.graphEdgeDecayEnabled`
+  // start as no-ops out of the box (opt-in posture).
+  const { parseConfig } = await import("../config.js");
+  const parsed = parseConfig({});
+  assert.equal(parsed.graphEdgeDecayEnabled, false);
+  assert.equal(parsed.graphEdgeDecayCadenceMs, 7 * 24 * 60 * 60 * 1000);
+  assert.equal(parsed.graphEdgeDecayWindowMs, 90 * 24 * 60 * 60 * 1000);
+  assert.equal(parsed.graphEdgeDecayPerWindow, 0.1);
+  assert.equal(parsed.graphEdgeDecayFloor, 0.1);
+  assert.equal(parsed.graphEdgeDecayVisibilityThreshold, 0.2);
+
+  // Boolean coercion: strings "false"/"0"/"off" must remain false (gotcha #36).
+  assert.equal(parseConfig({ graphEdgeDecayEnabled: "false" }).graphEdgeDecayEnabled, false);
+  assert.equal(parseConfig({ graphEdgeDecayEnabled: "0" }).graphEdgeDecayEnabled, false);
+  assert.equal(parseConfig({ graphEdgeDecayEnabled: "off" }).graphEdgeDecayEnabled, false);
+  assert.equal(parseConfig({ graphEdgeDecayEnabled: true }).graphEdgeDecayEnabled, true);
+  assert.equal(parseConfig({ graphEdgeDecayEnabled: "true" }).graphEdgeDecayEnabled, true);
+});
+
+// Suppress unused-import warning for `DAY_MS` when `node --test` strips it.
+void DAY_MS;

--- a/packages/remnic-core/src/maintenance/graph-edge-decay.ts
+++ b/packages/remnic-core/src/maintenance/graph-edge-decay.ts
@@ -1,0 +1,291 @@
+/**
+ * Graph-edge decay maintenance job (issue #681 PR 2/3).
+ *
+ * For each edge in the on-disk JSONL graph stores
+ * (`<memoryDir>/state/graphs/{entity,time,causal}.jsonl`) call
+ * {@link decayEdgeConfidence} from PR 1/3 and write the decayed edge
+ * back to disk via the temp+rename atomic-replace pattern (CLAUDE.md
+ * gotcha #54: never delete-before-write).
+ *
+ * Emits a structured telemetry record per run that the doctor surface
+ * (`remnic doctor`) and a tail of the maintenance ledger can consume.
+ *
+ * Pure-helper-style API (the function takes a `memoryDir` + opts and
+ * returns a record); callers wire the cron / MCP tool / CLI surfaces.
+ */
+
+import {
+  mkdir,
+  readFile,
+  rename,
+  writeFile,
+} from "node:fs/promises";
+import path from "node:path";
+
+import {
+  decayEdgeConfidence,
+  DEFAULT_DECAY_FLOOR,
+  DEFAULT_DECAY_PER_WINDOW,
+  DEFAULT_DECAY_WINDOW_MS,
+  readEdgeConfidence,
+  type DecayOptions,
+} from "../graph-edge-reinforcement.js";
+import {
+  graphFilePath,
+  graphsDir,
+  type GraphEdge,
+  type GraphType,
+} from "../graph.js";
+
+/** Default visibility threshold for the "below visibility" telemetry counter. */
+export const DEFAULT_VISIBILITY_THRESHOLD = 0.2;
+
+const GRAPH_TYPES: readonly GraphType[] = ["entity", "time", "causal"] as const;
+
+/** Per-edge-type breakdown emitted by {@link runGraphEdgeDecayMaintenance}. */
+export interface GraphEdgeDecayPerTypeStats {
+  type: GraphType;
+  edgesTotal: number;
+  edgesDecayed: number;
+  edgesBelowVisibilityThreshold: number;
+}
+
+/** Top-decayed-entity entry (label + total confidence drop summed across edges). */
+export interface GraphEdgeDecayTopEntity {
+  label: string;
+  totalDrop: number;
+  edgeCount: number;
+}
+
+/**
+ * Telemetry record emitted by every run of the decay job. Persisted to
+ * `<memoryDir>/state/graph-edge-decay-status.json` for doctor consumption
+ * and (optionally) appended to the maintenance ledger by callers.
+ */
+export interface GraphEdgeDecayTelemetry {
+  ranAt: string;
+  durationMs: number;
+  edgesTotal: number;
+  edgesDecayed: number;
+  edgesBelowVisibilityThreshold: number;
+  topDecayedEntities: GraphEdgeDecayTopEntity[];
+  perType: GraphEdgeDecayPerTypeStats[];
+  windowMs: number;
+  perWindow: number;
+  floor: number;
+  visibilityThreshold: number;
+}
+
+export interface GraphEdgeDecayOptions extends DecayOptions {
+  /** Confidence threshold below which an edge counts as "low visibility". */
+  visibilityThreshold?: number;
+  /** Override "now" for deterministic testing. Defaults to `new Date().toISOString()`. */
+  now?: string;
+  /** When `true`, do not write decayed edges back — just compute telemetry. */
+  dryRun?: boolean;
+}
+
+/** Path of the latest-run status file. */
+export function graphEdgeDecayStatusPath(memoryDir: string): string {
+  return path.join(memoryDir, "state", "graph-edge-decay-status.json");
+}
+
+/** Write a JSONL file atomically using temp+rename (CLAUDE.md gotcha #54). */
+async function writeJsonlAtomic(filePath: string, edges: GraphEdge[]): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const body = edges.length === 0 ? "" : edges.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  // Codex P2 / gotcha #54: write to temp then rename. Never rmSync(target)
+  // before the rename succeeds; rename is atomic on the same filesystem.
+  // Include pid + monotonic-ish suffix so concurrent runs cannot collide.
+  const tempPath = `${filePath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  await writeFile(tempPath, body, "utf-8");
+  await rename(tempPath, filePath);
+}
+
+async function readEdgesIfPresent(filePath: string): Promise<GraphEdge[]> {
+  try {
+    const raw = await readFile(filePath, "utf-8");
+    const edges: GraphEdge[] = [];
+    for (const line of raw.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        edges.push(JSON.parse(trimmed) as GraphEdge);
+      } catch {
+        // Skip corrupt lines — same fail-open posture as `readEdges` in graph.ts.
+      }
+    }
+    return edges;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Run a single decay pass over every edge type.
+ *
+ * Idempotency: PR 1/3's `decayEdgeConfidence` advances `lastReinforcedAt`
+ * by exactly the windows it just charged for, so a second run with the
+ * same `now` (or any `now` inside the new grace window) is a no-op.
+ *
+ * Returns the telemetry record. The record is also persisted to
+ * {@link graphEdgeDecayStatusPath} so doctor / CLI can read the last run
+ * without re-scanning the graphs.
+ */
+export async function runGraphEdgeDecayMaintenance(
+  memoryDir: string,
+  options: GraphEdgeDecayOptions = {},
+): Promise<GraphEdgeDecayTelemetry> {
+  const startedAt = Date.now();
+  const ranAt = options.now ?? new Date().toISOString();
+  const windowMs = options.windowMs ?? DEFAULT_DECAY_WINDOW_MS;
+  const perWindow = options.perWindow ?? DEFAULT_DECAY_PER_WINDOW;
+  const floor = options.floor ?? DEFAULT_DECAY_FLOOR;
+  const visibilityThreshold =
+    typeof options.visibilityThreshold === "number" && Number.isFinite(options.visibilityThreshold)
+      ? Math.max(0, Math.min(1, options.visibilityThreshold))
+      : DEFAULT_VISIBILITY_THRESHOLD;
+  const dryRun = options.dryRun === true;
+
+  await mkdir(graphsDir(memoryDir), { recursive: true });
+
+  const perType: GraphEdgeDecayPerTypeStats[] = [];
+  // Aggregate per-label decay drops across ALL graph types so the
+  // "top decayed entities" list reflects whichever label dominated
+  // each edge (entity name, threadId, or causal phrase). Sorting by
+  // total confidence drop highlights the edges decay actually moved
+  // most in this pass.
+  const dropByLabel = new Map<string, { totalDrop: number; edgeCount: number }>();
+
+  let edgesTotal = 0;
+  let edgesDecayed = 0;
+  let edgesBelowVisibilityThreshold = 0;
+
+  for (const type of GRAPH_TYPES) {
+    const filePath = graphFilePath(memoryDir, type);
+    const edges = await readEdgesIfPresent(filePath);
+    const updated: GraphEdge[] = new Array(edges.length);
+
+    let typeDecayed = 0;
+    let typeBelow = 0;
+    let typeChangedAny = false;
+
+    for (let i = 0; i < edges.length; i += 1) {
+      const edge = edges[i];
+      const before = readEdgeConfidence(edge);
+      const decayed = decayEdgeConfidence(edge, ranAt, { windowMs, perWindow, floor });
+      const after = readEdgeConfidence(decayed);
+
+      // Only count as "decayed" when the confidence actually dropped.
+      // `decayEdgeConfidence` may return an unchanged copy (still inside
+      // the grace window, or already at/below the floor) — those are
+      // visited but not decayed.
+      if (after < before) {
+        typeDecayed += 1;
+        edgesDecayed += 1;
+        const drop = before - after;
+        const label = typeof edge.label === "string" ? edge.label : "";
+        // Skip empty labels in the top list — surfacing them produces
+        // a meaningless "" entry that crowds the report.
+        if (label.length > 0) {
+          const prev = dropByLabel.get(label);
+          if (prev) {
+            prev.totalDrop += drop;
+            prev.edgeCount += 1;
+          } else {
+            dropByLabel.set(label, { totalDrop: drop, edgeCount: 1 });
+          }
+        }
+      }
+      if (after < visibilityThreshold) {
+        typeBelow += 1;
+        edgesBelowVisibilityThreshold += 1;
+      }
+      updated[i] = decayed;
+      // Detect any structural change (confidence OR lastReinforcedAt anchor advance)
+      // so we only rewrite the JSONL when there's something to persist.
+      if (
+        decayed.confidence !== edge.confidence ||
+        decayed.lastReinforcedAt !== edge.lastReinforcedAt
+      ) {
+        typeChangedAny = true;
+      }
+    }
+
+    edgesTotal += edges.length;
+    perType.push({
+      type,
+      edgesTotal: edges.length,
+      edgesDecayed: typeDecayed,
+      edgesBelowVisibilityThreshold: typeBelow,
+    });
+
+    if (!dryRun && typeChangedAny && edges.length > 0) {
+      await writeJsonlAtomic(filePath, updated);
+    }
+  }
+
+  // Stable secondary key on label keeps ordering deterministic when two
+  // labels happen to have exactly the same totalDrop (gotcha #19).
+  const topDecayedEntities: GraphEdgeDecayTopEntity[] = [...dropByLabel.entries()]
+    .map(([label, agg]) => ({ label, totalDrop: agg.totalDrop, edgeCount: agg.edgeCount }))
+    .sort((a, b) => {
+      if (b.totalDrop !== a.totalDrop) return b.totalDrop - a.totalDrop;
+      return a.label.localeCompare(b.label);
+    })
+    .slice(0, 5);
+
+  const telemetry: GraphEdgeDecayTelemetry = {
+    ranAt,
+    durationMs: Date.now() - startedAt,
+    edgesTotal,
+    edgesDecayed,
+    edgesBelowVisibilityThreshold,
+    topDecayedEntities,
+    perType,
+    windowMs,
+    perWindow,
+    floor,
+    visibilityThreshold,
+  };
+
+  if (!dryRun) {
+    await persistTelemetry(memoryDir, telemetry);
+  }
+
+  return telemetry;
+}
+
+async function persistTelemetry(
+  memoryDir: string,
+  telemetry: GraphEdgeDecayTelemetry,
+): Promise<void> {
+  const statusPath = graphEdgeDecayStatusPath(memoryDir);
+  await mkdir(path.dirname(statusPath), { recursive: true });
+  const tempPath = `${statusPath}.${process.pid}.${Date.now()}.${Math.random().toString(36).slice(2)}.tmp`;
+  // Wrap I/O in try/catch (gotcha #13) — failing to persist telemetry must
+  // not blow up the maintenance run; the in-memory record is still returned.
+  try {
+    await writeFile(tempPath, JSON.stringify(telemetry, null, 2) + "\n", "utf-8");
+    await rename(tempPath, statusPath);
+  } catch {
+    // Best-effort: callers still receive the in-memory telemetry record.
+  }
+}
+
+/** Read the last persisted decay-run telemetry, if any. */
+export async function readGraphEdgeDecayStatus(
+  memoryDir: string,
+): Promise<GraphEdgeDecayTelemetry | null> {
+  try {
+    const raw = await readFile(graphEdgeDecayStatusPath(memoryDir), "utf-8");
+    const parsed = JSON.parse(raw);
+    // Validate the parsed payload is a plain object (gotcha #18: JSON.parse('null') is valid).
+    if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+      return null;
+    }
+    return parsed as GraphEdgeDecayTelemetry;
+  } catch {
+    return null;
+  }
+}

--- a/packages/remnic-core/src/maintenance/graph-edge-decay.ts
+++ b/packages/remnic-core/src/maintenance/graph-edge-decay.ts
@@ -16,6 +16,7 @@
 
 import {
   mkdir,
+  readdir,
   readFile,
   rename,
   writeFile,
@@ -33,9 +34,12 @@ import {
 import {
   graphFilePath,
   graphsDir,
+  readEdgesStrict,
+  withGraphWriteLock,
   type GraphEdge,
   type GraphType,
 } from "../graph.js";
+import { isSafeRouteNamespace } from "../routing/engine.js";
 
 /** Default visibility threshold for the "below visibility" telemetry counter. */
 export const DEFAULT_VISIBILITY_THRESHOLD = 0.2;
@@ -102,25 +106,6 @@ async function writeJsonlAtomic(filePath: string, edges: GraphEdge[]): Promise<v
   await rename(tempPath, filePath);
 }
 
-async function readEdgesIfPresent(filePath: string): Promise<GraphEdge[]> {
-  try {
-    const raw = await readFile(filePath, "utf-8");
-    const edges: GraphEdge[] = [];
-    for (const line of raw.split("\n")) {
-      const trimmed = line.trim();
-      if (!trimmed) continue;
-      try {
-        edges.push(JSON.parse(trimmed) as GraphEdge);
-      } catch {
-        // Skip corrupt lines — same fail-open posture as `readEdges` in graph.ts.
-      }
-    }
-    return edges;
-  } catch {
-    return [];
-  }
-}
-
 /**
  * Run a single decay pass over every edge type.
  *
@@ -163,66 +148,86 @@ export async function runGraphEdgeDecayMaintenance(
 
   for (const type of GRAPH_TYPES) {
     const filePath = graphFilePath(memoryDir, type);
-    const edges = await readEdgesIfPresent(filePath);
-    const updated: GraphEdge[] = new Array(edges.length);
 
-    let typeDecayed = 0;
-    let typeBelow = 0;
-    let typeChangedAny = false;
+    // Hold the per-graph-file write lock across BOTH the read-snapshot
+    // and the atomic rewrite so concurrent `appendEdge()` calls cannot
+    // sneak in between (issue #729 / Codex P1, line 224). Without this
+    // lock the snapshot rewrite would silently drop any edge appended
+    // by extraction during the same window. Read failures other than
+    // ENOENT are surfaced via `readEdgesStrict` so I/O outages cannot
+    // be reported as "no edges to decay" (Codex P1, line 120).
+    const {
+      typeDecayed,
+      typeBelow,
+      typeTotal,
+    } = await withGraphWriteLock(filePath, async () => {
+      const edges = await readEdgesStrict(memoryDir, type);
+      const updated: GraphEdge[] = new Array(edges.length);
 
-    for (let i = 0; i < edges.length; i += 1) {
-      const edge = edges[i];
-      const before = readEdgeConfidence(edge);
-      const decayed = decayEdgeConfidence(edge, ranAt, { windowMs, perWindow, floor });
-      const after = readEdgeConfidence(decayed);
+      let localDecayed = 0;
+      let localBelow = 0;
+      let localChangedAny = false;
 
-      // Only count as "decayed" when the confidence actually dropped.
-      // `decayEdgeConfidence` may return an unchanged copy (still inside
-      // the grace window, or already at/below the floor) — those are
-      // visited but not decayed.
-      if (after < before) {
-        typeDecayed += 1;
-        edgesDecayed += 1;
-        const drop = before - after;
-        const label = typeof edge.label === "string" ? edge.label : "";
-        // Skip empty labels in the top list — surfacing them produces
-        // a meaningless "" entry that crowds the report.
-        if (label.length > 0) {
-          const prev = dropByLabel.get(label);
-          if (prev) {
-            prev.totalDrop += drop;
-            prev.edgeCount += 1;
-          } else {
-            dropByLabel.set(label, { totalDrop: drop, edgeCount: 1 });
+      for (let i = 0; i < edges.length; i += 1) {
+        const edge = edges[i];
+        const before = readEdgeConfidence(edge);
+        const decayed = decayEdgeConfidence(edge, ranAt, { windowMs, perWindow, floor });
+        const after = readEdgeConfidence(decayed);
+
+        // Only count as "decayed" when the confidence actually dropped.
+        // `decayEdgeConfidence` may return an unchanged copy (still inside
+        // the grace window, or already at/below the floor) — those are
+        // visited but not decayed.
+        if (after < before) {
+          localDecayed += 1;
+          const drop = before - after;
+          const label = typeof edge.label === "string" ? edge.label : "";
+          // Skip empty labels in the top list — surfacing them produces
+          // a meaningless "" entry that crowds the report.
+          if (label.length > 0) {
+            const prev = dropByLabel.get(label);
+            if (prev) {
+              prev.totalDrop += drop;
+              prev.edgeCount += 1;
+            } else {
+              dropByLabel.set(label, { totalDrop: drop, edgeCount: 1 });
+            }
           }
         }
+        if (after < visibilityThreshold) {
+          localBelow += 1;
+        }
+        updated[i] = decayed;
+        // Detect any structural change (confidence OR lastReinforcedAt anchor advance)
+        // so we only rewrite the JSONL when there's something to persist.
+        if (
+          decayed.confidence !== edge.confidence ||
+          decayed.lastReinforcedAt !== edge.lastReinforcedAt
+        ) {
+          localChangedAny = true;
+        }
       }
-      if (after < visibilityThreshold) {
-        typeBelow += 1;
-        edgesBelowVisibilityThreshold += 1;
-      }
-      updated[i] = decayed;
-      // Detect any structural change (confidence OR lastReinforcedAt anchor advance)
-      // so we only rewrite the JSONL when there's something to persist.
-      if (
-        decayed.confidence !== edge.confidence ||
-        decayed.lastReinforcedAt !== edge.lastReinforcedAt
-      ) {
-        typeChangedAny = true;
-      }
-    }
 
-    edgesTotal += edges.length;
+      if (!dryRun && localChangedAny && edges.length > 0) {
+        await writeJsonlAtomic(filePath, updated);
+      }
+
+      return {
+        typeDecayed: localDecayed,
+        typeBelow: localBelow,
+        typeTotal: edges.length,
+      };
+    });
+
+    edgesDecayed += typeDecayed;
+    edgesBelowVisibilityThreshold += typeBelow;
+    edgesTotal += typeTotal;
     perType.push({
       type,
-      edgesTotal: edges.length,
+      edgesTotal: typeTotal,
       edgesDecayed: typeDecayed,
       edgesBelowVisibilityThreshold: typeBelow,
     });
-
-    if (!dryRun && typeChangedAny && edges.length > 0) {
-      await writeJsonlAtomic(filePath, updated);
-    }
   }
 
   // Stable secondary key on label keeps ordering deterministic when two
@@ -288,4 +293,102 @@ export async function readGraphEdgeDecayStatus(
   } catch {
     return null;
   }
+}
+
+/**
+ * Per-namespace telemetry record returned by
+ * {@link runGraphEdgeDecayMaintenanceAcrossNamespaces}. Each entry
+ * pairs the namespace name with its decay telemetry (or an error
+ * string if that namespace's run failed). Allows operators to spot
+ * I/O outages on a single namespace without masking the rest.
+ */
+export interface GraphEdgeDecayNamespaceResult {
+  namespace: string;
+  storageRoot: string;
+  telemetry?: GraphEdgeDecayTelemetry;
+  error?: string;
+}
+
+/**
+ * Discover every namespace storage root that may contain graph files.
+ *
+ * Returns a list of `{ namespace, storageRoot }` entries:
+ *   - The default namespace at `memoryDir` (always present).
+ *   - Each subdirectory under `memoryDir/namespaces/` that passes
+ *     `isSafeRouteNamespace`.
+ *
+ * Per gotcha #42: read paths must enumerate the same namespace layer
+ * as write paths so non-default namespaces don't get skipped during
+ * maintenance. Issue #729 / Codex P2.
+ */
+export async function discoverGraphNamespaceRoots(
+  memoryDir: string,
+  options: { namespacesEnabled: boolean; defaultNamespace: string },
+): Promise<{ namespace: string; storageRoot: string }[]> {
+  const seen = new Map<string, string>();
+  // Default namespace always lives at memoryDir (NamespaceStorageRouter
+  // falls back to memoryDir when memoryDir/namespaces/<default> does
+  // not exist).
+  seen.set(options.defaultNamespace, memoryDir);
+
+  if (!options.namespacesEnabled) {
+    return [...seen.entries()].map(([namespace, storageRoot]) => ({ namespace, storageRoot }));
+  }
+
+  const namespacesDir = path.join(memoryDir, "namespaces");
+  let entries: import("node:fs").Dirent[];
+  try {
+    entries = await readdir(namespacesDir, { withFileTypes: true });
+  } catch {
+    // No namespaces dir yet — only the default namespace exists.
+    return [...seen.entries()].map(([namespace, storageRoot]) => ({ namespace, storageRoot }));
+  }
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+    if (!isSafeRouteNamespace(entry.name)) continue;
+    const root = path.join(namespacesDir, entry.name);
+    seen.set(entry.name, root);
+  }
+
+  return [...seen.entries()].map(([namespace, storageRoot]) => ({ namespace, storageRoot }));
+}
+
+/**
+ * Run the decay maintenance pass against every namespace storage root.
+ *
+ * In namespaces-enabled deployments, non-default namespaces store
+ * their graph JSONLs under `memoryDir/namespaces/<ns>/state/graphs/`,
+ * so a single-root run only updates the default namespace and silently
+ * skips the rest (issue #729 / Codex P2).
+ *
+ * Failures in one namespace do not block other namespaces; per-root
+ * errors are surfaced in the `error` field of each result.
+ */
+export async function runGraphEdgeDecayMaintenanceAcrossNamespaces(
+  memoryDir: string,
+  options: GraphEdgeDecayOptions & {
+    namespacesEnabled: boolean;
+    defaultNamespace: string;
+  },
+): Promise<GraphEdgeDecayNamespaceResult[]> {
+  const { namespacesEnabled, defaultNamespace, ...decayOptions } = options;
+  const roots = await discoverGraphNamespaceRoots(memoryDir, {
+    namespacesEnabled,
+    defaultNamespace,
+  });
+
+  const results: GraphEdgeDecayNamespaceResult[] = [];
+  for (const { namespace, storageRoot } of roots) {
+    try {
+      const telemetry = await runGraphEdgeDecayMaintenance(storageRoot, decayOptions);
+      results.push({ namespace, storageRoot, telemetry });
+    } catch (err) {
+      results.push({
+        namespace,
+        storageRoot,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+  return results;
 }

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -288,10 +288,15 @@ export async function ensureGraphEdgeDecayCron(
       ? options.agentId.trim()
       : "main";
 
+  const scheduleLabel = graphEdgeDecayScheduleLabel(scheduleExpr);
+
   return ensureCronJob(jobsPath, GRAPH_EDGE_DECAY_CRON_ID, () => ({
     id: GRAPH_EDGE_DECAY_CRON_ID,
     agentId,
-    name: "Remnic Graph Edge Decay (weekly)",
+    // Schedule label reflects the actual cron expression (`daily` /
+    // `weekly` / `custom`) so cron dashboards do not show "weekly"
+    // when the schedule is in fact daily — Cursor review on PR #729.
+    name: `Remnic Graph Edge Decay (${scheduleLabel})`,
     enabled: true,
     schedule: {
       kind: "cron",
@@ -315,10 +320,9 @@ export async function ensureGraphEdgeDecayCron(
 /**
  * Pick a cron expression that approximates a cadence in milliseconds.
  *
- * - cadence < 1 day → daily at 04:13 (sub-daily cadence is not natively
+ * - cadence < 7 days → daily at 04:13 (sub-daily cadence is not natively
  *   expressible in 5-field cron without `*\/N` patterns; daily is the
  *   safe upper bound that won't trip the cron more often than requested).
- * - 1 day ≤ cadence < 7 days → daily at 04:13.
  * - cadence ≥ 7 days → weekly on Sunday 04:13.
  *
  * Operators who need finer-grained control should set `scheduleExpr`
@@ -329,7 +333,17 @@ export function graphEdgeDecayCadenceToCronExpr(cadenceMs: number): string {
     return "13 4 * * 0";
   }
   const day = 24 * 60 * 60 * 1000;
-  if (cadenceMs < day) return "13 4 * * *";
   if (cadenceMs < 7 * day) return "13 4 * * *";
   return "13 4 * * 0";
+}
+
+/**
+ * Derive a human-friendly schedule label ("daily" / "weekly" / "custom")
+ * for the given cron expression. Used to keep the cron job name in
+ * sync with the actual schedule (Cursor review on PR #729).
+ */
+function graphEdgeDecayScheduleLabel(scheduleExpr: string): string {
+  if (scheduleExpr === "13 4 * * *") return "daily";
+  if (scheduleExpr === "13 4 * * 0") return "weekly";
+  return "custom";
 }

--- a/packages/remnic-core/src/maintenance/memory-governance-cron.ts
+++ b/packages/remnic-core/src/maintenance/memory-governance-cron.ts
@@ -5,6 +5,7 @@ const DAY_SUMMARY_CRON_ID = "engram-day-summary";
 const GOVERNANCE_CRON_ID = "engram-nightly-governance";
 const PROCEDURAL_MINING_CRON_ID = "engram-procedural-mining";
 const CONTRADICTION_SCAN_CRON_ID = "engram-contradiction-scan";
+const GRAPH_EDGE_DECAY_CRON_ID = "engram-graph-edge-decay";
 
 type CronJobsShape =
   | Array<Record<string, unknown>>
@@ -261,4 +262,74 @@ export async function ensureContradictionScanCron(
     },
     delivery: { mode: "none" },
   }));
+}
+
+/**
+ * Register a cron job that runs the graph-edge-decay maintenance pass
+ * (issue #681 PR 2/3). Default schedule is weekly on Sunday 04:13 — the
+ * cadence is configurable via `scheduleExpr`. Cadence is also expressible
+ * in milliseconds via `Config.graphEdgeDecayCadenceMs`; the orchestrator
+ * picks the right cron expression for sub-daily, daily, or weekly cadence.
+ */
+export async function ensureGraphEdgeDecayCron(
+  jobsPath: string,
+  options: {
+    timezone: string;
+    agentId?: string;
+    scheduleExpr?: string;
+  },
+): Promise<{ created: boolean; jobId: string }> {
+  const scheduleExpr =
+    typeof options.scheduleExpr === "string" && options.scheduleExpr.trim().length > 0
+      ? options.scheduleExpr.trim()
+      : "13 4 * * 0";
+  const agentId =
+    typeof options.agentId === "string" && options.agentId.trim().length > 0
+      ? options.agentId.trim()
+      : "main";
+
+  return ensureCronJob(jobsPath, GRAPH_EDGE_DECAY_CRON_ID, () => ({
+    id: GRAPH_EDGE_DECAY_CRON_ID,
+    agentId,
+    name: "Remnic Graph Edge Decay (weekly)",
+    enabled: true,
+    schedule: {
+      kind: "cron",
+      expr: scheduleExpr,
+      tz: options.timezone,
+    },
+    sessionTarget: "isolated",
+    wakeMode: "now",
+    payload: {
+      kind: "agentTurn",
+      timeoutSeconds: 900,
+      thinking: "off",
+      message:
+        "You are OpenClaw automation. Call tool `engram.graph_edge_decay_run` with empty params. " +
+        "If successful output exactly NO_REPLY. On error output one concise line. Do NOT use message tool.",
+    },
+    delivery: { mode: "none" },
+  }));
+}
+
+/**
+ * Pick a cron expression that approximates a cadence in milliseconds.
+ *
+ * - cadence < 1 day → daily at 04:13 (sub-daily cadence is not natively
+ *   expressible in 5-field cron without `*\/N` patterns; daily is the
+ *   safe upper bound that won't trip the cron more often than requested).
+ * - 1 day ≤ cadence < 7 days → daily at 04:13.
+ * - cadence ≥ 7 days → weekly on Sunday 04:13.
+ *
+ * Operators who need finer-grained control should set `scheduleExpr`
+ * directly via `ensureGraphEdgeDecayCron`.
+ */
+export function graphEdgeDecayCadenceToCronExpr(cadenceMs: number): string {
+  if (!Number.isFinite(cadenceMs) || cadenceMs <= 0) {
+    return "13 4 * * 0";
+  }
+  const day = 24 * 60 * 60 * 1000;
+  if (cadenceMs < day) return "13 4 * * *";
+  if (cadenceMs < 7 * day) return "13 4 * * *";
+  return "13 4 * * 0";
 }

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1206,6 +1206,11 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // false-missing warnings.
   checks.push(await summarizeConsolidationProvenance(new StorageManager(config.memoryDir), config));
 
+  // Graph-edge decay maintenance status (issue #681 PR 2/3).
+  // Reports whether the periodic decay job has run and surfaces last-run
+  // counts. Disabled is "ok" with a note; enabled-but-never-run is "warn".
+  checks.push(await summarizeGraphEdgeDecayStatus(config));
+
   // Security mitigation status (issue #565).
   // Reports whether the cross-namespace budget and anomaly detection
   // mitigations are enabled and surfaces config values for operator review.
@@ -1392,6 +1397,57 @@ export async function summarizeBufferSurpriseDistribution(
  * Exported so unit tests can exercise the summarization without booting a
  * full orchestrator.
  */
+
+async function summarizeGraphEdgeDecayStatus(
+  config: Pick<
+    PluginConfig,
+    "memoryDir" | "graphEdgeDecayEnabled" | "graphEdgeDecayCadenceMs"
+  >,
+): Promise<OperatorDoctorCheck> {
+  // Lazy import to keep the doctor fast when the feature is disabled.
+  const { readGraphEdgeDecayStatus } = await import("./maintenance/graph-edge-decay.js");
+  const enabled = config.graphEdgeDecayEnabled === true;
+  if (!enabled) {
+    return {
+      key: "graph_edge_decay",
+      status: "ok",
+      summary: "Graph-edge decay maintenance is disabled (graphEdgeDecayEnabled = false).",
+      remediation: "Set graphEdgeDecayEnabled = true to opt into the periodic decay job (issue #681).",
+      details: { enabled: false },
+    };
+  }
+
+  const status = await readGraphEdgeDecayStatus(config.memoryDir);
+  if (!status) {
+    return {
+      key: "graph_edge_decay",
+      status: "warn",
+      summary: "Graph-edge decay is enabled but has not run yet (no status file present).",
+      remediation:
+        "Trigger the cron, run `engram.graph_edge_decay_run` via MCP, or wait for the scheduled cadence to fire.",
+      details: { enabled: true, lastRun: null, cadenceMs: config.graphEdgeDecayCadenceMs },
+    };
+  }
+
+  return {
+    key: "graph_edge_decay",
+    status: "ok",
+    summary:
+      `Graph-edge decay last ran at ${status.ranAt} ` +
+      `(${status.edgesDecayed}/${status.edgesTotal} edges decayed, ` +
+      `${status.edgesBelowVisibilityThreshold} below visibility threshold).`,
+    details: {
+      enabled: true,
+      lastRun: status.ranAt,
+      durationMs: status.durationMs,
+      edgesTotal: status.edgesTotal,
+      edgesDecayed: status.edgesDecayed,
+      edgesBelowVisibilityThreshold: status.edgesBelowVisibilityThreshold,
+      topDecayedEntities: status.topDecayedEntities,
+      cadenceMs: config.graphEdgeDecayCadenceMs,
+    },
+  };
+}
 
 function summarizeSecurityMitigations(
   config: Pick<

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -77,6 +77,8 @@ import {
   ensureNightlyGovernanceCron,
   ensureProceduralMiningCron,
   ensureContradictionScanCron,
+  ensureGraphEdgeDecayCron,
+  graphEdgeDecayCadenceToCronExpr,
 } from "./maintenance/memory-governance-cron.js";
 import { ModelRegistry } from "./model-registry.js";
 import { applyRuntimeRetrievalPolicy, expandQuery } from "./retrieval.js";
@@ -2399,6 +2401,15 @@ export class Orchestrator {
       }
     }
 
+    // Auto-register graph-edge decay cron (gated by config — issue #681 PR 2/3).
+    if (this.config.graphEdgeDecayEnabled) {
+      try {
+        await this.autoRegisterGraphEdgeDecayCron();
+      } catch (err) {
+        log.debug(`graph edge decay cron auto-register failed (non-fatal): ${err}`);
+      }
+    }
+
     log.info("orchestrator initialized (full — deferred steps complete)");
   }
 
@@ -2632,6 +2643,29 @@ export class Orchestrator {
       }
     } catch (err) {
       log.debug(`contradiction scan cron auto-register error: ${err}`);
+    }
+  }
+
+  private async autoRegisterGraphEdgeDecayCron(): Promise<void> {
+    const home = resolveHomeDir();
+    const jobsPath = path.join(home, ".openclaw", "cron", "jobs.json");
+    try {
+      if (!existsSync(jobsPath)) {
+        log.debug("graph edge decay cron: jobs.json not found, skipping auto-register");
+        return;
+      }
+      const scheduleExpr = graphEdgeDecayCadenceToCronExpr(this.config.graphEdgeDecayCadenceMs);
+      const created = await ensureGraphEdgeDecayCron(jobsPath, {
+        timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+        scheduleExpr,
+      });
+      if (created.created) {
+        log.info(`graph edge decay cron auto-registered (${created.jobId}, ${scheduleExpr})`);
+      } else {
+        log.debug("graph edge decay cron already exists, skipping auto-register");
+      }
+    } catch (err) {
+      log.debug(`graph edge decay cron auto-register error: ${err}`);
     }
   }
 

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1279,6 +1279,21 @@ export interface PluginConfig {
   graphLateralInhibitionBeta: number;
   /** Number of top competing nodes considered for inhibition (default 7). */
   graphLateralInhibitionTopM: number;
+
+  // Issue #681 PR 2/3 — graph-edge confidence decay maintenance.
+  /** Enable the periodic graph-edge confidence decay job. Default false (opt-in). */
+  graphEdgeDecayEnabled: boolean;
+  /** Cadence in milliseconds at which the cron triggers the decay job. Default 7d. */
+  graphEdgeDecayCadenceMs: number;
+  /** Decay window passed through to `decayEdgeConfidence`. Default 90 days. */
+  graphEdgeDecayWindowMs: number;
+  /** Per-window confidence drop. Default 0.1. */
+  graphEdgeDecayPerWindow: number;
+  /** Floor confidence will not decay below. Default 0.1. */
+  graphEdgeDecayFloor: number;
+  /** Confidence threshold for the "below visibility" telemetry counter. Default 0.2. */
+  graphEdgeDecayVisibilityThreshold: number;
+
   // v8.2: Temporal Memory Tree
   temporalMemoryTreeEnabled: boolean;
   tmtHourlyMinMemories: number;

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -221,6 +221,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.review_list",
     "engram.review_resolve",
     "engram.contradiction_scan_run",
+    "engram.graph_edge_decay_run",
   ];
   const canonicalListed = legacyListed.map((name) => name.replace(/^engram\./, "remnic."));
   assert.deepEqual(listed, legacyListed.flatMap((name, index) => [canonicalListed[index], name]));


### PR DESCRIPTION
## Summary

PR 2/3 of the graph-edge confidence decay rollout (issue #681).

PR 1/3 (#717) shipped the pure helpers in `graph-edge-reinforcement.ts`. This PR wires them into a periodic maintenance pass:

- New `maintenance/graph-edge-decay.ts` job walks every edge in the on-disk JSONL graph stores (entity / time / causal), applies `decayEdgeConfidence`, and writes the result back via temp+rename atomic replace (CLAUDE.md gotcha #54).
- Emits a structured telemetry record per run (`edges_total`, `edges_decayed`, `edges_below_visibility_threshold`, `top_decayed_entities`, per-edge-type breakdown) and persists it to `state/graph-edge-decay-status.json`.
- Config: `graphEdgeDecayEnabled` (default `false`, opt-in), `graphEdgeDecayCadenceMs` (default 7d), and the four parameters that thread through to the PR 1 helper (`windowMs`, `perWindow`, `floor`, `visibilityThreshold`). Boolean flag goes through `coerceBooleanLike` (gotcha #36).
- Cron: `ensureGraphEdgeDecayCron` registers `engram-graph-edge-decay`. Cadence in ms maps to a daily / weekly cron expression via `graphEdgeDecayCadenceToCronExpr`. Auto-registered from `Orchestrator.initialize` when the flag is on.
- MCP tool `engram.graph_edge_decay_run` (+ `remnic.*` alias). Off → no-op returning `{disabled: true}`.
- Doctor: `graph_edge_decay` check reports `enabled` / `lastRun` / counts / top-decayed-entities.
- Plugin schema entries with documented defaults.

## Tests

`packages/remnic-core/src/maintenance/graph-edge-decay.test.ts` — 7 tests, all pass:

- Fresh / mid-decay / floor-pinned fixture: decays only the mid edge, preserves floor and fresh-window edges.
- Idempotent re-run produces no further decay (PR 1 anchor advance reseats the grace window correctly).
- Dry-run leaves graph files + status file untouched.
- Telemetry record shape (ranAt / durationMs / per-type breakdown / top-5 ordering / persisted-status round-trip).
- Custom visibility threshold counter.
- Missing graph files treated as empty (fail-open).
- Disabled flag honored by parsed config + boolean coercion (string `"false"` / `"0"` / `"off"`).

```
$ npx tsc --noEmit              # clean
$ npx tsx --test src/maintenance/graph-edge-decay.test.ts
# tests 7 / pass 7 / fail 0
```

The 4 cancelled lcm-engine tests in the wider suite are pre-existing flakiness on `main` (unrelated to this PR).

## Out of scope (defer to PR 3/3)

- PageRank weighting integration
- Recall traversal pruning
- X-ray surface for decay events
- `docs/graph-edge-decay.md`

Refs: #681 #717

## Test plan

- [x] `npx tsc --noEmit` from `packages/remnic-core` clean
- [x] New test file passes (7/7)
- [x] No regressions in `config.test.ts`
- [ ] CI green
- [ ] AI reviewers (cursor / codex) post no blockers

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new maintenance path that rewrites on-disk graph JSONL files and auto-registers a cron/MCP entry point; bugs could drop edges or mis-handle I/O, though the feature is opt-in and guarded by locks and defaults.
> 
> **Overview**
> Introduces an *opt-in* graph-edge confidence decay maintenance job that periodically scans and rewrites the `{entity,time,causal}.jsonl` graph stores, applying confidence decay and persisting last-run telemetry to `state/graph-edge-decay-status.json`.
> 
> Wires the job into the system via new config knobs (`graphEdgeDecayEnabled` + cadence/decay parameters), an MCP tool (`engram.graph_edge_decay_run` with `remnic.*` alias) that no-ops when disabled, and an auto-registered cron job whose schedule is derived from `graphEdgeDecayCadenceMs`.
> 
> Hardens graph file concurrency and error handling by adding a per-graph-file write lock shared by `appendEdge` and the decay rewrite path, plus a strict edge reader for maintenance, and adds doctor reporting + unit tests covering decay behavior, dry-run, namespace enumeration, and concurrency safety.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit af3bd09ec9e509ccf35b4d5a51fe4dff5d6aa5e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->