### PR TITLE
feat(secure-store): add disable decrypt command

### DIFF
--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -108,6 +108,31 @@ remnic engram secure-store migrate
 layer. Remaining sidecar coverage is tracked separately so the migration command
 does not encrypt files that older code paths would still read as plaintext.
 
+### Disable Encryption
+
+```bash
+remnic engram secure-store disable
+```
+
+Decrypts encrypted storage-managed files back to plaintext using the currently
+unlocked secure-store key. Plaintext files are skipped, so the command is safe
+to rerun.
+
+This command requires the store to be initialized and unlocked:
+
+```bash
+remnic engram secure-store unlock
+remnic engram secure-store disable
+```
+
+The `.secure-store/header.json` metadata is kept in place. Use the `decrypt`
+subcommand as an alias when you want the command name to describe the file
+operation:
+
+```bash
+remnic engram secure-store decrypt
+```
+
 ### Lock
 
 ```bash

--- a/packages/remnic-core/src/cli.ts
+++ b/packages/remnic-core/src/cli.ts
@@ -8792,6 +8792,42 @@ export function registerCli(
           }
         });
 
+      async function runSecureStoreDisableCommand(options: Record<string, unknown>): Promise<void> {
+        const { runSecureStoreDisable, renderDisableReport } = await import(
+          "./secure-store/index.js"
+        );
+        const memoryDir = expandTildePath(orchestrator.config.memoryDir);
+        const report = await runSecureStoreDisable({ memoryDir });
+        if (options.json === true) {
+          console.log(JSON.stringify(report, null, 2));
+        } else {
+          console.log(renderDisableReport(report));
+        }
+        if (!report.ok) {
+          process.exitCode = 1;
+        }
+      }
+
+      secureStoreCmd
+        .command("disable")
+        .description(
+          "Decrypt storage-managed secure-store files back to plaintext. Requires an initialized, unlocked secure-store and keeps .secure-store metadata in place.",
+        )
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          await runSecureStoreDisableCommand(options);
+        });
+
+      secureStoreCmd
+        .command("decrypt")
+        .description("Alias for `secure-store disable`.")
+        .option("--json", "Emit machine-readable JSON only")
+        .action(async (...args: unknown[]) => {
+          const options = (args[0] ?? {}) as Record<string, unknown>;
+          await runSecureStoreDisableCommand(options);
+        });
+
       secureStoreCmd
         .command("status")
         .description(

--- a/packages/remnic-core/src/secure-store/cli-handlers.ts
+++ b/packages/remnic-core/src/secure-store/cli-handlers.ts
@@ -1,6 +1,6 @@
 /**
  * Pure handlers behind the `remnic secure-store {init,unlock,lock,
- * status,migrate}` CLI surface (issue #690 PR 2/4 + #779).
+ * status,migrate,disable}` CLI surface (issue #690 PR 2/4 + #779/#780).
  *
  * Each handler:
  *   - takes an explicit `memoryDir` (already `~`-expanded by the CLI),
@@ -33,7 +33,12 @@ import {
   type KdfAlgorithm,
   type ScryptParams,
 } from "./kdf.js";
-import { migrateMemoryDirToEncrypted, type MigrateResult } from "./secure-fs.js";
+import {
+  decryptMemoryDirToPlaintext,
+  migrateMemoryDirToEncrypted,
+  type DecryptResult,
+  type MigrateResult,
+} from "./secure-fs.js";
 
 /** Passphrase source — async so callers can read from a TTY without echo. */
 export type PassphraseReader = (
@@ -225,6 +230,51 @@ export async function runSecureStoreMigrate(
   }
 
   const result = await migrateMemoryDirToEncrypted(memoryDir, key);
+  if (result.errors.length > 0) {
+    return { ok: false, reason: "file-errors", ...result };
+  }
+  return { ok: true, ...result };
+}
+
+// ─── disable/decrypt ─────────────────────────────────────────────────
+
+export interface SecureStoreDisableOptions extends SecureStoreHandlerCommon {}
+
+export type SecureStoreDisableReport =
+  | ({ ok: true } & DecryptResult)
+  | ({
+      ok: false;
+      reason: "not-initialized" | "locked" | "file-errors";
+    } & DecryptResult);
+
+export async function runSecureStoreDisable(
+  options: SecureStoreDisableOptions,
+): Promise<SecureStoreDisableReport> {
+  const { memoryDir } = options;
+  const header = await readHeader(memoryDir);
+  if (!header) {
+    return {
+      ok: false,
+      reason: "not-initialized",
+      decrypted: 0,
+      skipped: 0,
+      errors: [],
+    };
+  }
+
+  const id = options.keyringId ?? secureStoreDir(memoryDir);
+  const key = keyring.getKey(id);
+  if (key === null) {
+    return {
+      ok: false,
+      reason: "locked",
+      decrypted: 0,
+      skipped: 0,
+      errors: [],
+    };
+  }
+
+  const result = await decryptMemoryDirToPlaintext(memoryDir, key);
   if (result.errors.length > 0) {
     return { ok: false, reason: "file-errors", ...result };
   }

--- a/packages/remnic-core/src/secure-store/cli-renderer.ts
+++ b/packages/remnic-core/src/secure-store/cli-renderer.ts
@@ -1,6 +1,6 @@
 /**
  * Console-text renderers for the `remnic engram secure-store {init,unlock,
- * lock,status,migrate}` CLI surface (issue #690 PR 2/4 + #779).
+ * lock,status,migrate,disable}` CLI surface (issue #690 PR 2/4 + #779/#780).
  *
  * Pure: each `render*` function takes a typed report and returns a
  * string. CLI handlers do the `console.log`. Tests assert on the
@@ -10,6 +10,7 @@
 import type {
   SecureStoreInitReport,
   SecureStoreLockReport,
+  SecureStoreDisableReport,
   SecureStoreMigrateReport,
   SecureStoreStatusReport,
   SecureStoreUnlockReport,
@@ -66,6 +67,29 @@ export function renderMigrateReport(report: SecureStoreMigrateReport): string {
   if (report.errors.length > 10) {
     lines.push(`- ... ${report.errors.length - 10} more error(s)`);
   }
+  return lines.join("\n");
+}
+
+export function renderDisableReport(report: SecureStoreDisableReport): string {
+  if (!report.ok && report.reason === "not-initialized") {
+    return "ERR — secure-store is not initialized. Run 'remnic engram secure-store init' first.";
+  }
+  if (!report.ok && report.reason === "locked") {
+    return "ERR — secure-store is locked. Run 'remnic engram secure-store unlock' before disable.";
+  }
+
+  const lines: string[] = [];
+  lines.push(report.ok ? "OK — secure-store disable complete." : "ERR — secure-store disable completed with file errors.");
+  lines.push(`decrypted: ${report.decrypted}`);
+  lines.push(`skipped: ${report.skipped}`);
+  lines.push(`errors: ${report.errors.length}`);
+  for (const entry of report.errors.slice(0, 10)) {
+    lines.push(`- ${entry.filePath}: ${entry.error}`);
+  }
+  if (report.errors.length > 10) {
+    lines.push(`- ... ${report.errors.length - 10} more error(s)`);
+  }
+  lines.push("header: kept");
   return lines.join("\n");
 }
 

--- a/packages/remnic-core/src/secure-store/index.ts
+++ b/packages/remnic-core/src/secure-store/index.ts
@@ -85,6 +85,7 @@ export {
   MIN_PASSPHRASE_LENGTH,
   runSecureStoreInit,
   runSecureStoreLock,
+  runSecureStoreDisable,
   runSecureStoreMigrate,
   runSecureStoreStatus,
   runSecureStoreUnlock,
@@ -93,6 +94,8 @@ export {
   type SecureStoreInitReport,
   type SecureStoreLockOptions,
   type SecureStoreLockReport,
+  type SecureStoreDisableOptions,
+  type SecureStoreDisableReport,
   type SecureStoreMigrateOptions,
   type SecureStoreMigrateReport,
   type SecureStoreStatusOptions,
@@ -102,6 +105,7 @@ export {
 } from "./cli-handlers.js";
 
 export {
+  renderDisableReport,
   renderInitReport,
   renderLockReport,
   renderMigrateReport,
@@ -119,6 +123,7 @@ export {
   MAGIC_HEADER_SIZE,
   SecureStoreDecryptError,
   SecureStoreLockedError,
+  decryptMemoryDirToPlaintext,
   decryptFileBody,
   encryptFileBody,
   filePathAad,
@@ -127,5 +132,6 @@ export {
   readMaybeEncryptedFile,
   writeMaybeEncryptedFile,
   type MigrateResult,
+  type DecryptResult,
   type WriteMaybeEncryptedFileOptions,
 } from "./secure-fs.js";

--- a/packages/remnic-core/src/secure-store/secure-fs.ts
+++ b/packages/remnic-core/src/secure-store/secure-fs.ts
@@ -299,6 +299,15 @@ export interface MigrateResult {
   errors: Array<{ filePath: string; error: string }>;
 }
 
+export interface DecryptResult {
+  /** Number of files successfully decrypted back to plaintext. */
+  decrypted: number;
+  /** Number of files already plaintext (skipped). */
+  skipped: number;
+  /** Files that failed to decrypt (path → error message). */
+  errors: Array<{ filePath: string; error: string }>;
+}
+
 /**
  * Walk `dir` recursively, find encryptable `.md` files that are not
  * yet encrypted, and re-write them as encrypted files under `key`.
@@ -344,7 +353,7 @@ export async function migrateMemoryDirToEncrypted(
         }
       }
       const content = buf.toString("utf8");
-      const aad = filePathAad(filePath, dir);
+      const aad = filePathAad(filePath, storageAadRootForFile(filePath, dir));
       const encrypted = encryptFileBody(content, key, aad);
 
       // Atomic write: temp → rename (gotcha #54).
@@ -374,6 +383,57 @@ export async function migrateMemoryDirToEncrypted(
   return result;
 }
 
+/**
+ * Walk `dir` recursively, find storage-managed encrypted files, and
+ * re-write them as plaintext under the same paths.
+ *
+ * This is the reversible counterpart to {@link migrateMemoryDirToEncrypted}.
+ * It only touches files under the same storage-managed roots, skips
+ * plaintext files, skips symlinks, excludes `.secure-store/`, and writes
+ * each plaintext replacement via temp-file + rename so a per-file failure
+ * leaves the ciphertext intact.
+ */
+export async function decryptMemoryDirToPlaintext(
+  dir: string,
+  key: Buffer,
+): Promise<DecryptResult> {
+  const result: DecryptResult = { decrypted: 0, skipped: 0, errors: [] };
+
+  const files = await collectStorageManagedFiles(dir, isDecryptableStoragePath);
+  for (const filePath of files) {
+    try {
+      const buf = await readFile(filePath);
+      if (!isEncryptedFile(buf)) {
+        result.skipped++;
+        continue;
+      }
+
+      const aad = filePathAad(filePath, storageAadRootForFile(filePath, dir));
+      const plaintext = decryptFileBody(buf, key, aad);
+      const tempPath = `${filePath}.dec-tmp-${process.pid}-${Date.now()}`;
+      try {
+        await writeFile(tempPath, plaintext, { mode: 0o600 });
+        await rename(tempPath, filePath);
+        result.decrypted++;
+      } catch (writeErr) {
+        try {
+          await unlink(tempPath);
+        } catch {
+          // ignore cleanup errors; original ciphertext is still intact.
+        }
+        throw writeErr;
+      }
+    } catch (err) {
+      result.errors.push({
+        filePath,
+        error: err instanceof Error ? err.message : String(err),
+      });
+    }
+  }
+
+  return result;
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -384,6 +444,21 @@ export async function migrateMemoryDirToEncrypted(
  * and `.secure-store/` metadata.
  */
 async function collectMdFiles(dir: string, rootDir = dir): Promise<string[]> {
+  const files = await collectStorageManagedFiles(dir, isEncryptableStoragePath, rootDir);
+  return files.filter((filePath) => path.basename(filePath).endsWith(".md"));
+}
+
+/**
+ * Recursively collect regular files under storage-managed roots, excluding
+ * symlinked entries and `.secure-store/` metadata. This broader collector is
+ * used by the decrypt/disable path so future encrypted sidecars can be
+ * restored without requiring extension-specific logic.
+ */
+async function collectStorageManagedFiles(
+  dir: string,
+  includeFile: (filePath: string, rootDir: string) => boolean,
+  rootDir = dir,
+): Promise<string[]> {
   const results: string[] = [];
   let names: string[];
   try {
@@ -405,9 +480,9 @@ async function collectMdFiles(dir: string, rootDir = dir): Promise<string[]> {
       continue;
     }
     if (isDir) {
-      const sub = await collectMdFiles(full, rootDir);
+      const sub = await collectStorageManagedFiles(full, includeFile, rootDir);
       results.push(...sub);
-    } else if (isFile && name.endsWith(".md") && isEncryptableStoragePath(full, rootDir)) {
+    } else if (isFile && includeFile(full, rootDir)) {
       results.push(full);
     }
   }
@@ -417,10 +492,38 @@ async function collectMdFiles(dir: string, rootDir = dir): Promise<string[]> {
 function isEncryptableStoragePath(filePath: string, rootDir: string): boolean {
   const rel = path.relative(rootDir, filePath);
   if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return false;
-  const normalized = rel.split(path.sep).join("/");
+  const normalized = normalizeStorageRelativePath(rel);
   if (normalized === "profile.md") return true;
   const firstSegment = normalized.split("/", 1)[0];
   return ENCRYPTABLE_STORAGE_ROOTS.has(firstSegment);
+}
+
+function isDecryptableStoragePath(filePath: string, rootDir: string): boolean {
+  if (isEncryptableStoragePath(filePath, rootDir)) return true;
+  const rel = path.relative(rootDir, filePath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return false;
+  const normalized = normalizeStorageRelativePath(rel);
+  const firstSegment = normalized.split("/", 1)[0];
+  return DECRYPTABLE_SIDECAR_ROOTS.has(firstSegment);
+}
+
+function normalizeStorageRelativePath(rel: string): string {
+  const normalized = rel.split(path.sep).join("/");
+  const parts = normalized.split("/");
+  if (parts[0] === "namespaces" && parts.length >= 3) {
+    return parts.slice(2).join("/");
+  }
+  return normalized;
+}
+
+function storageAadRootForFile(filePath: string, rootDir: string): string {
+  const rel = path.relative(rootDir, filePath);
+  if (rel === "" || rel.startsWith("..") || path.isAbsolute(rel)) return rootDir;
+  const parts = rel.split(path.sep);
+  if (parts[0] === "namespaces" && parts.length >= 3 && parts[1]) {
+    return path.join(rootDir, "namespaces", parts[1]);
+  }
+  return rootDir;
 }
 
 const ENCRYPTABLE_STORAGE_ROOTS = new Set([
@@ -430,4 +533,11 @@ const ENCRYPTABLE_STORAGE_ROOTS = new Set([
   "reasoning-traces",
   "artifacts",
   "archive",
+]);
+
+const DECRYPTABLE_SIDECAR_ROOTS = new Set([
+  "state",
+  "indexes",
+  "index",
+  "provenance",
 ]);

--- a/tests/cli-secure-store.test.ts
+++ b/tests/cli-secure-store.test.ts
@@ -25,6 +25,7 @@ import {
   keyring,
   parseHeader,
   readHeader,
+  runSecureStoreDisable,
   runSecureStoreInit,
   runSecureStoreLock,
   runSecureStoreMigrate,
@@ -424,6 +425,80 @@ test("migrate fails clearly when the secure-store is locked", async () => {
   });
 });
 
+test("disable decrypts encrypted files and leaves the header in place", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    await runSecureStoreUnlock({
+      memoryDir,
+      keyringId,
+      readPassphrase: staticPassphraseReader(TEST_PASSPHRASE).reader,
+    });
+
+    const filePath = path.join(memoryDir, "facts", "2026-04-28", "fact-a.md");
+    const original = "---\nid: fact-a\ncategory: fact\n---\nprivate fact";
+    await mkdir(path.dirname(filePath), { recursive: true });
+    await writeFile(filePath, original, "utf8");
+    await runSecureStoreMigrate({ memoryDir, keyringId });
+    assert.equal(isEncryptedFile(await readFile(filePath)), true);
+
+    const report = await runSecureStoreDisable({ memoryDir, keyringId });
+    assert.equal(report.ok, true);
+    assert.equal(report.decrypted, 1);
+    assert.equal(report.skipped, 0);
+    assert.equal(report.errors.length, 0);
+    assert.equal(await readFile(filePath, "utf8"), original);
+    assert.equal(isEncryptedFile(await readFile(filePath)), false);
+    assert.notEqual(await readHeader(memoryDir), null);
+
+    const second = await runSecureStoreDisable({ memoryDir, keyringId });
+    assert.equal(second.ok, true);
+    assert.equal(second.decrypted, 0);
+    assert.equal(second.skipped, 1);
+    assert.equal(second.errors.length, 0);
+  });
+});
+
+test("disable fails clearly when the secure-store is not initialized", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const report = await runSecureStoreDisable({ memoryDir, keyringId });
+    assert.deepEqual(report, {
+      ok: false,
+      reason: "not-initialized",
+      decrypted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+});
+
+test("disable fails clearly when the secure-store is locked", async () => {
+  await withTmpMemoryDir(async (memoryDir, keyringId) => {
+    const init = staticPassphraseReader(TEST_PASSPHRASE, TEST_PASSPHRASE);
+    await runSecureStoreInit({
+      memoryDir,
+      keyringId,
+      readPassphrase: init.reader,
+      algorithm: "scrypt",
+      params: FAST_SCRYPT,
+    });
+    const report = await runSecureStoreDisable({ memoryDir, keyringId });
+    assert.deepEqual(report, {
+      ok: false,
+      reason: "locked",
+      decrypted: 0,
+      skipped: 0,
+      errors: [],
+    });
+  });
+});
+
 test("cli.ts registers the secure-store migrate subcommand", async () => {
   const cliSource = await readFile(
     path.resolve(
@@ -439,6 +514,24 @@ test("cli.ts registers the secure-store migrate subcommand", async () => {
   assert.match(cliSource, /\.command\("migrate"\)/);
   assert.match(cliSource, /runSecureStoreMigrate/);
   assert.match(cliSource, /renderMigrateReport/);
+});
+
+test("cli.ts registers the secure-store disable and decrypt subcommands", async () => {
+  const cliSource = await readFile(
+    path.resolve(
+      import.meta.dirname,
+      "..",
+      "packages",
+      "remnic-core",
+      "src",
+      "cli.ts",
+    ),
+    "utf8",
+  );
+  assert.match(cliSource, /\.command\("disable"\)/);
+  assert.match(cliSource, /\.command\("decrypt"\)/);
+  assert.match(cliSource, /runSecureStoreDisable/);
+  assert.match(cliSource, /renderDisableReport/);
 });
 
 // ─── status (initialized) ────────────────────────────────────────────

--- a/tests/secure-store/storage-wrap.test.ts
+++ b/tests/secure-store/storage-wrap.test.ts
@@ -22,6 +22,7 @@ import {
   SecureStoreDecryptError,
   SecureStoreLockedError,
   decryptFileBody,
+  decryptMemoryDirToPlaintext,
   encryptFileBody,
   isEncryptedFile,
   migrateMemoryDirToEncrypted,
@@ -271,6 +272,7 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
       path.join(dir, "facts", "2024-01-01", "fact.md"),
       path.join(dir, "artifacts", "2024-01-01", "artifact.md"),
       path.join(dir, "archive", "2024-01-01", "archived.md"),
+      path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md"),
       path.join(dir, "profile.md"),
     ];
     const plainPaths = [
@@ -289,6 +291,14 @@ test("migrateMemoryDirToEncrypted — only encrypts storage-secure markdown path
     for (const f of encryptedPaths) {
       assert.ok(isEncryptedFile(await readFile(f)), `${f} should be encrypted`);
     }
+    assert.strictEqual(
+      await readMaybeEncryptedFile(
+        path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md"),
+        key,
+        path.join(dir, "namespaces", "team-a"),
+      ),
+      "content for fact.md",
+    );
     for (const f of plainPaths) {
       assert.strictEqual((await readFile(f, "utf8")).startsWith("content for"), true);
     }
@@ -341,6 +351,67 @@ test("migrateMemoryDirToEncrypted — decryptable after migration", async () => 
     const decrypted = await readMaybeEncryptedFile(filePath, key, dir);
     assert.strictEqual(decrypted, originalContent);
   });
+});
+
+test("decryptMemoryDirToPlaintext — decrypts encrypted files and is idempotent", async () => {
+  await withTempDir(async (dir) => {
+    const key = makeKey();
+    const encryptedFile = path.join(dir, "facts", "2024-01-01", "fact.md");
+    const namespacedFile = path.join(dir, "namespaces", "team-a", "facts", "2024-01-01", "fact.md");
+    const plaintextFile = path.join(dir, "facts", "2024-01-01", "plain.md");
+    const stateFile = path.join(dir, "state", "fact-hashes.txt");
+    await mkdir(path.dirname(encryptedFile), { recursive: true });
+    await mkdir(path.dirname(namespacedFile), { recursive: true });
+    await mkdir(path.dirname(stateFile), { recursive: true });
+    await writeMaybeEncryptedFile(encryptedFile, "encrypted fact", key, {}, dir);
+    await writeMaybeEncryptedFile(
+      namespacedFile,
+      "encrypted namespaced fact",
+      key,
+      {},
+      path.join(dir, "namespaces", "team-a"),
+    );
+    await writeFile(plaintextFile, "already plain", "utf8");
+    await writeMaybeEncryptedFile(stateFile, "encrypted state", key, {}, dir);
+
+    const first = await decryptMemoryDirToPlaintext(dir, key);
+    assert.strictEqual(first.decrypted, 3);
+    assert.strictEqual(first.skipped, 1);
+    assert.strictEqual(first.errors.length, 0);
+    assert.strictEqual(await readFile(encryptedFile, "utf8"), "encrypted fact");
+    assert.strictEqual(await readFile(namespacedFile, "utf8"), "encrypted namespaced fact");
+    assert.strictEqual(await readFile(plaintextFile, "utf8"), "already plain");
+    assert.strictEqual(await readFile(stateFile, "utf8"), "encrypted state");
+
+    const second = await decryptMemoryDirToPlaintext(dir, key);
+    assert.strictEqual(second.decrypted, 0);
+    assert.strictEqual(second.skipped, 4);
+    assert.strictEqual(second.errors.length, 0);
+  });
+});
+
+test("decryptMemoryDirToPlaintext — skips symlinked directories and secure metadata", async () => {
+  const outside = await mkdtemp(path.join(os.tmpdir(), "remnic-secure-outside-"));
+  try {
+    await withTempDir(async (dir) => {
+      const key = makeKey();
+      const outsideFile = path.join(outside, "outside.md");
+      await writeMaybeEncryptedFile(outsideFile, "outside content", key, {}, outside);
+      await symlink(outside, path.join(dir, "facts"), "dir");
+      const metadataFile = path.join(dir, ".secure-store", "header.md");
+      await mkdir(path.dirname(metadataFile), { recursive: true });
+      await writeMaybeEncryptedFile(metadataFile, "metadata content", key, {}, dir);
+
+      const result = await decryptMemoryDirToPlaintext(dir, key);
+
+      assert.strictEqual(result.decrypted, 0);
+      assert.strictEqual(result.errors.length, 0);
+      assert.strictEqual(isEncryptedFile(await readFile(outsideFile)), true);
+      assert.strictEqual(isEncryptedFile(await readFile(metadataFile)), true);
+    });
+  } finally {
+    await rm(outside, { recursive: true, force: true });
+  }
 });
 
 test("migrateMemoryDirToEncrypted — invokes onBeforeEncrypt callback", async () => {


### PR DESCRIPTION
## Summary
- add `secure-store disable` plus `decrypt` alias to convert encrypted storage-managed files back to plaintext
- require initialized + unlocked secure-store, keep `.secure-store` metadata, skip plaintext, and write decrypted files atomically
- document the reversible disable flow and cover idempotency, locked/not-initialized errors, symlink exclusion, and metadata exclusion

Closes #780.
Follow-up to #690.

## Verification
- `npm exec -- tsx --test tests/cli-secure-store.test.ts tests/secure-store/storage-wrap.test.ts`
- `npm run check-types`
- `npm run build`
- `git diff --check`
- `npm run preflight:quick` (typecheck/config-contract/review-patterns passed; broad repo `npm test` phase hung and was interrupted after the known fan-out)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new CLI flow that decrypts and overwrites on-disk encrypted storage files, which is inherently data-sensitive despite using atomic writes and conservative path filters.
> 
> **Overview**
> Adds `remnic engram secure-store disable` (plus `decrypt` alias) to decrypt storage-managed secure-store files back to plaintext, requiring an initialized header and an unlocked key and returning structured reports with a new `renderDisableReport`.
> 
> Implements `decryptMemoryDirToPlaintext` as the reversible counterpart to `migrateMemoryDirToEncrypted`, including idempotent skipping of plaintext files, exclusion of `.secure-store/` and symlinks, atomic temp-file rewrites, and expanded path handling for decryptable sidecar roots.
> 
> Updates secure-store docs and tests to cover the new command, error cases (locked/not initialized), idempotency, and namespaced/AAD-root behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fbc788f3125cb1e667972ac0da8743e4ca42e88f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->