### PR TITLE
feat(http): add capsule export endpoint

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -539,6 +539,27 @@ export class EngramAccessHttpServer {
       return;
     }
 
+    if (
+      req.method === "POST" &&
+      (pathname === "/engram/v1/capsules/export" || pathname === "/remnic/v1/capsules/export")
+    ) {
+      const body = await this.readValidatedBody(req, "capsuleExport");
+      this.ensureWriteRateLimitAvailable();
+      const result = await this.service.capsuleExport({
+        name: body.name,
+        namespace: this.resolveNamespace(req, body.namespace),
+        principal: this.resolveRequestPrincipal(req),
+        since: body.since,
+        includeKinds: body.includeKinds,
+        peerIds: body.peerIds,
+        includeTranscripts: body.includeTranscripts,
+        encrypt: body.encrypt,
+      });
+      this.recordWriteRateLimitHit();
+      this.respondJson(res, 200, result);
+      return;
+    }
+
     if (req.method === "POST" && pathname === "/engram/v1/recall/explain") {
       const body = await this.readValidatedBody(req, "recallExplain");
       const response = await this.service.recallExplain({

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -3,6 +3,7 @@
 // field-level detail so consumers get clear feedback on malformed requests.
 
 import { z } from "zod";
+import { CAPSULE_ID_PATTERN } from "./transfer/types.js";
 
 // ---------------------------------------------------------------------------
 // Error formatting
@@ -248,6 +249,82 @@ export const daySummaryRequestSchema = z.object({
 });
 
 // ---------------------------------------------------------------------------
+// Capsule export
+// ---------------------------------------------------------------------------
+
+const capsuleTopLevelSegmentSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(128)
+  .refine(
+    (value) => !value.includes("/") && !value.includes("\\"),
+    "must be a top-level directory name without path separators",
+  );
+
+const capsulePeerIdSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .max(256)
+  .refine(
+    (value) => value !== "." && value !== ".." && !value.includes("/") && !value.includes("\\"),
+    "must be a plain peer id without path separators",
+  );
+
+const CAPSULE_ISO_8601_RE =
+  /^\d{4}-\d{2}-\d{2}(?:[Tt]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:[Zz]|[+-]\d{2}:?\d{2}))?$/;
+
+function isValidCapsuleSince(value: string): boolean {
+  if (!CAPSULE_ISO_8601_RE.test(value)) return false;
+  const ms = Date.parse(value);
+  if (!Number.isFinite(ms)) return false;
+  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
+  if (!match) return false;
+  const offsetMatch = /([+-])(\d{2}):?(\d{2})$/.exec(value);
+  let displayMs = ms;
+  if (offsetMatch) {
+    const sign = offsetMatch[1] === "-" ? -1 : 1;
+    const offsetMin = sign * (Number(offsetMatch[2]) * 60 + Number(offsetMatch[3]));
+    displayMs = ms + offsetMin * 60_000;
+  }
+  const date = new Date(displayMs);
+  return (
+    date.getUTCFullYear() === Number(match[1]) &&
+    date.getUTCMonth() + 1 === Number(match[2]) &&
+    date.getUTCDate() === Number(match[3])
+  );
+}
+
+const capsuleIsoSinceSchema = z
+  .string()
+  .trim()
+  .min(1, "since must be a non-empty ISO 8601 timestamp")
+  .max(128)
+  .refine(
+    isValidCapsuleSince,
+    "since must be a valid ISO 8601 timestamp with no calendar overflow",
+  );
+
+export const capsuleExportRequestSchema = z.object({
+  name: z
+    .string()
+    .trim()
+    .min(1, "name is required")
+    .max(64, "name must be 64 characters or fewer")
+    .regex(
+      CAPSULE_ID_PATTERN,
+      "name must be alphanumeric with single dashes (no spaces, no leading/trailing dashes)",
+    ),
+  namespace: namespaceSchema,
+  since: capsuleIsoSinceSchema.optional(),
+  includeKinds: z.array(capsuleTopLevelSegmentSchema).max(50).optional(),
+  peerIds: z.array(capsulePeerIdSchema).max(100).optional(),
+  includeTranscripts: z.boolean().optional(),
+  encrypt: z.boolean().optional(),
+});
+
+// ---------------------------------------------------------------------------
 // Inferred types
 // ---------------------------------------------------------------------------
 
@@ -262,6 +339,7 @@ export type TrustZonePromoteRequest = z.infer<typeof trustZonePromoteRequestSche
 export type TrustZoneDemoSeedRequest = z.infer<typeof trustZoneDemoSeedRequestSchema>;
 export type LcmSearchRequest = z.infer<typeof lcmSearchRequestSchema>;
 export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
+export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
 
 // ---------------------------------------------------------------------------
 // Validation helper
@@ -278,7 +356,8 @@ export type SchemaName =
   | "trustZonePromote"
   | "trustZoneDemoSeed"
   | "lcmSearch"
-  | "daySummary";
+  | "daySummary"
+  | "capsuleExport";
 
 export type SchemaTypeFor<N extends SchemaName> =
   N extends "recall" ? RecallRequest
@@ -292,6 +371,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "trustZoneDemoSeed" ? TrustZoneDemoSeedRequest
   : N extends "lcmSearch" ? LcmSearchRequest
   : N extends "daySummary" ? DaySummaryRequest
+  : N extends "capsuleExport" ? CapsuleExportRequest
   : never;
 
 const schemas: Record<SchemaName, z.ZodTypeAny> = {
@@ -306,6 +386,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   trustZoneDemoSeed: trustZoneDemoSeedRequestSchema,
   lcmSearch: lcmSearchRequestSchema,
   daySummary: daySummaryRequestSchema,
+  capsuleExport: capsuleExportRequestSchema,
 };
 
 /**

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -3,6 +3,7 @@
 // field-level detail so consumers get clear feedback on malformed requests.
 
 import { z } from "zod";
+import { isValidCapsuleSince } from "./transfer/capsule-export.js";
 import { CAPSULE_ID_PATTERN } from "./transfer/types.js";
 
 // ---------------------------------------------------------------------------
@@ -271,30 +272,6 @@ const capsulePeerIdSchema = z
     (value) => value !== "." && value !== ".." && !value.includes("/") && !value.includes("\\"),
     "must be a plain peer id without path separators",
   );
-
-const CAPSULE_ISO_8601_RE =
-  /^\d{4}-\d{2}-\d{2}(?:[Tt]\d{2}:\d{2}(?::\d{2}(?:\.\d{1,9})?)?(?:[Zz]|[+-]\d{2}:?\d{2}))?$/;
-
-function isValidCapsuleSince(value: string): boolean {
-  if (!CAPSULE_ISO_8601_RE.test(value)) return false;
-  const ms = Date.parse(value);
-  if (!Number.isFinite(ms)) return false;
-  const match = /^(\d{4})-(\d{2})-(\d{2})/.exec(value);
-  if (!match) return false;
-  const offsetMatch = /([+-])(\d{2}):?(\d{2})$/.exec(value);
-  let displayMs = ms;
-  if (offsetMatch) {
-    const sign = offsetMatch[1] === "-" ? -1 : 1;
-    const offsetMin = sign * (Number(offsetMatch[2]) * 60 + Number(offsetMatch[3]));
-    displayMs = ms + offsetMin * 60_000;
-  }
-  const date = new Date(displayMs);
-  return (
-    date.getUTCFullYear() === Number(match[1]) &&
-    date.getUTCMonth() + 1 === Number(match[2]) &&
-    date.getUTCDate() === Number(match[3])
-  );
-}
 
 const capsuleIsoSinceSchema = z
   .string()

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4514,7 +4514,7 @@ export class EngramAccessService {
     },
   ): Promise<ExportCapsuleResult> {
     const { namespace, principal, root: explicitRoot, memoryDir: explicitMemoryDir, ...exportOptions } = opts;
-    const resolvedNamespace = this.resolveReadableNamespace(namespace, principal);
+    const resolvedNamespace = this.resolveWritableNamespace(namespace, undefined, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const root = explicitRoot ?? storage.dir;
     const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -123,6 +123,22 @@ import {
 
 export class EngramAccessInputError extends Error {}
 
+let cachedPackageVersion: string | null = null;
+
+async function getPackageVersion(): Promise<string> {
+  if (cachedPackageVersion !== null) return cachedPackageVersion;
+  try {
+    const raw = await nodeFs.readFile(new URL("../package.json", import.meta.url), "utf-8");
+    const parsed = JSON.parse(raw) as { version?: unknown };
+    cachedPackageVersion = typeof parsed.version === "string" && parsed.version.length > 0
+      ? parsed.version
+      : "unknown";
+  } catch {
+    cachedPackageVersion = "unknown";
+  }
+  return cachedPackageVersion;
+}
+
 function normalizeTrustZoneInputError(error: unknown): EngramAccessInputError | null {
   const message = error instanceof Error ? error.message : null;
   if (!message) {
@@ -4518,8 +4534,10 @@ export class EngramAccessService {
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const root = explicitRoot ?? storage.dir;
     const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
+    const pluginVersion = exportOptions.pluginVersion ?? await getPackageVersion();
     return exportCapsuleFn({
       ...exportOptions,
+      pluginVersion,
       root,
       memoryDir: exportOptions.encrypt === true ? memoryDir : undefined,
     });

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -115,6 +115,11 @@ import {
   type ImportCapsuleOptions,
   type ImportCapsuleResult,
 } from "./transfer/capsule-import.js";
+import {
+  exportCapsule as exportCapsuleFn,
+  type ExportCapsuleOptions,
+  type ExportCapsuleResult,
+} from "./transfer/capsule-export.js";
 
 export class EngramAccessInputError extends Error {}
 
@@ -4491,6 +4496,33 @@ export class EngramAccessService {
       sidecarDir: this.orchestrator.config.versioningSidecarDir,
     };
     return importCapsuleFn({ ...opts, root, versioning });
+  }
+
+  /**
+   * Export a capsule archive from the orchestrator's memory directory.
+   *
+   * HTTP and future MCP surfaces use this rather than calling the transfer
+   * helper directly so namespace ACL checks stay consistent with other read
+   * surfaces. The exporter still owns archive construction and validation.
+   */
+  async capsuleExport(
+    opts: Omit<ExportCapsuleOptions, "root" | "memoryDir"> & {
+      root?: string;
+      memoryDir?: string;
+      namespace?: string;
+      principal?: string;
+    },
+  ): Promise<ExportCapsuleResult> {
+    const { namespace, principal, root: explicitRoot, memoryDir: explicitMemoryDir, ...exportOptions } = opts;
+    const resolvedNamespace = this.resolveReadableNamespace(namespace, principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const root = explicitRoot ?? storage.dir;
+    const memoryDir = explicitMemoryDir ?? root;
+    return exportCapsuleFn({
+      ...exportOptions,
+      root,
+      memoryDir: exportOptions.encrypt === true ? memoryDir : undefined,
+    });
   }
 
   // ── Dreams pipeline telemetry surfaces (issue #678 PR 3+4) ──────────────

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4517,7 +4517,7 @@ export class EngramAccessService {
     const resolvedNamespace = this.resolveReadableNamespace(namespace, principal);
     const storage = await this.orchestrator.getStorage(resolvedNamespace);
     const root = explicitRoot ?? storage.dir;
-    const memoryDir = explicitMemoryDir ?? root;
+    const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
     return exportCapsuleFn({
       ...exportOptions,
       root,

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -4518,8 +4518,9 @@ export class EngramAccessService {
    * Export a capsule archive from the orchestrator's memory directory.
    *
    * HTTP and future MCP surfaces use this rather than calling the transfer
-   * helper directly so namespace ACL checks stay consistent with other read
-   * surfaces. The exporter still owns archive construction and validation.
+   * helper directly so namespace ACL checks stay consistent with the archive
+   * write side effect. The exporter still owns archive construction and
+   * validation.
    */
   async capsuleExport(
     opts: Omit<ExportCapsuleOptions, "root" | "memoryDir"> & {

--- a/packages/remnic-core/src/transfer/capsule-export.ts
+++ b/packages/remnic-core/src/transfer/capsule-export.ts
@@ -334,6 +334,15 @@ function parseSince(since: string | undefined): number | null {
   return ms;
 }
 
+export function isValidCapsuleSince(since: string): boolean {
+  try {
+    parseSince(since);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Verify that parsing {@link since} did not silently normalize an invalid
  * calendar date (e.g. `2026-02-31` → `2026-03-03`). We extract the

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -379,6 +379,36 @@ function createFakeService(): EngramAccessService {
         recallMaxProcedures: 2,
       },
     }),
+    capsuleExport: async ({ name }) => ({
+      archivePath: `/tmp/engram/.capsules/${name}.capsule.json.gz`,
+      manifestPath: `/tmp/engram/.capsules/${name}.manifest.json`,
+      encryptedArchivePath: null,
+      manifest: {
+        format: "remnic-capsule",
+        schemaVersion: 2,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        pluginVersion: "9.3.243",
+        includesTranscripts: false,
+        files: [{ path: "facts/2026-04-28/fact-a.md", sha256: "abc123", bytes: 42 }],
+        capsule: {
+          id: name,
+          version: "1.0.0",
+          createdAt: "2026-04-28T00:00:00.000Z",
+          parentCapsule: null,
+          description: "HTTP test capsule",
+          retrievalPolicy: {
+            directAnswerEnabled: false,
+            tierWeights: {},
+          },
+          includes: {
+            taxonomy: false,
+            identityAnchors: false,
+            peerProfiles: false,
+            procedural: false,
+          },
+        },
+      },
+    }),
   } as unknown as EngramAccessService;
 }
 
@@ -528,6 +558,36 @@ test("access HTTP server enforces bearer auth and serves phase 1 routes", async 
     assert.equal(proceduralStats.config.enabled, true);
     assert.equal(proceduralStats.config.recallMaxProcedures, 2);
 
+    const capsuleDenied = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "daily-ops" }),
+    });
+    assert.equal(capsuleDenied.status, 401);
+
+    const capsuleExportRes = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "daily-ops",
+        namespace: "global",
+        includeKinds: ["facts"],
+        includeTranscripts: true,
+      }),
+    });
+    assert.equal(capsuleExportRes.status, 200);
+    const capsuleExport = await capsuleExportRes.json() as {
+      archivePath: string;
+      manifestPath: string;
+      encryptedArchivePath: string | null;
+      manifest: { capsule: { id: string }; files: Array<{ path: string }> };
+    };
+    assert.equal(capsuleExport.archivePath, "/tmp/engram/.capsules/daily-ops.capsule.json.gz");
+    assert.equal(capsuleExport.manifestPath, "/tmp/engram/.capsules/daily-ops.manifest.json");
+    assert.equal(capsuleExport.encryptedArchivePath, null);
+    assert.equal(capsuleExport.manifest.capsule.id, "daily-ops");
+    assert.deepEqual(capsuleExport.manifest.files.map((file) => file.path), ["facts/2026-04-28/fact-a.md"]);
+
     // Operator console state (issue #688 PR 2/3).
     const consoleStateRes = await fetch(`${base}/engram/v1/console/state`, { headers });
     assert.equal(consoleStateRes.status, 200);
