### PR TITLE
feat(mcp): add capsule tools

### DIFF
--- a/packages/remnic-core/src/access-http.ts
+++ b/packages/remnic-core/src/access-http.ts
@@ -1572,6 +1572,10 @@ export class EngramAccessHttpServer {
         toolName === "remnic.suggestion_submit" ||
         toolName === "engram.observe" ||
         toolName === "remnic.observe" ||
+        toolName === "engram.capsule_export" ||
+        toolName === "remnic.capsule_export" ||
+        toolName === "engram.capsule_import" ||
+        toolName === "remnic.capsule_import" ||
         (
           !dreamsRunDryRun &&
           (toolName === "engram.dreams_run" || toolName === "remnic.dreams_run")

--- a/packages/remnic-core/src/access-mcp.ts
+++ b/packages/remnic-core/src/access-mcp.ts
@@ -2,10 +2,19 @@ import type { Readable, Writable } from "node:stream";
 import { readFile } from "node:fs/promises";
 import { randomUUID } from "node:crypto";
 import { EngramAccessInputError, type EngramAccessService, type EngramAccessRecallResponse } from "./access-service.js";
+import {
+  validateRequest,
+  type CapsuleExportRequest,
+  type CapsuleImportRequest,
+  type CapsuleListRequest,
+  type SchemaName,
+  type SchemaTypeFor,
+} from "./access-schema.js";
 import { readEnvVar } from "./runtime/env.js";
 import type { RecallDisclosure, RecallPlanMode } from "./types.js";
 import { validateBriefingFormat } from "./briefing.js";
 import { buildCitationGuidance, type CitationMetadata } from "./citations.js";
+import { expandTildePath } from "./utils/path.js";
 
 type JsonRpcId = string | number | null;
 
@@ -43,6 +52,46 @@ function withToolAliases(tool: McpTool): McpTool[] {
   const canonicalTool = canonicalName === tool.name ? tool : { ...tool, name: canonicalName };
   if (canonicalName === tool.name) return [canonicalTool];
   return [canonicalTool, tool];
+}
+
+const STRICT_MCP_SCHEMA_KEYS: Partial<Record<SchemaName, readonly string[]>> = {
+  capsuleExport: [
+    "name",
+    "namespace",
+    "since",
+    "includeKinds",
+    "peerIds",
+    "includeTranscripts",
+    "encrypt",
+  ],
+  capsuleImport: ["archivePath", "namespace", "mode"],
+  capsuleList: ["namespace"],
+};
+
+function parseMcpRequest<N extends SchemaName>(
+  schemaName: N,
+  args: Record<string, unknown>,
+): SchemaTypeFor<N> {
+  const allowedKeys = STRICT_MCP_SCHEMA_KEYS[schemaName];
+  if (allowedKeys) {
+    const allowed = new Set(allowedKeys);
+    const unexpected = Object.keys(args).filter((key) => !allowed.has(key));
+    if (unexpected.length > 0) {
+      throw new EngramAccessInputError(
+        `request validation failed: (root): Unrecognized key(s) in object: ${unexpected.join(", ")}`,
+      );
+    }
+  }
+  const validation = validateRequest<SchemaTypeFor<N>>(schemaName, args);
+  if (validation.success) return validation.data;
+  const details = validation.error.details
+    .map((detail) => `${detail.field}: ${detail.message}`)
+    .join("; ");
+  throw new EngramAccessInputError(
+    details.length > 0
+      ? `${validation.error.error}: ${details}`
+      : validation.error.error,
+  );
 }
 
 async function getMcpServerVersion(): Promise<string> {
@@ -258,6 +307,70 @@ export class EngramMcpServer {
             namespace: { type: "string" },
           },
           required: [],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.capsule_export",
+        description: "Export a portable Remnic capsule archive from the namespace-scoped memory store.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            name: {
+              type: "string",
+              description: "Capsule id (alphanumeric with single dashes, max 64 characters).",
+            },
+            namespace: { type: "string" },
+            since: {
+              type: "string",
+              description: "Only include files modified on or after this ISO 8601 timestamp.",
+            },
+            includeKinds: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional top-level directory allow-list.",
+            },
+            peerIds: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional peer id allow-list for the peers/ subtree.",
+            },
+            includeTranscripts: { type: "boolean" },
+            encrypt: { type: "boolean" },
+          },
+          required: ["name"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.capsule_import",
+        description: "Import a Remnic capsule archive into the namespace-scoped memory store.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            archivePath: {
+              type: "string",
+              description: "Path to a .capsule.json.gz or .capsule.json.gz.enc archive.",
+            },
+            namespace: { type: "string" },
+            mode: {
+              type: "string",
+              enum: ["skip", "overwrite", "fork"],
+              description: "Conflict handling mode. Defaults to skip.",
+            },
+          },
+          required: ["archivePath"],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "engram.capsule_list",
+        description: "List capsule archives in the namespace-scoped capsule store.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            namespace: { type: "string" },
+          },
           additionalProperties: false,
         },
       },
