### PR TITLE
feat(connectors): GitHub notes connector (issue #683 PR 5/6)

### DIFF
--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -777,6 +777,49 @@
                 "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
               }
             }
+          },
+          "github": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
+              },
+              "userLogin": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
+              },
+              "repos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "includeDiscussions": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
+              }
+            }
           }
         }
       },

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -777,6 +777,49 @@
                 "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
               }
             }
+          },
+          "github": {
+            "type": "object",
+            "additionalProperties": false,
+            "default": {},
+            "description": "GitHub live connector (issue #683 PR 5/6). Imports issue comments, PR review comments, and optionally discussion posts authored by the configured user from watched repos into Remnic on a poll schedule.",
+            "properties": {
+              "enabled": {
+                "type": "boolean",
+                "default": false,
+                "description": "Master gate. Default off — set to true to enable GitHub imports. The connector additionally requires token, userLogin, and at least one repo to be populated before it will run."
+              },
+              "token": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub personal access token. Populate from your secret store (e.g. ${GITHUB_TOKEN}). Never commit a real value to source."
+              },
+              "userLogin": {
+                "type": "string",
+                "default": "",
+                "description": "GitHub login of the user whose comments will be imported. Only comments authored by this login are ingested. Required when enabled."
+              },
+              "repos": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "default": [],
+                "description": "Array of repos to poll in \"owner/repo\" format. Empty = connector is a no-op."
+              },
+              "pollIntervalMs": {
+                "type": "integer",
+                "minimum": 1000,
+                "maximum": 86400000,
+                "default": 300000,
+                "description": "How often the scheduler should call the connector's syncIncremental, in milliseconds. Defaults to 5 minutes; max 24 hours."
+              },
+              "includeDiscussions": {
+                "type": "boolean",
+                "default": false,
+                "description": "Whether to import GitHub Discussion comments in addition to issue and PR review comments. Default false."
+              }
+            }
           }
         }
       },

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -2652,6 +2652,65 @@ export function parseConfig(raw: unknown): PluginConfig {
           notionDatabaseIds.push(trimmed);
         }
       }
+      // github (#683 PR 5/6)
+      if (
+        rawConnectors.github !== undefined &&
+        (rawConnectors.github === null ||
+          typeof rawConnectors.github !== "object" ||
+          Array.isArray(rawConnectors.github))
+      ) {
+        throw new Error(
+          `connectors.github must be an object (got ${JSON.stringify(rawConnectors.github)}).`,
+        );
+      }
+      const rawGitHub =
+        rawConnectors.github &&
+        typeof rawConnectors.github === "object" &&
+        !Array.isArray(rawConnectors.github)
+          ? (rawConnectors.github as Record<string, unknown>)
+          : {};
+      const githubEnabled = coerceBool(rawGitHub.enabled) === true;
+      const githubToken =
+        typeof rawGitHub.token === "string" ? rawGitHub.token : "";
+      const githubUserLogin =
+        typeof rawGitHub.userLogin === "string" ? rawGitHub.userLogin : "";
+      const githubPollCoerced = coerceNumber(rawGitHub.pollIntervalMs);
+      let githubPollIntervalMs = 300_000;
+      if (githubPollCoerced !== undefined) {
+        if (
+          !Number.isFinite(githubPollCoerced) ||
+          !Number.isInteger(githubPollCoerced) ||
+          githubPollCoerced < 1_000 ||
+          githubPollCoerced > 86_400_000
+        ) {
+          throw new Error(
+            `connectors.github.pollIntervalMs must be an integer in [1000, 86400000] ms (got ${JSON.stringify(rawGitHub.pollIntervalMs)})`,
+          );
+        }
+        githubPollIntervalMs = githubPollCoerced;
+      }
+      let githubRepos: string[] = [];
+      if (rawGitHub.repos !== undefined) {
+        if (!Array.isArray(rawGitHub.repos)) {
+          throw new Error(
+            `connectors.github.repos must be an array of strings (got ${typeof rawGitHub.repos})`,
+          );
+        }
+        const seen = new Set<string>();
+        for (const value of rawGitHub.repos) {
+          if (typeof value !== "string") {
+            throw new Error(
+              `connectors.github.repos entries must be strings; found ${typeof value}`,
+            );
+          }
+          const trimmed = value.trim();
+          if (trimmed.length === 0) continue;
+          if (seen.has(trimmed)) continue;
+          seen.add(trimmed);
+          githubRepos.push(trimmed);
+        }
+      }
+      const githubIncludeDiscussions = coerceBool(rawGitHub.includeDiscussions) === true;
       return {
         googleDrive: {
           enabled: driveEnabled,
@@ -2666,6 +2725,14 @@ export function parseConfig(raw: unknown): PluginConfig {
           token: notionToken,
           databaseIds: notionDatabaseIds,
           pollIntervalMs: notionPollIntervalMs,
+        },
+        github: {
+          enabled: githubEnabled,
+          token: githubToken,
+          userLogin: githubUserLogin,
+          repos: githubRepos,
+          pollIntervalMs: githubPollIntervalMs,
+          includeDiscussions: githubIncludeDiscussions,
         },
       };
     })(),

--- a/packages/remnic-core/src/connectors/live/github.test.ts
+++ b/packages/remnic-core/src/connectors/live/github.test.ts
@@ -869,3 +869,231 @@ test("watermark advances for non-matching-author and empty comments so they aren
   const payload = JSON.parse(result.nextCursor.value) as { watermarks: Record<string, string> };
   assert.equal(payload.watermarks[`${REPO_A}/issue-comment`], "2026-04-26T09:00:00.000Z");
 });
