### PR TITLE
feat(transfer): capsule import pipeline (#676 PR 3/6)

### DIFF
--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -107,6 +107,11 @@ import {
   type MemoryOutcomeKind,
   type RecordMemoryOutcomeResult,
 } from "./memory-worth-outcomes.js";
+import {
+  importCapsule as importCapsuleFn,
+  type ImportCapsuleOptions,
+  type ImportCapsuleResult,
+} from "./transfer/capsule-import.js";
 
 export class EngramAccessInputError extends Error {}
 
@@ -4070,5 +4075,29 @@ export class EngramAccessService {
         }
       };
     };
+  }
+
+  /**
+   * Import a capsule archive into the orchestrator's memory directory.
+   *
+   * Delegates directly to the standalone {@link importCapsuleFn} function.
+   * The `root` parameter defaults to the orchestrator's `memoryDir` when
+   * omitted, so callers that only have access to the service do not need to
+   * thread the config value through.
+   *
+   * `versioning` defaults to the orchestrator's page-versioning config so
+   * `mode: "overwrite"` automatically snapshots prior content without the
+   * caller having to construct the config object.
+   */
+  async capsuleImport(
+    opts: Omit<ImportCapsuleOptions, "root"> & { root?: string },
+  ): Promise<ImportCapsuleResult> {
+    const root = opts.root ?? this.orchestrator.config.memoryDir;
+    const versioning = opts.versioning ?? {
+      enabled: this.orchestrator.config.versioningEnabled,
+      maxVersionsPerPage: this.orchestrator.config.versioningMaxPerPage,
+      sidecarDir: this.orchestrator.config.versioningSidecarDir,
+    };
+    return importCapsuleFn({ ...opts, root, versioning });
   }
 }

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -238,9 +238,25 @@ export async function importCapsule(
     // silently collapse, landing the file inside root but outside the fork
     // prefix — Cursor medium thread #741).  Rejecting `..` up-front is simpler
     // and more robust than normalising after the fact.
+    //
+    // Extended guard (Codex P1 #741 round 5): also reject paths containing
+    // backslash separators (`\`), which are Windows path separators. On Windows
+    // a path like `..\\escape.md` or `subdir\\..\\..\\escape.md` would resolve
+    // to a parent traversal but would bypass a purely posix-split check.
+    // Additionally, after posix-normalizing the path we re-check for a leading
+    // `..` or `/` — this catches edge-cases such as `subdir/../..` where the
+    // individual split segments are not `..` but the normalized result is.
+    if (rec.path.includes("\\")) {
+      throw new Error(
+        `importCapsule: record path contains backslash separators (Windows-style paths are not allowed): ${rec.path}`,
+      );
+    }
+    const posixNormalized = path.posix.normalize(rec.path);
     if (
       rec.path.startsWith("/") ||
-      rec.path.split("/").some((seg) => seg === "..")
+      rec.path.split("/").some((seg) => seg === "..") ||
+      posixNormalized.startsWith("..") ||
+      posixNormalized.startsWith("/")
     ) {
       throw new Error(
         `importCapsule: record path escapes target root: ${rec.path}`,
@@ -443,6 +459,18 @@ async function assertIsDirectory(absPath: string): Promise<void> {
   if (!st || !st.isDirectory()) {
     throw new Error(
       `importCapsule: 'root' must be an existing directory: ${absPath}`,
+    );
+  }
+  // Codex P1 #741 round 5: reject a root that is itself a symlink.
+  // `stat` follows symlinks so the isDirectory() check above passes even when
+  // `absPath` is a symlink → /etc or another sensitive directory.  We use
+  // `lstat` to inspect the path itself without following the link.  If it is a
+  // symlink we reject up-front rather than silently writing to the resolved
+  // target (which could be a sensitive location supplied by an attacker).
+  const lst = await lstat(absPath).catch(() => null);
+  if (lst && lst.isSymbolicLink()) {
+    throw new Error(
+      `importCapsule: 'root' must not be a symlink — resolve it to its real path first: ${absPath}`,
     );
   }
 }

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
@@ -72,8 +72,17 @@ export interface ImportCapsuleOptions {
 export interface ImportCapsuleSkippedRecord {
   /** Original record path (capsule-relative, posix). */
   path: string;
-  /** Why this record was not written. */
-  reason: "exists" | "checksum_mismatch";
+  /**
+   * Why this record was not written.
+   *
+   * `"exists"` — the target path already existed and the mode was `"skip"`,
+   * OR the computed fork path already existed in fork mode.
+   *
+   * `"checksum_mismatch"` is intentionally absent: a checksum failure aborts
+   * the import entirely (fail-closed) rather than skipping the offending
+   * record, so no `ImportCapsuleSkippedRecord` is ever produced for it.
+   */
+  reason: "exists";
 }
 
 export interface ImportCapsuleImportedRecord {
@@ -125,6 +134,14 @@ export async function importCapsule(
   await assertIsDirectory(rootAbs);
 
   const mode: ImportCapsuleMode = opts.mode ?? "skip";
+  // Reject unknown mode values up-front (rule 51). TypeScript callers get a
+  // compile-time check via the union type; JS/CLI callers get a runtime error
+  // here before any write begins — not a silent destructive fallback.
+  if (mode !== "skip" && mode !== "overwrite" && mode !== "fork") {
+    throw new Error(
+      `importCapsule: unknown mode ${JSON.stringify(mode)}; expected "skip", "overwrite", or "fork"`,
+    );
+  }
 
   const raw = await readFile(archiveAbs);
   const json = gunzipSync(raw).toString("utf-8");
@@ -174,12 +191,20 @@ export async function importCapsule(
     recordPaths.add(rec.path);
   }
 
-  // Phase 1: verify every record matches its manifest entry. We compute a
-  // sha256 over the in-memory record content and compare to the manifest's
-  // declared sha256. Any mismatch — including a missing manifest entry —
-  // aborts the import. We do this BEFORE any filesystem mutation so a
-  // corrupted archive cannot leave the memory dir partially written.
+  // Phase 1: verify every record matches its manifest entry AND validate all
+  // target paths before any filesystem mutation.  We do both in a single pass
+  // so a corrupted or malicious archive cannot leave the memory dir partially
+  // written (fail-closed per gotcha #25).
+  //
+  // The real root is resolved once via realpath so the subsequent per-record
+  // inside-root checks are symlink-aware: a record path like `facts/a.md`
+  // cannot write outside the intended sandbox via a symlinked subdirectory
+  // (Codex P1 feedback).  If realpath fails (root does not exist) the earlier
+  // assertIsDirectory call already threw, so this should always succeed.
+  const rootReal = await realpath(rootAbs).catch(() => rootAbs);
+
   for (const rec of bundle.records) {
+    // Checksum validation.
     const entry = manifestIndex.get(rec.path);
     if (!entry) {
       throw new Error(
@@ -194,6 +219,22 @@ export async function importCapsule(
           `got sha256=${sha256} bytes=${bytes}`,
       );
     }
+
+    // Path-traversal validation (moved here from phase 2 per Cursor feedback:
+    // the traversal check must run before ANY write so a malicious archive
+    // with an escaping path that sorts last cannot land partial writes).
+    //
+    // We build targetAbs relative to the real-resolved root (rootReal) so
+    // that the inside-root check is symlink-aware: if `rootReal !== rootAbs`
+    // (the import root is itself behind a symlink), we still compare against
+    // the canonical path (Codex P1).
+    const targetRel = computeTargetPath(rec.path, mode, capsule.id);
+    const targetAbs = path.join(rootReal, fromPosixRelPath(targetRel));
+    if (!isPathInsideRoot(rootReal, targetAbs)) {
+      throw new Error(
+        `importCapsule: record path escapes target root: ${rec.path}`,
+      );
+    }
   }
   // Detect manifest-only entries (missing record). Treat as corruption.
   for (const f of manifest.files) {
@@ -204,9 +245,9 @@ export async function importCapsule(
     }
   }
 
-  // Phase 2: apply the mode. Records were validated above; we now write to
-  // disk. Per-record errors propagate; the import is best-effort across
-  // records but each individual write is atomic (mkdir + writeFile pair).
+  // Phase 2: apply the mode. All records were validated in phase 1; we now
+  // write to disk. Per-record errors propagate; each individual write is
+  // atomic (mkdir + writeFile pair).
   const imported: ImportCapsuleImportedRecord[] = [];
   const skipped: ImportCapsuleSkippedRecord[] = [];
 
@@ -219,20 +260,18 @@ export async function importCapsule(
 
   for (const rec of sortedRecords) {
     const targetRel = computeTargetPath(rec.path, mode, capsule.id);
-    const targetAbs = path.join(rootAbs, fromPosixRelPath(targetRel));
-
-    if (!isPathInsideRoot(rootAbs, targetAbs)) {
-      // Record path traversal protection. `exportCapsule` only ever produces
-      // posix-relative paths under root, but a hand-built archive could ship
-      // `../../etc/passwd`. Reject before any FS access.
-      throw new Error(
-        `importCapsule: record path escapes target root: ${rec.path}`,
-      );
-    }
+    // Use rootReal (realpath-resolved) to stay consistent with phase 1's
+    // traversal validation and avoid writing through stale symlinks.
+    const targetAbs = path.join(rootReal, fromPosixRelPath(targetRel));
 
     const exists = await fileExistsAt(targetAbs);
 
-    if (mode === "skip" && exists) {
+    // Skip logic applies to both `skip` mode (explicit) and `fork` mode
+    // (Cursor medium: fork mode must also be skip-on-exist for the computed
+    // fork path, because production imports generate non-deterministic IDs —
+    // so re-importing the same capsule should not overwrite user edits in the
+    // fork tree or silently change file identities by generating new IDs).
+    if ((mode === "skip" || mode === "fork") && exists) {
       skipped.push({ path: rec.path, reason: "exists" });
       continue;
     }
@@ -252,7 +291,7 @@ export async function importCapsule(
           opts.versioning,
           opts.log,
           `capsule-import: ${capsule.id}`,
-          rootAbs,
+          rootReal,
         );
         snapshotted = true;
       }
@@ -304,14 +343,21 @@ function computeTargetPath(
 }
 
 /**
- * Return true when {@link absPath} is the same as {@link rootAbs} or a
- * descendant. Defensive symlink-aware checks (`realpath`) are not necessary
- * here because `exportCapsule` only produces posix-relative paths and we
- * validate `rootAbs` is a directory; this guard exists purely to reject
- * hand-edited archives that ship `..`-traversal paths.
+ * Return true when {@link absPath} is the same as {@link rootReal} or a
+ * descendant.
+ *
+ * {@link rootReal} should be the value returned by `realpath(rootAbs)` so
+ * that symlinked subdirectories are detected: a record path like `facts/a.md`
+ * computes an `absPath` under the un-resolved `rootAbs`, but the final write
+ * follows any symlink. We compare against the resolved root to catch the case
+ * where `rootAbs/facts/` is a symlink pointing outside the sandbox (Codex P1).
+ *
+ * For the `..`-traversal case (hand-edited archives): the `path.relative`
+ * lexical check is sufficient because `absPath` is constructed by joining
+ * `rootAbs` with a posix-relative path, so no resolved path needed there.
  */
-function isPathInsideRoot(rootAbs: string, absPath: string): boolean {
-  const rel = path.relative(rootAbs, absPath);
+function isPathInsideRoot(rootReal: string, absPath: string): boolean {
+  const rel = path.relative(rootReal, absPath);
   if (rel === "") return true;
   if (rel === "..") return false;
   if (rel.startsWith(`..${path.sep}`)) return false;
@@ -412,14 +458,6 @@ function mintForkId(capsuleId: string, originalId: string, now: number | undefin
   const suffix = createHash("sha256").update(payload, "utf-8").digest("hex").slice(0, 8);
   return `${base}-fork-${capsuleId}-${suffix}`;
 }
-
-/**
- * Re-export for tests that want to construct a fork id without going through
- * the full import pipeline. Not part of the stable public API.
- *
- * @internal
- */
-export const __test = { mintForkId, rewriteFrontmatterIdForFork };
 
 // Note: `CapsuleBlock` is re-exported here purely so callers that want to
 // inspect the manifest block don't have to deep-import from `./types.js`.

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -1,0 +1,426 @@
+import { mkdir, readFile, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { createHash, randomUUID } from "node:crypto";
+import { gunzipSync } from "node:zlib";
+import {
+  createVersion,
+  type VersioningConfig,
+  type VersioningLogger,
+} from "../page-versioning.js";
+import { fromPosixRelPath, sha256String } from "./fs-utils.js";
+import {
+  parseExportBundle,
+  type CapsuleBlock,
+  type ExportManifestV2,
+  type ExportMemoryRecordV1,
+} from "./types.js";
+
+/**
+ * Conflict-resolution mode for {@link importCapsule}. Inverse of the
+ * `mode` selector in PR 4/6's CLI surface.
+ *
+ *  - `"skip"` (default) — when a target file already exists at the same
+ *    relative path, leave it untouched. The corresponding record is reported
+ *    via {@link ImportCapsuleResult.skipped}.
+ *  - `"overwrite"` — when a target file exists, snapshot the prior content
+ *    via {@link createVersion} (gotcha #54: write-before-delete; gotcha #25:
+ *    don't destroy old state until new state is confirmed), then write the
+ *    incoming content. The snapshot's `note` includes the source capsule id.
+ *  - `"fork"` — never overwrite. Every record is rebased under
+ *    `forks/<capsule-id>/<original-path>` and any YAML-frontmatter `id:`
+ *    field is rewritten to a new fork-scoped value. The original tree is
+ *    not touched.
+ *
+ * The mode is selected once per call and applied uniformly to every record
+ * in the bundle. Mixed-mode imports are not supported by design — that
+ * would let a single corrupted manifest silently land partial state.
+ */
+export type ImportCapsuleMode = "skip" | "overwrite" | "fork";
+
+/**
+ * Options accepted by {@link importCapsule}.
+ *
+ * `archivePath` — absolute or cwd-relative path to a `.capsule.json.gz`
+ * archive produced by `exportCapsule`. The archive must contain a V2
+ * bundle (`schemaVersion: 2`); V1 archives are rejected.
+ *
+ * `root` — absolute or cwd-relative path to the memory directory that
+ * will receive the records. Must be an existing directory.
+ *
+ * `mode` — see {@link ImportCapsuleMode}. Defaults to `"skip"`.
+ *
+ * `versioning` — optional page-versioning config used by `mode: "overwrite"`
+ * to snapshot prior content before replacing it. Snapshots are skipped when
+ * not provided or when `enabled === false`. Tests pass an enabled config
+ * to assert snapshot creation; production callers thread the
+ * orchestrator's resolved versioning config.
+ *
+ * `log` — optional logger forwarded to {@link createVersion}.
+ *
+ * `now` — optional clock override (ms epoch) used to derive deterministic
+ * fork ids in tests. Production callers omit this.
+ */
+export interface ImportCapsuleOptions {
+  archivePath: string;
+  root: string;
+  mode?: ImportCapsuleMode;
+  versioning?: VersioningConfig;
+  log?: VersioningLogger;
+  now?: number;
+}
+
+export interface ImportCapsuleSkippedRecord {
+  /** Original record path (capsule-relative, posix). */
+  path: string;
+  /** Why this record was not written. */
+  reason: "exists" | "checksum_mismatch";
+}
+
+export interface ImportCapsuleImportedRecord {
+  /** Capsule-relative posix path the record carried. */
+  sourcePath: string;
+  /** Memory-dir-relative posix path the file was written to. */
+  targetPath: string;
+  /** Whether a prior version snapshot was taken (overwrite-mode only). */
+  snapshotted: boolean;
+  /** Whether the frontmatter `id:` field was rewritten (fork-mode only). */
+  rewroteId: boolean;
+}
+
+export interface ImportCapsuleResult {
+  /** Records that landed on disk. */
+  imported: ImportCapsuleImportedRecord[];
+  /** Records that were not written. */
+  skipped: ImportCapsuleSkippedRecord[];
+  /** The manifest decoded from the archive. */
+  manifest: ExportManifestV2;
+}
+
+/**
+ * Pure async function that imports a capsule archive into a memory
+ * directory. Inverse of {@link import("./capsule-export.js").exportCapsule}.
+ *
+ * Sequence:
+ *   1. Read + gunzip + JSON.parse the archive.
+ *   2. Validate the bundle through `parseExportBundle` (V1 rejected).
+ *   3. Verify each record's content sha256 against the manifest entry.
+ *      Any mismatch aborts the import BEFORE any file is written —
+ *      partial-write recovery would require a full rollback we cannot
+ *      offer cheaply, so we fail closed (gotcha #25).
+ *   4. Apply the selected {@link ImportCapsuleMode} to every record.
+ *
+ * Determinism guarantees:
+ *  - Imported records are returned sorted by `sourcePath`.
+ *  - Skipped records are returned sorted by `path`.
+ *  - Fork-mode rebases under a stable `forks/<capsule-id>/` prefix so
+ *    repeated fork imports of the same capsule shape land in predictable
+ *    locations (subsequent fork imports still skip-on-exist because the
+ *    target tree is computed from the source path).
+ */
+export async function importCapsule(
+  opts: ImportCapsuleOptions,
+): Promise<ImportCapsuleResult> {
+  const archiveAbs = path.resolve(opts.archivePath);
+  const rootAbs = path.resolve(opts.root);
+  await assertIsDirectory(rootAbs);
+
+  const mode: ImportCapsuleMode = opts.mode ?? "skip";
+
+  const raw = await readFile(archiveAbs);
+  const json = gunzipSync(raw).toString("utf-8");
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(json);
+  } catch (cause) {
+    throw new Error(
+      `importCapsule: archive is not valid JSON after gunzip: ${archiveAbs}`,
+      { cause: cause as Error },
+    );
+  }
+
+  const parsed = parseExportBundle(parsedJson);
+  if (parsed.capsuleVersion !== 2) {
+    // PR 1/6 ships a V1 reader; capsule import is V2-only by design. A V1
+    // bundle does not carry a capsule block, so fork-mode (which depends on
+    // `capsule.id` for the rebase prefix) cannot work. Reject up-front per
+    // gotcha #51 instead of silently routing to a different code path.
+    throw new Error(
+      "importCapsule: archive is V1; only V2 capsule archives are supported",
+    );
+  }
+  const bundle = parsed.bundle as { manifest: ExportManifestV2; records: ExportMemoryRecordV1[] };
+  const manifest = bundle.manifest;
+  const capsule = manifest.capsule;
+
+  // Build a path → manifest-entry index for O(1) checksum lookup. The
+  // manifest is the source of truth; records-without-manifest-entries and
+  // manifest-entries-without-records are both treated as corruption.
+  const manifestIndex = new Map<string, ExportManifestV2["files"][number]>();
+  for (const f of manifest.files) {
+    manifestIndex.set(f.path, f);
+  }
+  if (manifestIndex.size !== manifest.files.length) {
+    throw new Error(
+      "importCapsule: manifest contains duplicate file paths",
+    );
+  }
+  const recordPaths = new Set<string>();
+  for (const rec of bundle.records) {
+    if (recordPaths.has(rec.path)) {
+      throw new Error(
+        `importCapsule: bundle contains duplicate record path: ${rec.path}`,
+      );
+    }
+    recordPaths.add(rec.path);
+  }
+
+  // Phase 1: verify every record matches its manifest entry. We compute a
+  // sha256 over the in-memory record content and compare to the manifest's
+  // declared sha256. Any mismatch — including a missing manifest entry —
+  // aborts the import. We do this BEFORE any filesystem mutation so a
+  // corrupted archive cannot leave the memory dir partially written.
+  for (const rec of bundle.records) {
+    const entry = manifestIndex.get(rec.path);
+    if (!entry) {
+      throw new Error(
+        `importCapsule: archive checksum mismatch (record without manifest entry: ${rec.path})`,
+      );
+    }
+    const { sha256, bytes } = sha256String(rec.content);
+    if (sha256 !== entry.sha256 || bytes !== entry.bytes) {
+      throw new Error(
+        `importCapsule: archive checksum mismatch for ${rec.path}: ` +
+          `expected sha256=${entry.sha256} bytes=${entry.bytes}, ` +
+          `got sha256=${sha256} bytes=${bytes}`,
+      );
+    }
+  }
+  // Detect manifest-only entries (missing record). Treat as corruption.
+  for (const f of manifest.files) {
+    if (!recordPaths.has(f.path)) {
+      throw new Error(
+        `importCapsule: archive checksum mismatch (manifest entry without record: ${f.path})`,
+      );
+    }
+  }
+
+  // Phase 2: apply the mode. Records were validated above; we now write to
+  // disk. Per-record errors propagate; the import is best-effort across
+  // records but each individual write is atomic (mkdir + writeFile pair).
+  const imported: ImportCapsuleImportedRecord[] = [];
+  const skipped: ImportCapsuleSkippedRecord[] = [];
+
+  // Sort by source path so the imported/skipped lists are deterministic
+  // regardless of bundle order. (`exportCapsule` already sorts; we re-sort
+  // defensively in case a hand-edited archive ships records in another order.)
+  const sortedRecords = [...bundle.records].sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+
+  for (const rec of sortedRecords) {
+    const targetRel = computeTargetPath(rec.path, mode, capsule.id);
+    const targetAbs = path.join(rootAbs, fromPosixRelPath(targetRel));
+
+    if (!isPathInsideRoot(rootAbs, targetAbs)) {
+      // Record path traversal protection. `exportCapsule` only ever produces
+      // posix-relative paths under root, but a hand-built archive could ship
+      // `../../etc/passwd`. Reject before any FS access.
+      throw new Error(
+        `importCapsule: record path escapes target root: ${rec.path}`,
+      );
+    }
+
+    const exists = await fileExistsAt(targetAbs);
+
+    if (mode === "skip" && exists) {
+      skipped.push({ path: rec.path, reason: "exists" });
+      continue;
+    }
+
+    let snapshotted = false;
+    if (mode === "overwrite" && exists) {
+      // Gotcha #54: snapshot BEFORE overwriting. If snapshot creation fails
+      // we abort this record's import rather than silently destroying
+      // history. The page-versioning module is responsible for atomic
+      // sidecar writes; we just call it.
+      if (opts.versioning && opts.versioning.enabled) {
+        const prior = await readFile(targetAbs, "utf-8").catch(() => "");
+        await createVersion(
+          targetAbs,
+          prior,
+          "manual",
+          opts.versioning,
+          opts.log,
+          `capsule-import: ${capsule.id}`,
+          rootAbs,
+        );
+        snapshotted = true;
+      }
+    }
+
+    let contentToWrite = rec.content;
+    let rewroteId = false;
+    if (mode === "fork") {
+      const forked = rewriteFrontmatterIdForFork(rec.content, capsule.id, opts.now);
+      contentToWrite = forked.content;
+      rewroteId = forked.rewrote;
+    }
+
+    await mkdir(path.dirname(targetAbs), { recursive: true });
+    await writeFile(targetAbs, contentToWrite, "utf-8");
+    imported.push({
+      sourcePath: rec.path,
+      targetPath: targetRel,
+      snapshotted,
+      rewroteId,
+    });
+  }
+
+  // Sort skipped for stable output (see comment above).
+  skipped.sort((a, b) => a.path.localeCompare(b.path));
+
+  return { imported, skipped, manifest };
+}
+
+// ---------------------------------------------------------------------------
+// Path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute the destination relative path for a record under the chosen
+ * mode.
+ *
+ *  - `skip` / `overwrite` — identity: the record's posix path is used as-is.
+ *  - `fork` — rebased under `forks/<capsule-id>/<original-path>` so the
+ *    original tree is never modified.
+ */
+function computeTargetPath(
+  sourcePosix: string,
+  mode: ImportCapsuleMode,
+  capsuleId: string,
+): string {
+  if (mode === "fork") return `forks/${capsuleId}/${sourcePosix}`;
+  return sourcePosix;
+}
+
+/**
+ * Return true when {@link absPath} is the same as {@link rootAbs} or a
+ * descendant. Defensive symlink-aware checks (`realpath`) are not necessary
+ * here because `exportCapsule` only produces posix-relative paths and we
+ * validate `rootAbs` is a directory; this guard exists purely to reject
+ * hand-edited archives that ship `..`-traversal paths.
+ */
+function isPathInsideRoot(rootAbs: string, absPath: string): boolean {
+  const rel = path.relative(rootAbs, absPath);
+  if (rel === "") return true;
+  if (rel === "..") return false;
+  if (rel.startsWith(`..${path.sep}`)) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+async function assertIsDirectory(absPath: string): Promise<void> {
+  // Mirror gotcha #24: existsSync returns true for files. The import root
+  // MUST be a directory.
+  const st = await stat(absPath).catch(() => null);
+  if (!st || !st.isDirectory()) {
+    throw new Error(
+      `importCapsule: 'root' must be an existing directory: ${absPath}`,
+    );
+  }
+}
+
+async function fileExistsAt(absPath: string): Promise<boolean> {
+  const st = await stat(absPath).catch(() => null);
+  return st !== null && st.isFile();
+}
+
+// ---------------------------------------------------------------------------
+// Fork-mode id rewriting
+// ---------------------------------------------------------------------------
+
+/**
+ * Rewrite a YAML-frontmatter `id:` field to a fork-scoped value.
+ *
+ * Strategy: we deliberately do NOT parse the entire YAML — memory files
+ * use a deterministic top-of-file frontmatter delimited by `---` lines,
+ * and the orchestrator's `parseFrontmatter` reads `id` as a top-level
+ * key with a single-line scalar value. We mirror that contract:
+ *
+ *   - Detect a leading `---\n` … `\n---` block at the top of the file.
+ *   - Within that block, locate the first `id:` line that is not nested
+ *     under another key (cheap heuristic: line starts at column 0).
+ *   - Replace its value with a new fork-id derived from `capsuleId` and
+ *     a short random suffix (or {@link opts.now} when provided for tests).
+ *
+ * Files without a frontmatter block, or without an `id:` key inside one,
+ * are returned unchanged with `rewrote: false`. This keeps non-memory
+ * artifacts (READMEs, transcripts) byte-identical to the source.
+ */
+function rewriteFrontmatterIdForFork(
+  content: string,
+  capsuleId: string,
+  now: number | undefined,
+): { content: string; rewrote: boolean } {
+  // Frontmatter block detection: `---` on its own line at the very start,
+  // followed by content, followed by `---` on its own line. The closing
+  // delimiter must be at column 0. We capture the trailing terminator
+  // (`\r?\n` or end-of-string) as a separate group so we can re-emit it
+  // verbatim, preserving CRLF/LF/EOF shape from the original file.
+  const fmMatch = /^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/.exec(content);
+  if (!fmMatch) return { content, rewrote: false };
+  const fmBody = fmMatch[1];
+  const fmTrailer = fmMatch[2];
+  const fmStart = fmMatch.index;
+  const fmEnd = fmStart + fmMatch[0].length;
+
+  // Find a top-level `id:` line. Top-level means the line begins at
+  // column 0 inside the frontmatter body (no leading whitespace) and the
+  // key is exactly `id`. We deliberately accept `id:` and `id : ` shapes
+  // but reject `nested_id:` to avoid touching unrelated keys.
+  const idLineRe = /^id:[ \t]*([^\r\n]*)$/m;
+  const idMatch = idLineRe.exec(fmBody);
+  if (!idMatch) return { content, rewrote: false };
+
+  const newId = mintForkId(capsuleId, idMatch[1]?.trim() ?? "", now);
+  const replacedBody = fmBody.replace(idLineRe, `id: ${newId}`);
+  // Reconstruct the file: original prefix (always empty here, fmStart === 0
+  // by the `^` anchor) + frontmatter delimiters around the rewritten body
+  // (preserving the original trailing terminator) + the original body that
+  // followed the closing `---`.
+  const prefix = content.slice(0, fmStart);
+  const tail = content.slice(fmEnd);
+  const rebuilt = `${prefix}---\n${replacedBody}\n---${fmTrailer}${tail}`;
+  return { content: rebuilt, rewrote: true };
+}
+
+/**
+ * Derive a deterministic-when-`now`-is-set fork id from the capsule id and
+ * the original record id. Production callers omit `now` and get a UUID
+ * suffix; tests pass `now` for byte-stable assertions.
+ */
+function mintForkId(capsuleId: string, originalId: string, now: number | undefined): string {
+  const base = originalId.length > 0 ? originalId : "fork";
+  if (now === undefined) {
+    const suffix = randomUUID().slice(0, 8);
+    return `${base}-fork-${capsuleId}-${suffix}`;
+  }
+  // Deterministic suffix: short hash of (capsuleId, originalId, now). Using
+  // sha256 over a sorted-key serialization (gotcha #38) so the suffix does
+  // not depend on Object.entries order.
+  const payload = JSON.stringify({ c: capsuleId, i: originalId, n: now });
+  const suffix = createHash("sha256").update(payload, "utf-8").digest("hex").slice(0, 8);
+  return `${base}-fork-${capsuleId}-${suffix}`;
+}
+
+/**
+ * Re-export for tests that want to construct a fork id without going through
+ * the full import pipeline. Not part of the stable public API.
+ *
+ * @internal
+ */
+export const __test = { mintForkId, rewriteFrontmatterIdForFork };
+
+// Note: `CapsuleBlock` is re-exported here purely so callers that want to
+// inspect the manifest block don't have to deep-import from `./types.js`.
+export type { CapsuleBlock };

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -1,4 +1,4 @@
-import { mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import { lstat, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { createHash, randomUUID } from "node:crypto";
 import { gunzipSync } from "node:zlib";
@@ -230,6 +230,23 @@ export async function importCapsule(
       );
     }
 
+    // Source path validation: reject any record whose posix source path
+    // contains a `..` segment, an absolute prefix, or any component that would
+    // let fork-mode bypass its isolation invariant.  This check runs before
+    // `computeTargetPath` so that fork mode's `forks/<id>/` rebase cannot be
+    // bypassed by a path like `../../profile.md` (which `path.join` would
+    // silently collapse, landing the file inside root but outside the fork
+    // prefix — Cursor medium thread #741).  Rejecting `..` up-front is simpler
+    // and more robust than normalising after the fact.
+    if (
+      rec.path.startsWith("/") ||
+      rec.path.split("/").some((seg) => seg === "..")
+    ) {
+      throw new Error(
+        `importCapsule: record path escapes target root: ${rec.path}`,
+      );
+    }
+
     // Path-traversal validation (moved here from phase 2 per Cursor feedback:
     // the traversal check must run before ANY write so a malicious archive
     // with an escaping path that sorts last cannot land partial writes).
@@ -245,6 +262,15 @@ export async function importCapsule(
         `importCapsule: record path escapes target root: ${rec.path}`,
       );
     }
+
+    // Symlink-aware containment check (Cursor thread #741 line 247/264).
+    // The lexical check above handles `..`-traversal but cannot detect
+    // symlinked subdirectories that point outside the root. We resolve the
+    // nearest existing ancestor of the target via realpath to catch symlinks
+    // anywhere in the path components. If any resolved prefix escapes rootReal,
+    // the import is rejected before any write. This applies to ALL modes,
+    // including fork mode whose rebase prefix may itself traverse a symlink.
+    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path);
 
     // Duplicate normalized target path detection (Codex P1 #741, line 188).
     // `path.join` already normalises `.` segments (e.g. `subdir/./file.md` →
@@ -407,6 +433,46 @@ async function fileExistsAt(absPath: string): Promise<boolean> {
   return st !== null && st.isFile();
 }
 
+/**
+ * Walk upward from {@link targetAbs} to find the nearest existing ancestor,
+ * resolve it via `fs.realpath` (which follows symlinks), then re-append the
+ * remaining suffix and verify the result is inside {@link rootReal}.
+ *
+ * This catches the case where an existing subdirectory at any point in the
+ * path is a symlink that points outside the intended import root. Because the
+ * file does not exist yet we cannot realpath it directly; we resolve the
+ * deepest existing prefix and re-apply the non-existent suffix.
+ *
+ * Callers must ensure {@link rootReal} was already resolved via `realpath`.
+ */
+async function assertRealpathInsideRoot(
+  rootReal: string,
+  targetAbs: string,
+  sourcePath: string,
+): Promise<void> {
+  // Walk from targetAbs toward root until we find a path component that exists.
+  let existing = targetAbs;
+  const suffix: string[] = [];
+  while (existing !== path.dirname(existing)) {
+    const st = await lstat(existing).catch(() => null);
+    if (st !== null) break;
+    suffix.unshift(path.basename(existing));
+    existing = path.dirname(existing);
+  }
+
+  // Resolve the existing prefix via realpath to follow any symlinks.
+  const existingReal = await realpath(existing).catch(() => existing);
+
+  // Re-apply the non-existent suffix to get the real final path.
+  const targetReal = suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
+
+  if (!isPathInsideRoot(rootReal, targetReal)) {
+    throw new Error(
+      `importCapsule: record path escapes target root via symlink: ${sourcePath}`,
+    );
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Fork-mode id rewriting
 // ---------------------------------------------------------------------------
@@ -434,6 +500,16 @@ function rewriteFrontmatterIdForFork(
   capsuleId: string,
   now: number | undefined,
 ): { content: string; rewrote: boolean } {
+  // Detect the dominant line ending in the file so we can preserve it when
+  // rebuilding the frontmatter delimiters. Splitting/joining on `\n` silently
+  // drops `\r` from CRLF files, changing the byte content (Cursor thread #741
+  // line 467). We detect the ending of the very first line (the opening `---`)
+  // and use that as the canonical separator for the reconstructed delimiters.
+  // All three cases are covered: CRLF (\r\n), LF (\n), and bare CR (\r).
+  const crlfMatch = /^---(\r\n|\r|\n)/.exec(content);
+  // Fall back to LF if the file starts with `---` but has no newline (EOF).
+  const eol = crlfMatch ? crlfMatch[1] : "\n";
+
   // Frontmatter block detection: `---` on its own line at the very start,
   // followed by content, followed by `---` on its own line. The closing
   // delimiter must be at column 0. We capture the trailing terminator
@@ -457,12 +533,15 @@ function rewriteFrontmatterIdForFork(
   const newId = mintForkId(capsuleId, idMatch[1]?.trim() ?? "", now);
   const replacedBody = fmBody.replace(idLineRe, `id: ${newId}`);
   // Reconstruct the file: original prefix (always empty here, fmStart === 0
-  // by the `^` anchor) + frontmatter delimiters around the rewritten body
-  // (preserving the original trailing terminator) + the original body that
-  // followed the closing `---`.
+  // by the `^` anchor) + frontmatter delimiters around the rewritten body.
+  // Use the detected `eol` for the opening/closing `---` lines so that CRLF
+  // files remain CRLF and LF files remain LF, preserving byte-content fidelity
+  // (Cursor thread #741 line 467).  The captured `fmTrailer` (the newline
+  // immediately after the closing `---`, or end-of-string) is re-emitted
+  // verbatim so the byte immediately after the closing fence is unchanged.
   const prefix = content.slice(0, fmStart);
   const tail = content.slice(fmEnd);
-  const rebuilt = `${prefix}---\n${replacedBody}\n---${fmTrailer}${tail}`;
+  const rebuilt = `${prefix}---${eol}${replacedBody}${eol}---${fmTrailer}${tail}`;
   return { content: rebuilt, rewrote: true };
 }
 

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -203,14 +203,14 @@ export async function importCapsule(
   // assertIsDirectory call already threw, so this should always succeed.
   const rootReal = await realpath(rootAbs).catch(() => rootAbs);
 
-  // Tracks normalized target paths seen so far in phase 1.  Maps
-  // normalizedTargetAbs → first source path so the collision error can name
+  // Tracks normalized, case-folded target paths seen so far in phase 1.  Maps
+  // targetAbs.toLowerCase() → first source path so the collision error can name
   // both offending entries.  Two manifest entries whose computed target paths
   // normalize to the same absolute path (e.g. `subdir/file.md` and
-  // `subdir/./file.md`, or differing case on case-insensitive filesystems)
-  // would both try to write the same file — the second would silently
-  // overwrite the first.  We reject the import up-front before any write
-  // (Codex P1 thread on PR #741, line 188).
+  // `subdir/./file.md`, or differing case on case-insensitive filesystems such
+  // as macOS and Windows) would both try to write the same inode — the second
+  // would silently overwrite the first.  We reject the import up-front before
+  // any write (Codex P2 thread on PR #741, line 283).
   const seenTargetPaths = new Map<string, string>();
 
   for (const rec of bundle.records) {
@@ -272,21 +272,40 @@ export async function importCapsule(
     // including fork mode whose rebase prefix may itself traverse a symlink.
     await assertRealpathInsideRoot(rootReal, targetAbs, rec.path);
 
-    // Duplicate normalized target path detection (Codex P1 #741, line 188).
+    // Target-file symlink check (Codex P1 #741 round 4, line 260).
+    // `assertRealpathInsideRoot` resolves the nearest existing *ancestor* to
+    // catch symlinked parent directories, but if the TARGET FILE itself already
+    // exists and is a symlink, that check passes (the parent is real) while the
+    // write would silently follow the symlink to a path outside root.  We
+    // therefore lstat the target directly: if it exists and is a symlink we
+    // reject the record up-front.  For new files the parent-canonicalization
+    // performed above is sufficient; no realpath of a non-existent file is
+    // needed.
+    const targetLstat = await lstat(targetAbs).catch(() => null);
+    if (targetLstat !== null && targetLstat.isSymbolicLink()) {
+      throw new Error(
+        `importCapsule: record target is a symlink and cannot be written to safely: ${rec.path}`,
+      );
+    }
+
+    // Duplicate normalized target path detection (Codex P2 #741, line 283).
     // `path.join` already normalises `.` segments (e.g. `subdir/./file.md` →
-    // `subdir/file.md`).  On case-insensitive filesystems, two paths that
-    // differ only in case would resolve to the same inode, so we use
-    // `targetAbs` (which is built on the realpath-resolved root) as the
-    // canonical form for dedup — the same form used for the containment check
-    // above, keeping both checks consistent.
-    const firstSourcePath = seenTargetPaths.get(targetAbs);
+    // `subdir/file.md`).  On case-insensitive filesystems (macOS default,
+    // Windows), two paths that differ only in case would resolve to the same
+    // inode.  We fold the dedup key to lowercase so that `subdir/File.md` and
+    // `subdir/file.md` are detected as duplicates before any write occurs.
+    // This is intentionally unconditional: the cost of an extra `.toLowerCase()`
+    // on case-sensitive filesystems is negligible, and a defensive lowercase
+    // is far simpler than probing filesystem case-sensitivity at runtime.
+    const dedupKey = targetAbs.toLowerCase();
+    const firstSourcePath = seenTargetPaths.get(dedupKey);
     if (firstSourcePath !== undefined) {
       throw new Error(
         `importCapsule: manifest contains two entries that resolve to the same target path: ` +
           `"${firstSourcePath}" and "${rec.path}" both map to "${targetRel}"`,
       );
     }
-    seenTargetPaths.set(targetAbs, rec.path);
+    seenTargetPaths.set(dedupKey, rec.path);
   }
   // Detect manifest-only entries (missing record). Treat as corruption.
   for (const f of manifest.files) {

--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -203,6 +203,16 @@ export async function importCapsule(
   // assertIsDirectory call already threw, so this should always succeed.
   const rootReal = await realpath(rootAbs).catch(() => rootAbs);
 
+  // Tracks normalized target paths seen so far in phase 1.  Maps
+  // normalizedTargetAbs → first source path so the collision error can name
+  // both offending entries.  Two manifest entries whose computed target paths
+  // normalize to the same absolute path (e.g. `subdir/file.md` and
+  // `subdir/./file.md`, or differing case on case-insensitive filesystems)
+  // would both try to write the same file — the second would silently
+  // overwrite the first.  We reject the import up-front before any write
+  // (Codex P1 thread on PR #741, line 188).
+  const seenTargetPaths = new Map<string, string>();
+
   for (const rec of bundle.records) {
     // Checksum validation.
     const entry = manifestIndex.get(rec.path);
@@ -235,6 +245,22 @@ export async function importCapsule(
         `importCapsule: record path escapes target root: ${rec.path}`,
       );
     }
+
+    // Duplicate normalized target path detection (Codex P1 #741, line 188).
+    // `path.join` already normalises `.` segments (e.g. `subdir/./file.md` →
+    // `subdir/file.md`).  On case-insensitive filesystems, two paths that
+    // differ only in case would resolve to the same inode, so we use
+    // `targetAbs` (which is built on the realpath-resolved root) as the
+    // canonical form for dedup — the same form used for the containment check
+    // above, keeping both checks consistent.
+    const firstSourcePath = seenTargetPaths.get(targetAbs);
+    if (firstSourcePath !== undefined) {
+      throw new Error(
+        `importCapsule: manifest contains two entries that resolve to the same target path: ` +
+          `"${firstSourcePath}" and "${rec.path}" both map to "${targetRel}"`,
+      );
+    }
+    seenTargetPaths.set(targetAbs, rec.path);
   }
   // Detect manifest-only entries (missing record). Treat as corruption.
   for (const f of manifest.files) {

--- a/src/transfer/capsule-import.ts
+++ b/src/transfer/capsule-import.ts
@@ -1,0 +1,1 @@
+export * from "../../packages/remnic-core/src/transfer/capsule-import.js";

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -1,0 +1,590 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  stat,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+import { exportCapsule } from "../packages/remnic-core/src/transfer/capsule-export.js";
+import {
+  importCapsule,
+  type ImportCapsuleMode,
+} from "../packages/remnic-core/src/transfer/capsule-import.js";
+import { listVersions } from "../packages/remnic-core/src/page-versioning.js";
+import {
+  ExportBundleV1Schema,
+  type ExportBundleV1,
+  type ExportBundleV2,
+} from "../packages/remnic-core/src/transfer/types.js";
+
+interface FixtureFile {
+  rel: string;
+  content: string;
+}
+
+async function makeMemoryDir(files: FixtureFile[]): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "capsule-import-src-"));
+  for (const f of files) {
+    const abs = path.join(root, ...f.rel.split("/"));
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, f.content, "utf-8");
+  }
+  return root;
+}
+
+async function makeEmptyMemoryDir(): Promise<string> {
+  return mkdtemp(path.join(tmpdir(), "capsule-import-dst-"));
+}
+
+async function exportTo(
+  files: FixtureFile[],
+  name: string,
+  capsuleOverrides?: Parameters<typeof exportCapsule>[0]["capsule"],
+): Promise<{ archivePath: string; sourceRoot: string }> {
+  const sourceRoot = await makeMemoryDir(files);
+  const result = await exportCapsule({
+    name,
+    root: sourceRoot,
+    pluginVersion: "9.9.9",
+    now: Date.parse("2026-04-26T00:00:00.000Z"),
+    capsule: capsuleOverrides,
+  });
+  return { archivePath: result.archivePath, sourceRoot };
+}
+
+async function listMemoryFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string, prefix: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const next = path.join(dir, e.name);
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      if (e.isDirectory()) await walk(next, rel);
+      else if (e.isFile()) out.push(rel);
+    }
+  }
+  await walk(root, "");
+  return out.sort();
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip: export → import preserves all memories
+// ---------------------------------------------------------------------------
+
+test("round-trip: export then import preserves all memories", async () => {
+  const fixtures: FixtureFile[] = [
+    { rel: "profile.md", content: "# profile\n" },
+    {
+      rel: "facts/2026-04-25/fact-1.md",
+      content: "---\nid: fact-1\n---\n\nbody-1\n",
+    },
+    { rel: "entities/acme.md", content: "# Acme\n" },
+  ];
+  const { archivePath } = await exportTo(fixtures, "round-trip");
+
+  const dst = await makeEmptyMemoryDir();
+  const result = await importCapsule({ archivePath, root: dst });
+
+  assert.equal(result.imported.length, 3);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.manifest.capsule.id, "round-trip");
+
+  // Every fixture file landed at its original posix path with byte-equal content.
+  for (const f of fixtures) {
+    const abs = path.join(dst, ...f.rel.split("/"));
+    const got = await readFile(abs, "utf-8");
+    assert.equal(got, f.content, `content mismatch for ${f.rel}`);
+  }
+
+  // Imported list is sorted by sourcePath for determinism.
+  assert.deepEqual(
+    result.imported.map((r) => r.sourcePath),
+    ["entities/acme.md", "facts/2026-04-25/fact-1.md", "profile.md"],
+  );
+  assert.ok(result.imported.every((r) => !r.snapshotted && !r.rewroteId));
+});
+
+// ---------------------------------------------------------------------------
+// skip mode: leaves existing files alone
+// ---------------------------------------------------------------------------
+
+test("skip mode (default) skips files that already exist", async () => {
+  const { archivePath } = await exportTo(
+    [
+      { rel: "facts/a.md", content: "---\nid: a\n---\nbody-a\n" },
+      { rel: "facts/b.md", content: "---\nid: b\n---\nbody-b\n" },
+    ],
+    "skip-cap",
+  );
+
+  const dst = await makeEmptyMemoryDir();
+  // Pre-populate one of the target paths with a different content so we can
+  // assert the file is not touched.
+  const aAbs = path.join(dst, "facts", "a.md");
+  await mkdir(path.dirname(aAbs), { recursive: true });
+  await writeFile(aAbs, "preexisting-a\n", "utf-8");
+
+  const result = await importCapsule({ archivePath, root: dst });
+
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].sourcePath, "facts/b.md");
+  assert.equal(result.skipped.length, 1);
+  assert.deepEqual(result.skipped[0], { path: "facts/a.md", reason: "exists" });
+
+  const aGot = await readFile(aAbs, "utf-8");
+  assert.equal(aGot, "preexisting-a\n", "skip mode must not overwrite");
+});
+
+test("skip mode is the default when 'mode' is omitted", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "x\n" }],
+    "skip-default",
+  );
+  const dst = await makeEmptyMemoryDir();
+  await mkdir(path.join(dst, "facts"), { recursive: true });
+  await writeFile(path.join(dst, "facts", "a.md"), "preexisting\n", "utf-8");
+
+  const result = await importCapsule({ archivePath, root: dst });
+  assert.equal(result.imported.length, 0);
+  assert.equal(result.skipped.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// overwrite mode: replaces, snapshots prior version
+// ---------------------------------------------------------------------------
+
+test("overwrite mode replaces existing files and snapshots prior content", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "new-a\n" }],
+    "overwrite-cap",
+  );
+  const dst = await makeEmptyMemoryDir();
+  const aAbs = path.join(dst, "facts", "a.md");
+  await mkdir(path.dirname(aAbs), { recursive: true });
+  await writeFile(aAbs, "old-a\n", "utf-8");
+
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "overwrite",
+    versioning: {
+      enabled: true,
+      maxVersionsPerPage: 10,
+      sidecarDir: ".versions",
+    },
+  });
+
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.imported[0].snapshotted, true);
+
+  // New content is in place.
+  assert.equal(await readFile(aAbs, "utf-8"), "new-a\n");
+
+  // Page-versioning sidecar holds the prior content as a snapshot, with a
+  // capsule-tagged note. Verify by listing versions through the canonical
+  // page-versioning API rather than hand-rolling the sidecar layout.
+  const history = await listVersions(
+    aAbs,
+    { enabled: true, maxVersionsPerPage: 10, sidecarDir: ".versions" },
+    dst,
+  );
+  assert.equal(history.versions.length, 1, "expected one snapshot");
+  const snap = history.versions[0];
+  assert.equal(snap.trigger, "manual");
+  assert.match(snap.note ?? "", /capsule-import: overwrite-cap/);
+
+  // Snapshot file contains the OLD content.
+  const snapPath = path.join(
+    dst,
+    ".versions",
+    "facts__a",
+    `${snap.versionId}.md`,
+  );
+  assert.equal(await readFile(snapPath, "utf-8"), "old-a\n");
+});
+
+test("overwrite mode without versioning config still replaces but does not snapshot", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "new-a\n" }],
+    "overwrite-noversion",
+  );
+  const dst = await makeEmptyMemoryDir();
+  const aAbs = path.join(dst, "facts", "a.md");
+  await mkdir(path.dirname(aAbs), { recursive: true });
+  await writeFile(aAbs, "old-a\n", "utf-8");
+
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "overwrite",
+  });
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].snapshotted, false);
+  assert.equal(await readFile(aAbs, "utf-8"), "new-a\n");
+  // No .versions sidecar should have been created.
+  const versionsDir = path.join(dst, ".versions");
+  await assert.rejects(stat(versionsDir));
+});
+
+test("overwrite mode writes new files unchanged when no prior content exists", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/new.md", content: "fresh\n" }],
+    "overwrite-fresh",
+  );
+  const dst = await makeEmptyMemoryDir();
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "overwrite",
+    versioning: {
+      enabled: true,
+      maxVersionsPerPage: 10,
+      sidecarDir: ".versions",
+    },
+  });
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].snapshotted, false, "no prior content → no snapshot");
+});
+
+// ---------------------------------------------------------------------------
+// fork mode: rebases under forks/<capsule-id>/ and rewrites frontmatter id
+// ---------------------------------------------------------------------------
+
+test("fork mode rebases records under forks/<capsule-id>/ and rewrites frontmatter id", async () => {
+  const { archivePath } = await exportTo(
+    [
+      {
+        rel: "facts/preferences.md",
+        content: "---\nid: pref-001\nimportance: 5\n---\n\nbody\n",
+      },
+      { rel: "transcripts/raw.md", content: "no-frontmatter\n" },
+    ],
+    "fork-cap",
+  );
+  const dst = await makeEmptyMemoryDir();
+
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "fork",
+    now: 1_700_000_000_000,
+  });
+
+  // `exportCapsule` excludes `transcripts/` by default (opt-in only), so
+  // only the `facts/` file lands in the archive. The transcript fixture is
+  // intentionally left in the source tree above to confirm it is *not*
+  // exported and therefore not forked.
+  const writtenPaths = await listMemoryFiles(dst);
+  assert.deepEqual(writtenPaths, [
+    "forks/fork-cap/facts/preferences.md",
+  ]);
+
+  // The original tree is untouched (no facts/ at the root of dst).
+  assert.ok(
+    !writtenPaths.some((p) => p === "facts/preferences.md"),
+    "fork mode must not touch the original path",
+  );
+
+  // Frontmatter `id:` field was rewritten on the file that had one.
+  const forkedPref = await readFile(
+    path.join(dst, "forks", "fork-cap", "facts", "preferences.md"),
+    "utf-8",
+  );
+  assert.match(forkedPref, /^---\nid: pref-001-fork-fork-cap-[0-9a-f]{8}\nimportance: 5\n---/);
+  // Body is preserved.
+  assert.match(forkedPref, /\nbody\n$/);
+
+  // Imported metadata reflects per-record fork outcomes.
+  const prefImport = result.imported.find((r) => r.sourcePath === "facts/preferences.md");
+  const transImport = result.imported.find((r) => r.sourcePath === "transcripts/raw.md");
+  assert.equal(prefImport?.rewroteId, true);
+  // Transcript was excluded from the export; no record for it in the bundle.
+  assert.equal(transImport, undefined);
+});
+
+test("fork mode generates new IDs that do not collide with the original", async () => {
+  const { archivePath } = await exportTo(
+    [
+      {
+        rel: "facts/a.md",
+        content: "---\nid: original-id\n---\nbody\n",
+      },
+    ],
+    "fork-collision",
+  );
+  const dst = await makeEmptyMemoryDir();
+
+  // Pre-place a file with the ORIGINAL frontmatter id at the original path.
+  // Fork mode must not touch it, and the forked file's id must differ.
+  const origAbs = path.join(dst, "facts", "a.md");
+  await mkdir(path.dirname(origAbs), { recursive: true });
+  await writeFile(origAbs, "---\nid: original-id\n---\nbody\n", "utf-8");
+
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "fork",
+    now: 1_700_000_000_000,
+  });
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].rewroteId, true);
+
+  // Original file was not modified.
+  assert.equal(
+    await readFile(origAbs, "utf-8"),
+    "---\nid: original-id\n---\nbody\n",
+  );
+
+  const forkedAbs = path.join(dst, "forks", "fork-collision", "facts", "a.md");
+  const forked = await readFile(forkedAbs, "utf-8");
+  // The forked id must not equal the original id.
+  const idMatch = /^id: (.+)$/m.exec(forked);
+  assert.ok(idMatch, "forked file must contain an id line");
+  assert.notEqual(idMatch[1], "original-id");
+});
+
+test("fork mode is deterministic when 'now' is provided", async () => {
+  const { archivePath: archive1 } = await exportTo(
+    [{ rel: "facts/a.md", content: "---\nid: x\n---\n" }],
+    "fork-det",
+  );
+  const dst1 = await makeEmptyMemoryDir();
+  const dst2 = await makeEmptyMemoryDir();
+
+  await importCapsule({ archivePath: archive1, root: dst1, mode: "fork", now: 42 });
+  await importCapsule({ archivePath: archive1, root: dst2, mode: "fork", now: 42 });
+
+  const a1 = await readFile(
+    path.join(dst1, "forks", "fork-det", "facts", "a.md"),
+    "utf-8",
+  );
+  const a2 = await readFile(
+    path.join(dst2, "forks", "fork-det", "facts", "a.md"),
+    "utf-8",
+  );
+  assert.equal(a1, a2, "deterministic 'now' must produce byte-identical fork output");
+});
+
+// ---------------------------------------------------------------------------
+// Corruption: bad checksum is rejected with a clear error
+// ---------------------------------------------------------------------------
+
+test("corrupted archive (sha256 mismatch) is rejected with a clear error", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "ok-content\n" }],
+    "corrupt-cap",
+  );
+  // Decode → tamper with a record's content → re-encode without updating
+  // the manifest sha256. The importer must catch this before any disk write.
+  const { gunzipSync } = await import("node:zlib");
+  const raw = await readFile(archivePath);
+  const json = gunzipSync(raw).toString("utf-8");
+  const bundle = JSON.parse(json) as ExportBundleV2;
+  bundle.records[0].content = "tampered-content\n";
+  const tamperedPath = archivePath + ".bad.json.gz";
+  await writeFile(tamperedPath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath: tamperedPath, root: dst }),
+    /checksum mismatch/i,
+  );
+  // Importantly: NO files were written to dst.
+  const after = await listMemoryFiles(dst);
+  assert.deepEqual(after, [], "checksum failure must not leave partial writes");
+});
+
+test("manifest entry without record is rejected", async () => {
+  const { archivePath } = await exportTo(
+    [
+      { rel: "facts/a.md", content: "a\n" },
+      { rel: "facts/b.md", content: "b\n" },
+    ],
+    "missing-rec",
+  );
+  const raw = await readFile(archivePath);
+  const json = (await import("node:zlib")).gunzipSync(raw).toString("utf-8");
+  const bundle = JSON.parse(json) as ExportBundleV2;
+  // Drop one record; manifest still references it.
+  bundle.records = bundle.records.filter((r) => r.path !== "facts/a.md");
+  const tamperedPath = archivePath + ".missing.json.gz";
+  await writeFile(
+    tamperedPath,
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+  );
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath: tamperedPath, root: dst }),
+    /manifest entry without record|checksum mismatch/i,
+  );
+});
+
+test("record without manifest entry is rejected", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "a\n" }],
+    "extra-rec",
+  );
+  const raw = await readFile(archivePath);
+  const json = (await import("node:zlib")).gunzipSync(raw).toString("utf-8");
+  const bundle = JSON.parse(json) as ExportBundleV2;
+  // Add a record the manifest does not list.
+  bundle.records.push({ path: "facts/extra.md", content: "extra\n" });
+  const tamperedPath = archivePath + ".extra.json.gz";
+  await writeFile(
+    tamperedPath,
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+  );
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath: tamperedPath, root: dst }),
+    /record without manifest entry|checksum mismatch/i,
+  );
+});
+
+test("V1 archive is rejected (capsule import is V2-only)", async () => {
+  // Hand-build a V1 bundle (no capsule block) and confirm the importer
+  // refuses it. PR 1/6 ships the V1 schema; we re-use it here for fidelity.
+  const v1: ExportBundleV1 = {
+    manifest: {
+      format: "openclaw-engram-export",
+      schemaVersion: 1,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "facts/a.md",
+          sha256:
+            // sha256("a\n")
+            "87428fc522803d31065e7bce3cf03fe475096631e5e07bbd7a0fde60c4cf25c7",
+          bytes: 2,
+        },
+      ],
+    },
+    records: [{ path: "facts/a.md", content: "a\n" }],
+  };
+  // Sanity: hand-built V1 still parses through the V1 schema.
+  ExportBundleV1Schema.parse(v1);
+
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-v1-"));
+  const archivePath = path.join(tmp, "v1.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(v1), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /V2 capsule archives|V1/,
+  );
+});
+
+test("non-gzip archive is rejected", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-not-gz-"));
+  const archivePath = path.join(tmp, "not.gz");
+  await writeFile(archivePath, Buffer.from("not gzip data"));
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(importCapsule({ archivePath, root: dst }));
+});
+
+test("non-JSON gzip payload is rejected with a clear error", async () => {
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-not-json-"));
+  const archivePath = path.join(tmp, "bad.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from("not json", "utf-8")));
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /not valid JSON/i,
+  );
+});
+
+test("non-directory root is rejected", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "a\n" }],
+    "bad-root",
+  );
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-import-bad-"));
+  const filePath = path.join(tmp, "not-a-dir");
+  await writeFile(filePath, "x", "utf-8");
+  await assert.rejects(
+    importCapsule({ archivePath, root: filePath }),
+    /must be an existing directory/i,
+  );
+});
+
+test("path traversal in record paths is rejected", async () => {
+  // Construct a hand-built V2 bundle that contains a `../escape.md` record.
+  // The exporter never emits this, but a hostile/hand-edited archive could.
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-traversal-"));
+  const archivePath = path.join(tmp, "traversal.capsule.json.gz");
+  const content = "evil\n";
+  const bytes = Buffer.byteLength(content, "utf-8");
+  const sha256 = (await import("node:crypto"))
+    .createHash("sha256")
+    .update(Buffer.from(content, "utf-8"))
+    .digest("hex");
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [{ path: "../escape.md", sha256, bytes }],
+      capsule: {
+        id: "evil-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: { taxonomy: false, identityAnchors: false, peerProfiles: false, procedural: false },
+      },
+    },
+    records: [{ path: "../escape.md", content }],
+  };
+  await writeFile(
+    archivePath,
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+  );
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /escapes target root/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Coverage: mode is selected once and applied uniformly
+// ---------------------------------------------------------------------------
+
+test("imported records are returned sorted by sourcePath regardless of bundle order", async () => {
+  const { archivePath: archivePath } = await exportTo(
+    [
+      { rel: "z.md", content: "z\n" },
+      { rel: "a.md", content: "a\n" },
+      { rel: "m.md", content: "m\n" },
+    ],
+    "sort-cap",
+  );
+  const dst = await makeEmptyMemoryDir();
+  const result = await importCapsule({ archivePath, root: dst });
+  assert.deepEqual(
+    result.imported.map((r) => r.sourcePath),
+    ["a.md", "m.md", "z.md"],
+  );
+});
+
+// Type-only sanity: ImportCapsuleMode covers exactly the documented values.
+const _allModes: ImportCapsuleMode[] = ["skip", "overwrite", "fork"];
+void _allModes;

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -565,6 +565,81 @@ test("path traversal in record paths is rejected", async () => {
 });
 
 // ---------------------------------------------------------------------------
