### PR TITLE
test(audit): close audit gaps for issues #680, #685, #689

### DIFF
--- a/docs/trace-to-primitive.md
+++ b/docs/trace-to-primitive.md
@@ -133,7 +133,7 @@ The trace is noise. The primitive is the product.
 | Surface | What you'll see |
 |---------|-----------------|
 | `@remnic/core` types | The `MemoryObservation` interface ships in the public types so callers can read post-extraction state without reaching into `extraction.ts`. |
-| `remnic doctor` | *(future)* Will report observation throughput, judge acceptance rate, and the most recent `observedAt`. Today these signals live in the separate observation-ledger / judge stats paths; surfacing them in `doctor` is tracked as a follow-up. |
+| `remnic doctor` | Reports observation throughput, judge accept/reject/defer breakdown, and the most recent `observedAt` via the `observations` check (issue #685). Reads from `state/observation-ledger/extraction-judge-verdicts.jsonl`. |
 | `recall` responses | `<oai-mem-citation>` blocks point at the primitive ids that came out the other end of the pipeline. |
 | `remnic tier list` / `tier explain` | Inspect what happened to primitives after they were written (issue #686). |
 | `observation-ledger` | A separate concept: a JSONL telemetry directory (`state/observation-ledger/`) capturing turn-count aggregates (`maintenance/rebuild-observations.ts`) and judge verdict events (`extraction-judge-telemetry.ts`). Operator-observability data, distinct from the lifecycle-event ledger and from the `MemoryObservation` type — see the naming note below. |

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -46,6 +46,7 @@ import type {
   PluginConfig,
 } from "./types.js";
 import { reportBufferSurpriseDistribution } from "./buffer-surprise-report.js";
+import { readJudgeVerdictStats } from "./extraction-judge-telemetry.js";
 
 interface QmdRuntimeLike {
   probe(): Promise<boolean>;
@@ -1216,6 +1217,15 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   // mitigations are enabled and surfaces config values for operator review.
   checks.push(summarizeSecurityMitigations(config));
 
+  // Observation throughput + judge acceptance rate (issue #685).
+  // Surfaces the total verdict count, accept/reject/defer breakdown, and the
+  // most recent `observedAt` timestamp from the extraction-judge telemetry
+  // ledger.  This closes the *(future)* item deferred in
+  // `docs/trace-to-primitive.md`.  The check is purely informational — it
+  // always resolves to `ok`; an empty ledger is the expected cold-install
+  // state and is never an error.
+  checks.push(await summarizeObservationThroughput(config.memoryDir));
+
   const summary = checks.reduce(
     (acc, check) => {
       acc[check.status] += 1;
@@ -1509,6 +1519,61 @@ function summarizeSecurityMitigations(
     summary: `Memory-extraction mitigation config enabled: ${budgetEnabled ? "budget" : ""}${budgetEnabled && anomalyEnabled ? ", " : ""}${anomalyEnabled ? "anomaly detection" : ""}.`,
     details: { ...details, configOnly: true },
   };
+}
+
+/**
+ * Observation throughput check for `remnic doctor` (issue #685).
+ *
+ * Reads the extraction-judge verdict ledger to surface:
+ *  - total observations (verdicts) recorded
+ *  - accept / reject / defer breakdown
+ *  - most-recent `observedAt` timestamp
+ *
+ * The check is purely informational (always `ok`): a missing or empty
+ * ledger is the expected state on a fresh install and is never an error.
+ * This closes the `*(future)*` item deferred in `docs/trace-to-primitive.md`.
+ */
+export async function summarizeObservationThroughput(
+  memoryDir: string,
+): Promise<OperatorDoctorCheck> {
+  try {
+    const stats = await readJudgeVerdictStats(memoryDir);
+    if (stats.total === 0) {
+      return {
+        key: "observations",
+        status: "ok",
+        summary: "No observations recorded yet (extraction-judge telemetry ledger is empty or missing).",
+        details: { total: 0, accept: 0, reject: 0, defer: 0, lastObservedAt: null },
+      };
+    }
+    const acceptPct = ((stats.accept / stats.total) * 100).toFixed(1);
+    const rejectPct = ((stats.reject / stats.total) * 100).toFixed(1);
+    const deferPct = ((stats.defer / stats.total) * 100).toFixed(1);
+    return {
+      key: "observations",
+      status: "ok",
+      summary: `${stats.total} observations recorded: accept=${acceptPct}%, reject=${rejectPct}%, defer=${deferPct}%. Last observed: ${stats.lastTs ?? "unknown"}.`,
+      details: {
+        total: stats.total,
+        accept: stats.accept,
+        reject: stats.reject,
+        defer: stats.defer,
+        deferCapTriggered: stats.deferCapTriggered,
+        deferRate: stats.deferRate,
+        meanElapsedMs: stats.meanElapsedMs,
+        firstObservedAt: stats.firstTs ?? null,
+        lastObservedAt: stats.lastTs ?? null,
+      },
+    };
+  } catch (err) {
+    return {
+      key: "observations",
+      status: "warn",
+      summary: "Could not read observation telemetry ledger.",
+      remediation: "Retry `remnic doctor` after ensuring the memory state directory is readable.",
+      details: { error: String(err) },
+    };
+  }
 }
 
 export async function summarizeConsolidationProvenance(

--- a/packages/remnic-core/src/recall-xray.ts
+++ b/packages/remnic-core/src/recall-xray.ts
@@ -147,6 +147,17 @@ export interface RecallXrayResult {
    * went.
    */
   estimatedTokens?: number;
+  /**
+   * Free-form tags from the memory's YAML frontmatter (issue #689 PR 3/3).
+   * Populated by the X-ray capture path when the caller passes a `tags`
+   * filter so per-result tags are available alongside the filter trace
+   * in `snapshot.filters`.  Also populated without a filter when the
+   * orchestrator decorates results via `xrayCapture: true` so all X-ray
+   * consumers can inspect memory labels without a separate storage read.
+   * Absent (not `[]`) when the frontmatter has no tags or the memory
+   * could not be read.
+   */
+  tags?: string[];
 }
 
 /**
@@ -416,6 +427,18 @@ function cloneResult(result: RecallXrayResult): RecallXrayResult {
     result.estimatedTokens >= 0
   ) {
     out.estimatedTokens = Math.floor(result.estimatedTokens);
+  }
+  // Tags from frontmatter (issue #689 PR 3/3).  Normalize identically to
+  // the recall-surface path: trim and drop empty strings so consumers can
+  // compare tags directly without a secondary normalization step.
+  if (Array.isArray(result.tags)) {
+    const cleanedTags = result.tags
+      .filter((t): t is string => typeof t === "string")
+      .map((t) => t.trim())
+      .filter((t) => t.length > 0);
+    if (cleanedTags.length > 0) {
+      out.tags = cleanedTags;
+    }
   }
   return out;
 }

--- a/src/extraction-judge-telemetry.ts
+++ b/src/extraction-judge-telemetry.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/extraction-judge-telemetry.js";

--- a/src/temporal-validity.ts
+++ b/src/temporal-validity.ts
@@ -1,0 +1,1 @@
+export * from "../packages/remnic-core/src/temporal-validity.js";

--- a/tests/access-service-recall-xray-tags.test.ts
+++ b/tests/access-service-recall-xray-tags.test.ts
@@ -1,0 +1,439 @@
+/**
+ * Integration tests for per-result `tags` on `RecallXrayResult` and the
+ * tag-filter trace in `snapshot.filters` (issue #689 PR 3/3).
+ *
+ * Acceptance criteria:
+ *   1. `RecallXrayResult.tags` is populated from memory frontmatter when an
+ *      X-ray recall runs with a tag filter.
+ *   2. `snapshot.filters` contains a `tag-filter` entry showing the correct
+ *      `considered` / `admitted` counts.
+ *   3. Results excluded by the tag filter do not appear in `snapshot.results`.
+ *   4. Per-result `tags` is propagated correctly through `cloneResult` in
+ *      `buildXraySnapshot` / `RecallXrayBuilder`.
+ *
+ * These tests use lightweight orchestrator stubs (mirrors the pattern in
+ * `tests/access-service-recall-xray.test.ts`) so no live QMD or OpenAI
+ * connection is needed.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { EngramAccessService } from "../src/access-service.js";
+import type { RecallXraySnapshot, RecallXrayResult } from "../src/recall-xray.js";
+import { buildXraySnapshot } from "../src/recall-xray.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function fakeXrayResult(
+  overrides: Partial<RecallXrayResult> & { path: string; memoryId: string },
+): RecallXrayResult {
+  return {
+    servedBy: "hybrid",
+    scoreDecomposition: { final: 0.8 },
+    admittedBy: ["importance-gate"],
+    ...overrides,
+  };
+}
+
+function fakeSnapshot(
+  overrides: Partial<RecallXraySnapshot> = {},
+): RecallXraySnapshot {
+  return {
+    schemaVersion: "1",
+    query: "q",
+    snapshotId: "snap-1",
+    capturedAt: 1_700_000_000_000,
+    tierExplain: null,
+    results: [],
+    filters: [],
+    budget: { chars: 4096, used: 0 },
+    ...overrides,
+  };
+}
+
+/**
+ * Build a stub orchestrator whose `getStorage` returns a fake StorageManager
+ * that resolves `readMemoryByPath` from a provided map of path → tags.
+ */
+function stubOrchestrator(opts: {
+  snapshot?: RecallXraySnapshot | null;
+  pathToTags?: Record<string, string[]>;
+}) {
+  const state = {
+    clearedSnapshot: 0,
+    snapshot: opts.snapshot ?? null,
+  };
+  const pathToTags = opts.pathToTags ?? {};
+
+  const orchestrator = {
+    config: {
+      memoryDir: "/tmp/engram-xray-tags",
+      namespacesEnabled: false,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallBudgetChars: 4096,
+    },
+    recall: async (
+      _prompt: string,
+      _sessionKey: string | undefined,
+      _options: Record<string, unknown>,
+    ) => {
+      return "ctx";
+    },
+    clearLastXraySnapshot: () => {
+      state.clearedSnapshot += 1;
+      state.snapshot = null;
+    },
+    getLastXraySnapshot: () => state.snapshot,
+    setSnapshot: (snap: RecallXraySnapshot | null) => {
+      state.snapshot = snap;
+    },
+    lastRecall: {
+      get: () => null,
+      getMostRecent: () => null,
+    },
+    getStorage: async (_namespace: string) => ({
+      dir: "/tmp/engram-xray-tags",
+      readMemoryByPath: async (p: string) => {
+        const tags = pathToTags[p];
+        if (!tags) return null;
+        return {
+          path: p,
+          content: "some content",
+          frontmatter: {
+            id: path.basename(p, ".md"),
+            category: "fact",
+            created: "2026-01-01T00:00:00Z",
+            updated: "2026-01-01T00:00:00Z",
+            source: "extraction",
+            confidence: 0.8,
+            confidenceTier: "confident",
+            tags,
+          },
+        };
+      },
+      getMemoryById: async () => null,
+      getMemoryTimeline: async () => [],
+    }),
+  };
+
+  return { orchestrator, state };
+}
+
+// ---------------------------------------------------------------------------
+// Unit: RecallXrayResult.tags passes through buildXraySnapshot
+// ---------------------------------------------------------------------------
+
+test("buildXraySnapshot: tags field is preserved on RecallXrayResult", () => {
+  const result = fakeXrayResult({
+    memoryId: "fact-1",
+    path: "/mem/fact-1.md",
+    tags: ["alice", "location"],
+  });
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+  });
+  assert.ok(snapshot.results.length === 1);
+  assert.deepEqual(snapshot.results[0].tags, ["alice", "location"]);
+});
+
+test("buildXraySnapshot: tags field is absent when not provided", () => {
+  const result = fakeXrayResult({
+    memoryId: "fact-2",
+    path: "/mem/fact-2.md",
+    // no tags field
+  });
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+  });
+  assert.equal(snapshot.results[0].tags, undefined);
+});
+
+test("buildXraySnapshot: empty tags array is not attached (absent, not [])", () => {
+  const result = fakeXrayResult({
+    memoryId: "fact-3",
+    path: "/mem/fact-3.md",
+    tags: [],
+  });
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+  });
+  // cloneResult drops empty tag arrays — undefined not []
+  assert.equal(snapshot.results[0].tags, undefined);
+});
+
+test("buildXraySnapshot: whitespace-only tags are stripped; non-empty ones survive", () => {
+  const result = fakeXrayResult({
+    memoryId: "fact-4",
+    path: "/mem/fact-4.md",
+    tags: ["  ", "tag-a", "  tag-b  ", ""],
+  });
+  const snapshot = buildXraySnapshot({
+    query: "q",
+    results: [result],
+  });
+  assert.deepEqual(snapshot.results[0].tags, ["tag-a", "tag-b"]);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: recallXray with tags filter — tag-filter trace + per-result tags
+// ---------------------------------------------------------------------------
+
+test("recallXray with tags filter: tag-filter trace appears in snapshot.filters with correct counts", async () => {
+  // Two results in the raw snapshot: one tagged [alice, location],
+  // one tagged [bob, work].  Filter for tag=alice.
+  const snap = fakeSnapshot({
+    results: [
+      fakeXrayResult({
+        memoryId: "fact-alice",
+        path: "/mem/fact-alice.md",
+      }),
+      fakeXrayResult({
+        memoryId: "fact-bob",
+        path: "/mem/fact-bob.md",
+      }),
+    ],
+  });
+
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: snap,
+    pathToTags: {
+      "/mem/fact-alice.md": ["alice", "location"],
+      "/mem/fact-bob.md": ["bob", "work"],
+    },
+  });
+
+  // Inject the snap AFTER recall fires (simulates real capture path).
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: Parameters<typeof orchestrator.recall>) => {
+    const result = await originalRecall.apply(orchestrator, args as Parameters<typeof originalRecall>);
+    state.snapshot = snap;
+    return result;
+  };
+
+  const service = new EngramAccessService(orchestrator as never);
+  const response = await service.recallXray({ query: "alice location", tags: ["alice"] });
+
+  assert.equal(response.snapshotFound, true);
+  assert.ok(response.snapshot);
+
+  const { snapshot: resultSnapshot } = response;
+  assert.ok(resultSnapshot);
+
+  // Only alice's result should remain.
+  assert.equal(resultSnapshot.results.length, 1);
+  assert.equal(resultSnapshot.results[0].memoryId, "fact-alice");
+
+  // tag-filter trace must be present.
+  const tagTrace = resultSnapshot.filters.find((f) => f.name === "tag-filter");
+  assert.ok(tagTrace, "tag-filter trace should be present in snapshot.filters");
+  assert.equal(tagTrace.considered, 2, "considered should be 2 (both results)");
+  assert.equal(tagTrace.admitted, 1, "admitted should be 1 (only alice matches)");
+});
+
+test("recallXray with tags=all mode: admits only results matching all tags", async () => {
+  const snap = fakeSnapshot({
+    results: [
+      fakeXrayResult({ memoryId: "mem-ab", path: "/mem/mem-ab.md" }),
+      fakeXrayResult({ memoryId: "mem-a",  path: "/mem/mem-a.md" }),
+      fakeXrayResult({ memoryId: "mem-b",  path: "/mem/mem-b.md" }),
+    ],
+  });
+
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: snap,
+    pathToTags: {
+      "/mem/mem-ab.md": ["tag-a", "tag-b"],
+      "/mem/mem-a.md": ["tag-a"],
+      "/mem/mem-b.md": ["tag-b"],
+    },
+  });
+
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: Parameters<typeof orchestrator.recall>) => {
+    const result = await originalRecall.apply(orchestrator, args as Parameters<typeof originalRecall>);
+    state.snapshot = snap;
+    return result;
+  };
+
+  const service = new EngramAccessService(orchestrator as never);
+  const response = await service.recallXray({
+    query: "both tags",
+    tags: ["tag-a", "tag-b"],
+    tagMatch: "all",
+  });
+
+  assert.equal(response.snapshotFound, true);
+  const snapshot = response.snapshot;
+  assert.ok(snapshot);
+
+  // Only mem-ab has BOTH tags.
+  assert.equal(snapshot.results.length, 1);
+  assert.equal(snapshot.results[0].memoryId, "mem-ab");
+
+  const tagTrace = snapshot.filters.find((f) => f.name === "tag-filter");
+  assert.ok(tagTrace);
+  assert.equal(tagTrace.considered, 3);
+  assert.equal(tagTrace.admitted, 1);
+  assert.match(tagTrace.reason ?? "", /match=all/);
+});
+
+test("recallXray with no tags filter: no tag-filter trace emitted", async () => {
+  const snap = fakeSnapshot({
+    results: [
+      fakeXrayResult({ memoryId: "mem-1", path: "/mem/mem-1.md" }),
+    ],
+  });
+
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: snap,
+    pathToTags: { "/mem/mem-1.md": ["x"] },
+  });
+
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: Parameters<typeof orchestrator.recall>) => {
+    const result = await originalRecall.apply(orchestrator, args as Parameters<typeof originalRecall>);
+    state.snapshot = snap;
+    return result;
+  };
+
+  const service = new EngramAccessService(orchestrator as never);
+  const response = await service.recallXray({ query: "no tag filter" });
+
+  assert.equal(response.snapshotFound, true);
+  const snapshot = response.snapshot;
+  assert.ok(snapshot);
+
+  const tagTrace = snapshot.filters.find((f) => f.name === "tag-filter");
+  assert.equal(tagTrace, undefined, "no tag-filter trace should appear when no filter is requested");
+  assert.equal(snapshot.results.length, 1, "all results should be present");
+});
+
+test("recallXray: any-match (default) admits result with at least one matching tag", async () => {
+  const snap = fakeSnapshot({
+    results: [
+      fakeXrayResult({ memoryId: "mem-xy", path: "/mem/mem-xy.md" }),
+      fakeXrayResult({ memoryId: "mem-z",  path: "/mem/mem-z.md" }),
+    ],
+  });
+
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: snap,
+    pathToTags: {
+      "/mem/mem-xy.md": ["x", "y"],
+      "/mem/mem-z.md":  ["z"],
+    },
+  });
+
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: Parameters<typeof orchestrator.recall>) => {
+    const result = await originalRecall.apply(orchestrator, args as Parameters<typeof originalRecall>);
+    state.snapshot = snap;
+    return result;
+  };
+
+  const service = new EngramAccessService(orchestrator as never);
+  // Filter for "x" OR "z" — both results should pass (any-match).
+  const response = await service.recallXray({
+    query: "any match test",
+    tags: ["x", "z"],
+    // tagMatch defaults to "any"
+  });
+
+  assert.equal(response.snapshotFound, true);
+  const snapshot = response.snapshot;
+  assert.ok(snapshot);
+
+  // Both mem-xy (has x) and mem-z (has z) pass the any-match filter.
+  assert.equal(snapshot.results.length, 2);
+
+  const tagTrace = snapshot.filters.find((f) => f.name === "tag-filter");
+  assert.ok(tagTrace);
+  assert.equal(tagTrace.considered, 2);
+  assert.equal(tagTrace.admitted, 2);
+});
+
+// ---------------------------------------------------------------------------
+// Integration: end-to-end with real fixture memoryDir
+// ---------------------------------------------------------------------------
+
+test("recallXray with real storage fixture: per-result tags populated from frontmatter", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-xray-tags-e2e-"),
+  );
+
+  // Write two memory files directly using StorageManager.
+  const { StorageManager } = await import("../src/storage.js");
+  const storage = new StorageManager(memoryDir);
+
+  const idA = await storage.writeMemory("fact", "Eve is a cryptographer.", {
+    tags: ["eve", "cryptography"],
+  });
+  const idB = await storage.writeMemory("fact", "Frank is a botanist.", {
+    tags: ["frank", "botany"],
+  });
+
+  const allMems = await storage.readAllMemories();
+  const memA = allMems.find((m) => m.frontmatter.id === idA);
+  const memB = allMems.find((m) => m.frontmatter.id === idB);
+  assert.ok(memA && memB, "both memories should exist");
+
+  // Build a fake snapshot that references the real paths.
+  const snap = fakeSnapshot({
+    results: [
+      fakeXrayResult({ memoryId: idA, path: memA.path }),
+      fakeXrayResult({ memoryId: idB, path: memB.path }),
+    ],
+  });
+
+  const { orchestrator, state } = stubOrchestrator({
+    snapshot: snap,
+    // Override getStorage to return the real storage instance.
+  });
+
+  // Patch getStorage to return the real storage.
+  (orchestrator as Record<string, unknown>).getStorage = async () => storage;
+
+  const originalRecall = orchestrator.recall;
+  orchestrator.recall = async (...args: Parameters<typeof orchestrator.recall>) => {
+    const result = await originalRecall.apply(orchestrator, args as Parameters<typeof originalRecall>);
+    state.snapshot = snap;
+    return result;
+  };
+
+  const service = new EngramAccessService(orchestrator as never);
+  const response = await service.recallXray({
+    query: "cryptographer",
+    tags: ["cryptography"],
+  });
+
+  assert.equal(response.snapshotFound, true);
+  const snapshot = response.snapshot;
+  assert.ok(snapshot);
+
+  // Only Eve's memory should pass the tag filter.
+  assert.equal(snapshot.results.length, 1);
+  assert.equal(snapshot.results[0].memoryId, idA);
+
+  // tag-filter trace present with correct counts.
+  const tagTrace = snapshot.filters.find((f) => f.name === "tag-filter");
+  assert.ok(tagTrace, "tag-filter trace should be present");
+  assert.equal(tagTrace.considered, 2);
+  assert.equal(tagTrace.admitted, 1);
+});

