### PR TITLE
docs(connectors): correct live scheduler cadence

### DIFF
--- a/docs/connectors.md
+++ b/docs/connectors.md
@@ -115,8 +115,9 @@ failure, exits `1`, writes the error to stderr, and records the failure in the
 connector's state file so `connectors list` reflects it.
 
 The maintenance scheduler calls the MCP tool `engram.live_connectors_run` every
-five minutes through the `engram-live-connectors-sync` cron. That runner honors
-each connector's `pollIntervalMs` and covers every enabled built-in connector.
+minute once connectors are configured through the `engram-live-connectors-sync`
+cron. That runner honors each connector's `pollIntervalMs` and covers every
+enabled built-in connector.
 `remnic connectors run <name>` currently supports Google Drive and Notion as the
 single-connector debug path.
 

--- a/docs/live-connectors.md
+++ b/docs/live-connectors.md
@@ -268,11 +268,11 @@ maintenance cron job:
 
 | Job id | Schedule | Tool |
 |--------|----------|------|
-| `engram-live-connectors-sync` | `*/5 * * * *` | `engram.live_connectors_run` |
+| `engram-live-connectors-sync` | `* * * * *` when configured; `*/5 * * * *` before connector config loads | `engram.live_connectors_run` |
 
-The cron wakes every five minutes and runs only connectors whose own
-`pollIntervalMs` says they are due. Operators can call the same MCP tool with
-`{"force": true}` to bypass the due check during debugging.
+The cron wakes every minute once connectors are configured and runs only
+connectors whose own `pollIntervalMs` says they are due. Operators can call the
+same MCP tool with `{"force": true}` to bypass the due check during debugging.
 
 ## What's deferred
 


### PR DESCRIPTION
## Summary
- correct the live connector scheduler docs to match the enabled one-minute wrapper cadence
- clarify that connector-level pollIntervalMs still controls whether each source actually syncs

## Verification
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk documentation-only change correcting the described cron schedule and due-check behavior; no runtime code is modified.
> 
> **Overview**
> Corrects live connector scheduler docs to indicate the `engram-live-connectors-sync` cron runs **every minute once connector config is loaded** (with a fallback `*/5` cadence before config is available).
> 
> Clarifies in both `docs/connectors.md` and `docs/live-connectors.md` that the minute-level cron is only a wrapper and each connector’s own `pollIntervalMs` still determines whether it actually syncs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 49d9b82533c1ff580b626d0861a1aeda3d75035f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->