### PR TITLE
feat(peers): async peer profile reasoner (#679 PR 2/5)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2922,8 +2922,8 @@
       },
       "peerProfileReasonerModel": {
         "type": "string",
-        "default": "gpt-5.2",
-        "description": "Model identifier used by the peer profile reasoner. Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+        "default": "auto",
+        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
       },
       "peerProfileReasonerMinInteractions": {
         "type": "number",

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -2915,6 +2915,28 @@
         "default": false,
         "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
+      "peerProfileReasonerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
+      },
+      "peerProfileReasonerModel": {
+        "type": "string",
+        "default": "gpt-5.2",
+        "description": "Model identifier used by the peer profile reasoner. Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+      },
+      "peerProfileReasonerMinInteractions": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+      },
+      "peerProfileReasonerMaxFieldsPerRun": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+      },
       "creationMemoryEnabled": {
         "type": "boolean",
         "default": false,
@@ -4726,6 +4748,26 @@
       "label": "Operator-Aware Consolidation Prompt",
       "advanced": true,
       "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+    },
+    "peerProfileReasonerEnabled": {
+      "label": "Peer Profile Reasoner",
+      "advanced": true,
+      "help": "Enable the async peer profile reasoner (issue #679). Runs in the REM phase after semantic consolidation and updates per-peer profile.md files with provenance-tagged field updates derived from each peer's interaction log. Default off (opt-in)."
+    },
+    "peerProfileReasonerModel": {
+      "label": "Peer Profile Reasoner Model",
+      "advanced": true,
+      "help": "Model identifier the peer profile reasoner records on telemetry. Dispatch still routes through the FallbackLlmClient used by semantic consolidation."
+    },
+    "peerProfileReasonerMinInteractions": {
+      "label": "Peer Profile Reasoner Min Interactions",
+      "advanced": true,
+      "help": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+    },
+    "peerProfileReasonerMaxFieldsPerRun": {
+      "label": "Peer Profile Reasoner Max Fields Per Run",
+      "advanced": true,
+      "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2912,6 +2912,28 @@
         "default": false,
         "description": "Opt in to operator-aware consolidation prompts so the LLM returns structured {operator, output} JSON and SPLIT/MERGE/UPDATE is recorded on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
       },
+      "peerProfileReasonerEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable the async peer profile reasoner (issue #679). Runs after semantic consolidation in the REM phase and updates per-peer profile.md files with provenance-tagged field updates derived from the peer's interaction log. Default off (opt-in)."
+      },
+      "peerProfileReasonerModel": {
+        "type": "string",
+        "default": "gpt-5.2",
+        "description": "Model identifier used by the peer profile reasoner. Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+      },
+      "peerProfileReasonerMinInteractions": {
+        "type": "number",
+        "default": 5,
+        "minimum": 0,
+        "description": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+      },
+      "peerProfileReasonerMaxFieldsPerRun": {
+        "type": "number",
+        "default": 8,
+        "minimum": 0,
+        "description": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
+      },
       "creationMemoryEnabled": {
         "type": "boolean",
         "default": false,
@@ -4723,6 +4745,26 @@
       "label": "Operator-Aware Consolidation Prompt",
       "advanced": true,
       "help": "Opt in to operator-aware consolidation prompts (default off). When enabled, the LLM returns structured {operator, output} JSON and we record SPLIT/MERGE/UPDATE on derived_via. When disabled (default), derived_via still populates via the cluster-shape heuristic."
+    },
+    "peerProfileReasonerEnabled": {
+      "label": "Peer Profile Reasoner",
+      "advanced": true,
+      "help": "Enable the async peer profile reasoner (issue #679). Runs in the REM phase after semantic consolidation and updates per-peer profile.md files with provenance-tagged field updates derived from each peer's interaction log. Default off (opt-in)."
+    },
+    "peerProfileReasonerModel": {
+      "label": "Peer Profile Reasoner Model",
+      "advanced": true,
+      "help": "Model identifier the peer profile reasoner records on telemetry. Dispatch still routes through the FallbackLlmClient used by semantic consolidation."
+    },
+    "peerProfileReasonerMinInteractions": {
+      "label": "Peer Profile Reasoner Min Interactions",
+      "advanced": true,
+      "help": "Minimum new interaction-log entries a peer must accumulate since the previous reasoner run before being processed again. Set to 0 to consider every peer on every run."
+    },
+    "peerProfileReasonerMaxFieldsPerRun": {
+      "label": "Peer Profile Reasoner Max Fields Per Run",
+      "advanced": true,
+      "help": "Hard cap on the total number of profile fields the reasoner will apply across all peers in a single run. Set to 0 to disable applying any fields."
     },
     "creationMemoryEnabled": {
       "label": "Creation Memory",

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -2919,8 +2919,8 @@
       },
       "peerProfileReasonerModel": {
         "type": "string",
-        "default": "gpt-5.2",
-        "description": "Model identifier used by the peer profile reasoner. Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
+        "default": "auto",
+        "description": "Model identifier used by the peer profile reasoner. 'auto' inherits the gateway's primary chain (recommended). Logged for telemetry only — actual dispatch routes through the same FallbackLlmClient used by semantic consolidation."
       },
       "peerProfileReasonerMinInteractions": {
         "type": "number",

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -1552,6 +1552,29 @@ export function parseConfig(raw: unknown): PluginConfig {
     // wiring keeps working without operator-aware prompts.
     operatorAwareConsolidationEnabled:
       coerceBool(cfg.operatorAwareConsolidationEnabled) ?? false,
+    // Async peer profile reasoner (issue #679 PR 2/5). Defaults to
+    // `false` (opt-in) per Gotchas #30/#48 — least-privileged default.
+    // `coerceBool` handles "true"/"1"/"yes"/"on" CLI strings (Gotcha
+    // #36). Numeric thresholds clamp at zero (Gotcha #28 + #45 — 0
+    // is a documented disable value for both, so the schema minimum
+    // matches and we do NOT silently bump to 1).
+    peerProfileReasonerEnabled:
+      coerceBool(cfg.peerProfileReasonerEnabled) ?? false,
+    peerProfileReasonerModel:
+      typeof cfg.peerProfileReasonerModel === "string" &&
+      cfg.peerProfileReasonerModel.trim().length > 0
+        ? cfg.peerProfileReasonerModel.trim()
+        : "gpt-5.2",
+    peerProfileReasonerMinInteractions:
+      typeof cfg.peerProfileReasonerMinInteractions === "number" &&
+      Number.isFinite(cfg.peerProfileReasonerMinInteractions)
+        ? Math.max(0, Math.floor(cfg.peerProfileReasonerMinInteractions))
+        : 5,
+    peerProfileReasonerMaxFieldsPerRun:
+      typeof cfg.peerProfileReasonerMaxFieldsPerRun === "number" &&
+      Number.isFinite(cfg.peerProfileReasonerMaxFieldsPerRun)
+        ? Math.max(0, Math.floor(cfg.peerProfileReasonerMaxFieldsPerRun))
+        : 8,
     creationMemoryEnabled: cfg.creationMemoryEnabled === true,
     memoryUtilityLearningEnabled: cfg.memoryUtilityLearningEnabled === true,
     promotionByOutcomeEnabled: cfg.promotionByOutcomeEnabled === true,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -174,6 +174,16 @@ function parseSemanticChunkingConfig(
   return out;
 }
 
+// Cursor review on PR #736: the default reasoning model used by the
+// extraction pipeline (`config.model`) and the new peer profile
+// reasoner (`peerProfileReasonerModel`) was hardcoded as `"gpt-5.2"`
+// in two places. Centralize the default so both surfaces — and any
+// future LLM-backed surface — always agree on the same model id.
+// Sibling packages (briefing, active-recall) keep their own constants
+// because they're scoped to those subsystems; this one lives in the
+// config module because it spans extraction + peer-profile.
+export const DEFAULT_REASONING_MODEL = "gpt-5.2";
+
 const VALID_EFFORTS: ReasoningEffort[] = ["none", "low", "medium", "high"];
 const VALID_TRIGGERS: TriggerMode[] = ["smart", "every_n", "time_based"];
 const VALID_IDENTITY_INJECTION_MODES: IdentityInjectionMode[] = ["recovery_only", "minimal", "full"];
@@ -376,7 +386,7 @@ export function parseConfig(raw: unknown): PluginConfig {
   const model =
     typeof cfg.model === "string" && cfg.model.length > 0
       ? cfg.model
-      : "gpt-5.2";
+      : DEFAULT_REASONING_MODEL;
   const captureMode =
     cfg.captureMode === "explicit" || cfg.captureMode === "hybrid"
       ? cfg.captureMode
@@ -1560,21 +1570,34 @@ export function parseConfig(raw: unknown): PluginConfig {
     // matches and we do NOT silently bump to 1).
     peerProfileReasonerEnabled:
       coerceBool(cfg.peerProfileReasonerEnabled) ?? false,
+    // Cursor M on PR #736: use the routing alias `"auto"` rather than
+    // a hardcoded model identifier. Matches the convention established
+    // by sibling `semanticConsolidationModel`. Operators can still
+    // override via config; the value is logged for telemetry only.
     peerProfileReasonerModel:
       typeof cfg.peerProfileReasonerModel === "string" &&
       cfg.peerProfileReasonerModel.trim().length > 0
         ? cfg.peerProfileReasonerModel.trim()
-        : "gpt-5.2",
-    peerProfileReasonerMinInteractions:
-      typeof cfg.peerProfileReasonerMinInteractions === "number" &&
-      Number.isFinite(cfg.peerProfileReasonerMinInteractions)
-        ? Math.max(0, Math.floor(cfg.peerProfileReasonerMinInteractions))
-        : 5,
-    peerProfileReasonerMaxFieldsPerRun:
-      typeof cfg.peerProfileReasonerMaxFieldsPerRun === "number" &&
-      Number.isFinite(cfg.peerProfileReasonerMaxFieldsPerRun)
-        ? Math.max(0, Math.floor(cfg.peerProfileReasonerMaxFieldsPerRun))
-        : 8,
+        : "auto",
+    // Cursor L on PR #736: numeric config keys must coerce string CLI
+    // values (Gotcha #28 — `--config peerProfileReasonerMaxFieldsPerRun=2`
+    // arrives as the string "2"). Pre-fix `typeof === "number"`
+    // rejected string inputs and silently fell back to defaults. The
+    // shared `coerceNonNegativeInt` helper accepts both forms, throws
+    // on invalid input (Gotcha #51 — reject rather than silently
+    // default), and falls back to the documented default when the
+    // key is absent. 0 is a valid documented disable value here, so
+    // the helper does NOT bump to 1.
+    peerProfileReasonerMinInteractions: coerceNonNegativeInt(
+      cfg.peerProfileReasonerMinInteractions,
+      5,
+      "peerProfileReasonerMinInteractions",
+    ),
+    peerProfileReasonerMaxFieldsPerRun: coerceNonNegativeInt(
+      cfg.peerProfileReasonerMaxFieldsPerRun,
+      8,
+      "peerProfileReasonerMaxFieldsPerRun",
+    ),
     creationMemoryEnabled: cfg.creationMemoryEnabled === true,
     memoryUtilityLearningEnabled: cfg.memoryUtilityLearningEnabled === true,
     promotionByOutcomeEnabled: cfg.promotionByOutcomeEnabled === true,
@@ -2530,6 +2553,40 @@ function parseBriefingConfig(raw: unknown): import("./types.js").BriefingConfig 
 function clampNonNegativeNumber(value: unknown): number | undefined {
   if (typeof value !== "number" || !Number.isFinite(value)) return undefined;
   return Math.max(0, Math.floor(value));
+}
+
+/**
+ * Cursor L on PR #736: numeric config keys must accept BOTH numbers
+ * and CLI-string forms (`--config peerProfileReasonerMinInteractions=10`
+ * arrives as the string `"10"` per CLAUDE.md Gotcha #28). Pre-fix
+ * `typeof === "number"` rejected strings and silently fell back to the
+ * default — operators thought their override applied.
+ *
+ * Behavior:
+ *   - `undefined` / `null` / missing → return `fallback`
+ *   - finite number ≥ 0           → return floor(value)
+ *   - string that parses to finite ≥ 0 → return floor(value)
+ *   - anything else (NaN, ±Infinity, negative, non-numeric string,
+ *     boolean, object) → throw an Error listing the offending key.
+ *
+ * Throwing matches Gotcha #51 — reject invalid input rather than
+ * silently defaulting — and is consistent with how the surprise
+ * knobs validate their inputs.
+ */
+function coerceNonNegativeInt(
+  value: unknown,
+  fallback: number,
+  keyName?: string,
+): number {
+  if (value === undefined || value === null) return fallback;
+  const coerced = coerceNumber(value);
+  if (coerced === undefined || coerced < 0) {
+    const label = keyName ? ` (${keyName})` : "";
+    throw new Error(
+      `config value${label} must be a non-negative finite number; got ${JSON.stringify(value)}`,
+    );
+  }
+  return Math.floor(coerced);
 }
 
 // -----------------------------------------------------------------------------

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -3058,6 +3058,41 @@ export class Orchestrator {
       );
     }
 
+    // Issue #679 PR 2/5 — async peer profile reasoner runs as part of
+    // the REM phase, immediately after semantic consolidation. Gated
+    // on `peerProfileReasonerEnabled` (default false, opt-in). Wrapped
+    // in a try/catch because reasoner I/O (LLM call, peer-profile
+    // writes) must never abort the consolidation result. The reasoner
+    // itself also defends against partial failure — see profile-reasoner.ts.
+    if (this.config.peerProfileReasonerEnabled) {
+      try {
+        const { runPeerProfileReasoner } = await import("./peers/index.js");
+        const llm = new FallbackLlmClient(this.config.gatewayConfig);
+        const peerResult = await runPeerProfileReasoner({
+          memoryDir: this.config.memoryDir,
+          enabled: true,
+          llm,
+          model: this.config.peerProfileReasonerModel,
+          minInteractions: this.config.peerProfileReasonerMinInteractions,
+          maxFieldsPerRun: this.config.peerProfileReasonerMaxFieldsPerRun,
+          log: {
+            debug: (msg) => log.debug(msg),
+            info: (msg) => log.info(msg),
+            warn: (msg) => log.warn(msg),
+          },
+        });
+        log.info(
+          `[peer-profile-reasoner] complete: peers=${peerResult.peersConsidered}, processed=${peerResult.peersProcessed}, fields=${peerResult.fieldsApplied}`,
+        );
+      } catch (err) {
+        log.warn(
+          `[peer-profile-reasoner] post-consolidation hook failed (non-fatal): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
     return result;
   }
 

--- a/packages/remnic-core/src/peers/index.ts
+++ b/packages/remnic-core/src/peers/index.ts
@@ -1,10 +1,12 @@
 /**
  * Peer registry — public barrel.
  *
- * Issue #679 PR 1/5 — schema + storage primitives only. The async profile
- * reasoner (PR 2/5), recall injection (PR 3/5), CLI/HTTP/MCP surfaces
- * (PR 4/5), and migration of existing identity-anchor data (PR 5) are
- * deferred.
+ * Issue #679 PR 1/5 — schema + storage primitives only.
+ * Issue #679 PR 2/5 — async peer profile reasoner (re-exports
+ * `runPeerProfileReasoner`; implementation in `./profile-reasoner.ts`).
+ *
+ * Recall injection (PR 3/5), CLI/HTTP/MCP surfaces (PR 4/5), and
+ * migration of existing identity-anchor data (PR 5) are deferred.
  */
 
 export type {
@@ -25,6 +27,18 @@ export {
   listPeers,
   appendInteractionLog,
   readInteractionLogRaw,
+  readPeerInteractionLog,
   readPeerProfile,
   writePeerProfile,
 } from "./storage.js";
+
+export {
+  runPeerProfileReasoner,
+  parsePeerProfileReasonerResponse,
+  buildPeerProfileReasonerPrompt,
+  type PeerProfileReasonerOptions,
+  type PeerProfileReasonerResult,
+  type PeerProfileReasonerPeerResult,
+  type PeerProfileReasonerLlm,
+  type PeerProfileReasonerProposal,
+} from "./profile-reasoner.js";

--- a/packages/remnic-core/src/peers/profile-reasoner.ts
+++ b/packages/remnic-core/src/peers/profile-reasoner.ts
@@ -1,0 +1,657 @@
+/**
+ * Peer profile reasoner — issue #679 PR 2/5.
+ *
+ * Pure async function that, for each peer:
+ *
+ *   1. Reads recent interaction-log entries via `readPeerInteractionLog`.
+ *   2. Calls an injected LLM client (same chat shape as
+ *      `FallbackLlmClient.chatCompletion`) to derive 0..N profile-field
+ *      proposals with provenance `{observedAt, signal, sourceSessionId,
+ *      note}`.
+ *   3. Merges the proposals into the peer's existing `PeerProfile`,
+ *      appending provenance entries (never replacing existing
+ *      provenance — the reasoner is additive by design so the operator
+ *      retains the full audit trail).
+ *   4. Writes via `writePeerProfile`.
+ *
+ * Gating is handled in two layers:
+ *
+ *   - The orchestrator wires the call behind the
+ *     `peerProfileReasonerEnabled` config flag (default `false` —
+ *     opt-in per Gotcha #30/#48). The reasoner ALSO short-circuits
+ *     when `options.enabled !== true`, so direct callers can't
+ *     accidentally bypass the flag.
+ *   - Per-peer, the `peerProfileReasonerMinInteractions` threshold
+ *     skips peers whose log has fewer entries since the last reasoner
+ *     run than required.
+ *
+ * The reasoner is intentionally storage-agnostic — it accepts an LLM
+ * client by interface (`PeerProfileReasonerLlm`) so tests can mock the
+ * call and the orchestrator can inject either the gateway client or
+ * a fast local model. No direct OpenAI imports here.
+ */
+
+import {
+  appendInteractionLog,
+  listPeers,
+  readPeerInteractionLog,
+  readPeerProfile,
+  writePeerProfile,
+} from "./storage.js";
+import type {
+  Peer,
+  PeerInteractionLogEntry,
+  PeerProfile,
+  PeerProfileFieldProvenance,
+} from "./types.js";
+import { PEER_ID_PATTERN } from "./types.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Minimal chat-completion contract the reasoner depends on. Matches
+ * `FallbackLlmClient.chatCompletion` so the orchestrator can pass it
+ * through directly. Tests inject a mock that returns canned strings.
+ *
+ * Returning `null` means the LLM is unavailable / failed — the
+ * reasoner treats that as "no proposals for this peer" rather than an
+ * error so a flaky LLM never aborts the whole pass.
+ */
+export interface PeerProfileReasonerLlm {
+  chatCompletion(
+    messages: Array<{ role: "system" | "user" | "assistant"; content: string }>,
+    options?: { temperature?: number; maxTokens?: number; timeoutMs?: number },
+  ): Promise<{ content: string } | null>;
+}
+
+/**
+ * One LLM-proposed profile-field update.
+ *
+ * `value` is the new markdown string to set under `field`. The
+ * provenance entry the LLM emits travels alongside it; the reasoner
+ * does NOT trust the LLM's `observedAt` — it always overwrites with
+ * the run's `now` timestamp so provenance can never claim future or
+ * past observation timestamps the operator didn't witness.
+ */
+export interface PeerProfileReasonerProposal {
+  /** Stable section key, e.g. "communication_style". */
+  readonly field: string;
+  /** Markdown value to set under that key. */
+  readonly value: string;
+  /**
+   * Short label for the signal that justified the inference,
+   * e.g. "explicit_preference", "tool_pattern", "topic_recurrence".
+   */
+  readonly signal: string;
+  /** Optional free-form note explaining the inference. */
+  readonly note?: string;
+  /**
+   * Originating session id, when the LLM can attribute the inference
+   * to a specific log line. Reasoner clamps this to a value that
+   * actually appeared in the log window so the LLM can't hallucinate.
+   */
+  readonly sourceSessionId?: string;
+}
+
+export interface PeerProfileReasonerOptions {
+  /** Memory directory containing the peers/ subtree. */
+  readonly memoryDir: string;
+  /**
+   * Master gate. When `false` (the default the orchestrator passes
+   * when the config flag is off), the reasoner is a no-op and
+   * returns an empty result. Direct callers must explicitly pass
+   * `true` so the gate can never be defaulted ON by accident
+   * (Gotcha #48 — least-privileged default).
+   */
+  readonly enabled: boolean;
+  /** Injected LLM client. Required when `enabled === true`. */
+  readonly llm?: PeerProfileReasonerLlm;
+  /** Model name to log for telemetry; not used to dispatch. */
+  readonly model?: string;
+  /**
+   * Minimum new interaction-log entries since last reasoner run
+   * before this peer is processed. Peers below the threshold are
+   * skipped with `reason: "below_min_interactions"`.
+   */
+  readonly minInteractions: number;
+  /**
+   * Hard cap on profile fields the reasoner will accept across all
+   * peers in a single run. Tracked in insertion order: once the cap
+   * is reached, subsequent proposals are dropped with
+   * `dropped_due_to_cap` in the per-peer result. Use to bound LLM
+   * cost and reviewer load per pass.
+   */
+  readonly maxFieldsPerRun: number;
+  /**
+   * Optional restriction to specific peer ids. When omitted, the
+   * reasoner enumerates the entire peer registry via `listPeers`.
+   */
+  readonly peerIds?: ReadonlyArray<string>;
+  /**
+   * Maximum number of recent log entries to feed the LLM per peer.
+   * Defaults to 50. Bounded so a runaway log can't blow the prompt.
+   */
+  readonly maxLogEntriesPerPeer?: number;
+  /**
+   * Reasoner run timestamp. Defaults to `new Date()` at call time.
+   * Tests inject a deterministic clock; the orchestrator passes
+   * `new Date()` so provenance entries reflect actual wall time.
+   */
+  readonly now?: Date;
+  /**
+   * Optional logger; defaults to a no-op so the reasoner stays
+   * silent in unit tests. The orchestrator wires its `log` here so
+   * runs surface in the gateway log under the
+   * `[peer-profile-reasoner]` prefix.
+   */
+  readonly log?: {
+    debug?: (msg: string) => void;
+    info?: (msg: string) => void;
+    warn?: (msg: string) => void;
+  };
+  /**
+   * Whether to append a `peer_profile_reasoner_run` entry to the
+   * peer's interaction log when the reasoner emits at least one
+   * field for that peer. Defaults to `true`. Disable in tests that
+   * want to assert the log was untouched.
+   */
+  readonly appendRunMarkerToLog?: boolean;
+  /**
+   * Optional abort signal. The reasoner checks between peers and
+   * returns the partial result if cancelled mid-run.
+   */
+  readonly signal?: AbortSignal;
+}
+
+export interface PeerProfileReasonerPeerResult {
+  readonly peerId: string;
+  readonly status:
+    | "processed"
+    | "skipped_below_min_interactions"
+    | "skipped_no_log"
+    | "skipped_disabled"
+    | "skipped_no_llm"
+    | "skipped_llm_unavailable"
+    | "skipped_invalid_proposal"
+    | "skipped_cap_reached"
+    | "skipped_aborted"
+    | "error";
+  /** Number of fields actually applied to the peer's profile. */
+  readonly fieldsApplied: number;
+  /** Number of proposals dropped because the per-run cap was hit. */
+  readonly droppedDueToCap: number;
+  /** Set of field keys applied; useful for tests and telemetry. */
+  readonly fields: ReadonlyArray<string>;
+  /** Error message, when `status === "error"`. */
+  readonly error?: string;
+}
+
+export interface PeerProfileReasonerResult {
+  readonly peersConsidered: number;
+  readonly peersProcessed: number;
+  readonly fieldsApplied: number;
+  readonly perPeer: ReadonlyArray<PeerProfileReasonerPeerResult>;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Prompt + parser (pure, exported for tests)
+// ──────────────────────────────────────────────────────────────────────
+
+/**
+ * Build the user-facing reasoner prompt. The system message carries
+ * the strict-JSON instruction; this function emits the user message
+ * with the peer context and the recent log slice.
+ *
+ * The prompt is intentionally schema-prescriptive — sibling modules
+ * (`semantic-consolidation.ts`, `extraction-judge.ts`) demonstrated
+ * that letting the LLM improvise field names produces unstable
+ * profiles across runs.
+ */
+export function buildPeerProfileReasonerPrompt(input: {
+  peer: Peer;
+  existingProfile: PeerProfile | null;
+  log: ReadonlyArray<PeerInteractionLogEntry>;
+  maxFields: number;
+}): string {
+  const existingFields = input.existingProfile
+    ? Object.keys(input.existingProfile.fields)
+    : [];
+  const logBlock = input.log
+    .map((e) => {
+      const session = e.sessionId ? ` session=${e.sessionId}` : "";
+      return `- [${e.timestamp}] (${e.kind})${session} ${e.summary}`;
+    })
+    .join("\n");
+  return [
+    `You are an async peer-profile reasoner. Your job is to read recent interaction-log entries for one peer and propose 0..${input.maxFields} profile-field updates.`,
+    "",
+    `Peer:`,
+    `  id: ${input.peer.id}`,
+    `  kind: ${input.peer.kind}`,
+    `  displayName: ${input.peer.displayName}`,
+    "",
+    `Existing profile field keys (preserve names when proposing updates that refine an existing field): ${existingFields.length > 0 ? existingFields.join(", ") : "(none yet)"}`,
+    "",
+    `Recent interaction log (oldest first):`,
+    logBlock.length > 0 ? logBlock : "(no entries)",
+    "",
+    `Output a single JSON object: {"proposals": [{"field": "<stable_key>", "value": "<markdown>", "signal": "<short_label>", "note": "<optional>", "sourceSessionId": "<optional>"}]}.`,
+    "",
+    `Rules:`,
+    `1. Only propose fields supported by evidence in the log. Do not invent.`,
+    `2. Keys are short snake_case (e.g. "communication_style", "tool_patterns").`,
+    `3. value is markdown. signal is a short label like "explicit_preference" or "topic_recurrence".`,
+    `4. Omit fields you can't justify. Empty proposals array is valid.`,
+    `5. Output JSON ONLY — no prose before or after.`,
+  ].join("\n");
+}
+
+/**
+ * Parse the LLM response. Tolerates a fenced code block wrapper.
+ * Returns an empty array on any malformed payload — the contract is
+ * that flaky LLM output silently produces zero proposals rather than
+ * surfacing an error to the caller.
+ *
+ * Exported so unit tests can verify parser behavior without spinning
+ * up the full reasoner.
+ */
+export function parsePeerProfileReasonerResponse(
+  raw: string,
+): PeerProfileReasonerProposal[] {
+  if (typeof raw !== "string" || raw.trim() === "") return [];
+  const trimmed = raw.trim();
+  const fenced = /^```(?:json)?\s*([\s\S]*?)```\s*$/u.exec(trimmed);
+  const payload = fenced ? fenced[1].trim() : trimmed;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(payload);
+  } catch {
+    return [];
+  }
+  // Gotcha #18: JSON.parse('null') succeeds. Reject non-objects.
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    return [];
+  }
+  const obj = parsed as { proposals?: unknown };
+  if (!Array.isArray(obj.proposals)) return [];
+  const out: PeerProfileReasonerProposal[] = [];
+  // Gotcha — drop prototype-pollution keys at the field-name layer.
+  const RESERVED_KEYS = new Set(["__proto__", "constructor", "prototype"]);
+  for (const item of obj.proposals) {
+    if (typeof item !== "object" || item === null || Array.isArray(item)) continue;
+    const r = item as Record<string, unknown>;
+    if (typeof r.field !== "string" || r.field.trim() === "") continue;
+    if (RESERVED_KEYS.has(r.field)) continue;
+    if (typeof r.value !== "string" || r.value.trim() === "") continue;
+    if (typeof r.signal !== "string" || r.signal.trim() === "") continue;
+    const proposal: PeerProfileReasonerProposal = {
+      field: r.field,
+      value: r.value,
+      signal: r.signal,
+      ...(typeof r.note === "string" && r.note.length > 0 ? { note: r.note } : {}),
+      ...(typeof r.sourceSessionId === "string" && r.sourceSessionId.length > 0
+        ? { sourceSessionId: r.sourceSessionId }
+        : {}),
+    };
+    out.push(proposal);
+  }
+  return out;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Reasoner core
+// ──────────────────────────────────────────────────────────────────────
+
+const SYSTEM_MESSAGE =
+  'You are a peer-profile reasoner. Output ONLY a JSON object of the form {"proposals":[{"field":"...","value":"...","signal":"...","note":"...","sourceSessionId":"..."}]}. No prose, no fenced code block, no commentary.';
+
+const RUN_MARKER_KIND = "peer_profile_reasoner_run";
+
+/**
+ * Find the most recent reasoner-run marker timestamp in the log.
+ * Used to count "interactions since last run" so the threshold
+ * gate doesn't keep firing on the same dormant log forever.
+ */
+function lastRunTimestamp(
+  log: ReadonlyArray<PeerInteractionLogEntry>,
+): string | undefined {
+  let latest: string | undefined;
+  for (const entry of log) {
+    if (entry.kind !== RUN_MARKER_KIND) continue;
+    if (latest === undefined || entry.timestamp > latest) {
+      latest = entry.timestamp;
+    }
+  }
+  return latest;
+}
+
+function noopLogger(): NonNullable<PeerProfileReasonerOptions["log"]> {
+  return { debug: () => {}, info: () => {}, warn: () => {} };
+}
+
+/**
+ * Run the reasoner across all (or the requested subset of) peers.
+ *
+ * Always returns a `PeerProfileReasonerResult` — never throws to the
+ * caller — so the orchestrator can wire it as a best-effort
+ * post-consolidation hook (Gotcha #13).
+ */
+export async function runPeerProfileReasoner(
+  options: PeerProfileReasonerOptions,
+): Promise<PeerProfileReasonerResult> {
+  const log = {
+    debug: options.log?.debug ?? noopLogger().debug!,
+    info: options.log?.info ?? noopLogger().info!,
+    warn: options.log?.warn ?? noopLogger().warn!,
+  };
+  const result: {
+    peersConsidered: number;
+    peersProcessed: number;
+    fieldsApplied: number;
+    perPeer: PeerProfileReasonerPeerResult[];
+  } = {
+    peersConsidered: 0,
+    peersProcessed: 0,
+    fieldsApplied: 0,
+    perPeer: [],
+  };
+  // Disabled flag is the master gate. Defaults to false in callers'
+  // config; we additionally require strict `=== true` here so a
+  // stray "true" string doesn't silently flip the flag (Gotcha #36).
+  if (options.enabled !== true) {
+    log.debug("[peer-profile-reasoner] disabled — no-op");
+    return result;
+  }
+  if (!options.llm) {
+    log.warn("[peer-profile-reasoner] no LLM client supplied — skipping run");
+    return result;
+  }
+  const minInteractions = Number.isFinite(options.minInteractions)
+    ? Math.max(0, Math.floor(options.minInteractions))
+    : 0;
+  const maxFields = Number.isFinite(options.maxFieldsPerRun)
+    ? Math.max(0, Math.floor(options.maxFieldsPerRun))
+    : 0;
+  if (maxFields === 0) {
+    log.debug("[peer-profile-reasoner] maxFieldsPerRun=0 — no-op");
+    return result;
+  }
+  const maxLogPerPeer = Number.isFinite(options.maxLogEntriesPerPeer ?? NaN)
+    ? Math.max(1, Math.floor(options.maxLogEntriesPerPeer as number))
+    : 50;
+  const now = options.now ?? new Date();
+  const nowIso = now.toISOString();
+
+  let peers: Peer[];
+  try {
+    if (options.peerIds && options.peerIds.length > 0) {
+      // Filter the explicit list against on-disk peers so we never
+      // act on an id the operator typed but didn't register.
+      const all = await listPeers(options.memoryDir);
+      const wanted = new Set(
+        options.peerIds.filter(
+          (id) => typeof id === "string" && PEER_ID_PATTERN.test(id),
+        ),
+      );
+      peers = all.filter((p) => wanted.has(p.id));
+    } else {
+      peers = await listPeers(options.memoryDir);
+    }
+  } catch (err) {
+    log.warn(
+      `[peer-profile-reasoner] listPeers failed: ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return result;
+  }
+  result.peersConsidered = peers.length;
+  let fieldsAppliedTotal = 0;
+
+  for (const peer of peers) {
+    if (options.signal?.aborted) {
+      result.perPeer.push({
+        peerId: peer.id,
+        status: "skipped_aborted",
+        fieldsApplied: 0,
+        droppedDueToCap: 0,
+        fields: [],
+      });
+      continue;
+    }
+    try {
+      const recentLog = await readPeerInteractionLog(
+        options.memoryDir,
+        peer.id,
+        { limit: maxLogPerPeer },
+      );
+      if (recentLog.length === 0) {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "skipped_no_log",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+      // Count interactions since the last reasoner-run marker, so
+      // dormant peers don't trigger another LLM call until enough
+      // new signal accumulates. Run markers themselves don't count.
+      const lastRun = lastRunTimestamp(recentLog);
+      const sinceLastRun = lastRun
+        ? recentLog.filter(
+            (e) => e.timestamp > lastRun && e.kind !== RUN_MARKER_KIND,
+          )
+        : recentLog.filter((e) => e.kind !== RUN_MARKER_KIND);
+      if (sinceLastRun.length < minInteractions) {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "skipped_below_min_interactions",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+
+      const existingProfile = await readPeerProfile(options.memoryDir, peer.id);
+
+      const remainingBudget = maxFields - fieldsAppliedTotal;
+      if (remainingBudget <= 0) {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "skipped_cap_reached",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+
+      const prompt = buildPeerProfileReasonerPrompt({
+        peer,
+        existingProfile,
+        log: sinceLastRun,
+        maxFields: remainingBudget,
+      });
+      const messages = [
+        { role: "system" as const, content: SYSTEM_MESSAGE },
+        { role: "user" as const, content: prompt },
+      ];
+      let response: { content: string } | null;
+      try {
+        response = await options.llm.chatCompletion(messages, {
+          temperature: 0.2,
+          maxTokens: 1500,
+        });
+      } catch (err) {
+        log.warn(
+          `[peer-profile-reasoner] LLM call failed for "${peer.id}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "skipped_llm_unavailable",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+      if (!response || typeof response.content !== "string") {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "skipped_llm_unavailable",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+
+      const proposals = parsePeerProfileReasonerResponse(response.content);
+      if (proposals.length === 0) {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: "processed",
+          fieldsApplied: 0,
+          droppedDueToCap: 0,
+          fields: [],
+        });
+        continue;
+      }
+
+      // Build the merged profile. We never replace existing
+      // provenance entries — provenance is append-only so the
+      // operator retains a full audit trail.
+      const sessionIdsInWindow = new Set(
+        sinceLastRun
+          .map((e) => e.sessionId)
+          .filter((s): s is string => typeof s === "string" && s.length > 0),
+      );
+      const baseFields: Record<string, string> = existingProfile
+        ? { ...existingProfile.fields }
+        : {};
+      const baseProvenance: Record<string, PeerProfileFieldProvenance[]> = {};
+      if (existingProfile) {
+        for (const [k, list] of Object.entries(existingProfile.provenance)) {
+          baseProvenance[k] = [...list];
+        }
+      }
+
+      const appliedFieldsForPeer: string[] = [];
+      let droppedDueToCap = 0;
+      let invalidProposalSeen = false;
+      for (const proposal of proposals) {
+        if (fieldsAppliedTotal >= maxFields) {
+          droppedDueToCap += 1;
+          continue;
+        }
+        // Final defensive guard against prototype keys (parser
+        // already drops them, but be redundant for safety).
+        if (
+          proposal.field === "__proto__" ||
+          proposal.field === "constructor" ||
+          proposal.field === "prototype"
+        ) {
+          invalidProposalSeen = true;
+          continue;
+        }
+        // Sanity-check field key matches a conservative pattern so a
+        // hostile LLM can't sneak path-traversal-shaped keys through
+        // for downstream consumers.
+        if (!/^[a-zA-Z][a-zA-Z0-9_]{0,63}$/.test(proposal.field)) {
+          invalidProposalSeen = true;
+          continue;
+        }
+        baseFields[proposal.field] = proposal.value;
+        const sourceSessionId =
+          proposal.sourceSessionId &&
+          sessionIdsInWindow.has(proposal.sourceSessionId)
+            ? proposal.sourceSessionId
+            : undefined;
+        const provEntry: PeerProfileFieldProvenance = {
+          observedAt: nowIso,
+          signal: proposal.signal,
+          ...(sourceSessionId ? { sourceSessionId } : {}),
+          ...(proposal.note && proposal.note.length > 0
+            ? { note: proposal.note }
+            : {}),
+        };
+        const list = baseProvenance[proposal.field] ?? [];
+        list.push(provEntry);
+        baseProvenance[proposal.field] = list;
+        appliedFieldsForPeer.push(proposal.field);
+        fieldsAppliedTotal += 1;
+      }
+
+      if (appliedFieldsForPeer.length === 0) {
+        result.perPeer.push({
+          peerId: peer.id,
+          status: invalidProposalSeen
+            ? "skipped_invalid_proposal"
+            : droppedDueToCap > 0
+              ? "skipped_cap_reached"
+              : "processed",
+          fieldsApplied: 0,
+          droppedDueToCap,
+          fields: [],
+        });
+        continue;
+      }
+
+      const merged: PeerProfile = {
+        peerId: peer.id,
+        updatedAt: nowIso,
+        fields: baseFields,
+        provenance: baseProvenance,
+      };
+      await writePeerProfile(options.memoryDir, merged);
+
+      // Append a run marker so the next reasoner pass can compute
+      // "interactions since last run" without a dedicated state
+      // file. The marker is best-effort — a write failure here
+      // logs but does not roll back the profile (the operator
+      // would prefer a slightly noisy threshold over a lost
+      // profile update).
+      const wantsMarker = options.appendRunMarkerToLog ?? true;
+      if (wantsMarker) {
+        try {
+          await appendInteractionLog(options.memoryDir, peer.id, {
+            timestamp: nowIso,
+            kind: RUN_MARKER_KIND,
+            summary: `applied ${appliedFieldsForPeer.length} field(s) via ${options.model ?? "unknown-model"}`,
+          });
+        } catch (err) {
+          log.warn(
+            `[peer-profile-reasoner] run-marker append failed for "${peer.id}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+
+      result.perPeer.push({
+        peerId: peer.id,
+        status: "processed",
+        fieldsApplied: appliedFieldsForPeer.length,
+        droppedDueToCap,
+        fields: appliedFieldsForPeer,
+      });
+      result.peersProcessed += 1;
+      result.fieldsApplied = fieldsAppliedTotal;
+    } catch (err) {
+      log.warn(
+        `[peer-profile-reasoner] error processing peer "${peer.id}": ${err instanceof Error ? err.message : String(err)}`,
+      );
+      result.perPeer.push({
+        peerId: peer.id,
+        status: "error",
+        fieldsApplied: 0,
+        droppedDueToCap: 0,
+        fields: [],
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}

--- a/packages/remnic-core/src/peers/profile-reasoner.ts
+++ b/packages/remnic-core/src/peers/profile-reasoner.ts
@@ -420,12 +420,20 @@ export async function runPeerProfileReasoner(
       continue;
     }
     try {
-      const recentLog = await readPeerInteractionLog(
+      // Codex P2 review on PR #736: the min-interactions threshold
+      // must reflect the FULL log of new activity, not the
+      // `maxLogPerPeer`-truncated slice. Otherwise a peer with a
+      // genuinely active conversation history can be permanently
+      // marked `skipped_below_min_interactions` whenever
+      // `peerProfileReasonerMinInteractions > maxLogEntriesPerPeer`,
+      // because the slice will never include enough new entries.
+      // Read the full log first to compute the gate, then truncate
+      // for prompt construction below.
+      const fullLog = await readPeerInteractionLog(
         options.memoryDir,
         peer.id,
-        { limit: maxLogPerPeer },
       );
-      if (recentLog.length === 0) {
+      if (fullLog.length === 0) {
         result.perPeer.push({
           peerId: peer.id,
           status: "skipped_no_log",
@@ -438,13 +446,13 @@ export async function runPeerProfileReasoner(
       // Count interactions since the last reasoner-run marker, so
       // dormant peers don't trigger another LLM call until enough
       // new signal accumulates. Run markers themselves don't count.
-      const lastRun = lastRunTimestamp(recentLog);
-      const sinceLastRun = lastRun
-        ? recentLog.filter(
+      const lastRun = lastRunTimestamp(fullLog);
+      const sinceLastRunFull = lastRun
+        ? fullLog.filter(
             (e) => e.timestamp > lastRun && e.kind !== RUN_MARKER_KIND,
           )
-        : recentLog.filter((e) => e.kind !== RUN_MARKER_KIND);
-      if (sinceLastRun.length < minInteractions) {
+        : fullLog.filter((e) => e.kind !== RUN_MARKER_KIND);
+      if (sinceLastRunFull.length < minInteractions) {
         result.perPeer.push({
           peerId: peer.id,
           status: "skipped_below_min_interactions",
@@ -454,6 +462,14 @@ export async function runPeerProfileReasoner(
         });
         continue;
       }
+      // Truncate ONLY for prompt construction so the LLM context
+      // stays bounded. Use the most recent `maxLogPerPeer` entries
+      // from the full since-last-run set so the prompt prefers fresh
+      // signal over older entries.
+      const sinceLastRun =
+        sinceLastRunFull.length > maxLogPerPeer
+          ? sinceLastRunFull.slice(sinceLastRunFull.length - maxLogPerPeer)
+          : sinceLastRunFull;
 
       const existingProfile = await readPeerProfile(options.memoryDir, peer.id);
 
@@ -539,11 +555,25 @@ export async function runPeerProfileReasoner(
         }
       }
 
+      // Codex P1 review on PR #736: the global `fieldsAppliedTotal`
+      // counter must NOT be incremented until the profile write
+      // actually succeeds. Otherwise a transient I/O error here
+      // poisons the per-run cap for every subsequent peer — they get
+      // marked `skipped_cap_reached` for fields that were never
+      // persisted. Track the candidate count locally and only
+      // commit it to the run-wide budget after `writePeerProfile`
+      // returns successfully (Gotcha #25 — don't destroy old state
+      // before confirming new state succeeds).
       const appliedFieldsForPeer: string[] = [];
       let droppedDueToCap = 0;
       let invalidProposalSeen = false;
       for (const proposal of proposals) {
-        if (fieldsAppliedTotal >= maxFields) {
+        // Use a candidate-budget projection so we never propose more
+        // than the run-wide cap allows even before we know the write
+        // will succeed.
+        const candidateBudget =
+          maxFields - fieldsAppliedTotal - appliedFieldsForPeer.length;
+        if (candidateBudget <= 0) {
           droppedDueToCap += 1;
           continue;
         }
@@ -582,7 +612,9 @@ export async function runPeerProfileReasoner(
         list.push(provEntry);
         baseProvenance[proposal.field] = list;
         appliedFieldsForPeer.push(proposal.field);
-        fieldsAppliedTotal += 1;
+        // NOTE: fieldsAppliedTotal is NOT incremented here — see the
+        // P1 comment above. We commit the budget after the write
+        // succeeds.
       }
 
       if (appliedFieldsForPeer.length === 0) {
@@ -607,6 +639,11 @@ export async function runPeerProfileReasoner(
         provenance: baseProvenance,
       };
       await writePeerProfile(options.memoryDir, merged);
+      // Write succeeded — NOW commit the budget. A throw above
+      // bubbles to the outer catch, where the peer is recorded as
+      // `error` and the global cap remains intact for subsequent
+      // peers (Codex P1 fix on PR #736).
+      fieldsAppliedTotal += appliedFieldsForPeer.length;
 
       // Append a run marker so the next reasoner pass can compute
       // "interactions since last run" without a dedicated state

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -720,11 +720,23 @@ function formatLogEntry(entry: PeerInteractionLogEntry): string {
   // session id, summary. ALL fields are passed through `sanitizeLogField`
   // so a stray newline anywhere can't shatter the append-only invariant
   // (cursor Medium on PR #723).
+  //
+  // Cursor Low on PR #736: the previous bare `session=<id>` token was
+  // ambiguous with summaries that literally start with `session=`
+  // (e.g. summary `"session=foo bar"` round-tripped to
+  // `{sessionId: "foo", summary: "bar"}`). New entries wrap the
+  // session marker in square brackets — `[session=<id>]` — which a
+  // sanitized summary can never start with (sanitizeLogField never
+  // emits `[` as the first character of a summary that originally
+  // started with `session=`, and bracketed metadata is unambiguously
+  // distinct from `session=` text). Old entries written by previous
+  // code remain parseable through the legacy fallback in
+  // `parseLogLine`.
   const ts = sanitizeLogField(entry.timestamp);
   const kind = sanitizeLogField(entry.kind);
   const summary = sanitizeLogField(entry.summary);
   const session = entry.sessionId
-    ? ` session=${sanitizeLogField(entry.sessionId)}`
+    ? ` [session=${sanitizeLogField(entry.sessionId)}]`
     : "";
   return `- [${ts}] (${kind})${session} ${summary}`;
 }
@@ -1070,10 +1082,20 @@ export async function readInteractionLogRaw(
  * callers can keep the rest of the log even when a single entry was
  * hand-edited or partially written.
  *
- * Format (must match `formatLogEntry` exactly):
+ * Formats accepted (must match `formatLogEntry`):
  *
- *   - [TS] (KIND) session=SID SUMMARY
- *   - [TS] (KIND) SUMMARY                  // session optional
+ *   - [TS] (KIND) [session=SID] SUMMARY     // canonical (PR #736)
+ *   - [TS] (KIND) SUMMARY                   // session optional
+ *
+ * The unbracketed `session=SID` form (which would have been written
+ * by an earlier draft of #679 PR 2/5) is intentionally NOT parsed —
+ * the cursor #736 finding showed it was indistinguishable from a
+ * summary that legitimately starts with `session=`. Since #679 PR
+ * 2/5 is the first shipped writer for `sessionId` AND ships the
+ * bracketed canonical form simultaneously, there is no real legacy
+ * data on disk to support. A summary like `session=foo bar` thus
+ * round-trips verbatim into `summary` rather than being mis-claimed
+ * as a session id.
  *
  * Whitespace inside SUMMARY is preserved verbatim. The parser is
  * deliberately strict — anything that doesn't start with `- [` is
@@ -1097,18 +1119,38 @@ function parseLogLine(line: string): PeerInteractionLogEntry | null {
   if (kind === "") return null;
   cursor = kindClose + 1;
   let sessionId: string | undefined;
-  // Optional ` session=<id>` token. We tolerate any leading whitespace
+  // Optional session id token. We tolerate any leading whitespace
   // count; `formatLogEntry` always emits exactly one space, but
   // operator-edited logs may diverge.
   while (cursor < line.length && line[cursor] === " ") cursor += 1;
-  if (line.slice(cursor, cursor + "session=".length) === "session=") {
-    cursor += "session=".length;
-    const space = line.indexOf(" ", cursor);
-    const end = space === -1 ? line.length : space;
-    const sid = line.slice(cursor, end).trim();
-    if (sid.length > 0) sessionId = sid;
-    cursor = end;
+  // Canonical form (PR #736): `[session=<id>]`. Unambiguous because
+  // a sanitized summary cannot start with `[session=` followed by a
+  // closing bracket and a space — sanitization preserves user content
+  // verbatim except for newlines/CR/tab, so a summary that literally
+  // begins `[session=foo]` would imply the OPERATOR wrote a real
+  // session marker, which is acceptable as session attribution.
+  if (line.startsWith("[session=", cursor)) {
+    const close = line.indexOf("]", cursor + "[session=".length);
+    // A `[session=...]` with no closing bracket on the same line is
+    // malformed metadata; treat the whole tail as summary instead of
+    // misclaiming a session id.
+    if (close > -1) {
+      const sid = line.slice(cursor + "[session=".length, close).trim();
+      if (sid.length > 0) sessionId = sid;
+      cursor = close + 1;
+    }
   }
+  // NOTE: the legacy unbracketed `session=<id>` form is intentionally
+  // NOT parsed. The cursor #736 finding is fundamentally a format
+  // ambiguity: `- [TS] (KIND) session=foo bar` is indistinguishable
+  // from a real session token vs. a summary that begins with the
+  // literal text `session=foo bar`. Since #679 PR 2/5 is the first
+  // PR that writes `sessionId` to the log AND ships the bracketed
+  // canonical form simultaneously, there is no production legacy
+  // data to support. Old `session=`-style summaries — both real
+  // operator notes and hypothetical legacy entries — round-trip
+  // verbatim into `summary` rather than being silently mis-claimed
+  // as a session id.
   // Remaining tail is the summary (possibly empty if the log was
   // hand-edited; we still accept "" because `formatLogEntry` itself
   // accepts an empty summary string).

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -1062,3 +1062,110 @@ export async function readInteractionLogRaw(
     throw err;
   }
 }
+
+/**
+ * Inverse of `formatLogEntry`. Used by `readPeerInteractionLog` to
+ * convert the on-disk one-line bullet form back into a structured
+ * `PeerInteractionLogEntry`. Returns `null` for malformed lines so
+ * callers can keep the rest of the log even when a single entry was
+ * hand-edited or partially written.
+ *
+ * Format (must match `formatLogEntry` exactly):
+ *
+ *   - [TS] (KIND) session=SID SUMMARY
+ *   - [TS] (KIND) SUMMARY                  // session optional
+ *
+ * Whitespace inside SUMMARY is preserved verbatim. The parser is
+ * deliberately strict — anything that doesn't start with `- [` is
+ * rejected and dropped (the file is also markdown-friendly, so blank
+ * lines and stray prose are simply ignored).
+ */
+function parseLogLine(line: string): PeerInteractionLogEntry | null {
+  if (!line.startsWith("- [")) return null;
+  const tsClose = line.indexOf("]", 3);
+  if (tsClose === -1) return null;
+  const timestamp = line.slice(3, tsClose).trim();
+  if (timestamp === "") return null;
+  // Skip optional whitespace between `]` and `(`.
+  let cursor = tsClose + 1;
+  while (cursor < line.length && line[cursor] === " ") cursor += 1;
+  if (line[cursor] !== "(") return null;
+  const kindOpen = cursor;
+  const kindClose = line.indexOf(")", kindOpen + 1);
+  if (kindClose === -1) return null;
+  const kind = line.slice(kindOpen + 1, kindClose).trim();
+  if (kind === "") return null;
+  cursor = kindClose + 1;
+  let sessionId: string | undefined;
+  // Optional ` session=<id>` token. We tolerate any leading whitespace
+  // count; `formatLogEntry` always emits exactly one space, but
+  // operator-edited logs may diverge.
+  while (cursor < line.length && line[cursor] === " ") cursor += 1;
+  if (line.slice(cursor, cursor + "session=".length) === "session=") {
+    cursor += "session=".length;
+    const space = line.indexOf(" ", cursor);
+    const end = space === -1 ? line.length : space;
+    const sid = line.slice(cursor, end).trim();
+    if (sid.length > 0) sessionId = sid;
+    cursor = end;
+  }
+  // Remaining tail is the summary (possibly empty if the log was
+  // hand-edited; we still accept "" because `formatLogEntry` itself
+  // accepts an empty summary string).
+  while (cursor < line.length && line[cursor] === " ") cursor += 1;
+  const summary = line.slice(cursor);
+  return sessionId === undefined
+    ? { timestamp, kind, summary }
+    : { timestamp, kind, sessionId, summary };
+}
+
+/**
+ * Read the structured interaction log for a peer.
+ *
+ * Returns an empty array when the log file does not exist. Each line
+ * is parsed via `parseLogLine`; malformed lines are silently skipped
+ * so the reasoner can still derive profile fields from a partially
+ * corrupt log rather than aborting the whole pass.
+ *
+ * `options.limit` (when > 0) restricts the result to the most recent
+ * N entries. `options.afterTimestamp` (ISO-8601) filters out entries
+ * with `timestamp < afterTimestamp` (string compare is safe for
+ * canonical ISO-8601 form). Both filters are applied in order:
+ * timestamp first, then limit.
+ *
+ * Order: oldest → newest, matching the append-only on-disk order so
+ * downstream consumers can reason about temporal evolution without
+ * re-sorting.
+ */
+export async function readPeerInteractionLog(
+  memoryDir: string,
+  peerId: string,
+  options: { limit?: number; afterTimestamp?: string } = {},
+): Promise<PeerInteractionLogEntry[]> {
+  const raw = await readInteractionLogRaw(memoryDir, peerId);
+  if (raw === "") return [];
+  const entries: PeerInteractionLogEntry[] = [];
+  // Split on bare newlines; logs are written with a trailing `\n` per
+  // entry by `appendInteractionLog`, so the final element after split
+  // is typically the empty string. Both `\r\n` and `\n` are tolerated.
+  for (const lineRaw of raw.split(/\r?\n/)) {
+    const line = lineRaw.trimEnd();
+    if (line === "") continue;
+    const parsed = parseLogLine(line);
+    if (parsed === null) continue;
+    entries.push(parsed);
+  }
+  let filtered = entries;
+  if (typeof options.afterTimestamp === "string" && options.afterTimestamp.length > 0) {
+    const cutoff = options.afterTimestamp;
+    filtered = filtered.filter((e) => e.timestamp > cutoff);
+  }
+  // Gotcha #27: guard slice(-n) against n === 0 — `slice(-0)` returns
+  // the entire array. Treat 0 and negatives as "no limit applied".
+  if (typeof options.limit === "number" && options.limit > 0) {
+    if (filtered.length > options.limit) {
+      filtered = filtered.slice(filtered.length - options.limit);
+    }
+  }
+  return filtered;
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -831,6 +831,32 @@ export interface PluginConfig {
    * `chooseConsolidationOperator`.  Issue #561 PR 3.
    */
   operatorAwareConsolidationEnabled: boolean;
+  /**
+   * Async peer profile reasoner — issue #679 PR 2/5.
+   *
+   * Default `false` (opt-in). When enabled, the reasoner runs after
+   * `runSemanticConsolidation` (the REM phase of the dreams pipeline)
+   * and updates per-peer profile.md files with provenance-tagged
+   * field updates derived from the peer's interaction log.
+   */
+  peerProfileReasonerEnabled: boolean;
+  /**
+   * Model identifier used by the peer profile reasoner. Logged for
+   * telemetry only — actual dispatch is via the same FallbackLlmClient
+   * the orchestrator uses for semantic consolidation. Default `gpt-5.2`.
+   */
+  peerProfileReasonerModel: string;
+  /**
+   * Minimum new interaction-log entries a peer must accumulate since
+   * the previous reasoner run before being processed again. Default 5.
+   * Setting to 0 forces every run to consider every peer.
+   */
+  peerProfileReasonerMinInteractions: number;
+  /**
+   * Hard cap on the total number of profile fields the reasoner will
+   * apply across all peers in a single run. Default 8.
+   */
+  peerProfileReasonerMaxFieldsPerRun: number;
   // Creation-memory foundation
   creationMemoryEnabled: boolean;
   memoryUtilityLearningEnabled: boolean;

--- a/tests/peers/profile-reasoner-wiring.test.ts
+++ b/tests/peers/profile-reasoner-wiring.test.ts
@@ -76,16 +76,19 @@ test("config defaults expose peerProfileReasoner* keys with least-privileged def
     "peerProfileReasonerEnabled must default to false via coerceBool",
   );
   // Numeric clamps must accept 0 (Gotcha #45 — schema documents 0 as
-  // a disable value, code path must honour it).
+  // a disable value, code path must honour it). After cursor L #736
+  // we route via the shared `coerceNonNegativeInt` helper so string
+  // CLI values are coerced uniformly with sibling numeric keys
+  // (Gotcha #28).
   assert.match(
     src,
-    /peerProfileReasonerMinInteractions:[\s\S]*Math\.max\(0,/,
-    "min-interactions clamp must accept 0",
+    /peerProfileReasonerMinInteractions:\s*coerceNonNegativeInt\(\s*cfg\.peerProfileReasonerMinInteractions,/,
+    "min-interactions must route via coerceNonNegativeInt for string CLI coercion",
   );
   assert.match(
     src,
-    /peerProfileReasonerMaxFieldsPerRun:[\s\S]*Math\.max\(0,/,
-    "max-fields clamp must accept 0",
+    /peerProfileReasonerMaxFieldsPerRun:\s*coerceNonNegativeInt\(\s*cfg\.peerProfileReasonerMaxFieldsPerRun,/,
+    "max-fields must route via coerceNonNegativeInt for string CLI coercion",
   );
 });
 
@@ -103,10 +106,13 @@ test("plugin manifest exposes peerProfileReasoner* keys with matching defaults",
       false,
       `${rel}: peerProfileReasonerEnabled default must be false`,
     );
+    // Cursor M #736: model default must be the routing alias "auto",
+    // not a hardcoded model identifier. Matches sibling
+    // semanticConsolidationModel convention.
     assert.equal(
       cfg.peerProfileReasonerModel?.default,
-      "gpt-5.2",
-      `${rel}: peerProfileReasonerModel default must be "gpt-5.2"`,
+      "auto",
+      `${rel}: peerProfileReasonerModel default must be "auto"`,
     );
     assert.equal(
       cfg.peerProfileReasonerMinInteractions?.default,

--- a/tests/peers/profile-reasoner-wiring.test.ts
+++ b/tests/peers/profile-reasoner-wiring.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Structural wiring test for the peer profile reasoner — issue #679 PR 2/5.
+ *
+ * The reasoner runs as a post-consolidation hook in the REM phase
+ * (`runSemanticConsolidation` in `orchestrator.ts`). The full
+ * orchestrator is too heavy for a unit test, so we verify the wiring
+ * structurally: the reasoner call site must exist, must be gated on
+ * `peerProfileReasonerEnabled`, and must fire AFTER the materialize
+ * post-hook so the materialized snapshot is not stale-shadowed by a
+ * later peer-profile write.
+ *
+ * If a future refactor drops the gate or re-orders the calls, the
+ * assertions below fail loudly.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+const repoRoot = path.resolve(__dirname, "..", "..");
+
+test("orchestrator REM phase invokes the peer profile reasoner gated on the config flag", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/orchestrator.ts"),
+    "utf-8",
+  );
+  // Gate must exist verbatim so a typo on the flag silently disabling
+  // the reasoner is impossible.
+  assert.match(
+    src,
+    /if \(this\.config\.peerProfileReasonerEnabled\)/,
+    "orchestrator must gate the reasoner on `peerProfileReasonerEnabled`",
+  );
+  // Dynamic import keeps the reasoner out of the cold-path bundle when
+  // the flag is off.
+  assert.match(
+    src,
+    /await import\("\.\/peers\/index\.js"\)/,
+    "orchestrator must lazily import the peers barrel",
+  );
+  assert.match(
+    src,
+    /runPeerProfileReasoner\(/,
+    "orchestrator must call runPeerProfileReasoner",
+  );
+});
+
+test("orchestrator runs the peer profile reasoner AFTER the materialize post-hook", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/orchestrator.ts"),
+    "utf-8",
+  );
+  const materializeIdx = src.indexOf("materializeAfterSemanticConsolidation(");
+  const reasonerIdx = src.indexOf("runPeerProfileReasoner(");
+  assert.ok(materializeIdx > 0, "materialize call must exist");
+  assert.ok(reasonerIdx > 0, "reasoner call must exist");
+  assert.ok(
+    reasonerIdx > materializeIdx,
+    "reasoner must run after materialize so the materialized snapshot is consistent",
+  );
+});
+
+test("config defaults expose peerProfileReasoner* keys with least-privileged defaults", () => {
+  const src = readFileSync(
+    path.join(repoRoot, "packages/remnic-core/src/config.ts"),
+    "utf-8",
+  );
+  // Default-off (Gotcha #48 — least-privileged default).
+  assert.match(
+    src,
+    /peerProfileReasonerEnabled:\s*\n\s*coerceBool\(cfg\.peerProfileReasonerEnabled\) \?\? false/,
+    "peerProfileReasonerEnabled must default to false via coerceBool",
+  );
+  // Numeric clamps must accept 0 (Gotcha #45 — schema documents 0 as
+  // a disable value, code path must honour it).
+  assert.match(
+    src,
+    /peerProfileReasonerMinInteractions:[\s\S]*Math\.max\(0,/,
+    "min-interactions clamp must accept 0",
+  );
+  assert.match(
+    src,
+    /peerProfileReasonerMaxFieldsPerRun:[\s\S]*Math\.max\(0,/,
+    "max-fields clamp must accept 0",
+  );
+});
+
+test("plugin manifest exposes peerProfileReasoner* keys with matching defaults", () => {
+  for (const rel of [
+    "openclaw.plugin.json",
+    "packages/plugin-openclaw/openclaw.plugin.json",
+  ]) {
+    const raw = readFileSync(path.join(repoRoot, rel), "utf-8");
+    const json = JSON.parse(raw);
+    const cfg = json.configSchema?.properties ?? json.configSchema?.properties;
+    assert.ok(cfg, `${rel} must expose configSchema.properties`);
+    assert.equal(
+      cfg.peerProfileReasonerEnabled?.default,
+      false,
+      `${rel}: peerProfileReasonerEnabled default must be false`,
+    );
+    assert.equal(
+      cfg.peerProfileReasonerModel?.default,
+      "gpt-5.2",
+      `${rel}: peerProfileReasonerModel default must be "gpt-5.2"`,
+    );
+    assert.equal(
+      cfg.peerProfileReasonerMinInteractions?.default,
+      5,
+      `${rel}: peerProfileReasonerMinInteractions default must be 5`,
+    );
+    assert.equal(
+      cfg.peerProfileReasonerMinInteractions?.minimum,
+      0,
+      `${rel}: peerProfileReasonerMinInteractions minimum must be 0 to honour disable`,
+    );
+    assert.equal(
+      cfg.peerProfileReasonerMaxFieldsPerRun?.default,
+      8,
+      `${rel}: peerProfileReasonerMaxFieldsPerRun default must be 8`,
+    );
+    assert.equal(
+      cfg.peerProfileReasonerMaxFieldsPerRun?.minimum,
+      0,
+      `${rel}: peerProfileReasonerMaxFieldsPerRun minimum must be 0 to honour disable`,
+    );
+  }
+});

--- a/tests/peers/profile-reasoner.test.ts
+++ b/tests/peers/profile-reasoner.test.ts
@@ -53,10 +53,20 @@ function syntheticPeer(overrides: Partial<Peer> = {}): Peer {
   };
 }
 
-/** Mock LLM that returns a fixed JSON payload. */
+/** Mock LLM that returns a fixed JSON payload.
+ *
+ * Cursor M review on PR #736: the previous shape returned a wrapper
+ * with a `calls` getter, but tests destructured `{ llm } = fakeLlm()`
+ * and later read `llm.calls` — which was `undefined`, not zero. The
+ * `?? 0` in the assertion made the check vacuous (it would have
+ * passed even if the LLM had been called). Return both `llm` and a
+ * `state` object that the caller can read directly (no getter, no
+ * destructuring loss); each test checks `state.calls` against the
+ * expected value.
+ */
 function fakeLlm(payload: string): {
   llm: PeerProfileReasonerLlm;
-  calls: number;
+  state: { calls: number };
 } {
   const state = { calls: 0 };
   const llm: PeerProfileReasonerLlm = {
@@ -65,12 +75,7 @@ function fakeLlm(payload: string): {
       return { content: payload };
     },
   };
-  return {
-    llm,
-    get calls() {
-      return state.calls;
-    },
-  } as { llm: PeerProfileReasonerLlm; calls: number };
+  return { llm, state };
 }
 
 /** Append N synthetic interaction-log entries spanning T+0..T+N-1 minutes. */
@@ -206,7 +211,7 @@ test("runPeerProfileReasoner is a no-op when enabled=false", async () => {
   await writePeer(dir, peer);
   await seedLog(dir, peer.id, 10);
 
-  const { llm } = fakeLlm("{}");
+  const { llm, state } = fakeLlm("{}");
 
   const result = await runPeerProfileReasoner({
     memoryDir: dir,
@@ -219,8 +224,12 @@ test("runPeerProfileReasoner is a no-op when enabled=false", async () => {
   assert.equal(result.peersConsidered, 0);
   assert.equal(result.peersProcessed, 0);
   assert.equal(result.fieldsApplied, 0);
-  // The mock LLM must not have been called.
-  assert.equal((llm as unknown as { calls: number }).calls ?? 0, 0);
+  // Cursor M #736: read `state.calls` directly so the assertion
+  // actually exercises the LLM invocation count (the previous
+  // `(llm as { calls }).calls ?? 0` was vacuous because destructuring
+  // dropped the getter). The reasoner must NOT have called the LLM
+  // when `enabled: false`.
+  assert.equal(state.calls, 0);
 
   // No profile written.
   const profile = await readPeerProfile(dir, peer.id);
@@ -236,7 +245,7 @@ test("runPeerProfileReasoner stays a no-op when enabled is a truthy non-boolean 
   await writePeer(dir, peer);
   await seedLog(dir, peer.id, 5);
 
-  const { llm } = fakeLlm(
+  const { llm, state } = fakeLlm(
     JSON.stringify({
       proposals: [
         { field: "should_not_apply", value: "x", signal: "x" },
@@ -255,6 +264,8 @@ test("runPeerProfileReasoner stays a no-op when enabled is a truthy non-boolean 
 
   assert.equal(result.peersConsidered, 0);
   assert.equal(result.fieldsApplied, 0);
+  // The strict-true gate must NOT have invoked the LLM.
+  assert.equal(state.calls, 0);
   const profile = await readPeerProfile(dir, peer.id);
   assert.equal(profile, null);
 });
@@ -517,6 +528,97 @@ test("runPeerProfileReasoner records skipped_aborted when signal is aborted", as
 // 7. Run-marker effect on subsequent runs
 // ──────────────────────────────────────────────────────────────────────
 
+test("min-interactions threshold uses the FULL log, not the truncated slice (codex P2 #736)", async () => {
+  // Reproduces the bug codex flagged: when
+  // `peerProfileReasonerMinInteractions` exceeds `maxLogEntriesPerPeer`,
+  // a peer with plenty of new activity could be permanently skipped
+  // because the threshold check ran against the capped slice.
+  //
+  // Fix: read the full log for the gate, then truncate only for the
+  // prompt window.
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.bigfeed" });
+  await writePeer(dir, peer);
+  // Seed 30 interactions; configure the prompt window to 5 and the
+  // threshold to 10. Pre-fix this would skip; post-fix it processes.
+  await seedLog(dir, peer.id, 30);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [{ field: "k", value: "v", signal: "s" }],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 10,
+    maxFieldsPerRun: 4,
+    maxLogEntriesPerPeer: 5,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  assert.equal(result.peersProcessed, 1);
+  assert.equal(result.fieldsApplied, 1);
+  assert.equal(result.perPeer[0].status, "processed");
+});
+
+test("run-wide cap is NOT consumed when writePeerProfile throws (codex P1 #736)", async () => {
+  // Reproduces the bug codex flagged: the per-run `fieldsAppliedTotal`
+  // counter was incremented BEFORE the profile write, so a transient
+  // I/O failure would leave the cap inflated and starve subsequent
+  // peers of their fair share of the budget.
+  //
+  // Fix: increment the global counter only after the write succeeds.
+  // Simulate the failure by replacing peer A's profile.md path with
+  // a directory so writePeerProfile's open(O_TRUNC) fails.
+  const dir = await makeTempDir();
+  const peerA = syntheticPeer({ id: "synthetic.afail" });
+  const peerB = syntheticPeer({ id: "synthetic.bsucceed" });
+  await writePeer(dir, peerA);
+  await writePeer(dir, peerB);
+  await seedLog(dir, peerA.id, 5);
+  await seedLog(dir, peerB.id, 5);
+
+  // Sabotage peer A's profile.md by creating a directory at the
+  // file path so the open(O_TRUNC|O_WRONLY) fails.
+  await fs.mkdir(path.join(dir, "peers", peerA.id, "profile.md"));
+
+  const payload = JSON.stringify({
+    proposals: [
+      { field: "field_one", value: "v1", signal: "s1" },
+      { field: "field_two", value: "v2", signal: "s2" },
+    ],
+  });
+  const { llm } = fakeLlm(payload);
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 2,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  // Peer A's write throws — recorded as error, NO budget consumed.
+  const aResult = result.perPeer.find((r) => r.peerId === peerA.id);
+  assert.equal(aResult?.status, "error");
+  assert.equal(aResult?.fieldsApplied, 0);
+
+  // Peer B should now succeed and consume the full budget — pre-fix
+  // it would have been starved with skipped_cap_reached.
+  const bResult = result.perPeer.find((r) => r.peerId === peerB.id);
+  assert.equal(bResult?.status, "processed");
+  assert.equal(bResult?.fieldsApplied, 2);
+
+  // Run total reflects only successful writes.
+  assert.equal(result.fieldsApplied, 2);
+});
+
 test("run-marker counts interactions since previous reasoner run", async () => {
   const dir = await makeTempDir();
   const peer = syntheticPeer({ id: "synthetic.marker" });
@@ -556,4 +658,129 @@ test("run-marker counts interactions since previous reasoner run", async () => {
     second.perPeer[0].status,
     "skipped_below_min_interactions",
   );
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 8. Cursor #736: log parser must not confuse a `session=`-prefixed
+//    summary with the optional session metadata token.
+// ──────────────────────────────────────────────────────────────────────
+
+test("interaction-log parser does NOT misread summaries that start with `session=` (cursor #736)", async () => {
+  // Reproduces the cursor finding: writing an entry with no
+  // sessionId but a SUMMARY that literally begins `session=foo bar`
+  // round-tripped to `{sessionId: "foo", summary: "bar"}` — silently
+  // misclaiming a session id and mangling the summary.
+  //
+  // Fix: writer wraps the optional session token in square brackets
+  // (`[session=<id>]`); reader prefers the bracketed form. A summary
+  // that genuinely starts with `session=` is preserved verbatim.
+  const dir = await makeTempDir();
+  const peerId = "synthetic.parser";
+  await writePeer(dir, syntheticPeer({ id: peerId }));
+
+  // Entry 1: no sessionId, summary begins with literal `session=`.
+  // Pre-fix this would have been mis-parsed.
+  await appendInteractionLog(dir, peerId, {
+    timestamp: "2026-04-26T00:00:00.000Z",
+    kind: "note",
+    summary: "session=spoofed-value bar baz",
+  });
+  // Entry 2: explicit sessionId, normal summary. Confirms the
+  // bracketed metadata form still round-trips.
+  await appendInteractionLog(dir, peerId, {
+    timestamp: "2026-04-26T00:01:00.000Z",
+    kind: "note",
+    sessionId: "real-session-id",
+    summary: "hello world",
+  });
+
+  // Read via the public surface.
+  const { readPeerInteractionLog } = await import(
+    "../../packages/remnic-core/src/peers/index.js"
+  );
+  const entries = await readPeerInteractionLog(dir, peerId);
+
+  assert.equal(entries.length, 2);
+  // Entry 1 — sessionId must be undefined; summary must be intact.
+  assert.equal(entries[0].sessionId, undefined);
+  assert.equal(entries[0].summary, "session=spoofed-value bar baz");
+  // Entry 2 — bracketed metadata round-trips.
+  assert.equal(entries[1].sessionId, "real-session-id");
+  assert.equal(entries[1].summary, "hello world");
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 9. Cursor #736: config coercion + shared default model.
+// ──────────────────────────────────────────────────────────────────────
+
+test("parseConfig coerces string CLI numerics for peer-profile reasoner (cursor L #736)", async () => {
+  const { parseConfig } = await import(
+    "../../packages/remnic-core/src/config.js"
+  );
+  // Mimic CLI input: `--config peerProfileReasonerMinInteractions=10`
+  // arrives as the string "10" per Gotcha #28.
+  const cfg = parseConfig({
+    peerProfileReasonerMinInteractions: "10",
+    peerProfileReasonerMaxFieldsPerRun: "3",
+  });
+  assert.equal(cfg.peerProfileReasonerMinInteractions, 10);
+  assert.equal(cfg.peerProfileReasonerMaxFieldsPerRun, 3);
+});
+
+test("parseConfig accepts 0 as a valid disable value for peer-profile numerics (cursor L #736)", async () => {
+  const { parseConfig } = await import(
+    "../../packages/remnic-core/src/config.js"
+  );
+  const cfg = parseConfig({
+    peerProfileReasonerMinInteractions: 0,
+    peerProfileReasonerMaxFieldsPerRun: "0",
+  });
+  assert.equal(cfg.peerProfileReasonerMinInteractions, 0);
+  assert.equal(cfg.peerProfileReasonerMaxFieldsPerRun, 0);
+});
+
+test("parseConfig throws on invalid peer-profile numeric input (cursor L #736 + gotcha #51)", async () => {
+  const { parseConfig } = await import(
+    "../../packages/remnic-core/src/config.js"
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        peerProfileReasonerMinInteractions: "not-a-number",
+      }),
+    /peerProfileReasonerMinInteractions/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        peerProfileReasonerMaxFieldsPerRun: -3,
+      }),
+    /peerProfileReasonerMaxFieldsPerRun/,
+  );
+});
+
+test("peerProfileReasonerModel default is `auto` (cursor M #736 — shared with semantic-consolidation)", async () => {
+  const { parseConfig } = await import(
+    "../../packages/remnic-core/src/config.js"
+  );
+  const cfg = parseConfig({});
+  assert.equal(cfg.peerProfileReasonerModel, "auto");
+  // Sibling check — both reasoner-style models default to the same
+  // routing alias rather than a hardcoded model id.
+  assert.equal(cfg.semanticConsolidationModel, "auto");
+});
+
+test("DEFAULT_REASONING_MODEL is exported and used as the extraction model fallback (cursor M #736)", async () => {
+  const config = await import(
+    "../../packages/remnic-core/src/config.js"
+  );
+  // The shared constant exists and is re-exportable.
+  assert.equal(typeof config.DEFAULT_REASONING_MODEL, "string");
+  assert.ok(
+    (config.DEFAULT_REASONING_MODEL as string).length > 0,
+    "DEFAULT_REASONING_MODEL must be non-empty",
+  );
+  const cfg = config.parseConfig({});
+  // The extraction model defaults to the shared constant.
+  assert.equal(cfg.model, config.DEFAULT_REASONING_MODEL);
 });

--- a/tests/peers/profile-reasoner.test.ts
+++ b/tests/peers/profile-reasoner.test.ts
@@ -1,0 +1,559 @@
+/**
+ * Async peer profile reasoner — issue #679 PR 2/5.
+ *
+ * Covers:
+ *   - reasoner reads log + writes profile with provenance
+ *   - disabled flag is a true no-op
+ *   - min-interactions guard skips peers below threshold
+ *   - max-fields cap respected across peers
+ *   - parser tolerates fenced code block / malformed payloads
+ *   - existing peer storage tests still pass (separate file —
+ *     `packages/remnic-core/src/peers/peers.test.ts` continues to run
+ *     under the same `tsx --test` glob).
+ *
+ * All fixtures are synthetic. The repository is public; no real names,
+ * sessions, or interactions appear here.
+ */
+
+import assert from "node:assert/strict";
+import { promises as fs } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  appendInteractionLog,
+  buildPeerProfileReasonerPrompt,
+  parsePeerProfileReasonerResponse,
+  readPeerProfile,
+  runPeerProfileReasoner,
+  writePeer,
+  writePeerProfile,
+  type Peer,
+  type PeerProfile,
+  type PeerProfileReasonerLlm,
+} from "../../packages/remnic-core/src/peers/index.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Fixtures + helpers
+// ──────────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+  return await fs.mkdtemp(path.join(os.tmpdir(), "peer-reasoner-test-"));
+}
+
+function syntheticPeer(overrides: Partial<Peer> = {}): Peer {
+  return {
+    id: "synthetic.alpha",
+    kind: "agent",
+    displayName: "Synthetic Alpha",
+    createdAt: "2026-04-25T00:00:00.000Z",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** Mock LLM that returns a fixed JSON payload. */
+function fakeLlm(payload: string): {
+  llm: PeerProfileReasonerLlm;
+  calls: number;
+} {
+  const state = { calls: 0 };
+  const llm: PeerProfileReasonerLlm = {
+    async chatCompletion() {
+      state.calls += 1;
+      return { content: payload };
+    },
+  };
+  return {
+    llm,
+    get calls() {
+      return state.calls;
+    },
+  } as { llm: PeerProfileReasonerLlm; calls: number };
+}
+
+/** Append N synthetic interaction-log entries spanning T+0..T+N-1 minutes. */
+async function seedLog(
+  memoryDir: string,
+  peerId: string,
+  count: number,
+  prefix = "synthetic-interaction",
+): Promise<void> {
+  const base = Date.UTC(2026, 3, 25, 12, 0, 0);
+  for (let i = 0; i < count; i += 1) {
+    await appendInteractionLog(memoryDir, peerId, {
+      timestamp: new Date(base + i * 60_000).toISOString(),
+      kind: "message",
+      sessionId: `synthetic-session-${i}`,
+      summary: `${prefix} ${i}`,
+    });
+  }
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// 1. Happy path — log → LLM → profile with provenance
+// ──────────────────────────────────────────────────────────────────────
+
+test("runPeerProfileReasoner reads log and writes profile with provenance", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.writer", kind: "agent" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 6);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [
+        {
+          field: "communication_style",
+          value: "concise, prefers structured replies",
+          signal: "explicit_preference",
+          note: "derived from synthetic recurrence",
+          sourceSessionId: "synthetic-session-2",
+        },
+      ],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 3,
+    maxFieldsPerRun: 4,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  assert.equal(result.peersConsidered, 1);
+  assert.equal(result.peersProcessed, 1);
+  assert.equal(result.fieldsApplied, 1);
+  assert.equal(result.perPeer[0].status, "processed");
+  assert.deepEqual(result.perPeer[0].fields, ["communication_style"]);
+
+  const profile = await readPeerProfile(dir, peer.id);
+  assert.ok(profile, "profile should be written");
+  assert.equal(profile.peerId, peer.id);
+  assert.equal(profile.fields.communication_style, "concise, prefers structured replies");
+  assert.equal(profile.updatedAt, "2026-04-26T00:00:00.000Z");
+  const prov = profile.provenance.communication_style;
+  assert.ok(prov && prov.length === 1);
+  assert.equal(prov[0].observedAt, "2026-04-26T00:00:00.000Z");
+  assert.equal(prov[0].signal, "explicit_preference");
+  assert.equal(prov[0].sourceSessionId, "synthetic-session-2");
+  assert.equal(prov[0].note, "derived from synthetic recurrence");
+});
+
+test("runPeerProfileReasoner appends to existing provenance instead of replacing", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.beta" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const existing: PeerProfile = {
+    peerId: peer.id,
+    updatedAt: "2026-04-25T12:00:00.000Z",
+    fields: { communication_style: "old value" },
+    provenance: {
+      communication_style: [
+        {
+          observedAt: "2026-04-25T12:00:00.000Z",
+          signal: "manual_seed",
+        },
+      ],
+    },
+  };
+  await writePeerProfile(dir, existing);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [
+        {
+          field: "communication_style",
+          value: "new value",
+          signal: "explicit_preference",
+        },
+      ],
+    }),
+  );
+
+  await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  const profile = await readPeerProfile(dir, peer.id);
+  assert.ok(profile);
+  assert.equal(profile.fields.communication_style, "new value");
+  // Existing provenance preserved + new entry appended.
+  assert.equal(profile.provenance.communication_style.length, 2);
+  assert.equal(profile.provenance.communication_style[0].signal, "manual_seed");
+  assert.equal(profile.provenance.communication_style[1].signal, "explicit_preference");
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 2. Disabled flag — true no-op
+// ──────────────────────────────────────────────────────────────────────
+
+test("runPeerProfileReasoner is a no-op when enabled=false", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.disabled" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 10);
+
+  const { llm } = fakeLlm("{}");
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: false,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+  });
+
+  assert.equal(result.peersConsidered, 0);
+  assert.equal(result.peersProcessed, 0);
+  assert.equal(result.fieldsApplied, 0);
+  // The mock LLM must not have been called.
+  assert.equal((llm as unknown as { calls: number }).calls ?? 0, 0);
+
+  // No profile written.
+  const profile = await readPeerProfile(dir, peer.id);
+  assert.equal(profile, null);
+});
+
+test("runPeerProfileReasoner stays a no-op when enabled is a truthy non-boolean string", async () => {
+  // Defensive — Gotcha #36: `"false"` is truthy in JS. The reasoner
+  // requires strict `=== true`. Pass any non-boolean value and verify
+  // it's still treated as disabled.
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.gamma" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [
+        { field: "should_not_apply", value: "x", signal: "x" },
+      ],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    // @ts-expect-error — intentionally invalid to exercise the strict check
+    enabled: "true",
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+  });
+
+  assert.equal(result.peersConsidered, 0);
+  assert.equal(result.fieldsApplied, 0);
+  const profile = await readPeerProfile(dir, peer.id);
+  assert.equal(profile, null);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 3. Min-interactions guard
+// ──────────────────────────────────────────────────────────────────────
+
+test("runPeerProfileReasoner skips peers below the min-interactions threshold", async () => {
+  const dir = await makeTempDir();
+  const lowVolume = syntheticPeer({ id: "synthetic.low" });
+  const highVolume = syntheticPeer({ id: "synthetic.high" });
+  await writePeer(dir, lowVolume);
+  await writePeer(dir, highVolume);
+  await seedLog(dir, lowVolume.id, 2);
+  await seedLog(dir, highVolume.id, 8);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [
+        {
+          field: "tool_patterns",
+          value: "frequent search usage",
+          signal: "tool_recurrence",
+        },
+      ],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 5,
+    maxFieldsPerRun: 4,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  // Both peers considered; only the high-volume one was processed.
+  assert.equal(result.peersConsidered, 2);
+  assert.equal(result.peersProcessed, 1);
+  const lowResult = result.perPeer.find((r) => r.peerId === lowVolume.id);
+  const highResult = result.perPeer.find((r) => r.peerId === highVolume.id);
+  assert.equal(lowResult?.status, "skipped_below_min_interactions");
+  assert.equal(highResult?.status, "processed");
+  assert.equal(highResult?.fieldsApplied, 1);
+
+  // Low-volume peer's profile was NOT written.
+  assert.equal(await readPeerProfile(dir, lowVolume.id), null);
+  // High-volume peer's profile WAS written.
+  assert.notEqual(await readPeerProfile(dir, highVolume.id), null);
+});
+
+test("runPeerProfileReasoner skips peers with no interaction log", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.empty" });
+  await writePeer(dir, peer);
+
+  const { llm } = fakeLlm("{}");
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 0,
+    maxFieldsPerRun: 4,
+  });
+
+  assert.equal(result.peersConsidered, 1);
+  assert.equal(result.peersProcessed, 0);
+  assert.equal(result.perPeer[0].status, "skipped_no_log");
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 4. Max-fields cap
+// ──────────────────────────────────────────────────────────────────────
+
+test("runPeerProfileReasoner respects maxFieldsPerRun across peers", async () => {
+  const dir = await makeTempDir();
+  const a = syntheticPeer({ id: "synthetic.aaa" });
+  const b = syntheticPeer({ id: "synthetic.bbb" });
+  await writePeer(dir, a);
+  await writePeer(dir, b);
+  await seedLog(dir, a.id, 5);
+  await seedLog(dir, b.id, 5);
+
+  // Each peer gets a fake LLM proposing TWO fields. With cap=2 total,
+  // peer A should consume the budget and peer B should be skipped or
+  // have its proposals dropped.
+  const proposalsPayload = JSON.stringify({
+    proposals: [
+      { field: "field_one", value: "v1", signal: "signal_one" },
+      { field: "field_two", value: "v2", signal: "signal_two" },
+    ],
+  });
+  const { llm } = fakeLlm(proposalsPayload);
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 2,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: false,
+  });
+
+  assert.equal(result.peersConsidered, 2);
+  assert.equal(result.fieldsApplied, 2);
+  // Listing order for peers is alphabetical (listPeers sorts), so 'a'
+  // is processed first.
+  const aResult = result.perPeer.find((r) => r.peerId === a.id);
+  const bResult = result.perPeer.find((r) => r.peerId === b.id);
+  assert.equal(aResult?.fieldsApplied, 2);
+  assert.equal(bResult?.fieldsApplied, 0);
+  assert.equal(bResult?.status, "skipped_cap_reached");
+});
+
+test("runPeerProfileReasoner with maxFieldsPerRun=0 is a no-op", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.cap0" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [{ field: "any_field", value: "v", signal: "s" }],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 0,
+  });
+
+  assert.equal(result.fieldsApplied, 0);
+  assert.equal(await readPeerProfile(dir, peer.id), null);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 5. Parser robustness
+// ──────────────────────────────────────────────────────────────────────
+
+test("parsePeerProfileReasonerResponse handles fenced code blocks", () => {
+  const parsed = parsePeerProfileReasonerResponse(
+    '```json\n{"proposals":[{"field":"k","value":"v","signal":"s"}]}\n```',
+  );
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].field, "k");
+});
+
+test("parsePeerProfileReasonerResponse rejects malformed JSON", () => {
+  assert.deepEqual(parsePeerProfileReasonerResponse(""), []);
+  assert.deepEqual(parsePeerProfileReasonerResponse("not-json"), []);
+  assert.deepEqual(parsePeerProfileReasonerResponse("null"), []);
+  assert.deepEqual(parsePeerProfileReasonerResponse("[1,2,3]"), []);
+});
+
+test("parsePeerProfileReasonerResponse drops proposals missing required fields", () => {
+  const raw = JSON.stringify({
+    proposals: [
+      { field: "", value: "v", signal: "s" }, // empty field
+      { field: "k", value: "", signal: "s" }, // empty value
+      { field: "k", value: "v", signal: "" }, // empty signal
+      { field: "__proto__", value: "v", signal: "s" }, // prototype-pollution
+      { field: "k", value: "v", signal: "s" }, // valid
+    ],
+  });
+  const parsed = parsePeerProfileReasonerResponse(raw);
+  assert.equal(parsed.length, 1);
+  assert.equal(parsed[0].field, "k");
+});
+
+test("parsePeerProfileReasonerResponse rejects non-object root", () => {
+  assert.deepEqual(parsePeerProfileReasonerResponse("42"), []);
+  assert.deepEqual(parsePeerProfileReasonerResponse('"a string"'), []);
+});
+
+test("buildPeerProfileReasonerPrompt produces a deterministic, schema-prescriptive prompt", () => {
+  const prompt = buildPeerProfileReasonerPrompt({
+    peer: syntheticPeer({ id: "synthetic.prompt" }),
+    existingProfile: null,
+    log: [
+      {
+        timestamp: "2026-04-25T12:00:00.000Z",
+        kind: "message",
+        sessionId: "synthetic-session-7",
+        summary: "synthetic interaction body",
+      },
+    ],
+    maxFields: 3,
+  });
+  assert.match(prompt, /synthetic\.prompt/);
+  assert.match(prompt, /Output a single JSON object/);
+  assert.match(prompt, /synthetic-session-7/);
+  assert.match(prompt, /maxFields|0\.\.3|0..3/);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 6. LLM unavailable / abort
+// ──────────────────────────────────────────────────────────────────────
+
+test("runPeerProfileReasoner records skipped_llm_unavailable on null response", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.nullresp" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const llm: PeerProfileReasonerLlm = {
+    async chatCompletion() {
+      return null;
+    },
+  };
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+  });
+
+  assert.equal(result.fieldsApplied, 0);
+  assert.equal(result.perPeer[0].status, "skipped_llm_unavailable");
+});
+
+test("runPeerProfileReasoner records skipped_aborted when signal is aborted", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.aborted" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const controller = new AbortController();
+  controller.abort();
+
+  const { llm } = fakeLlm(
+    JSON.stringify({
+      proposals: [{ field: "k", value: "v", signal: "s" }],
+    }),
+  );
+
+  const result = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+    signal: controller.signal,
+  });
+
+  assert.equal(result.fieldsApplied, 0);
+  assert.equal(result.perPeer[0].status, "skipped_aborted");
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// 7. Run-marker effect on subsequent runs
+// ──────────────────────────────────────────────────────────────────────
+
+test("run-marker counts interactions since previous reasoner run", async () => {
+  const dir = await makeTempDir();
+  const peer = syntheticPeer({ id: "synthetic.marker" });
+  await writePeer(dir, peer);
+  await seedLog(dir, peer.id, 5);
+
+  const payload = JSON.stringify({
+    proposals: [{ field: "k", value: "v", signal: "s" }],
+  });
+  const { llm } = fakeLlm(payload);
+
+  // First run — applies field, writes a run marker into the log.
+  const first = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+    now: new Date("2026-04-26T00:00:00.000Z"),
+    appendRunMarkerToLog: true,
+  });
+  assert.equal(first.fieldsApplied, 1);
+
+  // Second run with NO new interactions — should skip due to threshold,
+  // because the run marker now represents "0 new interactions since last run".
+  const second = await runPeerProfileReasoner({
+    memoryDir: dir,
+    enabled: true,
+    llm,
+    minInteractions: 1,
+    maxFieldsPerRun: 4,
+    now: new Date("2026-04-26T01:00:00.000Z"),
+    appendRunMarkerToLog: true,
+  });
+  assert.equal(second.peersProcessed, 0);
+  assert.equal(
+    second.perPeer[0].status,
+    "skipped_below_min_interactions",
+  );
+});


### PR DESCRIPTION
## Summary

Issue #679 PR 2/5. Ships the REM-phase async peer profile reasoner that runs after `runSemanticConsolidation`. PR 1/5 (#723) shipped the peer registry schema + storage; this slice populates the *evolving cognitive profile* half of that contract.

For each peer, the reasoner:
1. Reads recent interaction-log entries via `readPeerInteractionLog` (new structured reader added to `peers/storage.ts` alongside the existing `readInteractionLogRaw`).
2. Calls a `FallbackLlmClient` (same client used by semantic consolidation) to derive 0..N profile-field proposals as JSON.
3. Merges proposals into the peer's `profile.md` with append-only provenance entries (`{observedAt, signal, sourceSessionId, note}`).
4. Appends a `peer_profile_reasoner_run` marker to the peer's interaction log so the next pass can compute "interactions since last run" without a separate state file.

### Gating

- **Master flag:** `peerProfileReasonerEnabled` defaults to `false` (opt-in, Gotchas #30/#48 — least-privileged default). Reasoner additionally requires strict `=== true` to bypass Gotcha #36 (`"false"` is truthy).
- **Per-peer threshold:** `peerProfileReasonerMinInteractions` (default `5`). Peers below the threshold record `skipped_below_min_interactions`.
- **Per-run cap:** `peerProfileReasonerMaxFieldsPerRun` (default `8`). Once the cap is hit, subsequent peers/proposals are dropped with `skipped_cap_reached` / `droppedDueToCap`.
- **Schema honors disable values:** `minimum: 0` on both numeric thresholds (Gotcha #45 — schema must match documented disable behavior).
- **Telemetry model:** `peerProfileReasonerModel` defaults to `gpt-5.2`. Logged for observability; dispatch still routes through `FallbackLlmClient`.

### Wiring

The reasoner runs at the tail of `Orchestrator.runSemanticConsolidation` (the REM phase per `docs/dreams.md`), AFTER the Codex `materializeAfterSemanticConsolidation` post-hook. Wrapped in a try/catch — reasoner failures are logged and never abort the consolidation result. The `peers/index.js` import is dynamic so the reasoner stays out of the cold path when the flag is off.

### Files

- `packages/remnic-core/src/peers/profile-reasoner.ts` — pure async `runPeerProfileReasoner({...})`, `parsePeerProfileReasonerResponse`, `buildPeerProfileReasonerPrompt`, plus the `PeerProfileReasonerLlm` interface so tests can inject a mock without spinning up the gateway client.
- `packages/remnic-core/src/peers/storage.ts` — new `readPeerInteractionLog(memoryDir, peerId, {limit, afterTimestamp})` structured reader; tolerates malformed lines, deterministic oldest-first order.
- `packages/remnic-core/src/peers/index.ts` — re-exports the reasoner barrel.
- `packages/remnic-core/src/config.ts` + `types.ts` — four new config keys (defaults: `false`, `"gpt-5.2"`, `5`, `8`) parsed via `coerceBool` / `Math.max(0, ...)`.
- `packages/remnic-core/src/orchestrator.ts` — REM-phase wiring.
- `openclaw.plugin.json` + `packages/plugin-openclaw/openclaw.plugin.json` — JSON schema entries (configSchema + UI hints) in BOTH manifests, with `minimum: 0` on numeric thresholds.

### Tests

- `tests/peers/profile-reasoner.test.ts` (16 tests) — log → LLM → profile-with-provenance happy path; provenance is append-only across runs; `enabled: false` is a true no-op (verifies the LLM is never called and no profile is written); `enabled: "true"` (string) is also disabled per Gotcha #36; min-interactions guard skips peers below threshold; cap respected across peers in alphabetical order; `maxFieldsPerRun: 0` is a no-op; parser tolerates fenced blocks and rejects malformed/null/array/string roots; prototype-pollution keys dropped at every layer; `skipped_aborted` on aborted signal; run marker correctly skips dormant peers on the next pass.
- `tests/peers/profile-reasoner-wiring.test.ts` (4 tests) — structural assertions: gate exists with the correct flag name, reasoner runs after materialize, config defaults are least-privileged, both plugin manifests expose `minimum: 0`.
- `packages/remnic-core/src/peers/peers.test.ts` (existing 19 tests) — unchanged; verified still green.

Combined: 39 peer-related tests pass; full type-check clean; `npm run build` clean; `npm run test:entity-hardening` (194 tests covering config + recall surfaces) passes.

## Test plan

- [x] All peer registry tests pass (`packages/remnic-core/src/peers/peers.test.ts` — 19 tests)
- [x] New reasoner tests pass (`tests/peers/profile-reasoner.test.ts` — 16 tests)
- [x] Wiring/structural tests pass (`tests/peers/profile-reasoner-wiring.test.ts` — 4 tests)
- [x] `npm run test:entity-hardening` (194 tests, includes `config-recall-pipeline.test.ts`) — all green
- [x] `npm run build` clean
- [x] `tsc --noEmit` clean
- [ ] CI green on PR
- [ ] Codex + cursor + AI reviewers green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new LLM-backed post-consolidation pipeline that reads/writes peer profile and interaction-log files; while gated off by default and wrapped as non-fatal, it introduces new I/O and parsing paths that could affect REM-phase runtime when enabled.
> 
> **Overview**
> Adds an **opt-in async peer profile reasoner** that runs in the REM phase immediately after semantic consolidation, using the gateway `FallbackLlmClient` to derive profile-field updates from each peer’s interaction log and persist them to per-peer `profile.md` with append-only provenance.
> 
> Introduces new config/plugin-manifest knobs (`peerProfileReasonerEnabled`, `peerProfileReasonerModel`, `peerProfileReasonerMinInteractions`, `peerProfileReasonerMaxFieldsPerRun`) plus stricter numeric coercion for CLI string inputs, and centralizes the extraction default model via `DEFAULT_REASONING_MODEL`.
> 
> Extends peer storage with a structured `readPeerInteractionLog` and updates interaction-log formatting to use an unambiguous `[session=...]` marker; adds comprehensive unit and wiring tests to enforce gating, ordering, caps/thresholds, and parser robustness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82c81ce26df95bd36b6d21ab41a3a9289ea1839c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->