### PR TITLE
feat(peers): CLI / HTTP / MCP surfaces for peer registry (issue #679 PR 4/5)

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1119,6 +1119,70 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    // ── Peer Registry endpoints (issue #679 PR 4/5) ──────────────────────────
+    //   GET    /engram/v1/peers              — list all peers
+    //   GET    /engram/v1/peers/:id          — get one peer
+    //   PUT    /engram/v1/peers/:id          — upsert (create/update)
+    //   DELETE /engram/v1/peers/:id          — delete (idempotent)
+    //   GET    /engram/v1/peers/:id/profile  — get peer profile
+    if (req.method === "GET" && pathname === "/engram/v1/peers") {
+      const result = await this.service.peerList();
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    const peerProfileMatch = /^\/engram\/v1\/peers\/([^/]+)\/profile$/.exec(pathname);
+    if (peerProfileMatch) {
+      if (req.method !== "GET") {
+        this.respondJson(res, 405, { error: "method_not_allowed", code: "method_not_allowed" });
+        return;
+      }
+      const peerId = decodeURIComponent(peerProfileMatch[1] ?? "");
+      const result = await this.service.peerProfileGet(peerId);
+      if (!result.found) {
+        this.respondJson(res, 404, { error: "peer_profile_not_found", code: "peer_profile_not_found" });
+        return;
+      }
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    const peerIdMatch = /^\/engram\/v1\/peers\/([^/]+)$/.exec(pathname);
+    if (peerIdMatch) {
+      const peerId = decodeURIComponent(peerIdMatch[1] ?? "");
+
+      if (req.method === "GET") {
+        const result = await this.service.peerGet(peerId);
+        if (!result.found) {
+          this.respondJson(res, 404, { error: "peer_not_found", code: "peer_not_found" });
+          return;
+        }
+        this.respondJson(res, 200, result);
+        return;
+      }
+
+      if (req.method === "PUT") {
+        const body = await this.readJsonBody(req) as Record<string, unknown>;
+        const result = await this.service.peerSet({
+          id: peerId,
+          kind: typeof body.kind === "string" ? body.kind : undefined,
+          displayName: typeof body.displayName === "string" ? body.displayName : undefined,
+          notes: typeof body.notes === "string" ? body.notes : undefined,
+        });
+        this.respondJson(res, result.created ? 201 : 200, result);
+        return;
+      }
+
+      if (req.method === "DELETE") {
+        const result = await this.service.peerDelete(peerId);
+        this.respondJson(res, 200, result);
+        return;
+      }
+
+      this.respondJson(res, 405, { error: "method_not_allowed", code: "method_not_allowed" });
+      return;
+    }
+
     this.respondJson(res, 404, { error: "not_found", code: "not_found" });
   }
 

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -108,6 +108,19 @@ function parseTrustZoneFilter(raw: string | null): TrustZoneName | undefined {
   throw new HttpError(400, "zone must be one of quarantine|working|trusted", "invalid_zone_filter");
 }
 
+/**
+ * Decode a `:peerId` URL path segment, converting malformed percent-encoded
+ * input (e.g., `%E0%A4%A`) into a 400 client error rather than letting
+ * `URIError` bubble up as a 500 `internal_error`.
+ */
+function decodePeerIdSegment(raw: string): string {
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    throw new EngramAccessInputError("peerId path segment is not valid percent-encoded input");
+  }
+}
+
 export class EngramAccessHttpServer {
   private readonly service: EngramAccessService;
   private readonly host: string;
@@ -1137,7 +1150,7 @@ export class EngramAccessHttpServer {
         this.respondJson(res, 405, { error: "method_not_allowed", code: "method_not_allowed" });
         return;
       }
-      const peerId = decodeURIComponent(peerProfileMatch[1] ?? "");
+      const peerId = decodePeerIdSegment(peerProfileMatch[1] ?? "");
       const result = await this.service.peerProfileGet(peerId);
       if (!result.found) {
         this.respondJson(res, 404, { error: "peer_profile_not_found", code: "peer_profile_not_found" });
@@ -1149,7 +1162,7 @@ export class EngramAccessHttpServer {
 
     const peerIdMatch = /^\/engram\/v1\/peers\/([^/]+)$/.exec(pathname);
     if (peerIdMatch) {
-      const peerId = decodeURIComponent(peerIdMatch[1] ?? "");
+      const peerId = decodePeerIdSegment(peerIdMatch[1] ?? "");
 
       if (req.method === "GET") {
         const result = await this.service.peerGet(peerId);
@@ -1163,6 +1176,22 @@ export class EngramAccessHttpServer {
 
       if (req.method === "PUT") {
         const body = await this.readJsonBody(req) as Record<string, unknown>;
+        // Reject malformed types up front rather than silently dropping them
+        // to undefined and letting peerSet fall back to defaults
+        // (CLAUDE.md rule 51: no silent defaults on bad input).
+        if ("kind" in body && body.kind !== undefined && typeof body.kind !== "string") {
+          throw new EngramAccessInputError("kind must be a string when provided");
+        }
+        if (
+          "displayName" in body &&
+          body.displayName !== undefined &&
+          typeof body.displayName !== "string"
+        ) {
+          throw new EngramAccessInputError("displayName must be a string when provided");
+        }
+        if ("notes" in body && body.notes !== undefined && typeof body.notes !== "string") {
+          throw new EngramAccessInputError("notes must be a string when provided");
+        }
         const result = await this.service.peerSet({
           id: peerId,
           kind: typeof body.kind === "string" ? body.kind : undefined,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2077,6 +2077,20 @@ export class EngramMcpServer {
       case "remnic.peer_set": {
         const id = typeof args.id === "string" ? args.id : "";
         if (!id) throw new Error("engram.peer_set: id is required");
+        // Codex P2 (PR #756 round 2): mirror the HTTP surface — reject
+        // non-string `kind`/`displayName`/`notes` rather than silently
+        // coercing to `undefined` and letting peerSet fall back to its
+        // "human" default. Symmetry across access surfaces (CLAUDE.md
+        // rule 39) and no-silent-defaults on bad input (rule 51).
+        if (args.kind !== undefined && typeof args.kind !== "string") {
+          throw new Error("engram.peer_set: kind must be a string when provided");
+        }
+        if (args.displayName !== undefined && typeof args.displayName !== "string") {
+          throw new Error("engram.peer_set: displayName must be a string when provided");
+        }
+        if (args.notes !== undefined && typeof args.notes !== "string") {
+          throw new Error("engram.peer_set: notes must be a string when provided");
+        }
         return this.service.peerSet({
           id,
           kind: typeof args.kind === "string" ? args.kind : undefined,

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -1002,6 +1002,76 @@ export class EngramMcpServer {
           additionalProperties: false,
         },
       },
+      // ── Peer Registry tools (issue #679 PR 4/5) ─────────────────────────
+      {
+        name: "engram.peer_list",
+        description:
+          "List all registered peers in the peer registry (issue #679). Returns an array of peer identity records sorted alphabetically by id.",
+        inputSchema: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.peer_get",
+        description:
+          "Get a single peer by id. Returns the peer's identity record or { found: false } when not found (issue #679).",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Peer id to look up." },
+          },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.peer_set",
+        description:
+          "Create or update a peer identity record (issue #679). On first write, creates the peer with the given kind (default 'human'). On subsequent writes, updates displayName and/or notes; kind and createdAt are immutable.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Peer id — must match PEER_ID_PATTERN." },
+            kind: {
+              type: "string",
+              enum: ["self", "human", "agent", "integration"],
+              description: "Kind of peer. Required on first write; ignored on updates.",
+            },
+            displayName: { type: "string", description: "Human-readable display name." },
+            notes: { type: "string", description: "Optional free-form markdown notes." },
+          },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.peer_delete",
+        description:
+          "Delete a peer's identity record (issue #679). Idempotent — succeeds even if the peer does not exist. The peer directory is preserved so profile and interaction-log data are not destroyed.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Peer id to delete." },
+          },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.peer_profile_get",
+        description:
+          "Get the evolving cognitive profile for a peer (issue #679). Returns the profile written by the async reasoner (PR 2/5), or { found: false } if no profile has been generated yet.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Peer id whose profile to retrieve." },
+          },
+          required: ["id"],
+          additionalProperties: false,
+        },
+      },
     ].flatMap((tool) => withToolAliases(tool));
   }
 
@@ -1992,6 +2062,39 @@ export class EngramMcpServer {
           },
         );
         return { results };
+      }
+      // ── Peer Registry dispatchers (issue #679 PR 4/5) ─────────────────
+      case "engram.peer_list":
+      case "remnic.peer_list":
+        return this.service.peerList();
+      case "engram.peer_get":
+      case "remnic.peer_get": {
+        const id = typeof args.id === "string" ? args.id : "";
+        if (!id) throw new Error("engram.peer_get: id is required");
+        return this.service.peerGet(id);
+      }
+      case "engram.peer_set":
+      case "remnic.peer_set": {
+        const id = typeof args.id === "string" ? args.id : "";
+        if (!id) throw new Error("engram.peer_set: id is required");
+        return this.service.peerSet({
+          id,
+          kind: typeof args.kind === "string" ? args.kind : undefined,
+          displayName: typeof args.displayName === "string" ? args.displayName : undefined,
+          notes: typeof args.notes === "string" ? args.notes : undefined,
+        });
+      }
+      case "engram.peer_delete":
+      case "remnic.peer_delete": {
+        const id = typeof args.id === "string" ? args.id : "";
+        if (!id) throw new Error("engram.peer_delete: id is required");
+        return this.service.peerDelete(id);
+      }
+      case "engram.peer_profile_get":
+      case "remnic.peer_profile_get": {
+        const id = typeof args.id === "string" ? args.id : "";
+        if (!id) throw new Error("engram.peer_profile_get: id is required");
+        return this.service.peerProfileGet(id);
       }
       default:
         throw new Error(`unknown tool: ${name}`);

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4224,23 +4224,14 @@ export class EngramAccessService {
     } catch (err) {
       throw new EngramAccessInputError((err as Error).message);
     }
-    const { promises: fs } = await import("node:fs");
-    const path = await import("node:path");
-    const identityFile = path.join(
-      this.orchestrator.config.memoryDir,
-      "peers",
-      peerId,
-      "identity.md",
-    );
-    try {
-      await fs.unlink(identityFile);
-      return { ok: true, deleted: true };
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
-        return { ok: true, deleted: false };
-      }
-      throw err;
-    }
+    // Cursor M (PR #756 review): route through `peers.deletePeer` so
+    // the unlink runs `assertPeerDirNotEscaped`, the peers-root
+    // symlink check, and the parent-inode-stable / O_NOFOLLOW guards
+    // shared with `readPeer`/`writePeer`. A manual `path.join` +
+    // raw `fs.unlink` would let a symlinked `peers/<id>/` redirect
+    // the delete to an arbitrary `identity.md` outside `memoryDir`.
+    const deleted = await peers.deletePeer(this.orchestrator.config.memoryDir, peerId);
+    return { ok: true, deleted };
   }
 
   /**

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4109,6 +4109,164 @@ export class EngramAccessService {
     return { submitted: memoryIds.length, matched: matchedIds.length };
   }
 
+  // ── Peer Registry surfaces (issue #679 PR 4/5) ────────────────────────────
+
+  /**
+   * List all registered peers. Returns the array of `Peer` objects in
+   * deterministic alphabetical order (mirroring `listPeers` storage semantics).
+   */
+  async peerList(): Promise<{ peers: import("./peers/types.js").Peer[] }> {
+    const { listPeers } = await import("./peers/index.js");
+    const peers = await listPeers(this.orchestrator.config.memoryDir);
+    return { peers };
+  }
+
+  /**
+   * Get a single peer by id. Returns `{ found: false }` when the peer does
+   * not exist rather than throwing, matching the `memoryGet` / `entityGet`
+   * pattern used throughout the service.
+   */
+  async peerGet(
+    peerId: string,
+  ): Promise<
+    | { found: true; peer: import("./peers/types.js").Peer }
+    | { found: false }
+  > {
+    const peers = await import("./peers/index.js");
+    const validateId: (id: unknown) => void = peers.assertValidPeerId;
+    try {
+      validateId(peerId);
+    } catch (err) {
+      throw new EngramAccessInputError((err as Error).message);
+    }
+    const peer = await peers.readPeer(this.orchestrator.config.memoryDir, peerId);
+    if (!peer) return { found: false };
+    return { found: true, peer };
+  }
+
+  /**
+   * Upsert a peer. Writes `peers/{id}/identity.md`. On first write the
+   * `createdAt` timestamp is set to now; on subsequent writes only
+   * `displayName` and `notes` are mutated (kind and createdAt are immutable
+   * once set, per the storage contract).
+   *
+   * Returns `{ created: true }` on first write, `{ created: false }` on update.
+   */
+  async peerSet(input: {
+    id: string;
+    kind?: string;
+    displayName?: string;
+    notes?: string;
+  }): Promise<{ ok: true; created: boolean; peer: import("./peers/types.js").Peer }> {
+    const peers = await import("./peers/index.js");
+    const validateId: (id: unknown) => void = peers.assertValidPeerId;
+
+    const { id } = input;
+    try {
+      validateId(id);
+    } catch (err) {
+      throw new EngramAccessInputError((err as Error).message);
+    }
+
+    const memoryDir = this.orchestrator.config.memoryDir;
+    const now = new Date().toISOString();
+    const existing = await peers.readPeer(memoryDir, id);
+
+    const ALLOWED_KINDS = new Set(["self", "human", "agent", "integration"]);
+    if (!existing) {
+      // First write — require kind.
+      const kind = input.kind ?? "human";
+      if (!ALLOWED_KINDS.has(kind)) {
+        throw new EngramAccessInputError(
+          `peer kind must be one of ${[...ALLOWED_KINDS].join(", ")}`,
+        );
+      }
+      const newPeer: import("./peers/types.js").Peer = {
+        id,
+        kind: kind as import("./peers/types.js").PeerKind,
+        displayName: input.displayName ?? id,
+        createdAt: now,
+        updatedAt: now,
+        ...(typeof input.notes === "string" ? { notes: input.notes } : {}),
+      };
+      await peers.writePeer(memoryDir, newPeer);
+      return { ok: true, created: true, peer: newPeer };
+    }
+
+    // Update — kind and createdAt are immutable.
+    const updated: import("./peers/types.js").Peer = {
+      id: existing.id,
+      kind: existing.kind,
+      createdAt: existing.createdAt,
+      updatedAt: now,
+      displayName: input.displayName !== undefined ? input.displayName : existing.displayName,
+      ...(input.notes !== undefined
+        ? { notes: input.notes }
+        : existing.notes !== undefined
+          ? { notes: existing.notes }
+          : {}),
+    };
+    await peers.writePeer(memoryDir, updated);
+    return { ok: true, created: false, peer: updated };
+  }
+
+  /**
+   * Delete a peer by removing `peers/{id}/identity.md`. If the file does not
+   * exist the call is a no-op (idempotent). The peer directory itself
+   * (`peers/{id}/`) is intentionally left in place — profile and interaction
+   * log data are not destroyed.
+   */
+  async peerDelete(peerId: string): Promise<{ ok: true; deleted: boolean }> {
+    const peers = await import("./peers/index.js");
+    const validateId: (id: unknown) => void = peers.assertValidPeerId;
+    try {
+      validateId(peerId);
+    } catch (err) {
+      throw new EngramAccessInputError((err as Error).message);
+    }
+    const { promises: fs } = await import("node:fs");
+    const path = await import("node:path");
+    const identityFile = path.join(
+      this.orchestrator.config.memoryDir,
+      "peers",
+      peerId,
+      "identity.md",
+    );
+    try {
+      await fs.unlink(identityFile);
+      return { ok: true, deleted: true };
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+        return { ok: true, deleted: false };
+      }
+      throw err;
+    }
+  }
+
+  /**
+   * Get the evolving cognitive profile for a peer. Returns `{ found: false }`
+   * when no profile file exists yet (profile is written by the async reasoner,
+   * PR 2/5). The peer identity itself need not exist for a profile to exist,
+   * but in practice the reasoner only writes profiles for registered peers.
+   */
+  async peerProfileGet(
+    peerId: string,
+  ): Promise<
+    | { found: true; profile: import("./peers/types.js").PeerProfile }
+    | { found: false }
+  > {
+    const peers = await import("./peers/index.js");
+    const validateId: (id: unknown) => void = peers.assertValidPeerId;
+    try {
+      validateId(peerId);
+    } catch (err) {
+      throw new EngramAccessInputError((err as Error).message);
+    }
+    const profile = await peers.readPeerProfile(this.orchestrator.config.memoryDir, peerId);
+    if (!profile) return { found: false };
+    return { found: true, profile };
+  }
+
   // ── Contradiction Review (issue #520) ──────────────────────────────────────
 
   get memoryDir(): string {

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7715,56 +7715,28 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             console.error("peer id is required");
             process.exit(1);
           }
