### PR TITLE
Improve benchmark answer and recall readiness

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -146,7 +146,8 @@ test("direct adapter recall expands search hits with adjacent stored results", a
     );
 
     assert.match(recalled, /Environment result: trail mix/);
-    assert.match(recalled, /\[arena-session turn 1, assistant\]/);
+    assert.match(recalled, /\[arena-session, turn 1, assistant/);
+    assert.ok(recalled.length <= 24_000);
   } finally {
     await adapter.destroy();
   }

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -5,7 +5,7 @@
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import { Orchestrator, parseConfig } from "@remnic/core";
+import { buildEvidencePack, Orchestrator, parseConfig } from "@remnic/core";
 import type {
   BenchJudge,
   BenchMemoryAdapter,
@@ -14,6 +14,7 @@ import type {
   Message,
   SearchResult,
 } from "./types.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../recall-budget.js";
 
 export interface RemnicAdapterOptions {
   configOverrides?: Record<string, unknown>;
@@ -259,16 +260,32 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
       async recall(sessionId: string, query: string, budgetChars?: number): Promise<string> {
         const engine = getEngine();
-        const budget = budgetChars ?? 32_000;
+        const budget = budgetChars ?? DEFAULT_BENCH_RECALL_BUDGET_CHARS;
+        if (budget <= 0) {
+          return "";
+        }
+
         const sections: string[] = [];
+        let usedChars = 0;
 
         if (query) {
-          const searchResults = await engine.searchContextFull(query, 20, sessionId);
+          const searchBudget = Math.max(0, Math.floor(budget * 0.7));
+          const searchLimit = Math.max(4, Math.min(12, Math.floor(budget / 3_000)));
+          const searchResults = await engine.searchContextFull(
+            query,
+            searchLimit,
+            sessionId,
+          );
           if (searchResults.length > 0) {
-            const expandedByTurn = new Map<
-              string,
-              { sessionId: string; turn_index: number; role: string; content: string }
-            >();
+            const evidenceItems: Array<{
+              id: string;
+              sessionId: string;
+              turnIndex: number;
+              role: string;
+              content: string;
+              score?: number;
+            }> = [];
+            const seenTurns = new Set<string>();
 
             for (const result of searchResults) {
               const fromTurn = Math.max(0, result.turn_index - 1);
@@ -277,46 +294,59 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
                 result.session_id,
                 fromTurn,
                 toTurn,
-                800,
+                600,
               );
 
               if (expanded.length === 0) {
-                expandedByTurn.set(`${result.session_id}:${result.turn_index}`, {
-                  sessionId: result.session_id,
-                  turn_index: result.turn_index,
-                  role: result.role,
-                  content: result.content,
-                });
+                const id = `${result.session_id}:${result.turn_index}`;
+                if (!seenTurns.has(id)) {
+                  seenTurns.add(id);
+                  evidenceItems.push({
+                    id,
+                    sessionId: result.session_id,
+                    turnIndex: result.turn_index,
+                    role: result.role,
+                    content: result.content,
+                    ...(typeof result.score === "number"
+                      ? { score: result.score }
+                      : {}),
+                  });
+                }
                 continue;
               }
 
               for (const message of expanded) {
-                expandedByTurn.set(`${result.session_id}:${message.turn_index}`, {
+                const id = `${result.session_id}:${message.turn_index}`;
+                if (seenTurns.has(id)) continue;
+                seenTurns.add(id);
+                evidenceItems.push({
+                  id,
                   sessionId: result.session_id,
-                  ...message,
+                  turnIndex: message.turn_index,
+                  role: message.role,
+                  content: message.content,
+                  ...(message.turn_index === result.turn_index &&
+                  typeof result.score === "number"
+                    ? { score: result.score }
+                    : {}),
                 });
               }
             }
 
-            const expandedResults = [...expandedByTurn.values()].sort((a, b) => {
-              if (a.sessionId !== b.sessionId) {
-                return a.sessionId.localeCompare(b.sessionId);
-              }
-              return a.turn_index - b.turn_index;
+            const searchEvidence = buildEvidencePack(evidenceItems, {
+              title: "Search evidence",
+              maxChars: searchBudget,
+              maxItemChars: 900,
             });
-
-            sections.push(
-              `## Search results\n${expandedResults
-                .map(
-                  (result) =>
-                    `[${result.sessionId} turn ${result.turn_index}, ${result.role}]: ${result.content}`,
-                )
-                .join("\n\n")}`,
-            );
+            if (searchEvidence) {
+              sections.push(searchEvidence);
+              usedChars += searchEvidence.length;
+            }
           }
         }
 
-        const recallText = await engine.assembleRecall(sessionId, budget);
+        const summaryBudget = Math.max(0, budget - usedChars - 4);
+        const recallText = await engine.assembleRecall(sessionId, summaryBudget);
         if (recallText) {
           sections.push(recallText);
         }

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -1,7 +1,11 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { answerBenchmarkQuestion } from "./answering.ts";
+import {
+  answerBenchmarkQuestion,
+  buildStrictBenchmarkQuestion,
+  inferAnswerFormat,
+} from "./answering.ts";
 
 test("without a responder the benchmark answer falls back to recalled text", async () => {
   const result = await answerBenchmarkQuestion({
@@ -23,9 +27,11 @@ test("with a responder the benchmark answer uses the generated final answer and 
   const result = await answerBenchmarkQuestion({
     question: "What happened?",
     recalledText: "The recalled memory.",
+    answerMode: "strict",
     responder: {
       async respond(question, recalledText) {
-        assert.equal(question, "What happened?");
+        assert.match(question, /What happened\?/);
+        assert.match(question, /Benchmark answer protocol:/);
         assert.equal(recalledText, "The recalled memory.");
         return {
           text: "The generated answer.",
@@ -49,4 +55,57 @@ test("with a responder the benchmark answer uses the generated final answer and 
   });
   assert.equal(result.latencyMs, 44);
   assert.equal(result.model, "gpt-5.4-mini");
+});
+
+test("default answering preserves legacy exact questions", async () => {
+  const result = await answerBenchmarkQuestion({
+    question: "What happened?",
+    recalledText: "The recalled memory.",
+    answerMode: "default",
+    responder: {
+      async respond(question) {
+        assert.equal(question, "What happened?");
+        return {
+          text: "The generated answer.",
+          tokens: { input: 1, output: 1 },
+          latencyMs: 1,
+          model: "test-model",
+        };
+      },
+    },
+  });
+
+  assert.equal(result.finalAnswer, "The generated answer.");
+});
+
+test("strict question builder preserves structured protocols", () => {
+  assert.equal(
+    inferAnswerFormat("Choices:\nA. Tea\nB. Coffee\nPlease output the correct option"),
+    "choice-letter",
+  );
+  assert.equal(
+    inferAnswerFormat("Answer choices:\n1. Tea\n2. Coffee"),
+    "choice-number",
+  );
+  assert.match(
+    buildStrictBenchmarkQuestion("Final output format:\n=== Traveler Plan ==="),
+    /Preserve the requested structured output format exactly/,
+  );
+});
+
+test("strict question builder preserves free-form summarization prompts", () => {
+  const question = [
+    "You are given a book above and you are tasked to summarize it.",
+    "Now summarize the book.",
+  ].join("\n");
+
+  assert.equal(inferAnswerFormat(question), "auto");
+  assert.doesNotMatch(
+    buildStrictBenchmarkQuestion(question),
+    /shortest complete answer/,
+  );
+  assert.match(
+    buildStrictBenchmarkQuestion(question, "short"),
+    /shortest complete answer/,
+  );
 });

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -1,5 +1,14 @@
 import type { BenchResponder } from "./adapters/types.js";
 
+export type BenchmarkAnswerMode = "default" | "strict";
+
+export type BenchmarkAnswerFormat =
+  | "auto"
+  | "choice-letter"
+  | "choice-number"
+  | "short"
+  | "structured";
+
 export interface BenchmarkAnswerResult {
   finalAnswer: string;
   recalledText: string;
@@ -16,6 +25,8 @@ export async function answerBenchmarkQuestion(options: {
   question: string;
   recalledText: string;
   responder?: BenchResponder;
+  answerMode?: BenchmarkAnswerMode;
+  answerFormat?: BenchmarkAnswerFormat;
 }): Promise<BenchmarkAnswerResult> {
   if (!options.responder) {
     return {
@@ -30,8 +41,17 @@ export async function answerBenchmarkQuestion(options: {
     };
   }
 
+  const answerMode = options.answerMode ?? "default";
+  const answerFormat =
+    options.answerFormat === "auto" || options.answerFormat === undefined
+      ? inferAnswerFormat(options.question)
+      : options.answerFormat;
+  const question =
+    answerMode === "strict"
+      ? buildStrictBenchmarkQuestion(options.question, answerFormat)
+      : options.question;
   const response = await options.responder.respond(
-    options.question,
+    question,
     options.recalledText,
   );
 
@@ -43,4 +63,71 @@ export async function answerBenchmarkQuestion(options: {
     tokens: response.tokens,
     model: response.model,
   };
+}
+
+export function buildStrictBenchmarkQuestion(
+  question: string,
+  answerFormat: BenchmarkAnswerFormat = "auto",
+): string {
+  const resolvedFormat =
+    answerFormat === "auto" ? inferAnswerFormat(question) : answerFormat;
+  const instructions = [
+    "Benchmark answer protocol:",
+    "- Use only the supplied Remnic memory context as evidence.",
+    "- Answer the benchmark question directly; do not add prefaces, caveats, or unsupported facts.",
+    "- If the context is insufficient, answer \"unknown\".",
+    "- Resolve relative temporal references from the timestamps or dated facts in the memory context when possible.",
+    "- For date or year questions, prefer the absolute date or year over relative wording like yesterday or last year.",
+  ];
+
+  switch (resolvedFormat) {
+    case "choice-letter":
+      instructions.push(
+        "- Return only the selected option letter, such as A, B, C, or D.",
+      );
+      break;
+    case "choice-number":
+      instructions.push("- Return only the selected option number.");
+      break;
+    case "structured":
+      instructions.push(
+        "- Preserve the requested structured output format exactly and omit unrelated explanation.",
+      );
+      break;
+    case "short":
+      instructions.push(
+        "- Return the shortest complete answer that satisfies the question.",
+      );
+      break;
+    case "auto":
+      break;
+    default: {
+      const exhaustive: never = resolvedFormat;
+      throw new Error(`Unhandled answer format: ${String(exhaustive)}`);
+    }
+  }
+
+  return `${question}\n\n${instructions.join("\n")}`;
+}
+
+export function inferAnswerFormat(question: string): BenchmarkAnswerFormat {
+  if (
+    /\b[A-D]\.\s+/i.test(question) &&
+    (/\bchoices?:/i.test(question) ||
+      /\boptions?:/i.test(question) ||
+      /final answer:\s*\[letter\]/i.test(question))
+  ) {
+    return "choice-letter";
+  }
+  if (/answer choices?:/i.test(question) && /\b1\.\s+/i.test(question)) {
+    return "choice-number";
+  }
+  if (
+    /final output format:/i.test(question) ||
+    /===\s*traveler plan\s*===/i.test(question) ||
+    /the recommendations are:/i.test(question)
+  ) {
+    return "structured";
+  }
+  return "auto";
 }

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -10,6 +10,7 @@ import {
   type AMABenchEpisode,
 } from "./fixture.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../../../recall-budget.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -74,12 +75,17 @@ export async function runAmaBenchBenchmark(
     for (const qa of episode.qa_pairs) {
       try {
         const { result: recalledText, durationMs } = await timed(async () =>
-          options.system.recall(sessionId, qa.question),
+          options.system.recall(
+            sessionId,
+            qa.question,
+            DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+          ),
         );
         const answered = await answerBenchmarkQuestion({
           question: qa.question,
           recalledText,
           responder: options.system.responder,
+          answerMode: "strict",
         });
         const judgeResult = await llmJudgeScoreDetailed(
           options.system.judge,

--- a/packages/bench/src/benchmarks/published/amemgym/runner.ts
+++ b/packages/bench/src/benchmarks/published/amemgym/runner.ts
@@ -7,6 +7,7 @@ import { readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../../../recall-budget.js";
 import {
   AMEMGYM_SMOKE_FIXTURE,
   type AMemGymProfile,
@@ -117,12 +118,17 @@ export async function runAMemGymBenchmark(
 
       try {
         const { result: recallText, durationMs } = await timed(async () => {
-          return options.system.recall(sessionId, qa.query);
+          return options.system.recall(
+            sessionId,
+            qa.query,
+            DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+          );
         });
         const answered = await answerBenchmarkQuestion({
           question: benchmarkQuestion,
           recalledText: recallText,
           responder: options.system.responder,
+          answerMode: "strict",
         });
         const selectedChoice = parseAMemGymChoice(answered.finalAnswer, qa);
         const answerForScoring = selectedChoice?.choice.answer ?? answered.finalAnswer;

--- a/packages/bench/src/benchmarks/published/beam/runner.ts
+++ b/packages/bench/src/benchmarks/published/beam/runner.ts
@@ -9,6 +9,7 @@ import path from "node:path";
 import { createInterface } from "node:readline/promises";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { benchmarkRecallBudgetForSessionCount } from "../../../recall-budget.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -112,9 +113,12 @@ export async function runBeamBenchmark(
         try {
           const rubricTargets = normalizeRubricTargets(probe.rubric);
           const { result: recalledText, durationMs } = await timed(async () => {
+            const recallBudget = benchmarkRecallBudgetForSessionCount(
+              sessionIds.length,
+            );
             const recalledSessions = await Promise.all(
               sessionIds.map((sessionId) =>
-                options.system.recall(sessionId, probe.question),
+                options.system.recall(sessionId, probe.question, recallBudget),
               ),
             );
             return recalledSessions.filter(Boolean).join("\n\n");
@@ -123,6 +127,7 @@ export async function runBeamBenchmark(
             question: probe.question,
             recalledText,
             responder: options.system.responder,
+            answerMode: "strict",
           });
           const searchResults = await options.system.search(probe.question, 10);
           const judgeResult = await llmJudgeScoreDetailed(

--- a/packages/bench/src/benchmarks/published/harness.ts
+++ b/packages/bench/src/benchmarks/published/harness.ts
@@ -28,6 +28,7 @@ import { randomUUID } from "node:crypto";
 
 import type { Message } from "../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../answering.js";
+import { benchmarkRecallBudgetForSessionCount } from "../../recall-budget.js";
 import { getGitSha, getRemnicVersion } from "../../reporter.js";
 import {
   aggregateTaskScores,
@@ -258,9 +259,12 @@ async function executeTrial(
   trial: HarnessTrial,
 ): Promise<TaskResult> {
   const { result: recalledText, durationMs } = await timed(async () => {
+    const recallBudget = benchmarkRecallBudgetForSessionCount(
+      trial.recallSessionIds.length,
+    );
     const recalledSessions = await Promise.all(
       trial.recallSessionIds.map((sessionId) =>
-        ctx.options.system.recall(sessionId, trial.question),
+        ctx.options.system.recall(sessionId, trial.question, recallBudget),
       ),
     );
     return recalledSessions.filter(Boolean).join("\n\n");
@@ -269,6 +273,7 @@ async function executeTrial(
     question: trial.question,
     recalledText,
     responder: ctx.options.system.responder,
+    answerMode: "strict",
   });
 
   // Post-answer hook runs before the judge so dataset-specific signals

--- a/packages/bench/src/benchmarks/published/locomo/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.test.ts
@@ -4,11 +4,13 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import type { Message } from "../../../adapters/types.js";
 import { locomoDefinition, runLoCoMoBenchmark } from "./runner.ts";
 
 test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from the official dataset", async () => {
   const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-locomo-"));
   const datasetPath = path.join(tempDir, "locomo10.json");
+  const storedMessages: Message[] = [];
 
   try {
     await writeFile(
@@ -52,7 +54,9 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
       mode: "full",
       datasetDir: tempDir,
       system: {
-        async store() {},
+        async store(_sessionId, messages) {
+          storedMessages.push(...messages);
+        },
         async recall(_sessionId, question) {
           if (question.includes("year")) {
             return "2022";
@@ -86,6 +90,7 @@ test("LoCoMo normalizes numeric answers and adversarial-answer fallbacks from th
     assert.equal(result.results.tasks.length, 2);
     assert.equal(result.results.tasks[0]?.expected, "2022");
     assert.equal(result.results.tasks[1]?.expected, "blue");
+    assert.equal(storedMessages[0]?.content, "[D1:1] Maya: I moved in 2022.");
   } finally {
     await rm(tempDir, { recursive: true, force: true });
   }

--- a/packages/bench/src/benchmarks/published/locomo/runner.ts
+++ b/packages/bench/src/benchmarks/published/locomo/runner.ts
@@ -69,7 +69,7 @@ function buildMessages(
 ): Message[] {
   return turns.map((turn) => ({
     role: turn.speaker === speakerA ? "user" : "assistant",
-    content: turn.text,
+    content: `[${turn.dia_id}] ${turn.speaker}: ${turn.text}`,
   }));
 }
 

--- a/packages/bench/src/benchmarks/published/membench/runner.ts
+++ b/packages/bench/src/benchmarks/published/membench/runner.ts
@@ -10,6 +10,7 @@ import {
   type MemBenchCase,
 } from "./fixture.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../../../recall-budget.js";
 import type { Message } from "../../../adapters/types.js";
 import type {
   BenchmarkDefinition,
@@ -104,13 +105,18 @@ export async function runMemBenchBenchmark(
 
       const recallQuery = buildRecallQuery(testCase);
       const { result: recalledText, durationMs } = await timed(async () =>
-        options.system.recall(sessionId, recallQuery),
+        options.system.recall(
+          sessionId,
+          recallQuery,
+          DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+        ),
       );
       const answerQuestion = buildQuestionPrompt(testCase);
       const answered = await answerBenchmarkQuestion({
         question: answerQuestion,
         recalledText,
         responder: options.system.responder,
+        answerMode: "strict",
       });
       const predictedChoice = testCase.choices && options.system.responder
         ? extractChoice(answered.finalAnswer)

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -14,6 +14,7 @@ import {
   type DomainData,
 } from "./fixture.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../../../recall-budget.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -116,7 +117,11 @@ export async function runMemoryArenaBenchmark(
           }
 
           const { result: recalledText, durationMs } = await timed(async () =>
-            options.system.recall(sessionId, question),
+            options.system.recall(
+              sessionId,
+              question,
+              DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+            ),
           );
           const benchmarkQuestion = formatMemoryArenaQuestion(
             task.category,
@@ -127,6 +132,7 @@ export async function runMemoryArenaBenchmark(
             question: benchmarkQuestion,
             recalledText,
             responder: options.system.responder,
+            answerMode: "strict",
           });
           const domainScores = scoreMemoryArenaDomainAnswer(
             task.category,

--- a/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
+++ b/packages/bench/src/benchmarks/published/memoryagentbench/runner.ts
@@ -7,6 +7,7 @@ import { access, readFile } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { benchmarkRecallBudgetForSessionCount } from "../../../recall-budget.js";
 import {
   MEMORY_AGENT_BENCH_SMOKE_FIXTURE,
   type MemoryAgentBenchCompetency,
@@ -159,9 +160,12 @@ export async function runMemoryAgentBenchBenchmark(
         protocol = getProtocolForSource(item.metadata.source);
         const officialQuestion = buildOfficialQuery(protocol, question);
         const { result: recalledText, durationMs } = await timed(async () => {
+          const recallBudget = benchmarkRecallBudgetForSessionCount(
+            sessionIds.length,
+          );
           const recalledSessions = await Promise.all(
             sessionIds.map((sessionId) =>
-              options.system.recall(sessionId, question),
+              options.system.recall(sessionId, question, recallBudget),
             ),
           );
           return recalledSessions.filter(Boolean).join("\n\n");
@@ -170,6 +174,7 @@ export async function runMemoryAgentBenchBenchmark(
           question: officialQuestion,
           recalledText,
           responder: options.system.responder,
+          answerMode: "strict",
         });
         if (protocol === "recsys_redial" && !recsysMappingLoaded) {
           recsysMapping = await loadRecSysEntityMapping(options.datasetDir);

--- a/packages/bench/src/benchmarks/published/personamem/runner.ts
+++ b/packages/bench/src/benchmarks/published/personamem/runner.ts
@@ -7,6 +7,7 @@ import { readFile, realpath } from "node:fs/promises";
 import path from "node:path";
 import type { Message } from "../../../adapters/types.js";
 import { answerBenchmarkQuestion } from "../../../answering.js";
+import { DEFAULT_BENCH_RECALL_BUDGET_CHARS } from "../../../recall-budget.js";
 import type {
   BenchmarkDefinition,
   BenchmarkResult,
@@ -99,7 +100,11 @@ export async function runPersonaMemBenchmark(
       }
 
       const { result: recalledText, durationMs } = await timed(async () =>
-        options.system.recall(sessionId, sample.userQuery),
+        options.system.recall(
+          sessionId,
+          sample.userQuery,
+          DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+        ),
       );
       const searchResults = await options.system.search(
         sample.userQuery,
@@ -121,6 +126,7 @@ export async function runPersonaMemBenchmark(
         question: evaluationQuestion,
         recalledText,
         responder: options.system.responder,
+        answerMode: "strict",
       });
       const judgeResult = await llmJudgeScoreDetailed(
         options.system.judge,

--- a/packages/bench/src/recall-budget.test.ts
+++ b/packages/bench/src/recall-budget.test.ts
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+  benchmarkRecallBudgetForSessionCount,
+} from "./recall-budget.ts";
+
+test("benchmarkRecallBudgetForSessionCount caps combined multi-session context", () => {
+  assert.equal(
+    benchmarkRecallBudgetForSessionCount(1),
+    DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+  );
+  assert.equal(benchmarkRecallBudgetForSessionCount(3), 12_000);
+  assert.equal(benchmarkRecallBudgetForSessionCount(6), 6_000);
+  assert.equal(benchmarkRecallBudgetForSessionCount(20), 1_800);
+  assert.equal(benchmarkRecallBudgetForSessionCount(100), 360);
+  assert.equal(benchmarkRecallBudgetForSessionCount(40_000), 0);
+});
+
+test("benchmarkRecallBudgetForSessionCount falls back for invalid counts", () => {
+  assert.equal(
+    benchmarkRecallBudgetForSessionCount(0),
+    DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+  );
+  assert.equal(
+    benchmarkRecallBudgetForSessionCount(1.5),
+    DEFAULT_BENCH_RECALL_BUDGET_CHARS,
+  );
+});

--- a/packages/bench/src/recall-budget.ts
+++ b/packages/bench/src/recall-budget.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_BENCH_RECALL_BUDGET_CHARS = 24_000;
+export const MAX_COMBINED_RECALL_BUDGET_CHARS = 36_000;
+
+export function benchmarkRecallBudgetForSessionCount(
+  sessionCount: number,
+): number {
+  if (!Number.isInteger(sessionCount) || sessionCount <= 0) {
+    return DEFAULT_BENCH_RECALL_BUDGET_CHARS;
+  }
+
+  if (sessionCount === 1) {
+    return DEFAULT_BENCH_RECALL_BUDGET_CHARS;
+  }
+
+  return Math.floor(MAX_COMBINED_RECALL_BUDGET_CHARS / sessionCount);
+}

--- a/packages/bench/src/responders.ts
+++ b/packages/bench/src/responders.ts
@@ -20,6 +20,8 @@ const DEFAULT_RESPONDER_SYSTEM_PROMPT = [
   "You answer benchmark questions using only the supplied Remnic memory context.",
   "If the context does not contain enough information, say that the answer is unknown.",
   "Do not invent facts that are not grounded in the provided context.",
+  "When the question includes an output protocol, follow it exactly.",
+  "Prefer absolute dates or years over relative wording when memory evidence supports them.",
 ].join(" ");
 
 const DEFAULT_JUDGE_SYSTEM_PROMPT = [

--- a/packages/plugin-openclaw/src/bridge.ts
+++ b/packages/plugin-openclaw/src/bridge.ts
@@ -23,7 +23,7 @@ export interface BridgeConfig {
 const DEFAULT_HOST = "127.0.0.1";
 const DEFAULT_PORT = 4318;
 const LEGACY_HEALTH_PATH = "/engram/v1/health";
-const SYNC_HEALTH_TIMEOUT_MS = 750;
+const SYNC_HEALTH_TIMEOUT_MS = 2000;
 const HEALTH_WORKER_SOURCE = `
 import { request } from "node:http";
 import { workerData } from "node:worker_threads";

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4190,8 +4190,13 @@ export class EngramAccessService {
     // scoped storage dir while delegating everything else to the real
     // orchestrator (buffer, qmd, extraction queue, etc. are process-global
     // and don't require further namespace scoping for a read-only snapshot).
-    const orchestratorProxy = Object.create(this.orchestrator) as typeof this.orchestrator;
-    orchestratorProxy.config = { ...this.orchestrator.config, memoryDir: storage.dir };
+    const orchestratorProxy = Object.create(this.orchestrator, {
+      config: {
+        value: { ...this.orchestrator.config, memoryDir: storage.dir },
+        enumerable: true,
+        configurable: true,
+      },
+    }) as import("./console/state.js").ConsoleStateOrchestratorLike;
     return gatherConsoleState(orchestratorProxy);
   }
 

--- a/packages/remnic-core/src/evidence-pack.test.ts
+++ b/packages/remnic-core/src/evidence-pack.test.ts
@@ -1,0 +1,55 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { buildEvidencePack } from "./evidence-pack.js";
+
+test("buildEvidencePack deduplicates evidence and stays within budget", () => {
+  const pack = buildEvidencePack(
+    [
+      {
+        sessionId: "s1",
+        turnIndex: 1,
+        role: "assistant",
+        content: "The project deadline is Friday.",
+      },
+      {
+        sessionId: "s1",
+        turnIndex: 1,
+        role: "assistant",
+        content: "The project deadline is Friday.",
+      },
+      {
+        sessionId: "s1",
+        turnIndex: 2,
+        role: "user",
+        content: "Please remind me about the Friday deadline.",
+      },
+    ],
+    { title: "Search evidence", maxChars: 180, maxItemChars: 80 },
+  );
+
+  assert.ok(pack.length <= 180);
+  assert.match(pack, /^## Search evidence/);
+  assert.equal(
+    pack.match(/The project deadline is Friday\./g)?.length,
+    1,
+  );
+  assert.match(pack, /\[s1, turn 2, user\]/);
+});
+
+test("buildEvidencePack returns empty text when no useful evidence fits", () => {
+  assert.equal(
+    buildEvidencePack(
+      [{ sessionId: "s1", turnIndex: 1, role: "user", content: "   " }],
+      { maxChars: 100 },
+    ),
+    "",
+  );
+  assert.equal(
+    buildEvidencePack(
+      [{ sessionId: "s1", turnIndex: 1, role: "user", content: "hello" }],
+      { maxChars: 0 },
+    ),
+    "",
+  );
+});

--- a/packages/remnic-core/src/evidence-pack.ts
+++ b/packages/remnic-core/src/evidence-pack.ts
@@ -1,0 +1,110 @@
+export interface EvidencePackItem {
+  id?: string;
+  sessionId?: string;
+  turnIndex?: number;
+  role?: string;
+  content: string;
+  score?: number;
+}
+
+export interface EvidencePackOptions {
+  title?: string;
+  maxChars: number;
+  maxItemChars?: number;
+}
+
+const DEFAULT_MAX_ITEM_CHARS = 1_200;
+
+export function buildEvidencePack(
+  items: readonly EvidencePackItem[],
+  options: EvidencePackOptions,
+): string {
+  const budget = normalizePositiveInteger(options.maxChars);
+  if (budget <= 0 || items.length === 0) {
+    return "";
+  }
+
+  const maxItemChars = normalizePositiveInteger(
+    options.maxItemChars ?? DEFAULT_MAX_ITEM_CHARS,
+  );
+  if (maxItemChars <= 0) {
+    return "";
+  }
+
+  const title = options.title ?? "Evidence";
+  const lines: string[] = [`## ${title}`];
+  const seenIds = new Set<string>();
+  const seenContent = new Set<string>();
+  let used = lines[0]!.length;
+
+  for (const item of items) {
+    const content = item.content.trim();
+    if (!content) continue;
+
+    const id = item.id ?? evidenceItemFallbackId(item);
+    if (id && seenIds.has(id)) continue;
+
+    const contentKey = normalizeEvidenceContent(content);
+    if (seenContent.has(contentKey)) continue;
+
+    const label = formatEvidenceLabel(item);
+    const clipped = clipText(content, maxItemChars);
+    const block = `${label}: ${clipped}`;
+    const separatorLength = lines.length > 0 ? 2 : 0;
+    const remaining = budget - used - separatorLength;
+    if (remaining <= 0) break;
+
+    const finalBlock =
+      block.length > remaining ? clipText(block, remaining) : block;
+    if (!finalBlock.trim()) break;
+
+    lines.push(finalBlock);
+    used += separatorLength + finalBlock.length;
+    if (id) seenIds.add(id);
+    seenContent.add(contentKey);
+  }
+
+  return lines.length === 1 ? "" : lines.join("\n\n");
+}
+
+function normalizePositiveInteger(value: number): number {
+  if (!Number.isFinite(value) || value <= 0) {
+    return 0;
+  }
+  return Math.floor(value);
+}
+
+function evidenceItemFallbackId(item: EvidencePackItem): string | undefined {
+  if (item.sessionId && typeof item.turnIndex === "number") {
+    return `${item.sessionId}:${item.turnIndex}`;
+  }
+  return undefined;
+}
+
+function normalizeEvidenceContent(content: string): string {
+  return content.toLowerCase().replace(/\s+/g, " ").trim();
+}
+
+function formatEvidenceLabel(item: EvidencePackItem): string {
+  const parts: string[] = [];
+  if (item.sessionId) parts.push(item.sessionId);
+  if (typeof item.turnIndex === "number") parts.push(`turn ${item.turnIndex}`);
+  if (item.role) parts.push(item.role);
+  if (typeof item.score === "number" && Number.isFinite(item.score)) {
+    parts.push(`score ${item.score.toFixed(3)}`);
+  }
+  return parts.length > 0 ? `[${parts.join(", ")}]` : "[evidence]";
+}
+
+function clipText(text: string, maxChars: number): string {
+  if (text.length <= maxChars) {
+    return text;
+  }
+  if (maxChars <= 1) {
+    return text.slice(0, maxChars);
+  }
+  if (maxChars <= 3) {
+    return text.slice(0, maxChars);
+  }
+  return `${text.slice(0, maxChars - 3).trimEnd()}...`;
+}

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -45,6 +45,12 @@ export {
   defaultWorkspaceDir,
 } from "./orchestrator.js";
 
+export {
+  buildEvidencePack,
+  type EvidencePackItem,
+  type EvidencePackOptions,
+} from "./evidence-pack.js";
+
 // ---------------------------------------------------------------------------
 // Storage
 // ---------------------------------------------------------------------------

--- a/tests/fixtures/bench-smoke/baseline.json
+++ b/tests/fixtures/bench-smoke/baseline.json
@@ -12,9 +12,9 @@
     "locomo": {
       "metrics": {
         "contains_answer": 1,
-        "f1": 0.055556,
+        "f1": 0.041667,
         "llm_judge": 1,
-        "rouge_l": 0.055556
+        "rouge_l": 0.041667
       }
     }
   }


### PR DESCRIPTION
## Summary
- add a core evidence-pack helper and use it in the Remnic bench adapter to preserve high-signal search evidence under recall budgets
- add strict answer prompting for published benchmarks while preserving legacy/custom benchmark behavior
- add per-session recall budgets, speaker-aware LoCoMo storage, and a bridge health timeout fix found during preflight

## Verification
- npm run check-types
- node node_modules/tsx/dist/cli.mjs scripts/bench/bench-smoke.ts
- pnpm exec tsx --test packages/bench/src/answering.test.ts packages/bench/src/adapters/remnic-adapter.test.ts packages/bench/src/recall-budget.test.ts packages/remnic-core/src/evidence-pack.test.ts packages/bench/src/benchmarks/published/locomo/runner.test.ts tests/bench-amemgym-runner.test.ts
- pnpm exec tsx --test tests/register-multi-registry.test.ts tests/intent.test.ts tests/runtime-input-guards.test.ts tests/artifact-recall-limit.test.ts tests/artifact-status-snapshot.test.ts tests/recall-no-recall-short-circuit.test.ts tests/orchestrator-path-filter.test.ts tests/artifact-cache.test.ts
- pnpm --filter @remnic/bench build
- pnpm --filter @remnic/core build
- git diff --check

## Notes
- npm run preflight:quick was attempted twice. The first run exposed a load-sensitive bridge health timeout, fixed here. The second run still failed in the repository-wide npm test expansion after long fallback-client tests; the direct quick-gate target files listed above pass when run without the broad npm-test glob expansion.
- Ollama Cloud smoke after the LoCoMo speaker fix scored 2/2 LoCoMo tasks with contains_answer/f1/llm_judge/rouge_l all at 1.0 in the isolated temp benchmark config.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes benchmark recall/answer prompting and context budgeting across multiple published runners, which can affect reported scores and regression baselines. Low security risk, but higher behavioral risk due to altered prompt text and recall truncation logic.
> 
> **Overview**
> **Bench runs now enforce stricter, more consistent recall/answer behavior.** Published benchmarks call `answerBenchmarkQuestion` in *strict* mode, which appends a standardized "Benchmark answer protocol" and auto-detects output constraints (MCQ letters/numbers and structured formats) to reduce off-protocol responses.
> 
> **Recall output is now explicitly budgeted and higher-signal.** A new `DEFAULT_BENCH_RECALL_BUDGET_CHARS` and `benchmarkRecallBudgetForSessionCount()` cap combined multi-session recall, and the Remnic bench adapter uses the new core `buildEvidencePack()` helper to include deduped, budget-bounded search evidence before assembling the summary.
> 
> Also updates LoCoMo ingestion to prefix turns with speaker + `dia_id` for clearer attribution, increases the OpenClaw bridge sync health timeout, and adjusts smoke/baseline expectations and tests to match the new formatting and budgets.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 54a64b52d0d103cf4c31051e7c629956272ef000. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->