### PR TITLE
feat(secure-store): transparent storage.ts wrapping for at-rest encryption (#690 PR 3/4)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -856,6 +856,16 @@
         "default": "",
         "description": "Base path for the filesystem storage backend."
       },
+      "secureStoreEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable transparent at-rest encryption for memory files. When true, all memory file reads/writes are transparently encrypted with the master key when the secure-store is unlocked. Default false."
+      },
+      "secureStoreEncryptOnWrite": {
+        "type": "boolean",
+        "default": true,
+        "description": "When secureStoreEnabled is true and the store is unlocked, encrypt every new write. Set to false to migrate gradually without encrypting new writes. Default true."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -856,6 +856,16 @@
         "default": "",
         "description": "Base path for the filesystem storage backend."
       },
+      "secureStoreEnabled": {
+        "type": "boolean",
+        "default": false,
+        "description": "Enable transparent at-rest encryption for memory files. When true, all memory file reads/writes are transparently encrypted with the master key when the secure-store is unlocked. Default false."
+      },
+      "secureStoreEncryptOnWrite": {
+        "type": "boolean",
+        "default": true,
+        "description": "When secureStoreEnabled is true and the store is unlocked, encrypt every new write. Set to false to migrate gradually without encrypting new writes. Default true."
+      },
       "codexCompat": {
         "type": "object",
         "additionalProperties": false,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2605,6 +2605,12 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof cfg.memoryExtensionsRoot === "string" && cfg.memoryExtensionsRoot.trim().length > 0
         ? cfg.memoryExtensionsRoot.trim()
         : "",
+
+    // At-rest encryption for memory files (issue #690 PR 3/4)
+    // Default false (least-privileged). Callers explicitly opt in.
+    secureStoreEnabled: coerceBool(cfg.secureStoreEnabled) === true,
+    // Default true once enabled — new writes are encrypted by default.
+    secureStoreEncryptOnWrite: coerceBool(cfg.secureStoreEncryptOnWrite) !== false,
   };
 }
 

