### PR TITLE
feat(capsule): capsule export pipeline (#676 PR 2/6)

### DIFF
--- a/.changeset/676-pr2-capsule-export.md
+++ b/.changeset/676-pr2-capsule-export.md
@@ -1,0 +1,12 @@
+---
+"@remnic/core": minor
+---
+
+feat(capsule): capsule export pipeline (#676 PR 2/6)
+
+Add `exportCapsule()` in `packages/remnic-core/src/transfer/capsule-export.ts`
+— a pure async function that bundles a memory directory into a portable,
+capsule-aware V2 export. Output is a single `.capsule.json.gz` archive plus
+a sidecar `manifest.json`. Supports `since` (mtime cutoff), `includeKinds`
+(top-level subdirectory allow-list, transcripts opt-in), and `peerIds`
+(peers/ subtree filter). No CLI surface yet; that lands in PR 6/6.

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/Users/joshuawarren/src/remnic/node_modules

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/Users/joshuawarren/src/remnic/node_modules

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -130,6 +130,12 @@ export async function exportCapsule(
   const outDirAbs = path.resolve(opts.outDir ?? path.join(rootAbs, ".capsules"));
   await mkdir(outDirAbs, { recursive: true });
 
+  // If the output directory lives inside the export root, scan results would
+  // re-import previous capsule archives on subsequent runs. Compute the
+  // posix-relative path of the outDir under rootAbs (or `null` when it sits
+  // outside) so {@link shouldInclude} can skip the entire subtree.
+  const outDirRelPosix = computeOutDirRel(rootAbs, outDirAbs);
+
   const filesAbs = await listFilesRecursive(rootAbs);
 
   const records: ExportMemoryRecordV1[] = [];
@@ -137,7 +143,7 @@ export async function exportCapsule(
 
   for (const abs of filesAbs) {
     const relPosix = toPosixRelPath(abs, rootAbs);
-    if (!shouldInclude(relPosix, includeKinds, peerFilter)) continue;
+    if (!shouldInclude(relPosix, includeKinds, peerFilter, outDirRelPosix)) continue;
 
     if (sinceMs !== null) {
       const st = await stat(abs);
@@ -263,6 +269,23 @@ function normalizePeerIds(
   return set;
 }
 
+/**
+ * Return the posix-relative path of {@link outDirAbs} under {@link rootAbs},
+ * or `null` if the output directory sits outside the export root. Used to
+ * exclude the output directory's subtree from the input scan so re-running
+ * the export does not package prior archives back into the new bundle.
+ *
+ * Both inputs are expected to be absolute paths already (post-`path.resolve`).
+ */
+function computeOutDirRel(rootAbs: string, outDirAbs: string): string | null {
+  const rel = path.relative(rootAbs, outDirAbs);
+  // outDir == root: degenerate, skip the whole tree by treating as ".".
+  if (rel === "") return ".";
+  // outDir outside root: nothing to exclude.
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  return rel.split(path.sep).join("/");
+}
+
 async function assertIsDirectory(absPath: string): Promise<void> {
   // Mirror gotcha #24: existsSync returns true for files. The export root
   // MUST be a directory or the walk silently succeeds with zero entries.
@@ -278,9 +301,19 @@ function shouldInclude(
   relPosix: string,
   includeKinds: ReadonlySet<string> | null,
   peerFilter: ReadonlySet<string> | null,
+  outDirRelPosix: string | null,
 ): boolean {
   const parts = relPosix.split("/");
   if (parts.some((p) => DEFAULT_EXCLUDE_DIRS.has(p))) return false;
+
+  // Exclude the output directory subtree. Without this, re-running against
+  // the same root packages prior `.capsule.json.gz` archives and sidecar
+  // manifests as records, causing bundle bloat and leaking stale exports.
+  if (outDirRelPosix !== null) {
+    if (outDirRelPosix === ".") return false; // degenerate: outDir == root
+    if (relPosix === outDirRelPosix) return false;
+    if (relPosix.startsWith(`${outDirRelPosix}/`)) return false;
+  }
 
   const top = parts[0];
 

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -213,13 +213,21 @@ function validateName(name: unknown): void {
 }
 
 /**
- * Strict ISO-8601 prefix used to validate {@link ExportCapsuleOptions.since}.
- * `Date.parse` accepts permissive values like `"April 26"`, which silently
- * defaults to the local timezone and the year 2001. Rule 51: reject invalid
- * input rather than silently coercing.
+ * Strict ISO-8601 form accepted by {@link parseSince}. We accept exactly two
+ * shapes:
+ *
+ *   1. Date-only:  `YYYY-MM-DD` — interpreted as UTC midnight per ECMAScript.
+ *   2. Date+time with an explicit timezone designator:
+ *      `YYYY-MM-DDTHH:MM(:SS(.fff)?)?(Z|±HH:MM)`.
+ *
+ * Notably **rejected**: date+time **without** a timezone (e.g.
+ * `2026-02-28T00:00:00`). ECMAScript treats this as local time, which makes
+ * acceptance and the resulting cutoff depend on the host's `TZ` and silently
+ * shifts incremental-export windows for users outside UTC. Rule 51: reject
+ * inputs that silently coerce to a host-dependent meaning.
  */
 const ISO_8601_RE =
-  /^\d{4}-\d{2}-\d{2}(?:[Tt]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:[Zz]|[+-]\d{2}:?\d{2})?)?$/;
+  /^\d{4}-\d{2}-\d{2}(?:[Tt]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:[Zz]|[+-]\d{2}:?\d{2}))?$/;
 
 function parseSince(since: string | undefined): number | null {
   if (since === undefined) return null;

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -128,6 +128,17 @@ export async function exportCapsule(
   await assertIsDirectory(rootAbs);
 
   const outDirAbs = path.resolve(opts.outDir ?? path.join(rootAbs, ".capsules"));
+  // Reject outDir === root: the input scan would otherwise be entirely
+  // skipped by `shouldInclude` (outDirRelPosix === ".") and the export would
+  // silently succeed with an empty manifest/archive — a Rule 51 violation
+  // and a data-loss footgun for callers that point outDir at the root.
+  if (outDirAbs === rootAbs) {
+    throw new Error(
+      "exportCapsule: 'outDir' must not equal 'root'. " +
+        "Choose a separate directory (default: <root>/.capsules) so the " +
+        "export does not overwrite or shadow the source tree.",
+    );
+  }
   await mkdir(outDirAbs, { recursive: true });
 
   // If the output directory lives inside the export root, scan results would
@@ -348,8 +359,12 @@ function normalizePeerIds(
  */
 function computeOutDirRel(rootAbs: string, outDirAbs: string): string | null {
   const rel = path.relative(rootAbs, outDirAbs);
-  // outDir == root: degenerate, skip the whole tree by treating as ".".
-  if (rel === "") return ".";
+  // outDir == root: degenerate. {@link exportCapsule} rejects this case
+  // before calling us; this branch is defensive only. Returning `"."` would
+  // make `shouldInclude` drop every file, masking the misuse — return `null`
+  // instead so any direct caller that bypasses the check still produces a
+  // populated manifest rather than a silent empty export.
+  if (rel === "") return null;
   // outDir outside root: nothing to exclude.
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
   return rel.split(path.sep).join("/");
@@ -378,8 +393,9 @@ function shouldInclude(
   // Exclude the output directory subtree. Without this, re-running against
   // the same root packages prior `.capsule.json.gz` archives and sidecar
   // manifests as records, causing bundle bloat and leaking stale exports.
+  // `outDir === root` is rejected at the entrypoint (`exportCapsule`), so
+  // {@link computeOutDirRel} never returns `"."` for the in-tree case here.
   if (outDirRelPosix !== null) {
-    if (outDirRelPosix === ".") return false; // degenerate: outDir == root
     if (relPosix === outDirRelPosix) return false;
     if (relPosix.startsWith(`${outDirRelPosix}/`)) return false;
   }

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -1,0 +1,355 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { CAPSULE_SCHEMA_VERSION, EXPORT_FORMAT } from "./constants.js";
+import {
+  listFilesRecursive,
+  sha256File,
+  toPosixRelPath,
+  writeJsonFile,
+} from "./fs-utils.js";
+import {
+  CAPSULE_ID_PATTERN,
+  CapsuleBlockSchema,
+  ExportBundleV2Schema,
+  ExportManifestV2Schema,
+  type CapsuleBlock,
+  type ExportBundleV2,
+  type ExportManifestV2,
+  type ExportMemoryRecordV1,
+} from "./types.js";
+
+/**
+ * Default subdirectory excludes applied to every capsule export. These match
+ * the existing `export-json` / `export-md` exclusions plus the `transcripts`
+ * directory, which is excluded by default and only included when the caller
+ * explicitly passes `transcripts` in {@link ExportCapsuleOptions.includeKinds}.
+ */
+const DEFAULT_EXCLUDE_DIRS: ReadonlySet<string> = new Set([
+  "node_modules",
+  ".git",
+]);
+
+const TRANSCRIPTS_DIR = "transcripts" as const;
+
+/**
+ * Top-level directory under {@link ExportCapsuleOptions.root} that holds
+ * per-peer profile bundles. When {@link ExportCapsuleOptions.peerIds} is
+ * provided, only files under `peers/<peerId>/...` for the listed ids are
+ * included; the rest of the `peers/` tree is excluded.
+ */
+const PEERS_DIR = "peers" as const;
+
+/**
+ * Options accepted by {@link exportCapsule}.
+ *
+ * `name` — capsule id, validated against {@link CAPSULE_ID_PATTERN}. The id
+ * also forms the manifest's `capsule.id` and the archive filename.
+ *
+ * `root` — absolute or cwd-relative path to the memory directory to export.
+ *
+ * `since` — optional ISO-8601 timestamp; only files with `mtime >= since`
+ * are included.
+ *
+ * `includeKinds` — optional allow-list of top-level subdirectory names
+ * (e.g. `facts`, `entities`, `corrections`, `transcripts`). When set, files
+ * directly under {@link root} are excluded and only files whose first path
+ * segment is in the allow-list are kept. Pass `transcripts` here explicitly
+ * to opt-in transcripts (they are excluded by default).
+ *
+ * `peerIds` — optional allow-list restricting the `peers/` tree to files
+ * under `peers/<peerId>/...`. When omitted the entire `peers/` tree is
+ * included (subject to {@link includeKinds}). When set to an empty array
+ * the `peers/` tree is excluded entirely.
+ *
+ * `outDir` — optional output directory. Defaults to `<root>/.capsules`.
+ *
+ * `pluginVersion` — recorded in the manifest. Defaults to `"0.0.0"` so
+ * tests do not need to thread a version through; production callers SHOULD
+ * pass the running plugin version.
+ *
+ * `capsule` — optional overrides for the manifest's `capsule` block. The
+ * caller may pass any subset; remaining fields are filled with conservative
+ * defaults documented inline below.
+ *
+ * `now` — optional clock override (ms epoch) used for `manifest.createdAt`.
+ * Tests pass a fixed value for deterministic output.
+ */
+export interface ExportCapsuleOptions {
+  name: string;
+  root: string;
+  since?: string;
+  includeKinds?: readonly string[];
+  peerIds?: readonly string[];
+  outDir?: string;
+  pluginVersion?: string;
+  capsule?: Partial<Omit<CapsuleBlock, "id">>;
+  now?: number;
+}
+
+export interface ExportCapsuleResult {
+  archivePath: string;
+  manifestPath: string;
+  manifest: ExportManifestV2;
+}
+
+/**
+ * Pure function that exports a memory directory as a portable, capsule-aware
+ * V2 bundle.
+ *
+ * The output is a single `.capsule.json.gz` archive containing the entire
+ * `ExportBundleV2` (manifest + records) plus a sidecar `manifest.json` for
+ * cheap inspection. The bundle format is intentionally identical to the
+ * existing `export-json` shape so PR 3/6's importer can reuse the V1 code
+ * path with only a manifest version-dispatch.
+ *
+ * Determinism guarantees:
+ *  - `manifest.files` and `bundle.records` are sorted by posix path.
+ *  - `manifest.createdAt` is taken from {@link ExportCapsuleOptions.now}
+ *    when provided.
+ *  - The archive is gzip-compressed with default settings; no timestamp is
+ *    embedded (Node's `gzipSync` does not write a header timestamp when
+ *    using the synchronous helper, so byte-identical outputs are possible
+ *    given identical inputs).
+ *
+ * Empty result handling: a capsule with zero matching files is still a
+ * valid capsule and produces a well-formed manifest with an empty `files`
+ * array and an archive containing the empty bundle.
+ */
+export async function exportCapsule(
+  opts: ExportCapsuleOptions,
+): Promise<ExportCapsuleResult> {
+  validateName(opts.name);
+  const sinceMs = parseSince(opts.since);
+  const includeKinds = normalizeIncludeKinds(opts.includeKinds);
+  const peerFilter = normalizePeerIds(opts.peerIds);
+
+  const rootAbs = path.resolve(opts.root);
+  await assertIsDirectory(rootAbs);
+
+  const outDirAbs = path.resolve(opts.outDir ?? path.join(rootAbs, ".capsules"));
+  await mkdir(outDirAbs, { recursive: true });
+
+  const filesAbs = await listFilesRecursive(rootAbs);
+
+  const records: ExportMemoryRecordV1[] = [];
+  const manifestFiles: ExportManifestV2["files"] = [];
+
+  for (const abs of filesAbs) {
+    const relPosix = toPosixRelPath(abs, rootAbs);
+    if (!shouldInclude(relPosix, includeKinds, peerFilter)) continue;
+
+    if (sinceMs !== null) {
+      const st = await stat(abs);
+      if (st.mtimeMs < sinceMs) continue;
+    }
+
+    const content = await readFile(abs, "utf-8");
+    records.push({ path: relPosix, content });
+    const { sha256, bytes } = await sha256File(abs);
+    manifestFiles.push({ path: relPosix, sha256, bytes });
+  }
+
+  records.sort((a, b) => a.path.localeCompare(b.path));
+  manifestFiles.sort((a, b) => a.path.localeCompare(b.path));
+
+  const capsule = buildCapsuleBlock(opts.name, opts.capsule);
+  const includesTranscripts = (includeKinds ?? new Set<string>()).has(TRANSCRIPTS_DIR);
+
+  const createdAtMs = opts.now ?? Date.now();
+  const manifest = ExportManifestV2Schema.parse({
+    format: EXPORT_FORMAT,
+    schemaVersion: CAPSULE_SCHEMA_VERSION,
+    createdAt: new Date(createdAtMs).toISOString(),
+    pluginVersion: opts.pluginVersion ?? "0.0.0",
+    includesTranscripts,
+    files: manifestFiles,
+    capsule,
+  } satisfies ExportManifestV2);
+
+  const bundle: ExportBundleV2 = ExportBundleV2Schema.parse({
+    manifest,
+    records,
+  });
+
+  const archivePath = path.join(outDirAbs, `${opts.name}.capsule.json.gz`);
+  const manifestPath = path.join(outDirAbs, `${opts.name}.manifest.json`);
+
+  // Sidecar manifest for cheap inspection without decompressing the archive.
+  await writeJsonFile(manifestPath, manifest);
+
+  // Single-artifact gzip archive containing the whole bundle. JSON encoded
+  // before gzip so the archive is opaque to file-tree filtering. Using the
+  // sync helper keeps the function pure async (no filesystem callback chain)
+  // and matches the existing transfer modules' style.
+  const json = JSON.stringify(bundle);
+  const gz = gzipSync(Buffer.from(json, "utf-8"));
+  await writeFile(archivePath, gz);
+
+  return { archivePath, manifestPath, manifest };
+}
+
+// ---------------------------------------------------------------------------
+// Validation helpers
+// ---------------------------------------------------------------------------
+
+function validateName(name: unknown): void {
+  if (typeof name !== "string" || !CAPSULE_ID_PATTERN.test(name)) {
+    throw new Error(
+      `exportCapsule: invalid capsule name. Expected /${CAPSULE_ID_PATTERN.source}/`,
+    );
+  }
+  if (name.length > 64) {
+    throw new Error(
+      "exportCapsule: invalid capsule name. Must be 64 characters or fewer.",
+    );
+  }
+}
+
+function parseSince(since: string | undefined): number | null {
+  if (since === undefined) return null;
+  if (typeof since !== "string" || since.trim() === "") {
+    throw new Error("exportCapsule: 'since' must be a non-empty ISO-8601 string");
+  }
+  const ms = Date.parse(since);
+  if (!Number.isFinite(ms)) {
+    throw new Error(
+      `exportCapsule: 'since' is not a valid ISO-8601 timestamp: ${since}`,
+    );
+  }
+  return ms;
+}
+
+function normalizeIncludeKinds(
+  kinds: readonly string[] | undefined,
+): ReadonlySet<string> | null {
+  if (kinds === undefined) return null;
+  // Empty array is treated as "include nothing" rather than "include all"
+  // so callers cannot accidentally widen the filter by passing []. This
+  // mirrors PR-1/6 Rule 51: reject ambiguous input — but here we model it
+  // as "explicit empty allow-list" rather than throwing, because empty
+  // capsules ARE valid (see acceptance criteria).
+  const set = new Set<string>();
+  for (const raw of kinds) {
+    if (typeof raw !== "string" || raw.trim() === "") {
+      throw new Error("exportCapsule: 'includeKinds' entries must be non-empty strings");
+    }
+    if (raw.includes("/") || raw.includes("\\")) {
+      throw new Error(
+        `exportCapsule: 'includeKinds' entries must be top-level segment names, got: ${raw}`,
+      );
+    }
+    set.add(raw);
+  }
+  return set;
+}
+
+function normalizePeerIds(
+  peerIds: readonly string[] | undefined,
+): ReadonlySet<string> | null {
+  if (peerIds === undefined) return null;
+  const set = new Set<string>();
+  for (const raw of peerIds) {
+    if (typeof raw !== "string" || raw.trim() === "") {
+      throw new Error("exportCapsule: 'peerIds' entries must be non-empty strings");
+    }
+    if (raw.includes("/") || raw.includes("\\") || raw === "." || raw === "..") {
+      throw new Error(
+        `exportCapsule: 'peerIds' entries must be plain segment names, got: ${raw}`,
+      );
+    }
+    set.add(raw);
+  }
+  return set;
+}
+
+async function assertIsDirectory(absPath: string): Promise<void> {
+  // Mirror gotcha #24: existsSync returns true for files. The export root
+  // MUST be a directory or the walk silently succeeds with zero entries.
+  const st = await stat(absPath).catch(() => null);
+  if (!st || !st.isDirectory()) {
+    throw new Error(
+      `exportCapsule: 'root' must be an existing directory: ${absPath}`,
+    );
+  }
+}
+
+function shouldInclude(
+  relPosix: string,
+  includeKinds: ReadonlySet<string> | null,
+  peerFilter: ReadonlySet<string> | null,
+): boolean {
+  const parts = relPosix.split("/");
+  if (parts.some((p) => DEFAULT_EXCLUDE_DIRS.has(p))) return false;
+
+  const top = parts[0];
+
+  // Transcripts are opt-in: excluded unless caller explicitly listed them
+  // in includeKinds. This matches existing exporter behavior.
+  if (top === TRANSCRIPTS_DIR && (includeKinds === null || !includeKinds.has(TRANSCRIPTS_DIR))) {
+    return false;
+  }
+
+  if (includeKinds !== null) {
+    // includeKinds restricts to whitelisted top-level segments. Files at
+    // the repo root (no top-level dir) are excluded under an explicit
+    // allow-list because they are not categorized.
+    if (parts.length < 2) return false;
+    if (!includeKinds.has(top)) return false;
+  }
+
+  if (top === PEERS_DIR && peerFilter !== null) {
+    if (peerFilter.size === 0) return false;
+    if (parts.length < 2) return false;
+    if (!peerFilter.has(parts[1])) return false;
+  }
+
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Capsule-block defaults
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a {@link CapsuleBlock} for the manifest. PR 2/6 ships a minimal
+ * snapshot: tier-weights and `directAnswerEnabled` default to zod-passing
+ * placeholders so the bundle parses cleanly. PRs 3/6+ will wire real
+ * retrieval-policy and identity-anchor snapshots into the override path.
+ *
+ * Defaults (chosen to be safe + least-surprising):
+ *  - `version`           — `0.1.0` (capsule authors override per release).
+ *  - `schemaVersion`     — `taxonomy-v1` until the taxonomy registry stabilizes.
+ *  - `parentCapsule`     — `null` (explicit "no parent" sentinel).
+ *  - `description`       — empty string. Capsule authors override.
+ *  - `retrievalPolicy`   — empty `tierWeights` map + `directAnswerEnabled: false`.
+ *    Empty weights mean "no overrides"; importers fall back to their local
+ *    policy. `false` is the least-privileged default per Rule 48.
+ *  - `includes`          — all flags `false` until later PRs wire the
+ *    sub-bundles in.
+ */
+function buildCapsuleBlock(
+  name: string,
+  override: Partial<Omit<CapsuleBlock, "id">> | undefined,
+): CapsuleBlock {
+  const merged: CapsuleBlock = {
+    id: name,
+    version: override?.version ?? "0.1.0",
+    schemaVersion: override?.schemaVersion ?? "taxonomy-v1",
+    parentCapsule: override?.parentCapsule ?? null,
+    description: override?.description ?? "",
+    retrievalPolicy: override?.retrievalPolicy ?? {
+      tierWeights: {},
+      directAnswerEnabled: false,
+    },
+    includes: override?.includes ?? {
+      taxonomy: false,
+      identityAnchors: false,
+      peerProfiles: false,
+      procedural: false,
+    },
+  };
+  // Re-parse to surface invalid overrides with the same zod errors a caller
+  // would get when constructing a CapsuleBlock by hand.
+  return CapsuleBlockSchema.parse(merged);
+}

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -237,7 +237,54 @@ function parseSince(since: string | undefined): number | null {
       `exportCapsule: 'since' is not a valid ISO-8601 timestamp: ${since}`,
     );
   }
+  // Reject calendar overflow: `Date.parse("2026-02-31")` returns a finite ms
+  // for March 3 because the JS Date constructor silently normalizes invalid
+  // calendar values. Round-trip through `Date` and compare the year/month/day
+  // components against the input prefix to catch this. Rule 51: silent
+  // coercion of an exact time boundary is a Rule 51 violation that breaks
+  // incremental exports.
+  assertCalendarRoundTrip(since, ms);
   return ms;
+}
+
+/**
+ * Verify that parsing {@link since} did not silently normalize an invalid
+ * calendar date (e.g. `2026-02-31` → `2026-03-03`). We extract the
+ * year/month/day from the input string (regex-validated above) and compare
+ * against the parsed Date's UTC components. Both date-only forms and forms
+ * with an explicit Z/offset are normalized to UTC by `Date.parse`; for the
+ * non-Z case where the offset shifts the calendar day across midnight, we
+ * re-derive the input's intended UTC instant by accounting for the offset
+ * before the comparison.
+ */
+function assertCalendarRoundTrip(since: string, ms: number): void {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(since);
+  if (!m) return;
+  const wantY = Number(m[1]);
+  const wantMo = Number(m[2]);
+  const wantD = Number(m[3]);
+
+  // For inputs with an explicit non-zero offset, compare against the
+  // wall-clock components of that offset instead of UTC. Date.parse maps to
+  // UTC, so 2026-02-31T00:00:00-05:00 and 2026-02-31T00:00:00Z both fail the
+  // calendar check; the wall-clock comparison via `m[1..3]` is still the
+  // right reference because the input's stated calendar day must exist.
+  const offsetMatch = /([+-])(\d{2}):?(\d{2})$/.exec(since);
+  let displayMs = ms;
+  if (offsetMatch) {
+    const sign = offsetMatch[1] === "-" ? -1 : 1;
+    const offsetMin = sign * (Number(offsetMatch[2]) * 60 + Number(offsetMatch[3]));
+    displayMs = ms + offsetMin * 60_000;
+  }
+  const dd = new Date(displayMs);
+  const gotY = dd.getUTCFullYear();
+  const gotMo = dd.getUTCMonth() + 1;
+  const gotD = dd.getUTCDate();
+  if (gotY !== wantY || gotMo !== wantMo || gotD !== wantD) {
+    throw new Error(
+      `exportCapsule: 'since' is not a valid ISO-8601 timestamp: ${since}`,
+    );
+  }
 }
 
 function normalizeIncludeKinds(

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -365,8 +365,13 @@ function computeOutDirRel(rootAbs: string, outDirAbs: string): string | null {
   // instead so any direct caller that bypasses the check still produces a
   // populated manifest rather than a silent empty export.
   if (rel === "") return null;
-  // outDir outside root: nothing to exclude.
-  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+  // outDir outside root: nothing to exclude. Match real parent-traversal
+  // segments only — `rel.startsWith("..")` would also match valid in-tree
+  // names like `..capsules` and would skip excluding that subtree. The
+  // boundary check (`rel === ".."` or `rel` starts with `".." + sep`) is
+  // platform-aware via `path.sep` so Windows backslashes are respected.
+  if (rel === ".." || rel.startsWith(`..${path.sep}`)) return null;
+  if (path.isAbsolute(rel)) return null;
   return rel.split(path.sep).join("/");
 }
 

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -212,10 +212,24 @@ function validateName(name: unknown): void {
   }
 }
 
+/**
+ * Strict ISO-8601 prefix used to validate {@link ExportCapsuleOptions.since}.
+ * `Date.parse` accepts permissive values like `"April 26"`, which silently
+ * defaults to the local timezone and the year 2001. Rule 51: reject invalid
+ * input rather than silently coercing.
+ */
+const ISO_8601_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[Tt]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:[Zz]|[+-]\d{2}:?\d{2})?)?$/;
+
 function parseSince(since: string | undefined): number | null {
   if (since === undefined) return null;
   if (typeof since !== "string" || since.trim() === "") {
     throw new Error("exportCapsule: 'since' must be a non-empty ISO-8601 string");
+  }
+  if (!ISO_8601_RE.test(since)) {
+    throw new Error(
+      `exportCapsule: 'since' is not a valid ISO-8601 timestamp: ${since}`,
+    );
   }
   const ms = Date.parse(since);
   if (!Number.isFinite(ms)) {

--- a/packages/remnic-core/src/transfer/constants.ts
+++ b/packages/remnic-core/src/transfer/constants.ts
@@ -1,3 +1,13 @@
 export const EXPORT_FORMAT = "openclaw-engram-export" as const;
 export const EXPORT_SCHEMA_VERSION = 1 as const;
 
+/**
+ * Schema version for capsule-aware (V2) export manifests. See
+ * {@link ../types.ts} `ExportManifestV2Schema` for the wire format.
+ *
+ * V1 manifests remain the default for non-capsule exports
+ * (`exportJsonBundle` / `exportMarkdownBundle`). V2 is emitted by the
+ * capsule export pipeline only.
+ */
+export const CAPSULE_SCHEMA_VERSION = 2 as const;
+

--- a/src/transfer/capsule-export.ts
+++ b/src/transfer/capsule-export.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/remnic-core/src/transfer/capsule-export.js";

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -244,6 +244,55 @@ test("invalid 'since' is rejected", async () => {
   );
 });
 
+test("'since' rejects calendar-overflow dates (e.g. Feb 31)", async () => {
+  const root = await makeFixture([{ rel: "a.md", content: "a\n" }]);
+  // Each of these passes the regex but `Date.parse` silently normalizes to a
+  // different calendar day. We must reject them rather than shifting the
+  // user's intended cutoff window.
+  for (const bad of [
+    "2026-02-31",
+    "2026-02-30",
+    "2026-04-31",
+    "2026-13-01",
+    "2026-00-15",
+    "2026-02-31T00:00:00Z",
+    "2026-02-31T00:00:00-05:00",
+  ]) {
+    await assert.rejects(
+      exportCapsule({ name: "bad-cal", root, since: bad }),
+      /not a valid ISO/i,
+      `expected ${bad} to be rejected`,
+    );
+  }
+});
+
+test("'since' accepts well-formed timestamps with offsets", async () => {
+  const root = await makeFixture([
+    {
+      rel: "facts/a.md",
+      content: "a\n",
+      mtime: new Date("2026-04-01T00:00:00Z"),
+    },
+  ]);
+  for (const good of [
+    "2026-02-28",
+    "2026-02-28T00:00:00Z",
+    "2026-02-28T00:00:00.500Z",
+    "2026-02-28T19:00:00-05:00",
+    "2024-02-29", // leap year
+  ]) {
+    const result = await exportCapsule({
+      name: "good-since",
+      root,
+      since: good,
+    });
+    // The "since" cutoff (Feb 28 2026, etc.) should not exclude an April 1 mtime.
+    if (good.startsWith("2026-")) {
+      assert.equal(result.manifest.files.length, 1, `expected file kept for ${good}`);
+    }
+  }
+});
+
 test("non-directory root is rejected", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "capsule-root-file-"));
   const filePath = path.join(tmp, "not-a-dir");

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -480,6 +480,30 @@ test("outDir outside root does not affect inclusion", async () => {
   );
 });
 
+test("outDir named '..capsules' (valid in-tree dir) is still excluded", async () => {
+  // Boundary check: `rel.startsWith("..")` would falsely treat `<root>/..capsules`
+  // as outside the root. Use `rel === ".."` or `rel.startsWith(".." + sep)`
+  // so valid in-tree names like `..capsules` are still excluded on re-export.
+  const root = await makeFixture([{ rel: "facts/a.md", content: "a\n" }]);
+  const trickyOut = path.join(root, "..capsules");
+
+  await exportCapsule({ name: "first", root, outDir: trickyOut });
+  const second = await exportCapsule({
+    name: "second",
+    root,
+    outDir: trickyOut,
+  });
+  assert.deepEqual(
+    second.manifest.files.map((f) => f.path),
+    ["facts/a.md"],
+    "files under '..capsules' (an in-tree dir) must be excluded on re-export",
+  );
+  assert.ok(
+    !second.manifest.files.some((f) => f.path.startsWith("..capsules/")),
+    "the in-tree '..capsules' subtree must not leak into the manifest",
+  );
+});
+
 test("default-excluded directories (.git, node_modules) are skipped", async () => {
   const root = await makeFixture([
     { rel: "facts/a.md", content: "a\n" },

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -434,6 +434,33 @@ test("outDir resolving to root via '.' segments is also rejected", async () => {
   );
 });
 
+test("outDir name starting with '..' is treated as in-tree (not parent-traversal)", async () => {
+  // Codex P2 (#731): the prior outside-root check used `rel.startsWith("..")`,
+  // which incorrectly classified valid in-tree directory names like
+  // `..capsules` as parent-traversal and skipped excluding them. The boundary
+  // check (`rel === ".."` or starts with `".." + path.sep`) correctly treats
+  // `..capsules` as in-tree and excludes its subtree from re-export.
+  const root = await makeFixture([{ rel: "facts/a.md", content: "a\n" }]);
+  const dotsDir = path.join(root, "..capsules");
+
+  // First export — writes archive + sidecar into the literal `..capsules`
+  // subdir. The directory name resolves under root (no traversal).
+  await exportCapsule({ name: "first", root, outDir: dotsDir });
+
+  const second = await exportCapsule({
+    name: "second",
+    root,
+    outDir: dotsDir,
+  });
+  // The first run's archive + manifest must not appear in the second manifest.
+  for (const f of second.manifest.files) {
+    assert.ok(
+      !f.path.startsWith("..capsules/"),
+      `..capsules contents must be excluded, got: ${f.path}`,
+    );
+  }
+});
+
 test("outDir outside root does not affect inclusion", async () => {
   const root = await makeFixture([
     { rel: "facts/a.md", content: "a\n" },

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -412,6 +412,28 @@ test("explicit outDir under root is also excluded from the input scan", async ()
   );
 });
 
+test("outDir equal to root is rejected (avoids silent empty export)", async () => {
+  const root = await makeFixture([{ rel: "facts/a.md", content: "a\n" }]);
+
+  await assert.rejects(
+    () => exportCapsule({ name: "self", root, outDir: root }),
+    /'outDir' must not equal 'root'/,
+    "exportCapsule must throw when outDir resolves to the same path as root",
+  );
+});
+
+test("outDir resolving to root via '.' segments is also rejected", async () => {
+  const root = await makeFixture([{ rel: "facts/a.md", content: "a\n" }]);
+  // outDir is logically the same directory as root but written with a trailing
+  // "/." — `path.resolve` normalizes both to the same absolute path, so the
+  // equality check must catch this case too.
+  await assert.rejects(
+    () => exportCapsule({ name: "self", root, outDir: path.join(root, ".") }),
+    /'outDir' must not equal 'root'/,
+    "outDir written as `<root>/.` must still be rejected",
+  );
+});
+
 test("outDir outside root does not affect inclusion", async () => {
   const root = await makeFixture([
     { rel: "facts/a.md", content: "a\n" },

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -298,6 +298,72 @@ test("capsule overrides flow into the manifest", async () => {
   assert.equal(result.manifest.capsule.includes.taxonomy, true);
 });
 
+test("default outDir under root is excluded from the input scan (idempotent re-export)", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+  ]);
+
+  // First export — outDir defaults to <root>/.capsules and writes archive +
+  // sidecar there. Without the outDir filter, the SECOND run would re-
+  // package those artifacts as records under `.capsules/...`.
+  const first = await exportCapsule({ name: "round-1", root });
+  assert.equal(first.manifest.files.length, 1);
+  assert.equal(first.manifest.files[0].path, "facts/a.md");
+
+  const second = await exportCapsule({ name: "round-2", root });
+  // Still only the original fixture file. No `.capsules/` entries leak in.
+  assert.deepEqual(
+    second.manifest.files.map((f) => f.path),
+    ["facts/a.md"],
+  );
+  assert.ok(
+    !second.manifest.files.some((f) => f.path.startsWith(".capsules/")),
+    "default outDir contents must never appear in the manifest",
+  );
+});
+
+test("explicit outDir under root is also excluded from the input scan", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+  ]);
+  const customOut = path.join(root, "exports", "nested");
+
+  await exportCapsule({ name: "first", root, outDir: customOut });
+  const second = await exportCapsule({
+    name: "second",
+    root,
+    outDir: customOut,
+  });
+
+  assert.deepEqual(
+    second.manifest.files.map((f) => f.path),
+    ["facts/a.md"],
+  );
+  assert.ok(
+    !second.manifest.files.some((f) => f.path.startsWith("exports/")),
+    "files under the custom outDir must be excluded",
+  );
+});
+
+test("outDir outside root does not affect inclusion", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: "exports/note.md", content: "n\n" },
+  ]);
+  const outsideOut = await mkdtemp(path.join(tmpdir(), "capsule-outside-"));
+
+  const result = await exportCapsule({
+    name: "outside",
+    root,
+    outDir: outsideOut,
+  });
+  // exports/note.md is NOT the outDir; it must still be included.
+  assert.deepEqual(
+    result.manifest.files.map((f) => f.path).sort(),
+    ["exports/note.md", "facts/a.md"],
+  );
+});
+
 test("default-excluded directories (.git, node_modules) are skipped", async () => {
   const root = await makeFixture([
     { rel: "facts/a.md", content: "a\n" },

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -293,6 +293,24 @@ test("'since' accepts well-formed timestamps with offsets", async () => {
   }
 });
 
+test("'since' rejects time-of-day forms without a timezone designator", async () => {
+  const root = await makeFixture([{ rel: "a.md", content: "a\n" }]);
+  // ECMAScript parses these as local time, which makes acceptance and the
+  // resulting cutoff depend on the host's TZ. The strict regex requires an
+  // explicit Z or ±HH:MM offset whenever a time component is present.
+  for (const bad of [
+    "2026-02-28T00:00:00",
+    "2026-02-28T12:34",
+    "2026-02-28T00:00:00.500",
+  ]) {
+    await assert.rejects(
+      exportCapsule({ name: "bad-tz", root, since: bad }),
+      /not a valid ISO/i,
+      `expected ${bad} to be rejected`,
+    );
+  }
+});
+
 test("non-directory root is rejected", async () => {
   const tmp = await mkdtemp(path.join(tmpdir(), "capsule-root-file-"));
   const filePath = path.join(tmp, "not-a-dir");

--- a/tests/capsule-export.test.ts
+++ b/tests/capsule-export.test.ts
@@ -1,0 +1,311 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, readFile, utimes, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+
+import { exportCapsule } from "../src/transfer/capsule-export.js";
+import {
+  CAPSULE_ID_PATTERN,
+  ExportBundleV2Schema,
+  parseExportBundle,
+  parseExportManifest,
+} from "../src/transfer/types.js";
+
+interface FixtureFile {
+  rel: string;
+  content: string;
+  mtime?: Date;
+}
+
+async function makeFixture(files: FixtureFile[]): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "capsule-export-"));
+  for (const f of files) {
+    const abs = path.join(root, ...f.rel.split("/"));
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, f.content, "utf-8");
+    if (f.mtime) {
+      await utimes(abs, f.mtime, f.mtime);
+    }
+  }
+  return root;
+}
+
+function readArchive(absPath: string): Promise<Buffer> {
+  return readFile(absPath);
+}
+
+test("exportCapsule writes a V2 manifest and gzipped bundle that round-trips", async () => {
+  const root = await makeFixture([
+    { rel: "profile.md", content: "# profile\n" },
+    {
+      rel: "facts/2026-04-25/fact-1.md",
+      content: "---\nid: fact-1\n---\n\nbody-1\n",
+    },
+    {
+      rel: "entities/acme.md",
+      content: "# Acme\n",
+    },
+  ]);
+
+  const result = await exportCapsule({
+    name: "test-capsule",
+    root,
+    pluginVersion: "9.9.9",
+    now: Date.parse("2026-04-26T00:00:00.000Z"),
+  });
+
+  assert.equal(result.manifest.schemaVersion, 2);
+  assert.equal(result.manifest.format, "openclaw-engram-export");
+  assert.equal(result.manifest.pluginVersion, "9.9.9");
+  assert.equal(result.manifest.includesTranscripts, false);
+  assert.equal(result.manifest.capsule.id, "test-capsule");
+  assert.equal(result.manifest.capsule.parentCapsule, null);
+
+  // 3 fixture files, all included.
+  assert.equal(result.manifest.files.length, 3);
+  assert.deepEqual(
+    result.manifest.files.map((f) => f.path),
+    [
+      "entities/acme.md",
+      "facts/2026-04-25/fact-1.md",
+      "profile.md",
+    ],
+  );
+
+  // Sidecar manifest.json mirrors the in-memory manifest.
+  const sidecar = JSON.parse(await readFile(result.manifestPath, "utf-8"));
+  assert.deepEqual(sidecar, result.manifest);
+
+  // Archive: gunzip + parse + validate against V2 bundle schema.
+  const gz = await readArchive(result.archivePath);
+  const json = gunzipSync(gz).toString("utf-8");
+  const bundle = ExportBundleV2Schema.parse(JSON.parse(json));
+  assert.equal(bundle.records.length, 3);
+  assert.deepEqual(
+    bundle.records.map((r) => r.path),
+    [
+      "entities/acme.md",
+      "facts/2026-04-25/fact-1.md",
+      "profile.md",
+    ],
+  );
+  // Records and manifest agree on file content via sha256.
+  for (const rec of bundle.records) {
+    const entry = bundle.manifest.files.find((f) => f.path === rec.path);
+    assert.ok(entry, `manifest entry for ${rec.path}`);
+    assert.equal(entry.bytes, Buffer.byteLength(rec.content, "utf-8"));
+  }
+
+  // parseExportBundle (V1/V2 dispatcher from PR 1/6) accepts the output.
+  const parsed = parseExportBundle(JSON.parse(json));
+  assert.equal(parsed.capsuleVersion, 2);
+  assert.equal(parsed.capsule?.id, "test-capsule");
+});
+
+test("'since' filter excludes files older than the cutoff", async () => {
+  const oldMtime = new Date("2026-01-01T00:00:00Z");
+  const newMtime = new Date("2026-04-01T00:00:00Z");
+  const root = await makeFixture([
+    { rel: "facts/old.md", content: "old\n", mtime: oldMtime },
+    { rel: "facts/new.md", content: "new\n", mtime: newMtime },
+  ]);
+
+  const result = await exportCapsule({
+    name: "since-capsule",
+    root,
+    since: "2026-03-01T00:00:00.000Z",
+  });
+
+  assert.equal(result.manifest.files.length, 1);
+  assert.equal(result.manifest.files[0].path, "facts/new.md");
+});
+
+test("'includeKinds' restricts top-level subdirectories", async () => {
+  const root = await makeFixture([
+    { rel: "profile.md", content: "p\n" },
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: "entities/b.md", content: "b\n" },
+    { rel: "corrections/c.md", content: "c\n" },
+  ]);
+
+  const result = await exportCapsule({
+    name: "kinds-capsule",
+    root,
+    includeKinds: ["facts", "entities"],
+  });
+
+  assert.deepEqual(
+    result.manifest.files.map((f) => f.path),
+    ["entities/b.md", "facts/a.md"],
+  );
+  // root-level files (profile.md) excluded under an explicit allow-list.
+  assert.ok(!result.manifest.files.some((f) => f.path === "profile.md"));
+});
+
+test("transcripts are excluded by default and opt-in via includeKinds", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: "transcripts/t.md", content: "t\n" },
+  ]);
+
+  const exclude = await exportCapsule({ name: "no-transcripts", root });
+  assert.equal(exclude.manifest.includesTranscripts, false);
+  assert.ok(!exclude.manifest.files.some((f) => f.path.startsWith("transcripts/")));
+
+  const include = await exportCapsule({
+    name: "with-transcripts",
+    root,
+    includeKinds: ["facts", "transcripts"],
+  });
+  assert.equal(include.manifest.includesTranscripts, true);
+  assert.ok(include.manifest.files.some((f) => f.path === "transcripts/t.md"));
+});
+
+test("'peerIds' restricts the peers/ tree", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: "peers/alice/profile.md", content: "alice\n" },
+    { rel: "peers/bob/profile.md", content: "bob\n" },
+    { rel: "peers/carol/profile.md", content: "carol\n" },
+  ]);
+
+  const result = await exportCapsule({
+    name: "peers-capsule",
+    root,
+    peerIds: ["alice", "carol"],
+  });
+  const peerPaths = result.manifest.files
+    .filter((f) => f.path.startsWith("peers/"))
+    .map((f) => f.path)
+    .sort();
+  assert.deepEqual(peerPaths, [
+    "peers/alice/profile.md",
+    "peers/carol/profile.md",
+  ]);
+  // bob is excluded.
+  assert.ok(!result.manifest.files.some((f) => f.path.startsWith("peers/bob/")));
+  // Non-peer kinds still flow through.
+  assert.ok(result.manifest.files.some((f) => f.path === "facts/a.md"));
+});
+
+test("empty 'peerIds' array excludes the entire peers/ tree", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: "peers/alice/profile.md", content: "alice\n" },
+  ]);
+
+  const result = await exportCapsule({
+    name: "no-peers",
+    root,
+    peerIds: [],
+  });
+  assert.ok(!result.manifest.files.some((f) => f.path.startsWith("peers/")));
+  assert.ok(result.manifest.files.some((f) => f.path === "facts/a.md"));
+});
+
+test("empty result still produces a valid manifest + archive", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+  ]);
+
+  const result = await exportCapsule({
+    name: "empty-capsule",
+    root,
+    // No top-level segment matches → all files filtered out.
+    includeKinds: ["nonexistent"],
+  });
+
+  assert.equal(result.manifest.files.length, 0);
+  const gz = await readArchive(result.archivePath);
+  const bundle = ExportBundleV2Schema.parse(JSON.parse(gunzipSync(gz).toString("utf-8")));
+  assert.equal(bundle.records.length, 0);
+  // Manifest still parses through the V1/V2 dispatcher.
+  const parsed = parseExportManifest(bundle.manifest);
+  assert.equal(parsed.capsuleVersion, 2);
+});
+
+test("invalid name is rejected", async () => {
+  const root = await makeFixture([{ rel: "a.md", content: "a\n" }]);
+  await assert.rejects(
+    exportCapsule({ name: "Invalid Name!", root }),
+    /invalid capsule name/i,
+  );
+  // Confirm the regex test agrees.
+  assert.equal(CAPSULE_ID_PATTERN.test("Invalid Name!"), false);
+});
+
+test("invalid 'since' is rejected", async () => {
+  const root = await makeFixture([{ rel: "a.md", content: "a\n" }]);
+  await assert.rejects(
+    exportCapsule({ name: "bad-since", root, since: "not-a-date" }),
+    /not a valid ISO/i,
+  );
+});
+
+test("non-directory root is rejected", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-root-file-"));
+  const filePath = path.join(tmp, "not-a-dir");
+  await writeFile(filePath, "x", "utf-8");
+  await assert.rejects(
+    exportCapsule({ name: "bad-root", root: filePath }),
+    /must be an existing directory/i,
+  );
+});
+
+test("includeKinds entries with path separators are rejected", async () => {
+  const root = await makeFixture([{ rel: "a/b.md", content: "a\n" }]);
+  await assert.rejects(
+    exportCapsule({ name: "bad-kind", root, includeKinds: ["facts/sub"] }),
+    /top-level segment/i,
+  );
+});
+
+test("peerIds entries with traversal segments are rejected", async () => {
+  const root = await makeFixture([{ rel: "peers/a/p.md", content: "a\n" }]);
+  await assert.rejects(
+    exportCapsule({ name: "bad-peer", root, peerIds: [".."] }),
+    /plain segment/i,
+  );
+});
+
+test("capsule overrides flow into the manifest", async () => {
+  const root = await makeFixture([{ rel: "a.md", content: "a\n" }]);
+  const result = await exportCapsule({
+    name: "override-capsule",
+    root,
+    capsule: {
+      version: "1.2.3",
+      description: "research bundle",
+      parentCapsule: "parent-id",
+      retrievalPolicy: {
+        tierWeights: { bm25: 0.5, vector: 0.5 },
+        directAnswerEnabled: true,
+      },
+      includes: {
+        taxonomy: true,
+        identityAnchors: false,
+        peerProfiles: false,
+        procedural: true,
+      },
+    },
+  });
+  assert.equal(result.manifest.capsule.version, "1.2.3");
+  assert.equal(result.manifest.capsule.description, "research bundle");
+  assert.equal(result.manifest.capsule.parentCapsule, "parent-id");
+  assert.equal(result.manifest.capsule.retrievalPolicy.directAnswerEnabled, true);
+  assert.equal(result.manifest.capsule.includes.taxonomy, true);
+});
+
+test("default-excluded directories (.git, node_modules) are skipped", async () => {
+  const root = await makeFixture([
+    { rel: "facts/a.md", content: "a\n" },
+    { rel: ".git/HEAD", content: "ref\n" },
+    { rel: "node_modules/dep/index.js", content: "x\n" },
+  ]);
+  const result = await exportCapsule({ name: "no-junk", root });
+  assert.ok(result.manifest.files.every((f) => !f.path.startsWith(".git/")));
+  assert.ok(result.manifest.files.every((f) => !f.path.startsWith("node_modules/")));
+  assert.ok(result.manifest.files.some((f) => f.path === "facts/a.md"));
+});