-          const peersSet = await import("./peers/index.js");
-          const validateIdSet: (id: unknown) => void = peersSet.assertValidPeerId;
+          // Cursor L (PR #756 review): route through EngramAccessService.peerSet
+          // so the CLI shares the canonical create-or-update flow (existence
+          // check, kind validation, immutable-field preservation, notes/displayName
+          // merge) with HTTP and MCP. Reimplementing here previously risked
+          // silent divergence when the service-layer semantics changed.
+          const peerSetService = new EngramAccessService(orchestrator);
           try {
-            validateIdSet(id);
+            const result = await peerSetService.peerSet({
+              id,
+              ...(typeof options.kind === "string" ? { kind: options.kind } : {}),
+              ...(typeof options.displayName === "string" ? { displayName: options.displayName } : {}),
+              ...(typeof options.notes === "string" ? { notes: options.notes } : {}),
+            });
+            if (options.json === true) {
+              console.log(JSON.stringify(result, null, 2));
+              return;
+            }
+            console.log(`${result.created ? "Created" : "Updated"} peer "${id}".`);
           } catch (err) {
-            console.error(`Invalid peer id: ${(err as Error).message}`);
+            console.error(`Failed to set peer: ${(err as Error).message}`);
             process.exit(1);
           }
-          const memoryDir = orchestrator.config.memoryDir;
-          const now = new Date().toISOString();
-          const existing = await peersSet.readPeer(memoryDir, id);
-          const ALLOWED_KINDS = new Set(["self", "human", "agent", "integration"]);
-          let peer: import("./peers/types.js").Peer;
-          let created: boolean;
-          if (!existing) {
-            const kind = (typeof options.kind === "string" ? options.kind : "human");
-            if (!ALLOWED_KINDS.has(kind)) {
-              console.error(`Invalid kind "${kind}". Must be one of: ${[...ALLOWED_KINDS].join(", ")}`);
-              process.exit(1);
-            }
-            peer = {
-              id,
-              kind: kind as import("./peers/types.js").PeerKind,
-              displayName: typeof options.displayName === "string" ? options.displayName : id,
-              createdAt: now,
-              updatedAt: now,
-              ...(typeof options.notes === "string" ? { notes: options.notes } : {}),
-            };
-            created = true;
-          } else {
-            peer = {
-              id: existing.id,
-              kind: existing.kind,
-              createdAt: existing.createdAt,
-              updatedAt: now,
-              displayName: typeof options.displayName === "string" ? options.displayName : existing.displayName,
-              ...(options.notes !== undefined
-                ? { notes: options.notes as string }
-                : existing.notes !== undefined
-                  ? { notes: existing.notes }
-                  : {}),
-            };
-            created = false;
-          }
-          await peersSet.writePeer(memoryDir, peer);
-          if (options.json === true) {
-            console.log(JSON.stringify({ ok: true, created, peer }, null, 2));
-            return;
-          }
-          console.log(`${created ? "Created" : "Updated"} peer "${id}".`);
         });
 
       peerCmd