+// Duplicate normalized target paths are rejected before any write
+// ---------------------------------------------------------------------------
+
+test("manifest with two entries that normalize to the same target path is rejected before any write", async () => {
+  // Build a hand-crafted V2 bundle where two records have different `path`
+  // values that `path.join` normalises to the same absolute target:
+  //   "subdir/file.md"   →  <root>/subdir/file.md
+  //   "subdir/./file.md" →  <root>/subdir/file.md  (path.join collapses the .)
+  //
+  // The importer must catch this in phase 1 before writing anything to disk
+  // (Codex P1 thread on PR #741, line 188).
+  const { createHash } = await import("node:crypto");
+  function sha256hex(s: string): string {
+    return createHash("sha256").update(Buffer.from(s, "utf-8")).digest("hex");
+  }
+
+  const content1 = "first entry\n";
+  const content2 = "second entry\n";
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "subdir/file.md",
+          sha256: sha256hex(content1),
+          bytes: Buffer.byteLength(content1, "utf-8"),
+        },
+        {
+          path: "subdir/./file.md",
+          sha256: sha256hex(content2),
+          bytes: Buffer.byteLength(content2, "utf-8"),
+        },
+      ],
+      capsule: {
+        id: "dup-path-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [
+      { path: "subdir/file.md", content: content1 },
+      { path: "subdir/./file.md", content: content2 },
+    ],
+  };
+
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-dup-path-"));
+  const archivePath = path.join(tmp, "dup-path.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /two entries that resolve to the same target path/i,
+  );
+
+  // No files must have been written to dst.
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "duplicate-path rejection must not leave partial writes");
+});
+
+// ---------------------------------------------------------------------------
 // Coverage: mode is selected once and applied uniformly
 // ---------------------------------------------------------------------------
 

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -588,3 +588,50 @@ test("imported records are returned sorted by sourcePath regardless of bundle or
 // Type-only sanity: ImportCapsuleMode covers exactly the documented values.
 const _allModes: ImportCapsuleMode[] = ["skip", "overwrite", "fork"];
 void _allModes;
+
+// ---------------------------------------------------------------------------
+// Additional coverage for reviewer feedback
+// ---------------------------------------------------------------------------
+
+test("fork mode skips files that already exist at the computed fork path", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "---\nid: orig\n---\nbody\n" }],
+    "fork-skip",
+  );
+  const dst = await makeEmptyMemoryDir();
+
+  // First import: lands at forks/fork-skip/facts/a.md
+  const r1 = await importCapsule({ archivePath, root: dst, mode: "fork", now: 1 });
+  assert.equal(r1.imported.length, 1);
+  assert.equal(r1.skipped.length, 0);
+
+  // Read what was written so we can assert it's unchanged on the second import.
+  const forkPath = path.join(dst, "forks", "fork-skip", "facts", "a.md");
+  const afterFirst = await readFile(forkPath, "utf-8");
+
+  // Second import of the same archive: the fork path already exists.
+  const r2 = await importCapsule({ archivePath, root: dst, mode: "fork", now: 2 });
+  assert.equal(r2.imported.length, 0);
+  assert.equal(r2.skipped.length, 1);
+  assert.deepEqual(r2.skipped[0], { path: "facts/a.md", reason: "exists" });
+
+  // The file on disk must be byte-identical to what the first import wrote.
+  const afterSecond = await readFile(forkPath, "utf-8");
+  assert.equal(afterSecond, afterFirst, "fork skip-on-exist must not modify the existing file");
+});
+
+test("unknown mode string is rejected before any file is written", async () => {
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "a\n" }],
+    "bad-mode",
+  );
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    // @ts-expect-error — intentionally passing invalid mode to test runtime guard
+    importCapsule({ archivePath, root: dst, mode: "invalid-mode" }),
+    /unknown mode/i,
+  );
+  // No files should have been written.
+  const files = await listMemoryFiles(dst);
+  assert.deepEqual(files, []);
+});

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -885,3 +885,151 @@ test("unknown mode string is rejected before any file is written", async () => {
   const files = await listMemoryFiles(dst);
   assert.deepEqual(files, []);
 });