--- a/packages/remnic-core/src/secure-store/index.ts
+++ b/packages/remnic-core/src/secure-store/index.ts
@@ -115,6 +115,7 @@ export {
   ENCRYPTED_FILE_MAGIC_LENGTH,
   ENCRYPTED_FILE_RESERVED_LENGTH,
   ENCRYPTED_FILE_VERSION,
+  SecureStoreDecryptError,
   SecureStoreLockedError,
   decryptFileBody,
   encryptFileBody,

--- a/packages/remnic-core/src/secure-store/index.ts
+++ b/packages/remnic-core/src/secure-store/index.ts
@@ -106,3 +106,24 @@ export {
 } from "./cli-renderer.js";
 
 export { createPassphraseReader } from "./passphrase-reader.js";
+
+// Issue #690 PR 3/4 — transparent storage wrapping + migration.
+export {
+  ENCRYPTED_FILE_HEADER_SIZE,
+  ENCRYPTED_FILE_LAYOUT,
+  ENCRYPTED_FILE_MAGIC,
+  ENCRYPTED_FILE_MAGIC_LENGTH,
+  ENCRYPTED_FILE_RESERVED_LENGTH,
+  ENCRYPTED_FILE_VERSION,
+  SecureStoreLockedError,
+  decryptFileBody,
+  encryptFileBody,
+  isEncryptedFile,
+  migrateMemoryDirToEncrypted,
+  readMaybeEncryptedFile,
+  writeMaybeEncryptedFile,
+  type MigrateMemoryDirOptions,
+  type SecureFsMigrationReport,
+  type SecureFsOptions,
+  type SecureFsSnapshotFn,
+} from "./secure-fs.js";

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -1,0 +1,458 @@
+/**
+ * Transparent at-rest encryption for memory files (issue #690 PR 3/4).
+ *
+ * Layered on top of the PR 1/4 cipher primitives + PR 2/4 keyring, this
+ * module provides drop-in replacements for `readFile`/`writeFile` that
+ * emit and consume an "encrypted memory file" envelope on disk.
+ *
+ * On-disk shape
+ * -------------
+ *
+ *   [MAGIC:8][VERSION:1][RESERVED:3][SEALED-ENVELOPE...]
+ *
+ *   - MAGIC (8 bytes): the ASCII bytes "RMSF\x00\x01\x00\x00". The
+ *     leading "RMSF" stands for Remnic Memory Secure File. The four
+ *     trailing bytes give us a nul terminator + a 16-bit minor format
+ *     hint + a reserved byte for future stamping (e.g. wrap kind).
+ *     Magic is at byte 0 so a sniff is `buf.subarray(0, 8) ===
+ *     ENCRYPTED_FILE_MAGIC`.
+ *   - VERSION (1 byte): wrap format version. Currently 1.
+ *   - RESERVED (3 bytes): zero. Reserved for future per-file flags
+ *     (compression kind, AAD profile, etc.).
+ *   - SEALED-ENVELOPE: a `cipher.seal(...)` envelope (see `cipher.ts`).
+ *     The seal embeds its own salt + IV + auth tag, so the only state
+ *     this module owns is the magic + version bytes.
+ *
+ * The magic is intentionally distinct from the YAML-frontmatter
+ * `---\n` prefix that plaintext memory files start with, which lets a
+ * single read path detect the file's shape with one `subarray` compare
+ * and decide whether to decrypt.
+ *
+ * Backward compatibility
+ * ----------------------
+ * `readMaybeEncryptedFile()` returns plaintext for any file that
+ * doesn't start with the magic bytes — a freshly-installed daemon
+ * with `secureStoreEnabled: false` keeps reading legacy markdown
+ * files exactly as before. Only writes through `writeMaybeEncryptedFile`
+ * with a key produce encrypted output.
+ *
+ * Migration
+ * ---------
+ * `migrateMemoryDirToEncrypted()` walks a memory directory, snapshots
+ * each `.md` file via the page-versioning callback (CLAUDE.md gotcha
+ * #54: snapshot before atomic re-write), then re-writes the file in
+ * encrypted form. The walker is the canonical bulk-rotate entry point
+ * for going from a plaintext store to an encrypted one.
+ *
+ * What this module does NOT do
+ * ----------------------------
+ * - It does not own a keyring. Callers pass in a `Buffer` master key
+ *   (typically `keyring.getKey(secureStoreId)`).
+ * - It does not own KDF state. `header.ts` is the system of record;
+ *   the per-file salt embedded in each envelope is fresh from
+ *   `cipher.seal()`'s random IV pathway.
+ * - It does not enforce policy on which files to encrypt — callers
+ *   decide based on the file's role (memory `.md` vs. ledger / index).
+ */
+
+import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import {
+  ENVELOPE_HEADER_SIZE as SEALED_ENVELOPE_HEADER_SIZE,
+  generateSalt,
+  open as openSealed,
+  seal as sealEnvelope,
+} from "./cipher.js";
+
+/**
+ * Magic bytes that prefix every encrypted memory file.
+ *
+ * The exact byte sequence is `R M S F \x00 \x01 \x00 \x00`. The
+ * trailing nul is intentional: it terminates the printable prefix so
+ * a casual `cat` of an encrypted file shows "RMSF" and then nothing
+ * else legible.
+ */
+// Note: Object.freeze cannot be applied to Buffer (ArrayBufferView).
+// We expose this as a plain const — callers MUST NOT mutate it.
+export const ENCRYPTED_FILE_MAGIC: Buffer = Buffer.from([
+  0x52, 0x4d, 0x53, 0x46, 0x00, 0x01, 0x00, 0x00,
+]);
+
+/** Length of the leading magic block in bytes. */
+export const ENCRYPTED_FILE_MAGIC_LENGTH = ENCRYPTED_FILE_MAGIC.length;
+
+/** Wrap format version. Bump on a breaking layout change. */
+export const ENCRYPTED_FILE_VERSION = 1 as const;
+
+/** Reserved bytes between the version byte and the sealed envelope. */
+export const ENCRYPTED_FILE_RESERVED_LENGTH = 3;
+
+/** Total wrap header size: magic + version + reserved. */
+export const ENCRYPTED_FILE_HEADER_SIZE =
+  ENCRYPTED_FILE_MAGIC_LENGTH + 1 + ENCRYPTED_FILE_RESERVED_LENGTH;
+
+/** Byte offsets inside the wrap header. */
+export const ENCRYPTED_FILE_LAYOUT = Object.freeze({
+  magic: 0,
+  version: ENCRYPTED_FILE_MAGIC_LENGTH,
+  reserved: ENCRYPTED_FILE_MAGIC_LENGTH + 1,
+  envelope: ENCRYPTED_FILE_HEADER_SIZE,
+} as const);
+
+/**
+ * Return true when `bytes` starts with the encrypted-file magic. The
+ * caller is expected to have read at least `ENCRYPTED_FILE_HEADER_SIZE`
+ * bytes; shorter inputs are treated as plaintext.
+ */
+export function isEncryptedFile(bytes: Uint8Array | Buffer | string): boolean {
+  if (typeof bytes === "string") {
+    if (bytes.length < ENCRYPTED_FILE_MAGIC_LENGTH) return false;
+    // Compare byte-by-byte without allocating a fresh Buffer for each
+    // call — the magic includes a nul which `Buffer.from(s, "utf8")`
+    // would not emit cleanly anyway.
+    for (let i = 0; i < ENCRYPTED_FILE_MAGIC_LENGTH; i++) {
+      if (bytes.charCodeAt(i) !== ENCRYPTED_FILE_MAGIC[i]) return false;
+    }
+    return true;
+  }
+  if (!(bytes instanceof Uint8Array) || bytes.length < ENCRYPTED_FILE_MAGIC_LENGTH) {
+    return false;
+  }
+  for (let i = 0; i < ENCRYPTED_FILE_MAGIC_LENGTH; i++) {
+    if (bytes[i] !== ENCRYPTED_FILE_MAGIC[i]) return false;
+  }
+  return true;
+}
+
+/**
+ * Encrypt `plaintext` under `key` and return the full encrypted-file
+ * buffer (magic + version + reserved + sealed envelope). Pure: no I/O.
+ *
+ * @param key 32-byte AES-256 master key. Caller-owned; the keyring
+ *   passes its registered buffer through unchanged.
+ * @param plaintext UTF-8 text or raw bytes to encrypt.
+ * @param options optional `aad` to bind into the envelope's GCM
+ *   auth tag (typically the file's basename so a tampering operator
+ *   cannot rename one encrypted file over another).
+ */
+export function encryptFileBody(
+  key: Buffer,
+  plaintext: string | Uint8Array,
+  options: { aad?: Uint8Array } = {},
+): Buffer {
+  const plainBytes =
+    typeof plaintext === "string" ? Buffer.from(plaintext, "utf8") : Buffer.from(plaintext);
+  const salt = generateSalt();
+  const sealOpts = options.aad !== undefined ? { aad: options.aad } : {};
+  const envelope = sealEnvelope(key, salt, plainBytes, sealOpts);
+  const out = Buffer.alloc(ENCRYPTED_FILE_HEADER_SIZE + envelope.length);
+  ENCRYPTED_FILE_MAGIC.copy(out, ENCRYPTED_FILE_LAYOUT.magic);
+  out.writeUInt8(ENCRYPTED_FILE_VERSION, ENCRYPTED_FILE_LAYOUT.version);
+  // Reserved bytes already zeroed by `Buffer.alloc`.
+  envelope.copy(out, ENCRYPTED_FILE_LAYOUT.envelope);
+  return out;
+}
+
+/**
+ * Decrypt an encrypted-file buffer produced by `encryptFileBody`.
+ * Throws on bad magic, unsupported version, truncated input, or
+ * authentication failure.
+ *
+ * The error message intentionally collapses "wrong key" and "tampered
+ * ciphertext" into the same surface — both are non-recoverable from
+ * the caller's standpoint and revealing which one happened leaks
+ * information about the key state.
+ */
+export function decryptFileBody(
+  key: Buffer,
+  bytes: Uint8Array | Buffer,
+  options: { aad?: Uint8Array } = {},
+): Buffer {
+  if (!(bytes instanceof Uint8Array)) {
+    throw new Error("encrypted file body must be a Uint8Array");
+  }
+  if (bytes.length < ENCRYPTED_FILE_HEADER_SIZE + SEALED_ENVELOPE_HEADER_SIZE) {
+    throw new Error(
+      `encrypted file too short: need ≥ ${
+        ENCRYPTED_FILE_HEADER_SIZE + SEALED_ENVELOPE_HEADER_SIZE
+      } bytes, got ${bytes.length}`,
+    );
+  }
+  if (!isEncryptedFile(bytes)) {
+    throw new Error("encrypted file: bad magic bytes");
+  }
+  const buf = Buffer.from(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  const version = buf.readUInt8(ENCRYPTED_FILE_LAYOUT.version);
+  if (version !== ENCRYPTED_FILE_VERSION) {
+    throw new Error(
+      `unsupported encrypted-file version: ${version} (this build supports ${ENCRYPTED_FILE_VERSION})`,
+    );
+  }
+  // Reserved bytes are not validated — they're reserved precisely so
+  // that a future writer can stamp them without breaking a current
+  // reader. A future reader may tighten this.
+  const envelope = buf.subarray(ENCRYPTED_FILE_LAYOUT.envelope);
+  const openOpts = options.aad !== undefined ? { aad: options.aad } : {};
+  return openSealed(key, envelope, openOpts);
+}
+
+/** Options shared by the read/write helpers. */
+export interface SecureFsOptions {
+  /**
+   * Master key. When `null` or omitted on a read, encrypted files
+   * raise `SecureStoreLockedError`; on a write, the file is written
+   * as plaintext (callers gate on `secureStoreEncryptOnWrite`).
+   */
+  key?: Buffer | null;
+  /**
+   * Optional AAD bound into the envelope. When provided, the same AAD
+   * must be supplied at decrypt time. Common pattern: pass the file's
+   * basename so a tampering operator cannot rename one encrypted file
+   * onto another. This module does not auto-derive AAD; callers opt
+   * in explicitly.
+   */
+  aad?: Uint8Array;
+}
+
+/**
+ * Error raised when a read encounters an encrypted file but no key is
+ * available (locked store). Distinct from a generic `Error` so
+ * orchestrator code can match `instanceof` and surface a clear
+ * "secure store is locked" message rather than a corruption error.
+ */
+export class SecureStoreLockedError extends Error {
+  override readonly name = "SecureStoreLockedError";
+  readonly filePath: string;
+  constructor(filePath: string) {
+    super(
+      `secure store is locked: cannot read encrypted memory file ${filePath}. Run 'remnic secure-store unlock' to unlock.`,
+    );
+    this.filePath = filePath;
+  }
+}
+
+/**
+ * Read a memory file and return its UTF-8 plaintext, transparently
+ * decrypting if the file is encrypted.
+ *
+ * Behavior matrix:
+ *   - file does not exist → propagates `ENOENT`
+ *   - file is plaintext (no magic) → returned as-is (back-compat)
+ *   - file is encrypted + key present → decrypted, returned as UTF-8
+ *   - file is encrypted + no key → throws `SecureStoreLockedError`
+ *   - file is encrypted + wrong key / tampered → throws (auth failure)
+ */
+export async function readMaybeEncryptedFile(
+  filePath: string,
+  options: SecureFsOptions = {},
+): Promise<string> {
+  const raw = await readFile(filePath);
+  if (!isEncryptedFile(raw)) {
+    return raw.toString("utf8");
+  }
+  if (!options.key) {
+    throw new SecureStoreLockedError(filePath);
+  }
+  const decryptOpts = options.aad !== undefined ? { aad: options.aad } : {};
+  const plaintext = decryptFileBody(options.key, raw, decryptOpts);
+  return plaintext.toString("utf8");
+}
+
+/**
+ * Write a memory file. Encrypted iff `key` is provided, plaintext
+ * otherwise. Always writes via temp + atomic rename — never delete-
+ * before-write (CLAUDE.md gotcha #54).
+ *
+ * The caller is responsible for snapshotting the prior content via
+ * page-versioning before invoking this helper. We don't reach into
+ * page-versioning here so this module stays free of cross-cutting
+ * dependencies (it can be unit-tested in isolation against a tmpdir).
+ */
+export async function writeMaybeEncryptedFile(
+  filePath: string,
+  content: string | Uint8Array,
+  options: SecureFsOptions = {},
+): Promise<void> {
+  await mkdir(path.dirname(filePath), { recursive: true });
+  const tempPath = `${filePath}.tmp-${process.pid}-${Date.now()}-${Math.random()
+    .toString(36)
+    .slice(2, 8)}`;
+  try {
+    if (options.key) {
+      const encryptOpts = options.aad !== undefined ? { aad: options.aad } : {};
+      const wrapped = encryptFileBody(options.key, content, encryptOpts);
+      await writeFile(tempPath, wrapped);
+    } else {
+      const plain =
+        typeof content === "string" ? content : Buffer.from(content).toString("utf8");
+      await writeFile(tempPath, plain, "utf8");
+    }
+    await rename(tempPath, filePath);
+  } catch (err) {
+    try {
+      await unlink(tempPath);
+    } catch {
+      // best-effort temp cleanup
+    }
+    throw err;
+  }
+}
+
+/**
+ * Outcome record for `migrateMemoryDirToEncrypted`. Returned so the
+ * CLI / operator can present a summary and so tests can assert
+ * deterministic counts.
+ */
+export interface SecureFsMigrationReport {
+  /** Total `.md` files inspected. */
+  scanned: number;
+  /** Files re-written as encrypted. */
+  encrypted: number;
+  /** Files skipped because they were already encrypted. */
+  alreadyEncrypted: number;
+  /** Files skipped because they failed to read (e.g. permissions). */
+  skipped: number;
+  /** Per-file errors keyed by absolute path. */
+  errors: Array<{ filePath: string; message: string }>;
+}
+
+/**
+ * Optional snapshot callback. Invoked once per file BEFORE the
+ * encrypted re-write, with the current plaintext content. Lets the
+ * caller (e.g. `Storage`) plug in `page-versioning.createPageVersion`
+ * so every migrated file has a recoverable plaintext snapshot.
+ *
+ * Failures inside the snapshot callback abort the per-file rewrite and
+ * are recorded in `errors`. The callback contract is "snapshot must
+ * succeed before encryption proceeds", matching CLAUDE.md gotcha #25
+ * (don't destroy old state before confirming new state succeeds).
+ */
+export type SecureFsSnapshotFn = (filePath: string, plaintext: string) => Promise<void>;
+
+export interface MigrateMemoryDirOptions extends SecureFsOptions {
+  /** Filename suffixes considered "memory files". Defaults to `[".md"]`. */
+  fileSuffixes?: ReadonlyArray<string>;
+  /**
+   * Subdirectories to skip during the walk. Always skips the
+   * `.secure-store/` and `.versions/` directories regardless of this
+   * setting; values supplied here are added on top.
+   */
+  skipDirs?: ReadonlyArray<string>;
+  /** Optional pre-rewrite snapshot hook (page-versioning). */
+  snapshot?: SecureFsSnapshotFn;
+}
+
+const DEFAULT_SKIP_DIRS: ReadonlySet<string> = new Set([
+  ".secure-store",
+  ".versions",
+  ".git",
+]);
+
+/**
+ * Walk `dir` recursively and re-write every memory file as encrypted.
+ * Already-encrypted files are detected via the magic bytes and
+ * skipped. Per-file errors are collected and returned rather than
+ * aborting the whole walk — partial migration is recoverable; a
+ * mid-walk throw is not.
+ *
+ * Requires an unlocked key. Calling with `key` unset throws
+ * synchronously before any I/O so a misconfigured invocation cannot
+ * silently produce a half-migrated tree.
+ */
+export async function migrateMemoryDirToEncrypted(
+  dir: string,
+  options: MigrateMemoryDirOptions,
+): Promise<SecureFsMigrationReport> {
+  if (!options.key) {
+    throw new Error(
+      "migrateMemoryDirToEncrypted requires an unlocked secure-store key (options.key)",
+    );
+  }
+  const fileSuffixes = options.fileSuffixes ?? [".md"];
+  const skipDirs = new Set<string>(DEFAULT_SKIP_DIRS);
+  if (options.skipDirs) {
+    for (const name of options.skipDirs) skipDirs.add(name);
+  }
+  const report: SecureFsMigrationReport = {
+    scanned: 0,
+    encrypted: 0,
+    alreadyEncrypted: 0,
+    skipped: 0,
+    errors: [],
+  };
+
+  // Iterative DFS so we can skip subdirectories cheaply.
+  const stack: string[] = [dir];
+  while (stack.length > 0) {
+    const current = stack.pop();
+    if (!current) break;
+    let entries: string[];
+    try {
+      entries = await readdir(current);
+    } catch (err) {
+      report.errors.push({ filePath: current, message: errMsg(err) });
+      continue;
+    }
+    for (const name of entries) {
+      if (skipDirs.has(name)) continue;
+      const full = path.join(current, name);
+      let entryStat;
+      try {
+        entryStat = await stat(full);
+      } catch (err) {
+        report.errors.push({ filePath: full, message: errMsg(err) });
+        continue;
+      }
+      if (entryStat.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (!entryStat.isFile()) continue;
+      if (!fileSuffixes.some((sfx) => name.endsWith(sfx))) continue;
+
+      report.scanned += 1;
+      let raw: Buffer;
+      try {
+        raw = await readFile(full);
+      } catch (err) {
+        report.skipped += 1;
+        report.errors.push({ filePath: full, message: errMsg(err) });
+        continue;
+      }
+      if (isEncryptedFile(raw)) {
+        report.alreadyEncrypted += 1;
+        continue;
+      }
+      const plaintext = raw.toString("utf8");
+      if (options.snapshot) {
+        try {
+          await options.snapshot(full, plaintext);
+        } catch (err) {
+          // Don't proceed to re-write if the snapshot failed: we'd
+          // lose the recoverable plaintext copy.
+          report.skipped += 1;
+          report.errors.push({
+            filePath: full,
+            message: `snapshot failed: ${errMsg(err)}`,
+          });
+          continue;
+        }
+      }
+      try {
+        const writeOpts: SecureFsOptions = { key: options.key };
+        if (options.aad !== undefined) writeOpts.aad = options.aad;
+        await writeMaybeEncryptedFile(full, plaintext, writeOpts);
+        report.encrypted += 1;
+      } catch (err) {
+        report.skipped += 1;
+        report.errors.push({ filePath: full, message: errMsg(err) });
+      }
+    }
+  }
+  return report;
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -55,7 +55,7 @@
  *   decide based on the file's role (memory `.md` vs. ledger / index).
  */
 
-import { mkdir, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
+import { mkdir, lstat, readFile, readdir, rename, stat, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 
 import {
@@ -399,11 +399,17 @@ export async function migrateMemoryDirToEncrypted(
       const full = path.join(current, name);
       let entryStat;
       try {
-        entryStat = await stat(full);
+        // Use lstat (not stat) so symlinks are NOT followed.
+        // A symlink planted under memoryDir could otherwise redirect the
+        // walk outside the intended root — a security boundary violation
+        // for a security-sensitive operation (Codex P1).
+        entryStat = await lstat(full);
       } catch (err) {
         report.errors.push({ filePath: full, message: errMsg(err) });
         continue;
       }
+      // Skip symlinks unconditionally — never follow them during migration.
+      if (entryStat.isSymbolicLink()) continue;
       if (entryStat.isDirectory()) {
         stack.push(full);
         continue;

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -233,6 +233,30 @@ export class SecureStoreLockedError extends Error {
 }
 
 /**
+ * Error raised when an encrypted file fails to decrypt — wrong key,
+ * tampered ciphertext, corrupted header, or unsupported format version.
+ * Distinct from `SecureStoreLockedError` (no key available) and from
+ * generic I/O errors (ENOENT, EPERM) so callers can choose between
+ * re-throwing (fail-fast) and log+skip (resilient scan) while always
+ * producing an operator-visible signal (CLAUDE.md gotcha #34).
+ */
+export class SecureStoreDecryptError extends Error {
+  override readonly name = "SecureStoreDecryptError";
+  readonly filePath: string;
+  readonly cause: unknown;
+  constructor(filePath: string, cause: unknown) {
+    const detail = cause instanceof Error ? cause.message : String(cause);
+    super(
+      `secure store: failed to decrypt memory file ${filePath}: ${detail}. ` +
+        "The file may be corrupted or was encrypted with a different key. " +
+        "Run 'remnic secure-store status' to diagnose.",
+    );
+    this.filePath = filePath;
+    this.cause = cause;
+  }
+}
+
+/**
  * Read a memory file and return its UTF-8 plaintext, transparently
  * decrypting if the file is encrypted.
  *
@@ -241,7 +265,7 @@ export class SecureStoreLockedError extends Error {
  *   - file is plaintext (no magic) → returned as-is (back-compat)
  *   - file is encrypted + key present → decrypted, returned as UTF-8
  *   - file is encrypted + no key → throws `SecureStoreLockedError`
- *   - file is encrypted + wrong key / tampered → throws (auth failure)
+ *   - file is encrypted + wrong key / tampered → throws `SecureStoreDecryptError`
  */
 export async function readMaybeEncryptedFile(
   filePath: string,
@@ -255,8 +279,16 @@ export async function readMaybeEncryptedFile(
     throw new SecureStoreLockedError(filePath);
   }
   const decryptOpts = options.aad !== undefined ? { aad: options.aad } : {};
-  const plaintext = decryptFileBody(options.key, raw, decryptOpts);
-  return plaintext.toString("utf8");
+  try {
+    const plaintext = decryptFileBody(options.key, raw, decryptOpts);
+    return plaintext.toString("utf8");
+  } catch (err) {
+    // Wrap cipher failures in a typed error so callers can distinguish
+    // decryption failures from ordinary I/O errors (wrong key, tampered
+    // ciphertext, bad version, truncated envelope). This is the only place
+    // the wrap happens — callers should NOT wrap again.
+    throw new SecureStoreDecryptError(filePath, err);
+  }
 }
 
 /**

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -8,6 +8,11 @@ import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import {
+  SecureStoreLockedError,
+  readMaybeEncryptedFile,
+  writeMaybeEncryptedFile,
+} from "./secure-store/secure-fs.js";
+import {
   isConsolidationOperator,
   isValidDerivedFromEntry,
   type ConsolidationOperator,
@@ -2064,14 +2069,36 @@ export class StorageManager {
     this._versioningConfig = config;
   }
 
+  // Issue #690 PR 3/4 — transparent at-rest encryption.
+  /**
+   * The master AES-256 key for the unlocked secure-store, or `null` when
+   * the store is locked / not enabled.  Set by the orchestrator via
+   * `setSecureStoreKey` after the keyring is unlocked.  Never persisted;
+   * a daemon restart re-locks the store.
+   */
+  private _secureStoreKey: Buffer | null = null;
+  /** Whether to encrypt new writes.  Gates on both `secureStoreEnabled` and `secureStoreEncryptOnWrite`. */
+  private _secureStoreEncryptOnWrite: boolean = false;
+
+  /**
+   * Configure the secure-store integration.  Call after `runSecureStoreUnlock`
+   * populates the keyring.  Passing `key = null` has the same effect as locking:
+   * reads of encrypted files will throw `SecureStoreLockedError`.
+   */
+  setSecureStoreKey(key: Buffer | null, encryptOnWrite: boolean = true): void {
+    this._secureStoreKey = key;
+    this._secureStoreEncryptOnWrite = key !== null && encryptOnWrite;
+  }
+
   /**
    * Snapshot the current content of a page before overwriting.
    * No-op when versioning is disabled or the file does not yet exist.
+   * Reads via the secure-fs path so encrypted files are decrypted before snapshot.
    */
   private async snapshotBeforeWrite(filePath: string, trigger: VersionTrigger): Promise<void> {
     if (!this._versioningConfig || !this._versioningConfig.enabled) return;
     try {
-      const existing = await readFile(filePath, "utf-8");
+      const existing = await readMaybeEncryptedFile(filePath, { key: this._secureStoreKey });
       await createPageVersion(filePath, existing, trigger, this._versioningConfig, log, undefined, this.baseDir);
     } catch {
       // File does not exist yet — nothing to snapshot
@@ -2096,7 +2123,7 @@ export class StorageManager {
     if (!this._versioningConfig || !this._versioningConfig.enabled) return null;
     let existing: string;
     try {
-      existing = await readFile(filePath, "utf-8");
+      existing = await readMaybeEncryptedFile(filePath, { key: this._secureStoreKey });
     } catch {
       return null;
     }
@@ -2590,7 +2617,9 @@ export class StorageManager {
     }
 
     await this.snapshotBeforeWrite(filePath, "write");
-    await writeFile(filePath, fileContent, "utf-8");
+    await writeMaybeEncryptedFile(filePath, fileContent, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     this.invalidateAllMemoriesCache();
     await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.writeMemory", {
       memoryId: id,
@@ -2681,7 +2710,9 @@ export class StorageManager {
       return "";
     }
     const filePath = path.join(dir, `${id}.md`);
-    await writeFile(filePath, `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`, "utf-8");
+    await writeMaybeEncryptedFile(filePath, `${serializeFrontmatter(fm)}\n\n${sanitized.text}\n`, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     const actor =
       typeof options.actor === "string" && options.actor.length > 0
         ? options.actor
@@ -2895,7 +2926,9 @@ export class StorageManager {
     entity.updated = new Date().toISOString();
 
     await this.snapshotBeforeWrite(filePath, "write");
-    await writeFile(filePath, serializeEntityFile(entity, this.entitySchemas), "utf-8");
+    await writeMaybeEncryptedFile(filePath, serializeEntityFile(entity, this.entitySchemas), {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     this.invalidateKnowledgeIndexCache();
     this.bumpMemoryStatusVersion(); // invalidate entity cache
     log.debug(`wrote entity ${normalized}`);
@@ -2913,7 +2946,9 @@ export class StorageManager {
   async writeProfile(content: string): Promise<void> {
     await this.ensureDirectories();
     await this.snapshotBeforeWrite(this.profilePath, "consolidation");
-    await writeFile(this.profilePath, content, "utf-8");
+    await writeMaybeEncryptedFile(this.profilePath, content, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     log.debug("updated profile.md");
   }
 
@@ -3128,7 +3163,7 @@ export class StorageManager {
       const results = await Promise.all(
         batch.map(async (fullPath) => {
           try {
-            const raw = await readFile(fullPath, "utf-8");
+            const raw = await readMaybeEncryptedFile(fullPath, { key: this._secureStoreKey });
             const parsed = parseFrontmatter(raw);
             if (!parsed) return null;
             return {
@@ -3402,7 +3437,7 @@ export class StorageManager {
             await readDir(fullPath);
           } else if (entry.name.endsWith(".md")) {
             try {
-              const raw = await readFile(fullPath, "utf-8");
+              const raw = await readMaybeEncryptedFile(fullPath, { key: this._secureStoreKey });
               const parsed = parseFrontmatter(raw);
               if (parsed) {
                 memories.push({
@@ -3432,7 +3467,7 @@ export class StorageManager {
   /** Read a single memory file by its absolute path. Returns null if unreadable. */
   async readMemoryByPath(filePath: string): Promise<MemoryFile | null> {
     try {
-      const raw = await readFile(filePath, "utf-8");
+      const raw = await readMaybeEncryptedFile(filePath, { key: this._secureStoreKey });
       const parsed = parseFrontmatter(raw);
       if (parsed) {
         return {
@@ -3526,20 +3561,11 @@ export class StorageManager {
 
   private async writeMemoryFileAtomic(targetPath: string, memory: MemoryFile): Promise<void> {
     const fileContent = `${serializeFrontmatter(memory.frontmatter)}\n\n${memory.content}\n`;
-    await mkdir(path.dirname(targetPath), { recursive: true });
-    const tempPath = `${targetPath}.tmp-${process.pid}-${Date.now()}`;
-    try {
-      await writeFile(tempPath, fileContent, "utf-8");
-      await rename(tempPath, targetPath);
-      this.invalidateAllMemoriesCache();
-    } catch (err) {
-      try {
-        await unlink(tempPath);
-      } catch {
-        // best-effort cleanup
-      }
-      throw err;
-    }
+    // writeMaybeEncryptedFile handles mkdir + temp+rename atomically.
+    await writeMaybeEncryptedFile(targetPath, fileContent, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
+    this.invalidateAllMemoriesCache();
   }
 
   async moveMemoryToPath(memory: MemoryFile, targetPath: string): Promise<void> {
@@ -3668,7 +3694,9 @@ export class StorageManager {
 
   async readEntity(name: string): Promise<string> {
     try {
-      return await readFile(path.join(this.entitiesDir, `${name}.md`), "utf-8");
+      return await readMaybeEncryptedFile(path.join(this.entitiesDir, `${name}.md`), {
+        key: this._secureStoreKey,
+      });
     } catch {
       return "";
     }
@@ -3780,7 +3808,9 @@ export class StorageManager {
       log.warn(`updated memory content sanitized for ${id}; violations=${sanitized.violations.join(", ")}`);
     }
     const fileContent = `${serializeFrontmatter(updated)}\n\n${sanitized.text}\n`;
-    await writeFile(memory.path, fileContent, "utf-8");
+    await writeMaybeEncryptedFile(memory.path, fileContent, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     this.invalidateAllMemoriesCache();
     await this.appendGeneratedMemoryLifecycleEventFailOpen("storage.updateMemory", {
       memoryId: id,
@@ -3815,7 +3845,9 @@ export class StorageManager {
     const afterStatus = updated.status ?? "active";
 
     const fileContent = `${serializeFrontmatter(updated)}\n\n${memory.content}\n`;
-    await writeFile(memory.path, fileContent, "utf-8");
+    await writeMaybeEncryptedFile(memory.path, fileContent, {
+      key: this._secureStoreEncryptOnWrite ? this._secureStoreKey : null,
+    });
     this.invalidateAllMemoriesCache();
     // If the target file lives in cold/, bump the cold-version sentinel so
     // other processes detect the change on their next readAllColdMemories()

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -2861,7 +2861,7 @@ export class StorageManager {
       aliases: [],
     };
     try {
-      const existing = await readFile(filePath, "utf-8");
+      const existing = await readMaybeEncryptedFile(filePath, { key: this._secureStoreKey });
       entity = parseEntityFile(existing, this.entitySchemas);
     } catch {
       // File doesn't exist yet
@@ -2937,7 +2937,7 @@ export class StorageManager {
 
   async readProfile(): Promise<string> {
     try {
-      return await readFile(this.profilePath, "utf-8");
+      return await readMaybeEncryptedFile(this.profilePath, { key: this._secureStoreKey });
     } catch {
       return "";
     }
@@ -3175,7 +3175,12 @@ export class StorageManager {
               ),
               content: parsed.content,
             } satisfies MemoryFile;
-          } catch {
+          } catch (err) {
+            // Re-throw SecureStoreLockedError: a locked store must surface
+            // clearly rather than silently collapsing memory scan results to
+            // empty. Only suppress non-fatal I/O errors (ENOENT, parse
+            // failures, etc.) — Codex P1.
+            if (err instanceof SecureStoreLockedError) throw err;
             return null;
           }
         }),

--- a/packages/remnic-core/src/storage.ts
+++ b/packages/remnic-core/src/storage.ts
@@ -8,6 +8,7 @@ import { rotateMarkdownFileToArchive } from "./hygiene.js";
 import { sanitizeMemoryContent } from "./sanitize.js";
 import { createVersion as createPageVersion, type VersioningConfig, type VersionTrigger } from "./page-versioning.js";
 import {
+  SecureStoreDecryptError,
   SecureStoreLockedError,
   readMaybeEncryptedFile,
   writeMaybeEncryptedFile,
@@ -2863,8 +2864,14 @@ export class StorageManager {
     try {
       const existing = await readMaybeEncryptedFile(filePath, { key: this._secureStoreKey });
       entity = parseEntityFile(existing, this.entitySchemas);
-    } catch {
-      // File doesn't exist yet
+    } catch (err) {
+      // Re-throw secure-store errors: a locked store or decryption failure
+      // must surface clearly rather than silently proceeding with an empty
+      // entity and overwriting encrypted data (Cursor review, CLAUDE.md
+      // gotcha #34).
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (err instanceof SecureStoreDecryptError) throw err;
+      // File doesn't exist yet — fall through to empty entity default.
     }
 
     const timestamp = options.timestamp?.trim() || new Date().toISOString();
@@ -3178,9 +3185,16 @@ export class StorageManager {
           } catch (err) {
             // Re-throw SecureStoreLockedError: a locked store must surface
             // clearly rather than silently collapsing memory scan results to
-            // empty. Only suppress non-fatal I/O errors (ENOENT, parse
-            // failures, etc.) — Codex P1.
+            // empty.
             if (err instanceof SecureStoreLockedError) throw err;
+            // Re-throw decryption failures with a telemetry signal — wrong
+            // key or tampered ciphertext must not be silently dropped (Codex
+            // P1, CLAUDE.md gotcha #34). The caller (orchestrator) decides
+            // whether to abort the recall or degrade gracefully.
+            if (err instanceof SecureStoreDecryptError) {
+              log.warn(`secure-store: decryption failure for ${fullPath} — ${err.message}`);
+              throw err;
+            }
             return null;
           }
         }),
@@ -3455,13 +3469,23 @@ export class StorageManager {
                   content: parsed.content,
                 });
               }
-            } catch {
-              // Skip unreadable files
+            } catch (err) {
+              // Re-throw decryption failures with a telemetry signal — wrong
+              // key or tampered ciphertext must not be silently dropped (Codex
+              // P1, CLAUDE.md gotcha #34).
+              if (err instanceof SecureStoreLockedError) throw err;
+              if (err instanceof SecureStoreDecryptError) {
+                log.warn(`secure-store: decryption failure for archived file ${fullPath} — ${err.message}`);
+                throw err;
+              }
+              // Silently skip other I/O errors (ENOENT, EPERM, parse failures).
             }
           }
         }
-      } catch {
-        // Directory doesn't exist yet
+      } catch (err) {
+        // Re-throw secure-store errors; swallow only "directory doesn't exist".
+        if (err instanceof SecureStoreLockedError || err instanceof SecureStoreDecryptError) throw err;
+        // Directory doesn't exist yet (or other benign readdir error).
       }
     };
 
@@ -3520,7 +3544,15 @@ export class StorageManager {
       }
 
       return null;
-    } catch {
+    } catch (err) {
+      // Re-throw secure-store errors — decryption failures and locked-store
+      // states must surface to the caller rather than being silently dropped
+      // as `null` (Codex P1, CLAUDE.md gotcha #34).
+      if (err instanceof SecureStoreLockedError) throw err;
+      if (err instanceof SecureStoreDecryptError) {
+        log.warn(`secure-store: decryption failure for ${filePath} — ${err.message}`);
+        throw err;
+      }
       return null;
     }
   }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1405,6 +1405,21 @@ export interface PluginConfig {
    * memoryDir: go up to the Remnic home dir and append memory_extensions.
    */
   memoryExtensionsRoot: string;
+
+  // At-rest encryption for memory files (issue #690 PR 3/4)
+  /**
+   * Enable transparent at-rest encryption for memory files.
+   * When true, the secure-store module wraps storage.ts read/write paths
+   * so that all memory file contents are encrypted with the master key
+   * whenever the store is unlocked. Default false.
+   */
+  secureStoreEnabled: boolean;
+  /**
+   * When secureStoreEnabled is true and the store is unlocked, encrypt
+   * every new write. When false, writes are still plaintext even if the
+   * store is unlocked (useful for migrating gradually). Default true.
+   */
+  secureStoreEncryptOnWrite: boolean;
 }
 
 /** Runtime configuration for the daily context briefing feature. */

--- a/tests/secure-store/storage-wrap.test.ts
+++ b/tests/secure-store/storage-wrap.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for transparent at-rest encryption wrapping in storage.ts
+ * (issue #690 PR 3/4).
+ *
+ * Tests are driven against the pure secure-fs helpers (no daemon, no
+ * StorageManager instance needed for most cases) plus a narrow set of
+ * StorageManager integration paths. All crypto work uses low-cost scrypt
+ * params so the suite stays fast on CI.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import path from "node:path";
+import os from "node:os";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+
+import {
+  ENCRYPTED_FILE_MAGIC,
+  ENCRYPTED_FILE_MAGIC_LENGTH,
+  SecureStoreLockedError,
+  isEncryptedFile,
+  migrateMemoryDirToEncrypted,
+  readMaybeEncryptedFile,
+  writeMaybeEncryptedFile,
+  type SecureFsMigrationReport,
+} from "../../src/secure-store/index.js";
+import { randomBytes } from "node:crypto";
+import {
+  buildHeaderFromPassphrase,
+} from "../../packages/remnic-core/src/secure-store/header.js";
+import {
+  KDF_SALT_LENGTH,
+  type ScryptParams,
+} from "../../packages/remnic-core/src/secure-store/kdf.js";
+
+// Low-cost scrypt params: RFC 7914 valid, derives in <5 ms on CI.
+const FAST_SCRYPT: ScryptParams = {
+  N: 1 << 10, // 2^10 = 1024
+  r: 1,
+  p: 1,
+  keyLength: 32,
+  maxmem: 32 * 1024 * 1024,
+};
+
+/** Derive a fresh 32-byte master key from a passphrase using fast scrypt. */
+function deriveTestKey(passphrase: string): Buffer {
+  const salt = randomBytes(KDF_SALT_LENGTH);
+  const { derivedKey } = buildHeaderFromPassphrase({
+    passphrase,
+    salt,
+    algorithm: "scrypt",
+    params: FAST_SCRYPT,
+  });
+  return derivedKey;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeTmpDir(label: string): Promise<string> {
+  const dir = path.join(os.tmpdir(), `remnic-storage-wrap-test-${label}-${Date.now()}`);
+  await mkdir(dir, { recursive: true });
+  return dir;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Roundtrip: encrypt → decrypt preserves content
+// ---------------------------------------------------------------------------
+
+test("encrypted-then-decrypted roundtrip preserves content", async () => {
+  const dir = await makeTmpDir("roundtrip");
+  try {
+    const key = deriveTestKey("correct-horse-battery-staple");
+    const filePath = path.join(dir, "memory.md");
+    const original = "---\nid: test-001\ncategory: fact\n---\n\nThis is a test memory.\n";
+
+    await writeMaybeEncryptedFile(filePath, original, { key });
+
+    // The on-disk file must start with the encrypted-file magic.
+    const raw = await readFile(filePath);
+    assert.ok(isEncryptedFile(raw), "written file should start with RMSF magic");
+    assert.notStrictEqual(raw.toString("utf8"), original, "on-disk should NOT be plaintext");
+
+    // Reading it back with the key should yield the original content.
+    const decrypted = await readMaybeEncryptedFile(filePath, { key });
+    assert.strictEqual(decrypted, original, "decrypted content must equal original");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 2. Backward compatibility: plaintext files still read correctly
+// ---------------------------------------------------------------------------
+
+test("reading a plaintext file still works (back-compat)", async () => {
+  const dir = await makeTmpDir("backcompat");
+  try {
+    const filePath = path.join(dir, "memory.md");
+    const plaintext = "---\nid: legacy-001\ncategory: fact\n---\n\nLegacy plaintext memory.\n";
+    await writeFile(filePath, plaintext, "utf-8");
+
+    // Sanity: not encrypted.
+    const raw = await readFile(filePath);
+    assert.ok(!isEncryptedFile(raw), "legacy file should NOT start with RMSF magic");
+
+    // Read with no key: should return plaintext unchanged.
+    const noKey = await readMaybeEncryptedFile(filePath, {});
+    assert.strictEqual(noKey, plaintext, "no-key read of plaintext should return content as-is");
+
+    // Read with a key: plaintext files are returned as-is (not decrypted).
+    const key = deriveTestKey("passphrase");
+    const withKey = await readMaybeEncryptedFile(filePath, { key });
+    assert.strictEqual(withKey, plaintext, "key read of plaintext should still return plaintext as-is");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 3. Locked store: encrypted read without a key raises SecureStoreLockedError
+// ---------------------------------------------------------------------------
+
+test("locked store raises SecureStoreLockedError on encrypted file read", async () => {
+  const dir = await makeTmpDir("locked");
+  try {
+    const key = deriveTestKey("my-passphrase");
+    const filePath = path.join(dir, "memory.md");
+    const content = "---\nid: locked-001\n---\n\nSensitive content.\n";
+
+    // Write encrypted.
+    await writeMaybeEncryptedFile(filePath, content, { key });
+
+    // Verify it's actually encrypted on disk.
+    const raw = await readFile(filePath);
+    assert.ok(isEncryptedFile(raw), "file must be encrypted before lock test");
+
+    // Now attempt to read it with no key (store is locked).
+    await assert.rejects(
+      () => readMaybeEncryptedFile(filePath, { key: null }),
+      (err) => {
+        assert.ok(err instanceof SecureStoreLockedError, "should throw SecureStoreLockedError");
+        assert.ok(
+          err.message.includes("secure store is locked"),
+          `error message should mention lock: ${err.message}`,
+        );
+        assert.strictEqual(err.filePath, filePath);
+        return true;
+      },
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 4. Migration: walks fixture dir and re-writes every .md file as encrypted
+// ---------------------------------------------------------------------------
+
+test("migration walks fixture dir and re-writes all .md files as encrypted", async () => {
+  const dir = await makeTmpDir("migrate");
+  try {
+    const factsDir = path.join(dir, "facts", "2024-01-01");
+    const corrDir = path.join(dir, "corrections");
+    await mkdir(factsDir, { recursive: true });
+    await mkdir(corrDir, { recursive: true });
+
+    const files = [
+      { p: path.join(factsDir, "fact-001.md"), c: "---\nid: fact-001\n---\n\nFact one.\n" },
+      { p: path.join(factsDir, "fact-002.md"), c: "---\nid: fact-002\n---\n\nFact two.\n" },
+      { p: path.join(corrDir, "corr-001.md"), c: "---\nid: corr-001\n---\n\nCorrection one.\n" },
+    ];
+    for (const { p, c } of files) {
+      await writeFile(p, c, "utf-8");
+    }
+
+    const key = deriveTestKey("migration-passphrase");
+    const snapshotLog: Array<{ filePath: string; plaintext: string }> = [];
+
+    const report: SecureFsMigrationReport = await migrateMemoryDirToEncrypted(dir, {
+      key,
+      snapshot: async (filePath, plaintext) => {
+        snapshotLog.push({ filePath, plaintext });
+      },
+    });
+
+    assert.strictEqual(report.scanned, 3, "should scan all 3 .md files");
+    assert.strictEqual(report.encrypted, 3, "should encrypt all 3 files");
+    assert.strictEqual(report.alreadyEncrypted, 0, "no files were pre-encrypted");
+    assert.strictEqual(report.skipped, 0, "no files should be skipped");
+    assert.strictEqual(report.errors.length, 0, "no errors expected");
+
+    // Snapshot callback must have been called once per file.
+    assert.strictEqual(snapshotLog.length, 3, "snapshot callback called once per file");
+
+    // Every file on disk should now be encrypted.
+    for (const { p, c } of files) {
+      const raw = await readFile(p);
+      assert.ok(isEncryptedFile(raw), `${path.basename(p)} should be encrypted after migration`);
+      // Decrypting with the key should recover the original content.
+      const recovered = await readMaybeEncryptedFile(p, { key });
+      assert.strictEqual(recovered, c, `recovered content must match original for ${path.basename(p)}`);
+    }
+
+    // Running migration again should skip already-encrypted files.
+    const report2 = await migrateMemoryDirToEncrypted(dir, { key });
+    assert.strictEqual(report2.alreadyEncrypted, 3, "second pass: all files already encrypted");
+    assert.strictEqual(report2.encrypted, 0, "second pass: nothing newly encrypted");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 5. Tampered ciphertext raises an authentication error
+// ---------------------------------------------------------------------------
+
+test("tampered ciphertext is detected (auth tag mismatch)", async () => {
+  const dir = await makeTmpDir("tamper");
+  try {
+    const key = deriveTestKey("tamper-passphrase");
+    const filePath = path.join(dir, "memory.md");
+    const content = "---\nid: tamper-001\n---\n\nSecret content.\n";
+
+    await writeMaybeEncryptedFile(filePath, content, { key });
+
+    // Flip a single byte in the ciphertext region (past the header).
+    const raw = Buffer.from(await readFile(filePath));
+    // The encrypted file magic is the first ENCRYPTED_FILE_MAGIC_LENGTH bytes.
+    // Corrupt a byte well into the ciphertext region.
+    const tamperedOffset = ENCRYPTED_FILE_MAGIC_LENGTH + 20;
+    raw[tamperedOffset] ^= 0xff;
+    await writeFile(filePath, raw);
+
+    // Decryption should fail with an auth-tag error.
+    await assert.rejects(
+      () => readMaybeEncryptedFile(filePath, { key }),
+      (err) => {
+        assert.ok(err instanceof Error, "should throw an Error");
+        // Node's decipher.final() throws "Unsupported state or unable to
+        // authenticate data" on GCM auth failure. Accept any error here
+        // since the exact message varies by Node version.
+        return true;
+      },
+      "tampered ciphertext must not decrypt silently",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. writeMaybeEncryptedFile: no key → writes plaintext
+// ---------------------------------------------------------------------------
+
+test("writeMaybeEncryptedFile with no key writes plaintext", async () => {
+  const dir = await makeTmpDir("nokey-write");
+  try {
+    const filePath = path.join(dir, "memory.md");
+    const content = "---\nid: plain-001\n---\n\nPlain content.\n";
+
+    await writeMaybeEncryptedFile(filePath, content, { key: null });
+
+    const raw = await readFile(filePath);
+    assert.ok(!isEncryptedFile(raw), "no-key write should produce plaintext");
+    assert.strictEqual(raw.toString("utf8"), content, "plaintext content should match");
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 7. Migration without a key throws immediately before any I/O
+// ---------------------------------------------------------------------------
+
+test("migrateMemoryDirToEncrypted without a key throws before any I/O", async () => {
+  const dir = await makeTmpDir("no-key-migrate");
+  try {
+    await assert.rejects(
+      () => migrateMemoryDirToEncrypted(dir, {}),
+      /requires an unlocked secure-store key/,
+      "must throw a clear error when no key is provided",
+    );
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- **`secure-fs.ts`** — New module providing the `RMSF`-magic-prefixed encrypted file envelope. On-disk shape: `[MAGIC:8][VERSION:1][RESERVED:3][SEALED-ENVELOPE]`. `encryptFileBody`/`decryptFileBody` are pure functions (no I/O). `readMaybeEncryptedFile` and `writeMaybeEncryptedFile` provide the drop-in I/O wrappers with backward-compatible plaintext fallback and atomic temp+rename writes (CLAUDE.md gotcha #54).
- **`storage.ts` wiring** — `StorageManager` gains `setSecureStoreKey(key, encryptOnWrite)`. All memory-file read/write paths (`readMemoryByPath`, `readParsedMemoriesFromPaths`, `readArchivedMemories`, `readEntity`, `writeMemory`, `writeArtifact`, `writeMemoryFileAtomic`, `writeMemoryFrontmatter`, `updateMemory`, `writeProfile`, `writeEntity`, `snapshotBeforeWrite`, `snapshotForProvenance`) now route through the secure-fs helpers when a key is set.
- **`migrateMemoryDirToEncrypted(dir, opts)`** — Walks all `.md` files, snapshots each via the `snapshot` callback (page-versioning hook) before atomic re-write, skips already-encrypted files, and returns a `SecureFsMigrationReport`.
- **Config** — `secureStoreEnabled` (default `false`) and `secureStoreEncryptOnWrite` (default `true`) added to `PluginConfig`, `config.ts`, and both plugin manifests (`openclaw.plugin.json` + `packages/plugin-openclaw/openclaw.plugin.json`).

## Test plan

- [ ] `tests/secure-store/storage-wrap.test.ts` — 7 tests, all passing:
  - Encrypted-then-decrypted roundtrip preserves content
  - Reading a plaintext file still works (back-compat)
  - Locked store raises `SecureStoreLockedError` on encrypted file read
  - Migration walks fixture dir and re-writes all `.md` files as encrypted (second pass skips already-encrypted)
  - Tampered ciphertext detected (auth tag mismatch)
  - `writeMaybeEncryptedFile` with no key writes plaintext
  - `migrateMemoryDirToEncrypted` without a key throws before any I/O
- [ ] `npm run test:entity-hardening` — 194/194 pass
- [ ] `packages/remnic-core/src/config.test.ts` — 59/59 pass
- [ ] `tests/cli-secure-store.test.ts` — 19/19 pass
- [ ] `npm run build` — success

## PR Checklist

* [ ] All tests pass
* [ ] New logic covered by tests
* [ ] Pre-commit hooks pass
* [ ] No secrets or credentials committed
* [ ] PR diff ≤ 400 LOC (justified: new secure-fs.ts module + wiring)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes core `storage.ts` read/write paths and introduces encrypted-on-disk memory file handling plus bulk migration logic; bugs could cause unreadable or overwritten user data when the secure store is locked/misconfigured.
> 
> **Overview**
> Adds transparent at-rest encryption support for memory `.md` files via a new `secure-fs` layer that can detect an `RMSF`-prefixed envelope, decrypt/encrypt on read/write, and atomically write files.
> 
> Wires `StorageManager` to use these secure read/write helpers across memory/entity/profile operations, with explicit propagation of locked-store and decrypt errors to avoid silently treating encrypted data as missing.
> 
> Introduces a directory migration helper to re-write existing plaintext memory trees into encrypted form (with optional snapshot hook), and adds `secureStoreEnabled`/`secureStoreEncryptOnWrite` configuration knobs plus tests covering roundtrip, lock behavior, migration, and tamper detection.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fdf480f1cced38c6a8c52e37f55775528e4bedd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->