### PR TITLE
feat(secure-store): implement Argon2id KDF

### DIFF
--- a/docs/capsules.md
+++ b/docs/capsules.md
@@ -238,7 +238,9 @@ Encrypted capsule and backup files use a simple binary format:
 
 ```
 [MAGIC: 11 bytes]  "REMNIC-ENC\x00" — ASCII magic + NUL sentinel
-[VERSION: 1 byte]  Format version (currently 1)
+[VERSION: 1 byte]  Format version (currently 2)
+[KDF_LEN: 2 bytes] Little-endian byte length of the KDF JSON section
+[KDF_JSON]         Compact JSON: { algorithm, params, salt }
 [ENVELOPE: rest]   AES-256-GCM sealed envelope (cipher.ts format):
                      [VERSION:1][SALT:16][IV:12][AUTHTAG:16][CIPHERTEXT:...]
                    The ciphertext is the original .gz payload.
@@ -250,7 +252,7 @@ The REMNIC-ENC magic is:
 - Obviously non-JSON — will not parse as `{...}`.
 - Obviously non-gzip — gzip magic is `0x1f 0x8b`; `R` is `0x52`.
 
-The KDF salt (16 bytes, scrypt) is embedded inside the AES-GCM envelope, so
+The KDF algorithm, parameters, and salt are embedded in the archive header, so
 the file is self-contained: any machine that knows the original passphrase can
 re-derive the same key and decrypt without any external metadata.
 
@@ -270,9 +272,9 @@ To restore an encrypted capsule on a different machine:
    ```bash
    remnic secure-store init
    ```
-   Scrypt is deterministic: the same passphrase + the salt embedded in the
-   envelope produces the same key, so you do not need to transfer any key
-   material out-of-band.
+   The recorded KDF is deterministic: the same passphrase plus the embedded
+   KDF parameters and salt produces the same key, so you do not need to
+   transfer any key material out-of-band.
 3. Unlock the store:
    ```bash
    remnic secure-store unlock