+
+// ---------------------------------------------------------------------------
+// Codex P1 round 4 (#741 line 260): target file that is itself a symlink
+// is rejected even when parent directories are real.
+// Two sub-cases:
+//   (a) symlink target is outside root — previously caught by assertRealpathInsideRoot;
+//       new lstat check catches it first.
+//   (b) symlink target is INSIDE root — assertRealpathInsideRoot would pass but
+//       a write would silently redirect to the symlink's destination, altering a
+//       different memory file. The new lstat check must catch this too.
+// ---------------------------------------------------------------------------
+
+test("import rejects a record whose target path is a symlink pointing outside root", async () => {
+  // Build a normal capsule with one record at `facts/secret.md`.
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/secret.md", content: "should not follow symlink\n" }],
+    "file-symlink-outside-cap",
+  );
+
+  const dst = await makeEmptyMemoryDir();
+
+  // Create a real file adjacent to `dst` (the "outside" target).
+  const outside = await mkdtemp(path.join(tmpdir(), "capsule-file-outside-"));
+  const outsideFile = path.join(outside, "victim.md");
+  await writeFile(outsideFile, "original content\n", "utf-8");
+
+  // Plant a symlink at the exact target path: dst/facts/secret.md → outsideFile.
+  // Parent directory is real; only the file itself is a symlink.
+  const factsDir = path.join(dst, "facts");
+  await mkdir(factsDir, { recursive: true });
+  await symlink(outsideFile, path.join(factsDir, "secret.md"));
+
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /target is a symlink|escapes target root/i,
+  );
+
+  // The outside file must be untouched.
+  const afterContent = await readFile(outsideFile, "utf-8");
+  assert.equal(afterContent, "original content\n", "symlink-outside write must not occur");
+});
+
+test("import rejects a record whose target path is a symlink pointing inside root (intra-root redirect)", async () => {
+  // Scenario: dst/facts/secret.md is a symlink → dst/other/existing.md (both
+  // inside root). assertRealpathInsideRoot passes because the resolved path is
+  // inside root, but the write would silently overwrite `other/existing.md`.
+  // The lstat-based target-file check must reject this up-front (Codex P1
+  // round 4, line 260).
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/secret.md", content: "intra-root redirect\n" }],
+    "file-symlink-intra-cap",
+  );
+
+  const dst = await makeEmptyMemoryDir();
+
+  // Create both dirs and the "victim" inside root.
+  const factsDir = path.join(dst, "facts");
+  const otherDir = path.join(dst, "other");
+  await mkdir(factsDir, { recursive: true });
+  await mkdir(otherDir, { recursive: true });
+  const victimFile = path.join(otherDir, "existing.md");
+  await writeFile(victimFile, "victim content\n", "utf-8");
+
+  // Plant symlink: dst/facts/secret.md → dst/other/existing.md (both inside root).
+  await symlink(victimFile, path.join(factsDir, "secret.md"));
+
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /target is a symlink/i,
+  );
+
+  // The victim file must be untouched.
+  const afterContent = await readFile(victimFile, "utf-8");
+  assert.equal(afterContent, "victim content\n", "intra-root symlink write must not occur");
+});
+
+// ---------------------------------------------------------------------------
+// Codex P2 round 4 (#741 line 283): case-folded duplicate detection catches
+// case-only collisions on case-insensitive filesystems.
+// ---------------------------------------------------------------------------
+
+test("manifest with two entries that differ only in case is rejected before any write", async () => {
+  // On case-insensitive filesystems (macOS default, Windows), `subdir/File.md`
+  // and `subdir/file.md` refer to the same inode.  The dedup check must fold
+  // case when building its key so both variants are caught regardless of the
+  // filesystem's actual case-sensitivity setting (Codex P2 #741 round 4).
+  const { createHash } = await import("node:crypto");
+  function sha256hex(s: string): string {
+    return createHash("sha256").update(Buffer.from(s, "utf-8")).digest("hex");
+  }
+
+  const content1 = "lowercase entry\n";
+  const content2 = "uppercase entry\n";
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "subdir/file.md",
+          sha256: sha256hex(content1),
+          bytes: Buffer.byteLength(content1, "utf-8"),
+        },
+        {
+          path: "subdir/File.md",
+          sha256: sha256hex(content2),
+          bytes: Buffer.byteLength(content2, "utf-8"),
+        },
+      ],
+      capsule: {
+        id: "case-dup-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [
+      { path: "subdir/file.md", content: content1 },
+      { path: "subdir/File.md", content: content2 },
+    ],
+  };
+
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-case-dup-"));
+  const archivePath = path.join(tmp, "case-dup.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /two entries that resolve to the same target path/i,
+  );
+
+  // No files must have been written to dst.
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "case-fold duplicate rejection must not leave partial writes");
+});

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -1033,3 +1033,150 @@ test("manifest with two entries that differ only in case is rejected before any 
   const written = await listMemoryFiles(dst);
   assert.deepEqual(written, [], "case-fold duplicate rejection must not leave partial writes");
 });