+
+// ---------------------------------------------------------------------------
+// P1 fix: Same-timestamp dedup via seenIds (PRRT_kwDORJXyws59sfBq)
+// ---------------------------------------------------------------------------
+
+test("seenIds are stored in cursor for ingested comments at the watermark second", async () => {
+  // Two comments with the same second-level timestamp. Both are new (above watermark).
+  const c1 = makeComment(10, SYNTHETIC_LOGIN, "first comment", "2026-04-26T10:00:00.000Z");
+  const c2 = makeComment(11, SYNTHETIC_LOGIN, "second comment", "2026-04-26T10:00:00.500Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [c1, c2] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({
+    [`${REPO_A}/issue-comment`]: "2026-04-26T09:00:00.000Z",
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.equal(result.newDocs.length, 2);
+
+  const payload = JSON.parse(result.nextCursor.value) as {
+    watermarks: Record<string, string>;
+    seenIds: Record<string, string>;
+  };
+  // seenIds must contain both ingested comment ids.
+  assert.ok(
+    `${REPO_A}/issue-comment/10` in payload.seenIds,
+    "seenIds must include comment 10",
+  );
+  assert.ok(
+    `${REPO_A}/issue-comment/11` in payload.seenIds,
+    "seenIds must include comment 11",
+  );
+});
+
+test("seenIds prevent re-importing same-second comments on the next poll", async () => {
+  // Scenario: c1 was ingested on the previous pass and is recorded in seenIds.
+  // On this poll GitHub re-returns it (inclusive `since=` at the watermark
+  // second). It must be skipped without emitting a new document.
+  const ts = "2026-04-26T10:00:00.000Z";
+  const c1 = makeComment(10, SYNTHETIC_LOGIN, "already imported", ts);
+  const c2 = makeComment(12, SYNTHETIC_LOGIN, "new this poll", "2026-04-26T10:00:01.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [c1, c2] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  // Cursor encodes the watermark at c1's timestamp AND c1 already in seenIds.
+  const cursor: import("./framework.js").ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({
+      watermarks: { [`${REPO_A}/issue-comment`]: ts },
+      seenIds: { [`${REPO_A}/issue-comment/10`]: ts },
+    }),
+    updatedAt: "2026-04-26T10:00:00.000Z",
+  };
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  // c1 must be skipped (in seenIds); only c2 should be imported.
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/12`);
+});
+
+test("seenIds are cleared when the watermark advances past a second boundary", async () => {
+  // Previous cursor has seenIds entries at the old second.
+  // After ingesting c2 which is in a new second, seenIds must be cleared.
+  const oldTs = "2026-04-26T10:00:00.000Z";
+  const newTs = "2026-04-26T10:00:01.000Z";
+  const c1Old = makeComment(10, SYNTHETIC_LOGIN, "old second item", oldTs);
+  const c2New = makeComment(20, SYNTHETIC_LOGIN, "new second item", newTs);
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [c1Old, c2New] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  // Cursor: watermark is at oldTs, seenIds contains c1Old's id.
+  const cursor: import("./framework.js").ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({
+      watermarks: { [`${REPO_A}/issue-comment`]: oldTs },
+      seenIds: { [`${REPO_A}/issue-comment/10`]: oldTs },
+    }),
+    updatedAt: oldTs,
+  };
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  // c1Old is in seenIds → skipped. c2New (above watermark) → imported.
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/20`);
+
+  const payload = JSON.parse(result.nextCursor.value) as {
+    watermarks: Record<string, string>;
+    seenIds: Record<string, string>;
+  };
+  // Watermark must have advanced to the new second.
+  assert.equal(payload.watermarks[`${REPO_A}/issue-comment`], newTs);
+  // seenIds for c1Old must be cleared (watermark crossed the second boundary).
+  assert.ok(
+    !(`${REPO_A}/issue-comment/10` in payload.seenIds),
+    "stale seenId from old second must be cleared",
+  );
+  // c2New must be in the fresh seenIds.
+  assert.ok(
+    `${REPO_A}/issue-comment/20` in payload.seenIds,
+    "new-second comment must be in seenIds",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// P1 fix: Skip-aware budget — skipped records don't consume the cap
+// (PRRT_kwDORJXyws59sfBs)
+// ---------------------------------------------------------------------------
+
+test("skipped (wrong-author) records do not consume the per-pass budget", async () => {
+  // Build MAX_ITEMS_PER_PASS wrong-author comments followed by one valid one.
+  // The budget should NOT be exhausted by the skipped ones, so the valid
+  // comment at the end must still be ingested.
+  const MAX = 200; // matches MAX_ITEMS_PER_PASS constant
+  const skippedComments = Array.from({ length: MAX }, (_, i) =>
+    makeComment(1000 + i, "other-user", `not mine ${i}`, `2026-04-26T09:00:${String(i).padStart(2, "0")}.000Z`),
+  );
+  const validComment = makeComment(9999, SYNTHETIC_LOGIN, "mine", "2026-04-26T09:05:00.000Z");
+
+  // All comments returned on first page (we return MAX+1 items so pagination
+  // doesn't trigger — but since GITHUB_PAGE_SIZE=100 we need to simulate
+  // multiple pages).  Simpler: just return one page with all items (>100),
+  // but since the page-size check caps at 100 we'll use a single page of
+  // exactly the right set. Instead use a simpler approach: return the skipped
+  // comments as 2 pages of 100, then the valid comment on a "short" 3rd page.
+  let callCount = 0;
+  const issuePages: (typeof skippedComments)[] = [
+    skippedComments.slice(0, 100),
+    skippedComments.slice(100, 200),
+    [validComment],
+  ];
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => {
+        const page = issuePages[callCount] ?? [];
+        callCount++;
+        return { status: 200, data: page };
+      },
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+
+  // The valid comment must be imported despite all the skipped ones.
+  assert.equal(
+    result.newDocs.length,
+    1,
+    "the valid comment must not be starved by budget-consuming skipped items",
+  );
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/9999`);
+  assert.equal(result.skippedOtherAuthor, MAX);
+});
+
+test("skipped (empty-body) records do not consume the per-pass budget", async () => {
+  // 5 empty-body comments followed by 3 valid ones within a budget of 3.
+  const emptyComments = Array.from({ length: 5 }, (_, i) =>
+    makeComment(200 + i, SYNTHETIC_LOGIN, "", `2026-04-26T09:00:0${i}.000Z`),
+  );
+  const validComments = Array.from({ length: 3 }, (_, i) =>
+    makeComment(300 + i, SYNTHETIC_LOGIN, `valid ${i}`, `2026-04-26T09:01:0${i}.000Z`),
+  );
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [...emptyComments, ...validComments] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  // Use a budget of 3. With the old (buggy) code, the 5 empty comments would
+  // exhaust the budget before reaching the valid ones.
+  // We can't set MAX_ITEMS_PER_PASS directly; instead verify that with the
+  // default budget all 3 valid comments are imported.
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+
+  assert.equal(result.newDocs.length, 3, "all 3 valid comments must be imported");
+  assert.equal(result.skippedEmpty, 5);
+});

--- a/packages/remnic-core/src/connectors/live/github.test.ts
+++ b/packages/remnic-core/src/connectors/live/github.test.ts
@@ -486,15 +486,24 @@ test("incremental sync advances watermark after importing comments", async () =>
   assert.equal(payload.watermarks[`${REPO_A}/issue-comment`], "2026-04-26T10:00:00.000Z");
 });
 
-test("incremental sync skips items at or before the watermark", async () => {
-  // Comment with updated_at equal to the watermark should be skipped.
-  const staleComment = makeComment(1, SYNTHETIC_LOGIN, "old", "2026-04-25T00:00:00.000Z");
-  const newComment = makeComment(2, SYNTHETIC_LOGIN, "new", "2026-04-26T09:00:00.000Z");
+test("incremental sync skips items strictly before the watermark", async () => {
+  // Only comments whose updated_at is STRICTLY before the watermark are
+  // dropped by the filter. A comment AT the watermark second passes through
+  // to the seenIds check (and, if not in seenIds, is ingested). A comment
+  // one second after the watermark is always ingested.
+  //
+  // "beforeComment" has a timestamp 1 second before the watermark → skipped.
+  // "atComment" is AT the watermark second and NOT in seenIds → ingested.
+  // "afterComment" is after the watermark → ingested.
+  const watermark = "2026-04-25T00:00:01.000Z";
+  const beforeComment = makeComment(1, SYNTHETIC_LOGIN, "before", "2026-04-25T00:00:00.000Z");
+  const atComment = makeComment(2, SYNTHETIC_LOGIN, "at watermark", watermark);
+  const afterComment = makeComment(3, SYNTHETIC_LOGIN, "after", "2026-04-25T00:00:02.000Z");
 
   const fetchFn = makeFetch([
     {
       match: (url) => url.includes("/issues/comments"),
-      respond: () => ({ status: 200, data: [staleComment, newComment] }),
+      respond: () => ({ status: 200, data: [beforeComment, atComment, afterComment] }),
     },
     {
       match: (url) => url.includes("/pulls/comments"),
@@ -504,13 +513,24 @@ test("incremental sync skips items at or before the watermark", async () => {
 
   const connector = createGitHubConnector({ fetchFn });
   const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
-  const cursor = makeGitHubCursor({
-    [`${REPO_A}/issue-comment`]: "2026-04-25T00:00:00.000Z",
-  });
+  // Cursor watermark at exactly the "at" second; seenIds is empty.
+  const cursor: import("./framework.js").ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({
+      watermarks: { [`${REPO_A}/issue-comment`]: watermark },
+      seenIds: {},
+    }),
+    updatedAt: watermark,
+  };
 
   const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
-  assert.equal(result.newDocs.length, 1);
-  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/2`);
+  // beforeComment is strictly before the watermark → skipped.
+  // atComment is AT the watermark and not in seenIds → ingested.
+  // afterComment is after the watermark → ingested.
+  assert.equal(result.newDocs.length, 2);
+  const ids = result.newDocs.map((d) => d.source.externalId);
+  assert.ok(ids.includes(`${REPO_A}/issue-comment/2`), "atComment must be ingested");
+  assert.ok(ids.includes(`${REPO_A}/issue-comment/3`), "afterComment must be ingested");
 });
 
 // ---------------------------------------------------------------------------
@@ -1096,4 +1116,103 @@ test("skipped (empty-body) records do not consume the per-pass budget", async ()
 
   assert.equal(result.newDocs.length, 3, "all 3 valid comments must be imported");
   assert.equal(result.skippedEmpty, 5);
+});
+
+// ---------------------------------------------------------------------------
+// Regression: strict watermark filter (<, not <=) + timestamp-gated seenIds
+// Fixes: Cursor High finding (watermark boundary), Codex P1 finding (seenIds).
+// ---------------------------------------------------------------------------
+
+test("watermark uses strict < so boundary-second comments pass through to seenIds", async () => {
+  // Scenario: The cursor watermark is set to T. On the next poll GitHub's
+  // `since=T` filter re-returns any comment whose updated_at equals T
+  // (GitHub's `since` parameter is inclusive). With the old `<=` filter these
+  // were silently dropped before seenIds could distinguish them. This test
+  // verifies the `<` fix: a comment AT exactly the watermark second that is
+  // NOT in seenIds must be ingested.
+  const ts = "2026-04-26T12:00:00.000Z";
+  // commentAtTs is at the exact watermark second but was NOT ingested before.
+  const commentAtTs = makeComment(42, SYNTHETIC_LOGIN, "exactly at watermark", ts);
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [commentAtTs] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  // Cursor watermark is AT ts; seenIds is empty (comment was NOT previously seen).
+  const cursor: import("./framework.js").ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({
+      watermarks: { [`${REPO_A}/issue-comment`]: ts },
+      seenIds: {},
+    }),
+    updatedAt: ts,
+  };
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  // With `<` fix: commentAtTs is NOT before the watermark, NOT in seenIds →
+  // must be ingested. With old `<=` it would have been silently dropped.
+  assert.equal(
+    result.newDocs.length,
+    1,
+    "comment exactly at watermark second must be ingested when not in seenIds",
+  );
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/42`);
+});
+
+test("seenIds check gates on (id + timestamp), not id alone", async () => {
+  // Scenario: A comment was previously imported at ts1. It is then edited and
+  // re-fetched at ts2 (same id, newer updated_at). With the old `!== undefined`
+  // check the edited version would be silently dropped. With the new
+  // `=== comment.updated_at` check only the exact (id, ts) pair is suppressed.
+  const ts1 = "2026-04-26T13:00:00.000Z";
+  const ts2 = "2026-04-26T13:00:01.000Z";
+  // Same id as the previously-ingested comment, but updated_at has advanced.
+  const editedComment = makeComment(77, SYNTHETIC_LOGIN, "edited body", ts2);
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [editedComment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  // Cursor records id 77 with ts1 in seenIds (the old ingested version).
+  // Watermark is at ts1 so the edited comment (ts2 > ts1) is above it.
+  const cursor: import("./framework.js").ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({
+      watermarks: { [`${REPO_A}/issue-comment`]: ts1 },
+      seenIds: { [`${REPO_A}/issue-comment/77`]: ts1 },
+    }),
+    updatedAt: ts1,
+  };
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  // The edited comment (same id, newer ts) must be ingested — seenIds only
+  // suppresses the (id, ts1) pair, not (id, ts2).
+  assert.equal(
+    result.newDocs.length,
+    1,
+    "edited comment with newer updated_at must not be suppressed by seenIds",
+  );
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/77`);
+  assert.ok(
+    result.newDocs[0].content.includes("edited body"),
+    "imported document must contain the new body",
+  );
 });