### PR DESCRIPTION
## Summary

Issue #676 PR 2/6. Builds on PR 1/6 (#720) which shipped the V2 capsule manifest schema. Adds the `exportCapsule()` pipeline in `packages/remnic-core/src/transfer/capsule-export.ts`.

- Pure async function: bundles a memory directory into a portable, capsule-aware V2 export.
- Output: single `.capsule.json.gz` archive containing the full `ExportBundleV2` (manifest + records) plus a sidecar `manifest.json` for cheap inspection.
- Filters: `since` (ISO-8601 mtime cutoff), `includeKinds` (top-level subdirectory allow-list, transcripts opt-in), `peerIds` (restricts the `peers/` subtree).
- Defaults per Rule 48: all `includes` flags `false`, `directAnswerEnabled: false`, empty `tierWeights`.
- Determinism: `manifest.files` and `bundle.records` sorted by posix path; optional `now` clock override.
- No CLI surface — that lands in PR 6/6.

## Files

- `packages/remnic-core/src/transfer/capsule-export.ts` (new) — implementation
- `src/transfer/capsule-export.ts` (new) — re-export shim matching the rest of `src/transfer/`
- `packages/remnic-core/src/transfer/constants.ts` — adds `CAPSULE_SCHEMA_VERSION = 2`
- `tests/capsule-export.test.ts` (new) — 14 tests
- `.changeset/676-pr2-capsule-export.md` — `@remnic/core: minor`

