### PR TITLE
feat(secure-store): CLI {init,unlock,lock,status} + in-memory keyring (#690 PR 2/4)

### DIFF
--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7322,18 +7322,124 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(`  Cooled down: ${result.cooledDown}`);
         });
 
-      // ── Console subcommand (issue #688) ─────────────────────────────────
-      // PR 1/3 (#721) shipped the structured engine-state aggregator
-      // and the `--state-only` flag (one-shot JSON snapshot). PR 2/3
-      // wires the interactive TUI: invoking `remnic console` with no
-      // flags starts a clear+repaint refresh loop. Trace replay
-      // (`--trace <session-id>`) lands in PR 3/3 along with the HTTP
-      // `/console/state` endpoint and the MCP `engram.console_state`
-      // tool.
+      // ── Secure-store subcommand (issue #690 PR 2/4) ─────────────────────
+      // CLI for the at-rest encryption header + in-memory keyring. Pure
+      // primitives (KDF + cipher + metadata) shipped in PR 1/4. This PR
+      // wires the operator-facing init / unlock / lock / status flow.
+      // Storage integration (PR 3/4) and capsule export --encrypt (PR 4/4)
+      // build on the keyring registered here.
+      const secureStoreCmd = cmd
+        .command("secure-store")
+        .description(
+          "At-rest encryption keyring (issue #690). Manage the secure-store header and the in-memory master key used by the running daemon.",
+        );
+
+      secureStoreCmd
+        .command("init")
+        .description(
+          "Initialize a new secure-store header. Prompts for a passphrase, derives a master key via scrypt, and writes the verifier to <memoryDir>/.secure-store/header.json. Refuses to overwrite an existing header.",
+        )
+        .option("--note <text>", "Optional human-readable note recorded in metadata. Never include secrets.")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const {
+            runSecureStoreInit,
+            createPassphraseReader,
+            renderInitReport,
+          } = await import("./secure-store/index.js");
+          const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const initOpts: Parameters<typeof runSecureStoreInit>[0] = {
+            memoryDir,
+            readPassphrase: createPassphraseReader(),
+          };
+          if (typeof options.note === "string") initOpts.note = options.note;
+          const report = await runSecureStoreInit(initOpts);
+          if (options.json === true) {
+            console.log(JSON.stringify(report, null, 2));
+            return;
+          }
+          console.log(renderInitReport(report));
+        });
+
+      secureStoreCmd
+        .command("unlock")
+        .description(
+          "Unlock the secure-store. Prompts for the passphrase, validates it against the header verifier, and registers the master key in the daemon's in-memory keyring. The key is cleared on `lock`, daemon restart, or process exit.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const {
+            runSecureStoreUnlock,
+            createPassphraseReader,
+            renderUnlockReport,
+          } = await import("./secure-store/index.js");
+          const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const report = await runSecureStoreUnlock({
+            memoryDir,
+            readPassphrase: createPassphraseReader(),
+          });
+          if (options.json === true) {
+            console.log(JSON.stringify(report, null, 2));
+          } else {
+            console.log(renderUnlockReport(report));
+          }
+          if (!report.ok) {
+            process.exitCode = 1;
+          }
+        });
+
+      secureStoreCmd
+        .command("lock")
+        .description(
+          "Lock the secure-store. Clears the master key from the daemon's in-memory keyring. Idempotent — succeeds even if the store is already locked.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const { runSecureStoreLock, renderLockReport } = await import(
+            "./secure-store/index.js"
+          );
+          const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const report = runSecureStoreLock({ memoryDir });
+          if (options.json === true) {
+            console.log(JSON.stringify(report, null, 2));
+            return;
+          }
+          console.log(renderLockReport(report));
+        });
+
+      secureStoreCmd
+        .command("status")
+        .description(
+          "Report secure-store status: whether a header exists, whether the daemon currently holds the key, KDF parameters, and last-unlock timestamp.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const { runSecureStoreStatus, renderStatusReport } = await import(
+            "./secure-store/index.js"
+          );
+          const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const report = await runSecureStoreStatus({ memoryDir });
+          if (options.json === true) {
+            console.log(JSON.stringify(report, null, 2));
+            return;
+          }
+          console.log(renderStatusReport(report));
+        });
+
+      // ── Console subcommand (issue #688 PR 1/3) ──────────────────────────
+      // Structured engine-state aggregator. PR 1/3 ships only the
+      // `--state-only` flag which prints the snapshot as JSON. The
+      // interactive TUI (PR 2/3), HTTP `/console/state`, MCP
+      // `engram.console_state`, and trace replay (PR 3/3) land in
+      // follow-ups.
       cmd
         .command("console")
         .description(
-          "Operator console (issue #688). With no flags: launches the interactive TUI. With --state-only: prints a single JSON snapshot and exits.",
+          "Operator console (issue #688). PR 1/3 ships --state-only, which emits a structured engine-state snapshot as JSON. The interactive TUI lands in PR 2/3.",
         )
         .option(
           "--state-only",
@@ -7341,15 +7447,16 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         )
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
-          if (options.stateOnly === true) {
-            const { gatherConsoleState } = await import("./console/state.js");
-            const snapshot = await gatherConsoleState(orchestrator);
-            console.log(JSON.stringify(snapshot, null, 2));
+          if (options.stateOnly !== true) {
+            console.error(
+              "remnic console: interactive TUI not yet available (issue #688 PR 2/3). Pass --state-only to print a JSON snapshot.",
+            );
+            process.exitCode = 1;
             return;
           }
-          const { runConsoleTui } = await import("./console/tui.js");
-          const handle = runConsoleTui(orchestrator);
-          await handle.done;
+          const { gatherConsoleState } = await import("./console/state.js");
+          const snapshot = await gatherConsoleState(orchestrator);
+          console.log(JSON.stringify(snapshot, null, 2));
         });
     },
     { commands: ["engram"] },

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7430,16 +7430,18 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(renderStatusReport(report));
         });
 
-      // ── Console subcommand (issue #688 PR 1/3) ──────────────────────────
-      // Structured engine-state aggregator. PR 1/3 ships only the
-      // `--state-only` flag which prints the snapshot as JSON. The
-      // interactive TUI (PR 2/3), HTTP `/console/state`, MCP
-      // `engram.console_state`, and trace replay (PR 3/3) land in
-      // follow-ups.
+      // ── Console subcommand (issue #688) ─────────────────────────────────
+      // PR 1/3 (#721) shipped the structured engine-state aggregator
+      // and the `--state-only` flag (one-shot JSON snapshot). PR 2/3
+      // wires the interactive TUI: invoking `remnic console` with no
+      // flags starts a clear+repaint refresh loop. Trace replay
+      // (`--trace <session-id>`) lands in PR 3/3 along with the HTTP
+      // `/console/state` endpoint and the MCP `engram.console_state`
+      // tool.
       cmd
         .command("console")
         .description(
-          "Operator console (issue #688). PR 1/3 ships --state-only, which emits a structured engine-state snapshot as JSON. The interactive TUI lands in PR 2/3.",
+          "Operator console (issue #688). With no flags: launches the interactive TUI. With --state-only: prints a single JSON snapshot and exits.",
         )
         .option(
           "--state-only",
@@ -7447,16 +7449,15 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
         )
         .action(async (...args: unknown[]) => {
           const options = (args[0] ?? {}) as Record<string, unknown>;
-          if (options.stateOnly !== true) {
-            console.error(
-              "remnic console: interactive TUI not yet available (issue #688 PR 2/3). Pass --state-only to print a JSON snapshot.",
-            );
-            process.exitCode = 1;
+          if (options.stateOnly === true) {
+            const { gatherConsoleState } = await import("./console/state.js");
+            const snapshot = await gatherConsoleState(orchestrator);
+            console.log(JSON.stringify(snapshot, null, 2));
             return;
           }
-          const { gatherConsoleState } = await import("./console/state.js");
-          const snapshot = await gatherConsoleState(orchestrator);
-          console.log(JSON.stringify(snapshot, null, 2));
+          const { runConsoleTui } = await import("./console/tui.js");
+          const handle = runConsoleTui(orchestrator);
+          await handle.done;
         });
     },
     { commands: ["engram"] },