@@ -1241,12 +1354,15 @@ export class EngramMcpServer {
     if (method === "tools/call") {
       const params = request.params ?? {};
       const name = typeof params.name === "string" ? params.name : "";
-      const argumentsObject =
-        params.arguments && typeof params.arguments === "object" && !Array.isArray(params.arguments)
-          ? (params.arguments as Record<string, unknown>)
-          : {};
 
       try {
+        let argumentsObject: Record<string, unknown> = {};
+        if ("arguments" in params && params.arguments !== undefined) {
+          if (params.arguments === null || typeof params.arguments !== "object" || Array.isArray(params.arguments)) {
+            throw new EngramAccessInputError("tools/call arguments must be an object when provided");
+          }
+          argumentsObject = params.arguments as Record<string, unknown>;
+        }
         const effectivePrincipal = options?.principalOverride ?? this.authenticatedPrincipal;
         const result = await this.callTool(name, argumentsObject, effectivePrincipal, options?.sessionId);
         return {
@@ -1664,6 +1780,35 @@ export class EngramMcpServer {
           sessionKey: typeof args.sessionKey === "string" ? args.sessionKey : undefined,
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,
         });
+      case "engram.capsule_export": {
+        const body: CapsuleExportRequest = parseMcpRequest("capsuleExport", args);
+        return this.service.capsuleExport({
+          name: body.name,
+          namespace: body.namespace,
+          principal: effectivePrincipal,
+          since: body.since,
+          includeKinds: body.includeKinds,
+          peerIds: body.peerIds,
+          includeTranscripts: body.includeTranscripts,
+          encrypt: body.encrypt,
+        });
+      }
+      case "engram.capsule_import": {
+        const body: CapsuleImportRequest = parseMcpRequest("capsuleImport", args);
+        return this.service.capsuleImport({
+          archivePath: expandTildePath(body.archivePath),
+          namespace: body.namespace,
+          principal: effectivePrincipal,
+          mode: body.mode,
+        });
+      }
+      case "engram.capsule_list": {
+        const body: CapsuleListRequest = parseMcpRequest("capsuleList", args);
+        return this.service.capsuleList({
+          namespace: body.namespace,
+          principal: effectivePrincipal,
+        });
+      }
       case "engram.memory_governance_run":
         return this.service.governanceRun({
           namespace: typeof args.namespace === "string" ? args.namespace : undefined,

--- a/packages/remnic-core/src/access-schema.ts
+++ b/packages/remnic-core/src/access-schema.ts
@@ -283,29 +283,36 @@ const capsuleIsoSinceSchema = z
     "since must be a valid ISO 8601 timestamp with no calendar overflow",
   );
 
-export const capsuleExportRequestSchema = z.object({
-  name: z
-    .string()
-    .trim()
-    .min(1, "name is required")
-    .max(64, "name must be 64 characters or fewer")
-    .regex(
-      CAPSULE_ID_PATTERN,
-      "name must be alphanumeric with single dashes (no spaces, no leading/trailing dashes)",
-    ),
-  namespace: namespaceSchema,
-  since: capsuleIsoSinceSchema.optional(),
-  includeKinds: z.array(capsuleTopLevelSegmentSchema).max(50).optional(),
-  peerIds: z.array(capsulePeerIdSchema).max(100).optional(),
-  includeTranscripts: z.boolean().optional(),
-  encrypt: z.boolean().optional(),
-});
+export const capsuleExportRequestSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(1, "name is required")
+      .max(64, "name must be 64 characters or fewer")
+      .regex(
+        CAPSULE_ID_PATTERN,
+        "name must be alphanumeric with single dashes (no spaces, no leading/trailing dashes)",
+      ),
+    namespace: namespaceSchema,
+    since: capsuleIsoSinceSchema.optional(),
+    includeKinds: z.array(capsuleTopLevelSegmentSchema).max(50).optional(),
+    peerIds: z.array(capsulePeerIdSchema).max(100).optional(),
+    includeTranscripts: z.boolean().optional(),
+    encrypt: z.boolean().optional(),
+  });
 
-export const capsuleImportRequestSchema = z.object({
-  archivePath: z.string().trim().min(1, "archivePath is required").max(4096),
-  namespace: namespaceSchema,
-  mode: z.enum(["skip", "overwrite", "fork"]).optional(),
-});
+export const capsuleImportRequestSchema = z
+  .object({
+    archivePath: z.string().trim().min(1, "archivePath is required").max(4096),
+    namespace: namespaceSchema,
+    mode: z.enum(["skip", "overwrite", "fork"]).optional(),
+  });
+
+export const capsuleListRequestSchema = z
+  .object({
+    namespace: namespaceSchema,
+  });
 
 // ---------------------------------------------------------------------------
 // Inferred types
@@ -324,6 +331,7 @@ export type LcmSearchRequest = z.infer<typeof lcmSearchRequestSchema>;
 export type DaySummaryRequest = z.infer<typeof daySummaryRequestSchema>;
 export type CapsuleExportRequest = z.infer<typeof capsuleExportRequestSchema>;
 export type CapsuleImportRequest = z.infer<typeof capsuleImportRequestSchema>;
+export type CapsuleListRequest = z.infer<typeof capsuleListRequestSchema>;
 
 // ---------------------------------------------------------------------------
 // Validation helper
@@ -342,7 +350,8 @@ export type SchemaName =
   | "lcmSearch"
   | "daySummary"
   | "capsuleExport"
-  | "capsuleImport";
+  | "capsuleImport"
+  | "capsuleList";
 
 export type SchemaTypeFor<N extends SchemaName> =
   N extends "recall" ? RecallRequest
@@ -358,6 +367,7 @@ export type SchemaTypeFor<N extends SchemaName> =
   : N extends "daySummary" ? DaySummaryRequest
   : N extends "capsuleExport" ? CapsuleExportRequest
   : N extends "capsuleImport" ? CapsuleImportRequest
+  : N extends "capsuleList" ? CapsuleListRequest
   : never;
 
 const schemas: Record<SchemaName, z.ZodTypeAny> = {
@@ -374,6 +384,7 @@ const schemas: Record<SchemaName, z.ZodTypeAny> = {
   daySummary: daySummaryRequestSchema,
   capsuleExport: capsuleExportRequestSchema,
   capsuleImport: capsuleImportRequestSchema,
+  capsuleList: capsuleListRequestSchema,
 };
 
 /**

--- a/packages/remnic-core/src/access-service.ts
+++ b/packages/remnic-core/src/access-service.ts
@@ -122,6 +122,10 @@ import {
   type ExportCapsuleOptions,
   type ExportCapsuleResult,
 } from "./transfer/capsule-export.js";
+import {
+  defaultCapsulesDir,
+  type CapsuleListEntry,
+} from "./capsule-cli.js";
 
 export class EngramAccessInputError extends Error {}
 
@@ -557,6 +561,12 @@ export interface EngramAccessQualityResponse {
     qualityScore?: EngramAccessReviewQueueResponse["qualityScore"];
     reviewQueueCount: number;
   };
+}
+
+export interface EngramAccessCapsuleListResponse {
+  namespace: string;
+  capsulesDir: string;
+  capsules: CapsuleListEntry[];
 }
 
 async function buildProjectedGovernanceProposedActions(
@@ -4611,6 +4621,110 @@ export class EngramAccessService {
       root,
       memoryDir: exportOptions.encrypt === true ? memoryDir : undefined,
     });
+  }
+
+  /**
+   * List capsule archives in the namespace-scoped capsule store.
+   *
+   * MCP uses this access-layer method instead of reading arbitrary paths so
+   * capsule discovery remains bound to the same namespace ACLs as export and
+   * import.
+   */
+  async capsuleList(options?: {
+    namespace?: string;
+    principal?: string;
+  }): Promise<EngramAccessCapsuleListResponse> {
+    const resolvedNamespace = this.resolveReadableNamespace(options?.namespace, options?.principal);
+    const storage = await this.orchestrator.getStorage(resolvedNamespace);
+    const capsulesDir = defaultCapsulesDir(storage.dir);
+    let dirEntries: import("node:fs").Dirent[];
+    try {
+      const capsulesDirStat = await nodeFs.lstat(capsulesDir);
+      if (capsulesDirStat.isSymbolicLink()) {
+        throw new EngramAccessInputError("capsule list failed: capsule store directory must not be a symlink");
+      }
+      if (!capsulesDirStat.isDirectory()) {
+        throw new EngramAccessInputError("capsule list failed: capsule store path must be a directory");
+      }
+      dirEntries = await nodeFs.readdir(capsulesDir, { withFileTypes: true });
+    } catch (err) {
+      const code = typeof err === "object" && err !== null && "code" in err
+        ? (err as { code?: unknown }).code
+        : undefined;
+      if (code === "ENOENT") {
+        return { namespace: resolvedNamespace, capsulesDir, capsules: [] };
+      }
+      throw err;
+    }
+
+    const archiveNames = dirEntries
+      .filter(
+        (entry) =>
+          entry.isFile() &&
+          (entry.name.endsWith(".capsule.json.gz") ||
+            entry.name.endsWith(".capsule.json.gz.enc")),
+      )
+      .map((entry) => entry.name)
+      .sort();
+
+    const capsules: CapsuleListEntry[] = [];
+    for (const archiveName of archiveNames) {
+      const archivePath = nodePath.join(capsulesDir, archiveName);
+      const id = archiveName
+        .replace(/\.capsule\.json\.gz\.enc$/, "")
+        .replace(/\.capsule\.json\.gz$/, "");
+      const manifestPath = nodePath.join(capsulesDir, `${id}.manifest.json`);
+
+      let createdAt: string | null = null;
+      let pluginVersion: string | null = null;
+      let fileCount: number | null = null;
+      let description: string | null = null;
+      let manifestPathOrNull: string | null = manifestPath;
+
+      try {
+        const manifestStat = await nodeFs.lstat(manifestPath);
+        if (manifestStat.isSymbolicLink() || !manifestStat.isFile()) {
+          capsules.push({
+            id,
+            archivePath,
+            manifestPath: manifestPathOrNull,
+            createdAt,
+            pluginVersion,
+            fileCount,
+            description,
+          });
+          continue;
+        }
+        const raw = await nodeFs.readFile(manifestPath, "utf-8");
+        const sidecar = JSON.parse(raw) as Record<string, unknown>;
+        createdAt = typeof sidecar.createdAt === "string" ? sidecar.createdAt : null;
+        pluginVersion = typeof sidecar.pluginVersion === "string" ? sidecar.pluginVersion : null;
+        fileCount = Array.isArray(sidecar.files) ? sidecar.files.length : null;
+        const capsule = sidecar.capsule as Record<string, unknown> | undefined;
+        description = capsule && typeof capsule.description === "string"
+          ? capsule.description
+          : null;
+      } catch (err) {
+        const code = typeof err === "object" && err !== null && "code" in err
+          ? (err as { code?: unknown }).code
+          : undefined;
+        if (code === "ENOENT") {
+          manifestPathOrNull = null;
+        }
+      }
+
+      capsules.push({
+        id,
+        archivePath,
+        manifestPath: manifestPathOrNull,
+        createdAt,
+        pluginVersion,
+        fileCount,
+        description,
+      });
+    }
+
+    return { namespace: resolvedNamespace, capsulesDir, capsules };
   }
 
   // ── Dreams pipeline telemetry surfaces (issue #678 PR 3+4) ──────────────

--- a/tests/access-http.test.ts
+++ b/tests/access-http.test.ts
@@ -2240,6 +2240,21 @@ test("access HTTP server rate-limits MCP write tool calls", async () => {
     });
     assert.equal(limitedDreamsRun.status, 429);
 
+    const limitedCapsuleExport = await fetch(`${base}/mcp`, {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1003,
+        method: "tools/call",
+        params: {
+          name: "remnic.capsule_export",
+          arguments: { name: "overflow-capsule" },
+        },
+      }),
+    });
+    assert.equal(limitedCapsuleExport.status, 429);
+
     // Read-only MCP calls should still work
     const recallRes = await fetch(`${base}/mcp`, {
       method: "POST",

--- a/tests/access-mcp.test.ts
+++ b/tests/access-mcp.test.ts
@@ -142,6 +142,79 @@ function createFakeService(): EngramAccessService {
       runId: "gov-1",
       reviewQueue: [{ memoryId: "fact-1", reasonCode: "disputed_memory" }],
     }),
+    capsuleExport: async ({ name, namespace, includeKinds, peerIds, includeTranscripts, encrypt }) => ({
+      archivePath: `/tmp/remnic/.capsules/${name}.capsule.json.gz${encrypt === true ? ".enc" : ""}`,
+      manifestPath: `/tmp/remnic/.capsules/${name}.manifest.json`,
+      encryptedArchivePath: encrypt === true ? `/tmp/remnic/.capsules/${name}.capsule.json.gz.enc` : null,
+      manifest: {
+        format: "openclaw-engram-export",
+        schemaVersion: 2,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        pluginVersion: "test",
+        includesTranscripts: includeTranscripts === true,
+        files: [{ path: "facts/2026-04-28/fact-a.md", sha256: "abc123", bytes: 42 }],
+        capsule: {
+          id: name,
+          version: "1.0.0",
+          schemaVersion: "test",
+          parentCapsule: null,
+          parent: null,
+          description: `namespace=${namespace ?? "default"} kinds=${(includeKinds ?? []).join(",")} peers=${(peerIds ?? []).join(",")}`,
+          retrievalPolicy: { directAnswerEnabled: false, tierWeights: {} },
+          includes: {
+            taxonomy: false,
+            identityAnchors: false,
+            peerProfiles: false,
+            procedural: false,
+          },
+        },
+      },
+    }),
+    capsuleImport: async ({ archivePath, mode }) => ({
+      imported: [{
+        sourcePath: "facts/2026-04-28/fact-a.md",
+        targetPath: "facts/2026-04-28/fact-a.md",
+        snapshotted: mode === "overwrite",
+        rewroteId: false,
+      }],
+      skipped: [],
+      manifest: {
+        format: "openclaw-engram-export",
+        schemaVersion: 2,
+        createdAt: "2026-04-28T00:00:00.000Z",
+        pluginVersion: "test",
+        includesTranscripts: false,
+        files: [{ path: "facts/2026-04-28/fact-a.md", sha256: "abc123", bytes: 42 }],
+        capsule: {
+          id: String(archivePath).split("/").pop()?.replace(/\.capsule\.json\.gz(?:\.enc)?$/, "") ?? "imported",
+          version: "1.0.0",
+          schemaVersion: "test",
+          parentCapsule: null,
+          parent: null,
+          description: "MCP import test capsule",
+          retrievalPolicy: { directAnswerEnabled: false, tierWeights: {} },
+          includes: {
+            taxonomy: false,
+            identityAnchors: false,
+            peerProfiles: false,
+            procedural: false,
+          },
+        },
+      },
+    }),
+    capsuleList: async () => ({
+      namespace: "global",
+      capsulesDir: "/tmp/remnic/.capsules",
+      capsules: [{
+        id: "daily-ops",
+        archivePath: "/tmp/remnic/.capsules/daily-ops.capsule.json.gz",
+        manifestPath: "/tmp/remnic/.capsules/daily-ops.manifest.json",
+        createdAt: "2026-04-28T00:00:00.000Z",
+        pluginVersion: "test",
+        fileCount: 1,
+        description: "Daily ops capsule",
+      }],
+    }),
     briefingEnabled: true,
     peerList: async () => ({
       peers: [
@@ -240,6 +313,9 @@ test("MCP server advertises tools and dispatches recall", async () => {
     "engram.recall_tier_explain",
     "engram.recall_xray",
     "engram.day_summary",
+    "engram.capsule_export",
+    "engram.capsule_import",
+    "engram.capsule_list",
     "engram.memory_governance_run",
     "engram.procedure_mining_run",
     "engram.pattern_reinforcement_run",
@@ -343,9 +419,65 @@ test("MCP server advertises tools and dispatches recall", async () => {
   assert.equal(governanceResult.structuredContent.runId, "gov-1");
   assert.equal(governanceResult.structuredContent.mode, "shadow");
 
-  const liveConnectors = await server.handleRequest({
+  const capsuleExport = await server.handleRequest({
     jsonrpc: "2.0",
     id: 6,
+    method: "tools/call",
+    params: {
+      name: "remnic.capsule_export",
+      arguments: {
+        name: "daily-ops",
+        namespace: "global",
+        includeKinds: ["facts"],
+        peerIds: ["alice"],
+        includeTranscripts: true,
+      },
+    },
+  });
+  const capsuleExportResult = capsuleExport?.result as {
+    structuredContent: { archivePath: string; manifest: { capsule: { id: string; description: string } } };
+  };
+  assert.equal(capsuleExportResult.structuredContent.archivePath, "/tmp/remnic/.capsules/daily-ops.capsule.json.gz");
+  assert.equal(capsuleExportResult.structuredContent.manifest.capsule.id, "daily-ops");
+  assert.match(capsuleExportResult.structuredContent.manifest.capsule.description, /kinds=facts/);
+  assert.match(capsuleExportResult.structuredContent.manifest.capsule.description, /peers=alice/);
+
+  const capsuleImport = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 7,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_import",
+      arguments: {
+        archivePath: "/tmp/remnic/.capsules/daily-ops.capsule.json.gz",
+        mode: "overwrite",
+      },
+    },
+  });
+  const capsuleImportResult = capsuleImport?.result as {
+    structuredContent: { imported: Array<{ targetPath: string; snapshotted: boolean }> };
+  };
+  assert.equal(capsuleImportResult.structuredContent.imported[0]?.targetPath, "facts/2026-04-28/fact-a.md");
+  assert.equal(capsuleImportResult.structuredContent.imported[0]?.snapshotted, true);
+
+  const capsuleList = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 8,
+    method: "tools/call",
+    params: {
+      name: "remnic.capsule_list",
+      arguments: {},
+    },
+  });
+  const capsuleListResult = capsuleList?.result as {
+    structuredContent: { capsules: Array<{ id: string; fileCount: number | null }> };
+  };
+  assert.equal(capsuleListResult.structuredContent.capsules[0]?.id, "daily-ops");
+  assert.equal(capsuleListResult.structuredContent.capsules[0]?.fileCount, 1);
+
+  const liveConnectors = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 9,
     method: "tools/call",
     params: {
       name: "engram.live_connectors_run",
@@ -360,7 +492,7 @@ test("MCP server advertises tools and dispatches recall", async () => {
 
   const entity = await server.handleRequest({
     jsonrpc: "2.0",
-    id: 7,
+    id: 10,
     method: "tools/call",
     params: {
       name: "engram.entity_get",
@@ -369,6 +501,100 @@ test("MCP server advertises tools and dispatches recall", async () => {
   });
   const entityResult = entity?.result as { structuredContent: { entity: { name: string } } };
   assert.equal(entityResult.structuredContent.entity.name, "person-alex");
+});
+
+test("MCP capsule tools reject invalid arguments before calling service", async () => {
+  let exportCalls = 0;
+  let importCalls = 0;
+  let listCalls = 0;
+  const service = {
+    ...createFakeService(),
+    capsuleExport: async () => {
+      exportCalls += 1;
+      return {};
+    },
+    capsuleImport: async () => {
+      importCalls += 1;
+      return {};
+    },
+    capsuleList: async () => {
+      listCalls += 1;
+      return {};
+    },
+  } as unknown as EngramAccessService;
+  const server = new EngramMcpServer(service);
+
+  const badExport = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_export",
+      arguments: { name: "../bad" },
+    },
+  });
+  assert.match(toolCallErrorMessage(badExport), /name: name must be alphanumeric/);
+  assert.equal(exportCalls, 0);
+
+  const badImport = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 2,
+    method: "tools/call",
+    params: {
+      name: "remnic.capsule_import",
+      arguments: { archivePath: "/tmp/bad.capsule.json.gz", mode: "merge" },
+    },
+  });
+  assert.match(toolCallErrorMessage(badImport), /mode: Invalid enum value/);
+  assert.equal(importCalls, 0);
+
+  const badList = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 3,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_list",
+      arguments: { namespace: 42 },
+    },
+  });
+  assert.match(toolCallErrorMessage(badList), /namespace: Expected string/);
+  assert.equal(listCalls, 0);
+
+  const typoList = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 4,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_list",
+      arguments: { namespce: "global" },
+    },
+  });
+  assert.match(toolCallErrorMessage(typoList), /Unrecognized key/);
+  assert.equal(listCalls, 0);
+
+  const stringArguments = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 5,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_list",
+      arguments: "oops",
+    },
+  });
+  assert.match(toolCallErrorMessage(stringArguments), /arguments must be an object/);
+  assert.equal(listCalls, 0);
+
+  const nullArguments = await server.handleRequest({
+    jsonrpc: "2.0",
+    id: 6,
+    method: "tools/call",
+    params: {
+      name: "engram.capsule_list",
+      arguments: null,
+    },
+  });
+  assert.match(toolCallErrorMessage(nullArguments), /arguments must be an object/);
+  assert.equal(listCalls, 0);
 });
 
 test("engram.dreams_status rejects invalid windowHours without calling service", async () => {

--- a/tests/access-service.test.ts
+++ b/tests/access-service.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import os from "node:os";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
-import { chmod, mkdtemp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { chmod, mkdtemp, mkdir, readFile, rm, symlink, writeFile } from "node:fs/promises";
 import { EngramAccessInputError, EngramAccessService } from "../src/access-service.js";
 import { runMemoryGovernance } from "../src/maintenance/memory-governance.ts";
 import { rebuildMemoryProjection } from "../src/maintenance/rebuild-memory-projection.ts";
@@ -303,6 +303,165 @@ function memoryDoc(id: string, content: string, extra: string[] = []): string {
     "",
   ].join("\n");
 }
+
+test("capsuleList returns namespace-scoped capsule metadata with read ACLs", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-list-ns-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  const capsulesDir = path.join(namespaceDir, ".capsules");
+  await mkdir(capsulesDir, { recursive: true });
+  await writeFile(path.join(capsulesDir, "daily-ops.capsule.json.gz"), "archive", "utf8");
+  await writeFile(
+    path.join(capsulesDir, "daily-ops.manifest.json"),
+    JSON.stringify({
+      createdAt: "2026-04-28T00:00:00.000Z",
+      pluginVersion: "9.3.243",
+      files: [{ path: "facts/2026-04-28/fact-a.md" }],
+      capsule: { description: "Daily ops capsule" },
+    }),
+    "utf8",
+  );
+  await writeFile(path.join(capsulesDir, "weekly-rollup.capsule.json.gz.enc"), "archive", "utf8");
+  await writeFile(path.join(capsulesDir, "broken-sidecar.capsule.json.gz"), "archive", "utf8");
+  await writeFile(path.join(capsulesDir, "broken-sidecar.manifest.json"), "{not-json", "utf8");
+  await writeFile(path.join(capsulesDir, "linked-sidecar.capsule.json.gz"), "archive", "utf8");
+  const foreignManifestPath = path.join(memoryDir, "foreign-manifest.json");
+  await writeFile(
+    foreignManifestPath,
+    JSON.stringify({
+      createdAt: "2026-04-27T00:00:00.000Z",
+      pluginVersion: "0.0.1-foreign",
+      files: [{ path: "facts/foreign.md" }],
+      capsule: { description: "Foreign metadata must not leak" },
+    }),
+    "utf8",
+  );
+  await symlink(foreignManifestPath, path.join(capsulesDir, "linked-sidecar.manifest.json"));
+  let resolvedNamespace: string | undefined;
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x", "read-only"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async (namespace: string | undefined) => {
+      resolvedNamespace = namespace;
+      return { dir: namespaceDir };
+    },
+  } as any);
+
+  try {
+    await assert.rejects(
+      () => service.capsuleList({ namespace: "project-x" }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /authentication required/.test(err.message),
+    );
+
+    const result = await service.capsuleList({
+      namespace: "project-x",
+      principal: "read-only",
+    });
+
+    assert.equal(resolvedNamespace, "project-x");
+    assert.equal(result.namespace, "project-x");
+    assert.equal(result.capsulesDir, capsulesDir);
+    assert.deepEqual(result.capsules.map((entry) => entry.id), [
+      "broken-sidecar",
+      "daily-ops",
+      "linked-sidecar",
+      "weekly-rollup",
+    ]);
+    assert.equal(result.capsules[0]?.manifestPath, path.join(capsulesDir, "broken-sidecar.manifest.json"));
+    assert.equal(result.capsules[0]?.createdAt, null);
+    assert.equal(result.capsules[0]?.pluginVersion, null);
+    assert.equal(result.capsules[0]?.fileCount, null);
+    assert.equal(result.capsules[0]?.description, null);
+    assert.equal(result.capsules[1]?.manifestPath, path.join(capsulesDir, "daily-ops.manifest.json"));
+    assert.equal(result.capsules[1]?.createdAt, "2026-04-28T00:00:00.000Z");
+    assert.equal(result.capsules[1]?.pluginVersion, "9.3.243");
+    assert.equal(result.capsules[1]?.fileCount, 1);
+    assert.equal(result.capsules[1]?.description, "Daily ops capsule");
+    assert.equal(result.capsules[2]?.manifestPath, path.join(capsulesDir, "linked-sidecar.manifest.json"));
+    assert.equal(result.capsules[2]?.createdAt, null);
+    assert.equal(result.capsules[2]?.pluginVersion, null);
+    assert.equal(result.capsules[2]?.fileCount, null);
+    assert.equal(result.capsules[2]?.description, null);
+    assert.equal(result.capsules[3]?.manifestPath, null);
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
+
+test("capsuleList rejects symlinked capsule store directories", async () => {
+  const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-list-symlink-"));
+  const namespaceDir = path.join(memoryDir, "namespaces", "project-x");
+  const outsideCapsulesDir = path.join(memoryDir, "outside-capsules");
+  await mkdir(namespaceDir, { recursive: true });
+  await mkdir(outsideCapsulesDir, { recursive: true });
+  await symlink(outsideCapsulesDir, path.join(namespaceDir, ".capsules"), "dir");
+
+  const service = new EngramAccessService({
+    config: {
+      memoryDir,
+      namespacesEnabled: true,
+      defaultNamespace: "global",
+      sharedNamespace: "shared",
+      principalFromSessionKeyMode: "prefix",
+      principalFromSessionKeyRules: [],
+      namespacePolicies: [
+        {
+          name: "project-x",
+          readPrincipals: ["project-x", "read-only"],
+          writePrincipals: ["project-x"],
+        },
+      ],
+      defaultRecallNamespaces: ["self"],
+      searchBackend: "qmd",
+      qmdEnabled: true,
+      nativeKnowledge: undefined,
+      recallCrossNamespaceBudgetEnabled: false,
+      recallCrossNamespaceBudgetWindowMs: 60_000,
+      recallCrossNamespaceBudgetSoftLimit: 10,
+      recallCrossNamespaceBudgetHardLimit: 30,
+      dreamsPhases: dreamsPhasesConfig(),
+    },
+    recall: async () => "ctx",
+    lastRecall: { get: () => null, getMostRecent: () => null },
+    getStorage: async () => ({ dir: namespaceDir }),
+  } as any);
+
+  try {
+    await assert.rejects(
+      () => service.capsuleList({ namespace: "project-x", principal: "read-only" }),
+      (err: unknown) =>
+        err instanceof EngramAccessInputError &&
+        /capsule store directory must not be a symlink/.test(err.message),
+    );
+  } finally {
+    await rm(memoryDir, { recursive: true, force: true });
+  }
+});
 
 test("capsuleExport encrypts namespace exports with the root secure-store keyring", async () => {
   const memoryDir = await mkdtemp(path.join(os.tmpdir(), "remnic-capsule-export-ns-"));


### PR DESCRIPTION
Closes #778.

## Summary
- expose remnic/engram MCP tools for capsule export, import, and list
- add schema validation for capsule MCP payloads
- add namespace-scoped capsule listing through the access service

## Verification
- npm exec -- tsx --test tests/access-mcp.test.ts
- npm exec -- tsx --test --test-name-pattern "capsuleList" tests/access-service.test.ts
- npm exec -- tsx --test --test-name-pattern "capsule" tests/access-mcp.test.ts
- git diff --check

Note: npm run check-types is currently blocked in this local worktree by missing @node-rs/argon2 module/type declarations before it reaches this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new MCP tool surfaces that trigger capsule export/import and introduces a new filesystem-backed capsule listing API, which impacts namespace ACL enforcement and write rate limiting. Risk is moderate due to new input validation paths and directory/manifest parsing (including symlink checks) that could affect access behavior.
> 
> **Overview**
> Adds new MCP tools `engram/remnic.capsule_export`, `capsule_import`, and `capsule_list`, wiring them to the access service and applying stricter request validation (rejects non-object `arguments` and unexpected keys).
> 
> Extends the access service with `capsuleList`, which lists capsule archives from the namespace-scoped `.capsules` directory and returns parsed manifest metadata while guarding against symlinked capsule directories/sidecars.
> 
> Updates HTTP MCP write-rate-limiting to treat capsule export/import as write operations, and adds tests covering tool registration, validation failures, rate limiting, and capsule listing ACL/symlink behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d05c368e46dc6cf72ebbe00510d606952610a100. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->