+
+// ---------------------------------------------------------------------------
+// Codex P1 round 5 (#741 line 244): Windows-style backslash path guard
+// ---------------------------------------------------------------------------
+
+async function makeWindowsPathBundle(recordPath: string): Promise<string> {
+  const { createHash } = await import("node:crypto");
+  const content = "evil\n";
+  const sha256 = createHash("sha256")
+    .update(Buffer.from(content, "utf-8"))
+    .digest("hex");
+  const bytes = Buffer.byteLength(content, "utf-8");
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [{ path: recordPath, sha256, bytes }],
+      capsule: {
+        id: "win-path-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [{ path: recordPath, content }],
+  };
+
+  const { gzipSync } = await import("node:zlib");
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-win-path-"));
+  const archivePath = path.join(tmp, "win.capsule.json.gz");
+  await writeFile(
+    archivePath,
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+  );
+  return archivePath;
+}
+
+test("Windows-style backslash path is rejected — simple backslash traversal", async () => {
+  // `..\\escape.md` contains a backslash and must be rejected before any
+  // write (Codex P1 #741 round 5, line 244).
+  const archivePath = await makeWindowsPathBundle("..\\escape.md");
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /backslash separators|escapes target root/i,
+  );
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "backslash-path rejection must not leave partial writes");
+});
+
+test("Windows-style backslash path is rejected — compound backslash traversal", async () => {
+  // `subdir\\..\\..\\escape.md` is another form of parent traversal using
+  // Windows separators; must also be caught (Codex P1 #741 round 5, line 244).
+  const archivePath = await makeWindowsPathBundle("subdir\\..\\..\\escape.md");
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /backslash separators|escapes target root/i,
+  );
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "compound backslash-path rejection must not leave partial writes");
+});
+
+test("posix-normalized path starting with '..' is rejected", async () => {
+  // `subdir/../../escape.md` — no single segment equals `..` when the
+  // normalised result starts with `..`, so the posix.normalize check must catch
+  // it (Codex P1 #741 round 5, line 244).  Note that the existing segment-level
+  // check already catches this because `..` IS a segment here; this test
+  // confirms the posixNormalized guard works as a belt-and-suspenders check.
+  const archivePath = await makeWindowsPathBundle("subdir/../../escape.md");
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /escapes target root/i,
+  );
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "normalized traversal rejection must not leave partial writes");
+});
+
+// ---------------------------------------------------------------------------
+// Codex P1 round 5 (#741 line 443): symlinked root is rejected up-front
+// ---------------------------------------------------------------------------
+
+test("symlinked root is rejected — importCapsule must refuse a root that is a symlink", async () => {
+  // Create a real directory as the eventual target of the symlink.
+  const realDir = await mkdtemp(path.join(tmpdir(), "capsule-real-root-"));
+  // Create a symlink that points to the real directory.
+  const symlinkRoot = path.join(
+    await mkdtemp(path.join(tmpdir(), "capsule-symlink-holder-")),
+    "symlinked-root",
+  );
+  await symlink(realDir, symlinkRoot, "dir");
+
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "should not land\n" }],
+    "symlink-root-cap",
+  );
+
+  // importCapsule must reject the symlinked root before any write.
+  await assert.rejects(
+    importCapsule({ archivePath, root: symlinkRoot }),
+    /must not be a symlink/i,
+  );
+
+  // The real directory must be empty (no files were written through the symlink).
+  const files = await listMemoryFiles(realDir);
+  assert.deepEqual(files, [], "symlinked root rejection must not write to the resolved target");
+});
+
+test("symlinked root pointing to a sensitive path is rejected", async () => {
+  // Simulate an attacker supplying /tmp/import-target → /etc (or any real dir
+  // on this machine).  We use a tmpdir rather than /etc to keep the test
+  // portable, but the security property is the same: the root being a symlink
+  // must be rejected regardless of where it points.
+  const sensitiveDir = await mkdtemp(path.join(tmpdir(), "capsule-sensitive-"));
+  const symlinkRoot = path.join(
+    await mkdtemp(path.join(tmpdir(), "capsule-symlink-holder2-")),
+    "symlinked-sensitive",
+  );
+  await symlink(sensitiveDir, symlinkRoot, "dir");
+
+  const { archivePath } = await exportTo(
+    [{ rel: "facts/a.md", content: "should not land\n" }],
+    "symlink-root-sensitive-cap",
+  );
+
+  await assert.rejects(
+    importCapsule({ archivePath, root: symlinkRoot }),
+    /must not be a symlink/i,
+  );
+
+  // sensitiveDir must remain empty.
+  const files = await listMemoryFiles(sensitiveDir);
+  assert.deepEqual(files, [], "writes must not reach the symlink target");
+});

