### PR TITLE
fix(access): graph snapshot symlink-bypass guard (#691 follow-up)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -3864,6 +3864,12 @@ export class EngramAccessService {
         );
         return null;
       }
+      // Both `canonical` (realpath of candidate) and `namespaceRootReal`
+      // (realpath of storage.dir) are fully resolved here, so the
+      // containment check above is comparing apples-to-apples even when
+      // storage.dir (= storage.baseDir) is itself a symlink to the real
+      // directory.  Pass `canonical` — not the pre-realpath `candidate` —
+      // so the storage read also uses the stable real path.
       const memory = await storage.readMemoryByPath(canonical);
       if (!memory) return null;
       const fm = memory.frontmatter;
@@ -3873,8 +3879,13 @@ export class EngramAccessService {
         updated: fm.updated,
       };
     };
+    // Use the realpath-resolved namespace root for the edge-file read so
+    // the JSONL location is stable whether storage.dir is a direct path
+    // or a symlink.  namespaceRootReal was computed via `fs.realpath`
+    // above; using it here keeps both the graph-file I/O and the loadNode
+    // containment check on the same resolved base path.
     return buildGraphSnapshot({
-      memoryDir: storage.dir,
+      memoryDir: namespaceRootReal,
       graphConfig: {
         entityGraphEnabled: cfg.entityGraphEnabled === true,
         timeGraphEnabled: cfg.timeGraphEnabled === true,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1,4 +1,5 @@
 import { stat } from "node:fs/promises";
+import * as nodeFs from "node:fs/promises";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
@@ -3790,29 +3791,48 @@ export class EngramAccessService {
     );
     const storage = await this.orchestrator.getStorage(namespace);
     const cfg = this.orchestrator.config;
-    // Canonicalize the storage root once so the path-traversal guard below
-    // can compare resolved absolute paths.  This is required because
+    // Canonicalize the storage root once — through `realpath` so that any
+    // symlink in the namespace root path itself is resolved before we
+    // compare children against it.  This is required because
     // `GraphEdge.from` / `to` are JSONL-parsed strings — a malformed edge
-    // with an absolute path or a `..` segment would otherwise read a
-    // memory file from outside the resolved namespace, leaking metadata
-    // across tenants (codex P1 on PR #734; CLAUDE.md rule 42).
-    const namespaceRoot = nodePath.resolve(storage.dir);
-    const namespaceRootWithSep = namespaceRoot.endsWith(nodePath.sep)
-      ? namespaceRoot
-      : namespaceRoot + nodePath.sep;
+    // with an absolute path, a `..` segment, OR a symlink that resolves
+    // to a file outside the namespace would otherwise read a memory file
+    // from a peer namespace, leaking metadata across tenants
+    // (codex P1 + follow-up on PR #734; CLAUDE.md rule 42).
+    let namespaceRootReal: string;
+    try {
+      namespaceRootReal = await nodeFs.realpath(storage.dir);
+    } catch {
+      // If the namespace root itself doesn't exist on disk yet (fresh
+      // install with no memories), fall back to the lexical resolve so
+      // the snapshot can still return an empty result rather than
+      // throwing.  No symlink can resolve through a missing path, so
+      // this fallback is safe — every candidate we see will fail the
+      // realpath step below and surface as `null`.
+      namespaceRootReal = nodePath.resolve(storage.dir);
+    }
+    const namespaceRootWithSep = namespaceRootReal.endsWith(nodePath.sep)
+      ? namespaceRootReal
+      : namespaceRootReal + nodePath.sep;
     const loadNode = async (relPath: string): Promise<GraphSnapshotNodeMetadata | null> => {
       // `GraphEdge.from` / `to` are storage-relative paths; resolve against
       // the namespaced storage root so the metadata read honors namespace
       // boundaries even when the same memory id exists in multiple
       // namespaces.
       //
-      // Reject absolute paths and `..` traversals up front rather than
-      // letting them silently escape the namespace root.  We compare the
-      // *canonicalized* absolute path against the namespace prefix so
-      // symlinks / mixed separators / `.` segments can't sneak past.
-      // Bad paths log a warning with a redacted form (length only — never
-      // echo the offending segments back into logs, which themselves cross
-      // namespace boundaries) and fall through to a `null` metadata result.
+      // Three-stage guard:
+      //   1. Reject absolute paths up front — only relative endpoints are
+      //      ever produced by the writer, so anything else is malformed.
+      //   2. Lexical containment check on the resolved path.  This catches
+      //      `..` traversals before we touch the filesystem.
+      //   3. `fs.realpath` containment check — resolves symlinks so an
+      //      in-namespace path that *points* at an out-of-namespace file
+      //      is still rejected.  Without this step a symlinked endpoint
+      //      could leak a peer namespace's frontmatter.
+      // Bad paths surface a length-only warning (never echo the offending
+      // segments — those would themselves cross namespace boundaries
+      // through the log surface) and fall through to a `null` metadata
+      // result.
       if (nodePath.isAbsolute(relPath)) {
         log.warn(
           `graphSnapshot: rejected absolute edge endpoint (len=${relPath.length}) `
@@ -3820,20 +3840,36 @@ export class EngramAccessService {
         );
         return null;
       }
-      const candidate = nodePath.resolve(namespaceRoot, relPath);
-      if (candidate !== namespaceRoot && !candidate.startsWith(namespaceRootWithSep)) {
+      const candidate = nodePath.resolve(namespaceRootReal, relPath);
+      if (candidate !== namespaceRootReal && !candidate.startsWith(namespaceRootWithSep)) {
         log.warn(
           `graphSnapshot: rejected traversing edge endpoint (len=${relPath.length}) `
           + `outside namespace root`,
         );
         return null;
       }
-      const memory = await storage.readMemoryByPath(candidate);
+      let canonical: string;
+      try {
+        canonical = await nodeFs.realpath(candidate);
+      } catch {
+        // Missing file — `readMemoryByPath` will return null too.  We
+        // intentionally still call it so callers see a consistent
+        // "unknown" result rather than special-casing missing edges.
+        canonical = candidate;
+      }
+      if (canonical !== namespaceRootReal && !canonical.startsWith(namespaceRootWithSep)) {
+        log.warn(
+          `graphSnapshot: rejected symlinked edge endpoint (len=${relPath.length}) `
+          + `that resolved outside namespace root`,
+        );
+        return null;
+      }
+      const memory = await storage.readMemoryByPath(canonical);
       if (!memory) return null;
       const fm = memory.frontmatter;
       return {
         category: fm.category ?? "unknown",
-        label: fm.id ?? nodePath.basename(candidate, nodePath.extname(candidate)),
+        label: fm.id ?? nodePath.basename(canonical, nodePath.extname(canonical)),
         updated: fm.updated,
       };
     };

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -13,7 +13,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import * as path from "node:path";
-import { mkdtemp, mkdir, writeFile, rm } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, symlink } from "node:fs/promises";
 
 import { EngramAccessHttpServer } from "../src/access-http.js";
 import type { EngramAccessService } from "../src/access-service.js";
@@ -994,4 +994,87 @@ test(
   },
 );
 
+test(
+  "graphSnapshot loads valid in-namespace files when baseDir is itself a symlink",
+  async () => {
+    // Regression for the Cursor thread PRRT_kwDORJXyws59rLFq on PR #738:
+    // if storage.baseDir is a symlink to a real directory, the realpath
+    // containment check must compare the realpath of the candidate against
+    // the realpath of baseDir — not the raw symlink path.  Without
+    // realpath-resolving both sides, a legitimate in-namespace file whose
+    // canonical path starts with the *real* directory prefix (not the
+    // symlink prefix) would fail the startsWith check and be rejected.
+    //
+    // This test creates:
+    //   root/real-ns/       — the actual memory directory on disk
+    //   root/link-ns  → root/real-ns  — symlink used as storage.baseDir
+    //
+    // Files are seeded into root/real-ns (via the symlink) and the service
+    // is constructed with link-ns as memoryDir.  The snapshot must resolve
+    // and return metadata for the valid files rather than treating them as
+    // out-of-namespace.
+    const root = await mkdtemp(path.join(os.tmpdir(), "engram-gs-baselink-"));
+    try {
+      const realNs = path.join(root, "real-ns");
+      const linkNs = path.join(root, "link-ns");
+      await mkdir(path.join(realNs, "facts", "2026-04-20"), { recursive: true });
+      // Create the symlink: link-ns → real-ns
+      await symlink(realNs, linkNs);
 
+      // Seed a valid memory file inside real-ns.
+      await writeFile(
+        path.join(realNs, "facts", "2026-04-20", "alpha.md"),
+        "---\nid: alpha\ncategory: fact\nupdated: 2026-04-20T12:00:00.000Z\n---\nalpha content\n",
+        "utf-8",
+      );
+
+      // Seed an edge using the symlink path as memoryDir.
+      // appendEdge writes to link-ns/.engram-graphs/entity.jsonl which
+      // resolves (via the symlink) to real-ns/.engram-graphs/entity.jsonl.
+      await appendEdge(linkNs, {
+        from: "facts/2026-04-20/alpha.md",
+        to: "facts/2026-04-20/alpha.md",
+        type: "entity",
+        weight: 1.0,
+        label: "self",
+        ts: "2026-04-20T12:00:00.000Z",
+      });
+
+      // Build the service with the *symlink* path as memoryDir.
+      const { service, readsByPath } = buildSnapshotService(linkNs);
+      const snapshot = await service.graphSnapshot({});
+
+      // The edge must survive (not be dropped as out-of-namespace).
+      assert.equal(snapshot.edges.length, 1, "edge should not be filtered out");
+
+      // The alpha node must surface and carry its loaded metadata (not fall
+      // back to kind:"unknown", which would indicate the loader returned null).
+      const alpha = snapshot.nodes.find((n) => n.id === "facts/2026-04-20/alpha.md");
+      assert.ok(alpha, "alpha node should be present in snapshot");
+      assert.notEqual(
+        alpha!.kind,
+        "unknown",
+        "symlinked baseDir must not cause in-namespace files to be rejected",
+      );
+
+      // At least one storage read must have been attempted for the alpha path.
+      assert.ok(
+        readsByPath.some((p) => p.endsWith(path.join("facts", "2026-04-20", "alpha.md"))),
+        `expected alpha.md read; got: ${readsByPath.join(",")}`,
+      );
+
+      // All storage reads must remain within the real namespace root.
+      const fs = await import("node:fs/promises");
+      const realRoot = await fs.realpath(linkNs);
+      const realRootWithSep = realRoot.endsWith(path.sep) ? realRoot : realRoot + path.sep;
+      for (const p of readsByPath) {
+        assert.ok(
+          p === realRoot || p.startsWith(realRootWithSep),
+          `read escaped real namespace root: ${p} (real root: ${realRoot})`,
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);

--- a/tests/graph-snapshot.test.ts
+++ b/tests/graph-snapshot.test.ts
@@ -866,11 +866,19 @@ test(
         readsByPath.some((p) => p.endsWith(path.join("facts", "2026-04-20", "beta.md"))),
         `expected beta.md read, saw ${readsByPath.join(",")}`,
       );
-      // Resolved reads must remain inside the namespace root.
+      // Resolved reads must remain inside the namespace root.  The
+      // access-service loader canonicalizes the namespace root through
+      // `fs.realpath` (issue #691 PR 2/5 follow-up — codex P1 symlink
+      // bypass), so on platforms where the tmpdir is itself a symlink
+      // (macOS resolves `/var/folders/...` → `/private/var/folders/...`)
+      // we have to compare against the realpath form too.
+      const fs = await import("node:fs/promises");
+      const realDir = await fs.realpath(dir);
+      const realDirWithSep = realDir.endsWith(path.sep) ? realDir : realDir + path.sep;
       for (const p of readsByPath) {
         assert.ok(
-          p.startsWith(dir + path.sep) || p === dir,
-          `read path ${p} escaped namespace root ${dir}`,
+          p.startsWith(realDirWithSep) || p === realDir,
+          `read path ${p} escaped namespace root ${realDir}`,
         );
       }
     } finally {
@@ -879,8 +887,111 @@ test(
   },
 );
 
-// Suppress unused-import warning for `mkdir` / `writeFile` (kept for future
-// fixture extensions that exercise the orchestrator-backed loader).
-void mkdir;
-void writeFile;
+test(
+  "graphSnapshot loader rejects symlinked endpoints that escape the namespace",
+  async () => {
+    // Regression for the codex P1 follow-up on PR #734 (symlink bypass):
+    // the lexical containment check is insufficient because an
+    // in-namespace path can be a symlink to an out-of-namespace file.
+    // The loader must canonicalize via `fs.realpath` and reject
+    // resolved paths that escape the namespace root.
+    const root = await mkdtemp(path.join(os.tmpdir(), "engram-graph-snapshot-symlink-"));
+    try {
+      const ns = path.join(root, "ns");
+      const peer = path.join(root, "peer");
+      await mkdir(path.join(ns, "facts", "2026-04-20"), { recursive: true });
+      await mkdir(peer, { recursive: true });
+
+      // Out-of-namespace "secret" memory.
+      const secret = path.join(peer, "secret.md");
+      await writeFile(
+        secret,
+        "---\nid: secret\ncategory: secret\n---\nsecret\n",
+        "utf-8",
+      );
+
+      // In-namespace symlink that points at the secret.  A naive
+      // lexical guard would accept this because the symlink itself
+      // sits under the namespace root.
+      const fs = await import("node:fs/promises");
+      const symlinked = path.join(ns, "facts", "2026-04-20", "alpha.md");
+      await fs.symlink(secret, symlinked);
+
+      // Seed an edge that uses the symlinked path as both endpoints
+      // (a self-loop is enough to exercise the guard).
+      await appendEdge(ns, {
+        from: "facts/2026-04-20/alpha.md",
+        to: "facts/2026-04-20/alpha.md",
+        type: "entity",
+        weight: 1.0,
+        label: "symlink",
+        ts: "2026-04-20T12:00:00.000Z",
+      });
+
+      // Replicate the access-service realpath loader; verify the
+      // symlinked endpoint is rejected.
+      const namespaceRoot = await fs.realpath(ns);
+      const namespaceRootWithSep = namespaceRoot.endsWith(path.sep)
+        ? namespaceRoot
+        : namespaceRoot + path.sep;
+      const readsByPath: string[] = [];
+      const guardedLoader = async (relPath: string) => {
+        if (path.isAbsolute(relPath)) return null;
+        const candidate = path.resolve(namespaceRoot, relPath);
+        if (candidate !== namespaceRoot && !candidate.startsWith(namespaceRootWithSep)) {
+          return null;
+        }
+        let canonical: string;
+        try {
+          canonical = await fs.realpath(candidate);
+        } catch {
+          canonical = candidate;
+        }
+        if (canonical !== namespaceRoot && !canonical.startsWith(namespaceRootWithSep)) {
+          return null;
+        }
+        readsByPath.push(canonical);
+        // Real file read.
+        try {
+          const raw = await fs.readFile(canonical, "utf-8");
+          const m = raw.match(/category:\s*(\w+)/);
+          return {
+            category: m?.[1] ?? "unknown",
+            label: path.basename(canonical, path.extname(canonical)),
+          };
+        } catch {
+          return null;
+        }
+      };
+
+      const snapshot = await buildGraphSnapshot({
+        memoryDir: ns,
+        graphConfig: {
+          entityGraphEnabled: true,
+          timeGraphEnabled: true,
+          causalGraphEnabled: true,
+        },
+        request: {},
+        loadNode: guardedLoader,
+      });
+
+      // The symlinked endpoint surfaces as an orphan node with
+      // `kind: "unknown"` because the realpath check rejected it.
+      const node = snapshot.nodes.find((n) => n.id === "facts/2026-04-20/alpha.md");
+      assert.ok(node, "symlinked node should still surface");
+      assert.equal(node!.kind, "unknown", "symlinked endpoint must NOT load secret metadata");
+
+      // We never read the secret file via the symlink.
+      for (const readPath of readsByPath) {
+        assert.ok(
+          !readPath.includes("secret.md"),
+          `secret file must never be read via symlink: ${readPath}`,
+        );
+      }
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  },
+);
+
 


### PR DESCRIPTION
## Summary

Post-merge P1 follow-up to PR #734 (graph snapshot endpoint). Codex flagged a symlink-bypass in the path-traversal guard a few minutes after #734 merged — the lexical containment check was insufficient because an in-namespace path could be a symlink to an out-of-namespace file. The loader now canonicalizes through `fs.realpath` and rejects resolved paths that escape the namespace root.

## Architecture

Three-stage guard in `EngramAccessService.graphSnapshot` loader:

1. Reject absolute edge endpoints up front — only relative paths are ever produced by the writer.
2. Lexical containment check on `path.resolve(namespaceRoot, relPath)` — catches `..` traversals before touching the filesystem.
3. `fs.realpath` containment check — resolves symlinks so an in-namespace path that *points* at an out-of-namespace file is still rejected.

Bad paths surface a length-only warning (never echo offending segments — those would themselves cross namespace boundaries via the log surface) and fall through to a `null` metadata result.

If the namespace root itself doesn't exist on disk yet (fresh install with no memories), the loader falls back to the lexical resolve so the snapshot can still return an empty result rather than throwing.

## Test plan

- [x] New `graphSnapshot loader rejects symlinked endpoints that escape the namespace` regression: seeds an in-namespace symlink to an out-of-namespace secret memory, asserts the snapshot surfaces the symlinked node with `kind: "unknown"` AND no file read ever follows the symlink.
- [x] Updated `graphSnapshot loads metadata for valid relative subdir paths` to compare reads against the realpath form of the namespace root (macOS resolves `/var/folders/...` → `/private/var/folders/...`).
- [x] `npx tsc --noEmit` clean.
- [x] `npx tsx --test tests/graph-snapshot.test.ts` — 23/23 passing.

## Issue link

Refs #691 (admin pane). Direct follow-up to PR #734.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Tightens path/namespace isolation in the `graphSnapshot` loader by adding `realpath`-based checks, which is security-sensitive but localized and covered by new regression tests.
> 
> **Overview**
> **Hardens `graphSnapshot` namespace isolation** by extending the edge-endpoint path guard to canonicalize both the namespace root and candidate files via `fs.realpath`, rejecting symlinked endpoints that resolve outside the namespace (while still handling missing roots/files gracefully).
> 
> Updates graph snapshot I/O to use the realpath-resolved base directory and adjusts/adds tests to cover the symlink-escape regression, macOS tmpdir realpath differences, and the case where the namespace `baseDir` itself is a symlink.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 650c04249351c102e8fa304994ea0e9abdbd66f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->