@@ -7778,32 +7750,24 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             console.error("peer id is required");
             process.exit(1);
           }
-          const peersDelete = await import("./peers/index.js");
-          const validateIdDelete: (id: unknown) => void = peersDelete.assertValidPeerId;
+          // Cursor M (PR #756 review): route through EngramAccessService.peerDelete
+          // so the CLI gets the same `assertPeerDirNotEscaped` + symlink + parent-
+          // inode-stable guards used by HTTP and MCP. The previous direct
+          // `path.join` + `fs.unlink` bypassed the storage module's protections
+          // and would have followed a symlinked `peers/<id>/` to an arbitrary
+          // `identity.md` outside `memoryDir`.
+          const peerDeleteService = new EngramAccessService(orchestrator);
           try {
-            validateIdDelete(id);
+            const result = await peerDeleteService.peerDelete(id);
+            if (options.json === true) {
+              console.log(JSON.stringify(result, null, 2));
+              return;
+            }
+            console.log(result.deleted ? `Deleted peer "${id}".` : `Peer "${id}" not found (no-op).`);
           } catch (err) {
-            console.error(`Invalid peer id: ${(err as Error).message}`);
+            console.error(`Failed to delete peer: ${(err as Error).message}`);
             process.exit(1);
           }
-          const { promises: fsP } = await import("node:fs");
-          const pathM = await import("node:path");
-          const identityFile = pathM.join(orchestrator.config.memoryDir, "peers", id, "identity.md");
-          let deleted = false;
-          try {
-            await fsP.unlink(identityFile);
-            deleted = true;
-          } catch (err) {
-            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-              console.error(`Failed to delete peer: ${(err as Error).message}`);
-              process.exit(1);
-            }
-          }
-          if (options.json === true) {
-            console.log(JSON.stringify({ ok: true, deleted }, null, 2));
-            return;
-          }
-          console.log(deleted ? `Deleted peer "${id}".` : `Peer "${id}" not found (no-op).`);
         });
 
       peerCmd

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7704,7 +7704,15 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
       peerCmd
         .command("set <id>")
         .description("Create or update a peer identity record")
-        .option("--kind <kind>", "Peer kind: self | human | agent | integration (only on first write)", "human")
+        // Cursor H (PR #756 round 2): no Commander default for --kind. A
+        // default would make `options.kind` always present, so the CLI
+        // would forward kind on every call — including updates where
+        // the user only set --display-name. peerSet treats kind as
+        // immutable on update, but forcing the default also overrides
+        // any future change to the service-layer create-time default.
+        // Let the service own the default; the CLI only forwards an
+        // explicit --kind flag.
+        .option("--kind <kind>", "Peer kind: self | human | agent | integration (only on first write)")
         .option("--display-name <name>", "Human-readable display name")
         .option("--notes <text>", "Optional free-form markdown notes")
         .option("--json", "Emit machine-readable JSON only")

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -7637,6 +7637,216 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           console.log(renderStatusReport(report));
         });
 