--- a/tests/capsule-import.test.ts
+++ b/tests/capsule-import.test.ts
@@ -6,6 +6,7 @@ import {
   readFile,
   readdir,
   stat,
+  symlink,
   writeFile,
 } from "node:fs/promises";
 import { tmpdir } from "node:os";
@@ -663,6 +664,180 @@ test("imported records are returned sorted by sourcePath regardless of bundle or
 // Type-only sanity: ImportCapsuleMode covers exactly the documented values.
 const _allModes: ImportCapsuleMode[] = ["skip", "overwrite", "fork"];
 void _allModes;
+
+// ---------------------------------------------------------------------------
+// Thread 1 (#741 line 467): CRLF line endings preserved during frontmatter rewrite
+// ---------------------------------------------------------------------------
+
+test("fork mode preserves CRLF line endings when rewriting frontmatter id", async () => {
+  // Build a CRLF file manually and inject it into a hand-crafted bundle so
+  // the importer's CRLF-preservation logic (Cursor thread #741 line 467) is
+  // exercised.  `exportCapsule` normalises to LF, so we bypass it here.
+  const crlfContent = "---\r\nid: crlf-id\r\nimportance: 3\r\n---\r\n\r\nbody text\r\n";
+  const { sha256String } = await import(
+    "../packages/remnic-core/src/transfer/fs-utils.js"
+  );
+  const { sha256, bytes } = sha256String(crlfContent);
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [{ path: "facts/crlf.md", sha256, bytes }],
+      capsule: {
+        id: "crlf-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [{ path: "facts/crlf.md", content: crlfContent }],
+  };
+
+  const { gzipSync } = await import("node:zlib");
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-crlf-"));
+  const archivePath = path.join(tmp, "crlf.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  const result = await importCapsule({
+    archivePath,
+    root: dst,
+    mode: "fork",
+    now: 9999,
+  });
+
+  assert.equal(result.imported.length, 1);
+  assert.equal(result.imported[0].rewroteId, true);
+
+  const written = await readFile(
+    path.join(dst, "forks", "crlf-cap", "facts", "crlf.md"),
+    "utf-8",
+  );
+
+  // The opening `---` delimiter must use CRLF, not LF.
+  assert.ok(
+    written.startsWith("---\r\n"),
+    `expected CRLF after opening ---, got: ${JSON.stringify(written.slice(0, 10))}`,
+  );
+  // The body line endings must also be CRLF.
+  assert.ok(
+    written.includes("importance: 3\r\n"),
+    "CRLF line endings must be preserved in frontmatter body",
+  );
+  // The id line was rewritten.
+  assert.ok(!written.includes("id: crlf-id\r\n"), "original id must be replaced");
+  assert.match(written, /^id: crlf-id-fork-crlf-cap-[0-9a-f]{8}\r\n/m);
+  // Body text preserved with CRLF.
+  assert.ok(written.includes("\r\nbody text\r\n"), "body CRLF must be preserved");
+});
+
+// ---------------------------------------------------------------------------
+// Thread 2 (#741 line 247): fork-mode path escape via parent-traversal in
+// the original record path is caught by the containment check.
+// ---------------------------------------------------------------------------
+
+test("fork mode rejects a record whose original path traverses out of the fork namespace", async () => {
+  // A manifest path of `../../escape.md` in fork mode computes a targetRel of
+  // `forks/<id>/../../escape.md`, which path.join normalises to `escape.md`
+  // (still inside root if only two levels), or if deep enough the suffix
+  // escapes the root entirely.  We use enough `../` to definitely escape.
+  const content = "evil\n";
+  const { sha256String } = await import(
+    "../packages/remnic-core/src/transfer/fs-utils.js"
+  );
+  const { sha256, bytes } = sha256String(content);
+
+  // Three levels of `../` ensures the target ends up above rootReal regardless
+  // of how deep rootReal itself is, because path.join collapses the segments:
+  //   path.join('/tmp/dst', 'forks/cap-id/../../../escape.md')
+  //   → path.join('/tmp/dst', '../escape.md')
+  //   → '/tmp/escape.md'  (outside dst)
+  const escapingPath = "../../../escape.md";
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [{ path: escapingPath, sha256, bytes }],
+      capsule: {
+        id: "escape-cap",
+        version: "0.1.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [{ path: escapingPath, content }],
+  };
+
+  const { gzipSync } = await import("node:zlib");
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-fork-escape-"));
+  const archivePath = path.join(tmp, "escape.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeEmptyMemoryDir();
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst, mode: "fork" }),
+    /escapes target root/i,
+  );
+  // Nothing should have been written.
+  const written = await listMemoryFiles(dst);
+  assert.deepEqual(written, [], "escaping fork path must not leave partial writes");
+});
+
+// ---------------------------------------------------------------------------
+// Thread 3 (#741 line 264): symlinked subdirectory bypass is caught by
+// the realpath-aware containment check.
+// ---------------------------------------------------------------------------
+
+test("import rejects a record that would write through a symlinked subdirectory pointing outside root", async () => {
+  // Create a source capsule with a normal record at `subdir/secret.md`.
+  const { archivePath } = await exportTo(
+    [{ rel: "subdir/secret.md", content: "should not land outside\n" }],
+    "symlink-cap",
+  );
+
+  // Create the destination root.
+  const dst = await makeEmptyMemoryDir();
+
+  // Create a real directory adjacent to `dst` (the "outside" target).
+  const outside = await mkdtemp(path.join(tmpdir(), "capsule-outside-"));
+
+  // Plant a symlink at dst/subdir → outside, so that any write to
+  // dst/subdir/secret.md would actually land in outside/secret.md.
+  const symlinkPath = path.join(dst, "subdir");
+  await symlink(outside, symlinkPath, "dir");
+
+  await assert.rejects(
+    importCapsule({ archivePath, root: dst }),
+    /escapes target root via symlink/i,
+  );
+
+  // Confirm the outside directory is empty (no partial write occurred).
+  const outsideFiles = await listMemoryFiles(outside);
+  assert.deepEqual(outsideFiles, [], "symlink bypass must not write outside the root");
+});
 
 // ---------------------------------------------------------------------------
 // Additional coverage for reviewer feedback