--- a/tests/memory-observation-type-shape.test.ts
+++ b/tests/memory-observation-type-shape.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for the `MemoryObservation` exported type shape (issue #685 PR 1/3).
+ *
+ * These tests verify:
+ *   1. `MemoryObservation` is exported from `@remnic/core` with the correct
+ *      required and optional fields.
+ *   2. The `summarizeObservationThroughput` doctor check produces an `ok`
+ *      status check with the expected shape for both empty and populated
+ *      ledgers.
+ *
+ * Tests are purely structural / behavioral — they do not require a real
+ * OpenAI key or QMD daemon.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
+
+// Verify the public export chain.
+import type { MemoryObservation } from "../src/types.js";
+// Also verify it flows through the barrel export.
+import type { MemoryObservation as BarrelMemoryObservation } from "../src/index.js";
+
+import { summarizeObservationThroughput } from "../src/operator-toolkit.js";
+import {
+  judgeTelemetryPath,
+} from "../src/extraction-judge-telemetry.js";
+import { EXTRACTION_JUDGE_VERDICT_CATEGORY } from "../src/extraction-judge-telemetry.js";
+
+// ---------------------------------------------------------------------------
+// Type-shape tests (compile-time + runtime)
+// ---------------------------------------------------------------------------
+
+test("MemoryObservation has required id, observedAt, and fact fields", () => {
+  // Construct a minimal valid MemoryObservation at the type level.
+  const obs: MemoryObservation = {
+    id: "obs-1",
+    observedAt: "2026-01-01T00:00:00Z",
+    fact: {
+      category: "fact",
+      content: "The sky is blue.",
+      confidence: 0.9,
+      tags: [],
+    },
+  };
+
+  assert.equal(obs.id, "obs-1");
+  assert.equal(obs.observedAt, "2026-01-01T00:00:00Z");
+  assert.equal(obs.fact.content, "The sky is blue.");
+  assert.equal(obs.fact.category, "fact");
+  assert.equal(obs.fact.confidence, 0.9);
+  assert.deepEqual(obs.fact.tags, []);
+});
+
+test("MemoryObservation optional fields are assignable", () => {
+  const full: MemoryObservation = {
+    id: "obs-2",
+    sessionId: "session-abc",
+    observedAt: "2026-01-01T01:00:00Z",
+    fact: {
+      category: "fact",
+      content: "TypeScript is structurally typed.",
+      confidence: 0.8,
+      tags: ["typescript", "typing"],
+    },
+    importance: 0.7,
+    judgeAccepted: true,
+    judgeRejectionReason: undefined,
+    resultingPrimitiveId: "fact-xyz",
+  };
+
+  assert.equal(full.sessionId, "session-abc");
+  assert.equal(full.importance, 0.7);
+  assert.equal(full.judgeAccepted, true);
+  assert.equal(full.resultingPrimitiveId, "fact-xyz");
+});
+
+test("MemoryObservation rejected observation is assignable", () => {
+  const rejected: MemoryObservation = {
+    id: "obs-3",
+    observedAt: "2026-01-01T02:00:00Z",
+    fact: {
+      category: "fact",
+      content: "ok",
+      confidence: 0.1,
+      tags: [],
+    },
+    judgeAccepted: false,
+    judgeRejectionReason: "trivial content",
+  };
+  assert.equal(rejected.judgeAccepted, false);
+  assert.equal(rejected.judgeRejectionReason, "trivial content");
+});
+
+test("MemoryObservation and barrel export are the same shape", () => {
+  // Both type aliases must accept the same object — this verifies that
+  // the barrel export hasn't been removed or aliased to a different type.
+  const obs: BarrelMemoryObservation = {
+    id: "obs-barrel",
+    observedAt: "2026-01-01T00:00:00Z",
+    fact: {
+      category: "fact",
+      content: "Barrel export test.",
+      confidence: 0.5,
+      tags: [],
+    },
+  };
+  assert.equal(obs.id, "obs-barrel");
+});
+
+// ---------------------------------------------------------------------------
+// summarizeObservationThroughput (doctor check) tests
+// ---------------------------------------------------------------------------
+
+test("summarizeObservationThroughput: returns ok with zero count when ledger is absent", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-obs-check-"),
+  );
+  const check = await summarizeObservationThroughput(memoryDir);
+
+  assert.equal(check.key, "observations");
+  assert.equal(check.status, "ok");
+  assert.match(check.summary, /No observations/);
+
+  const details = check.details as Record<string, unknown>;
+  assert.equal(details.total, 0);
+  assert.equal(details.accept, 0);
+  assert.equal(details.reject, 0);
+  assert.equal(details.defer, 0);
+  assert.equal(details.lastObservedAt, null);
+});
+
+test("summarizeObservationThroughput: surfaces counts from populated ledger", async () => {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-obs-populated-"),
+  );
+  const ledgerPath = judgeTelemetryPath(memoryDir);
+  await mkdir(path.dirname(ledgerPath), { recursive: true });
+
+  const baseEvent = {
+    version: 1 as const,
+    category: EXTRACTION_JUDGE_VERDICT_CATEGORY,
+    deferrals: 0,
+    elapsedMs: 10,
+    candidateCategory: "fact",
+    confidence: 0.8,
+    contentHash: "abc123",
+    fromCache: false,
+  };
+
+  const rows = [
+    { ...baseEvent, ts: "2026-01-01T00:00:00Z", verdictKind: "accept" },
+    { ...baseEvent, ts: "2026-01-01T00:01:00Z", verdictKind: "accept" },
+    { ...baseEvent, ts: "2026-01-01T00:02:00Z", verdictKind: "reject" },
+    { ...baseEvent, ts: "2026-01-01T00:03:00Z", verdictKind: "defer" },
+    { ...baseEvent, ts: "2026-01-01T00:04:00Z", verdictKind: "accept" },
+  ];
+
+  await writeFile(
+    ledgerPath,
+    rows.map((r) => JSON.stringify(r)).join("\n") + "\n",
+    "utf-8",
+  );
+
+  const check = await summarizeObservationThroughput(memoryDir);
+
+  assert.equal(check.key, "observations");
+  assert.equal(check.status, "ok");
+
+  const details = check.details as Record<string, unknown>;
+  assert.equal(details.total, 5);
+  assert.equal(details.accept, 3);
+  assert.equal(details.reject, 1);
+  assert.equal(details.defer, 1);
+  assert.equal(details.lastObservedAt, "2026-01-01T00:04:00Z");
+  assert.equal(details.firstObservedAt, "2026-01-01T00:00:00Z");
+
+  // Summary string should include the percentages.
+  assert.match(check.summary, /5 observations recorded/);
+  assert.match(check.summary, /Last observed:/);
+});
+
+test("summarizeObservationThroughput: check key is 'observations'", async () => {
+  // Regression guard: the key must be exactly 'observations' so the
+  // doctor CLI section-header and JSON output match the documented name.
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-obs-key-"),
+  );
+  const check = await summarizeObservationThroughput(memoryDir);
+  assert.equal(check.key, "observations");
+});

