### PR TITLE
feat(access): graph snapshot endpoint (#691 PR 2/5)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1010,6 +1010,99 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // Graph snapshot (issue #691 PR 2/5) — read-only adjacency view used by
+    // the admin-pane scaffold shipped in PR 1/5.  All filters are query
+    // params so the surface stays cacheable; invalid values yield 400 with
+    // a descriptive body (CLAUDE.md rule 51 — never silently default).
+    if (req.method === "GET" && pathname === "/engram/v1/graph/snapshot") {
+      const limitRaw = parsed.searchParams.get("limit");
+      let limit: number | undefined;
+      if (limitRaw !== null && limitRaw.length > 0) {
+        const parsedLimit = Number(limitRaw);
+        if (
+          !Number.isFinite(parsedLimit)
+          || !Number.isInteger(parsedLimit)
+          || parsedLimit <= 0
+        ) {
+          this.respondJson(res, 400, {
+            error: "invalid_limit",
+            code: "invalid_limit",
+            message: "limit must be a positive integer",
+          });
+          return;
+        }
+        limit = parsedLimit;
+      }
+      const sinceRaw = parsed.searchParams.get("since");
+      let since: string | undefined;
+      if (sinceRaw !== null && sinceRaw.length > 0) {
+        // Validate up-front so the access service can stay focused on the
+        // pure snapshot logic (parser also runs there as a defense in
+        // depth, but rejecting at the boundary preserves the
+        // "invalid_since" error code instead of leaking a generic 500).
+        if (!Number.isFinite(Date.parse(sinceRaw))) {
+          this.respondJson(res, 400, {
+            error: "invalid_since",
+            code: "invalid_since",
+            message: "since must be a parseable ISO timestamp",
+          });
+          return;
+        }
+        since = sinceRaw;
+      }
+      const focusNodeIdRaw = parsed.searchParams.get("focusNodeId");
+      const focusNodeId = focusNodeIdRaw && focusNodeIdRaw.length > 0
+        ? focusNodeIdRaw
+        : undefined;
+      const categoriesRaw = parsed.searchParams.get("categories");
+      let categories: string[] | undefined;
+      if (categoriesRaw !== null && categoriesRaw.length > 0) {
+        categories = categoriesRaw
+          .split(",")
+          .map((value) => value.trim())
+          .filter((value) => value.length > 0);
+        if (categories.length === 0) {
+          this.respondJson(res, 400, {
+            error: "invalid_categories",
+            code: "invalid_categories",
+            message:
+              "categories must be a comma-separated list with at least one non-empty value",
+          });
+          return;
+        }
+      }
+      const namespaceParam = parsed.searchParams.get("namespace");
+      const namespace = this.resolveNamespace(
+        req,
+        namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined,
+      );
+      try {
+        const snapshot = await this.service.graphSnapshot(
+          {
+            namespace,
+            ...(limit !== undefined ? { limit } : {}),
+            ...(since !== undefined ? { since } : {}),
+            ...(focusNodeId !== undefined ? { focusNodeId } : {}),
+            ...(categories !== undefined ? { categories } : {}),
+          },
+          this.resolveRequestPrincipal(req),
+        );
+        this.respondJson(res, 200, snapshot);
+      } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+        if (message.startsWith("graphSnapshot:")) {
+          this.respondJson(res, 400, {
+            error: "invalid_request",
+            code: "invalid_request",
+            message,
+          });
+          return;
+        }
+        throw err;
+      }
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/contradiction-scan") {
       const body = await this.readJsonBody(req) as Record<string, unknown>;
       const { runContradictionScan } = await import("./contradiction/contradiction-scan.js");

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -835,6 +835,30 @@ export class EngramMcpServer {
         },
       },
       {
+        // Graph snapshot for the admin pane (issue #691 PR 2/5).  Returns
+        // a read-only `{ nodes, edges, generatedAt }` view of the
+        // multi-graph adjacency, with the same filter knobs as the HTTP
+        // surface so connectors / CLI clients can hit either endpoint
+        // interchangeably.
+        name: "engram.graph_snapshot",
+        description: "Return a read-only graph snapshot (nodes + edges) for the admin pane. Filters: limit (default 500, max 5000), since (ISO timestamp), focusNodeId (restricts to neighborhood), categories (allow-list of memory categories).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: { type: "string" },
+            limit: { type: "number", description: "Maximum number of edges to return (default 500, max 5000)." },
+            since: { type: "string", description: "Inclusive lower bound on edge timestamp (ISO-8601)." },
+            focusNodeId: { type: "string", description: "When set, restrict the snapshot to the focus node and its neighbors." },
+            categories: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional category allow-list (e.g. ['fact', 'decision']).",
+            },
+          },
+          additionalProperties: false,
+        },
+      },
+      {
         name: "engram.memory_feedback",
         description: "Record relevance feedback (thumbs up/down) for a specific memory.",
         inputSchema: {
@@ -1761,6 +1785,51 @@ export class EngramMcpServer {
         return this.service.graphExplainLastRecall(
           typeof args.namespace === "string" ? args.namespace : undefined,
         );
+      case "engram.graph_snapshot": {
+        // Validate the typed inputs at the boundary — silently coercing
+        // unknown shapes (e.g. `limit: "200"`) would defeat the access
+        // service's tighter parser (CLAUDE.md rule 28 + 51).
+        if (args.limit !== undefined && typeof args.limit !== "number") {
+          throw new Error("engram.graph_snapshot: limit must be a number");
+        }
+        if (args.since !== undefined && typeof args.since !== "string") {
+          throw new Error("engram.graph_snapshot: since must be a string");
+        }
+        if (
+          args.focusNodeId !== undefined
+          && typeof args.focusNodeId !== "string"
+        ) {
+          throw new Error("engram.graph_snapshot: focusNodeId must be a string");
+        }
+        let categories: string[] | undefined;
+        if (args.categories !== undefined) {
+          if (!Array.isArray(args.categories)) {
+            throw new Error(
+              "engram.graph_snapshot: categories must be an array of strings",
+            );
+          }
+          categories = args.categories.map((value, index) => {
+            if (typeof value !== "string") {
+              throw new Error(
+                `engram.graph_snapshot: categories[${index}] must be a string`,
+              );
+            }
+            return value;
+          });
+        }
+        return this.service.graphSnapshot(
+          {
+            namespace: typeof args.namespace === "string" ? args.namespace : undefined,
+            limit: typeof args.limit === "number" ? args.limit : undefined,
+            since: typeof args.since === "string" ? args.since : undefined,
+            focusNodeId: typeof args.focusNodeId === "string"
+              ? args.focusNodeId
+              : undefined,
+            ...(categories !== undefined ? { categories } : {}),
+          },
+          effectivePrincipal,
+        );
+      }
       case "engram.memory_feedback":
         return this.service.memoryFeedback({
           memoryId: typeof args.memoryId === "string" ? args.memoryId : "",

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3790,20 +3790,50 @@ export class EngramAccessService {
     );
     const storage = await this.orchestrator.getStorage(namespace);
     const cfg = this.orchestrator.config;
+    // Canonicalize the storage root once so the path-traversal guard below
+    // can compare resolved absolute paths.  This is required because
+    // `GraphEdge.from` / `to` are JSONL-parsed strings — a malformed edge
+    // with an absolute path or a `..` segment would otherwise read a
+    // memory file from outside the resolved namespace, leaking metadata
+    // across tenants (codex P1 on PR #734; CLAUDE.md rule 42).
+    const namespaceRoot = nodePath.resolve(storage.dir);
+    const namespaceRootWithSep = namespaceRoot.endsWith(nodePath.sep)
+      ? namespaceRoot
+      : namespaceRoot + nodePath.sep;
     const loadNode = async (relPath: string): Promise<GraphSnapshotNodeMetadata | null> => {
       // `GraphEdge.from` / `to` are storage-relative paths; resolve against
       // the namespaced storage root so the metadata read honors namespace
       // boundaries even when the same memory id exists in multiple
       // namespaces.
-      const absPath = nodePath.isAbsolute(relPath)
-        ? relPath
-        : nodePath.join(storage.dir, relPath);
-      const memory = await storage.readMemoryByPath(absPath);
+      //
+      // Reject absolute paths and `..` traversals up front rather than
+      // letting them silently escape the namespace root.  We compare the
+      // *canonicalized* absolute path against the namespace prefix so
+      // symlinks / mixed separators / `.` segments can't sneak past.
+      // Bad paths log a warning with a redacted form (length only — never
+      // echo the offending segments back into logs, which themselves cross
+      // namespace boundaries) and fall through to a `null` metadata result.
+      if (nodePath.isAbsolute(relPath)) {
+        log.warn(
+          `graphSnapshot: rejected absolute edge endpoint (len=${relPath.length}) `
+          + `outside namespace root`,
+        );
+        return null;
+      }
+      const candidate = nodePath.resolve(namespaceRoot, relPath);
+      if (candidate !== namespaceRoot && !candidate.startsWith(namespaceRootWithSep)) {
+        log.warn(
+          `graphSnapshot: rejected traversing edge endpoint (len=${relPath.length}) `
+          + `outside namespace root`,
+        );
+        return null;
+      }
+      const memory = await storage.readMemoryByPath(candidate);
       if (!memory) return null;
       const fm = memory.frontmatter;
       return {
         category: fm.category ?? "unknown",
-        label: fm.id ?? nodePath.basename(absPath, nodePath.extname(absPath)),
+        label: fm.id ?? nodePath.basename(candidate, nodePath.extname(candidate)),
         updated: fm.updated,
       };
     };

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -51,6 +51,13 @@ import type {
 } from "./orchestrator.js";
 import { parseEntityFile, StorageManager } from "./storage.js";
 import {
+  buildGraphSnapshot,
+  type GraphSnapshotRequest,
+  type GraphSnapshotResponse,
+  type GraphSnapshotNodeMetadata,
+} from "./graph-snapshot.js";
+import * as nodePath from "node:path";
+import {
   buildBriefing,
   FileCalendarSource,
   parseBriefingFocus,
@@ -3762,6 +3769,59 @@ export class EngramAccessService {
   async graphExplainLastRecall(namespace?: string): Promise<unknown> {
     const explanation = await this.orchestrator.explainLastGraphRecall({ namespace });
     return { explanation };
+  }
+
+  /**
+   * Read-only graph snapshot for the admin pane (issue #691 PR 2/5).
+   *
+   * Reads adjacency from the JSONL edge store written by `GraphIndex` and
+   * resolves node metadata via the namespaced storage manager.  Namespace
+   * resolution mirrors the read-side path used by `recall` /
+   * `procedureStats`, so multi-principal deployments can't leak edges from
+   * a peer namespace (CLAUDE.md rule 42).
+   */
+  async graphSnapshot(
+    request: GraphSnapshotRequest & { namespace?: string },
+    authenticatedPrincipal?: string,
+  ): Promise<GraphSnapshotResponse> {
+    const namespace = this.resolveReadableNamespace(
+      request.namespace,
+      authenticatedPrincipal,
+    );
+    const storage = await this.orchestrator.getStorage(namespace);
+    const cfg = this.orchestrator.config;
+    const loadNode = async (relPath: string): Promise<GraphSnapshotNodeMetadata | null> => {
+      // `GraphEdge.from` / `to` are storage-relative paths; resolve against
+      // the namespaced storage root so the metadata read honors namespace
+      // boundaries even when the same memory id exists in multiple
+      // namespaces.
+      const absPath = nodePath.isAbsolute(relPath)
+        ? relPath
+        : nodePath.join(storage.dir, relPath);
+      const memory = await storage.readMemoryByPath(absPath);
+      if (!memory) return null;
+      const fm = memory.frontmatter;
+      return {
+        category: fm.category ?? "unknown",
+        label: fm.id ?? nodePath.basename(absPath, nodePath.extname(absPath)),
+        updated: fm.updated,
+      };
+    };
+    return buildGraphSnapshot({
+      memoryDir: storage.dir,
+      graphConfig: {
+        entityGraphEnabled: cfg.entityGraphEnabled === true,
+        timeGraphEnabled: cfg.timeGraphEnabled === true,
+        causalGraphEnabled: cfg.causalGraphEnabled === true,
+      },
+      request: {
+        limit: request.limit,
+        since: request.since,
+        focusNodeId: request.focusNodeId,
+        categories: request.categories,
+      },
+      loadNode,
+    });
   }
 
   async memoryFeedback(request: {

--- a/packages/remnic-core/src/graph-snapshot.ts
+++ b/packages/remnic-core/src/graph-snapshot.ts
@@ -183,33 +183,59 @@ export async function buildGraphSnapshot(opts: {
     return aKey < bKey ? -1 : 1;
   });
 
-  // Resolve metadata for every endpoint we may need, after time + focus
-  // filtering but BEFORE the limit so the category filter applies to the
-  // pre-trimmed neighborhood.  Cap the load surface at 2× max-limit to
-  // bound worst-case memory reads.
-  const candidatePaths = collectEndpointPaths(sortedEdges).slice(
-    0,
-    GRAPH_SNAPSHOT_MAX_LIMIT * 2,
-  );
-  const metadata = await loadMetadataMap(candidatePaths, opts.loadNode);
+  // Streaming category + limit pass.  Metadata is loaded lazily per
+  // endpoint with a memoization cache (`metadata`) so we never re-read the
+  // same memory file twice, never read more than `2 × limit` files, and
+  // never silently drop matching edges because a static cap fired before
+  // the category filter saw them — the bug Cursor flagged on PR #734
+  // when the pre-limit edge set referenced more than `2 × MAX_LIMIT`
+  // unique nodes.
+  const metadata = new Map<string, GraphSnapshotNodeMetadata | null>();
+  const trimmedEdges: GraphEdge[] = [];
 
-  // Category filter — applied per edge, requiring BOTH endpoints to match.
-  // Endpoints with no metadata are kept only when no filter is active
-  // (matches admin-pane intent: a category filter is an allow-list).
-  const categoryFilteredEdges = categoryFilter === null
-    ? sortedEdges
-    : sortedEdges.filter((edge) => {
-        const fromMeta = metadata.get(edge.from);
-        const toMeta = metadata.get(edge.to);
-        if (!fromMeta || !toMeta) return false;
-        return categoryFilter.has(fromMeta.category) && categoryFilter.has(toMeta.category);
-      });
+  const ensureMetadata = async (relPath: string): Promise<GraphSnapshotNodeMetadata | null> => {
+    if (metadata.has(relPath)) return metadata.get(relPath) ?? null;
+    let resolved: GraphSnapshotNodeMetadata | null = null;
+    try {
+      resolved = await opts.loadNode(relPath);
+    } catch {
+      // Loader errors are best-effort — leave the path absent so it
+      // falls through to the basename label / "unknown" category.
+      resolved = null;
+    }
+    metadata.set(relPath, resolved);
+    return resolved;
+  };
 
-  // Apply limit AFTER all filters (we want the most recent N edges that
-  // survive every filter, not the most recent N raw edges).
-  const trimmedEdges = categoryFilteredEdges.slice(0, limit);
+  for (const edge of sortedEdges) {
+    if (trimmedEdges.length >= limit) break;
+    if (categoryFilter !== null) {
+      const fromMeta = await ensureMetadata(edge.from);
+      const toMeta = await ensureMetadata(edge.to);
+      if (!fromMeta || !toMeta) continue;
+      if (
+        !categoryFilter.has(fromMeta.category)
+        || !categoryFilter.has(toMeta.category)
+      ) {
+        continue;
+      }
+    } else {
+      // Even without a category filter we still want labels / kinds for
+      // the surfaced nodes, so warm the metadata cache for this edge.
+      // The cache is bounded by `2 × limit` because we stop iterating
+      // once `trimmedEdges` reaches `limit`.
+      await ensureMetadata(edge.from);
+      await ensureMetadata(edge.to);
+    }
+    trimmedEdges.push(edge);
+  }
 
-  const nodes = buildNodeIndex(trimmedEdges, metadata);
+  const resolvedMetadata = new Map<string, GraphSnapshotNodeMetadata>();
+  for (const [key, value] of metadata) {
+    if (value) resolvedMetadata.set(key, value);
+  }
+
+  const nodes = buildNodeIndex(trimmedEdges, resolvedMetadata);
   const edges: GraphSnapshotEdge[] = trimmedEdges.map((edge) => ({
     source: edge.from,
     target: edge.to,
@@ -242,43 +268,6 @@ function normalizeCategoryFilter(
     throw new Error("graphSnapshot: categories must contain at least one non-empty value");
   }
   return cleaned;
-}
-
-function collectEndpointPaths(edges: GraphEdge[]): string[] {
-  const seen = new Set<string>();
-  const ordered: string[] = [];
-  for (const edge of edges) {
-    if (!seen.has(edge.from)) {
-      seen.add(edge.from);
-      ordered.push(edge.from);
-    }
-    if (!seen.has(edge.to)) {
-      seen.add(edge.to);
-      ordered.push(edge.to);
-    }
-  }
-  return ordered;
-}
-
-async function loadMetadataMap(
-  paths: string[],
-  loadNode: GraphSnapshotNodeLoader,
-): Promise<Map<string, GraphSnapshotNodeMetadata>> {
-  const out = new Map<string, GraphSnapshotNodeMetadata>();
-  // Sequential loads keep the I/O footprint predictable; the upper bound is
-  // 2 × GRAPH_SNAPSHOT_MAX_LIMIT.  Switching to bounded parallelism is a
-  // future tuning knob — the on-disk metadata is cached by `StorageManager`.
-  for (const relPath of paths) {
-    try {
-      const meta = await loadNode(relPath);
-      if (meta) out.set(relPath, meta);
-    } catch {
-      // Loader errors are best-effort — leave the path absent so it falls
-      // through to the basename label / "unknown" category.  We never let
-      // metadata I/O fail the whole snapshot.
-    }
-  }
-  return out;
 }
 
 function buildNodeIndex(

--- a/packages/remnic-core/src/graph-snapshot.ts
+++ b/packages/remnic-core/src/graph-snapshot.ts
@@ -1,0 +1,340 @@
+/**
+ * Graph snapshot — read-only view of the multi-graph memory adjacency
+ * (issue #691 PR 2/5).
+ *
+ * Composes the JSONL edge store from `graph.ts` with optional node-metadata
+ * loading so HTTP / MCP / future CLI surfaces can return a consistent
+ * `{ nodes, edges, generatedAt }` shape suitable for the admin pane scaffold
+ * shipped in PR 1/5.
+ *
+ * All inputs are validated and clamped at this layer so the access surface
+ * (which is responsible for HTTP/MCP-flavored errors) can keep the wiring
+ * thin.  The module is pure async I/O — no global state, no caches.
+ */
+
+import type { GraphEdge, GraphType } from "./graph.js";
+import { readAllEdges } from "./graph.js";
+import { readEdgeConfidence } from "./graph-edge-reinforcement.js";
+import * as path from "path";
+
+/** Default `limit` when the caller omits it. */
+export const GRAPH_SNAPSHOT_DEFAULT_LIMIT = 500;
+
+/** Hard upper bound on `limit` to keep responses sized for the admin pane. */
+export const GRAPH_SNAPSHOT_MAX_LIMIT = 5000;
+
+/** Categories accepted by the `categories` filter; matches `MemoryFile.frontmatter.category`. */
+export type GraphSnapshotCategory = string;
+
+export interface GraphSnapshotNode {
+  /** Stable identifier — relative memory path (matches `GraphEdge.from` / `to`). */
+  id: string;
+  /** Short human label.  Falls back to the basename when no metadata is available. */
+  label: string;
+  /** Memory category (e.g. `fact`, `decision`, `entity`).  `"unknown"` when metadata is missing. */
+  kind: string;
+  /** Aggregate edge confidence touching this node, used for sizing in the admin pane. */
+  score: number;
+  /** Most recent edge timestamp (ISO) touching this node — best-effort recency signal. */
+  lastUpdated: string | null;
+}
+
+export interface GraphSnapshotEdge {
+  source: string;
+  target: string;
+  kind: GraphType;
+  /** Edge confidence in [0, 1]; legacy edges without confidence return 1.0. */
+  confidence: number;
+}
+
+export interface GraphSnapshotResponse {
+  nodes: GraphSnapshotNode[];
+  edges: GraphSnapshotEdge[];
+  generatedAt: string;
+}
+
+export interface GraphSnapshotRequest {
+  /** Max number of edges to include (after filtering).  Default 500, max 5000. */
+  limit?: number;
+  /** Inclusive lower bound on edge `ts` (ISO string).  Edges older than this are dropped. */
+  since?: string;
+  /** When set, restrict the snapshot to the focus node and its direct neighbors. */
+  focusNodeId?: string;
+  /**
+   * Optional category allow-list.  Edges are kept only when both endpoints
+   * resolve to nodes whose category falls in this set; nodes are kept only
+   * when their category matches.  When omitted, no category filter is applied.
+   */
+  categories?: GraphSnapshotCategory[];
+}
+
+/**
+ * Loader contract: given a relative memory path, return `{ category, label,
+ * updated }` or `null` when the memory cannot be resolved.  Implementations
+ * typically wrap `StorageManager.readMemoryByPath`; the snapshot module stays
+ * agnostic so tests can pass a synchronous in-memory map.
+ */
+export type GraphSnapshotNodeLoader = (
+  relPath: string,
+) => Promise<GraphSnapshotNodeMetadata | null>;
+
+export interface GraphSnapshotNodeMetadata {
+  /** Memory category, e.g. `fact` / `decision` / `entity`. */
+  category: string;
+  /** Display label — usually the memory id or the entity name. */
+  label: string;
+  /** ISO `updated` timestamp from frontmatter, when available. */
+  updated?: string;
+}
+
+/**
+ * Coerce a caller-supplied limit into the `[1, GRAPH_SNAPSHOT_MAX_LIMIT]` range.
+ *
+ * - `undefined` / `null` → `GRAPH_SNAPSHOT_DEFAULT_LIMIT`.
+ * - non-finite or non-integer → throws `Error` (callers translate to 400).
+ * - `<= 0` → throws.
+ * - `> GRAPH_SNAPSHOT_MAX_LIMIT` → clamped to the max (no error — admin
+ *   panel callers send liberal limits).
+ */
+export function normalizeGraphSnapshotLimit(raw: unknown): number {
+  if (raw === undefined || raw === null) return GRAPH_SNAPSHOT_DEFAULT_LIMIT;
+  if (typeof raw !== "number" || !Number.isFinite(raw) || !Number.isInteger(raw)) {
+    throw new Error("graphSnapshot: limit must be a positive integer");
+  }
+  if (raw <= 0) {
+    throw new Error("graphSnapshot: limit must be a positive integer");
+  }
+  if (raw > GRAPH_SNAPSHOT_MAX_LIMIT) return GRAPH_SNAPSHOT_MAX_LIMIT;
+  return raw;
+}
+
+/**
+ * Validate and parse an ISO timestamp into a millisecond epoch.  Throws
+ * when the input cannot be parsed; callers translate to a 400.  `undefined`
+ * input yields `undefined`.
+ */
+export function parseGraphSnapshotSince(raw: string | undefined): number | undefined {
+  if (raw === undefined || raw === null || raw === "") return undefined;
+  const ms = Date.parse(raw);
+  if (!Number.isFinite(ms)) {
+    throw new Error("graphSnapshot: since must be a parseable ISO timestamp");
+  }
+  return ms;
+}
+
+/**
+ * Build a `GraphSnapshotResponse` from the raw edge JSONL on disk plus an
+ * optional node-metadata loader.
+ *
+ * The function is split into pure subroutines so HTTP / MCP / tests can
+ * exercise the same logic without spinning up a full `StorageManager`.
+ */
+export async function buildGraphSnapshot(opts: {
+  memoryDir: string;
+  graphConfig: {
+    entityGraphEnabled: boolean;
+    timeGraphEnabled: boolean;
+    causalGraphEnabled: boolean;
+  };
+  request: GraphSnapshotRequest;
+  loadNode: GraphSnapshotNodeLoader;
+  /** Override clock for deterministic tests. */
+  now?: () => Date;
+}): Promise<GraphSnapshotResponse> {
+  const limit = normalizeGraphSnapshotLimit(opts.request.limit);
+  const sinceMs = parseGraphSnapshotSince(opts.request.since);
+  const focusNodeId = opts.request.focusNodeId?.trim();
+  const categoryFilter = normalizeCategoryFilter(opts.request.categories);
+
+  const allEdges = await readAllEdges(opts.memoryDir, opts.graphConfig);
+
+  // Time-window filter (CLAUDE.md rule 35 — half-open `[since, +∞)`; equality
+  // is treated as inclusive because callers expect a single-point pin to
+  // surface edges stamped exactly at that instant).
+  const timeFiltered = sinceMs === undefined
+    ? allEdges
+    : allEdges.filter((edge) => {
+        const ts = Date.parse(edge.ts);
+        return Number.isFinite(ts) && ts >= sinceMs;
+      });
+
+  // Focus-node neighborhood filter — restrict to edges incident on the node.
+  const focusFiltered = focusNodeId
+    ? timeFiltered.filter((edge) => edge.from === focusNodeId || edge.to === focusNodeId)
+    : timeFiltered;
+
+  // Sort newest-first so the limit window keeps the most recent edges.  `ts`
+  // is an ISO string, so a string comparison agrees with chronological order
+  // for any well-formed timestamp; we still parse to avoid surprising
+  // ordering when timezones drift, falling back to lexicographic compare on
+  // tie / parse failure for stable ordering (CLAUDE.md rule 19).
+  const sortedEdges = [...focusFiltered].sort((a, b) => {
+    const aMs = Date.parse(a.ts);
+    const bMs = Date.parse(b.ts);
+    if (Number.isFinite(aMs) && Number.isFinite(bMs) && aMs !== bMs) {
+      return bMs - aMs;
+    }
+    if (a.ts !== b.ts) return a.ts < b.ts ? 1 : -1;
+    // Stable secondary key: from/to/type so identical-ts edges have a
+    // deterministic order across runs.
+    const aKey = `${a.from}|${a.to}|${a.type}`;
+    const bKey = `${b.from}|${b.to}|${b.type}`;
+    if (aKey === bKey) return 0;
+    return aKey < bKey ? -1 : 1;
+  });
+
+  // Resolve metadata for every endpoint we may need, after time + focus
+  // filtering but BEFORE the limit so the category filter applies to the
+  // pre-trimmed neighborhood.  Cap the load surface at 2× max-limit to
+  // bound worst-case memory reads.
+  const candidatePaths = collectEndpointPaths(sortedEdges).slice(
+    0,
+    GRAPH_SNAPSHOT_MAX_LIMIT * 2,
+  );
+  const metadata = await loadMetadataMap(candidatePaths, opts.loadNode);
+
+  // Category filter — applied per edge, requiring BOTH endpoints to match.
+  // Endpoints with no metadata are kept only when no filter is active
+  // (matches admin-pane intent: a category filter is an allow-list).
+  const categoryFilteredEdges = categoryFilter === null
+    ? sortedEdges
+    : sortedEdges.filter((edge) => {
+        const fromMeta = metadata.get(edge.from);
+        const toMeta = metadata.get(edge.to);
+        if (!fromMeta || !toMeta) return false;
+        return categoryFilter.has(fromMeta.category) && categoryFilter.has(toMeta.category);
+      });
+
+  // Apply limit AFTER all filters (we want the most recent N edges that
+  // survive every filter, not the most recent N raw edges).
+  const trimmedEdges = categoryFilteredEdges.slice(0, limit);
+
+  const nodes = buildNodeIndex(trimmedEdges, metadata);
+  const edges: GraphSnapshotEdge[] = trimmedEdges.map((edge) => ({
+    source: edge.from,
+    target: edge.to,
+    kind: edge.type,
+    confidence: readEdgeConfidence(edge),
+  }));
+
+  const generatedAt = (opts.now ? opts.now() : new Date()).toISOString();
+  return { nodes, edges, generatedAt };
+}
+
+function normalizeCategoryFilter(
+  raw: GraphSnapshotCategory[] | undefined,
+): Set<string> | null {
+  if (raw === undefined || raw === null) return null;
+  if (!Array.isArray(raw)) {
+    throw new Error("graphSnapshot: categories must be an array of strings");
+  }
+  const cleaned = new Set<string>();
+  for (const value of raw) {
+    if (typeof value !== "string") {
+      throw new Error("graphSnapshot: categories must be an array of strings");
+    }
+    const trimmed = value.trim();
+    if (trimmed.length > 0) cleaned.add(trimmed);
+  }
+  // Empty allow-list → reject everything.  We surface this as a 400 because
+  // the admin pane should never send `categories=` with no values.
+  if (cleaned.size === 0) {
+    throw new Error("graphSnapshot: categories must contain at least one non-empty value");
+  }
+  return cleaned;
+}
+
+function collectEndpointPaths(edges: GraphEdge[]): string[] {
+  const seen = new Set<string>();
+  const ordered: string[] = [];
+  for (const edge of edges) {
+    if (!seen.has(edge.from)) {
+      seen.add(edge.from);
+      ordered.push(edge.from);
+    }
+    if (!seen.has(edge.to)) {
+      seen.add(edge.to);
+      ordered.push(edge.to);
+    }
+  }
+  return ordered;
+}
+
+async function loadMetadataMap(
+  paths: string[],
+  loadNode: GraphSnapshotNodeLoader,
+): Promise<Map<string, GraphSnapshotNodeMetadata>> {
+  const out = new Map<string, GraphSnapshotNodeMetadata>();
+  // Sequential loads keep the I/O footprint predictable; the upper bound is
+  // 2 × GRAPH_SNAPSHOT_MAX_LIMIT.  Switching to bounded parallelism is a
+  // future tuning knob — the on-disk metadata is cached by `StorageManager`.
+  for (const relPath of paths) {
+    try {
+      const meta = await loadNode(relPath);
+      if (meta) out.set(relPath, meta);
+    } catch {
+      // Loader errors are best-effort — leave the path absent so it falls
+      // through to the basename label / "unknown" category.  We never let
+      // metadata I/O fail the whole snapshot.
+    }
+  }
+  return out;
+}
+
+function buildNodeIndex(
+  edges: GraphEdge[],
+  metadata: Map<string, GraphSnapshotNodeMetadata>,
+): GraphSnapshotNode[] {
+  type Aggregate = {
+    score: number;
+    lastUpdatedMs: number | null;
+    lastUpdatedIso: string | null;
+  };
+  const aggregates = new Map<string, Aggregate>();
+
+  function bump(id: string, edge: GraphEdge): void {
+    const current = aggregates.get(id) ?? {
+      score: 0,
+      lastUpdatedMs: null,
+      lastUpdatedIso: null,
+    };
+    current.score += readEdgeConfidence(edge);
+    const ms = Date.parse(edge.ts);
+    if (Number.isFinite(ms) && (current.lastUpdatedMs === null || ms > current.lastUpdatedMs)) {
+      current.lastUpdatedMs = ms;
+      current.lastUpdatedIso = edge.ts;
+    }
+    aggregates.set(id, current);
+  }
+
+  for (const edge of edges) {
+    bump(edge.from, edge);
+    bump(edge.to, edge);
+  }
+
+  // Stable order: descending score, then ascending id for determinism.
+  const ids = Array.from(aggregates.keys()).sort((a, b) => {
+    const aScore = aggregates.get(a)?.score ?? 0;
+    const bScore = aggregates.get(b)?.score ?? 0;
+    if (aScore !== bScore) return bScore - aScore;
+    if (a === b) return 0;
+    return a < b ? -1 : 1;
+  });
+
+  return ids.map((id) => {
+    const meta = metadata.get(id);
+    const aggregate = aggregates.get(id);
+    return {
+      id,
+      label: meta?.label ?? defaultLabelFromPath(id),
+      kind: meta?.category ?? "unknown",
+      score: Number((aggregate?.score ?? 0).toFixed(4)),
+      lastUpdated: aggregate?.lastUpdatedIso ?? null,
+    };
+  });
+}
+
+function defaultLabelFromPath(relPath: string): string {
+  const base = path.basename(relPath, path.extname(relPath));
+  return base.length > 0 ? base : relPath;
+}

--- a/src/graph-snapshot.ts
+++ b/src/graph-snapshot.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/graph-snapshot.js";

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -213,6 +213,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.memory_intent_debug",
     "engram.memory_qmd_debug",
     "engram.memory_graph_explain",
+    "engram.graph_snapshot",
     "engram.memory_feedback",
     "engram.memory_promote",
     "engram.memory_outcome",

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -242,6 +242,183 @@ test("buildGraphSnapshot since filter drops older edges", async () => {
   }
 });
 
+test("buildGraphSnapshot streaming category filter does not silently truncate large edge sets", async () => {
+  // Regression for the Cursor Bugbot finding on PR #734: the previous
+  // implementation pre-loaded metadata for the first 2× MAX_LIMIT unique
+  // node ids and then applied the category filter on the cached map.  When
+  // the relevant matching edges referenced nodes whose metadata fell
+  // outside that window, those edges were silently dropped.  The streaming
+  // implementation now lazy-loads metadata per edge and walks until either
+  // (a) the limit is reached, or (b) the edge stream is exhausted — so
+  // late-stream matches survive.
+  const dir = await makeFixtureDir();
+  try {
+    // Build many `decision` edges first (these will be dropped by the
+    // `fact` allow-list) and then a single `fact` edge near the end.
+    const baseTs = Date.UTC(2026, 3, 20, 0, 0);
+    for (let i = 0; i < 50; i += 1) {
+      await appendEdge(dir, {
+        from: `decisions/2026-04-20/d${i}.md`,
+        to: `decisions/2026-04-20/d${i + 1}.md`,
+        type: "entity",
+        weight: 1.0,
+        label: "noise",
+        ts: new Date(baseTs + i * 1000).toISOString(),
+      });
+    }
+    await appendEdge(dir, {
+      from: "facts/2026-04-20/alpha.md",
+      to: "facts/2026-04-20/beta.md",
+      type: "entity",
+      weight: 1.0,
+      label: "real",
+      ts: new Date(baseTs - 60_000).toISOString(),
+    });
+    const loadNode = async (relPath: string) => {
+      if (relPath.startsWith("facts/")) {
+        return { category: "fact", label: relPath };
+      }
+      return { category: "decision", label: relPath };
+    };
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: { categories: ["fact"], limit: 10 },
+      loadNode,
+    });
+    // The streaming filter must surface the single `fact` edge even though
+    // it sorts after 50 `decision` edges.
+    assert.equal(snapshot.edges.length, 1);
+    assert.equal(snapshot.edges[0]!.source, "facts/2026-04-20/alpha.md");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("graphSnapshot loader rejects path traversal in edge endpoints", async () => {
+  // Regression for the codex P1 finding on PR #734: a malformed edge with
+  // an absolute path or `../` traversal must not read memory files from
+  // outside the resolved namespace.  We replicate the access-service's
+  // path-guarded loader against two sibling directories and confirm
+  // (a) the benign endpoint resolves, (b) the absolute-path endpoint is
+  // rejected, (c) the `..` traversal endpoint is rejected — even though
+  // the file at the traversal target exists on disk and would otherwise
+  // be readable.
+  const root = await mkdtemp(path.join(os.tmpdir(), "engram-graph-snapshot-traversal-"));
+  try {
+    const nsA = path.join(root, "ns-a");
+    const nsB = path.join(root, "ns-b");
+    await mkdir(path.join(nsA, "facts", "2026-04-20"), { recursive: true });
+    await mkdir(nsB, { recursive: true });
+
+    await writeFile(
+      path.join(nsA, "facts", "2026-04-20", "alpha.md"),
+      "---\nid: alpha\ncategory: fact\nupdated: 2026-04-20T00:00:00.000Z\n---\nalpha\n",
+      "utf-8",
+    );
+    const secretPath = path.join(nsB, "secret.md");
+    await writeFile(
+      secretPath,
+      "---\nid: secret\ncategory: secret\n---\nsecret\n",
+      "utf-8",
+    );
+
+    // Replicate the access-service loader.  The path guard rejects
+    // absolute paths and `..` traversals.
+    const namespaceRoot = path.resolve(nsA);
+    const namespaceRootWithSep = namespaceRoot.endsWith(path.sep)
+      ? namespaceRoot
+      : namespaceRoot + path.sep;
+    const callsToReadFile: string[] = [];
+    const fs = await import("node:fs/promises");
+    const guardedLoader = async (relPath: string) => {
+      if (path.isAbsolute(relPath)) return null;
+      const candidate = path.resolve(namespaceRoot, relPath);
+      if (candidate !== namespaceRoot && !candidate.startsWith(namespaceRootWithSep)) {
+        return null;
+      }
+      callsToReadFile.push(candidate);
+      try {
+        const raw = await fs.readFile(candidate, "utf-8");
+        const fm = raw.match(/category:\s*(\w+)/);
+        return {
+          category: fm?.[1] ?? "unknown",
+          label: path.basename(candidate, path.extname(candidate)),
+        };
+      } catch {
+        return null;
+      }
+    };
+
+    // Drive `buildGraphSnapshot` with three edges: benign / absolute /
+    // traversing.  The metadata for the secret memory must never be
+    // read — assert via both the snapshot kind AND the recorded read
+    // attempts.
+    await appendEdge(nsA, {
+      from: "facts/2026-04-20/alpha.md",
+      to: "facts/2026-04-20/alpha.md",
+      type: "entity",
+      weight: 1.0,
+      label: "self-loop",
+      ts: "2026-04-20T12:00:00.000Z",
+    });
+    await appendEdge(nsA, {
+      from: "facts/2026-04-20/alpha.md",
+      to: secretPath,
+      type: "entity",
+      weight: 1.0,
+      label: "absolute",
+      ts: "2026-04-20T12:01:00.000Z",
+    });
+    await appendEdge(nsA, {
+      from: "facts/2026-04-20/alpha.md",
+      to: "../ns-b/secret.md",
+      type: "entity",
+      weight: 1.0,
+      label: "traversal",
+      ts: "2026-04-20T12:02:00.000Z",
+    });
+
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: nsA,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: {},
+      loadNode: guardedLoader,
+    });
+
+    // Benign alpha resolves.
+    const alpha = snapshot.nodes.find((n) => n.id === "facts/2026-04-20/alpha.md");
+    assert.ok(alpha, "alpha node should be present");
+    assert.equal(alpha!.kind, "fact");
+    // Absolute / traversal endpoints surface as orphan nodes with
+    // `kind: "unknown"` — the loader returned null for them.
+    const absoluteNode = snapshot.nodes.find((n) => n.id === secretPath);
+    const traversalNode = snapshot.nodes.find((n) => n.id === "../ns-b/secret.md");
+    assert.ok(absoluteNode);
+    assert.ok(traversalNode);
+    assert.equal(absoluteNode!.kind, "unknown");
+    assert.equal(traversalNode!.kind, "unknown");
+    // Critically: we never attempted to read the secret file on disk.
+    for (const call of callsToReadFile) {
+      assert.ok(
+        call.startsWith(namespaceRootWithSep) || call === namespaceRoot,
+        `file read escaped namespace: ${call}`,
+      );
+      assert.ok(!call.includes("secret.md"), `secret file must never be read: ${call}`);
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
 test("buildGraphSnapshot rejects empty categories array", async () => {
   const dir = await makeFixtureDir();
   try {
@@ -536,7 +713,3 @@ test("MCP graph_snapshot rejects non-numeric limit at the boundary", async () =>
   }
 });
 
-// Suppress unused-import warning for `mkdir` / `writeFile` (kept for future
-// fixture extensions that exercise the orchestrator-backed loader).
-void mkdir;
-void writeFile;

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -1,0 +1,542 @@
+/**
+ * Tests for the graph snapshot HTTP surface (issue #691 PR 2/5).
+ *
+ * Covers:
+ *   - the pure `buildGraphSnapshot` builder against a fixture memory dir,
+ *   - the `EngramAccessHttpServer` route (auth, query-param validation,
+ *     focus / category filters, limit enforcement),
+ *   - the dual MCP tool name (`engram.graph_snapshot` /
+ *     `remnic.graph_snapshot`).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import * as path from "node:path";
+import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+
+import { EngramAccessHttpServer } from "../src/access-http.js";
+import type { EngramAccessService } from "../src/access-service.js";
+import {
+  buildGraphSnapshot,
+  GRAPH_SNAPSHOT_DEFAULT_LIMIT,
+  GRAPH_SNAPSHOT_MAX_LIMIT,
+  normalizeGraphSnapshotLimit,
+  parseGraphSnapshotSince,
+  type GraphSnapshotResponse,
+} from "../src/graph-snapshot.js";
+import { appendEdge } from "../src/graph.js";
+import { EngramMcpServer } from "../src/access-mcp.js";
+
+async function makeFixtureDir(): Promise<string> {
+  return mkdtemp(path.join(os.tmpdir(), "engram-graph-snapshot-test-"));
+}
+
+async function seedEdges(memoryDir: string): Promise<void> {
+  const ts = (offset: number): string =>
+    new Date(Date.UTC(2026, 3, 20, 12, offset)).toISOString();
+  await appendEdge(memoryDir, {
+    from: "facts/2026-04-20/alpha.md",
+    to: "facts/2026-04-20/beta.md",
+    type: "entity",
+    weight: 1.0,
+    label: "project-x",
+    ts: ts(0),
+    confidence: 0.9,
+  });
+  await appendEdge(memoryDir, {
+    from: "facts/2026-04-20/beta.md",
+    to: "facts/2026-04-20/gamma.md",
+    type: "entity",
+    weight: 1.0,
+    label: "project-x",
+    ts: ts(5),
+    confidence: 0.8,
+  });
+  await appendEdge(memoryDir, {
+    from: "decisions/2026-04-20/d1.md",
+    to: "facts/2026-04-20/alpha.md",
+    type: "causal",
+    weight: 1.0,
+    label: "because",
+    ts: ts(10),
+  });
+}
+
+const META_FIXTURE: Record<string, { category: string; label: string; updated: string }> = {
+  "facts/2026-04-20/alpha.md": {
+    category: "fact",
+    label: "alpha",
+    updated: "2026-04-20T12:00:00.000Z",
+  },
+  "facts/2026-04-20/beta.md": {
+    category: "fact",
+    label: "beta",
+    updated: "2026-04-20T12:05:00.000Z",
+  },
+  "facts/2026-04-20/gamma.md": {
+    category: "fact",
+    label: "gamma",
+    updated: "2026-04-20T12:05:00.000Z",
+  },
+  "decisions/2026-04-20/d1.md": {
+    category: "decision",
+    label: "d1",
+    updated: "2026-04-20T12:10:00.000Z",
+  },
+};
+
+function buildLoader() {
+  return async (relPath: string) => META_FIXTURE[relPath] ?? null;
+}
+
+test("normalizeGraphSnapshotLimit defaults / clamps / rejects", () => {
+  assert.equal(normalizeGraphSnapshotLimit(undefined), GRAPH_SNAPSHOT_DEFAULT_LIMIT);
+  assert.equal(normalizeGraphSnapshotLimit(50), 50);
+  assert.equal(
+    normalizeGraphSnapshotLimit(GRAPH_SNAPSHOT_MAX_LIMIT + 100),
+    GRAPH_SNAPSHOT_MAX_LIMIT,
+  );
+  assert.throws(() => normalizeGraphSnapshotLimit(0), /positive integer/);
+  assert.throws(() => normalizeGraphSnapshotLimit(-3), /positive integer/);
+  assert.throws(() => normalizeGraphSnapshotLimit(1.5), /positive integer/);
+  assert.throws(() => normalizeGraphSnapshotLimit("50" as unknown), /positive integer/);
+});
+
+test("parseGraphSnapshotSince accepts ISO and rejects garbage", () => {
+  assert.equal(parseGraphSnapshotSince(undefined), undefined);
+  assert.equal(parseGraphSnapshotSince(""), undefined);
+  const ms = parseGraphSnapshotSince("2026-04-20T12:00:00Z");
+  assert.equal(typeof ms, "number");
+  assert.throws(() => parseGraphSnapshotSince("not-a-date"), /ISO/);
+});
+
+test("buildGraphSnapshot returns nodes/edges from a fixture memory dir", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: {},
+      loadNode: buildLoader(),
+    });
+    assert.equal(snapshot.edges.length, 3);
+    // Node count = 4 (alpha, beta, gamma, d1).
+    assert.equal(snapshot.nodes.length, 4);
+    // Edges include the canonical fields.
+    const first = snapshot.edges[0]!;
+    assert.ok(typeof first.source === "string");
+    assert.ok(typeof first.target === "string");
+    assert.match(first.kind, /^(entity|time|causal)$/);
+    assert.ok(first.confidence > 0 && first.confidence <= 1);
+    // generatedAt is an ISO string.
+    assert.ok(!Number.isNaN(Date.parse(snapshot.generatedAt)));
+    // Nodes carry resolved label / kind / score.
+    const beta = snapshot.nodes.find((n) => n.id === "facts/2026-04-20/beta.md");
+    assert.ok(beta);
+    assert.equal(beta!.label, "beta");
+    assert.equal(beta!.kind, "fact");
+    assert.ok(beta!.score > 0);
+    assert.ok(beta!.lastUpdated && !Number.isNaN(Date.parse(beta!.lastUpdated)));
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraphSnapshot enforces limit", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: { limit: 1 },
+      loadNode: buildLoader(),
+    });
+    assert.equal(snapshot.edges.length, 1);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraphSnapshot focusNodeId returns only neighborhood", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: { focusNodeId: "facts/2026-04-20/alpha.md" },
+      loadNode: buildLoader(),
+    });
+    // alpha appears in edges 1 (alpha->beta) and 3 (d1->alpha) — both incident.
+    assert.equal(snapshot.edges.length, 2);
+    for (const edge of snapshot.edges) {
+      assert.ok(
+        edge.source === "facts/2026-04-20/alpha.md" || edge.target === "facts/2026-04-20/alpha.md",
+        `edge ${edge.source}->${edge.target} should touch focus node`,
+      );
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraphSnapshot categories filter requires both endpoints to match", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: { categories: ["fact"] },
+      loadNode: buildLoader(),
+    });
+    // Only the two fact↔fact entity edges survive; the decision↔fact causal
+    // edge is dropped because `decision` is outside the allow-list.
+    assert.equal(snapshot.edges.length, 2);
+    for (const edge of snapshot.edges) {
+      assert.equal(edge.kind, "entity");
+    }
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraphSnapshot since filter drops older edges", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    const snapshot = await buildGraphSnapshot({
+      memoryDir: dir,
+      graphConfig: {
+        entityGraphEnabled: true,
+        timeGraphEnabled: true,
+        causalGraphEnabled: true,
+      },
+      request: { since: "2026-04-20T12:08:00Z" },
+      loadNode: buildLoader(),
+    });
+    // Only the 12:10 causal edge passes the cutoff.
+    assert.equal(snapshot.edges.length, 1);
+    assert.equal(snapshot.edges[0]!.kind, "causal");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("buildGraphSnapshot rejects empty categories array", async () => {
+  const dir = await makeFixtureDir();
+  try {
+    await seedEdges(dir);
+    await assert.rejects(
+      buildGraphSnapshot({
+        memoryDir: dir,
+        graphConfig: {
+          entityGraphEnabled: true,
+          timeGraphEnabled: true,
+          causalGraphEnabled: true,
+        },
+        request: { categories: [] },
+        loadNode: buildLoader(),
+      }),
+      /at least one non-empty value/,
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// HTTP surface tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+function createFakeService(overrides: Partial<EngramAccessService> = {}): EngramAccessService {
+  return {
+    graphSnapshot: async (request: { limit?: number; namespace?: string }) => ({
+      nodes: [
+        {
+          id: "facts/2026-04-20/alpha.md",
+          label: "alpha",
+          kind: "fact",
+          score: 0.9,
+          lastUpdated: "2026-04-20T12:00:00.000Z",
+        },
+      ],
+      edges: [
+        {
+          source: "facts/2026-04-20/alpha.md",
+          target: "facts/2026-04-20/beta.md",
+          kind: "entity" as const,
+          confidence: 0.9,
+        },
+      ],
+      generatedAt: "2026-04-20T12:30:00.000Z",
+      ...(request.limit !== undefined ? { _capturedLimit: request.limit } : {}),
+      ...(request.namespace !== undefined ? { _capturedNamespace: request.namespace } : {}),
+    }),
+    ...overrides,
+  } as unknown as EngramAccessService;
+}
+
+test("HTTP /engram/v1/graph/snapshot rejects unauthenticated requests", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const res = await fetch(`http://${started.host}:${started.port}/engram/v1/graph/snapshot`);
+    assert.equal(res.status, 401);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /engram/v1/graph/snapshot returns nodes and edges", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const res = await fetch(
+      `http://${started.host}:${started.port}/engram/v1/graph/snapshot`,
+      { headers: { Authorization: "Bearer secret-token" } },
+    );
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as GraphSnapshotResponse;
+    assert.equal(body.edges.length, 1);
+    assert.equal(body.nodes.length, 1);
+    assert.equal(body.edges[0]!.source, "facts/2026-04-20/alpha.md");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /engram/v1/graph/snapshot rejects invalid limit", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const res = await fetch(
+      `http://${started.host}:${started.port}/engram/v1/graph/snapshot?limit=abc`,
+      { headers: { Authorization: "Bearer secret-token" } },
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, "invalid_limit");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /engram/v1/graph/snapshot rejects invalid since", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const res = await fetch(
+      `http://${started.host}:${started.port}/engram/v1/graph/snapshot?since=not-a-date`,
+      { headers: { Authorization: "Bearer secret-token" } },
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, "invalid_since");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /engram/v1/graph/snapshot rejects empty categories list", async () => {
+  const server = new EngramAccessHttpServer({
+    service: createFakeService(),
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const res = await fetch(
+      `http://${started.host}:${started.port}/engram/v1/graph/snapshot?categories=,,,`,
+      { headers: { Authorization: "Bearer secret-token" } },
+    );
+    assert.equal(res.status, 400);
+    const body = (await res.json()) as { code: string };
+    assert.equal(body.code, "invalid_categories");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("HTTP /engram/v1/graph/snapshot forwards filters to the service", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const service = createFakeService({
+    graphSnapshot: async (request: Record<string, unknown>) => {
+      captured.push(request);
+      return {
+        nodes: [],
+        edges: [],
+        generatedAt: "2026-04-20T12:30:00.000Z",
+      };
+    },
+  } as unknown as Partial<EngramAccessService>);
+  const server = new EngramAccessHttpServer({
+    service,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+  });
+  const started = await server.start();
+  try {
+    const url = `http://${started.host}:${started.port}/engram/v1/graph/snapshot`
+      + `?limit=42&since=2026-04-20T00:00:00Z&focusNodeId=facts%2Falpha.md`
+      + `&categories=fact,decision`;
+    const res = await fetch(url, {
+      headers: { Authorization: "Bearer secret-token" },
+    });
+    assert.equal(res.status, 200);
+    assert.equal(captured.length, 1);
+    const args = captured[0]!;
+    assert.equal(args.limit, 42);
+    assert.equal(args.since, "2026-04-20T00:00:00Z");
+    assert.equal(args.focusNodeId, "facts/alpha.md");
+    assert.deepEqual(args.categories, ["fact", "decision"]);
+  } finally {
+    await server.stop();
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// MCP surface tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("MCP graph_snapshot tool is exposed under both prefixes", async () => {
+  const service = createFakeService();
+  const mcp = new EngramMcpServer(service);
+  const init = await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  assert.ok(init);
+  const tools = await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/list",
+    params: {},
+  });
+  const listed = (tools?.result as { tools: Array<{ name: string }> }).tools.map(
+    (tool) => tool.name,
+  );
+  assert.ok(
+    listed.includes("engram.graph_snapshot"),
+    `expected engram.graph_snapshot in ${listed.join(",")}`,
+  );
+  assert.ok(
+    listed.includes("remnic.graph_snapshot"),
+    `expected remnic.graph_snapshot in ${listed.join(",")}`,
+  );
+});
+
+test("MCP graph_snapshot tool dispatches to the service", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const service = createFakeService({
+    graphSnapshot: async (request: Record<string, unknown>) => {
+      captured.push(request);
+      return {
+        nodes: [],
+        edges: [],
+        generatedAt: "2026-04-20T12:30:00.000Z",
+      };
+    },
+  } as unknown as Partial<EngramAccessService>);
+  const mcp = new EngramMcpServer(service);
+  await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  const result = await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.graph_snapshot",
+      arguments: {
+        limit: 100,
+        since: "2026-04-20T00:00:00Z",
+        focusNodeId: "facts/x.md",
+        categories: ["fact"],
+      },
+    },
+  });
+  assert.ok(result?.result);
+  assert.equal(captured.length, 1);
+  assert.equal(captured[0]!.limit, 100);
+  assert.deepEqual(captured[0]!.categories, ["fact"]);
+});
+
+test("MCP graph_snapshot rejects non-numeric limit at the boundary", async () => {
+  const service = createFakeService();
+  const mcp = new EngramMcpServer(service);
+  await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "initialize",
+    params: {},
+  });
+  const result = await mcp.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "engram.graph_snapshot",
+      arguments: { limit: "100" },
+    },
+  });
+  // Errors are surfaced via the standard MCP error envelope.
+  assert.ok(result);
+  const wrapped = result as { result?: { isError?: boolean }; error?: unknown };
+  // Either MCP error or `isError: true` content is acceptable; we just need
+  // the boundary to NOT silently coerce.
+  if (wrapped.error === undefined) {
+    assert.equal(wrapped.result?.isError, true);
+  }
+});
+
+// Suppress unused-import warning for `mkdir` / `writeFile` (kept for future
+// fixture extensions that exercise the orchestrator-backed loader).
+void mkdir;
+void writeFile;

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -713,3 +713,174 @@ test("MCP graph_snapshot rejects non-numeric limit at the boundary", async () =>
   }
 });
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Path-traversal tests for EngramAccessService.graphSnapshot loader (#734)
+//
+// `GraphEdge.from` / `to` are JSONL-parsed strings.  A malformed edge with
+// an absolute path or a `..` traversal must NOT cause `loadNode` to read a
+// memory file from outside the resolved namespace root, otherwise file
+// metadata can leak across tenants in multi-principal deployments.
+// ─────────────────────────────────────────────────────────────────────────────
+
+import { EngramAccessService } from "../src/access-service.js";
+
+function buildSnapshotService(memoryDir: string): {
+  service: EngramAccessService;
+  readsByPath: string[];
+} {
+  const readsByPath: string[] = [];
+  const config = {
+    memoryDir,
+    namespacesEnabled: false,
+    defaultNamespace: "global",
+    sharedNamespace: "shared",
+    entityGraphEnabled: true,
+    timeGraphEnabled: true,
+    causalGraphEnabled: true,
+    recallCrossNamespaceBudgetEnabled: false,
+    recallCrossNamespaceBudgetWindowMs: 60_000,
+    recallCrossNamespaceBudgetSoftLimit: 10,
+    recallCrossNamespaceBudgetHardLimit: 30,
+    recallAuditAnomalyDetectionEnabled: false,
+    recallAuditAnomalyWindowMs: 60_000,
+    recallAuditAnomalyRepeatQueryLimit: 100,
+    recallAuditAnomalyNamespaceWalkLimit: 100,
+    recallAuditAnomalyHighCardinalityLimit: 100,
+    recallAuditAnomalyRapidFireLimit: 100,
+  };
+  const orchestrator = {
+    config,
+    // The path-traversal guard must run BEFORE this storage method is
+    // invoked.  Tests capture every path that reaches the storage layer so
+    // we can assert that bogus endpoints never trigger I/O.
+    getStorage: async () => ({
+      dir: memoryDir,
+      readMemoryByPath: async (filePath: string) => {
+        readsByPath.push(filePath);
+        return {
+          path: filePath,
+          content: "",
+          frontmatter: {
+            id: path.basename(filePath, path.extname(filePath)),
+            category: "fact",
+            created: "2026-01-01T00:00:00Z",
+            updated: "2026-01-01T00:00:00Z",
+          },
+        };
+      },
+    }),
+  };
+  return {
+    service: new EngramAccessService(orchestrator as never),
+    readsByPath,
+  };
+}
+
+test(
+  "graphSnapshot rejects absolute edge endpoints before reading memory metadata",
+  async () => {
+    const dir = await makeFixtureDir();
+    try {
+      // Without the guard, `path.resolve(root, absolutePath)` returns the
+      // absolute path verbatim, so a malformed edge could leak metadata
+      // from any readable file (e.g. `/etc/passwd`).
+      await appendEdge(dir, {
+        from: "/etc/passwd",
+        to: "facts/2026-04-20/alpha.md",
+        type: "entity",
+        weight: 1.0,
+        label: "exploit",
+        ts: "2026-04-20T12:00:00.000Z",
+      });
+      const { service, readsByPath } = buildSnapshotService(dir);
+      const snapshot = await service.graphSnapshot({});
+      assert.ok(
+        readsByPath.every((p) => !p.includes("/etc/passwd")),
+        `expected no read of /etc/passwd, saw ${readsByPath.join(",")}`,
+      );
+      const passwdNode = snapshot.nodes.find((n) => n.id === "/etc/passwd");
+      // The node may still appear in the index (the edge survives and bumps
+      // both endpoints) but its metadata must fall through to the
+      // unknown-category fallback rather than expose anything from the
+      // out-of-namespace file.
+      if (passwdNode) {
+        assert.equal(passwdNode.kind, "unknown");
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "graphSnapshot rejects ../ traversing edge endpoints before reading metadata",
+  async () => {
+    const dir = await makeFixtureDir();
+    try {
+      await appendEdge(dir, {
+        from: "../../etc/passwd",
+        to: "facts/2026-04-20/alpha.md",
+        type: "entity",
+        weight: 1.0,
+        label: "traversal",
+        ts: "2026-04-20T12:00:00.000Z",
+      });
+      const { service, readsByPath } = buildSnapshotService(dir);
+      const snapshot = await service.graphSnapshot({});
+      assert.ok(
+        readsByPath.every((p) => !p.includes("etc/passwd")),
+        `expected no read of etc/passwd, saw ${readsByPath.join(",")}`,
+      );
+      const escapeNode = snapshot.nodes.find((n) => n.id === "../../etc/passwd");
+      if (escapeNode) {
+        assert.equal(escapeNode.kind, "unknown");
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+test(
+  "graphSnapshot loads metadata for valid relative subdir paths",
+  async () => {
+    const dir = await makeFixtureDir();
+    try {
+      await appendEdge(dir, {
+        from: "facts/2026-04-20/alpha.md",
+        to: "facts/2026-04-20/beta.md",
+        type: "entity",
+        weight: 1.0,
+        label: "valid",
+        ts: "2026-04-20T12:00:00.000Z",
+      });
+      const { service, readsByPath } = buildSnapshotService(dir);
+      const snapshot = await service.graphSnapshot({});
+      assert.equal(snapshot.edges.length, 1);
+      // Both endpoints must have hit the loader (storage reads).
+      assert.ok(
+        readsByPath.some((p) => p.endsWith(path.join("facts", "2026-04-20", "alpha.md"))),
+        `expected alpha.md read, saw ${readsByPath.join(",")}`,
+      );
+      assert.ok(
+        readsByPath.some((p) => p.endsWith(path.join("facts", "2026-04-20", "beta.md"))),
+        `expected beta.md read, saw ${readsByPath.join(",")}`,
+      );
+      // Resolved reads must remain inside the namespace root.
+      for (const p of readsByPath) {
+        assert.ok(
+          p.startsWith(dir + path.sep) || p === dir,
+          `read path ${p} escaped namespace root ${dir}`,
+        );
+      }
+    } finally {
+      await rm(dir, { recursive: true, force: true });
+    }
+  },
+);
+
+// Suppress unused-import warning for `mkdir` / `writeFile` (kept for future
+// fixture extensions that exercise the orchestrator-backed loader).
+void mkdir;
+void writeFile;
+


### PR DESCRIPTION
## Summary

- Adds `GET /engram/v1/graph/snapshot` HTTP endpoint and the matching `engram.graph_snapshot` / `remnic.graph_snapshot` MCP tool. Returns `{ nodes, edges, generatedAt }` for the admin-pane scaffold shipped in #691 PR 1/5.
- Snapshot logic is a new pure module `packages/remnic-core/src/graph-snapshot.ts` that composes the existing JSONL edge store (`graph.ts`) with namespace-scoped node metadata; HTTP / MCP / future CLI surfaces all share it.
- Filter knobs: `limit` (default 500, max 5000), `since` (ISO timestamp), `focusNodeId` (restricts to neighborhood), `categories` (allow-list). Invalid values yield 400s with descriptive codes — never silent defaults (CLAUDE.md rule 51).

## Architecture notes

- **Namespace scope.** `EngramAccessService.graphSnapshot` resolves the readable namespace via the same helper used by recall / procedureStats, then uses the namespaced `StorageManager.dir` as the graph root so multi-principal deployments cannot leak edges from peer namespaces (CLAUDE.md rule 42).
- **Edge confidence.** The response surfaces edge `confidence` via `readEdgeConfidence` from `graph-edge-reinforcement.ts` so legacy edges (no `confidence` field) read as 1.0 — matches the conventions established in #681 PR 1/3.
- **Filter ordering.** Time → focus → category → limit. Limit is applied last so filters operate on the full neighborhood before the response is trimmed.
- **Sort determinism.** Edges sort newest-first, with a stable `(from, to, type)` secondary key for tie-breaking (CLAUDE.md rule 19).

## Test plan

- [x] `tests/graph-snapshot.test.ts` — pure builder (limit / since / focus / categories), HTTP wiring (auth, query-param validation, filter forwarding), MCP dual-name exposure, boundary type checking.
- [x] `tests/access-mcp.test.ts` — `legacyListed` updated for the new tool.
- [x] `npx tsc --noEmit` clean.
- [x] Targeted runs: `access-mcp.test.ts`, `access-mcp-recall-xray.test.ts`, `access-http.test.ts`, `graph-snapshot.test.ts` — 49/49 passing on this branch.
- [x] `npm run preflight:quick` — failures match `main` (pre-existing memory projection / LCM / observe failures, not introduced here).

## Issue link

Part of #691 (admin pane). Builds on #691 PR 1/5 (already merged on `main`).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new externally reachable read-only API/tool that reads from on-disk graph edges and memory metadata, including new input validation and path-safety guards. Risk is moderate due to new surface area and filesystem path handling, though changes are scoped and covered by new tests.
> 
> **Overview**
> Adds a new read-only graph snapshot capability for the admin pane, exposed as `GET /engram/v1/graph/snapshot` and MCP tool `engram.graph_snapshot` (with `remnic.*` alias), returning `{ nodes, edges, generatedAt }` and supporting `limit`, `since`, `focusNodeId`, `categories`, and `namespace` filters.
> 
> Introduces a shared `buildGraphSnapshot` module that reads the JSONL edge store, applies deterministic sorting and filter/limit logic, enriches nodes via best-effort metadata loading, and surfaces edge confidence.
> 
> Updates `EngramAccessService` to implement `graphSnapshot` with namespace scoping plus a path-traversal/absolute-path guard when loading node metadata, and adds comprehensive tests for HTTP/MCP wiring, validation errors, filtering behavior, and traversal protections.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c9275b02c7a2be770eea52ea276a36f718fd0d18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->