--- a/packages/remnic-core/src/secure-store/cli-handlers.ts
+++ b/packages/remnic-core/src/secure-store/cli-handlers.ts
@@ -1,0 +1,259 @@
+/**
+ * Pure handlers behind the `remnic secure-store {init,unlock,lock,
+ * status}` CLI surface (issue #690 PR 2/4).
+ *
+ * Each handler:
+ *   - takes an explicit `memoryDir` (already `~`-expanded by the CLI),
+ *   - takes an injectable passphrase reader (so tests don't need a
+ *     real TTY and never touch real readline state),
+ *   - returns a structured report (no `console.log` inside),
+ *   - never logs the passphrase or any secret material.
+ *
+ * The actual `console.log` formatting lives in `cli-renderer.ts` so
+ * tests can assert on the report shape without parsing text.
+ */
+
+import { generateSalt as generateEnvelopeSalt } from "./cipher.js";
+import {
+  buildHeaderFromPassphrase,
+  deriveKeyFromHeader,
+  headerPath,
+  readHeader,
+  secureStoreDir,
+  verifyKey,
+  writeHeader,
+  type SecureStoreHeader,
+} from "./header.js";
+import * as keyring from "./keyring.js";
+import {
+  DEFAULT_ARGON2ID_PARAMS,
+  DEFAULT_SCRYPT_PARAMS,
+  KDF_SALT_LENGTH,
+  type Argon2idParams,
+  type KdfAlgorithm,
+  type ScryptParams,
+} from "./kdf.js";
+
+/** Passphrase source — async so callers can read from a TTY without echo. */
+export type PassphraseReader = (
+  prompt: string,
+  options?: { confirm?: boolean },
+) => Promise<string>;
+
+/** Common options accepted by every handler. */
+export interface SecureStoreHandlerCommon {
+  memoryDir: string;
+  /**
+   * Stable identifier for the in-memory keyring entry. Defaults to
+   * the secure-store directory under `memoryDir`. Tests override
+   * this to keep entries from leaking across cases.
+   */
+  keyringId?: string;
+  /** Optional clock injection for deterministic tests. */
+  now?: () => Date;
+}
+
+// ─── init ─────────────────────────────────────────────────────────────
+
+export interface SecureStoreInitOptions extends SecureStoreHandlerCommon {
+  /** Passphrase reader — called twice (entry + confirmation). */
+  readPassphrase: PassphraseReader;
+  /**
+   * KDF algorithm. Defaults to `"scrypt"`. `"argon2id"` is reserved
+   * but not implemented in this build (PR 1/4 throws on use).
+   */
+  algorithm?: KdfAlgorithm;
+  /** KDF parameter override; defaults to OWASP-acceptable scrypt params. */
+  params?: ScryptParams | Argon2idParams;
+  /** Pre-generated salt for tests; production callers should omit. */
+  salt?: Buffer;
+  /** Optional human-readable note recorded in metadata. Never persist secrets. */
+  note?: string;
+}
+
+export interface SecureStoreInitReport {
+  ok: true;
+  /** Absolute path of the header file that was written. */
+  headerPath: string;
+  /** Algorithm + params used for the master key derivation. */
+  kdf: SecureStoreHeader["metadata"]["kdf"];
+  /** ISO-8601 timestamp recorded in the header. */
+  createdAt: string;
+}
+
+/**
+ * Initialize a new secure-store header. Refuses to overwrite an
+ * existing header (use `header.ts:writeHeader` directly with explicit
+ * intent if you need to reinitialize a destroyed store).
+ */
+export async function runSecureStoreInit(
+  options: SecureStoreInitOptions,
+): Promise<SecureStoreInitReport> {
+  const { memoryDir, readPassphrase } = options;
+  if (typeof memoryDir !== "string" || memoryDir.length === 0) {
+    throw new Error("secure-store init: memoryDir is required");
+  }
+  // Fail fast if a header already exists, before we waste KDF time.
+  const existing = await readHeader(memoryDir);
+  if (existing !== null) {
+    throw new Error(
+      `secure-store header already exists at ${headerPath(memoryDir)}. Run 'remnic secure-store status' to inspect, or remove the .secure-store directory explicitly to reinitialize.`,
+    );
+  }
+  const passphrase = await readPassphrase("Enter new passphrase: ", { confirm: true });
+  validatePassphrase(passphrase);
+
+  const algorithm: KdfAlgorithm = options.algorithm ?? "scrypt";
+  const params = resolveParams(algorithm, options.params);
+  const salt = options.salt ?? generateEnvelopeSalt();
+  if (salt.length !== KDF_SALT_LENGTH) {
+    throw new Error(`salt must be ${KDF_SALT_LENGTH} bytes, got ${salt.length}`);
+  }
+
+  const built = buildHeaderFromPassphrase({
+    passphrase,
+    salt,
+    algorithm,
+    params,
+    ...(options.note !== undefined ? { note: options.note } : {}),
+    ...(options.now ? { createdAt: options.now().toISOString() } : {}),
+  });
+  // Zero the derived key — init does NOT auto-unlock; the operator
+  // must run `unlock` separately. This mirrors GnuPG-style hygiene
+  // and keeps `init` safe to run from automation that should never
+  // hold the master key in memory.
+  built.derivedKey.fill(0);
+
+  const writtenPath = await writeHeader(memoryDir, built.header);
+  return {
+    ok: true,
+    headerPath: writtenPath,
+    kdf: built.header.metadata.kdf,
+    createdAt: built.header.createdAt,
+  };
+}
+
+// ─── unlock ───────────────────────────────────────────────────────────
+
+export interface SecureStoreUnlockOptions extends SecureStoreHandlerCommon {
+  readPassphrase: PassphraseReader;
+}
+
+export type SecureStoreUnlockReport =
+  | { ok: true; unlockedAt: string; algorithm: KdfAlgorithm }
+  | { ok: false; reason: "not-initialized" | "wrong-passphrase" };
+
+export async function runSecureStoreUnlock(
+  options: SecureStoreUnlockOptions,
+): Promise<SecureStoreUnlockReport> {
+  const { memoryDir, readPassphrase } = options;
+  const header = await readHeader(memoryDir);
+  if (!header) {
+    return { ok: false, reason: "not-initialized" };
+  }
+  const passphrase = await readPassphrase("Enter passphrase: ");
+  validatePassphrase(passphrase);
+  const candidateKey = deriveKeyFromHeader(header, passphrase);
+  if (!verifyKey(header, candidateKey)) {
+    candidateKey.fill(0);
+    return { ok: false, reason: "wrong-passphrase" };
+  }
+  const id = options.keyringId ?? secureStoreDir(memoryDir);
+  const now = options.now ?? (() => new Date());
+  keyring.unlock(id, candidateKey, now);
+  const status = keyring.status(id);
+  return {
+    ok: true,
+    unlockedAt: status.unlockedAt ?? now().toISOString(),
+    algorithm: header.metadata.kdf.algorithm,
+  };
+}
+
+// ─── lock ─────────────────────────────────────────────────────────────
+
+export interface SecureStoreLockOptions extends SecureStoreHandlerCommon {}
+
+export interface SecureStoreLockReport {
+  ok: true;
+  /** True if a key was registered and is now cleared; false if it was already locked. */
+  cleared: boolean;
+}
+
+export function runSecureStoreLock(options: SecureStoreLockOptions): SecureStoreLockReport {
+  const id = options.keyringId ?? secureStoreDir(options.memoryDir);
+  const cleared = keyring.lock(id);
+  return { ok: true, cleared };
+}
+
+// ─── status ───────────────────────────────────────────────────────────
+
+export interface SecureStoreStatusOptions extends SecureStoreHandlerCommon {}
+
+export interface SecureStoreStatusReport {
+  /** True iff a header file exists in `<memoryDir>/.secure-store/`. */
+  initialized: boolean;
+  /** Path the status check probed. Useful for operators. */
+  headerPath: string;
+  /** Locked/unlocked state of the in-memory keyring entry. */
+  locked: boolean;
+  /** ISO-8601 timestamp of the most recent unlock, or null when locked. */
+  unlockedAt: string | null;
+  /** Header metadata (algorithm + params + salt hex), or null when uninitialized. */
+  kdf: SecureStoreHeader["metadata"]["kdf"] | null;
+  /** Header `createdAt`, or null when uninitialized. */
+  createdAt: string | null;
+}
+
+export async function runSecureStoreStatus(
+  options: SecureStoreStatusOptions,
+): Promise<SecureStoreStatusReport> {
+  const { memoryDir } = options;
+  const id = options.keyringId ?? secureStoreDir(memoryDir);
+  const header = await readHeader(memoryDir);
+  const ks = keyring.status(id);
+  const target = headerPath(memoryDir);
+  if (!header) {
+    return {
+      initialized: false,
+      headerPath: target,
+      locked: !ks.unlocked,
+      unlockedAt: ks.unlockedAt,
+      kdf: null,
+      createdAt: null,
+    };
+  }
+  return {
+    initialized: true,
+    headerPath: target,
+    locked: !ks.unlocked,
+    unlockedAt: ks.unlockedAt,
+    kdf: header.metadata.kdf,
+    createdAt: header.createdAt,
+  };
+}
+
+// ─── helpers ──────────────────────────────────────────────────────────
+
+/** Minimum passphrase length. 8 chars is intentionally permissive — operators may use phrase managers. */
+export const MIN_PASSPHRASE_LENGTH = 8;
+
+function validatePassphrase(passphrase: string): void {
+  if (typeof passphrase !== "string") {
+    throw new Error("passphrase must be a string");
+  }
+  if (passphrase.length === 0) {
+    throw new Error("passphrase must not be empty");
+  }
+  if (passphrase.length < MIN_PASSPHRASE_LENGTH) {
+    throw new Error(`passphrase must be at least ${MIN_PASSPHRASE_LENGTH} characters`);
+  }
+}
+
+function resolveParams(
+  algorithm: KdfAlgorithm,
+  override: ScryptParams | Argon2idParams | undefined,
+): ScryptParams | Argon2idParams {
+  if (override !== undefined) return override;
+  if (algorithm === "scrypt") return { ...DEFAULT_SCRYPT_PARAMS };
+  return { ...DEFAULT_ARGON2ID_PARAMS };
+}

--- a/packages/remnic-core/src/secure-store/cli-renderer.ts
+++ b/packages/remnic-core/src/secure-store/cli-renderer.ts
@@ -1,0 +1,84 @@
+/**
+ * Console-text renderers for the `remnic secure-store {init,unlock,
+ * lock,status}` CLI surface (issue #690 PR 2/4).
+ *
+ * Pure: each `render*` function takes a typed report and returns a
+ * string. CLI handlers do the `console.log`. Tests assert on the
+ * returned text directly so behavior stays decoupled from stdout.
+ */
+
+import type {
+  SecureStoreInitReport,
+  SecureStoreLockReport,
+  SecureStoreStatusReport,
+  SecureStoreUnlockReport,
+} from "./cli-handlers.js";
+import type { SecureStoreHeader } from "./header.js";
+
+export function renderInitReport(report: SecureStoreInitReport): string {
+  const lines: string[] = [];
+  lines.push("=== Remnic secure-store initialized ===");
+  lines.push("");
+  lines.push(`header: ${report.headerPath}`);
+  lines.push(`createdAt: ${report.createdAt}`);
+  lines.push(...renderKdfLines(report.kdf));
+  lines.push("");
+  lines.push("Note: init does NOT auto-unlock the store. Run");
+  lines.push("  remnic engram secure-store unlock");
+  lines.push("to register the master key with the running daemon.");
+  return lines.join("\n");
+}
+
+export function renderUnlockReport(report: SecureStoreUnlockReport): string {
+  if (report.ok) {
+    return `OK — secure-store unlocked at ${report.unlockedAt} (algorithm=${report.algorithm}).`;
+  }
+  if (report.reason === "not-initialized") {
+    return "ERR — secure-store is not initialized. Run 'remnic engram secure-store init' first.";
+  }
+  return "ERR — wrong passphrase.";
+}
+
+export function renderLockReport(report: SecureStoreLockReport): string {
+  if (report.cleared) {
+    return "OK — secure-store key cleared from in-memory keyring.";
+  }
+  return "OK — secure-store was already locked (no in-memory key to clear).";
+}
+
+export function renderStatusReport(report: SecureStoreStatusReport): string {
+  const lines: string[] = [];
+  lines.push("=== Remnic secure-store status ===");
+  lines.push("");
+  lines.push(`header: ${report.headerPath}`);
+  lines.push(`initialized: ${report.initialized ? "yes" : "no"}`);
+  if (!report.initialized) {
+    lines.push("");
+    lines.push("Run 'remnic engram secure-store init' to initialize a new store.");
+    return lines.join("\n");
+  }
+  lines.push(`createdAt: ${report.createdAt ?? "n/a"}`);
+  lines.push(`locked: ${report.locked ? "yes" : "no"}`);
+  if (!report.locked) {
+    lines.push(`lastUnlockAt: ${report.unlockedAt ?? "n/a"}`);
+  }
+  if (report.kdf) {
+    lines.push(...renderKdfLines(report.kdf));
+  }
+  return lines.join("\n");
+}
+
+function renderKdfLines(kdf: SecureStoreHeader["metadata"]["kdf"]): string[] {
+  const lines: string[] = [];
+  lines.push(`kdf.algorithm: ${kdf.algorithm}`);
+  if (kdf.algorithm === "scrypt") {
+    const { N, r, p, keyLength, maxmem } = kdf.params;
+    lines.push(`kdf.params: N=${N} r=${r} p=${p} keyLength=${keyLength} maxmem=${maxmem}`);
+  } else {
+    const { memoryKiB, iterations, parallelism, keyLength } = kdf.params;
+    lines.push(
+      `kdf.params: memoryKiB=${memoryKiB} iterations=${iterations} parallelism=${parallelism} keyLength=${keyLength}`,
+    );
+  }
+  return lines;
+}

