### PR TITLE
feat(admin): graph search highlight + drill-through (issue #691 PR 4/5)

### DIFF
--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -688,6 +688,21 @@ let graphHighlightIds = new Map();
 let graphPulsePhase = 0;
 
 /**
+ * Return true if `str` ends with `suffix` at a path-segment boundary.
+ * Prevents "ammemory.md" matching against suffix "memory.md".
+ * Accepts an exact match or a match preceded by "/".
+ *
+ * @param {string} str
+ * @param {string} suffix
+ * @returns {boolean}
+ */
+function pathEndsWith(str, suffix) {
+  if (!str || !suffix) return false;
+  if (str === suffix) return true;
+  return str.endsWith("/" + suffix);
+}
+
+/**
  * Pure function — given a snapshot node list and a recall result list, return a
  * Map from matched node ID → recall result frontmatter ID.
  *
@@ -702,11 +717,14 @@ let graphPulsePhase = 0;
  *
  * Matching rules (applied in order, first match wins per node):
  *   1. `node.id` === `result.path` (exact absolute path — rare)
- *   2. `result.path` ends with `node.id` (absolute path has node's relative tail)
- *   3. `node.id` ends with `result.path` (inverse, node has absolute prefix)
+ *   2. `result.path` ends with "/" + `node.id` (absolute path has node's relative tail)
+ *   3. `node.id` ends with "/" + `result.path` (inverse, node has absolute prefix)
  *   4. `node.id` === `result.id` (frontmatter ID match — only for non-path IDs)
- *   5. `node.id` ends with `result.id` (relative path ends with frontmatter ID)
- *   6. `result.id` ends with `node.id` (inverse suffix)
+ *   5. `node.id` ends with "/" + `result.id` (relative path ends with frontmatter ID)
+ *   6. `result.id` ends with "/" + `node.id` (inverse suffix)
+ *
+ * All suffix comparisons use path-segment boundary checks (pathEndsWith) so that
+ * e.g. "ammemory.md" does NOT match a suffix of "memory.md".
  *
  * Returns a Map so callers can retrieve the frontmatter ID for the memory-detail
  * endpoint without a separate lookup.
@@ -729,15 +747,16 @@ function resolveHighlights(nodes, results) {
       const rpath = result.path || "";
       // Path-based matching (handles the typical production case where graph
       // node IDs are relative paths and recall results carry absolute paths).
+      // Uses pathEndsWith() to respect path-segment boundaries.
       if (rpath) {
-        if (nid === rpath || rpath.endsWith(nid) || nid.endsWith(rpath)) {
+        if (nid === rpath || pathEndsWith(rpath, nid) || pathEndsWith(nid, rpath)) {
           matched.set(nid, rid);
           break;
         }
       }
       // Frontmatter-ID matching as fallback (e.g. custom deployments where
       // node IDs are not file paths).
-      if (rid && (nid === rid || nid.endsWith(rid) || rid.endsWith(nid))) {
+      if (rid && (nid === rid || pathEndsWith(nid, rid) || pathEndsWith(rid, nid))) {
         matched.set(nid, rid);
         break;
       }
@@ -1034,28 +1053,38 @@ function attachGraphInteractions(canvas) {
   let viewStart = { tx: 0, ty: 0 };
   /** Track whether the mousedown moved before mouseup (drag vs click). */
   let didDrag = false;
+  /**
+   * mousedownOnCanvas: set to true only when the mousedown that began the
+   * gesture originated on this canvas.  Prevents a mouseup from a pan that
+   * started outside the canvas (e.g. drag from a sidebar) from spuriously
+   * opening the node panel.
+   */
+  let mousedownOnCanvas = false;
 
   canvas.addEventListener("mousedown", (e) => {
     if (e.button !== 0) return;
     dragging = true;
     didDrag = false;
+    mousedownOnCanvas = true;
     dragStart = { x: e.clientX, y: e.clientY };
     viewStart = { tx: graphView.tx, ty: graphView.ty };
   });
 
   canvas.addEventListener("mouseup", (e) => {
     if (e.button !== 0) { dragging = false; return; }
-    // If the cursor didn't move more than 4px it's a click, not a drag.
+    // Only open a node panel if this mouseup has a matching mousedown on the
+    // same canvas and no drag movement occurred (click vs drag-pan).
     const rect = canvas.getBoundingClientRect();
     const cx = e.clientX - rect.left;
     const cy = e.clientY - rect.top;
-    if (!didDrag) {
+    if (mousedownOnCanvas && !didDrag) {
       const node = hitTestNode(cx, cy);
       if (node) {
         void openGraphNodePanel(node);
       }
     }
     dragging = false;
+    mousedownOnCanvas = false;
   });
 
   canvas.addEventListener("mousemove", (e) => {
@@ -1095,7 +1124,7 @@ function attachGraphInteractions(canvas) {
     hideGraphTooltip();
   });
 
-  canvas.addEventListener("mouseleave", () => { dragging = false; didDrag = false; hideGraphTooltip(); });
+  canvas.addEventListener("mouseleave", () => { dragging = false; didDrag = false; mousedownOnCanvas = false; hideGraphTooltip(); });
 
   // Zoom via scroll wheel.
   canvas.addEventListener("wheel", (e) => {
@@ -1161,6 +1190,11 @@ async function loadMemoryGraph() {
   const nodes = Array.isArray(snapshot.nodes) ? snapshot.nodes : [];
   const edges = Array.isArray(snapshot.edges) ? snapshot.edges : [];
 
+  // Always reset highlights and close panel at the start of every reload,
+  // before branching on empty vs non-empty — so stale state never persists.
+  graphHighlightIds = new Map();
+  closeGraphNodePanel();
+
   if (nodes.length === 0) {
     graphData = null;
     const ctx = canvas.getContext("2d");
@@ -1183,11 +1217,9 @@ async function loadMemoryGraph() {
     return;
   }
 
-  // Reset colours and highlights on each fresh fetch so legend is consistent.
+  // Reset colours on each fresh fetch so legend is consistent.
   graphCategoryColors.clear();
   graphCategoryColorIndex = 0;
-  graphHighlightIds = new Map();
-  closeGraphNodePanel();
 
   // Pre-warm category colours in node order.
   for (const n of nodes) graphColorForCategory(n.kind);
@@ -1285,15 +1317,30 @@ function closeGraphNodePanel() {
 }
 
 /**
+ * Monotonically incrementing token for in-flight node-panel requests.
+ * Incremented on every openGraphNodePanel call; the async continuation
+ * compares against the token at the time the fetch resolved to discard
+ * stale responses when the user clicks multiple nodes in quick succession.
+ */
+let graphNodePanelToken = 0;
+
+/**
  * Fetch `GET /engram/v1/memories/:id` and render the result into the
  * node detail side panel.  Builds a frontmatter table, renders raw content,
  * and lists related edges from the in-memory snapshot.
+ *
+ * Uses a monotonic token to discard stale responses when the user clicks
+ * a second node before the first fetch resolves (race-free panel updates).
  *
  * @param {object} node - graph node object (has `.id`, `.kind`, `.score`, etc.)
  */
 async function openGraphNodePanel(node) {
   const panel = $("graphNodePanel");
   if (!panel) return;
+
+  // Claim this request's token before any await so concurrent calls get a
+  // different value and their responses are discarded when they resolve.
+  const myToken = ++graphNodePanelToken;
 
   // Show panel immediately with loading state.
   panel.classList.add("visible");
@@ -1305,9 +1352,19 @@ async function openGraphNodePanel(node) {
 
   if (title) title.textContent = node.id;
   if (status) { status.textContent = `Loading ${node.id}…`; status.className = "status"; }
-  if (frontmatterEl) frontmatterEl.innerHTML = "<em>Loading…</em>";
+  if (frontmatterEl) {
+    clearChildren(frontmatterEl);
+    const em = document.createElement("em");
+    em.textContent = "Loading…";
+    frontmatterEl.appendChild(em);
+  }
   if (contentEl) contentEl.textContent = "Loading…";
-  if (edgesEl) edgesEl.innerHTML = "<strong>Loading edges…</strong>";
+  if (edgesEl) {
+    clearChildren(edgesEl);
+    const strong = document.createElement("strong");
+    strong.textContent = "Loading edges…";
+    edgesEl.appendChild(strong);
+  }
 
   // Use the frontmatter memory ID for the endpoint when available (attached
   // by runGraphSearch via resolveHighlights).  Graph node IDs are relative
@@ -1318,6 +1375,10 @@ async function openGraphNodePanel(node) {
 
   try {
     const response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(lookupId)}`);
+
+    // Discard if a newer openGraphNodePanel call was made while we awaited.
+    if (myToken !== graphNodePanelToken) return;
+
     const mem = response.memory || {};
 
     // Build frontmatter table from top-level scalar fields.
@@ -1351,6 +1412,7 @@ async function openGraphNodePanel(node) {
     }
 
     // Render related edges from the snapshot already in memory.
+    // Uses DOM methods exclusively — no innerHTML — to avoid XSS.
     if (edgesEl && graphData) {
       const related = graphData.edges.filter(
         (e) => e._srcNode?.id === node.id || e._tgtNode?.id === node.id,
@@ -1365,7 +1427,12 @@ async function openGraphNodePanel(node) {
           const isSource = e._srcNode?.id === node.id;
           const peerId = isSource ? e._tgtNode?.id : e._srcNode?.id;
           const direction = isSource ? "→" : "←";
-          li.innerHTML = `<strong>${direction} ${e.kind}</strong> ${peerId || "?"} (confidence ${e.confidence?.toFixed(2) ?? "?"})`;
+          const strong = document.createElement("strong");
+          strong.textContent = `${direction} ${e.kind ?? ""}`;
+          li.appendChild(strong);
+          li.appendChild(document.createTextNode(
+            ` ${peerId || "?"} (confidence ${e.confidence?.toFixed(2) ?? "?"})`,
+          ));
           ul.appendChild(li);
         });
         edgesEl.appendChild(ul);
@@ -1374,6 +1441,8 @@ async function openGraphNodePanel(node) {
 
     if (status) { status.textContent = `Loaded ${lookupId}.`; status.className = "status ok"; }
   } catch (err) {
+    // Discard stale error responses too.
+    if (myToken !== graphNodePanelToken) return;
     if (status) { status.textContent = err.message || String(err); status.className = "status error"; }
     if (contentEl) contentEl.textContent = "Failed to load memory content.";
   }

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -756,14 +756,20 @@ function resolveHighlights(nodes, results) {
   for (const node of nodes) {
     const nid = node.id;
     if (!nid) continue;
+    // Normalize the node ID once for all comparisons.
+    const nidN = normalizeSep(nid);
     for (const result of results) {
       const rid = result.id;
       const rpath = result.path || "";
       // Path-based matching (handles the typical production case where graph
-      // node IDs are relative paths and recall results carry absolute paths).
-      // Uses pathEndsWith() to respect path-segment boundaries.
+      // node IDs are relative paths and recall results carry absolute or
+      // relative paths).  Both sides are separator-normalized so
+      // Windows backslash paths compare correctly against forward-slash
+      // graph node IDs.  Uses pathEndsWith() to respect path-segment
+      // boundaries.
       if (rpath) {
-        if (nid === rpath || pathEndsWith(rpath, nid) || pathEndsWith(nid, rpath)) {
+        const rpathN = normalizeSep(rpath);
+        if (nidN === rpathN || pathEndsWith(rpathN, nidN) || pathEndsWith(nidN, rpathN)) {
           matched.set(nid, rid);
           break;
         }
@@ -1246,6 +1252,17 @@ async function loadMemoryGraph() {
     edge._tgtNode = nodeIndex.get(edge.target) ?? null;
   }
 
+  // Pre-bind each node's frontmatter memory ID from snapshot metadata so
+  // drill-through works for every node, not just those matched by a search.
+  // `node.metadata.memoryId` is the field the graph-snapshot endpoint sets
+  // when it can resolve the node back to a stored memory record.
+  // Any later runGraphSearch() result will overwrite this with the recall-
+  // result ID (which may be more precise), but this ensures non-searched
+  // nodes also open with a valid memory-detail fetch.
+  for (const n of nodes) {
+    n._memoryId = n.metadata?.memoryId || null;
+  }
+
   graphData = { nodes, edges };
   // Reset view on fresh load.
   graphView.tx = 0;
@@ -1310,8 +1327,15 @@ async function runGraphSearch() {
       [];
     // Guard again: graphData may have been cleared during the fetch.
     if (!graphData) return;
+    // Second token check immediately before mutating shared highlight state.
+    // A graph reload that ran between the first guard and here will have bumped
+    // graphSearchToken, so stale responses from a superseded search are dropped
+    // even if graphData was coincidentally re-populated in the interim.
+    if (myToken !== graphSearchToken) return;
     graphHighlightIds = resolveHighlights(graphData.nodes, rawResults);
     // Store frontmatter IDs on matched nodes for drill-through.
+    // Preserve any snapshot-bound _memoryId for nodes that weren't in results
+    // by only overwriting nodes that are actually in the highlight set.
     for (const [nodeId, memId] of graphHighlightIds.entries()) {
       const node = graphData.nodes.find((n) => n.id === nodeId);
       if (node) node._memoryId = memId;
@@ -1336,6 +1360,14 @@ function clearGraphSearch() {
   // Invalidate any in-flight search so its response is discarded.
   graphSearchToken += 1;
   graphHighlightIds = new Map();
+  // Clear search-assigned _memoryId from all nodes so subsequent drill-through
+  // fetches fall back to the snapshot-bound metadata ID rather than using a
+  // stale frontmatter ID from a previous search query.
+  if (graphData) {
+    for (const n of graphData.nodes) {
+      n._memoryId = n.metadata?.memoryId || null;
+    }
+  }
   const input = $("graphSearchQuery");
   if (input) input.value = "";
   if (graphData) drawGraph();
@@ -1399,15 +1431,16 @@ async function openGraphNodePanel(node) {
     edgesEl.appendChild(strong);
   }
 
-  // Use the frontmatter memory ID for the endpoint when available (attached
-  // by runGraphSearch via resolveHighlights).  Graph node IDs are relative
-  // paths; the memory-detail endpoint resolves by frontmatter ID, not path.
-  //
-  // When no frontmatter ID is available (node not yet matched by a search),
-  // we attempt the lookup with node.id and gracefully fall back to showing
-  // the snapshot metadata if the endpoint returns 404 — so the panel is still
-  // informative for every node, not just searched ones.
-  const lookupId = node._memoryId || node.id;
+  // Resolve the frontmatter memory ID to use for GET /engram/v1/memories/:id.
+  // Priority order:
+  //   1. node._memoryId  — set by runGraphSearch() from recall result.id, or
+  //                        pre-bound from snapshot metadata in loadMemoryGraph()
+  //   2. node.metadata?.memoryId — snapshot field (direct access, in case
+  //                        _memoryId was not pre-bound for some reason)
+  //   3. node.id         — last resort; the endpoint will 404 for path IDs but
+  //                        the caller handles 404 gracefully by showing snapshot
+  //                        data, so the panel is still informative.
+  const lookupId = node._memoryId || node.metadata?.memoryId || node.id;
 
   let response = null;
   try {

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -650,7 +650,8 @@ async function seedTrustZoneDemo(dryRun) {
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Memory Graph — force-directed Verlet simulation (issue #691 PR 3/5)
-// No external dependencies.  ~150 lines.
+// Semantic search highlight + drill-through (issue #691 PR 4/5)
+// No external dependencies.
 // ─────────────────────────────────────────────────────────────────────────────
 
 /** Stable colour palette keyed by category string. */
@@ -670,6 +671,50 @@ const GRAPH_EDGE_COLORS = { entity: "#0f6b63", time: "#c9a227", causal: "#8b3a22
 /** Per-session category → colour mapping, built lazily. */
 const graphCategoryColors = new Map();
 let graphCategoryColorIndex = 0;
+
+// ─── Highlight state (issue #691 PR 4/5) ────────────────────────────────────
+
+/** Set of node IDs currently highlighted by a search. Empty = no active search. */
+let graphHighlightIds = new Set();
+
+/**
+ * Pulse animation state.
+ * `graphPulsePhase` advances each frame; nodes use it to vary their ring size.
+ */
+let graphPulsePhase = 0;
+
+/**
+ * Pure function — given a snapshot and a recall result list, return a Set of
+ * node IDs whose identity matches one of the recalled memory IDs.
+ *
+ * Matching rules (applied in order, first match wins):
+ *   1. Exact `node.id === result.id`
+ *   2. `node.id` ends with `result.id` (relative path suffix)
+ *   3. `result.id` ends with `node.id` (inverse suffix)
+ *
+ * @param {Array<{id: string}>} nodes  - nodes from the snapshot
+ * @param {Array<{id: string}>} results - recall result objects; each must have an `id` field
+ * @returns {Set<string>}
+ */
+function resolveHighlights(nodes, results) {
+  const matched = new Set();
+  if (!Array.isArray(nodes) || !Array.isArray(results) || results.length === 0) {
+    return matched;
+  }
+  for (const node of nodes) {
+    const nid = node.id;
+    if (!nid) continue;
+    for (const result of results) {
+      const rid = result.id;
+      if (!rid) continue;
+      if (nid === rid || nid.endsWith(rid) || rid.endsWith(nid)) {
+        matched.add(nid);
+        break;
+      }
+    }
+  }
+  return matched;
+}
 
 function graphColorForCategory(cat) {
   if (!cat || cat === "unknown") return GRAPH_UNKNOWN_COLOR;
@@ -848,14 +893,35 @@ function drawGraph() {
   }
 
   // Draw nodes.
+  const hasHighlights = graphHighlightIds.size > 0;
+  graphPulsePhase = (graphPulsePhase + 0.06) % (2 * Math.PI);
+  const pulseExtra = Math.sin(graphPulsePhase) * 3.5;
+
   for (const n of graphData.nodes) {
     const r = nodeRadius(n.score);
+    const isHighlighted = hasHighlights && graphHighlightIds.has(n.id);
+    const isDimmed = hasHighlights && !isHighlighted;
+
+    // Draw highlight ring + pulse halo before the node fill.
+    if (isHighlighted) {
+      const haloR = r + 5 + Math.max(0, pulseExtra);
+      ctx.beginPath();
+      ctx.arc(n.x, n.y, haloR, 0, 2 * Math.PI);
+      ctx.strokeStyle = "#f5c842";
+      ctx.globalAlpha = 0.55 + Math.sin(graphPulsePhase) * 0.2;
+      ctx.lineWidth = 2.5;
+      ctx.stroke();
+      ctx.globalAlpha = 1;
+    }
+
     ctx.beginPath();
     ctx.arc(n.x, n.y, r, 0, 2 * Math.PI);
     ctx.fillStyle = graphColorForCategory(n.kind);
+    ctx.globalAlpha = isDimmed ? 0.22 : 1;
     ctx.fill();
-    ctx.strokeStyle = "rgba(255,255,255,0.6)";
-    ctx.lineWidth = 1.5;
+    ctx.globalAlpha = 1;
+    ctx.strokeStyle = isHighlighted ? "#f5c842" : "rgba(255,255,255,0.6)";
+    ctx.lineWidth = isHighlighted ? 2.5 : 1.5;
     ctx.stroke();
   }
 
@@ -932,16 +998,34 @@ function attachGraphInteractions(canvas) {
   if (graphInteractionsAttached) return;
   graphInteractionsAttached = true;
 
-  // Pan.
+  // Pan + click-to-drill-through.
   let dragging = false;
   let dragStart = { x: 0, y: 0 };
   let viewStart = { tx: 0, ty: 0 };
+  /** Track whether the mousedown moved before mouseup (drag vs click). */
+  let didDrag = false;
 
   canvas.addEventListener("mousedown", (e) => {
     if (e.button !== 0) return;
     dragging = true;
+    didDrag = false;
     dragStart = { x: e.clientX, y: e.clientY };
     viewStart = { tx: graphView.tx, ty: graphView.ty };
+  });
+
+  canvas.addEventListener("mouseup", (e) => {
+    if (e.button !== 0) { dragging = false; return; }
+    // If the cursor didn't move more than 4px it's a click, not a drag.
+    const rect = canvas.getBoundingClientRect();
+    const cx = e.clientX - rect.left;
+    const cy = e.clientY - rect.top;
+    if (!didDrag) {
+      const node = hitTestNode(cx, cy);
+      if (node) {
+        void openGraphNodePanel(node);
+      }
+    }
+    dragging = false;
   });
 
   canvas.addEventListener("mousemove", (e) => {
@@ -950,8 +1034,11 @@ function attachGraphInteractions(canvas) {
     const cy = e.clientY - rect.top;
 
     if (dragging) {
-      graphView.tx = viewStart.tx + (e.clientX - dragStart.x);
-      graphView.ty = viewStart.ty + (e.clientY - dragStart.y);
+      const dx = e.clientX - dragStart.x;
+      const dy = e.clientY - dragStart.y;
+      if (Math.abs(dx) > 4 || Math.abs(dy) > 4) didDrag = true;
+      graphView.tx = viewStart.tx + dx;
+      graphView.ty = viewStart.ty + dy;
       drawGraph();
       hideGraphTooltip();
       return;
@@ -978,8 +1065,7 @@ function attachGraphInteractions(canvas) {
     hideGraphTooltip();
   });
 
-  canvas.addEventListener("mouseup", () => { dragging = false; });
-  canvas.addEventListener("mouseleave", () => { dragging = false; hideGraphTooltip(); });
+  canvas.addEventListener("mouseleave", () => { dragging = false; didDrag = false; hideGraphTooltip(); });
 
   // Zoom via scroll wheel.
   canvas.addEventListener("wheel", (e) => {
@@ -1067,9 +1153,11 @@ async function loadMemoryGraph() {
     return;
   }
 
-  // Reset colours on each fresh fetch so legend is consistent.
+  // Reset colours and highlights on each fresh fetch so legend is consistent.
   graphCategoryColors.clear();
   graphCategoryColorIndex = 0;
+  graphHighlightIds = new Set();
+  closeGraphNodePanel();
 
   // Pre-warm category colours in node order.
   for (const n of nodes) graphColorForCategory(n.kind);
@@ -1101,6 +1189,152 @@ async function loadMemoryGraph() {
     `Loaded ${nodes.length} nodes, ${edges.length} edges. Generated ${snapshot.generatedAt}.`,
     "ok",
   );
+}
+
+// ─── Graph search + drill-through (issue #691 PR 4/5) ───────────────────────
+
+/**
+ * Run a recall search against the existing recall endpoint and highlight the
+ * matching nodes in the graph.  Uses `POST /engram/v1/recall` — the same
+ * endpoint as the Recall Debugger — with a fixed `sessionKey` so it does not
+ * pollute the user's recall state.
+ */
+async function runGraphSearch() {
+  const query = $("graphSearchQuery")?.value?.trim() || "";
+  if (!query) return;
+  if (!graphData) {
+    setStatus("graphStatus", "Load the graph first before searching.", "error");
+    return;
+  }
+  setStatus("graphStatus", `Searching for "${query}"…`);
+  try {
+    const recall = await fetchJson("/engram/v1/recall", {
+      method: "POST",
+      body: JSON.stringify({ query, sessionKey: "admin-console-graph-search" }),
+    });
+    // Normalise: recall response may have results in different shapes.
+    // `recall.memories`, `recall.results`, or fall back to empty.
+    const rawResults =
+      Array.isArray(recall.memories) ? recall.memories :
+      Array.isArray(recall.results)  ? recall.results  :
+      [];
+    graphHighlightIds = resolveHighlights(graphData.nodes, rawResults);
+    drawGraph();
+    const count = graphHighlightIds.size;
+    setStatus(
+      "graphStatus",
+      count > 0
+        ? `Highlighted ${count} node${count === 1 ? "" : "s"} matching "${query}".`
+        : `No graph nodes matched "${query}".`,
+      count > 0 ? "ok" : "default",
+    );
+  } catch (err) {
+    setStatus("graphStatus", err.message || String(err), "error");
+  }
+}
+
+/** Clear the current highlight selection and redraw. */
+function clearGraphSearch() {
+  graphHighlightIds = new Set();
+  const input = $("graphSearchQuery");
+  if (input) input.value = "";
+  if (graphData) drawGraph();
+  closeGraphNodePanel();
+  setStatus("graphStatus", "Search cleared.", "default");
+}
+
+/** Close the node detail panel. */
+function closeGraphNodePanel() {
+  const panel = $("graphNodePanel");
+  if (panel) panel.classList.remove("visible");
+}
+
+/**
+ * Fetch `GET /engram/v1/memories/:id` and render the result into the
+ * node detail side panel.  Builds a frontmatter table, renders raw content,
+ * and lists related edges from the in-memory snapshot.
+ *
+ * @param {object} node - graph node object (has `.id`, `.kind`, `.score`, etc.)
+ */
+async function openGraphNodePanel(node) {
+  const panel = $("graphNodePanel");
+  if (!panel) return;
+
+  // Show panel immediately with loading state.
+  panel.classList.add("visible");
+  const title = $("graphNodePanelTitle");
+  const status = $("graphNodePanelStatus");
+  const frontmatterEl = $("graphNodeFrontmatter");
+  const contentEl = $("graphNodeContent");
+  const edgesEl = $("graphNodeEdges");
+
+  if (title) title.textContent = node.id;
+  if (status) { status.textContent = `Loading ${node.id}…`; status.className = "status"; }
+  if (frontmatterEl) frontmatterEl.innerHTML = "<em>Loading…</em>";
+  if (contentEl) contentEl.textContent = "Loading…";
+  if (edgesEl) edgesEl.innerHTML = "<strong>Loading edges…</strong>";
+
+  try {
+    const response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(node.id)}`);
+    const mem = response.memory || {};
+
+    // Build frontmatter table from top-level scalar fields.
+    if (frontmatterEl) {
+      const table = document.createElement("table");
+      const FRONTMATTER_KEYS = [
+        "id", "category", "status", "importance", "entityRef",
+        "created", "updated", "path",
+      ];
+      FRONTMATTER_KEYS.forEach((key) => {
+        const val = mem[key];
+        if (val == null) return;
+        const tr = document.createElement("tr");
+        const tdKey = document.createElement("td");
+        tdKey.textContent = key;
+        const tdVal = document.createElement("td");
+        tdVal.textContent = String(val);
+        tr.appendChild(tdKey);
+        tr.appendChild(tdVal);
+        table.appendChild(tr);
+      });
+      clearChildren(frontmatterEl);
+      frontmatterEl.appendChild(table);
+    }
+
+    // Render content — raw text.
+    if (contentEl) {
+      contentEl.textContent = typeof mem.content === "string"
+        ? mem.content
+        : JSON.stringify(mem, null, 2);
+    }
+
+    // Render related edges from the snapshot already in memory.
+    if (edgesEl && graphData) {
+      const related = graphData.edges.filter(
+        (e) => e._srcNode?.id === node.id || e._tgtNode?.id === node.id,
+      );
+      clearChildren(edgesEl);
+      if (related.length === 0) {
+        edgesEl.textContent = "No edges in current snapshot.";
+      } else {
+        const ul = document.createElement("ul");
+        related.forEach((e) => {
+          const li = document.createElement("li");
+          const isSource = e._srcNode?.id === node.id;
+          const peerId = isSource ? e._tgtNode?.id : e._srcNode?.id;
+          const direction = isSource ? "→" : "←";
+          li.innerHTML = `<strong>${direction} ${e.kind}</strong> ${peerId || "?"} (confidence ${e.confidence?.toFixed(2) ?? "?"})`;
+          ul.appendChild(li);
+        });
+        edgesEl.appendChild(ul);
+      }
+    }
+
+    if (status) { status.textContent = `Loaded ${node.id}.`; status.className = "status ok"; }
+  } catch (err) {
+    if (status) { status.textContent = err.message || String(err); status.className = "status error"; }
+    if (contentEl) contentEl.textContent = "Failed to load memory content.";
+  }
 }
 
 async function connectAndBootstrap() {
@@ -1188,6 +1422,11 @@ function bootstrap() {
   $("copyMemoryPathButton")?.addEventListener("click", copyMemoryPath);
   $("refreshGraphButton")?.addEventListener("click", () => void loadMemoryGraph());
   $("resetGraphViewButton")?.addEventListener("click", resetGraphView);
+  $("graphSearchButton")?.addEventListener("click", () => void runGraphSearch());
+  $("graphClearSearchButton")?.addEventListener("click", clearGraphSearch);
+  $("graphSearchQuery")?.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") void runGraphSearch();
+  });
 
   if (remembered) {
     void connectAndBootstrap();

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -696,10 +696,24 @@ let graphPulsePhase = 0;
  * @param {string} suffix
  * @returns {boolean}
  */
+/**
+ * Normalize a file path to forward-slash form so Windows backslash paths
+ * compare correctly against the forward-slash-normalized graph node IDs.
+ * @param {string} p
+ * @returns {string}
+ */
+function normalizeSep(p) {
+  return p.replace(/\\/g, "/");
+}
+
 function pathEndsWith(str, suffix) {
   if (!str || !suffix) return false;
-  if (str === suffix) return true;
-  return str.endsWith("/" + suffix);
+  // Normalize separators before comparison so Windows backslash paths
+  // (from recall result.path) match forward-slash graph node IDs.
+  const s = normalizeSep(str);
+  const fx = normalizeSep(suffix);
+  if (s === fx) return true;
+  return s.endsWith("/" + fx);
 }
 
 /**
@@ -1190,8 +1204,9 @@ async function loadMemoryGraph() {
   const nodes = Array.isArray(snapshot.nodes) ? snapshot.nodes : [];
   const edges = Array.isArray(snapshot.edges) ? snapshot.edges : [];
 
-  // Always reset highlights and close panel at the start of every reload,
-  // before branching on empty vs non-empty — so stale state never persists.
+  // Always reset highlights, invalidate in-flight searches, and close panel
+  // at the start of every reload — so stale state never persists.
+  graphSearchToken += 1;
   graphHighlightIds = new Map();
   closeGraphNodePanel();
 
@@ -1256,6 +1271,14 @@ async function loadMemoryGraph() {
 // ─── Graph search + drill-through (issue #691 PR 4/5) ───────────────────────
 
 /**
+ * Monotonically incrementing token for in-flight graph search requests.
+ * Incremented on every runGraphSearch call; the async continuation discards
+ * results if the token changed while the fetch was in flight (e.g. because
+ * the user refreshed the graph or cleared search before it resolved).
+ */
+let graphSearchToken = 0;
+
+/**
  * Run a recall search against the existing recall endpoint and highlight the
  * matching nodes in the graph.  Uses `POST /engram/v1/recall` — the same
  * endpoint as the Recall Debugger — with a fixed `sessionKey` so it does not
@@ -1268,18 +1291,25 @@ async function runGraphSearch() {
     setStatus("graphStatus", "Load the graph first before searching.", "error");
     return;
   }
+  // Claim a token before the first await so a concurrent call gets a
+  // different value and this response is discarded when it resolves late.
+  const myToken = ++graphSearchToken;
   setStatus("graphStatus", `Searching for "${query}"…`);
   try {
     const recall = await fetchJson("/engram/v1/recall", {
       method: "POST",
       body: JSON.stringify({ query, sessionKey: "admin-console-graph-search" }),
     });
+    // Discard if a newer search (or a graph refresh/clear) ran while we awaited.
+    if (myToken !== graphSearchToken) return;
     // Normalise: recall response may have results in different shapes.
     // `recall.memories`, `recall.results`, or fall back to empty.
     const rawResults =
       Array.isArray(recall.memories) ? recall.memories :
       Array.isArray(recall.results)  ? recall.results  :
       [];
+    // Guard again: graphData may have been cleared during the fetch.
+    if (!graphData) return;
     graphHighlightIds = resolveHighlights(graphData.nodes, rawResults);
     // Store frontmatter IDs on matched nodes for drill-through.
     for (const [nodeId, memId] of graphHighlightIds.entries()) {
@@ -1296,12 +1326,15 @@ async function runGraphSearch() {
       count > 0 ? "ok" : "default",
     );
   } catch (err) {
+    if (myToken !== graphSearchToken) return;
     setStatus("graphStatus", err.message || String(err), "error");
   }
 }
 
 /** Clear the current highlight selection and redraw. */
 function clearGraphSearch() {
+  // Invalidate any in-flight search so its response is discarded.
+  graphSearchToken += 1;
   graphHighlightIds = new Map();
   const input = $("graphSearchQuery");
   if (input) input.value = "";
@@ -1369,82 +1402,114 @@ async function openGraphNodePanel(node) {
   // Use the frontmatter memory ID for the endpoint when available (attached
   // by runGraphSearch via resolveHighlights).  Graph node IDs are relative
   // paths; the memory-detail endpoint resolves by frontmatter ID, not path.
-  // Fall back to node.id so non-search-originated clicks still attempt a
-  // lookup (will 404 gracefully if the node ID isn't a frontmatter ID).
+  //
+  // When no frontmatter ID is available (node not yet matched by a search),
+  // we attempt the lookup with node.id and gracefully fall back to showing
+  // the snapshot metadata if the endpoint returns 404 — so the panel is still
+  // informative for every node, not just searched ones.
   const lookupId = node._memoryId || node.id;
 
+  let response = null;
   try {
-    const response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(lookupId)}`);
-
-    // Discard if a newer openGraphNodePanel call was made while we awaited.
+    response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(lookupId)}`);
+  } catch (err) {
+    // Discard stale errors.
     if (myToken !== graphNodePanelToken) return;
-
-    const mem = response.memory || {};
-
-    // Build frontmatter table from top-level scalar fields.
-    if (frontmatterEl) {
-      const table = document.createElement("table");
-      const FRONTMATTER_KEYS = [
-        "id", "category", "status", "importance", "entityRef",
-        "created", "updated", "path",
-      ];
-      FRONTMATTER_KEYS.forEach((key) => {
-        const val = mem[key];
-        if (val == null) return;
-        const tr = document.createElement("tr");
-        const tdKey = document.createElement("td");
-        tdKey.textContent = key;
-        const tdVal = document.createElement("td");
-        tdVal.textContent = String(val);
-        tr.appendChild(tdKey);
-        tr.appendChild(tdVal);
-        table.appendChild(tr);
-      });
-      clearChildren(frontmatterEl);
-      frontmatterEl.appendChild(table);
+    // On 404 (no frontmatter ID known yet) fall through with null response so
+    // the panel still shows snapshot data.  Surface real errors as-is.
+    const isNotFound = err?.payload?.error === "Not found" ||
+      (err?.message || "").includes("404");
+    if (!isNotFound) {
+      if (status) { status.textContent = err.message || String(err); status.className = "status error"; }
+      if (contentEl) contentEl.textContent = "Failed to load memory content.";
+      return;
     }
+    // 404 — fall through with response = null; we'll show snapshot data.
+  }
 
-    // Render content — raw text.
-    if (contentEl) {
+  // Discard if a newer openGraphNodePanel call was made while we awaited.
+  if (myToken !== graphNodePanelToken) return;
+
+  // When lookup succeeded, use the full memory record.
+  // When it 404-ed (response === null), synthesise from snapshot node data
+  // so the panel is informative for every node, not just searched ones.
+  const mem = response?.memory || {};
+  const isSnapshotOnly = !response?.found;
+
+  // Build frontmatter table from top-level scalar fields.
+  if (frontmatterEl) {
+    const table = document.createElement("table");
+    const FRONTMATTER_KEYS = [
+      "id", "category", "status", "importance", "entityRef",
+      "created", "updated", "path",
+    ];
+    FRONTMATTER_KEYS.forEach((key) => {
+      const val = mem[key];
+      if (val == null) return;
+      const tr = document.createElement("tr");
+      const tdKey = document.createElement("td");
+      tdKey.textContent = key;
+      const tdVal = document.createElement("td");
+      tdVal.textContent = String(val);
+      tr.appendChild(tdKey);
+      tr.appendChild(tdVal);
+      table.appendChild(tr);
+    });
+    clearChildren(frontmatterEl);
+    frontmatterEl.appendChild(table);
+  }
+
+  // Render content — raw text, or snapshot summary when no detail loaded.
+  if (contentEl) {
+    if (isSnapshotOnly) {
+      contentEl.textContent = [
+        `id: ${node.id}`,
+        `category: ${node.kind || "unknown"}`,
+        `score: ${typeof node.score === "number" ? node.score.toFixed(3) : "?"}`,
+        node.lastUpdated ? `updated: ${node.lastUpdated}` : null,
+        "",
+        "(Run a graph search to load the full memory detail for this node.)",
+      ].filter((l) => l !== null).join("\n");
+    } else {
       contentEl.textContent = typeof mem.content === "string"
         ? mem.content
         : JSON.stringify(mem, null, 2);
     }
+  }
 
-    // Render related edges from the snapshot already in memory.
-    // Uses DOM methods exclusively — no innerHTML — to avoid XSS.
-    if (edgesEl && graphData) {
-      const related = graphData.edges.filter(
-        (e) => e._srcNode?.id === node.id || e._tgtNode?.id === node.id,
-      );
-      clearChildren(edgesEl);
-      if (related.length === 0) {
-        edgesEl.textContent = "No edges in current snapshot.";
-      } else {
-        const ul = document.createElement("ul");
-        related.forEach((e) => {
-          const li = document.createElement("li");
-          const isSource = e._srcNode?.id === node.id;
-          const peerId = isSource ? e._tgtNode?.id : e._srcNode?.id;
-          const direction = isSource ? "→" : "←";
-          const strong = document.createElement("strong");
-          strong.textContent = `${direction} ${e.kind ?? ""}`;
-          li.appendChild(strong);
-          li.appendChild(document.createTextNode(
-            ` ${peerId || "?"} (confidence ${e.confidence?.toFixed(2) ?? "?"})`,
-          ));
-          ul.appendChild(li);
-        });
-        edgesEl.appendChild(ul);
-      }
+  // Render related edges from the snapshot already in memory.
+  // Uses DOM methods exclusively — no innerHTML — to avoid XSS.
+  if (edgesEl && graphData) {
+    const related = graphData.edges.filter(
+      (e) => e._srcNode?.id === node.id || e._tgtNode?.id === node.id,
+    );
+    clearChildren(edgesEl);
+    if (related.length === 0) {
+      edgesEl.textContent = "No edges in current snapshot.";
+    } else {
+      const ul = document.createElement("ul");
+      related.forEach((e) => {
+        const li = document.createElement("li");
+        const isSource = e._srcNode?.id === node.id;
+        const peerId = isSource ? e._tgtNode?.id : e._srcNode?.id;
+        const direction = isSource ? "→" : "←";
+        const strong = document.createElement("strong");
+        strong.textContent = `${direction} ${e.kind ?? ""}`;
+        li.appendChild(strong);
+        li.appendChild(document.createTextNode(
+          ` ${peerId || "?"} (confidence ${e.confidence?.toFixed(2) ?? "?"})`,
+        ));
+        ul.appendChild(li);
+      });
+      edgesEl.appendChild(ul);
     }
+  }
 
-    if (status) { status.textContent = `Loaded ${lookupId}.`; status.className = "status ok"; }
-  } catch (err) {
-    // Discard stale error responses too.
-    if (myToken !== graphNodePanelToken) return;
-    if (status) { status.textContent = err.message || String(err); status.className = "status error"; }
-    if (contentEl) contentEl.textContent = "Failed to load memory content.";
+  if (status) {
+    status.textContent = isSnapshotOnly
+      ? `Snapshot data for ${node.id}. Search to load full detail.`
+      : `Loaded ${lookupId}.`;
+    status.className = isSnapshotOnly ? "status" : "status ok";
   }
 }
 

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -674,8 +674,12 @@ let graphCategoryColorIndex = 0;
 
 // ─── Highlight state (issue #691 PR 4/5) ────────────────────────────────────
 
-/** Set of node IDs currently highlighted by a search. Empty = no active search. */
-let graphHighlightIds = new Set();
+/**
+ * Map of highlighted node IDs → frontmatter memory IDs, populated by search.
+ * Empty map = no active search.  Values are the recall result `id` field, which
+ * is the frontmatter memory ID required by GET /engram/v1/memories/:id.
+ */
+let graphHighlightIds = new Map();
 
 /**
  * Pulse animation state.
@@ -684,20 +688,36 @@ let graphHighlightIds = new Set();
 let graphPulsePhase = 0;
 
 /**
- * Pure function — given a snapshot and a recall result list, return a Set of
- * node IDs whose identity matches one of the recalled memory IDs.
+ * Pure function — given a snapshot node list and a recall result list, return a
+ * Map from matched node ID → recall result frontmatter ID.
  *
- * Matching rules (applied in order, first match wins):
- *   1. Exact `node.id === result.id`
- *   2. `node.id` ends with `result.id` (relative path suffix)
- *   3. `result.id` ends with `node.id` (inverse suffix)
+ * Recall results have two identifiers:
+ *   - `result.id`   — frontmatter memory ID (e.g. "fact-abc123"); used by the
+ *                     memory-detail endpoint GET /engram/v1/memories/:id.
+ *   - `result.path` — absolute file path (e.g. "/home/user/.remnic/facts/foo.md");
+ *                     path-based matching bridges absolute backend paths to
+ *                     relative graph node IDs.
  *
- * @param {Array<{id: string}>} nodes  - nodes from the snapshot
- * @param {Array<{id: string}>} results - recall result objects; each must have an `id` field
- * @returns {Set<string>}
+ * Graph snapshot `node.id` values are relative memory paths (e.g. "facts/foo.md").
+ *
+ * Matching rules (applied in order, first match wins per node):
+ *   1. `node.id` === `result.path` (exact absolute path — rare)
+ *   2. `result.path` ends with `node.id` (absolute path has node's relative tail)
+ *   3. `node.id` ends with `result.path` (inverse, node has absolute prefix)
+ *   4. `node.id` === `result.id` (frontmatter ID match — only for non-path IDs)
+ *   5. `node.id` ends with `result.id` (relative path ends with frontmatter ID)
+ *   6. `result.id` ends with `node.id` (inverse suffix)
+ *
+ * Returns a Map so callers can retrieve the frontmatter ID for the memory-detail
+ * endpoint without a separate lookup.
+ *
+ * @param {Array<{id: string}>} nodes   - nodes from the snapshot
+ * @param {Array<{id: string, path?: string}>} results - recall result objects
+ * @returns {Map<string, string>}  nodeId → frontmatterMemoryId
  */
 function resolveHighlights(nodes, results) {
-  const matched = new Set();
+  /** @type {Map<string, string>} */
+  const matched = new Map();
   if (!Array.isArray(nodes) || !Array.isArray(results) || results.length === 0) {
     return matched;
   }
@@ -706,9 +726,19 @@ function resolveHighlights(nodes, results) {
     if (!nid) continue;
     for (const result of results) {
       const rid = result.id;
-      if (!rid) continue;
-      if (nid === rid || nid.endsWith(rid) || rid.endsWith(nid)) {
-        matched.add(nid);
+      const rpath = result.path || "";
+      // Path-based matching (handles the typical production case where graph
+      // node IDs are relative paths and recall results carry absolute paths).
+      if (rpath) {
+        if (nid === rpath || rpath.endsWith(nid) || nid.endsWith(rpath)) {
+          matched.set(nid, rid);
+          break;
+        }
+      }
+      // Frontmatter-ID matching as fallback (e.g. custom deployments where
+      // node IDs are not file paths).
+      if (rid && (nid === rid || nid.endsWith(rid) || rid.endsWith(nid))) {
+        matched.set(nid, rid);
         break;
       }
     }
@@ -899,7 +929,7 @@ function drawGraph() {
 
   for (const n of graphData.nodes) {
     const r = nodeRadius(n.score);
-    const isHighlighted = hasHighlights && graphHighlightIds.has(n.id);
+    const isHighlighted = hasHighlights && graphHighlightIds.has(n.id);  // Map.has()
     const isDimmed = hasHighlights && !isHighlighted;
 
     // Draw highlight ring + pulse halo before the node fill.
@@ -1156,7 +1186,7 @@ async function loadMemoryGraph() {
   // Reset colours and highlights on each fresh fetch so legend is consistent.
   graphCategoryColors.clear();
   graphCategoryColorIndex = 0;
-  graphHighlightIds = new Set();
+  graphHighlightIds = new Map();
   closeGraphNodePanel();
 
   // Pre-warm category colours in node order.
@@ -1219,6 +1249,11 @@ async function runGraphSearch() {
       Array.isArray(recall.results)  ? recall.results  :
       [];
     graphHighlightIds = resolveHighlights(graphData.nodes, rawResults);
+    // Store frontmatter IDs on matched nodes for drill-through.
+    for (const [nodeId, memId] of graphHighlightIds.entries()) {
+      const node = graphData.nodes.find((n) => n.id === nodeId);
+      if (node) node._memoryId = memId;
+    }
     drawGraph();
     const count = graphHighlightIds.size;
     setStatus(
@@ -1235,7 +1270,7 @@ async function runGraphSearch() {
 
 /** Clear the current highlight selection and redraw. */
 function clearGraphSearch() {
-  graphHighlightIds = new Set();
+  graphHighlightIds = new Map();
   const input = $("graphSearchQuery");
   if (input) input.value = "";
   if (graphData) drawGraph();
@@ -1274,8 +1309,15 @@ async function openGraphNodePanel(node) {
   if (contentEl) contentEl.textContent = "Loading…";
   if (edgesEl) edgesEl.innerHTML = "<strong>Loading edges…</strong>";
 
+  // Use the frontmatter memory ID for the endpoint when available (attached
+  // by runGraphSearch via resolveHighlights).  Graph node IDs are relative
+  // paths; the memory-detail endpoint resolves by frontmatter ID, not path.
+  // Fall back to node.id so non-search-originated clicks still attempt a
+  // lookup (will 404 gracefully if the node ID isn't a frontmatter ID).
+  const lookupId = node._memoryId || node.id;
+
   try {
-    const response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(node.id)}`);
+    const response = await fetchJson(`/engram/v1/memories/${encodeURIComponent(lookupId)}`);
     const mem = response.memory || {};
 
     // Build frontmatter table from top-level scalar fields.
@@ -1330,7 +1372,7 @@ async function openGraphNodePanel(node) {
       }
     }
 
-    if (status) { status.textContent = `Loaded ${node.id}.`; status.className = "status ok"; }
+    if (status) { status.textContent = `Loaded ${lookupId}.`; status.className = "status ok"; }
   } catch (err) {
     if (status) { status.textContent = err.message || String(err); status.className = "status error"; }
     if (contentEl) contentEl.textContent = "Failed to load memory content.";

--- a/admin-console/public/index.html
+++ b/admin-console/public/index.html
@@ -286,6 +286,104 @@
         border-radius: 50%;
         flex-shrink: 0;
       }
+      /* ── Graph search highlight + drill-through (issue #691 PR 4/5) ── */
+      .graph-search-bar {
+        display: flex;
+        gap: 10px;
+        align-items: flex-end;
+        margin-top: 12px;
+        flex-wrap: wrap;
+      }
+      .graph-search-bar label {
+        flex: 1 1 220px;
+      }
+      .graph-node-panel {
+        border: 1px solid var(--line);
+        border-radius: 14px;
+        background: rgba(255, 255, 255, 0.82);
+        padding: 16px;
+        margin-top: 12px;
+        display: none;
+      }
+      .graph-node-panel.visible {
+        display: block;
+      }
+      .graph-node-panel h3 {
+        margin: 0 0 8px;
+        font-size: 0.9rem;
+        letter-spacing: 0.02em;
+        text-transform: uppercase;
+        color: var(--muted);
+      }
+      .graph-node-panel-body {
+        display: grid;
+        gap: 12px;
+        grid-template-columns: 1fr 1fr;
+      }
+      .graph-node-frontmatter {
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        background: #fffdf9;
+        padding: 10px;
+        font-size: 0.82rem;
+        overflow: auto;
+        max-height: 260px;
+      }
+      .graph-node-frontmatter table {
+        border-collapse: collapse;
+        width: 100%;
+      }
+      .graph-node-frontmatter td {
+        padding: 3px 6px;
+        vertical-align: top;
+      }
+      .graph-node-frontmatter td:first-child {
+        color: var(--muted);
+        white-space: nowrap;
+        font-weight: 600;
+        padding-right: 10px;
+      }
+      .graph-node-content {
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        background: #fffdf9;
+        padding: 10px;
+        font-size: 0.82rem;
+        line-height: 1.55;
+        overflow: auto;
+        max-height: 260px;
+        white-space: pre-wrap;
+        word-break: break-word;
+      }
+      .graph-node-edges {
+        grid-column: 1 / -1;
+        border-radius: 10px;
+        border: 1px solid var(--line);
+        background: #fffdf9;
+        padding: 10px;
+        font-size: 0.82rem;
+        overflow: auto;
+        max-height: 160px;
+      }
+      .graph-node-edges ul {
+        margin: 0;
+        padding-left: 18px;
+      }
+      .graph-node-edges li {
+        margin-bottom: 3px;
+        color: var(--muted);
+      }
+      .graph-node-edges li strong {
+        color: var(--ink);
+      }
+      @media (max-width: 768px) {
+        .graph-node-panel-body {
+          grid-template-columns: 1fr;
+        }
+        .graph-node-edges {
+          grid-column: 1;
+        }
+      }
       @media (max-width: 1080px) {
         .grid,
         .subgrid,
@@ -534,12 +632,33 @@
           <button id="refreshGraphButton">Refresh</button>
           <button class="secondary" id="resetGraphViewButton">Reset View</button>
         </div>
+        <div class="graph-search-bar">
+          <label style="flex: 1;">
+            Search Nodes
+            <input id="graphSearchQuery" type="text" placeholder="Semantic search — highlights matching nodes" />
+          </label>
+          <button id="graphSearchButton">Search</button>
+          <button class="secondary" id="graphClearSearchButton">Clear</button>
+        </div>
         <div class="status" id="graphStatus">Graph will load after connect.</div>
         <div class="graph-wrap">
           <canvas id="graphCanvas"></canvas>
           <div id="graphTooltip"></div>
         </div>
         <div class="graph-legend" id="graphLegend"></div>
+        <div class="graph-node-panel" id="graphNodePanel">
+          <h3 id="graphNodePanelTitle">Node Detail</h3>
+          <div class="status" id="graphNodePanelStatus"></div>
+          <div class="graph-node-panel-body">
+            <div class="graph-node-frontmatter" id="graphNodeFrontmatter">
+              <em>No node selected.</em>
+            </div>
+            <div class="graph-node-content" id="graphNodeContent">No node selected.</div>
+            <div class="graph-node-edges" id="graphNodeEdges">
+              <strong>Related edges will appear here.</strong>
+            </div>
+          </div>
+        </div>
       </section>
 
       <section class="card" style="margin-top: 16px;">

--- a/tests/admin-console-app.test.ts
+++ b/tests/admin-console-app.test.ts
@@ -113,6 +113,10 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
     drawGraph: vm.runInContext("drawGraph", context) as () => void,
     graphData: vm.runInContext("graphData", context),
     graphView: vm.runInContext("graphView", context) as { tx: number; ty: number; scale: number },
+    resolveHighlights: vm.runInContext("resolveHighlights", context) as (
+      nodes: Array<{ id: string }>,
+      results: Array<{ id: string }>,
+    ) => Set<string>,
   };
 }
 
@@ -241,4 +245,87 @@ test("graph pane HTML elements are present in index.html", async () => {
   assert.ok(html.includes('id="resetGraphViewButton"'), "resetGraphViewButton missing");
   assert.ok(html.includes('id="graphLimit"'), "graphLimit select missing");
   assert.ok(html.includes('id="graphFocusNodeId"'), "graphFocusNodeId input missing");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Semantic-search highlight + drill-through — issue #691 PR 4/5
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("graph search highlight HTML elements are present in index.html", async () => {
+  const htmlPath = path.resolve("admin-console/public/index.html");
+  const html = await readFile(htmlPath, "utf8");
+
+  assert.ok(html.includes('id="graphSearchQuery"'), "graphSearchQuery input missing");
+  assert.ok(html.includes('id="graphSearchButton"'), "graphSearchButton missing");
+  assert.ok(html.includes('id="graphClearSearchButton"'), "graphClearSearchButton missing");
+  assert.ok(html.includes('id="graphNodePanel"'), "graphNodePanel missing");
+  assert.ok(html.includes('id="graphNodeFrontmatter"'), "graphNodeFrontmatter missing");
+  assert.ok(html.includes('id="graphNodeContent"'), "graphNodeContent missing");
+  assert.ok(html.includes('id="graphNodeEdges"'), "graphNodeEdges missing");
+});
+
+test("resolveHighlights returns empty set when results array is empty", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  const nodes = [{ id: "facts/foo.md" }, { id: "facts/bar.md" }];
+  const result = resolveHighlights(nodes, []);
+  assert.equal(result.size, 0);
+});
+
+test("resolveHighlights matches on exact node id", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  const nodes = [
+    { id: "facts/foo.md" },
+    { id: "facts/bar.md" },
+    { id: "decisions/baz.md" },
+  ];
+  const results = [{ id: "facts/foo.md" }, { id: "decisions/baz.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 2);
+  assert.ok(matched.has("facts/foo.md"));
+  assert.ok(matched.has("decisions/baz.md"));
+  assert.ok(!matched.has("facts/bar.md"));
+});
+
+test("resolveHighlights matches when result id is a suffix of node id", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  // Node has a full path; recall result may return only the relative part.
+  const nodes = [{ id: "/Users/me/.remnic/facts/foo.md" }];
+  const results = [{ id: "facts/foo.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 1);
+  assert.ok(matched.has("/Users/me/.remnic/facts/foo.md"));
+});
+
+test("resolveHighlights matches when node id is a suffix of result id", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  // Inverse case: node uses short path, result has full absolute path.
+  const nodes = [{ id: "facts/foo.md" }];
+  const results = [{ id: "/Users/me/.remnic/facts/foo.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 1);
+  assert.ok(matched.has("facts/foo.md"));
+});
+
+test("resolveHighlights does not match unrelated ids", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  const nodes = [{ id: "facts/alpha.md" }, { id: "facts/beta.md" }];
+  const results = [{ id: "decisions/gamma.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 0);
+});
+
+test("resolveHighlights handles nodes with missing ids gracefully", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  // Some nodes may have empty or missing ids.
+  const nodes = [{ id: "" }, { id: "facts/foo.md" }] as Array<{ id: string }>;
+  const results = [{ id: "facts/foo.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 1);
+  assert.ok(matched.has("facts/foo.md"));
+});
+
+test("resolveHighlights returns empty set when nodes array is empty", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
+  const matched = resolveHighlights([], [{ id: "facts/foo.md" }]);
+  assert.equal(matched.size, 0);
 });

--- a/tests/admin-console-app.test.ts
+++ b/tests/admin-console-app.test.ts
@@ -115,8 +115,8 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
     graphView: vm.runInContext("graphView", context) as { tx: number; ty: number; scale: number },
     resolveHighlights: vm.runInContext("resolveHighlights", context) as (
       nodes: Array<{ id: string }>,
-      results: Array<{ id: string }>,
-    ) => Set<string>,
+      results: Array<{ id: string; path?: string }>,
+    ) => Map<string, string>,
   };
 }
 
@@ -264,31 +264,47 @@ test("graph search highlight HTML elements are present in index.html", async () 
   assert.ok(html.includes('id="graphNodeEdges"'), "graphNodeEdges missing");
 });
 
-test("resolveHighlights returns empty set when results array is empty", async () => {
+test("resolveHighlights returns empty map when results array is empty", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
   const nodes = [{ id: "facts/foo.md" }, { id: "facts/bar.md" }];
   const result = resolveHighlights(nodes, []);
   assert.equal(result.size, 0);
 });
 
-test("resolveHighlights matches on exact node id", async () => {
+test("resolveHighlights matches via result.path suffix against node.id (production case)", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
+  // Typical production: node.id is relative path, result carries absolute path + frontmatter id.
   const nodes = [
     { id: "facts/foo.md" },
     { id: "facts/bar.md" },
     { id: "decisions/baz.md" },
   ];
-  const results = [{ id: "facts/foo.md" }, { id: "decisions/baz.md" }];
+  const results = [
+    { id: "fact-abc123", path: "/Users/me/.remnic/facts/foo.md" },
+    { id: "decision-xyz", path: "/Users/me/.remnic/decisions/baz.md" },
+  ];
   const matched = resolveHighlights(nodes, results);
   assert.equal(matched.size, 2);
+  // Map keys are node IDs; values are frontmatter IDs for the detail endpoint.
   assert.ok(matched.has("facts/foo.md"));
+  assert.equal(matched.get("facts/foo.md"), "fact-abc123");
   assert.ok(matched.has("decisions/baz.md"));
+  assert.equal(matched.get("decisions/baz.md"), "decision-xyz");
   assert.ok(!matched.has("facts/bar.md"));
 });
 
-test("resolveHighlights matches when result id is a suffix of node id", async () => {
+test("resolveHighlights falls back to frontmatter id match when path absent", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
-  // Node has a full path; recall result may return only the relative part.
+  // When result has no path, fall back to id-based suffix matching.
+  const nodes = [{ id: "facts/foo.md" }];
+  const results = [{ id: "facts/foo.md" }];
+  const matched = resolveHighlights(nodes, results);
+  assert.equal(matched.size, 1);
+  assert.ok(matched.has("facts/foo.md"));
+});
+
+test("resolveHighlights matches when result id is a suffix of node id (no path)", async () => {
+  const { resolveHighlights } = await loadAdminConsoleContext("25");
   const nodes = [{ id: "/Users/me/.remnic/facts/foo.md" }];
   const results = [{ id: "facts/foo.md" }];
   const matched = resolveHighlights(nodes, results);
@@ -296,36 +312,35 @@ test("resolveHighlights matches when result id is a suffix of node id", async ()
   assert.ok(matched.has("/Users/me/.remnic/facts/foo.md"));
 });
 
-test("resolveHighlights matches when node id is a suffix of result id", async () => {
+test("resolveHighlights matches when node id is a suffix of result path", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
-  // Inverse case: node uses short path, result has full absolute path.
   const nodes = [{ id: "facts/foo.md" }];
-  const results = [{ id: "/Users/me/.remnic/facts/foo.md" }];
+  const results = [{ id: "fact-xyz", path: "/Users/me/.remnic/facts/foo.md" }];
   const matched = resolveHighlights(nodes, results);
   assert.equal(matched.size, 1);
-  assert.ok(matched.has("facts/foo.md"));
+  // Value is the frontmatter ID, not the path.
+  assert.equal(matched.get("facts/foo.md"), "fact-xyz");
 });
 
 test("resolveHighlights does not match unrelated ids", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
   const nodes = [{ id: "facts/alpha.md" }, { id: "facts/beta.md" }];
-  const results = [{ id: "decisions/gamma.md" }];
+  const results = [{ id: "decision-xyz", path: "/Users/me/.remnic/decisions/gamma.md" }];
   const matched = resolveHighlights(nodes, results);
   assert.equal(matched.size, 0);
 });
 
 test("resolveHighlights handles nodes with missing ids gracefully", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
-  // Some nodes may have empty or missing ids.
   const nodes = [{ id: "" }, { id: "facts/foo.md" }] as Array<{ id: string }>;
-  const results = [{ id: "facts/foo.md" }];
+  const results = [{ id: "fact-abc", path: "/Users/me/.remnic/facts/foo.md" }];
   const matched = resolveHighlights(nodes, results);
   assert.equal(matched.size, 1);
   assert.ok(matched.has("facts/foo.md"));
 });
 
-test("resolveHighlights returns empty set when nodes array is empty", async () => {
+test("resolveHighlights returns empty map when nodes array is empty", async () => {
   const { resolveHighlights } = await loadAdminConsoleContext("25");
-  const matched = resolveHighlights([], [{ id: "facts/foo.md" }]);
+  const matched = resolveHighlights([], [{ id: "fact-abc", path: "/Users/me/.remnic/facts/foo.md" }]);
   assert.equal(matched.size, 0);
 });


### PR DESCRIPTION
## Summary

- Adds a semantic-search input to the Memory Graph pane that calls `POST /engram/v1/recall` (the existing endpoint) and highlights matching nodes in the force-directed graph.
- Matched nodes render with a yellow pulse-ring animation; unmatched nodes are dimmed so results stand out.
- Clicking any node (highlighted or not) opens a drill-through side panel (`#graphNodePanel`) that fetches `GET /engram/v1/memories/:id` and shows: frontmatter key-value table, raw memory content, and a related-edge list sourced from the in-memory snapshot data (no extra round-trip for edges).
- `resolveHighlights()` is a pure export function with exact/suffix/inverse-suffix matching rules so short relative paths in recall results reliably match full-path node IDs from the graph snapshot.
- Clear-search button resets highlights, closes the panel, and redraws. Fresh graph loads also wipe stale highlights.

## Changes

| File | What changed |
|------|-------------|
| `admin-console/public/app.js` | `resolveHighlights()`, `runGraphSearch()`, `clearGraphSearch()`, `openGraphNodePanel()`, `closeGraphNodePanel()`; updated `drawGraph()` for pulse/dim rendering; updated `attachGraphInteractions()` for click-to-drill; wired new buttons in `bootstrap()` |
| `admin-console/public/index.html` | Search-bar row (`#graphSearchQuery`, `#graphSearchButton`, `#graphClearSearchButton`), node-detail side panel (`#graphNodePanel`, `#graphNodeFrontmatter`, `#graphNodeContent`, `#graphNodeEdges`), supporting CSS |
| `tests/admin-console-app.test.ts` | 8 new tests: HTML element presence (1), `resolveHighlights` unit tests (7); total 17/17 pass |

## Test plan

- [ ] All 17 `admin-console-app` tests pass (`node --test tests/admin-console-app.test.ts`)
- [ ] `resolveHighlights` pure function: empty results, exact match, suffix match, inverse-suffix match, no-match, missing-id, empty-nodes
- [ ] HTML presence test confirms all new element IDs are in `index.html`
- [ ] Preflight type-check passes (`npm run check-types`)
- [ ] No personal data, API keys, or user-specific references in diff

## PR series

| PR | Status |
|----|--------|
| #1/5 — admin scaffolding | merged |
| #2/5 — `GET /graph/snapshot` (#734) | merged |
| #3/5 — force-directed pane (#740) | merged |
| **#4/5 — search highlight + drill-through** | **this PR** |
| #5/5 — TBD | pending |

## Checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] No secrets or credentials committed
- [x] No personal data in diff
- [x] PR diff ≤ 400 LOC (454 lines, slightly above — justified: new feature + HTML + tests in one slice)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new client-side search and detail-fetch flows on the Memory Graph pane, including new async request/race-handling and click-vs-drag interaction logic. Risk is moderate due to potential UI regressions and extra API traffic, but changes are isolated to the admin console frontend with added tests for the matching logic.
> 
> **Overview**
> Adds semantic search to the Memory Graph pane by calling `POST /engram/v1/recall`, mapping results back to snapshot node IDs via the new pure `resolveHighlights()` matcher, and visually emphasizing matches with a pulsing ring while dimming non-matches.
> 
> Introduces click-to-drill-through on graph nodes with a new side panel that fetches `GET /engram/v1/memories/:id` (using snapshot `metadata.memoryId` and/or search-bound IDs), renders frontmatter/content/related edges, and uses request tokens to avoid stale async updates; graph reloads and “Clear” reset highlights/panel state.
> 
> Updates `index.html` with the search bar and node detail panel + CSS, wires new event handlers in `app.js`, and adds tests covering new DOM IDs plus `resolveHighlights()` matching behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8cc8bc738baedfc08647fd11f45fdfd793e28163. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->