### PR TITLE
fix(bench): align MemoryAgentBench official protocol

### DIFF
--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -3,7 +3,7 @@
  */
 
 import { randomUUID } from "node:crypto";
-import { readFile } from "node:fs/promises";
+import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
@@ -25,6 +25,7 @@ import {
   containsAnswer,
   f1Score,
   llmJudgeScoreDetailed,
+  recallAtK,
   rougeL,
   timed,
 } from "../../../scorer.js";
@@ -84,6 +85,23 @@ const DATASET_BUNDLE_CANDIDATES = [
   "MemoryAgentBench.jsonl",
 ] as const;
 
+type MemoryAgentBenchProtocol =
+  | "ruler_qa"
+  | "longmemeval"
+  | "eventqa"
+  | "in_context_learning"
+  | "recsys_redial"
+  | "infbench_sum"
+  | "detective_qa"
+  | "factconsolidation";
+
+interface RecSysEntityMapping {
+  idToName: Map<number, string>;
+  movieCandidates: string[];
+  aliasCounts: Map<string, number>;
+  sourcePath: string;
+}
+
 export const memoryAgentBenchDefinition: BenchmarkDefinition = {
   id: "memoryagentbench",
   title: "MemoryAgentBench",
@@ -105,6 +123,8 @@ export async function runMemoryAgentBenchBenchmark(
   options: ResolvedRunBenchmarkOptions,
 ): Promise<BenchmarkResult> {
   const dataset = await loadDataset(options.mode, options.datasetDir, options.limit);
+  let recsysMappingLoaded = false;
+  let recsysMapping: RecSysEntityMapping | null = null;
   const tasks: TaskResult[] = [];
 
   const totalQuestions = dataset.reduce(
@@ -133,38 +153,94 @@ export async function runMemoryAgentBenchBenchmark(
       const taskResultId =
         item.metadata.qa_pair_ids?.[questionIndex] ??
         `${item.metadata.source}-q${questionIndex}`;
+      let protocol: MemoryAgentBenchProtocol | undefined;
 
       try {
+        protocol = getProtocolForSource(item.metadata.source);
+        const officialQuestion = buildOfficialQuery(protocol, question);
         const { result: recalledText, durationMs } = await timed(async () => {
           const recalledSessions = await Promise.all(
-            sessionIds.map((sessionId) => options.system.recall(sessionId, question)),
+            sessionIds.map((sessionId) =>
+              options.system.recall(sessionId, question),
+            ),
           );
           return recalledSessions.filter(Boolean).join("\n\n");
         });
         const answered = await answerBenchmarkQuestion({
-          question,
+          question: officialQuestion,
           recalledText,
           responder: options.system.responder,
         });
-        const bestExpectedAnswer = selectBestMatchingAnswer(answered.finalAnswer, answerVariants);
+        if (protocol === "recsys_redial" && !recsysMappingLoaded) {
+          recsysMapping = await loadRecSysEntityMapping(options.datasetDir);
+          recsysMappingLoaded = true;
+        }
+        const officialScoring = scoreOfficialProtocol({
+          protocol,
+          actual: answered.finalAnswer,
+          answerVariants,
+          recsysMapping: protocol === "recsys_redial" ? recsysMapping : null,
+        });
+        const bestExpectedAnswer = selectBestMatchingAnswer(
+          officialScoring.parsedAnswer ?? answered.finalAnswer,
+          answerVariants,
+        );
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,
           question,
-          answered.finalAnswer,
+          officialScoring.parsedAnswer ?? answered.finalAnswer,
           bestExpectedAnswer,
         );
 
         const scores: Record<string, number> = {
-          f1: scoreAgainstVariants(answered.finalAnswer, answerVariants, f1Score),
+          f1: scoreAgainstVariants(
+            officialScoring.parsedAnswer ?? answered.finalAnswer,
+            answerVariants,
+            f1Score,
+          ),
           contains_answer: answerVariants.some((variant) =>
-            containsAnswer(answered.finalAnswer, variant),
+            containsAnswer(officialScoring.parsedAnswer ?? answered.finalAnswer, variant),
           )
             ? 1
             : 0,
-          rouge_l: scoreAgainstVariants(answered.finalAnswer, answerVariants, rougeL),
+          rouge_l: scoreAgainstVariants(
+            officialScoring.parsedAnswer ?? answered.finalAnswer,
+            answerVariants,
+            rougeL,
+          ),
+          ...officialScoring.scores,
         };
         if (judgeResult.score >= 0) {
           scores.llm_judge = judgeResult.score;
+        }
+
+        const details: Record<string, unknown> = {
+          competency: item.metadata.competency,
+          source: item.metadata.source,
+          questionType: item.metadata.question_types?.[questionIndex],
+          questionId: item.metadata.question_ids?.[questionIndex],
+          questionDate: item.metadata.question_dates?.[questionIndex],
+          previousEvent: item.metadata.previous_events?.[questionIndex],
+          keypoints: item.metadata.keypoints ?? [],
+          officialProtocol: protocol,
+          officialQuestion,
+          answerVariants,
+          bestExpectedAnswer,
+          parsedOfficialAnswer: officialScoring.parsedAnswer,
+          sessionIds,
+          storedSessionCount: sessionIds.length,
+          recalledLength: recalledText.length,
+          answeredLength: answered.finalAnswer.length,
+          recalledText,
+          answeredText: answered.finalAnswer,
+          responderModel: answered.model,
+          judgeModel: judgeResult.model,
+        };
+        if (protocol === "recsys_redial") {
+          details.recsysScoringReady = officialScoring.recsysScoringReady;
+          details.recsysEntityMappingPath = recsysMapping?.sourcePath;
+          details.recsysGroundTruthMovies = officialScoring.groundTruthMovies;
+          details.recsysPredictedMovies = officialScoring.predictedMovies;
         }
 
         tasks.push({
@@ -178,25 +254,7 @@ export async function runMemoryAgentBenchBenchmark(
             input: answered.tokens.input + judgeResult.tokens.input,
             output: answered.tokens.output + judgeResult.tokens.output,
           },
-          details: {
-            competency: item.metadata.competency,
-            source: item.metadata.source,
-            questionType: item.metadata.question_types?.[questionIndex],
-            questionId: item.metadata.question_ids?.[questionIndex],
-            questionDate: item.metadata.question_dates?.[questionIndex],
-            previousEvent: item.metadata.previous_events?.[questionIndex],
-            keypoints: item.metadata.keypoints ?? [],
-            answerVariants,
-            bestExpectedAnswer,
-            sessionIds,
-            storedSessionCount: sessionIds.length,
-            recalledLength: recalledText.length,
-            answeredLength: answered.finalAnswer.length,
-            recalledText,
-            answeredText: answered.finalAnswer,
-            responderModel: answered.model,
-            judgeModel: judgeResult.model,
-          },
+          details,
         });
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -206,7 +264,7 @@ export async function runMemoryAgentBenchBenchmark(
           question,
           expected: answerVariants[0]!,
           actual: `(error: ${message})`,
-          scores: { f1: -1, contains_answer: -1, rouge_l: -1, llm_judge: -1 },
+          scores: errorScoresForProtocol(protocol),
           latencyMs: 0,
           tokens: { input: 0, output: 0 },
           details: { error: message },
@@ -259,6 +317,682 @@ export async function runMemoryAgentBenchBenchmark(
       hardware: process.arch,
     },
   };
+}
+
+function errorScoresForProtocol(
+  protocol: MemoryAgentBenchProtocol | undefined,
+): Record<string, number> {
+  const scores: Record<string, number> = {
+    f1: -1,
+    contains_answer: -1,
+    rouge_l: -1,
+    llm_judge: -1,
+    official_protocol_ready: 0,
+  };
+  if (protocol !== "recsys_redial") {
+    scores.official_exact_match = -1;
+    scores.official_f1 = -1;
+    scores.official_substring_exact_match = -1;
+    scores.official_rouge_l = -1;
+  }
+  if (protocol === "eventqa") {
+    scores.eventqa_recall = -1;
+  }
+  if (protocol === "recsys_redial") {
+    scores.recsys_recall_at_1 = -1;
+    scores.recsys_recall_at_5 = -1;
+    scores.recsys_recall_at_10 = -1;
+  }
+  return scores;
+}
+
+function getProtocolForSource(source: string): MemoryAgentBenchProtocol {
+  const normalized = source.toLowerCase();
+  if (normalized.startsWith("ruler_")) {
+    return "ruler_qa";
+  }
+  if (normalized.startsWith("longmemeval")) {
+    return "longmemeval";
+  }
+  if (normalized.startsWith("eventqa")) {
+    return "eventqa";
+  }
+  if (normalized.startsWith("icl_")) {
+    return "in_context_learning";
+  }
+  if (normalized.startsWith("recsys_")) {
+    return "recsys_redial";
+  }
+  if (normalized.startsWith("infbench_")) {
+    return "infbench_sum";
+  }
+  if (normalized.startsWith("detective_")) {
+    return "detective_qa";
+  }
+  if (normalized.startsWith("factconsolidation")) {
+    return "factconsolidation";
+  }
+  throw new Error(
+    `MemoryAgentBench metadata.source "${source}" does not map to a supported official protocol.`,
+  );
+}
+
+function buildOfficialQuery(
+  protocol: MemoryAgentBenchProtocol,
+  question: string,
+): string {
+  switch (protocol) {
+    case "ruler_qa":
+      return [
+        "Answer the question based on the memorized documents. Only give me the answer and do not output any other words.",
+        "",
+        `Question: ${question}`,
+        "",
+        "Answer:",
+      ].join("\n");
+    case "longmemeval":
+      return [
+        "The history chats are between you and a user. Based on the relevant chat history, answer the question as concisely as you can, using a single phrase if possible.",
+        "",
+        question,
+        "",
+        "Answer:",
+      ].join("\n");
+    case "eventqa":
+      return [
+        "Based on the context you memorized, complete the task below:",
+        "",
+        question,
+        "",
+        "The event that happens next is:",
+      ].join("\n");
+    case "in_context_learning":
+      return [
+        "Use the provided mapping from the context to numerical label to assign a numerical label to the context.",
+        'Only output "label: {label}" and nothing else.',
+        "",
+        question,
+        "",
+        "label:",
+      ].join("\n");
+    case "recsys_redial":
+      return [
+        "Pretend you are a movie recommender system. You need to recommend movies based on the dialogues you have memorized.",
+        "Now I will give you a new conversation between a user and you, a recommender system.",
+        "Based on the conversation, reply with 20 movie recommendations without extra sentences.",
+        "",
+        "For Example:",
+        "",
+        "[Conversation]",
+        "",
+        "The recommendations are:",
+        "1. movie1",
+        "2. movie2",
+        "...",
+        "",
+        `Here is the conversation: ${question}`,
+        "",
+        "The recommendations are:",
+      ].join("\n");
+    case "infbench_sum":
+      return [
+        "You are given a book above and you are tasked to summarize it.",
+        "",
+        question,
+        "",
+        "Now summarize the book.",
+      ].join("\n");
+    case "detective_qa":
+      return [
+        "Based on the context you memorized, answer the question below. You are required to answer the question based on the strict output format.",
+        "",
+        question,
+      ].join("\n");
+    case "factconsolidation":
+      return [
+        "Pretend you are a knowledge management system. Each fact in the knowledge pool is provided with a serial number at the beginning, and the newer fact has larger serial number.",
+        "You need to solve conflicts in the knowledge pool by finding the newest fact with the larger serial number.",
+        "Answer only from the knowledge pool you memorized, not from real-world facts. Give a very concise answer without other words.",
+        "",
+        "For example:",
+        "",
+        "[Knowledge Pool]",
+        "",
+        "Question: Based on the provided Knowledge Pool, what is the name of the current president of Russia?",
+        "Answer: Donald Trump",
+        "",
+        `Now Answer the Question: Based on the provided Knowledge Pool, ${question}`,
+        "Answer:",
+      ].join("\n");
+  }
+}
+
+function scoreOfficialProtocol(options: {
+  protocol: MemoryAgentBenchProtocol;
+  actual: string;
+  answerVariants: string[];
+  recsysMapping: RecSysEntityMapping | null;
+}): {
+  scores: Record<string, number>;
+  parsedAnswer: string | undefined;
+  recsysScoringReady?: boolean;
+  predictedMovies?: string[];
+  groundTruthMovies?: string[];
+} {
+  if (options.protocol === "recsys_redial") {
+    return scoreRecSysRedial(options.actual, options.answerVariants, options.recsysMapping);
+  }
+
+  const parsedAnswer =
+    options.protocol === "in_context_learning"
+      ? parseIclLabel(options.actual)
+      : options.protocol === "eventqa"
+        ? parseEventQaAnswer(options.actual)
+        : parseOfficialAnswer(options.actual);
+  const answerForScoring = parsedAnswer ?? options.actual;
+  const textScores = calculateOfficialTextScores(answerForScoring, options.answerVariants);
+  const scores: Record<string, number> = {
+    official_exact_match: textScores.exactMatch,
+    official_f1: textScores.f1,
+    official_substring_exact_match: textScores.substringExactMatch,
+    official_rouge_l: scoreAgainstVariants(answerForScoring, options.answerVariants, rougeL),
+    official_protocol_ready: 1,
+  };
+
+  if (options.protocol === "eventqa") {
+    scores.eventqa_recall =
+      options.answerVariants.some((variant) =>
+        answerForScoring.toLowerCase().includes(variant.toLowerCase()),
+      )
+        ? 1
+        : 0;
+  }
+
+  return { scores, parsedAnswer: answerForScoring };
+}
+
+function calculateOfficialTextScores(
+  prediction: string,
+  answerVariants: string[],
+): {
+  exactMatch: number;
+  f1: number;
+  substringExactMatch: number;
+} {
+  return answerVariants.reduce(
+    (best, answer) => {
+      const normalizedPrediction = normalizeOfficialAnswer(prediction);
+      const normalizedAnswer = normalizeOfficialAnswer(answer);
+      return {
+        exactMatch: Math.max(
+          best.exactMatch,
+          normalizedPrediction === normalizedAnswer ? 1 : 0,
+        ),
+        f1: Math.max(best.f1, officialF1(prediction, answer)),
+        substringExactMatch: Math.max(
+          best.substringExactMatch,
+          normalizedPrediction.includes(normalizedAnswer) ? 1 : 0,
+        ),
+      };
+    },
+    { exactMatch: 0, f1: 0, substringExactMatch: 0 },
+  );
+}
+
+function scoreRecSysRedial(
+  actual: string,
+  answerVariants: string[],
+  recsysMapping: RecSysEntityMapping | null,
+): {
+  scores: Record<string, number>;
+  parsedAnswer: string | undefined;
+  recsysScoringReady: boolean;
+  predictedMovies?: string[];
+  groundTruthMovies?: string[];
+} {
+  if (!recsysMapping) {
+    return {
+      scores: { official_protocol_ready: 0 },
+      parsedAnswer: parseOfficialAnswer(actual),
+      recsysScoringReady: false,
+    };
+  }
+
+  const predictedMovies = extractRecommendationMovies(
+    actual,
+    recsysMapping.movieCandidates,
+    recsysMapping.aliasCounts,
+  );
+  const groundTruthIds = answerVariants.map((answer) =>
+    Number.parseInt(answer.trim(), 10),
+  );
+  const hasIncompleteGroundTruthMapping =
+    groundTruthIds.length === 0 ||
+    groundTruthIds.some(
+      (id) => !Number.isInteger(id) || !recsysMapping.idToName.has(id),
+    );
+
+  if (hasIncompleteGroundTruthMapping) {
+    return {
+      scores: { official_protocol_ready: 0 },
+      parsedAnswer: predictedMovies.join("\n"),
+      recsysScoringReady: false,
+      predictedMovies,
+    };
+  }
+
+  const groundTruthMovies = groundTruthIds.map((id) => recsysMapping.idToName.get(id)!);
+
+  return {
+    scores: {
+      recsys_recall_at_1: recallAtK(predictedMovies, groundTruthMovies, 1),
+      recsys_recall_at_5: recallAtK(predictedMovies, groundTruthMovies, 5),
+      recsys_recall_at_10: recallAtK(predictedMovies, groundTruthMovies, 10),
+      official_protocol_ready: 1,
+    },
+    parsedAnswer: predictedMovies.join("\n"),
+    recsysScoringReady: true,
+    predictedMovies,
+    groundTruthMovies,
+  };
+}
+
+function parseOfficialAnswer(output: string): string {
+  const matches = [...output.matchAll(/answer:\s*/gi)];
+  const lastMatch = matches.at(-1);
+  if (lastMatch?.index !== undefined) {
+    const answerStart = lastMatch.index + lastMatch[0].length;
+    const answer = output.slice(answerStart).trim();
+    if (answer.length > 0) {
+      return answer;
+    }
+  }
+  return output.trim();
+}
+
+function parseIclLabel(output: string): string {
+  const officialAnswer = parseOfficialAnswer(output);
+  const finalTokenMatch =
+    /\blabel\s*:\s*([A-Za-z0-9_-]+)\s*[.!?]?\s*$/i.exec(officialAnswer);
+  if (finalTokenMatch?.[1]) {
+    return finalTokenMatch[1].trim();
+  }
+  return officialAnswer;
+}
+
+function parseEventQaAnswer(output: string): string {
+  return parseOfficialAnswer(output)
+    .replace(/^the event that happens next is\s*:?\s*/i, "")
+    .trim();
+}
+
+function normalizeOfficialAnswer(answer: string): string {
+  return answer
+    .toLowerCase()
+    .replace(/[!"#$%&'()*+,\-./:;<=>?@[\\\]^_`{|}~]/g, "")
+    .replace(/\b(a|an|the)\b/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function officialF1(prediction: string, groundTruth: string): number {
+  const normalizedPrediction = normalizeOfficialAnswer(prediction);
+  const normalizedGroundTruth = normalizeOfficialAnswer(groundTruth);
+  if (
+    new Set(["yes", "no", "noanswer"]).has(normalizedPrediction) !==
+      new Set(["yes", "no", "noanswer"]).has(normalizedGroundTruth) ||
+    (new Set(["yes", "no", "noanswer"]).has(normalizedPrediction) &&
+      normalizedPrediction !== normalizedGroundTruth)
+  ) {
+    return 0;
+  }
+
+  const predictionTokens = normalizedPrediction.split(" ").filter(Boolean);
+  const groundTruthTokens = normalizedGroundTruth.split(" ").filter(Boolean);
+  if (predictionTokens.length === 0 || groundTruthTokens.length === 0) {
+    return 0;
+  }
+
+  const predictionCounts = countTokens(predictionTokens);
+  const groundTruthCounts = countTokens(groundTruthTokens);
+  let common = 0;
+  for (const [token, predictionCount] of predictionCounts) {
+    common += Math.min(predictionCount, groundTruthCounts.get(token) ?? 0);
+  }
+  if (common === 0) {
+    return 0;
+  }
+  const precision = common / predictionTokens.length;
+  const recall = common / groundTruthTokens.length;
+  return (2 * precision * recall) / (precision + recall);
+}
+
+function countTokens(tokens: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const token of tokens) {
+    counts.set(token, (counts.get(token) ?? 0) + 1);
+  }
+  return counts;
+}
+
+function extractRecommendationMovies(
+  output: string,
+  movieCandidates: string[],
+  aliasCounts: Map<string, number>,
+): string[] {
+  let recommendationText = output;
+  const numberedStart = output.search(/\b1\.\s*/);
+  if (numberedStart >= 0) {
+    recommendationText = output.slice(numberedStart).replace(/^\s*1\.\s*/, "");
+  }
+
+  return recommendationText
+    .split("\n")
+    .map((line) =>
+      line
+        .replace(/^\s*\d+[\.)]\s*/, "")
+        .replace(/\s+/g, " ")
+        .trim(),
+    )
+    .filter(Boolean)
+    .flatMap((line) =>
+      extractRecommendationMoviesFromLine(line, movieCandidates, aliasCounts),
+    );
+}
+
+function extractRecommendationMoviesFromLine(
+  line: string,
+  movieCandidates: string[],
+  aliasCounts: Map<string, number>,
+): string[] {
+  const exactMatches = findMovieCandidateMentions(line, movieCandidates, aliasCounts);
+  if (exactMatches.length > 0) {
+    return exactMatches;
+  }
+
+  const commaSeparatedMovies = line
+    .split(/\s*,\s*/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+  if (commaSeparatedMovies.length > 1) {
+    return commaSeparatedMovies.flatMap((movie) =>
+      /\(\d{4}\)/.test(movie)
+        ? findNearestMovieIfClose(movie, movieCandidates)
+        : extractRecommendationMoviesFromLine(movie, movieCandidates, aliasCounts),
+    );
+  }
+
+  if (/\(\d{4}\)/.test(line)) {
+    return findNearestMovieIfClose(line, movieCandidates);
+  }
+
+  return [];
+}
+
+function findMovieCandidateMentions(
+  line: string,
+  movieCandidates: string[],
+  aliasCounts: Map<string, number>,
+): string[] {
+  const normalizedLine = line.toLowerCase();
+  const mentions = movieCandidates
+    .map((movie) => findMovieCandidateMention(normalizedLine, movie, aliasCounts))
+    .filter((mention): mention is { movie: string; index: number; end: number } =>
+      mention !== null,
+    )
+    .sort((a, b) => b.movie.length - a.movie.length || a.index - b.index);
+
+  const selected: typeof mentions = [];
+  for (const mention of mentions) {
+    if (
+      selected.some(
+        (existing) => mention.index < existing.end && existing.index < mention.end,
+      )
+    ) {
+      continue;
+    }
+    selected.push(mention);
+  }
+
+  return selected.sort((a, b) => a.index - b.index).map((mention) => mention.movie);
+}
+
+function findMovieCandidateMention(
+  normalizedLine: string,
+  movie: string,
+  aliasCounts: Map<string, number>,
+): { movie: string; index: number; end: number } | null {
+  for (const alias of movieAliases(movie)) {
+    const normalizedAlias = alias.toLowerCase();
+    if ((aliasCounts.get(normalizedAlias) ?? 0) > 1) {
+      continue;
+    }
+    if (
+      normalizedAlias.length < 4 &&
+      stripTrailingRecommendationPunctuation(normalizedLine) !== normalizedAlias
+    ) {
+      continue;
+    }
+    const index = findDelimitedIndex(normalizedLine, normalizedAlias);
+    if (index >= 0) {
+      return { movie, index, end: index + alias.length };
+    }
+  }
+  return null;
+}
+
+function stripTrailingRecommendationPunctuation(value: string): string {
+  return value
+    .replace(/^["'`]+/g, "")
+    .replace(/["'`.!?;:]+$/g, "")
+    .trim();
+}
+
+function countMovieAliases(movieCandidates: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const movie of movieCandidates) {
+    for (const alias of movieAliases(movie)) {
+      const normalizedAlias = alias.toLowerCase();
+      counts.set(normalizedAlias, (counts.get(normalizedAlias) ?? 0) + 1);
+    }
+  }
+  return counts;
+}
+
+function movieAliases(movie: string): string[] {
+  const aliases = [movie];
+  const titleWithoutYear = movie.replace(/\s*\(\d{4}\)\s*$/, "").trim();
+  if (titleWithoutYear.length >= 2 && titleWithoutYear !== movie) {
+    aliases.push(titleWithoutYear);
+  }
+  const titleWithoutArticle = titleWithoutYear.replace(/^(?:the|a|an)\s+/i, "").trim();
+  if (titleWithoutArticle.length >= 2 && titleWithoutArticle !== titleWithoutYear) {
+    aliases.push(titleWithoutArticle);
+  }
+  return aliases;
+}
+
+function findDelimitedIndex(haystack: string, needle: string): number {
+  let start = 0;
+  while (start < haystack.length) {
+    const index = haystack.indexOf(needle, start);
+    if (index < 0) {
+      return -1;
+    }
+    const before = index > 0 ? haystack[index - 1] : undefined;
+    const after = haystack[index + needle.length];
+    if (isMovieAliasBoundary(before) && isMovieAliasBoundary(after)) {
+      return index;
+    }
+    start = index + 1;
+  }
+  return -1;
+}
+
+function isMovieAliasBoundary(char: string | undefined): boolean {
+  return char === undefined || !/[a-z0-9]/i.test(char);
+}
+
+function findNearestMovieIfClose(
+  targetName: string,
+  movieCandidates: string[],
+): string[] {
+  const match = findNearestMovieMatch(targetName, movieCandidates);
+  if (!match) {
+    return [];
+  }
+  const maxLength = Math.max(targetName.length, match.movie.length);
+  const maxDistance = Math.max(3, Math.ceil(maxLength * 0.35));
+  return match.distance <= maxDistance ? [match.movie] : [];
+}
+
+function findNearestMovieMatch(
+  targetName: string,
+  movieCandidates: string[],
+): { movie: string; distance: number } | null {
+  if (movieCandidates.length === 0) {
+    return null;
+  }
+  let bestMovie = movieCandidates[0] ?? targetName;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  const normalizedTarget = targetName.toLowerCase();
+
+  for (const candidate of movieCandidates) {
+    const distance = editDistance(normalizedTarget, candidate.toLowerCase());
+    if (distance < bestDistance) {
+      bestMovie = candidate;
+      bestDistance = distance;
+    }
+  }
+
+  return { movie: bestMovie, distance: bestDistance };
+}
+
+function editDistance(a: string, b: string): number {
+  const previous = Array.from({ length: b.length + 1 }, (_, index) => index);
+  const current = new Array<number>(b.length + 1);
+
+  for (let i = 1; i <= a.length; i += 1) {
+    current[0] = i;
+    for (let j = 1; j <= b.length; j += 1) {
+      const substitutionCost = a[i - 1] === b[j - 1] ? 0 : 1;
+      current[j] = Math.min(
+        previous[j]! + 1,
+        current[j - 1]! + 1,
+        previous[j - 1]! + substitutionCost,
+      );
+    }
+    previous.splice(0, previous.length, ...current);
+  }
+
+  return previous[b.length] ?? 0;
+}
+
+async function loadRecSysEntityMapping(
+  datasetDir: string | undefined,
+): Promise<RecSysEntityMapping | null> {
+  const candidates = recsysEntityMappingCandidates(datasetDir);
+  for (const candidate of candidates) {
+    if (!(await fileExists(candidate))) {
+      continue;
+    }
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await readFile(candidate, "utf8")) as unknown;
+    } catch (error) {
+      console.error(
+        `  [WARN] MemoryAgentBench ReDial entity mapping ${candidate} is invalid JSON; trying the next candidate: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      continue;
+    }
+    if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+      console.error(
+        `  [WARN] MemoryAgentBench ReDial entity mapping ${candidate} must be an object; trying the next candidate.`,
+      );
+      continue;
+    }
+
+    const idToName = new Map<number, string>();
+    let invalidMapping = false;
+    for (const [rawName, rawId] of Object.entries(parsed)) {
+      const id = typeof rawId === "number" ? rawId : Number(rawId);
+      if (!Number.isInteger(id)) {
+        console.error(
+          `  [WARN] MemoryAgentBench ReDial entity mapping ${candidate} has non-integer id for ${rawName}; trying the next candidate.`,
+        );
+        invalidMapping = true;
+        break;
+      }
+      idToName.set(id, extractMovieName(rawName));
+    }
+    if (invalidMapping) {
+      continue;
+    }
+    if (idToName.size === 0) {
+      console.error(
+        `  [WARN] MemoryAgentBench ReDial entity mapping ${candidate} is empty; trying the next candidate.`,
+      );
+      continue;
+    }
+
+    return {
+      idToName,
+      movieCandidates: [...new Set(idToName.values())],
+      aliasCounts: countMovieAliases([...new Set(idToName.values())]),
+      sourcePath: candidate,
+    };
+  }
+  return null;
+}
+
+function recsysEntityMappingCandidates(datasetDir: string | undefined): string[] {
+  if (!datasetDir) {
+    return [];
+  }
+  const absoluteDatasetDir = path.resolve(datasetDir);
+  const roots = [
+    absoluteDatasetDir,
+    path.dirname(absoluteDatasetDir),
+  ];
+
+  const canonicalSuffixes = [
+    path.join("processed_data", "Recsys_Redial", "entity2id.json"),
+    path.join("Recsys_Redial", "entity2id.json"),
+  ];
+  const looseSuffixes = ["entity2id.json"];
+
+  return [
+    ...roots.flatMap((root) =>
+      canonicalSuffixes.map((suffix) => path.join(root, suffix)),
+    ),
+    ...looseSuffixes.map((suffix) => path.join(absoluteDatasetDir, suffix)),
+  ];
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function extractMovieName(rawName: string): string {
+  const filename = rawName.split("/").pop() ?? rawName;
+  const decodedFilename = decodeUrlComponentSafely(filename);
+  return decodedFilename
+    .replace(/[_>]+/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+function decodeUrlComponentSafely(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
 }
 
 async function loadDataset(

--- a/tests/bench-memoryagentbench-runner.test.ts
+++ b/tests/bench-memoryagentbench-runner.test.ts
@@ -6,6 +6,7 @@ import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import type {
   BenchMemoryAdapter,
   BenchJudge,
+  BenchResponder,
   Message,
   SearchResult,
 } from "../packages/bench/src/index.js";
@@ -13,10 +14,13 @@ import { runBenchmark } from "../packages/bench/src/index.js";
 
 class FakeMemoryAdapter implements BenchMemoryAdapter {
   readonly sessions = new Map<string, Message[]>();
+  readonly recallCalls: Array<{ sessionId: string; query: string }> = [];
   readonly judge?: BenchJudge;
+  readonly responder?: BenchResponder;
 
-  constructor(judge?: BenchJudge) {
+  constructor(judge?: BenchJudge, responder?: BenchResponder) {
     this.judge = judge;
+    this.responder = responder;
   }
 
   async store(sessionId: string, messages: Message[]): Promise<void> {
@@ -25,6 +29,7 @@ class FakeMemoryAdapter implements BenchMemoryAdapter {
   }
 
   async recall(sessionId: string, _query: string): Promise<string> {
+    this.recallCalls.push({ sessionId, query: _query });
     return (this.sessions.get(sessionId) ?? [])
       .map((message) => message.content)
       .join("\n");
@@ -198,6 +203,68 @@ test("runBenchmark maps current MemoryAgentBench source aliases like ruler_qa1_1
   assert.equal(result.results.tasks[0]?.expected, "the cedar box");
   assert.equal(result.results.tasks[0]?.details.competency, "accurate_retrieval");
   assert.equal(result.results.tasks[0]?.details.source, "ruler_qa1_197K");
+});
+
+test("runBenchmark maps broad MemoryAgentBench InfBench and Recsys source variants to official protocols", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-protocol-variants-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond(question) {
+      return {
+        text: question.includes("movie recommender")
+          ? "The Big Lebowski (1998)"
+          : "brief summary",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Long document asks for a short summary.",
+        questions: ["What is the summary?"],
+        answers: [["brief summary"]],
+        metadata: {
+          source: "infbench_qa",
+          qa_pair_ids: ["mab-infbench-variant-q1"],
+        },
+      },
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_custom",
+          qa_pair_ids: ["mab-recsys-variant-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.officialProtocol, "infbench_sum");
+  assert.equal(result.results.tasks[0]?.actual, "brief summary");
+  assert.equal(result.results.tasks[1]?.details.officialProtocol, "recsys_redial");
+  assert.equal(result.results.tasks[1]?.scores.recsys_recall_at_1, 1);
 });
 
 test("runBenchmark uses the best-matching MemoryAgentBench answer variant for judge scoring", async () => {
@@ -406,4 +473,1565 @@ test("runBenchmark rejects unsupported memoryagentbench metadata sources with a 
       }),
     /does not map to a supported competency/,
   );
+});
+
+test("runBenchmark uses official MemoryAgentBench ICL prompts and label scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-icl-protocol-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const responderQuestions: string[] = [];
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond(question, _recalledText) {
+      responderQuestions.push(question);
+      return {
+        text: "label: 28",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "A disposable card problem maps to label: 28.",
+        questions: ["My disposable card does not work."],
+        answers: [["28"]],
+        metadata: {
+          source: "icl_banking77_5900shot_balance",
+          qa_pair_ids: ["mab-icl-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.match(responderQuestions[0] ?? "", /Only output "label: \{label\}"/);
+  assert.equal(result.results.tasks[0]?.details.officialProtocol, "in_context_learning");
+  assert.equal(result.results.tasks[0]?.details.parsedOfficialAnswer, "28");
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 1);
+  assert.equal(result.results.tasks[0]?.scores.official_f1, 1);
+});
+
+test("runBenchmark parses the final explicit ICL label mention for official scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-final-icl-label-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "Earlier example label: 12\nFinal label: 28",
+        tokens: { input: 1, output: 2 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "A disposable card problem maps to label: 28.",
+        questions: ["My disposable card does not work."],
+        answers: [["28"]],
+        metadata: {
+          source: "icl_banking77_5900shot_balance",
+          qa_pair_ids: ["mab-icl-final-label-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.parsedOfficialAnswer, "28");
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 1);
+});
+
+test("runBenchmark does not coerce trailing ICL reasoning text into a label", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-icl-no-label-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "Earlier example label: 12\nI cannot determine",
+        tokens: { input: 1, output: 2 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "A disposable card problem maps to label: 28.",
+        questions: ["My disposable card does not work."],
+        answers: [["28"]],
+        metadata: {
+          source: "icl_banking77_5900shot_balance",
+          qa_pair_ids: ["mab-icl-no-label-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(
+    result.results.tasks[0]?.details.parsedOfficialAnswer,
+    "Earlier example label: 12\nI cannot determine",
+  );
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 0);
+});
+
+test("runBenchmark preserves multiline official answers for MemoryAgentBench scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-multiline-answer-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "Answer: red scarf\nblue hat",
+        tokens: { input: 1, output: 2 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "The detective noted a red scarf and a blue hat.",
+        questions: ["Which two items were noted?"],
+        answers: [["red scarf blue hat"]],
+        metadata: {
+          source: "detective_qa",
+          qa_pair_ids: ["mab-multiline-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(
+    result.results.tasks[0]?.details.parsedOfficialAnswer,
+    "red scarf\nblue hat",
+  );
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 1);
+});
+
+test("runBenchmark parses the last Answer block for MemoryAgentBench official scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-last-answer-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "Example Answer: wrong\nReasoning...\nAnswer: final answer",
+        tokens: { input: 1, output: 3 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "The final answer is recorded in the last answer block.",
+        questions: ["What is the final answer?"],
+        answers: [["final answer"]],
+        metadata: {
+          source: "detective_qa",
+          qa_pair_ids: ["mab-last-answer-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.parsedOfficialAnswer, "final answer");
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 1);
+});
+
+test("runBenchmark scores EventQA recall against any accepted answer variant", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-eventqa-variants-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "The event that happens next is: she went to the riverside market",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Maya visited the museum, then walked to the riverside market.",
+        questions: ["After the museum, what happened next?"],
+        answers: [["the cafe", "riverside market"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-eventqa-variant-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.scores.eventqa_recall, 1);
+});
+
+test("runBenchmark strips EventQA prompt prefix before official text scoring", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-eventqa-prefix-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "The event that happens next is: riverside market",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Maya visited the museum, then walked to the riverside market.",
+        questions: ["After the museum, what happened next?"],
+        answers: [["riverside market"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-eventqa-prefix-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.parsedOfficialAnswer, "riverside market");
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, 1);
+  assert.equal(result.results.tasks[0]?.scores.official_f1, 1);
+});
+
+test("runBenchmark records official MemoryAgentBench metrics on task errors", async () => {
+  class FailingRecallAdapter extends FakeMemoryAdapter {
+    override async recall(sessionId: string, query: string): Promise<string> {
+      this.recallCalls.push({ sessionId, query });
+      throw new Error("recall unavailable");
+    }
+  }
+
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-error-official-scores-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FailingRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Maya visited the museum, then walked to the riverside market.",
+        questions: ["After the museum, what happened next?"],
+        answers: [["riverside market"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-error-official-scores-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.scores.f1, -1);
+  assert.equal(result.results.tasks[0]?.scores.official_exact_match, -1);
+  assert.equal(result.results.tasks[0]?.scores.official_f1, -1);
+  assert.equal(result.results.tasks[0]?.scores.official_rouge_l, -1);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.eventqa_recall, -1);
+  assert.equal(result.results.aggregates.official_f1?.mean, -1);
+});
+
+test("runBenchmark keeps ReDial error metrics out of official text aggregates", async () => {
+  class FailingRecallAdapter extends FakeMemoryAdapter {
+    override async recall(sessionId: string, query: string): Promise<string> {
+      this.recallCalls.push({ sessionId, query });
+      throw new Error("recall unavailable");
+    }
+  }
+
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-redial-error-scores-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FailingRecallAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-redial-error-scores-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.scores.official_f1, undefined);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, -1);
+  assert.equal(result.results.aggregates.official_f1, undefined);
+  assert.equal(result.results.aggregates.recsys_recall_at_1?.mean, -1);
+});
+
+test("runBenchmark does not load ReDial mappings for non-ReDial MemoryAgentBench samples", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-non-redial-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter();
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(path.join(mappingDir, "entity2id.json"), "[malformed", "utf8");
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Priya checked in at the library and then went to the cafe.",
+        questions: ["Where did Priya go after the library?"],
+        answers: [["cafe"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-no-redial-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks.length, 1);
+  assert.equal(result.results.tasks[0]?.details.officialProtocol, "eventqa");
+});
+
+test("runBenchmark scores ReDial recommendations with the official entity mapping when present", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-protocol-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: ["1. The Big Lebowski (1998)", "2. Fargo (1996)"].join("\n"),
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/The_Big_Lebowski_(1998)": 7008,
+      "/movie/Fargo_(1996)": 22364,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy and crime films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.officialProtocol, "recsys_redial");
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, true);
+  assert.deepEqual(result.results.tasks[0]?.details.recsysGroundTruthMovies, [
+    "The Big Lebowski (1998)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_5, 1);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_10, 1);
+});
+
+test("runBenchmark prefers canonical ReDial mappings over loose entity2id fallbacks", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-canonical-map-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "entity2id.json"),
+    JSON.stringify({ "/movie/Stale_Local_Map_(2000)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-canonical-map-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.match(
+    String(result.results.tasks[0]?.details.recsysEntityMappingPath),
+    /processed_data/,
+  );
+  assert.deepEqual(result.results.tasks[0]?.details.recsysGroundTruthMovies, [
+    "The Big Lebowski (1998)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark marks ReDial tasks not leaderboard-scorable when any answer ID is unmapped", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-partial-groundtruth-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008", "9999"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-partial-groundtruth-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, false);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, undefined);
+  assert.equal(result.results.tasks[0]?.details.recsysGroundTruthMovies, undefined);
+});
+
+test("runBenchmark uses the raw MemoryAgentBench question for recall and the official prompt for response", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recall-query-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const responderQuestions: string[] = [];
+  const rawQuestion = "System: recommend a comedy movie";
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond(question) {
+      responderQuestions.push(question);
+      return {
+        text: "The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: [rawQuestion],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recall-query-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(adapter.recallCalls.length, 1);
+  assert.equal(adapter.recallCalls[0]?.query, rawQuestion);
+  assert.equal(responderQuestions.length, 1);
+  assert.match(responderQuestions[0] ?? "", /movie recommender system/);
+  assert.match(responderQuestions[0] ?? "", new RegExp(rawQuestion));
+});
+
+test("runBenchmark preserves comma-containing ReDial movie titles while parsing recommendations", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-comma-title-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. O Brother, Where Art Thou? (2000)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/O_Brother,_Where_Art_Thou?_(2000)": 1001,
+      "/movie/O_(2001)": 1002,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comic odyssey films.",
+        questions: ["System: "],
+        answers: [["1001"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-comma-title-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "O Brother, Where Art Thou? (2000)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark parses comma-separated ReDial recommendations as separate movies", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-comma-list-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "The Big Lebowski (1998), Fargo (1996)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/The_Big_Lebowski_(1998)": 7008,
+      "/movie/Fargo_(1996)": 22364,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy and crime films.",
+        questions: ["System: "],
+        answers: [["22364"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-comma-list-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "The Big Lebowski (1998)",
+    "Fargo (1996)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_5, 1);
+});
+
+test("runBenchmark ignores unmatched ReDial preamble lines instead of nearest-mapping them", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-preamble-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: ["Sure!", "The recommendations are:", "1. The Big Lebowski (1998)"].join("\n"),
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/Sabrina_(1995)": 123,
+      "/movie/The_Big_Lebowski_(1998)": 7008,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-preamble-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "The Big Lebowski (1998)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark matches yearless ReDial recommendations to year-bearing entity titles", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-yearless-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: ["1. The Big Lebowski", "2. Fargo"].join("\n"),
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/The_Big_Lebowski_(1998)": 7008,
+      "/movie/Fargo_(1996)": 22364,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy and crime films.",
+        questions: ["System: "],
+        answers: [["22364"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-yearless-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "The Big Lebowski (1998)",
+    "Fargo (1996)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_5, 1);
+});
+
+test("runBenchmark decodes URL escapes in ReDial entity movie names", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-url-decode-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. Ocean's Eleven",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/Ocean%27s_Eleven_(2001)": 9001 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions heist films.",
+        questions: ["System: "],
+        answers: [["9001"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-url-decode-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "Ocean's Eleven (2001)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark preserves hyphens in ReDial entity movie names", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-hyphen-title-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. Spider-Man",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/Spider-Man_(2002)": 2002 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions superhero films.",
+        questions: ["System: "],
+        answers: [["2002"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-hyphen-title-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "Spider-Man (2002)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark matches short yearless ReDial movie titles", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-short-title-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: '1. "Up."',
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/Up_(2009)": 2009 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions animated films.",
+        questions: ["System: "],
+        answers: [["2009"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-short-title-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "Up (2009)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark does not match short ReDial titles inside ordinary words", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-short-word-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "I came up with The Big Lebowski (1998), Fargo (1996)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/Up_(2009)": 2009,
+      "/movie/The_Big_Lebowski_(1998)": 7008,
+      "/movie/Fargo_(1996)": 22364,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy and crime films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-short-word-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "The Big Lebowski (1998)",
+    "Fargo (1996)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark ignores ambiguous yearless ReDial aliases for duplicate movie titles", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-duplicate-title-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. King Kong",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/King_Kong_(1933)": 1933,
+      "/movie/King_Kong_(2005)": 2005,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions monster movies.",
+        questions: ["System: "],
+        answers: [["2005"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-duplicate-title-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, []);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 0);
+});
+
+test("runBenchmark prefers the most specific overlapping ReDial movie title", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-overlap-title-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Matrix Revolutions",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/The_Matrix_(1999)": 1999,
+      "/movie/The_Matrix_Revolutions_(2003)": 2003,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions science fiction sequels.",
+        questions: ["System: "],
+        answers: [["2003"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-overlap-title-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "The Matrix Revolutions (2003)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark parses comma-separated short yearless ReDial titles", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-short-comma-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "Up,Her",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({
+      "/movie/Up_(2009)": 2009,
+      "/movie/Her_(2013)": 2013,
+    }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions animated and near-future films.",
+        questions: ["System: "],
+        answers: [["2013"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-short-comma-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.deepEqual(result.results.tasks[0]?.details.recsysPredictedMovies, [
+    "Up (2009)",
+    "Her (2013)",
+  ]);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_5, 1);
+});
+
+test("runBenchmark scopes ReDial mapping details to ReDial MemoryAgentBench tasks", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-detail-scope-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond(question) {
+      return {
+        text: question.includes("System:")
+          ? "The Big Lebowski (1998)"
+          : "the riverside market",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(
+    path.join(mappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-detail-scope-redial"],
+        },
+      },
+      {
+        context: "Maya visited the museum, then walked to the riverside market.",
+        questions: ["After the museum, what happened next?"],
+        answers: [["riverside market"]],
+        metadata: {
+          source: "eventqa_full",
+          qa_pair_ids: ["mab-recsys-detail-scope-eventqa"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  const redialDetails = result.results.tasks[0]?.details ?? {};
+  const eventQaDetails = result.results.tasks[1]?.details ?? {};
+  assert.equal(redialDetails.recsysScoringReady, true);
+  assert.equal(typeof redialDetails.recsysEntityMappingPath, "string");
+  assert.equal("recsysScoringReady" in eventQaDetails, false);
+  assert.equal("recsysEntityMappingPath" in eventQaDetails, false);
+  assert.equal("recsysGroundTruthMovies" in eventQaDetails, false);
+  assert.equal("recsysPredictedMovies" in eventQaDetails, false);
+});
+
+test("runBenchmark marks ReDial tasks not leaderboard-scorable when entity mapping is malformed", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-bad-map-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const mappingDir = path.join(tmpDir, "datasets", "processed_data", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(mappingDir, { recursive: true });
+  await writeFile(path.join(mappingDir, "entity2id.json"), "[malformed", "utf8");
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-bad-map-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, false);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, undefined);
+});
+
+test("runBenchmark keeps searching ReDial mapping candidates after a malformed file", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-map-fallback-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const badMappingDir = path.join(
+    tmpDir,
+    "datasets",
+    "processed_data",
+    "Recsys_Redial",
+  );
+  const goodMappingDir = path.join(tmpDir, "datasets", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(badMappingDir, { recursive: true });
+  await mkdir(goodMappingDir, { recursive: true });
+  await writeFile(path.join(badMappingDir, "entity2id.json"), "[malformed", "utf8");
+  await writeFile(
+    path.join(goodMappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-map-fallback-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, true);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark skips empty ReDial mapping candidates before accepting a fallback", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-empty-map-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const emptyMappingDir = path.join(
+    tmpDir,
+    "datasets",
+    "processed_data",
+    "Recsys_Redial",
+  );
+  const goodMappingDir = path.join(tmpDir, "datasets", "Recsys_Redial");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await mkdir(emptyMappingDir, { recursive: true });
+  await mkdir(goodMappingDir, { recursive: true });
+  await writeFile(path.join(emptyMappingDir, "entity2id.json"), "{}", "utf8");
+  await writeFile(
+    path.join(goodMappingDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-empty-map-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, true);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, 1);
+});
+
+test("runBenchmark marks ReDial tasks not leaderboard-scorable when entity mapping is missing", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-missing-map-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-no-map-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, false);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, undefined);
+});
+
+test("runBenchmark does not use loose ReDial mapping files outside the dataset bundle", async () => {
+  const tmpDir = await mkdtemp(
+    path.join(os.tmpdir(), "remnic-bench-memoryagentbench-recsys-ancestor-map-"),
+  );
+  const datasetDir = path.join(tmpDir, "datasets", "memoryagentbench");
+  const adapter = new FakeMemoryAdapter(undefined, {
+    async respond() {
+      return {
+        text: "1. The Big Lebowski (1998)",
+        tokens: { input: 1, output: 1 },
+        latencyMs: 0,
+        model: "fake",
+      };
+    },
+  });
+  await mkdir(datasetDir, { recursive: true });
+  await writeFile(
+    path.join(tmpDir, "entity2id.json"),
+    JSON.stringify({ "/movie/The_Big_Lebowski_(1998)": 7008 }),
+    "utf8",
+  );
+  await writeFile(
+    path.join(datasetDir, "memoryagentbench.json"),
+    JSON.stringify([
+      {
+        context: "Dialogue history mentions comedy films.",
+        questions: ["System: "],
+        answers: [["7008"]],
+        metadata: {
+          source: "recsys_redial_full",
+          qa_pair_ids: ["mab-recsys-ancestor-map-q1"],
+        },
+      },
+    ]),
+    "utf8",
+  );
+
+  const result = await runBenchmark("memoryagentbench", {
+    mode: "full",
+    datasetDir,
+    system: adapter,
+  });
+
+  assert.equal(result.results.tasks[0]?.details.recsysScoringReady, false);
+  assert.equal(result.results.tasks[0]?.scores.official_protocol_ready, 0);
+  assert.equal(result.results.tasks[0]?.scores.recsys_recall_at_1, undefined);
 });


### PR DESCRIPTION
## Summary
- apply MemoryAgentBench official sub-dataset query protocols for RULER, LongMemEval, EventQA, ICL, ReDial, InfBench, DetectiveQA, and fact consolidation
- add official text metrics and source-specific scoring, including ReDial recall@1/5/10 when entity2id.json is present
- mark ReDial tasks as not leaderboard-scorable when the required ReDial entity mapping is missing instead of silently emitting fake recall numbers

## Test Plan
- pnpm exec tsx --test tests/bench-memoryagentbench-runner.test.ts
- pnpm --filter @remnic/core build
- pnpm --filter @remnic/bench check-types

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the MemoryAgentBench runner’s prompting and scoring logic (including new protocol-specific metrics and ReDial entity mapping handling), which will materially shift benchmark outputs and could impact leaderboard comparability if incorrect.
> 
> **Overview**
> Aligns `memoryagentbench` execution with the benchmark’s **official per-subdataset prompting protocols**, by mapping `metadata.source` to an explicit protocol and sending protocol-specific prompt templates to the responder while still using the raw question for memory recall.
> 
> Adds **official scoring metrics** alongside existing ones: normalized exact-match/F1/substring/ROUGE-L for most protocols, `eventqa_recall` for EventQA, and ReDial `recall@1/5/10` computed from recommended movie titles when `entity2id.json` is available; ReDial tasks are now marked *not leaderboard-scorable* (`official_protocol_ready: 0`) when the mapping is missing/invalid/partial.
> 
> Expands task `details` to record protocol, official prompt, parsed answers, and (for ReDial) mapping path plus predicted/ground-truth movie lists, and updates error paths to emit protocol-appropriate sentinel metrics; adds extensive new tests covering protocol mapping, parsing, ReDial mapping discovery/fallbacks, and recommendation extraction edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50612c615cb0aa9113bb99699f909f9d0c6be725. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->