### PR TITLE
feat(transfer): capsule merge semantics (#676 PR 5/6)

### DIFF
--- a/packages/remnic-core/src/transfer/capsule-import.ts
+++ b/packages/remnic-core/src/transfer/capsule-import.ts
@@ -7,7 +7,13 @@ import {
   type VersioningConfig,
   type VersioningLogger,
 } from "../page-versioning.js";
-import { fromPosixRelPath, sha256String } from "./fs-utils.js";
+import {
+  assertIsDirectoryNotSymlink,
+  assertRealpathInsideRoot,
+  fromPosixRelPath,
+  isPathInsideRoot,
+  sha256String,
+} from "./fs-utils.js";
 import {
   parseExportBundle,
   type CapsuleBlock,
@@ -131,7 +137,7 @@ export async function importCapsule(
 ): Promise<ImportCapsuleResult> {
   const archiveAbs = path.resolve(opts.archivePath);
   const rootAbs = path.resolve(opts.root);
-  await assertIsDirectory(rootAbs);
+  await assertIsDirectoryNotSymlink(rootAbs, "importCapsule", "root");
 
   const mode: ImportCapsuleMode = opts.mode ?? "skip";
   // Reject unknown mode values up-front (rule 51). TypeScript callers get a
@@ -200,7 +206,7 @@ export async function importCapsule(
   // inside-root checks are symlink-aware: a record path like `facts/a.md`
   // cannot write outside the intended sandbox via a symlinked subdirectory
   // (Codex P1 feedback).  If realpath fails (root does not exist) the earlier
-  // assertIsDirectory call already threw, so this should always succeed.
+  // assertIsDirectoryNotSymlink call already threw, so this should always succeed.
   const rootReal = await realpath(rootAbs).catch(() => rootAbs);
 
   // Tracks normalized, case-folded target paths seen so far in phase 1.  Maps
@@ -286,7 +292,7 @@ export async function importCapsule(
     // anywhere in the path components. If any resolved prefix escapes rootReal,
     // the import is rejected before any write. This applies to ALL modes,
     // including fork mode whose rebase prefix may itself traverse a symlink.
-    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path);
+    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path, "importCapsule");
 
     // Target-file symlink check (Codex P1 #741 round 4, line 260).
     // `assertRealpathInsideRoot` resolves the nearest existing *ancestor* to
@@ -429,95 +435,9 @@ function computeTargetPath(
   return sourcePosix;
 }
 
-/**
- * Return true when {@link absPath} is the same as {@link rootReal} or a
- * descendant.
- *
- * {@link rootReal} should be the value returned by `realpath(rootAbs)` so
- * that symlinked subdirectories are detected: a record path like `facts/a.md`
- * computes an `absPath` under the un-resolved `rootAbs`, but the final write
- * follows any symlink. We compare against the resolved root to catch the case
- * where `rootAbs/facts/` is a symlink pointing outside the sandbox (Codex P1).
- *
- * For the `..`-traversal case (hand-edited archives): the `path.relative`
- * lexical check is sufficient because `absPath` is constructed by joining
- * `rootAbs` with a posix-relative path, so no resolved path needed there.
- */
-function isPathInsideRoot(rootReal: string, absPath: string): boolean {
-  const rel = path.relative(rootReal, absPath);
-  if (rel === "") return true;
-  if (rel === "..") return false;
-  if (rel.startsWith(`..${path.sep}`)) return false;
-  if (path.isAbsolute(rel)) return false;
-  return true;
-}
-
-async function assertIsDirectory(absPath: string): Promise<void> {
-  // Mirror gotcha #24: existsSync returns true for files. The import root
-  // MUST be a directory.
-  const st = await stat(absPath).catch(() => null);
-  if (!st || !st.isDirectory()) {
-    throw new Error(
-      `importCapsule: 'root' must be an existing directory: ${absPath}`,
-    );
-  }
-  // Codex P1 #741 round 5: reject a root that is itself a symlink.
-  // `stat` follows symlinks so the isDirectory() check above passes even when
-  // `absPath` is a symlink → /etc or another sensitive directory.  We use
-  // `lstat` to inspect the path itself without following the link.  If it is a
-  // symlink we reject up-front rather than silently writing to the resolved
-  // target (which could be a sensitive location supplied by an attacker).
-  const lst = await lstat(absPath).catch(() => null);
-  if (lst && lst.isSymbolicLink()) {
-    throw new Error(
-      `importCapsule: 'root' must not be a symlink — resolve it to its real path first: ${absPath}`,
-    );
-  }
-}
-
 async function fileExistsAt(absPath: string): Promise<boolean> {
   const st = await stat(absPath).catch(() => null);
   return st !== null && st.isFile();
-}
-
-/**
- * Walk upward from {@link targetAbs} to find the nearest existing ancestor,
- * resolve it via `fs.realpath` (which follows symlinks), then re-append the
- * remaining suffix and verify the result is inside {@link rootReal}.
- *
- * This catches the case where an existing subdirectory at any point in the
- * path is a symlink that points outside the intended import root. Because the
- * file does not exist yet we cannot realpath it directly; we resolve the
- * deepest existing prefix and re-apply the non-existent suffix.
- *
- * Callers must ensure {@link rootReal} was already resolved via `realpath`.
- */
-async function assertRealpathInsideRoot(
-  rootReal: string,
-  targetAbs: string,
-  sourcePath: string,
-): Promise<void> {
-  // Walk from targetAbs toward root until we find a path component that exists.
-  let existing = targetAbs;
-  const suffix: string[] = [];
-  while (existing !== path.dirname(existing)) {
-    const st = await lstat(existing).catch(() => null);
-    if (st !== null) break;
-    suffix.unshift(path.basename(existing));
-    existing = path.dirname(existing);
-  }
-
-  // Resolve the existing prefix via realpath to follow any symlinks.
-  const existingReal = await realpath(existing).catch(() => existing);
-
-  // Re-apply the non-existent suffix to get the real final path.
-  const targetReal = suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
-
-  if (!isPathInsideRoot(rootReal, targetReal)) {
-    throw new Error(
-      `importCapsule: record path escapes target root via symlink: ${sourcePath}`,
-    );
-  }
 }
 
 // ---------------------------------------------------------------------------

--- a/packages/remnic-core/src/transfer/capsule-merge.ts
+++ b/packages/remnic-core/src/transfer/capsule-merge.ts
@@ -6,7 +6,13 @@ import {
   type VersioningConfig,
   type VersioningLogger,
 } from "../page-versioning.js";
-import { fromPosixRelPath, sha256String } from "./fs-utils.js";
+import {
+  assertIsDirectoryNotSymlink,
+  assertRealpathInsideRoot,
+  fromPosixRelPath,
+  isPathInsideRoot,
+  sha256String,
+} from "./fs-utils.js";
 import {
   parseExportBundle,
   type CapsuleBlock,
@@ -64,9 +70,6 @@ export type MergeCapsuleConflictMode =
  * overwrites proceed without snapshotting (not recommended for production).
  *
  * `log` — optional logger forwarded to {@link createVersion}.
- *
- * `now` — optional clock override (ms epoch) used in tests to produce
- * deterministic version timestamps.
  */
 export interface MergeCapsuleOptions {
   sourceArchive: string;
@@ -74,7 +77,6 @@ export interface MergeCapsuleOptions {
   conflictMode?: MergeCapsuleConflictMode;
   versioning?: VersioningConfig;
   log?: VersioningLogger;
-  now?: number;
 }
 
 export interface MergeCapsuleWrittenRecord {
@@ -156,7 +158,7 @@ export async function mergeCapsule(
   const archiveAbs = path.resolve(opts.sourceArchive);
   const rootAbs = path.resolve(opts.targetRoot);
 
-  await assertIsDirectory(rootAbs);
+  await assertIsDirectoryNotSymlink(rootAbs, "mergeCapsule", "targetRoot");
 
   const conflictMode: MergeCapsuleConflictMode =
     opts.conflictMode ?? "skip-conflicts";
@@ -238,6 +240,19 @@ export async function mergeCapsule(
 
   const rootReal = await realpath(rootAbs).catch(() => rootAbs);
 
+  // Tracks normalized, case-folded target paths seen so far in phase 1.  Maps
+  // targetAbs.toLowerCase() → first source path so the collision error can name
+  // both offending entries.  Two manifest entries whose computed target paths
+  // normalise to the same absolute path (e.g. `subdir/file.md` and
+  // `subdir/./file.md`, or differing case on case-insensitive filesystems such
+  // as macOS and Windows) would both refer to the same inode.  In
+  // `skip-conflicts`/`prefer-local` modes one entry would be misclassified as a
+  // local conflict against the OTHER entry's just-written content; in
+  // `prefer-source` the second entry would silently overwrite the first.  We
+  // reject the import up-front before any write (Codex P2 thread on PR #748,
+  // mirroring `capsule-import.ts`).
+  const seenTargetPaths = new Map<string, string>();
+
   for (const rec of bundle.records) {
     // Checksum validation.
     const entry = manifestIndex.get(rec.path);
@@ -281,8 +296,8 @@ export async function mergeCapsule(
       );
     }
 
-    // Symlink-aware containment check (mirrors capsule-import.ts).
-    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path);
+    // Symlink-aware containment check (shared helper from fs-utils).
+    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path, "mergeCapsule");
 
     // Target-file symlink guard: if the target already exists as a symlink,
     // reject — writes through symlinks can redirect to unexpected locations.
@@ -292,6 +307,29 @@ export async function mergeCapsule(
         `mergeCapsule: record target is a symlink and cannot be written to safely: ${rec.path}`,
       );
     }
+
+    // Duplicate normalized target path detection (Codex P2 #748, mirrors
+    // capsule-import.ts).  `path.join` already normalises `.` segments
+    // (e.g. `subdir/./file.md` → `subdir/file.md`).  On case-insensitive
+    // filesystems (macOS default, Windows), two paths that differ only in case
+    // would resolve to the same inode.  We fold the dedup key to lowercase so
+    // that `subdir/File.md` and `subdir/file.md` are detected as duplicates
+    // before any write occurs.  This is intentionally unconditional: the cost
+    // of an extra `.toLowerCase()` on case-sensitive filesystems is negligible,
+    // and a defensive lowercase is far simpler than probing filesystem
+    // case-sensitivity at runtime.  Without this guard, prefer-source mode
+    // would silently overwrite one entry with the other, and skip-conflicts /
+    // prefer-local would misclassify the second entry as a local conflict
+    // against the first entry's freshly written content.
+    const dedupKey = targetAbs.toLowerCase();
+    const firstSourcePath = seenTargetPaths.get(dedupKey);
+    if (firstSourcePath !== undefined) {
+      throw new Error(
+        `mergeCapsule: manifest contains two entries that resolve to the same target path: ` +
+          `"${firstSourcePath}" and "${rec.path}" both map to "${rec.path}"`,
+      );
+    }
+    seenTargetPaths.set(dedupKey, rec.path);
   }
 
   // Detect manifest-only entries (missing record). Treat as corruption.
@@ -382,57 +420,8 @@ export async function mergeCapsule(
 }
 
 // ---------------------------------------------------------------------------
-// Private helpers (mirrors capsule-import.ts)
+// Private helpers
 // ---------------------------------------------------------------------------
-
-function isPathInsideRoot(rootReal: string, absPath: string): boolean {
-  const rel = path.relative(rootReal, absPath);
-  if (rel === "") return true;
-  if (rel === "..") return false;
-  if (rel.startsWith(`..${path.sep}`)) return false;
-  if (path.isAbsolute(rel)) return false;
-  return true;
-}
-
-async function assertIsDirectory(absPath: string): Promise<void> {
-  // Gotcha #24: existsSync returns true for files; use stat().isDirectory().
-  const st = await stat(absPath).catch(() => null);
-  if (!st || !st.isDirectory()) {
-    throw new Error(
-      `mergeCapsule: 'targetRoot' must be an existing directory: ${absPath}`,
-    );
-  }
-  // Reject symlinked roots (mirrors capsule-import.ts gotcha P1 round 5).
-  const lst = await lstat(absPath).catch(() => null);
-  if (lst && lst.isSymbolicLink()) {
-    throw new Error(
-      `mergeCapsule: 'targetRoot' must not be a symlink — resolve it to its real path first: ${absPath}`,
-    );
-  }
-}
-
-async function assertRealpathInsideRoot(
-  rootReal: string,
-  targetAbs: string,
-  sourcePath: string,
-): Promise<void> {
-  let existing = targetAbs;
-  const suffix: string[] = [];
-  while (existing !== path.dirname(existing)) {
-    const st = await lstat(existing).catch(() => null);
-    if (st !== null) break;
-    suffix.unshift(path.basename(existing));
-    existing = path.dirname(existing);
-  }
-  const existingReal = await realpath(existing).catch(() => existing);
-  const targetReal =
-    suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
-  if (!isPathInsideRoot(rootReal, targetReal)) {
-    throw new Error(
-      `mergeCapsule: record path escapes target root via symlink: ${sourcePath}`,
-    );
-  }
-}
 
 async function readLocalFile(absPath: string): Promise<string | null> {
   const st = await stat(absPath).catch(() => null);

--- a/packages/remnic-core/src/transfer/capsule-merge.ts
+++ b/packages/remnic-core/src/transfer/capsule-merge.ts
@@ -1,0 +1,444 @@
+import { lstat, mkdir, readFile, realpath, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { gunzipSync } from "node:zlib";
+import {
+  createVersion,
+  type VersioningConfig,
+  type VersioningLogger,
+} from "../page-versioning.js";
+import { fromPosixRelPath, sha256String } from "./fs-utils.js";
+import {
+  parseExportBundle,
+  type CapsuleBlock,
+  type ExportManifestV2,
+  type ExportMemoryRecordV1,
+} from "./types.js";
+
+/**
+ * Three-way conflict-resolution mode for {@link mergeCapsule}.
+ *
+ * A "conflict" is defined as: the same memory-file path exists in both the
+ * source archive and the target directory AND the content hash of the local
+ * file differs from the archive's manifest entry for that path.
+ *
+ * Files that exist only in the archive (no local counterpart) are always
+ * written regardless of mode — there is no conflict to resolve.
+ *
+ * Files that are byte-identical (same content hash in both locations) are
+ * recorded as {@link MergeCapsuleResult.skipped} with reason `"identical"` and
+ * are never re-written regardless of mode; this is a no-op optimisation rather
+ * than a conflict.
+ *
+ *  - `"skip-conflicts"` (default) — log the conflict, skip the conflicting
+ *    archive entries, but continue importing non-conflicting entries. The
+ *    resulting merge is the union of:
+ *      - all non-conflicting archive files (written to target)
+ *      - all pre-existing local files (left unchanged)
+ *
+ *  - `"prefer-source"` — for conflicting files, snapshot the local content via
+ *    page-versioning (gotcha #54: snapshot before overwrite) then overwrite
+ *    with the archive content.
+ *
+ *  - `"prefer-local"` — for conflicting files, keep the local content; the
+ *    archive entry is skipped.
+ */
+export type MergeCapsuleConflictMode =
+  | "skip-conflicts"
+  | "prefer-source"
+  | "prefer-local";
+
+/**
+ * Options accepted by {@link mergeCapsule}.
+ *
+ * `sourceArchive` — absolute or cwd-relative path to a `.capsule.json.gz`
+ * archive produced by `exportCapsule`. Must be a V2 bundle.
+ *
+ * `targetRoot` — absolute or cwd-relative path to the memory directory that
+ * receives the merged records. Must be an existing, non-symlink directory.
+ *
+ * `conflictMode` — see {@link MergeCapsuleConflictMode}. Defaults to
+ * `"skip-conflicts"`.
+ *
+ * `versioning` — optional page-versioning config forwarded to
+ * {@link createVersion} in `"prefer-source"` mode. When omitted or disabled,
+ * overwrites proceed without snapshotting (not recommended for production).
+ *
+ * `log` — optional logger forwarded to {@link createVersion}.
+ *
+ * `now` — optional clock override (ms epoch) used in tests to produce
+ * deterministic version timestamps.
+ */
+export interface MergeCapsuleOptions {
+  sourceArchive: string;
+  targetRoot: string;
+  conflictMode?: MergeCapsuleConflictMode;
+  versioning?: VersioningConfig;
+  log?: VersioningLogger;
+  now?: number;
+}
+
+export interface MergeCapsuleWrittenRecord {
+  /** Capsule-relative posix path. */
+  sourcePath: string;
+  /** Memory-dir-relative posix path written on disk. */
+  targetPath: string;
+  /** Whether a page-versioning snapshot was taken before overwriting. */
+  snapshotted: boolean;
+}
+
+export interface MergeCapsuleSkippedRecord {
+  /** Capsule-relative posix path. */
+  path: string;
+  /**
+   * Why the archive entry was not written.
+   *
+   * `"conflict"` — the entry existed locally with different content and the
+   * active mode did not resolve the conflict with a write (`"skip-conflicts"` /
+   * `"prefer-local"`).
+   *
+   * `"identical"` — the entry's content hash matches what is already on disk;
+   * no write is needed.
+   */
+  reason: "conflict" | "identical";
+}
+
+export interface MergeCapsuleConflictRecord {
+  /** Capsule-relative posix path of the conflicting entry. */
+  path: string;
+  /** SHA-256 of the archive's copy. */
+  archiveSha256: string;
+  /** SHA-256 of the local copy. */
+  localSha256: string;
+}
+
+export interface MergeCapsuleResult {
+  /** Records that were written to the target directory. */
+  merged: MergeCapsuleWrittenRecord[];
+  /**
+   * Records that were NOT written (conflict skipped, or byte-identical).
+   * Includes conflicts that were resolved by `"prefer-local"`.
+   */
+  skipped: MergeCapsuleSkippedRecord[];
+  /**
+   * Metadata about every detected conflict, regardless of which mode resolved
+   * it. Callers can use this to report "N conflicts encountered; M overwritten".
+   */
+  conflicts: MergeCapsuleConflictRecord[];
+  /** The manifest decoded from the archive. */
+  manifest: ExportManifestV2;
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point
+// ---------------------------------------------------------------------------
+
+/**
+ * Merge a V2 capsule archive into an existing memory directory using
+ * three-way conflict semantics.
+ *
+ * Sequence:
+ *   1. Read + gunzip + JSON.parse the archive.
+ *   2. Validate through `parseExportBundle` (V1 rejected).
+ *   3. Verify every record's content sha256 against the manifest.
+ *      Any mismatch aborts BEFORE any file is written (gotcha #25).
+ *   4. Classify each record as: new (no local copy), identical (same hash),
+ *      or conflicting (different hash).
+ *   5. Apply the selected {@link MergeCapsuleConflictMode} to conflicting
+ *      entries; always write new entries; always skip identical entries.
+ *
+ * Determinism: `merged`, `skipped`, and `conflicts` are all returned sorted
+ * by `path`/`sourcePath` so callers get stable output regardless of bundle
+ * order.
+ */
+export async function mergeCapsule(
+  opts: MergeCapsuleOptions,
+): Promise<MergeCapsuleResult> {
+  const archiveAbs = path.resolve(opts.sourceArchive);
+  const rootAbs = path.resolve(opts.targetRoot);
+
+  await assertIsDirectory(rootAbs);
+
+  const conflictMode: MergeCapsuleConflictMode =
+    opts.conflictMode ?? "skip-conflicts";
+
+  // Rule 51: reject invalid conflictMode values up-front before any I/O.
+  if (
+    conflictMode !== "skip-conflicts" &&
+    conflictMode !== "prefer-source" &&
+    conflictMode !== "prefer-local"
+  ) {
+    throw new Error(
+      `mergeCapsule: unknown conflictMode ${JSON.stringify(conflictMode)}; ` +
+        `expected "skip-conflicts", "prefer-source", or "prefer-local"`,
+    );
+  }
+
+  // ---------------------------------------------------------------------------
+  // Parse + validate archive
+  // ---------------------------------------------------------------------------
+
+  const raw = await readFile(archiveAbs);
+  let json: string;
+  try {
+    json = gunzipSync(raw).toString("utf-8");
+  } catch (cause) {
+    throw new Error(
+      `mergeCapsule: archive is not a valid gzip file: ${archiveAbs}`,
+      { cause: cause as Error },
+    );
+  }
+
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(json);
+  } catch (cause) {
+    throw new Error(
+      `mergeCapsule: archive is not valid JSON after gunzip: ${archiveAbs}`,
+      { cause: cause as Error },
+    );
+  }
+
+  const parsed = parseExportBundle(parsedJson);
+  if (parsed.capsuleVersion !== 2) {
+    throw new Error(
+      "mergeCapsule: archive is V1; only V2 capsule archives are supported",
+    );
+  }
+
+  const bundle = parsed.bundle as {
+    manifest: ExportManifestV2;
+    records: ExportMemoryRecordV1[];
+  };
+  const manifest = bundle.manifest;
+  const capsule = manifest.capsule;
+
+  // Build path → manifest entry index for O(1) checksum lookup.
+  const manifestIndex = new Map<string, ExportManifestV2["files"][number]>();
+  for (const f of manifest.files) {
+    manifestIndex.set(f.path, f);
+  }
+  if (manifestIndex.size !== manifest.files.length) {
+    throw new Error("mergeCapsule: manifest contains duplicate file paths");
+  }
+
+  const recordPaths = new Set<string>();
+  for (const rec of bundle.records) {
+    if (recordPaths.has(rec.path)) {
+      throw new Error(
+        `mergeCapsule: bundle contains duplicate record path: ${rec.path}`,
+      );
+    }
+    recordPaths.add(rec.path);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase 1: verify checksums + validate paths before ANY filesystem mutation.
+  // (gotcha #25: don't destroy old state before confirming new state succeeds)
+  // ---------------------------------------------------------------------------
+
+  const rootReal = await realpath(rootAbs).catch(() => rootAbs);
+
+  for (const rec of bundle.records) {
+    // Checksum validation.
+    const entry = manifestIndex.get(rec.path);
+    if (!entry) {
+      throw new Error(
+        `mergeCapsule: archive checksum mismatch (record without manifest entry: ${rec.path})`,
+      );
+    }
+    const { sha256, bytes } = sha256String(rec.content);
+    if (sha256 !== entry.sha256 || bytes !== entry.bytes) {
+      throw new Error(
+        `mergeCapsule: archive checksum mismatch for ${rec.path}: ` +
+          `expected sha256=${entry.sha256} bytes=${entry.bytes}, ` +
+          `got sha256=${sha256} bytes=${bytes}`,
+      );
+    }
+
+    // Path-traversal validation (mirrors capsule-import.ts).
+    if (rec.path.includes("\\")) {
+      throw new Error(
+        `mergeCapsule: record path contains backslash separators (Windows-style paths are not allowed): ${rec.path}`,
+      );
+    }
+    const posixNormalized = path.posix.normalize(rec.path);
+    if (
+      rec.path.startsWith("/") ||
+      rec.path.split("/").some((seg) => seg === "..") ||
+      posixNormalized.startsWith("..") ||
+      posixNormalized.startsWith("/")
+    ) {
+      throw new Error(
+        `mergeCapsule: record path escapes target root: ${rec.path}`,
+      );
+    }
+
+    // Lexical root containment check.
+    const targetAbs = path.join(rootReal, fromPosixRelPath(rec.path));
+    if (!isPathInsideRoot(rootReal, targetAbs)) {
+      throw new Error(
+        `mergeCapsule: record path escapes target root: ${rec.path}`,
+      );
+    }
+
+    // Symlink-aware containment check (mirrors capsule-import.ts).
+    await assertRealpathInsideRoot(rootReal, targetAbs, rec.path);
+
+    // Target-file symlink guard: if the target already exists as a symlink,
+    // reject — writes through symlinks can redirect to unexpected locations.
+    const targetLstat = await lstat(targetAbs).catch(() => null);
+    if (targetLstat !== null && targetLstat.isSymbolicLink()) {
+      throw new Error(
+        `mergeCapsule: record target is a symlink and cannot be written to safely: ${rec.path}`,
+      );
+    }
+  }
+
+  // Detect manifest-only entries (missing record). Treat as corruption.
+  for (const f of manifest.files) {
+    if (!recordPaths.has(f.path)) {
+      throw new Error(
+        `mergeCapsule: archive checksum mismatch (manifest entry without record: ${f.path})`,
+      );
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Phase 2: classify records and apply conflict mode.
+  // ---------------------------------------------------------------------------
+
+  const merged: MergeCapsuleWrittenRecord[] = [];
+  const skipped: MergeCapsuleSkippedRecord[] = [];
+  const conflicts: MergeCapsuleConflictRecord[] = [];
+
+  // Sort by source path for deterministic output (mirrors capsule-import.ts).
+  const sortedRecords = [...bundle.records].sort((a, b) =>
+    a.path.localeCompare(b.path),
+  );
+
+  for (const rec of sortedRecords) {
+    const targetAbs = path.join(rootReal, fromPosixRelPath(rec.path));
+    const entry = manifestIndex.get(rec.path)!; // validated above
+
+    const localContent = await readLocalFile(targetAbs);
+
+    if (localContent === null) {
+      // No local copy — always write regardless of mode.
+      await mkdir(path.dirname(targetAbs), { recursive: true });
+      await writeFile(targetAbs, rec.content, "utf-8");
+      merged.push({ sourcePath: rec.path, targetPath: rec.path, snapshotted: false });
+      continue;
+    }
+
+    // Local file exists. Check if it is byte-identical to the archive entry.
+    const { sha256: localSha256 } = sha256String(localContent);
+
+    if (localSha256 === entry.sha256) {
+      // Byte-identical — no write needed.
+      skipped.push({ path: rec.path, reason: "identical" });
+      continue;
+    }
+
+    // Content differs → conflict.
+    const { sha256: archiveSha256 } = sha256String(rec.content);
+    conflicts.push({
+      path: rec.path,
+      archiveSha256,
+      localSha256,
+    });
+
+    if (conflictMode === "skip-conflicts" || conflictMode === "prefer-local") {
+      // Keep local copy, skip archive entry.
+      skipped.push({ path: rec.path, reason: "conflict" });
+      continue;
+    }
+
+    // conflictMode === "prefer-source": snapshot local then overwrite.
+    let snapshotted = false;
+    if (opts.versioning && opts.versioning.enabled) {
+      // Gotcha #54: snapshot BEFORE overwriting.
+      await createVersion(
+        targetAbs,
+        localContent,
+        "manual",
+        opts.versioning,
+        opts.log,
+        `capsule-merge: ${capsule.id}`,
+        rootReal,
+      );
+      snapshotted = true;
+    }
+
+    await writeFile(targetAbs, rec.content, "utf-8");
+    merged.push({ sourcePath: rec.path, targetPath: rec.path, snapshotted });
+  }
+
+  // Sort output lists for determinism.
+  merged.sort((a, b) => a.sourcePath.localeCompare(b.sourcePath));
+  skipped.sort((a, b) => a.path.localeCompare(b.path));
+  conflicts.sort((a, b) => a.path.localeCompare(b.path));
+
+  return { merged, skipped, conflicts, manifest };
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers (mirrors capsule-import.ts)
+// ---------------------------------------------------------------------------
+
+function isPathInsideRoot(rootReal: string, absPath: string): boolean {
+  const rel = path.relative(rootReal, absPath);
+  if (rel === "") return true;
+  if (rel === "..") return false;
+  if (rel.startsWith(`..${path.sep}`)) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+async function assertIsDirectory(absPath: string): Promise<void> {
+  // Gotcha #24: existsSync returns true for files; use stat().isDirectory().
+  const st = await stat(absPath).catch(() => null);
+  if (!st || !st.isDirectory()) {
+    throw new Error(
+      `mergeCapsule: 'targetRoot' must be an existing directory: ${absPath}`,
+    );
+  }
+  // Reject symlinked roots (mirrors capsule-import.ts gotcha P1 round 5).
+  const lst = await lstat(absPath).catch(() => null);
+  if (lst && lst.isSymbolicLink()) {
+    throw new Error(
+      `mergeCapsule: 'targetRoot' must not be a symlink — resolve it to its real path first: ${absPath}`,
+    );
+  }
+}
+
+async function assertRealpathInsideRoot(
+  rootReal: string,
+  targetAbs: string,
+  sourcePath: string,
+): Promise<void> {
+  let existing = targetAbs;
+  const suffix: string[] = [];
+  while (existing !== path.dirname(existing)) {
+    const st = await lstat(existing).catch(() => null);
+    if (st !== null) break;
+    suffix.unshift(path.basename(existing));
+    existing = path.dirname(existing);
+  }
+  const existingReal = await realpath(existing).catch(() => existing);
+  const targetReal =
+    suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
+  if (!isPathInsideRoot(rootReal, targetReal)) {
+    throw new Error(
+      `mergeCapsule: record path escapes target root via symlink: ${sourcePath}`,
+    );
+  }
+}
+
+async function readLocalFile(absPath: string): Promise<string | null> {
+  const st = await stat(absPath).catch(() => null);
+  if (!st || !st.isFile()) return null;
+  return readFile(absPath, "utf-8");
+}
+
+// Re-export CapsuleBlock so callers don't need a deep import from types.ts.
+export type { CapsuleBlock };

--- a/packages/remnic-core/src/transfer/fs-utils.ts
+++ b/packages/remnic-core/src/transfer/fs-utils.ts
@@ -1,5 +1,13 @@
 import { createHash } from "node:crypto";
-import { mkdir, readdir, readFile, stat, writeFile } from "node:fs/promises";
+import {
+  lstat,
+  mkdir,
+  readdir,
+  readFile,
+  realpath,
+  stat,
+  writeFile,
+} from "node:fs/promises";
 import path from "node:path";
 
 export async function sha256File(filePath: string): Promise<{ sha256: string; bytes: number }> {
@@ -62,4 +70,89 @@ export function toPosixRelPath(absPath: string, rootDir: string): string {
 
 export function fromPosixRelPath(relPath: string): string {
   return relPath.split("/").join(path.sep);
+}
+
+// ---------------------------------------------------------------------------
+// Shared path-safety helpers (used by capsule-import and capsule-merge).
+//
+// These three helpers were previously duplicated across both modules. They are
+// security-critical (path-traversal and symlink-bypass guards), so any future
+// fix must apply uniformly. The `errorPrefix` argument lets each caller surface
+// a module-specific error message ("importCapsule:" vs "mergeCapsule:") without
+// forking the implementation.
+// ---------------------------------------------------------------------------
+
+/**
+ * Return true when {@link absPath} is the same as {@link rootReal} or a
+ * descendant. {@link rootReal} should be the value returned by
+ * `realpath(rootAbs)` so that symlinked subdirectories are detected.
+ */
+export function isPathInsideRoot(rootReal: string, absPath: string): boolean {
+  const rel = path.relative(rootReal, absPath);
+  if (rel === "") return true;
+  if (rel === "..") return false;
+  if (rel.startsWith(`..${path.sep}`)) return false;
+  if (path.isAbsolute(rel)) return false;
+  return true;
+}
+
+/**
+ * Assert that {@link absPath} is an existing directory and is not itself a
+ * symlink. `existsSync` returns true for files (gotcha #24); a stat-based
+ * check is required. Symlinked roots are rejected up-front so an attacker
+ * cannot hand the importer a `~/import-target` link → `/etc` and have writes
+ * silently follow the link (Codex P1 round 5 thread on PR #741).
+ */
+export async function assertIsDirectoryNotSymlink(
+  absPath: string,
+  errorPrefix: string,
+  argName: string,
+): Promise<void> {
+  const st = await stat(absPath).catch(() => null);
+  if (!st || !st.isDirectory()) {
+    throw new Error(
+      `${errorPrefix}: '${argName}' must be an existing directory: ${absPath}`,
+    );
+  }
+  const lst = await lstat(absPath).catch(() => null);
+  if (lst && lst.isSymbolicLink()) {
+    throw new Error(
+      `${errorPrefix}: '${argName}' must not be a symlink — resolve it to its real path first: ${absPath}`,
+    );
+  }
+}
+
+/**
+ * Walk upward from {@link targetAbs} to find the nearest existing ancestor,
+ * resolve it via `fs.realpath` (which follows symlinks), then re-append the
+ * remaining suffix and verify the result is inside {@link rootReal}.
+ *
+ * This catches the case where an existing subdirectory at any point in the
+ * path is a symlink that points outside the intended root. Because the file
+ * does not exist yet we cannot realpath it directly; we resolve the deepest
+ * existing prefix and re-apply the non-existent suffix. Callers must ensure
+ * {@link rootReal} was already resolved via `realpath`.
+ */
+export async function assertRealpathInsideRoot(
+  rootReal: string,
+  targetAbs: string,
+  sourcePath: string,
+  errorPrefix: string,
+): Promise<void> {
+  let existing = targetAbs;
+  const suffix: string[] = [];
+  while (existing !== path.dirname(existing)) {
+    const st = await lstat(existing).catch(() => null);
+    if (st !== null) break;
+    suffix.unshift(path.basename(existing));
+    existing = path.dirname(existing);
+  }
+  const existingReal = await realpath(existing).catch(() => existing);
+  const targetReal =
+    suffix.length > 0 ? path.join(existingReal, ...suffix) : existingReal;
+  if (!isPathInsideRoot(rootReal, targetReal)) {
+    throw new Error(
+      `${errorPrefix}: record path escapes target root via symlink: ${sourcePath}`,
+    );
+  }
 }

--- a/tests/transfer/capsule-merge.test.ts
+++ b/tests/transfer/capsule-merge.test.ts
@@ -607,7 +607,135 @@ test("symlinked targetRoot is rejected", async () => {
 });
 
 // ---------------------------------------------------------------------------
-// 14. conflicts.archiveSha256 and localSha256 are accurate
+// 14. Normalized-path collisions are rejected before any write
+// (Codex P2 thread on PR #748 — mirrors capsule-import.ts hardening.)
+// ---------------------------------------------------------------------------
+
+test("manifest with two entries that normalize to the same target path is rejected before any write", async () => {
+  // `subdir/file.md` and `subdir/./file.md` both resolve to <root>/subdir/file.md
+  // after path.join normalisation. Without the dedup guard:
+  //   - skip-conflicts/prefer-local would misclassify the second entry as a
+  //     local conflict against the first entry's freshly written content;
+  //   - prefer-source would silently overwrite the first with the second.
+  // Reject in phase 1 before any write.
+  const content1 = "first entry\n";
+  const content2 = "second entry\n";
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "subdir/file.md",
+          sha256: sha256hex(content1),
+          bytes: Buffer.byteLength(content1, "utf-8"),
+        },
+        {
+          path: "subdir/./file.md",
+          sha256: sha256hex(content2),
+          bytes: Buffer.byteLength(content2, "utf-8"),
+        },
+      ],
+      capsule: {
+        id: "dup-norm-cap",
+        version: "1.0.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [
+      { path: "subdir/file.md", content: content1 },
+      { path: "subdir/./file.md", content: content2 },
+    ],
+  };
+  const archivePath = await writeBundleArchive(
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+    "dup-norm",
+  );
+  const dst = await makeTargetDir();
+
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: dst }),
+    /two entries that resolve to the same target path/i,
+  );
+
+  assert.deepEqual(await listFiles(dst), [], "must not leave partial writes");
+});
+
+test("manifest with two entries that differ only in case is rejected before any write", async () => {
+  // On case-insensitive filesystems (macOS default, Windows), `subdir/File.md`
+  // and `subdir/file.md` refer to the same inode. The dedup check folds case
+  // so both variants are caught regardless of the host's case-sensitivity.
+  const content1 = "lowercase\n";
+  const content2 = "uppercase\n";
+
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "subdir/file.md",
+          sha256: sha256hex(content1),
+          bytes: Buffer.byteLength(content1, "utf-8"),
+        },
+        {
+          path: "subdir/File.md",
+          sha256: sha256hex(content2),
+          bytes: Buffer.byteLength(content2, "utf-8"),
+        },
+      ],
+      capsule: {
+        id: "case-dup-cap",
+        version: "1.0.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: false },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records: [
+      { path: "subdir/file.md", content: content1 },
+      { path: "subdir/File.md", content: content2 },
+    ],
+  };
+  const archivePath = await writeBundleArchive(
+    gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")),
+    "case-dup",
+  );
+  const dst = await makeTargetDir();
+
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: dst }),
+    /two entries that resolve to the same target path/i,
+  );
+
+  assert.deepEqual(await listFiles(dst), [], "must not leave partial writes");
+});
+
+// ---------------------------------------------------------------------------
+// 15. conflicts.archiveSha256 and localSha256 are accurate
 // ---------------------------------------------------------------------------
 
 test("conflict record contains accurate sha256 values for both sides", async () => {

--- a/tests/transfer/capsule-merge.test.ts
+++ b/tests/transfer/capsule-merge.test.ts
@@ -1,0 +1,633 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  mkdir,
+  mkdtemp,
+  readFile,
+  readdir,
+  symlink,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+import { createHash } from "node:crypto";
+
+import { exportCapsule } from "../../packages/remnic-core/src/transfer/capsule-export.js";
+import { mergeCapsule } from "../../packages/remnic-core/src/transfer/capsule-merge.js";
+import { listVersions } from "../../packages/remnic-core/src/page-versioning.js";
+import { sha256String } from "../../packages/remnic-core/src/transfer/fs-utils.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+interface FixtureFile {
+  rel: string;
+  content: string;
+}
+
+async function makeMemoryDir(files: FixtureFile[]): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "capsule-merge-src-"));
+  for (const f of files) {
+    const abs = path.join(root, ...f.rel.split("/"));
+    await mkdir(path.dirname(abs), { recursive: true });
+    await writeFile(abs, f.content, "utf-8");
+  }
+  return root;
+}
+
+async function makeTargetDir(
+  preexisting?: FixtureFile[],
+): Promise<string> {
+  const root = await mkdtemp(path.join(tmpdir(), "capsule-merge-dst-"));
+  if (preexisting) {
+    for (const f of preexisting) {
+      const abs = path.join(root, ...f.rel.split("/"));
+      await mkdir(path.dirname(abs), { recursive: true });
+      await writeFile(abs, f.content, "utf-8");
+    }
+  }
+  return root;
+}
+
+async function exportFixtures(
+  files: FixtureFile[],
+  name: string,
+): Promise<string> {
+  const src = await makeMemoryDir(files);
+  const result = await exportCapsule({
+    name,
+    root: src,
+    pluginVersion: "9.9.9",
+    now: Date.parse("2026-04-26T00:00:00.000Z"),
+  });
+  return result.archivePath;
+}
+
+async function listFiles(root: string): Promise<string[]> {
+  const out: string[] = [];
+  async function walk(dir: string, prefix: string): Promise<void> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    for (const e of entries) {
+      const next = path.join(dir, e.name);
+      const rel = prefix ? `${prefix}/${e.name}` : e.name;
+      if (e.isDirectory()) await walk(next, rel);
+      else if (e.isFile()) out.push(rel);
+    }
+  }
+  await walk(root, "");
+  return out.sort();
+}
+
+function sha256hex(s: string): string {
+  return createHash("sha256").update(Buffer.from(s, "utf-8")).digest("hex");
+}
+
+/**
+ * Build a minimal hand-crafted V2 bundle (bypasses exportCapsule so we can
+ * control exact content for conflict scenarios).
+ */
+function makeBundle(
+  capsuleId: string,
+  records: Array<{ path: string; content: string }>,
+): Buffer {
+  const files = records.map((r) => ({
+    path: r.path,
+    sha256: sha256hex(r.content),
+    bytes: Buffer.byteLength(r.content, "utf-8"),
+  }));
+  const bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 2 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files,
+      capsule: {
+        id: capsuleId,
+        version: "1.0.0",
+        schemaVersion: "taxonomy-v1",
+        parentCapsule: null,
+        description: "test capsule",
+        retrievalPolicy: { tierWeights: {}, directAnswerEnabled: true },
+        includes: {
+          taxonomy: false,
+          identityAnchors: false,
+          peerProfiles: false,
+          procedural: false,
+        },
+      },
+    },
+    records,
+  };
+  return gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8"));
+}
+
+async function writeBundleArchive(
+  buf: Buffer,
+  label: string,
+): Promise<string> {
+  const tmp = await mkdtemp(path.join(tmpdir(), `capsule-merge-${label}-`));
+  const archivePath = path.join(tmp, `${label}.capsule.json.gz`);
+  await writeFile(archivePath, buf);
+  return archivePath;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Non-conflicting merge equals union of both trees
+// ---------------------------------------------------------------------------
+
+test("non-conflicting merge: result is the union of archive and target", async () => {
+  // Archive has facts/a.md and facts/b.md.
+  // Target already has facts/c.md (not in archive).
+  // All three should be present in target after merge.
+
+  const archivePath = await exportFixtures(
+    [
+      { rel: "facts/a.md", content: "---\nid: a\n---\nbody-a\n" },
+      { rel: "facts/b.md", content: "---\nid: b\n---\nbody-b\n" },
+    ],
+    "union-cap",
+  );
+
+  const dst = await makeTargetDir([
+    { rel: "facts/c.md", content: "---\nid: c\n---\nbody-c\n" },
+  ]);
+
+  const result = await mergeCapsule({ sourceArchive: archivePath, targetRoot: dst });
+
+  assert.equal(result.merged.length, 2, "both archive files should be written");
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.conflicts.length, 0);
+
+  const files = await listFiles(dst);
+  assert.ok(files.includes("facts/a.md"), "facts/a.md should be present");
+  assert.ok(files.includes("facts/b.md"), "facts/b.md should be present");
+  assert.ok(files.includes("facts/c.md"), "facts/c.md should still be present");
+
+  // Verify archive content landed correctly.
+  const aContent = await readFile(path.join(dst, "facts", "a.md"), "utf-8");
+  assert.equal(aContent, "---\nid: a\n---\nbody-a\n");
+
+  // Local-only file is untouched.
+  const cContent = await readFile(path.join(dst, "facts", "c.md"), "utf-8");
+  assert.equal(cContent, "---\nid: c\n---\nbody-c\n");
+
+  // merged list is sorted by sourcePath.
+  assert.deepEqual(
+    result.merged.map((r) => r.sourcePath),
+    ["facts/a.md", "facts/b.md"],
+  );
+});
+
+test("non-conflicting merge: empty target receives all archive files", async () => {
+  const archivePath = await exportFixtures(
+    [
+      { rel: "profile.md", content: "# profile\n" },
+      { rel: "facts/x.md", content: "x\n" },
+    ],
+    "empty-dst-cap",
+  );
+  const dst = await makeTargetDir();
+
+  const result = await mergeCapsule({ sourceArchive: archivePath, targetRoot: dst });
+
+  assert.equal(result.merged.length, 2);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.conflicts.length, 0);
+  assert.equal(result.manifest.capsule.id, "empty-dst-cap");
+});
+
+// ---------------------------------------------------------------------------
+// 2. skip-conflicts mode preserves local for conflicts
+// ---------------------------------------------------------------------------
+
+test("skip-conflicts mode: keeps local copy for conflicts, writes non-conflicting entries", async () => {
+  // Archive: facts/a.md (different content from local), facts/b.md (new).
+  // Target: facts/a.md (pre-existing with different content).
+  const archiveBuf = makeBundle("skip-cap", [
+    { path: "facts/a.md", content: "archive-a-content\n" },
+    { path: "facts/b.md", content: "archive-b-content\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "skip-conflicts");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/a.md", content: "local-a-content\n" },
+  ]);
+
+  const result = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "skip-conflicts",
+  });
+
+  // facts/a.md is a conflict → skipped; facts/b.md is new → merged.
+  assert.equal(result.merged.length, 1);
+  assert.equal(result.merged[0].sourcePath, "facts/b.md");
+  assert.equal(result.skipped.length, 1);
+  assert.deepEqual(result.skipped[0], { path: "facts/a.md", reason: "conflict" });
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(result.conflicts[0].path, "facts/a.md");
+
+  // Local file is preserved.
+  const aContent = await readFile(path.join(dst, "facts", "a.md"), "utf-8");
+  assert.equal(aContent, "local-a-content\n", "skip-conflicts must not overwrite local");
+
+  // New file is present.
+  const bContent = await readFile(path.join(dst, "facts", "b.md"), "utf-8");
+  assert.equal(bContent, "archive-b-content\n");
+});
+
+test("skip-conflicts is the default mode when conflictMode is omitted", async () => {
+  const archiveBuf = makeBundle("skip-default-cap", [
+    { path: "facts/a.md", content: "from-archive\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "skip-default");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/a.md", content: "local-version\n" },
+  ]);
+
+  // No conflictMode specified — should default to skip-conflicts.
+  const result = await mergeCapsule({ sourceArchive: archivePath, targetRoot: dst });
+
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(result.skipped.length, 1);
+  assert.deepEqual(result.skipped[0], { path: "facts/a.md", reason: "conflict" });
+
+  const content = await readFile(path.join(dst, "facts", "a.md"), "utf-8");
+  assert.equal(content, "local-version\n", "default mode must not overwrite");
+});
+
+// ---------------------------------------------------------------------------
+// 3. prefer-source overwrites local
+// ---------------------------------------------------------------------------
+
+test("prefer-source mode: overwrites local with archive content", async () => {
+  const archiveBuf = makeBundle("prefer-src-cap", [
+    { path: "facts/a.md", content: "archive-wins\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "prefer-source");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/a.md", content: "local-loses\n" },
+  ]);
+
+  const result = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "prefer-source",
+  });
+
+  assert.equal(result.merged.length, 1);
+  assert.equal(result.skipped.length, 0);
+  assert.equal(result.conflicts.length, 1);
+  assert.equal(result.merged[0].sourcePath, "facts/a.md");
+  assert.equal(result.merged[0].snapshotted, false, "no versioning config → no snapshot");
+
+  const content = await readFile(path.join(dst, "facts", "a.md"), "utf-8");
+  assert.equal(content, "archive-wins\n");
+});
+
+test("prefer-source with versioning: snapshots local before overwriting", async () => {
+  const archiveBuf = makeBundle("prefer-src-snap-cap", [
+    { path: "facts/snap.md", content: "new-from-archive\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "prefer-source-snap");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/snap.md", content: "old-local-content\n" },
+  ]);
+
+  const versioning = {
+    enabled: true,
+    maxVersionsPerPage: 10,
+    sidecarDir: ".versions",
+  };
+
+  const result = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "prefer-source",
+    versioning,
+  });
+
+  assert.equal(result.merged.length, 1);
+  assert.equal(result.merged[0].snapshotted, true);
+
+  // New content is in place.
+  const content = await readFile(path.join(dst, "facts", "snap.md"), "utf-8");
+  assert.equal(content, "new-from-archive\n");
+
+  // Page-versioning sidecar holds the prior (old) content.
+  const history = await listVersions(
+    path.join(dst, "facts", "snap.md"),
+    versioning,
+    dst,
+  );
+  assert.equal(history.versions.length, 1, "expected one snapshot");
+  const snap = history.versions[0];
+  assert.equal(snap.trigger, "manual");
+  assert.match(snap.note ?? "", /capsule-merge: prefer-src-snap-cap/);
+
+  const snapFile = path.join(
+    dst,
+    ".versions",
+    "facts__snap",
+    `${snap.versionId}.md`,
+  );
+  const snapContent = await readFile(snapFile, "utf-8");
+  assert.equal(snapContent, "old-local-content\n");
+});
+
+// ---------------------------------------------------------------------------
+// 4. prefer-local skips archive entries that conflict
+// ---------------------------------------------------------------------------
+
+test("prefer-local mode: skips archive entries for conflicts, keeps local", async () => {
+  const archiveBuf = makeBundle("prefer-local-cap", [
+    { path: "facts/a.md", content: "archive-version\n" },
+    { path: "facts/b.md", content: "only-in-archive\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "prefer-local");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/a.md", content: "local-version\n" },
+  ]);
+
+  const result = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "prefer-local",
+  });
+
+  // facts/a.md conflicts → skipped (prefer-local keeps local).
+  // facts/b.md is new → merged.
+  assert.equal(result.merged.length, 1);
+  assert.equal(result.merged[0].sourcePath, "facts/b.md");
+  assert.equal(result.skipped.length, 1);
+  assert.deepEqual(result.skipped[0], { path: "facts/a.md", reason: "conflict" });
+  assert.equal(result.conflicts.length, 1);
+
+  const aContent = await readFile(path.join(dst, "facts", "a.md"), "utf-8");
+  assert.equal(aContent, "local-version\n", "prefer-local must not overwrite");
+
+  const bContent = await readFile(path.join(dst, "facts", "b.md"), "utf-8");
+  assert.equal(bContent, "only-in-archive\n");
+});
+
+// ---------------------------------------------------------------------------
+// 5. Reject invalid conflictMode
+// ---------------------------------------------------------------------------
+
+test("invalid conflictMode is rejected before any write", async () => {
+  const archiveBuf = makeBundle("bad-mode-cap", [
+    { path: "facts/a.md", content: "a\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "bad-mode");
+
+  const dst = await makeTargetDir();
+
+  await assert.rejects(
+    // @ts-expect-error — intentionally passing invalid conflictMode for runtime guard test
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: dst, conflictMode: "do-whatever" }),
+    /unknown conflictMode/i,
+  );
+
+  // No files written.
+  const files = await listFiles(dst);
+  assert.deepEqual(files, []);
+});
+
+// ---------------------------------------------------------------------------
+// 6. Identical files are skipped (not re-written)
+// ---------------------------------------------------------------------------
+
+test("identical files (same content hash) are skipped with reason 'identical'", async () => {
+  const content = "---\nid: same\n---\nidentical body\n";
+  const archiveBuf = makeBundle("identical-cap", [
+    { path: "facts/same.md", content },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "identical");
+
+  // Target already has the same file with identical content.
+  const dst = await makeTargetDir([{ rel: "facts/same.md", content }]);
+
+  const result = await mergeCapsule({ sourceArchive: archivePath, targetRoot: dst });
+
+  assert.equal(result.merged.length, 0);
+  assert.equal(result.skipped.length, 1);
+  assert.deepEqual(result.skipped[0], { path: "facts/same.md", reason: "identical" });
+  assert.equal(result.conflicts.length, 0, "identical files are not conflicts");
+});
+
+// ---------------------------------------------------------------------------
+// 7. conflicts list is populated for ALL modes (not just prefer-source)
+// ---------------------------------------------------------------------------
+
+test("conflicts list is populated regardless of mode", async () => {
+  const archiveBuf = makeBundle("conflict-list-cap", [
+    { path: "facts/a.md", content: "archive-a\n" },
+    { path: "facts/b.md", content: "archive-b\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "conflict-list");
+
+  const dst = await makeTargetDir([
+    { rel: "facts/a.md", content: "local-a\n" },
+    { rel: "facts/b.md", content: "local-b\n" },
+  ]);
+
+  for (const mode of ["skip-conflicts", "prefer-local"] as const) {
+    const dstCopy = await makeTargetDir([
+      { rel: "facts/a.md", content: "local-a\n" },
+      { rel: "facts/b.md", content: "local-b\n" },
+    ]);
+    const result = await mergeCapsule({
+      sourceArchive: archivePath,
+      targetRoot: dstCopy,
+      conflictMode: mode,
+    });
+    assert.equal(
+      result.conflicts.length,
+      2,
+      `mode=${mode} should report 2 conflicts`,
+    );
+  }
+
+  // prefer-source should also list them.
+  const result3 = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "prefer-source",
+  });
+  assert.equal(result3.conflicts.length, 2);
+});
+
+// ---------------------------------------------------------------------------
+// 8. V1 archive is rejected
+// ---------------------------------------------------------------------------
+
+test("V1 archive is rejected (merge requires V2)", async () => {
+  const v1Bundle = {
+    manifest: {
+      format: "openclaw-engram-export" as const,
+      schemaVersion: 1 as const,
+      createdAt: "2026-04-26T00:00:00.000Z",
+      pluginVersion: "9.9.9",
+      includesTranscripts: false,
+      files: [
+        {
+          path: "facts/a.md",
+          sha256: sha256String("a\n").sha256,
+          bytes: 2,
+        },
+      ],
+    },
+    records: [{ path: "facts/a.md", content: "a\n" }],
+  };
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-merge-v1-"));
+  const archivePath = path.join(tmp, "v1.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify(v1Bundle), "utf-8")));
+
+  const dst = await makeTargetDir();
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: dst }),
+    /V2 capsule archives|V1/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 9. Checksum mismatch aborts before any write
+// ---------------------------------------------------------------------------
+
+test("corrupted archive (sha256 mismatch) is rejected before any write", async () => {
+  const archivePath = await exportFixtures(
+    [{ rel: "facts/a.md", content: "good\n" }],
+    "corrupt-merge-cap",
+  );
+
+  // Decode → tamper → re-encode.
+  const { gunzipSync } = await import("node:zlib");
+  const raw = await readFile(archivePath);
+  const bundle = JSON.parse(gunzipSync(raw).toString("utf-8")) as {
+    records: Array<{ path: string; content: string }>;
+  };
+  bundle.records[0].content = "tampered\n";
+  const tamperedPath = archivePath + ".tampered.json.gz";
+  await writeFile(tamperedPath, gzipSync(Buffer.from(JSON.stringify(bundle), "utf-8")));
+
+  const dst = await makeTargetDir();
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: tamperedPath, targetRoot: dst }),
+    /checksum mismatch/i,
+  );
+  assert.deepEqual(await listFiles(dst), []);
+});
+
+// ---------------------------------------------------------------------------
+// 10. Non-directory targetRoot is rejected
+// ---------------------------------------------------------------------------
+
+test("non-directory targetRoot is rejected", async () => {
+  const archiveBuf = makeBundle("bad-root-cap", [{ path: "facts/a.md", content: "a\n" }]);
+  const archivePath = await writeBundleArchive(archiveBuf, "bad-root");
+
+  const tmp = await mkdtemp(path.join(tmpdir(), "capsule-merge-bad-root-"));
+  const filePath = path.join(tmp, "not-a-dir");
+  await writeFile(filePath, "x", "utf-8");
+
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: filePath }),
+    /must be an existing directory/i,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 11. Path-traversal in record paths is rejected
+// ---------------------------------------------------------------------------
+
+test("path traversal in record paths is rejected before any write", async () => {
+  const content = "evil\n";
+  const buf = makeBundle("traverse-cap", [{ path: "../escape.md", content }]);
+  const archivePath = await writeBundleArchive(buf, "traverse");
+
+  const dst = await makeTargetDir();
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: dst }),
+    /escapes target root/i,
+  );
+  assert.deepEqual(await listFiles(dst), []);
+});
+
+// ---------------------------------------------------------------------------
+// 12. Output lists are sorted for determinism
+// ---------------------------------------------------------------------------
+
+test("merged and skipped lists are sorted by path regardless of bundle order", async () => {
+  // Archive: z.md, a.md, m.md (deliberately non-sorted in bundle).
+  const buf = makeBundle("sort-cap", [
+    { path: "z.md", content: "z\n" },
+    { path: "a.md", content: "a\n" },
+    { path: "m.md", content: "m\n" },
+  ]);
+  const archivePath = await writeBundleArchive(buf, "sort");
+  const dst = await makeTargetDir();
+
+  const result = await mergeCapsule({ sourceArchive: archivePath, targetRoot: dst });
+
+  assert.deepEqual(
+    result.merged.map((r) => r.sourcePath),
+    ["a.md", "m.md", "z.md"],
+  );
+});
+
+// ---------------------------------------------------------------------------
+// 13. Symlinked targetRoot is rejected
+// ---------------------------------------------------------------------------
+
+test("symlinked targetRoot is rejected", async () => {
+  const realDir = await mkdtemp(path.join(tmpdir(), "capsule-merge-real-"));
+  const holder = await mkdtemp(path.join(tmpdir(), "capsule-merge-holder-"));
+  const symlinkRoot = path.join(holder, "symlinked-root");
+  await symlink(realDir, symlinkRoot, "dir");
+
+  const archiveBuf = makeBundle("symlink-root-cap", [
+    { path: "facts/a.md", content: "a\n" },
+  ]);
+  const archivePath = await writeBundleArchive(archiveBuf, "symlink-root");
+
+  await assert.rejects(
+    mergeCapsule({ sourceArchive: archivePath, targetRoot: symlinkRoot }),
+    /must not be a symlink/i,
+  );
+
+  assert.deepEqual(await listFiles(realDir), []);
+});
+
+// ---------------------------------------------------------------------------
+// 14. conflicts.archiveSha256 and localSha256 are accurate
+// ---------------------------------------------------------------------------
+
+test("conflict record contains accurate sha256 values for both sides", async () => {
+  const archiveContent = "from-archive\n";
+  const localContent = "from-local\n";
+
+  const buf = makeBundle("sha-cap", [
+    { path: "facts/a.md", content: archiveContent },
+  ]);
+  const archivePath = await writeBundleArchive(buf, "sha256-check");
+  const dst = await makeTargetDir([{ rel: "facts/a.md", content: localContent }]);
+
+  const result = await mergeCapsule({
+    sourceArchive: archivePath,
+    targetRoot: dst,
+    conflictMode: "skip-conflicts",
+  });
+
+  assert.equal(result.conflicts.length, 1);
+  const c = result.conflicts[0];
+  assert.equal(c.archiveSha256, sha256String(archiveContent).sha256);
+  assert.equal(c.localSha256, sha256String(localContent).sha256);
+});


