### PR TITLE
feat(connectors): Notion live connector (issue #683 PR 3/6)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -744,6 +744,39 @@
                 "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
               }
             }
+          },
+          "notion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
+              },
+              "databaseIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
           }
         }
       },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -744,6 +744,39 @@
                 "description": "Optional array of Google Drive folder ids to scope the import. Empty = all accessible files. Folder ids are validated for shape; nested folders are NOT auto-included."
               }
             }
+          },
+          "notion": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "Notion live connector (issue #683 PR 3/N). Imports text content from Notion database pages into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable Notion imports. The connector additionally requires a token and at least one databaseId to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "Notion integration token (starts with secret_). Populate from your secret store (e.g. ${NOTION_TOKEN}). Never commit a real value to source."
+              },
+              "databaseIds": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of Notion database ids to import pages from. Accepts compact 32-hex-char ids or standard UUID format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              }
+            }
           }
         }
       },

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2596,6 +2596,62 @@ export function parseConfig(raw: unknown): PluginConfig {
           driveFolderIds.push(trimmed);
         }
       }
+      // notion (#683 PR 3/N)
+      if (
+        rawConnectors.notion !== undefined &&
+        (rawConnectors.notion === null ||
+          typeof rawConnectors.notion !== "object" ||
+          Array.isArray(rawConnectors.notion))
+      ) {
+        throw new Error(
+          `connectors.notion must be an object (got ${JSON.stringify(rawConnectors.notion)}).`,
+        );
+      }
+      const rawNotion =
+        rawConnectors.notion &&
+        typeof rawConnectors.notion === "object" &&
+        !Array.isArray(rawConnectors.notion)
+          ? (rawConnectors.notion as Record<string, unknown>)
+          : {};
+      const notionEnabled = coerceBool(rawNotion.enabled) === true;
+      const notionToken =
+        typeof rawNotion.token === "string" ? rawNotion.token : "";
+      const notionPollCoerced = coerceNumber(rawNotion.pollIntervalMs);
+      let notionPollIntervalMs = 300_000;
+      if (notionPollCoerced !== undefined) {
+        if (
+          !Number.isFinite(notionPollCoerced) ||
+          !Number.isInteger(notionPollCoerced) ||
+          notionPollCoerced < 1_000 ||
+          notionPollCoerced > 86_400_000
+        ) {
+          throw new Error(
+            `connectors.notion.pollIntervalMs must be an integer in [1000, 86400000] ms (got ${JSON.stringify(rawNotion.pollIntervalMs)})`,
+          );
+        }
+        notionPollIntervalMs = notionPollCoerced;
+      }
+      let notionDatabaseIds: string[] = [];
+      if (rawNotion.databaseIds !== undefined) {
+        if (!Array.isArray(rawNotion.databaseIds)) {
+          throw new Error(
+            `connectors.notion.databaseIds must be an array of strings (got ${typeof rawNotion.databaseIds})`,
+          );
+        }
+        const seen = new Set<string>();
+        for (const value of rawNotion.databaseIds) {
+          if (typeof value !== "string") {
+            throw new Error(
+              `connectors.notion.databaseIds entries must be strings; found ${typeof value}`,
+            );
+          }
+          const trimmed = value.trim();
+          if (trimmed.length === 0) continue;
+          if (seen.has(trimmed)) continue;
+          seen.add(trimmed);
+          notionDatabaseIds.push(trimmed);
+        }
+      }
       return {
         googleDrive: {
           enabled: driveEnabled,
@@ -2604,6 +2660,12 @@ export function parseConfig(raw: unknown): PluginConfig {
           refreshToken: driveRefreshToken,
           pollIntervalMs: drivePollIntervalMs,
           folderIds: driveFolderIds,
+        },
+        notion: {
+          enabled: notionEnabled,
+          token: notionToken,
+          databaseIds: notionDatabaseIds,
+          pollIntervalMs: notionPollIntervalMs,
         },
       };
     })(),

--- a/packages/remnic-core/src/connectors/live/index.ts
+++ b/packages/remnic-core/src/connectors/live/index.ts
@@ -51,3 +51,17 @@ export {
   type GoogleDriveConnectorConfig,
   type GoogleDriveSyncResult,
 } from "./google-drive.js";
+
+export {
+  NOTION_CONNECTOR_ID,
+  NOTION_CURSOR_KIND,
+  NOTION_DEFAULT_POLL_INTERVAL_MS,
+  createNotionConnector,
+  isTransientNotionError,
+  validateNotionConfig,
+  type NotionBlock,
+  type NotionConnectorConfig,
+  type NotionFetchFn,
+  type NotionPage,
+  type NotionSyncResult,
+} from "./notion.js";