+      // ── Peer Registry subcommand (issue #679 PR 4/5) ────────────────────
+      const peerCmd = cmd.command("peer").description("Manage the peer registry (issue #679).");
+
+      peerCmd
+        .command("list")
+        .description("List all registered peers")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const { listPeers } = await import("./peers/index.js");
+          const peers = await listPeers(orchestrator.config.memoryDir);
+          if (options.json === true) {
+            console.log(JSON.stringify({ peers }, null, 2));
+            return;
+          }
+          if (peers.length === 0) {
+            console.log("No peers registered.");
+            return;
+          }
+          console.log(`${peers.length} peer(s):\n`);
+          for (const p of peers) {
+            console.log(`  ${p.id} (${p.kind})  ${p.displayName}`);
+            console.log(`    created: ${p.createdAt}  updated: ${p.updatedAt}`);
+          }
+        });
+
+      peerCmd
+        .command("show <id>")
+        .description("Show a peer's identity record")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const id = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          if (!id) {
+            console.error("peer id is required");
+            process.exit(1);
+          }
+          const peersShow = await import("./peers/index.js");
+          const validateIdShow: (id: unknown) => void = peersShow.assertValidPeerId;
+          try {
+            validateIdShow(id);
+          } catch (err) {
+            console.error(`Invalid peer id: ${(err as Error).message}`);
+            process.exit(1);
+          }
+          const peer = await peersShow.readPeer(orchestrator.config.memoryDir, id);
+          if (!peer) {
+            console.error(`Peer "${id}" not found.`);
+            process.exit(1);
+          }
+          if (options.json === true) {
+            console.log(JSON.stringify(peer, null, 2));
+            return;
+          }
+          console.log(`Peer: ${peer.id}`);
+          console.log(`  Kind:         ${peer.kind}`);
+          console.log(`  Display name: ${peer.displayName}`);
+          console.log(`  Created:      ${peer.createdAt}`);
+          console.log(`  Updated:      ${peer.updatedAt}`);
+          if (peer.notes) {
+            console.log(`  Notes:\n${peer.notes.split("\n").map((l) => `    ${l}`).join("\n")}`);
+          }
+        });
+
+      peerCmd
+        .command("set <id>")
+        .description("Create or update a peer identity record")
+        .option("--kind <kind>", "Peer kind: self | human | agent | integration (only on first write)", "human")
+        .option("--display-name <name>", "Human-readable display name")
+        .option("--notes <text>", "Optional free-form markdown notes")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const id = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          if (!id) {
+            console.error("peer id is required");
+            process.exit(1);
+          }
+          const peersSet = await import("./peers/index.js");
+          const validateIdSet: (id: unknown) => void = peersSet.assertValidPeerId;
+          try {
+            validateIdSet(id);
+          } catch (err) {
+            console.error(`Invalid peer id: ${(err as Error).message}`);
+            process.exit(1);
+          }
+          const memoryDir = orchestrator.config.memoryDir;
+          const now = new Date().toISOString();
+          const existing = await peersSet.readPeer(memoryDir, id);
+          const ALLOWED_KINDS = new Set(["self", "human", "agent", "integration"]);
+          let peer: import("./peers/types.js").Peer;
+          let created: boolean;
+          if (!existing) {
+            const kind = (typeof options.kind === "string" ? options.kind : "human");
+            if (!ALLOWED_KINDS.has(kind)) {
+              console.error(`Invalid kind "${kind}". Must be one of: ${[...ALLOWED_KINDS].join(", ")}`);
+              process.exit(1);
+            }
+            peer = {
+              id,
+              kind: kind as import("./peers/types.js").PeerKind,
+              displayName: typeof options.displayName === "string" ? options.displayName : id,
+              createdAt: now,
+              updatedAt: now,
+              ...(typeof options.notes === "string" ? { notes: options.notes } : {}),
+            };
+            created = true;
+          } else {
+            peer = {
+              id: existing.id,
+              kind: existing.kind,
+              createdAt: existing.createdAt,
+              updatedAt: now,
+              displayName: typeof options.displayName === "string" ? options.displayName : existing.displayName,
+              ...(options.notes !== undefined
+                ? { notes: options.notes as string }
+                : existing.notes !== undefined
+                  ? { notes: existing.notes }
+                  : {}),
+            };
+            created = false;
+          }
+          await peersSet.writePeer(memoryDir, peer);
+          if (options.json === true) {
+            console.log(JSON.stringify({ ok: true, created, peer }, null, 2));
+            return;
+          }
+          console.log(`${created ? "Created" : "Updated"} peer "${id}".`);
+        });
+
+      peerCmd
+        .command("delete <id>")
+        .description("Delete a peer's identity record (idempotent; directory and profile are preserved)")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const id = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          if (!id) {
+            console.error("peer id is required");
+            process.exit(1);
+          }
+          const peersDelete = await import("./peers/index.js");
+          const validateIdDelete: (id: unknown) => void = peersDelete.assertValidPeerId;
+          try {
+            validateIdDelete(id);
+          } catch (err) {
+            console.error(`Invalid peer id: ${(err as Error).message}`);
+            process.exit(1);
+          }
+          const { promises: fsP } = await import("node:fs");
+          const pathM = await import("node:path");
+          const identityFile = pathM.join(orchestrator.config.memoryDir, "peers", id, "identity.md");
+          let deleted = false;
+          try {
+            await fsP.unlink(identityFile);
+            deleted = true;
+          } catch (err) {
+            if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+              console.error(`Failed to delete peer: ${(err as Error).message}`);
+              process.exit(1);
+            }
+          }
+          if (options.json === true) {
+            console.log(JSON.stringify({ ok: true, deleted }, null, 2));
+            return;
+          }
+          console.log(deleted ? `Deleted peer "${id}".` : `Peer "${id}" not found (no-op).`);
+        });
+
+      peerCmd
+        .command("profile <id>")
+        .description("Show the evolving cognitive profile for a peer")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const id = typeof args[0] === "string" ? args[0] : "";
+          const options = (args[1] ?? {}) as Record<string, unknown>;
+          if (!id) {
+            console.error("peer id is required");
+            process.exit(1);
+          }
+          const peersProfile = await import("./peers/index.js");
+          const validateIdProfile: (id: unknown) => void = peersProfile.assertValidPeerId;
+          try {
+            validateIdProfile(id);
+          } catch (err) {
+            console.error(`Invalid peer id: ${(err as Error).message}`);
+            process.exit(1);
+          }
+          const profile = await peersProfile.readPeerProfile(orchestrator.config.memoryDir, id);
+          if (!profile) {
+            console.error(`No profile found for peer "${id}". The profile is written by the async reasoner.`);
+            process.exit(1);
+          }
+          if (options.json === true) {
+            console.log(JSON.stringify(profile, null, 2));
+            return;
+          }
+          console.log(`Profile for peer: ${id}`);
+          console.log(`  Updated: ${profile.updatedAt}`);
+          const fieldKeys = Object.keys(profile.fields);
+          if (fieldKeys.length === 0) {
+            console.log("  No profile fields yet.");
+          } else {
+            for (const k of fieldKeys) {
+              console.log(`  ${k}:`);
+              console.log(`    ${profile.fields[k]}`);
+            }
+          }
+        });
+
       // ── Console subcommand (issue #688) ─────────────────────────────────
       // PR 1/3 (#721) shipped the structured engine-state aggregator
       // and the `--state-only` flag (one-shot JSON snapshot). PR 2/3

