### PR TITLE
feat(admin): force-directed memory graph pane (#691 PR 3/5)

### DIFF
--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -798,6 +798,13 @@ function resetGraphView() {
 /** Last rendered snapshot, kept for re-draw on resize / pan / zoom. */
 let graphData = null; // { nodes, edges }
 
+/**
+ * Guard flag: canvas interaction listeners (mouse/wheel) must be attached
+ * exactly once during pane initialisation. Without this, every graph refresh
+ * stacks another set of listeners that all fire simultaneously.
+ */
+let graphInteractionsAttached = false;
+
 /** Node radius derived from score (clamped). */
 function nodeRadius(score) {
   return Math.max(5, Math.min(14, 5 + score * 9));
@@ -916,8 +923,15 @@ function hideGraphTooltip() {
   if (tip) tip.style.display = "none";
 }
 
-/** Wire pan / zoom / tooltip mouse handlers onto the canvas. */
+/** Wire pan / zoom / tooltip mouse handlers onto the canvas.
+ *  Must be called once per canvas lifetime; subsequent calls are no-ops.
+ */
 function attachGraphInteractions(canvas) {
+  // Attach only once — re-attaching on every refresh stacks duplicate
+  // listeners that each fire on the same event (Codex P2 / Cursor review).
+  if (graphInteractionsAttached) return;
+  graphInteractionsAttached = true;
+
   // Pan.
   let dragging = false;
   let dragStart = { x: 0, y: 0 };

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -648,6 +648,447 @@ async function seedTrustZoneDemo(dryRun) {
   );
 }
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Memory Graph — force-directed Verlet simulation (issue #691 PR 3/5)
+// No external dependencies.  ~150 lines.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Stable colour palette keyed by category string. */
+const GRAPH_CATEGORY_COLORS = [
+  "#0f6b63", // accent (fact)
+  "#8b3a22", // warn  (decision)
+  "#2563a8", // blue  (preference)
+  "#6b4f0f", // amber (entity)
+  "#3d226b", // purple (procedure)
+  "#1d7a3e", // green  (observation)
+  "#7a2b5f", // rose
+  "#2b5e7a", // teal-dark
+];
+const GRAPH_UNKNOWN_COLOR = "#aaa";
+const GRAPH_EDGE_COLORS = { entity: "#0f6b63", time: "#c9a227", causal: "#8b3a22" };
+
+/** Per-session category → colour mapping, built lazily. */
+const graphCategoryColors = new Map();
+let graphCategoryColorIndex = 0;
+
+function graphColorForCategory(cat) {
+  if (!cat || cat === "unknown") return GRAPH_UNKNOWN_COLOR;
+  if (!graphCategoryColors.has(cat)) {
+    graphCategoryColors.set(cat, GRAPH_CATEGORY_COLORS[graphCategoryColorIndex % GRAPH_CATEGORY_COLORS.length]);
+    graphCategoryColorIndex += 1;
+  }
+  return graphCategoryColors.get(cat);
+}
+
+/** Current simulation state — replaced on every refresh. */
+let graphSim = null;
+
+/**
+ * Run a Verlet-style force simulation on `nodes` / `edges`.
+ * Mutates `nodes` in-place; every element gains `.x`, `.y`, `.vx`, `.vy`.
+ * Returns a handle with `.stop()` and `.restart()`.
+ */
+function createForceSimulation(nodes, edges, width, height) {
+  const REPULSION = 6000;
+  const SPRING_LENGTH = 90;
+  const SPRING_K = 0.06;
+  const DAMPING = 0.82;
+  const CENTERING = 0.012;
+
+  // Place nodes in a circle to avoid degenerate starts.
+  nodes.forEach((n, i) => {
+    const angle = (2 * Math.PI * i) / nodes.length;
+    const r = Math.min(width, height) * 0.3;
+    n.x = width / 2 + r * Math.cos(angle);
+    n.y = height / 2 + r * Math.sin(angle);
+    n.vx = 0;
+    n.vy = 0;
+  });
+
+  let running = true;
+  let rafId = null;
+
+  function tick() {
+    if (!running) return;
+
+    // Repulsion between all pairs (O(n²) — acceptable for ≤ 1000 nodes in admin console).
+    for (let i = 0; i < nodes.length; i += 1) {
+      for (let j = i + 1; j < nodes.length; j += 1) {
+        const ni = nodes[i];
+        const nj = nodes[j];
+        const dx = ni.x - nj.x;
+        const dy = ni.y - nj.y;
+        const dist2 = dx * dx + dy * dy || 1;
+        const dist = Math.sqrt(dist2);
+        const force = REPULSION / dist2;
+        const fx = (force * dx) / dist;
+        const fy = (force * dy) / dist;
+        ni.vx += fx;
+        ni.vy += fy;
+        nj.vx -= fx;
+        nj.vy -= fy;
+      }
+    }
+
+    // Spring attraction along edges.
+    for (const edge of edges) {
+      const src = edge._srcNode;
+      const tgt = edge._tgtNode;
+      if (!src || !tgt) continue;
+      const dx = tgt.x - src.x;
+      const dy = tgt.y - src.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const stretch = dist - SPRING_LENGTH;
+      const fx = (SPRING_K * stretch * dx) / dist;
+      const fy = (SPRING_K * stretch * dy) / dist;
+      src.vx += fx;
+      src.vy += fy;
+      tgt.vx -= fx;
+      tgt.vy -= fy;
+    }
+
+    // Centering pull.
+    for (const n of nodes) {
+      n.vx += (width / 2 - n.x) * CENTERING;
+      n.vy += (height / 2 - n.y) * CENTERING;
+      // Damping + integrate.
+      n.vx *= DAMPING;
+      n.vy *= DAMPING;
+      n.x += n.vx;
+      n.y += n.vy;
+    }
+  }
+
+  let onDraw = null;
+
+  function loop() {
+    tick();
+    if (onDraw) onDraw();
+    if (running) rafId = requestAnimationFrame(loop);
+  }
+
+  return {
+    start(drawFn) {
+      onDraw = drawFn;
+      running = true;
+      rafId = requestAnimationFrame(loop);
+    },
+    stop() {
+      running = false;
+      if (rafId !== null) cancelAnimationFrame(rafId);
+    },
+    restart(drawFn) {
+      this.stop();
+      this.start(drawFn);
+    },
+  };
+}
+
+/** Pan/zoom transform for the canvas. */
+const graphView = { tx: 0, ty: 0, scale: 1 };
+
+/** Resets view transform to identity and re-draws. */
+function resetGraphView() {
+  graphView.tx = 0;
+  graphView.ty = 0;
+  graphView.scale = 1;
+  drawGraph();
+}
+
+/** Last rendered snapshot, kept for re-draw on resize / pan / zoom. */
+let graphData = null; // { nodes, edges }
+
+/** Node radius derived from score (clamped). */
+function nodeRadius(score) {
+  return Math.max(5, Math.min(14, 5 + score * 9));
+}
+
+/** Draw a single frame onto the canvas. */
+function drawGraph() {
+  const canvas = $("graphCanvas");
+  if (!canvas || !graphData) return;
+  const dpr = window.devicePixelRatio || 1;
+  // Keep bitmap resolution in sync with layout size.
+  const lw = canvas.offsetWidth;
+  const lh = canvas.offsetHeight;
+  if (canvas.width !== lw * dpr || canvas.height !== lh * dpr) {
+    canvas.width = lw * dpr;
+    canvas.height = lh * dpr;
+  }
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+  ctx.save();
+  ctx.scale(dpr, dpr);
+  ctx.clearRect(0, 0, lw, lh);
+
+  ctx.save();
+  ctx.translate(graphView.tx, graphView.ty);
+  ctx.scale(graphView.scale, graphView.scale);
+
+  // Draw edges.
+  for (const edge of graphData.edges) {
+    const src = edge._srcNode;
+    const tgt = edge._tgtNode;
+    if (!src || !tgt) continue;
+    ctx.beginPath();
+    ctx.moveTo(src.x, src.y);
+    ctx.lineTo(tgt.x, tgt.y);
+    ctx.strokeStyle = GRAPH_EDGE_COLORS[edge.kind] || "#ccc";
+    ctx.globalAlpha = 0.45 + edge.confidence * 0.45;
+    ctx.lineWidth = 0.8 + edge.confidence * 1.2;
+    ctx.stroke();
+    ctx.globalAlpha = 1;
+  }
+
+  // Draw nodes.
+  for (const n of graphData.nodes) {
+    const r = nodeRadius(n.score);
+    ctx.beginPath();
+    ctx.arc(n.x, n.y, r, 0, 2 * Math.PI);
+    ctx.fillStyle = graphColorForCategory(n.kind);
+    ctx.fill();
+    ctx.strokeStyle = "rgba(255,255,255,0.6)";
+    ctx.lineWidth = 1.5;
+    ctx.stroke();
+  }
+
+  ctx.restore();
+  ctx.restore();
+}
+
+/** Convert canvas-relative point to simulation space. */
+function canvasToSim(cx, cy) {
+  return {
+    x: (cx - graphView.tx) / graphView.scale,
+    y: (cy - graphView.ty) / graphView.scale,
+  };
+}
+
+/** Find the node under a canvas-relative cursor point, or null. */
+function hitTestNode(cx, cy) {
+  if (!graphData) return null;
+  const sim = canvasToSim(cx, cy);
+  for (const n of graphData.nodes) {
+    const r = nodeRadius(n.score) + 4; // slight hit-padding
+    const dx = sim.x - n.x;
+    const dy = sim.y - n.y;
+    if (dx * dx + dy * dy <= r * r) return n;
+  }
+  return null;
+}
+
+/** Find the edge under a canvas-relative cursor point, or null. */
+function hitTestEdge(cx, cy) {
+  if (!graphData) return null;
+  const sim = canvasToSim(cx, cy);
+  const THRESHOLD = 6;
+  for (const edge of graphData.edges) {
+    const src = edge._srcNode;
+    const tgt = edge._tgtNode;
+    if (!src || !tgt) continue;
+    // Point-to-segment distance.
+    const dx = tgt.x - src.x;
+    const dy = tgt.y - src.y;
+    const len2 = dx * dx + dy * dy || 1;
+    const t = Math.max(0, Math.min(1, ((sim.x - src.x) * dx + (sim.y - src.y) * dy) / len2));
+    const px = src.x + t * dx - sim.x;
+    const py = src.y + t * dy - sim.y;
+    if (px * px + py * py <= THRESHOLD * THRESHOLD) return edge;
+  }
+  return null;
+}
+
+/** Show the floating tooltip near the cursor. */
+function showGraphTooltip(canvas, clientX, clientY, text) {
+  const tip = $("graphTooltip");
+  if (!tip) return;
+  const rect = canvas.getBoundingClientRect();
+  const x = clientX - rect.left + 12;
+  const y = clientY - rect.top + 12;
+  tip.textContent = text;
+  tip.style.left = `${x}px`;
+  tip.style.top = `${y}px`;
+  tip.style.display = "block";
+}
+
+function hideGraphTooltip() {
+  const tip = $("graphTooltip");
+  if (tip) tip.style.display = "none";
+}
+
+/** Wire pan / zoom / tooltip mouse handlers onto the canvas. */
+function attachGraphInteractions(canvas) {
+  // Pan.
+  let dragging = false;
+  let dragStart = { x: 0, y: 0 };
+  let viewStart = { tx: 0, ty: 0 };
+
+  canvas.addEventListener("mousedown", (e) => {
+    if (e.button !== 0) return;
+    dragging = true;
+    dragStart = { x: e.clientX, y: e.clientY };
+    viewStart = { tx: graphView.tx, ty: graphView.ty };
+  });
+
+  canvas.addEventListener("mousemove", (e) => {
+    const rect = canvas.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+
+    if (dragging) {
+      graphView.tx = viewStart.tx + (e.clientX - dragStart.x);
+      graphView.ty = viewStart.ty + (e.clientY - dragStart.y);
+      drawGraph();
+      hideGraphTooltip();
+      return;
+    }
+
+    // Tooltip: check node first, then edge.
+    const node = hitTestNode(cx, cy);
+    if (node) {
+      const lines = [
+        `id: ${node.id}`,
+        `category: ${node.kind}`,
+        `score: ${node.score.toFixed(3)}`,
+        node.lastUpdated ? `updated: ${node.lastUpdated}` : null,
+      ].filter(Boolean).join("\n");
+      showGraphTooltip(canvas, e.clientX, e.clientY, lines);
+      return;
+    }
+    const edge = hitTestEdge(cx, cy);
+    if (edge) {
+      const text = `kind: ${edge.kind}\nconfidence: ${edge.confidence.toFixed(3)}`;
+      showGraphTooltip(canvas, e.clientX, e.clientY, text);
+      return;
+    }
+    hideGraphTooltip();
+  });
+
+  canvas.addEventListener("mouseup", () => { dragging = false; });
+  canvas.addEventListener("mouseleave", () => { dragging = false; hideGraphTooltip(); });
+
+  // Zoom via scroll wheel.
+  canvas.addEventListener("wheel", (e) => {
+    e.preventDefault();
+    const rect = canvas.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+    const factor = e.deltaY < 0 ? 1.12 : 0.89;
+    const newScale = Math.max(0.1, Math.min(10, graphView.scale * factor));
+    // Keep the point under the cursor stationary.
+    graphView.tx = cx - (cx - graphView.tx) * (newScale / graphView.scale);
+    graphView.ty = cy - (cy - graphView.ty) * (newScale / graphView.scale);
+    graphView.scale = newScale;
+    drawGraph();
+  }, { passive: false });
+}
+
+/** Rebuild the legend strip below the canvas. */
+function renderGraphLegend() {
+  const legend = $("graphLegend");
+  if (!legend) return;
+  clearChildren(legend);
+  for (const [cat, color] of graphCategoryColors.entries()) {
+    const item = document.createElement("span");
+    item.className = "graph-legend-item";
+    const swatch = document.createElement("span");
+    swatch.className = "graph-legend-swatch";
+    swatch.style.background = color;
+    item.appendChild(swatch);
+    const label = document.createElement("span");
+    label.textContent = cat;
+    item.appendChild(label);
+    legend.appendChild(item);
+  }
+}
+
+/**
+ * Fetch `GET /engram/v1/graph/snapshot`, build simulation, and start drawing.
+ */
+async function loadMemoryGraph() {
+  const canvas = $("graphCanvas");
+  if (!canvas) return;
+
+  // Stop any running simulation.
+  if (graphSim) { graphSim.stop(); graphSim = null; }
+
+  setStatus("graphStatus", "Fetching graph snapshot...");
+
+  const params = new URLSearchParams();
+  const limit = $("graphLimit")?.value?.trim();
+  const focus = $("graphFocusNodeId")?.value?.trim();
+  if (limit) params.set("limit", limit);
+  if (focus) params.set("focusNodeId", focus);
+
+  let snapshot;
+  try {
+    snapshot = await fetchJson(`/engram/v1/graph/snapshot?${params.toString()}`);
+  } catch (err) {
+    setStatus("graphStatus", err.message || String(err), "error");
+    return;
+  }
+
+  const nodes = Array.isArray(snapshot.nodes) ? snapshot.nodes : [];
+  const edges = Array.isArray(snapshot.edges) ? snapshot.edges : [];
+
+  if (nodes.length === 0) {
+    graphData = null;
+    const ctx = canvas.getContext("2d");
+    if (ctx) {
+      const dpr = window.devicePixelRatio || 1;
+      const lw = canvas.offsetWidth;
+      const lh = canvas.offsetHeight;
+      canvas.width = lw * dpr;
+      canvas.height = lh * dpr;
+      ctx.save();
+      ctx.scale(dpr, dpr);
+      ctx.clearRect(0, 0, lw, lh);
+      ctx.fillStyle = "#aaa";
+      ctx.font = "14px Avenir Next, Segoe UI, sans-serif";
+      ctx.textAlign = "center";
+      ctx.fillText("No graph data — memory graph is empty.", lw / 2, lh / 2);
+      ctx.restore();
+    }
+    setStatus("graphStatus", "Graph snapshot is empty.", "default");
+    return;
+  }
+
+  // Reset colours on each fresh fetch so legend is consistent.
+  graphCategoryColors.clear();
+  graphCategoryColorIndex = 0;
+
+  // Pre-warm category colours in node order.
+  for (const n of nodes) graphColorForCategory(n.kind);
+
+  // Build id → node index for edge wiring.
+  const nodeIndex = new Map(nodes.map((n) => [n.id, n]));
+  for (const edge of edges) {
+    edge._srcNode = nodeIndex.get(edge.source) ?? null;
+    edge._tgtNode = nodeIndex.get(edge.target) ?? null;
+  }
+
+  graphData = { nodes, edges };
+  // Reset view on fresh load.
+  graphView.tx = 0;
+  graphView.ty = 0;
+  graphView.scale = 1;
+
+  const lw = canvas.offsetWidth || 800;
+  const lh = canvas.offsetHeight || 520;
+
+  graphSim = createForceSimulation(nodes, edges, lw, lh);
+  graphSim.start(drawGraph);
+
+  attachGraphInteractions(canvas);
+  renderGraphLegend();
+
+  setStatus(
+    "graphStatus",
+    `Loaded ${nodes.length} nodes, ${edges.length} edges. Generated ${snapshot.generatedAt}.`,
+    "ok",
+  );
+}
+
 async function connectAndBootstrap() {
   const input = $("tokenInput");
   const token = input?.value?.trim() || readToken();
@@ -668,6 +1109,7 @@ async function connectAndBootstrap() {
       loadEntities(),
       loadQuality(),
       loadMaintenance(),
+      loadMemoryGraph(),
     ]);
   } catch (error) {
     setStatus("authStatus", error.message || String(error), "error");
@@ -730,6 +1172,8 @@ function bootstrap() {
   $("refreshQueueButton")?.addEventListener("click", () => void loadReviewQueue());
   $("searchEntitiesButton")?.addEventListener("click", () => void loadEntities());
   $("copyMemoryPathButton")?.addEventListener("click", copyMemoryPath);
+  $("refreshGraphButton")?.addEventListener("click", () => void loadMemoryGraph());
+  $("resetGraphViewButton")?.addEventListener("click", resetGraphView);
 
   if (remembered) {
     void connectAndBootstrap();

--- a/admin-console/public/index.html
+++ b/admin-console/public/index.html
@@ -230,6 +230,62 @@
       .subgrid {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
+      /* ── Memory Graph pane ─────────────────────────────────── */
+      .graph-wrap {
+        position: relative;
+        width: 100%;
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: #fffdf9;
+        overflow: hidden;
+        margin-top: 12px;
+      }
+      #graphCanvas {
+        display: block;
+        width: 100%;
+        height: 520px;
+        cursor: grab;
+        touch-action: none;
+      }
+      #graphCanvas:active {
+        cursor: grabbing;
+      }
+      #graphTooltip {
+        position: absolute;
+        top: 0;
+        left: 0;
+        pointer-events: none;
+        background: rgba(27, 29, 34, 0.88);
+        color: #fff;
+        border-radius: 9px;
+        padding: 7px 11px;
+        font-size: 0.78rem;
+        line-height: 1.5;
+        max-width: 280px;
+        white-space: pre-wrap;
+        word-break: break-all;
+        display: none;
+        z-index: 10;
+      }
+      .graph-legend {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+        margin-top: 8px;
+        font-size: 0.78rem;
+        color: var(--muted);
+      }
+      .graph-legend-item {
+        display: flex;
+        align-items: center;
+        gap: 5px;
+      }
+      .graph-legend-swatch {
+        width: 12px;
+        height: 12px;
+        border-radius: 50%;
+        flex-shrink: 0;
+      }
       @media (max-width: 1080px) {
         .grid,
         .subgrid,
@@ -458,6 +514,33 @@
           </div>
         </section>
       </div>
+
+      <section class="card" style="margin-top: 16px;">
+        <h2>Memory Graph</h2>
+        <div class="toolbar">
+          <label>
+            Edge Limit
+            <select id="graphLimit">
+              <option value="100">100</option>
+              <option value="250" selected>250</option>
+              <option value="500">500</option>
+              <option value="1000">1000</option>
+            </select>
+          </label>
+          <label style="flex: 1;">
+            Focus Node Id
+            <input id="graphFocusNodeId" type="text" placeholder="Optional — relative memory path" />
+          </label>
+          <button id="refreshGraphButton">Refresh</button>
+          <button class="secondary" id="resetGraphViewButton">Reset View</button>
+        </div>
+        <div class="status" id="graphStatus">Graph will load after connect.</div>
+        <div class="graph-wrap">
+          <canvas id="graphCanvas"></canvas>
+          <div id="graphTooltip"></div>
+        </div>
+        <div class="graph-legend" id="graphLegend"></div>
+      </section>
 
       <section class="card" style="margin-top: 16px;">
         <h2>Maintenance</h2>

--- a/docs/admin-console.md
+++ b/docs/admin-console.md
@@ -1,0 +1,63 @@
+# Remnic Admin Console
+
+Local operator surface served by `remnic access http-serve` at
+`/remnic/ui` (and the legacy `/engram/ui` alias). All data fetches and
+operator actions go through the loopback bearer-token API; the page
+itself is a static `index.html` + `app.js` shell shipped under
+`admin-console/public/`.
+
+## Panes
+
+- **Memory Browser** — paginated list of `/engram/v1/memories` with
+  query / status / category / sort filters.
+- **Memory Detail** — content + timeline for a selected memory, with
+  raw-path copy.
+- **Recall Debugger** — runs `/engram/v1/recall` and
+  `/engram/v1/recall/explain` for a session key.
+- **Quality Dashboard** — counts + latest governance run from
+  `/engram/v1/quality`.
+- **Trust Zones** — browse and (optionally) promote trust-zone
+  records.
+- **Review Queue** — governance review queue with confirm / reject /
+  archive dispositions.
+- **Entity Explorer** — search and inspect entities.
+- **Memory Graph** — static force-directed view of the multi-graph
+  adjacency from `GET /engram/v1/graph/snapshot` (issue #691).
+- **Maintenance** — JSON dump of the current maintenance summary.
+
+## Memory Graph pane (#691 PR 3/5)
+
+The graph pane fetches a read-only snapshot from
+`GET /engram/v1/graph/snapshot` and renders it with a small vanilla
+force-directed simulation (no new runtime dependencies). Updates are
+**static** in this revision — every refresh re-fetches and re-runs
+the layout. Live patch streaming ships in PR 5/5.
+
+Controls:
+
+- **Limit** — caps the number of edges fetched (100 / 250 / 500 /
+  1000). The endpoint enforces a server-side maximum of 5000.
+- **Focus Node Id** — forwards as `focusNodeId` so the snapshot is
+  restricted to the focus node and its direct neighbors.
+- **Refresh** — re-fetches and re-renders.
+- **Reset View** — clears any pan / zoom transform.
+
+Interactions:
+
+- **Pan** — click and drag the canvas.
+- **Zoom** — scroll-wheel over the canvas.
+- **Node tooltip** — hover a node to see its memory id, category,
+  aggregate score, and last-updated timestamp.
+- **Edge tooltip** — hover an edge to see its kind (entity / time /
+  causal) and confidence (0–1).
+- **Color coding** — nodes are colored by category; the legend below
+  the canvas surfaces the category → color mapping.
+
+Operator notes:
+
+- The pane only renders after the bearer token connects successfully;
+  the snapshot endpoint requires the same loopback auth as every
+  other admin call.
+- The first fetch runs automatically as part of the connect bootstrap
+  alongside the other panes.
+- Empty snapshots render an inline placeholder rather than failing.

--- a/tests/admin-console-app.test.ts
+++ b/tests/admin-console-app.test.ts
@@ -19,6 +19,44 @@ class FakeElement {
   }
 }
 
+/** Minimal fake canvas context — records calls but does nothing. */
+class FakeCanvasContext {
+  calls: string[] = [];
+  save() { this.calls.push("save"); }
+  restore() { this.calls.push("restore"); }
+  clearRect() { this.calls.push("clearRect"); }
+  scale() {}
+  beginPath() {}
+  arc() {}
+  fill() {}
+  stroke() {}
+  moveTo() {}
+  lineTo() {}
+  fillText() {}
+  get fillStyle() { return ""; }
+  set fillStyle(_v: string) {}
+  get strokeStyle() { return ""; }
+  set strokeStyle(_v: string) {}
+  get lineWidth() { return 1; }
+  set lineWidth(_v: number) {}
+  get globalAlpha() { return 1; }
+  set globalAlpha(_v: number) {}
+  get font() { return ""; }
+  set font(_v: string) {}
+  get textAlign() { return ""; }
+  set textAlign(_v: string) {}
+}
+
+class FakeCanvas extends FakeElement {
+  width = 0;
+  height = 0;
+  offsetWidth = 800;
+  offsetHeight = 520;
+  _ctx = new FakeCanvasContext();
+  getContext(_type: string) { return this._ctx; }
+  getBoundingClientRect() { return { left: 0, top: 0, right: 800, bottom: 520 }; }
+}
+
 async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Record<string, FakeElement> = {}) {
   const scriptPath = path.resolve("admin-console/public/app.js");
   const script = await readFile(scriptPath, "utf8");
@@ -33,6 +71,8 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
   const context = vm.createContext({
     console,
     URLSearchParams,
+    requestAnimationFrame: (_fn: () => void) => 0,
+    cancelAnimationFrame: (_id: number) => {},
     document: {
       getElementById(id: string) {
         return elements.get(id) ?? null;
@@ -42,6 +82,7 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
       },
     },
     window: {
+      devicePixelRatio: 1,
       sessionStorage: {
         getItem(key: string) {
           return session.get(key) ?? "";
@@ -62,6 +103,16 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
     copyMemoryPath: vm.runInContext("copyMemoryPath", context) as () => void,
     renderQuality: vm.runInContext("renderQuality", context) as (response: unknown) => void,
     stepMemoryPage: vm.runInContext("stepMemoryPage", context) as (direction: number) => void,
+    graphColorForCategory: vm.runInContext("graphColorForCategory", context) as (cat: string) => string,
+    createForceSimulation: vm.runInContext("createForceSimulation", context) as (
+      nodes: Array<{ id: string; score: number; kind: string; x?: number; y?: number; vx?: number; vy?: number }>,
+      edges: Array<{ _srcNode: unknown; _tgtNode: unknown }>,
+      width: number,
+      height: number,
+    ) => { start: (fn: () => void) => void; stop: () => void },
+    drawGraph: vm.runInContext("drawGraph", context) as () => void,
+    graphData: vm.runInContext("graphData", context),
+    graphView: vm.runInContext("graphView", context) as { tx: number; ty: number; scale: number },
   };
 }
 
@@ -112,4 +163,82 @@ test("admin console copy path fails cleanly when no memory is selected", async (
 
   assert.equal(detailStatus.textContent, "No memory path to copy.");
   assert.equal(detailStatus.className, "status error");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Memory Graph pane — issue #691 PR 3/5
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("graph category colour palette returns a stable colour for known categories", async () => {
+  const { graphColorForCategory } = await loadAdminConsoleContext("25");
+  const c1 = graphColorForCategory("fact");
+  const c2 = graphColorForCategory("fact");
+  // Same category always yields the same colour.
+  assert.equal(c1, c2);
+  // Unknown / empty yields the grey fallback.
+  assert.equal(graphColorForCategory("unknown"), "#aaa");
+  assert.equal(graphColorForCategory(""), "#aaa");
+});
+
+test("graph category colour palette assigns different colours to distinct categories", async () => {
+  const { graphColorForCategory } = await loadAdminConsoleContext("25");
+  const factColor = graphColorForCategory("fact");
+  const decisionColor = graphColorForCategory("decision");
+  // Two distinct categories must not share the same colour
+  // (palette has 8 entries; the first two are always different).
+  assert.notEqual(factColor, decisionColor);
+});
+
+test("force simulation places all nodes with x/y after start", async () => {
+  const { createForceSimulation } = await loadAdminConsoleContext("25");
+
+  const nodes = [
+    { id: "a", score: 0.9, kind: "fact" },
+    { id: "b", score: 0.5, kind: "decision" },
+    { id: "c", score: 0.3, kind: "fact" },
+  ];
+  const edges = [
+    { _srcNode: nodes[0], _tgtNode: nodes[1] },
+    { _srcNode: nodes[1], _tgtNode: nodes[2] },
+  ];
+
+  const sim = createForceSimulation(nodes, edges, 800, 520);
+  // start with a no-op draw callback; raf is stubbed to 0 so no loop runs.
+  sim.start(() => {});
+  sim.stop();
+
+  for (const n of nodes) {
+    assert.ok(typeof (n as { x?: number }).x === "number", `node ${n.id} missing x`);
+    assert.ok(typeof (n as { y?: number }).y === "number", `node ${n.id} missing y`);
+    assert.ok(!Number.isNaN((n as { x?: number }).x));
+    assert.ok(!Number.isNaN((n as { y?: number }).y));
+  }
+});
+
+test("drawGraph is a no-op when graphData is null", async () => {
+  const canvas = new FakeCanvas();
+  const graphStatus = new FakeElement();
+  const { drawGraph } = await loadAdminConsoleContext("25", {
+    graphCanvas: canvas,
+    graphStatus,
+  });
+
+  // graphData starts null; drawGraph must not throw.
+  assert.doesNotThrow(() => drawGraph());
+  // Canvas context must not have been touched (no save calls).
+  assert.equal(canvas._ctx.calls.length, 0);
+});
+
+test("graph pane HTML elements are present in index.html", async () => {
+  const htmlPath = path.resolve("admin-console/public/index.html");
+  const html = await readFile(htmlPath, "utf8");
+
+  assert.ok(html.includes('id="graphCanvas"'), "graphCanvas element missing");
+  assert.ok(html.includes('id="graphTooltip"'), "graphTooltip element missing");
+  assert.ok(html.includes('id="graphStatus"'), "graphStatus element missing");
+  assert.ok(html.includes('id="graphLegend"'), "graphLegend element missing");
+  assert.ok(html.includes('id="refreshGraphButton"'), "refreshGraphButton missing");
+  assert.ok(html.includes('id="resetGraphViewButton"'), "resetGraphViewButton missing");
+  assert.ok(html.includes('id="graphLimit"'), "graphLimit select missing");
+  assert.ok(html.includes('id="graphFocusNodeId"'), "graphFocusNodeId input missing");
 });


### PR DESCRIPTION
## Summary

- Adds a **Memory Graph** pane to the admin console (`admin-console/public/`) that calls `GET /engram/v1/graph/snapshot` (shipped in PR 2/5) and renders a force-directed graph with no new runtime dependencies.
- Vanilla Verlet simulation (~150 lines): repulsion, spring attraction along edges, centering pull, Verlet integration with damping.
- Pan (drag), zoom (scroll-wheel), node tooltip (memory id / category / score / last-updated), edge tooltip (kind / confidence), category color-coding with auto-built legend.
- Controls: edge limit (100/250/500/1000), optional `focusNodeId` filter, Refresh, Reset View.
- First fetch fires automatically alongside the other panes on `connectAndBootstrap`.
- Empty snapshots render an inline placeholder; errors surface in the status bar.
- Adds `docs/admin-console.md` documenting all console panes.
- **Static only** — live patch streaming ships in PR 5/5.

## Test plan

- [ ] 9 new/existing tests pass (`node --test tests/admin-console-app.test.ts`)
  - Colour palette stability + distinctness
  - Verlet simulation initialises node positions
  - `drawGraph` is a no-op when `graphData` is null
  - HTML structure assertion: all new element IDs present
  - Pre-existing pagination, quality-renderer, copy-path tests unaffected
- [ ] No new runtime dependencies added
- [ ] Docs committed (`docs/admin-console.md`)

## PR checklist

- [x] All tests pass
- [x] No secrets or credentials committed
- [x] Docs updated
- [x] Diff scoped to admin console UI + test + docs only

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new interactive canvas-based graph viewer with a custom force simulation and event handling; risk is mainly UI regressions/performance (O(n²) layout) and new API call wiring, but it’s isolated to the admin console.
> 
> **Overview**
> Adds a new **Memory Graph** pane to the admin console that fetches `GET /engram/v1/graph/snapshot` (with optional `limit` and `focusNodeId`) and renders a force-directed canvas view.
> 
> Implements an in-browser Verlet-style force simulation plus pan/zoom, node/edge hover tooltips, category-based node coloring with a generated legend, and safe handling for empty snapshots; the graph loads during `connectAndBootstrap` and can be refreshed/reset via new controls.
> 
> Includes new styling/HTML for the pane, adds `docs/admin-console.md`, and extends `tests/admin-console-app.test.ts` with canvas fakes and coverage for the palette, simulation init, draw no-op behavior, and presence of new DOM IDs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e0ecd298cb1e6647491bf89817f789083407d3b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->