--- a/packages/remnic-core/src/connectors/live/notion.test.ts
+++ b/packages/remnic-core/src/connectors/live/notion.test.ts
@@ -1,0 +1,963 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  NOTION_CONNECTOR_ID,
+  NOTION_CURSOR_KIND,
+  NOTION_DEFAULT_POLL_INTERVAL_MS,
+  createNotionConnector,
+  isTransientNotionError,
+  validateNotionConfig,
+  type NotionFetchFn,
+  type NotionPage,
+  type NotionSyncResult,
+} from "./notion.js";
+import type { ConnectorCursor } from "./framework.js";
+
+/**
+ * Tests for the Notion connector (#683 PR 3/N). All Notion API calls are
+ * stubbed via the `fetchFn` test hook — the test suite never touches the
+ * network.
+ *
+ * Per CLAUDE.md privacy rules: no real tokens, no real database ids, no
+ * real page ids. All inputs are obviously-synthetic strings shaped roughly
+ * like the real values.
+ */
+
+// ---------------------------------------------------------------------------
+// Synthetic test data
+// ---------------------------------------------------------------------------
+
+/** Synthetic integration token shaped like a real one. */
+const SYNTHETIC_TOKEN = "secret_synthetic_integration_token_DO_NOT_USE_aabbccdd";
+
+/** Synthetic Notion UUIDs (hex-only compact form). */
+const DB_ID_A = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+const DB_ID_B = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+const PAGE_ID_1 = "11111111111111111111111111111111";
+const PAGE_ID_2 = "22222222222222222222222222222222";
+
+const SYNTHETIC_CONFIG = Object.freeze({
+  token: SYNTHETIC_TOKEN,
+  databaseIds: [DB_ID_A],
+});
+
+function makeSyntheticPage(
+  id: string,
+  lastEdited: string,
+  title?: string,
+): NotionPage {
+  const properties: NotionPage["properties"] = {};
+  if (title !== undefined) {
+    properties["Name"] = {
+      type: "title",
+      title: [{ plain_text: title }],
+    };
+  }
+  return {
+    id,
+    last_edited_time: lastEdited,
+    url: `https://notion.so/${id}`,
+    properties,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fetch stub. Per-URL handlers return raw JSON-compatible objects;
+ * the stub serialises them through `res.json()`.
+ *
+ * `handlers` maps URL substring patterns to response factories.
+ */
+function makeFetch(
+  handlers: Array<{
+    match: (url: string) => boolean;
+    respond: (url: string, body: unknown) => { status: number; data: unknown };
+  }>,
+): NotionFetchFn {
+  return async (url, init) => {
+    let body: unknown = undefined;
+    if (init.body) {
+      try {
+        body = JSON.parse(init.body);
+      } catch {
+        body = init.body;
+      }
+    }
+    for (const handler of handlers) {
+      if (handler.match(url)) {
+        const { status, data } = handler.respond(url, body);
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          json: async () => data,
+        };
+      }
+    }
+    throw new Error(`fetch stub: no handler for ${url}`);
+  };
+}
+
+/** Returns an empty paginated response for any database query. */
+function emptyQueryFetch(): NotionFetchFn {
+  return makeFetch([
+    {
+      match: (url) => url.includes("/databases/"),
+      respond: () => ({
+        status: 200,
+        data: { object: "list", results: [], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: { object: "list", results: [], has_more: false, next_cursor: null },
+      }),
+    },
+  ]);
+}
+
+/** Build a valid first-sync cursor from a payload. */
+function makeNotionCursor(payload: { pages: Record<string, string>; databases: Record<string, string> }): ConnectorCursor {
+  return {
+    kind: NOTION_CURSOR_KIND,
+    value: JSON.stringify(payload),
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+test("validateNotionConfig accepts a minimal valid config", () => {
+  const cfg = validateNotionConfig({ token: SYNTHETIC_TOKEN });
+  assert.equal(cfg.token, SYNTHETIC_TOKEN);
+  assert.equal(cfg.pollIntervalMs, NOTION_DEFAULT_POLL_INTERVAL_MS);
+  assert.deepEqual([...cfg.databaseIds], []);
+});
+
+test("validateNotionConfig rejects non-object input", () => {
+  assert.throws(() => validateNotionConfig(null), /must be an object/);
+  assert.throws(() => validateNotionConfig([]), /must be an object/);
+  assert.throws(() => validateNotionConfig("nope"), /must be an object/);
+});
+
+test("validateNotionConfig rejects missing or empty token", () => {
+  assert.throws(() => validateNotionConfig({}), /token must be a string/);
+  assert.throws(() => validateNotionConfig({ token: "" }), /non-empty/);
+  assert.throws(() => validateNotionConfig({ token: "   " }), /non-empty/);
+});
+
+test("validateNotionConfig rejects tokens not starting with secret_", () => {
+  assert.throws(
+    () => validateNotionConfig({ token: "ntn_not_an_integration_token_xxxx" }),
+    /must start with "secret_"/,
+  );
+  assert.throws(
+    () => validateNotionConfig({ token: "sk-openai-wrong-token-here" }),
+    /must start with "secret_"/,
+  );
+});
+
+test("validateNotionConfig rejects malformed pollIntervalMs", () => {
+  // Non-number.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, pollIntervalMs: "300000" }),
+    /pollIntervalMs/,
+  );
+  // Below floor.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, pollIntervalMs: 50 }),
+    /≥1000/,
+  );
+  // Above ceiling.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, pollIntervalMs: 25 * 60 * 60 * 1000 }),
+    /≤/,
+  );
+  // Non-integer.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, pollIntervalMs: 3000.5 }),
+    /integer/,
+  );
+});
+
+test("validateNotionConfig accepts valid databaseIds (compact + UUID formats)", () => {
+  const compactId = "abcdef1234567890abcdef1234567890"; // 32 hex
+  const uuidId = "abcdef12-3456-7890-abcd-ef1234567890"; // standard UUID
+
+  const cfg1 = validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: [compactId] });
+  assert.deepEqual([...cfg1.databaseIds], [compactId]);
+
+  const cfg2 = validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: [uuidId] });
+  assert.deepEqual([...cfg2.databaseIds], [uuidId]);
+});
+
+test("validateNotionConfig rejects invalid databaseIds", () => {
+  // Non-array.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: "not-an-array" }),
+    /databaseIds.*array/,
+  );
+  // Non-string entry.
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: [42] }),
+    /databaseIds.*strings/,
+  );
+  // Wrong shape (not 32 hex or UUID).
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: ["short"] }),
+    /not a valid Notion id/,
+  );
+  assert.throws(
+    () => validateNotionConfig({ token: SYNTHETIC_TOKEN, databaseIds: ["../etc/passwd"] }),
+    /not a valid Notion id/,
+  );
+});
+
+test("validateNotionConfig deduplicates databaseIds", () => {
+  const cfg = validateNotionConfig({
+    token: SYNTHETIC_TOKEN,
+    databaseIds: [DB_ID_A, DB_ID_A, DB_ID_B],
+  });
+  assert.deepEqual([...cfg.databaseIds], [DB_ID_A, DB_ID_B]);
+});
+
+// ---------------------------------------------------------------------------
+// Connector identity
+// ---------------------------------------------------------------------------
+
+test("createNotionConnector exposes the documented id and display name", () => {
+  const connector = createNotionConnector({ fetchFn: emptyQueryFetch() });
+  assert.equal(connector.id, NOTION_CONNECTOR_ID);
+  assert.equal(connector.displayName, "Notion");
+  assert.equal(connector.id, "notion"); // stable id contract
+});
+
+// ---------------------------------------------------------------------------
+// No-op when databaseIds is empty
+// ---------------------------------------------------------------------------
+
+test("syncIncremental is a no-op when databaseIds is empty", async () => {
+  let fetchCalled = false;
+  const fetchFn: NotionFetchFn = async () => {
+    fetchCalled = true;
+    throw new Error("should not be called");
+  };
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN });
+
+  // cursor=null (first sync) with empty databaseIds.
+  const r1 = (await connector.syncIncremental({ cursor: null, config })) as NotionSyncResult;
+  assert.deepEqual(r1.newDocs, []);
+  assert.equal(r1.nextCursor.kind, NOTION_CURSOR_KIND);
+  assert.equal(fetchCalled, false);
+
+  // cursor present, still no-op.
+  const r2 = (await connector.syncIncremental({
+    cursor: r1.nextCursor,
+    config,
+  })) as NotionSyncResult;
+  assert.deepEqual(r2.newDocs, []);
+  assert.equal(fetchCalled, false);
+});
+
+// ---------------------------------------------------------------------------
+// First-sync bootstrap behavior (cursor=null)
+// ---------------------------------------------------------------------------
+
+test("first sync (cursor=null) seeds watermark and returns no docs", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-25T10:00:00.000Z", "Seed Page");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+
+  const result = (await connector.syncIncremental({ cursor: null, config })) as NotionSyncResult;
+
+  // No docs on first sync — we only seed the watermark.
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.nextCursor.kind, NOTION_CURSOR_KIND);
+
+  // The cursor payload must contain the page's last_edited_time.
+  const payload = JSON.parse(result.nextCursor.value) as {
+    pages: Record<string, string>;
+    databases: Record<string, string>;
+  };
+  assert.equal(payload.pages[PAGE_ID_1], "2026-04-25T10:00:00.000Z");
+  assert.equal(payload.databases[DB_ID_A], "2026-04-25T10:00:00.000Z");
+});
+
+test("first sync with empty database seeds an empty cursor", async () => {
+  const connector = createNotionConnector({ fetchFn: emptyQueryFetch() });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+
+  const result = await connector.syncIncremental({ cursor: null, config });
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.nextCursor.kind, NOTION_CURSOR_KIND);
+});
+
+// ---------------------------------------------------------------------------
+// Incremental sync: produces expected documents
+// ---------------------------------------------------------------------------
+
+test("incremental sync emits ConnectorDocument for pages edited after watermark", async () => {
+  const page1 = makeSyntheticPage(PAGE_ID_1, "2026-04-26T09:00:00.000Z", "New Page");
+
+  // Stub: database query returns page1; block fetch returns a paragraph.
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page1], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes(`/blocks/${PAGE_ID_1}/children`),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "block-1",
+              type: "paragraph",
+              has_children: false,
+              paragraph: { rich_text: [{ plain_text: "Hello world" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+
+  // Cursor with a watermark older than page1's last_edited_time.
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+
+  assert.equal(result.newDocs.length, 1);
+  const doc = result.newDocs[0];
+  assert.equal(doc.source.connector, NOTION_CONNECTOR_ID);
+  assert.equal(doc.source.externalId, PAGE_ID_1);
+  assert.equal(doc.source.externalRevision, "2026-04-26T09:00:00.000Z");
+  assert.equal(doc.source.externalUrl, `https://notion.so/${PAGE_ID_1}`);
+  assert.equal(doc.title, "New Page");
+  assert.ok(doc.content.includes("Hello world"));
+});
+
+test("incremental sync skips pages whose watermark is up-to-date", async () => {
+  // PAGE_ID_1 has same last_edited_time as what's in the cursor → skip.
+  const page1 = makeSyntheticPage(PAGE_ID_1, "2026-04-25T00:00:00.000Z", "Old Page");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page1], has_more: false, next_cursor: null },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({
+    pages: { [PAGE_ID_1]: "2026-04-25T00:00:00.000Z" },
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.skippedUnchanged, 1);
+});
+
+test("incremental sync advances cursor after importing pages", async () => {
+  const page1 = makeSyntheticPage(PAGE_ID_1, "2026-04-26T10:00:00.000Z");
+  const page2 = makeSyntheticPage(PAGE_ID_2, "2026-04-26T11:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page2, page1], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "blk",
+              type: "paragraph",
+              has_children: false,
+              paragraph: { rich_text: [{ plain_text: "content" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.equal(result.newDocs.length, 2);
+
+  const payload = JSON.parse(result.nextCursor.value) as {
+    pages: Record<string, string>;
+    databases: Record<string, string>;
+  };
+  assert.equal(payload.pages[PAGE_ID_1], "2026-04-26T10:00:00.000Z");
+  assert.equal(payload.pages[PAGE_ID_2], "2026-04-26T11:00:00.000Z");
+  // Database watermark should be the latest across both pages.
+  assert.equal(payload.databases[DB_ID_A], "2026-04-26T11:00:00.000Z");
+});
+
+test("incremental sync handles multiple databases independently", async () => {
+  const pageA = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z", "Page A");
+  const pageB = makeSyntheticPage(PAGE_ID_2, "2026-04-26T09:00:00.000Z", "Page B");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [pageA], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_B}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [pageB], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "blk",
+              type: "paragraph",
+              has_children: false,
+              paragraph: { rich_text: [{ plain_text: "body" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({
+    token: SYNTHETIC_TOKEN,
+    databaseIds: [DB_ID_A, DB_ID_B],
+  });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.equal(result.newDocs.length, 2);
+  const ids = result.newDocs.map((d) => d.source.externalId).sort();
+  assert.deepEqual(ids, [PAGE_ID_1, PAGE_ID_2].sort());
+});
+
+// ---------------------------------------------------------------------------
+// Empty/too-large pages
+// ---------------------------------------------------------------------------
+
+test("incremental sync skips empty pages (no extractable text)", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: { results: [], has_more: false, next_cursor: null },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.skippedEmpty, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Block text extraction (heading, todo, list items)
+// ---------------------------------------------------------------------------
+
+test("block text extraction handles headings, todos, and list items", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z", "Rich Page");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes(`/blocks/${PAGE_ID_1}/children`),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "b1",
+              type: "heading_1",
+              has_children: false,
+              heading_1: { rich_text: [{ plain_text: "Title" }] },
+            },
+            {
+              id: "b2",
+              type: "heading_2",
+              has_children: false,
+              heading_2: { rich_text: [{ plain_text: "Subtitle" }] },
+            },
+            {
+              id: "b3",
+              type: "heading_3",
+              has_children: false,
+              heading_3: { rich_text: [{ plain_text: "Section" }] },
+            },
+            {
+              id: "b4",
+              type: "to_do",
+              has_children: false,
+              to_do: { rich_text: [{ plain_text: "Task" }], checked: false },
+            },
+            {
+              id: "b5",
+              type: "bulleted_list_item",
+              has_children: false,
+              bulleted_list_item: { rich_text: [{ plain_text: "Bullet" }] },
+            },
+            {
+              id: "b6",
+              type: "numbered_list_item",
+              has_children: false,
+              numbered_list_item: { rich_text: [{ plain_text: "Number" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = await connector.syncIncremental({ cursor, config });
+  assert.equal(result.newDocs.length, 1);
+  const content = result.newDocs[0].content;
+  assert.ok(content.includes("# Title"), `expected '# Title' in: ${content}`);
+  assert.ok(content.includes("## Subtitle"));
+  assert.ok(content.includes("### Section"));
+  assert.ok(content.includes("- [ ] Task"));
+  assert.ok(content.includes("- Bullet"));
+  assert.ok(content.includes("- Number"));
+});
+
+// ---------------------------------------------------------------------------
+// Error classification: transient vs terminal
+// ---------------------------------------------------------------------------
+
+test("isTransientNotionError classifies common error shapes", () => {
+  // Terminal — skip-and-continue.
+  assert.equal(isTransientNotionError({ notionStatus: 404 }), false);
+  assert.equal(isTransientNotionError({ notionStatus: 403 }), false);
+  assert.equal(isTransientNotionError({ notionStatus: 400 }), false);
+  assert.equal(isTransientNotionError({ status: 410 }), false);
+  // Transient — re-throw.
+  assert.equal(isTransientNotionError({ notionStatus: 429 }), true);
+  assert.equal(isTransientNotionError({ notionStatus: 500 }), true);
+  assert.equal(isTransientNotionError({ notionStatus: 503 }), true);
+  assert.equal(isTransientNotionError({ status: 504 }), true);
+  // Network errors.
+  assert.equal(isTransientNotionError({ code: "ECONNRESET" }), true);
+  assert.equal(isTransientNotionError({ code: "ETIMEDOUT" }), true);
+  assert.equal(isTransientNotionError({ code: "ENOTFOUND" }), true);
+  assert.equal(isTransientNotionError({ code: "EAI_AGAIN" }), true);
+  // AbortError.
+  assert.equal(isTransientNotionError({ name: "AbortError" }), true);
+  // Bare Error with no metadata — conservatively transient.
+  assert.equal(isTransientNotionError(new Error("unknown")), true);
+  // Non-objects.
+  assert.equal(isTransientNotionError(null), false);
+  assert.equal(isTransientNotionError(undefined), false);
+  assert.equal(isTransientNotionError("oops"), false);
+});
+
+// ---------------------------------------------------------------------------
+// 404 / 403 skip-and-continue
+// ---------------------------------------------------------------------------
+
+test("a 404 on block fetch is treated as terminal (skip page, cursor advances)", async () => {
+  const goodPage = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z", "Good Page");
+  const notFoundPage = makeSyntheticPage(PAGE_ID_2, "2026-04-26T08:00:00.000Z", "Not Found Page");
+
+  let blockCallCount = 0;
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [goodPage, notFoundPage], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: (url) => {
+        blockCallCount++;
+        if (url.includes(PAGE_ID_2)) {
+          return {
+            status: 404,
+            data: {
+              object: "error",
+              status: 404,
+              code: "object_not_found",
+              message: "Could not find block with ID",
+            },
+          };
+        }
+        return {
+          status: 200,
+          data: {
+            results: [
+              {
+                id: "blk",
+                type: "paragraph",
+                has_children: false,
+                paragraph: { rich_text: [{ plain_text: "body" }] },
+              },
+            ],
+            has_more: false,
+            next_cursor: null,
+          },
+        };
+      },
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = await connector.syncIncremental({ cursor, config });
+  // Good page imported, 404 page skipped.
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, PAGE_ID_1);
+  assert.ok(blockCallCount >= 2, "should have called blocks for both pages");
+  // Cursor must still advance.
+  const payload = JSON.parse(result.nextCursor.value) as { pages: Record<string, string> };
+  assert.ok(payload.pages[PAGE_ID_1]);
+});
+
+test("a 403 on block fetch is treated as terminal (skip page, cursor advances)", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 403,
+        data: {
+          object: "error",
+          status: 403,
+          code: "restricted_resource",
+          message: "Insufficient permissions",
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = await connector.syncIncremental({ cursor, config });
+  assert.deepEqual(result.newDocs, []);
+  // Cursor advances even for terminal errors so we don't retry forever.
+  const payload = JSON.parse(result.nextCursor.value) as { pages: Record<string, string> };
+  assert.ok(payload.pages[PAGE_ID_1]);
+});
+
+// ---------------------------------------------------------------------------
+// 429 / 5xx re-throw (transient)
+// ---------------------------------------------------------------------------
+
+test("a 429 on database query re-throws and cursor does NOT advance", async () => {
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 429,
+        data: {
+          object: "error",
+          status: 429,
+          code: "rate_limited",
+          message: "Rate limit exceeded",
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /Rate limit exceeded/,
+  );
+});
+
+test("a 429 on block fetch re-throws and cursor does NOT advance", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 429,
+        data: {
+          object: "error",
+          status: 429,
+          code: "rate_limited",
+          message: "Rate limit exceeded",
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /Rate limit exceeded/,
+  );
+});
+
+test("a 503 on database query re-throws", async () => {
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 503,
+        data: {
+          object: "error",
+          status: 503,
+          code: "service_unavailable",
+          message: "Service temporarily unavailable",
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /temporarily unavailable/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// AbortError propagation
+// ---------------------------------------------------------------------------
+
+test("an AbortError raised mid-fetch re-throws", async () => {
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T09:00:00.000Z");
+
+  const fetchFn: NotionFetchFn = async (url) => {
+    if (url.includes("/blocks/")) {
+      throw Object.assign(new Error("request aborted"), { name: "AbortError" });
+    }
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ results: [page], has_more: false, next_cursor: null }),
+    };
+  };
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /aborted/,
+  );
+});
+
+test("syncIncremental honors abortSignal via throwIfAborted", async () => {
+  const controller = new AbortController();
+  let callCount = 0;
+
+  const fetchFn: NotionFetchFn = async () => {
+    callCount++;
+    // Abort after the first call.
+    if (callCount === 1) controller.abort();
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        results: [makeSyntheticPage(PAGE_ID_1, "2026-04-26T09:00:00.000Z")],
+        has_more: false,
+        next_cursor: null,
+      }),
+    };
+  };
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config, abortSignal: controller.signal }),
+    /aborted/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Cursor validation
+// ---------------------------------------------------------------------------
+
+test("syncIncremental rejects a cursor of an unexpected kind", async () => {
+  const connector = createNotionConnector({ fetchFn: emptyQueryFetch() });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const badCursor: ConnectorCursor = {
+    kind: "wrong-kind",
+    value: "{}",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor: badCursor, config }),
+    /unexpected cursor kind/,
+  );
+});
+
+test("syncIncremental rejects a cursor with invalid JSON value", async () => {
+  const connector = createNotionConnector({ fetchFn: emptyQueryFetch() });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const badCursor: ConnectorCursor = {
+    kind: NOTION_CURSOR_KIND,
+    value: "{ not valid json",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor: badCursor, config }),
+    /not valid JSON/,
+  );
+});
+
+test("validateConfig is enforced again on every sync pass", async () => {
+  const connector = createNotionConnector({ fetchFn: emptyQueryFetch() });
+  // Craft a config that looks like a ConnectorConfig (Record<string, unknown>)
+  // but would fail validateNotionConfig (missing token prefix).
+  const badConfig = { token: "ntn_wrong_prefix" } as unknown as import("./framework.js").ConnectorConfig;
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config: badConfig }),
+    /secret_/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Network-layer transient error
+// ---------------------------------------------------------------------------
+
+test("a network ECONNRESET on database query re-throws as transient", async () => {
+  const fetchFn: NotionFetchFn = async () => {
+    throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+  };
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /socket hang up/,
+  );
+});