--- a/packages/remnic-core/src/peers/index.ts
+++ b/packages/remnic-core/src/peers/index.ts
@@ -24,6 +24,7 @@ export {
   assertValidPeerId,
   readPeer,
   writePeer,
+  deletePeer,
   listPeers,
   appendInteractionLog,
   readInteractionLogRaw,

--- a/packages/remnic-core/src/peers/peers.test.ts
+++ b/packages/remnic-core/src/peers/peers.test.ts
@@ -14,6 +14,7 @@ import test from "node:test";
 import {
   appendInteractionLog,
   assertValidPeerId,
+  deletePeer,
   listPeers,
   PEER_ID_PATTERN,
   readInteractionLogRaw,
@@ -351,4 +352,68 @@ test("identity.md is YAML frontmatter + markdown body", async () => {
   assert.ok(fmBlock.includes("updatedAt:"));
   const body = lines.slice(closeIndex + 1).join("\n");
   assert.ok(body.includes("Operator notes."));
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// deletePeer (Cursor M, PR #756) — symlink-safe unlink contract.
+// ──────────────────────────────────────────────────────────────────────
+
+test("deletePeer removes identity.md and is idempotent", async () => {
+  const dir = await makeTempDir();
+  const peer = samplePeer({ id: "alice", kind: "human" });
+  await writePeer(dir, peer);
+  const first = await deletePeer(dir, "alice");
+  assert.equal(first, true);
+  const second = await deletePeer(dir, "alice");
+  assert.equal(second, false);
+});
+
+test("deletePeer returns false when peer dir does not exist", async () => {
+  const dir = await makeTempDir();
+  const result = await deletePeer(dir, "ghost");
+  assert.equal(result, false);
+});
+
+test("deletePeer rejects invalid peer ids", async () => {
+  const dir = await makeTempDir();
+  await assert.rejects(() => deletePeer(dir, "../escape"), /invalid|peerId/i);
+});
+
+test("deletePeer refuses to follow a symlinked identity.md", async () => {
+  const dir = await makeTempDir();
+  // Build a peer dir without writing identity.md, then plant a symlink at
+  // identity.md pointing outside memoryDir. A naive `fs.unlink` would
+  // remove the symlink itself, but the safe-delete contract refuses to
+  // touch it (we can't safely distinguish symlink-removal from following
+  // a redirected-target unlink without lstat).
+  const peerDir = path.join(dir, "peers", "alice");
+  await fs.mkdir(peerDir, { recursive: true });
+  const outsideTarget = path.join(dir, "outside-target.md");
+  await fs.writeFile(outsideTarget, "should not be deleted", "utf8");
+  await fs.symlink(outsideTarget, path.join(peerDir, "identity.md"));
+  await assert.rejects(() => deletePeer(dir, "alice"), /symlink/);
+  // The outside file is intact.
+  const stillThere = await fs.readFile(outsideTarget, "utf8");
+  assert.equal(stillThere, "should not be deleted");
+});
+
+test("deletePeer leaves sibling profile and interaction log intact", async () => {
+  const dir = await makeTempDir();
+  const peer = samplePeer({ id: "alice", kind: "human" });
+  await writePeer(dir, peer);
+  const profile: PeerProfile = {
+    peerId: "alice",
+    fields: { tone: "warm" },
+    provenance: {},
+    updatedAt: "2026-04-26T00:00:00.000Z",
+  };
+  await writePeerProfile(dir, profile);
+  const result = await deletePeer(dir, "alice");
+  assert.equal(result, true);
+  // Profile survives.
+  const reread = await readPeerProfile(dir, "alice");
+  assert.ok(reread, "profile should still exist after deletePeer");
+  // Identity is gone.
+  const identity = await readPeer(dir, "alice");
+  assert.equal(identity, null);
 });

--- a/packages/remnic-core/src/peers/storage.ts
+++ b/packages/remnic-core/src/peers/storage.ts
@@ -590,6 +590,62 @@ export async function writePeer(memoryDir: string, peer: Peer): Promise<void> {
 }
 
 /**
+ * Delete a peer's `identity.md` if present, applying the same symlink
+ * and path-escape protections as the read/write paths.
+ *
+ * Returns `true` if a regular file was unlinked, `false` if no
+ * `identity.md` existed at the time of the call. The peer directory
+ * itself is left in place so any companion files (`profile.md`,
+ * `interactions/`, etc.) are untouched. Idempotent: missing target
+ * returns `false` rather than throwing.
+ *
+ * Cursor M (PR #756 review): a manual `path.join` + raw `fs.unlink`
+ * bypasses `assertPeerDirNotEscaped`, the peers-root symlink check,
+ * and the parent-inode-stable / lstat guards used by every other
+ * peer I/O entrypoint. A symlinked `peers/<id>/` could redirect the
+ * unlink to an arbitrary `identity.md` outside `memoryDir`. This
+ * function consolidates the safe-delete contract so callers cannot
+ * skip the guards.
+ */
+export async function deletePeer(memoryDir: string, peerId: string): Promise<boolean> {
+  assertValidPeerId(peerId);
+  await assertPeerDirNotEscaped(memoryDir, peerId);
+  const file = identityPath(memoryDir, peerId);
+  // Refuse to follow a symlink at `identity.md` itself: lstat first
+  // and reject if the target is a symlink. Then verify the parent
+  // directory inode is stable across the unlink (mirrors the
+  // assertParentDirInodeStable + O_NOFOLLOW pattern used by
+  // writeFileNoFollow). This narrows the TOCTOU window between the
+  // lstat and the unlink to the same few microseconds the write path
+  // accepts.
+  let lstatBefore: import("node:fs").Stats;
+  try {
+    lstatBefore = await fs.lstat(file);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+  if (lstatBefore.isSymbolicLink()) {
+    throw new Error(`refusing to unlink "${file}": target is a symlink`);
+  }
+  if (!lstatBefore.isFile()) {
+    throw new Error(`refusing to unlink "${file}": target is not a regular file`);
+  }
+  await assertParentDirInodeStable(file);
+  try {
+    await fs.unlink(file);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
+    }
+    throw err;
+  }
+  return true;
+}
+
+/**
  * Enumerate all peers under `memoryDir/peers/`.
  *
  * Returns an empty array if the peers root does not exist. Subdirectories

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -318,6 +318,81 @@ test("MCP server advertises tools and dispatches recall", async () => {
   assert.equal(entityResult.structuredContent.entity.name, "person-alex");
 });
 
+test("engram.peer_set rejects non-string kind/displayName/notes (Codex P2 PR #756 round 2)", async () => {
+  // Surface-symmetry test: HTTP rejects non-string field types with
+  // 400; MCP must reject the same payloads with a tools/call error
+  // rather than silently coercing to `undefined` and letting
+  // peerSet fall back to its "human" default.
+  let lastSetArgs: unknown = null;
+  const baseFake = createFakeService();
+  const fakeService = {
+    ...baseFake,
+    peerSet: async (input: { id: string; kind?: string; displayName?: string; notes?: string }) => {
+      lastSetArgs = input;
+      return {
+        ok: true as const,
+        created: true,
+        peer: {
+          id: input.id,
+          kind: "human" as const,
+          displayName: input.displayName ?? input.id,
+          createdAt: "t",
+          updatedAt: "t",
+        },
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(fakeService);
+
+  // Helper: tools/call surfaces dispatcher errors via { result: { isError: true, content: [{text}] } }.
+  const errMessage = (resp: unknown): string => {
+    const r = resp as { result?: { isError?: boolean; content?: Array<{ text?: string }> } };
+    if (!r?.result?.isError) return "";
+    return r.result.content?.[0]?.text ?? "";
+  };
+
+  // Non-string kind → error.
+  const r1 = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: { name: "engram.peer_set", arguments: { id: "bob", kind: 123 } },
+  });
+  assert.match(errMessage(r1), /kind must be a string/);
+
+  // Non-string displayName → error.
+  const r2 = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: { name: "engram.peer_set", arguments: { id: "bob", displayName: 42 } },
+  });
+  assert.match(errMessage(r2), /displayName must be a string/);
+
+  // Non-string notes → error.
+  const r3 = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: { name: "engram.peer_set", arguments: { id: "bob", notes: { x: 1 } } },
+  });
+  assert.match(errMessage(r3), /notes must be a string/);
+
+  // Service.peerSet must NOT have been invoked for any of the rejected payloads.
+  assert.equal(lastSetArgs, null);
+
+  // A valid payload still works.
+  const ok = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: { name: "engram.peer_set", arguments: { id: "bob", kind: "human", displayName: "Bob" } },
+  });
+  const okResult = ok as { result?: { isError?: boolean } };
+  assert.equal(okResult?.result?.isError, false, "expected valid payload to succeed");
+  assert.deepEqual(lastSetArgs, { id: "bob", kind: "human", displayName: "Bob", notes: undefined });
+});
+
 test("MCP initialize re-reads the server version for each server instance", async () => {
   const originalVersion = process.env.OPENCLAW_ENGRAM_VERSION;
   try {

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -126,6 +126,40 @@ function createFakeService(): EngramAccessService {
       reviewQueue: [{ memoryId: "fact-1", reasonCode: "disputed_memory" }],
     }),
     briefingEnabled: true,
+    peerList: async () => ({
+      peers: [
+        {
+          id: "alice",
+          kind: "human",
+          displayName: "Alice",
+          createdAt: "2026-04-01T00:00:00.000Z",
+          updatedAt: "2026-04-01T00:00:00.000Z",
+        },
+      ],
+    }),
+    peerGet: async (id: string) => ({
+      found: true,
+      peer: {
+        id,
+        kind: "human",
+        displayName: "Alice",
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      },
+    }),
+    peerSet: async ({ id }: { id: string }) => ({
+      ok: true,
+      created: true,
+      peer: {
+        id,
+        kind: "human",
+        displayName: id,
+        createdAt: "2026-04-01T00:00:00.000Z",
+        updatedAt: "2026-04-01T00:00:00.000Z",
+      },
+    }),
+    peerDelete: async () => ({ ok: true, deleted: true }),
+    peerProfileGet: async () => ({ found: false }),
   } as unknown as EngramAccessService;
 }
 
@@ -224,6 +258,11 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.review_resolve",
     "engram.contradiction_scan_run",
     "engram.graph_edge_decay_run",
+    "engram.peer_list",
+    "engram.peer_get",
+    "engram.peer_set",
+    "engram.peer_delete",
+    "engram.peer_profile_get",
   ];
   const canonicalListed = legacyListed.map((name) => name.replace(/^engram\./, "remnic."));
   assert.deepEqual(listed, legacyListed.flatMap((name, index) => [canonicalListed[index], name]));

--- a/tests/cli/peers.test.ts
+++ b/tests/cli/peers.test.ts
@@ -1,0 +1,337 @@
+/**
+ * CLI-level tests for `remnic peer` subcommands (issue #679 PR 4/5).
+ *
+ * These tests exercise the storage primitives that the CLI delegates to
+ * directly — no orchestrator required. Each test creates a fresh temp
+ * directory and tears it down afterward.
+ *
+ * Covered commands:
+ *   - peer list      (via listPeers)
+ *   - peer show      (via readPeer)
+ *   - peer set       (via writePeer / readPeer round-trip)
+ *   - peer delete    (via writePeer + unlink round-trip)
+ *   - peer profile   (via readPeerProfile)
+ *
+ * All test data is synthetic (CLAUDE.md public-repo rule: no real
+ * conversation content or user identifiers).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  assertValidPeerId,
+  listPeers,
+  readPeer,
+  writePeer,
+  readPeerProfile,
+  writePeerProfile,
+} from "../../packages/remnic-core/src/peers/index.js";
+import type { Peer, PeerProfile } from "../../packages/remnic-core/src/peers/types.js";
+
+// ──────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────
+
+async function makeTempDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), "remnic-peers-test-"));
+}
+
+async function removeTempDir(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+function makePeer(overrides: Partial<Peer> & { id: string }): Peer {
+  return {
+    kind: "human",
+    displayName: overrides.id,
+    createdAt: "2026-04-01T00:00:00.000Z",
+    updatedAt: "2026-04-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// assertValidPeerId
+// ──────────────────────────────────────────────────────────────────────
+
+test("assertValidPeerId accepts valid ids", () => {
+  const valid = ["alice", "bob-42", "agent.codex", "self", "a", "A1", "integration_v2"];
+  for (const id of valid) {
+    assert.doesNotThrow(() => assertValidPeerId(id), `expected ${id} to be valid`);
+  }
+});
+
+test("assertValidPeerId rejects empty string", () => {
+  assert.throws(() => assertValidPeerId(""), /must not be empty/);
+});
+
+test("assertValidPeerId rejects ids with consecutive separators", () => {
+  // The regex itself rejects `--` (requires alphanumeric after each separator),
+  // so the error message refers to the pattern rather than "consecutive" text.
+  assert.throws(() => assertValidPeerId("alice--bob"), /invalid/i);
+});
+
+test("assertValidPeerId rejects ids exceeding max length", () => {
+  const longId = "a".repeat(65);
+  assert.throws(() => assertValidPeerId(longId), /≤ 64/);
+});
+
+test("assertValidPeerId rejects non-string", () => {
+  assert.throws(() => assertValidPeerId(42), /must be a string/);
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// peer list — via listPeers
+// ──────────────────────────────────────────────────────────────────────
+
+test("peer list: returns empty array when no peers directory exists", async () => {
+  const dir = await makeTempDir();
+  try {
+    const peers = await listPeers(dir);
+    assert.deepEqual(peers, []);
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer list: returns registered peers sorted alphabetically", async () => {
+  const dir = await makeTempDir();
+  try {
+    const now = "2026-04-01T00:00:00.000Z";
+    await writePeer(dir, makePeer({ id: "zara", kind: "human", displayName: "Zara", createdAt: now, updatedAt: now }));
+    await writePeer(dir, makePeer({ id: "alice", kind: "human", displayName: "Alice", createdAt: now, updatedAt: now }));
+    await writePeer(dir, makePeer({ id: "bob", kind: "agent", displayName: "Bob Bot", createdAt: now, updatedAt: now }));
+
+    const peers = await listPeers(dir);
+    assert.equal(peers.length, 3);
+    assert.equal(peers[0]!.id, "alice");
+    assert.equal(peers[1]!.id, "bob");
+    assert.equal(peers[2]!.id, "zara");
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// peer show — via readPeer
+// ──────────────────────────────────────────────────────────────────────
+
+test("peer show: returns null for non-existent peer", async () => {
+  const dir = await makeTempDir();
+  try {
+    const peer = await readPeer(dir, "missing");
+    assert.equal(peer, null);
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer show: round-trips identity fields", async () => {
+  const dir = await makeTempDir();
+  try {
+    const original = makePeer({
+      id: "alice",
+      kind: "human",
+      displayName: "Alice Aliceson",
+      createdAt: "2026-04-01T10:00:00.000Z",
+      updatedAt: "2026-04-01T10:00:00.000Z",
+      notes: "Works in ops",
+    });
+    await writePeer(dir, original);
+
+    const retrieved = await readPeer(dir, "alice");
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.id, "alice");
+    assert.equal(retrieved.kind, "human");
+    assert.equal(retrieved.displayName, "Alice Aliceson");
+    assert.equal(retrieved.notes, "Works in ops");
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// peer set — create then update (writePeer logic)
+// ──────────────────────────────────────────────────────────────────────
+
+test("peer set: creates peer on first write", async () => {
+  const dir = await makeTempDir();
+  try {
+    const peer = makePeer({ id: "codex-agent", kind: "agent", displayName: "Codex" });
+    await writePeer(dir, peer);
+
+    const retrieved = await readPeer(dir, "codex-agent");
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.kind, "agent");
+    assert.equal(retrieved.displayName, "Codex");
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer set: overwrites displayName on update (kind immutable by convention)", async () => {
+  const dir = await makeTempDir();
+  try {
+    const now = "2026-04-01T00:00:00.000Z";
+    const later = "2026-04-02T00:00:00.000Z";
+    await writePeer(dir, makePeer({ id: "alice", createdAt: now, updatedAt: now }));
+
+    const updated: Peer = {
+      id: "alice",
+      kind: "human",
+      displayName: "Alice Updated",
+      createdAt: now,
+      updatedAt: later,
+    };
+    await writePeer(dir, updated);
+
+    const retrieved = await readPeer(dir, "alice");
+    assert.ok(retrieved !== null);
+    assert.equal(retrieved.displayName, "Alice Updated");
+    assert.equal(retrieved.createdAt, now);
+    assert.equal(retrieved.updatedAt, later);
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer set: rejects invalid peer id", async () => {
+  const dir = await makeTempDir();
+  try {
+    const peer: Peer = {
+      id: "bad/id",
+      kind: "human",
+      displayName: "Bad",
+      createdAt: "2026-04-01T00:00:00.000Z",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+    };
+    await assert.rejects(
+      () => writePeer(dir, peer),
+      /invalid/i,
+    );
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// peer delete — via unlink of identity.md
+// ──────────────────────────────────────────────────────────────────────
+
+test("peer delete: identity.md removed; directory preserved", async () => {
+  const dir = await makeTempDir();
+  try {
+    const { promises: fs } = await import("node:fs");
+    const path = await import("node:path");
+
+    const peer = makePeer({ id: "to-delete", kind: "human" });
+    await writePeer(dir, peer);
+
+    // Verify file exists.
+    const identityFile = path.join(dir, "peers", "to-delete", "identity.md");
+    await assert.doesNotReject(() => fs.access(identityFile));
+
+    // Delete.
+    await fs.unlink(identityFile);
+
+    // File gone; directory still present.
+    await assert.rejects(() => fs.access(identityFile), /ENOENT/);
+    const peerDirStat = await fs.stat(path.join(dir, "peers", "to-delete"));
+    assert.ok(peerDirStat.isDirectory());
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer delete: idempotent — unlink on missing file gives ENOENT only", async () => {
+  const dir = await makeTempDir();
+  try {
+    const { promises: fs } = await import("node:fs");
+    const path = await import("node:path");
+
+    const identityFile = path.join(dir, "peers", "ghost", "identity.md");
+    const err = await fs.unlink(identityFile).then(() => null).catch((e: unknown) => e);
+    assert.ok(err instanceof Error);
+    assert.equal((err as NodeJS.ErrnoException).code, "ENOENT");
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// peer profile — via readPeerProfile
+// ──────────────────────────────────────────────────────────────────────
+
+test("peer profile: returns null when no profile file exists", async () => {
+  const dir = await makeTempDir();
+  try {
+    // Write peer identity so the directory exists but no profile.
+    await writePeer(dir, makePeer({ id: "no-profile" }));
+    const profile = await readPeerProfile(dir, "no-profile");
+    assert.equal(profile, null);
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer profile: round-trips structured profile data", async () => {
+  const dir = await makeTempDir();
+  try {
+    await writePeer(dir, makePeer({ id: "with-profile" }));
+
+    const profileIn: PeerProfile = {
+      peerId: "with-profile",
+      updatedAt: "2026-04-10T00:00:00.000Z",
+      fields: {
+        communication_style: "Prefers async, concise summaries.",
+        recurring_concerns: "Performance regressions in hot path.",
+      },
+      provenance: {
+        communication_style: [
+          {
+            observedAt: "2026-04-09T00:00:00.000Z",
+            signal: "explicit_preference",
+            note: "Stated directly in session",
+          },
+        ],
+      },
+    };
+    await writePeerProfile(dir, profileIn);
+
+    const profileOut = await readPeerProfile(dir, "with-profile");
+    assert.ok(profileOut !== null);
+    assert.equal(profileOut.peerId, "with-profile");
+    assert.equal(profileOut.updatedAt, "2026-04-10T00:00:00.000Z");
+    assert.equal(profileOut.fields.communication_style, "Prefers async, concise summaries.");
+    assert.equal(profileOut.fields.recurring_concerns, "Performance regressions in hot path.");
+    assert.equal(profileOut.provenance.communication_style?.[0]?.signal, "explicit_preference");
+  } finally {
+    await removeTempDir(dir);
+  }
+});
+
+test("peer profile: handles profile with empty fields gracefully", async () => {
+  const dir = await makeTempDir();
+  try {
+    await writePeer(dir, makePeer({ id: "empty-profile" }));
+
+    const emptyProfile: PeerProfile = {
+      peerId: "empty-profile",
+      updatedAt: "2026-04-01T00:00:00.000Z",
+      fields: {},
+      provenance: {},
+    };
+    await writePeerProfile(dir, emptyProfile);
+
+    const result = await readPeerProfile(dir, "empty-profile");
+    assert.ok(result !== null);
+    assert.deepEqual(result.fields, {});
+    assert.deepEqual(result.provenance, {});
+  } finally {
+    await removeTempDir(dir);
+  }
+});

--- a/tests/peers/http.test.ts
+++ b/tests/peers/http.test.ts
@@ -1,0 +1,257 @@
+/**
+ * HTTP-surface tests for the peer registry endpoints (issue #679 PR 4/5).
+ *
+ * Endpoints covered:
+ *   GET    /engram/v1/peers              — list all peers
+ *   GET    /engram/v1/peers/:id          — get one peer
+ *   PUT    /engram/v1/peers/:id          — upsert (create/update)
+ *   DELETE /engram/v1/peers/:id          — delete (idempotent)
+ *   GET    /engram/v1/peers/:id/profile  — get peer profile
+ *
+ * Uses a minimal fake EngramAccessService, matching the pattern in
+ * tests/access-http.test.ts. No real filesystem I/O is performed here.
+ *
+ * All test data is synthetic (CLAUDE.md public-repo rule).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import { EngramAccessHttpServer } from "../../packages/remnic-core/src/access-http.js";
+import type { EngramAccessService } from "../../packages/remnic-core/src/access-service.js";
+
+const AUTH_TOKEN = "test-token-peers-http";
+const BASE_URL = "http://127.0.0.1";
+
+// ──────────────────────────────────────────────────────────────────────
+// Fake service
+// ──────────────────────────────────────────────────────────────────────
+
+const FAKE_PEER = {
+  id: "alice",
+  kind: "human" as const,
+  displayName: "Alice",
+  createdAt: "2026-04-01T00:00:00.000Z",
+  updatedAt: "2026-04-01T00:00:00.000Z",
+};
+
+const FAKE_PROFILE = {
+  peerId: "alice",
+  updatedAt: "2026-04-10T00:00:00.000Z",
+  fields: { communication_style: "Async, concise." },
+  provenance: {},
+};
+
+function createFakeService(): EngramAccessService {
+  return {
+    health: async () => ({
+      ok: true,
+      memoryDir: "/tmp/engram",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledgeEnabled: false,
+      projectionAvailable: true,
+    }),
+    peerList: async () => ({ peers: [FAKE_PEER] }),
+    peerGet: async (id: string) =>
+      id === "alice"
+        ? { found: true, peer: FAKE_PEER }
+        : { found: false },
+    peerSet: async ({ id }: { id: string }) => ({
+      ok: true,
+      created: id !== "alice",
+      peer: { ...FAKE_PEER, id },
+    }),
+    peerDelete: async (id: string) => ({
+      ok: true,
+      deleted: id === "alice",
+    }),
+    peerProfileGet: async (id: string) =>
+      id === "alice"
+        ? { found: true, profile: FAKE_PROFILE }
+        : { found: false },
+  } as unknown as EngramAccessService;
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Helper
+// ──────────────────────────────────────────────────────────────────────
+
+async function request(
+  port: number,
+  method: string,
+  path: string,
+  body?: unknown,
+): Promise<{ status: number; json: unknown }> {
+  const url = `${BASE_URL}:${port}${path}`;
+  const opts: RequestInit = {
+    method,
+    headers: {
+      authorization: `Bearer ${AUTH_TOKEN}`,
+      "content-type": "application/json",
+    },
+  };
+  if (body !== undefined) {
+    opts.body = JSON.stringify(body);
+  }
+  const res = await fetch(url, opts);
+  const json = await res.json();
+  return { status: res.status, json };
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────
+
+test("GET /engram/v1/peers — returns peer list", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers");
+    assert.equal(status, 200);
+    const body = json as { peers: unknown[] };
+    assert.ok(Array.isArray(body.peers));
+    assert.equal(body.peers.length, 1);
+    const peer = body.peers[0] as { id: string };
+    assert.equal(peer.id, "alice");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("GET /engram/v1/peers/:id — returns peer when found", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers/alice");
+    assert.equal(status, 200);
+    const body = json as { found: boolean; peer: { id: string } };
+    assert.equal(body.found, true);
+    assert.equal(body.peer.id, "alice");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("GET /engram/v1/peers/:id — 404 when not found", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers/nobody");
+    assert.equal(status, 404);
+    const body = json as { error: string };
+    assert.equal(body.error, "peer_not_found");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("PUT /engram/v1/peers/:id — 201 on create", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "PUT", "/engram/v1/peers/new-peer", {
+      kind: "agent",
+      displayName: "New Peer",
+    });
+    assert.equal(status, 201);
+    const body = json as { ok: boolean; created: boolean };
+    assert.equal(body.ok, true);
+    assert.equal(body.created, true);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("PUT /engram/v1/peers/:id — 200 on update (alice already exists)", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "PUT", "/engram/v1/peers/alice", {
+      displayName: "Alice Updated",
+    });
+    assert.equal(status, 200);
+    const body = json as { ok: boolean; created: boolean };
+    assert.equal(body.ok, true);
+    assert.equal(body.created, false);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("DELETE /engram/v1/peers/:id — 200 with deleted:true when peer exists", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "DELETE", "/engram/v1/peers/alice");
+    assert.equal(status, 200);
+    const body = json as { ok: boolean; deleted: boolean };
+    assert.equal(body.ok, true);
+    assert.equal(body.deleted, true);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("DELETE /engram/v1/peers/:id — 200 with deleted:false when peer absent", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "DELETE", "/engram/v1/peers/nobody");
+    assert.equal(status, 200);
+    const body = json as { ok: boolean; deleted: boolean };
+    assert.equal(body.ok, true);
+    assert.equal(body.deleted, false);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("GET /engram/v1/peers/:id/profile — 200 when profile exists", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers/alice/profile");
+    assert.equal(status, 200);
+    const body = json as { found: boolean; profile: { peerId: string } };
+    assert.equal(body.found, true);
+    assert.equal(body.profile.peerId, "alice");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("GET /engram/v1/peers/:id/profile — 404 when no profile", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers/nobody/profile");
+    assert.equal(status, 404);
+    const body = json as { error: string };
+    assert.equal(body.error, "peer_profile_not_found");
+  } finally {
+    await server.stop();
+  }
+});
+
+test("POST /engram/v1/peers/:id — 405 method not allowed", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status } = await request(port, "POST", "/engram/v1/peers/alice");
+    assert.equal(status, 405);
+  } finally {
+    await server.stop();
+  }
+});

--- a/tests/peers/http.test.ts
+++ b/tests/peers/http.test.ts
@@ -255,3 +255,78 @@ test("POST /engram/v1/peers/:id — 405 method not allowed", async () => {
     await server.stop();
   }
 });
+
+// ──────────────────────────────────────────────────────────────────────
+// PR #756 review: input-hardening for the peer ID surface.
+// ──────────────────────────────────────────────────────────────────────
+
+test("GET /engram/v1/peers/:id — malformed percent-encoding returns 400 not 500", async () => {
+  // Codex P2 #1 (PR #756): a path segment like `%E0%A4%A` is malformed
+  // percent-encoding. The handler must convert the URIError into a 400
+  // client-error rather than letting it bubble up as a 500.
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "GET", "/engram/v1/peers/%E0%A4%A");
+    assert.equal(status, 400);
+    const body = json as { error: string; code: string };
+    assert.equal(body.code, "input_error");
+    assert.match(body.error, /percent-encoded/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("PUT /engram/v1/peers/:id — non-string `kind` is rejected with 400", async () => {
+  // Codex P2 #2 (PR #756): a payload like `{ "kind": 123 }` previously
+  // got coerced to undefined and silently fell back to the "human"
+  // default on create. The handler must reject the malformed type up
+  // front rather than producing an unintended record.
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "PUT", "/engram/v1/peers/bob", { kind: 123 });
+    assert.equal(status, 400);
+    const body = json as { error: string; code: string };
+    assert.equal(body.code, "input_error");
+    assert.match(body.error, /kind must be a string/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("PUT /engram/v1/peers/:id — non-string `displayName` is rejected with 400", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "PUT", "/engram/v1/peers/bob", {
+      displayName: 42,
+    });
+    assert.equal(status, 400);
+    const body = json as { error: string; code: string };
+    assert.equal(body.code, "input_error");
+    assert.match(body.error, /displayName must be a string/);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("PUT /engram/v1/peers/:id — non-string `notes` is rejected with 400", async () => {
+  const service = createFakeService();
+  const server = new EngramAccessHttpServer({ service, authToken: AUTH_TOKEN });
+  const { port } = await server.start();
+  try {
+    const { status, json } = await request(port, "PUT", "/engram/v1/peers/bob", {
+      notes: { a: 1 },
+    });
+    assert.equal(status, 400);
+    const body = json as { error: string; code: string };
+    assert.equal(body.code, "input_error");
+    assert.match(body.error, /notes must be a string/);
+  } finally {
+    await server.stop();
+  }
+});


### PR DESCRIPTION
## Summary

Issue #679 PR 4/5 — wires the peer registry storage primitives (PRs 1–3) through all three access surfaces.

**Previous PRs merged:**
- #723 — registry schema + storage primitives (PR 1/5)
- #736 — async profile reasoner (PR 2/5)
- #750 — recall integration (PR 3/5)

**This PR ships:**

### CLI — `remnic peer <subcommand>`
- `peer list` — list all registered peers (alphabetical, `--json` flag)
- `peer show <id>` — show identity record (`--json` flag)
- `peer set <id>` — create or update (`--kind`, `--display-name`, `--notes`, `--json`)
- `peer delete <id>` — idempotent delete of identity.md; directory preserved
- `peer profile <id>` — show reasoner-generated cognitive profile

### HTTP — `/engram/v1/peers`
- `GET /engram/v1/peers` — list
- `GET /engram/v1/peers/:id` — get (404 when absent)
- `PUT /engram/v1/peers/:id` — upsert (201 on create, 200 on update)
- `DELETE /engram/v1/peers/:id` — idempotent delete (200 + `deleted: bool`)
- `GET /engram/v1/peers/:id/profile` — get profile (404 when absent)

### MCP tools (dual `engram.*` + `remnic.*` naming)
- `peer_list`, `peer_get`, `peer_set`, `peer_delete`, `peer_profile_get`

### Service layer
Five new methods on `EngramAccessService`: `peerList()`, `peerGet()`, `peerSet()`, `peerDelete()`, `peerProfileGet()`. All validate peer IDs via `assertValidPeerId` and throw `EngramAccessInputError` on bad input (CLAUDE.md rule 51).

### Tests
- `tests/cli/peers.test.ts` — 17 tests covering storage round-trips for all 5 subcommands
- `tests/peers/http.test.ts` — 10 tests covering all 5 endpoints + 405 guard
- `tests/access-mcp.test.ts` — `legacyListed` fixture updated with 5 new tool names

## Test plan
- [ ] `npm run check-types` passes (zero TS errors)
- [ ] `npx tsx --test tests/cli/peers.test.ts tests/peers/http.test.ts tests/access-mcp.test.ts` — 32/32 pass
- [ ] `npm run preflight:quick` — no new failures (46 pre-existing unrelated failures remain)
- [ ] `remnic peer list` in a real install shows registered peers
- [ ] MCP `tools/list` response includes `remnic.peer_list` and `engram.peer_list`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new peer-registry read/write surfaces across HTTP, MCP, and CLI plus new filesystem delete behavior; moderate risk due to new API surface area and file operations, mitigated by strict validation and symlink-safe delete guards.
> 
> **Overview**
> Adds end-to-end **peer registry management** across all access surfaces.
> 
> HTTP gains `/engram/v1/peers` endpoints for list/get/upsert/delete plus `/profile`, including input hardening (invalid percent-encoding now returns 400; non-string `kind`/`displayName`/`notes` rejected instead of defaulting). MCP gains new `engram.*`/`remnic.*` tools (`peer_list`, `peer_get`, `peer_set`, `peer_delete`, `peer_profile_get`) with matching argument validation.
> 
> `EngramAccessService` adds `peerList`/`peerGet`/`peerSet`/`peerDelete`/`peerProfileGet` backed by peers storage; deletion is routed through a new symlink-safe `deletePeer` that unlinks only regular `identity.md` while preserving the peer directory and profile/log data. CLI adds `remnic peer` subcommands that delegate to the service/storage semantics, and tests are added/updated to cover the new HTTP/MCP/CLI behaviors and the safe-delete contract.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ef5d25e76cbd181416358bb0183b4a6a0d1b4b35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->