### PR TITLE
Fix OpenClaw memory tool parameter schemas

### DIFF
--- a/packages/plugin-openclaw/src/openclaw-tools/memory-get-tool.test.ts
+++ b/packages/plugin-openclaw/src/openclaw-tools/memory-get-tool.test.ts
@@ -3,6 +3,32 @@ import test from "node:test";
 
 import { buildMemoryGetTool } from "./memory-get-tool.js";
 
+function validateOpenClawPluginTool(tool: unknown): string | null {
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+    return "tool must be an object";
+  }
+  const spec = tool as { name?: unknown; execute?: unknown; parameters?: unknown };
+  if (typeof spec.name !== "string" || spec.name.trim().length === 0) {
+    return "missing non-empty name";
+  }
+  if (typeof spec.execute !== "function") {
+    return `${spec.name} missing execute function`;
+  }
+  if (!spec.parameters || typeof spec.parameters !== "object" || Array.isArray(spec.parameters)) {
+    return `${spec.name} missing parameters object`;
+  }
+  return null;
+}
+
+test("memory-get tool exposes parameters for OpenClaw plugin validation", () => {
+  const tool = buildMemoryGetTool({} as never, {
+    getMemoryForActiveMemory: async () => ({ error: "not_found" }),
+  });
+
+  assert.equal(validateOpenClawPluginTool(tool), null);
+  assert.equal(tool.parameters, tool.inputSchema);
+});
+
 test("memory-get tool returns the active-memory bridge payload without markdown formatting", async () => {
   let sessionKeyFromTool: string | null = null;
   const tool = buildMemoryGetTool(

--- a/packages/plugin-openclaw/src/openclaw-tools/memory-get-tool.ts
+++ b/packages/plugin-openclaw/src/openclaw-tools/memory-get-tool.ts
@@ -15,6 +15,7 @@ export function buildMemoryGetTool(
   return {
     name: "memory_get",
     description: "Fetch one Remnic memory for the OpenClaw active-memory surface.",
+    parameters: MemoryGetInputSchema,
     inputSchema: MemoryGetInputSchema,
     async execute(
       _toolCallId: string,

--- a/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.test.ts
+++ b/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.test.ts
@@ -3,6 +3,32 @@ import test from "node:test";
 
 import { buildMemorySearchTool } from "./memory-search-tool.js";
 
+function validateOpenClawPluginTool(tool: unknown): string | null {
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+    return "tool must be an object";
+  }
+  const spec = tool as { name?: unknown; execute?: unknown; parameters?: unknown };
+  if (typeof spec.name !== "string" || spec.name.trim().length === 0) {
+    return "missing non-empty name";
+  }
+  if (typeof spec.execute !== "function") {
+    return `${spec.name} missing execute function`;
+  }
+  if (!spec.parameters || typeof spec.parameters !== "object" || Array.isArray(spec.parameters)) {
+    return `${spec.name} missing parameters object`;
+  }
+  return null;
+}
+
+test("memory-search tool exposes parameters for OpenClaw plugin validation", () => {
+  const tool = buildMemorySearchTool({} as never, {
+    recallForActiveMemory: async () => ({ results: [], truncated: false }),
+  });
+
+  assert.equal(validateOpenClawPluginTool(tool), null);
+  assert.equal(tool.parameters, tool.inputSchema);
+});
+
 test("memory-search tool uses ctx session key and returns a structured JSON payload", async () => {
   let received: Record<string, unknown> | null = null;
   const tool = buildMemorySearchTool(

--- a/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.ts
+++ b/packages/plugin-openclaw/src/openclaw-tools/memory-search-tool.ts
@@ -16,6 +16,7 @@ export function buildMemorySearchTool(
   return {
     name: "memory_search",
     description: "Search Remnic memories for the OpenClaw active-memory surface.",
+    parameters: MemorySearchInputSchema,
     inputSchema: MemorySearchInputSchema,
     async execute(
       _toolCallId: string,

--- a/tests/sdk-compat-integration.test.ts
+++ b/tests/sdk-compat-integration.test.ts
@@ -140,10 +140,28 @@ interface MockApi {
   _hookHandlers: Map<string, unknown>;
   _registeredToolCount: number;
   _registeredToolNames: string[];
+  _registeredToolSpecs: unknown[];
   _registeredServiceIds: string[];
   _memoryPromptSectionRegistered: boolean;
   _registeredMemoryCapability?: any;
   _registeredCommands: unknown[];
+}
+
+function validateOpenClawPluginTool(tool: unknown): string | null {
+  if (!tool || typeof tool !== "object" || Array.isArray(tool)) {
+    return "tool must be an object";
+  }
+  const spec = tool as { name?: unknown; execute?: unknown; parameters?: unknown };
+  if (typeof spec.name !== "string" || spec.name.trim().length === 0) {
+    return "missing non-empty name";
+  }
+  if (typeof spec.execute !== "function") {
+    return `${spec.name} missing execute function`;
+  }
+  if (!spec.parameters || typeof spec.parameters !== "object" || Array.isArray(spec.parameters)) {
+    return `${spec.name} missing parameters object`;
+  }
+  return null;
 }
 
 function buildNewSdkApi(label: string): MockApi {
@@ -156,11 +174,13 @@ function buildNewSdkApi(label: string): MockApi {
     _hookHandlers: new Map(),
     _registeredToolCount: 0,
     _registeredToolNames: [],
+    _registeredToolSpecs: [],
     _registeredServiceIds: [],
     _memoryPromptSectionRegistered: false,
     _registeredCommands: [],
     registerTool(spec: unknown) {
       api._registeredToolCount++;
+      api._registeredToolSpecs.push(spec);
       if (spec && typeof spec === "object" && typeof (spec as { name?: unknown }).name === "string") {
         api._registeredToolNames.push((spec as { name: string }).name);
       }
@@ -196,11 +216,13 @@ function buildLegacySdkApi(label: string): MockApi {
     _hookHandlers: new Map(),
     _registeredToolCount: 0,
     _registeredToolNames: [],
+    _registeredToolSpecs: [],
     _registeredServiceIds: [],
     _memoryPromptSectionRegistered: false,
     _registeredCommands: [],
     registerTool(spec: unknown) {
       api._registeredToolCount++;
+      api._registeredToolSpecs.push(spec);
       if (spec && typeof spec === "object" && typeof (spec as { name?: unknown }).name === "string") {
         api._registeredToolNames.push((spec as { name: string }).name);
       }
@@ -399,6 +421,27 @@ test("new SDK registers active-memory tool names and slash commands", async () =
       api._registeredToolNames.includes("memory_get"),
       "memory_get should be registered for OpenClaw active-memory routing",
     );
+    for (const tool of api._registeredToolSpecs) {
+      const name =
+        tool && typeof tool === "object" && typeof (tool as { name?: unknown }).name === "string"
+          ? (tool as { name: string }).name
+          : "<unknown>";
+      assert.equal(
+        validateOpenClawPluginTool(tool),
+        null,
+        `${name} should satisfy OpenClaw's plugin tool validator`,
+      );
+    }
+    for (const toolName of ["memory_search", "memory_get"]) {
+      const tool = api._registeredToolSpecs.find((spec) =>
+        spec && typeof spec === "object" && (spec as { name?: unknown }).name === toolName
+      );
+      assert.equal(
+        validateOpenClawPluginTool(tool),
+        null,
+        `${toolName} should satisfy OpenClaw's plugin tool validator`,
+      );
+    }
     assert.ok(
       api._registeredCommands.length > 0,
       "registerCommand should be used when available for session-scoped recall toggles",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: small schema-surface change to tool specs plus additional tests; no changes to recall/get behavior or persistence logic.
> 
> **Overview**
> Updates the OpenClaw `memory_search` and `memory_get` tool specs to **explicitly expose a `parameters` object** (mirroring `inputSchema`) to satisfy the current OpenClaw plugin validator.
> 
> Adds focused unit tests asserting `parameters` is present/equal to `inputSchema`, and extends the SDK compatibility integration test to capture all registered tool specs and validate each against the expected OpenClaw tool shape (`name`, `execute`, `parameters`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 70b48b42f408ac2a2e2e19851a3dbb61cd8468c7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->