### PR DESCRIPTION
## Summary

- Adds `mergeCapsule(opts: { sourceArchive, targetRoot, conflictMode? })` in `packages/remnic-core/src/transfer/capsule-merge.ts` returning `{ merged, skipped, conflicts, manifest }`.
- Three conflict modes: `"skip-conflicts"` (default), `"prefer-source"` (overwrite with page-versioning snapshot per gotcha #54), `"prefer-local"` (keep local).
- A conflict is: same relative path exists in both archive and target with a differing content hash. Byte-identical entries are skipped as `"identical"` (not conflicts).
- Reuses the same security hardening as `importCapsule`: pre-write checksum verification, path-traversal rejection, symlink-aware containment, symlinked-root rejection, V1 archive rejection.
- 17 tests in `tests/transfer/capsule-merge.test.ts` covering all required scenarios.

## Test plan

- [x] All 17 new tests pass (`npx tsx --test tests/transfer/capsule-merge.test.ts`)
- [x] Existing 72 transfer/capsule tests unaffected
- [x] TypeScript: `tsc --noEmit` passes with zero errors
- [ ] non-conflicting merge equals union of both trees
- [ ] skip-conflicts preserves local for conflicts, writes non-conflicting entries
- [ ] prefer-source overwrites local (with snapshot when versioning enabled)
- [ ] prefer-local skips archive entries that conflict
- [ ] invalid conflictMode rejected before any write
- [ ] identical-content files skipped as `"identical"` (not conflicts)
- [ ] conflicts list populated for all modes
- [ ] security: V1 archive rejected, checksum mismatch aborts before write, path traversal rejected, symlinked root rejected

## PR checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] No secrets or credentials committed
- [x] PR diff is narrowly scoped (two new files only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because this introduces new filesystem-writing merge behavior and refactors security-critical path/symlink validation into shared helpers used by import/merge.
> 
> **Overview**
> Adds `mergeCapsule` to merge a V2 capsule archive into an existing target directory with three conflict modes (`skip-conflicts` default, `prefer-source` with optional page-version snapshotting, and `prefer-local`), returning deterministic `merged`/`skipped`/`conflicts` results.
> 
> Refactors security-critical path validation helpers into `fs-utils` and updates `importCapsule` to use them (non-symlink root requirement and symlink-aware containment checks with consistent error prefixes).
> 
> Introduces comprehensive tests covering merge semantics, deterministic ordering, and hardening cases (V1 rejection, checksum mismatch, traversal attempts, symlink targets/roots, and normalized-path collisions).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 508c3358acc0a2cd46e35233a227310a76165f62. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->