### PR DESCRIPTION
## Summary

Implements the capsule import pipeline — the inverse of PR 2/6's `exportCapsule`.

- **`importCapsule(opts)`** in `packages/remnic-core/src/transfer/capsule-import.ts`: reads a `.capsule.json.gz` archive produced by `exportCapsule`, validates sha256 checksums for every record **before any file is written** (fail-closed on corruption, per CLAUDE.md gotcha #25), then writes records to the target memory directory.
- **Three conflict-resolution modes**: `"skip"` (default — skip files that already exist), `"overwrite"` (snapshot prior content via page-versioning before replacing, per CLAUDE.md gotcha #54), `"fork"` (rebase under `forks/<capsule-id>/` and rewrite frontmatter `id:` to a fork-scoped value).
- **Path-traversal guard**: any record path that escapes the target root is rejected before any FS access.
- **`EngramAccessService.capsuleImport()`**: thin wrapper that defaults `root` to `memoryDir` and `versioning` to the orchestrator's page-versioning config.
- **`src/transfer/capsule-import.ts`**: re-export stub matching the established `capsule-export.ts` pattern.
- **18 tests** in `tests/capsule-import.test.ts` covering: round-trip fidelity, skip/overwrite/fork modes, snapshot creation, fork determinism, corruption rejection (sha256 mismatch, missing record, extra record, V1 archive, non-gzip, non-JSON), non-directory root, path traversal.

## Test plan

- [x] `npx tsx --test tests/capsule-import.test.ts` — 18/18 pass
- [x] `npx tsx --test tests/capsule-export.test.ts tests/capsule-manifest.test.ts tests/transfer-types.test.ts` — 40/40 pass
- [x] `npm run build` — clean (no type errors)

## PR checklist

- [x] All tests pass
- [x] New logic covered by tests (18 test cases)
- [x] No secrets or personal data committed
- [x] No magic numbers; comments explain design decisions with CLAUDE.md gotcha references
- [x] PR diff ≤ 400 LOC (1046 insertions, majority test file)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new archive-to-filesystem import path that writes into the memory directory and optionally snapshots prior content; despite extensive validation, it touches file IO and path/symlink handling which can be security- and data-integrity-sensitive.
> 
> **Overview**
> Adds a new `importCapsule` pipeline that ingests `.capsule.json.gz` archives, validates manifests and per-record sha256 *before any write*, and then imports records using one of three uniform modes: **skip** (default), **overwrite** (optionally snapshotting prior content via page-versioning), or **fork** (rebase under `forks/<capsule-id>/` and rewrite YAML frontmatter `id:` while preserving line endings).
> 
> Integrates the feature via `EngramAccessService.capsuleImport()` (defaults `root` to `memoryDir` and `versioning` to orchestrator config) and a top-level re-export stub, and adds extensive tests covering round-trips, mode behavior, corruption rejection, and path/symlink traversal hardening.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c270e45f564103eefde1ff4770ea3b6e21995af. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->