--- a/packages/remnic-core/src/connectors/live/github.test.ts
+++ b/packages/remnic-core/src/connectors/live/github.test.ts
@@ -1,0 +1,871 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  GITHUB_CONNECTOR_ID,
+  GITHUB_CURSOR_KIND,
+  GITHUB_DEFAULT_POLL_INTERVAL_MS,
+  createGitHubConnector,
+  isTransientGitHubError,
+  validateGitHubConfig,
+  type GitHubComment,
+  type GitHubFetchFn,
+  type GitHubSyncResult,
+} from "./github.js";
+import type { ConnectorCursor } from "./framework.js";
+
+/**
+ * Tests for the GitHub connector (#683 PR 5/6). All GitHub API calls are
+ * stubbed via the `fetchFn` test hook — the suite never touches the network.
+ *
+ * Per CLAUDE.md privacy rules: no real tokens, no real usernames, no real
+ * repo names. All inputs are obviously synthetic.
+ */
+
+// ---------------------------------------------------------------------------
+// Synthetic test data
+// ---------------------------------------------------------------------------
+
+const SYNTHETIC_TOKEN = "ghp_synthetic_token_DO_NOT_USE_0000000000000000";
+const SYNTHETIC_LOGIN = "synthetic-user";
+const REPO_A = "synthetic-org/repo-alpha";
+const REPO_B = "synthetic-org/repo-beta";
+
+const SYNTHETIC_CONFIG = Object.freeze({
+  token: SYNTHETIC_TOKEN,
+  userLogin: SYNTHETIC_LOGIN,
+  repos: [REPO_A],
+});
+
+function makeComment(
+  id: number,
+  login: string,
+  body: string,
+  updatedAt: string,
+  htmlUrl?: string,
+): GitHubComment {
+  return {
+    id,
+    body,
+    user: { login },
+    created_at: updatedAt,
+    updated_at: updatedAt,
+    html_url: htmlUrl ?? `https://github.com/${REPO_A}/issues/1#issuecomment-${id}`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Mock fetch builder
+// ---------------------------------------------------------------------------
+
+type HandlerEntry = {
+  match: (url: string) => boolean;
+  respond: (url: string) => { status: number; data: unknown };
+};
+
+function makeFetch(handlers: HandlerEntry[]): GitHubFetchFn {
+  return async (url) => {
+    for (const handler of handlers) {
+      if (handler.match(url)) {
+        const { status, data } = handler.respond(url);
+        return {
+          ok: status >= 200 && status < 300,
+          status,
+          headers: {
+            get: (_name: string) => null,
+          },
+          json: async () => data,
+        };
+      }
+    }
+    throw new Error(`fetch stub: no handler for ${url}`);
+  };
+}
+
+/** Returns an empty array for all API calls. */
+function emptyFetch(): GitHubFetchFn {
+  return makeFetch([
+    {
+      match: () => true,
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+}
+
+function makeGitHubCursor(watermarks: Record<string, string>): ConnectorCursor {
+  return {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify({ watermarks }),
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+test("validateGitHubConfig accepts a minimal valid config", () => {
+  const cfg = validateGitHubConfig({
+    token: SYNTHETIC_TOKEN,
+    userLogin: SYNTHETIC_LOGIN,
+  });
+  assert.equal(cfg.token, SYNTHETIC_TOKEN);
+  assert.equal(cfg.userLogin, SYNTHETIC_LOGIN);
+  assert.deepEqual([...cfg.repos], []);
+  assert.equal(cfg.pollIntervalMs, GITHUB_DEFAULT_POLL_INTERVAL_MS);
+  assert.equal(cfg.includeDiscussions, false);
+});
+
+test("validateGitHubConfig rejects non-object input", () => {
+  assert.throws(() => validateGitHubConfig(null), /must be an object/);
+  assert.throws(() => validateGitHubConfig([]), /must be an object/);
+  assert.throws(() => validateGitHubConfig("nope"), /must be an object/);
+});
+
+test("validateGitHubConfig rejects missing or empty token", () => {
+  assert.throws(() => validateGitHubConfig({ userLogin: SYNTHETIC_LOGIN }), /token must be a string/);
+  assert.throws(
+    () => validateGitHubConfig({ token: "", userLogin: SYNTHETIC_LOGIN }),
+    /token must be non-empty/,
+  );
+  assert.throws(
+    () => validateGitHubConfig({ token: "   ", userLogin: SYNTHETIC_LOGIN }),
+    /token must be non-empty/,
+  );
+});
+
+test("validateGitHubConfig rejects missing or empty userLogin", () => {
+  assert.throws(
+    () => validateGitHubConfig({ token: SYNTHETIC_TOKEN }),
+    /userLogin must be a string/,
+  );
+  assert.throws(
+    () => validateGitHubConfig({ token: SYNTHETIC_TOKEN, userLogin: "" }),
+    /userLogin must be non-empty/,
+  );
+});
+
+test("validateGitHubConfig rejects malformed pollIntervalMs", () => {
+  assert.throws(
+    () =>
+      validateGitHubConfig({ token: SYNTHETIC_TOKEN, userLogin: SYNTHETIC_LOGIN, pollIntervalMs: "300000" }),
+    /pollIntervalMs/,
+  );
+  assert.throws(
+    () =>
+      validateGitHubConfig({ token: SYNTHETIC_TOKEN, userLogin: SYNTHETIC_LOGIN, pollIntervalMs: 50 }),
+    /≥1000/,
+  );
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        pollIntervalMs: 25 * 60 * 60 * 1000,
+      }),
+    /≤/,
+  );
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        pollIntervalMs: 3000.5,
+      }),
+    /integer/,
+  );
+});
+
+test("validateGitHubConfig accepts valid repos in owner/repo format", () => {
+  const cfg = validateGitHubConfig({
+    token: SYNTHETIC_TOKEN,
+    userLogin: SYNTHETIC_LOGIN,
+    repos: [REPO_A, REPO_B],
+  });
+  assert.deepEqual([...cfg.repos], [REPO_A, REPO_B]);
+});
+
+test("validateGitHubConfig rejects malformed repo slugs", () => {
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        repos: ["no-slash"],
+      }),
+    /owner\/repo/,
+  );
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        repos: ["../../../etc/passwd"],
+      }),
+    /owner\/repo/,
+  );
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        repos: [42 as unknown as string],
+      }),
+    /repos entries must be strings/,
+  );
+});
+
+test("validateGitHubConfig deduplicates repos", () => {
+  const cfg = validateGitHubConfig({
+    token: SYNTHETIC_TOKEN,
+    userLogin: SYNTHETIC_LOGIN,
+    repos: [REPO_A, REPO_A, REPO_B],
+  });
+  assert.deepEqual([...cfg.repos], [REPO_A, REPO_B]);
+});
+
+test("validateGitHubConfig rejects non-boolean includeDiscussions", () => {
+  assert.throws(
+    () =>
+      validateGitHubConfig({
+        token: SYNTHETIC_TOKEN,
+        userLogin: SYNTHETIC_LOGIN,
+        includeDiscussions: "yes" as unknown as boolean,
+      }),
+    /includeDiscussions must be a boolean/,
+  );
+});
+
+test("validateGitHubConfig accepts includeDiscussions: true", () => {
+  const cfg = validateGitHubConfig({
+    token: SYNTHETIC_TOKEN,
+    userLogin: SYNTHETIC_LOGIN,
+    includeDiscussions: true,
+  });
+  assert.equal(cfg.includeDiscussions, true);
+});
+
+// ---------------------------------------------------------------------------
+// Connector identity
+// ---------------------------------------------------------------------------
+
+test("createGitHubConnector exposes the documented id and display name", () => {
+  const connector = createGitHubConnector({ fetchFn: emptyFetch() });
+  assert.equal(connector.id, GITHUB_CONNECTOR_ID);
+  assert.equal(connector.id, "github");
+  assert.equal(connector.displayName, "GitHub");
+});
+
+// ---------------------------------------------------------------------------
+// No-op when repos is empty
+// ---------------------------------------------------------------------------
+
+test("syncIncremental is a no-op when repos is empty", async () => {
+  let fetchCalled = false;
+  const fetchFn: GitHubFetchFn = async () => {
+    fetchCalled = true;
+    throw new Error("should not be called");
+  };
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ token: SYNTHETIC_TOKEN, userLogin: SYNTHETIC_LOGIN });
+
+  const r1 = (await connector.syncIncremental({ cursor: null, config })) as GitHubSyncResult;
+  assert.deepEqual(r1.newDocs, []);
+  assert.equal(r1.nextCursor.kind, GITHUB_CURSOR_KIND);
+  assert.equal(fetchCalled, false);
+
+  const r2 = (await connector.syncIncremental({
+    cursor: r1.nextCursor,
+    config,
+  })) as GitHubSyncResult;
+  assert.deepEqual(r2.newDocs, []);
+  assert.equal(fetchCalled, false);
+});
+
+// ---------------------------------------------------------------------------
+// First-sync bootstrap
+// ---------------------------------------------------------------------------
+
+test("first sync (cursor=null) seeds watermark and returns no docs", async () => {
+  const comment = makeComment(1, SYNTHETIC_LOGIN, "Hello", "2026-04-25T10:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      // issue comments seed
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [comment] }),
+    },
+    {
+      // PR review comments seed
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+
+  const result = (await connector.syncIncremental({ cursor: null, config })) as GitHubSyncResult;
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.nextCursor.kind, GITHUB_CURSOR_KIND);
+
+  // The cursor must record the watermark from the seeded comment.
+  const payload = JSON.parse(result.nextCursor.value) as { watermarks: Record<string, string> };
+  assert.equal(
+    payload.watermarks[`${REPO_A}/issue-comment`],
+    "2026-04-25T10:00:00.000Z",
+  );
+});
+
+test("first sync with empty API responses seeds empty cursor", async () => {
+  const connector = createGitHubConnector({ fetchFn: emptyFetch() });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+
+  const result = await connector.syncIncremental({ cursor: null, config });
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.nextCursor.kind, GITHUB_CURSOR_KIND);
+});
+
+// ---------------------------------------------------------------------------
+// Incremental sync: basic happy path
+// ---------------------------------------------------------------------------
+
+test("incremental sync emits ConnectorDocument for matching issue comments", async () => {
+  const comment = makeComment(
+    42,
+    SYNTHETIC_LOGIN,
+    "This is my note",
+    "2026-04-26T09:00:00.000Z",
+    `https://github.com/${REPO_A}/issues/10#issuecomment-42`,
+  );
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [comment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({
+    [`${REPO_A}/issue-comment`]: "2026-04-25T00:00:00.000Z",
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+
+  assert.equal(result.newDocs.length, 1);
+  const doc = result.newDocs[0];
+  assert.equal(doc.source.connector, GITHUB_CONNECTOR_ID);
+  assert.equal(doc.source.externalId, `${REPO_A}/issue-comment/42`);
+  assert.equal(doc.source.externalRevision, "2026-04-26T09:00:00.000Z");
+  assert.equal(doc.source.externalUrl, `https://github.com/${REPO_A}/issues/10#issuecomment-42`);
+  assert.equal(doc.content, "This is my note");
+  assert.ok(doc.title?.includes("Issue comment"));
+  assert.ok(doc.title?.includes(REPO_A));
+});
+
+test("incremental sync emits ConnectorDocument for matching PR review comments", async () => {
+  const comment = makeComment(99, SYNTHETIC_LOGIN, "PR note here", "2026-04-26T10:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [comment] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+
+  assert.equal(result.newDocs.length, 1);
+  const doc = result.newDocs[0];
+  assert.equal(doc.source.externalId, `${REPO_A}/pr-review-comment/99`);
+  assert.ok(doc.title?.includes("PR review comment"));
+});
+
+// ---------------------------------------------------------------------------
+// Author filtering
+// ---------------------------------------------------------------------------
+
+test("incremental sync skips comments authored by a different user", async () => {
+  const myComment = makeComment(1, SYNTHETIC_LOGIN, "Mine", "2026-04-26T09:00:00.000Z");
+  const otherComment = makeComment(2, "other-user", "Not mine", "2026-04-26T09:01:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [myComment, otherComment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/1`);
+  assert.equal(result.skippedOtherAuthor, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Empty / too-large bodies
+// ---------------------------------------------------------------------------
+
+test("incremental sync skips comments with empty body", async () => {
+  const emptyComment = makeComment(5, SYNTHETIC_LOGIN, "", "2026-04-26T09:00:00.000Z");
+  const whitespaceComment = makeComment(6, SYNTHETIC_LOGIN, "   \n\t  ", "2026-04-26T09:01:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [emptyComment, whitespaceComment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.skippedEmpty, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Watermark advancement
+// ---------------------------------------------------------------------------
+
+test("incremental sync advances watermark after importing comments", async () => {
+  const c1 = makeComment(10, SYNTHETIC_LOGIN, "first", "2026-04-26T09:00:00.000Z");
+  const c2 = makeComment(11, SYNTHETIC_LOGIN, "second", "2026-04-26T10:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [c1, c2] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({
+    [`${REPO_A}/issue-comment`]: "2026-04-25T00:00:00.000Z",
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.equal(result.newDocs.length, 2);
+
+  const payload = JSON.parse(result.nextCursor.value) as { watermarks: Record<string, string> };
+  // Watermark must advance to the latest comment's updated_at.
+  assert.equal(payload.watermarks[`${REPO_A}/issue-comment`], "2026-04-26T10:00:00.000Z");
+});
+
+test("incremental sync skips items at or before the watermark", async () => {
+  // Comment with updated_at equal to the watermark should be skipped.
+  const staleComment = makeComment(1, SYNTHETIC_LOGIN, "old", "2026-04-25T00:00:00.000Z");
+  const newComment = makeComment(2, SYNTHETIC_LOGIN, "new", "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [staleComment, newComment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({
+    [`${REPO_A}/issue-comment`]: "2026-04-25T00:00:00.000Z",
+  });
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/issue-comment/2`);
+});
+
+// ---------------------------------------------------------------------------
+// Multiple repos
+// ---------------------------------------------------------------------------
+
+test("incremental sync handles multiple repos independently", async () => {
+  const commentA = makeComment(1, SYNTHETIC_LOGIN, "In A", "2026-04-26T09:00:00.000Z");
+  const commentB = makeComment(2, SYNTHETIC_LOGIN, "In B", "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes(`${REPO_A}/issues/comments`),
+      respond: () => ({ status: 200, data: [commentA] }),
+    },
+    {
+      match: (url) => url.includes(`${REPO_B}/issues/comments`),
+      respond: () => ({ status: 200, data: [commentB] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({
+    token: SYNTHETIC_TOKEN,
+    userLogin: SYNTHETIC_LOGIN,
+    repos: [REPO_A, REPO_B],
+  });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.equal(result.newDocs.length, 2);
+  const ids = result.newDocs.map((d) => d.source.externalId).sort();
+  assert.deepEqual(ids, [
+    `${REPO_A}/issue-comment/1`,
+    `${REPO_B}/issue-comment/2`,
+  ].sort());
+});
+
+// ---------------------------------------------------------------------------
+// Discussion comments (opt-in)
+// ---------------------------------------------------------------------------
+
+test("discussion comments are not fetched unless includeDiscussions is true", async () => {
+  let discussionFetched = false;
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/discussions"),
+      respond: () => {
+        discussionFetched = true;
+        return { status: 200, data: [] };
+      },
+    },
+    {
+      match: () => true,
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({
+    ...SYNTHETIC_CONFIG,
+    includeDiscussions: false,
+  });
+  const cursor = makeGitHubCursor({});
+
+  await connector.syncIncremental({ cursor, config });
+  assert.equal(discussionFetched, false);
+});
+
+test("discussion comments are fetched when includeDiscussions is true", async () => {
+  let discussionFetched = false;
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/discussions"),
+      respond: () => {
+        discussionFetched = true;
+        return { status: 200, data: [] };
+      },
+    },
+    {
+      match: () => true,
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({
+    ...SYNTHETIC_CONFIG,
+    includeDiscussions: true,
+  });
+  const cursor = makeGitHubCursor({});
+
+  await connector.syncIncremental({ cursor, config });
+  assert.equal(discussionFetched, true);
+});
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+test("isTransientGitHubError classifies common error shapes", () => {
+  // Terminal — skip-and-continue.
+  assert.equal(isTransientGitHubError({ githubStatus: 404 }), false);
+  assert.equal(isTransientGitHubError({ githubStatus: 403 }), false);
+  assert.equal(isTransientGitHubError({ githubStatus: 400 }), false);
+  assert.equal(isTransientGitHubError({ status: 410 }), false);
+  // Transient — re-throw.
+  assert.equal(isTransientGitHubError({ githubStatus: 429 }), true);
+  assert.equal(isTransientGitHubError({ githubStatus: 500 }), true);
+  assert.equal(isTransientGitHubError({ githubStatus: 503 }), true);
+  assert.equal(isTransientGitHubError({ status: 504 }), true);
+  // Network errors.
+  assert.equal(isTransientGitHubError({ code: "ECONNRESET" }), true);
+  assert.equal(isTransientGitHubError({ code: "ETIMEDOUT" }), true);
+  assert.equal(isTransientGitHubError({ code: "ENOTFOUND" }), true);
+  assert.equal(isTransientGitHubError({ code: "EAI_AGAIN" }), true);
+  // AbortError.
+  assert.equal(isTransientGitHubError({ name: "AbortError" }), true);
+  // Bare Error with no metadata — conservatively transient.
+  assert.equal(isTransientGitHubError(new Error("unknown")), true);
+  // Non-objects.
+  assert.equal(isTransientGitHubError(null), false);
+  assert.equal(isTransientGitHubError(undefined), false);
+  assert.equal(isTransientGitHubError("oops"), false);
+});
+
+// ---------------------------------------------------------------------------
+// HTTP error handling
+// ---------------------------------------------------------------------------
+
+test("a 429 on issue comments re-throws (transient) and cursor does NOT advance", async () => {
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({
+        status: 429,
+        data: { message: "API rate limit exceeded" },
+      }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({
+    [`${REPO_A}/issue-comment`]: "2026-04-25T00:00:00.000Z",
+  });
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /rate limit/i,
+  );
+});
+
+test("a 503 on issue comments re-throws (transient)", async () => {
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({
+        status: 503,
+        data: { message: "Service Unavailable" },
+      }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /503/,
+  );
+});
+
+test("a 404 on issue comments is terminal (skip repo resource, continue)", async () => {
+  // Issue comments returns 404 → skipped.
+  // PR review comments returns a valid comment → should still be imported.
+  const prComment = makeComment(77, SYNTHETIC_LOGIN, "PR note", "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({
+        status: 404,
+        data: { message: "Not Found" },
+      }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [prComment] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  // The 404 should be swallowed (terminal), and the PR comment should be imported.
+  assert.equal(result.newDocs.length, 1);
+  assert.equal(result.newDocs[0].source.externalId, `${REPO_A}/pr-review-comment/77`);
+});
+
+test("a 403 on issue comments is terminal (skip, continue to PR comments)", async () => {
+  const prComment = makeComment(88, SYNTHETIC_LOGIN, "Another PR note", "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({
+        status: 403,
+        data: { message: "Forbidden" },
+      }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [prComment] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.equal(result.newDocs.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// AbortSignal
+// ---------------------------------------------------------------------------
+
+test("syncIncremental honors abortSignal", async () => {
+  const controller = new AbortController();
+  let callCount = 0;
+
+  const fetchFn: GitHubFetchFn = async () => {
+    callCount++;
+    if (callCount === 1) controller.abort();
+    return {
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => [],
+    };
+  };
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config, abortSignal: controller.signal }),
+    /aborted/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Cursor validation
+// ---------------------------------------------------------------------------
+
+test("syncIncremental rejects a cursor of an unexpected kind", async () => {
+  const connector = createGitHubConnector({ fetchFn: emptyFetch() });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const badCursor: ConnectorCursor = {
+    kind: "wrong-kind",
+    value: "{}",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor: badCursor, config }),
+    /unexpected cursor kind/,
+  );
+});
+
+test("syncIncremental rejects a cursor with invalid JSON", async () => {
+  const connector = createGitHubConnector({ fetchFn: emptyFetch() });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const badCursor: ConnectorCursor = {
+    kind: GITHUB_CURSOR_KIND,
+    value: "{ not valid json",
+    updatedAt: "2026-04-25T00:00:00.000Z",
+  };
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor: badCursor, config }),
+    /not valid JSON/,
+  );
+});
+
+test("validateConfig is enforced again on every sync pass", async () => {
+  const connector = createGitHubConnector({ fetchFn: emptyFetch() });
+  const badConfig = { token: SYNTHETIC_TOKEN } as unknown as import("./framework.js").ConnectorConfig;
+  const cursor = makeGitHubCursor({});
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config: badConfig }),
+    /userLogin/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Network-layer transient error
+// ---------------------------------------------------------------------------
+
+test("a network ECONNRESET on issue comments re-throws as transient", async () => {
+  const fetchFn: GitHubFetchFn = async () => {
+    throw Object.assign(new Error("socket hang up"), { code: "ECONNRESET" });
+  };
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  await assert.rejects(
+    connector.syncIncremental({ cursor, config }),
+    /socket hang up/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Non-matching author watermark advancement (CLAUDE.md gotcha #44 regression)
+// ---------------------------------------------------------------------------
+
+test("watermark advances for non-matching-author and empty comments so they aren't re-fetched", async () => {
+  // A comment from a different user. The watermark must still advance so we
+  // don't fetch the same item on every subsequent poll.
+  const otherComment = makeComment(200, "other-user", "Not mine", "2026-04-26T09:00:00.000Z");
+
+  const fetchFn = makeFetch([
+    {
+      match: (url) => url.includes("/issues/comments"),
+      respond: () => ({ status: 200, data: [otherComment] }),
+    },
+    {
+      match: (url) => url.includes("/pulls/comments"),
+      respond: () => ({ status: 200, data: [] }),
+    },
+  ]);
+
+  const connector = createGitHubConnector({ fetchFn });
+  const config = connector.validateConfig({ ...SYNTHETIC_CONFIG });
+  const cursor = makeGitHubCursor({});
+
+  const result = (await connector.syncIncremental({ cursor, config })) as GitHubSyncResult;
+  assert.deepEqual(result.newDocs, []);
+  assert.equal(result.skippedOtherAuthor, 1);
+
+  // The watermark must have advanced past the other-author comment so the
+  // next incremental pass skips it via the `since` filter.
+  const payload = JSON.parse(result.nextCursor.value) as { watermarks: Record<string, string> };
+  assert.equal(payload.watermarks[`${REPO_A}/issue-comment`], "2026-04-26T09:00:00.000Z");
+});

--- a/packages/remnic-core/src/connectors/live/github.ts
+++ b/packages/remnic-core/src/connectors/live/github.ts
@@ -125,6 +125,17 @@ interface GitHubCursorPayload {
    * `kind` is one of `"issue-comment"`, `"pr-review-comment"`, `"discussion"`.
    */
   watermarks: Record<string, string>;
+  /**
+   * Same-second dedup map: maps `{repo}/{kind}/{commentId}` → `updated_at`
+   * ISO string for every comment processed within the same second as the
+   * current watermark. Cleared when the watermark advances past that second
+   * boundary. Prevents re-importing comments whose `updated_at` matches the
+   * watermark exactly — GitHub's `since=` filter is inclusive, so comments at
+   * the exact watermark timestamp are re-returned on every subsequent poll.
+   *
+   * Mirrors the Gmail connector's `seenIds` pattern from #745.
+   */
+  seenIds: Record<string, string>;
 }
 
 // ---------------------------------------------------------------------------
@@ -315,7 +326,12 @@ function parseCursorPayload(cursor: ConnectorCursor): GitHubCursorPayload {
     typeof p.watermarks === "object" && p.watermarks !== null && !Array.isArray(p.watermarks)
       ? (p.watermarks as Record<string, string>)
       : {};
-  return { watermarks };
+  // seenIds: tolerate missing key (old cursors lack it).
+  const seenIds: Record<string, string> =
+    typeof p.seenIds === "object" && p.seenIds !== null && !Array.isArray(p.seenIds)
+      ? (p.seenIds as Record<string, string>)
+      : {};
+  return { watermarks, seenIds };
 }
 
 function watermarkKey(repo: string, kind: string): string {
@@ -504,7 +520,7 @@ export function createGitHubConnector(
 
       // Short-circuit: nothing to do if no repos are configured.
       if (config.repos.length === 0) {
-        const emptyPayload: GitHubCursorPayload = { watermarks: {} };
+        const emptyPayload: GitHubCursorPayload = { watermarks: {}, seenIds: {} };
         const result: GitHubSyncResult = {
           newDocs: [],
           nextCursor: makeCursor(emptyPayload),
@@ -518,7 +534,7 @@ export function createGitHubConnector(
       // Parse or seed cursor.
       const isFirstSync = args.cursor === null;
       const payload: GitHubCursorPayload = isFirstSync
-        ? { watermarks: {} }
+        ? { watermarks: {}, seenIds: {} }
         : parseCursorPayload(args.cursor);
 
       if (isFirstSync) {
@@ -553,6 +569,7 @@ async function seedWatermarks(
   signal: AbortSignal | undefined,
 ): Promise<GitHubCursorPayload> {
   const watermarks = { ...initial.watermarks };
+  // seenIds starts empty for first-sync; nothing has been processed yet.
 
   for (const repo of config.repos) {
     throwIfAborted(signal);
@@ -606,7 +623,7 @@ async function seedWatermarks(
     }
   }
 
-  return { watermarks };
+  return { watermarks, seenIds: {} };
 }
 
 /**
@@ -646,6 +663,14 @@ async function incrementalSync(
   let skippedTooLarge = 0;
   let totalConsumed = 0;
 
+  // P1 fix (same-timestamp dedup): carry seenIds forward from the cursor.
+  // Maps `{repo}/{kind}/{commentId}` → `updated_at` ISO string for all
+  // comments processed within the same second as their resource watermark.
+  // Cleared per-resource when the watermark advances into a new second.
+  const currentSeenIds: Record<string, string> = { ...payload.seenIds };
+  // Accumulate seenIds updates for each resource; merged into nextSeenIds below.
+  const updatedSeenIds: Record<string, string> = { ...payload.seenIds };
+
   for (const repo of config.repos) {
     if (totalConsumed >= MAX_ITEMS_PER_PASS) break;
     throwIfAborted(signal);
@@ -665,6 +690,7 @@ async function incrementalSync(
           since,
           fetchedAt,
           MAX_ITEMS_PER_PASS - totalConsumed,
+          currentSeenIds,
           signal,
         );
         for (const doc of result.docs) newDocs.push(doc);
@@ -673,7 +699,19 @@ async function incrementalSync(
         skippedTooLarge += result.skippedTooLarge;
         totalConsumed += result.consumed;
         if (result.latestWatermark) {
-          updatedWatermarks[wmKey] = result.latestWatermark;
+          const prevWm = updatedWatermarks[wmKey];
+          const nextWm = result.latestWatermark;
+          updatedWatermarks[wmKey] = nextWm;
+          // Clear seenIds for this resource if the watermark crossed a second
+          // boundary; otherwise merge the newly-seen ids.
+          if (prevWm && watermarkCrossedSecond(prevWm, nextWm)) {
+            for (const k of Object.keys(updatedSeenIds)) {
+              if (k.startsWith(`${repo}/issue-comment/`)) delete updatedSeenIds[k];
+            }
+          }
+          for (const [k, v] of Object.entries(result.newSeenIds)) {
+            updatedSeenIds[k] = v;
+          }
         }
       } catch (err) {
         if (isTransientGitHubError(err)) throw err;
@@ -699,6 +737,7 @@ async function incrementalSync(
           since,
           fetchedAt,
           MAX_ITEMS_PER_PASS - totalConsumed,
+          currentSeenIds,
           signal,
         );
         for (const doc of result.docs) newDocs.push(doc);
@@ -707,7 +746,17 @@ async function incrementalSync(
         skippedTooLarge += result.skippedTooLarge;
         totalConsumed += result.consumed;
         if (result.latestWatermark) {
-          updatedWatermarks[wmKey] = result.latestWatermark;
+          const prevWm = updatedWatermarks[wmKey];
+          const nextWm = result.latestWatermark;
+          updatedWatermarks[wmKey] = nextWm;
+          if (prevWm && watermarkCrossedSecond(prevWm, nextWm)) {
+            for (const k of Object.keys(updatedSeenIds)) {
+              if (k.startsWith(`${repo}/pr-review-comment/`)) delete updatedSeenIds[k];
+            }
+          }
+          for (const [k, v] of Object.entries(result.newSeenIds)) {
+            updatedSeenIds[k] = v;
+          }
         }
       } catch (err) {
         if (isTransientGitHubError(err)) throw err;
@@ -730,6 +779,7 @@ async function incrementalSync(
           since,
           fetchedAt,
           MAX_ITEMS_PER_PASS - totalConsumed,
+          currentSeenIds,
           signal,
         );
         for (const doc of result.docs) newDocs.push(doc);
@@ -738,7 +788,17 @@ async function incrementalSync(
         skippedTooLarge += result.skippedTooLarge;
         totalConsumed += result.consumed;
         if (result.latestWatermark) {
-          updatedWatermarks[wmKey] = result.latestWatermark;
+          const prevWm = updatedWatermarks[wmKey];
+          const nextWm = result.latestWatermark;
+          updatedWatermarks[wmKey] = nextWm;
+          if (prevWm && watermarkCrossedSecond(prevWm, nextWm)) {
+            for (const k of Object.keys(updatedSeenIds)) {
+              if (k.startsWith(`${repo}/discussion/`)) delete updatedSeenIds[k];
+            }
+          }
+          for (const [k, v] of Object.entries(result.newSeenIds)) {
+            updatedSeenIds[k] = v;
+          }
         }
       } catch (err) {
         if (isTransientGitHubError(err)) throw err;
@@ -748,11 +808,20 @@ async function incrementalSync(
 
   return {
     newDocs,
-    nextCursor: makeCursor({ watermarks: updatedWatermarks }),
+    nextCursor: makeCursor({ watermarks: updatedWatermarks, seenIds: updatedSeenIds }),
     skippedOtherAuthor,
     skippedEmpty,
     skippedTooLarge,
   };
+}
+
+/**
+ * Returns true when the new watermark has crossed into a new second relative
+ * to the previous watermark. ISO 8601 strings sort lexicographically and the
+ * second boundary is at the 19-character prefix (e.g. "2026-04-26T09:00:01").
+ */
+function watermarkCrossedSecond(prev: string, next: string): boolean {
+  return prev.slice(0, 19) < next.slice(0, 19);
 }
 
 // ---------------------------------------------------------------------------
@@ -785,15 +854,36 @@ interface FetchAndFilterResult {
   skippedOtherAuthor: number;
   skippedEmpty: number;
   skippedTooLarge: number;
+  /** Count of items that were actually ingested (budget-counted). Skipped
+   *  items (wrong author, empty body, too-large, seenIds dedup) do NOT
+   *  consume budget — see P1 fix `PRRT_kwDORJXyws59sfBs`. */
   consumed: number;
-  /** Latest `updated_at` we saw in this batch (only from matching author). */
+  /** Latest `updated_at` we saw in this batch (includes skipped items so the
+   *  watermark can advance past them). */
   latestWatermark: string | undefined;
+  /**
+   * New seenId entries accumulated during this pass. Maps
+   * `{repo}/{kind}/{commentId}` → `updated_at` ISO string for every ingested
+   * comment. Used by the caller to build the next cursor's `seenIds` map
+   * (P1 fix `PRRT_kwDORJXyws59sfBq`).
+   */
+  newSeenIds: Record<string, string>;
 }
 
 /**
  * Page through the comments at `firstPageUrl`, filter to comments authored
  * by `userLogin`, and build `ConnectorDocument` instances. Respects the
  * per-pass cap via `remainingBudget`.
+ *
+ * Budget fix (P1 `PRRT_kwDORJXyws59sfBs`): only count ingested records
+ * against the budget. Items skipped for wrong author, empty/too-large body,
+ * or same-second seenId dedup do NOT advance the cap counter — they should
+ * not starve valid records.
+ *
+ * Same-timestamp dedup (P1 `PRRT_kwDORJXyws59sfBq`): `seenIds` carries
+ * comment ids already processed within the same second as the current
+ * watermark. If GitHub re-returns them because `since=` is inclusive and
+ * matches the exact watermark second, we skip them without re-importing.
  *
  * Uses `since` as a client-side lower-bound filter in addition to the
  * server-side `?since=` param (the server may return items exactly at
@@ -809,6 +899,7 @@ async function fetchAndFilterComments(
   since: string | undefined,
   fetchedAt: string,
   remainingBudget: number,
+  seenIds: Record<string, string>,
   signal: AbortSignal | undefined,
 ): Promise<FetchAndFilterResult> {
   const docs: ConnectorDocument[] = [];
@@ -817,6 +908,7 @@ async function fetchAndFilterComments(
   let skippedTooLarge = 0;
   let consumed = 0;
   let latestWatermark: string | undefined = undefined;
+  const newSeenIds: Record<string, string> = {};
   let nextUrl: string | undefined = firstPageUrl;
 
   while (nextUrl && consumed < remainingBudget) {
@@ -830,15 +922,26 @@ async function fetchAndFilterComments(
       throwIfAborted(signal);
 
       const comment = item as GitHubComment;
-      consumed++;
 
       // Skip items at or before the watermark (server returns inclusive).
+      // These are cursor artifacts — do NOT count them against the budget.
       if (since && comment.updated_at <= since) {
-        // Don't count toward skippedOtherAuthor — this is a cursor artifact.
         continue;
       }
 
-      // Author filter (client-side).
+      // P1 fix (same-timestamp dedup): skip comments already processed in the
+      // same second as the watermark. GitHub's `since=` filter is inclusive at
+      // second granularity, so on the next poll it re-returns any comment whose
+      // `updated_at` ISO second matches the watermark second exactly. We use
+      // the seenIds map (keyed by `{repo}/{kind}/{commentId}`) to detect and
+      // skip these without re-importing or consuming budget.
+      const seenKey = `${repo}/${kind}/${comment.id}`;
+      if (seenIds[seenKey] !== undefined) {
+        continue;
+      }
+
+      // Author filter (client-side). Not counted against budget —
+      // P1 fix `PRRT_kwDORJXyws59sfBs`: only ingested records consume budget.
       const authorLogin = comment.user?.login ?? null;
       if (authorLogin !== userLogin) {
         skippedOtherAuthor++;
@@ -850,7 +953,7 @@ async function fetchAndFilterComments(
         continue;
       }
 
-      // Body validation.
+      // Body validation. Also not counted against budget.
       const body = comment.body ?? "";
       const trimmed = body.trim();
       if (trimmed.length === 0) {
@@ -868,6 +971,9 @@ async function fetchAndFilterComments(
         continue;
       }
 
+      // This item will be ingested — count it against the budget.
+      consumed++;
+
       // Build document.
       const doc = buildDocument(comment, repo, kind, fetchedAt);
       docs.push(doc);
@@ -875,6 +981,9 @@ async function fetchAndFilterComments(
       if (!latestWatermark || comment.updated_at > latestWatermark) {
         latestWatermark = comment.updated_at;
       }
+
+      // Record in newSeenIds for same-second dedup on subsequent polls.
+      newSeenIds[seenKey] = comment.updated_at;
     }
 
     // Follow GitHub's `Link: <url>; rel="next"` header for pagination.
@@ -890,7 +999,7 @@ async function fetchAndFilterComments(
     }
   }
 
-  return { docs, skippedOtherAuthor, skippedEmpty, skippedTooLarge, consumed, latestWatermark };
+  return { docs, skippedOtherAuthor, skippedEmpty, skippedTooLarge, consumed, latestWatermark, newSeenIds };
 }
 
 /**

--- a/packages/remnic-core/src/connectors/live/github.ts
+++ b/packages/remnic-core/src/connectors/live/github.ts
@@ -923,20 +923,23 @@ async function fetchAndFilterComments(
 
       const comment = item as GitHubComment;
 
-      // Skip items at or before the watermark (server returns inclusive).
-      // These are cursor artifacts — do NOT count them against the budget.
-      if (since && comment.updated_at <= since) {
+      // Skip items strictly before the watermark. Items whose `updated_at`
+      // equals the watermark second must pass through so the seenIds check
+      // below can distinguish already-ingested comments from new ones at the
+      // same timestamp. Using `<` (strict) here is intentional — `<=` would
+      // make seenIds unreachable for boundary items, permanently dropping any
+      // comment that arrives in the same second as the current watermark.
+      if (since && comment.updated_at < since) {
         continue;
       }
 
-      // P1 fix (same-timestamp dedup): skip comments already processed in the
-      // same second as the watermark. GitHub's `since=` filter is inclusive at
-      // second granularity, so on the next poll it re-returns any comment whose
-      // `updated_at` ISO second matches the watermark second exactly. We use
-      // the seenIds map (keyed by `{repo}/{kind}/{commentId}`) to detect and
-      // skip these without re-importing or consuming budget.
+      // Same-second dedup: skip only if this exact (id, updated_at) pair was
+      // already ingested on a prior pass. A later edit of the same comment
+      // produces a newer `updated_at`, so we must NOT gate on id alone — we
+      // must also confirm the timestamp matches before skipping. This prevents
+      // silent data loss when a comment is edited after its first ingestion.
       const seenKey = `${repo}/${kind}/${comment.id}`;
-      if (seenIds[seenKey] !== undefined) {
+      if (seenIds[seenKey] === comment.updated_at) {
         continue;
       }
 

--- a/packages/remnic-core/src/connectors/live/github.ts
+++ b/packages/remnic-core/src/connectors/live/github.ts
@@ -1,0 +1,956 @@
+/**
+ * @remnic/core — GitHub live connector (issue #683 PR 5/6)
+ *
+ * Concrete `LiveConnector` implementation that incrementally imports notes
+ * from a user's GitHub activity into Remnic. Fetches via the GitHub REST
+ * API using raw `fetch` with a personal access token — no octokit dep,
+ * per à-la-carte packaging rules (CLAUDE.md gotcha #57).
+ *
+ * What is imported:
+ *   - Issue comments authored by `userLogin` on watched repos.
+ *   - PR review comments authored by `userLogin` on watched repos.
+ *   - Discussion comments authored by `userLogin` (optional, off by default).
+ *
+ * Design notes:
+ *
+ *   - **Auth.** GitHub personal access token via `connectors.github.token`.
+ *     The token is accepted at config-parse time but never logged. Operators
+ *     must populate it from a secret store; no real value may appear in
+ *     tests, fixtures, or comments.
+ *
+ *   - **Cursor semantics.** The cursor encodes a per-repo, per-resource-type
+ *     watermark (latest `updated_at` ISO 8601 string seen). On the very first
+ *     sync (cursor=null) we seed the watermark from the current latest
+ *     comment timestamp WITHOUT importing any content — mirrors Drive's
+ *     `getStartPageToken` bootstrap pattern. Subsequent passes only import
+ *     items created/updated after the stored watermark.
+ *
+ *   - **Watermark field.** All three GitHub resource types expose
+ *     `updated_at` at the comment level. We always use `updated_at` (not
+ *     `created_at`) so edits re-trigger ingestion.
+ *
+ *   - **Raw `fetch`.** We call `https://api.github.com/…` directly.
+ *     `Authorization: Bearer <token>` + `User-Agent: remnic-connector` headers
+ *     on every request. The `fetchFn` parameter is the test injection point —
+ *     production callers omit it and the connector uses the global `fetch`.
+ *
+ *   - **Idempotency.** `ConnectorDocument.source.externalId` is
+ *     `{repo}/{kind}/{commentId}` and `externalRevision` is `updated_at`, so
+ *     downstream dedup (CLAUDE.md gotcha #44) can recognise repeat fetches.
+ *
+ *   - **Filtering by userLogin.** GitHub's `/issues/comments` endpoint does
+ *     not support server-side author filtering in the public API. We filter
+ *     client-side by comparing `comment.user.login` to the configured
+ *     `userLogin`. This keeps the implementation free from authenticated
+ *     user lookups and avoids an extra round-trip on first run.
+ *
+ *   - **Privacy.** No comment body is ever logged. Repo names and counts
+ *     may be logged. The token is never exposed in logs, state, or errors.
+ *
+ *   - **Read-only.** This connector only reads. It never posts, edits,
+ *     reacts to, or otherwise mutates any GitHub resource.
+ *
+ *   - **Error classification.** 429/5xx → transient (re-throw, cursor
+ *     does NOT advance). 404/403/410 → terminal (skip repo/resource,
+ *     continue). Network errors → transient.
+ */
+
+import type {
+  ConnectorConfig,
+  ConnectorCursor,
+  ConnectorDocument,
+  LiveConnector,
+  SyncIncrementalArgs,
+  SyncIncrementalResult,
+} from "./framework.js";
+
+// ---------------------------------------------------------------------------
+// Public constants
+// ---------------------------------------------------------------------------
+
+/** Stable connector id. */
+export const GITHUB_CONNECTOR_ID = "github";
+
+/** Cursor `kind` emitted by this connector. */
+export const GITHUB_CURSOR_KIND = "githubWatermark";
+
+/** Default poll interval: 5 minutes. */
+export const GITHUB_DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/** Hard cap on poll interval: 24 hours. */
+const GITHUB_MAX_POLL_INTERVAL_MS = 24 * 60 * 60 * 1000;
+
+/** Hard cap on body text we'll accept for a single comment. */
+const MAX_BODY_BYTES = 5 * 1024 * 1024;
+
+/** Maximum number of items (across all repos and resource types) per pass. */
+const MAX_ITEMS_PER_PASS = 200;
+
+/** Page size for GitHub list requests. Maximum allowed by the API. */
+const GITHUB_PAGE_SIZE = 100;
+
+// ---------------------------------------------------------------------------
+// Config types
+// ---------------------------------------------------------------------------
+
+/**
+ * Validated, frozen view of `connectors.github.*`.
+ */
+export interface GitHubConnectorConfig {
+  /** Personal access token. Populate from a secret store; never commit. */
+  readonly token: string;
+  /** Only import comments authored by this GitHub login. Required. */
+  readonly userLogin: string;
+  /** Repos to poll, in `owner/repo` format. */
+  readonly repos: readonly string[];
+  /** Poll interval in ms. */
+  readonly pollIntervalMs: number;
+  /** Whether to import Discussion comments. Default false. */
+  readonly includeDiscussions: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor payload
+// ---------------------------------------------------------------------------
+
+/**
+ * JSON payload encoded into `ConnectorCursor.value`.
+ *
+ * Watermarks are stored per repo per resource kind. We use ISO 8601 strings
+ * (which sort lexicographically) for all comparisons — no epoch math needed.
+ */
+interface GitHubCursorPayload {
+  /**
+   * Maps `{repo}/{kind}` → latest `updated_at` ISO string already ingested.
+   * `kind` is one of `"issue-comment"`, `"pr-review-comment"`, `"discussion"`.
+   */
+  watermarks: Record<string, string>;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API response shapes (only the fields we consume)
+// ---------------------------------------------------------------------------
+
+export interface GitHubComment {
+  readonly id: number;
+  readonly body?: string | null;
+  readonly user?: { readonly login?: string | null } | null;
+  readonly created_at: string;
+  readonly updated_at: string;
+  readonly html_url?: string | null;
+  /** Present on PR review comments. */
+  readonly pull_request_url?: string | null;
+  /** Present on issue comments. */
+  readonly issue_url?: string | null;
+}
+
+export interface GitHubDiscussionComment {
+  readonly id: number;
+  readonly body?: string | null;
+  readonly author?: { readonly login?: string | null } | null;
+  readonly createdAt?: string | null;
+  readonly updatedAt?: string | null;
+  readonly url?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// Fetch abstraction (test hook)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal fetch-compatible surface used by the connector. Tests inject a
+ * stub; production delegates to global `fetch`.
+ */
+export type GitHubFetchFn = (
+  url: string,
+  init: {
+    method: string;
+    headers: Record<string, string>;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  ok: boolean;
+  status: number;
+  headers: { get(name: string): string | null };
+  json(): Promise<unknown>;
+}>;
+
+// ---------------------------------------------------------------------------
+// Config validation
+// ---------------------------------------------------------------------------
+
+/** Pattern for `owner/repo`. Both segments allow alphanumeric + `-` + `_` + `.`. */
+const REPO_SLUG_PATTERN = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+$/;
+
+/**
+ * Validate and normalise raw config. Throws with a concrete message on any
+ * malformed input — never silently defaults (CLAUDE.md gotcha #51).
+ */
+export function validateGitHubConfig(raw: unknown): GitHubConnectorConfig {
+  if (typeof raw !== "object" || raw === null || Array.isArray(raw)) {
+    throw new TypeError(
+      `github: config must be an object, got ${raw === null ? "null" : Array.isArray(raw) ? "array" : typeof raw}`,
+    );
+  }
+  const r = raw as Record<string, unknown>;
+
+  // token
+  if (typeof r.token !== "string") {
+    throw new TypeError(`github: token must be a string (got ${typeof r.token})`);
+  }
+  const token = r.token.trim();
+  if (token.length === 0) {
+    throw new RangeError("github: token must be non-empty");
+  }
+
+  // userLogin
+  if (typeof r.userLogin !== "string") {
+    throw new TypeError(`github: userLogin must be a string (got ${typeof r.userLogin})`);
+  }
+  const userLogin = r.userLogin.trim();
+  if (userLogin.length === 0) {
+    throw new RangeError("github: userLogin must be non-empty");
+  }
+
+  // pollIntervalMs
+  let pollIntervalMs: number;
+  if (r.pollIntervalMs === undefined) {
+    pollIntervalMs = GITHUB_DEFAULT_POLL_INTERVAL_MS;
+  } else if (typeof r.pollIntervalMs !== "number" || !Number.isFinite(r.pollIntervalMs)) {
+    throw new TypeError(
+      `github: pollIntervalMs must be a finite number (got ${JSON.stringify(r.pollIntervalMs)})`,
+    );
+  } else if (!Number.isInteger(r.pollIntervalMs)) {
+    throw new TypeError(`github: pollIntervalMs must be an integer (got ${r.pollIntervalMs})`);
+  } else if (r.pollIntervalMs < 1_000) {
+    throw new RangeError(`github: pollIntervalMs must be ≥1000ms; got ${r.pollIntervalMs}`);
+  } else if (r.pollIntervalMs > GITHUB_MAX_POLL_INTERVAL_MS) {
+    throw new RangeError(
+      `github: pollIntervalMs must be ≤${GITHUB_MAX_POLL_INTERVAL_MS} (24h); got ${r.pollIntervalMs}`,
+    );
+  } else {
+    pollIntervalMs = r.pollIntervalMs;
+  }
+
+  // repos
+  let repos: readonly string[] = [];
+  if (r.repos !== undefined) {
+    if (!Array.isArray(r.repos)) {
+      throw new TypeError(
+        `github: repos must be an array of strings (got ${typeof r.repos})`,
+      );
+    }
+    const seen = new Set<string>();
+    const out: string[] = [];
+    for (const value of r.repos) {
+      if (typeof value !== "string") {
+        throw new TypeError(
+          `github: repos entries must be strings; found ${typeof value}`,
+        );
+      }
+      const trimmed = value.trim();
+      if (!REPO_SLUG_PATTERN.test(trimmed)) {
+        throw new RangeError(
+          `github: repos entry ${JSON.stringify(value)} is not a valid "owner/repo" slug`,
+        );
+      }
+      // Dedupe per CLAUDE.md gotcha #49.
+      if (seen.has(trimmed)) continue;
+      seen.add(trimmed);
+      out.push(trimmed);
+    }
+    repos = Object.freeze(out);
+  }
+
+  // includeDiscussions (optional, default false)
+  let includeDiscussions = false;
+  if (r.includeDiscussions !== undefined) {
+    if (typeof r.includeDiscussions !== "boolean") {
+      throw new TypeError(
+        `github: includeDiscussions must be a boolean (got ${typeof r.includeDiscussions})`,
+      );
+    }
+    includeDiscussions = r.includeDiscussions;
+  }
+
+  return Object.freeze({
+    token,
+    userLogin,
+    repos,
+    pollIntervalMs,
+    includeDiscussions,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Cursor helpers
+// ---------------------------------------------------------------------------
+
+function makeCursor(payload: GitHubCursorPayload): ConnectorCursor {
+  return {
+    kind: GITHUB_CURSOR_KIND,
+    value: JSON.stringify(payload),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function parseCursorPayload(cursor: ConnectorCursor): GitHubCursorPayload {
+  if (cursor.kind !== GITHUB_CURSOR_KIND) {
+    throw new Error(
+      `github: unexpected cursor kind ${JSON.stringify(cursor.kind)}; expected ${GITHUB_CURSOR_KIND}`,
+    );
+  }
+  // CLAUDE.md gotcha #18: validate after parse.
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cursor.value);
+  } catch {
+    throw new Error(`github: cursor value is not valid JSON`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`github: cursor value does not match GitHubCursorPayload shape`);
+  }
+  const p = parsed as Record<string, unknown>;
+  const watermarks =
+    typeof p.watermarks === "object" && p.watermarks !== null && !Array.isArray(p.watermarks)
+      ? (p.watermarks as Record<string, string>)
+      : {};
+  return { watermarks };
+}
+
+function watermarkKey(repo: string, kind: string): string {
+  return `${repo}/${kind}`;
+}
+
+// ---------------------------------------------------------------------------
+// Error classification
+// ---------------------------------------------------------------------------
+
+/**
+ * Classify a fetch error as transient (re-throw — cursor does NOT advance,
+ * next poll retries) vs. terminal (skip this repo/resource and continue).
+ *
+ * Transient:
+ *   - 429 (rate-limit — retry after backoff)
+ *   - 5xx (GitHub backend error)
+ *   - AbortError / network-layer errors
+ *
+ * Terminal (skip-and-continue):
+ *   - 404 (repo deleted, comment gone, or no access)
+ *   - 403 (permission denied)
+ *   - 410 (gone)
+ *   - any other 4xx that isn't 429
+ */
+export function isTransientGitHubError(err: unknown): boolean {
+  if (err === null || typeof err !== "object") return false;
+  const e = err as {
+    name?: unknown;
+    code?: unknown;
+    status?: unknown;
+    githubStatus?: unknown;
+    message?: unknown;
+  };
+
+  // AbortError
+  if (typeof e.name === "string" && e.name === "AbortError") return true;
+
+  // HTTP status attached by our own error-throwing code.
+  const status = pickNumericGitHubStatus(e);
+  if (status !== undefined) {
+    if (status === 429) return true;
+    if (status >= 500 && status <= 599) return true;
+    // Any classified 4xx that isn't 429 is terminal.
+    return false;
+  }
+
+  // Network-layer error codes.
+  const codeStr = typeof e.code === "string" ? e.code : undefined;
+  if (codeStr !== undefined) {
+    const transientCodes = new Set([
+      "ECONNRESET",
+      "ECONNREFUSED",
+      "ECONNABORTED",
+      "ETIMEDOUT",
+      "ESOCKETTIMEDOUT",
+      "ENOTFOUND",
+      "EAI_AGAIN",
+      "EPIPE",
+      "EHOSTUNREACH",
+      "ENETUNREACH",
+      "ENETDOWN",
+      "ERR_NETWORK",
+      "ERR_NETWORK_CHANGED",
+    ]);
+    if (transientCodes.has(codeStr)) return true;
+    return false;
+  }
+
+  // No status, no code — treat as transient (plain network failures).
+  return true;
+}
+
+function pickNumericGitHubStatus(e: {
+  status?: unknown;
+  githubStatus?: unknown;
+  code?: unknown;
+}): number | undefined {
+  if (typeof e.githubStatus === "number" && Number.isFinite(e.githubStatus)) {
+    return e.githubStatus;
+  }
+  if (typeof e.status === "number" && Number.isFinite(e.status)) {
+    return e.status;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// GitHub API client helpers
+// ---------------------------------------------------------------------------
+
+const GITHUB_API_BASE = "https://api.github.com";
+
+function throwIfAborted(signal: AbortSignal | undefined): void {
+  if (signal?.aborted) {
+    const err = new Error("github: sync aborted");
+    err.name = "AbortError";
+    throw err;
+  }
+}
+
+function makeGitHubApiError(status: number, message: string): Error & { githubStatus: number } {
+  const err = new Error(`github: HTTP ${status}: ${message}`) as Error & {
+    githubStatus: number;
+  };
+  err.githubStatus = status;
+  return err;
+}
+
+/**
+ * Execute a GET request against the GitHub REST API. Returns the parsed JSON
+ * body on success. Throws a structured error on non-2xx responses.
+ */
+async function githubGet(
+  fetchFn: GitHubFetchFn,
+  token: string,
+  url: string,
+  signal: AbortSignal | undefined,
+): Promise<unknown> {
+  const res = await fetchFn(url, {
+    method: "GET",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "User-Agent": "remnic-connector",
+      Accept: "application/vnd.github+json",
+      "X-GitHub-Api-Version": "2022-11-28",
+    },
+    signal,
+  });
+
+  const data = await res.json();
+  if (!res.ok) {
+    const message =
+      typeof data === "object" &&
+      data !== null &&
+      typeof (data as Record<string, unknown>).message === "string"
+        ? ((data as Record<string, unknown>).message as string)
+        : `HTTP ${res.status}`;
+    throw makeGitHubApiError(res.status, message);
+  }
+  return data;
+}
+
+// ---------------------------------------------------------------------------
+// Sync result type
+// ---------------------------------------------------------------------------
+
+/**
+ * Result of a single sync pass. Superset of `SyncIncrementalResult` for
+ * richer test assertions.
+ */
+export interface GitHubSyncResult extends SyncIncrementalResult {
+  readonly skippedOtherAuthor: number;
+  readonly skippedEmpty: number;
+  readonly skippedTooLarge: number;
+}
+
+// ---------------------------------------------------------------------------
+// Connector factory
+// ---------------------------------------------------------------------------
+
+/**
+ * Construct the GitHub connector. `fetchFn` is the test hook — production
+ * callers omit it and the connector delegates to global `fetch`.
+ */
+export function createGitHubConnector(
+  options: { fetchFn?: GitHubFetchFn } = {},
+): LiveConnector {
+  const fetchFn: GitHubFetchFn =
+    options.fetchFn ??
+    (globalThis.fetch as unknown as GitHubFetchFn);
+
+  return {
+    id: GITHUB_CONNECTOR_ID,
+    displayName: "GitHub",
+    description:
+      "Imports issue comments, PR review comments, and discussion posts authored by the configured user from watched repos into Remnic.",
+
+    validateConfig(raw: unknown): ConnectorConfig {
+      return validateGitHubConfig(raw) as unknown as ConnectorConfig;
+    },
+
+    async syncIncremental(args: SyncIncrementalArgs): Promise<SyncIncrementalResult> {
+      const config = validateGitHubConfig(args.config);
+      throwIfAborted(args.abortSignal);
+
+      // Short-circuit: nothing to do if no repos are configured.
+      if (config.repos.length === 0) {
+        const emptyPayload: GitHubCursorPayload = { watermarks: {} };
+        const result: GitHubSyncResult = {
+          newDocs: [],
+          nextCursor: makeCursor(emptyPayload),
+          skippedOtherAuthor: 0,
+          skippedEmpty: 0,
+          skippedTooLarge: 0,
+        };
+        return result;
+      }
+
+      // Parse or seed cursor.
+      const isFirstSync = args.cursor === null;
+      const payload: GitHubCursorPayload = isFirstSync
+        ? { watermarks: {} }
+        : parseCursorPayload(args.cursor);
+
+      if (isFirstSync) {
+        const seededPayload = await seedWatermarks(fetchFn, config, payload, args.abortSignal);
+        return {
+          newDocs: [],
+          nextCursor: makeCursor(seededPayload),
+          skippedOtherAuthor: 0,
+          skippedEmpty: 0,
+          skippedTooLarge: 0,
+        } as GitHubSyncResult;
+      }
+
+      return await incrementalSync(fetchFn, config, payload, args.abortSignal);
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// First-sync: seed watermarks without importing
+// ---------------------------------------------------------------------------
+
+/**
+ * For each configured repo and resource type, query the current latest
+ * item timestamp and record it as the starting watermark. Returns without
+ * emitting any documents, mirroring Drive's `getStartPageToken` pattern.
+ */
+async function seedWatermarks(
+  fetchFn: GitHubFetchFn,
+  config: GitHubConnectorConfig,
+  initial: GitHubCursorPayload,
+  signal: AbortSignal | undefined,
+): Promise<GitHubCursorPayload> {
+  const watermarks = { ...initial.watermarks };
+
+  for (const repo of config.repos) {
+    throwIfAborted(signal);
+
+    // Issue comments
+    try {
+      const latest = await fetchLatestTimestamp(
+        fetchFn,
+        config.token,
+        `${GITHUB_API_BASE}/repos/${repo}/issues/comments?sort=updated&direction=desc&per_page=1`,
+        "updated_at",
+        signal,
+      );
+      if (latest) watermarks[watermarkKey(repo, "issue-comment")] = latest;
+    } catch (err) {
+      if (isTransientGitHubError(err)) throw err;
+      // 404/403 → repo inaccessible, skip silently.
+    }
+
+    throwIfAborted(signal);
+
+    // PR review comments
+    try {
+      const latest = await fetchLatestTimestamp(
+        fetchFn,
+        config.token,
+        `${GITHUB_API_BASE}/repos/${repo}/pulls/comments?sort=updated&direction=desc&per_page=1`,
+        "updated_at",
+        signal,
+      );
+      if (latest) watermarks[watermarkKey(repo, "pr-review-comment")] = latest;
+    } catch (err) {
+      if (isTransientGitHubError(err)) throw err;
+    }
+
+    // Discussions (GraphQL not used; we use the REST search endpoint for simplicity)
+    if (config.includeDiscussions) {
+      throwIfAborted(signal);
+      try {
+        const latest = await fetchLatestTimestamp(
+          fetchFn,
+          config.token,
+          `${GITHUB_API_BASE}/repos/${repo}/discussions?sort=updated&direction=desc&per_page=1`,
+          "updated_at",
+          signal,
+        );
+        if (latest) watermarks[watermarkKey(repo, "discussion")] = latest;
+      } catch (err) {
+        if (isTransientGitHubError(err)) throw err;
+      }
+    }
+  }
+
+  return { watermarks };
+}
+
+/**
+ * Fetch the first page of a sorted list and return the `updated_at` field of
+ * the first item, or `undefined` if the list is empty.
+ */
+async function fetchLatestTimestamp(
+  fetchFn: GitHubFetchFn,
+  token: string,
+  url: string,
+  field: string,
+  signal: AbortSignal | undefined,
+): Promise<string | undefined> {
+  const data = await githubGet(fetchFn, token, url, signal);
+  if (!Array.isArray(data) || data.length === 0) return undefined;
+  const first = data[0];
+  if (typeof first !== "object" || first === null) return undefined;
+  const ts = (first as Record<string, unknown>)[field];
+  return typeof ts === "string" && ts.length > 0 ? ts : undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Incremental sync
+// ---------------------------------------------------------------------------
+
+async function incrementalSync(
+  fetchFn: GitHubFetchFn,
+  config: GitHubConnectorConfig,
+  payload: GitHubCursorPayload,
+  signal: AbortSignal | undefined,
+): Promise<GitHubSyncResult> {
+  const fetchedAt = new Date().toISOString();
+  const newDocs: ConnectorDocument[] = [];
+  const updatedWatermarks = { ...payload.watermarks };
+  let skippedOtherAuthor = 0;
+  let skippedEmpty = 0;
+  let skippedTooLarge = 0;
+  let totalConsumed = 0;
+
+  for (const repo of config.repos) {
+    if (totalConsumed >= MAX_ITEMS_PER_PASS) break;
+    throwIfAborted(signal);
+
+    // --- Issue comments ---
+    {
+      const wmKey = watermarkKey(repo, "issue-comment");
+      const since = payload.watermarks[wmKey];
+      try {
+        const result = await fetchAndFilterComments(
+          fetchFn,
+          config.token,
+          buildIssueCommentsUrl(repo, since),
+          repo,
+          "issue-comment",
+          config.userLogin,
+          since,
+          fetchedAt,
+          MAX_ITEMS_PER_PASS - totalConsumed,
+          signal,
+        );
+        for (const doc of result.docs) newDocs.push(doc);
+        skippedOtherAuthor += result.skippedOtherAuthor;
+        skippedEmpty += result.skippedEmpty;
+        skippedTooLarge += result.skippedTooLarge;
+        totalConsumed += result.consumed;
+        if (result.latestWatermark) {
+          updatedWatermarks[wmKey] = result.latestWatermark;
+        }
+      } catch (err) {
+        if (isTransientGitHubError(err)) throw err;
+        // Terminal (404/403): skip this resource for this repo.
+      }
+    }
+
+    if (totalConsumed >= MAX_ITEMS_PER_PASS) break;
+    throwIfAborted(signal);
+
+    // --- PR review comments ---
+    {
+      const wmKey = watermarkKey(repo, "pr-review-comment");
+      const since = payload.watermarks[wmKey];
+      try {
+        const result = await fetchAndFilterComments(
+          fetchFn,
+          config.token,
+          buildPrReviewCommentsUrl(repo, since),
+          repo,
+          "pr-review-comment",
+          config.userLogin,
+          since,
+          fetchedAt,
+          MAX_ITEMS_PER_PASS - totalConsumed,
+          signal,
+        );
+        for (const doc of result.docs) newDocs.push(doc);
+        skippedOtherAuthor += result.skippedOtherAuthor;
+        skippedEmpty += result.skippedEmpty;
+        skippedTooLarge += result.skippedTooLarge;
+        totalConsumed += result.consumed;
+        if (result.latestWatermark) {
+          updatedWatermarks[wmKey] = result.latestWatermark;
+        }
+      } catch (err) {
+        if (isTransientGitHubError(err)) throw err;
+      }
+    }
+
+    // --- Discussion comments (optional) ---
+    if (config.includeDiscussions && totalConsumed < MAX_ITEMS_PER_PASS) {
+      throwIfAborted(signal);
+      const wmKey = watermarkKey(repo, "discussion");
+      const since = payload.watermarks[wmKey];
+      try {
+        const result = await fetchAndFilterComments(
+          fetchFn,
+          config.token,
+          buildDiscussionsUrl(repo, since),
+          repo,
+          "discussion",
+          config.userLogin,
+          since,
+          fetchedAt,
+          MAX_ITEMS_PER_PASS - totalConsumed,
+          signal,
+        );
+        for (const doc of result.docs) newDocs.push(doc);
+        skippedOtherAuthor += result.skippedOtherAuthor;
+        skippedEmpty += result.skippedEmpty;
+        skippedTooLarge += result.skippedTooLarge;
+        totalConsumed += result.consumed;
+        if (result.latestWatermark) {
+          updatedWatermarks[wmKey] = result.latestWatermark;
+        }
+      } catch (err) {
+        if (isTransientGitHubError(err)) throw err;
+      }
+    }
+  }
+
+  return {
+    newDocs,
+    nextCursor: makeCursor({ watermarks: updatedWatermarks }),
+    skippedOtherAuthor,
+    skippedEmpty,
+    skippedTooLarge,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// URL builders
+// ---------------------------------------------------------------------------
+
+function buildIssueCommentsUrl(repo: string, since?: string): string {
+  const base = `${GITHUB_API_BASE}/repos/${repo}/issues/comments?sort=updated&direction=asc&per_page=${GITHUB_PAGE_SIZE}`;
+  return since ? `${base}&since=${encodeURIComponent(since)}` : base;
+}
+
+function buildPrReviewCommentsUrl(repo: string, since?: string): string {
+  const base = `${GITHUB_API_BASE}/repos/${repo}/pulls/comments?sort=updated&direction=asc&per_page=${GITHUB_PAGE_SIZE}`;
+  return since ? `${base}&since=${encodeURIComponent(since)}` : base;
+}
+
+function buildDiscussionsUrl(repo: string, since?: string): string {
+  // GitHub Discussions REST API (available for repos with discussions enabled).
+  // No server-side `since` filter exists, so we page and filter client-side.
+  const base = `${GITHUB_API_BASE}/repos/${repo}/discussions?sort=updated&direction=asc&per_page=${GITHUB_PAGE_SIZE}`;
+  return since ? `${base}&since=${encodeURIComponent(since)}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Comment fetching + filtering
+// ---------------------------------------------------------------------------
+
+interface FetchAndFilterResult {
+  docs: ConnectorDocument[];
+  skippedOtherAuthor: number;
+  skippedEmpty: number;
+  skippedTooLarge: number;
+  consumed: number;
+  /** Latest `updated_at` we saw in this batch (only from matching author). */
+  latestWatermark: string | undefined;
+}
+
+/**
+ * Page through the comments at `firstPageUrl`, filter to comments authored
+ * by `userLogin`, and build `ConnectorDocument` instances. Respects the
+ * per-pass cap via `remainingBudget`.
+ *
+ * Uses `since` as a client-side lower-bound filter in addition to the
+ * server-side `?since=` param (the server may return items exactly at
+ * the watermark that we already ingested).
+ */
+async function fetchAndFilterComments(
+  fetchFn: GitHubFetchFn,
+  token: string,
+  firstPageUrl: string,
+  repo: string,
+  kind: string,
+  userLogin: string,
+  since: string | undefined,
+  fetchedAt: string,
+  remainingBudget: number,
+  signal: AbortSignal | undefined,
+): Promise<FetchAndFilterResult> {
+  const docs: ConnectorDocument[] = [];
+  let skippedOtherAuthor = 0;
+  let skippedEmpty = 0;
+  let skippedTooLarge = 0;
+  let consumed = 0;
+  let latestWatermark: string | undefined = undefined;
+  let nextUrl: string | undefined = firstPageUrl;
+
+  while (nextUrl && consumed < remainingBudget) {
+    throwIfAborted(signal);
+
+    const data = await githubGet(fetchFn, token, nextUrl, signal);
+    if (!Array.isArray(data)) break;
+
+    for (const item of data) {
+      if (consumed >= remainingBudget) break;
+      throwIfAborted(signal);
+
+      const comment = item as GitHubComment;
+      consumed++;
+
+      // Skip items at or before the watermark (server returns inclusive).
+      if (since && comment.updated_at <= since) {
+        // Don't count toward skippedOtherAuthor — this is a cursor artifact.
+        continue;
+      }
+
+      // Author filter (client-side).
+      const authorLogin = comment.user?.login ?? null;
+      if (authorLogin !== userLogin) {
+        skippedOtherAuthor++;
+        // Still track watermark for non-matching items to prevent re-fetching
+        // them on every subsequent poll.
+        if (!latestWatermark || comment.updated_at > latestWatermark) {
+          latestWatermark = comment.updated_at;
+        }
+        continue;
+      }
+
+      // Body validation.
+      const body = comment.body ?? "";
+      const trimmed = body.trim();
+      if (trimmed.length === 0) {
+        skippedEmpty++;
+        if (!latestWatermark || comment.updated_at > latestWatermark) {
+          latestWatermark = comment.updated_at;
+        }
+        continue;
+      }
+      if (trimmed.length > MAX_BODY_BYTES) {
+        skippedTooLarge++;
+        if (!latestWatermark || comment.updated_at > latestWatermark) {
+          latestWatermark = comment.updated_at;
+        }
+        continue;
+      }
+
+      // Build document.
+      const doc = buildDocument(comment, repo, kind, fetchedAt);
+      docs.push(doc);
+
+      if (!latestWatermark || comment.updated_at > latestWatermark) {
+        latestWatermark = comment.updated_at;
+      }
+    }
+
+    // Follow GitHub's `Link: <url>; rel="next"` header for pagination.
+    // We don't have direct header access via the minimal fetch abstraction,
+    // so pagination is signaled by a full page being returned. If the page
+    // has fewer items than GITHUB_PAGE_SIZE we've reached the end.
+    // This is conservative but correct — a short page always means "no more".
+    if (data.length < GITHUB_PAGE_SIZE) {
+      nextUrl = undefined;
+    } else {
+      // Full page received — there may be more. Advance via page parameter.
+      nextUrl = advancePageUrl(nextUrl);
+    }
+  }
+
+  return { docs, skippedOtherAuthor, skippedEmpty, skippedTooLarge, consumed, latestWatermark };
+}
+
+/**
+ * Advance a paginated GitHub URL by incrementing the `page` query parameter.
+ * GitHub uses 1-based page numbers; if no `page` param is present we assume
+ * we're on page 1 and bump to page 2.
+ */
+function advancePageUrl(url: string): string {
+  try {
+    const u = new URL(url);
+    const page = parseInt(u.searchParams.get("page") ?? "1", 10);
+    u.searchParams.set("page", String(isNaN(page) ? 2 : page + 1));
+    return u.toString();
+  } catch {
+    // If URL parsing fails, bail — don't loop infinitely.
+    return "";
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Document builder
+// ---------------------------------------------------------------------------
+
+function buildDocument(
+  comment: GitHubComment,
+  repo: string,
+  kind: string,
+  fetchedAt: string,
+): ConnectorDocument {
+  const externalId = `${repo}/${kind}/${comment.id}`;
+  const externalUrl =
+    typeof comment.html_url === "string" && comment.html_url.length > 0
+      ? comment.html_url
+      : undefined;
+  const title = buildTitle(repo, kind, comment);
+
+  return {
+    id: externalId,
+    title,
+    content: (comment.body ?? "").trim(),
+    source: {
+      connector: GITHUB_CONNECTOR_ID,
+      externalId,
+      externalRevision: comment.updated_at,
+      externalUrl,
+      fetchedAt,
+    },
+  };
+}
+
+/**
+ * Build a short human-readable title for the comment document.
+ * We avoid fetching the issue/PR title to keep the connector read-light.
+ */
+function buildTitle(repo: string, kind: string, comment: GitHubComment): string {
+  const kindLabel =
+    kind === "issue-comment"
+      ? "Issue comment"
+      : kind === "pr-review-comment"
+        ? "PR review comment"
+        : "Discussion comment";
+  return `${kindLabel} in ${repo} (#${comment.id})`;
+}

--- a/packages/remnic-core/src/connectors/live/index.ts
+++ b/packages/remnic-core/src/connectors/live/index.ts
@@ -65,3 +65,16 @@ export {
   type NotionPage,
   type NotionSyncResult,
 } from "./notion.js";
+
+export {
+  GITHUB_CONNECTOR_ID,
+  GITHUB_CURSOR_KIND,
+  GITHUB_DEFAULT_POLL_INTERVAL_MS,
+  createGitHubConnector,
+  isTransientGitHubError,
+  validateGitHubConfig,
+  type GitHubComment,
+  type GitHubConnectorConfig,
+  type GitHubFetchFn,
+  type GitHubSyncResult,
+} from "./github.js";

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -1619,6 +1619,8 @@ export interface LiveConnectorsConfig {
   googleDrive: GoogleDriveLiveConnectorConfig;
   /** Notion live connector (issue #683 PR 3/N). */
   notion: NotionLiveConnectorConfig;
+  /** GitHub live connector (issue #683 PR 5/6). */
+  github: GitHubLiveConnectorConfig;
 }
 
 /**
@@ -1668,6 +1670,32 @@ export interface NotionLiveConnectorConfig {
   databaseIds: string[];
   /** Poll interval in ms. Default 300000 (5 min); min 1000; max 86400000 (24h). */
   pollIntervalMs: number;
+}
+
+/**
+ * Operator-facing config for the GitHub live connector (issue #683 PR 5/6).
+ * The connector module defines a separate validated `GitHubConnectorConfig`
+ * shape (frozen, post-validation). This interface is the pre-validation shape
+ * that `parseConfig` round-trips through.
+ *
+ * `token` is stored as a string here so operators can populate it from a
+ * secret store (e.g. an env-substituted plist or systemd EnvironmentFile).
+ * It MUST NEVER be committed to source. The repo-wide privacy policy in
+ * CLAUDE.md applies.
+ */
+export interface GitHubLiveConnectorConfig {
+  /** Master gate. Default false — operators must opt in explicitly. */
+  enabled: boolean;
+  /** GitHub personal access token. Populate from a secret store; never commit. */
+  token: string;
+  /** GitHub login of the user whose comments will be imported. Required. */
+  userLogin: string;
+  /** Repos to poll in "owner/repo" format. Empty = connector is a no-op. */
+  repos: string[];
+  /** Poll interval in ms. Default 300000 (5 min); min 1000; max 86400000 (24h). */
+  pollIntervalMs: number;
+  /** Whether to fetch Discussion comments in addition to issue/PR comments. Default false. */
+  includeDiscussions: boolean;
 }
 
 export interface BootstrapOptions {


### PR DESCRIPTION
## Summary

Adds the GitHub live connector (issue #683 PR 5/6).

- New file: `packages/remnic-core/src/connectors/live/github.ts` implementing `LiveConnector`. Polls repos for issue comments, PR review comments, and opt-in discussion posts by the configured userLogin.
- Auth: personal access token via config; raw fetch; no octokit.
- Cursor: per-repo per-resource updated_at watermarks. First sync seeds without importing.
- Author filtering client-side. 429/5xx transient; 404/403 terminal.
- Config: connectors.github.{enabled,token,userLogin,repos,pollIntervalMs,includeDiscussions}.
- Both openclaw.plugin.json, config.ts, types.ts updated.
- 34 hermetic tests; all pass.

## Test plan

- [x] 34/34 connector unit tests pass
- [x] 118/118 full live-connector suite pass
- [x] preflight:quick — no new failures vs main baseline
- [x] No secrets or personal data in diff

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new networked live connector that ingests GitHub content using a personal access token and introduces new cursor/state semantics; issues here could affect polling behavior and data duplication/skips.
> 
> **Overview**
> Adds a new **GitHub live connector** that polls configured repos and imports issue comments, PR review comments, and *optionally* discussion comments authored by a specified `userLogin`, using a PAT and raw `fetch`.
> 
> Wires the connector into the operator config surface by extending `openclaw.plugin.json`, `config.ts` parsing/validation, and `types.ts` with `connectors.github` settings (`enabled`, `token`, `userLogin`, `repos`, `pollIntervalMs`, `includeDiscussions`).
> 
> Implements cursor-based incremental sync with per-repo/resource `updated_at` watermarks plus `seenIds` to prevent same-timestamp reimports, and adds an extensive stubbed test suite covering validation, first-sync seeding, filtering/dedup, watermark advancement, budgeting, aborts, and error classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef8a308556ba5f7808ac3a835ca1b01bfb0eebe8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->