### PR TITLE
feat(admin): real-time SSE graph events (issue #691 PR 5/5)

### DIFF
--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -1292,6 +1292,18 @@ async function loadMemoryGraph() {
 // ─── Real-time graph SSE updates (issue #691 PR 5/5) ────────────────────────
 
 /**
+ * Pending edge-added payloads whose source or target node had not yet arrived
+ * when the event was first processed.  Retried on every subsequent node-added
+ * event (Codex review thread PRRT_kwDORJXyws59soGK).
+ *
+ * Entries are removed once both endpoint nodes exist in graphData.nodes.
+ * The queue is bounded to 200 entries to prevent unbounded growth from a
+ * disconnected or very busy stream.
+ */
+const _orphanEdgeQueue = [];
+const _ORPHAN_EDGE_QUEUE_MAX = 200;
+
+/**
  * Active EventSource connection for /engram/v1/graph/events.
  * Only one connection is maintained at a time; `mountGraphEventSource` closes
  * the previous one before opening a new one.
@@ -1331,8 +1343,36 @@ function applyGraphEvent(event) {
       };
       graphData.nodes.push(node);
       graphColorForCategory(node.kind);
+      // Drain any queued orphan edges now that a new node has arrived.
+      // Iterate backwards so splicing by index is safe.
+      let drainedAny = false;
+      for (let i = _orphanEdgeQueue.length - 1; i >= 0; i--) {
+        const op = _orphanEdgeQueue[i];
+        const s = graphData.nodes.find((n) => n.id === op.source);
+        const t = graphData.nodes.find((n) => n.id === op.target);
+        if (s && t) {
+          _orphanEdgeQueue.splice(i, 1);
+          const alreadyExists = graphData.edges.some(
+            (e) => e.source === op.source && e.target === op.target && e.kind === op.kind,
+          );
+          if (!alreadyExists) {
+            graphData.edges.push({
+              source: op.source,
+              target: op.target,
+              kind: op.kind,
+              weight: typeof op.weight === "number" ? op.weight : 1.0,
+              label: op.label || "",
+              confidence: typeof op.confidence === "number" ? op.confidence : 1.0,
+              _srcNode: s,
+              _tgtNode: t,
+            });
+            drainedAny = true;
+          }
+        }
+      }
       if (graphSim) graphSim.reheat();
       drawGraph();
+      if (drainedAny && graphSim) graphSim.reheat();
     }
     return;
   }
@@ -1369,6 +1409,26 @@ function applyGraphEvent(event) {
         graphData.edges.push(edge);
         if (graphSim) graphSim.reheat();
         drawGraph();
+      }
+    } else {
+      // One or both endpoint nodes haven't arrived yet — queue the edge payload
+      // so it can be applied once the missing nodes appear (Codex review thread
+      // PRRT_kwDORJXyws59soGK).  Enforce a cap to prevent unbounded growth.
+      const alreadyQueued = _orphanEdgeQueue.some(
+        (e) => e.source === p.source && e.target === p.target && e.kind === p.kind,
+      );
+      if (!alreadyQueued) {
+        if (_orphanEdgeQueue.length >= _ORPHAN_EDGE_QUEUE_MAX) {
+          _orphanEdgeQueue.shift(); // drop the oldest orphan
+        }
+        _orphanEdgeQueue.push({
+          source: p.source,
+          target: p.target,
+          kind: p.kind,
+          weight: p.weight,
+          label: p.label,
+          confidence: p.confidence,
+        });
       }
     }
     return;

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -1386,16 +1386,28 @@ function applyGraphEvent(event) {
   }
 
   if (event.type === "edge-removed") {
+    // Track which nodes had at least one edge BEFORE this removal so we
+    // only prune nodes that lost their last edge.  Nodes that were already
+    // isolated (no edges at all) are intentional standalone nodes and must
+    // not be removed (Cursor review thread `app.js:1398`).
+    const hadEdges = new Set();
+    for (const e of graphData.edges) {
+      hadEdges.add(e.source);
+      hadEdges.add(e.target);
+    }
     graphData.edges = graphData.edges.filter(
       (e) => !(e.source === p.source && e.target === p.target && e.kind === p.kind),
     );
-    // Prune orphan nodes (nodes with no remaining edges).
-    const connected = new Set();
+    // Build the still-connected set after removal.
+    const stillConnected = new Set();
     for (const e of graphData.edges) {
-      connected.add(e.source);
-      connected.add(e.target);
+      stillConnected.add(e.source);
+      stillConnected.add(e.target);
     }
-    graphData.nodes = graphData.nodes.filter((n) => connected.has(n.id));
+    // Only prune a node when it was connected before AND is now orphaned.
+    graphData.nodes = graphData.nodes.filter(
+      (n) => !hadEdges.has(n.id) || stillConnected.has(n.id),
+    );
     if (graphSim) graphSim.reheat();
     drawGraph();
   }

--- a/admin-console/public/app.js
+++ b/admin-console/public/app.js
@@ -1278,11 +1278,185 @@ async function loadMemoryGraph() {
   attachGraphInteractions(canvas);
   renderGraphLegend();
 
+  // Open (or re-open) the SSE stream so new edges appear in real time
+  // without a full re-fetch (issue #691 PR 5/5).
+  mountGraphEventSource();
+
   setStatus(
     "graphStatus",
     `Loaded ${nodes.length} nodes, ${edges.length} edges. Generated ${snapshot.generatedAt}.`,
     "ok",
   );
+}
+
+// ─── Real-time graph SSE updates (issue #691 PR 5/5) ────────────────────────
+
+/**
+ * Active EventSource connection for /engram/v1/graph/events.
+ * Only one connection is maintained at a time; `mountGraphEventSource` closes
+ * the previous one before opening a new one.
+ */
+let graphEventSource = null;
+
+/**
+ * Apply a single graph mutation event to the in-memory graphData and
+ * re-render without a full re-fetch.
+ *
+ * Supported mutation types:
+ *   node-added    — add a node if not already present
+ *   node-updated  — update label/kind on an existing node
+ *   edge-added    — add an edge if the source/target nodes exist
+ *   edge-updated  — update weight/confidence on a matching edge
+ *   edge-removed  — remove matching edges from the simulation
+ */
+function applyGraphEvent(event) {
+  if (!graphData) return; // graph not loaded yet; skip
+  const p = event.payload;
+
+  if (event.type === "node-added") {
+    const existing = graphData.nodes.find((n) => n.id === p.nodeId);
+    if (!existing) {
+      const node = {
+        id: p.nodeId,
+        label: p.label || p.nodeId,
+        kind: p.kind || "unknown",
+        score: 1,
+        lastUpdated: p.lastUpdated || event.ts,
+        // Place new nodes at a random position near the canvas centre.
+        x: (Math.random() - 0.5) * 200,
+        y: (Math.random() - 0.5) * 200,
+        vx: 0,
+        vy: 0,
+        _memoryId: null,
+      };
+      graphData.nodes.push(node);
+      graphColorForCategory(node.kind);
+      if (graphSim) graphSim.reheat();
+      drawGraph();
+    }
+    return;
+  }
+
+  if (event.type === "node-updated") {
+    const node = graphData.nodes.find((n) => n.id === p.nodeId);
+    if (node) {
+      node.label = p.label || node.label;
+      node.kind = p.kind || node.kind;
+      if (p.lastUpdated) node.lastUpdated = p.lastUpdated;
+      drawGraph();
+    }
+    return;
+  }
+
+  if (event.type === "edge-added") {
+    const srcNode = graphData.nodes.find((n) => n.id === p.source);
+    const tgtNode = graphData.nodes.find((n) => n.id === p.target);
+    if (srcNode && tgtNode) {
+      const alreadyExists = graphData.edges.some(
+        (e) => e.source === p.source && e.target === p.target && e.kind === p.kind,
+      );
+      if (!alreadyExists) {
+        const edge = {
+          source: p.source,
+          target: p.target,
+          kind: p.kind,
+          weight: typeof p.weight === "number" ? p.weight : 1.0,
+          label: p.label || "",
+          confidence: typeof p.confidence === "number" ? p.confidence : 1.0,
+          _srcNode: srcNode,
+          _tgtNode: tgtNode,
+        };
+        graphData.edges.push(edge);
+        if (graphSim) graphSim.reheat();
+        drawGraph();
+      }
+    }
+    return;
+  }
+
+  if (event.type === "edge-updated") {
+    for (const edge of graphData.edges) {
+      if (edge.source === p.source && edge.target === p.target && edge.kind === p.kind) {
+        if (typeof p.weight === "number") edge.weight = p.weight;
+        if (typeof p.confidence === "number") edge.confidence = p.confidence;
+      }
+    }
+    drawGraph();
+    return;
+  }
+
+  if (event.type === "edge-removed") {
+    graphData.edges = graphData.edges.filter(
+      (e) => !(e.source === p.source && e.target === p.target && e.kind === p.kind),
+    );
+    // Prune orphan nodes (nodes with no remaining edges).
+    const connected = new Set();
+    for (const e of graphData.edges) {
+      connected.add(e.source);
+      connected.add(e.target);
+    }
+    graphData.nodes = graphData.nodes.filter((n) => connected.has(n.id));
+    if (graphSim) graphSim.reheat();
+    drawGraph();
+  }
+}
+
+/**
+ * Open a Server-Sent Events connection to /engram/v1/graph/events and
+ * patch graphData in-place as events arrive.
+ *
+ * Called once during graph pane initialisation (inside loadMemoryGraph).
+ * Re-opening is handled via the EventSource's built-in reconnect logic.
+ *
+ * The EventSource spec requires the URL to carry auth, because the
+ * EventSource constructor does not support headers.  We pass the bearer
+ * token as `?token=...` — the server checks both the Authorization header
+ * and this query parameter so curl/browser callers both work.
+ */
+function mountGraphEventSource() {
+  // Close any previous connection first (e.g. after a graph refresh).
+  if (graphEventSource) {
+    try { graphEventSource.close(); } catch { /* ignore */ }
+    graphEventSource = null;
+  }
+
+  const token = readToken();
+  if (!token) return; // no token → no stream; user can still use manual refresh
+
+  const url = `/engram/v1/graph/events?token=${encodeURIComponent(token)}`;
+  let es;
+  try {
+    es = new EventSource(url);
+  } catch {
+    // EventSource not supported (e.g. test environment); silently skip.
+    return;
+  }
+  graphEventSource = es;
+
+  es.onmessage = (e) => {
+    let parsed;
+    try { parsed = JSON.parse(e.data); } catch { return; }
+    if (!parsed || typeof parsed !== "object") return;
+
+    if (parsed.type === "connected" || parsed.type === "heartbeat") {
+      // Control frames — no graphData mutation needed.
+      return;
+    }
+
+    if (parsed.type === "batch" && Array.isArray(parsed.events)) {
+      for (const ev of parsed.events) {
+        applyGraphEvent(ev);
+      }
+      return;
+    }
+
+    // Fallback: treat as a single event (forward compatibility).
+    if (parsed.type) applyGraphEvent(parsed);
+  };
+
+  es.onerror = () => {
+    // EventSource reconnects automatically; nothing to do here.
+  };
 }
 
 // ─── Graph search + drill-through (issue #691 PR 4/5) ───────────────────────

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -134,6 +134,13 @@ export class EngramAccessHttpServer {
   /** Throttle batch: pending SSE event batches per client. */
   private readonly sseBatchTimers = new Map<ServerResponse, ReturnType<typeof setTimeout>>();
   private readonly ssePendingBatches = new Map<ServerResponse, GraphEvent[]>();
+  /**
+   * Per-client cleanup callbacks: clear heartbeat interval, flush timer,
+   * unsubscribe from bus, and end the response.  Stored here so `stop()`
+   * can invoke them even when the client hasn't disconnected yet
+   * (Cursor review thread `access-http.ts:232`).
+   */
+  private readonly sseCleanupFns = new Set<() => void>();
 
   constructor(options: EngramAccessHttpServerOptions) {
     this.service = options.service;
@@ -219,8 +226,16 @@ export class EngramAccessHttpServer {
     const server = this.server;
     this.server = null;
     this.boundPort = 0;
-    // Drain all pending SSE batch timers and close client streams before
-    // closing the HTTP server so no dangling keep-alive connections block it.
+    // Invoke each SSE client's cleanup callback so heartbeat intervals,
+    // batch timers, and graph-bus subscriptions are all released before the
+    // HTTP server closes.  Without this, long-running SSE connections leak
+    // setInterval handles and EventEmitter listeners (Cursor review thread
+    // `access-http.ts:232`).
+    for (const cleanup of this.sseCleanupFns) {
+      try { cleanup(); } catch { /* ignore */ }
+    }
+    this.sseCleanupFns.clear();
+    // Belt-and-suspenders: clear any state not yet reached by cleanup fns.
     for (const [res, timer] of this.sseBatchTimers.entries()) {
       clearTimeout(timer);
       this.sseBatchTimers.delete(res);
@@ -351,7 +366,7 @@ export class EngramAccessHttpServer {
       return;
     }
 
-    if (!this.isAuthorized(req)) {
+    if (!this.isAuthorized(req, pathname)) {
       const body = JSON.stringify({ error: "unauthorized", code: "unauthorized" });
       res.writeHead(401, {
         "content-type": "application/json; charset=utf-8",
@@ -1172,13 +1187,27 @@ export class EngramAccessHttpServer {
    * Lifecycle:
    *  1. Write SSE headers (Content-Type: text/event-stream).
    *  2. Register this response in `sseClients`.
-   *  3. Subscribe to the graph event bus for the resolved memoryDir.
+   *  3. Resolve the namespace from the request and subscribe to THAT
+   *     namespace's graph event bus (Codex P1: in multi-namespace
+   *     deployments each namespace has its own bus keyed by its storage
+   *     dir — subscribing to the global root leaks events across tenants).
    *  4. On each event, add to a 200 ms batch; flush batch as a single SSE frame.
    *  5. Send heartbeat every 25 s.
    *  6. On client disconnect (req "close"), clean up timers and unsubscribe.
+   *  7. Register the cleanup callback in `sseCleanupFns` so `stop()` can
+   *     release the heartbeat interval and bus subscription even when the
+   *     client never disconnects (Cursor review thread `access-http.ts:232`).
    */
   private async handleGraphEventsSSE(req: IncomingMessage, res: ServerResponse): Promise<void> {
-    const memoryDir = this.service.memoryDir;
+    // Resolve namespace from the ?namespace= query parameter (same pattern
+    // as graphSnapshot and other read endpoints).  Falls back to the
+    // default namespace when absent.
+    const parsed = new URL(req.url ?? "/", `http://${hostToUrlAuthority(this.host)}`);
+    const namespaceParam = parsed.searchParams.get("namespace");
+    const namespace = namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined;
+    // Resolve to the per-namespace storage directory so the bus subscription
+    // is scoped to the correct tenant (CLAUDE.md rule 42).
+    const memoryDir = await this.service.getMemoryDirForNamespace(namespace);
 
     res.writeHead(200, {
       "content-type": "text/event-stream; charset=utf-8",
@@ -1238,8 +1267,14 @@ export class EngramAccessHttpServer {
       this.ssePendingBatches.delete(res);
       unsubscribe();
       this.sseClients.delete(res);
+      this.sseCleanupFns.delete(cleanup);
       try { res.end(); } catch { /* ignore */ }
     };
+
+    // Register so stop() can invoke cleanup even when the client is still
+    // connected (releases the heartbeat interval and bus subscription
+    // before the HTTP server is torn down).
+    this.sseCleanupFns.add(cleanup);
 
     req.once("close", cleanup);
     req.once("error", cleanup);
@@ -1381,7 +1416,7 @@ export class EngramAccessHttpServer {
     return result.data as SchemaTypeFor<S>;
   }
 
-  private isAuthorized(req: IncomingMessage): boolean {
+  private isAuthorized(req: IncomingMessage, pathname?: string): boolean {
     if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter) return false;
     // Primary path: Authorization: Bearer <token> header.
     const raw = req.headers.authorization;
@@ -1395,11 +1430,15 @@ export class EngramAccessHttpServer {
         }
       }
     }
-    // Fallback: ?token= query parameter for SSE clients (EventSource can't
-    // set request headers).  Only accepted when no Authorization header is
-    // present — Authorization always wins.  CLAUDE.md rule 6: same security
-    // model as the header path; timing-safe compare used below.
-    if (!candidate) {
+    // Fallback: ?token= query parameter — ONLY accepted for the SSE
+    // endpoint (/engram/v1/graph/events).  EventSource cannot set request
+    // headers, so SSE clients must pass the token via the query string.
+    // Allowing this fallback on every endpoint would let a CSRF attacker
+    // embed a credentialed URL anywhere — restricting it to SSE limits the
+    // attack surface (Codex P2 review thread `access-http.ts:1406`; Cursor
+    // review thread `access-http.ts:1412`).  Authorization header always
+    // wins; timing-safe compare used below.
+    if (!candidate && pathname === "/engram/v1/graph/events") {
       try {
         const parsed = new URL(req.url ?? "/", `http://${hostToUrlAuthority(this.host)}`);
         const queryToken = parsed.searchParams.get("token");

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -14,6 +14,10 @@ import { isRecallDisclosure } from "./types.js";
 import { isTrustZoneName, type TrustZoneName, type TrustZoneRecordKind, type TrustZoneSourceClass } from "./trust-zones.js";
 import { AdapterRegistry, type ResolvedIdentity } from "./adapters/index.js";
 import type { CitationEntry } from "./citations.js";
+import {
+  subscribeGraphEvents,
+  type GraphEvent,
+} from "./graph-events.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -125,6 +129,11 @@ export class EngramAccessHttpServer {
   private readonly mcpServer: EngramMcpServer;
   private server: Server | null = null;
   private boundPort = 0;
+  /** Active SSE response objects for /engram/v1/graph/events. */
+  private readonly sseClients = new Set<ServerResponse>();
+  /** Throttle batch: pending SSE event batches per client. */
+  private readonly sseBatchTimers = new Map<ServerResponse, ReturnType<typeof setTimeout>>();
+  private readonly ssePendingBatches = new Map<ServerResponse, GraphEvent[]>();
 
   constructor(options: EngramAccessHttpServerOptions) {
     this.service = options.service;
@@ -210,6 +219,17 @@ export class EngramAccessHttpServer {
     const server = this.server;
     this.server = null;
     this.boundPort = 0;
+    // Drain all pending SSE batch timers and close client streams before
+    // closing the HTTP server so no dangling keep-alive connections block it.
+    for (const [res, timer] of this.sseBatchTimers.entries()) {
+      clearTimeout(timer);
+      this.sseBatchTimers.delete(res);
+    }
+    this.ssePendingBatches.clear();
+    for (const res of this.sseClients) {
+      try { res.end(); } catch { /* ignore */ }
+    }
+    this.sseClients.clear();
     await new Promise<void>((resolve, reject) => {
       server.close((err) => (err ? reject(err) : resolve()));
     });
@@ -1119,7 +1139,110 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // ── Graph mutation event stream (issue #691 PR 5/5) ──────────────────────
+    //
+    // GET /engram/v1/graph/events
+    //
+    // Server-Sent Events stream that emits graph mutation events in real time.
+    // Event types: node-added, node-updated, edge-added, edge-updated, edge-removed.
+    //
+    // Auth: same Bearer token scheme as every other endpoint (checked above).
+    //
+    // The SSE handler subscribes to the in-process graph event bus for the
+    // resolved memory dir.  Events are batched within a 200 ms window so a
+    // burst of writes (e.g. extraction of a large turn) doesn't overwhelm
+    // the admin UI canvas with individual re-renders.
+    //
+    // The client receives a `data: <json>\n\n` line per batch.  Each batch
+    // payload is { events: GraphEvent[] }.
+    //
+    // The stream sends a heartbeat `data: {"type":"heartbeat"}\n\n` every
+    // 25 s so load balancers and proxies don't time out idle connections.
+    if (req.method === "GET" && pathname === "/engram/v1/graph/events") {
+      await this.handleGraphEventsSSE(req, res);
+      return;
+    }
+
     this.respondJson(res, 404, { error: "not_found", code: "not_found" });
+  }
+
+  /**
+   * SSE handler for /engram/v1/graph/events.
+   *
+   * Lifecycle:
+   *  1. Write SSE headers (Content-Type: text/event-stream).
+   *  2. Register this response in `sseClients`.
+   *  3. Subscribe to the graph event bus for the resolved memoryDir.
+   *  4. On each event, add to a 200 ms batch; flush batch as a single SSE frame.
+   *  5. Send heartbeat every 25 s.
+   *  6. On client disconnect (req "close"), clean up timers and unsubscribe.
+   */
+  private async handleGraphEventsSSE(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const memoryDir = this.service.memoryDir;
+
+    res.writeHead(200, {
+      "content-type": "text/event-stream; charset=utf-8",
+      "cache-control": "no-cache, no-store, must-revalidate",
+      "connection": "keep-alive",
+      "x-accel-buffering": "no",     // prevent nginx buffering
+      "transfer-encoding": "chunked",
+    });
+
+    // Send initial "connected" frame so the client knows the stream is live.
+    const writeSSE = (payload: unknown): void => {
+      try {
+        res.write(`data: ${JSON.stringify(payload)}\n\n`);
+      } catch {
+        // client already gone — cleanup will fire via "close"
+      }
+    };
+
+    writeSSE({ type: "connected" });
+
+    this.sseClients.add(res);
+
+    // --- 200 ms batch throttle -----------------------------------------------
+    const flushBatch = (): void => {
+      const batch = this.ssePendingBatches.get(res);
+      if (!batch || batch.length === 0) return;
+      this.ssePendingBatches.delete(res);
+      this.sseBatchTimers.delete(res);
+      writeSSE({ type: "batch", events: batch });
+    };
+
+    const unsubscribe = subscribeGraphEvents(memoryDir, (event: GraphEvent) => {
+      let batch = this.ssePendingBatches.get(res);
+      if (!batch) {
+        batch = [];
+        this.ssePendingBatches.set(res, batch);
+      }
+      batch.push(event);
+      if (!this.sseBatchTimers.has(res)) {
+        this.sseBatchTimers.set(res, setTimeout(flushBatch, 200));
+      }
+    });
+
+    // --- 25 s heartbeat -------------------------------------------------------
+    const heartbeatInterval = setInterval(() => {
+      writeSSE({ type: "heartbeat" });
+    }, 25_000);
+
+    // --- Cleanup on client disconnect -----------------------------------------
+    const cleanup = (): void => {
+      clearInterval(heartbeatInterval);
+      const timer = this.sseBatchTimers.get(res);
+      if (timer !== undefined) {
+        clearTimeout(timer);
+        this.sseBatchTimers.delete(res);
+      }
+      this.ssePendingBatches.delete(res);
+      unsubscribe();
+      this.sseClients.delete(res);
+      try { res.end(); } catch { /* ignore */ }
+    };
+
+    req.once("close", cleanup);
+    req.once("error", cleanup);
   }
 
   private async handleMcpRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
@@ -1260,13 +1383,35 @@ export class EngramAccessHttpServer {
 
   private isAuthorized(req: IncomingMessage): boolean {
     if (!this.authToken && this.authTokens.length === 0 && !this.authTokensGetter) return false;
+    // Primary path: Authorization: Bearer <token> header.
     const raw = req.headers.authorization;
-    if (!raw) return false;
-    const separator = raw.indexOf(" ");
-    if (separator <= 0) return false;
-    const scheme = raw.slice(0, separator).toLowerCase();
-    if (scheme !== "bearer") return false;
-    const token = raw.slice(separator + 1).trim();
+    let candidate: string | null = null;
+    if (raw) {
+      const separator = raw.indexOf(" ");
+      if (separator > 0) {
+        const scheme = raw.slice(0, separator).toLowerCase();
+        if (scheme === "bearer") {
+          candidate = raw.slice(separator + 1).trim();
+        }
+      }
+    }
+    // Fallback: ?token= query parameter for SSE clients (EventSource can't
+    // set request headers).  Only accepted when no Authorization header is
+    // present — Authorization always wins.  CLAUDE.md rule 6: same security
+    // model as the header path; timing-safe compare used below.
+    if (!candidate) {
+      try {
+        const parsed = new URL(req.url ?? "/", `http://${hostToUrlAuthority(this.host)}`);
+        const queryToken = parsed.searchParams.get("token");
+        if (queryToken && queryToken.length > 0) {
+          candidate = queryToken;
+        }
+      } catch {
+        // Malformed URL — don't authenticate
+      }
+    }
+    if (!candidate) return false;
+    const token = candidate;
     // Check primary token
     if (this.authToken && this.timingSafeStringEqual(token, this.authToken)) return true;
     // Check static multi-connector tokens

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1207,7 +1207,11 @@ export class EngramAccessHttpServer {
     const namespace = namespaceParam && namespaceParam.length > 0 ? namespaceParam : undefined;
     // Resolve to the per-namespace storage directory so the bus subscription
     // is scoped to the correct tenant (CLAUDE.md rule 42).
-    const memoryDir = await this.service.getMemoryDirForNamespace(namespace);
+    // Pass the request principal so namespace ACL is enforced — without it,
+    // resolveReadableNamespace throws when namespacesEnabled=true (Cursor
+    // thread PRRT_kwDORJXyws59snoR / Codex thread PRRT_kwDORJXyws59soGJ).
+    const principal = this.resolveRequestPrincipal(req);
+    const memoryDir = await this.service.getMemoryDirForNamespace(namespace, principal);
 
     res.writeHead(200, {
       "content-type": "text/event-stream; charset=utf-8",

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4115,6 +4115,21 @@ export class EngramAccessService {
     return this.orchestrator.config.memoryDir;
   }
 
+  /**
+   * Resolve the storage directory for a given namespace.  Used by the SSE
+   * graph-event handler to subscribe to the correct per-namespace bus rather
+   * than the global root (CLAUDE.md rule 42 — read/write paths must resolve
+   * through the same namespace layer).
+   *
+   * Falls back to `this.memoryDir` when namespaces are disabled or the
+   * namespace is absent, matching the behaviour of every other read path.
+   */
+  async getMemoryDirForNamespace(namespace?: string): Promise<string> {
+    const resolved = this.resolveReadableNamespace(namespace, undefined);
+    const storage = await this.orchestrator.getStorage(resolved);
+    return storage.dir;
+  }
+
   get storageRef(): StorageManager {
     return this.orchestrator.storage;
   }

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4121,11 +4121,16 @@ export class EngramAccessService {
    * than the global root (CLAUDE.md rule 42 — read/write paths must resolve
    * through the same namespace layer).
    *
+   * `principal` must be the transport-bound request principal (from
+   * `resolveRequestPrincipal`).  When namespaces are enabled, an absent
+   * principal causes `resolveReadableNamespace` to throw an auth error,
+   * matching the behaviour of every other authenticated read path.
+   *
    * Falls back to `this.memoryDir` when namespaces are disabled or the
    * namespace is absent, matching the behaviour of every other read path.
    */
-  async getMemoryDirForNamespace(namespace?: string): Promise<string> {
-    const resolved = this.resolveReadableNamespace(namespace, undefined);
+  async getMemoryDirForNamespace(namespace?: string, principal?: string): Promise<string> {
+    const resolved = this.resolveReadableNamespace(namespace, principal);
     const storage = await this.orchestrator.getStorage(resolved);
     return storage.dir;
   }

--- a/packages/remnic-core/src/graph-events.ts
+++ b/packages/remnic-core/src/graph-events.ts
@@ -1,0 +1,151 @@
+/**
+ * In-process EventEmitter for graph mutation events (issue #691 PR 5/5).
+ *
+ * The singleton is keyed by memoryDir so multiple orchestrator instances in
+ * the same process get distinct event buses (CLAUDE.md rule 11: scope globals
+ * per service).  The SSE handler in access-http.ts subscribes to the bus for
+ * the resolved namespace and fans out to connected clients.
+ *
+ * Event types mirror the five mutations the graph layer can produce:
+ *   node-added    — a memory file was referenced for the first time
+ *   node-updated  — a memory file's metadata changed
+ *   edge-added    — a new edge was appended
+ *   edge-updated  — an existing edge's confidence/weight was modified
+ *   edge-removed  — an edge was pruned (e.g. by decay maintenance)
+ *
+ * The `GraphEventBus` interface is intentionally narrow so nothing outside
+ * this module needs to import Node.js EventEmitter directly.
+ */
+
+import { EventEmitter } from "node:events";
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type GraphEventType =
+  | "node-added"
+  | "node-updated"
+  | "edge-added"
+  | "edge-updated"
+  | "edge-removed";
+
+export interface GraphEvent {
+  type: GraphEventType;
+  /** Memory dir that owns this event (absolute path). */
+  memoryDir: string;
+  /** ISO timestamp of the event. */
+  ts: string;
+  /** Payload depends on event type — always serialisable to JSON. */
+  payload: Record<string, unknown>;
+}
+
+export interface NodeAddedPayload {
+  nodeId: string;   // relative memory path
+  kind: string;
+  label: string;
+  lastUpdated: string;
+}
+
+export interface NodeUpdatedPayload {
+  nodeId: string;
+  kind: string;
+  label: string;
+  lastUpdated: string;
+}
+
+export interface EdgeAddedPayload {
+  source: string;
+  target: string;
+  kind: string;
+  weight: number;
+  label: string;
+  confidence: number;
+}
+
+export interface EdgeUpdatedPayload {
+  source: string;
+  target: string;
+  kind: string;
+  weight: number;
+  confidence: number;
+}
+
+export interface EdgeRemovedPayload {
+  source: string;
+  target: string;
+  kind: string;
+}
+
+// ---------------------------------------------------------------------------
+// Per-memoryDir singleton bus
+// ---------------------------------------------------------------------------
+
+const buses = new Map<string, EventEmitter>();
+
+/**
+ * Return (or lazily create) the event bus for the given memoryDir.
+ * The same bus is shared by the write side (graph.ts → appendEdge hooks) and
+ * the read side (EngramAccessHttpServer SSE handler).
+ */
+export function getGraphEventBus(memoryDir: string): EventEmitter {
+  let bus = buses.get(memoryDir);
+  if (!bus) {
+    bus = new EventEmitter();
+    // Remove the default listener-count warning — SSE clients may hold many
+    // concurrent connections. Each SSE client registers one "graph-event"
+    // listener; warn only when an unreasonably high count suggests a leak.
+    bus.setMaxListeners(200);
+    buses.set(memoryDir, bus);
+  }
+  return bus;
+}
+
+/**
+ * Emit a single graph event onto the bus for memoryDir.
+ * Fails open: any listener that throws is caught so one bad client can't
+ * crash the extraction pipeline.
+ */
+export function emitGraphEvent(
+  memoryDir: string,
+  type: GraphEventType,
+  payload: Record<string, unknown>,
+): void {
+  const event: GraphEvent = {
+    type,
+    memoryDir,
+    ts: new Date().toISOString(),
+    payload,
+  };
+  const bus = getGraphEventBus(memoryDir);
+  try {
+    bus.emit("graph-event", event);
+  } catch {
+    // fail-open: never propagate listener errors to the write path
+  }
+}
+
+/**
+ * Subscribe to graph events for a given memoryDir.
+ * Returns an unsubscribe function.
+ */
+export function subscribeGraphEvents(
+  memoryDir: string,
+  listener: (event: GraphEvent) => void,
+): () => void {
+  const bus = getGraphEventBus(memoryDir);
+  bus.on("graph-event", listener);
+  return () => bus.off("graph-event", listener);
+}
+
+/**
+ * Remove all listeners and the bus entry for a memoryDir.
+ * Useful for tests that spin up isolated memory dirs.
+ */
+export function destroyGraphEventBus(memoryDir: string): void {
+  const bus = buses.get(memoryDir);
+  if (bus) {
+    bus.removeAllListeners();
+    buses.delete(memoryDir);
+  }
+}

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -14,6 +14,7 @@ import { mkdir, appendFile, readFile } from "node:fs/promises";
 import * as path from "path";
 
 import { readEdgeConfidence } from "./graph-edge-reinforcement.js";
+import { emitGraphEvent } from "./graph-events.js";
 
 export type GraphType = "entity" | "time" | "causal";
 
@@ -125,6 +126,17 @@ export async function appendEdge(memoryDir: string, edge: GraphEdge): Promise<vo
   const line = JSON.stringify(edge) + "\n";
   await withGraphWriteLock(filePath, async () => {
     await appendFile(filePath, line, "utf8");
+  });
+  // Emit edge-added event for SSE subscribers (issue #691 PR 5/5).
+  // Fail-open: emitGraphEvent catches listener errors so a bad SSE client
+  // can never surface into the extraction pipeline.
+  emitGraphEvent(memoryDir, "edge-added", {
+    source: edge.from,
+    target: edge.to,
+    kind: edge.type,
+    weight: edge.weight,
+    label: edge.label,
+    confidence: typeof edge.confidence === "number" ? edge.confidence : 1.0,
   });
 }
 

--- a/src/graph-events.ts
+++ b/src/graph-events.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/graph-events.js";

--- a/tests/admin-console-app.test.ts
+++ b/tests/admin-console-app.test.ts
@@ -98,6 +98,13 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
     navigator: {},
   });
   vm.runInContext(script, context, { filename: scriptPath });
+
+  type GraphNode = { id: string; label: string; kind: string; score: number; lastUpdated: string; x: number; y: number; vx: number; vy: number; _memoryId: null };
+  type GraphEdge = { source: string; target: string; kind: string; weight: number; label: string; confidence: number; _srcNode: GraphNode; _tgtNode: GraphNode };
+  type GraphData = { nodes: GraphNode[]; edges: GraphEdge[] } | null;
+  type OrphanEdge = { source: string; target: string; kind: string; weight?: number; label?: string; confidence?: number };
+  type AppEvent = { type: string; payload: Record<string, unknown>; ts: string };
+
   return {
     browserState: vm.runInContext("browserState", context) as { limit: number; offset: number; total: number },
     copyMemoryPath: vm.runInContext("copyMemoryPath", context) as () => void,
@@ -111,12 +118,15 @@ async function loadAdminConsoleContext(pageSizeValue: string, extraElements: Rec
       height: number,
     ) => { start: (fn: () => void) => void; stop: () => void },
     drawGraph: vm.runInContext("drawGraph", context) as () => void,
-    graphData: vm.runInContext("graphData", context),
+    graphData: vm.runInContext("graphData", context) as GraphData,
     graphView: vm.runInContext("graphView", context) as { tx: number; ty: number; scale: number },
     resolveHighlights: vm.runInContext("resolveHighlights", context) as (
       nodes: Array<{ id: string }>,
       results: Array<{ id: string; path?: string }>,
     ) => Map<string, string>,
+    applyGraphEvent: vm.runInContext("applyGraphEvent", context) as (event: AppEvent) => void,
+    _orphanEdgeQueue: vm.runInContext("_orphanEdgeQueue", context) as OrphanEdge[],
+    getContext: () => context,
   };
 }
 
@@ -343,4 +353,120 @@ test("resolveHighlights returns empty map when nodes array is empty", async () =
   const { resolveHighlights } = await loadAdminConsoleContext("25");
   const matched = resolveHighlights([], [{ id: "fact-abc", path: "/Users/me/.remnic/facts/foo.md" }]);
   assert.equal(matched.size, 0);
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orphan edge queue — issue #691 PR 5/5 (Codex thread PRRT_kwDORJXyws59soGK)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Build a minimal graphData-aware context for applyGraphEvent unit tests.
+ * We initialise graphData using a small VM snippet that assigns the script's
+ * own `let graphData` binding, so applyGraphEvent's closure sees the value.
+ */
+async function loadGraphEventContext() {
+  const ctx = await loadAdminConsoleContext("25");
+  const ts = new Date().toISOString();
+  // Run a snippet inside the same VM context that assigns the module-level
+  // `graphData` variable directly.  Setting vmCtx.graphData would NOT work
+  // because the script's `let graphData` shadows the context property.
+  vm.runInContext("graphData = { nodes: [], edges: [] };", ctx.getContext());
+  // Expose a live reference to the array objects via the VM's own getter.
+  const getGraphData = vm.runInContext("() => graphData", ctx.getContext()) as () => { nodes: unknown[]; edges: unknown[] };
+  return { ...ctx, ts, getGraphData };
+}
+
+test("edge-added with both nodes present is applied immediately (no orphan queue)", async () => {
+  const { applyGraphEvent, _orphanEdgeQueue, getGraphData, ts } = await loadGraphEventContext();
+
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/a.md", kind: "fact", label: "A" }, ts });
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/b.md", kind: "fact", label: "B" }, ts });
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  assert.equal(getGraphData().edges.length, 1, "edge must be applied immediately when both nodes exist");
+  assert.equal(_orphanEdgeQueue.length, 0, "orphan queue must be empty when both nodes were present");
+});
+
+test("edge-added with missing source node is queued and applied when node arrives", async () => {
+  const { applyGraphEvent, _orphanEdgeQueue, getGraphData, ts } = await loadGraphEventContext();
+
+  // Only target node present.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/b.md", kind: "fact", label: "B" }, ts });
+
+  // Edge arrives before source node.
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  assert.equal(getGraphData().edges.length, 0, "edge must not be applied while source node is absent");
+  assert.equal(_orphanEdgeQueue.length, 1, "edge must be queued while source node is absent");
+
+  // Source node arrives later.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/a.md", kind: "fact", label: "A" }, ts });
+
+  assert.equal(getGraphData().edges.length, 1, "queued edge must be applied once source node arrives");
+  assert.equal(_orphanEdgeQueue.length, 0, "orphan queue must be drained after source node arrives");
+});
+
+test("edge-added with missing target node is queued and applied when node arrives", async () => {
+  const { applyGraphEvent, _orphanEdgeQueue, getGraphData, ts } = await loadGraphEventContext();
+
+  // Only source node present.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/a.md", kind: "fact", label: "A" }, ts });
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/c.md", kind: "entity", weight: 0.8, label: "x", confidence: 0.9 }, ts });
+
+  assert.equal(getGraphData().edges.length, 0);
+  assert.equal(_orphanEdgeQueue.length, 1);
+
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/c.md", kind: "fact", label: "C" }, ts });
+
+  assert.equal(getGraphData().edges.length, 1);
+  assert.equal(_orphanEdgeQueue.length, 0);
+  // Weight and confidence must be preserved through the queue.
+  const edge = getGraphData().edges[0] as Record<string, unknown>;
+  assert.equal(edge.weight, 0.8);
+  assert.equal(edge.confidence, 0.9);
+});
+
+test("orphan edge with both nodes missing is applied once the second node arrives", async () => {
+  const { applyGraphEvent, _orphanEdgeQueue, getGraphData, ts } = await loadGraphEventContext();
+
+  // Neither endpoint node is present yet.
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/x.md", target: "facts/y.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  assert.equal(_orphanEdgeQueue.length, 1, "edge must be queued when both nodes are absent");
+
+  // First node arrives — still can't apply edge.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/x.md", kind: "fact", label: "X" }, ts });
+  assert.equal(getGraphData().edges.length, 0, "edge still pending after only one node arrives");
+  assert.equal(_orphanEdgeQueue.length, 1, "edge still in queue after only one node arrives");
+
+  // Second node arrives — edge can now be applied.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/y.md", kind: "fact", label: "Y" }, ts });
+  assert.equal(getGraphData().edges.length, 1, "edge applied once second node arrives");
+  assert.equal(_orphanEdgeQueue.length, 0, "orphan queue empty after both nodes arrived");
+});
+
+test("duplicate orphan edges are not queued twice", async () => {
+  const { applyGraphEvent, _orphanEdgeQueue, ts } = await loadGraphEventContext();
+
+  // Same edge twice before either node arrives.
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/p.md", target: "facts/q.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/p.md", target: "facts/q.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  assert.equal(_orphanEdgeQueue.length, 1, "duplicate orphan edge must not be queued twice");
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// applyGraphEvent: guard for graphData === null
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("applyGraphEvent is a no-op when graphData is null", async () => {
+  const ctx = await loadAdminConsoleContext("25");
+  // graphData starts as null; applyGraphEvent must not throw.
+  assert.doesNotThrow(() =>
+    ctx.applyGraphEvent({
+      type: "edge-added",
+      payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity", weight: 1, label: "", confidence: 1 },
+      ts: new Date().toISOString(),
+    }),
+  );
 });

--- a/tests/graph-events-sse.test.ts
+++ b/tests/graph-events-sse.test.ts
@@ -1,0 +1,362 @@
+/**
+ * Tests for real-time SSE graph events (issue #691 PR 5/5).
+ *
+ * Covers:
+ *  1. emitGraphEvent() reaches subscribeGraphEvents() listener.
+ *  2. appendEdge() automatically emits an "edge-added" event.
+ *  3. GET /engram/v1/graph/events returns 200 text/event-stream.
+ *  4. An "edge-added" event emitted after connection appears in the stream.
+ *  5. 401 when auth token is missing or wrong.
+ *  6. ?token= query-parameter auth accepted (EventSource path).
+ *  7. destroyGraphEventBus() cleans up listener set so subsequent tests start fresh.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import * as path from "node:path";
+import http from "node:http";
+import { mkdtemp, rm } from "node:fs/promises";
+
+import {
+  emitGraphEvent,
+  subscribeGraphEvents,
+  destroyGraphEventBus,
+  type GraphEvent,
+} from "../src/graph-events.js";
+import { appendEdge } from "../src/graph.js";
+import { EngramAccessHttpServer } from "../src/access-http.js";
+import type { EngramAccessService } from "../src/access-service.js";
+
+// ---------------------------------------------------------------------------
+// Minimal fake service (sufficient for the SSE route)
+// ---------------------------------------------------------------------------
+
+function makeFakeService(memoryDir: string): EngramAccessService {
+  // We only need the memoryDir getter for the SSE handler.
+  return {
+    memoryDir,
+    health: async () => ({
+      ok: true,
+      memoryDir,
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      searchBackend: "qmd",
+      qmdEnabled: false,
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: false,
+    }),
+    // All other methods are not exercised in these tests.
+  } as unknown as EngramAccessService;
+}
+
+// ---------------------------------------------------------------------------
+// Helper: collect N SSE data frames from an HTTP response stream.
+// ---------------------------------------------------------------------------
+
+function collectSseFrames(
+  options: http.RequestOptions,
+  n: number,
+  timeoutMs = 3000,
+): Promise<unknown[]> {
+  return new Promise((resolve, reject) => {
+    const frames: unknown[] = [];
+    const timer = setTimeout(() => {
+      req.destroy();
+      if (frames.length >= n) {
+        resolve(frames.slice(0, n));
+      } else {
+        reject(new Error(`SSE timeout: collected ${frames.length} frames, expected ${n}`));
+      }
+    }, timeoutMs);
+
+    const req = http.request(options, (res) => {
+      let buf = "";
+      res.setEncoding("utf8");
+      res.on("data", (chunk: string) => {
+        buf += chunk;
+        const lines = buf.split("\n");
+        buf = lines.pop() ?? "";
+        for (const line of lines) {
+          const trimmed = line.trim();
+          if (trimmed.startsWith("data: ")) {
+            try {
+              frames.push(JSON.parse(trimmed.slice(6)));
+            } catch {
+              // ignore non-JSON lines
+            }
+            if (frames.length >= n) {
+              clearTimeout(timer);
+              req.destroy();
+              resolve(frames.slice(0, n));
+              return;
+            }
+          }
+        }
+      });
+      res.on("error", (err) => {
+        clearTimeout(timer);
+        // Ignore ECONNRESET from req.destroy() once we have enough frames
+        if (frames.length >= n) {
+          resolve(frames.slice(0, n));
+        } else {
+          reject(err);
+        }
+      });
+    });
+    req.on("error", (err) => {
+      clearTimeout(timer);
+      if (frames.length >= n) {
+        resolve(frames.slice(0, n));
+      } else {
+        reject(err);
+      }
+    });
+    req.end();
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: graph-events module
+// ---------------------------------------------------------------------------
+
+test("emitGraphEvent reaches subscribeGraphEvents listener", () => {
+  const dir = "/tmp/engram-test-emit-" + Date.now();
+  try {
+    const received: GraphEvent[] = [];
+    const unsub = subscribeGraphEvents(dir, (e) => received.push(e));
+    emitGraphEvent(dir, "edge-added", { source: "a.md", target: "b.md", kind: "entity" });
+    unsub();
+    assert.equal(received.length, 1);
+    assert.equal(received[0]!.type, "edge-added");
+    assert.equal((received[0]!.payload as Record<string, unknown>).source, "a.md");
+    assert.equal(received[0]!.memoryDir, dir);
+    assert.ok(!Number.isNaN(Date.parse(received[0]!.ts)));
+  } finally {
+    destroyGraphEventBus(dir);
+  }
+});
+
+test("subscribeGraphEvents unsubscribe prevents further delivery", () => {
+  const dir = "/tmp/engram-test-unsub-" + Date.now();
+  try {
+    const received: GraphEvent[] = [];
+    const unsub = subscribeGraphEvents(dir, (e) => received.push(e));
+    unsub();
+    emitGraphEvent(dir, "edge-added", { source: "x.md", target: "y.md" });
+    assert.equal(received.length, 0);
+  } finally {
+    destroyGraphEventBus(dir);
+  }
+});
+
+test("destroyGraphEventBus removes all listeners", () => {
+  const dir = "/tmp/engram-test-destroy-" + Date.now();
+  const received: GraphEvent[] = [];
+  subscribeGraphEvents(dir, (e) => received.push(e));
+  destroyGraphEventBus(dir);
+  emitGraphEvent(dir, "edge-added", { source: "a.md", target: "b.md" });
+  // emitGraphEvent recreates a fresh bus after destroy; old listener not attached
+  assert.equal(received.length, 0);
+  destroyGraphEventBus(dir);
+});
+
+test("appendEdge emits edge-added event on the graph event bus", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-append-edge-"));
+  try {
+    const received: GraphEvent[] = [];
+    const unsub = subscribeGraphEvents(dir, (e) => received.push(e));
+    await appendEdge(dir, {
+      from: "facts/a.md",
+      to: "facts/b.md",
+      type: "entity",
+      weight: 1.0,
+      label: "test-entity",
+      ts: new Date().toISOString(),
+      confidence: 0.9,
+    });
+    unsub();
+    assert.equal(received.length, 1);
+    const ev = received[0]!;
+    assert.equal(ev.type, "edge-added");
+    assert.equal((ev.payload as Record<string, unknown>).source, "facts/a.md");
+    assert.equal((ev.payload as Record<string, unknown>).target, "facts/b.md");
+    assert.equal((ev.payload as Record<string, unknown>).kind, "entity");
+    assert.equal((ev.payload as Record<string, unknown>).confidence, 0.9);
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// HTTP / SSE integration tests
+// ---------------------------------------------------------------------------
+
+async function startTestServer(memoryDir: string, token = "test-token") {
+  const service = makeFakeService(memoryDir);
+  const server = new EngramAccessHttpServer({
+    service,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: token,
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  return { server, port: status.port };
+}
+
+test("GET /engram/v1/graph/events returns 200 text/event-stream", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-headers-"));
+  try {
+    const { server, port } = await startTestServer(dir);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/engram/v1/graph/events",
+            headers: { Authorization: "Bearer test-token" },
+          },
+          (res) => {
+            assert.equal(res.statusCode, 200);
+            assert.ok(
+              res.headers["content-type"]?.includes("text/event-stream"),
+              `expected text/event-stream, got ${res.headers["content-type"]}`,
+            );
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+    } finally {
+      await server.stop();
+    }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("GET /engram/v1/graph/events returns 401 with wrong token", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-unauth-"));
+  try {
+    const { server, port } = await startTestServer(dir, "correct-token");
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/engram/v1/graph/events",
+            headers: { Authorization: "Bearer wrong-token" },
+          },
+          (res) => {
+            assert.equal(res.statusCode, 401);
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+    } finally {
+      await server.stop();
+    }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("GET /engram/v1/graph/events accepts ?token= query parameter", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-qtoken-"));
+  try {
+    const { server, port } = await startTestServer(dir, "qtoken-secret");
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/engram/v1/graph/events?token=qtoken-secret",
+            // No Authorization header — browser EventSource path
+          },
+          (res) => {
+            assert.equal(res.statusCode, 200);
+            assert.ok(
+              res.headers["content-type"]?.includes("text/event-stream"),
+            );
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+    } finally {
+      await server.stop();
+    }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("edge-added event emitted after connection appears in the SSE stream", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-event-"));
+  try {
+    const { server, port } = await startTestServer(dir, "stream-token");
+    try {
+      // Collect the first two frames: "connected" + a batch with edge-added.
+      const framesPromise = collectSseFrames(
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/engram/v1/graph/events",
+          headers: { Authorization: "Bearer stream-token" },
+        },
+        2, // connected frame + one batch frame
+      );
+
+      // Wait a tick for the SSE connection to be established before emitting.
+      await new Promise<void>((r) => setTimeout(r, 50));
+
+      // Emit directly via the event bus (avoids needing a full storage setup).
+      emitGraphEvent(dir, "edge-added", {
+        source: "facts/p.md",
+        target: "facts/q.md",
+        kind: "entity",
+        weight: 1.0,
+        label: "test",
+        confidence: 1.0,
+      });
+
+      const frames = await framesPromise;
+
+      // First frame must be "connected"
+      const first = frames[0] as Record<string, unknown>;
+      assert.equal(first.type, "connected");
+
+      // Second frame should be a batch containing our edge-added event.
+      const second = frames[1] as Record<string, unknown>;
+      assert.equal(second.type, "batch");
+      const events = second.events as Array<Record<string, unknown>>;
+      assert.ok(Array.isArray(events) && events.length >= 1);
+      const edgeEvent = events.find((e) => e.type === "edge-added");
+      assert.ok(edgeEvent, "expected edge-added event in batch");
+      assert.equal(
+        (edgeEvent!.payload as Record<string, unknown>).source,
+        "facts/p.md",
+      );
+    } finally {
+      await server.stop();
+    }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/graph-events-sse.test.ts
+++ b/tests/graph-events-sse.test.ts
@@ -51,7 +51,7 @@ function makeFakeService(memoryDir: string): EngramAccessService {
     }),
     // Namespace resolution for the SSE handler — single-namespace stub
     // always returns the root memoryDir.
-    getMemoryDirForNamespace: async (_ns?: string) => memoryDir,
+    getMemoryDirForNamespace: async (_ns?: string, _principal?: string) => memoryDir,
     // All other methods are not exercised in these tests.
   } as unknown as EngramAccessService;
 }
@@ -392,7 +392,7 @@ test("SSE handler subscribes to namespace-resolved bus dir", async () => {
       nativeKnowledgeEnabled: false,
       projectionAvailable: false,
     }),
-    getMemoryDirForNamespace: async (ns?: string) => {
+    getMemoryDirForNamespace: async (ns?: string, _principal?: string) => {
       const resolved = ns === "tenant-a" ? nsDir : rootDir;
       resolvedDirs.push(resolved);
       return resolved;
@@ -442,6 +442,81 @@ test("SSE handler subscribes to namespace-resolved bus dir", async () => {
   }
 });
 
+// ---------------------------------------------------------------------------
+// Fix (Cursor PRRT_kwDORJXyws59snoR + Codex PRRT_kwDORJXyws59soGJ):
+// SSE handler must forward the request principal to getMemoryDirForNamespace
+// so namespace ACLs are enforced when namespacesEnabled=true.
+// ---------------------------------------------------------------------------
+
+test("SSE handler forwards request principal to getMemoryDirForNamespace", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-principal-"));
+
+  const capturedCalls: Array<{ ns: string | undefined; principal: string | undefined }> = [];
+  const fakeService = {
+    memoryDir: rootDir,
+    health: async () => ({
+      ok: true,
+      memoryDir: rootDir,
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      searchBackend: "qmd",
+      qmdEnabled: false,
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: false,
+    }),
+    getMemoryDirForNamespace: async (ns?: string, principal?: string) => {
+      capturedCalls.push({ ns, principal });
+      return rootDir;
+    },
+  } as unknown as import("../src/access-service.js").EngramAccessService;
+
+  // Use trustPrincipalHeader so the x-engram-principal header is forwarded as
+  // the request principal (matching the production authenticated path).
+  const server = new EngramAccessHttpServer({
+    service: fakeService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "principal-token",
+    adminConsoleEnabled: false,
+    trustPrincipalHeader: true,
+  });
+  const { port } = await server.start();
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      const req = http.request(
+        {
+          host: "127.0.0.1",
+          port,
+          path: "/engram/v1/graph/events",
+          headers: {
+            Authorization: "Bearer principal-token",
+            "x-engram-principal": "user-alice",
+          },
+        },
+        (res) => {
+          assert.equal(res.statusCode, 200);
+          req.destroy();
+          resolve();
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+
+    // Give the async SSE handler time to resolve the service call.
+    await new Promise<void>((r) => setTimeout(r, 80));
+
+    assert.ok(capturedCalls.length >= 1, "getMemoryDirForNamespace must be called");
+    const call = capturedCalls[capturedCalls.length - 1]!;
+    assert.equal(call.principal, "user-alice", "principal must be forwarded to getMemoryDirForNamespace");
+  } finally {
+    await server.stop();
+    destroyGraphEventBus(rootDir);
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
 test("SSE events from a different namespace do not reach an unrelated subscriber", async () => {
   const rootDir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-ns-iso-"));
   const nsA = path.join(rootDir, "ns-a");
@@ -453,7 +528,7 @@ test("SSE events from a different namespace do not reach an unrelated subscriber
   const fakeService = {
     memoryDir: rootDir,
     health: async () => ({ ok: true, memoryDir: rootDir, namespacesEnabled: true, defaultNamespace: "global", searchBackend: "qmd", qmdEnabled: false, nativeKnowledgeEnabled: false, projectionAvailable: false }),
-    getMemoryDirForNamespace: async (ns?: string) => ns === "ns-a" ? nsA : rootDir,
+    getMemoryDirForNamespace: async (ns?: string, _principal?: string) => ns === "ns-a" ? nsA : rootDir,
   } as unknown as import("../src/access-service.js").EngramAccessService;
 
   const server = new EngramAccessHttpServer({

--- a/tests/graph-events-sse.test.ts
+++ b/tests/graph-events-sse.test.ts
@@ -33,7 +33,10 @@ import type { EngramAccessService } from "../src/access-service.js";
 // ---------------------------------------------------------------------------
 
 function makeFakeService(memoryDir: string): EngramAccessService {
-  // We only need the memoryDir getter for the SSE handler.
+  // We only need the memoryDir getter and getMemoryDirForNamespace for
+  // the SSE handler (the latter is needed after the namespace-scoped bus
+  // fix — it resolves the per-namespace storage dir so the handler
+  // subscribes to the correct bus).
   return {
     memoryDir,
     health: async () => ({
@@ -46,6 +49,9 @@ function makeFakeService(memoryDir: string): EngramAccessService {
       nativeKnowledgeEnabled: false,
       projectionAvailable: false,
     }),
+    // Namespace resolution for the SSE handler — single-namespace stub
+    // always returns the root memoryDir.
+    getMemoryDirForNamespace: async (_ns?: string) => memoryDir,
     // All other methods are not exercised in these tests.
   } as unknown as EngramAccessService;
 }
@@ -355,6 +361,331 @@ test("edge-added event emitted after connection appears in the SSE stream", asyn
     } finally {
       await server.stop();
     }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fix 1 (Codex P1): SSE subscribes to the namespace-resolved bus, not global
+// ---------------------------------------------------------------------------
+
+test("SSE handler subscribes to namespace-resolved bus dir", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-ns-"));
+  const nsDir = path.join(rootDir, "namespaces", "tenant-a");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(nsDir, { recursive: true });
+
+  // Build a service stub where getMemoryDirForNamespace returns a different
+  // dir for "tenant-a" than the root — simulating a multi-namespace deploy.
+  const resolvedDirs: string[] = [];
+  const fakeService = {
+    memoryDir: rootDir,
+    health: async () => ({
+      ok: true,
+      memoryDir: rootDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      searchBackend: "qmd",
+      qmdEnabled: false,
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: false,
+    }),
+    getMemoryDirForNamespace: async (ns?: string) => {
+      const resolved = ns === "tenant-a" ? nsDir : rootDir;
+      resolvedDirs.push(resolved);
+      return resolved;
+    },
+  } as unknown as import("../src/access-service.js").EngramAccessService;
+
+  const server = new EngramAccessHttpServer({
+    service: fakeService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "ns-token",
+    adminConsoleEnabled: false,
+  });
+  const status = await server.start();
+  const port = status.port;
+
+  try {
+    // Connect to the SSE endpoint requesting namespace=tenant-a.
+    const framesPromise = collectSseFrames(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/engram/v1/graph/events?namespace=tenant-a",
+        headers: { Authorization: "Bearer ns-token" },
+      },
+      2,
+      2000,
+    );
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    // Emit to the namespace-specific dir — should reach the client.
+    emitGraphEvent(nsDir, "node-added", { nodeId: "facts/ns.md", kind: "fact", label: "ns" });
+
+    const frames = await framesPromise;
+    assert.equal((frames[0] as Record<string, unknown>).type, "connected");
+    const batch = frames[1] as Record<string, unknown>;
+    assert.equal(batch.type, "batch");
+
+    // Verify the handler resolved getMemoryDirForNamespace with "tenant-a".
+    assert.ok(resolvedDirs.includes(nsDir), "getMemoryDirForNamespace should have been called with tenant-a dir");
+  } finally {
+    await server.stop();
+    destroyGraphEventBus(rootDir);
+    destroyGraphEventBus(nsDir);
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+test("SSE events from a different namespace do not reach an unrelated subscriber", async () => {
+  const rootDir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-ns-iso-"));
+  const nsA = path.join(rootDir, "ns-a");
+  const nsB = path.join(rootDir, "ns-b");
+  const { mkdir } = await import("node:fs/promises");
+  await mkdir(nsA, { recursive: true });
+  await mkdir(nsB, { recursive: true });
+
+  const fakeService = {
+    memoryDir: rootDir,
+    health: async () => ({ ok: true, memoryDir: rootDir, namespacesEnabled: true, defaultNamespace: "global", searchBackend: "qmd", qmdEnabled: false, nativeKnowledgeEnabled: false, projectionAvailable: false }),
+    getMemoryDirForNamespace: async (ns?: string) => ns === "ns-a" ? nsA : rootDir,
+  } as unknown as import("../src/access-service.js").EngramAccessService;
+
+  const server = new EngramAccessHttpServer({
+    service: fakeService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "iso-token",
+    adminConsoleEnabled: false,
+  });
+  const { port } = await server.start();
+
+  try {
+    // Client subscribes to ns-a.
+    const framesPromise = collectSseFrames(
+      {
+        host: "127.0.0.1",
+        port,
+        path: "/engram/v1/graph/events?namespace=ns-a",
+        headers: { Authorization: "Bearer iso-token" },
+      },
+      1, // only the "connected" frame — we don't expect any batch
+      800,
+    );
+
+    await new Promise<void>((r) => setTimeout(r, 50));
+
+    // Emit to ns-b — should NOT reach the ns-a client.
+    emitGraphEvent(nsB, "node-added", { nodeId: "facts/other.md", kind: "fact", label: "other" });
+
+    const frames = await framesPromise;
+    // Only the "connected" frame should have arrived.
+    assert.equal(frames.length, 1);
+    assert.equal((frames[0] as Record<string, unknown>).type, "connected");
+  } finally {
+    await server.stop();
+    destroyGraphEventBus(rootDir);
+    destroyGraphEventBus(nsA);
+    destroyGraphEventBus(nsB);
+    await rm(rootDir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2+5 (Codex P2 + Cursor): ?token= fallback restricted to SSE endpoint
+// ---------------------------------------------------------------------------
+
+test("?token= query param rejected on non-SSE endpoints", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-qtoken-reject-"));
+  try {
+    const { server, port } = await startTestServer(dir, "secret-tok");
+    try {
+      // Try ?token= on the health endpoint — must return 401, not 200.
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/engram/v1/health?token=secret-tok",
+            // No Authorization header
+          },
+          (res) => {
+            assert.equal(
+              res.statusCode,
+              401,
+              `?token= should be rejected on /health; got ${res.statusCode}`,
+            );
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+
+      // Confirm the same token works via Authorization: Bearer header.
+      await new Promise<void>((resolve, reject) => {
+        const req = http.request(
+          {
+            host: "127.0.0.1",
+            port,
+            path: "/engram/v1/health",
+            headers: { Authorization: "Bearer secret-tok" },
+          },
+          (res) => {
+            assert.equal(res.statusCode, 200);
+            req.destroy();
+            resolve();
+          },
+        );
+        req.on("error", reject);
+        req.end();
+      });
+    } finally {
+      await server.stop();
+    }
+  } finally {
+    destroyGraphEventBus(dir);
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Fix 3 (Cursor): edge-removed must not prune intentionally isolated nodes
+// ---------------------------------------------------------------------------
+
+// This test is a unit test of the applyGraphEvent() logic in app.js.
+// We inline a minimal version of the function so it runs in Node without a
+// DOM, mirroring the real implementation.
+
+function makeApplyGraphEvent() {
+  type GraphNode = { id: string; label: string; kind: string; score: number; lastUpdated: string; x: number; y: number; vx: number; vy: number; _memoryId: null };
+  type GraphEdge = { source: string; target: string; kind: string; weight: number; label: string; confidence: number; _srcNode: GraphNode; _tgtNode: GraphNode };
+  const graphData: { nodes: GraphNode[]; edges: GraphEdge[] } = { nodes: [], edges: [] };
+  const graphSim = null;
+
+  function applyGraphEvent(event: { type: string; payload: Record<string, unknown>; ts: string }) {
+    if (!graphData) return;
+    const p = event.payload;
+
+    if (event.type === "node-added") {
+      const existing = graphData.nodes.find((n) => n.id === p.nodeId);
+      if (!existing) {
+        graphData.nodes.push({ id: p.nodeId as string, label: (p.label as string) || (p.nodeId as string), kind: (p.kind as string) || "unknown", score: 1, lastUpdated: (p.lastUpdated as string) || event.ts, x: 0, y: 0, vx: 0, vy: 0, _memoryId: null });
+      }
+      return;
+    }
+
+    if (event.type === "edge-added") {
+      const srcNode = graphData.nodes.find((n) => n.id === p.source);
+      const tgtNode = graphData.nodes.find((n) => n.id === p.target);
+      if (srcNode && tgtNode) {
+        const alreadyExists = graphData.edges.some((e) => e.source === p.source && e.target === p.target && e.kind === p.kind);
+        if (!alreadyExists) {
+          graphData.edges.push({ source: p.source as string, target: p.target as string, kind: p.kind as string, weight: typeof p.weight === "number" ? p.weight : 1.0, label: (p.label as string) || "", confidence: typeof p.confidence === "number" ? p.confidence : 1.0, _srcNode: srcNode, _tgtNode: tgtNode });
+        }
+      }
+      return;
+    }
+
+    if (event.type === "edge-removed") {
+      // Mirror the FIXED logic from app.js: only prune nodes that had edges AND now have none.
+      const hadEdges = new Set<string>();
+      for (const e of graphData.edges) { hadEdges.add(e.source); hadEdges.add(e.target); }
+      graphData.edges = graphData.edges.filter((e) => !(e.source === p.source && e.target === p.target && e.kind === p.kind));
+      const stillConnected = new Set<string>();
+      for (const e of graphData.edges) { stillConnected.add(e.source); stillConnected.add(e.target); }
+      graphData.nodes = graphData.nodes.filter((n) => !hadEdges.has(n.id) || stillConnected.has(n.id));
+      if (graphSim) (graphSim as unknown as { reheat(): void }).reheat();
+    }
+  }
+
+  return { graphData, applyGraphEvent };
+}
+
+test("edge-removed: isolated (edgeless) nodes are preserved", () => {
+  const { graphData, applyGraphEvent } = makeApplyGraphEvent();
+  const ts = new Date().toISOString();
+
+  // Add three nodes: A and B will be connected; I is intentionally isolated.
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/a.md", kind: "fact", label: "A" }, ts });
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/b.md", kind: "fact", label: "B" }, ts });
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/i.md", kind: "fact", label: "I" }, ts });
+
+  // Connect A → B.
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  assert.equal(graphData.nodes.length, 3);
+  assert.equal(graphData.edges.length, 1);
+
+  // Remove the A → B edge.
+  applyGraphEvent({ type: "edge-removed", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity" }, ts });
+
+  // A and B should be pruned (they had an edge and lost it).
+  // I must remain (it never had an edge).
+  assert.equal(graphData.edges.length, 0);
+  assert.equal(graphData.nodes.length, 1, "isolated node I must survive edge-removed");
+  assert.equal(graphData.nodes[0]!.id, "facts/i.md");
+});
+
+test("edge-removed: node with other remaining edges is preserved", () => {
+  const { graphData, applyGraphEvent } = makeApplyGraphEvent();
+  const ts = new Date().toISOString();
+
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/a.md", kind: "fact", label: "A" }, ts });
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/b.md", kind: "fact", label: "B" }, ts });
+  applyGraphEvent({ type: "node-added", payload: { nodeId: "facts/c.md", kind: "fact", label: "C" }, ts });
+
+  // A → B and A → C
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+  applyGraphEvent({ type: "edge-added", payload: { source: "facts/a.md", target: "facts/c.md", kind: "entity", weight: 1, label: "", confidence: 1 }, ts });
+
+  // Remove only A → B.
+  applyGraphEvent({ type: "edge-removed", payload: { source: "facts/a.md", target: "facts/b.md", kind: "entity" }, ts });
+
+  // B loses all its edges → pruned.
+  // A and C still share an edge → preserved.
+  assert.equal(graphData.edges.length, 1);
+  assert.equal(graphData.nodes.length, 2);
+  const ids = graphData.nodes.map((n) => n.id).sort();
+  assert.deepEqual(ids, ["facts/a.md", "facts/c.md"]);
+});
+
+// ---------------------------------------------------------------------------
+// Fix 4 (Cursor): stop() cleans up heartbeat intervals and bus subscriptions
+// ---------------------------------------------------------------------------
+
+test("stop() cleans up heartbeat intervals and bus subscriptions without waiting for client disconnect", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "engram-sse-stop-"));
+  try {
+    const { server, port } = await startTestServer(dir, "stop-token");
+
+    // Open an SSE connection and keep it open (never close from the client side).
+    const req = http.request({
+      host: "127.0.0.1",
+      port,
+      path: "/engram/v1/graph/events",
+      headers: { Authorization: "Bearer stop-token" },
+    });
+    req.end();
+
+    // Wait for the connection to be established.
+    await new Promise<void>((r) => setTimeout(r, 80));
+
+    // Stop the server — must not hang even though the SSE client is still connected.
+    const stopPromise = server.stop();
+    const timeout = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("stop() timed out — likely leaked interval or open handle")), 2000),
+    );
+    await Promise.race([stopPromise, timeout]);
+
+    // Clean up the dangling client request.
+    req.destroy();
   } finally {
     destroyGraphEventBus(dir);
     await rm(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

- Adds `GET /engram/v1/graph/events` — a Server-Sent Events stream that pushes graph mutation events (`edge-added`, `edge-updated`, `edge-removed`, `node-added`, `node-updated`) to connected clients in real time.
- New `graph-events.ts` module: in-process `EventEmitter` bus keyed per `memoryDir`; public API: `emitGraphEvent`, `subscribeGraphEvents`, `destroyGraphEventBus`. Bus is scoped per service instance (CLAUDE.md rule 11).
- `graph.ts`: `appendEdge` emits `edge-added` onto the bus after persisting to JSONL (fail-open — listener errors are caught so write pipeline is never affected).
- `access-http.ts`: SSE handler with 200 ms event batching (throttles bursty extraction writes), 25 s heartbeat, and full cleanup on client disconnect/server stop. Auth accepts `Authorization: Bearer <token>` header **or** `?token=` query param (needed because browser `EventSource` cannot set request headers).
- `admin-console/public/app.js`: `mountGraphEventSource()` opens an `EventSource` when the graph pane loads; `applyGraphEvent()` patches `graphData` in-place (node/edge add/update/remove) and calls `drawGraph()` without a full re-fetch.

## Test plan

- [ ] 8 new tests in `tests/graph-events-sse.test.ts`:
  - `emitGraphEvent` reaches `subscribeGraphEvents` listener
  - Unsubscribe stops delivery
  - `destroyGraphEventBus` cleans up listeners between tests
  - `appendEdge` automatically emits `edge-added` event
  - `GET /engram/v1/graph/events` returns `200 text/event-stream`
  - Returns `401` with wrong token
  - Accepts `?token=` query param (EventSource path)
  - End-to-end: event emitted after connection appears in the stream as a `batch` frame
- [ ] All 8 pass locally (`npx tsx --test tests/graph-events-sse.test.ts`)
- [ ] Existing graph-snapshot + access-http tests (43) still pass
- [ ] 61 pre-existing failures on `main` are unrelated (bench-smoke, LCM, SQLite subsystems)

## PR checklist

- [x] All tests pass
- [x] New logic covered by tests
- [x] No secrets or creds committed
- [x] No personal data
- [x] PR diff < 400 LOC core logic (851 total including tests and app.js)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new long-lived SSE endpoint plus client-side in-place graph mutation logic and tweaks auth handling to allow `?token=` on that route; mistakes could cause data leakage across namespaces or resource leaks if cleanup/regression fails.
> 
> **Overview**
> Adds real-time graph updates end-to-end: the core graph writer now emits mutation events onto a new per-`memoryDir` in-process bus (`graph-events.ts`), and `EngramAccessHttpServer` exposes `GET /engram/v1/graph/events` as an SSE stream that batches events and sends heartbeats.
> 
> Updates the admin console graph to open an `EventSource` on load and apply incoming node/edge add/update/remove events directly to `graphData` (including a bounded *orphan edge* queue for out-of-order events and safer node pruning on `edge-removed`) so the canvas re-renders without a full snapshot refresh.
> 
> Extends auth to accept `?token=` **only** for the SSE endpoint (since `EventSource` can’t set headers), scopes SSE subscriptions by namespace-resolved storage dir/principal, and adds integration/unit tests covering delivery, auth behavior, namespace isolation, and server shutdown cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14535994b19a5adc8acb38ea09e087a7da6bd03a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->