### PR TITLE
feat(access): SecretRef resolution for agentAccessHttp.authToken (issue #757)

### DIFF
--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -47,7 +47,7 @@ Backward compatibility note:
 | `agentAccessHttp.enabled` | `false` | Start a local authenticated Remnic HTTP API during plugin startup |
 | `agentAccessHttp.host` | `127.0.0.1` | Loopback bind host for the Remnic HTTP API |
 | `agentAccessHttp.port` | `4318` | Bind port for the Remnic HTTP API (`0` = ephemeral port) |
-| `agentAccessHttp.authToken` | `OPENCLAW_ENGRAM_ACCESS_TOKEN` | Bearer token for the local HTTP API; supports `${ENV_VAR}` references |
+| `agentAccessHttp.authToken` | `OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN` | Bearer token for the local HTTP API. Accepts a literal string (with `${ENV_VAR}` expansion) or — under OpenClaw — a SecretRef object such as `{"source":"exec","provider":"kc_openclaw_remnic_token","id":"value"}` resolved at startup via the gateway secret resolver (issue #757). Standalone Remnic accepts strings only. |
 | `agentAccessHttp.maxBodyBytes` | `131072` | Maximum accepted JSON request body size |
 
 When `agentAccessHttp.enabled` is on (or `openclaw engram access http-serve` is running), the same loopback server also serves the browser-based admin console shell at `/engram/ui/`. The shell is static, ships with packaged plugin builds, and still requires the configured bearer token over `/engram/v1/...` for memory data and operator actions.

--- a/docs/integration/deployment-topologies.md
+++ b/docs/integration/deployment-topologies.md
@@ -141,10 +141,38 @@ services:
 All topologies require a bearer token. Set it via:
 
 1. `--token` CLI flag
-2. `OPENCLAW_ENGRAM_ACCESS_TOKEN` environment variable
+2. `OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN` environment variable
 3. `agentAccessHttp.authToken` in `openclaw.json`
 
 Clients must send `Authorization: Bearer <token>` with every request.
+
+### SecretRef tokens (OpenClaw plugin mode, issue #757)
+
+When running under OpenClaw, `agentAccessHttp.authToken` accepts an OpenClaw
+SecretRef object instead of a literal string. Remnic delegates resolution to
+the gateway's built-in secret resolver — the same path that handles
+`gateway.auth.token` and channel `botToken` / `token` fields — so the token
+never appears in cleartext in `openclaw.json`:
+
+```json
+{
+  "agentAccessHttp": {
+    "enabled": true,
+    "authToken": {
+      "source": "exec",
+      "provider": "kc_openclaw_remnic_token",
+      "id": "value"
+    }
+  }
+}
+```
+
+Resolution happens once at plugin startup, before the HTTP listener opens.
+If resolution fails (Keychain locked, missing exec provider, empty value),
+the bridge refuses to start rather than serving requests with no auth.
+
+Standalone Remnic (no OpenClaw gateway present) does **not** support
+SecretRef objects — use a literal string or `${ENV_VAR}` expansion instead.
 
 ## Health Check
 

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1450,8 +1450,31 @@
             "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
           },
           "authToken": {
-            "type": "string",
-            "description": "Bearer token for the local Remnic HTTP API. Supports ${ENV_VAR} expansion. If omitted, OPENCLAW_ENGRAM_ACCESS_TOKEN is used."
+            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "object",
+                "required": [
+                  "source"
+                ],
+                "properties": {
+                  "source": {
+                    "type": "string",
+                    "minLength": 1
+                  },
+                  "provider": {
+                    "type": "string"
+                  },
+                  "id": {
+                    "type": "string"
+                  },
+                  "command": {}
+                }
+              }
+            ]
           },
           "principal": {
             "type": "string",
@@ -2260,8 +2283,14 @@
       },
       "patternReinforcementCategories": {
         "type": "array",
-        "items": { "type": "string" },
-        "default": ["preference", "fact", "decision"],
+        "items": {
+          "type": "string"
+        },
+        "default": [
+          "preference",
+          "fact",
+          "decision"
+        ],
         "description": "Memory categories the pattern-reinforcement job considers. Skips procedural memories so it stays disjoint from procedural mining. Default: preference, fact, decision."
       },
       "reinforcementRecallBoostEnabled": {

--- a/packages/plugin-openclaw/openclaw.plugin.json
+++ b/packages/plugin-openclaw/openclaw.plugin.json
@@ -1450,8 +1450,20 @@
             "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
           },
           "authToken": {
-            "type": "string",
-            "description": "Bearer token for the local Remnic HTTP API. Supports ${ENV_VAR} expansion. If omitted, OPENCLAW_ENGRAM_ACCESS_TOKEN is used."
+            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "required": ["source"],
+                "properties": {
+                  "source": { "type": "string", "minLength": 1 },
+                  "provider": { "type": "string" },
+                  "id": { "type": "string" },
+                  "command": {}
+                }
+              }
+            ]
           },
           "principal": {
             "type": "string",

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -89,6 +89,7 @@ import { WebDavServer } from "./network/webdav.js";
 import { GraphDashboardServer, type DashboardStatus } from "./dashboard-runtime.js";
 import { EngramAccessService } from "./access-service.js";
 import { EngramAccessHttpServer } from "./access-http.js";
+import { resolveAgentAccessAuthToken } from "./resolve-auth-token.js";
 import { EngramMcpServer } from "./access-mcp.js";
 import { runCompatChecks } from "./compat/checks.js";
 import { parseConfig } from "./config.js";
@@ -6583,15 +6584,23 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
           // that arrive during warmup still work — orchestrator.recall() awaits
           // its internal init gate (15s timeout) so callers get a correct (if
           // slightly delayed) response rather than "connection refused".
+          // Resolve SecretRef authToken if config carries one (issue #757).
+          // The CLI flag override (--token) wins; otherwise, resolve config.
+          const cliTokenOverride =
+            typeof options.token === "string" && options.token.trim().length > 0
+              ? options.token
+              : undefined;
+          const resolvedConfigAuthToken = cliTokenOverride
+            ? undefined
+            : await resolveAgentAccessAuthToken(
+                orchestrator.config.agentAccessHttp.authToken,
+              );
           const status = await runAccessHttpServeCliCommand({
             service: accessService,
             enabled: true,
             host: typeof options.host === "string" ? options.host : "127.0.0.1",
             port: Number.isFinite(portRaw) ? portRaw : 4318,
-            authToken:
-              typeof options.token === "string" && options.token.trim().length > 0
-                ? options.token
-                : orchestrator.config.agentAccessHttp.authToken,
+            authToken: cliTokenOverride ?? resolvedConfigAuthToken,
             principal: resolveAccessPrincipalOverride(options.principal, orchestrator.config.agentAccessHttp.principal),
             maxBodyBytes: Number.isFinite(maxBodyBytesRaw) ? maxBodyBytesRaw : 131072,
             trustPrincipalHeader: options.trustPrincipalHeader === true,

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -89,7 +89,10 @@ import { WebDavServer } from "./network/webdav.js";
 import { GraphDashboardServer, type DashboardStatus } from "./dashboard-runtime.js";
 import { EngramAccessService } from "./access-service.js";
 import { EngramAccessHttpServer } from "./access-http.js";
-import { resolveAgentAccessAuthToken } from "./resolve-auth-token.js";
+import {
+  resolveAgentAccessAuthToken,
+  type ResolveSecretRefFn,
+} from "./resolve-auth-token.js";
 import { EngramMcpServer } from "./access-mcp.js";
 import { runCompatChecks } from "./compat/checks.js";
 import { parseConfig } from "./config.js";
@@ -240,6 +243,15 @@ interface CliApi {
     options: { commands: string[] },
   ): void;
 }
+
+type RegisterCliOptions = {
+  resolveSecretRef?: ResolveSecretRefFn | null;
+  loadResolveSecretRef?: () =>
+    | Promise<ResolveSecretRefFn | null | undefined>
+    | ResolveSecretRefFn
+    | null
+    | undefined;
+};
 
 interface CliProgram {
   command(name: string): CliCommand;
@@ -3415,7 +3427,11 @@ function buildConversationIndexRebuildAction(orchestrator: Orchestrator) {
   };
 }
 
-export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
+export function registerCli(
+  api: CliApi,
+  orchestrator: Orchestrator,
+  registerOptions: RegisterCliOptions = {},
+): void {
   api.registerCli(
     ({ program }) => {
       const cmd = program
@@ -6590,10 +6606,16 @@ export function registerCli(api: CliApi, orchestrator: Orchestrator): void {
             typeof options.token === "string" && options.token.trim().length > 0
               ? options.token
               : undefined;
+          const resolveSecretRef =
+            registerOptions.resolveSecretRef ??
+            (registerOptions.loadResolveSecretRef
+              ? await registerOptions.loadResolveSecretRef()
+              : null);
           const resolvedConfigAuthToken = cliTokenOverride
             ? undefined
             : await resolveAgentAccessAuthToken(
                 orchestrator.config.agentAccessHttp.authToken,
+                { resolveSecretRef },
               );
           const status = await runAccessHttpServeCliCommand({
             service: accessService,

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -77,7 +77,7 @@ function coerceBooleanLike(value: unknown): boolean | undefined {
 function isSecretRefShape(value: unknown): value is import("./types.js").SecretRef {
   if (!value || typeof value !== "object" || Array.isArray(value)) return false;
   const obj = value as Record<string, unknown>;
-  return typeof obj.source === "string" && obj.source.length > 0;
+  return typeof obj.source === "string" && obj.source.trim().length > 0;
 }
 
 /**

--- a/packages/remnic-core/src/config.ts
+++ b/packages/remnic-core/src/config.ts
@@ -68,6 +68,47 @@ function coerceBooleanLike(value: unknown): boolean | undefined {
   return undefined;
 }
 
+/**
+ * Detect a SecretRef-shaped object (issue #757) without resolving it.
+ * SecretRefs are preserved verbatim through `parseConfig` and resolved at
+ * service-start time via `resolveAgentAccessAuthToken` (which delegates to
+ * OpenClaw's gateway resolver). Standalone Remnic does not resolve these.
+ */
+function isSecretRefShape(value: unknown): value is import("./types.js").SecretRef {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return false;
+  const obj = value as Record<string, unknown>;
+  return typeof obj.source === "string" && obj.source.length > 0;
+}
+
+/**
+ * Parse the `agentAccessHttp.authToken` field. Accepts:
+ *   - `string` → env-expanded immediately (current behavior preserved)
+ *   - `SecretRef` object (`{source, ...}`) → preserved verbatim for runtime
+ *     resolution by OpenClaw's gateway secret resolver
+ *   - `undefined` / empty string → fall back to env var, then `undefined`
+ *   - Any other shape → throw with a clear, actionable error so operators can
+ *     debug rather than chasing a generic startup failure (issue #757).
+ */
+function parseAgentAccessAuthToken(raw: unknown): import("./types.js").AgentAccessAuthToken | undefined {
+  if (raw === undefined || raw === null) {
+    return readEnvVar("OPENCLAW_REMNIC_ACCESS_TOKEN") ?? readEnvVar("OPENCLAW_ENGRAM_ACCESS_TOKEN");
+  }
+  if (typeof raw === "string") {
+    if (raw.trim().length === 0) {
+      return readEnvVar("OPENCLAW_REMNIC_ACCESS_TOKEN") ?? readEnvVar("OPENCLAW_ENGRAM_ACCESS_TOKEN");
+    }
+    return resolveEnvVars(raw);
+  }
+  if (isSecretRefShape(raw)) {
+    return raw;
+  }
+  throw new Error(
+    "unsupported SecretRef shape for agentAccessHttp.authToken — " +
+      "expected a string or an object with a non-empty `source` field " +
+      "(see https://github.com/joshuaswarren/remnic/issues/757)",
+  );
+}
+
 function resolveEnvVars(value: string): string {
   const resolved = value.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, envVar: string) => {
     const envValue = readEnvVar(envVar);
@@ -861,10 +902,7 @@ export function parseConfig(raw: unknown): PluginConfig {
       typeof rawAgentAccessHttp?.port === "number"
         ? Math.max(0, Math.floor(rawAgentAccessHttp.port))
         : 4318,
-    authToken:
-      typeof rawAgentAccessHttp?.authToken === "string" && rawAgentAccessHttp.authToken.trim().length > 0
-        ? resolveEnvVars(rawAgentAccessHttp.authToken)
-        : readEnvVar("OPENCLAW_REMNIC_ACCESS_TOKEN") ?? readEnvVar("OPENCLAW_ENGRAM_ACCESS_TOKEN"),
+    authToken: parseAgentAccessAuthToken(rawAgentAccessHttp?.authToken),
     principal:
       typeof rawAgentAccessHttp?.principal === "string" && rawAgentAccessHttp.principal.trim().length > 0
         ? resolveEnvVars(rawAgentAccessHttp.principal)

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -231,6 +231,18 @@ export { EngramAccessService, EngramAccessInputError } from "./access-service.js
 export { EngramAccessHttpServer } from "./access-http.js";
 export { EngramMcpServer } from "./access-mcp.js";
 
+// agentAccessHttp.authToken SecretRef resolution (issue #757). Exposed so
+// host-specific bootstrap code (the OpenClaw plugin in `src/index.ts`, the
+// standalone server, the CLI) can resolve a SecretRef to a literal bearer
+// token before constructing the HTTP server.
+export {
+  resolveAgentAccessAuthToken,
+  isAgentAccessSecretRef,
+  clearAuthTokenSecretCache,
+  __setSecretRefResolverForTest,
+} from "./resolve-auth-token.js";
+export type { SecretRef, AgentAccessAuthToken } from "./types.js";
+
 // Recall X-ray CLI helpers (issue #570).  Exported so the standalone
 // `@remnic/cli` binary can wire the `remnic xray` command without
 // reimporting core-internal modules by relative path (CLAUDE.md rule 26).

--- a/packages/remnic-core/src/index.ts
+++ b/packages/remnic-core/src/index.ts
@@ -239,8 +239,8 @@ export {
   resolveAgentAccessAuthToken,
   isAgentAccessSecretRef,
   clearAuthTokenSecretCache,
-  __setSecretRefResolverForTest,
 } from "./resolve-auth-token.js";
+export type { ResolveSecretRefFn } from "./resolve-auth-token.js";
 export type { SecretRef, AgentAccessAuthToken } from "./types.js";
 
 // Recall X-ray CLI helpers (issue #570).  Exported so the standalone

--- a/packages/remnic-core/src/operator-toolkit.ts
+++ b/packages/remnic-core/src/operator-toolkit.ts
@@ -1149,21 +1149,30 @@ export async function runOperatorDoctor(options: OperatorDoctorOptions): Promise
   });
 
   const agentAccessEnabled = config.agentAccessHttp?.enabled === true;
+  // A SecretRef object counts as "configured" (issue #757) — resolution
+  // happens at service-start time, not at doctor-time.  We only check that
+  // *something* is set; we never log the resolved value.
+  const rawAuthToken = config.agentAccessHttp?.authToken;
+  const authTokenConfigured =
+    (typeof rawAuthToken === "string" && rawAuthToken.length > 0) ||
+    (rawAuthToken !== null &&
+      typeof rawAuthToken === "object" &&
+      typeof (rawAuthToken as { source?: unknown }).source === "string");
   checks.push({
     key: "access_http_auth",
     status: !agentAccessEnabled
       ? "warn"
-      : config.agentAccessHttp?.authToken
+      : authTokenConfigured
       ? "ok"
       : "error",
     summary: !agentAccessEnabled
       ? "Agent access HTTP bridge is disabled."
-      : config.agentAccessHttp?.authToken
+      : authTokenConfigured
       ? "Agent access HTTP bridge has an auth token configured."
       : "Agent access HTTP bridge is enabled without an auth token.",
     remediation: !agentAccessEnabled
       ? "Ignore unless you plan to enable the HTTP bridge."
-      : config.agentAccessHttp?.authToken
+      : authTokenConfigured
       ? undefined
       : "Set `agentAccessHttp.authToken` before exposing the bridge.",
   });

--- a/packages/remnic-core/src/resolve-auth-token.test.ts
+++ b/packages/remnic-core/src/resolve-auth-token.test.ts
@@ -2,7 +2,6 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
-  __setSecretRefResolverForTest,
   clearAuthTokenSecretCache,
   isAgentAccessSecretRef,
   resolveAgentAccessAuthToken,
@@ -30,17 +29,20 @@ test("resolveAgentAccessAuthToken returns undefined for empty / undefined input"
 test("resolveAgentAccessAuthToken delegates SecretRef objects to gateway resolver", async () => {
   clearAuthTokenSecretCache();
   const calls: unknown[] = [];
-  __setSecretRefResolverForTest(async (ref) => {
+  const resolveSecretRef = async (ref: any) => {
     calls.push(ref);
     return "resolved-secret-value";
-  });
+  };
 
   try {
-    const result = await resolveAgentAccessAuthToken({
-      source: "exec",
-      provider: "kc_openclaw_remnic_token",
-      id: "value",
-    });
+    const result = await resolveAgentAccessAuthToken(
+      {
+        source: "exec",
+        provider: "kc_openclaw_remnic_token",
+        id: "value",
+      },
+      { resolveSecretRef },
+    );
     assert.equal(result, "resolved-secret-value");
     assert.equal(calls.length, 1);
     assert.deepEqual(calls[0], {
@@ -49,7 +51,24 @@ test("resolveAgentAccessAuthToken delegates SecretRef objects to gateway resolve
       id: "value",
     });
   } finally {
-    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken trims SecretRef resolver output", async () => {
+  clearAuthTokenSecretCache();
+
+  try {
+    const result = await resolveAgentAccessAuthToken(
+      {
+        source: "exec",
+        provider: "kc_openclaw_remnic_token",
+        id: "value",
+      },
+      { resolveSecretRef: async () => "  resolved-secret-value\n" },
+    );
+    assert.equal(result, "resolved-secret-value");
+  } finally {
     clearAuthTokenSecretCache();
   }
 });
@@ -57,23 +76,22 @@ test("resolveAgentAccessAuthToken delegates SecretRef objects to gateway resolve
 test("resolveAgentAccessAuthToken caches resolved SecretRef values", async () => {
   clearAuthTokenSecretCache();
   let callCount = 0;
-  __setSecretRefResolverForTest(async () => {
+  const resolveSecretRef = async () => {
     callCount += 1;
     return "cached-token";
-  });
+  };
 
   try {
     const ref = { source: "exec", provider: "kc_x", id: "value" };
-    const first = await resolveAgentAccessAuthToken(ref);
-    const second = await resolveAgentAccessAuthToken(ref);
+    const first = await resolveAgentAccessAuthToken(ref, { resolveSecretRef });
+    const second = await resolveAgentAccessAuthToken(ref, { resolveSecretRef });
     // Same shape but different object reference — should still hit cache
-    const third = await resolveAgentAccessAuthToken({ ...ref });
+    const third = await resolveAgentAccessAuthToken({ ...ref }, { resolveSecretRef });
     assert.equal(first, "cached-token");
     assert.equal(second, "cached-token");
     assert.equal(third, "cached-token");
     assert.equal(callCount, 1);
   } finally {
-    __setSecretRefResolverForTest(null);
     clearAuthTokenSecretCache();
   }
 });
@@ -81,24 +99,28 @@ test("resolveAgentAccessAuthToken caches resolved SecretRef values", async () =>
 test("resolveAgentAccessAuthToken cache key is order-independent", async () => {
   clearAuthTokenSecretCache();
   let callCount = 0;
-  __setSecretRefResolverForTest(async () => {
+  const resolveSecretRef = async () => {
     callCount += 1;
     return "stable-token";
-  });
+  };
 
   try {
-    await resolveAgentAccessAuthToken({ source: "exec", provider: "p", id: "v" });
-    await resolveAgentAccessAuthToken({ id: "v", provider: "p", source: "exec" });
+    await resolveAgentAccessAuthToken(
+      { source: "exec", provider: "p", id: "v" },
+      { resolveSecretRef },
+    );
+    await resolveAgentAccessAuthToken(
+      { id: "v", provider: "p", source: "exec" },
+      { resolveSecretRef },
+    );
     assert.equal(callCount, 1, "key sort should make order-permuted refs share a cache slot");
   } finally {
-    __setSecretRefResolverForTest(null);
     clearAuthTokenSecretCache();
   }
 });
 
-test("resolveAgentAccessAuthToken throws when gateway resolver is unavailable", async () => {
+test("resolveAgentAccessAuthToken throws when no SecretRef resolver is provided", async () => {
   clearAuthTokenSecretCache();
-  __setSecretRefResolverForTest(null);
 
   await assert.rejects(
     () =>
@@ -107,7 +129,7 @@ test("resolveAgentAccessAuthToken throws when gateway resolver is unavailable", 
         provider: "kc_x",
         id: "value",
       }),
-    /OpenClaw gateway secret resolver is not available|cannot resolve/i,
+    /SecretRef resolver was not provided|cannot resolve/i,
   );
 });
 
@@ -120,44 +142,54 @@ test("resolveAgentAccessAuthToken throws on missing source field", async () => {
       } as unknown as Parameters<typeof resolveAgentAccessAuthToken>[0]),
     /missing required `source` field/,
   );
+  await assert.rejects(
+    () =>
+      resolveAgentAccessAuthToken({
+        source: "   ",
+      } as unknown as Parameters<typeof resolveAgentAccessAuthToken>[0]),
+    /missing required `source` field/,
+  );
 });
 
 test("resolveAgentAccessAuthToken throws when SecretRef resolves to empty string", async () => {
   clearAuthTokenSecretCache();
-  __setSecretRefResolverForTest(async () => "");
   try {
     await assert.rejects(
       () =>
-        resolveAgentAccessAuthToken({
-          source: "exec",
-          provider: "kc_x",
-          id: "value",
-        }),
+        resolveAgentAccessAuthToken(
+          {
+            source: "exec",
+            provider: "kc_x",
+            id: "value",
+          },
+          { resolveSecretRef: async () => "" },
+        ),
       /resolved to empty value/,
     );
   } finally {
-    __setSecretRefResolverForTest(null);
     clearAuthTokenSecretCache();
   }
 });
 
 test("resolveAgentAccessAuthToken surfaces resolver errors with context", async () => {
   clearAuthTokenSecretCache();
-  __setSecretRefResolverForTest(async () => {
+  const resolveSecretRef = async () => {
     throw new Error("keychain locked");
-  });
+  };
   try {
     await assert.rejects(
       () =>
-        resolveAgentAccessAuthToken({
-          source: "exec",
-          provider: "kc_x",
-          id: "value",
-        }),
+        resolveAgentAccessAuthToken(
+          {
+            source: "exec",
+            provider: "kc_x",
+            id: "value",
+          },
+          { resolveSecretRef },
+        ),
       /failed to resolve.*SecretRef.*keychain locked/,
     );
   } finally {
-    __setSecretRefResolverForTest(null);
     clearAuthTokenSecretCache();
   }
 });
@@ -165,19 +197,18 @@ test("resolveAgentAccessAuthToken surfaces resolver errors with context", async 
 test("resolveAgentAccessAuthToken does not cache failed resolutions", async () => {
   clearAuthTokenSecretCache();
   let callCount = 0;
-  __setSecretRefResolverForTest(async () => {
+  const resolveSecretRef = async () => {
     callCount += 1;
     if (callCount === 1) throw new Error("transient");
     return "second-try-success";
-  });
+  };
   try {
     const ref = { source: "exec", provider: "kc_x", id: "value" };
-    await assert.rejects(() => resolveAgentAccessAuthToken(ref));
-    const second = await resolveAgentAccessAuthToken(ref);
+    await assert.rejects(() => resolveAgentAccessAuthToken(ref, { resolveSecretRef }));
+    const second = await resolveAgentAccessAuthToken(ref, { resolveSecretRef });
     assert.equal(second, "second-try-success");
     assert.equal(callCount, 2);
   } finally {
-    __setSecretRefResolverForTest(null);
     clearAuthTokenSecretCache();
   }
 });
@@ -190,5 +221,6 @@ test("isAgentAccessSecretRef recognizes SecretRef shapes", () => {
   assert.equal(isAgentAccessSecretRef(null), false);
   assert.equal(isAgentAccessSecretRef({}), false);
   assert.equal(isAgentAccessSecretRef({ source: "" }), false);
+  assert.equal(isAgentAccessSecretRef({ source: "   " }), false);
   assert.equal(isAgentAccessSecretRef([1, 2, 3]), false);
 });

--- a/packages/remnic-core/src/resolve-auth-token.test.ts
+++ b/packages/remnic-core/src/resolve-auth-token.test.ts
@@ -1,0 +1,194 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  __setSecretRefResolverForTest,
+  clearAuthTokenSecretCache,
+  isAgentAccessSecretRef,
+  resolveAgentAccessAuthToken,
+} from "./resolve-auth-token.js";
+
+test("resolveAgentAccessAuthToken passes through plain strings", async () => {
+  clearAuthTokenSecretCache();
+  const result = await resolveAgentAccessAuthToken("plain-bearer-token");
+  assert.equal(result, "plain-bearer-token");
+});
+
+test("resolveAgentAccessAuthToken trims surrounding whitespace", async () => {
+  clearAuthTokenSecretCache();
+  const result = await resolveAgentAccessAuthToken("  spaced-token  ");
+  assert.equal(result, "spaced-token");
+});
+
+test("resolveAgentAccessAuthToken returns undefined for empty / undefined input", async () => {
+  clearAuthTokenSecretCache();
+  assert.equal(await resolveAgentAccessAuthToken(undefined), undefined);
+  assert.equal(await resolveAgentAccessAuthToken(""), undefined);
+  assert.equal(await resolveAgentAccessAuthToken("   "), undefined);
+});
+
+test("resolveAgentAccessAuthToken delegates SecretRef objects to gateway resolver", async () => {
+  clearAuthTokenSecretCache();
+  const calls: unknown[] = [];
+  __setSecretRefResolverForTest(async (ref) => {
+    calls.push(ref);
+    return "resolved-secret-value";
+  });
+
+  try {
+    const result = await resolveAgentAccessAuthToken({
+      source: "exec",
+      provider: "kc_openclaw_remnic_token",
+      id: "value",
+    });
+    assert.equal(result, "resolved-secret-value");
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], {
+      source: "exec",
+      provider: "kc_openclaw_remnic_token",
+      id: "value",
+    });
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken caches resolved SecretRef values", async () => {
+  clearAuthTokenSecretCache();
+  let callCount = 0;
+  __setSecretRefResolverForTest(async () => {
+    callCount += 1;
+    return "cached-token";
+  });
+
+  try {
+    const ref = { source: "exec", provider: "kc_x", id: "value" };
+    const first = await resolveAgentAccessAuthToken(ref);
+    const second = await resolveAgentAccessAuthToken(ref);
+    // Same shape but different object reference — should still hit cache
+    const third = await resolveAgentAccessAuthToken({ ...ref });
+    assert.equal(first, "cached-token");
+    assert.equal(second, "cached-token");
+    assert.equal(third, "cached-token");
+    assert.equal(callCount, 1);
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken cache key is order-independent", async () => {
+  clearAuthTokenSecretCache();
+  let callCount = 0;
+  __setSecretRefResolverForTest(async () => {
+    callCount += 1;
+    return "stable-token";
+  });
+
+  try {
+    await resolveAgentAccessAuthToken({ source: "exec", provider: "p", id: "v" });
+    await resolveAgentAccessAuthToken({ id: "v", provider: "p", source: "exec" });
+    assert.equal(callCount, 1, "key sort should make order-permuted refs share a cache slot");
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken throws when gateway resolver is unavailable", async () => {
+  clearAuthTokenSecretCache();
+  __setSecretRefResolverForTest(null);
+
+  await assert.rejects(
+    () =>
+      resolveAgentAccessAuthToken({
+        source: "exec",
+        provider: "kc_x",
+        id: "value",
+      }),
+    /OpenClaw gateway secret resolver is not available|cannot resolve/i,
+  );
+});
+
+test("resolveAgentAccessAuthToken throws on missing source field", async () => {
+  clearAuthTokenSecretCache();
+  await assert.rejects(
+    () =>
+      resolveAgentAccessAuthToken({
+        provider: "no-source-field",
+      } as unknown as Parameters<typeof resolveAgentAccessAuthToken>[0]),
+    /missing required `source` field/,
+  );
+});
+
+test("resolveAgentAccessAuthToken throws when SecretRef resolves to empty string", async () => {
+  clearAuthTokenSecretCache();
+  __setSecretRefResolverForTest(async () => "");
+  try {
+    await assert.rejects(
+      () =>
+        resolveAgentAccessAuthToken({
+          source: "exec",
+          provider: "kc_x",
+          id: "value",
+        }),
+      /resolved to empty value/,
+    );
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken surfaces resolver errors with context", async () => {
+  clearAuthTokenSecretCache();
+  __setSecretRefResolverForTest(async () => {
+    throw new Error("keychain locked");
+  });
+  try {
+    await assert.rejects(
+      () =>
+        resolveAgentAccessAuthToken({
+          source: "exec",
+          provider: "kc_x",
+          id: "value",
+        }),
+      /failed to resolve.*SecretRef.*keychain locked/,
+    );
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("resolveAgentAccessAuthToken does not cache failed resolutions", async () => {
+  clearAuthTokenSecretCache();
+  let callCount = 0;
+  __setSecretRefResolverForTest(async () => {
+    callCount += 1;
+    if (callCount === 1) throw new Error("transient");
+    return "second-try-success";
+  });
+  try {
+    const ref = { source: "exec", provider: "kc_x", id: "value" };
+    await assert.rejects(() => resolveAgentAccessAuthToken(ref));
+    const second = await resolveAgentAccessAuthToken(ref);
+    assert.equal(second, "second-try-success");
+    assert.equal(callCount, 2);
+  } finally {
+    __setSecretRefResolverForTest(null);
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("isAgentAccessSecretRef recognizes SecretRef shapes", () => {
+  assert.equal(isAgentAccessSecretRef({ source: "exec", provider: "x" }), true);
+  assert.equal(isAgentAccessSecretRef({ source: "env" }), true);
+  assert.equal(isAgentAccessSecretRef("plain-string"), false);
+  assert.equal(isAgentAccessSecretRef(undefined), false);
+  assert.equal(isAgentAccessSecretRef(null), false);
+  assert.equal(isAgentAccessSecretRef({}), false);
+  assert.equal(isAgentAccessSecretRef({ source: "" }), false);
+  assert.equal(isAgentAccessSecretRef([1, 2, 3]), false);
+});

--- a/packages/remnic-core/src/resolve-auth-token.ts
+++ b/packages/remnic-core/src/resolve-auth-token.ts
@@ -1,0 +1,233 @@
+import { log } from "./logger.js";
+import { findGatewayRuntimeModules } from "./resolve-provider-secret.js";
+import type { AgentAccessAuthToken, SecretRef } from "./types.js";
+
+/**
+ * Resolve `agentAccessHttp.authToken` (issue #757).
+ *
+ * Two shapes are accepted:
+ *
+ *   1. Plain string — returned unchanged. This is the only shape supported
+ *      in standalone Remnic; it preserves backward compatibility with every
+ *      pre-#757 config.
+ *
+ *   2. OpenClaw SecretRef object (`{source, provider?, id?, command?, ...}`)
+ *      — resolved by delegating to the gateway's own secret resolver, the
+ *      same codepath that handles `gateway.auth.token`,
+ *      `channels.telegram.accounts[*].botToken`, and `secrets.providers.*`.
+ *      We never re-implement exec/file/env resolution ourselves; that's the
+ *      lesson from PR #318 (the prior attempt to reinvent SecretRef
+ *      resolution shipped a 1Password-specific path that broke for everyone
+ *      else and had to be reverted).
+ *
+ * Resolution flow for SecretRef objects:
+ *
+ *   - Discover `runtime-secret*` and `runtime-model-auth*` modules in the
+ *     OpenClaw `dist/` directory using the same install-method-agnostic
+ *     discovery as `resolve-provider-secret.ts`.
+ *   - Probe each module for one of the known SecretRef resolver export
+ *     names. The first match wins.
+ *   - If no resolver is found (e.g. running in standalone Remnic with no
+ *     OpenClaw runtime present), throw a clear, actionable error rather
+ *     than silently leaving the bridge open or starting with no auth.
+ *
+ * Lessons baked in from PRs #316–#319:
+ *
+ *   - Plain strings short-circuit before any filesystem scan.
+ *   - The discovery scan caches its negative result with a backoff so
+ *     standalone Remnic doesn't readdir the filesystem on every restart.
+ *   - Successful resolutions are cached for the process lifetime; failures
+ *     are not cached so transient issues (Keychain unlocked late, agent
+ *     restarts) recover automatically.
+ */
+
+type ResolveSecretRefFn = (
+  ref: SecretRef,
+  context?: unknown,
+) => Promise<string | undefined> | string | undefined;
+
+const RESOLVER_RETRY_BACKOFF_MS = 60_000;
+
+/** Export names probed on each runtime module, in order of preference. */
+const RESOLVER_EXPORT_NAMES = [
+  "resolveSecretRef",
+  "resolveSecret",
+  "loadSecretRef",
+  "readSecretRef",
+] as const;
+
+/** Filename prefixes scanned in the gateway dist/ directory. */
+const RESOLVER_MODULE_PREFIXES = [
+  "runtime-secret-resolver.runtime-",
+  "runtime-secrets.runtime-",
+  "runtime-secret.runtime-",
+  "runtime-model-auth.runtime-",
+] as const;
+
+let _resolveSecretRef: ResolveSecretRefFn | null = null;
+let _resolverLoaded = false;
+let _resolverNextRetryAt = 0;
+const resolvedCache = new Map<string, string>();
+
+/**
+ * SecretRef objects are stable per (source, provider, id, command) tuple.
+ * Sort keys before serializing so semantically-identical refs hit the same
+ * cache slot regardless of authoring order (Lesson 38 in CLAUDE.md).
+ */
+function cacheKeyForSecretRef(ref: SecretRef): string {
+  const sortedKeys = Object.keys(ref).sort();
+  const stable: Record<string, unknown> = {};
+  for (const key of sortedKeys) {
+    stable[key] = ref[key];
+  }
+  return JSON.stringify(stable);
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function loadGatewaySecretRefResolver(): Promise<ResolveSecretRefFn | null> {
+  if (_resolverLoaded) return _resolveSecretRef;
+  if (_resolverNextRetryAt > 0 && Date.now() < _resolverNextRetryAt) return null;
+
+  try {
+    const { pathToFileURL } = await import("node:url");
+    for (const prefix of RESOLVER_MODULE_PREFIXES) {
+      const candidates = await findGatewayRuntimeModules(prefix);
+      for (const candidate of candidates) {
+        try {
+          const importUrl = pathToFileURL(candidate).href;
+          const mod = (await import(importUrl)) as Record<string, unknown>;
+          for (const exportName of RESOLVER_EXPORT_NAMES) {
+            const fn = mod[exportName];
+            if (typeof fn === "function") {
+              _resolveSecretRef = fn as ResolveSecretRefFn;
+              _resolverLoaded = true;
+              log.debug(
+                `loaded gateway SecretRef resolver "${exportName}" from ${prefix}*.js`,
+              );
+              return _resolveSecretRef;
+            }
+          }
+        } catch {
+          // Try next candidate
+        }
+      }
+    }
+  } catch {
+    // Silent — fall through to backoff
+  }
+
+  _resolverNextRetryAt = Date.now() + RESOLVER_RETRY_BACKOFF_MS;
+  log.debug(
+    `gateway SecretRef resolver not available — will retry after ${
+      RESOLVER_RETRY_BACKOFF_MS / 1000
+    }s`,
+  );
+  return null;
+}
+
+/**
+ * Resolve an `agentAccessHttp.authToken` value to a literal bearer string.
+ *
+ * @returns the resolved string, or `undefined` if input was undefined/empty.
+ * @throws if the input is a SecretRef and the gateway resolver is not
+ *         available, or if the resolver returns no value, or if the input
+ *         shape is malformed.
+ */
+export async function resolveAgentAccessAuthToken(
+  value: AgentAccessAuthToken | undefined,
+): Promise<string | undefined> {
+  if (value === undefined || value === null) return undefined;
+
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (!isPlainObject(value)) {
+    throw new Error(
+      "unsupported SecretRef shape for agentAccessHttp.authToken — " +
+        "expected a string or an object with a `source` field " +
+        "(see https://github.com/joshuaswarren/remnic/issues/757)",
+    );
+  }
+
+  const ref = value as SecretRef;
+  if (typeof ref.source !== "string" || ref.source.length === 0) {
+    throw new Error(
+      "unsupported SecretRef shape for agentAccessHttp.authToken — " +
+        "missing required `source` field " +
+        "(see https://github.com/joshuaswarren/remnic/issues/757)",
+    );
+  }
+
+  const cacheKey = cacheKeyForSecretRef(ref);
+  const cached = resolvedCache.get(cacheKey);
+  if (cached !== undefined) return cached;
+
+  const resolver = await loadGatewaySecretRefResolver();
+  if (!resolver) {
+    throw new Error(
+      `cannot resolve agentAccessHttp.authToken SecretRef (source="${ref.source}") — ` +
+        "OpenClaw gateway secret resolver is not available. " +
+        "If you are running standalone Remnic, use a literal string or " +
+        "${ENV_VAR} expansion instead. " +
+        "If you are running under OpenClaw, ensure the gateway version " +
+        "exposes a SecretRef resolver runtime module " +
+        "(see https://github.com/joshuaswarren/remnic/issues/757).",
+    );
+  }
+
+  let resolved: string | undefined;
+  try {
+    const out = await resolver(ref);
+    if (typeof out === "string" && out.length > 0) {
+      resolved = out;
+    }
+  } catch (err) {
+    throw new Error(
+      `failed to resolve agentAccessHttp.authToken SecretRef (source="${ref.source}"): ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+  }
+
+  if (!resolved) {
+    throw new Error(
+      `agentAccessHttp.authToken SecretRef resolved to empty value (source="${ref.source}", provider="${
+        ref.provider ?? ""
+      }") — refusing to start the HTTP bridge with an empty bearer token.`,
+    );
+  }
+
+  resolvedCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+/**
+ * Returns true if the value is a SecretRef object (issue #757). Useful for
+ * surfaces (CLI flags, doctor checks) that want to render a redacted
+ * placeholder instead of leaking the unresolved object shape.
+ */
+export function isAgentAccessSecretRef(value: unknown): value is SecretRef {
+  if (!isPlainObject(value)) return false;
+  const ref = value as Record<string, unknown>;
+  return typeof ref.source === "string" && ref.source.length > 0;
+}
+
+/** Test-only hook: inject a synthetic resolver. */
+export function __setSecretRefResolverForTest(resolver: ResolveSecretRefFn | null): void {
+  _resolveSecretRef = resolver;
+  _resolverLoaded = resolver !== null;
+  _resolverNextRetryAt = 0;
+}
+
+/** Test/operations hook: drop the cache and force resolver rediscovery. */
+export function clearAuthTokenSecretCache(): void {
+  resolvedCache.clear();
+  _resolveSecretRef = null;
+  _resolverLoaded = false;
+  _resolverNextRetryAt = 0;
+}

--- a/packages/remnic-core/src/resolve-auth-token.ts
+++ b/packages/remnic-core/src/resolve-auth-token.ts
@@ -1,5 +1,3 @@
-import { log } from "./logger.js";
-import { findGatewayRuntimeModules } from "./resolve-provider-secret.js";
 import type { AgentAccessAuthToken, SecretRef } from "./types.js";
 
 /**
@@ -11,62 +9,34 @@ import type { AgentAccessAuthToken, SecretRef } from "./types.js";
  *      in standalone Remnic; it preserves backward compatibility with every
  *      pre-#757 config.
  *
- *   2. OpenClaw SecretRef object (`{source, provider?, id?, command?, ...}`)
- *      — resolved by delegating to the gateway's own secret resolver, the
- *      same codepath that handles `gateway.auth.token`,
- *      `channels.telegram.accounts[*].botToken`, and `secrets.providers.*`.
- *      We never re-implement exec/file/env resolution ourselves; that's the
- *      lesson from PR #318 (the prior attempt to reinvent SecretRef
- *      resolution shipped a 1Password-specific path that broke for everyone
- *      else and had to be reverted).
+ *   2. SecretRef-like object (`{source, provider?, id?, command?, ...}`) —
+ *      resolved only through a resolver supplied by the host adapter. Core
+ *      stays host-agnostic and never scans OpenClaw, Hermes, or any other
+ *      runtime directly.
  *
  * Resolution flow for SecretRef objects:
  *
- *   - Discover `runtime-secret*` and `runtime-model-auth*` modules in the
- *     OpenClaw `dist/` directory using the same install-method-agnostic
- *     discovery as `resolve-provider-secret.ts`.
- *   - Probe each module for one of the known SecretRef resolver export
- *     names. The first match wins.
- *   - If no resolver is found (e.g. running in standalone Remnic with no
- *     OpenClaw runtime present), throw a clear, actionable error rather
+ *   - Plain strings short-circuit before any host work.
+ *   - Host adapters pass their native SecretRef resolver in `options`.
+ *   - If no resolver is provided, throw a clear, actionable error rather
  *     than silently leaving the bridge open or starting with no auth.
  *
  * Lessons baked in from PRs #316–#319:
  *
- *   - Plain strings short-circuit before any filesystem scan.
- *   - The discovery scan caches its negative result with a backoff so
- *     standalone Remnic doesn't readdir the filesystem on every restart.
  *   - Successful resolutions are cached for the process lifetime; failures
  *     are not cached so transient issues (Keychain unlocked late, agent
  *     restarts) recover automatically.
  */
 
-type ResolveSecretRefFn = (
+export type ResolveSecretRefFn = (
   ref: SecretRef,
   context?: unknown,
 ) => Promise<string | undefined> | string | undefined;
 
-const RESOLVER_RETRY_BACKOFF_MS = 60_000;
+type ResolveAgentAccessAuthTokenOptions = {
+  resolveSecretRef?: ResolveSecretRefFn | null;
+};
 
-/** Export names probed on each runtime module, in order of preference. */
-const RESOLVER_EXPORT_NAMES = [
-  "resolveSecretRef",
-  "resolveSecret",
-  "loadSecretRef",
-  "readSecretRef",
-] as const;
-
-/** Filename prefixes scanned in the gateway dist/ directory. */
-const RESOLVER_MODULE_PREFIXES = [
-  "runtime-secret-resolver.runtime-",
-  "runtime-secrets.runtime-",
-  "runtime-secret.runtime-",
-  "runtime-model-auth.runtime-",
-] as const;
-
-let _resolveSecretRef: ResolveSecretRefFn | null = null;
-let _resolverLoaded = false;
-let _resolverNextRetryAt = 0;
 const resolvedCache = new Map<string, string>();
 
 /**
@@ -87,57 +57,16 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
-async function loadGatewaySecretRefResolver(): Promise<ResolveSecretRefFn | null> {
-  if (_resolverLoaded) return _resolveSecretRef;
-  if (_resolverNextRetryAt > 0 && Date.now() < _resolverNextRetryAt) return null;
-
-  try {
-    const { pathToFileURL } = await import("node:url");
-    for (const prefix of RESOLVER_MODULE_PREFIXES) {
-      const candidates = await findGatewayRuntimeModules(prefix);
-      for (const candidate of candidates) {
-        try {
-          const importUrl = pathToFileURL(candidate).href;
-          const mod = (await import(importUrl)) as Record<string, unknown>;
-          for (const exportName of RESOLVER_EXPORT_NAMES) {
-            const fn = mod[exportName];
-            if (typeof fn === "function") {
-              _resolveSecretRef = fn as ResolveSecretRefFn;
-              _resolverLoaded = true;
-              log.debug(
-                `loaded gateway SecretRef resolver "${exportName}" from ${prefix}*.js`,
-              );
-              return _resolveSecretRef;
-            }
-          }
-        } catch {
-          // Try next candidate
-        }
-      }
-    }
-  } catch {
-    // Silent — fall through to backoff
-  }
-
-  _resolverNextRetryAt = Date.now() + RESOLVER_RETRY_BACKOFF_MS;
-  log.debug(
-    `gateway SecretRef resolver not available — will retry after ${
-      RESOLVER_RETRY_BACKOFF_MS / 1000
-    }s`,
-  );
-  return null;
-}
-
 /**
  * Resolve an `agentAccessHttp.authToken` value to a literal bearer string.
  *
  * @returns the resolved string, or `undefined` if input was undefined/empty.
- * @throws if the input is a SecretRef and the gateway resolver is not
- *         available, or if the resolver returns no value, or if the input
- *         shape is malformed.
+ * @throws if the input is a SecretRef and no resolver is provided, if the
+ *         resolver returns no value, or if the input shape is malformed.
  */
 export async function resolveAgentAccessAuthToken(
   value: AgentAccessAuthToken | undefined,
+  options: ResolveAgentAccessAuthTokenOptions = {},
 ): Promise<string | undefined> {
   if (value === undefined || value === null) return undefined;
 
@@ -155,7 +84,7 @@ export async function resolveAgentAccessAuthToken(
   }
 
   const ref = value as SecretRef;
-  if (typeof ref.source !== "string" || ref.source.length === 0) {
+  if (typeof ref.source !== "string" || ref.source.trim().length === 0) {
     throw new Error(
       "unsupported SecretRef shape for agentAccessHttp.authToken — " +
         "missing required `source` field " +
@@ -167,15 +96,13 @@ export async function resolveAgentAccessAuthToken(
   const cached = resolvedCache.get(cacheKey);
   if (cached !== undefined) return cached;
 
-  const resolver = await loadGatewaySecretRefResolver();
+  const resolver = options.resolveSecretRef ?? null;
   if (!resolver) {
     throw new Error(
       `cannot resolve agentAccessHttp.authToken SecretRef (source="${ref.source}") — ` +
-        "OpenClaw gateway secret resolver is not available. " +
-        "If you are running standalone Remnic, use a literal string or " +
-        "${ENV_VAR} expansion instead. " +
-        "If you are running under OpenClaw, ensure the gateway version " +
-        "exposes a SecretRef resolver runtime module " +
+        "a SecretRef resolver was not provided. Use a literal string or " +
+        "${ENV_VAR} expansion in standalone Remnic, or have the host adapter " +
+        "resolve SecretRef objects through its native secret resolver " +
         "(see https://github.com/joshuaswarren/remnic/issues/757).",
     );
   }
@@ -183,8 +110,9 @@ export async function resolveAgentAccessAuthToken(
   let resolved: string | undefined;
   try {
     const out = await resolver(ref);
-    if (typeof out === "string" && out.length > 0) {
-      resolved = out;
+    if (typeof out === "string") {
+      const trimmed = out.trim();
+      if (trimmed.length > 0) resolved = trimmed;
     }
   } catch (err) {
     throw new Error(
@@ -214,20 +142,10 @@ export async function resolveAgentAccessAuthToken(
 export function isAgentAccessSecretRef(value: unknown): value is SecretRef {
   if (!isPlainObject(value)) return false;
   const ref = value as Record<string, unknown>;
-  return typeof ref.source === "string" && ref.source.length > 0;
-}
-
-/** Test-only hook: inject a synthetic resolver. */
-export function __setSecretRefResolverForTest(resolver: ResolveSecretRefFn | null): void {
-  _resolveSecretRef = resolver;
-  _resolverLoaded = resolver !== null;
-  _resolverNextRetryAt = 0;
+  return typeof ref.source === "string" && ref.source.trim().length > 0;
 }
 
 /** Test/operations hook: drop the cache and force resolver rediscovery. */
 export function clearAuthTokenSecretCache(): void {
   resolvedCache.clear();
-  _resolveSecretRef = null;
-  _resolverLoaded = false;
-  _resolverNextRetryAt = 0;
 }

--- a/packages/remnic-core/src/resolve-provider-secret.ts
+++ b/packages/remnic-core/src/resolve-provider-secret.ts
@@ -105,12 +105,21 @@ async function getGatewayResolver(): Promise<ResolveApiKeyFn | null> {
  * Uses require.resolve to find the openclaw package regardless of install method.
  */
 async function findRuntimeModules(): Promise<string[]> {
+  return findGatewayRuntimeModules("runtime-model-auth.runtime-");
+}
+
+/**
+ * Discover gateway runtime module files matching the given filename prefix.
+ *
+ * Reused by adjacent SecretRef resolution code (`resolve-auth-token.ts`,
+ * issue #757). Walks the same dist-dir candidates as the model-auth path
+ * so callers don't reimplement install-method discovery.
+ */
+export async function findGatewayRuntimeModules(filePrefix: string): Promise<string[]> {
   const { accessSync, constants, readdirSync, realpathSync, statSync } = await import("node:fs");
   const { createRequire } = await import("node:module");
   const candidates: string[] = [];
 
-  // Discover the openclaw dist directory from the installed package,
-  // regardless of how it was installed (Homebrew, npm global, local, etc.)
   const distDirs: string[] = [];
   const pushDistDirs = (entryPath: string): void => {
     const resolvedEntryDir = path.dirname(entryPath);
@@ -128,7 +137,6 @@ async function findRuntimeModules(): Promise<string[]> {
   };
 
   try {
-    // require.resolve finds the package from the current process context
     const req = createRequire(import.meta.url);
     const openclawMain = req.resolve("openclaw");
     pushDistDirs(openclawMain);
@@ -136,8 +144,6 @@ async function findRuntimeModules(): Promise<string[]> {
     // openclaw not resolvable from plugin context — try alternate paths
   }
 
-  // Fallback: infer from the running process (gateway runs from its own dist/)
-  // Use fs.realpathSync to resolve symlinks (e.g., /usr/local/bin/openclaw → actual path)
   try {
     const mainScript = process.argv[1];
     if (mainScript) {
@@ -150,9 +156,6 @@ async function findRuntimeModules(): Promise<string[]> {
     // Silent
   }
 
-  // Fallback: inspect the installed openclaw binary on PATH (Homebrew/global npm)
-  // without spawning `which`. OpenClaw's plugin installer blocks process-launch
-  // patterns in packaged plugins.
   try {
     const openclawBin = findExecutableOnPath("openclaw", accessSync, statSync, constants.X_OK);
     if (openclawBin) {
@@ -166,7 +169,7 @@ async function findRuntimeModules(): Promise<string[]> {
     try {
       const files = readdirSync(dir);
       for (const f of files) {
-        if (f.startsWith("runtime-model-auth.runtime-") && f.endsWith(".js")) {
+        if (f.startsWith(filePrefix) && f.endsWith(".js")) {
           candidates.push(path.join(dir, f));
         }
       }

--- a/packages/remnic-core/src/types.ts
+++ b/packages/remnic-core/src/types.ts
@@ -223,11 +223,35 @@ export interface NativeKnowledgeOpenClawWorkspaceConfig {
   sharedSafeGlobs: string[];
 }
 
+/**
+ * OpenClaw SecretRef shape (issue #757).
+ *
+ * OpenClaw resolves these at runtime via its built-in secret resolver
+ * (e.g. exec providers like `kc_*` for macOS Keychain). Plugins receive
+ * the raw object in `pluginConfig` and must call the gateway's resolver
+ * before using the value. Standalone Remnic does NOT resolve SecretRefs;
+ * operators must use plain strings or `${ENV_VAR}` expansion instead.
+ */
+export interface SecretRef {
+  source: string;
+  provider?: string;
+  id?: string;
+  command?: unknown;
+  [key: string]: unknown;
+}
+
+export type AgentAccessAuthToken = string | SecretRef;
+
 export interface AgentAccessHttpConfig {
   enabled: boolean;
   host: string;
   port: number;
-  authToken?: string;
+  /**
+   * Bearer token. Either a literal string (env-expanded) or an unresolved
+   * SecretRef object preserved verbatim from openclaw.json — resolved at
+   * service-start time via {@link resolveAgentAccessAuthToken}.
+   */
+  authToken?: AgentAccessAuthToken;
   principal?: string;
   maxBodyBytes: number;
 }

--- a/packages/shim-openclaw-engram/openclaw.plugin.json
+++ b/packages/shim-openclaw-engram/openclaw.plugin.json
@@ -1273,8 +1273,20 @@
             "description": "Bind port for the Engram HTTP access server. Use 0 for an ephemeral port."
           },
           "authToken": {
-            "type": "string",
-            "description": "Bearer token for the local Remnic HTTP API. Supports ${ENV_VAR} expansion. If omitted, OPENCLAW_ENGRAM_ACCESS_TOKEN is used."
+            "description": "Bearer token for the local Remnic HTTP API. Either a literal string (supports ${ENV_VAR} expansion) or an OpenClaw SecretRef object (e.g. {\"source\":\"exec\",\"provider\":\"kc_openclaw_remnic_token\",\"id\":\"value\"}) resolved at startup via the OpenClaw gateway secret resolver (issue #757). If omitted, OPENCLAW_REMNIC_ACCESS_TOKEN / OPENCLAW_ENGRAM_ACCESS_TOKEN is used.",
+            "anyOf": [
+              { "type": "string" },
+              {
+                "type": "object",
+                "required": ["source"],
+                "properties": {
+                  "source": { "type": "string", "minLength": 1 },
+                  "provider": { "type": "string" },
+                  "id": { "type": "string" },
+                  "command": {}
+                }
+              }
+            ]
           },
           "principal": {
             "type": "string",

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,7 +70,7 @@ import {
   resolveCodexSessionIdentity,
 } from "./codex-compat.js";
 import { planRecallMode } from "../packages/remnic-core/src/intent.js";
-import { resolvePrincipal } from "@remnic/core";
+import { resolvePrincipal, resolveAgentAccessAuthToken } from "@remnic/core";
 import { createDreamsSurface } from "../packages/remnic-core/src/surfaces/dreams.js";
 import { createHeartbeatSurface, type HeartbeatEntry } from "../packages/remnic-core/src/surfaces/heartbeat.js";
 import type { ConsolidationObservation } from "../packages/remnic-core/src/types.js";
@@ -593,6 +593,29 @@ const pluginDefinition = {
         : new EngramAccessService(orchestrator);
     (globalThis as any)[keys.ACCESS_SERVICE] = accessService;
 
+    // ── agentAccessHttp.authToken SecretRef wiring (issue #757) ──────────
+    //
+    // `parseConfig` preserves SecretRef objects verbatim; resolution must
+    // happen before any request validation runs. Two construction paths:
+    //
+    //   1. String authToken (the pre-#757 shape): pass through unchanged.
+    //
+    //   2. SecretRef authToken: construct the server with `authToken:
+    //      undefined` and route the resolved value through
+    //      `authTokensGetter`, which is already the mechanism used for
+    //      dynamic tokens. The closure starts empty (rejects all requests)
+    //      and is populated by `registerService.start()` *before* the HTTP
+    //      listener is opened — so there is no window in which the bridge
+    //      accepts connections without an auth token. Resolution failure
+    //      (missing OpenClaw resolver, empty value) throws inside start()
+    //      and aborts the listener entirely.
+    const rawAuthToken = cfg.agentAccessHttp.authToken;
+    const authTokenIsSecretRef =
+      rawAuthToken !== undefined && typeof rawAuthToken !== "string";
+    let resolvedSecretRefAuthToken: string | undefined;
+    const authTokensFromSecretRef = (): string[] =>
+      resolvedSecretRefAuthToken ? [resolvedSecretRefAuthToken] : [];
+
     const existingAccessHttpServer = (globalThis as any)[
       keys.ACCESS_HTTP_SERVER
     ] as EngramAccessHttpServer | undefined;
@@ -604,7 +627,12 @@ const pluginDefinition = {
             service: accessService,
             host: cfg.agentAccessHttp.host,
             port: cfg.agentAccessHttp.port,
-            authToken: cfg.agentAccessHttp.authToken,
+            authToken: authTokenIsSecretRef
+              ? undefined
+              : (rawAuthToken as string | undefined),
+            authTokensGetter: authTokenIsSecretRef
+              ? authTokensFromSecretRef
+              : undefined,
             principal: cfg.agentAccessHttp.principal,
             maxBodyBytes: cfg.agentAccessHttp.maxBodyBytes,
             citationsEnabled: cfg.citationsEnabled,
@@ -3769,6 +3797,28 @@ const pluginDefinition = {
             if (cfg.agentAccessHttp.enabled) {
               // Abort if stop() was called before starting the HTTP server.
               if (!didCountStart) return;
+              // Resolve agentAccessHttp.authToken SecretRef (issue #757).
+              // This MUST run before accessHttpServer.start() so the listener
+              // never opens with an empty auth set. A resolution failure is
+              // fatal — log loudly and skip starting the bridge entirely.
+              if (authTokenIsSecretRef) {
+                try {
+                  const resolved = await resolveAgentAccessAuthToken(rawAuthToken);
+                  if (!resolved) {
+                    log.error(
+                      "agentAccessHttp.authToken SecretRef resolved to empty value — refusing to start the HTTP bridge",
+                    );
+                    return;
+                  }
+                  resolvedSecretRefAuthToken = resolved;
+                } catch (err) {
+                  log.error(
+                    "failed to resolve agentAccessHttp.authToken SecretRef — HTTP bridge will not start",
+                    err,
+                  );
+                  return;
+                }
+              }
               try {
                 const status = await accessHttpServer.start();
                 log.info(

--- a/src/index.ts
+++ b/src/index.ts
@@ -71,6 +71,7 @@ import {
 } from "./codex-compat.js";
 import { planRecallMode } from "../packages/remnic-core/src/intent.js";
 import { resolvePrincipal, resolveAgentAccessAuthToken } from "@remnic/core";
+import { findGatewayRuntimeModules } from "./resolve-provider-secret.js";
 import { createDreamsSurface } from "../packages/remnic-core/src/surfaces/dreams.js";
 import { createHeartbeatSurface, type HeartbeatEntry } from "../packages/remnic-core/src/surfaces/heartbeat.js";
 import type { ConsolidationObservation } from "../packages/remnic-core/src/types.js";
@@ -120,6 +121,80 @@ const SESSION_COMMANDS_REGISTERED_GUARD =
  * a true full stop where the gateway rebuilds its command registry.
  */
 const CLI_ACTIVE_SERVICE_COUNT = "__openclawEngramCliActiveServiceCount";
+const SECRET_REF_RESOLVER_TEST_KEY = "__openclawEngramSecretRefResolverForTest";
+
+type ResolveSecretRefFn = (
+  ref: import("../packages/remnic-core/src/types.js").SecretRef,
+  context?: unknown,
+) => Promise<string | undefined> | string | undefined;
+
+const SECRET_REF_RESOLVER_RETRY_BACKOFF_MS = 60_000;
+const SECRET_REF_RESOLVER_EXPORT_NAMES = [
+  "resolveSecretRef",
+  "resolveSecret",
+  "loadSecretRef",
+  "readSecretRef",
+] as const;
+const SECRET_REF_RESOLVER_MODULE_PREFIXES = [
+  "runtime-secret-resolver.runtime-",
+  "runtime-secrets.runtime-",
+  "runtime-secret.runtime-",
+  "runtime-model-auth.runtime-",
+] as const;
+
+let secretRefResolver: ResolveSecretRefFn | null = null;
+let secretRefResolverLoaded = false;
+let secretRefResolverNextRetryAt = 0;
+
+async function loadOpenClawSecretRefResolver(): Promise<ResolveSecretRefFn | null> {
+  const testResolver = (globalThis as Record<string, unknown>)[SECRET_REF_RESOLVER_TEST_KEY];
+  if (typeof testResolver === "function") {
+    return testResolver as ResolveSecretRefFn;
+  }
+  if (secretRefResolverLoaded) return secretRefResolver;
+  if (
+    secretRefResolverNextRetryAt > 0 &&
+    Date.now() < secretRefResolverNextRetryAt
+  ) {
+    return null;
+  }
+
+  try {
+    const { pathToFileURL } = await import("node:url");
+    for (const prefix of SECRET_REF_RESOLVER_MODULE_PREFIXES) {
+      const candidates = await findGatewayRuntimeModules(prefix);
+      for (const candidate of candidates) {
+        try {
+          const importUrl = pathToFileURL(candidate).href;
+          const mod = (await import(importUrl)) as Record<string, unknown>;
+          for (const exportName of SECRET_REF_RESOLVER_EXPORT_NAMES) {
+            const fn = mod[exportName];
+            if (typeof fn === "function") {
+              secretRefResolver = fn as ResolveSecretRefFn;
+              secretRefResolverLoaded = true;
+              log.debug(
+                `loaded OpenClaw SecretRef resolver "${exportName}" from ${prefix}*.js`,
+              );
+              return secretRefResolver;
+            }
+          }
+        } catch {
+          // Try next candidate.
+        }
+      }
+    }
+  } catch {
+    // Silent — fall through to backoff.
+  }
+
+  secretRefResolverNextRetryAt = Date.now() + SECRET_REF_RESOLVER_RETRY_BACKOFF_MS;
+  log.debug(
+    `OpenClaw SecretRef resolver not available — will retry after ${
+      SECRET_REF_RESOLVER_RETRY_BACKOFF_MS / 1000
+    }s`,
+  );
+  return null;
+}
 
 type ServiceKeys = {
   REGISTERED_GUARD: string;
@@ -127,6 +202,7 @@ type ServiceKeys = {
   HOOK_APIS: string;
   ACCESS_SERVICE: string;
   ACCESS_HTTP_SERVER: string;
+  ACCESS_HTTP_AUTH_STATE: string;
   /**
    * Guards service.start() against duplicate invocation when multiple api instances
    * each register the service (all registries get registerService, but initialize
@@ -151,6 +227,7 @@ function buildServiceKeys(serviceId: string): ServiceKeys {
     HOOK_APIS: `__openclawEngramHookApis${suffix}`,
     ACCESS_SERVICE: `__openclawEngramAccessService${suffix}`,
     ACCESS_HTTP_SERVER: `__openclawEngramAccessHttpServer${suffix}`,
+    ACCESS_HTTP_AUTH_STATE: `__openclawEngramAccessHttpAuthState${suffix}`,
     SERVICE_STARTED: `__openclawEngramServiceStarted${suffix}`,
     INIT_PROMISE: `__openclawEngramInitPromise${suffix}`,
     ORCHESTRATOR: `__openclawEngramOrchestrator${suffix}`,
@@ -612,9 +689,14 @@ const pluginDefinition = {
     const rawAuthToken = cfg.agentAccessHttp.authToken;
     const authTokenIsSecretRef =
       rawAuthToken !== undefined && typeof rawAuthToken !== "string";
-    let resolvedSecretRefAuthToken: string | undefined;
+    const accessHttpAuthState =
+      (((globalThis as any)[keys.ACCESS_HTTP_AUTH_STATE] ??= {
+        resolvedSecretRefAuthToken: undefined as string | undefined,
+      }) as { resolvedSecretRefAuthToken: string | undefined });
     const authTokensFromSecretRef = (): string[] =>
-      resolvedSecretRefAuthToken ? [resolvedSecretRefAuthToken] : [];
+      accessHttpAuthState.resolvedSecretRefAuthToken
+        ? [accessHttpAuthState.resolvedSecretRefAuthToken]
+        : [];
 
     const existingAccessHttpServer = (globalThis as any)[
       keys.ACCESS_HTTP_SERVER
@@ -3629,6 +3711,7 @@ const pluginDefinition = {
       registerCli(
         api as unknown as Parameters<typeof registerCli>[0],
         orchestrator,
+        { loadResolveSecretRef: loadOpenClawSecretRefResolver },
       );
     }
 
@@ -3802,22 +3885,15 @@ const pluginDefinition = {
               // never opens with an empty auth set. A resolution failure is
               // fatal — log loudly and skip starting the bridge entirely.
               if (authTokenIsSecretRef) {
-                try {
-                  const resolved = await resolveAgentAccessAuthToken(rawAuthToken);
-                  if (!resolved) {
-                    log.error(
-                      "agentAccessHttp.authToken SecretRef resolved to empty value — refusing to start the HTTP bridge",
-                    );
-                    return;
-                  }
-                  resolvedSecretRefAuthToken = resolved;
-                } catch (err) {
-                  log.error(
-                    "failed to resolve agentAccessHttp.authToken SecretRef — HTTP bridge will not start",
-                    err,
+                const resolved = await resolveAgentAccessAuthToken(rawAuthToken, {
+                  resolveSecretRef: await loadOpenClawSecretRefResolver(),
+                });
+                if (!resolved) {
+                  throw new Error(
+                    "agentAccessHttp.authToken SecretRef resolved to empty value — refusing to start the HTTP bridge",
                   );
-                  return;
                 }
+                accessHttpAuthState.resolvedSecretRefAuthToken = resolved;
               }
               try {
                 const status = await accessHttpServer.start();
@@ -4071,6 +4147,7 @@ const pluginDefinition = {
           removeDreamingObserver?.();
           removeDreamingObserver = null;
           delete (globalThis as any)[keys.ACCESS_HTTP_SERVER];
+          delete (globalThis as any)[keys.ACCESS_HTTP_AUTH_STATE];
           delete (globalThis as any)[keys.ACCESS_SERVICE];
         }
 

--- a/tests/config-access-http.test.ts
+++ b/tests/config-access-http.test.ts
@@ -106,6 +106,74 @@ test("parseConfig supports explicit local HTTP access config and env fallback", 
   }
 });
 
+test("parseConfig preserves SecretRef authToken object verbatim (issue #757)", () => {
+  const originalRemnic = process.env.OPENCLAW_REMNIC_ACCESS_TOKEN;
+  const original = process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+  delete process.env.OPENCLAW_REMNIC_ACCESS_TOKEN;
+  delete process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+  try {
+    const secretRef = {
+      source: "exec",
+      provider: "kc_openclaw_remnic_token",
+      id: "value",
+    };
+    const cfg = parseConfig({
+      openaiApiKey: "sk-test",
+      agentAccessHttp: {
+        enabled: true,
+        authToken: secretRef,
+      },
+    });
+    // SecretRef must NOT be coerced or stringified — runtime resolution
+    // happens inside resolveAgentAccessAuthToken() at service-start time.
+    assert.deepEqual(cfg.agentAccessHttp.authToken, secretRef);
+  } finally {
+    if (originalRemnic === undefined) {
+      delete process.env.OPENCLAW_REMNIC_ACCESS_TOKEN;
+    } else {
+      process.env.OPENCLAW_REMNIC_ACCESS_TOKEN = originalRemnic;
+    }
+    if (original === undefined) {
+      delete process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN;
+    } else {
+      process.env.OPENCLAW_ENGRAM_ACCESS_TOKEN = original;
+    }
+  }
+});
+
+test("parseConfig rejects non-string non-SecretRef authToken shapes (issue #757)", () => {
+  assert.throws(
+    () =>
+      parseConfig({
+        openaiApiKey: "sk-test",
+        agentAccessHttp: { enabled: true, authToken: 12345 as unknown as string },
+      }),
+    /unsupported SecretRef shape/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        openaiApiKey: "sk-test",
+        agentAccessHttp: {
+          enabled: true,
+          authToken: { provider: "no-source-field" } as unknown as string,
+        },
+      }),
+    /unsupported SecretRef shape/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        openaiApiKey: "sk-test",
+        agentAccessHttp: {
+          enabled: true,
+          authToken: ["not", "an", "object"] as unknown as string,
+        },
+      }),
+    /unsupported SecretRef shape/,
+  );
+});
+
 test("parseConfig preserves small explicit HTTP body limits", () => {
   const cfg = parseConfig({
     openaiApiKey: "sk-test",

--- a/tests/config-access-http.test.ts
+++ b/tests/config-access-http.test.ts
@@ -167,6 +167,17 @@ test("parseConfig rejects non-string non-SecretRef authToken shapes (issue #757)
         openaiApiKey: "sk-test",
         agentAccessHttp: {
           enabled: true,
+          authToken: { source: "   " } as unknown as string,
+        },
+      }),
+    /unsupported SecretRef shape/,
+  );
+  assert.throws(
+    () =>
+      parseConfig({
+        openaiApiKey: "sk-test",
+        agentAccessHttp: {
+          enabled: true,
           authToken: ["not", "an", "object"] as unknown as string,
         },
       }),

--- a/tests/operator-toolkit-cli.test.ts
+++ b/tests/operator-toolkit-cli.test.ts
@@ -5,6 +5,7 @@ import path from "node:path";
 import { mkdtemp, mkdir, writeFile } from "node:fs/promises";
 import { parseConfig } from "../src/config.js";
 import { registerCli } from "../src/cli.js";
+import { clearAuthTokenSecretCache } from "../packages/remnic-core/src/resolve-auth-token.js";
 import type { OperatorToolkitOrchestrator } from "../src/operator-toolkit.js";
 
 class MockCommand {
@@ -53,7 +54,10 @@ function openclawConfigDocument(pluginConfig: Record<string, unknown>): string {
   }, null, 2);
 }
 
-async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
+async function makeFixture(
+  overrides: Record<string, unknown> = {},
+  registerOptions: Parameters<typeof registerCli>[2] = {},
+): Promise<{
   configPath: string;
   orchestrator: OperatorToolkitOrchestrator;
   root: MockCommand;
@@ -97,6 +101,7 @@ async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
         return config.qmdEnabled ? "available" : "disabled";
       },
     },
+    async initialize() {},
     async getConversationIndexHealth() {
       return {
         enabled: false,
@@ -115,7 +120,7 @@ async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
         rebuilt: false,
       };
     },
-  };
+  } as OperatorToolkitOrchestrator;
 
   const root = new MockCommand("root");
   registerCli(
@@ -125,6 +130,7 @@ async function makeFixture(overrides: Record<string, unknown> = {}): Promise<{
       },
     },
     orchestrator as never,
+    registerOptions,
   );
 
   return { configPath, orchestrator, root };
@@ -186,6 +192,90 @@ test("operator toolkit JSON commands emit parseable JSON without trailing OK", a
     }
   } finally {
     delete process.env.OPENCLAW_ENGRAM_CONFIG_PATH;
+  }
+});
+
+test("access http-serve CLI resolves SecretRef authToken through injected host resolver", async () => {
+  const authToken = {
+    source: "exec",
+    provider: "kc_openclaw_remnic_token",
+    id: "http-serve-cli",
+  };
+  let resolverCalls = 0;
+  clearAuthTokenSecretCache();
+
+  const fixture = await makeFixture(
+    {
+      agentAccessHttp: {
+        enabled: true,
+        authToken,
+      },
+    },
+    {
+      loadResolveSecretRef: async () => {
+        return async (ref) => {
+          resolverCalls += 1;
+          assert.deepEqual(ref, authToken);
+          return " cli-secret-token\n";
+        };
+      },
+    },
+  );
+  const serve = getAction(fixture.root, ["engram", "access", "http-serve"]);
+  const stop = getAction(fixture.root, ["engram", "access", "http-stop"]);
+
+  try {
+    const result = await captureAction(serve, {
+      host: "127.0.0.1",
+      port: "0",
+    });
+    const status = JSON.parse(result.output.replace(/\nOK$/, "")) as {
+      running: boolean;
+      port: number;
+    };
+
+    assert.equal(result.exitCode, undefined);
+    assert.equal(status.running, true);
+    assert.equal(status.port > 0, true);
+    assert.equal(resolverCalls, 1);
+  } finally {
+    await captureAction(stop, {});
+    clearAuthTokenSecretCache();
+  }
+});
+
+test("access http-serve CLI reports missing SecretRef resolver distinctly", async () => {
+  clearAuthTokenSecretCache();
+  const fixture = await makeFixture(
+    {
+      agentAccessHttp: {
+        enabled: true,
+        authToken: {
+          source: "exec",
+          provider: "kc_openclaw_remnic_token",
+          id: "missing-resolver",
+        },
+      },
+    },
+    {
+      loadResolveSecretRef: async () => null,
+    },
+  );
+  const serve = getAction(fixture.root, ["engram", "access", "http-serve"]);
+
+  try {
+    await assert.rejects(
+      () =>
+        Promise.resolve(
+          serve({
+            host: "127.0.0.1",
+            port: "0",
+          }),
+        ),
+      /SecretRef resolver was not provided/,
+    );
+  } finally {
+    clearAuthTokenSecretCache();
   }
 });
 

--- a/tests/register-multi-registry.test.ts
+++ b/tests/register-multi-registry.test.ts
@@ -33,8 +33,11 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 import { spawnSync } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
 import { fileURLToPath } from "node:url";
 import { join, dirname } from "node:path";
+import { clearAuthTokenSecretCache } from "../packages/remnic-core/src/resolve-auth-token.js";
 
 // ============================================================================
 // Shared constants — must match src/index.ts
@@ -51,10 +54,12 @@ const HOOK_APIS_KEY = `__openclawEngramHookApis::${SERVICE_ID}`;
 const ORCH_KEY = `__openclawEngramOrchestrator::${SERVICE_ID}`;
 const ACCESS_SVC_KEY = `__openclawEngramAccessService::${SERVICE_ID}`;
 const ACCESS_HTTP_KEY = `__openclawEngramAccessHttpServer::${SERVICE_ID}`;
+const ACCESS_HTTP_AUTH_STATE_KEY = `__openclawEngramAccessHttpAuthState::${SERVICE_ID}`;
 const SERVICE_STARTED_KEY = `__openclawEngramServiceStarted::${SERVICE_ID}`;
 const INIT_PROMISE_KEY = `__openclawEngramInitPromise::${SERVICE_ID}`;
 const MIGRATION_PROMISE_KEY = "__openclawEngramMigrationPromise";
 const DISABLE_REGISTER_MIGRATION_ENV = "REMNIC_DISABLE_REGISTER_MIGRATION";
+const SECRET_REF_RESOLVER_TEST_KEY = "__openclawEngramSecretRefResolverForTest";
 
 // ============================================================================
 // Helpers
@@ -123,6 +128,7 @@ function saveAndResetGlobals() {
     cliActiveCount: (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT_KEY],
     accessSvc: (globalThis as any)[ACCESS_SVC_KEY],
     accessHttp: (globalThis as any)[ACCESS_HTTP_KEY],
+    accessHttpAuthState: (globalThis as any)[ACCESS_HTTP_AUTH_STATE_KEY],
     serviceStarted: (globalThis as any)[SERVICE_STARTED_KEY],
     initPromise: (globalThis as any)[INIT_PROMISE_KEY],
     migrationPromise: (globalThis as any)[MIGRATION_PROMISE_KEY],
@@ -135,6 +141,7 @@ function saveAndResetGlobals() {
   delete (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT_KEY];
   delete (globalThis as any)[ACCESS_SVC_KEY];
   delete (globalThis as any)[ACCESS_HTTP_KEY];
+  delete (globalThis as any)[ACCESS_HTTP_AUTH_STATE_KEY];
   delete (globalThis as any)[SERVICE_STARTED_KEY];
   delete (globalThis as any)[INIT_PROMISE_KEY];
   delete (globalThis as any)[MIGRATION_PROMISE_KEY];
@@ -198,6 +205,9 @@ function restoreGlobals(saved: ReturnType<typeof saveAndResetGlobals>) {
 
   if (saved.accessHttp !== undefined) (globalThis as any)[ACCESS_HTTP_KEY] = saved.accessHttp;
   else delete (globalThis as any)[ACCESS_HTTP_KEY];
+
+  if (saved.accessHttpAuthState !== undefined) (globalThis as any)[ACCESS_HTTP_AUTH_STATE_KEY] = saved.accessHttpAuthState;
+  else delete (globalThis as any)[ACCESS_HTTP_AUTH_STATE_KEY];
 
   if (saved.serviceStarted !== undefined) (globalThis as any)[SERVICE_STARTED_KEY] = saved.serviceStarted;
   else delete (globalThis as any)[SERVICE_STARTED_KEY];
@@ -408,6 +418,97 @@ test("concurrent start() calls await the in-flight init promise (regression: iss
     await awaitPendingMigration();
     restoreRegisterMigrationEnv(previousDisableMigration);
     restoreGlobals(saved);
+  }
+});
+
+test("SecretRef auth resolution failure rejects start() and rolls back service ownership", async () => {
+  const saved = saveAndResetGlobals();
+  const previousDisableMigration = disableRegisterMigrationForTest();
+  const memoryDir = await mkdtemp(join(tmpdir(), "remnic-secretref-start-"));
+  let first: ReturnType<typeof buildApi> | undefined;
+  let second: ReturnType<typeof buildApi> | undefined;
+  let resolverCalls = 0;
+
+  clearAuthTokenSecretCache();
+  (globalThis as any)[SECRET_REF_RESOLVER_TEST_KEY] = async () => {
+    resolverCalls += 1;
+    if (resolverCalls === 1) throw new Error("keychain locked");
+    return " retry-token\n";
+  };
+
+  try {
+    const { default: plugin } = await import("../src/index.js");
+
+    first = buildApi("secretref-failure-primary");
+    second = buildApi("secretref-failure-secondary");
+    const pluginConfig = {
+      memoryDir,
+      agentAccessHttp: {
+        enabled: true,
+        port: 0,
+        authToken: {
+          source: "exec",
+          provider: "kc_openclaw_remnic_token",
+          id: "value",
+        },
+      },
+    };
+    first.api.pluginConfig = pluginConfig;
+    second.api.pluginConfig = pluginConfig;
+
+    plugin.register(first.api as any);
+    plugin.register(second.api as any);
+
+    await assert.rejects(
+      () => first!.api._registeredStart?.() ?? Promise.resolve(),
+      /failed to resolve agentAccessHttp\.authToken SecretRef.*keychain locked/,
+    );
+
+    assert.equal(
+      (globalThis as any)[SERVICE_STARTED_KEY],
+      false,
+      "failed SecretRef auth start must leave SERVICE_STARTED=false",
+    );
+    assert.equal(
+      (globalThis as any)[INIT_PROMISE_KEY],
+      null,
+      "failed SecretRef auth start must clear INIT_PROMISE",
+    );
+    assert.equal(
+      (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT_KEY],
+      0,
+      "failed SecretRef auth start must decrement the active-service refcount",
+    );
+
+    await second.api._registeredStart?.();
+
+    assert.equal(resolverCalls, 2, "second registry should attempt a clean retry");
+    assert.equal(
+      (globalThis as any)[SERVICE_STARTED_KEY],
+      true,
+      "second start should complete after SecretRef auth retry succeeds",
+    );
+    const accessHttpServer = (globalThis as any)[ACCESS_HTTP_KEY] as
+      | { authTokensGetter?: () => string[] }
+      | undefined;
+    assert.deepEqual(
+      accessHttpServer?.authTokensGetter?.(),
+      ["retry-token"],
+      "reused HTTP server must read the retried SecretRef token from shared auth state",
+    );
+    assert.equal(
+      (globalThis as any)[CLI_ACTIVE_SERVICE_COUNT_KEY],
+      1,
+      "successful retry should leave exactly one active service owner",
+    );
+  } finally {
+    await safeStop(first?.api, second?.api);
+    delete (globalThis as any)[SECRET_REF_RESOLVER_TEST_KEY];
+    clearAuthTokenSecretCache();
+    await awaitPendingMigration();
+    restoreRegisterMigrationEnv(previousDisableMigration);
+    restoreGlobals(saved);
+    await rm(memoryDir, { recursive: true, force: true });
   }
 });
 


### PR DESCRIPTION
Closes #757.

## Summary

- `agentAccessHttp.authToken` now accepts an OpenClaw SecretRef object (`{source, provider?, id?, command?, ...}`) in addition to the existing literal-string shape. Resolution happens at plugin startup via the gateway's built-in secret resolver — the same path that handles `gateway.auth.token`, channel `botToken` / `token`, and `secrets.providers.*`.
- Standalone Remnic is unaffected: only string `authToken`s are accepted there. A SecretRef in standalone mode produces a clear, actionable error instead of a silent failure.
- Backward compatibility: zero break. Every existing string config keeps working unchanged.

## Why

Operators using OpenClaw's secret-management pattern (Keychain, `op`, exec providers) had no way to keep the Remnic auth token out of `openclaw.json`. It was the one field across the entire OpenClaw config that resisted SecretRef resolution, which leaked the token into every config snapshot, Time Machine backup, and Dropbox sync.

## How it's done (and how it avoids the past pitfalls)

Lessons baked in from the previous OpenClaw secret-resolution work (PRs #316, #318, #319):

- **Don't reimplement exec/file/env resolution.** PR #318 reverted a 1Password-specific implementation that broke for everyone else. This PR delegates to OpenClaw's runtime resolver via the same dynamic-discovery path used by `resolve-provider-secret.ts`.
- **Backoff filesystem scans.** PR #319 added a 60s backoff after resolver-discovery failures. The new `resolve-auth-token.ts` reuses that pattern so standalone Remnic doesn't hammer `readdirSync` on every restart.
- **Cache successful resolutions only.** Failures are retried so transient issues (Keychain locked, agent restarts) self-recover.
- **Sort cache keys before serialization.** Per CLAUDE.md rule 38 — semantically-identical SecretRefs hit the same cache slot regardless of authoring order.
- **Fail closed.** The HTTP listener never opens with empty auth: SecretRef resolution runs *inside* `registerService.start()` *before* `accessHttpServer.start()`. Resolution failure aborts the bridge entirely.
- **Don't mutate the constructor contract.** `EngramAccessHttpServerOptions.authToken` stays `string | undefined`; resolved SecretRef tokens are routed through the existing `authTokensGetter` callback, which is already the canonical mechanism for dynamic tokens.

## What's in the diff

- `packages/remnic-core/src/types.ts` — adds `SecretRef`, `AgentAccessAuthToken`. `authToken` is now `string | SecretRef | undefined`.
- `packages/remnic-core/src/config.ts` — `parseAgentAccessAuthToken()` accepts strings (env-expanded), SecretRef objects (preserved verbatim), and rejects malformed shapes with a clear actionable error.
- `packages/remnic-core/src/resolve-auth-token.ts` (new) — async resolver that delegates to the gateway's secret-resolver runtime modules. Probes export names `resolveSecretRef`, `resolveSecret`, `loadSecretRef`, `readSecretRef` across plausible runtime module prefixes. Cached, backoff-aware, error-clear.
- `packages/remnic-core/src/resolve-provider-secret.ts` — extracts `findGatewayRuntimeModules(prefix)` so the new resolver can reuse install-method-agnostic discovery without forking it.
- `src/index.ts` (OpenClaw plugin) — resolves the SecretRef in `registerService.start()`; routes the resolved value through `authTokensGetter` to avoid changing the HTTP server constructor contract.
- `packages/remnic-core/src/cli.ts` — `engram access http-serve` resolves SecretRef-shaped config values before constructing the server (CLI `--token` flag still wins).
- `packages/remnic-core/src/operator-toolkit.ts` — `engram doctor` recognizes SecretRefs as "configured" without dereferencing the value.
- `packages/{plugin-openclaw,}/openclaw.plugin.json` — schema now `anyOf: [string, object{source, …}]`. Sync gate passes.
- `docs/config-reference.md`, `docs/integration/deployment-topologies.md` — operator-facing documentation for both shapes.

## Test plan

- [x] `npx tsx --test tests/config-access-http.test.ts packages/remnic-core/src/resolve-auth-token.test.ts packages/remnic-core/src/resolve-provider-secret.test.ts tests/operator-toolkit.test.ts` — 41 / 41 pass.
- [x] `parseConfig` preserves SecretRef objects verbatim (no coercion / stringification).
- [x] `parseConfig` rejects non-string non-SecretRef shapes with a clear error.
- [x] `resolveAgentAccessAuthToken` covers: string passthrough, whitespace trim, undefined / empty input, SecretRef → gateway resolver delegation, cache, key-order stability, missing resolver rejection, missing `source` field, empty resolved value refusal, surfacing of resolver errors, retry-on-failure (no negative caching).
- [x] Doctor check (`access_http_auth`) recognizes SecretRefs as "configured".
- [x] Build green; typecheck green; openclaw plugin sync gate green.
- [ ] Manual: paste a `{"source":"exec","provider":"kc_*","id":"value"}` SecretRef into `openclaw.json`, restart the gateway, confirm the bridge starts and accepts the resolved bearer.

## Backward compatibility

- String configs: unchanged.
- Env-var fallback (`OPENCLAW_REMNIC_ACCESS_TOKEN` / `OPENCLAW_ENGRAM_ACCESS_TOKEN`): unchanged.
- Standalone Remnic: unchanged. SecretRef objects produce a clear error rather than silently breaking.
- Schema: `anyOf` is additive — every previously-valid `openclaw.json` is still valid.

No migration required.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication configuration and startup flow for the local HTTP access bridge, so mis-resolution could prevent the server from starting or (if buggy) weaken auth; changes are guarded with fail-closed behavior and tests but still security-adjacent.
> 
> **Overview**
> Adds support for configuring `agentAccessHttp.authToken` as an OpenClaw **SecretRef object** (in addition to strings), enabling the HTTP access token to be sourced from the gateway secret resolver rather than stored in cleartext.
> 
> Core config parsing now preserves SecretRef-shaped objects and rejects invalid shapes with clearer errors, and a new `resolveAgentAccessAuthToken` helper resolves/caches SecretRefs when a host-provided resolver is available. The OpenClaw plugin and `engram access http-serve` CLI wire in resolver discovery and **resolve before opening the HTTP listener** (fail-closed), while `engram doctor` treats SecretRefs as “configured” without dereferencing.
> 
> Updates OpenClaw plugin JSON schemas and docs to document the new env var fallback (`OPENCLAW_REMNIC_ACCESS_TOKEN`) and SecretRef usage; adds targeted unit/integration tests around parsing, resolution/caching, and startup rollback on resolution failure.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a2b86ffb037adc1c55adf98ba67779376836cf14. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->