## Test plan

- [x] `npx tsx --test tests/capsule-export.test.ts` — 14/14 pass
- [x] `npx tsx --test tests/capsule-manifest.test.ts tests/transfer-types.test.ts` — 16/16 pass (PR 1/6 schema regression check)
- [x] `npm run check-types` — clean
- [x] `bash scripts/check-review-patterns.sh` — no new warnings introduced
- [x] `npm run preflight:quick` — pre-existing failures only (better-sqlite3 native binding mismatch on Node 22; unrelated to this PR)

## Acceptance from issue #676

> PR 2/6 — `remnic capsule export`
> - New `transfer/capsule-export.ts` that reuses `export-json.ts` / `export-md.ts` and adds the capsule sub-bundles
> - Snapshot test: fixture memoryDir → capsule bundle → expected file tree

The implementation reuses `fs-utils.ts` (`listFilesRecursive`, `sha256File`, `toPosixRelPath`, `writeJsonFile`) and the V2 manifest/bundle Zod schemas shipped in PR 1/6. The CLI wiring is intentionally deferred to PR 6/6 per the dispatch spec; the core function is exposed for PRs 3/6–5/6 to consume.

Capsule sub-bundles (taxonomy / identity / retrieval-policy snapshots) are wired through the `capsule` override option on the manifest's `capsule` block. Default values are conservative (all `includes` flags `false`, `directAnswerEnabled: false`) so a minimal capsule round-trips cleanly. Wiring real subsystem snapshots is the next slice; this PR keeps the schema honest.