--- a/packages/remnic-core/src/connectors/live/notion.test.ts
+++ b/packages/remnic-core/src/connectors/live/notion.test.ts
@@ -947,6 +947,152 @@ test("validateConfig is enforced again on every sync pass", async () => {
 // Network-layer transient error
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Codex/Cursor review regressions (PR #744)
+// ---------------------------------------------------------------------------
+
+test("skipped empty pages record their revision so they aren't re-fetched on every poll", async () => {
+  // Codex P2: empty/too-large branches must update page watermark.
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T08:00:00.000Z");
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: { results: [], has_more: false, next_cursor: null },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({ pages: {}, databases: {} });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.equal(result.skippedEmpty, 1);
+  // Page revision must be recorded so the next poll's "knownRevision >= lastEdited"
+  // check skips this page as `skippedUnchanged` rather than re-fetching it.
+  const payload = JSON.parse(result.nextCursor.value) as { pages: Record<string, string> };
+  assert.equal(payload.pages[PAGE_ID_1], "2026-04-26T08:00:00.000Z");
+});
+
+test("incremental sync preserves prior database watermark when has_more=true with no next_cursor (defensive bail)", async () => {
+  // Codex P1 / Cursor "Descending sort with page cap drops older edits":
+  // when the database is NOT fully drained for this pass (cap hit, abort,
+  // or a defensive bail on a malformed has_more=true response), advancing
+  // databases[dbId] to the highest seen last_edited_time would cause the
+  // next pass's `after` filter to skip older unprocessed pages forever.
+  // Verify we leave the database watermark at its previous value.
+  //
+  // We exercise this via the defensive-bail path: has_more=true with
+  // next_cursor=null. The connector breaks out of the page loop without
+  // marking the database fully drained.
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T10:00:00.000Z");
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: true, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "blk",
+              type: "paragraph",
+              has_children: false,
+              paragraph: { rich_text: [{ plain_text: "body" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const priorWatermark = "2026-04-25T00:00:00.000Z";
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: priorWatermark },
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  // The page WAS imported and per-page watermark recorded.
+  assert.equal(result.newDocs.length, 1);
+  const payload = JSON.parse(result.nextCursor.value) as {
+    pages: Record<string, string>;
+    databases: Record<string, string>;
+  };
+  assert.equal(payload.pages[PAGE_ID_1], "2026-04-26T10:00:00.000Z");
+  // Database watermark NOT advanced because we didn't fully drain — the
+  // next pass will retry the same `after` filter and pick up the older
+  // pages we missed.
+  assert.equal(payload.databases[DB_ID_A], priorWatermark);
+});
+
+test("incremental sync advances database watermark when fully drained", async () => {
+  // Counterpart to the test above: when the database IS fully drained
+  // (has_more=false), the database watermark MUST advance to the latest
+  // last_edited_time we saw, otherwise we'd re-query the same window
+  // forever.
+  const page = makeSyntheticPage(PAGE_ID_1, "2026-04-26T10:00:00.000Z");
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`/databases/${DB_ID_A}/query`),
+      respond: () => ({
+        status: 200,
+        data: { results: [page], has_more: false, next_cursor: null },
+      }),
+    },
+    {
+      match: (url) => url.includes("/blocks/"),
+      respond: () => ({
+        status: 200,
+        data: {
+          results: [
+            {
+              id: "blk",
+              type: "paragraph",
+              has_children: false,
+              paragraph: { rich_text: [{ plain_text: "body" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        },
+      }),
+    },
+  ]);
+
+  const connector = createNotionConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, databaseIds: [DB_ID_A] });
+  const cursor = makeNotionCursor({
+    pages: {},
+    databases: { [DB_ID_A]: "2026-04-25T00:00:00.000Z" },
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as NotionSyncResult;
+  assert.equal(result.newDocs.length, 1);
+  const payload = JSON.parse(result.nextCursor.value) as { databases: Record<string, string> };
+  // Drained → watermark advances.
+  assert.equal(payload.databases[DB_ID_A], "2026-04-26T10:00:00.000Z");
+});
+
 test("a network ECONNRESET on database query re-throws as transient", async () => {
   const fetchFn: NotionFetchFn = async () => {
     throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });

--- a/packages/remnic-core/src/connectors/live/notion.ts
+++ b/packages/remnic-core/src/connectors/live/notion.ts
@@ -848,6 +848,21 @@ async function incrementalSync(
     const dbWatermark = payload.databases[dbId];
     let notionCursor: string | undefined = undefined;
     let latestInDb = dbWatermark ?? "";
+    // Track whether we fully drained this database during the pass.
+    //
+    // Why this matters (codex review P1): we sort the query descending by
+    // `last_edited_time` and filter `after: dbWatermark`. If we hit
+    // MAX_PAGES_PER_PASS or get aborted mid-database, the pages we
+    // *haven't* seen yet are *older* than the ones we have seen. Advancing
+    // `databases[dbId]` to the highest `last_edited_time` we saw would set
+    // the next pass's `after` filter past those still-pending older pages
+    // and skip them forever (they only resurface if re-edited).
+    //
+    // Solution: only persist the new database watermark when the database
+    // was fully drained for this pass. If we cut off early, leave
+    // `databases[dbId]` at its previous value so the next pass re-queries
+    // the same `after` filter and finishes the leftovers.
+    let databaseFullyDrained = false;
 
     while (true) {
       throwIfAborted(signal);
@@ -886,6 +901,7 @@ async function incrementalSync(
         has_more?: boolean;
       };
 
+      let cutoffMidPage = false;
       for (const notionPage of pageResp.results ?? []) {
         throwIfAborted(signal);
         totalConsumed++;
@@ -913,8 +929,16 @@ async function incrementalSync(
 
         if (doc === "too-large") {
           skippedTooLarge++;
+          // Codex review P2: record the revision so we don't re-fetch this
+          // oversized page on every subsequent poll. If the page shrinks
+          // below the limit on a future edit, `last_edited_time` will
+          // advance and the watermark check above will let it through.
+          updatedPages[pageId] = lastEdited;
         } else if (doc === "empty") {
           skippedEmpty++;
+          // Codex review P2: same reasoning as too-large — record the
+          // revision so we don't re-fetch an empty page indefinitely.
+          updatedPages[pageId] = lastEdited;
         } else if (doc !== null) {
           newDocs.push(doc);
           // Advance watermarks.
@@ -923,23 +947,47 @@ async function incrementalSync(
             latestInDb = lastEdited;
           }
         } else {
-          // null = terminal skip (404/403). Don't advance the page watermark;
-          // there's nothing to retry but we also don't want to re-attempt
-          // unless the page comes back or permissions change, so we still
-          // record the version to avoid repeated skip attempts.
+          // null = terminal skip (404/403). Record the version so we
+          // don't repeatedly attempt a permanently-inaccessible page.
           updatedPages[pageId] = lastEdited;
         }
 
-        if (totalConsumed >= MAX_PAGES_PER_PASS) break;
+        if (totalConsumed >= MAX_PAGES_PER_PASS) {
+          cutoffMidPage = true;
+          break;
+        }
       }
 
-      if (!pageResp.has_more || typeof pageResp.next_cursor !== "string" || pageResp.next_cursor === null) {
+      if (cutoffMidPage) {
+        // Hit the per-pass cap inside this database's results. The
+        // database is NOT fully drained; leave its watermark intact so
+        // the next pass re-queries the same `after` filter.
         break;
       }
-      notionCursor = pageResp.next_cursor;
+
+      if (pageResp.has_more === true) {
+        // Notion claims there are more pages.
+        if (typeof pageResp.next_cursor === "string" && pageResp.next_cursor.length > 0) {
+          // Continue paging.
+          notionCursor = pageResp.next_cursor;
+          continue;
+        }
+        // Defensive bail: has_more=true but no usable next_cursor. We do
+        // NOT mark the database fully drained — the next pass must retry
+        // the same `after` filter and pick up whatever we missed.
+        break;
+      }
+      // has_more is false (or absent): the database is fully drained for
+      // this pass. Safe to advance the database watermark below.
+      databaseFullyDrained = true;
+      break;
     }
 
-    if (latestInDb) updatedDatabases[dbId] = latestInDb;
+    // Only advance the database watermark when we fully drained the
+    // database. See the long comment above on `databaseFullyDrained`.
+    if (databaseFullyDrained && latestInDb) {
+      updatedDatabases[dbId] = latestInDb;
+    }
   }
 
   const nextCursor = makeCursor({ pages: updatedPages, databases: updatedDatabases });

--- a/packages/remnic-core/src/connectors/live/notion.ts
+++ b/packages/remnic-core/src/connectors/live/notion.ts
@@ -1,0 +1,996 @@
+/**
+ * @remnic/core — Notion live connector (issue #683 PR 3/N)
+ *
+ * Concrete `LiveConnector` implementation that incrementally imports text
+ * content from Notion database pages into Remnic. Built on top of the
+ * framework shipped in PR 1/N (`framework.ts` / `registry.ts` /
+ * `state-store.ts`) and mirrors the structure of the Google Drive connector
+ * (PR 2/N).
+ *
+ * Design notes:
+ *
+ *   - **Auth.** Integration token from config (`connectors.notion.token`).
+ *     The token is accepted at config-parse time but never logged. Operators
+ *     must populate it from a secret store; per the repo-wide privacy policy
+ *     no real value may appear in tests or comments.
+ *
+ *   - **Scope.** `databaseIds` in config limits the import to the listed
+ *     Notion databases. The connector queries each database for pages whose
+ *     `last_edited_time` is after a per-page high-water mark stored in the
+ *     cursor. When `databaseIds` is empty the connector does nothing (safe
+ *     default — no credentials → no import).
+ *
+ *   - **Cursor semantics.** The cursor is a JSON string encoding a
+ *     `NotionCursorPayload`: a map from page-id to last-seen
+ *     `last_edited_time` ISO string. On the first sync (cursor=null) we
+ *     seed the payload from the current state of each database WITHOUT
+ *     importing any content, so "first install" doesn't re-ingest history.
+ *     Each subsequent pass only imports pages edited after the stored
+ *     watermark.
+ *
+ *   - **Block extraction.** Page content is fetched via
+ *     `blocks.children.list` recursively up to `MAX_BLOCK_DEPTH` levels.
+ *     Block text is extracted to Markdown-ish plain text (no raw JSON blobs).
+ *     Only text-bearing block types are included; unsupported types are
+ *     silently skipped.
+ *
+ *   - **Raw `fetch`.** We call the Notion REST API directly rather than using
+ *     `@notionhq/client` — there is no optional-peer-dep machinery needed and
+ *     the API surface we consume is tiny. The `fetchFn` argument is the test
+ *     hook allowing stubbing without network access.
+ *
+ *   - **Idempotency.** `ConnectorDocument.source.externalId` is the page id
+ *     and `externalRevision` is `last_edited_time`, so downstream dedup can
+ *     recognise repeat fetches if the cursor is rewound.
+ *
+ *   - **Privacy.** No page content is ever logged. Database ids and counts
+ *     may be logged. The integration token is never exposed in logs, state,
+ *     or error messages.
+ *
+ *   - **Read-only.** This connector only reads. It never modifies pages,
+ *     databases, or any other Notion resource.
+ */
+
+import type {
+  ConnectorConfig,
+  ConnectorCursor,
+  ConnectorDocument,
+  LiveConnector,
+  SyncIncrementalArgs,
+  SyncIncrementalResult,
+} from "./framework.js";
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/** Stable connector id. Lives in the registry under this exact string. */
+export const NOTION_CONNECTOR_ID = "notion";
+
+/**
+ * Cursor `kind` we emit. Opaque to the framework; documented here so
+ * tests can assert on it.
+ */
+export const NOTION_CURSOR_KIND = "notionWatermark";
+
+/**
+ * Default poll interval (5 minutes). Notion's API has no push capability;
+ * polling sub-minute wastes quota for a personal memory layer.
+ */
+export const NOTION_DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Hard cap on poll interval: 24 hours. */
+const NOTION_MAX_POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Hard cap on individual page text size. Notion pages can be very long;
+ * we skip rather than blow the importer's heap.
+ */
+const MAX_TEXT_BYTES = 5 * 1024 * 1024;
+
+/**
+ * Maximum recursion depth when fetching block children. Notion pages can
+ * nest blocks (e.g. toggle → bulleted list → quote). We cap depth so a
+ * pathologically deep page doesn't exhaust the call stack or quota.
+ */
+const MAX_BLOCK_DEPTH = 5;
+
+/**
+ * Maximum number of pages we import in a single `syncIncremental` pass
+ * across all databases. Prevents one runaway pass from monopolising the
+ * scheduler.
+ */
+const MAX_PAGES_PER_PASS = 200;
+
+/**
+ * Notion integration tokens always start with `secret_`. We validate this
+ * prefix so a typo (e.g. pasting an OAuth token instead) is caught early.
+ */
+const NOTION_TOKEN_PREFIX = "secret_";
+
+// ---------------------------------------------------------------------------
+// Config types
+// ---------------------------------------------------------------------------
+
+/**
+ * Validated, frozen view of `connectors.notion.*`.
+ */
+export interface NotionConnectorConfig {
+  /** Notion integration token. Starts with `secret_`. */
+  readonly token: string;
+  /** Database ids to import pages from. Empty = connector is a no-op. */
+  readonly databaseIds: readonly string[];
+  /** Poll interval surfaced to the scheduler (ms). */
+  readonly pollIntervalMs: number;
+}
+
+/**
+ * The JSON payload we encode into `ConnectorCursor.value`. Maps each
+ * page id to the ISO 8601 `last_edited_time` we have already ingested.
+ * Also tracks the ISO 8601 high-water mark per database (used for the
+ * initial `filter.timestamp` query to skip unchanged pages).
+ */
+interface NotionCursorPayload {
+  /** pageId → last_edited_time (ISO 8601). */
+  pages: Record<string, string>;
+  /** databaseId → latest last_edited_time seen in that DB. */
+  databases: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// Notion API response shapes (only the fields we consume)
+// ---------------------------------------------------------------------------
+
+/** Minimal Notion page shape from `databases/{id}/query`. */
+export interface NotionPage {
+  readonly id: string;
+  readonly last_edited_time: string;
+  readonly url?: string;
+  readonly properties?: Record<
+    string,
+    {
+      type?: string;
+      title?: Array<{ plain_text?: string }>;
+    }
+  >;
+}
+
+/** Minimal block shape from `blocks/{id}/children`. */
+export interface NotionBlock {
+  readonly id: string;
+  readonly type: string;
+  readonly has_children?: boolean;
+  // We index by `type` to extract text.
+  readonly [key: string]: unknown;
+}
+
+/** Minimal Notion API error shape. */
+interface NotionApiError {
+  readonly object: "error";
+  readonly status: number;
+  readonly code: string;
+  readonly message: string;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch abstraction (test hook)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fetch-compatible surface we use. The real connector delegates to
+ * the global `fetch`; tests inject a stub factory.
+ */
+export type NotionFetchFn = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+}>;
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate and normalise raw config. Throws with a concrete message on any
+ * malformed input — never silently defaults (CLAUDE.md gotcha #51).
+ */
+export function validateNotionConfig(raw: unknown): NotionConnectorConfig {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new TypeError(
+      `notion: config must be an object, got ${raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw}`,
+    );
+  }
+  const r = raw as Record<string, unknown>;
+
+  // token
+  if (typeof r.token !== "string") {
+    throw new TypeError(`notion: token must be a string (got ${typeof r.token})`);
+  }
+  const token = r.token.trim();
+  if (token.length === 0) {
+    throw new RangeError("notion: token must be non-empty");
+  }
+  if (!token.startsWith(NOTION_TOKEN_PREFIX)) {
+    throw new RangeError(
+      `notion: token must start with "${NOTION_TOKEN_PREFIX}" (looks like a non-integration token)`,
+    );
+  }
+
+  // pollIntervalMs
+  let pollIntervalMs: number;
+  if (r.pollIntervalMs === undefined) {
+    pollIntervalMs = NOTION_DEFAULT_POLL_INTERVAL_MS;
+  } else if (typeof r.pollIntervalMs !== "number" || !Number.isFinite(r.pollIntervalMs)) {
+    throw new TypeError(
+      `notion: pollIntervalMs must be a finite number (got ${JSON.stringify(r.pollIntervalMs)})`,
+    );
+  } else if (!Number.isInteger(r.pollIntervalMs)) {
+    throw new TypeError(`notion: pollIntervalMs must be an integer (got ${r.pollIntervalMs})`);
+  } else if (r.pollIntervalMs < 1_000) {
+    throw new RangeError(`notion: pollIntervalMs must be ≥1000ms; got ${r.pollIntervalMs}`);
+  } else if (r.pollIntervalMs > NOTION_MAX_POLL_INTERVAL_MS) {
+    throw new RangeError(
+      `notion: pollIntervalMs must be ≤${NOTION_MAX_POLL_INTERVAL_MS} (24h); got ${r.pollIntervalMs}`,
+    );
+  } else {
+    pollIntervalMs = r.pollIntervalMs;
+  }
+
+  // databaseIds
+  let databaseIds: readonly string[] = [];
+  if (r.databaseIds !== undefined) {
+    if (!Array.isArray(r.databaseIds)) {
+      throw new TypeError(
+        `notion: databaseIds must be an array of strings (got ${typeof r.databaseIds})`,
+      );
+    }
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const value of r.databaseIds) {
+      if (typeof value !== "string") {
+        throw new TypeError(
+          `notion: databaseIds entries must be strings; found ${typeof value}`,
+        );
+      }
+      const trimmed = value.trim();
+      if (!isValidNotionId(trimmed)) {
+        throw new RangeError(
+          `notion: databaseIds entry ${JSON.stringify(value)} is not a valid Notion id`,
+        );
+      }
+      // Dedupe per CLAUDE.md gotcha #49.
+      if (seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+    databaseIds = Object.freeze(out);
+  }
+
+  return Object.freeze({ token, databaseIds, pollIntervalMs });
+}
+
+/**
+ * Notion UUIDs look like `xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx` (32 hex, no
+ * dashes) or `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` (standard UUID). We
+ * accept both and reject everything else to surface config typos.
+ */
+function isValidNotionId(value: string): boolean {
+  // Standard UUID with dashes.
+  if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value)) {
+    return true;
+  }
+  // Notion's compact form (32 hex chars, no dashes).
+  if (/^[0-9a-f]{32}$/i.test(value)) {
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor helpers
+// ---------------------------------------------------------------------------
+
+function makeCursor(payload: NotionCursorPayload): ConnectorCursor {
+  return {
+    kind: NOTION_CURSOR_KIND,
+    value: JSON.stringify(payload),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function parseCursorPayload(cursor: ConnectorCursor): NotionCursorPayload {
+  if (cursor.kind !== NOTION_CURSOR_KIND) {
+    throw new Error(
+      `notion: unexpected cursor kind ${JSON.stringify(cursor.kind)}; expected ${NOTION_CURSOR_KIND}`,
+    );
+  }
+  // CLAUDE.md gotcha #18: validate after parse.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cursor.value);
+  } catch {
+    throw new Error(`notion: cursor value is not valid JSON`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`notion: cursor value does not match NotionCursorPayload shape`);
+  }
+  const p = parsed as Record<string, unknown>;
+  const pages = typeof p.pages === "object" && p.pages !== null && !Array.isArray(p.pages)
+    ? (p.pages as Record<string, string>)
+    : {};
+  const databases = typeof p.databases === "object" && p.databases !== null && !Array.isArray(p.databases)
+    ? (p.databases as Record<string, string>)
+    : {};
+  return { pages, databases };
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a per-page fetch error as transient (re-throw to caller so the
+ * sync stops without advancing the cursor and the next poll retries) or
+ * terminal (skip the page and continue).
+ *
+ * We use raw `fetch`, so errors arrive either as network-layer `Error`
+ * instances (no `.status`) or we detect them ourselves by inspecting the
+ * HTTP status code from the parsed JSON body.
+ *
+ * Transient:
+ *   - 429 (rate-limit — retry after backoff)
+ *   - 5xx (Notion backend error)
+ *   - AbortError / network errors (ECONNRESET, ETIMEDOUT, …)
+ *
+ * Terminal (skip-and-continue):
+ *   - 404 (page/database deleted or not shared with integration)
+ *   - 403 (permission denied)
+ *   - 400 (bad request — won't be fixed by retrying)
+ *   - any other 4xx that isn't 429
+ */
+export function isTransientNotionError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const e = err as {
+    name?: unknown;
+    code?: unknown;
+    status?: unknown;
+    notionStatus?: unknown;
+    message?: unknown;
+  };
+
+  // AbortError
+  if (typeof e.name === "string" && e.name === "AbortError") return true;
+
+  // HTTP status attached by our own error-throwing code (see `notionFetch`).
+  const status = pickNumericStatus(e);
+  if (status !== undefined) {
+    if (status === 429) return true;
+    if (status >= 500 && status <= 599) return true;
+    // Any classified 4xx that isn't 429 is terminal.
+    return false;
+  }
+
+  // Network-layer error codes.
+  const codeStr = typeof e.code === "string" ? e.code : undefined;
+  if (codeStr !== undefined) {
+    const transientCodes = new Set([
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ECONNABORTED",
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "EPIPE",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "ENETDOWN",
+      "ERR_NETWORK",
+      "ERR_NETWORK_CHANGED",
+    ]);
+    if (transientCodes.has(codeStr)) return true;
+    return false;
+  }
+
+  // No status, no code — treat as transient (plain network failures).
+  return true;
+}
+
+function pickNumericStatus(e: {
+  status?: unknown;
+  notionStatus?: unknown;
+  code?: unknown;
+}): number | undefined {
+  if (typeof e.notionStatus === "number" && Number.isFinite(e.notionStatus)) {
+    return e.notionStatus;
+  }
+  if (typeof e.status === "number" && Number.isFinite(e.status)) {
+    return e.status;
+  }
+  if (typeof e.code === "number" && Number.isFinite(e.code)) {
+    return e.code;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Notion API client helpers
+// ---------------------------------------------------------------------------
+
+const NOTION_BASE_URL = "https://api.notion.com/v1";
+const NOTION_API_VERSION = "2022-06-28";
+
+/**
+ * Throw if aborted (cooperative cancellation).
+ */
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    const err = new Error("notion: sync aborted");
+    err.name = "AbortError";
+    throw err;
+  }
+}
+
+/**
+ * Build a Notion API error with the HTTP status attached for classification.
+ */
+function makeNotionApiError(apiErr: NotionApiError): Error & { notionStatus: number } {
+  const err = new Error(
+    `notion: API error ${apiErr.status} (${apiErr.code}): ${apiErr.message}`,
+  ) as Error & { notionStatus: number };
+  err.notionStatus = apiErr.status;
+  return err;
+}
+
+/**
+ * Helper to call a Notion API endpoint. Throws a structured error on
+ * non-2xx responses and propagates network errors unchanged so the
+ * transient/terminal classifier can inspect them.
+ */
+async function notionFetch(
+  fetchFn: NotionFetchFn,
+  token: string,
+  path: string,
+  body: unknown,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  const url = `${NOTION_BASE_URL}${path}`;
+  const res = await fetchFn(url, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Notion-Version": NOTION_API_VERSION,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    // Notion error responses carry `{object: "error", status, code, message}`.
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      (data as Record<string, unknown>).object === "error"
+    ) {
+      throw makeNotionApiError(data as NotionApiError);
+    }
+    // Unexpected non-error-shaped body.
+    const err = new Error(`notion: HTTP ${res.status}`) as Error & { notionStatus: number };
+    err.notionStatus = res.status;
+    throw err;
+  }
+  return data;
+}
+
+/**
+ * GET helper — used for block children (GET endpoint, no body).
+ */
+async function notionGet(
+  fetchFn: NotionFetchFn,
+  token: string,
+  path: string,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  const url = `${NOTION_BASE_URL}${path}`;
+  const res = await fetchFn(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Notion-Version": NOTION_API_VERSION,
+    },
+    signal,
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    if (
+      typeof data === "object" &&
+      data !== null &&
+      (data as Record<string, unknown>).object === "error"
+    ) {
+      throw makeNotionApiError(data as NotionApiError);
+    }
+    const err = new Error(`notion: HTTP ${res.status}`) as Error & { notionStatus: number };
+    err.notionStatus = res.status;
+    throw err;
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Block text extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract all `rich_text[].plain_text` segments from a rich-text array.
+ */
+function extractRichText(richText: unknown): string {
+  if (!Array.isArray(richText)) return "";
+  return richText
+    .map((span) => {
+      if (typeof span !== "object" || span === null) return "";
+      return typeof (span as Record<string, unknown>).plain_text === "string"
+        ? ((span as Record<string, unknown>).plain_text as string)
+        : "";
+    })
+    .join("");
+}
+
+/**
+ * Extract the text portion of a single block. Returns an empty string for
+ * block types we don't recognize.
+ */
+function extractBlockText(block: NotionBlock): string {
+  const type = block.type;
+  const blockData = block[type];
+  if (typeof blockData !== "object" || blockData === null) return "";
+  const data = blockData as Record<string, unknown>;
+
+  // Most text-bearing blocks have a `rich_text` array.
+  if (Array.isArray(data.rich_text)) {
+    const text = extractRichText(data.rich_text);
+    if (text.length > 0) {
+      // Prefix heading blocks with Markdown syntax.
+      if (type === "heading_1") return `# ${text}`;
+      if (type === "heading_2") return `## ${text}`;
+      if (type === "heading_3") return `### ${text}`;
+      if (type === "to_do") {
+        const checked = data.checked === true;
+        return `- [${checked ? "x" : " "}] ${text}`;
+      }
+      if (type === "bulleted_list_item" || type === "numbered_list_item") {
+        return `- ${text}`;
+      }
+      return text;
+    }
+    return "";
+  }
+
+  // Code block has `rich_text` plus an optional `language` field.
+  if (type === "code" && Array.isArray(data.rich_text)) {
+    return extractRichText(data.rich_text);
+  }
+
+  return "";
+}
+
+/**
+ * Recursively fetch all block children for a page (or block with children)
+ * and extract plain text. Bounded by `MAX_BLOCK_DEPTH` and `MAX_TEXT_BYTES`
+ * to prevent runaway recursion or OOM on huge pages.
+ */
+async function fetchPageText(
+  fetchFn: NotionFetchFn,
+  token: string,
+  blockId: string,
+  depth: number,
+  signal: AbortSignal | undefined,
+): Promise<string> {
+  if (depth > MAX_BLOCK_DEPTH) return "";
+  throwIfAborted(signal);
+
+  const lines: string[] = [];
+  let cursor: string | undefined = undefined;
+
+  // Page through block children.
+  while (true) {
+    throwIfAborted(signal);
+    const pathQuery = cursor
+      ? `/blocks/${blockId}/children?page_size=100&start_cursor=${encodeURIComponent(cursor)}`
+      : `/blocks/${blockId}/children?page_size=100`;
+    const data = await notionGet(fetchFn, token, pathQuery, signal);
+
+    if (typeof data !== "object" || data === null) break;
+    const page = data as {
+      results?: NotionBlock[];
+      next_cursor?: string | null;
+      has_more?: boolean;
+    };
+
+    for (const block of page.results ?? []) {
+      throwIfAborted(signal);
+      const text = extractBlockText(block);
+      if (text.length > 0) lines.push(text);
+
+      // Recurse into nested blocks.
+      if (block.has_children && depth < MAX_BLOCK_DEPTH) {
+        const childText = await fetchPageText(
+          fetchFn,
+          token,
+          block.id,
+          depth + 1,
+          signal,
+        );
+        if (childText.length > 0) lines.push(childText);
+      }
+
+      // Guard against oversized pages.
+      const currentSize = lines.reduce((acc, l) => acc + l.length + 1, 0);
+      if (currentSize >= MAX_TEXT_BYTES) break;
+    }
+
+    if (!page.has_more || typeof page.next_cursor !== "string" || page.next_cursor === null) {
+      break;
+    }
+    cursor = page.next_cursor;
+  }
+
+  return lines.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Page title extraction
+// ---------------------------------------------------------------------------
+
+/**
+ * Extract the page title from the page properties. Notion stores the title
+ * under a property of type `"title"` — typically named "Name" but the name
+ * can vary. We look for the first `type: "title"` property we find.
+ */
+function extractPageTitle(page: NotionPage): string | undefined {
+  if (typeof page.properties !== "object" || page.properties === null) return undefined;
+  for (const prop of Object.values(page.properties)) {
+    if (prop.type === "title" && Array.isArray(prop.title)) {
+      const text = prop.title.map((t) => t.plain_text ?? "").join("");
+      if (text.trim().length > 0) return text.trim();
+    }
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Sync result type
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a single sync pass. Superset of `SyncIncrementalResult` for
+ * richer test assertions.
+ */
+export interface NotionSyncResult extends SyncIncrementalResult {
+  readonly skippedUnchanged: number;
+  readonly skippedTooLarge: number;
+  readonly skippedEmpty: number;
+}
+
+// ---------------------------------------------------------------------------
+// Connector factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct the connector. The `fetchFn` argument is the test hook —
+ * production callers omit it and the connector uses the global `fetch`.
+ */
+export function createNotionConnector(
+  options: { fetchFn?: NotionFetchFn } = {},
+): LiveConnector {
+  const fetchFn: NotionFetchFn =
+    options.fetchFn ??
+    // Use global fetch (available in Node.js 18+). The cast is safe — we
+    // only use the subset defined in `NotionFetchFn`.
+    (globalThis.fetch as unknown as NotionFetchFn);
+
+  return {
+    id: NOTION_CONNECTOR_ID,
+    displayName: "Notion",
+    description:
+      "Imports text content from Notion database pages into Remnic on a poll schedule.",
+
+    validateConfig(raw: unknown): ConnectorConfig {
+      return validateNotionConfig(raw) as unknown as ConnectorConfig;
+    },
+
+    async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
+      const config = validateNotionConfig(args.config);
+      throwIfAborted(args.abortSignal);
+
+      // Short-circuit: if no databases are configured, there is nothing to do.
+      // We still return a valid cursor so the framework has something to
+      // persist (avoids a null-cursor on the next pass).
+      if (config.databaseIds.length === 0) {
+        const emptyPayload: NotionCursorPayload = { pages: {}, databases: {} };
+        const result: NotionSyncResult = {
+          newDocs: [],
+          nextCursor: makeCursor(emptyPayload),
+          skippedUnchanged: 0,
+          skippedTooLarge: 0,
+          skippedEmpty: 0,
+        };
+        return result;
+      }
+
+      // Parse or seed the cursor.
+      const isFirstSync = args.cursor === null;
+      const payload: NotionCursorPayload = isFirstSync
+        ? { pages: {}, databases: {} }
+        : parseCursorPayload(args.cursor);
+
+      // On first sync we seed the watermark WITHOUT importing any content
+      // (mirrors Drive's getStartPageToken bootstrap pattern).
+      if (isFirstSync) {
+        const seedPayload = await seedWatermark(
+          fetchFn,
+          config,
+          payload,
+          args.abortSignal,
+        );
+        return {
+          newDocs: [],
+          nextCursor: makeCursor(seedPayload),
+          skippedUnchanged: 0,
+          skippedTooLarge: 0,
+          skippedEmpty: 0,
+        } as NotionSyncResult;
+      }
+
+      // Incremental pass.
+      return await incrementalSync(fetchFn, config, payload, args.abortSignal);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// First-sync seeding
+// ---------------------------------------------------------------------------
+
+/**
+ * Seed the watermark from the current state of every configured database.
+ * We record the latest `last_edited_time` we see per page and per database
+ * so the next pass only imports future edits.
+ */
+async function seedWatermark(
+  fetchFn: NotionFetchFn,
+  config: NotionConnectorConfig,
+  payload: NotionCursorPayload,
+  signal: AbortSignal | undefined,
+): Promise<NotionCursorPayload> {
+  const pages = { ...payload.pages };
+  const databases = { ...payload.databases };
+
+  for (const dbId of config.databaseIds) {
+    throwIfAborted(signal);
+    let notionCursor: string | undefined = undefined;
+    let latestInDb = "";
+
+    while (true) {
+      throwIfAborted(signal);
+      const body: Record<string, unknown> = { page_size: 100, sorts: [] };
+      if (notionCursor) body.start_cursor = notionCursor;
+
+      const data = await notionFetch(
+        fetchFn,
+        config.token,
+        `/databases/${dbId}/query`,
+        body,
+        signal,
+      );
+
+      if (typeof data !== "object" || data === null) break;
+      const page = data as {
+        results?: NotionPage[];
+        next_cursor?: string | null;
+        has_more?: boolean;
+      };
+
+      for (const p of page.results ?? []) {
+        if (typeof p.id === "string" && typeof p.last_edited_time === "string") {
+          pages[p.id] = p.last_edited_time;
+          if (!latestInDb || p.last_edited_time > latestInDb) {
+            latestInDb = p.last_edited_time;
+          }
+        }
+      }
+
+      if (!page.has_more || typeof page.next_cursor !== "string" || page.next_cursor === null) {
+        break;
+      }
+      notionCursor = page.next_cursor;
+    }
+
+    if (latestInDb) databases[dbId] = latestInDb;
+  }
+
+  return { pages, databases };
+}
+
+// ---------------------------------------------------------------------------
+// Incremental sync
+// ---------------------------------------------------------------------------
+
+async function incrementalSync(
+  fetchFn: NotionFetchFn,
+  config: NotionConnectorConfig,
+  payload: NotionCursorPayload,
+  signal: AbortSignal | undefined,
+): Promise<NotionSyncResult> {
+  const fetchedAt = new Date().toISOString();
+  const newDocs: ConnectorDocument[] = [];
+  const updatedPages = { ...payload.pages };
+  const updatedDatabases = { ...payload.databases };
+  let skippedUnchanged = 0;
+  let skippedTooLarge = 0;
+  let skippedEmpty = 0;
+  let totalConsumed = 0;
+
+  for (const dbId of config.databaseIds) {
+    throwIfAborted(signal);
+    if (totalConsumed >= MAX_PAGES_PER_PASS) break;
+
+    const dbWatermark = payload.databases[dbId];
+    let notionCursor: string | undefined = undefined;
+    let latestInDb = dbWatermark ?? "";
+
+    while (true) {
+      throwIfAborted(signal);
+      if (totalConsumed >= MAX_PAGES_PER_PASS) break;
+
+      const body: Record<string, unknown> = {
+        page_size: 100,
+        sorts: [
+          {
+            timestamp: "last_edited_time",
+            direction: "descending",
+          },
+        ],
+      };
+      // Filter to pages edited after the database watermark.
+      if (dbWatermark) {
+        body.filter = {
+          timestamp: "last_edited_time",
+          last_edited_time: { after: dbWatermark },
+        };
+      }
+      if (notionCursor) body.start_cursor = notionCursor;
+
+      const data = await notionFetch(
+        fetchFn,
+        config.token,
+        `/databases/${dbId}/query`,
+        body,
+        signal,
+      );
+
+      if (typeof data !== "object" || data === null) break;
+      const pageResp = data as {
+        results?: NotionPage[];
+        next_cursor?: string | null;
+        has_more?: boolean;
+      };
+
+      for (const notionPage of pageResp.results ?? []) {
+        throwIfAborted(signal);
+        totalConsumed++;
+
+        const pageId = notionPage.id;
+        const lastEdited = notionPage.last_edited_time;
+
+        if (typeof pageId !== "string" || typeof lastEdited !== "string") continue;
+
+        // Skip pages that haven't changed since we last saw them.
+        const knownRevision = payload.pages[pageId];
+        if (knownRevision && knownRevision >= lastEdited) {
+          skippedUnchanged++;
+          continue;
+        }
+
+        // Fetch and build the document.
+        const doc = await fetchPageDocument(
+          fetchFn,
+          config.token,
+          notionPage,
+          fetchedAt,
+          signal,
+        );
+
+        if (doc === "too-large") {
+          skippedTooLarge++;
+        } else if (doc === "empty") {
+          skippedEmpty++;
+        } else if (doc !== null) {
+          newDocs.push(doc);
+          // Advance watermarks.
+          updatedPages[pageId] = lastEdited;
+          if (!latestInDb || lastEdited > latestInDb) {
+            latestInDb = lastEdited;
+          }
+        } else {
+          // null = terminal skip (404/403). Don't advance the page watermark;
+          // there's nothing to retry but we also don't want to re-attempt
+          // unless the page comes back or permissions change, so we still
+          // record the version to avoid repeated skip attempts.
+          updatedPages[pageId] = lastEdited;
+        }
+
+        if (totalConsumed >= MAX_PAGES_PER_PASS) break;
+      }
+
+      if (!pageResp.has_more || typeof pageResp.next_cursor !== "string" || pageResp.next_cursor === null) {
+        break;
+      }
+      notionCursor = pageResp.next_cursor;
+    }
+
+    if (latestInDb) updatedDatabases[dbId] = latestInDb;
+  }
+
+  const nextCursor = makeCursor({ pages: updatedPages, databases: updatedDatabases });
+  return {
+    newDocs,
+    nextCursor,
+    skippedUnchanged,
+    skippedTooLarge,
+    skippedEmpty,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-page document fetch
+// ---------------------------------------------------------------------------
+
+async function fetchPageDocument(
+  fetchFn: NotionFetchFn,
+  token: string,
+  notionPage: NotionPage,
+  fetchedAt: string,
+  signal: AbortSignal | undefined,
+): Promise<ConnectorDocument | "too-large" | "empty" | null> {
+  throwIfAborted(signal);
+
+  let text: string;
+  try {
+    text = await fetchPageText(fetchFn, token, notionPage.id, 0, signal);
+  } catch (err) {
+    if (isTransientNotionError(err)) {
+      throw err;
+    }
+    // Terminal (404/403/400): skip this page.
+    return null;
+  }
+
+  if (typeof text !== "string" || text.trim().length === 0) return "empty";
+  if (text.length > MAX_TEXT_BYTES) return "too-large";
+
+  const title = extractPageTitle(notionPage);
+
+  return {
+    id: notionPage.id,
+    title,
+    content: text,
+    source: {
+      connector: NOTION_CONNECTOR_ID,
+      externalId: notionPage.id,
+      externalRevision: notionPage.last_edited_time,
+      externalUrl: typeof notionPage.url === "string" ? notionPage.url : undefined,
+      fetchedAt,
+    },
+  };
+}

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1617,6 +1617,8 @@ export interface CodexConnectorConfig {
 export interface LiveConnectorsConfig {
   /** Google Drive live connector (issue #683 PR 2/N). */
   googleDrive: GoogleDriveLiveConnectorConfig;
+  /** Notion live connector (issue #683 PR 3/N). */
+  notion: NotionLiveConnectorConfig;
 }
 
 /**
@@ -1644,6 +1646,28 @@ export interface GoogleDriveLiveConnectorConfig {
   pollIntervalMs: number;
   /** Optional folder-id scope. Empty array = all accessible files. */
   folderIds: string[];
+}
+
+/**
+ * Operator-facing config for the Notion live connector (issue #683 PR 3/N).
+ * The connector module defines a separate validated `NotionConnectorConfig`
+ * shape (frozen, post-validation). This interface is the pre-validation shape
+ * that `parseConfig` round-trips through.
+ *
+ * `token` is stored as a string here so operators can populate it from a
+ * secret store (e.g. an env-substituted plist or systemd EnvironmentFile).
+ * It MUST NEVER be committed to source. The repo-wide privacy policy in
+ * CLAUDE.md applies.
+ */
+export interface NotionLiveConnectorConfig {
+  /** Master gate. Default false — operators must opt in explicitly. */
+  enabled: boolean;
+  /** Notion integration token. Starts with `secret_`. Populate from a secret store; never commit. */
+  token: string;
+  /** Array of Notion database ids to import pages from. Empty = connector is a no-op. */
+  databaseIds: string[];
+  /** Poll interval in ms. Default 300000 (5 min); min 1000; max 86400000 (24h). */
+  pollIntervalMs: number;
 }
 
 export interface BootstrapOptions {


### PR DESCRIPTION
## Summary

- Adds `packages/remnic-core/src/connectors/live/notion.ts` implementing the `LiveConnector` interface, mirroring the Google Drive connector (PR 2/6) in structure and error-classification semantics.
- Auth via Notion integration token from config (`connectors.notion.token`) — never logged, operators populate from secret store.
- `syncIncremental()` queries each configured `databaseIds` database for pages with `last_edited_time` after a per-page/per-database high-water mark cursor; fetches page blocks recursively (depth-capped at 5) via `blocks.children.list`; routes to `ConnectorDocument` for ingestion.
- First-sync bootstrap seeds the watermark without importing history (mirrors Drive's `getStartPageToken` pattern).
- `isTransientNotionError` mirrors `isTransientDriveError`: 429/5xx/AbortError/network codes re-throw; 404/403/4xx skip-and-continue.
- Uses raw `fetch` — no `@notionhq/client` dependency (à-la-carte contract upheld).
- Config (`connectors.notion.*`) wired in `config.ts`, `types.ts`, and both `openclaw.plugin.json` files: `enabled` (default `false`), `token`, `databaseIds`, `pollIntervalMs`.
- 30 tests in `notion.test.ts` — all pass, zero pre-existing regressions introduced.

## Test plan

- [x] `npx tsx --test packages/remnic-core/src/connectors/live/notion.test.ts` — 30/30 pass
- [x] `tsc --noEmit` — clean
- [x] `node scripts/check-openclaw-plugin-sync.mjs` — clean
- [ ] Config validation: enabled/token/databaseIds/pollIntervalMs rejects malformed input
- [ ] First sync: cursor=null seeds watermark, returns 0 docs
- [ ] Incremental sync: emits ConnectorDocument for pages edited after watermark
- [ ] Transient 429/5xx/AbortError/ECONNRESET re-throws (cursor does not advance)
- [ ] Terminal 404/403 skip-and-continue (cursor advances)
- [ ] Empty pages skipped (skippedEmpty counter)
- [ ] Multiple databases handled independently

## PR checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] Pre-commit hooks pass (tsc, plugin-sync)
- [x] No secrets or credentials committed
- [x] Mirrors Drive connector structure exactly (CLAUDE.md gotcha #55)
- [x] Both openclaw.plugin.json files updated (CLAUDE.md gotcha #4)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new networked live connector that ingests external Notion content and introduces new cursor/watermark logic; while gated by `enabled` and config validation, it increases integration surface area and failure modes (API errors, pagination, rate limits).
> 
> **Overview**
> Adds a new **Notion live connector** that can poll Notion databases and incrementally ingest page text into Remnic, including first-run watermark seeding, per-page/per-database cursors, block-to-text extraction, and transient vs terminal error handling.
> 
> Wires `connectors.notion` into config/schema (`openclaw.plugin.json`, `types.ts`, `config.ts`) with `enabled`, `token`, `databaseIds`, and `pollIntervalMs`, and exports the connector from `connectors/live/index.ts`. Includes a large stubbed test suite (`notion.test.ts`) covering config validation, cursor semantics, incremental behavior, and error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d5f1f84993f2bf0dd043421cbf9ba5296507530. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->