### PR TITLE
feat(secure-store): add migrate command

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -90,7 +90,7 @@ Derives the AES-256 key from your passphrase and stores it in the in-memory keyr
 ### Migrate Existing Files
 
 ```bash
-remnic secure-store migrate
+remnic engram secure-store migrate
 ```
 
 Encrypts existing plaintext storage-managed memory files using the currently
@@ -100,8 +100,8 @@ is safe to rerun.
 This command requires the store to be initialized and unlocked:
 
 ```bash
-remnic secure-store unlock
-remnic secure-store migrate
+remnic engram secure-store unlock
+remnic engram secure-store migrate
 ```
 
 `migrate` covers the storage roots already routed through Remnic's secure-fs

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -87,6 +87,27 @@ Derives the AES-256 key from your passphrase and stores it in the in-memory keyr
 
 **The key is never persisted to disk.** You must run `unlock` after every daemon restart.
 
+### Migrate Existing Files
+
+```bash
+remnic secure-store migrate
+```
+
+Encrypts existing plaintext storage-managed memory files using the currently
+unlocked secure-store key. Already encrypted files are skipped, so the command
+is safe to rerun.
+
+This command requires the store to be initialized and unlocked:
+
+```bash
+remnic secure-store unlock
+remnic secure-store migrate
+```
+
+`migrate` covers the storage roots already routed through Remnic's secure-fs
+layer. Remaining sidecar coverage is tracked separately so the migration command
+does not encrypt files that older code paths would still read as plaintext.
+
 ### Lock
 
 ```bash

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8770,6 +8770,29 @@ export function registerCli(
         });
 
       secureStoreCmd
+        .command("migrate")
+        .description(
+          "Encrypt existing plaintext storage-managed memory files in an initialized, unlocked secure-store. Idempotent; already-encrypted files are skipped.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          const { runSecureStoreMigrate, renderMigrateReport } = await import(
+            "./secure-store/index.js"
+          );
+          const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+          const report = await runSecureStoreMigrate({ memoryDir });
+          if (options.json === true) {
+            console.log(JSON.stringify(report, null, 2));
+          } else {
+            console.log(renderMigrateReport(report));
+          }
+          if (!report.ok) {
+            process.exitCode = 1;
+          }
+        });
+
+      secureStoreCmd
         .command("status")
         .description(
           "Report secure-store status: whether a header exists, whether the daemon currently holds the key, KDF parameters, and last-unlock timestamp.",

--- a/packages/remnic-core/src/secure-store/cli-handlers.ts
+++ b/packages/remnic-core/src/secure-store/cli-handlers.ts
@@ -1,6 +1,6 @@
 /**
  * Pure handlers behind the `remnic secure-store {init,unlock,lock,
- * status}` CLI surface (issue #690 PR 2/4).
+ * status,migrate}` CLI surface (issue #690 PR 2/4 + #779).
  *
  * Each handler:
  *   - takes an explicit `memoryDir` (already `~`-expanded by the CLI),
@@ -33,6 +33,7 @@ import {
   type KdfAlgorithm,
   type ScryptParams,
 } from "./kdf.js";
+import { migrateMemoryDirToEncrypted, type MigrateResult } from "./secure-fs.js";
 
 /** Passphrase source — async so callers can read from a TTY without echo. */
 export type PassphraseReader = (
@@ -183,6 +184,51 @@ export function runSecureStoreLock(options: SecureStoreLockOptions): SecureStore
   const id = options.keyringId ?? secureStoreDir(options.memoryDir);
   const cleared = keyring.lock(id);
   return { ok: true, cleared };
+}
+
+// ─── migrate ─────────────────────────────────────────────────────────
+
+export interface SecureStoreMigrateOptions extends SecureStoreHandlerCommon {}
+
+export type SecureStoreMigrateReport =
+  | ({ ok: true } & MigrateResult)
+  | ({
+      ok: false;
+      reason: "not-initialized" | "locked" | "file-errors";
+    } & MigrateResult);
+
+export async function runSecureStoreMigrate(
+  options: SecureStoreMigrateOptions,
+): Promise<SecureStoreMigrateReport> {
+  const { memoryDir } = options;
+  const header = await readHeader(memoryDir);
+  if (!header) {
+    return {
+      ok: false,
+      reason: "not-initialized",
+      encrypted: 0,
+      skipped: 0,
+      errors: [],
+    };
+  }
+
+  const id = options.keyringId ?? secureStoreDir(memoryDir);
+  const key = keyring.getKey(id);
+  if (key === null) {
+    return {
+      ok: false,
+      reason: "locked",
+      encrypted: 0,
+      skipped: 0,
+      errors: [],
+    };
+  }
+
+  const result = await migrateMemoryDirToEncrypted(memoryDir, key);
+  if (result.errors.length > 0) {
+    return { ok: false, reason: "file-errors", ...result };
+  }
+  return { ok: true, ...result };
 }
 
 // ─── status ───────────────────────────────────────────────────────────

--- a/packages/remnic-core/src/secure-store/cli-renderer.ts
+++ b/packages/remnic-core/src/secure-store/cli-renderer.ts
@@ -1,6 +1,6 @@
 /**
  * Console-text renderers for the `remnic secure-store {init,unlock,
- * lock,status}` CLI surface (issue #690 PR 2/4).
+ * lock,status,migrate}` CLI surface (issue #690 PR 2/4 + #779).
  *
  * Pure: each `render*` function takes a typed report and returns a
  * string. CLI handlers do the `console.log`. Tests assert on the
@@ -10,6 +10,7 @@
 import type {
   SecureStoreInitReport,
   SecureStoreLockReport,
+  SecureStoreMigrateReport,
   SecureStoreStatusReport,
   SecureStoreUnlockReport,
 } from "./cli-handlers.js";
@@ -24,7 +25,7 @@ export function renderInitReport(report: SecureStoreInitReport): string {
   lines.push(...renderKdfLines(report.kdf));
   lines.push("");
   lines.push("Note: init does NOT auto-unlock the store. Run");
-  lines.push("  remnic engram secure-store unlock");
+  lines.push("  remnic secure-store unlock");
   lines.push("to register the master key with the running daemon.");
   return lines.join("\n");
 }
@@ -34,7 +35,7 @@ export function renderUnlockReport(report: SecureStoreUnlockReport): string {
     return `OK — secure-store unlocked at ${report.unlockedAt} (algorithm=${report.algorithm}).`;
   }
   if (report.reason === "not-initialized") {
-    return "ERR — secure-store is not initialized. Run 'remnic engram secure-store init' first.";
+    return "ERR — secure-store is not initialized. Run 'remnic secure-store init' first.";
   }
   return "ERR — wrong passphrase.";
 }
@@ -46,6 +47,28 @@ export function renderLockReport(report: SecureStoreLockReport): string {
   return "OK — secure-store was already locked (no in-memory key to clear).";
 }
 
+export function renderMigrateReport(report: SecureStoreMigrateReport): string {
+  if (!report.ok && report.reason === "not-initialized") {
+    return "ERR — secure-store is not initialized. Run 'remnic secure-store init' first.";
+  }
+  if (!report.ok && report.reason === "locked") {
+    return "ERR — secure-store is locked. Run 'remnic secure-store unlock' before migrate.";
+  }
+
+  const lines: string[] = [];
+  lines.push(report.ok ? "OK — secure-store migration complete." : "ERR — secure-store migration completed with file errors.");
+  lines.push(`encrypted: ${report.encrypted}`);
+  lines.push(`skipped: ${report.skipped}`);
+  lines.push(`errors: ${report.errors.length}`);
+  for (const entry of report.errors.slice(0, 10)) {
+    lines.push(`- ${entry.filePath}: ${entry.error}`);
+  }
+  if (report.errors.length > 10) {
+    lines.push(`- ... ${report.errors.length - 10} more error(s)`);
+  }
+  return lines.join("\n");
+}
+
 export function renderStatusReport(report: SecureStoreStatusReport): string {
   const lines: string[] = [];
   lines.push("=== Remnic secure-store status ===");
@@ -54,7 +77,7 @@ export function renderStatusReport(report: SecureStoreStatusReport): string {
   lines.push(`initialized: ${report.initialized ? "yes" : "no"}`);
   if (!report.initialized) {
     lines.push("");
-    lines.push("Run 'remnic engram secure-store init' to initialize a new store.");
+    lines.push("Run 'remnic secure-store init' to initialize a new store.");
     return lines.join("\n");
   }
   lines.push(`createdAt: ${report.createdAt ?? "n/a"}`);

--- a/packages/remnic-core/src/secure-store/cli-renderer.ts
+++ b/packages/remnic-core/src/secure-store/cli-renderer.ts
@@ -1,5 +1,5 @@
 /**
- * Console-text renderers for the `remnic secure-store {init,unlock,
+ * Console-text renderers for the `remnic engram secure-store {init,unlock,
  * lock,status,migrate}` CLI surface (issue #690 PR 2/4 + #779).
  *
  * Pure: each `render*` function takes a typed report and returns a
@@ -25,7 +25,7 @@ export function renderInitReport(report: SecureStoreInitReport): string {
   lines.push(...renderKdfLines(report.kdf));
   lines.push("");
   lines.push("Note: init does NOT auto-unlock the store. Run");
-  lines.push("  remnic secure-store unlock");
+  lines.push("  remnic engram secure-store unlock");
   lines.push("to register the master key with the running daemon.");
   return lines.join("\n");
 }
@@ -35,7 +35,7 @@ export function renderUnlockReport(report: SecureStoreUnlockReport): string {
     return `OK — secure-store unlocked at ${report.unlockedAt} (algorithm=${report.algorithm}).`;
   }
   if (report.reason === "not-initialized") {
-    return "ERR — secure-store is not initialized. Run 'remnic secure-store init' first.";
+    return "ERR — secure-store is not initialized. Run 'remnic engram secure-store init' first.";
   }
   return "ERR — wrong passphrase.";
 }
@@ -49,10 +49,10 @@ export function renderLockReport(report: SecureStoreLockReport): string {
 
 export function renderMigrateReport(report: SecureStoreMigrateReport): string {
   if (!report.ok && report.reason === "not-initialized") {
-    return "ERR — secure-store is not initialized. Run 'remnic secure-store init' first.";
+    return "ERR — secure-store is not initialized. Run 'remnic engram secure-store init' first.";
   }
   if (!report.ok && report.reason === "locked") {
-    return "ERR — secure-store is locked. Run 'remnic secure-store unlock' before migrate.";
+    return "ERR — secure-store is locked. Run 'remnic engram secure-store unlock' before migrate.";
   }
 
   const lines: string[] = [];
@@ -77,7 +77,7 @@ export function renderStatusReport(report: SecureStoreStatusReport): string {
   lines.push(`initialized: ${report.initialized ? "yes" : "no"}`);
   if (!report.initialized) {
     lines.push("");
-    lines.push("Run 'remnic secure-store init' to initialize a new store.");
+    lines.push("Run 'remnic engram secure-store init' to initialize a new store.");
     return lines.join("\n");
   }
   lines.push(`createdAt: ${report.createdAt ?? "n/a"}`);

--- a/packages/remnic-core/src/secure-store/index.ts
+++ b/packages/remnic-core/src/secure-store/index.ts
@@ -85,6 +85,7 @@ export {
   MIN_PASSPHRASE_LENGTH,
   runSecureStoreInit,
   runSecureStoreLock,
+  runSecureStoreMigrate,
   runSecureStoreStatus,
   runSecureStoreUnlock,
   type PassphraseReader,
@@ -92,6 +93,8 @@ export {
   type SecureStoreInitReport,
   type SecureStoreLockOptions,
   type SecureStoreLockReport,
+  type SecureStoreMigrateOptions,
+  type SecureStoreMigrateReport,
   type SecureStoreStatusOptions,
   type SecureStoreStatusReport,
   type SecureStoreUnlockOptions,
@@ -101,6 +104,7 @@ export {
 export {
   renderInitReport,
   renderLockReport,
+  renderMigrateReport,
   renderStatusReport,
   renderUnlockReport,
 } from "./cli-renderer.js";

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -27,8 +27,11 @@ import {
   readHeader,
   runSecureStoreInit,
   runSecureStoreLock,
+  runSecureStoreMigrate,
   runSecureStoreStatus,
   runSecureStoreUnlock,
+  isEncryptedFile,
+  readMaybeEncryptedFile,
   secureStoreDir,
   serializeHeader,
   validateHeader,
@@ -342,6 +345,100 @@ test("lock clears the in-memory key and is idempotent", async () => {
     const second = runSecureStoreLock({ memoryDir, keyringId });
     assert.deepEqual(second, { ok: true, cleared: false });
   });
+});
+
+// ─── migrate ────────────────────────────────────────────────────────
+
+test("migrate encrypts plaintext storage files and is idempotent", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const unlock = staticPassphraseReader(TEST_PASSPHRASE);
+    await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: unlock.reader,
+    });
+
+    const filePath = path.join(memoryDir, "facts", "2026-04-28", "fact-a.md");
+    const original = "---\nid: fact-a\ncategory: fact\n---\nprivate fact";
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, original, "utf8");
+
+    const first = await runSecureStoreMigrate({ memoryDir, keyringId });
+    assert.equal(first.ok, true);
+    assert.equal(first.encrypted, 1);
+    assert.equal(first.skipped, 0);
+    assert.equal(first.errors.length, 0);
+    assert.equal(isEncryptedFile(await readFile(filePath)), true);
+    assert.equal(
+      await readMaybeEncryptedFile(filePath, keyring.getKey(keyringId), memoryDir),
+      original,
+    );
+
+    const second = await runSecureStoreMigrate({ memoryDir, keyringId });
+    assert.equal(second.ok, true);
+    assert.equal(second.encrypted, 0);
+    assert.equal(second.skipped, 1);
+    assert.equal(second.errors.length, 0);
+  });
+});
+
+test("migrate fails clearly when the secure-store is not initialized", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const report = await runSecureStoreMigrate({ memoryDir, keyringId });
+    assert.deepEqual(report, {
+      ok: false,
+      reason: "not-initialized",
+      encrypted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+});
+
+test("migrate fails clearly when the secure-store is locked", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const report = await runSecureStoreMigrate({ memoryDir, keyringId });
+    assert.deepEqual(report, {
+      ok: false,
+      reason: "locked",
+      encrypted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+});
+
+test("cli.ts registers the secure-store migrate subcommand", async () => {
+  const cliSource = await readFile(
+    path.resolve(
+      import.meta.dirname,
+      "..",
+      "packages",
+      "remnic-core",
+      "src",
+      "cli.ts",
+    ),
+    "utf8",
+  );
+  assert.match(cliSource, /\.command\("migrate"\)/);
+  assert.match(cliSource, /runSecureStoreMigrate/);
+  assert.match(cliSource, /renderMigrateReport/);
 });
 
 // ─── status (initialized) ────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- add `remnic secure-store migrate` to encrypt existing plaintext storage-managed memory files once secure-store is initialized and unlocked
- surface structured migrate reports for JSON and text CLI output, including initialized/locked/file-error failures
- document the migration command and cover success, idempotency, locked, uninitialized, and CLI registration behavior

Closes #779.
Follow-up to #690.

## Verification
- `npm exec -- tsx --test tests/cli-secure-store.test.ts tests/secure-store/storage-wrap.test.ts packages/remnic-core/src/secure-store/secure-store.test.ts`
- `npm run check-types`
- `npm run build`
- `git diff --check`
- `npm run preflight:quick` reached typecheck, config-contract, and review-pattern gates; the broad `npm test` phase invoked the full repo suite, showed an unrelated benchmark-adapter failure (`direct adapter recall expands search hits with adjacent stored results`), then stalled in later unrelated tests and was killed cleanly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new command that rewrites on-disk memory files into encrypted form, so bugs or partial failures could impact user data readability despite being designed as idempotent and atomic per file.
> 
> **Overview**
> Adds a new `remnic engram secure-store migrate` CLI command to encrypt existing plaintext, storage-managed `.md` memory files using the currently *initialized and unlocked* secure-store key, skipping already-encrypted files for idempotency.
> 
> Introduces a `runSecureStoreMigrate` handler that validates initialized/unlocked state, runs `migrateMemoryDirToEncrypted`, and returns structured results (encrypted/skipped/error list) with both JSON output and a new text renderer that surfaces clear failure reasons.
> 
> Updates docs to describe the migration workflow and adds tests covering success + idempotency, plus explicit failures for uninitialized/locked stores and CLI registration.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2e8384976d276d6858bbae92efca0645fb7eac1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->