### PR TITLE
feat(graph): add low-confidence traversal opt-in and docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@
 - [Memory Lifecycle](architecture/memory-lifecycle.md) — Write, consolidation, expiry
 - [Dreams: phased consolidation](dreams.md) — Light sleep / REM / deep sleep phase mapping over the existing maintenance pipeline (issue #678)
 - [Graph Reasoning](architecture/graph-reasoning.md) — Opt-in graph traversal, assist, and explainability
+- [Graph Edge Decay](graph-edge-decay.md) — Confidence decay model, maintenance job, traversal pruning, and `--include-low-confidence` (issue #681)
 - [Writing a Search Backend](writing-a-search-backend.md) — Build your own search adapter (v9.0)
 
 ## Guides

--- a/docs/config-reference.md
+++ b/docs/config-reference.md
@@ -858,6 +858,11 @@ of truth for similarity logic across read-time and write-time code paths.
 | `graphActivationDecay` | `0.7` | Per-hop decay factor |
 | `graphTraversalConfidenceFloor` | `0.2` | Minimum edge confidence required for traversal (issue #681 PR 3/3). Edges below this floor are pruned. Legacy edges without `confidence` are treated as `1.0`. Range `[0, 1]`. |
 | `graphTraversalPageRankIterations` | `8` | PageRank-style refinement iterations applied on top of BFS spreading-activation scores (issue #681 PR 3/3). Set to `0` to disable refinement. |
+| `graphEdgeDecayEnabled` | `false` | Enable the periodic graph-edge confidence decay maintenance job (issue #681 PR 2/3). When `false` all edges retain their initial confidence indefinitely. |
+| `graphEdgeDecayCadenceMs` | `604800000` | How often the decay job runs, in milliseconds (default 7 days). Minimum enforced at `60000` ms. |
+| `graphEdgeDecayWindowMs` | `7776000000` | Length of one decay window, in milliseconds (default 90 days). One window of inactivity costs `graphEdgeDecayPerWindow` confidence. Minimum enforced at `60000` ms. |
+| `graphEdgeDecayPerWindow` | `0.1` | Fraction of confidence lost per elapsed decay window. Range `[0, 1]`. |
+| `graphEdgeDecayFloor` | `0.1` | Minimum confidence an edge can decay to; the job will not reduce confidence below this value. Range `[0, 1]`. Set to `0` to allow full decay to zero. |
 | `graphExpansionActivationWeight` | `0.65` | Blend weight for graph activation vs seed QMD score (0-1) |
 | `graphExpansionBlendMin` | `0.05` | Lower clamp bound for blended graph-expanded scores (0-1) |
 | `graphExpansionBlendMax` | `0.95` | Upper clamp bound for blended graph-expanded scores (0-1) |

--- a/docs/graph-edge-decay.md
+++ b/docs/graph-edge-decay.md
@@ -1,0 +1,183 @@
+# Graph Edge Confidence Decay
+
+> Shipped in issue #681 (three PRs). PR 1/3 added the `confidence` schema
+> field to `GraphEdge`. PR 2/3 wired the maintenance job that decays edges
+> over time. PR 3/3 integrated confidence into the recall traversal path and
+> added `--include-low-confidence` for diagnostic queries.
+
+## Overview
+
+Every edge in Remnic's graph stores carries an optional `confidence ∈ [0, 1]`
+value. Newly written edges start at `1.0`. The maintenance job periodically
+reduces confidence for edges that have not been reinforced recently. Edges that
+remain below the configured floor are pruned from traversal, which focuses
+recall on high-quality, actively reinforced connections.
+
+## Model
+
+Each edge stores two fields:
+
+| Field | Type | Purpose |
+|-------|------|---------|
+| `confidence` | `number \| undefined` | Current trust level in `[0, 1]`. Missing means `1.0` (legacy). |
+| `lastReinforcedAt` | `string \| undefined` | ISO timestamp of the most recent reinforcement event. Missing means "never reinforced since write". |
+
+Confidence decreases at a fixed fractional rate per **decay window** that has
+elapsed since `lastReinforcedAt`. Edges that span multiple windows are charged
+for all elapsed windows in a single pass, so the job is idempotent — running it
+twice with the same timestamp is a no-op.
+
+When an edge is observed during extraction (e.g., two memories share a named
+entity), the reinforcement primitive resets `lastReinforcedAt` to `now` and
+returns the edge with `confidence` unchanged (reinforcement does not inflate
+confidence above its last-decayed value). This prevents repeated co-occurrence
+from driving confidence upward beyond what was initially established.
+
+**Confidence floor** — edges whose confidence drops to or below the configured
+`graphEdgeDecayFloor` are never decayed further. They remain in the graph but
+will be pruned during recall traversal unless `--include-low-confidence` is
+specified.
+
+## Maintenance Job
+
+The decay job runs on a configurable cadence and processes all three graph
+stores (`entity.jsonl`, `time.jsonl`, `causal.jsonl`).
+
+### Configuration
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `graphEdgeDecayEnabled` | `false` | Enable the decay maintenance job. Set to `true` to activate decay. |
+| `graphEdgeDecayCadenceMs` | `604800000` (7 days) | How often the job runs, in milliseconds. Minimum `60000`. |
+| `graphEdgeDecayWindowMs` | `7776000000` (90 days) | Length of one decay window, in milliseconds. One window of inactivity loses `graphEdgeDecayPerWindow` of confidence. Minimum `60000`. |
+| `graphEdgeDecayPerWindow` | `0.1` | Fraction of confidence lost per elapsed window. Range `[0, 1]`. |
+| `graphEdgeDecayFloor` | `0.1` | Minimum confidence an edge can decay to; decay stops here. Range `[0, 1]`. |
+
+### Tuning Guidance
+
+- **Aggressive decay** (high-churn environments): lower `graphEdgeDecayWindowMs`
+  to `30d` and raise `graphEdgeDecayPerWindow` to `0.2`–`0.3`. Edges that are
+  not reinforced within a month will lose confidence quickly, keeping the graph
+  lean.
+
+- **Conservative decay** (stable long-term knowledge): raise
+  `graphEdgeDecayWindowMs` to `180d` and lower `graphEdgeDecayPerWindow` to
+  `0.05`. Edges survive six months of inactivity before losing significant
+  confidence.
+
+- **Disable decay**: set `graphEdgeDecayEnabled` to `false` (the default). All
+  edges remain at their initial confidence for the lifetime of the graph.
+
+- **Raise the floor**: increasing `graphEdgeDecayFloor` keeps old edges visible
+  during traversal even without reinforcement. Lowering it to `0.0` allows edges
+  to decay to zero and be effectively invisible unless `--include-low-confidence`
+  is passed.
+
+### Telemetry
+
+Each run writes a JSON status file to
+`<memoryDir>/state/graph-edge-decay-status.json` with the following fields:
+
+```json
+{
+  "ranAt": "2026-04-27T00:00:00.000Z",
+  "durationMs": 123,
+  "edgesTotal": 4200,
+  "edgesDecayed": 311,
+  "edgesBelowVisibilityThreshold": 48,
+  "topDecayedEntities": [
+    { "label": "SomeEntity", "totalDrop": 0.3, "edgeCount": 3 }
+  ],
+  "perType": [
+    { "type": "entity", "edgesTotal": 2100, "edgesDecayed": 200, "edgesBelowVisibilityThreshold": 30 },
+    { "type": "time",   "edgesTotal": 1800, "edgesDecayed": 100, "edgesBelowVisibilityThreshold": 15 },
+    { "type": "causal", "edgesTotal": 300,  "edgesDecayed":  11, "edgesBelowVisibilityThreshold":  3 }
+  ],
+  "windowMs": 7776000000,
+  "perWindow": 0.1,
+  "floor": 0.1,
+  "visibilityThreshold": 0.2
+}
+```
+
+`remnic doctor` reads this file and surfaces the last run time and summary
+stats in its health report.
+
+## Recall Integration
+
+### Confidence-Weighted Spreading Activation
+
+During graph traversal, each edge's contribution to spreading activation is
+multiplied by its `confidence`:
+
+```
+score += edge.weight × edge.confidence × decay^hop
+```
+
+Legacy edges without a `confidence` field are treated as `1.0`, so old graphs
+work unchanged.
+
+### Traversal Pruning
+
+Edges with `confidence < graphTraversalConfidenceFloor` are excluded from the
+adjacency index before BFS begins. Pruned edges contribute no activation and
+cannot serve as intermediate hops to deeper neighbors.
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `graphTraversalConfidenceFloor` | `0.2` | Minimum confidence required for traversal. Range `[0, 1]`. Legacy edges (no `confidence` field) are always `1.0`. |
+| `graphTraversalPageRankIterations` | `8` | PageRank refinement iterations on top of BFS. Set `0` to use raw BFS scores. |
+
+### The `--include-low-confidence` Flag
+
+By default, recall traversal respects `graphTraversalConfidenceFloor` and
+ignores decayed edges. Pass `--include-low-confidence` to a `remnic recall`
+command to override this and include all edges regardless of confidence:
+
+```bash
+# Standard recall — low-confidence edges pruned
+remnic recall "what do I know about authentication?"
+
+# Diagnostic recall — all edges included even if heavily decayed
+remnic recall "what do I know about authentication?" --include-low-confidence
+```
+
+This is an **operator / debug tool**, not a tuning knob. Use it when:
+
+- You want to understand what edges exist before decay has cleared them.
+- You suspect a recall is missing results because edges have decayed below
+  the floor.
+- You are auditing graph state before or after a decay maintenance run.
+
+The flag threads through the full recall pipeline — both the
+`expandResultsViaGraph` hot path and the `applyColdFallbackPipeline` cold path
+respect it. It is also available via the HTTP API as a query parameter:
+
+```
+POST /engram/v1/recall
+{ "query": "...", "includeLowConfidence": true }
+
+# or as a query param:
+POST /engram/v1/recall?include_low_confidence=true
+{ "query": "..." }
+```
+
+## X-ray Surfacing
+
+When recall X-ray capture is enabled (`remnic xray <query>`), each graph result
+carries an `edgeConfidence` field in the per-result provenance. This is the
+confidence of the highest-confidence edge along the BFS path that landed the
+result. The `graphEdgeConfidences` array in the X-ray snapshot lists one entry
+per edge in the recall path, aligned with `graphPath`.
+
+Low-confidence results returned via `--include-low-confidence` will show
+reduced `edgeConfidence` values in the X-ray, making it easy to distinguish
+them from normally-admitted results.
+
+## Cross-References
+
+- [Graph Reasoning](architecture/graph-reasoning.md) — overall graph architecture,
+  spreading activation model, PageRank refinement, lateral inhibition
+- [Graph Dashboard](graph-dashboard.md) — live graph observability server
+- [Config Reference](config-reference.md) — all `graphEdgeDecay*` and
+  `graphTraversalConfidenceFloor` settings

--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -481,6 +481,26 @@ export class EngramAccessHttpServer {
           tagMatch = queryTagMatch;
         }
       }
+      // Issue #681 — `?include_low_confidence=true|false` mirrors the CLI
+      // `--include-low-confidence` flag. Body field wins so a JSON payload can
+      // explicitly clear a stale query parameter.
+      const bodyIncludeLowConfidence =
+        (body as { includeLowConfidence?: unknown }).includeLowConfidence;
+      const queryIncludeLowConfidence = parsed.searchParams.get("include_low_confidence");
+      if (
+        bodyIncludeLowConfidence === undefined &&
+        queryIncludeLowConfidence !== null &&
+        queryIncludeLowConfidence !== "true" &&
+        queryIncludeLowConfidence !== "false"
+      ) {
+        throw new EngramAccessInputError(
+          `include_low_confidence must be one of: true, false (got: ${queryIncludeLowConfidence})`,
+        );
+      }
+      const includeLowConfidence =
+        bodyIncludeLowConfidence === true ||
+        (bodyIncludeLowConfidence === undefined &&
+          queryIncludeLowConfidence === "true");
       const response = await this.service.recall({
         query: body.query ?? "",
         sessionKey: body.sessionKey,
@@ -499,6 +519,7 @@ export class EngramAccessHttpServer {
         ...(asOf !== undefined ? { asOf } : {}),
         ...(tags !== undefined ? { tags } : {}),
         ...(tagMatch !== undefined ? { tagMatch } : {}),
+        ...(includeLowConfidence ? { includeLowConfidence: true } : {}),
       });
       this.respondJson(res, 200, response);
       return;

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -106,6 +106,11 @@ export const recallRequestSchema = z.object({
    * provided and `tagMatch` is omitted. Ignored when `tags` is absent.
    */
   tagMatch: tagMatchSchema.optional(),
+  /**
+   * Include graph edges below `graphTraversalConfidenceFloor` for diagnostic
+   * recall traversal (issue #681). Defaults to false.
+   */
+  includeLowConfidence: z.boolean().optional(),
 });
 
 export const recallExplainRequestSchema = z.object({

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -217,6 +217,13 @@ export interface EngramAccessRecallRequest {
    * every filter tag to be present. Ignored when `tags` is absent or empty.
    */
   tagMatch?: "any" | "all";
+  /**
+   * Issue #681 — when `true`, bypasses the configured
+   * `graphTraversalConfidenceFloor` for this recall and includes graph edges
+   * below the floor in traversal.  Useful for diagnostic queries that need to
+   * surface results pruned by confidence decay.  Default `false`.
+   */
+  includeLowConfidence?: boolean;
 }
 
 /**
@@ -1532,6 +1539,7 @@ export class EngramAccessService {
       topK,
       mode,
       ...(asOf !== undefined ? { asOf } : {}),
+      ...(request.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
     };
     const startedAt = Date.now();
     const context = await this.orchestrator.recall(query, request.sessionKey, recallOptions);

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -5044,6 +5044,10 @@ export function registerCli(
           "--tag-match <mode>",
           "Tag-filter match mode: any (default) or all. Ignored when --tag is absent.",
         )
+        .option(
+          "--include-low-confidence",
+          "Include graph edges below the configured graphTraversalConfidenceFloor in traversal (issue #681). Default off.",
+        )
         .action(async (...args: unknown[]) => {
           const query = typeof args[0] === "string" ? args[0] : String(args[0] ?? "");
           if (!query || query.trim().length === 0) {
@@ -5156,6 +5160,11 @@ export function registerCli(
             tagMatch = raw;
           }
 
+          // Issue #681 — `--include-low-confidence` is a boolean flag; no
+          // value coercion needed beyond checking presence (Commander sets
+          // it to `true` when the flag is present, undefined otherwise).
+          const includeLowConfidence = options.includeLowConfidence === true;
+
           const accessService = new EngramAccessService(orchestrator);
           const response = await accessService.recall({
             query,
@@ -5166,6 +5175,7 @@ export function registerCli(
             ...(asOf !== undefined ? { asOf } : {}),
             ...(tags !== undefined ? { tags } : {}),
             ...(tagMatch !== undefined ? { tagMatch } : {}),
+            ...(includeLowConfidence ? { includeLowConfidence: true } : {}),
           });
 
           if (format === "json") {

--- a/packages/remnic-core/src/graph.ts
+++ b/packages/remnic-core/src/graph.ts
@@ -509,6 +509,15 @@ export class GraphIndex {
   async spreadingActivation(
     seeds: string[],
     maxSteps?: number,
+    opts?: {
+      /**
+       * Issue #681 — when `true`, bypasses the configured
+       * `graphTraversalConfidenceFloor` and includes low-confidence
+       * edges in traversal.  Equivalent to forcing the floor to `0`.
+       * Default `false` (floor from config is applied).
+       */
+      includeLowConfidence?: boolean;
+    },
   ): Promise<Array<{
     path: string;
     score: number;
@@ -526,9 +535,14 @@ export class GraphIndex {
     if (!this.cfg.multiGraphMemoryEnabled) return [];
     const steps = maxSteps ?? this.cfg.maxGraphTraversalSteps;
     const decay = this.cfg.graphActivationDecay;
-    // Clamp the configured floor into [0, 1] so misconfiguration cannot
-    // (a) admit edges with negative confidence or (b) reject every edge.
-    const floor = clampConfidenceFloor(this.cfg.graphTraversalConfidenceFloor);
+    // When `includeLowConfidence` is set, use floor=0 so all edges
+    // participate in traversal regardless of their decay state.
+    // Otherwise clamp the configured floor into [0, 1] so misconfiguration
+    // cannot (a) admit edges with negative confidence or (b) reject every
+    // edge.
+    const floor = opts?.includeLowConfidence === true
+      ? 0
+      : clampConfidenceFloor(this.cfg.graphTraversalConfidenceFloor);
     const iterations = clampPageRankIterations(
       this.cfg.graphTraversalPageRankIterations,
     );

--- a/packages/remnic-core/src/orchestrator.ts
+++ b/packages/remnic-core/src/orchestrator.ts
@@ -586,6 +586,13 @@ export interface RecallInvocationOptions {
    * rule 51); the orchestrator does NOT silently fall back here.
    */
   asOf?: string;
+  /**
+   * Issue #681 — when `true`, bypasses `graphTraversalConfidenceFloor`
+   * and includes edges below the floor in graph traversal.  Useful for
+   * diagnostic recall queries that need to surface results that would
+   * normally be pruned by confidence decay.  Default `false`.
+   */
+  includeLowConfidence?: boolean;
 }
 
 type QueryAwarePrefilter = {
@@ -5402,6 +5409,8 @@ export class Orchestrator {
     memoryResults: QmdSearchResult[];
     recallNamespaces: string[];
     recallResultLimit: number;
+    /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
+    includeLowConfidence?: boolean;
   }): Promise<{
     merged: QmdSearchResult[];
     seedPaths: string[];
@@ -5450,6 +5459,7 @@ export class Orchestrator {
       const expanded = await this.graphIndexFor(storage).spreadingActivation(
         seedRelativePaths,
         this.config.maxGraphTraversalSteps,
+        options.includeLowConfidence === true ? { includeLowConfidence: true } : undefined,
       );
       if (expanded.length === 0) continue;
 
@@ -8621,6 +8631,7 @@ export class Orchestrator {
               memoryResults,
               recallNamespaces,
               recallResultLimit,
+              ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
             graphSnapshotStatus = "completed";
             graphDecisionStatus = "completed";
@@ -8942,6 +8953,7 @@ export class Orchestrator {
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
             asOfMs,
+            ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
@@ -9151,6 +9163,7 @@ export class Orchestrator {
               abortSignal: options.abortSignal,
               xrayPoolSizeSink: xrayColdPoolSink,
               asOfMs,
+              ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
             });
             if (longTerm.length > 0) {
               recallSource = "cold_fallback";
@@ -9252,6 +9265,7 @@ export class Orchestrator {
                 abortSignal: options.abortSignal,
                 xrayPoolSizeSink: xrayColdPoolSink,
                 asOfMs,
+                ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
               });
               if (longTerm.length > 0) {
                 if (shouldPersistGraphSnapshot) {
@@ -9294,6 +9308,7 @@ export class Orchestrator {
             abortSignal: options.abortSignal,
             xrayPoolSizeSink: xrayColdPoolSink,
             asOfMs,
+            ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
           });
           if (longTerm.length > 0) {
             if (shouldPersistGraphSnapshot) {
@@ -14898,6 +14913,8 @@ export class Orchestrator {
      * Unset by default so existing call sites are unaffected.
      */
     xrayPoolSizeSink?: { size: number };
+    /** Issue #681 — when true, bypass graphTraversalConfidenceFloor. */
+    includeLowConfidence?: boolean;
   }): Promise<QmdSearchResult[]> {
     const coldQmdEnabled = this.config.qmdColdTierEnabled === true;
     const coldCollection =
@@ -14977,6 +14994,7 @@ export class Orchestrator {
         memoryResults: results,
         recallNamespaces: options.recallNamespaces,
         recallResultLimit: options.recallResultLimit,
+        ...(options.includeLowConfidence === true ? { includeLowConfidence: true } : {}),
       });
       results = merged;
     }

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -937,6 +937,152 @@ test("access HTTP server forwards namespace query params to governance endpoints
   }
 });
 
+test("access HTTP recall forwards include_low_confidence query flag", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const server = new EngramAccessHttpServer({
+    service: {
+      recall: async (request: Record<string, unknown>) => {
+        captured.push(request);
+        return {
+          query: request.query,
+          namespace: "global",
+          context: "",
+          count: 0,
+          memoryIds: [],
+          results: [],
+          recordedAt: "2026-03-08T00:00:00.000Z",
+          fallbackUsed: false,
+          sourcesUsed: [],
+          disclosure: "chunk",
+        };
+      },
+    } as unknown as EngramAccessService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(
+      `${base}/engram/v1/recall?include_low_confidence=true`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer secret-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: "diagnose graph traversal" }),
+      },
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0]!.includeLowConfidence, true);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("access HTTP recall body includeLowConfidence wins over query flag", async () => {
+  const captured: Array<Record<string, unknown>> = [];
+  const server = new EngramAccessHttpServer({
+    service: {
+      recall: async (request: Record<string, unknown>) => {
+        captured.push(request);
+        return {
+          query: request.query,
+          namespace: "global",
+          context: "",
+          count: 0,
+          memoryIds: [],
+          results: [],
+          recordedAt: "2026-03-08T00:00:00.000Z",
+          fallbackUsed: false,
+          sourcesUsed: [],
+          disclosure: "chunk",
+        };
+      },
+    } as unknown as EngramAccessService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(
+      `${base}/engram/v1/recall?include_low_confidence=true`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer secret-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          query: "diagnose graph traversal",
+          includeLowConfidence: false,
+        }),
+      },
+    );
+
+    assert.equal(response.status, 200);
+    assert.equal(captured.length, 1);
+    assert.equal(captured[0]!.includeLowConfidence, undefined);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("access HTTP recall rejects invalid include_low_confidence query flag", async () => {
+  const server = new EngramAccessHttpServer({
+    service: {
+      recall: async () => ({
+        query: "unused",
+        namespace: "global",
+        context: "",
+        count: 0,
+        memoryIds: [],
+        results: [],
+        recordedAt: "2026-03-08T00:00:00.000Z",
+        fallbackUsed: false,
+        sourcesUsed: [],
+        disclosure: "chunk",
+      }),
+    } as unknown as EngramAccessService,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+
+  try {
+    const response = await fetch(
+      `${base}/engram/v1/recall?include_low_confidence=1`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: "Bearer secret-token",
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({ query: "diagnose graph traversal" }),
+      },
+    );
+
+    assert.equal(response.status, 400);
+    const body = await response.json() as { error: string };
+    assert.match(body.error, /include_low_confidence/);
+  } finally {
+    await server.stop();
+  }
+});
+
 test("access HTTP server rejects oversized JSON bodies", async () => {
   const server = new EngramAccessHttpServer({
     service: createFakeService(),

--- a/tests/cli/include-low-confidence.test.ts
+++ b/tests/cli/include-low-confidence.test.ts
@@ -1,0 +1,205 @@
+/**
+ * Tests for the `--include-low-confidence` flag (issue #681 PR 3/3 completion).
+ *
+ * Exercises two pure-function layers that implement the flag without booting
+ * an orchestrator:
+ *
+ *  1. `GraphIndex.spreadingActivation()` — when `opts.includeLowConfidence`
+ *     is true the adjacency build must use floor=0, so edges below the
+ *     configured `graphTraversalConfidenceFloor` contribute activation.
+ *     When the flag is absent (default), those edges are still pruned.
+ *
+ *  2. `RecallInvocationOptions.includeLowConfidence` — the field is defined
+ *     and accepted by the interface (type-level sanity check).
+ *
+ * Test data is fully synthetic (CLAUDE.md public-repo rule: no real
+ * conversation content or user identifiers).
+ */
+
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  clampConfidenceFloor,
+  type GraphConfig,
+  GraphIndex,
+} from "../../packages/remnic-core/src/graph.js";
+import type { RecallInvocationOptions } from "../../packages/remnic-core/src/orchestrator.js";
+import { validateRequest } from "../../packages/remnic-core/src/access-schema.js";
+
+// ───────────────────────────────────────────────────────────────────────────
+// Helpers
+// ───────────────────────────────────────────────────────────────────────────
+
+/** Minimal GraphConfig that satisfies the interface. */
+function makeConfig(overrides: Partial<GraphConfig> = {}): GraphConfig {
+  return {
+    multiGraphMemoryEnabled: true,
+    entityGraphEnabled: true,
+    timeGraphEnabled: true,
+    causalGraphEnabled: true,
+    maxGraphTraversalSteps: 3,
+    graphActivationDecay: 0.7,
+    maxEntityGraphEdgesPerMemory: 10,
+    graphLateralInhibitionEnabled: false,
+    graphLateralInhibitionBeta: 1.0,
+    graphLateralInhibitionTopM: 7,
+    graphTraversalConfidenceFloor: 0.5, // floor set at 0.5 for tests
+    graphTraversalPageRankIterations: 0, // disable PageRank so BFS is deterministic
+    ...overrides,
+  };
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// 1. clampConfidenceFloor — unit tests (already exported)
+// ───────────────────────────────────────────────────────────────────────────
+
+test("clampConfidenceFloor returns default for non-finite input", () => {
+  assert.equal(clampConfidenceFloor(NaN), 0.2);
+  assert.equal(clampConfidenceFloor(undefined), 0.2);
+  assert.equal(clampConfidenceFloor("bad"), 0.2);
+});
+
+test("clampConfidenceFloor clamps to [0, 1]", () => {
+  assert.equal(clampConfidenceFloor(-1), 0);
+  assert.equal(clampConfidenceFloor(2), 1);
+  assert.equal(clampConfidenceFloor(0.3), 0.3);
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 2. spreadingActivation — confidence floor pruning
+//
+// We create a temporary on-disk JSONL store with two edges:
+//   seed → nodeA  (confidence 0.8 — above the 0.5 floor)
+//   seed → nodeB  (confidence 0.1 — below the 0.5 floor)
+//
+// Default behavior: only nodeA is returned.
+// With includeLowConfidence=true: both nodeA and nodeB are returned.
+// ───────────────────────────────────────────────────────────────────────────
+
+import { mkdir, writeFile, rm } from "node:fs/promises";
+import * as path from "node:path";
+import * as os from "node:os";
+
+async function makeTmpGraph(): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await (async () => {
+    const tmp = path.join(os.tmpdir(), `remnic-test-ilc-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+    await mkdir(path.join(tmp, "state", "graphs"), { recursive: true });
+    return tmp;
+  })();
+
+  // Write two entity edges: one above floor (0.8), one below floor (0.1)
+  const edges = [
+    { from: "seed.md", to: "nodeA.md", type: "entity", weight: 1.0, label: "TestEntity", ts: "2026-01-01T00:00:00.000Z", confidence: 0.8 },
+    { from: "seed.md", to: "nodeB.md", type: "entity", weight: 1.0, label: "TestEntity", ts: "2026-01-01T00:00:00.000Z", confidence: 0.1 },
+  ];
+  const body = edges.map((e) => JSON.stringify(e)).join("\n") + "\n";
+  await writeFile(path.join(dir, "state", "graphs", "entity.jsonl"), body, "utf-8");
+
+  return {
+    dir,
+    cleanup: () => rm(dir, { recursive: true, force: true }),
+  };
+}
+
+test("spreadingActivation — default floor prunes low-confidence edges", async () => {
+  const { dir, cleanup } = await makeTmpGraph();
+  try {
+    const cfg = makeConfig({ graphTraversalConfidenceFloor: 0.5 });
+    const index = new GraphIndex(dir, cfg);
+    const results = await index.spreadingActivation(["seed.md"]);
+    const paths = results.map((r) => r.path);
+    assert.ok(paths.includes("nodeA.md"), "nodeA (conf=0.8) should be included");
+    assert.ok(!paths.includes("nodeB.md"), "nodeB (conf=0.1) should be pruned by floor=0.5");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("spreadingActivation — includeLowConfidence bypasses floor", async () => {
+  const { dir, cleanup } = await makeTmpGraph();
+  try {
+    const cfg = makeConfig({ graphTraversalConfidenceFloor: 0.5 });
+    const index = new GraphIndex(dir, cfg);
+    const results = await index.spreadingActivation(
+      ["seed.md"],
+      undefined,
+      { includeLowConfidence: true },
+    );
+    const paths = results.map((r) => r.path);
+    assert.ok(paths.includes("nodeA.md"), "nodeA (conf=0.8) should be included");
+    assert.ok(paths.includes("nodeB.md"), "nodeB (conf=0.1) should be included when floor bypassed");
+  } finally {
+    await cleanup();
+  }
+});
+
+test("spreadingActivation — includeLowConfidence=false is equivalent to default", async () => {
+  const { dir, cleanup } = await makeTmpGraph();
+  try {
+    const cfg = makeConfig({ graphTraversalConfidenceFloor: 0.5 });
+    const index = new GraphIndex(dir, cfg);
+    const withFalse = await index.spreadingActivation(
+      ["seed.md"],
+      undefined,
+      { includeLowConfidence: false },
+    );
+    const withDefault = await index.spreadingActivation(["seed.md"]);
+    assert.deepEqual(
+      withFalse.map((r) => r.path).sort(),
+      withDefault.map((r) => r.path).sort(),
+      "explicit false should behave identically to omitting the option",
+    );
+  } finally {
+    await cleanup();
+  }
+});
+
+// ───────────────────────────────────────────────────────────────────────────
+// 3. RecallInvocationOptions type-level check
+//    (TypeScript would catch this at compile time, but we add a runtime
+//     check so the test suite catches regressions if the field is removed)
+// ───────────────────────────────────────────────────────────────────────────
+
+test("RecallInvocationOptions accepts includeLowConfidence field", () => {
+  // If the interface does not define the field this assignment produces a
+  // compile-time error (tsc --strict).  At runtime we just confirm the object
+  // can be constructed without throwing.
+  const opts: RecallInvocationOptions = {
+    includeLowConfidence: true,
+  };
+  assert.equal(opts.includeLowConfidence, true);
+});
+
+test("RecallInvocationOptions includeLowConfidence defaults to undefined (optional)", () => {
+  const opts: RecallInvocationOptions = {};
+  assert.equal(opts.includeLowConfidence, undefined);
+});
+
+test("recall request schema preserves includeLowConfidence body field", () => {
+  const result = validateRequest("recall", {
+    query: "diagnose graph traversal",
+    includeLowConfidence: true,
+  });
+
+  assert.equal(result.success, true);
+  if (!result.success) return;
+  assert.equal(
+    (result.data as { includeLowConfidence?: boolean }).includeLowConfidence,
+    true,
+  );
+});
+
+test("recall request schema rejects non-boolean includeLowConfidence", () => {
+  const result = validateRequest("recall", {
+    query: "diagnose graph traversal",
+    includeLowConfidence: "true",
+  });
+
+  assert.equal(result.success, false);
+  if (result.success) return;
+  assert.equal(result.error.code, "validation_error");
+  assert.ok(
+    result.error.details.some((detail) => detail.field === "includeLowConfidence"),
+    "expected includeLowConfidence validation detail",
+  );
+});


### PR DESCRIPTION
## Summary
- adds `--include-low-confidence` / HTTP recall opt-in so diagnostic recalls can traverse graph edges below `graphTraversalConfidenceFloor`
- threads the option through access service, orchestrator graph expansion, and cold fallback graph assist
- documents graph edge confidence decay and the diagnostic traversal flag

## Verification
- `npm exec -- tsx --test tests/cli/include-low-confidence.test.ts`
- `npm exec -- tsx --test tests/access-http.test.ts`
- `npm exec -- tsx --test tests/graph.test.ts`
- `npm exec -- tsx --test tests/graph-snapshot.test.ts`
- `npm exec -- tsx --test --test-name-pattern "access service recall forwards overrides" tests/access-service.test.ts`
- `npm run check-types`
- `git diff --check origin/main...HEAD`

Note: full `tests/access-service.test.ts` currently fails in this local worktree on the projection-backed cases because the native `better-sqlite3` binding cannot be located under `/Users/joshuawarren/src/remnic/node_modules`; the touched recall-forwarding test passes when run directly.

Completes #681.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Threads a new `includeLowConfidence` option through CLI/HTTP/service/orchestrator into graph traversal, changing recall behavior when enabled (though default remains off). Moderate risk due to touching hot-path retrieval and request validation surfaces.
> 
> **Overview**
> Adds a diagnostic opt-in (`--include-low-confidence` and `include_low_confidence`/`includeLowConfidence`) that bypasses `graphTraversalConfidenceFloor` so recall graph expansion can include decayed/low-confidence edges when explicitly requested.
> 
> Threads the new `includeLowConfidence` field through request validation (`access-schema`), HTTP parsing/forwarding (`access-http`), the access-service recall options, and orchestrator graph expansion paths (including cold-fallback graph assist) into `GraphIndex.spreadingActivation()`.
> 
> Updates docs with a new **Graph Edge Confidence Decay** page, links it from the docs index, extends the config reference with `graphEdgeDecay*` knobs, and adds tests covering the new HTTP query param behavior and the traversal-floor bypass.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e66fb1178c1771b486d5def8c09f709ff942487. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->