### PR TITLE
chore(openclaw): publish plugin 1.0.11

### DIFF
--- a/packages/plugin-openclaw/package.json
+++ b/packages/plugin-openclaw/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@remnic/plugin-openclaw",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "OpenClaw adapter for Remnic memory — thin wrapper delegating to @remnic/core",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Bump @remnic/plugin-openclaw to 1.0.11 so the merged OpenClaw validator fix publishes to npm.

## Verification
- pnpm exec tsx --test packages/plugin-openclaw/src/openclaw-tools/*.test.ts tests/sdk-compat-integration.test.ts
- pnpm --filter @remnic/plugin-openclaw run build

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: this PR only changes the package version metadata and does not modify runtime code or build configuration.
> 
> **Overview**
> Publishes a new release by bumping `@remnic/plugin-openclaw` version from `1.0.10` to `1.0.11` in `packages/plugin-openclaw/package.json`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5b997868d2f03e2252e96fc0c671ff06be43dd8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->