@@ -615,6 +675,100 @@ test("access HTTP server serves admin console shell without auth and rejects inv
       body: JSON.stringify({ memoryId: "fact-1", status: "bogus", reasonCode: "operator_confirmed" }),
     });
     assert.equal(badDispositionRes.status, 400);
+  } finally {
+    await server.stop();
+  }
+});
+
+test("access HTTP capsule export validates input and surfaces ACL errors", async () => {
+  let captured: Record<string, unknown> | null = null;
+  const service = {
+    ...createFakeService(),
+    capsuleExport: async (request: Record<string, unknown>) => {
+      captured = request;
+      if (request.namespace === "private") {
+        throw new EngramAccessInputError("namespace is not readable");
+      }
+      return {
+        archivePath: "/tmp/engram/.capsules/remnic-alias.capsule.json.gz",
+        manifestPath: "/tmp/engram/.capsules/remnic-alias.manifest.json",
+        encryptedArchivePath: null,
+        manifest: {
+          capsule: { id: request.name },
+          files: [],
+        },
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    principal: "principal-1",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+  const headers = { Authorization: "Bearer secret-token", "Content-Type": "application/json" };
+
+  try {
+    const invalidName = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "bad name" }),
+    });
+    assert.equal(invalidName.status, 400);
+    const invalidNamePayload = await invalidName.json() as { code: string; details: Array<{ field: string }> };
+    assert.equal(invalidNamePayload.code, "validation_error");
+    assert.equal(invalidNamePayload.details[0]?.field, "name");
+
+    const invalidKind = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "good-name", includeKinds: ["../facts"] }),
+    });
+    assert.equal(invalidKind.status, 400);
+
+    const invalidSince = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "good-name", since: "2026-02-31" }),
+    });
+    assert.equal(invalidSince.status, 400);
+
+    const deniedNamespace = await fetch(`${base}/engram/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ name: "good-name", namespace: "private" }),
+    });
+    assert.equal(deniedNamespace.status, 400);
+    const deniedPayload = await deniedNamespace.json() as { code: string; error: string };
+    assert.equal(deniedPayload.code, "input_error");
+    assert.equal(deniedPayload.error, "namespace is not readable");
+
+    const aliasResponse = await fetch(`${base}/remnic/v1/capsules/export`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        name: "remnic-alias",
+        namespace: "team-a",
+        since: "2026-04-28T00:00:00Z",
+        peerIds: ["peer-a"],
+        encrypt: true,
+      }),
+    });
+    assert.equal(aliasResponse.status, 200);
+    assert.deepEqual(captured, {
+      name: "remnic-alias",
+      namespace: "team-a",
+      principal: "principal-1",
+      since: "2026-04-28T00:00:00Z",
+      includeKinds: undefined,
+      peerIds: ["peer-a"],
+      includeTranscripts: undefined,
+      encrypt: true,
+    });
   } finally {
     await server.stop();
   }

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -7,8 +7,30 @@ import { EngramAccessInputError, EngramAccessService } from "../src/access-servi
 import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import { rebuildMemoryProjection } from "../src/maintenance/rebuild-memory-projection.ts";
 import { getMemoryProjectionPath } from "../src/memory-projection-store.js";
+import {
+  keyring,
+  runSecureStoreInit,
+  runSecureStoreUnlock,
+} from "../src/secure-store/index.js";
 import { StorageManager } from "../src/storage.js";
 import { recordTrustZoneRecord } from "../src/trust-zones.ts";
+import type { ScryptParams } from "../packages/remnic-core/src/secure-store/kdf.js";
+import { isEncryptedCapsuleFile } from "../packages/remnic-core/src/transfer/capsule-crypto.js";
+
+const FAST_SCRYPT: ScryptParams = {
+  N: 1 << 10,
+  r: 1,
+  p: 1,
+  keyLength: 32,
+  maxmem: 32 * 1024 * 1024,
+};
+
+const TEST_PASSPHRASE = "correct horse battery staple";
+
+function staticPassphraseReader(...sequence: string[]) {
+  let index = 0;
+  return async () => sequence[index++] ?? sequence[sequence.length - 1] ?? TEST_PASSPHRASE;
+}
 
 function dreamsPhasesConfig(deepSleepEnabled = true, deepSleepEnabledExplicitlySet = false) {
   return {
@@ -280,6 +302,78 @@ function memoryDoc(id: string, content: string, extra: string[] = []): string {
     "",
   ].join("\n");
 }
+
+test("capsuleExport encrypts namespace exports with the root secure-store keyring", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-export-ns-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  await writeText(
+    namespaceDir,
+    path.join("facts", "2026-04-28", "fact-a.md"),
+    "---\nid: fact-a\ncategory: fact\n---\nNamespace capsule export uses the root secure-store key.\n",
+  );
+  let resolvedNamespace: string | undefined;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async (namespace: string | undefined) => {
+      resolvedNamespace = namespace;
+      return { dir: namespaceDir };
+    },
+  } as any);
+
+  try {
+    await runSecureStoreInit({
+      memoryDir,
+      readPassphrase: staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE),
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const unlock = await runSecureStoreUnlock({
+      memoryDir,
+      readPassphrase: staticPassphraseReader(TEST_PASSPHRASE),
+    });
+    assert.equal(unlock.ok, true);
+
+    const result = await service.capsuleExport({
+      name: "project-x-export",
+      namespace: "project-x",
+      principal: "project-x",
+      encrypt: true,
+    });
+
+    assert.equal(resolvedNamespace, "project-x");
+    assert.equal(result.encryptedArchivePath, result.archivePath);
+    assert.match(result.archivePath, /project-x-export\.capsule\.json\.gz\.enc$/);
+    assert.equal(await isEncryptedCapsuleFile(result.archivePath), true);
+  } finally {
+    keyring.lockAll();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
 
 test("access service rejects empty recall queries as input errors", async () => {
   const service = createService();

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -72,7 +72,7 @@ function createService(dreamsPhases = dreamsPhasesConfig()) {
       namespacePolicies: [
         {
           name: "project-x",
-          readPrincipals: ["project-x"],
+          readPrincipals: ["project-x", "read-only"],
           writePrincipals: ["project-x"],
         },
         {
@@ -346,6 +346,17 @@ test("capsuleExport encrypts namespace exports with the root secure-store keyrin
   } as any);
 
   try {
+    await assert.rejects(
+      () => service.capsuleExport({
+        name: "read-only-export",
+        namespace: "project-x",
+        principal: "read-only",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /namespace is not writable: project-x/.test(err.message),
+    );
+
     await runSecureStoreInit({
       memoryDir,
       readPassphrase: staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE),

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -11,11 +11,10 @@ import {
   keyring,
   runSecureStoreInit,
   runSecureStoreUnlock,
+  type ScryptParams,
 } from "../src/secure-store/index.js";
 import { StorageManager } from "../src/storage.js";
 import { recordTrustZoneRecord } from "../src/trust-zones.ts";
-import type { ScryptParams } from "../packages/remnic-core/src/secure-store/kdf.js";
-import { isEncryptedCapsuleFile } from "../packages/remnic-core/src/transfer/capsule-crypto.js";
 
 const FAST_SCRYPT: ScryptParams = {
   N: 1 << 10,
@@ -379,7 +378,10 @@ test("capsuleExport encrypts namespace exports with the root secure-store keyrin
     assert.equal(resolvedNamespace, "project-x");
     assert.equal(result.encryptedArchivePath, result.archivePath);
     assert.match(result.archivePath, /project-x-export\.capsule\.json\.gz\.enc$/);
-    assert.equal(await isEncryptedCapsuleFile(result.archivePath), true);
+    const encrypted = await readFile(result.archivePath);
+    assert.equal(encrypted.subarray(0, 11).toString("ascii"), "REMNIC-ENC\0");
+    assert.notEqual(result.manifest.pluginVersion, "0.0.0");
+    assert.match(result.manifest.pluginVersion, /^\d+\.\d+\.\d+/);
   } finally {
     keyring.lockAll();
     await rm(memoryDir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary
- add `POST /engram/v1/capsules/export` plus the `/remnic/v1/capsules/export` alias
- validate capsule export request options before delegating to the existing capsule exporter through `EngramAccessService`
- enforce auth, namespace principal threading, and write rate limiting for archive creation

Closes #776.
Follow-up to #676.

## Verification
- `npm exec -- tsx --test tests/access-http.test.ts`
- `npm run check-types`
- `npm run build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated, rate-limited HTTP endpoint that triggers capsule archive creation (including optional encryption) and threads namespace/principal ACL decisions, so misvalidation or ACL mistakes could cause unwanted data export or writes.
> 
> **Overview**
> Adds a new **capsule export** HTTP API: `POST /engram/v1/capsules/export` with a `/remnic/v1/capsules/export` alias, enforcing bearer auth and write-rate limiting before delegating to `EngramAccessService.capsuleExport`.
> 
> Introduces `capsuleExport` request validation (capsule id format, safe `includeKinds`/`peerIds`, strict ISO `since` with calendar-overflow rejection) and extends the service layer to resolve writable namespaces, thread `principal`, and stamp `pluginVersion` (read from `package.json`) when exporting; encrypted exports pass `memoryDir` so the exporter can use the secure-store keyring.
> 
> Adds/updates tests covering the new route (auth, aliasing, validation + ACL error surfacing) and verifies encrypted namespace exports require write access and produce an encrypted archive header.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b7d9726bc57d7249dfc139164fbc8a49c4cf46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->