--- a/packages/remnic-core/src/secure-store/header.ts
+++ b/packages/remnic-core/src/secure-store/header.ts
@@ -1,0 +1,346 @@
+/**
+ * On-disk header for an initialized secure-store (issue #690 PR 2/4).
+ *
+ * The header file is the persistent record that a memory directory
+ * has had `remnic secure-store init` run against it. It is a JSON
+ * file at `<memoryDir>/.secure-store/header.json` with two parts:
+ *
+ *   1. The KDF metadata from PR 1/4 (`SecureStoreMetadata`) —
+ *      algorithm, params, and salt. Public; safe to read/copy.
+ *   2. A "verifier" — a tiny AES-GCM-encrypted envelope sealed under
+ *      the derived key at init time. Unlock re-derives the key from
+ *      the entered passphrase and tries to `open()` the verifier; if
+ *      the auth tag validates, the passphrase is correct.
+ *
+ * Why a verifier?
+ * ---------------
+ * Without one, "wrong passphrase" can only be detected when the
+ * daemon tries to decrypt actual memory data — too late for a
+ * useful CLI error. The verifier gives the unlock command a fast,
+ * data-independent passphrase check.
+ *
+ * The verifier plaintext is a fixed magic string (no secret content).
+ * Its only role is to be sealable + openable; the auth-tag check is
+ * what proves the key.
+ *
+ * Naming
+ * ------
+ * Directory: `.secure-store/` (leading dot — hidden, hints at
+ * sensitivity). File: `header.json`. Avoids collision with
+ * `.secure-store-metadata.json` from PR 1/4 docs since the header
+ * is a strict superset.
+ */
+
+import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import { open, seal } from "./cipher.js";
+import {
+  KDF_KEY_LENGTH,
+  KDF_SALT_LENGTH,
+  deriveKey,
+  type Argon2idParams,
+  type ScryptParams,
+} from "./kdf.js";
+import {
+  buildMetadata,
+  decodeMetadataSalt,
+  parseMetadata,
+  serializeMetadata,
+  type SecureStoreMetadata,
+} from "./metadata.js";
+
+/** Subdirectory under `memoryDir` that holds the header + future state. */
+export const SECURE_STORE_DIR_NAME = ".secure-store";
+
+/** Header filename. Stable name so operators can locate it. */
+export const HEADER_FILENAME = "header.json";
+
+/** Stable identifier so the file shape is sniffable without parsing JSON. */
+export const HEADER_FORMAT = "remnic.secure-store.header" as const;
+
+/** Current header format version. Bump on breaking schema changes. */
+export const HEADER_FORMAT_VERSION = 1 as const;
+
+/**
+ * Magic bytes sealed under the master key at init time. Constant
+ * across stores — there's no value in randomizing it because the
+ * salt + IV + auth tag already make every verifier envelope unique.
+ *
+ * The string never appears in plaintext on disk; it only exists
+ * inside an AES-GCM-sealed envelope. Its job is purely to give the
+ * cipher something to authenticate.
+ */
+export const VERIFIER_PLAINTEXT = Buffer.from("remnic-secure-store-v1", "utf8");
+
+/** AAD bound into the verifier envelope. */
+const VERIFIER_AAD = Buffer.from("remnic-secure-store/verifier", "utf8");
+
+export interface SecureStoreHeader {
+  format: typeof HEADER_FORMAT;
+  formatVersion: number;
+  /** KDF metadata (algorithm + params + salt). */
+  metadata: SecureStoreMetadata;
+  /** Hex-encoded sealed envelope. */
+  verifier: string;
+  /** ISO-8601 timestamp recorded at init time. */
+  createdAt: string;
+}
+
+/** Resolve the canonical secure-store directory for a memory root. */
+export function secureStoreDir(memoryDir: string): string {
+  return path.join(memoryDir, SECURE_STORE_DIR_NAME);
+}
+
+/** Resolve the canonical header path for a memory root. */
+export function headerPath(memoryDir: string): string {
+  return path.join(secureStoreDir(memoryDir), HEADER_FILENAME);
+}
+
+/**
+ * Build a `SecureStoreHeader` in memory from an already-derived key
+ * and metadata. Pure: does not touch the filesystem. The clock is
+ * read once if `createdAt` is omitted.
+ */
+export function buildHeader(options: {
+  metadata: SecureStoreMetadata;
+  derivedKey: Buffer;
+  createdAt?: string;
+}): SecureStoreHeader {
+  const { metadata, derivedKey } = options;
+  if (!Buffer.isBuffer(derivedKey) || derivedKey.length !== KDF_KEY_LENGTH) {
+    throw new Error(
+      `derivedKey must be a ${KDF_KEY_LENGTH}-byte Buffer, got length=${derivedKey?.length ?? "non-buffer"}`,
+    );
+  }
+  const salt = decodeMetadataSalt(metadata);
+  if (salt.length !== KDF_SALT_LENGTH) {
+    throw new Error(`metadata salt is ${salt.length} bytes, expected ${KDF_SALT_LENGTH}`);
+  }
+  const envelope = seal(derivedKey, salt, VERIFIER_PLAINTEXT, { aad: VERIFIER_AAD });
+  return {
+    format: HEADER_FORMAT,
+    formatVersion: HEADER_FORMAT_VERSION,
+    metadata,
+    verifier: envelope.toString("hex"),
+    createdAt: options.createdAt ?? new Date().toISOString(),
+  };
+}
+
+/** Stable JSON serialization with locked top-level key order. */
+export function serializeHeader(header: SecureStoreHeader): string {
+  validateHeader(header);
+  // Inline metadata as a parsed object so it shares the same
+  // canonical key ordering as the standalone metadata file.
+  const metadataString = serializeMetadata(header.metadata);
+  const metadataObject = JSON.parse(metadataString) as Record<string, unknown>;
+  const ordered = {
+    format: header.format,
+    formatVersion: header.formatVersion,
+    metadata: metadataObject,
+    verifier: header.verifier,
+    createdAt: header.createdAt,
+  };
+  return JSON.stringify(ordered, null, 2);
+}
+
+/** Parse a header JSON string. Throws on any structural problem. */
+export function parseHeader(json: string): SecureStoreHeader {
+  if (typeof json !== "string") {
+    throw new Error("header input must be a string");
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(json);
+  } catch (e) {
+    const msg = e instanceof Error ? e.message : String(e);
+    throw new Error(`header is not valid JSON: ${msg}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error("header must be a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+  if (obj.format !== HEADER_FORMAT) {
+    throw new Error(
+      `unexpected header format: ${String(obj.format)} (expected ${HEADER_FORMAT})`,
+    );
+  }
+  if (obj.formatVersion !== HEADER_FORMAT_VERSION) {
+    throw new Error(
+      `unsupported header formatVersion: ${String(obj.formatVersion)} (this build supports ${HEADER_FORMAT_VERSION})`,
+    );
+  }
+  if (typeof obj.verifier !== "string" || obj.verifier.length === 0) {
+    throw new Error("header.verifier must be a non-empty hex string");
+  }
+  if (!/^[0-9a-f]+$/i.test(obj.verifier)) {
+    throw new Error("header.verifier must be a hex-encoded string");
+  }
+  if (typeof obj.createdAt !== "string" || obj.createdAt.length === 0) {
+    throw new Error("header.createdAt must be a non-empty string");
+  }
+  if (typeof obj.metadata !== "object" || obj.metadata === null) {
+    throw new Error("header.metadata must be an object");
+  }
+  // Reuse the metadata parser for nested validation. We re-stringify
+  // the nested object and feed it through `parseMetadata` so any
+  // schema drift is caught in one place.
+  const metadata = parseMetadata(JSON.stringify(obj.metadata));
+  const header: SecureStoreHeader = {
+    format: HEADER_FORMAT,
+    formatVersion: HEADER_FORMAT_VERSION,
+    metadata,
+    verifier: obj.verifier,
+    createdAt: obj.createdAt,
+  };
+  validateHeader(header);
+  return header;
+}
+
+/** Validate a header object's invariants. Throws on the first problem. */
+export function validateHeader(header: SecureStoreHeader): void {
+  if (header.format !== HEADER_FORMAT) {
+    throw new Error(`header.format must be ${HEADER_FORMAT}`);
+  }
+  if (header.formatVersion !== HEADER_FORMAT_VERSION) {
+    throw new Error(`header.formatVersion must be ${HEADER_FORMAT_VERSION}`);
+  }
+  if (typeof header.createdAt !== "string" || header.createdAt.length === 0) {
+    throw new Error("header.createdAt must be a non-empty ISO-8601 string");
+  }
+  if (typeof header.verifier !== "string" || header.verifier.length === 0) {
+    throw new Error("header.verifier must be a non-empty hex string");
+  }
+  if (!/^[0-9a-f]+$/i.test(header.verifier)) {
+    throw new Error("header.verifier must be a hex-encoded string");
+  }
+  // The nested metadata object is already validated by `parseMetadata`
+  // when read from disk; on the build path, `buildHeader` constructs
+  // it via `buildMetadata`. We still re-run shape validation here as
+  // a belt-and-braces guard for callers that hand-construct headers.
+  if (header.metadata.format !== "remnic.secure-store.metadata") {
+    throw new Error("header.metadata.format must be remnic.secure-store.metadata");
+  }
+}
+
+/**
+ * Verify a candidate key against the header's verifier envelope.
+ *
+ * Returns true iff the AES-GCM auth tag validates. Wrong passphrase,
+ * tampered envelope, and tampered AAD all return false.
+ */
+export function verifyKey(header: SecureStoreHeader, candidateKey: Buffer): boolean {
+  if (!Buffer.isBuffer(candidateKey) || candidateKey.length !== KDF_KEY_LENGTH) {
+    return false;
+  }
+  const envelope = Buffer.from(header.verifier, "hex");
+  try {
+    const plaintext = open(candidateKey, envelope, { aad: VERIFIER_AAD });
+    return plaintext.equals(VERIFIER_PLAINTEXT);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Derive a key from the passphrase using the algorithm + params +
+ * salt recorded in the header. Pure: no I/O.
+ */
+export function deriveKeyFromHeader(header: SecureStoreHeader, passphrase: string): Buffer {
+  const salt = decodeMetadataSalt(header.metadata);
+  const params: ScryptParams | Argon2idParams =
+    header.metadata.kdf.algorithm === "scrypt"
+      ? header.metadata.kdf.params
+      : header.metadata.kdf.params;
+  return deriveKey(header.metadata.kdf.algorithm, passphrase, salt, params);
+}
+
+/**
+ * Read and parse the header at `<memoryDir>/.secure-store/header.json`.
+ * Returns `null` if the file does not exist; throws on malformed
+ * content.
+ */
+export async function readHeader(memoryDir: string): Promise<SecureStoreHeader | null> {
+  const target = headerPath(memoryDir);
+  let raw: string;
+  try {
+    raw = await readFile(target, "utf8");
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code === "ENOENT") {
+      return null;
+    }
+    throw e;
+  }
+  return parseHeader(raw);
+}
+
+/**
+ * Write the header atomically: serialize → write to a temp file in
+ * the same directory → fsync-by-rename → done.
+ *
+ * Refuses to overwrite an existing header; the caller must explicitly
+ * remove the existing header first. This guards against accidental
+ * reinitialization.
+ */
+export async function writeHeader(memoryDir: string, header: SecureStoreHeader): Promise<string> {
+  validateHeader(header);
+  const dir = secureStoreDir(memoryDir);
+  await mkdir(dir, { recursive: true });
+  const target = headerPath(memoryDir);
+  // Existence check via readFile: writeFile with `wx` flag would also
+  // work, but readFile gives a clearer error message.
+  let exists = false;
+  try {
+    await readFile(target, "utf8");
+    exists = true;
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw e;
+    }
+  }
+  if (exists) {
+    throw new Error(
+      `secure-store header already exists at ${target}. Refusing to overwrite — initialize a fresh store or remove the existing header explicitly.`,
+    );
+  }
+  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
+  // Per CLAUDE.md gotcha #54: write tmp first, rename atomically.
+  await writeFile(tmp, serializeHeader(header), { encoding: "utf8", mode: 0o600 });
+  await rename(tmp, target);
+  return target;
+}
+
+/** Convenience: build metadata + header in one call from a passphrase. */
+export function buildHeaderFromPassphrase(options: {
+  passphrase: string;
+  salt: Buffer;
+  /** Optional override; defaults to scrypt with `DEFAULT_SCRYPT_PARAMS`. */
+  algorithm?: "scrypt" | "argon2id";
+  params?: ScryptParams | Argon2idParams;
+  createdAt?: string;
+  note?: string;
+}): { header: SecureStoreHeader; derivedKey: Buffer } {
+  const { passphrase, salt } = options;
+  const algorithm = options.algorithm ?? "scrypt";
+  const metadataOpts: {
+    algorithm: "scrypt" | "argon2id";
+    salt: Buffer;
+    params?: ScryptParams | Argon2idParams;
+    createdAt?: string;
+    note?: string;
+  } = { algorithm, salt };
+  if (options.params !== undefined) metadataOpts.params = options.params;
+  if (options.createdAt !== undefined) metadataOpts.createdAt = options.createdAt;
+  if (options.note !== undefined) metadataOpts.note = options.note;
+  const metadata = buildMetadata(metadataOpts);
+  const params: ScryptParams | Argon2idParams =
+    metadata.kdf.algorithm === "scrypt" ? metadata.kdf.params : metadata.kdf.params;
+  const derivedKey = deriveKey(algorithm, passphrase, salt, params);
+  const headerOpts: { metadata: SecureStoreMetadata; derivedKey: Buffer; createdAt?: string } = {
+    metadata,
+    derivedKey,
+  };
+  if (options.createdAt !== undefined) headerOpts.createdAt = options.createdAt;
+  const header = buildHeader(headerOpts);
+  return { header, derivedKey };
+}

--- a/packages/remnic-core/src/secure-store/header.ts
+++ b/packages/remnic-core/src/secure-store/header.ts
@@ -31,7 +31,7 @@
  * is a strict superset.
  */
 
-import { mkdir, readFile, rename, writeFile } from "node:fs/promises";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import { open, seal } from "./cipher.js";
@@ -275,38 +275,46 @@ export async function readHeader(memoryDir: string): Promise<SecureStoreHeader |
 }
 
 /**
- * Write the header atomically: serialize → write to a temp file in
- * the same directory → fsync-by-rename → done.
+ * Write the header with atomic exclusive-create semantics.
  *
- * Refuses to overwrite an existing header; the caller must explicitly
- * remove the existing header first. This guards against accidental
- * reinitialization.
+ * Uses the `wx` flag (`O_CREAT | O_EXCL`) so the OS rejects the call
+ * atomically when the file already exists. Two concurrent
+ * `secure-store init` invocations cannot both observe "missing" and
+ * race to overwrite each other — the second writer reliably gets
+ * `EEXIST` and surfaces "Refusing to overwrite".
+ *
+ * Codex P1 on PR #737: a previous version pre-checked existence with
+ * `readFile` then `writeFile`+`rename`, which is a check-then-act
+ * race. The `wx` flag closes that window at the kernel layer.
+ *
+ * Crash safety: if the write is interrupted mid-flight, a partial
+ * `header.json` may remain on disk. `parseHeader` rejects partial
+ * files cleanly and the operator can delete the stub and retry. We
+ * don't use temp+rename here because (a) headers are tiny (≤ 1 KiB),
+ * (b) there is no prior valid file to destroy, and (c) `wx` already
+ * gives us atomic exclusivity — the rename trick (CLAUDE.md gotcha
+ * #54) is for replacing an existing valid file, which is exactly the
+ * scenario this function refuses.
  */
 export async function writeHeader(memoryDir: string, header: SecureStoreHeader): Promise<string> {
   validateHeader(header);
   const dir = secureStoreDir(memoryDir);
   await mkdir(dir, { recursive: true });
   const target = headerPath(memoryDir);
-  // Existence check via readFile: writeFile with `wx` flag would also
-  // work, but readFile gives a clearer error message.
-  let exists = false;
   try {
-    await readFile(target, "utf8");
-    exists = true;
+    await writeFile(target, serializeHeader(header), {
+      encoding: "utf8",
+      mode: 0o600,
+      flag: "wx",
+    });
   } catch (e) {
-    if ((e as NodeJS.ErrnoException).code !== "ENOENT") {
-      throw e;
+    if ((e as NodeJS.ErrnoException).code === "EEXIST") {
+      throw new Error(
+        `secure-store header already exists at ${target}. Refusing to overwrite — initialize a fresh store or remove the existing header explicitly.`,
+      );
     }
+    throw e;
   }
-  if (exists) {
-    throw new Error(
-      `secure-store header already exists at ${target}. Refusing to overwrite — initialize a fresh store or remove the existing header explicitly.`,
-    );
-  }
-  const tmp = `${target}.tmp-${process.pid}-${Date.now()}`;
-  // Per CLAUDE.md gotcha #54: write tmp first, rename atomically.
-  await writeFile(tmp, serializeHeader(header), { encoding: "utf8", mode: 0o600 });
-  await rename(tmp, target);
   return target;
 }
 

--- a/packages/remnic-core/src/secure-store/header.ts
+++ b/packages/remnic-core/src/secure-store/header.ts
@@ -173,8 +173,17 @@ export function parseHeader(json: string): SecureStoreHeader {
   if (typeof obj.verifier !== "string" || obj.verifier.length === 0) {
     throw new Error("header.verifier must be a non-empty hex string");
   }
-  if (!/^[0-9a-f]+$/i.test(obj.verifier)) {
+  if (!/^[0-9a-fA-F]+$/.test(obj.verifier)) {
     throw new Error("header.verifier must be a hex-encoded string");
+  }
+  // Codex P2 on PR #737: odd-length hex strings produce a malformed
+  // Buffer via `Buffer.from(hex, "hex")` — Node silently truncates the
+  // trailing nibble, yielding a buffer that is one byte shorter than
+  // expected. Reject odd-length strings before they reach the cipher.
+  if (obj.verifier.length % 2 !== 0) {
+    throw new Error(
+      "header.verifier hex string must have even length (each byte encodes as two hex digits)",
+    );
   }
   if (typeof obj.createdAt !== "string" || obj.createdAt.length === 0) {
     throw new Error("header.createdAt must be a non-empty string");
@@ -211,8 +220,15 @@ export function validateHeader(header: SecureStoreHeader): void {
   if (typeof header.verifier !== "string" || header.verifier.length === 0) {
     throw new Error("header.verifier must be a non-empty hex string");
   }
-  if (!/^[0-9a-f]+$/i.test(header.verifier)) {
+  if (!/^[0-9a-fA-F]+$/.test(header.verifier)) {
     throw new Error("header.verifier must be a hex-encoded string");
+  }
+  // Enforce even length: odd-length hex is silently truncated by
+  // `Buffer.from(hex, "hex")` which yields a malformed envelope.
+  if (header.verifier.length % 2 !== 0) {
+    throw new Error(
+      "header.verifier hex string must have even length (each byte encodes as two hex digits)",
+    );
   }
   // The nested metadata object is already validated by `parseMetadata`
   // when read from disk; on the build path, `buildHeader` constructs
@@ -248,10 +264,11 @@ export function verifyKey(header: SecureStoreHeader, candidateKey: Buffer): bool
  */
 export function deriveKeyFromHeader(header: SecureStoreHeader, passphrase: string): Buffer {
   const salt = decodeMetadataSalt(header.metadata);
-  const params: ScryptParams | Argon2idParams =
-    header.metadata.kdf.algorithm === "scrypt"
-      ? header.metadata.kdf.params
-      : header.metadata.kdf.params;
+  // Cursor low on PR #737: a previous version branched on the
+  // algorithm and returned `header.metadata.kdf.params` from both
+  // arms — a no-op conditional. Pass the discriminated union member
+  // through directly; `deriveKey` performs the algorithm dispatch.
+  const params: ScryptParams | Argon2idParams = header.metadata.kdf.params;
   return deriveKey(header.metadata.kdf.algorithm, passphrase, salt, params);
 }
 
@@ -341,8 +358,10 @@ export function buildHeaderFromPassphrase(options: {
   if (options.createdAt !== undefined) metadataOpts.createdAt = options.createdAt;
   if (options.note !== undefined) metadataOpts.note = options.note;
   const metadata = buildMetadata(metadataOpts);
-  const params: ScryptParams | Argon2idParams =
-    metadata.kdf.algorithm === "scrypt" ? metadata.kdf.params : metadata.kdf.params;
+  // Cursor low on PR #737: same identical-branches ternary as in
+  // `deriveKeyFromHeader`. The discriminated union already carries
+  // the right shape; `deriveKey` dispatches on `algorithm`.
+  const params: ScryptParams | Argon2idParams = metadata.kdf.params;
   const derivedKey = deriveKey(algorithm, passphrase, salt, params);
   const headerOpts: { metadata: SecureStoreMetadata; derivedKey: Buffer; createdAt?: string } = {
     metadata,

--- a/packages/remnic-core/src/secure-store/index.ts
+++ b/packages/remnic-core/src/secure-store/index.ts
@@ -58,3 +58,51 @@ export {
   type SecureStoreMetadataKdfArgon2id,
   type SecureStoreMetadataKdfScrypt,
 } from "./metadata.js";
+
+// Issue #690 PR 2/4 — header (metadata + verifier) and CLI surface.
+export {
+  HEADER_FILENAME,
+  HEADER_FORMAT,
+  HEADER_FORMAT_VERSION,
+  SECURE_STORE_DIR_NAME,
+  buildHeader,
+  buildHeaderFromPassphrase,
+  deriveKeyFromHeader,
+  headerPath,
+  parseHeader,
+  readHeader,
+  secureStoreDir,
+  serializeHeader,
+  validateHeader,
+  verifyKey,
+  writeHeader,
+  type SecureStoreHeader,
+} from "./header.js";
+
+export * as keyring from "./keyring.js";
+
+export {
+  MIN_PASSPHRASE_LENGTH,
+  runSecureStoreInit,
+  runSecureStoreLock,
+  runSecureStoreStatus,
+  runSecureStoreUnlock,
+  type PassphraseReader,
+  type SecureStoreInitOptions,
+  type SecureStoreInitReport,
+  type SecureStoreLockOptions,
+  type SecureStoreLockReport,
+  type SecureStoreStatusOptions,
+  type SecureStoreStatusReport,
+  type SecureStoreUnlockOptions,
+  type SecureStoreUnlockReport,
+} from "./cli-handlers.js";
+
+export {
+  renderInitReport,
+  renderLockReport,
+  renderStatusReport,
+  renderUnlockReport,
+} from "./cli-renderer.js";
+
+export { createPassphraseReader } from "./passphrase-reader.js";

--- a/packages/remnic-core/src/secure-store/keyring.ts
+++ b/packages/remnic-core/src/secure-store/keyring.ts
@@ -1,0 +1,106 @@
+/**
+ * In-memory keyring for the secure-store module (issue #690 PR 2/4).
+ *
+ * Holds derived AES-256-GCM master keys for unlocked stores. The
+ * keyring is process-local: keys are NEVER persisted to disk, never
+ * logged, and never serialized. A daemon restart re-locks every
+ * registered store.
+ *
+ * Scoping
+ * -------
+ * Entries are keyed by a stable string id (typically the absolute
+ * path to the secure-store directory, after `~` expansion). This
+ * lets multiple memory roots share a single daemon process without
+ * one store's key bleeding into another (matches the per-`serviceId`
+ * scoping discipline called out in CLAUDE.md gotcha #11).
+ *
+ * Lifecycle
+ * ---------
+ *   - `unlock(id, key)` — register a derived key.
+ *   - `getKey(id)` — read a registered key (or `null`).
+ *   - `lock(id)` — clear a single entry, zeroing the key bytes.
+ *   - `lockAll()` — clear every entry, zeroing every key.
+ *   - `status(id)` — non-secret status snapshot for `secure-store
+ *     status`.
+ *
+ * Zeroization
+ * -----------
+ * `lock` and `lockAll` overwrite the key buffer with zeros before
+ * dropping the reference. The JS engine may keep additional copies
+ * outside our control; this is best-effort hygiene, not a defense
+ * against memory-dump attacks.
+ */
+
+const ENTRIES = new Map<string, KeyringEntry>();
+
+/** A single unlocked store. The key buffer is never copied out. */
+interface KeyringEntry {
+  key: Buffer;
+  unlockedAt: string;
+}
+
+/** Status snapshot — no secret material. */
+export interface KeyringStatus {
+  /** True iff a key is currently registered for this id. */
+  unlocked: boolean;
+  /** ISO-8601 timestamp the key was registered, or null when locked. */
+  unlockedAt: string | null;
+}
+
+/**
+ * Register a derived key for the given id. If an entry already
+ * exists, its old key is zeroed before being replaced.
+ *
+ * The caller MUST pass an exclusive 32-byte buffer; the keyring
+ * takes ownership and will zero it on lock.
+ */
+export function unlock(id: string, key: Buffer, now: () => Date = () => new Date()): void {
+  if (typeof id !== "string" || id.length === 0) {
+    throw new Error("keyring id must be a non-empty string");
+  }
+  if (!Buffer.isBuffer(key) || key.length !== 32) {
+    throw new Error(`keyring key must be a 32-byte Buffer, got length=${key?.length ?? "non-buffer"}`);
+  }
+  const existing = ENTRIES.get(id);
+  if (existing) {
+    existing.key.fill(0);
+  }
+  ENTRIES.set(id, { key, unlockedAt: now().toISOString() });
+}
+
+/** Read the registered key for `id`, or `null` if locked. */
+export function getKey(id: string): Buffer | null {
+  const entry = ENTRIES.get(id);
+  return entry ? entry.key : null;
+}
+
+/** Clear a single entry. Zeros the underlying buffer. Returns true if cleared. */
+export function lock(id: string): boolean {
+  const entry = ENTRIES.get(id);
+  if (!entry) return false;
+  entry.key.fill(0);
+  ENTRIES.delete(id);
+  return true;
+}
+
+/** Clear every registered key. Used on shutdown or for tests. */
+export function lockAll(): void {
+  for (const entry of ENTRIES.values()) {
+    entry.key.fill(0);
+  }
+  ENTRIES.clear();
+}
+
+/** Non-secret status snapshot. */
+export function status(id: string): KeyringStatus {
+  const entry = ENTRIES.get(id);
+  if (!entry) {
+    return { unlocked: false, unlockedAt: null };
+  }
+  return { unlocked: true, unlockedAt: entry.unlockedAt };
+}
+
+/** Test-only helper: how many entries are currently registered. */
+export function size(): number {
+  return ENTRIES.size;
+}

--- a/packages/remnic-core/src/secure-store/passphrase-reader.ts
+++ b/packages/remnic-core/src/secure-store/passphrase-reader.ts
@@ -26,6 +26,7 @@
 
 import { createInterface } from "node:readline";
 import type { Readable, Writable } from "node:stream";
+import { StringDecoder } from "node:string_decoder";
 
 import type { PassphraseReader } from "./cli-handlers.js";
 
@@ -96,18 +97,27 @@ function readNoEcho(
     let buffer = "";
     let settled = false;
     const wasRaw = (input as Readable & { isRaw?: boolean }).isRaw === true;
+    // Codex P2 on PR #737: per-chunk `chunk.toString("utf8")` corrupts
+    // multibyte characters that straddle a chunk boundary (Node inserts
+    // U+FFFD replacement characters for incomplete sequences). Use a
+    // StringDecoder, which buffers partial sequences across chunks so
+    // non-ASCII passphrases survive intact.
+    const decoder = new StringDecoder("utf8");
     if (input.setRawMode) input.setRawMode(true);
     input.resume();
     const cleanup = (): void => {
       input.pause();
       input.removeListener("data", onData);
+      // Flush any remaining bytes the decoder is holding so trailing
+      // partial sequences are surfaced rather than silently swallowed.
+      decoder.end();
       // Restore the prior raw-mode state so we don't strand the parent shell
       // in an unexpected configuration.
       if (input.setRawMode) input.setRawMode(wasRaw);
       output.write("\n");
     };
     const onData = (chunk: Buffer): void => {
-      const str = chunk.toString("utf8");
+      const str = decoder.write(chunk);
       for (const ch of str) {
         if (settled) return;
         const code = ch.charCodeAt(0);
@@ -155,17 +165,31 @@ function readNoEcho(
 function readPlainLine(input: Readable, output: Writable): Promise<string> {
   return new Promise((resolve, reject) => {
     const rl = createInterface({ input, output, terminal: false });
-    rl.once("line", (line) => {
+    // Codex P1 on PR #737: a previous version called `rl.close()`
+    // before `resolve(line)`, but `close` emits synchronously and a
+    // separate `close` listener that resolved with `""` could win the
+    // race against the `line` listener — turning piped passphrases
+    // (`echo secret | remnic ...`) into empty input. Track settled
+    // state explicitly so the first event wins and subsequent events
+    // become no-ops.
+    let settled = false;
+    const settle = (fn: () => void): void => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    rl.on("line", (line) => {
+      settle(() => resolve(line));
       rl.close();
-      resolve(line);
     });
-    rl.once("close", () => {
-      // If close fires before line, the stream ended without a newline.
-      resolve("");
+    rl.on("close", () => {
+      // Stream ended without a newline — only honored if no line was
+      // delivered first.
+      settle(() => resolve(""));
     });
-    rl.once("error", (err) => {
+    rl.on("error", (err) => {
+      settle(() => reject(err));
       rl.close();
-      reject(err);
     });
   });
 }

--- a/packages/remnic-core/src/secure-store/passphrase-reader.ts
+++ b/packages/remnic-core/src/secure-store/passphrase-reader.ts
@@ -1,0 +1,171 @@
+/**
+ * TTY passphrase reader (issue #690 PR 2/4).
+ *
+ * Reads a line from stdin without echoing it back to the terminal.
+ * Disables echo by setting raw mode + manually buffering input until
+ * Enter / EOT.
+ *
+ * Why not `readline.question`?
+ * ----------------------------
+ * `readline` echoes by default and has no clean "no-echo" toggle that
+ * survives across Node versions. The raw-mode loop is the canonical
+ * idiom for reading passwords on Node and matches what `npm` uses
+ * internally.
+ *
+ * Security
+ * --------
+ *   - Never log the passphrase (no `console.log`, no debug output).
+ *   - Never include it in a thrown error message.
+ *   - On Ctrl+C / Ctrl+D, abort with a clear error rather than
+ *     silently treating EOF as an empty submission.
+ *   - On non-TTY stdin (pipe, redirect), read a line via line-buffered
+ *     readline so automation (`echo "passphrase" | remnic ...`) works.
+ *     Operators are responsible for not piping plaintext passphrases
+ *     in shell history; we surface a stderr warning.
+ */
+
+import { createInterface } from "node:readline";
+import type { Readable, Writable } from "node:stream";
+
+import type { PassphraseReader } from "./cli-handlers.js";
+
+export interface CreatePassphraseReaderOptions {
+  input?: Readable;
+  output?: Writable;
+  /** Override stderr for warning surface; defaults to `process.stderr`. */
+  errorStream?: Writable;
+}
+
+/**
+ * Build a `PassphraseReader` bound to the given streams. Exported so
+ * tests can construct one against in-memory streams without touching
+ * the real TTY.
+ */
+export function createPassphraseReader(
+  options: CreatePassphraseReaderOptions = {},
+): PassphraseReader {
+  const input = options.input ?? process.stdin;
+  const output = options.output ?? process.stdout;
+  const errorStream = options.errorStream ?? process.stderr;
+  return async function readPassphrase(
+    prompt: string,
+    readerOptions?: { confirm?: boolean },
+  ): Promise<string> {
+    const first = await readSinglePassphrase(prompt, input, output, errorStream);
+    if (readerOptions?.confirm) {
+      const second = await readSinglePassphrase("Confirm passphrase: ", input, output, errorStream);
+      if (first !== second) {
+        throw new Error("passphrases did not match");
+      }
+    }
+    return first;
+  };
+}
+
+async function readSinglePassphrase(
+  prompt: string,
+  input: Readable,
+  output: Writable,
+  errorStream: Writable,
+): Promise<string> {
+  const inputAsAny = input as Readable & {
+    isTTY?: boolean;
+    setRawMode?: (raw: boolean) => Readable;
+  };
+  if (inputAsAny.isTTY && typeof inputAsAny.setRawMode === "function") {
+    return readNoEcho(prompt, inputAsAny, output);
+  }
+  // Non-TTY: line-buffered fallback via readline. Warn once on stderr
+  // so operators piping plaintext passphrases in shell pipelines are
+  // aware their history may contain the secret.
+  errorStream.write(
+    "[remnic secure-store] warning: stdin is not a TTY; reading passphrase as a plain line. " +
+      "Take care that the passphrase is not exposed in shell history.\n",
+  );
+  output.write(prompt);
+  return readPlainLine(input, output);
+}
+
+function readNoEcho(
+  prompt: string,
+  input: Readable & { setRawMode?: (raw: boolean) => Readable },
+  output: Writable,
+): Promise<string> {
+  return new Promise((resolve, reject) => {
+    output.write(prompt);
+    let buffer = "";
+    let settled = false;
+    const wasRaw = (input as Readable & { isRaw?: boolean }).isRaw === true;
+    if (input.setRawMode) input.setRawMode(true);
+    input.resume();
+    const cleanup = (): void => {
+      input.pause();
+      input.removeListener("data", onData);
+      // Restore the prior raw-mode state so we don't strand the parent shell
+      // in an unexpected configuration.
+      if (input.setRawMode) input.setRawMode(wasRaw);
+      output.write("\n");
+    };
+    const onData = (chunk: Buffer): void => {
+      const str = chunk.toString("utf8");
+      for (const ch of str) {
+        if (settled) return;
+        const code = ch.charCodeAt(0);
+        // Enter / newline: submit.
+        if (ch === "\n" || ch === "\r") {
+          settled = true;
+          cleanup();
+          resolve(buffer);
+          return;
+        }
+        // Ctrl+C: abort.
+        if (code === 0x03) {
+          settled = true;
+          cleanup();
+          reject(new Error("passphrase entry aborted (Ctrl+C)"));
+          return;
+        }
+        // Ctrl+D / EOT: treat as abort if buffer is empty, else submit.
+        if (code === 0x04) {
+          settled = true;
+          cleanup();
+          if (buffer.length === 0) {
+            reject(new Error("passphrase entry aborted (EOF)"));
+          } else {
+            resolve(buffer);
+          }
+          return;
+        }
+        // Backspace / DEL.
+        if (code === 0x08 || code === 0x7f) {
+          if (buffer.length > 0) buffer = buffer.slice(0, -1);
+          continue;
+        }
+        // Ignore other control bytes (escape sequences, etc.).
+        if (code < 0x20) {
+          continue;
+        }
+        buffer += ch;
+      }
+    };
+    input.on("data", onData);
+  });
+}
+
+function readPlainLine(input: Readable, output: Writable): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const rl = createInterface({ input, output, terminal: false });
+    rl.once("line", (line) => {
+      rl.close();
+      resolve(line);
+    });
+    rl.once("close", () => {
+      // If close fires before line, the stream ended without a newline.
+      resolve("");
+    });
+    rl.once("error", (err) => {
+      rl.close();
+      reject(err);
+    });
+  });
+}

--- a/packages/remnic-core/src/secure-store/passphrase-reader.ts
+++ b/packages/remnic-core/src/secure-store/passphrase-reader.ts
@@ -48,43 +48,57 @@ export function createPassphraseReader(
   const input = options.input ?? process.stdin;
   const output = options.output ?? process.stdout;
   const errorStream = options.errorStream ?? process.stderr;
+  // Codex/Cursor on PR #737: a fresh readline interface per call
+  // breaks confirm-mode on piped non-TTY input — the first
+  // `createInterface` consumes the entire prebuffered stream
+  // (including the second line), so the second `createInterface`
+  // sees an already-ended stream and resolves to "". Fix: maintain
+  // ONE non-TTY line reader across both reads of a confirm-mode
+  // session and pull lines on demand from a buffered queue.
+  let nonTtyReader: NonTtyLineReader | null = null;
+  let nonTtyWarned = false;
   return async function readPassphrase(
     prompt: string,
     readerOptions?: { confirm?: boolean },
   ): Promise<string> {
-    const first = await readSinglePassphrase(prompt, input, output, errorStream);
+    const first = await readSinglePassphrase(prompt);
     if (readerOptions?.confirm) {
-      const second = await readSinglePassphrase("Confirm passphrase: ", input, output, errorStream);
+      const second = await readSinglePassphrase("Confirm passphrase: ");
       if (first !== second) {
         throw new Error("passphrases did not match");
       }
     }
     return first;
   };
-}
 
-async function readSinglePassphrase(
-  prompt: string,
-  input: Readable,
-  output: Writable,
-  errorStream: Writable,
-): Promise<string> {
-  const inputAsAny = input as Readable & {
-    isTTY?: boolean;
-    setRawMode?: (raw: boolean) => Readable;
-  };
-  if (inputAsAny.isTTY && typeof inputAsAny.setRawMode === "function") {
-    return readNoEcho(prompt, inputAsAny, output);
+  async function readSinglePassphrase(prompt: string): Promise<string> {
+    const inputAsAny = input as Readable & {
+      isTTY?: boolean;
+      setRawMode?: (raw: boolean) => Readable;
+    };
+    if (inputAsAny.isTTY && typeof inputAsAny.setRawMode === "function") {
+      return readNoEcho(prompt, inputAsAny, output);
+    }
+    // Non-TTY: line-buffered fallback. Warn once per reader so
+    // operators piping plaintext passphrases in shell pipelines are
+    // aware their history may contain the secret.
+    if (!nonTtyWarned) {
+      errorStream.write(
+        "[remnic secure-store] warning: stdin is not a TTY; reading passphrase as a plain line. " +
+          "Take care that the passphrase is not exposed in shell history.\n",
+      );
+      nonTtyWarned = true;
+    }
+    // Codex P1 on PR #737: write the prompt to stderr, not stdout.
+    // When the surrounding command outputs JSON to stdout (e.g.
+    // `remnic secure-store status --json`), injecting prompt text on
+    // stdout corrupts the JSON output and breaks machine consumers.
+    // The prompt is UI noise — it belongs on the error/diagnostics
+    // stream regardless of whether we're in a TTY.
+    errorStream.write(prompt);
+    if (!nonTtyReader) nonTtyReader = createNonTtyLineReader(input);
+    return nonTtyReader.next();
   }
-  // Non-TTY: line-buffered fallback via readline. Warn once on stderr
-  // so operators piping plaintext passphrases in shell pipelines are
-  // aware their history may contain the secret.
-  errorStream.write(
-    "[remnic secure-store] warning: stdin is not a TTY; reading passphrase as a plain line. " +
-      "Take care that the passphrase is not exposed in shell history.\n",
-  );
-  output.write(prompt);
-  return readPlainLine(input, output);
 }
 
 function readNoEcho(
@@ -147,8 +161,17 @@ function readNoEcho(
           return;
         }
         // Backspace / DEL.
+        // Cursor on PR #737: `buffer.slice(0, -1)` deletes one UTF-16
+        // code unit, which splits a surrogate pair when the last
+        // character is a non-BMP code point (emoji, etc.). Fix: count
+        // code points with `Array.from` and remove the last one. This
+        // correctly handles both BMP (single code unit) and non-BMP
+        // (surrogate pair) characters atomically.
         if (code === 0x08 || code === 0x7f) {
-          if (buffer.length > 0) buffer = buffer.slice(0, -1);
+          if (buffer.length > 0) {
+            const codePoints = Array.from(buffer);
+            buffer = codePoints.slice(0, -1).join("");
+          }
           continue;
         }
         // Ignore other control bytes (escape sequences, etc.).
@@ -162,34 +185,68 @@ function readNoEcho(
   });
 }
 
-function readPlainLine(input: Readable, output: Writable): Promise<string> {
-  return new Promise((resolve, reject) => {
-    const rl = createInterface({ input, output, terminal: false });
-    // Codex P1 on PR #737: a previous version called `rl.close()`
-    // before `resolve(line)`, but `close` emits synchronously and a
-    // separate `close` listener that resolved with `""` could win the
-    // race against the `line` listener — turning piped passphrases
-    // (`echo secret | remnic ...`) into empty input. Track settled
-    // state explicitly so the first event wins and subsequent events
-    // become no-ops.
-    let settled = false;
-    const settle = (fn: () => void): void => {
-      if (settled) return;
-      settled = true;
-      fn();
-    };
-    rl.on("line", (line) => {
-      settle(() => resolve(line));
-      rl.close();
-    });
-    rl.on("close", () => {
-      // Stream ended without a newline — only honored if no line was
-      // delivered first.
-      settle(() => resolve(""));
-    });
-    rl.on("error", (err) => {
-      settle(() => reject(err));
-      rl.close();
-    });
+/**
+ * One-shot line reader bound to a non-TTY input stream.
+ *
+ * Cursor medium on PR #737: a previous version constructed a fresh
+ * `readline.createInterface` per `next()` call. On piped non-TTY
+ * input, the first interface consumed the entire prebuffered stream
+ * (including any subsequent lines) into its internal buffer. The
+ * second interface saw an already-`end()`'d input and resolved to "".
+ * Fix: construct ONE readline interface, queue every emitted `line`,
+ * and let `next()` either return a queued line or wait for the next
+ * one. Pending waiters at `close` time are resolved with "" (so an
+ * abandoned-stream caller still sees a clean empty response).
+ */
+interface NonTtyLineReader {
+  next(): Promise<string>;
+}
+
+function createNonTtyLineReader(input: Readable): NonTtyLineReader {
+  const rl = createInterface({ input, terminal: false });
+  const lineQueue: string[] = [];
+  const waiterQueue: Array<(value: string) => void> = [];
+  const errorQueue: Array<(err: Error) => void> = [];
+  let closed = false;
+  let error: Error | null = null;
+
+  rl.on("line", (line: string) => {
+    const waiter = waiterQueue.shift();
+    if (waiter) {
+      waiter(line);
+    } else {
+      lineQueue.push(line);
+    }
   });
+  rl.on("close", () => {
+    closed = true;
+    while (waiterQueue.length > 0) {
+      const w = waiterQueue.shift()!;
+      // Drop the matching error slot since we're settling cleanly.
+      errorQueue.shift();
+      w("");
+    }
+  });
+  rl.on("error", (err: Error) => {
+    error = err;
+    while (errorQueue.length > 0) {
+      const r = errorQueue.shift()!;
+      // Drop the matching value slot.
+      waiterQueue.shift();
+      r(err);
+    }
+  });
+
+  return {
+    next(): Promise<string> {
+      if (error) return Promise.reject(error);
+      const queued = lineQueue.shift();
+      if (queued !== undefined) return Promise.resolve(queued);
+      if (closed) return Promise.resolve("");
+      return new Promise<string>((resolve, reject) => {
+        waiterQueue.push(resolve);
+        errorQueue.push(reject);
+      });
+    },
+  };
 }

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -14,6 +14,7 @@
  * silently regress them.
  */
 
+import { PassThrough } from "node:stream";
 import assert from "node:assert/strict";
 import test from "node:test";
 
@@ -28,6 +29,13 @@ import {
   parseEnvelope,
   seal,
 } from "./cipher.js";
+import {
+  HEADER_FORMAT,
+  HEADER_FORMAT_VERSION,
+  buildHeaderFromPassphrase,
+  parseHeader,
+  validateHeader,
+} from "./header.js";
 import {
   DEFAULT_ARGON2ID_PARAMS,
   DEFAULT_SCRYPT_PARAMS,
@@ -48,6 +56,7 @@ import {
   serializeMetadata,
   validateMetadata,
 } from "./metadata.js";
+import { createPassphraseReader } from "./passphrase-reader.js";
 
 /** Cheap scrypt params for tests — still hex-correct but ~milliseconds. */
 const FAST_SCRYPT: ScryptParams = {
@@ -521,4 +530,184 @@ test("metadata rejects keyLength != 32 (codex P2 — match cipher AES-256)", () 
     () => validateMetadata(meta as unknown as Parameters<typeof validateMetadata>[0]),
     /keyLength must be 32/,
   );
+});
+
+// ─── header.ts — Thread 6: even-length hex verifier (#737) ──────────────
+
+test("parseHeader rejects odd-length verifier hex (thread 6 — even-length guard)", () => {
+  // Build a valid header, then manually patch the verifier to odd length.
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x11);
+  const { header } = buildHeaderFromPassphrase({
+    passphrase: "test-pass",
+    salt,
+    algorithm: "scrypt",
+    params: { N: 1 << 10, r: 8, p: 1, keyLength: 32, maxmem: 64 * 1024 * 1024 },
+  });
+  // Make the verifier odd-length by trimming one hex char.
+  const badJson = JSON.stringify({
+    format: HEADER_FORMAT,
+    formatVersion: HEADER_FORMAT_VERSION,
+    metadata: JSON.parse(
+      JSON.stringify(header.metadata),
+    ),
+    verifier: header.verifier.slice(0, -1), // odd length
+    createdAt: header.createdAt,
+  });
+  assert.throws(
+    () => parseHeader(badJson),
+    /even length|even/i,
+  );
+});
+
+test("validateHeader rejects odd-length verifier hex (thread 6 — even-length guard)", () => {
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x22);
+  const { header } = buildHeaderFromPassphrase({
+    passphrase: "test-pass-2",
+    salt,
+    algorithm: "scrypt",
+    params: { N: 1 << 10, r: 8, p: 1, keyLength: 32, maxmem: 64 * 1024 * 1024 },
+  });
+  const bad = { ...header, verifier: header.verifier.slice(0, -1) }; // odd length
+  assert.throws(
+    () => validateHeader(bad),
+    /even length|even/i,
+  );
+});
+
+test("parseHeader rejects non-hex characters in verifier (thread 6)", () => {
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x33);
+  const { header } = buildHeaderFromPassphrase({
+    passphrase: "test-pass-3",
+    salt,
+    algorithm: "scrypt",
+    params: { N: 1 << 10, r: 8, p: 1, keyLength: 32, maxmem: 64 * 1024 * 1024 },
+  });
+  const badJson = JSON.stringify({
+    format: HEADER_FORMAT,
+    formatVersion: HEADER_FORMAT_VERSION,
+    metadata: JSON.parse(JSON.stringify(header.metadata)),
+    verifier: "zz" + header.verifier.slice(2), // non-hex prefix
+    createdAt: header.createdAt,
+  });
+  assert.throws(
+    () => parseHeader(badJson),
+    /hex/i,
+  );
+});
+
+// ─── passphrase-reader.ts — Thread 5: prompts to stderr (#737) ──────────
+
+test("non-TTY prompt is written to errorStream, not output (thread 5)", async () => {
+  // Build an in-memory PassThrough pair to act as piped stdin.
+  const inputStream = new PassThrough();
+  // Write the passphrase line before creating the reader so the stream
+  // is already buffered and the readline interface drains it immediately.
+  inputStream.end("test-passphrase\n");
+
+  const stdoutChunks: string[] = [];
+  const stderrChunks: string[] = [];
+
+  const fakeOutput = new PassThrough();
+  fakeOutput.on("data", (d: Buffer) => stdoutChunks.push(d.toString()));
+
+  const fakeError = new PassThrough();
+  fakeError.on("data", (d: Buffer) => stderrChunks.push(d.toString()));
+
+  const reader = createPassphraseReader({
+    input: inputStream,
+    output: fakeOutput,
+    errorStream: fakeError,
+  });
+
+  const passphrase = await reader("Enter passphrase: ");
+
+  assert.equal(passphrase, "test-passphrase");
+  // The prompt must appear on stderr, not stdout.
+  const stderr = stderrChunks.join("");
+  const stdout = stdoutChunks.join("");
+  assert.ok(
+    stderr.includes("Enter passphrase: "),
+    `expected prompt on stderr but got: ${JSON.stringify(stderr)}`,
+  );
+  assert.ok(
+    !stdout.includes("Enter passphrase: "),
+    `prompt must not appear on stdout but got: ${JSON.stringify(stdout)}`,
+  );
+});
+
+// ─── passphrase-reader.ts — Thread 7: surrogate-safe backspace (#737) ───
+
+test("backspace removes full non-BMP (emoji) code point atomically (thread 7)", async () => {
+  // Simulate TTY raw-mode input with a PassThrough that claims isTTY.
+  const inputStream = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    isRaw: boolean;
+    setRawMode(raw: boolean): void;
+  };
+  inputStream.isTTY = true;
+  inputStream.isRaw = false;
+  inputStream.setRawMode = (_: boolean): void => {};
+
+  const outputChunks: Buffer[] = [];
+  const fakeOutput = new PassThrough();
+  fakeOutput.on("data", (d: Buffer) => outputChunks.push(d));
+
+  const reader = createPassphraseReader({
+    input: inputStream,
+    output: fakeOutput,
+  });
+
+  const readPromise = reader("Passphrase: ");
+
+  // Type: 'a', then emoji U+1F511 (KEY, encodes as surrogate pair in
+  // UTF-16: 🔑), then backspace (DEL = 0x7f), then Enter.
+  // After the backspace the emoji must be fully removed, leaving just 'a'.
+  // We encode as UTF-8 bytes the way a terminal would send them.
+  const aBytes = Buffer.from("a", "utf8");
+  const emojiBytes = Buffer.from("\u{1F511}", "utf8"); // 4 bytes in UTF-8
+  const delByte = Buffer.from([0x7f]);
+  const enterByte = Buffer.from([0x0d]);
+
+  inputStream.push(aBytes);
+  inputStream.push(emojiBytes);
+  inputStream.push(delByte);
+  inputStream.push(enterByte);
+
+  const result = await readPromise;
+
+  assert.equal(
+    result,
+    "a",
+    `expected 'a' after backspace removed the emoji, but got: ${JSON.stringify(result)}`,
+  );
+});
+
+test("backspace on BMP character removes exactly one character (thread 7 — regression)", async () => {
+  const inputStream = new PassThrough() as PassThrough & {
+    isTTY: boolean;
+    isRaw: boolean;
+    setRawMode(raw: boolean): void;
+  };
+  inputStream.isTTY = true;
+  inputStream.isRaw = false;
+  inputStream.setRawMode = (_: boolean): void => {};
+
+  const fakeOutput = new PassThrough();
+
+  const reader = createPassphraseReader({
+    input: inputStream,
+    output: fakeOutput,
+  });
+
+  const readPromise = reader("Passphrase: ");
+
+  // Type 'abc', backspace twice, then Enter — should yield 'a'.
+  inputStream.push(Buffer.from("abc", "utf8"));
+  inputStream.push(Buffer.from([0x7f]));
+  inputStream.push(Buffer.from([0x7f]));
+  inputStream.push(Buffer.from([0x0d]));
+
+  const result = await readPromise;
+
+  assert.equal(result, "a");
 });

--- a/src/secure-store/index.ts
+++ b/src/secure-store/index.ts
@@ -1,0 +1,9 @@
+// Stub re-export so tests + downstream consumers can resolve the
+// secure-store surface via the conventional `src/` root used elsewhere
+// in this monorepo. Mirrors the pattern in `src/cli.ts`,
+// `src/access-cli.ts`, etc.
+export * from "../../packages/remnic-core/src/secure-store/index.js";
+// `export *` does NOT re-export namespace bindings (`export * as
+// keyring from ...`). Re-export those explicitly so the test surface
+// matches the package surface.
+export { keyring } from "../../packages/remnic-core/src/secure-store/index.js";

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -467,3 +467,36 @@ test("readHeader rejects a tampered header file", async () => {
     await assert.rejects(readHeader(memoryDir), /not valid JSON/);
   });
 });
+
+// ─── concurrent writeHeader: exactly one wins ────────────────────────
+
+test("concurrent writeHeader calls — exactly one succeeds, the rest get EEXIST", async () => {
+  // Codex P1 on PR #737: the previous read-then-write existence check
+  // was a check-then-act race. With the `wx` flag, the OS guarantees
+  // exactly one writer succeeds even when multiple inits are in
+  // flight simultaneously.
+  await withTmpMemoryDir(async (memoryDir) => {
+    const builds = Array.from({ length: 5 }, () =>
+      buildHeaderFromPassphrase({
+        passphrase: TEST_PASSPHRASE,
+        salt: generateSalt(),
+        algorithm: "scrypt",
+        params: FAST_SCRYPT,
+      }),
+    );
+    const results = await Promise.allSettled(
+      builds.map((b) => writeHeader(memoryDir, b.header)),
+    );
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    assert.equal(fulfilled.length, 1, "exactly one writer should succeed");
+    assert.equal(rejected.length, builds.length - 1);
+    for (const r of rejected) {
+      assert.match(
+        (r as PromiseRejectedResult).reason.message,
+        /Refusing to overwrite/,
+      );
+    }
+    for (const b of builds) b.derivedKey.fill(0);
+  });
+});

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -12,12 +12,14 @@ import assert from "node:assert/strict";
 import path from "node:path";
 import os from "node:os";
 import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { PassThrough } from "node:stream";
 
 import {
   HEADER_FILENAME,
   MIN_PASSPHRASE_LENGTH,
   SECURE_STORE_DIR_NAME,
   buildHeader,
+  createPassphraseReader,
   generateSalt,
   headerPath,
   keyring,
@@ -469,6 +471,54 @@ test("readHeader rejects a tampered header file", async () => {
 });
 
 // ─── concurrent writeHeader: exactly one wins ────────────────────────
+
+// ─── passphrase reader: piped (non-TTY) input round-trips ────────────
+
+test("createPassphraseReader: piped non-TTY input returns the supplied line", async () => {
+  // Codex P1 on PR #737: a previous version of `readPlainLine`
+  // could resolve the promise with "" because rl.close() emits
+  // synchronously and the close handler raced the line handler.
+  // This test asserts a piped passphrase survives intact.
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const errorStream = new PassThrough();
+  // Drain output / errorStream so writes don't backpressure the test.
+  output.on("data", () => {});
+  errorStream.on("data", () => {});
+  const reader = createPassphraseReader({ input, output, errorStream });
+  const promise = reader("Enter passphrase: ");
+  input.write("supplied-secret\n");
+  input.end();
+  const result = await promise;
+  assert.equal(result, "supplied-secret");
+});
+
+test("createPassphraseReader: confirm mode mismatches throw a clear error", async () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const errorStream = new PassThrough();
+  output.on("data", () => {});
+  errorStream.on("data", () => {});
+  const reader = createPassphraseReader({ input, output, errorStream });
+  const promise = reader("Enter passphrase: ", { confirm: true });
+  input.write("first-line\n");
+  input.write("different-confirm\n");
+  input.end();
+  await assert.rejects(promise, /did not match/);
+});
+
+test("createPassphraseReader: empty stream resolves to empty string (status-only path)", async () => {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const errorStream = new PassThrough();
+  output.on("data", () => {});
+  errorStream.on("data", () => {});
+  const reader = createPassphraseReader({ input, output, errorStream });
+  const promise = reader("Enter passphrase: ");
+  input.end();
+  const result = await promise;
+  assert.equal(result, "");
+});
 
 test("concurrent writeHeader calls — exactly one succeeds, the rest get EEXIST", async () => {
   // Codex P1 on PR #737: the previous read-then-write existence check

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -493,6 +493,27 @@ test("createPassphraseReader: piped non-TTY input returns the supplied line", as
   assert.equal(result, "supplied-secret");
 });
 
+test("createPassphraseReader: confirm mode preserves both lines on piped non-TTY input", async () => {
+  // Cursor medium on PR #737: a fresh readline per call breaks
+  // confirm-mode because the first interface consumes the entire
+  // prebuffered stream. With the queued line reader, both lines
+  // survive intact even when written together before the first read.
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const errorStream = new PassThrough();
+  output.on("data", () => {});
+  errorStream.on("data", () => {});
+  const reader = createPassphraseReader({ input, output, errorStream });
+  const promise = reader("Enter passphrase: ", { confirm: true });
+  // Both lines arrive in a single contiguous write — the worst case
+  // for the previous bug. Even after `end()` the queue should hand
+  // out both lines in order.
+  input.write("matching-secret\nmatching-secret\n");
+  input.end();
+  const result = await promise;
+  assert.equal(result, "matching-secret");
+});
+
 test("createPassphraseReader: confirm mode mismatches throw a clear error", async () => {
   const input = new PassThrough();
   const output = new PassThrough();

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -1,0 +1,469 @@
+/**
+ * Tests for the `remnic secure-store {init,unlock,lock,status}` CLI
+ * handlers (issue #690 PR 2/4).
+ *
+ * These tests drive the pure handler functions directly with an
+ * injected passphrase reader and a low-cost scrypt parameter set so
+ * the suite stays fast on CI.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+
+import {
+  HEADER_FILENAME,
+  MIN_PASSPHRASE_LENGTH,
+  SECURE_STORE_DIR_NAME,
+  buildHeader,
+  generateSalt,
+  headerPath,
+  keyring,
+  parseHeader,
+  readHeader,
+  runSecureStoreInit,
+  runSecureStoreLock,
+  runSecureStoreStatus,
+  runSecureStoreUnlock,
+  secureStoreDir,
+  serializeHeader,
+  validateHeader,
+  verifyKey,
+  writeHeader,
+} from "../src/secure-store/index.js";
+import {
+  buildHeaderFromPassphrase,
+  deriveKeyFromHeader,
+} from "../packages/remnic-core/src/secure-store/header.js";
+import {
+  buildMetadata,
+  type ScryptParams,
+} from "../packages/remnic-core/src/secure-store/metadata.js";
+
+// Low-cost scrypt params: still RFC 7914 valid (N power of 2),
+// derives in <5 ms. Used everywhere the test doesn't specifically
+// exercise default params.
+const FAST_SCRYPT: ScryptParams = {
+  N: 1 << 10, // 2^10 = 1024
+  r: 1,
+  p: 1,
+  keyLength: 32,
+  maxmem: 32 * 1024 * 1024,
+};
+
+const TEST_PASSPHRASE = "correct horse battery staple";
+const WRONG_PASSPHRASE = "wrong horse battery staple";
+
+function tmpDir(prefix: string): string {
+  return path.join(
+    os.tmpdir(),
+    `${prefix}-${Date.now()}-${Math.random().toString(16).slice(2)}`,
+  );
+}
+
+function staticPassphraseReader(...sequence: string[]): {
+  reader: (prompt: string, options?: { confirm?: boolean }) => Promise<string>;
+  callCount: () => number;
+} {
+  let i = 0;
+  const reader = async (
+    _prompt: string,
+    options?: { confirm?: boolean },
+  ): Promise<string> => {
+    const value = sequence[i++];
+    if (value === undefined) {
+      throw new Error(`passphrase reader called more times than sequence length (${sequence.length})`);
+    }
+    if (options?.confirm) {
+      const confirm = sequence[i++];
+      if (confirm === undefined) {
+        throw new Error("passphrase reader: missing confirm value in sequence");
+      }
+      if (confirm !== value) {
+        throw new Error("passphrases did not match");
+      }
+    }
+    return value;
+  };
+  return { reader, callCount: () => i };
+}
+
+async function withTmpMemoryDir(
+  body: (memoryDir: string, keyringId: string) => Promise<void>,
+): Promise<void> {
+  const memoryDir = tmpDir("secure-store-cli");
+  const keyringId = memoryDir; // unique per test
+  await mkdir(memoryDir, { recursive: true });
+  try {
+    await body(memoryDir, keyringId);
+  } finally {
+    keyring.lock(keyringId);
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+}
+
+// ─── status before init ──────────────────────────────────────────────
+
+test("status before init reports not-initialized + locked", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const report = await runSecureStoreStatus({ memoryDir, keyringId });
+    assert.equal(report.initialized, false);
+    assert.equal(report.locked, true);
+    assert.equal(report.unlockedAt, null);
+    assert.equal(report.kdf, null);
+    assert.equal(report.createdAt, null);
+    assert.equal(
+      report.headerPath,
+      path.join(memoryDir, SECURE_STORE_DIR_NAME, HEADER_FILENAME),
+    );
+  });
+});
+
+// ─── init creates header with valid KDF metadata ─────────────────────
+
+test("init writes a header with the chosen scrypt params and a sealed verifier", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const { reader } = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    const report = await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: reader,
+      params: FAST_SCRYPT,
+      note: "test-init",
+    });
+    assert.equal(report.ok, true);
+    assert.equal(report.kdf.algorithm, "scrypt");
+    if (report.kdf.algorithm === "scrypt") {
+      assert.equal(report.kdf.params.N, FAST_SCRYPT.N);
+      assert.equal(report.kdf.params.r, FAST_SCRYPT.r);
+    }
+    assert.match(report.headerPath, /\.secure-store\/header\.json$/);
+    // Header file landed on disk and round-trips through parse.
+    const raw = await readFile(report.headerPath, "utf8");
+    const header = parseHeader(raw);
+    assert.equal(header.metadata.note, "test-init");
+    // Init does NOT auto-unlock.
+    const status = keyring.status(keyringId);
+    assert.equal(status.unlocked, false);
+  });
+});
+
+test("init refuses to overwrite an existing header", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const first = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: first.reader,
+      params: FAST_SCRYPT,
+    });
+    const second = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await assert.rejects(
+      runSecureStoreInit({
+        memoryDir,
+        keyringId,
+        readPassphrase: second.reader,
+        params: FAST_SCRYPT,
+      }),
+      /already exists/,
+    );
+    // Bonus: passphrase reader should never have been called for the
+    // second attempt — early existence-check rejects before KDF.
+    assert.equal(second.callCount(), 0);
+  });
+});
+
+test("init rejects passphrases shorter than the minimum length", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const short = "a".repeat(MIN_PASSPHRASE_LENGTH - 1);
+    const { reader } = staticPassphraseReader(short, short);
+    await assert.rejects(
+      runSecureStoreInit({
+        memoryDir,
+        keyringId,
+        readPassphrase: reader,
+        params: FAST_SCRYPT,
+      }),
+      /at least .* characters/,
+    );
+    // Header must NOT have been written.
+    const exists = await readFile(headerPath(memoryDir), "utf8").catch(() => null);
+    assert.equal(exists, null);
+  });
+});
+
+test("init surfaces a passphrase-mismatch error from the reader", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const { reader } = staticPassphraseReader(TEST_PASSPHRASE, "different one");
+    await assert.rejects(
+      runSecureStoreInit({
+        memoryDir,
+        keyringId,
+        readPassphrase: reader,
+        params: FAST_SCRYPT,
+      }),
+      /did not match/,
+    );
+  });
+});
+
+// ─── unlock ──────────────────────────────────────────────────────────
+
+test("unlock with the correct passphrase registers the key in the keyring", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      params: FAST_SCRYPT,
+    });
+    assert.equal(keyring.status(keyringId).unlocked, false);
+
+    const unlock = staticPassphraseReader(TEST_PASSPHRASE);
+    const report = await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: unlock.reader,
+    });
+    assert.equal(report.ok, true);
+    if (report.ok) {
+      assert.equal(report.algorithm, "scrypt");
+      assert.match(report.unlockedAt, /^\d{4}-\d{2}-\d{2}T/);
+    }
+    const ks = keyring.status(keyringId);
+    assert.equal(ks.unlocked, true);
+    assert.notEqual(ks.unlockedAt, null);
+  });
+});
+
+test("unlock with the wrong passphrase fails cleanly and leaves the keyring locked", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      params: FAST_SCRYPT,
+    });
+
+    const unlock = staticPassphraseReader(WRONG_PASSPHRASE);
+    const report = await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: unlock.reader,
+    });
+    assert.equal(report.ok, false);
+    if (!report.ok) {
+      assert.equal(report.reason, "wrong-passphrase");
+    }
+    assert.equal(keyring.status(keyringId).unlocked, false);
+  });
+});
+
+test("unlock against a non-initialized memoryDir reports not-initialized", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const { reader } = staticPassphraseReader(TEST_PASSPHRASE);
+    const report = await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: reader,
+    });
+    assert.equal(report.ok, false);
+    if (!report.ok) {
+      assert.equal(report.reason, "not-initialized");
+    }
+  });
+});
+
+// ─── lock ────────────────────────────────────────────────────────────
+
+test("lock clears the in-memory key and is idempotent", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      params: FAST_SCRYPT,
+    });
+    const unlock = staticPassphraseReader(TEST_PASSPHRASE);
+    await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: unlock.reader,
+    });
+    assert.equal(keyring.status(keyringId).unlocked, true);
+
+    const first = runSecureStoreLock({ memoryDir, keyringId });
+    assert.deepEqual(first, { ok: true, cleared: true });
+    assert.equal(keyring.status(keyringId).unlocked, false);
+
+    // Idempotent: a second lock succeeds with `cleared: false`.
+    const second = runSecureStoreLock({ memoryDir, keyringId });
+    assert.deepEqual(second, { ok: true, cleared: false });
+  });
+});
+
+// ─── status (initialized) ────────────────────────────────────────────
+
+test("status after init reports initialized + locked + KDF params", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      params: FAST_SCRYPT,
+    });
+    const report = await runSecureStoreStatus({ memoryDir, keyringId });
+    assert.equal(report.initialized, true);
+    assert.equal(report.locked, true);
+    assert.equal(report.unlockedAt, null);
+    assert.ok(report.kdf);
+    assert.equal(report.kdf!.algorithm, "scrypt");
+    assert.match(report.createdAt!, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+test("status after unlock reports unlocked + last-unlock timestamp", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      params: FAST_SCRYPT,
+    });
+    const unlock = staticPassphraseReader(TEST_PASSPHRASE);
+    await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: unlock.reader,
+    });
+    const report = await runSecureStoreStatus({ memoryDir, keyringId });
+    assert.equal(report.initialized, true);
+    assert.equal(report.locked, false);
+    assert.notEqual(report.unlockedAt, null);
+    assert.match(report.unlockedAt!, /^\d{4}-\d{2}-\d{2}T/);
+  });
+});
+
+// ─── header round-trip ───────────────────────────────────────────────
+
+test("header serializes + parses via the public surface", async () => {
+  const salt = generateSalt();
+  const built = buildHeaderFromPassphrase({
+    passphrase: TEST_PASSPHRASE,
+    salt,
+    algorithm: "scrypt",
+    params: FAST_SCRYPT,
+  });
+  validateHeader(built.header);
+  const json = serializeHeader(built.header);
+  const parsed = parseHeader(json);
+  assert.deepEqual(parsed.metadata.kdf, built.header.metadata.kdf);
+  assert.equal(parsed.verifier, built.header.verifier);
+  assert.equal(parsed.createdAt, built.header.createdAt);
+  // Re-derive the key from the parsed header and verify the verifier opens.
+  const reDerived = deriveKeyFromHeader(parsed, TEST_PASSPHRASE);
+  assert.equal(verifyKey(parsed, reDerived), true);
+  built.derivedKey.fill(0);
+  reDerived.fill(0);
+});
+
+test("verifyKey rejects a key derived from the wrong passphrase", () => {
+  const salt = generateSalt();
+  const metadata = buildMetadata({ algorithm: "scrypt", salt, params: FAST_SCRYPT });
+  // Build the header under TEST_PASSPHRASE, then attempt to verify
+  // with a key derived from WRONG_PASSPHRASE.
+  const built = buildHeaderFromPassphrase({
+    passphrase: TEST_PASSPHRASE,
+    salt,
+    algorithm: "scrypt",
+    params: FAST_SCRYPT,
+  });
+  const wrong = deriveKeyFromHeader(
+    { ...built.header, metadata },
+    WRONG_PASSPHRASE,
+  );
+  assert.equal(verifyKey(built.header, wrong), false);
+  built.derivedKey.fill(0);
+  wrong.fill(0);
+});
+
+// ─── writeHeader atomicity / refusal ──────────────────────────────────
+
+test("writeHeader refuses to overwrite and never deletes the existing file", async () => {
+  await withTmpMemoryDir(async (memoryDir) => {
+    const salt = generateSalt();
+    const built = buildHeaderFromPassphrase({
+      passphrase: TEST_PASSPHRASE,
+      salt,
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const written = await writeHeader(memoryDir, built.header);
+    const before = await readFile(written, "utf8");
+    // Build a different header under a different passphrase; expect refusal.
+    const built2 = buildHeaderFromPassphrase({
+      passphrase: "another passphrase value",
+      salt: generateSalt(),
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    await assert.rejects(writeHeader(memoryDir, built2.header), /Refusing to overwrite/);
+    const after = await readFile(written, "utf8");
+    assert.equal(after, before);
+    built.derivedKey.fill(0);
+    built2.derivedKey.fill(0);
+  });
+});
+
+// ─── parseHeader strictness ───────────────────────────────────────────
+
+test("parseHeader rejects malformed JSON, wrong format string, and tampered verifier", () => {
+  // Invalid JSON.
+  assert.throws(() => parseHeader("{not json"), /not valid JSON/);
+  // Wrong format string.
+  const ok = buildHeader({
+    metadata: buildMetadata({ algorithm: "scrypt", salt: generateSalt(), params: FAST_SCRYPT }),
+    derivedKey: Buffer.alloc(32, 0xab),
+  });
+  const json = serializeHeader(ok);
+  const tampered = JSON.parse(json) as Record<string, unknown>;
+  tampered.format = "remnic.something-else";
+  assert.throws(() => parseHeader(JSON.stringify(tampered)), /unexpected header format/);
+  // Non-hex verifier.
+  const tampered2 = JSON.parse(json) as Record<string, unknown>;
+  tampered2.verifier = "not-hex!!";
+  assert.throws(() => parseHeader(JSON.stringify(tampered2)), /hex/i);
+});
+
+// ─── readHeader returns null for missing dirs ─────────────────────────
+
+test("readHeader returns null when no header exists", async () => {
+  await withTmpMemoryDir(async (memoryDir) => {
+    const result = await readHeader(memoryDir);
+    assert.equal(result, null);
+  });
+});
+
+test("secureStoreDir + headerPath honor memoryDir", () => {
+  const root = "/tmp/example";
+  assert.equal(secureStoreDir(root), path.join(root, SECURE_STORE_DIR_NAME));
+  assert.equal(headerPath(root), path.join(root, SECURE_STORE_DIR_NAME, HEADER_FILENAME));
+});
+
+// ─── pre-existing tampered header on disk is rejected by readHeader ──
+
+test("readHeader rejects a tampered header file", async () => {
+  await withTmpMemoryDir(async (memoryDir) => {
+    const dir = secureStoreDir(memoryDir);
+    await mkdir(dir, { recursive: true });
+    await writeFile(path.join(dir, HEADER_FILENAME), "not json", "utf8");
+    await assert.rejects(readHeader(memoryDir), /not valid JSON/);
+  });
+});


### PR DESCRIPTION
## Summary

Wires the operator-facing surface around the secure-store encryption primitives shipped in PR 1/4 (#718). PR 1/4 was pure scrypt + AES-256-GCM + metadata; this PR adds:

- An in-memory **daemon-side keyring** keyed by secure-store path (process-local, never persisted, zeroized on lock).
- An on-disk **header file** at `<memoryDir>/.secure-store/header.json` — PR-1/4 metadata block plus a sealed verifier envelope so wrong-passphrase is detected without touching real data.
- Four `remnic engram secure-store …` CLI subcommands: `init`, `unlock`, `lock`, `status`.

Storage integration (PR 3/4) and capsule export `--encrypt` (PR 4/4) build on the keyring registered here.

## What ships

**New modules** (`packages/remnic-core/src/secure-store/`):
- `keyring.ts` — in-memory key map keyed by store path. `lock`/`lockAll` zero key bytes before dropping the reference.
- `header.ts` — header format (metadata + hex-encoded sealed verifier), `buildHeader`/`parseHeader`/`serializeHeader`/`validateHeader`/`verifyKey`/`readHeader`/`writeHeader`. Atomic write-tmp-then-rename per CLAUDE.md gotcha #54. Refuses to overwrite an existing header.
- `cli-handlers.ts` — pure handlers: `runSecureStoreInit`, `runSecureStoreUnlock`, `runSecureStoreLock`, `runSecureStoreStatus`. Each takes an injectable passphrase reader and returns a typed report. Never logs secrets. `init` does NOT auto-unlock (operator must run `unlock` separately).
- `cli-renderer.ts` — text renderers shared by CLI / future surfaces (gotcha #22 — one formatter, not three).
- `passphrase-reader.ts` — TTY no-echo reader via raw mode with Ctrl+C / Ctrl+D handling and a non-TTY readline fallback that warns once on stderr.

**CLI registration** in `packages/remnic-core/src/cli.ts`:
- `engram secure-store init [--note <text>] [--json]`
- `engram secure-store unlock [--json]`
- `engram secure-store lock [--json]`
- `engram secure-store status [--json]`

Lazy-imported so non-secure-store CLI paths pay zero startup cost.

**Tests** (`tests/cli-secure-store.test.ts`, 18 cases, ~390 ms with `FAST_SCRYPT` params):
- status before init reports not-initialized + locked
- init writes a header with the chosen scrypt params + sealed verifier
- init refuses to overwrite an existing header (and short-circuits before invoking the passphrase reader)
- init rejects passphrases shorter than `MIN_PASSPHRASE_LENGTH` (8)
- init surfaces a passphrase-mismatch error from the reader
- unlock with the correct passphrase registers the key in the keyring
- unlock with the wrong passphrase fails cleanly + leaves locked
- unlock against a non-initialized memoryDir reports not-initialized
- lock clears the key and is idempotent
- status after init / after unlock reports correct state
- header serializes + parses + round-trips via the public surface
- verifyKey rejects keys derived from the wrong passphrase
- writeHeader refuses to overwrite + leaves the existing file intact
- parseHeader rejects malformed JSON, wrong format string, tampered verifier
- readHeader returns null when no header exists / rejects tampered files

## Notable invariants

- Init does NOT auto-unlock — keeps `init` safe to run from automation that should never hold the master key.
- The verifier is a fixed magic string sealed under the derived key. Its plaintext never appears on disk; the auth-tag check is what proves the passphrase.
- Wrong-passphrase / not-initialized / tampered-header are all distinct report shapes, not a single boolean (CLAUDE.md gotcha #34).
- Header file is written 0o600 + atomically (write-tmp + rename, gotcha #54). Existing-header check happens *before* KDF work so refusing-to-overwrite is fast.
- All passphrase paths are injectable for tests; the production reader uses raw-mode no-echo with Ctrl+C/Ctrl+D handling and restores the prior raw-mode state on cleanup.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx tsx --test tests/cli-secure-store.test.ts` — 18/18 pass
- [x] PR 1/4 primitives test (`packages/remnic-core/src/secure-store/secure-store.test.ts`) — 45/45 still pass
- [x] `bash scripts/check-review-patterns.sh` — no new pattern issues
- [ ] CI green
- [ ] Codex + cursor + AI reviewers green

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new at-rest encryption operational flows (passphrase input, key derivation, key lifetime/zeroization, and on-disk header writes), so bugs could lead to lockouts or inadvertent key exposure despite safeguards and tests.
> 
> **Overview**
> Adds a new `remnic secure-store` CLI surface with `init`, `unlock`, `lock`, and `status` commands (plus `--json` output) to manage at-rest encryption state for a memory directory.
> 
> Introduces a persistent `.secure-store/header.json` header (metadata + AES-GCM verifier) with strict parsing/validation and atomic exclusive-create semantics, plus a process-local in-memory keyring to hold/zeroize derived master keys on lock.
> 
> Includes a no-echo TTY/non-TTY passphrase reader (prompts/warnings to stderr to avoid corrupting JSON output), text renderers for human output, expanded exports, and comprehensive unit tests covering header integrity, concurrent init/write behavior, passphrase handling, and keyring state transitions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e9f107a609756110210f25fddbf0e4285a45197. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->