## Rules honored

- Rule 24: rejects file paths used as directory args (`assertIsDirectory`)
- Rule 48: enum/flag defaults are least-privileged
- Rule 51: invalid `since`, `name`, `includeKinds`, `peerIds` throw rather than silently defaulting
- Rule 38: manifest files / records sorted before serialization

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new filesystem export behavior (filtering, hashing, gzip bundle writing) and a new manifest schema version constant, which could affect portability/determinism or accidentally omit/include files if edge cases are missed.
> 
> **Overview**
> Adds a new `exportCapsule()` pipeline that scans a memory directory and emits a deterministic V2 capsule export: a gzipped `.capsule.json.gz` bundle (manifest + records) plus a sidecar `*.manifest.json`.
> 
> The export supports incremental and selective packaging via strict ISO-8601 `since` (mtime cutoff), `includeKinds` top-level allow-list (with *transcripts opt-in*), and `peerIds` filtering for the `peers/` subtree, while also preventing self-reimport by excluding the `outDir` subtree and rejecting `outDir === root`.
> 
> Adds `CAPSULE_SCHEMA_VERSION = 2`, a public re-export shim under `src/transfer/`, and comprehensive tests covering round-trip validity, determinism-related ordering, validation errors, and filter edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5905ab96eb40cdb453cce1ab0ac572abee00cd73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->