@@ -283,8 +285,8 @@ To restore an encrypted capsule on a different machine:
    ```
 
 > **Important:** The passphrase must match. The key is derived from the
-> passphrase using scrypt with the parameters and salt stored inside the
-> encrypted envelope. A different passphrase produces a different key and
+> passphrase using the algorithm, parameters, and salt stored inside the
+> encrypted archive. A different passphrase produces a different key and
 > decryption fails with an authentication error.
 
 ---

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -66,7 +66,14 @@ remnic secure-store init
 
 Creates a `.secure-store/header.json` metadata file in your memory directory. You will be prompted for a passphrase (twice for confirmation).
 
-**Minimum passphrase length:** 12 characters.
+New stores use Argon2id by default. Use `--kdf scrypt` only when you need to
+create a compatibility store that avoids the native Argon2id dependency:
+
+```bash
+remnic secure-store init --kdf scrypt
+```
+
+**Minimum passphrase length:** 8 characters.
 
 This command does NOT encrypt existing memory files. Run `remnic secure-store migrate` after init to encrypt existing files.
 
@@ -127,7 +134,19 @@ Run `remnic secure-store unlock` then restart the daemon to decrypt.
 
 **Algorithm:** AES-256-GCM (NIST SP 800-38D).
 
-**KDF:** scrypt with strong parameters:
+**KDF:** Argon2id by default, with scrypt retained for legacy/compatibility
+stores.
+
+Argon2id defaults:
+
+| Parameter | Value | Notes |
+|-----------|-------|-------|
+| memoryKiB | 65536 | 64 MiB memory cost |
+| iterations | 3 | Time cost |
+| parallelism | 4 | Parallel lanes |
+| Output | 32 bytes | AES-256 key |
+
+Legacy scrypt params:
 
 | Parameter | Value | Notes |
 |-----------|-------|-------|
@@ -158,7 +177,8 @@ Run `remnic secure-store unlock` then restart the daemon to decrypt.
 
 ## Performance
 
-Key derivation (scrypt N=2^17) takes approximately 100–300 ms on modern laptop hardware. This cost is paid once per `unlock` call, not per file read.
+Key derivation is paid once per `unlock` call, not per file read. Argon2id uses
+64 MiB, 3 iterations, and 4 lanes by default; legacy scrypt stores use N=2^17.
 
 Per-file encrypt/decrypt overhead is negligible (~microseconds) compared to disk I/O.
 

--- a/packages/plugin-openclaw/tsup.config.ts
+++ b/packages/plugin-openclaw/tsup.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "openclaw",
     "openai",
     "@remnic/core",
+    "@node-rs/argon2",
     "@lancedb/lancedb",
     "meilisearch",
     "@orama/orama",

--- a/packages/remnic-core/package.json
+++ b/packages/remnic-core/package.json
@@ -31,6 +31,7 @@
   "dependencies": {
     "@honcho-ai/sdk": "^2.0.0",
     "@lancedb/lancedb": "^0.26.2",
+    "@node-rs/argon2": "^2.0.2",
     "@orama/orama": "^3.0.0",
     "@orama/plugin-data-persistence": "^3.0.0",
     "@sinclair/typebox": "^0.34.0",

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8689,8 +8689,9 @@ export function registerCli(
       secureStoreCmd
         .command("init")
         .description(
-          "Initialize a new secure-store header. Prompts for a passphrase, derives a master key via scrypt, and writes the verifier to <memoryDir>/.secure-store/header.json. Refuses to overwrite an existing header.",
+          "Initialize a new secure-store header. Prompts for a passphrase, derives a master key via Argon2id by default, and writes the verifier to <memoryDir>/.secure-store/header.json. Refuses to overwrite an existing header.",
         )
+        .option("--kdf <algorithm>", "KDF algorithm: argon2id (default) or scrypt", "argon2id")
         .option("--note <text>", "Optional human-readable note recorded in metadata. Never include secrets.")
         .option("--json", "Emit machine-readable JSON only")
         .action(async (...args: unknown[]) => {
@@ -8701,9 +8702,15 @@ export function registerCli(
             renderInitReport,
           } = await import("./secure-store/index.js");
           const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const kdf = typeof options.kdf === "string" ? options.kdf.trim() : "argon2id";
+          if (kdf !== "argon2id" && kdf !== "scrypt") {
+            console.error(`Invalid --kdf '${String(options.kdf)}'. Must be one of: argon2id, scrypt`);
+            process.exit(1);
+          }
           const initOpts: Parameters<typeof runSecureStoreInit>[0] = {
             memoryDir,
             readPassphrase: createPassphraseReader(),
+            algorithm: kdf,
           };
           if (typeof options.note === "string") initOpts.note = options.note;
           const report = await runSecureStoreInit(initOpts);

--- a/packages/remnic-core/src/secure-store/cli-handlers.ts
+++ b/packages/remnic-core/src/secure-store/cli-handlers.ts
@@ -59,11 +59,11 @@ export interface SecureStoreInitOptions extends SecureStoreHandlerCommon {
   /** Passphrase reader — called twice (entry + confirmation). */
   readPassphrase: PassphraseReader;
   /**
-   * KDF algorithm. Defaults to `"scrypt"`. `"argon2id"` is reserved
-   * but not implemented in this build (PR 1/4 throws on use).
+   * KDF algorithm. Defaults to `"argon2id"` for new stores.
+   * `"scrypt"` remains supported for explicit compatibility cases.
    */
   algorithm?: KdfAlgorithm;
-  /** KDF parameter override; defaults to OWASP-acceptable scrypt params. */
+  /** KDF parameter override; defaults to OWASP-acceptable params for the selected KDF. */
   params?: ScryptParams | Argon2idParams;
   /** Pre-generated salt for tests; production callers should omit. */
   salt?: Buffer;
@@ -103,7 +103,7 @@ export async function runSecureStoreInit(
   const passphrase = await readPassphrase("Enter new passphrase: ", { confirm: true });
   validatePassphrase(passphrase);
 
-  const algorithm: KdfAlgorithm = options.algorithm ?? "scrypt";
+  const algorithm: KdfAlgorithm = options.algorithm ?? "argon2id";
   const params = resolveParams(algorithm, options.params);
   const salt = options.salt ?? generateEnvelopeSalt();
   if (salt.length !== KDF_SALT_LENGTH) {

--- a/packages/remnic-core/src/secure-store/header.ts
+++ b/packages/remnic-core/src/secure-store/header.ts
@@ -339,14 +339,14 @@ export async function writeHeader(memoryDir: string, header: SecureStoreHeader):
 export function buildHeaderFromPassphrase(options: {
   passphrase: string;
   salt: Buffer;
-  /** Optional override; defaults to scrypt with `DEFAULT_SCRYPT_PARAMS`. */
+  /** Optional override; defaults to Argon2id with `DEFAULT_ARGON2ID_PARAMS`. */
   algorithm?: "scrypt" | "argon2id";
   params?: ScryptParams | Argon2idParams;
   createdAt?: string;
   note?: string;
 }): { header: SecureStoreHeader; derivedKey: Buffer } {
   const { passphrase, salt } = options;
-  const algorithm = options.algorithm ?? "scrypt";
+  const algorithm = options.algorithm ?? "argon2id";
   const metadataOpts: {
     algorithm: "scrypt" | "argon2id";
     salt: Buffer;

--- a/packages/remnic-core/src/secure-store/kdf.ts
+++ b/packages/remnic-core/src/secure-store/kdf.ts
@@ -11,22 +11,15 @@
  * config, etc.). Reusing the `vault` namespace for at-rest encryption
  * would cause symbol collisions and reader confusion.
  *
- * KDF choice — scrypt today, Argon2id tomorrow
- * ---------------------------------------------
+ * KDF choice — Argon2id primary, scrypt compatibility
+ * ---------------------------------------------------
  * Issue #690 specifies Argon2id (OWASP m=64 MiB, t=3, p=4) as the
- * preferred KDF. Argon2id is not available via Node's built-in
- * `node:crypto`; it requires a third-party native module (`argon2` or
- * `@node-rs/argon2`) that has historically broken cross-platform
- * builds in this monorepo's CI matrix.
+ * preferred KDF. We use `@node-rs/argon2` for the Argon2id runtime
+ * and keep scrypt as the compatibility path for stores initialized
+ * before Argon2id support landed.
  *
- * Per the issue's "prefer scrypt with strong params over a broken
- * Argon2id" guidance, this PR ships **scrypt** (Node built-in) with
- * strong parameters (N = 2^17, r = 8, p = 1 — RFC 7914 / OWASP
- * acceptable for 2024+). The `KdfAlgorithm` enum and metadata format
- * are designed so a future PR can add `"argon2id"` without breaking
- * existing stores: the algorithm name + params are persisted in the
- * metadata file, so old stores keep deriving with scrypt while new
- * ones can opt into Argon2id.
+ * The algorithm name + params are persisted in the metadata file, so
+ * stores keep deriving with the same KDF they were initialized with.
  *
  * Trade-off summary:
  *   - scrypt N=2^17, r=8, p=1 → ~128 MiB memory, ~150 ms on a modern
@@ -39,6 +32,25 @@
  */
 
 import { scryptSync, timingSafeEqual } from "node:crypto";
+import { createRequire } from "node:module";
+
+type Argon2Runtime = typeof import("@node-rs/argon2");
+
+const requireArgon2 = createRequire(import.meta.url);
+let argon2Runtime: Argon2Runtime | undefined;
+
+function loadArgon2Runtime(): Argon2Runtime {
+  try {
+    argon2Runtime ??= requireArgon2("@node-rs/argon2") as Argon2Runtime;
+    return argon2Runtime;
+  } catch (cause) {
+    throw new Error(
+      "Argon2id KDF requires @node-rs/argon2 to be installed and loadable on this platform. " +
+        "Use scrypt compatibility mode for stores that must run without the Argon2 native binding.",
+      { cause },
+    );
+  }
+}
 
 /** KDF algorithms supported by the secure-store metadata format. */
 export type KdfAlgorithm = "scrypt" | "argon2id";
@@ -57,7 +69,7 @@ export interface ScryptParams {
   maxmem: number;
 }
 
-/** Parameters for the Argon2id KDF (reserved for future PR). */
+/** Parameters for the Argon2id KDF. */
 export interface Argon2idParams {
   /** Memory cost in KiB. OWASP default 65536 (64 MiB). */
   memoryKiB: number;
@@ -80,7 +92,7 @@ export const DEFAULT_SCRYPT_PARAMS: Readonly<ScryptParams> = Object.freeze({
   maxmem: 256 * 1024 * 1024,
 });
 
-/** OWASP Argon2id defaults — used when/if Argon2id support lands. */
+/** OWASP Argon2id defaults. */
 export const DEFAULT_ARGON2ID_PARAMS: Readonly<Argon2idParams> = Object.freeze({
   memoryKiB: 64 * 1024,
   iterations: 3,
@@ -132,6 +144,25 @@ export function validateScryptParams(params: ScryptParams): void {
   }
 }
 
+/** Validate Argon2id parameters before invoking the native KDF binding. */
+export function validateArgon2idParams(params: Argon2idParams): void {
+  const { memoryKiB, iterations, parallelism, keyLength } = params;
+  if (!Number.isInteger(memoryKiB) || memoryKiB < 8) {
+    throw new Error(`argon2id memoryKiB must be an integer ≥ 8, got ${memoryKiB}`);
+  }
+  if (!Number.isInteger(iterations) || iterations < 1) {
+    throw new Error(`argon2id iterations must be a positive integer, got ${iterations}`);
+  }
+  if (!Number.isInteger(parallelism) || parallelism < 1 || parallelism > 255) {
+    throw new Error(`argon2id parallelism must be an integer in [1, 255], got ${parallelism}`);
+  }
+  if (!Number.isInteger(keyLength) || keyLength !== KDF_KEY_LENGTH) {
+    throw new Error(
+      `argon2id keyLength must be ${KDF_KEY_LENGTH} (AES-256 requires a 32-byte key), got ${keyLength}`,
+    );
+  }
+}
+
 /**
  * Derive a key from a passphrase + salt using scrypt.
  *
@@ -166,9 +197,44 @@ export function deriveKeyScrypt(
 }
 
 /**
- * Algorithm-dispatching KDF. Today only `scrypt` is implemented; a
- * future PR can add `argon2id` here without breaking on-disk metadata
- * because the algorithm name is recorded in the metadata file.
+ * Derive a key from a passphrase + salt using Argon2id.
+ *
+ * The returned raw hash is used directly as the AES-256-GCM master key.
+ * The same public KDF params are persisted in secure-store metadata so
+ * unlock can reproduce the exact key later.
+ */
+export function deriveKeyArgon2id(
+  passphrase: string,
+  salt: Uint8Array,
+  params: Argon2idParams = DEFAULT_ARGON2ID_PARAMS,
+): Buffer {
+  if (typeof passphrase !== "string") {
+    throw new Error("passphrase must be a string");
+  }
+  if (passphrase.length === 0) {
+    throw new Error("passphrase must not be empty");
+  }
+  if (!(salt instanceof Uint8Array) || salt.length < 8) {
+    throw new Error(
+      `salt must be a Uint8Array of at least 8 bytes, got ${salt?.length ?? "non-buffer"}`,
+    );
+  }
+  validateArgon2idParams(params);
+  const { Algorithm, Version, hashRawSync } = loadArgon2Runtime();
+  return hashRawSync(passphrase, {
+    algorithm: Algorithm.Argon2id,
+    version: Version.V0x13,
+    memoryCost: params.memoryKiB,
+    timeCost: params.iterations,
+    parallelism: params.parallelism,
+    outputLen: params.keyLength,
+    salt,
+  });
+}
+
+/**
+ * Algorithm-dispatching KDF. The algorithm name is recorded in the
+ * metadata file so existing stores continue using their original KDF.
  */
 export function deriveKey(
   algorithm: KdfAlgorithm,
@@ -180,10 +246,7 @@ export function deriveKey(
     return deriveKeyScrypt(passphrase, salt, params as ScryptParams);
   }
   if (algorithm === "argon2id") {
-    throw new Error(
-      "argon2id KDF is reserved in the metadata format but not yet wired " +
-        "in this build. Use 'scrypt' until Argon2id native support lands.",
-    );
+    return deriveKeyArgon2id(passphrase, salt, params as Argon2idParams);
   }
   throw new Error(`unknown KDF algorithm: ${algorithm as string}`);
 }

--- a/packages/remnic-core/src/secure-store/metadata.ts
+++ b/packages/remnic-core/src/secure-store/metadata.ts
@@ -31,8 +31,8 @@
  *     "format": "remnic.secure-store.metadata",
  *     "formatVersion": 1,
  *     "kdf": {
- *       "algorithm": "scrypt",
- *       "params": { "N": 131072, "r": 8, "p": 1, "keyLength": 32, "maxmem": 268435456 },
+ *       "algorithm": "argon2id",
+ *       "params": { "memoryKiB": 65536, "iterations": 3, "parallelism": 4, "keyLength": 32 },
  *       "salt": "<32-hex-chars-for-16-bytes>"
  *     },
  *     "createdAt": "<ISO-8601 timestamp>",
@@ -371,8 +371,8 @@ export function validateMetadata(meta: SecureStoreMetadata): void {
     if (!Number.isInteger(iterations) || iterations < 1) {
       throw new Error("metadata.kdf.params.iterations must be a positive integer");
     }
-    if (!Number.isInteger(parallelism) || parallelism < 1) {
-      throw new Error("metadata.kdf.params.parallelism must be a positive integer");
+    if (!Number.isInteger(parallelism) || parallelism < 1 || parallelism > 255) {
+      throw new Error("metadata.kdf.params.parallelism must be an integer in [1, 255]");
     }
     // Codex P2: cipher.ts hard-requires a 32-byte AES-256 key
     // (`assertAesKey`). Accepting `keyLength: 16` here would parse

--- a/packages/remnic-core/src/secure-store/secure-store.test.ts
+++ b/packages/remnic-core/src/secure-store/secure-store.test.ts
@@ -43,8 +43,11 @@ import {
   KDF_SALT_LENGTH,
   constantTimeEqual,
   deriveKey,
+  deriveKeyArgon2id,
   deriveKeyScrypt,
+  validateArgon2idParams,
   validateScryptParams,
+  type Argon2idParams,
   type ScryptParams,
 } from "./kdf.js";
 import {
@@ -65,6 +68,13 @@ const FAST_SCRYPT: ScryptParams = {
   p: 1,
   keyLength: 32,
   maxmem: 64 * 1024 * 1024,
+};
+
+const FAST_ARGON2ID: Argon2idParams = {
+  memoryKiB: 8,
+  iterations: 1,
+  parallelism: 1,
+  keyLength: 32,
 };
 
 // ─── kdf.ts ─────────────────────────────────────────────────────────────
@@ -121,14 +131,48 @@ test("deriveKey('scrypt') dispatches to scryptSync", () => {
   assert.ok(viaWrapper.equals(direct));
 });
 
-test("deriveKey('argon2id') is reserved but not implemented in this PR", () => {
-  // Argon2id is recorded in the metadata enum so future PRs can opt
-  // in without breaking on-disk format. This PR's runtime refuses to
-  // use it — and the error message must say so clearly.
-  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0);
+test("deriveKeyArgon2id is deterministic for the same passphrase + salt + params", () => {
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x24);
+  const k1 = deriveKeyArgon2id("correct horse battery staple", salt, FAST_ARGON2ID);
+  const k2 = deriveKeyArgon2id("correct horse battery staple", salt, FAST_ARGON2ID);
+  assert.equal(k1.length, KDF_KEY_LENGTH);
+  assert.equal(k2.length, KDF_KEY_LENGTH);
+  assert.ok(k1.equals(k2), "same inputs must yield same key");
+});
+
+test("deriveKeyArgon2id produces different keys for different passphrases", () => {
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x24);
+  const k1 = deriveKeyArgon2id("passphrase-a", salt, FAST_ARGON2ID);
+  const k2 = deriveKeyArgon2id("passphrase-b", salt, FAST_ARGON2ID);
+  assert.equal(k1.equals(k2), false);
+});
+
+test("deriveKey('argon2id') dispatches to Argon2id", () => {
+  const salt = Buffer.alloc(KDF_SALT_LENGTH, 0x24);
+  const viaWrapper = deriveKey("argon2id", "pw", salt, FAST_ARGON2ID);
+  const direct = deriveKeyArgon2id("pw", salt, FAST_ARGON2ID);
+  assert.ok(viaWrapper.equals(direct));
+  assert.equal(DEFAULT_ARGON2ID_PARAMS.memoryKiB, 64 * 1024);
+  assert.equal(DEFAULT_ARGON2ID_PARAMS.iterations, 3);
+  assert.equal(DEFAULT_ARGON2ID_PARAMS.parallelism, 4);
+});
+
+test("validateArgon2idParams rejects invalid values", () => {
   assert.throws(
-    () => deriveKey("argon2id", "pw", salt, DEFAULT_ARGON2ID_PARAMS),
-    /argon2id/i,
+    () => validateArgon2idParams({ ...FAST_ARGON2ID, memoryKiB: 0 }),
+    /memoryKiB/,
+  );
+  assert.throws(
+    () => validateArgon2idParams({ ...FAST_ARGON2ID, iterations: 0 }),
+    /iterations/,
+  );
+  assert.throws(
+    () => validateArgon2idParams({ ...FAST_ARGON2ID, parallelism: 0 }),
+    /parallelism/,
+  );
+  assert.throws(
+    () => validateArgon2idParams({ ...FAST_ARGON2ID, keyLength: 16 }),
+    /keyLength/,
   );
 });
 
@@ -347,9 +391,7 @@ test("buildMetadata + serialize + parse round-trip (scrypt)", () => {
   assert.ok(decodeMetadataSalt(parsed).equals(salt));
 });
 
-test("buildMetadata + serialize + parse round-trip (argon2id placeholder)", () => {
-  // Argon2id is reserved in the metadata format even though the KDF
-  // dispatcher refuses to use it in this PR.
+test("buildMetadata + serialize + parse round-trip (argon2id)", () => {
   const salt = Buffer.alloc(KDF_SALT_LENGTH, 0xcd);
   const meta = buildMetadata({
     algorithm: "argon2id",

--- a/packages/remnic-core/src/transfer/capsule-crypto.ts
+++ b/packages/remnic-core/src/transfer/capsule-crypto.ts
@@ -46,7 +46,7 @@
  *
  * Cross-machine restore (Codex P1 / #690)
  * ----------------------------------------
- * Format v2 embeds the KDF params (algorithm + N/r/p/keyLength/maxmem + salt)
+ * Format v2 embeds the KDF params (algorithm + params + salt)
  * in the archive header as a compact JSON blob. Any machine that knows the
  * original passphrase can parse this blob and re-derive the exact same
  * 256-bit AES key using the documented algorithm + params + salt — no
@@ -402,11 +402,11 @@ async function loadKdfSection(memoryDir: string): Promise<KdfSection> {
   }
   const { generateSalt } = await import("../secure-store/cipher.js");
   const salt = generateSalt();
-  // Use default scrypt params from kdf.ts.
-  const { DEFAULT_SCRYPT_PARAMS } = await import("../secure-store/kdf.js");
+  // Use the current secure-store default when a header is unavailable.
+  const { DEFAULT_ARGON2ID_PARAMS } = await import("../secure-store/kdf.js");
   const json = JSON.stringify({
-    algorithm: "scrypt",
-    params: DEFAULT_SCRYPT_PARAMS,
+    algorithm: "argon2id",
+    params: DEFAULT_ARGON2ID_PARAMS,
     salt: salt.toString("hex"),
   });
   return { json, salt };

--- a/packages/remnic-core/src/transfer/capsule-encrypt.test.ts
+++ b/packages/remnic-core/src/transfer/capsule-encrypt.test.ts
@@ -15,8 +15,8 @@
  *  11. backupMemoryDir excludes .secure-store and .capsules dirs — Cursor
  *  12. exportCapsule with includeTranscripts=true includes transcripts+peers — Cursor
  *
- * KDF note: tests use a minimal scrypt param set (N=1024) to keep the suite
- * fast.  ONE integration test exercises the real unlock path so CLI
+ * KDF note: tests use a minimal scrypt param set (N=1024) for legacy-header
+ * fixtures so the suite stays fast. ONE integration test exercises the real unlock path so CLI
  * plumbing and keyring integration stay green.
  */
 
@@ -66,6 +66,7 @@ async function initAndUnlockStore(memoryDir: string): Promise<Buffer> {
   const { header, derivedKey } = buildHeaderFromPassphrase({
     passphrase: TEST_PASSPHRASE,
     salt,
+    algorithm: "scrypt",
     params: FAST_SCRYPT,
   });
   await writeHeader(memoryDir, header);
@@ -234,8 +235,8 @@ test("exportCapsule with encrypt=true + importCapsule roundtrip restores all fil
     // passphrase as the source. For this unit test, we simply pass srcDir as
     // the memoryDir for the import — the key was registered there and is still
     // in the keyring. In production, the operator runs `secure-store init` +
-    // `unlock` on the destination with the same passphrase; scrypt derives the
-    // same key because the salt is embedded in the sealed envelope.
+    // `unlock` on the destination with the same passphrase; the recorded KDF
+    // derives the same key because the salt is embedded in the sealed envelope.
     const importResult = await importCapsule({
       archivePath: exportResult.archivePath,
       root: dstDir,

--- a/packages/remnic-core/tsup.config.ts
+++ b/packages/remnic-core/tsup.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   dts: true,
   external: [
     "openclaw",
+    "@node-rs/argon2",
     "@lancedb/lancedb",
     "meilisearch",
     "@orama/orama",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -304,6 +304,9 @@ importers:
       '@lancedb/lancedb':
         specifier: ^0.26.2
         version: 0.26.2(apache-arrow@18.1.0)
+      '@node-rs/argon2':
+        specifier: ^2.0.2
+        version: 2.0.2
       '@orama/orama':
         specifier: ^3.0.0
         version: 3.1.18
@@ -462,6 +465,15 @@ packages:
   '@babel/types@7.29.0':
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
+
+  '@emnapi/core@1.10.0':
+    resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/wasi-threads@1.2.1':
+    resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -696,6 +708,100 @@ packages:
     resolution: {integrity: sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==}
     engines: {node: '>= 18'}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    resolution: {integrity: sha512-DV/H8p/jt40lrao5z5g6nM9dPNPGEHL+aK6Iy/og+dbL503Uj0AHLqj1Hk9aVUSCNnsDdUEKp4TVMi0YakDYKw==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [android]
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    resolution: {integrity: sha512-1LKwskau+8O1ktKx7TbK7jx1oMOMt4YEXZOdSNIar1TQKxm6isZ0cRXgHLibPHEcNHgYRsJWDE9zvDGBB17QDg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    resolution: {integrity: sha512-3TTNL/7wbcpNju5YcqUrCgXnXUSbD7ogeAKatzBVHsbpjZQbNb1NDxDjqqrWoTt6XL3z9mJUMGwbAk7zQltHtA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    resolution: {integrity: sha512-vNPfkLj5Ij5111UTiYuwgxMqE7DRbOS2y58O2DIySzSHbcnu+nipmRKg+P0doRq6eKIJStyBK8dQi5Ic8pFyDw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    resolution: {integrity: sha512-M8vQZk01qojQfCqQU0/O1j1a4zPPrz93zc9fSINY7Q/6RhQRBCYwDw7ltDCZXg5JRGlSaeS8cUXWyhPGar3cGg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    resolution: {integrity: sha512-7EmmEPHLzcu0G2GDh30L6G48CH38roFC2dqlQJmtRCxs6no3tTE/pvgBGatTp/o2n2oyOJcfmgndVFcUpwMnww==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    resolution: {integrity: sha512-6lsYh3Ftbk+HAIZ7wNuRF4SZDtxtFTfK+HYFAQQyW7Ig3LHqasqwfUKRXVSV5tJ+xTnxjqgKzvZSUJCAyIfHew==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    resolution: {integrity: sha512-p3YqVMNT/4DNR67tIHTYGbedYmXxW9QlFmF39SkXyEbGQwpgSf6pH457/fyXBIYznTU/smnG9EH+C1uzT5j4hA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    resolution: {integrity: sha512-ZM3jrHuJ0dKOhvA80gKJqBpBRmTJTFSo2+xVZR+phQcbAKRlDMSZMFDiKbSTnctkfwNFtjgDdh5g1vaEV04AvA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    resolution: {integrity: sha512-of5uPqk7oCRF/44a89YlWTEfjsftPywyTULwuFDKyD8QtVZoonrJR6ZWvfFE/6jBT68S0okAkAzzMEdBVWdxWw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    resolution: {integrity: sha512-U3PzLYKSQYzTERstgtHLd4ZTkOF9co57zTXT77r0cVUsleGZOrd6ut7rHzeWwoJSiHOVxxa0OhG1JVQeB7lLoQ==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    resolution: {integrity: sha512-Eisd7/NM0m23ijrGr6xI2iMocdOuyl6gO27gfMfya4C5BODbUSP7ljKJ7LrA0teqZMdYHesRDzx36Js++/vhiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    resolution: {integrity: sha512-GsE2ezwAYwh72f9gIjbGTZOf4HxEksb5M2eCaj+Y5rGYVwAdt7C12Q2e9H5LRYxWcFvLH4m4jiSZpQQ4upnPAQ==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    resolution: {integrity: sha512-cJxWXanH4Ew9CfuZ4IAEiafpOBCe97bzoKowHCGk5lG/7kR4WF/eknnBlHW9m8q7t10mKq75kruPLtbSDqgRTw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@node-rs/argon2@2.0.2':
+    resolution: {integrity: sha512-t64wIsPEtNd4aUPuTAyeL2ubxATCBGmeluaKXEMAFk/8w6AJIVVkeLKMBpgLW6LU2t5cQxT+env/c6jxbtTQBg==}
+    engines: {node: '>= 10'}
+
   '@orama/orama@3.1.18':
     resolution: {integrity: sha512-a61ljmRVVyG5MC/698C8/FfFDw5a8LOIvyOLW5fztgUXqUpc1jOfQzOitSCbge657OgXXThmY3Tk8fpiDb4UcA==}
     engines: {node: '>= 20.0.0'}
@@ -849,6 +955,9 @@ packages:
 
   '@swc/helpers@0.5.21':
     resolution: {integrity: sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/babel__core@7.20.5':
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1626,6 +1735,22 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@emnapi/core@1.10.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -1763,6 +1888,74 @@ snapshots:
 
   '@msgpack/msgpack@3.1.3': {}
 
+  '@napi-rs/wasm-runtime@0.2.12':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@node-rs/argon2-android-arm-eabi@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-android-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-arm64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-darwin-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-freebsd-x64@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm-gnueabihf@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-arm64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-gnu@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-linux-x64-musl@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-wasm32-wasi@2.0.2':
+    dependencies:
+      '@napi-rs/wasm-runtime': 0.2.12
+    optional: true
+
+  '@node-rs/argon2-win32-arm64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-ia32-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2-win32-x64-msvc@2.0.2':
+    optional: true
+
+  '@node-rs/argon2@2.0.2':
+    optionalDependencies:
+      '@node-rs/argon2-android-arm-eabi': 2.0.2
+      '@node-rs/argon2-android-arm64': 2.0.2
+      '@node-rs/argon2-darwin-arm64': 2.0.2
+      '@node-rs/argon2-darwin-x64': 2.0.2
+      '@node-rs/argon2-freebsd-x64': 2.0.2
+      '@node-rs/argon2-linux-arm-gnueabihf': 2.0.2
+      '@node-rs/argon2-linux-arm64-gnu': 2.0.2
+      '@node-rs/argon2-linux-arm64-musl': 2.0.2
+      '@node-rs/argon2-linux-x64-gnu': 2.0.2
+      '@node-rs/argon2-linux-x64-musl': 2.0.2
+      '@node-rs/argon2-wasm32-wasi': 2.0.2
+      '@node-rs/argon2-win32-arm64-msvc': 2.0.2
+      '@node-rs/argon2-win32-ia32-msvc': 2.0.2
+      '@node-rs/argon2-win32-x64-msvc': 2.0.2
+
   '@orama/orama@3.1.18': {}
 
   '@orama/plugin-data-persistence@3.1.18':
@@ -1854,6 +2047,11 @@ snapshots:
   '@swc/helpers@0.5.21':
     dependencies:
       tslib: 2.8.1
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/babel__core@7.20.5':
     dependencies:

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -3,7 +3,7 @@
  * handlers (issue #690 PR 2/4).
  *
  * These tests drive the pure handler functions directly with an
- * injected passphrase reader and a low-cost scrypt parameter set so
+ * injected passphrase reader and low-cost KDF parameter sets so
  * the suite stays fast on CI.
  */
 
@@ -39,10 +39,11 @@ import {
   buildHeaderFromPassphrase,
   deriveKeyFromHeader,
 } from "../packages/remnic-core/src/secure-store/header.js";
-import {
-  buildMetadata,
-  type ScryptParams,
-} from "../packages/remnic-core/src/secure-store/metadata.js";
+import { buildMetadata } from "../packages/remnic-core/src/secure-store/metadata.js";
+import type {
+  Argon2idParams,
+  ScryptParams,
+} from "../packages/remnic-core/src/secure-store/kdf.js";
 
 // Low-cost scrypt params: still RFC 7914 valid (N power of 2),
 // derives in <5 ms. Used everywhere the test doesn't specifically
@@ -53,6 +54,13 @@ const FAST_SCRYPT: ScryptParams = {
   p: 1,
   keyLength: 32,
   maxmem: 32 * 1024 * 1024,
+};
+
+const FAST_ARGON2ID: Argon2idParams = {
+  memoryKiB: 8,
+  iterations: 1,
+  parallelism: 1,
+  keyLength: 32,
 };
 
 const TEST_PASSPHRASE = "correct horse battery staple";
@@ -132,6 +140,7 @@ test("init writes a header with the chosen scrypt params and a sealed verifier",
       memoryDir,
       keyringId,
       readPassphrase: reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
       note: "test-init",
     });
@@ -152,6 +161,25 @@ test("init writes a header with the chosen scrypt params and a sealed verifier",
   });
 });
 
+test("init defaults new stores to argon2id", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const { reader } = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    const report = await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: reader,
+      params: FAST_ARGON2ID,
+    });
+    assert.equal(report.ok, true);
+    assert.equal(report.kdf.algorithm, "argon2id");
+    if (report.kdf.algorithm === "argon2id") {
+      assert.equal(report.kdf.params.memoryKiB, FAST_ARGON2ID.memoryKiB);
+      assert.equal(report.kdf.params.iterations, FAST_ARGON2ID.iterations);
+      assert.equal(report.kdf.params.parallelism, FAST_ARGON2ID.parallelism);
+    }
+  });
+});
+
 test("init refuses to overwrite an existing header", async () => {
   await withTmpMemoryDir(async (memoryDir, keyringId) => {
     const first = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
@@ -159,6 +187,7 @@ test("init refuses to overwrite an existing header", async () => {
       memoryDir,
       keyringId,
       readPassphrase: first.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
     const second = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
@@ -167,6 +196,7 @@ test("init refuses to overwrite an existing header", async () => {
         memoryDir,
         keyringId,
         readPassphrase: second.reader,
+        algorithm: "scrypt",
         params: FAST_SCRYPT,
       }),
       /already exists/,
@@ -186,6 +216,7 @@ test("init rejects passphrases shorter than the minimum length", async () => {
         memoryDir,
         keyringId,
         readPassphrase: reader,
+        algorithm: "scrypt",
         params: FAST_SCRYPT,
       }),
       /at least .* characters/,
@@ -204,6 +235,7 @@ test("init surfaces a passphrase-mismatch error from the reader", async () => {
         memoryDir,
         keyringId,
         readPassphrase: reader,
+        algorithm: "scrypt",
         params: FAST_SCRYPT,
       }),
       /did not match/,
@@ -220,6 +252,7 @@ test("unlock with the correct passphrase registers the key in the keyring", asyn
       memoryDir,
       keyringId,
       readPassphrase: init.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
     assert.equal(keyring.status(keyringId).unlocked, false);
@@ -248,6 +281,7 @@ test("unlock with the wrong passphrase fails cleanly and leaves the keyring lock
       memoryDir,
       keyringId,
       readPassphrase: init.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
 
@@ -289,6 +323,7 @@ test("lock clears the in-memory key and is idempotent", async () => {
       memoryDir,
       keyringId,
       readPassphrase: init.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
     const unlock = staticPassphraseReader(TEST_PASSPHRASE);
@@ -318,6 +353,7 @@ test("status after init reports initialized + locked + KDF params", async () => 
       memoryDir,
       keyringId,
       readPassphrase: init.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
     const report = await runSecureStoreStatus({ memoryDir, keyringId });
@@ -337,6 +373,7 @@ test("status after unlock reports unlocked + last-unlock timestamp", async () =>
       memoryDir,
       keyringId,
       readPassphrase: init.reader,
+      algorithm: "scrypt",
       params: FAST_SCRYPT,
     });
     const unlock = staticPassphraseReader(TEST_PASSPHRASE);

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -9,7 +9,14 @@ export default defineConfig({
   clean: true,
   sourcemap: true,
   dts: false,
-  external: ["openclaw", "@lancedb/lancedb", "meilisearch", "@orama/orama", "@orama/plugin-data-persistence"],
+  external: [
+    "openclaw",
+    "@node-rs/argon2",
+    "@lancedb/lancedb",
+    "meilisearch",
+    "@orama/orama",
+    "@orama/plugin-data-persistence",
+  ],
   banner: {
     js: "// openclaw-engram: Local-first memory plugin",
   },


### PR DESCRIPTION
## Summary
- implement the literal Argon2id KDF requested by issue #690 using `@node-rs/argon2`
- make new secure-store headers default to Argon2id while preserving scrypt unlock/init compatibility via metadata and `--kdf scrypt`
- update encrypted capsule KDF metadata fallback, docs, and tests for the Argon2id default

## Verification
- `npm exec -- tsx --test packages/remnic-core/src/secure-store/secure-store.test.ts tests/cli-secure-store.test.ts packages/remnic-core/src/transfer/capsule-encrypt.test.ts tests/secure-store/storage-wrap.test.ts`
- `npm run check-types`
- `git diff --check`

## Note
- `npm run preflight:quick` was attempted locally. It progressed through check-types, config contract checks, review-pattern checks, and a large chunk of the broad test run, then hung for several minutes in the unrelated `packages/remnic-core/src/lcm-engine.test.ts` child at 0% CPU. I stopped that hung local run and kept the focused KDF/capsule verification above green.

Closes #690.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Introduces a new native Argon2id KDF path and changes the default secure-store initialization behavior, which can impact encryption key derivation, cross-platform builds, and the ability to unlock/decrypt existing data if misconfigured.
> 
> **Overview**
> **Implements Argon2id support for secure-store key derivation** via `@node-rs/argon2`, including parameter validation and runtime loading, and updates `deriveKey()` to dispatch to Argon2id instead of treating it as a placeholder.
> 
> **Changes defaults and CLI behavior** so `remnic secure-store init` creates new headers with Argon2id by default and adds `--kdf {argon2id|scrypt}` for explicit compatibility stores; header/handler defaults are updated accordingly.
> 
> **Updates encrypted capsule KDF metadata and docs/tests** to reflect the new default KDF (including fallback KDF metadata when no header is available), plus build config/lockfile updates to externalize and ship the new Argon2 dependency.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be6112f575bc2b7e0265fe8cba876f90eb3e7de6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->