### PR TITLE
Exercise full Remnic pipeline in real benchmark runs

### DIFF
--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -182,3 +182,39 @@ test("runtime-backed adapter stores benchmark turns into Remnic recall surfaces"
     await adapter.destroy();
   }
 });
+
+test("runtime-backed adapter preserves transcript order for stored batches", async () => {
+  const adapter = await createRemnicAdapter({
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("agent:bench:main", [
+      {
+        role: "user",
+        content: "First turn: choose the train.",
+      },
+      {
+        role: "assistant",
+        content: "Second turn: the final snack is trail mix.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "agent:bench:main",
+      "What happened in the first and second turn?",
+    );
+    const firstIndex = recalled.indexOf("First turn: choose the train.");
+    const secondIndex = recalled.indexOf("Second turn: the final snack is trail mix.");
+
+    assert.notEqual(firstIndex, -1);
+    assert.notEqual(secondIndex, -1);
+    assert.equal(firstIndex < secondIndex, true);
+  } finally {
+    await adapter.destroy();
+  }
+});

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -5,6 +5,7 @@ import { parseConfig } from "@remnic/core";
 import {
   buildBenchAdapterConfig,
   buildBenchBaselineRemnicConfig,
+  createLightweightAdapter,
   createRemnicAdapter,
 } from "./remnic-adapter.ts";
 
@@ -214,6 +215,37 @@ test("runtime-backed adapter preserves transcript order for stored batches", asy
     assert.notEqual(firstIndex, -1);
     assert.notEqual(secondIndex, -1);
     assert.equal(firstIndex < secondIndex, true);
+  } finally {
+    await adapter.destroy();
+  }
+});
+
+test("lightweight adapter suppresses real Remnic pipeline even when feature overrides are present", async () => {
+  const adapter = await createLightweightAdapter({
+    configOverrides: {
+      transcriptEnabled: true,
+      qmdEnabled: true,
+      extractionMinUserTurns: 0,
+    },
+  });
+
+  try {
+    await adapter.store("agent:bench:main", [
+      {
+        role: "user",
+        content: "Remember the lightweight mode code is smoke-only.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "agent:bench:main",
+      "What is the lightweight mode code?",
+    );
+
+    assert.doesNotMatch(recalled, /## Remnic recall pipeline/);
+    assert.doesNotMatch(recalled, /Recent Conversation/);
+    assert.match(recalled, /smoke-only/);
   } finally {
     await adapter.destroy();
   }

--- a/packages/bench/src/adapters/remnic-adapter.test.ts
+++ b/packages/bench/src/adapters/remnic-adapter.test.ts
@@ -152,3 +152,33 @@ test("direct adapter recall expands search hits with adjacent stored results", a
     await adapter.destroy();
   }
 });
+
+test("runtime-backed adapter stores benchmark turns into Remnic recall surfaces", async () => {
+  const adapter = await createRemnicAdapter({
+    configOverrides: {
+      transcriptEnabled: true,
+      extractionMinUserTurns: 999,
+    },
+  });
+
+  try {
+    await adapter.store("agent:bench:main", [
+      {
+        role: "user",
+        content: "Remember the espresso code is crema-42.",
+      },
+    ]);
+    await adapter.drain?.();
+
+    const recalled = await adapter.recall(
+      "agent:bench:main",
+      "What is the espresso code?",
+    );
+
+    assert.match(recalled, /## Remnic recall pipeline/);
+    assert.match(recalled, /Recent Conversation/);
+    assert.match(recalled, /crema-42/);
+  } finally {
+    await adapter.destroy();
+  }
+});

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -265,35 +265,33 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
           return;
         }
 
-        const now = new Date().toISOString();
+        const batchStartMs = Date.now();
         const conversationalMessages = messages.filter(
           (message): message is Message & { role: "user" | "assistant" } =>
             message.role === "user" || message.role === "assistant",
         );
-        const replayTurns = conversationalMessages.map((message) => ({
+        const replayTurns = conversationalMessages.map((message, index) => ({
           source: "openclaw" as const,
           role: message.role,
           content: message.content,
-          timestamp: now,
+          timestamp: new Date(batchStartMs + index).toISOString(),
           sessionKey: sessionId,
         }));
 
-        await Promise.all(
-          conversationalMessages.map(async (message) => {
-            const turnId = nextBenchTranscriptTurnId(
-              sessionTurnCounters,
-              sessionId,
-              message,
-            );
-            await state.orchestrator.transcript.append({
-              timestamp: now,
-              role: message.role,
-              content: message.content,
-              sessionKey: sessionId,
-              turnId,
-            });
-          }),
-        );
+        for (const turn of replayTurns) {
+          const turnId = nextBenchTranscriptTurnId(
+            sessionTurnCounters,
+            sessionId,
+            turn,
+          );
+          await state.orchestrator.transcript.append({
+            timestamp: turn.timestamp,
+            role: turn.role,
+            content: turn.content,
+            sessionKey: sessionId,
+            turnId,
+          });
+        }
 
         await state.orchestrator.ingestReplayBatch(replayTurns);
       },
@@ -458,12 +456,19 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         });
         try {
           await Promise.race([
-            Promise.all([
-              engine.waitForObserveQueueIdle(),
-              state.orchestrator.waitForExtractionIdle(DRAIN_TIMEOUT_MS),
-              state.orchestrator.waitForConsolidationIdle(DRAIN_TIMEOUT_MS),
-            ]).catch((err: unknown) => {
-                if (abortController.signal.aborted) return;
+            (async () => {
+              const [, extractionIdle, consolidationIdle] = await Promise.all([
+                engine.waitForObserveQueueIdle(),
+                state.orchestrator.waitForExtractionIdle(DRAIN_TIMEOUT_MS),
+                state.orchestrator.waitForConsolidationIdle(DRAIN_TIMEOUT_MS),
+              ]);
+              if (!extractionIdle) {
+                throw new Error("drain() timed out waiting for extraction idle");
+              }
+              if (!consolidationIdle) {
+                throw new Error("drain() timed out waiting for consolidation idle");
+              }
+            })().catch((err: unknown) => {
               if (abortController.signal.aborted) return;
               throw err;
             }),

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -2,6 +2,7 @@
  * Package-owned Remnic adapters used by the phase-1 benchmark CLI surface.
  */
 
+import { createHash } from "node:crypto";
 import { mkdir, mkdtemp, rm } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import path from "node:path";
@@ -203,11 +204,13 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
   return async function createAdapter(
     options: RemnicAdapterOptions = {},
   ): Promise<BenchMemoryAdapter> {
+    const useCoreMemoryPipeline = shouldUseCoreMemoryPipeline(options);
     let state = await createBenchOrchestrator(
       mode,
       options.configOverrides,
       options.preserveRuntimeDefaults === true,
     );
+    const sessionTurnCounters = new Map<string, number>();
 
     const getEngine = () => {
       const engine = state.orchestrator.lcmEngine;
@@ -245,6 +248,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         options.configOverrides,
         options.preserveRuntimeDefaults === true,
       );
+      sessionTurnCounters.clear();
     };
 
     return {
@@ -256,6 +260,42 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             content: message.content,
           })),
         );
+
+        if (!useCoreMemoryPipeline || messages.length === 0) {
+          return;
+        }
+
+        const now = new Date().toISOString();
+        const conversationalMessages = messages.filter(
+          (message): message is Message & { role: "user" | "assistant" } =>
+            message.role === "user" || message.role === "assistant",
+        );
+        const replayTurns = conversationalMessages.map((message) => ({
+          source: "openclaw" as const,
+          role: message.role,
+          content: message.content,
+          timestamp: now,
+          sessionKey: sessionId,
+        }));
+
+        await Promise.all(
+          conversationalMessages.map(async (message) => {
+            const turnId = nextBenchTranscriptTurnId(
+              sessionTurnCounters,
+              sessionId,
+              message,
+            );
+            await state.orchestrator.transcript.append({
+              timestamp: now,
+              role: message.role,
+              content: message.content,
+              sessionKey: sessionId,
+              turnId,
+            });
+          }),
+        );
+
+        await state.orchestrator.ingestReplayBatch(replayTurns);
       },
 
       async recall(sessionId: string, query: string, budgetChars?: number): Promise<string> {
@@ -268,9 +308,25 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         const sections: string[] = [];
         let usedChars = 0;
 
+        if (useCoreMemoryPipeline) {
+          const coreBudget = Math.max(0, Math.floor(budget * 0.55));
+          const coreRecall = await state.orchestrator.recall(query, sessionId, {
+            budgetCharsOverride: coreBudget,
+            mode: "full",
+          });
+          if (coreRecall.trim().length > 0) {
+            const section = `## Remnic recall pipeline\n${coreRecall.trim()}`;
+            sections.push(section);
+            usedChars += section.length;
+          }
+        }
+
         if (query) {
-          const searchBudget = Math.max(0, Math.floor(budget * 0.7));
-          const searchLimit = Math.max(4, Math.min(12, Math.floor(budget / 3_000)));
+          const remainingAfterCore = Math.max(0, budget - usedChars);
+          const searchBudget = useCoreMemoryPipeline
+            ? Math.max(0, Math.floor(remainingAfterCore * 0.75))
+            : Math.max(0, Math.floor(budget * 0.7));
+          const searchLimit = Math.max(6, Math.min(18, Math.floor(budget / 2_000)));
           const searchResults = await engine.searchContextFull(
             query,
             searchLimit,
@@ -288,13 +344,14 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
             const seenTurns = new Set<string>();
 
             for (const result of searchResults) {
-              const fromTurn = Math.max(0, result.turn_index - 1);
-              const toTurn = result.turn_index + 1;
+              const windowRadius = useCoreMemoryPipeline ? 3 : 1;
+              const fromTurn = Math.max(0, result.turn_index - windowRadius);
+              const toTurn = result.turn_index + windowRadius;
               const expanded = await engine.expandContext(
                 result.session_id,
                 fromTurn,
                 toTurn,
-                600,
+                useCoreMemoryPipeline ? 1_600 : 600,
               );
 
               if (expanded.length === 0) {
@@ -401,7 +458,12 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
         });
         try {
           await Promise.race([
-            engine.waitForObserveQueueIdle().catch((err: unknown) => {
+            Promise.all([
+              engine.waitForObserveQueueIdle(),
+              state.orchestrator.waitForExtractionIdle(DRAIN_TIMEOUT_MS),
+              state.orchestrator.waitForConsolidationIdle(DRAIN_TIMEOUT_MS),
+            ]).catch((err: unknown) => {
+                if (abortController.signal.aborted) return;
               if (abortController.signal.aborted) return;
               throw err;
             }),
@@ -428,3 +490,50 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 
 export const createLightweightAdapter = createAdapterFactory("lightweight");
 export const createRemnicAdapter = createAdapterFactory("direct");
+
+function shouldUseCoreMemoryPipeline(options: RemnicAdapterOptions): boolean {
+  if (options.preserveRuntimeDefaults === true) {
+    return true;
+  }
+
+  const overrides = options.configOverrides ?? {};
+  return [
+    "qmdEnabled",
+    "qmdColdTierEnabled",
+    "transcriptEnabled",
+    "hourlySummariesEnabled",
+    "daySummaryEnabled",
+    "identityEnabled",
+    "entityRetrievalEnabled",
+    "knowledgeIndexEnabled",
+    "verifiedRecallEnabled",
+    "memoryBoxesEnabled",
+    "traceWeaverEnabled",
+    "episodeNoteModeEnabled",
+    "queryAwareIndexingEnabled",
+    "nativeKnowledge",
+  ].some((key) => {
+    const value = overrides[key];
+    if (key === "nativeKnowledge") {
+      return !!value
+        && typeof value === "object"
+        && !Array.isArray(value)
+        && (value as { enabled?: unknown }).enabled === true;
+    }
+    return value === true;
+  });
+}
+
+function nextBenchTranscriptTurnId(
+  counters: Map<string, number>,
+  sessionId: string,
+  message: Message,
+): string {
+  const index = counters.get(sessionId) ?? 0;
+  counters.set(sessionId, index + 1);
+  const digest = createHash("sha256")
+    .update(`${sessionId}\n${index}\n${message.role}\n${message.content}`)
+    .digest("hex")
+    .slice(0, 16);
+  return `bench-${index}-${digest}`;
+}

--- a/packages/bench/src/adapters/remnic-adapter.ts
+++ b/packages/bench/src/adapters/remnic-adapter.ts
@@ -204,7 +204,7 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
   return async function createAdapter(
     options: RemnicAdapterOptions = {},
   ): Promise<BenchMemoryAdapter> {
-    const useCoreMemoryPipeline = shouldUseCoreMemoryPipeline(options);
+    const useCoreMemoryPipeline = shouldUseCoreMemoryPipeline(mode, options);
     let state = await createBenchOrchestrator(
       mode,
       options.configOverrides,
@@ -496,7 +496,14 @@ function createAdapterFactory(mode: "lightweight" | "direct") {
 export const createLightweightAdapter = createAdapterFactory("lightweight");
 export const createRemnicAdapter = createAdapterFactory("direct");
 
-function shouldUseCoreMemoryPipeline(options: RemnicAdapterOptions): boolean {
+function shouldUseCoreMemoryPipeline(
+  mode: BenchAdapterMode,
+  options: RemnicAdapterOptions,
+): boolean {
+  if (mode === "lightweight") {
+    return false;
+  }
+
   if (options.preserveRuntimeDefaults === true) {
     return true;
   }

--- a/packages/bench/src/answering.test.ts
+++ b/packages/bench/src/answering.test.ts
@@ -110,6 +110,14 @@ test("strict question builder preserves free-form summarization prompts", () => 
   );
 });
 
+test("strict question builder reserves unknown for genuinely missing evidence", () => {
+  const prompt = buildStrictBenchmarkQuestion("What code did I save?");
+
+  assert.match(prompt, /best supported answer/);
+  assert.match(prompt, /only when the supplied context has no relevant evidence/);
+  assert.doesNotMatch(prompt, /If the context is insufficient, answer "unknown"/);
+});
+
 test("strict question builder supports concise answers with required specifics", () => {
   const question = "How many columns did I add?";
   const prompt = buildStrictBenchmarkQuestion(question, "short-with-specifics");

--- a/packages/bench/src/answering.ts
+++ b/packages/bench/src/answering.ts
@@ -77,7 +77,8 @@ export function buildStrictBenchmarkQuestion(
     "Benchmark answer protocol:",
     "- Use only the supplied Remnic memory context as evidence.",
     "- Answer the benchmark question directly; do not add prefaces, caveats, or unsupported facts.",
-    "- If the context is insufficient, answer \"unknown\".",
+    "- If the context contains enough evidence to answer, give the best supported answer even when other unrelated details are missing.",
+    "- Answer \"unknown\" only when the supplied context has no relevant evidence, has irreconcilably conflicting evidence, or lacks the specific value the question asks for.",
     "- Resolve relative temporal references from the timestamps or dated facts in the memory context when possible.",
     "- For date or year questions, prefer the absolute date or year over relative wording like yesterday or last year.",
   ];

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from "node:os";
 import path from "node:path";
 import test from "node:test";
 
+import { buildAmaBenchLeaderboardRows } from "../../../leaderboard-export.ts";
 import { amaBenchDefinition, runAmaBenchBenchmark } from "./runner.ts";
 
 test("AMA-Bench normalizes sparse null trajectory fields from the official dataset", async () => {
@@ -168,6 +169,89 @@ test("AMA-Bench records recommended and cross-judge protocol metrics", async () 
     provider: "ollama",
     model: "qwen3:32b",
   });
+});
+
+test("AMA-Bench failed tasks retain episode metadata for leaderboard export", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-ama-bench-"));
+  const datasetPath = path.join(tempDir, "open_end_qa_set.jsonl");
+
+  try {
+    await writeFile(
+      datasetPath,
+      JSON.stringify({
+        episode_id: 77,
+        task: "Failing AMA fixture",
+        task_type: "web",
+        domain: "WEB",
+        success: true,
+        num_turns: 1,
+        total_tokens: 12,
+        trajectory: [
+          {
+            turn_idx: 0,
+            action: "Open the settings page.",
+            observation: "Settings opened.",
+          },
+        ],
+        qa_pairs: [
+          {
+            question: "What page opened?",
+            answer: "settings",
+            type: "recall",
+            question_uuid: "ama-fail-q1",
+          },
+        ],
+      }) + "\n",
+      "utf8",
+    );
+
+    const result = await runAmaBenchBenchmark({
+      benchmark: amaBenchDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store() {},
+        async recall() {
+          throw new Error("recall unavailable");
+        },
+        async search() {
+          return [];
+        },
+        async reset() {},
+        async getStats() {
+          return {
+            totalMessages: 2,
+            totalSummaryNodes: 0,
+            maxDepth: 0,
+          };
+        },
+        async destroy() {},
+        judge: {
+          async score() {
+            return 0;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 0,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "judge-smoke",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks[0]?.details?.episodeId, 77);
+    assert.deepEqual(buildAmaBenchLeaderboardRows(result), [
+      {
+        episode_id: 77,
+        answer_list: ["unknown"],
+      },
+    ]);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
 });
 
 test("AMA-Bench omits cross-judge agreement for scalar primary protocol", async () => {

--- a/packages/bench/src/benchmarks/published/ama-bench/runner.ts
+++ b/packages/bench/src/benchmarks/published/ama-bench/runner.ts
@@ -183,7 +183,16 @@ export async function runAmaBenchBenchmark(
           scores: { f1: -1, contains_answer: -1, llm_judge: -1 },
           latencyMs: 0,
           tokens: { input: 0, output: 0 },
-          details: { error: message },
+          details: {
+            error: message,
+            qaType: qa.type,
+            domain: episode.domain,
+            episodeId: episode.episode_id,
+            task: episode.task,
+            taskType: episode.task_type,
+            numTurns: episode.num_turns,
+            totalTokens: episode.total_tokens,
+          },
         });
       }
 

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
@@ -183,3 +183,79 @@ test("MemoryArena accepts optional string-array backgrounds from dataset files",
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("MemoryArena passes the live task prompt into answer context", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-memory-arena-"));
+  const datasetPath = path.join(tempDir, "bundled_shopping.jsonl");
+  let responderContext = "";
+
+  try {
+    await writeFile(
+      datasetPath,
+      JSON.stringify({
+        id: 9,
+        category: "bundled_shopping",
+        questions: [
+          "Product 1 options: ASIN A costs $4. Product 2 options: ASIN B costs $5. Which bundle should be purchased?",
+        ],
+        answers: ["ASIN A | ASIN B"],
+      }) + "\n",
+      "utf8",
+    );
+
+    const result = await runMemoryArenaBenchmark({
+      benchmark: memoryArenaDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store() {},
+        async recall() {
+          return "Prior memory context.";
+        },
+        async search() {
+          return [];
+        },
+        async reset() {},
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        responder: {
+          async respond(_question, context) {
+            responderContext = context;
+            return {
+              text: "ASIN A | ASIN B",
+              tokens: { input: 1, output: 1 },
+              latencyMs: 1,
+              model: "responder-smoke",
+            };
+          },
+        },
+        judge: {
+          async score() {
+            return 1;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 1,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "judge-smoke",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks.length, 1);
+    assert.match(responderContext, /Current MemoryArena task prompt/);
+    assert.match(responderContext, /Product 1 options: ASIN A/);
+    assert.match(responderContext, /Prior memory context/);
+    assert.match(
+      String(result.results.tasks[0]?.details?.answerContext ?? ""),
+      /Product 2 options: ASIN B/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.test.ts
@@ -259,3 +259,65 @@ test("MemoryArena passes the live task prompt into answer context", async () => 
     await rm(tempDir, { recursive: true, force: true });
   }
 });
+
+test("MemoryArena no-responder runs do not score the live task prompt as recall", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-memory-arena-"));
+  const datasetPath = path.join(tempDir, "bundled_shopping.jsonl");
+
+  try {
+    await writeFile(
+      datasetPath,
+      JSON.stringify({
+        id: 10,
+        category: "bundled_shopping",
+        questions: [
+          "Product options include ASIN A. Which item should be purchased?",
+        ],
+        answers: ["ASIN A"],
+      }) + "\n",
+      "utf8",
+    );
+
+    const result = await runMemoryArenaBenchmark({
+      benchmark: memoryArenaDefinition,
+      mode: "full",
+      datasetDir: tempDir,
+      system: {
+        async store() {},
+        async recall() {
+          return "Prior memory context without the answer.";
+        },
+        async search() {
+          return [];
+        },
+        async reset() {},
+        async destroy() {},
+        async getStats() {
+          return { totalMessages: 0, totalSummaryNodes: 0, maxDepth: 0 };
+        },
+        judge: {
+          async score() {
+            return 0;
+          },
+          async scoreWithMetrics() {
+            return {
+              score: 0,
+              tokens: { input: 0, output: 0 },
+              latencyMs: 0,
+              model: "judge-smoke",
+            };
+          },
+        },
+      },
+    });
+
+    assert.equal(result.results.tasks[0]?.actual, "Prior memory context without the answer.");
+    assert.equal(result.results.tasks[0]?.scores.contains_answer, 0);
+    assert.match(
+      String(result.results.tasks[0]?.details?.answerContext ?? ""),
+      /Product options include ASIN A/,
+    );
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -134,7 +134,7 @@ export async function runMemoryArenaBenchmark(
           );
           const answered = await answerBenchmarkQuestion({
             question: benchmarkQuestion,
-            recalledText: answerContext,
+            recalledText: options.system.responder ? answerContext : recalledText,
             responder: options.system.responder,
             answerMode: "strict",
           });

--- a/packages/bench/src/benchmarks/published/memory-arena/runner.ts
+++ b/packages/bench/src/benchmarks/published/memory-arena/runner.ts
@@ -128,9 +128,13 @@ export async function runMemoryArenaBenchmark(
             question,
             expectedAnswer,
           );
+          const answerContext = buildMemoryArenaAnswerContext(
+            recalledText,
+            question,
+          );
           const answered = await answerBenchmarkQuestion({
             question: benchmarkQuestion,
-            recalledText,
+            recalledText: answerContext,
             responder: options.system.responder,
             answerMode: "strict",
           });
@@ -181,8 +185,10 @@ export async function runMemoryArenaBenchmark(
                 ? {}
                 : { initialSeedError }),
               recalledLength: recalledText.length,
+              answerContextLength: answerContext.length,
               answeredLength: answered.finalAnswer.length,
               recalledText,
+              answerContext,
               answeredText: answered.finalAnswer,
               responderModel: answered.model,
               judgeModel: judgeResult.model,
@@ -652,6 +658,23 @@ function formatMemoryArenaQuestion(
     "Current traveler request:",
     question,
   ].join("\n");
+}
+
+function buildMemoryArenaAnswerContext(
+  recalledText: string,
+  currentQuestion: string,
+): string {
+  const trimmedQuestion = currentQuestion.trim();
+  const trimmedRecall = recalledText.trim();
+  if (trimmedQuestion.length === 0) {
+    return trimmedRecall;
+  }
+  return [
+    "## Current MemoryArena task prompt",
+    trimmedQuestion,
+    trimmedRecall.length > 0 ? "## Remnic memory context" : "",
+    trimmedRecall,
+  ].filter((part) => part.length > 0).join("\n\n");
 }
 
 function scoreMemoryArenaDomainAnswer(

--- a/packages/bench/src/index.ts
+++ b/packages/bench/src/index.ts
@@ -151,6 +151,14 @@ export {
   answerBenchmarkQuestion,
 } from "./answering.js";
 export {
+  buildAmaBenchLeaderboardRows,
+  serializeJsonl,
+  writeLeaderboardArtifactsForResult,
+} from "./leaderboard-export.js";
+export type {
+  LeaderboardArtifactWrite,
+} from "./leaderboard-export.js";
+export {
   createGatewayResponder,
   createProviderBackedAmaBenchRecommendedJudge,
   createProviderBackedJudge,

--- a/packages/bench/src/leaderboard-export.test.ts
+++ b/packages/bench/src/leaderboard-export.test.ts
@@ -65,7 +65,7 @@ function amaResult(): BenchmarkResult {
           taskId: "q3",
           question: "What happened?",
           expected: "unknown",
-          actual: "",
+          actual: "(error: recall failed)",
           scores: { llm_judge: 0 },
           latencyMs: 1,
           tokens: { input: 0, output: 0 },
@@ -89,6 +89,16 @@ test("buildAmaBenchLeaderboardRows groups answers by episode in task order", () 
       answer_list: ["unknown"],
     },
   ]);
+});
+
+test("buildAmaBenchLeaderboardRows rejects missing episode ids instead of undercounting", () => {
+  const result = amaResult();
+  delete result.results.tasks[0]!.details;
+
+  assert.throws(
+    () => buildAmaBenchLeaderboardRows(result),
+    /requires details\.episodeId/,
+  );
 });
 
 test("serializeJsonl emits one valid JSON object per line", () => {

--- a/packages/bench/src/leaderboard-export.test.ts
+++ b/packages/bench/src/leaderboard-export.test.ts
@@ -1,0 +1,132 @@
+import assert from "node:assert/strict";
+import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import type { BenchmarkResult } from "./types.ts";
+import {
+  buildAmaBenchLeaderboardRows,
+  serializeJsonl,
+  writeLeaderboardArtifactsForResult,
+} from "./leaderboard-export.ts";
+
+function amaResult(): BenchmarkResult {
+  return {
+    meta: {
+      id: "run-1",
+      benchmark: "ama-bench",
+      benchmarkTier: "published",
+      version: "2.0.0",
+      remnicVersion: "9.3.231",
+      gitSha: "abc1234",
+      timestamp: "2026-04-28T01:22:39.635Z",
+      mode: "full",
+      runCount: 1,
+      seeds: [20260427],
+    },
+    config: {
+      systemProvider: null,
+      judgeProvider: null,
+      adapterMode: "direct",
+      remnicConfig: {},
+    },
+    cost: {
+      totalTokens: 0,
+      inputTokens: 0,
+      outputTokens: 0,
+      estimatedCostUsd: 0,
+      totalLatencyMs: 0,
+      meanQueryLatencyMs: 0,
+    },
+    results: {
+      tasks: [
+        {
+          taskId: "q1",
+          question: "What happened first?",
+          expected: "opened the app",
+          actual: "opened the app",
+          scores: { llm_judge: 1 },
+          latencyMs: 1,
+          tokens: { input: 0, output: 0 },
+          details: { episodeId: 101 },
+        },
+        {
+          taskId: "q2",
+          question: "What happened second?",
+          expected: "changed settings",
+          actual: " changed settings ",
+          scores: { llm_judge: 1 },
+          latencyMs: 1,
+          tokens: { input: 0, output: 0 },
+          details: { episode_id: 101 },
+        },
+        {
+          taskId: "q3",
+          question: "What happened?",
+          expected: "unknown",
+          actual: "",
+          scores: { llm_judge: 0 },
+          latencyMs: 1,
+          tokens: { input: 0, output: 0 },
+          details: { episodeId: 102 },
+        },
+      ],
+      aggregates: {},
+    },
+    environment: { os: "darwin", nodeVersion: "v25.9.0", hardware: "arm64" },
+  };
+}
+
+test("buildAmaBenchLeaderboardRows groups answers by episode in task order", () => {
+  assert.deepEqual(buildAmaBenchLeaderboardRows(amaResult()), [
+    {
+      episode_id: 101,
+      answer_list: ["opened the app", "changed settings"],
+    },
+    {
+      episode_id: 102,
+      answer_list: ["unknown"],
+    },
+  ]);
+});
+
+test("serializeJsonl emits one valid JSON object per line", () => {
+  const serialized = serializeJsonl(buildAmaBenchLeaderboardRows(amaResult()));
+  const lines = serialized.trimEnd().split("\n");
+
+  assert.equal(lines.length, 2);
+  assert.deepEqual(JSON.parse(lines[0]!), {
+    episode_id: 101,
+    answer_list: ["opened the app", "changed settings"],
+  });
+});
+
+test("writeLeaderboardArtifactsForResult writes AMA-Bench answer-list JSONL", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-leaderboard-"));
+  try {
+    const writes = await writeLeaderboardArtifactsForResult(amaResult(), tempDir);
+
+    assert.equal(writes.length, 1);
+    assert.equal(writes[0]?.benchmark, "ama-bench");
+    assert.equal(writes[0]?.format, "ama-bench-answer-list-jsonl");
+    assert.equal(writes[0]?.records, 2);
+
+    const raw = await readFile(writes[0]!.path, "utf8");
+    assert.match(raw, /"episode_id":101/);
+    assert.match(raw, /"answer_list":\["opened the app","changed settings"\]/);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});
+
+test("writeLeaderboardArtifactsForResult skips unsupported benchmark results", async () => {
+  const tempDir = await mkdtemp(path.join(tmpdir(), "remnic-leaderboard-"));
+  try {
+    const result = amaResult();
+    result.meta.benchmark = "locomo";
+    assert.deepEqual(await writeLeaderboardArtifactsForResult(result, tempDir), []);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+});

--- a/packages/bench/src/leaderboard-export.ts
+++ b/packages/bench/src/leaderboard-export.ts
@@ -1,0 +1,101 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+
+import type { BenchmarkResult, TaskResult } from "./types.js";
+
+export interface LeaderboardArtifactWrite {
+  benchmark: string;
+  path: string;
+  format: string;
+  records: number;
+}
+
+interface AmaBenchLeaderboardRow {
+  episode_id: number | string;
+  answer_list: string[];
+}
+
+export async function writeLeaderboardArtifactsForResult(
+  result: BenchmarkResult,
+  outputDir: string,
+): Promise<LeaderboardArtifactWrite[]> {
+  if (result.meta.benchmark !== "ama-bench") {
+    return [];
+  }
+
+  const rows = buildAmaBenchLeaderboardRows(result);
+  if (rows.length === 0) {
+    return [];
+  }
+
+  const leaderboardDir = path.join(outputDir, "leaderboard");
+  await mkdir(leaderboardDir, { recursive: true });
+  const timestamp = result.meta.timestamp.replace(/[:.]/g, "-");
+  const filePath = path.join(
+    leaderboardDir,
+    `ama-bench-${timestamp}-answers.jsonl`,
+  );
+  await writeFile(filePath, serializeJsonl(rows), "utf8");
+  return [
+    {
+      benchmark: "ama-bench",
+      path: filePath,
+      format: "ama-bench-answer-list-jsonl",
+      records: rows.length,
+    },
+  ];
+}
+
+export function buildAmaBenchLeaderboardRows(
+  result: BenchmarkResult,
+): AmaBenchLeaderboardRow[] {
+  const rowsByEpisode = new Map<
+    number | string,
+    { firstTaskIndex: number; answers: string[] }
+  >();
+
+  result.results.tasks.forEach((task, taskIndex) => {
+    const episodeId = amaBenchEpisodeIdForTask(task);
+    if (episodeId === undefined) {
+      return;
+    }
+
+    const existing = rowsByEpisode.get(episodeId);
+    const answer = normalizeAmaBenchAnswer(task.actual);
+    if (existing) {
+      existing.answers.push(answer);
+      return;
+    }
+    rowsByEpisode.set(episodeId, {
+      firstTaskIndex: taskIndex,
+      answers: [answer],
+    });
+  });
+
+  return [...rowsByEpisode.entries()]
+    .sort((left, right) => left[1].firstTaskIndex - right[1].firstTaskIndex)
+    .map(([episodeId, row]) => ({
+      episode_id: episodeId,
+      answer_list: row.answers,
+    }));
+}
+
+export function serializeJsonl(rows: readonly AmaBenchLeaderboardRow[]): string {
+  return rows.map((row) => JSON.stringify(row)).join("\n") + "\n";
+}
+
+function amaBenchEpisodeIdForTask(task: TaskResult): number | string | undefined {
+  const raw = task.details?.episodeId ?? task.details?.episode_id;
+  if (typeof raw === "number" && Number.isInteger(raw)) {
+    return raw;
+  }
+  if (typeof raw === "string" && raw.trim().length > 0) {
+    return raw;
+  }
+  return undefined;
+}
+
+function normalizeAmaBenchAnswer(answer: string): string {
+  const trimmed = answer.trim();
+  return trimmed.length > 0 ? trimmed : "unknown";
+}

--- a/packages/bench/src/leaderboard-export.ts
+++ b/packages/bench/src/leaderboard-export.ts
@@ -57,7 +57,9 @@ export function buildAmaBenchLeaderboardRows(
   result.results.tasks.forEach((task, taskIndex) => {
     const episodeId = amaBenchEpisodeIdForTask(task);
     if (episodeId === undefined) {
-      return;
+      throw new Error(
+        `AMA-Bench leaderboard export requires details.episodeId for every task; missing on ${task.taskId}.`,
+      );
     }
 
     const existing = rowsByEpisode.get(episodeId);
@@ -97,5 +99,8 @@ function amaBenchEpisodeIdForTask(task: TaskResult): number | string | undefined
 
 function normalizeAmaBenchAnswer(answer: string): string {
   const trimmed = answer.trim();
+  if (/^\(error:/i.test(trimmed)) {
+    return "unknown";
+  }
   return trimmed.length > 0 ? trimmed : "unknown";
 }

--- a/packages/bench/src/reporter.test.ts
+++ b/packages/bench/src/reporter.test.ts
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtemp, readFile, rm } from "node:fs/promises";
+import { mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import test from "node:test";
@@ -129,6 +129,35 @@ test("writeBenchmarkResult does not persist secret values", async () => {
     assert.match(raw, /"provider": "ollama"/);
     assert.match(raw, /"secretary": "office-role"/);
     assert.match(raw, /"credentialingOrg": "board"/);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("writeBenchmarkResult preserves main result when leaderboard sidecar write fails", async () => {
+  const dir = await mkdtemp(path.join(os.tmpdir(), "remnic-bench-reporter-"));
+  try {
+    await writeFile(path.join(dir, "leaderboard"), "not a directory", "utf8");
+    const result = buildResult();
+    result.results.tasks = [
+      {
+        taskId: "ama-q1",
+        question: "What happened?",
+        expected: "opened the app",
+        actual: "opened the app",
+        scores: { llm_judge: 1 },
+        latencyMs: 1,
+        tokens: { input: 0, output: 0 },
+        details: { episodeId: 1 },
+      },
+    ];
+
+    const filePath = await writeBenchmarkResult(result, dir);
+    const raw = await readFile(filePath, "utf8");
+
+    assert.match(raw, /"benchmark": "ama-bench"/);
+    assert.match(raw, /"format": "leaderboard-artifact-error"/);
+    assert.match(raw, /"records": 0/);
   } finally {
     await rm(dir, { recursive: true, force: true });
   }

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -11,6 +11,7 @@ import { isSecretKey } from "./security/secret-keys.js";
 import type { BenchmarkResult } from "./types.js";
 
 const REDACTED_SECRET = "[REDACTED]";
+const PROCESS_GIT_SHA = readGitSha();
 
 function sanitizeFilenameSegment(value: string): string {
   const sanitized = value.trim().replace(/[^a-zA-Z0-9._-]/g, "_");
@@ -88,6 +89,18 @@ export async function getRemnicVersion(): Promise<string> {
 }
 
 export function getGitSha(): string {
+  return PROCESS_GIT_SHA;
+}
+
+function readGitSha(): string {
+  const explicitSha =
+    process.env.REMNIC_BENCH_GIT_SHA ??
+    process.env.GITHUB_SHA ??
+    process.env.CI_COMMIT_SHA;
+  if (typeof explicitSha === "string" && explicitSha.trim().length > 0) {
+    return explicitSha.trim().slice(0, 40);
+  }
+
   try {
     return execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim();
   } catch {

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -52,6 +52,18 @@ export async function writeBenchmarkResult(
     outputDir,
     `${result.meta.benchmark}-v${safeRemnicVersion}-${timestamp}.json`,
   );
+  const leaderboardArtifacts = await writeLeaderboardArtifactsForResult(
+    result,
+    outputDir,
+  ).catch((error: unknown) => [
+    {
+      benchmark: result.meta.benchmark,
+      path: "",
+      format: "leaderboard-artifact-error",
+      records: 0,
+      error: error instanceof Error ? error.message : String(error),
+    },
+  ]);
 
   const resultWithArtifacts = {
     ...result,
@@ -59,10 +71,7 @@ export async function writeBenchmarkResult(
       ...result.config,
       benchmarkOptions: {
         ...(result.config.benchmarkOptions ?? {}),
-        leaderboardArtifacts: await writeLeaderboardArtifactsForResult(
-          result,
-          outputDir,
-        ),
+        leaderboardArtifacts,
       },
     },
   };

--- a/packages/bench/src/reporter.ts
+++ b/packages/bench/src/reporter.ts
@@ -6,6 +6,7 @@ import { execSync } from "node:child_process";
 import { mkdir, readFile, writeFile } from "node:fs/promises";
 import path from "node:path";
 import type { LegacyBenchmarkResult } from "./adapters/types.js";
+import { writeLeaderboardArtifactsForResult } from "./leaderboard-export.js";
 import { isSecretKey } from "./security/secret-keys.js";
 import type { BenchmarkResult } from "./types.js";
 
@@ -51,7 +52,21 @@ export async function writeBenchmarkResult(
     `${result.meta.benchmark}-v${safeRemnicVersion}-${timestamp}.json`,
   );
 
-  await writeFile(filePath, JSON.stringify(redactBenchmarkResultSecrets(result), null, 2) + "\n");
+  const resultWithArtifacts = {
+    ...result,
+    config: {
+      ...result.config,
+      benchmarkOptions: {
+        ...(result.config.benchmarkOptions ?? {}),
+        leaderboardArtifacts: await writeLeaderboardArtifactsForResult(
+          result,
+          outputDir,
+        ),
+      },
+    },
+  };
+
+  await writeFile(filePath, JSON.stringify(redactBenchmarkResultSecrets(resultWithArtifacts), null, 2) + "\n");
   return filePath;
 }
 


### PR DESCRIPTION
## Summary
- Route real/SOTA benchmark adapter stores through Remnic transcript and replay ingestion so extraction, QMD/indexing, entity/knowledge features, and full orchestrator recall are actually exercised.
- Keep LCM raw evidence as an additional fallback with wider context windows for benchmark questions.
- Make strict benchmark answering less over-conservative by reserving unknown for genuinely missing or conflicting evidence.
- Include the live MemoryArena task prompt in answer context so domains like bundled_shopping can reason over current product/options input plus Remnic memory.
- Write AMA-Bench answer-list JSONL sidecars automatically so full runs produce a leaderboard-ready submission artifact in addition to the internal result JSON.
- Pin the benchmark process git SHA so long runs remain reproducible even if the checkout changes while a suite is running.

## Verification
- pnpm --filter @remnic/bench exec tsc --noEmit
- pnpm exec tsx --test packages/bench/src/benchmarks/published/memory-arena/runner.test.ts packages/bench/src/reporter.test.ts packages/bench/src/leaderboard-export.test.ts packages/bench/src/adapters/remnic-adapter.test.ts packages/bench/src/answering.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches benchmark memory ingestion/recall composition and result serialization, which can change measured outputs and artifact formats; logic is localized to the bench package and covered by new tests.
> 
> **Overview**
> Benchmark `createRemnicAdapter` now optionally routes `store()` calls through Remnic transcript + `ingestReplayBatch()` (with stable per-session `turnId`s) and prepends an orchestrator `recall()` section, while keeping LCM search evidence as a fallback (tuned budgets, wider context windows); `drain()` also waits for extraction/consolidation idleness. `lightweight` mode explicitly suppresses the core pipeline even if feature overrides are set.
> 
> Strict answering prompts were updated to be less conservative about returning `"unknown"`. MemoryArena now includes the *live task prompt* alongside recalled memory when calling a responder (and records `answerContext` metadata). AMA-Bench failures now retain episode metadata so leaderboard export can still group answers.
> 
> Adds `leaderboard-export.ts` to generate AMA-Bench answer-list JSONL artifacts and wires it into `writeBenchmarkResult` (with error-tolerant sidecar writing), exports these APIs from `index.ts`, and pins `getGitSha()` to a process-level value (env override or `git rev-parse`) for long-run reproducibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4752a35a28a09fcfbb8e289dff40264b6ab60d3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->