### PR TITLE
feat(http): add capsule import endpoint

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -18,6 +18,7 @@ import {
   subscribeGraphEvents,
   type GraphEvent,
 } from "./graph-events.js";
+import { expandTildePath } from "./utils/path.js";
 
 export interface EngramAccessHttpServerOptions {
   service: EngramAccessService;
@@ -554,6 +555,23 @@ export class EngramAccessHttpServer {
         peerIds: body.peerIds,
         includeTranscripts: body.includeTranscripts,
         encrypt: body.encrypt,
+      });
+      this.recordWriteRateLimitHit();
+      this.respondJson(res, 200, result);
+      return;
+    }
+
+    if (
+      req.method === "POST" &&
+      (pathname === "/engram/v1/capsules/import" || pathname === "/remnic/v1/capsules/import")
+    ) {
+      const body = await this.readValidatedBody(req, "capsuleImport");
+      this.ensureWriteRateLimitAvailable();
+      const result = await this.service.capsuleImport({
+        archivePath: expandTildePath(body.archivePath),
+        namespace: this.resolveNamespace(req, body.namespace),
+        principal: this.resolveRequestPrincipal(req),
+        mode: body.mode,
       });
       this.recordWriteRateLimitHit();
       this.respondJson(res, 200, result);

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -301,6 +301,12 @@ export const capsuleExportRequestSchema = z.object({
   encrypt: z.boolean().optional(),
 });
 
+export const capsuleImportRequestSchema = z.object({
+  archivePath: z.string().trim().min(1, "archivePath is required").max(4096),
+  namespace: namespaceSchema,
+  mode: z.enum(["skip", "overwrite", "fork"]).optional(),
+});
+
 // ---------------------------------------------------------------------------
 // Inferred types
 // ---------------------------------------------------------------------------
@@ -317,6 +323,7 @@ export type TrustZoneDemoSeedRequest = z.infer<typeof trustZoneDemoSeedRequestSc
 export type LcmSearchRequest = z.infer<typeof lcmSearchRequestSchema>;
 export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
 export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
+export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
 
 // ---------------------------------------------------------------------------
 // Validation helper
@@ -334,7 +341,8 @@ export type SchemaName =
   | "trustZoneDemoSeed"
   | "lcmSearch"
   | "daySummary"
-  | "capsuleExport";
+  | "capsuleExport"
+  | "capsuleImport";
 
 export type SchemaTypeFor<N extends SchemaName> =
   N extends "recall" ? RecallRequest
@@ -349,6 +357,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "lcmSearch" ? LcmSearchRequest
   : N extends "daySummary" ? DaySummaryRequest
   : N extends "capsuleExport" ? CapsuleExportRequest
+  : N extends "capsuleImport" ? CapsuleImportRequest
   : never;
 
 const schemas: Record<SchemaName, z.ZodTypeAny> = {
@@ -364,6 +373,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   lcmSearch: lcmSearchRequestSchema,
   daySummary: daySummaryRequestSchema,
   capsuleExport: capsuleExportRequestSchema,
+  capsuleImport: capsuleImportRequestSchema,
 };
 
 /**

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -1,5 +1,7 @@
 import { stat } from "node:fs/promises";
 import * as nodeFs from "node:fs/promises";
+import { constants as fsConstants } from "node:fs";
+import { ZodError } from "zod";
 import { AccessIdempotencyStore, hashAccessIdempotencyPayload } from "./access-idempotency.js";
 import { AccessAuditAdapter, type AccessAuditConfig, type AccessAuditResult } from "./access-audit.js";
 import type { AnomalyDetectorResult } from "./recall-audit-anomaly.js";
@@ -4503,15 +4505,82 @@ export class EngramAccessService {
    * caller having to construct the config object.
    */
   async capsuleImport(
-    opts: Omit<ImportCapsuleOptions, "root"> & { root?: string },
+    opts: Omit<ImportCapsuleOptions, "root" | "memoryDir"> & {
+      root?: string;
+      memoryDir?: string;
+      namespace?: string;
+      principal?: string;
+    },
   ): Promise<ImportCapsuleResult> {
-    const root = opts.root ?? this.orchestrator.config.memoryDir;
-    const versioning = opts.versioning ?? {
+    const { namespace, principal, root: explicitRoot, memoryDir: explicitMemoryDir, ...importOptions } = opts;
+    const resolvedNamespace = this.resolveWritableNamespace(namespace, undefined, principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const root = explicitRoot ?? storage.dir;
+    const memoryDir = explicitMemoryDir ?? this.orchestrator.config.memoryDir;
+    const versioning = importOptions.versioning ?? {
       enabled: this.orchestrator.config.versioningEnabled,
       maxVersionsPerPage: this.orchestrator.config.versioningMaxPerPage,
       sidecarDir: this.orchestrator.config.versioningSidecarDir,
     };
-    return importCapsuleFn({ ...opts, root, versioning });
+    await this.validateCapsuleImportArchivePath(importOptions.archivePath);
+    try {
+      return await importCapsuleFn({ ...importOptions, root, memoryDir, versioning });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (this.isCapsuleImportArchiveInputError(err, message)) {
+        throw new EngramAccessInputError(`capsule import failed: ${message}`);
+      }
+      throw err;
+    }
+  }
+
+  private async validateCapsuleImportArchivePath(archivePath: string): Promise<void> {
+    let archiveStat;
+    try {
+      archiveStat = await stat(archivePath);
+    } catch (err) {
+      if (!this.isCapsuleImportPathInputFsError(err)) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new EngramAccessInputError(`capsule import failed: archive is not readable: ${message}`);
+    }
+    if (!archiveStat.isFile()) {
+      throw new EngramAccessInputError("capsule import failed: archivePath must point to a file");
+    }
+    try {
+      await nodeFs.access(archivePath, fsConstants.R_OK);
+    } catch (err) {
+      if (!this.isCapsuleImportPathInputFsError(err)) throw err;
+      const message = err instanceof Error ? err.message : String(err);
+      throw new EngramAccessInputError(`capsule import failed: archive is not readable: ${message}`);
+    }
+  }
+
+  private isCapsuleImportPathInputFsError(err: unknown): boolean {
+    const code = typeof err === "object" && err !== null && "code" in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+    return (
+      code === "ENOENT" ||
+      code === "ENOTDIR" ||
+      code === "EACCES" ||
+      code === "EPERM" ||
+      code === "ELOOP"
+    );
+  }
+
+  private isCapsuleImportArchiveInputError(err: unknown, message: string): boolean {
+    if (err instanceof ZodError) return true;
+    const code = typeof err === "object" && err !== null && "code" in err
+      ? (err as { code?: unknown }).code
+      : undefined;
+    if (typeof code === "string" && code.startsWith("Z_")) return true;
+    return (
+      message.startsWith("importCapsule: archive") ||
+      message.startsWith("importCapsule: bundle") ||
+      message.startsWith("importCapsule: manifest") ||
+      message.startsWith("importCapsule: record") ||
+      /incorrect header check|invalid stored block lengths|not in gzip format|unexpected end of file/i.test(message)
+    );
   }
 
   /**

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -409,6 +409,40 @@ function createFakeService(): EngramAccessService {
         },
       },
     }),
+    capsuleImport: async ({ archivePath, mode }) => ({
+      imported: [{
+        sourcePath: "facts/2026-04-28/fact-a.md",
+        targetPath: "facts/2026-04-28/fact-a.md",
+        snapshotted: mode === "overwrite",
+        rewroteId: false,
+      }],
+      skipped: [],
+      manifest: {
+        format: "remnic-capsule",
+        schemaVersion: 2,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        pluginVersion: "9.3.243",
+        includesTranscripts: false,
+        files: [{ path: "facts/2026-04-28/fact-a.md", sha256: "abc123", bytes: 42 }],
+        capsule: {
+          id: path.basename(String(archivePath)).replace(/\.capsule\.json\.gz(?:\.enc)?$/, ""),
+          version: "1.0.0",
+          createdAt: "2026-04-28T00:00:00.000Z",
+          parentCapsule: null,
+          description: "HTTP import test capsule",
+          retrievalPolicy: {
+            directAnswerEnabled: false,
+            tierWeights: {},
+          },
+          includes: {
+            taxonomy: false,
+            identityAnchors: false,
+            peerProfiles: false,
+            procedural: false,
+          },
+        },
+      },
+    }),
   } as unknown as EngramAccessService;
 }
 
@@ -587,6 +621,34 @@ test("access HTTP server enforces bearer auth and serves phase 1 routes", async 
     assert.equal(capsuleExport.encryptedArchivePath, null);
     assert.equal(capsuleExport.manifest.capsule.id, "daily-ops");
     assert.deepEqual(capsuleExport.manifest.files.map((file) => file.path), ["facts/2026-04-28/fact-a.md"]);
+
+    const capsuleImportDenied = await fetch(`${base}/engram/v1/capsules/import`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ archivePath: "/tmp/daily-ops.capsule.json.gz" }),
+    });
+    assert.equal(capsuleImportDenied.status, 401);
+
+    const capsuleImportRes = await fetch(`${base}/engram/v1/capsules/import`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        archivePath: "/tmp/daily-ops.capsule.json.gz",
+        namespace: "global",
+        mode: "overwrite",
+      }),
+    });
+    assert.equal(capsuleImportRes.status, 200);
+    const capsuleImport = await capsuleImportRes.json() as {
+      imported: Array<{ sourcePath: string; targetPath: string; snapshotted: boolean }>;
+      skipped: unknown[];
+      manifest: { capsule: { id: string } };
+    };
+    assert.equal(capsuleImport.imported.length, 1);
+    assert.equal(capsuleImport.imported[0]?.sourcePath, "facts/2026-04-28/fact-a.md");
+    assert.equal(capsuleImport.imported[0]?.snapshotted, true);
+    assert.deepEqual(capsuleImport.skipped, []);
+    assert.equal(capsuleImport.manifest.capsule.id, "daily-ops");
 
     // Operator console state (issue #688 PR 2/3).
     const consoleStateRes = await fetch(`${base}/engram/v1/console/state`, { headers });
@@ -768,6 +830,104 @@ test("access HTTP capsule export validates input and surfaces ACL errors", async
       peerIds: ["peer-a"],
       includeTranscripts: undefined,
       encrypt: true,
+    });
+  } finally {
+    await server.stop();
+  }
+});
+
+test("access HTTP capsule import validates input and surfaces ACL errors", async () => {
+  let captured: Record<string, unknown> | null = null;
+  const service = {
+    ...createFakeService(),
+    capsuleImport: async (request: Record<string, unknown>) => {
+      captured = request;
+      if (request.namespace === "private") {
+        throw new EngramAccessInputError("namespace is not writable");
+      }
+      return {
+        imported: [],
+        skipped: [{ path: "facts/2026-04-28/fact-a.md", reason: "exists" }],
+        manifest: {
+          format: "remnic-capsule",
+          schemaVersion: 2,
+          createdAt: "2026-04-28T00:00:00.000Z",
+          pluginVersion: "9.3.243",
+          includesTranscripts: false,
+          files: [],
+          capsule: {
+            id: "import-alias",
+            version: "1.0.0",
+            createdAt: "2026-04-28T00:00:00.000Z",
+            parentCapsule: null,
+            description: null,
+            retrievalPolicy: null,
+          },
+        },
+      };
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramAccessHttpServer({
+    service,
+    host: "127.0.0.1",
+    port: 0,
+    authToken: "secret-token",
+    principal: "principal-1",
+    maxBodyBytes: 1024,
+  });
+  const started = await server.start();
+  const base = `http://${started.host}:${started.port}`;
+  const headers = { Authorization: "Bearer secret-token", "Content-Type": "application/json" };
+
+  try {
+    const missingArchivePath = await fetch(`${base}/engram/v1/capsules/import`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ mode: "overwrite" }),
+    });
+    assert.equal(missingArchivePath.status, 400);
+    const missingArchivePayload = await missingArchivePath.json() as { code: string; details: Array<{ field: string }> };
+    assert.equal(missingArchivePayload.code, "validation_error");
+    assert.equal(missingArchivePayload.details[0]?.field, "archivePath");
+
+    const invalidMode = await fetch(`${base}/engram/v1/capsules/import`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ archivePath: "/tmp/import-alias.capsule.json.gz", mode: "merge" }),
+    });
+    assert.equal(invalidMode.status, 400);
+
+    const deniedNamespace = await fetch(`${base}/engram/v1/capsules/import`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({ archivePath: "/tmp/import-alias.capsule.json.gz", namespace: "private" }),
+    });
+    assert.equal(deniedNamespace.status, 400);
+    const deniedPayload = await deniedNamespace.json() as { code: string; error: string };
+    assert.equal(deniedPayload.code, "input_error");
+    assert.equal(deniedPayload.error, "namespace is not writable");
+
+    const aliasResponse = await fetch(`${base}/remnic/v1/capsules/import`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        archivePath: "~/import-alias.capsule.json.gz",
+        namespace: "team-a",
+        mode: "fork",
+      }),
+    });
+    assert.equal(aliasResponse.status, 200);
+    const aliasPayload = await aliasResponse.json() as {
+      skipped: Array<{ path: string; reason: string }>;
+      manifest: { capsule: { id: string } };
+    };
+    assert.deepEqual(aliasPayload.skipped, [{ path: "facts/2026-04-28/fact-a.md", reason: "exists" }]);
+    assert.equal(aliasPayload.manifest.capsule.id, "import-alias");
+    assert.deepEqual(captured, {
+      archivePath: path.join(os.homedir(), "import-alias.capsule.json.gz"),
+      namespace: "team-a",
+      principal: "principal-1",
+      mode: "fork",
     });
   } finally {
     await server.stop();

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -2,7 +2,8 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
-import { mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { gzipSync } from "node:zlib";
+import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { EngramAccessInputError, EngramAccessService } from "../src/access-service.js";
 import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import { rebuildMemoryProjection } from "../src/maintenance/rebuild-memory-projection.ts";
@@ -15,6 +16,7 @@ import {
 } from "../src/secure-store/index.js";
 import { StorageManager } from "../src/storage.js";
 import { recordTrustZoneRecord } from "../src/trust-zones.ts";
+import { exportCapsule } from "../src/transfer/capsule-export.js";
 
 const FAST_SCRYPT: ScryptParams = {
   N: 1 << 10,
@@ -384,6 +386,279 @@ test("capsuleExport encrypts namespace exports with the root secure-store keyrin
     assert.match(result.manifest.pluginVersion, /^\d+\.\d+\.\d+/);
   } finally {
     keyring.lockAll();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("capsuleImport decrypts namespace imports with the root secure-store keyring", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-import-ns-"));
+  const sourceDir = path.join(memoryDir, "source");
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  await mkdir(namespaceDir, { recursive: true });
+  await writeText(
+    sourceDir,
+    path.join("facts", "2026-04-28", "fact-a.md"),
+    "---\nid: fact-a\ncategory: fact\n---\nEncrypted namespace imports use the root secure-store key.\n",
+  );
+  let resolvedNamespace: string | undefined;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x", "read-only"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+      versioningEnabled: false,
+      versioningMaxPerPage: 50,
+      versioningSidecarDir: undefined,
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async (namespace: string | undefined) => {
+      resolvedNamespace = namespace;
+      return { dir: namespaceDir };
+    },
+  } as any);
+
+  try {
+    await runSecureStoreInit({
+      memoryDir,
+      readPassphrase: staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE),
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const unlock = await runSecureStoreUnlock({
+      memoryDir,
+      readPassphrase: staticPassphraseReader(TEST_PASSPHRASE),
+    });
+    assert.equal(unlock.ok, true);
+
+    const capsule = await exportCapsule({
+      name: "project-x-import",
+      root: sourceDir,
+      outDir: path.join(memoryDir, "out"),
+      encrypt: true,
+      memoryDir,
+    });
+
+    await assert.rejects(
+      () => service.capsuleImport({
+        archivePath: capsule.archivePath,
+        namespace: "project-x",
+        principal: "read-only",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /namespace is not writable: project-x/.test(err.message),
+    );
+
+    const result = await service.capsuleImport({
+      archivePath: capsule.archivePath,
+      namespace: "project-x",
+      principal: "project-x",
+    });
+
+    assert.equal(resolvedNamespace, "project-x");
+    assert.equal(result.imported.length, 1);
+    assert.equal(result.imported[0]?.targetPath, "facts/2026-04-28/fact-a.md");
+    const imported = await readFile(path.join(namespaceDir, "facts", "2026-04-28", "fact-a.md"), "utf-8");
+    assert.match(imported, /Encrypted namespace imports use the root secure-store key/);
+  } finally {
+    keyring.lockAll();
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("capsuleImport reports bad archive input as an access input error", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-import-bad-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  await mkdir(namespaceDir, { recursive: true });
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+      versioningEnabled: false,
+      versioningMaxPerPage: 50,
+      versioningSidecarDir: undefined,
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async () => ({ dir: namespaceDir }),
+  } as any);
+
+  try {
+    await assert.rejects(
+      () => service.capsuleImport({
+        archivePath: path.join(memoryDir, "missing.capsule.json.gz"),
+        namespace: "project-x",
+        principal: "project-x",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /capsule import failed:/.test(err.message),
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("capsuleImport reports unreadable archive paths as access input errors", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-import-unreadable-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  await mkdir(namespaceDir, { recursive: true });
+  const archivePath = path.join(memoryDir, "unreadable.capsule.json.gz");
+  await writeFile(archivePath, "not gzip", "utf8");
+  await chmod(archivePath, 0o000);
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+      versioningEnabled: false,
+      versioningMaxPerPage: 50,
+      versioningSidecarDir: undefined,
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async () => ({ dir: namespaceDir }),
+  } as any);
+
+  try {
+    await assert.rejects(
+      () => service.capsuleImport({
+        archivePath,
+        namespace: "project-x",
+        principal: "project-x",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /archive is not readable/.test(err.message),
+    );
+  } finally {
+    await chmod(archivePath, 0o600).catch(() => {});
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("capsuleImport reports malformed capsule bundles as access input errors", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-import-malformed-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  await mkdir(namespaceDir, { recursive: true });
+  const archivePath = path.join(memoryDir, "bad.capsule.json.gz");
+  const corruptGzipPath = path.join(memoryDir, "corrupt.capsule.json.gz");
+  await writeFile(archivePath, gzipSync(Buffer.from(JSON.stringify({ format: "not-remnic-capsule" }), "utf8")));
+  await writeFile(corruptGzipPath, "not gzip", "utf8");
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+      versioningEnabled: false,
+      versioningMaxPerPage: 50,
+      versioningSidecarDir: undefined,
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async () => ({ dir: namespaceDir }),
+  } as any);
+
+  try {
+    await assert.rejects(
+      () => service.capsuleImport({
+        archivePath,
+        namespace: "project-x",
+        principal: "project-x",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /capsule import failed:/.test(err.message),
+    );
+    await assert.rejects(
+      () => service.capsuleImport({
+        archivePath: corruptGzipPath,
+        namespace: "project-x",
+        principal: "project-x",
+      }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /capsule import failed:/.test(err.message),
+    );
+  } finally {
     await rm(memoryDir, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
## Summary
- add `POST /engram/v1/capsules/import` plus `/remnic/v1/capsules/import`
- validate archive path and import mode request bodies, then delegate to the existing capsule importer through `EngramAccessService`
- enforce auth, write ACL, root secure-store keyring fallback for encrypted namespace imports, and write rate limiting

Closes #777.
Follow-up to #676.

## Verification
- `npm exec -- tsx --test tests/access-http.test.ts`
- `npm exec -- tsx --test --test-name-pattern "capsuleImport decrypts namespace imports" tests/access-service.test.ts`
- `npm run check-types`
- `npm run build`
- `git diff --check`
- `npm run preflight:quick` (typecheck/config-contract/review-patterns passed; broad repo `npm test` phase hit existing unrelated benchmark adapter failures, then hung and was interrupted)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new authenticated, rate-limited write endpoint that imports archives from filesystem paths and expands `~`, which can affect data integrity and error handling if validation/ACL checks are wrong.
> 
> **Overview**
> Adds `POST /engram/v1/capsules/import` (plus `/remnic/v1/capsules/import`) to trigger capsule archive imports via `EngramAccessService`, including `~` path expansion, request-body validation, bearer auth, and write rate limiting.
> 
> Extends request schema support with `capsuleImport` (`archivePath`, optional `mode`, optional `namespace`) and enhances `EngramAccessService.capsuleImport` to resolve a writable namespace/root, validate archive readability, and convert common archive/FS/Zod failures into `EngramAccessInputError` for consistent 400 responses.
> 
> Adds/updates tests covering auth enforcement, input validation, ACL error surfacing, `~` expansion, encrypted namespace import decryption via the root keyring, and malformed/unreadable archive handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02e20423f52c99d6626951506d7c6fccacdb6fae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->