--- a/tests/temporal-recall-end-to-end.test.ts
+++ b/tests/temporal-recall-end-to-end.test.ts
@@ -1,0 +1,224 @@
+/**
+ * End-to-end temporal recall round-trip test (issue #680).
+ *
+ * Acceptance criterion:
+ *   - Ingest fact at T1, supersede it at T2.
+ *   - recall with `asOf=T1` returns the original fact.
+ *   - recall with no asOf returns the superseding fact only
+ *     (the original is filtered out by the supersession gate).
+ *
+ * Uses a real Orchestrator with a tmpdir fixture memoryDir so the full
+ * `orchestrator.recall()` path — including `boostSearchResults` with
+ * `isValidAsOf` — is exercised.  QMD and embedding fallback are disabled
+ * so the test stays self-contained and fast: recall falls back to the
+ * hot-tier / recent-scan path which reads all memories from disk.
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import os from "node:os";
+import path from "node:path";
+import { mkdtemp } from "node:fs/promises";
+
+import { parseConfig } from "../src/config.js";
+import { Orchestrator } from "../src/orchestrator.js";
+import { StorageManager } from "../src/storage.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function makeOrchestrator(): Promise<{
+  orchestrator: Orchestrator;
+  storage: StorageManager;
+  memoryDir: string;
+}> {
+  const memoryDir = await mkdtemp(
+    path.join(os.tmpdir(), "engram-temporal-recall-e2e-"),
+  );
+  const config = parseConfig({
+    openaiApiKey: "sk-test",
+    memoryDir,
+    workspaceDir: path.join(memoryDir, "workspace"),
+    qmdEnabled: false,
+    embeddingFallbackEnabled: false,
+    chunkingEnabled: false,
+    // Keep supersession filter ON (default) so the no-asOf path filters
+    // the superseded original, leaving only the successor.
+    temporalSupersessionEnabled: true,
+    temporalSupersessionIncludeInRecall: false,
+  });
+  const orchestrator = new Orchestrator(config);
+  const storage = (orchestrator as unknown as { storage: StorageManager })
+    .storage;
+  return { orchestrator, storage, memoryDir };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test("temporal recall: asOf=T1 returns original fact before supersession", async () => {
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  // T1 = yesterday.  T2 = now.
+  const T1 = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(); // yesterday
+  const T2 = new Date().toISOString(); // now
+
+  // Write the original fact with valid_at = T1.
+  const originalId = await storage.writeMemory(
+    "fact",
+    "Alice lives in Boston.",
+    { tags: ["alice", "location"] },
+  );
+  // Backdate valid_at to T1 by patching frontmatter.
+  const allMemsAfterOriginal = await storage.readAllMemories();
+  const originalMem = allMemsAfterOriginal.find(
+    (m) => m.frontmatter.id === originalId,
+  );
+  assert.ok(originalMem, "original memory should exist");
+  await storage.writeMemoryFrontmatter(originalMem, {
+    valid_at: T1,
+  });
+
+  // Write the superseding fact with valid_at = T2; mark the original as
+  // superseded with invalid_at = T2 to simulate the write path that issue
+  // #680 PR 2/4 adds to temporal-supersession.ts.
+  const supersederId = await storage.writeMemory(
+    "fact",
+    "Alice lives in San Francisco.",
+    { tags: ["alice", "location"] },
+  );
+  const allMemsAfterSuperseeder = await storage.readAllMemories();
+  const supersederMem = allMemsAfterSuperseeder.find(
+    (m) => m.frontmatter.id === supersederId,
+  );
+  assert.ok(supersederMem, "superseder memory should exist");
+  await storage.writeMemoryFrontmatter(supersederMem, {
+    valid_at: T2,
+  });
+  // Mark original as superseded with invalid_at = T2.
+  const updatedOriginal = allMemsAfterSuperseeder.find(
+    (m) => m.frontmatter.id === originalId,
+  );
+  assert.ok(updatedOriginal, "original memory should still exist");
+  await storage.writeMemoryFrontmatter(updatedOriginal, {
+    status: "superseded",
+    supersededBy: supersederId,
+    supersededAt: T2,
+    invalid_at: T2,
+  });
+
+  // Recall with asOf=T1: should surface the original (was valid at T1,
+  // invalid_at=T2 so it is NOT yet invalidated at T1), and NOT the
+  // superseder (valid_at=T2 so it starts after T1).
+  const sessionKey = "test-session-680";
+  await orchestrator.recall("Where does Alice live?", sessionKey, {
+    asOf: T1,
+  });
+  const snapshotAtT1 = orchestrator.lastRecall.get(sessionKey);
+  assert.ok(snapshotAtT1, "should have a recall snapshot for asOf=T1");
+  const pathsAtT1 = snapshotAtT1.resultPaths ?? [];
+
+  // The original memory file path should appear in results at T1.
+  const originalPath = updatedOriginal.path;
+  const supersederPath = supersederMem.path;
+
+  assert.ok(
+    pathsAtT1.some((p) => p === originalPath),
+    `asOf=T1 recall should include original fact (${originalPath}), got: ${JSON.stringify(pathsAtT1)}`,
+  );
+  assert.ok(
+    !pathsAtT1.some((p) => p === supersederPath),
+    `asOf=T1 recall should NOT include superseder (valid_at=${T2} is after T1), got: ${JSON.stringify(pathsAtT1)}`,
+  );
+});
+
+test("temporal recall: no asOf returns superseder, not the superseded original", async () => {
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  const T1 = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const T2 = new Date().toISOString();
+
+  // Write original + superseder (same setup as above).
+  const originalId = await storage.writeMemory(
+    "fact",
+    "Bob works at Initech.",
+    { tags: ["bob", "employer"] },
+  );
+  const allAfterOriginal = await storage.readAllMemories();
+  const originalMem = allAfterOriginal.find(
+    (m) => m.frontmatter.id === originalId,
+  );
+  assert.ok(originalMem);
+  await storage.writeMemoryFrontmatter(originalMem, { valid_at: T1 });
+
+  const supersederId = await storage.writeMemory(
+    "fact",
+    "Bob works at Initrode.",
+    { tags: ["bob", "employer"] },
+  );
+  const allAfterSuperseeder = await storage.readAllMemories();
+  const supersederMem = allAfterSuperseeder.find(
+    (m) => m.frontmatter.id === supersederId,
+  );
+  assert.ok(supersederMem);
+  await storage.writeMemoryFrontmatter(supersederMem, { valid_at: T2 });
+
+  const updatedOriginal = allAfterSuperseeder.find(
+    (m) => m.frontmatter.id === originalId,
+  );
+  assert.ok(updatedOriginal);
+  await storage.writeMemoryFrontmatter(updatedOriginal, {
+    status: "superseded",
+    supersededBy: supersederId,
+    supersededAt: T2,
+    invalid_at: T2,
+  });
+
+  // Recall without asOf: supersession filter drops the original;
+  // superseder should be present.
+  const sessionKey = "test-session-680-no-asof";
+  await orchestrator.recall("Where does Bob work?", sessionKey, {});
+  const snapshot = orchestrator.lastRecall.get(sessionKey);
+  assert.ok(snapshot, "should have a recall snapshot for no-asOf");
+  const paths = snapshot.resultPaths ?? [];
+
+  assert.ok(
+    paths.some((p) => p === supersederMem.path),
+    `no-asOf recall should include the superseder (${supersederMem.path}), got: ${JSON.stringify(paths)}`,
+  );
+  assert.ok(
+    !paths.some((p) => p === updatedOriginal.path),
+    `no-asOf recall should NOT include the superseded original (${updatedOriginal.path}), got: ${JSON.stringify(paths)}`,
+  );
+});
+
+test("temporal recall: fact with no invalid_at is valid at any asOf after valid_at", async () => {
+  const { orchestrator, storage } = await makeOrchestrator();
+
+  const T1 = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString(); // 1 week ago
+  const queryTs = new Date(Date.now() - 3 * 24 * 60 * 60 * 1000).toISOString(); // 3 days ago
+
+  const memId = await storage.writeMemory("fact", "Carol prefers dark mode.", {
+    tags: ["carol", "preference"],
+  });
+  const allMems = await storage.readAllMemories();
+  const mem = allMems.find((m) => m.frontmatter.id === memId);
+  assert.ok(mem);
+  // Backdate valid_at to T1 (one week ago); no invalid_at means always-valid.
+  await storage.writeMemoryFrontmatter(mem, { valid_at: T1 });
+
+  const sessionKey = "test-session-680-no-invalid";
+  await orchestrator.recall("What does Carol prefer?", sessionKey, {
+    asOf: queryTs,
+  });
+  const snapshot = orchestrator.lastRecall.get(sessionKey);
+  assert.ok(snapshot, "should have a recall snapshot");
+  const paths = snapshot.resultPaths ?? [];
+
+  assert.ok(
+    paths.some((p) => p === mem.path),
+    `fact with no invalid_at should be valid at any asOf after its valid_at, got: ${JSON.stringify(paths)}`,
+  );
+});


### PR DESCRIPTION
## Summary

Closes audit gaps across three issues in a single pass:

- **#680 — Temporal recall E2E round-trip test**: `tests/temporal-recall-end-to-end.test.ts` exercises the full `orchestrator.recall()` path with a real fixture `memoryDir`. Ingest fact at T1, supersede at T2; `asOf=T1` returns the original; no `asOf` returns only the superseder. Also covers the "no `invalid_at`" forever-valid case.

- **#685 — Observation throughput in `remnic doctor`**: New `summarizeObservationThroughput` helper in `operator-toolkit.ts` reads the extraction-judge verdict ledger and surfaces total / accept / reject / defer counts and last `observedAt` as an `observations` doctor check. Closes the `*(future)*` item deferred in `docs/trace-to-primitive.md`. Type-shape tests + doctor-check tests in `tests/memory-observation-type-shape.test.ts` verify the `MemoryObservation` public type contract and the check's output shape.

- **#689 — Per-result `tags` on `RecallXrayResult`**: Adds `tags?: string[]` to the interface, propagated and normalized through `cloneResult`. Integration tests in `tests/access-service-recall-xray-tags.test.ts` verify: tag-filter trace appears in `snapshot.filters` with correct `considered`/`admitted` counts; results excluded by the filter are absent; any-match / all-match semantics work; end-to-end with real storage confirms tags are read from frontmatter.

## Test plan

- [ ] `npx tsx --test tests/temporal-recall-end-to-end.test.ts` — 3 pass
- [ ] `npx tsx --test tests/memory-observation-type-shape.test.ts` — 7 pass
- [ ] `npx tsx --test tests/access-service-recall-xray-tags.test.ts` — 9 pass
- [ ] `npx tsx --test tests/access-service-recall-xray.test.ts` — existing 14 pass (no regressions)
- [ ] `npx tsx --test tests/temporal-improvements.test.ts` — existing 27 pass (no regressions)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes operator-facing `remnic doctor` output and extends the public `RecallXrayResult` schema; core recall behavior is only exercised via new tests rather than modified here.
> 
> **Overview**
> **Closes audit gaps for issues #680/#685/#689** by adding missing observability surfaces and end-to-end coverage.
> 
> `remnic doctor` now includes an **`observations` check** that reads the extraction-judge verdict telemetry ledger and reports total verdicts, accept/reject/defer rates, and most-recent `observedAt` (with cold-install treated as `ok`).
> 
> The X-ray snapshot schema is extended with optional per-result `tags`, normalized during snapshot cloning, and new integration tests validate tag-filter trace counts and any/all match behavior; additional tests cover `MemoryObservation` export shape and temporal recall `asOf` round-trips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1d825f8e3c4cc630198f3b09bf113b9f915d1477. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->